### PR TITLE
fix(discord): configuredBinding should not bypass requireMention in guild channels

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.acp-bindings.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.acp-bindings.test.ts
@@ -305,7 +305,7 @@ describe("preflightDiscordMessage configured ACP bindings", () => {
           author: message.author,
           message,
         }),
-        guildEntries: createAllowedGuildEntries(true),
+        guildEntries: createAllowedGuildEntries(false),
       }),
     );
 

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -766,6 +766,93 @@ describe("preflightDiscordMessage", () => {
     expect(result).not.toBeNull();
     expect(result?.wasMentioned).toBe(true);
   });
+
+  it("drops guild message without mention when channel has configuredBinding and requireMention: true", async () => {
+    const conversationRuntime = await import("openclaw/plugin-sdk/conversation-runtime");
+    const channelId = "ch-binding-1";
+    const bindingRoute = {
+      bindingResolution: {
+        record: {
+          targetSessionKey: "agent:main:acp:binding:discord:default:abc",
+          targetKind: "session",
+        },
+      } as never,
+      route: { agentId: "main", matchedBy: "binding.channel" } as never,
+      boundSessionKey: "agent:main:acp:binding:discord:default:abc",
+      boundAgentId: "main",
+    };
+    const routeSpy = vi
+      .spyOn(conversationRuntime, "resolveConfiguredBindingRoute")
+      .mockReturnValue(bindingRoute);
+    const ensureSpy = vi
+      .spyOn(conversationRuntime, "ensureConfiguredBindingRouteReady")
+      .mockResolvedValue({ ok: true });
+
+    try {
+      const result = await runGuildPreflight({
+        channelId,
+        guildId: "guild-1",
+        message: createDiscordMessage({
+          id: "m-binding-1",
+          channelId,
+          content: "hello without mention",
+          author: { id: "user-1", bot: false, username: "alice" },
+        }),
+        discordConfig: {} as DiscordConfig,
+        guildEntries: {
+          "guild-1": { channels: { [channelId]: { allow: true, requireMention: true } } },
+        },
+      });
+      expect(result).toBeNull();
+    } finally {
+      routeSpy.mockRestore();
+      ensureSpy.mockRestore();
+    }
+  });
+
+  it("allows guild message with mention when channel has configuredBinding and requireMention: true", async () => {
+    const conversationRuntime = await import("openclaw/plugin-sdk/conversation-runtime");
+    const channelId = "ch-binding-2";
+    const bindingRoute = {
+      bindingResolution: {
+        record: {
+          targetSessionKey: "agent:main:acp:binding:discord:default:def",
+          targetKind: "session",
+        },
+      } as never,
+      route: { agentId: "main", matchedBy: "binding.channel" } as never,
+      boundSessionKey: "agent:main:acp:binding:discord:default:def",
+      boundAgentId: "main",
+    };
+    const routeSpy = vi
+      .spyOn(conversationRuntime, "resolveConfiguredBindingRoute")
+      .mockReturnValue(bindingRoute);
+    const ensureSpy = vi
+      .spyOn(conversationRuntime, "ensureConfiguredBindingRouteReady")
+      .mockResolvedValue({ ok: true });
+
+    try {
+      const result = await runGuildPreflight({
+        channelId,
+        guildId: "guild-1",
+        message: createDiscordMessage({
+          id: "m-binding-2",
+          channelId,
+          content: "hello <@openclaw-bot>",
+          author: { id: "user-1", bot: false, username: "alice" },
+          mentionedUsers: [{ id: "openclaw-bot" }],
+        }),
+        discordConfig: {} as DiscordConfig,
+        guildEntries: {
+          "guild-1": { channels: { [channelId]: { allow: true, requireMention: true } } },
+        },
+      });
+      expect(result).not.toBeNull();
+    } finally {
+      routeSpy.mockRestore();
+      ensureSpy.mockRestore();
+    }
+  });
 });
 
 describe("shouldIgnoreBoundThreadWebhookMessage", () => {

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -490,7 +490,7 @@ export async function preflightDiscordMessage(
   });
   const boundAgentId = boundSessionKey ? effectiveRoute.agentId : undefined;
   const isBoundThreadSession = Boolean(threadBinding && earlyThreadChannel);
-  const bypassMentionRequirement = isBoundThreadSession || Boolean(configuredBinding);
+  const bypassMentionRequirement = isBoundThreadSession;
   if (
     isBoundThreadBotSystemMessage({
       isBoundThreadSession,


### PR DESCRIPTION
## Summary

- Problem: Discord guild channels with `requireMention: true` bypass the mention gate when an ACP configured binding exists, responding to messages without @mention.
- Why it matters: Breaks the `requireMention` contract. Inconsistent with how Telegram and Matrix handle bindings.
- What changed: Removed `Boolean(configuredBinding)` from `bypassMentionRequirement` in `extensions/discord/src/monitor/message-handler.preflight.ts`. Configured bindings are a routing concern and should not override activation policy.
- What did NOT change (scope boundary): `isBoundThreadSession` bypass preserved — bound thread sessions still bypass mention requirement as intended.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55887
- Related #50990, #34353, #51531
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `message-handler.preflight.ts:493` uses `isBoundThreadSession || Boolean(configuredBinding)`. The `isBoundThreadSession` bypass is correct, but `Boolean(configuredBinding)` unconditionally bypasses mention requirement for any channel with an ACP binding, regardless of the channel's `requireMention` setting.
- Missing detection / guardrail: No test coverage for `configuredBinding` + `requireMention: true` interaction.
- Prior context: The bypass was likely added to ensure ACP-bound channels receive messages, but it conflates routing with activation policy.
- Why this regressed now: More visible as ACP configured bindings became widely used with wildcard channel entries.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/message-handler.preflight.test.ts`
- Scenario the test should lock in: Guild message without mention in a channel with `configuredBinding` + `requireMention: true` must be dropped; same with mention must pass.
- Why this is the smallest reliable guardrail: Preflight is the single gate for all Discord inbound messages.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: Two new tests added.

## User-visible / Behavior Changes

Discord guild channels with `requireMention: true` and an ACP configured binding will now correctly require @mention before responding.

## Diagram (if applicable)

```text
Before:
[no @mention, requireMention: true, configuredBinding] -> bypass -> bot responds

After:
[no @mention, requireMention: true, configuredBinding] -> mention gate -> dropped
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Integration/channel: Discord
- Relevant config: `discord.guilds.<id>.channels.*: { allow: true, requireMention: true }` with ACP configured binding

### Steps

1. Configure Discord guild with wildcard `"*": { "allow": true, "requireMention": true }`
2. Ensure an ACP configured binding matches the channel
3. Send a message without @mentioning the bot

### Expected

- Message dropped (bot stays silent)

### Actual (before fix)

- Bot responds despite no mention

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Two new tests added. Cross-channel analysis confirms other channels with binding support do not bypass mention requirement:

| Channel | configuredBinding bypasses mention? |
|---------|-------------------------------------|
| Telegram | No — binding is routing-only |
| Matrix | No — binding checked after mention gate |
| Discord (before fix) | Yes — unconditional bypass |
| Discord (after fix) | No — consistent with Telegram/Matrix |

## Human Verification (required)

- Verified scenarios: (1) no mention + binding + requireMention:true is dropped; (2) with mention + binding + requireMention:true passes; (3) all 22 existing preflight tests pass
- Edge cases checked: Thread binding bypass, DM, bot messages, allowlist, audio mention detection — all unaffected
- What you did **not** verify: End-to-end against a live Discord gateway

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — bug fix, not behavior change
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: Channels relying on the bypass as implicit mention-free behavior will now enforce `requireMention`.
  - Mitigation: Correct behavior — set `requireMention: false` explicitly if no mention is desired.