### PR TITLE
fix: bind Claude permission replies to session

### DIFF
--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -278,11 +278,13 @@ export class OpenClawChannelBridge {
 
   async handleClaudePermissionRequest(params: {
     requestId: string;
+    sessionKey: string;
     toolName: string;
     description: string;
     inputPreview: string;
   }): Promise<void> {
     this.pendingClaudePermissions.set(params.requestId, {
+      sessionKey: params.sessionKey,
       toolName: params.toolName,
       description: params.description,
       inputPreview: params.inputPreview,
@@ -461,7 +463,10 @@ export class OpenClawChannelBridge {
     const permissionMatch = text ? CLAUDE_PERMISSION_REPLY_RE.exec(text) : null;
     if (permissionMatch) {
       const requestId = permissionMatch[2]?.toLowerCase();
-      if (requestId && this.pendingClaudePermissions.has(requestId)) {
+      const pendingPermission = requestId
+        ? this.pendingClaudePermissions.get(requestId)
+        : undefined;
+      if (requestId && pendingPermission?.sessionKey === sessionKey) {
         this.pendingClaudePermissions.delete(requestId);
         await this.sendNotification({
           method: "notifications/claude/channel/permission",

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -380,6 +380,7 @@ describe("openclaw channel mcp server", () => {
         server: { server: { notification: ReturnType<typeof vi.fn> } };
       }
     ).pendingClaudePermissions.set("abcde", {
+      sessionKey: "agent:main:main",
       toolName: "Bash",
       description: "run npm test",
       inputPreview: '{"cmd":"npm test"}',
@@ -407,6 +408,59 @@ describe("openclaw channel mcp server", () => {
         },
       }),
     ).resolves.toBeUndefined();
+  });
+
+  test("requires Claude permission replies to come from the bound session", async () => {
+    const bridge = new OpenClawChannelBridge({} as never, {
+      claudeChannelMode: "on",
+      verbose: false,
+    });
+    const notification = vi.fn().mockResolvedValue(undefined);
+    (
+      bridge as unknown as {
+        server: { server: { notification: ReturnType<typeof vi.fn> } };
+      }
+    ).server = { server: { notification } };
+
+    await bridge.handleClaudePermissionRequest({
+      requestId: "abcde",
+      sessionKey: "agent:main:trusted",
+      toolName: "Bash",
+      description: "run npm test",
+      inputPreview: '{"cmd":"npm test"}',
+    });
+
+    await (
+      bridge as unknown as {
+        handleSessionMessageEvent: (payload: Record<string, unknown>) => Promise<void>;
+      }
+    ).handleSessionMessageEvent({
+      sessionKey: "agent:main:attacker",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "yes abcde" }],
+      },
+    });
+    expect(notification).not.toHaveBeenCalled();
+
+    await (
+      bridge as unknown as {
+        handleSessionMessageEvent: (payload: Record<string, unknown>) => Promise<void>;
+      }
+    ).handleSessionMessageEvent({
+      sessionKey: "agent:main:trusted",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "yes abcde" }],
+      },
+    });
+    expect(notification).toHaveBeenCalledWith({
+      method: "notifications/claude/channel/permission",
+      params: {
+        request_id: "abcde",
+        behavior: "allow",
+      },
+    });
   });
 
   test("emits Claude channel and permission notifications", async () => {
@@ -469,6 +523,7 @@ describe("openclaw channel mcp server", () => {
         method: "notifications/claude/channel/permission_request",
         params: {
           request_id: "abcde",
+          session_key: sessionKey,
           tool_name: "Bash",
           description: "run npm test",
           input_preview: '{"cmd":"npm test"}',
@@ -493,6 +548,20 @@ describe("openclaw channel mcp server", () => {
         request_id: "abcde",
         behavior: "allow",
       });
+
+      emitSessionTranscriptUpdate({
+        sessionFile: path.join(path.dirname(storePath), "sess-claude.jsonl"),
+        sessionKey: "agent:main:attacker",
+        messageId: "msg-user-2-attacker",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "no abcde" }],
+          timestamp: Date.now() + 1,
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(permissionNotifications).toHaveLength(1);
 
       emitSessionTranscriptUpdate({
         sessionFile: path.join(path.dirname(storePath), "sess-claude.jsonl"),

--- a/src/mcp/channel-server.ts
+++ b/src/mcp/channel-server.ts
@@ -42,6 +42,7 @@ export async function createOpenClawChannelMcpServer(opts: OpenClawMcpServeOptio
   server.server.setNotificationHandler(ClaudePermissionRequestSchema, async ({ params }) => {
     await bridge.handleClaudePermissionRequest({
       requestId: params.request_id,
+      sessionKey: params.session_key,
       toolName: params.tool_name,
       description: params.description,
       inputPreview: params.input_preview,

--- a/src/mcp/channel-shared.ts
+++ b/src/mcp/channel-shared.ts
@@ -104,6 +104,7 @@ export type QueueEvent =
     };
 
 export type ClaudePermissionRequest = {
+  sessionKey: string;
   toolName: string;
   description: string;
   inputPreview: string;
@@ -118,6 +119,7 @@ export const ClaudePermissionRequestSchema = z.object({
   method: z.literal("notifications/claude/channel/permission_request"),
   params: z.object({
     request_id: z.string(),
+    session_key: z.string(),
     tool_name: z.string(),
     description: z.string(),
     input_preview: z.string(),


### PR DESCRIPTION
### Motivation
- Fix a security issue where Claude permission replies (`yes/no <id>`) could be spoofed from any session because pending requests were keyed only by a short `request_id`. 
- Ensure permission replies are only accepted from the same session that originated the permission request to prevent cross-session or untrusted-channel approvals. 
- Preserve existing behavior for legitimate requests while closing the approval spoofing vector. 

### Description
- Require `session_key` in the `notifications/claude/channel/permission_request` schema and propagate it through the MCP server; changed `src/mcp/channel-shared.ts` and `src/mcp/channel-server.ts`. 
- Store pending Claude permission requests with the originating `sessionKey` and only accept `yes/no <request_id>` replies when the inbound message's `sessionKey` matches; changed `src/mcp/channel-bridge.ts`. 
- Add and update tests to cover session-bound permission handling and regression scenarios, including rejecting attacker-session replies and accepting trusted-session replies; changed `src/mcp/channel-server.test.ts`. 

### Testing
- Ran the targeted unit tests with `pnpm test -- src/mcp/channel-server.test.ts`, which passed (`1 passed, 6 tests`). 
- Ran the repository verification gate with `pnpm check`, which completed successfully (lint/type checks passed).