### PR TITLE
feat(slack): status reaction lifecycle for tool/thinking progress indicators

### DIFF
--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -47,6 +47,7 @@ type SlackClient = {
   };
   reactions: {
     add: (...args: unknown[]) => unknown;
+    remove: (...args: unknown[]) => unknown;
   };
 };
 
@@ -87,6 +88,7 @@ function ensureSlackTestRuntime(): {
       },
       reactions: {
         add: (...args: unknown[]) => slackTestState.reactMock(...args),
+        remove: (...args: unknown[]) => slackTestState.reactMock(...args),
       },
     };
   }

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -588,6 +588,8 @@ describe("monitorSlackProvider tool results", () => {
         channel_type: "channel",
       }),
     });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await flush();
 
     expect(sendMock).not.toHaveBeenCalled();
     expect(reactMock).toHaveBeenCalledTimes(1);

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -648,6 +648,57 @@ describe("monitorSlackProvider tool results", () => {
     });
   });
 
+  it("restores ack reaction when dispatch fails before any reply is delivered", async () => {
+    replyMock.mockRejectedValue(new Error("boom"));
+    slackTestState.config = {
+      messages: {
+        responsePrefix: "PFX",
+        ackReaction: "👀",
+        ackReactionScope: "group-mentions",
+        removeAckAfterReply: true,
+        statusReactions: {
+          enabled: true,
+          timing: { debounceMs: 0, doneHoldMs: 0, errorHoldMs: 0 },
+        },
+      },
+      channels: {
+        slack: {
+          dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+          groupPolicy: "open",
+        },
+      },
+    };
+    const client = getSlackClient();
+    if (!client) {
+      throw new Error("Slack client not registered");
+    }
+    const conversations = client.conversations as {
+      info: ReturnType<typeof vi.fn>;
+    };
+    conversations.info.mockResolvedValueOnce({
+      channel: { name: "general", is_channel: true },
+    });
+
+    await runSlackMessageOnce(monitorSlackProvider, {
+      event: makeSlackMessageEvent({
+        text: "<@bot-user> hello",
+        ts: "456",
+        channel_type: "channel",
+      }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await flush();
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(reactMock.mock.calls.map(([args]) => String((args as { name: string }).name))).toEqual([
+      "eyes",
+      "scream",
+      "eyes",
+      "eyes",
+      "scream",
+    ]);
+  });
+
   it("replies with pairing code when dmPolicy is pairing and no allowFrom is set", async () => {
     setPairingOnlyDirectMessages();
 

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -553,6 +553,51 @@ describe("monitorSlackProvider tool results", () => {
     });
   });
 
+  it("keeps ack reaction when no reply is delivered and status reactions are disabled", async () => {
+    replyMock.mockResolvedValue(undefined);
+    slackTestState.config = {
+      messages: {
+        responsePrefix: "PFX",
+        ackReaction: "👀",
+        ackReactionScope: "group-mentions",
+        removeAckAfterReply: true,
+        statusReactions: { enabled: false },
+      },
+      channels: {
+        slack: {
+          dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+          groupPolicy: "open",
+        },
+      },
+    };
+    const client = getSlackClient();
+    if (!client) {
+      throw new Error("Slack client not registered");
+    }
+    const conversations = client.conversations as {
+      info: ReturnType<typeof vi.fn>;
+    };
+    conversations.info.mockResolvedValueOnce({
+      channel: { name: "general", is_channel: true },
+    });
+
+    await runSlackMessageOnce(monitorSlackProvider, {
+      event: makeSlackMessageEvent({
+        text: "<@bot-user> hello",
+        ts: "456",
+        channel_type: "channel",
+      }),
+    });
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(reactMock).toHaveBeenCalledTimes(1);
+    expect(reactMock).toHaveBeenCalledWith({
+      channel: "C1",
+      timestamp: "456",
+      name: "👀",
+    });
+  });
+
   it("replies with pairing code when dmPolicy is pairing and no allowFrom is set", async () => {
     setPairingOnlyDirectMessages();
 

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -598,6 +598,56 @@ describe("monitorSlackProvider tool results", () => {
     });
   });
 
+  it("keeps ack reaction when no reply is delivered and status reactions are enabled", async () => {
+    replyMock.mockResolvedValue(undefined);
+    slackTestState.config = {
+      messages: {
+        responsePrefix: "PFX",
+        ackReaction: "👀",
+        ackReactionScope: "group-mentions",
+        removeAckAfterReply: true,
+        statusReactions: {
+          enabled: true,
+          timing: { debounceMs: 0, doneHoldMs: 0, errorHoldMs: 0 },
+        },
+      },
+      channels: {
+        slack: {
+          dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+          groupPolicy: "open",
+        },
+      },
+    };
+    const client = getSlackClient();
+    if (!client) {
+      throw new Error("Slack client not registered");
+    }
+    const conversations = client.conversations as {
+      info: ReturnType<typeof vi.fn>;
+    };
+    conversations.info.mockResolvedValueOnce({
+      channel: { name: "general", is_channel: true },
+    });
+
+    await runSlackMessageOnce(monitorSlackProvider, {
+      event: makeSlackMessageEvent({
+        text: "<@bot-user> hello",
+        ts: "456",
+        channel_type: "channel",
+      }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await flush();
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(reactMock).toHaveBeenCalledTimes(1);
+    expect(reactMock).toHaveBeenCalledWith({
+      channel: "C1",
+      timestamp: "456",
+      name: "eyes",
+    });
+  });
+
   it("replies with pairing code when dmPolicy is pairing and no allowFrom is set", async () => {
     setPairingOnlyDirectMessages();
 

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -549,7 +549,7 @@ describe("monitorSlackProvider tool results", () => {
     expect(reactMock).toHaveBeenCalledWith({
       channel: "C1",
       timestamp: "456",
-      name: "👀",
+      name: "eyes",
     });
   });
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -560,7 +560,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       };
 
   let dispatchError: unknown;
-  let didAdvanceStatusReaction = false;
   let queuedFinal = false;
   let counts: { final?: number; block?: number } = {};
   try {
@@ -589,13 +588,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         onReasoningEnd: onDraftBoundary,
         onReasoningStream: statusReactionsEnabled
           ? async () => {
-              didAdvanceStatusReaction = true;
               await statusReactions.setThinking();
             }
           : undefined,
         onToolStart: statusReactionsEnabled
           ? async (payload) => {
-              didAdvanceStatusReaction = true;
               await statusReactions.setTool(payload.name);
             }
           : undefined,
@@ -646,9 +643,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       } else {
         void statusReactions.restoreInitial();
       }
-    } else if (didAdvanceStatusReaction) {
-      // Silent success should preserve the original ack instead of looking like
-      // we delivered a visible reply.
+    } else {
+      // Silent success should preserve queued state and clear any stall timers
+      // instead of transitioning to terminal/stall reactions after return.
       await statusReactions.restoreInitial();
     }
   }

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -692,7 +692,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   if (!statusReactionsEnabled) {
     removeAckReactionAfterReply({
-      removeAfterReply: ctx.removeAckAfterReply,
+      removeAfterReply: ctx.removeAckAfterReply && anyReplyDelivered,
       ackReactionPromise: prepared.ackReactionPromise,
       ackReactionValue: prepared.ackReactionValue,
       remove: () =>

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -559,7 +559,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         }
       };
 
-  let dispatchError = false;
+  let dispatchError: unknown;
+  let didAdvanceStatusReaction = false;
   let queuedFinal = false;
   let counts: { final?: number; block?: number } = {};
   try {
@@ -588,11 +589,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         onReasoningEnd: onDraftBoundary,
         onReasoningStream: statusReactionsEnabled
           ? async () => {
+              didAdvanceStatusReaction = true;
               await statusReactions.setThinking();
             }
           : undefined,
         onToolStart: statusReactionsEnabled
           ? async (payload) => {
+              didAdvanceStatusReaction = true;
               await statusReactions.setTool(payload.name);
             }
           : undefined,
@@ -601,30 +604,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     queuedFinal = result.queuedFinal;
     counts = result.counts;
   } catch (err) {
-    dispatchError = true;
-    throw err;
+    dispatchError = err;
   } finally {
     await draftStream?.flush();
     draftStream?.stop();
     markDispatchIdle();
-
-    if (statusReactionsEnabled) {
-      if (dispatchError) {
-        await statusReactions.setError();
-      } else {
-        await statusReactions.setDone();
-      }
-      if (ctx.removeAckAfterReply) {
-        void (async () => {
-          await sleep(
-            dispatchError ? statusReactionTiming.errorHoldMs : statusReactionTiming.doneHoldMs,
-          );
-          await statusReactions.clear();
-        })();
-      } else {
-        void statusReactions.restoreInitial();
-      }
-    }
   }
 
   // -----------------------------------------------------------------------
@@ -640,6 +624,38 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   }
 
   const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
+
+  if (statusReactionsEnabled) {
+    if (dispatchError) {
+      await statusReactions.setError();
+      if (ctx.removeAckAfterReply) {
+        void (async () => {
+          await sleep(statusReactionTiming.errorHoldMs);
+          await statusReactions.clear();
+        })();
+      } else {
+        void statusReactions.restoreInitial();
+      }
+    } else if (anyReplyDelivered) {
+      await statusReactions.setDone();
+      if (ctx.removeAckAfterReply) {
+        void (async () => {
+          await sleep(statusReactionTiming.doneHoldMs);
+          await statusReactions.clear();
+        })();
+      } else {
+        void statusReactions.restoreInitial();
+      }
+    } else if (didAdvanceStatusReaction) {
+      // Silent success should preserve the original ack instead of looking like
+      // we delivered a visible reply.
+      await statusReactions.restoreInitial();
+    }
+  }
+
+  if (dispatchError) {
+    throw dispatchError;
+  }
 
   // Record thread participation only when we actually delivered a reply and
   // know the thread ts that was used (set by deliverNormally, streaming start,

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -621,30 +621,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       } else {
         void statusReactions.restoreInitial();
       }
-    } else {
-      removeAckReactionAfterReply({
-        removeAfterReply: ctx.removeAckAfterReply,
-        ackReactionPromise: prepared.ackReactionPromise,
-        ackReactionValue: prepared.ackReactionValue,
-        remove: () =>
-          removeSlackReaction(
-            message.channel,
-            prepared.ackReactionMessageTs ?? "",
-            prepared.ackReactionValue,
-            {
-              token: ctx.botToken,
-              client: ctx.app.client,
-            },
-          ),
-        onError: (err) => {
-          logAckFailure({
-            log: logVerbose,
-            channel: "slack",
-            target: `${message.channel}/${message.ts}`,
-            error: err,
-          });
-        },
-      });
     }
   }
 
@@ -687,6 +663,32 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     logVerbose(
       `slack: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${prepared.replyTarget}`,
     );
+  }
+
+  if (!statusReactionsEnabled) {
+    removeAckReactionAfterReply({
+      removeAfterReply: ctx.removeAckAfterReply,
+      ackReactionPromise: prepared.ackReactionPromise,
+      ackReactionValue: prepared.ackReactionValue,
+      remove: () =>
+        removeSlackReaction(
+          message.channel,
+          prepared.ackReactionMessageTs ?? "",
+          prepared.ackReactionValue,
+          {
+            token: ctx.botToken,
+            client: ctx.app.client,
+          },
+        ),
+      onError: (err) => {
+        logAckFailure({
+          log: logVerbose,
+          channel: "slack",
+          target: `${message.channel}/${message.ts}`,
+          error: err,
+        });
+      },
+    });
   }
 
   if (prepared.isRoomish) {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -190,14 +190,17 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     replyToMode: prepared.replyToMode,
   });
 
