### PR TITLE
fix: phone-control: require operator.admin for arm/disarm on all channels

### DIFF
--- a/extensions/phone-control/index.test.ts
+++ b/extensions/phone-control/index.test.ts
@@ -143,26 +143,26 @@ describe("phone-control plugin", () => {
     });
   });
 
-  it("allows external channel callers without operator.admin to mutate phone control", async () => {
+  it("blocks external channel callers without operator.admin from mutating phone control", async () => {
     await withRegisteredPhoneControl(async ({ command, writeConfigFile }) => {
       const res = await command.handler({
         ...createCommandContext("arm writes 30s"),
         channel: "telegram",
       });
 
-      expect(String(res?.text ?? "")).toContain("Phone control: armed");
-      expect(writeConfigFile).toHaveBeenCalledTimes(1);
+      expect(String(res?.text ?? "")).toContain("requires operator.admin");
+      expect(writeConfigFile).not.toHaveBeenCalled();
     });
   });
 
-  it("allows external channel callers without operator.admin to disarm phone control", async () => {
+  it("blocks external channel callers without operator.admin from disarming phone control", async () => {
     await withRegisteredPhoneControl(async ({ command, writeConfigFile }) => {
       const res = await command.handler({
         ...createCommandContext("disarm"),
         channel: "telegram",
       });
 
-      expect(String(res?.text ?? "")).toContain("Phone control: disarmed.");
+      expect(String(res?.text ?? "")).toContain("requires operator.admin");
       expect(writeConfigFile).not.toHaveBeenCalled();
     });
   });

--- a/extensions/phone-control/index.ts
+++ b/extensions/phone-control/index.ts
@@ -358,7 +358,7 @@ export default definePluginEntry({
         }
 
         if (action === "disarm") {
-          if (ctx.channel === "webchat" && !ctx.gatewayClientScopes?.includes("operator.admin")) {
+          if (!ctx.gatewayClientScopes?.includes("operator.admin")) {
             return {
               text: "⚠️ /phone disarm requires operator.admin.",
             };
@@ -380,7 +380,7 @@ export default definePluginEntry({
         }
 
         if (action === "arm") {
-          if (ctx.channel === "webchat" && !ctx.gatewayClientScopes?.includes("operator.admin")) {
+          if (!ctx.gatewayClientScopes?.includes("operator.admin")) {
             return {
               text: "⚠️ /phone arm requires operator.admin.",
             };


### PR DESCRIPTION
### Motivation
- Close an authorization bypass that allowed external channels to arm/disarm phone control and persist gateway node allow/deny changes without `operator.admin`.

### Description
- Require `operator.admin` for both `/phone arm` and `/phone disarm` on all channels by removing the `ctx.channel === "webchat"` conditional in `extensions/phone-control/index.ts`.
- Update `extensions/phone-control/index.test.ts` to assert external callers without `operator.admin` are blocked for both `arm` and `disarm` paths while preserving admin behavior.
- Keep existing arm/disarm behavior intact for callers that include the `operator.admin` scope.

### Testing
- Ran the targeted unit tests with `pnpm test -- extensions/phone-control/index.test.ts`, and the test file passed (`6 passed`).
- Executed repository checks via the commit helper (`scripts/committer`) which runs `pnpm check` and linters, and they completed without errors.

