### PR TITLE
fix(gateway): keep two-phase exec approvals pending when no approval …

### DIFF
--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -202,7 +202,10 @@ export function createExecApprovalHandlers(
         }
       }
 
-      if (!hasExecApprovalClients && !forwarded) {
+      // Single-phase callers (e.g. CLI) fail fast when nobody can approve.
+      // Two-phase callers (agent tools) keep the request pending so Control UI /
+      // webchat can connect with operator.approvals scope and resolve before timeout.
+      if (!twoPhase && !hasExecApprovalClients && !forwarded) {
         manager.expire(record.id, "no-approval-route");
         respond(
           true,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -966,7 +966,52 @@ describe("exec approval handlers", () => {
     }
   });
 
-  it("fast-fails approvals when no approver clients and no forwarding targets", async () => {
+  it("keeps two-phase approvals pending when no approver clients and no forwarding targets", async () => {
+    vi.useFakeTimers();
+    try {
+      const { manager, handlers, forwarder, respond, context } =
+        createForwardingExecApprovalFixture();
+      const expireSpy = vi.spyOn(manager, "expire");
+
+      const requestPromise = requestExecApproval({
+        handlers,
+        respond,
+        context,
+        params: {
+          timeoutMs: 60_000,
+          id: "approval-two-phase-no-clients",
+          host: "gateway",
+          twoPhase: true,
+        },
+      });
+
+      // Drain microtasks so the handler reaches the twoPhase branch
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(forwarder.handleRequested).toHaveBeenCalledTimes(1);
+      // Two-phase request must NOT be expired immediately
+      expect(expireSpy).not.toHaveBeenCalled();
+      // Should have sent an "accepted" response (two-phase)
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          status: "accepted",
+          id: "approval-two-phase-no-clients",
+        }),
+        undefined,
+      );
+
+      // Advance past timeout so the approval expires naturally
+      await vi.advanceTimersByTimeAsync(60_000);
+      await requestPromise;
+
+      expect(expireSpy).toHaveBeenCalledWith("approval-two-phase-no-clients");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fast-fails single-phase approvals when no approver clients and no forwarding targets", async () => {
     const { manager, handlers, forwarder, respond, context } =
       createForwardingExecApprovalFixture();
     const expireSpy = vi.spyOn(manager, "expire");


### PR DESCRIPTION
fix(gateway): keep two-phase exec approvals pending when no approval clients connected

## Summary

- Problem: Two-phase exec approval requests (used by agent tools) were immediately expired with `no-approval-route` when no approval clients were connected, same as single-phase (CLI) requests.
- Why it matters: Agent tool calls need to stay pending so that Control UI or webchat can connect with `operator.approvals` scope and resolve the approval before timeout. Expiring them immediately breaks the two-phase approval flow.
- What changed: Added a `!twoPhase` guard to the fast-fail condition in `exec-approval.ts` so only single-phase callers fail fast. Two-phase callers now remain pending until timeout.
- What did NOT change (scope boundary): Single-phase (CLI) callers still fail fast when no approver is available. No changes to approval forwarding, timeout logic, or the approval manager.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The fast-fail condition `!hasExecApprovalClients && !forwarded` did not distinguish between single-phase and two-phase callers, expiring both immediately when no approval clients were connected.
- Missing detection / guardrail: No test existed that verified two-phase approvals are kept pending when no approval clients are connected.
- Prior context (`git blame`, prior PR, issue, or refactor if known): The fast-fail path was originally written for CLI (single-phase) only; two-phase support was added later without updating this condition.
- Why this regressed now: Two-phase approval flow began being exercised in environments where approval clients connect asynchronously (Control UI, webchat).
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/server-methods.test.ts`
- Scenario the test should lock in: Two-phase approval requests must NOT be expired when no approver clients are connected; they must remain pending and receive an `accepted` response.
- Why this is the smallest reliable guardrail: The unit test directly exercises the branch condition with fake timers and verifies that `expire` is not called immediately.
- Existing test that already covers this (if any): The prior test only covered the single-phase fast-fail path.
- If no new test is added, why not: New tests are included in this patch.

## User-visible / Behavior Changes

Agent tool approval requests now stay pending (instead of immediately failing) when no approval client is connected, giving operators time to connect via Control UI or webchat.

## Diagram (if applicable)

```text
Before:
[agent tool call] -> requestExecApproval(twoPhase=true) -> no clients -> expire("no-approval-route") -> DENIED

After:
[agent tool call] -> requestExecApproval(twoPhase=true) -> no clients -> respond("accepted") -> wait for timeout or approval
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): Gateway exec approval
- Relevant config (redacted): N/A

### Steps

1. Start gateway with no approval clients connected.
2. Trigger an agent tool call that sends a two-phase exec approval request.
3. Observe the approval request status.

### Expected

- Two-phase approval stays pending with `accepted` status until timeout or a client connects and resolves it.

### Actual

- Two-phase approval was immediately expired with `no-approval-route`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Two-phase approval stays pending; single-phase still fast-fails.
- Edge cases checked: Timeout expiry still fires for two-phase after `timeoutMs`.
- What you did **not** verify: End-to-end with live Control UI / webchat.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Two-phase requests now wait the full timeout before expiring if no client ever connects.
  - Mitigation: This is the intended behavior; the timeout is already set by the caller and acts as the natural upper bound.