+  const reactionMessageTs = prepared.ackReactionMessageTs;
   const messageTs = message.ts ?? message.event_ts;
   const incomingThreadTs = message.thread_ts;
   let didSetStatus = false;
   const statusReactionsEnabled =
-    Boolean(prepared.ackReactionPromise) && cfg.messages?.statusReactions?.enabled !== false;
+    Boolean(prepared.ackReactionPromise) &&
+    Boolean(reactionMessageTs) &&
+    cfg.messages?.statusReactions?.enabled !== false;
   const slackStatusAdapter: StatusReactionAdapter = {
     setReaction: async (emoji) => {
-      await reactSlackMessage(message.channel, message.ts ?? "", toSlackEmojiName(emoji), {
+      await reactSlackMessage(message.channel, reactionMessageTs ?? "", toSlackEmojiName(emoji), {
         token: ctx.botToken,
         client: ctx.app.client,
       }).catch((err) => {
@@ -208,7 +211,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       });
     },
     removeReaction: async (emoji) => {
-      await removeSlackReaction(message.channel, message.ts ?? "", toSlackEmojiName(emoji), {
+      await removeSlackReaction(message.channel, reactionMessageTs ?? "", toSlackEmojiName(emoji), {
         token: ctx.botToken,
         client: ctx.app.client,
       }).catch((err) => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -348,6 +348,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let streamSession: SlackStreamSession | null = null;
   let streamFailed = false;
   let usedReplyThreadTs: string | undefined;
+  let observedReplyDelivery = false;
 
   const deliverNormally = async (payload: ReplyPayload, forcedThreadTs?: string): Promise<void> => {
     const replyThreadTs = forcedThreadTs ?? replyPlan.nextThreadTs();
@@ -362,6 +363,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       replyToMode: prepared.replyToMode,
       ...(slackIdentity ? { identity: slackIdentity } : {}),
     });
+    observedReplyDelivery = true;
     // Record the thread ts only after confirmed delivery success.
     if (replyThreadTs) {
       usedReplyThreadTs ??= replyThreadTs;
@@ -399,6 +401,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           teamId: ctx.teamId,
           userId: message.user,
         });
+        observedReplyDelivery = true;
         usedReplyThreadTs ??= streamThreadTs;
         replyPlan.markSent();
         return;
@@ -455,6 +458,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
               ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
             },
           );
+          observedReplyDelivery = true;
           return;
         } catch (err) {
           logVerbose(
@@ -620,7 +624,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     }
   }
 
-  const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
+  const anyReplyDelivered =
+    observedReplyDelivery || queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
 
   if (statusReactionsEnabled) {
     if (dispatchError) {
@@ -628,7 +633,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       if (ctx.removeAckAfterReply) {
         void (async () => {
           await sleep(statusReactionTiming.errorHoldMs);
-          await statusReactions.clear();
+          if (anyReplyDelivered) {
+            await statusReactions.clear();
+            return;
+          }
+          await statusReactions.restoreInitial();
         })();
       } else {
         void statusReactions.restoreInitial();

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -1,8 +1,11 @@
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
+  createStatusReactionController,
+  DEFAULT_TIMING,
   logAckFailure,
   logTypingFailure,
   removeAckReactionAfterReply,
+  type StatusReactionAdapter,
 } from "openclaw/plugin-sdk/channel-feedback";
 import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
 import { resolveStorePath, updateLastRoute } from "openclaw/plugin-sdk/config-runtime";
@@ -35,6 +38,39 @@ import {
   resolveSlackThreadTs,
 } from "../replies.js";
 import type { PreparedSlackMessage } from "./types.js";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Slack reactions.add/remove expect shortcode names, not raw unicode emoji.
+const UNICODE_TO_SLACK: Record<string, string> = {
+  "👀": "eyes",
+  "🤔": "thinking_face",
+  "🔥": "fire",
+  "👨‍💻": "male-technologist",
+  "👨💻": "male-technologist",
+  "👩‍💻": "female-technologist",
+  "⚡": "zap",
+  "🌐": "globe_with_meridians",
+  "✅": "white_check_mark",
+  "👍": "thumbsup",
+  "❌": "x",
+  "😱": "scream",
+  "🥱": "yawning_face",
+  "😨": "fearful",
+  "⏳": "hourglass_flowing_sand",
+  "⚠️": "warning",
+  "✍": "writing_hand",
+  "🧠": "brain",
+  "🛠️": "hammer_and_wrench",
+  "💻": "computer",
+};
+
+function toSlackEmojiName(emoji: string): string {
+  const trimmed = emoji.trim().replace(/^:+|:+$/g, "");
+  return UNICODE_TO_SLACK[trimmed] ?? trimmed;
+}
 
 function hasMedia(payload: ReplyPayload): boolean {
   return resolveSendableOutboundReplyParts(payload).hasMedia;
@@ -157,6 +193,55 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   const messageTs = message.ts ?? message.event_ts;
   const incomingThreadTs = message.thread_ts;
   let didSetStatus = false;
+  const statusReactionsEnabled =
+    Boolean(prepared.ackReactionPromise) && cfg.messages?.statusReactions?.enabled !== false;
+  const slackStatusAdapter: StatusReactionAdapter = {
+    setReaction: async (emoji) => {
+      await reactSlackMessage(message.channel, message.ts ?? "", toSlackEmojiName(emoji), {
+        token: ctx.botToken,
+        client: ctx.app.client,
+      }).catch((err) => {
+        if (String(err).includes("already_reacted")) {
+          return;
+        }
+        throw err;
+      });
+    },
+    removeReaction: async (emoji) => {
+      await removeSlackReaction(message.channel, message.ts ?? "", toSlackEmojiName(emoji), {
+        token: ctx.botToken,
+        client: ctx.app.client,
+      }).catch((err) => {
+        if (String(err).includes("no_reaction")) {
+          return;
+        }
+        throw err;
+      });
+    },
+  };
+  const statusReactionTiming = {
+    ...DEFAULT_TIMING,
+    ...cfg.messages?.statusReactions?.timing,
+  };
+  const statusReactions = createStatusReactionController({
+    enabled: statusReactionsEnabled,
+    adapter: slackStatusAdapter,
+    initialEmoji: prepared.ackReactionValue || "eyes",
+    emojis: cfg.messages?.statusReactions?.emojis,
+    timing: cfg.messages?.statusReactions?.timing,
+    onError: (err) => {
+      logAckFailure({
+        log: logVerbose,
+        channel: "slack",
+        target: `${message.channel}/${message.ts}`,
+        error: err,
+      });
+    },
+  });
+
+  if (statusReactionsEnabled) {
+    void statusReactions.setQueued();
+  }
 
   // Shared mutable ref for "replyToMode=first". Both tool + auto-reply flows
   // mark this to ensure only the first reply is threaded.
@@ -471,34 +556,97 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         }
       };
 
-  const { queuedFinal, counts } = await dispatchInboundMessage({
-    ctx: prepared.ctxPayload,
-    cfg,
-    dispatcher,
-    replyOptions: {
-      ...replyOptions,
-      skillFilter: prepared.channelConfig?.skills,
-      hasRepliedRef,
-      disableBlockStreaming: useStreaming
-        ? true
-        : typeof account.config.blockStreaming === "boolean"
-          ? !account.config.blockStreaming
-          : undefined,
-      onModelSelected,
-      onPartialReply: useStreaming
-        ? undefined
-        : !previewStreamingEnabled
+  let dispatchError = false;
+  let queuedFinal = false;
+  let counts: { final?: number; block?: number } = {};
+  try {
+    const result = await dispatchInboundMessage({
+      ctx: prepared.ctxPayload,
+      cfg,
+      dispatcher,
+      replyOptions: {
+        ...replyOptions,
+        skillFilter: prepared.channelConfig?.skills,
+        hasRepliedRef,
+        disableBlockStreaming: useStreaming
+          ? true
+          : typeof account.config.blockStreaming === "boolean"
+            ? !account.config.blockStreaming
+            : undefined,
+        onModelSelected,
+        onPartialReply: useStreaming
           ? undefined
-          : async (payload) => {
-              updateDraftFromPartial(payload.text);
+          : !previewStreamingEnabled
+            ? undefined
+            : async (payload) => {
+                updateDraftFromPartial(payload.text);
+              },
+        onAssistantMessageStart: onDraftBoundary,
+        onReasoningEnd: onDraftBoundary,
+        onReasoningStream: statusReactionsEnabled
+          ? async () => {
+              await statusReactions.setThinking();
+            }
+          : undefined,
+        onToolStart: statusReactionsEnabled
+          ? async (payload) => {
+              await statusReactions.setTool(payload.name);
+            }
+          : undefined,
+      },
+    });
+    queuedFinal = result.queuedFinal;
+    counts = result.counts;
+  } catch (err) {
+    dispatchError = true;
+    throw err;
+  } finally {
+    await draftStream?.flush();
+    draftStream?.stop();
+    markDispatchIdle();
+
+    if (statusReactionsEnabled) {
+      if (dispatchError) {
+        await statusReactions.setError();
+      } else {
+        await statusReactions.setDone();
+      }
+      if (ctx.removeAckAfterReply) {
+        void (async () => {
+          await sleep(
+            dispatchError ? statusReactionTiming.errorHoldMs : statusReactionTiming.doneHoldMs,
+          );
+          await statusReactions.clear();
+        })();
+      } else {
+        void statusReactions.restoreInitial();
+      }
+    } else {
+      removeAckReactionAfterReply({
+        removeAfterReply: ctx.removeAckAfterReply,
+        ackReactionPromise: prepared.ackReactionPromise,
+        ackReactionValue: prepared.ackReactionValue,
+        remove: () =>
+          removeSlackReaction(
+            message.channel,
+            prepared.ackReactionMessageTs ?? "",
+            prepared.ackReactionValue,
+            {
+              token: ctx.botToken,
+              client: ctx.app.client,
             },
-      onAssistantMessageStart: onDraftBoundary,
-      onReasoningEnd: onDraftBoundary,
-    },
-  });
-  await draftStream?.flush();
-  draftStream?.stop();
-  markDispatchIdle();
+          ),
+        onError: (err) => {
+          logAckFailure({
+            log: logVerbose,
+            channel: "slack",
+            target: `${message.channel}/${message.ts}`,
+            error: err,
+          });
+        },
+      });
+    }
+  }
 
   // -----------------------------------------------------------------------
   // Finalize the stream if one was started
@@ -540,30 +688,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       `slack: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${prepared.replyTarget}`,
     );
   }
-
-  removeAckReactionAfterReply({
-    removeAfterReply: ctx.removeAckAfterReply,
-    ackReactionPromise: prepared.ackReactionPromise,
-    ackReactionValue: prepared.ackReactionValue,
-    remove: () =>
-      removeSlackReaction(
-        message.channel,
-        prepared.ackReactionMessageTs ?? "",
-        prepared.ackReactionValue,
-        {
-          token: ctx.botToken,
-          client: ctx.app.client,
-        },
-      ),
-    onError: (err) => {
-      logAckFailure({
-        log: logVerbose,
-        channel: "slack",
-        target: `${message.channel}/${message.ts}`,
-        error: err,
-      });
-    },
-  });
 
   if (prepared.isRoomish) {
     clearHistoryEntriesIfEnabled({

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -214,6 +214,33 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expectInboundContextContract(prepared!.ctxPayload as any);
   });
 
+  it("does not enable Slack status reactions when the message timestamp is missing", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        messages: {
+          ackReaction: "👀",
+          ackReactionScope: "all",
+          statusReactions: { enabled: true },
+        },
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+
+    const prepared = await prepareMessageWith(slackCtx, defaultAccount, {
+      channel: "D123",
+      channel_type: "im",
+      user: "U1",
+      text: "hi",
+      event_ts: "1.000",
+    } as SlackMessageEvent);
+
+    expect(prepared).toBeTruthy();
+    expect(prepared?.ackReactionMessageTs).toBeUndefined();
+    expect(prepared?.ackReactionPromise).toBeNull();
+  });
+
   it("includes forwarded shared attachment text in raw body", async () => {
     const prepared = await prepareWithDefaultCtx(
       createSlackMessage({

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -556,7 +556,9 @@ export async function prepareSlackMessage(params: {
 
   const ackReactionMessageTs = message.ts;
   const statusReactionsWillHandle =
-    cfg.messages?.statusReactions?.enabled !== false && shouldAckReaction();
+    Boolean(ackReactionMessageTs) &&
+    cfg.messages?.statusReactions?.enabled !== false &&
+    shouldAckReaction();
   const ackReactionPromise =
     !statusReactionsWillHandle && shouldAckReaction() && ackReactionMessageTs && ackReactionValue
       ? reactSlackMessage(message.channel, ackReactionMessageTs, ackReactionValue, {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -555,8 +555,10 @@ export async function prepareSlackMessage(params: {
     );
 
   const ackReactionMessageTs = message.ts;
+  const statusReactionsWillHandle =
+    cfg.messages?.statusReactions?.enabled !== false && shouldAckReaction();
   const ackReactionPromise =
-    shouldAckReaction() && ackReactionMessageTs && ackReactionValue
+    !statusReactionsWillHandle && shouldAckReaction() && ackReactionMessageTs && ackReactionValue
       ? reactSlackMessage(message.channel, ackReactionMessageTs, ackReactionValue, {
           token: ctx.botToken,
           client: ctx.app.client,
@@ -567,7 +569,9 @@ export async function prepareSlackMessage(params: {
             return false;
           },
         )
-      : null;
+      : statusReactionsWillHandle
+        ? Promise.resolve(true)
+        : null;
 
   const roomLabel = channelName ? `#${channelName}` : `#${message.channel}`;
   const senderName = await resolveSenderName();

--- a/src/channels/status-reactions.slack-lifecycle.test.ts
+++ b/src/channels/status-reactions.slack-lifecycle.test.ts
@@ -117,6 +117,33 @@ describe("Slack status reaction lifecycle", () => {
     expect(active.has(DEFAULT_EMOJIS.stallHard)).toBe(false);
   });
 
+  it("restoreInitial still applies initial emoji when it is only debounced", async () => {
+    const { adapter, active } = createSlackMockAdapter();
+    const ctrl = createStatusReactionController({
+      enabled: true,
+      adapter,
+      initialEmoji: "eyes",
+      emojis: { thinking: "eyes" },
+      timing: { debounceMs: 20, stallSoftMs: 99999, stallHardMs: 99999 },
+    });
+
+    void ctrl.setQueued();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(active.has("eyes")).toBe(true);
+
+    void ctrl.setTool("web_search");
+    await vi.advanceTimersByTimeAsync(25);
+    expect(active.has(DEFAULT_EMOJIS.web)).toBe(true);
+    expect(active.has("eyes")).toBe(false);
+
+    void ctrl.setThinking();
+    await ctrl.restoreInitial();
+
+    expect(active.has("eyes")).toBe(true);
+    expect(active.has(DEFAULT_EMOJIS.web)).toBe(false);
+    expect(adapter.setReaction).toHaveBeenCalledTimes(3);
+  });
+
   it("does nothing when disabled", async () => {
     const { adapter, active } = createSlackMockAdapter();
     const ctrl = createStatusReactionController({

--- a/src/channels/status-reactions.slack-lifecycle.test.ts
+++ b/src/channels/status-reactions.slack-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createStatusReactionController,
   DEFAULT_EMOJIS,
@@ -34,6 +34,10 @@ function createSlackMockAdapter() {
 describe("Slack status reaction lifecycle", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("queued -> thinking -> tool -> done -> clear", async () => {

--- a/src/channels/status-reactions.slack-lifecycle.test.ts
+++ b/src/channels/status-reactions.slack-lifecycle.test.ts
@@ -144,6 +144,43 @@ describe("Slack status reaction lifecycle", () => {
     expect(adapter.setReaction).toHaveBeenCalledTimes(3);
   });
 
+  it("restoreInitial re-applies initial emoji after an in-flight debounced transition", async () => {
+    let releaseThinking: (() => void) | undefined;
+    const { adapter, active } = createSlackMockAdapter();
+    adapter.setReaction = vi.fn(async (emoji: string) => {
+      if (emoji === DEFAULT_EMOJIS.thinking) {
+        await new Promise<void>((resolve) => {
+          releaseThinking = resolve;
+        });
+      }
+      if (active.has(emoji)) {
+        throw new Error("already_reacted");
+      }
+      active.add(emoji);
+    });
+
+    const ctrl = createStatusReactionController({
+      enabled: true,
+      adapter,
+      initialEmoji: "eyes",
+      timing: { debounceMs: 0, stallSoftMs: 99999, stallHardMs: 99999 },
+    });
+
+    void ctrl.setQueued();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(active.has("eyes")).toBe(true);
+
+    void ctrl.setThinking();
+    await vi.advanceTimersByTimeAsync(1);
+
+    const restorePromise = ctrl.restoreInitial();
+    releaseThinking?.();
+    await restorePromise;
+
+    expect(active.has("eyes")).toBe(true);
+    expect(active.has(DEFAULT_EMOJIS.thinking)).toBe(false);
+  });
+
   it("does nothing when disabled", async () => {
     const { adapter, active } = createSlackMockAdapter();
     const ctrl = createStatusReactionController({

--- a/src/channels/status-reactions.slack-lifecycle.test.ts
+++ b/src/channels/status-reactions.slack-lifecycle.test.ts
@@ -94,6 +94,29 @@ describe("Slack status reaction lifecycle", () => {
     expect(active.has(DEFAULT_EMOJIS.error)).toBe(false);
   });
 
+  it("restoreInitial clears stall timers without re-adding queued emoji", async () => {
+    const { adapter, active } = createSlackMockAdapter();
+    const ctrl = createStatusReactionController({
+      enabled: true,
+      adapter,
+      initialEmoji: "eyes",
+      timing: { debounceMs: 0, stallSoftMs: 10, stallHardMs: 20 },
+    });
+
+    void ctrl.setQueued();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(active.has("eyes")).toBe(true);
+    expect(adapter.setReaction).toHaveBeenCalledTimes(1);
+
+    await ctrl.restoreInitial();
+    await vi.advanceTimersByTimeAsync(30);
+
+    expect(adapter.setReaction).toHaveBeenCalledTimes(1);
+    expect(active.has("eyes")).toBe(true);
+    expect(active.has(DEFAULT_EMOJIS.stallSoft)).toBe(false);
+    expect(active.has(DEFAULT_EMOJIS.stallHard)).toBe(false);
+  });
+
   it("does nothing when disabled", async () => {
     const { adapter, active } = createSlackMockAdapter();
     const ctrl = createStatusReactionController({

--- a/src/channels/status-reactions.slack-lifecycle.test.ts
+++ b/src/channels/status-reactions.slack-lifecycle.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createStatusReactionController,
+  DEFAULT_EMOJIS,
+  type StatusReactionAdapter,
+} from "./status-reactions.js";
+
+function createSlackMockAdapter() {
+  const active = new Set<string>();
+  const log: string[] = [];
+
+  return {
+    adapter: {
+      setReaction: vi.fn(async (emoji: string) => {
+        if (active.has(emoji)) {
+          throw new Error("already_reacted");
+        }
+        active.add(emoji);
+        log.push(`+${emoji}`);
+      }),
+      removeReaction: vi.fn(async (emoji: string) => {
+        if (!active.has(emoji)) {
+          throw new Error("no_reaction");
+        }
+        active.delete(emoji);
+        log.push(`-${emoji}`);
+      }),
+    } as StatusReactionAdapter,
+    active,
+    log,
+  };
+}
+
+describe("Slack status reaction lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("queued -> thinking -> tool -> done -> clear", async () => {
+    const { adapter, active, log } = createSlackMockAdapter();
+    const ctrl = createStatusReactionController({
+      enabled: true,
+      adapter,
+      initialEmoji: "eyes",
+      timing: { debounceMs: 0, stallSoftMs: 99999, stallHardMs: 99999 },
+    });
+
+    void ctrl.setQueued();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(active.has("eyes")).toBe(true);
+
+    void ctrl.setThinking();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(active.has(DEFAULT_EMOJIS.thinking)).toBe(true);
+    expect(active.has("eyes")).toBe(false);
+
+    void ctrl.setTool("web_search");
+    await vi.advanceTimersByTimeAsync(10);
+    expect(active.has(DEFAULT_EMOJIS.web)).toBe(true);
+    expect(active.has(DEFAULT_EMOJIS.thinking)).toBe(false);
+
+    await ctrl.setDone();
+    expect(active.has(DEFAULT_EMOJIS.done)).toBe(true);
+    expect(active.has(DEFAULT_EMOJIS.web)).toBe(false);
+
+    await ctrl.clear();
+    expect(active.size).toBe(0);
+    expect(log.length).toBeGreaterThan(0);
+  });
+
+  it("queued -> error -> restoreInitial", async () => {
+    const { adapter, active } = createSlackMockAdapter();
+    const ctrl = createStatusReactionController({
+      enabled: true,
+      adapter,
+      initialEmoji: "eyes",
+      timing: { debounceMs: 0, stallSoftMs: 99999, stallHardMs: 99999 },
+    });
+
+    void ctrl.setQueued();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(active.has("eyes")).toBe(true);
+
+    await ctrl.setError();
+    expect(active.has(DEFAULT_EMOJIS.error)).toBe(true);
+    expect(active.has("eyes")).toBe(false);
+
+    await ctrl.restoreInitial();
+    expect(active.has("eyes")).toBe(true);
+    expect(active.has(DEFAULT_EMOJIS.error)).toBe(false);
+  });
+
+  it("does nothing when disabled", async () => {
+    const { adapter, active } = createSlackMockAdapter();
+    const ctrl = createStatusReactionController({
+      enabled: false,
+      adapter,
+      initialEmoji: "eyes",
+    });
+
+    void ctrl.setQueued();
+    void ctrl.setThinking();
+    await ctrl.setDone();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(active.size).toBe(0);
+    expect(adapter.setReaction).not.toHaveBeenCalled();
+  });
+
+  it("coding tool resolves to coding emoji", async () => {
+    const { adapter, active } = createSlackMockAdapter();
+    const ctrl = createStatusReactionController({
+      enabled: true,
+      adapter,
+      initialEmoji: "eyes",
+      timing: { debounceMs: 0, stallSoftMs: 99999, stallHardMs: 99999 },
+    });
+
+    void ctrl.setQueued();
+    await vi.advanceTimersByTimeAsync(10);
+
+    void ctrl.setTool("exec");
+    await vi.advanceTimersByTimeAsync(10);
+    expect(active.has(DEFAULT_EMOJIS.coding)).toBe(true);
+    expect(active.has("eyes")).toBe(false);
+  });
+});

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -379,7 +379,14 @@ export function createStatusReactionController(params: {
       return;
     }
 
+    const alreadyInitial = currentEmoji === initialEmoji;
+    const initialAlreadyPending = pendingEmoji === initialEmoji;
     clearAllTimers();
+    if (alreadyInitial || initialAlreadyPending) {
+      pendingEmoji = "";
+      return;
+    }
+
     await enqueue(async () => {
       await applyEmoji(initialEmoji);
       pendingEmoji = "";

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -282,6 +282,7 @@ export function createStatusReactionController(params: {
     } else {
       // Debounced execution for intermediate states
       debounceTimer = setTimeout(() => {
+        debounceTimer = null;
         void enqueue(async () => {
           await applyEmoji(emoji);
           pendingEmoji = "";
@@ -380,10 +381,15 @@ export function createStatusReactionController(params: {
     }
 
     const alreadyInitial = currentEmoji === initialEmoji;
-    const initialAlreadyQueuedImmediately = pendingEmoji === initialEmoji && debounceTimer === null;
+    const pendingBeforeClear = pendingEmoji;
+    const hadDebouncedPending = debounceTimer !== null;
     clearAllTimers();
-    if (alreadyInitial || initialAlreadyQueuedImmediately) {
+    if (alreadyInitial && (!pendingBeforeClear || hadDebouncedPending)) {
       pendingEmoji = "";
+      return;
+    }
+    if (pendingBeforeClear === initialEmoji && !hadDebouncedPending) {
+      await chainPromise;
       return;
     }
 

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -380,9 +380,9 @@ export function createStatusReactionController(params: {
     }
 
     const alreadyInitial = currentEmoji === initialEmoji;
-    const initialAlreadyPending = pendingEmoji === initialEmoji;
+    const initialAlreadyQueuedImmediately = pendingEmoji === initialEmoji && debounceTimer === null;
     clearAllTimers();
-    if (alreadyInitial || initialAlreadyPending) {
+    if (alreadyInitial || initialAlreadyQueuedImmediately) {
       pendingEmoji = "";
       return;
     }


### PR DESCRIPTION
## Summary

Wire the existing channel-agnostic `StatusReactionController` into the Slack dispatch flow, matching the Discord and Telegram implementations.

When `ackReaction` is enabled, the bot now cycles through emoji reactions on the user's message to show what it's doing in real-time:

```
👀 queued → 🤔 thinking → 🔥 tool / 👨‍💻 coding / 🌐 web → ✅ done (→ clear)
```

## Motivation

With Slack's "Agents & AI Apps" feature disabled (which many users prefer due to its UX), there's no way to show the bot is working. Discord and Telegram already have status reactions via `createStatusReactionController` — Slack was the only channel missing this.

This is especially useful as a replacement for the `assistant.threads.setStatus` typing indicator, which requires the "Agents & AI Apps" toggle to be enabled.

## Changes

Single file: `extensions/slack/src/monitor/message-handler/dispatch.ts`

- Creates a `StatusReactionAdapter` using existing `reactSlackMessage` / `removeSlackReaction`
- Initializes `createStatusReactionController` (from `openclaw/plugin-sdk/channel-feedback`)
- Hooks `onReasoningStream` → `setThinking()` and `onToolStart` → `setTool(name)` into `dispatchInboundMessage`
- Wraps dispatch in try/catch/finally for proper done/error/clear lifecycle
- Replaces the static `removeAckReactionAfterReply` with the full status reaction lifecycle
- Respects `messages.statusReactions.emojis` and `messages.statusReactions.timing` config

## Configuration

Works out of the box with existing `ackReaction` config. Emojis are customizable:

```yaml
messages:
  ackReaction: eyes
  ackReactionScope: all
  removeAckAfterReply: true
  statusReactions:
    emojis:
      thinking: brain
      tool: fire
      coding: female-technologist
      web: globe_with_meridians
      done: white_check_mark
      error: x
```

## Testing

- [x] Tested locally on macOS with Slack Socket Mode
- [x] Zero type errors in the Slack extension (`tsc --noEmit` clean)
- [x] Verified emoji cycling through full lifecycle: queued → thinking → tool → done → clear
- [x] Verified error state and stall detection work correctly
- [x] Backward compatible — no behavior change when `ackReaction` is not configured

## AI Disclosure

🤖 This PR was AI-assisted (Kiro CLI). The implementation follows the exact same pattern as the existing Discord integration in `src/discord/monitor/message-handler.process.ts`, adapted for Slack's API.