### PR TITLE
fix(feishu): update interactive cards in place and avoid duplicate replies

### DIFF
--- a/extensions/feishu/api.ts
+++ b/extensions/feishu/api.ts
@@ -4,4 +4,11 @@ export * from "./src/setup-surface.js";
 export * from "./src/thread-bindings.js";
 export { __testing as feishuThreadBindingTesting } from "./src/thread-bindings.js";
 
+export {
+  registerPendingCardUpdate,
+  getPendingCardUpdate,
+  completeCardUpdate,
+  type PendingCardUpdate,
+} from "./src/card-update.js";
+
 export const feishuSessionBindingAdapterChannels = ["feishu"] as const;

--- a/extensions/feishu/docs/card-interaction.md
+++ b/extensions/feishu/docs/card-interaction.md
@@ -1,0 +1,94 @@
+# Feishu Card Interaction Update
+
+## Overview
+
+The Feishu plugin supports interactive card updates. When users click buttons on cards, the card can immediately update to show a "processing" state while the agent works on the request.
+
+## How It Works
+
+1. **User clicks button** on an interactive card
+2. **Card immediately updates** to show "Processing..." with a yellow header
+3. **Agent receives the request** with an `updateId`
+4. **Agent processes** and calls `card.update` with results
+5. **Card updates** with the final result
+
+## Card Button Payload
+
+To create an updatable card button, use the `update` interaction kind:
+
+```json
+{
+  "tag": "button",
+  "text": { "tag": "plain_text", "content": "Generate Report" },
+  "type": "primary",
+  "value": {
+    "oc": "ocf1",
+    "k": "update",
+    "a": "feishu.card.update.generate",
+    "m": {
+      "messageId": "msg_xxx",
+      "prompt": "Generate a sales report",
+      "command": "/report"
+    },
+    "c": {
+      "u": "user_open_id",
+      "h": "chat_id",
+      "t": "group",
+      "e": 1700000060000
+    }
+  }
+}
+```
+
+### Metadata Fields (`m`)
+
+- `messageId` (required): The ID of the message containing this card (for updating)
+- `prompt` (optional): Description shown in processing state
+- `command` (optional): Command to execute (shown if prompt not provided)
+
+## Agent Usage
+
+When an `update` card action is triggered, the agent receives a message like:
+
+```
+[Card Update Request]
+updateId: cu_1700000000000_abc123
+prompt: Generate a sales report
+command: /report
+action: feishu.card.update.generate
+```
+
+### Updating the Card
+
+Use the `card.update` action:
+
+```json
+{
+  "action": "card.update",
+  "updateId": "cu_1700000000000_abc123",
+  "card": {
+    "schema": "2.0",
+    "header": {
+      "title": { "content": "Report Complete", "tag": "plain_text" },
+      "template": "green"
+    },
+    "body": {
+      "elements": [{ "tag": "markdown", "content": "Your report is ready!" }]
+    }
+  }
+}
+```
+
+Or with text:
+
+```json
+{
+  "action": "card.update",
+  "updateId": "cu_1700000000000_abc123",
+  "text": "Your report is ready! Total sales: $10,000"
+}
+```
+
+## Timeout
+
+Card updates are kept for 15 minutes. After that, the update ID expires and cannot be used.

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -26,10 +26,12 @@ vi.mock("./bot.js", () => ({
 
 const sendCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
+const updateCardFeishuMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./send.js", () => ({
   sendCardFeishu: sendCardFeishuMock,
   sendMessageFeishu: sendMessageFeishuMock,
+  updateCardFeishu: updateCardFeishuMock,
 }));
 
 import { handleFeishuMessage } from "./bot.js";
@@ -430,10 +432,10 @@ describe("Card Update Flow", () => {
 
     await handleFeishuCardAction({ cfg, event, runtime, accountId: "main" });
 
-    // Should immediately update card to processing state
-    expect(sendCardFeishuMock).toHaveBeenCalledWith(
+    // Should immediately update original card to processing state
+    expect(updateCardFeishuMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        to: "chat:chat1",
+        messageId: "msg_original_123",
         card: expect.objectContaining({
           header: expect.objectContaining({
             title: expect.objectContaining({ content: "Processing..." }),

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -405,6 +405,8 @@ describe("Card Update Flow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetProcessedFeishuCardActionTokensForTests();
+    // Ensure handleFeishuMessage mock returns a resolved promise
+    vi.mocked(handleFeishuMessage).mockResolvedValue(undefined as never);
   });
 
   it("immediately updates card and dispatches for 'update' kind actions", async () => {

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -397,3 +397,54 @@ describe("Feishu Card Action Handler", () => {
     vi.useRealTimers();
   });
 });
+
+describe("Card Update Flow", () => {
+  const cfg: ClawdbotConfig = {};
+  const runtime: RuntimeEnv = createRuntimeEnv();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetProcessedFeishuCardActionTokensForTests();
+  });
+
+  it("immediately updates card and dispatches for 'update' kind actions", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok_update_1",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "update",
+          a: "feishu.card.update.generate",
+          m: {
+            messageId: "msg_original_123",
+            prompt: "Generate a report",
+          },
+          c: { u: "u123", h: "chat1", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime, accountId: "main" });
+
+    // Should immediately update card to processing state
+    expect(sendCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:chat1",
+        card: expect.objectContaining({
+          header: expect.objectContaining({
+            title: expect.objectContaining({ content: "Processing..." }),
+          }),
+        }),
+        accountId: "main",
+      }),
+    );
+
+    // Should dispatch to agent with update context
+    expect(handleFeishuMessage).toHaveBeenCalled();
+    const dispatchCall = (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const messageContent = JSON.parse(dispatchCall.event.message.content);
+    expect(messageContent.text).toContain("updateId:");
+  });
+});

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1127,7 +1127,9 @@ export async function handleFeishuMessage(params: {
         agentId: route.agentId,
         runtime: runtime as RuntimeEnv,
         chatId: ctx.chatId,
-        replyToMessageId: replyTargetMessageId,
+        // Card update replies go via updateCardFeishu, not message reply.
+        // Suppress replyToMessageId to avoid typing indicator on synthetic card-action IDs.
+        replyToMessageId: cardUpdateContext ? undefined : replyTargetMessageId,
         skipReplyToInMessages: !isGroup,
         replyInThread,
         rootId: ctx.rootId,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -32,6 +32,7 @@ import {
   toMessageResourceType,
 } from "./bot-content.js";
 import { type FeishuPermissionError, resolveFeishuSenderName } from "./bot-sender-name.js";
+import { getPendingCardUpdate } from "./card-update.js";
 import { createFeishuClient } from "./client.js";
 import { finalizeFeishuMessageProcessing, tryRecordMessagePersistent } from "./dedup.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
@@ -952,6 +953,24 @@ export async function handleFeishuMessage(params: {
     const configReplyInThread =
       isGroup &&
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
+    const updateIdMatch =
+      typeof messageBody === "string"
+        ? messageBody.match(/(?:^|\n)updateId:\s*(cu_[A-Za-z0-9_]+)/)
+        : null;
+    const pendingCardUpdate = updateIdMatch ? getPendingCardUpdate(updateIdMatch[1]) : null;
+    const cardUpdateContext = pendingCardUpdate
+      ? {
+          updateId: updateIdMatch![1],
+          messageId: pendingCardUpdate.messageId,
+          accountId: pendingCardUpdate.accountId,
+        }
+      : null;
+    if (cardUpdateContext) {
+      log(
+        `feishu[${account.accountId}]: resolved pending card update ${cardUpdateContext.updateId} -> ${cardUpdateContext.messageId}`,
+      );
+    }
+
     const replyTargetMessageId =
       isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
@@ -1117,6 +1136,7 @@ export async function handleFeishuMessage(params: {
         accountId: account.accountId,
         identity,
         messageCreateTimeMs,
+        cardUpdate: cardUpdateContext,
       });
 
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -9,7 +9,7 @@ import {
   FEISHU_APPROVAL_CONFIRM_ACTION,
   FEISHU_APPROVAL_REQUEST_ACTION,
 } from "./card-ux-approval.js";
-import { sendCardFeishu, sendMessageFeishu } from "./send.js";
+import { sendCardFeishu, sendMessageFeishu, updateCardFeishu } from "./send.js";
 
 export type FeishuCardActionEvent = {
   operator: {
@@ -335,10 +335,10 @@ export async function handleFeishuCardAction(params: {
           `feishu[${account.accountId}]: handling card update ${updateId} for message ${messageId}`,
         );
 
-        // Send processing card to update in place
-        await sendCardFeishu({
+        // Update the original card in place to show processing state
+        await updateCardFeishu({
           cfg,
-          to: resolveCallbackTarget(event),
+          messageId,
           card: buildProcessingCard({ prompt: prompt || command }),
           accountId,
         });

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -2,6 +2,7 @@ import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent } from "./bot.js";
 import { decodeFeishuCardAction, buildFeishuCardActionTextFallback } from "./card-interaction.js";
+import { registerPendingCardUpdate } from "./card-update.js";
 import {
   createApprovalCard,
   FEISHU_APPROVAL_CANCEL_ACTION,
@@ -166,6 +167,31 @@ async function sendInvalidInteractionNotice(params: {
   });
 }
 
+function buildProcessingCard(params: { prompt?: string }): Record<string, unknown> {
+  const elements: Record<string, unknown>[] = [
+    {
+      tag: "markdown",
+      content: "Processing your request...",
+    },
+  ];
+
+  if (params.prompt) {
+    elements.push({
+      tag: "markdown",
+      content: `**Request:** ${params.prompt}`,
+    });
+  }
+
+  return {
+    schema: "2.0",
+    header: {
+      title: { content: "Processing...", tag: "plain_text" },
+      template: "yellow",
+    },
+    body: { elements },
+  };
+}
+
 export async function handleFeishuCardAction(params: {
   cfg: ClawdbotConfig;
   event: FeishuCardActionEvent;
@@ -274,6 +300,70 @@ export async function handleFeishuCardAction(params: {
           accountId,
           chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
         });
+        completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+        return;
+      }
+
+      // Handle update kind - immediate card update + async dispatch
+      if (envelope.k === "update") {
+        const metadata = envelope.m ?? {};
+        const messageId = typeof metadata.messageId === "string" ? metadata.messageId : "";
+        const prompt = typeof metadata.prompt === "string" ? metadata.prompt : "";
+        const command = typeof metadata.command === "string" ? metadata.command : "";
+
+        if (!messageId) {
+          log(`feishu[${account.accountId}]: update action missing messageId`);
+          await sendInvalidInteractionNotice({
+            cfg,
+            event,
+            reason: "malformed",
+            accountId,
+          });
+          completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+          return;
+        }
+
+        // Register the pending update first
+        const updateId = registerPendingCardUpdate({
+          accountId: account.accountId,
+          messageId,
+          chatId: event.context.chat_id || event.operator.open_id,
+          originalEnvelope: envelope,
+        });
+
+        log(
+          `feishu[${account.accountId}]: handling card update ${updateId} for message ${messageId}`,
+        );
+
+        // Send processing card to update in place
+        await sendCardFeishu({
+          cfg,
+          to: resolveCallbackTarget(event),
+          card: buildProcessingCard({ prompt: prompt || command }),
+          accountId,
+        });
+
+        // Build synthetic message with update context
+        const content = [
+          "[Card Update Request]",
+          `updateId: ${updateId}`,
+          prompt ? `prompt: ${prompt}` : "",
+          command ? `command: ${command}` : "",
+          `action: ${envelope.a}`,
+        ]
+          .filter(Boolean)
+          .join("\n");
+
+        await dispatchSyntheticCommand({
+          cfg,
+          event,
+          command: content,
+          botOpenId: params.botOpenId,
+          runtime,
+          accountId,
+          chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
+        });
+
         completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
         return;
       }

--- a/extensions/feishu/src/card-integration.test.ts
+++ b/extensions/feishu/src/card-integration.test.ts
@@ -20,10 +20,11 @@ vi.mock("./bot.js", () => ({
 }));
 
 const sendCardFeishuMock = vi.hoisted(() => vi.fn());
+const updateCardFeishuMock = vi.hoisted(() => vi.fn());
 vi.mock("./send.js", () => ({
   sendCardFeishu: sendCardFeishuMock,
   sendMessageFeishu: vi.fn(),
-  updateCardFeishu: vi.fn(),
+  updateCardFeishu: updateCardFeishuMock,
   buildMarkdownCard: vi.fn().mockReturnValue({ schema: "2.0" }),
 }));
 
@@ -63,9 +64,10 @@ describe("Feishu Card Update Integration", () => {
     // Step 2: Handle card action
     await handleFeishuCardAction({ cfg, event, runtime });
 
-    // Step 3: Verify card updated to processing
-    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
-    const processingCall = sendCardFeishuMock.mock.calls[0][0];
+    // Step 3: Verify original card updated to processing
+    expect(updateCardFeishuMock).toHaveBeenCalledTimes(1);
+    const processingCall = updateCardFeishuMock.mock.calls[0][0];
+    expect(processingCall.messageId).toBe("msg_original_456");
     expect(processingCall.card.header.title.content).toBe("Processing...");
 
     // Step 4: Verify agent was dispatched
@@ -106,10 +108,10 @@ describe("Feishu Card Update Integration", () => {
 
     await handleFeishuCardAction({ cfg, event, runtime });
 
-    // Verify processing card sent
-    expect(sendCardFeishuMock).toHaveBeenCalledWith(
+    // Verify processing card updated in place
+    expect(updateCardFeishuMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        to: "chat:p2p_chat_xyz",
+        messageId: "msg_p2p_789",
       }),
     );
 
@@ -185,7 +187,7 @@ describe("Feishu Card Update Integration", () => {
 
     // Should only dispatch once
     expect(handleFeishuMessage).toHaveBeenCalledTimes(1);
-    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(updateCardFeishuMock).toHaveBeenCalledTimes(1);
   });
 
   it("rejects update action missing messageId", async () => {
@@ -238,7 +240,7 @@ describe("Feishu Card Update Integration", () => {
     await handleFeishuCardAction({ cfg, event, runtime });
 
     // Verify processing card includes the prompt
-    const processingCall = sendCardFeishuMock.mock.calls[0][0];
+    const processingCall = updateCardFeishuMock.mock.calls[0][0];
     const elements = processingCall.card.body.elements;
     const hasPromptElement = elements.some(
       (el: { tag: string; content?: string }) =>

--- a/extensions/feishu/src/card-integration.test.ts
+++ b/extensions/feishu/src/card-integration.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createRuntimeEnv } from "../../../test/helpers/extensions/runtime-env.js";
+import type { ClawdbotConfig } from "../runtime-api.js";
+import {
+  handleFeishuCardAction,
+  resetProcessedFeishuCardActionTokensForTests,
+  type FeishuCardActionEvent,
+} from "./card-action.js";
+import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
+import { getPendingCardUpdate, resetCardUpdateRegistryForTests } from "./card-update.js";
+
+// Mock dependencies
+vi.mock("./accounts.js", () => ({
+  resolveFeishuAccount: vi.fn().mockReturnValue({ accountId: "mock-account" }),
+  resolveFeishuRuntimeAccount: vi.fn().mockReturnValue({ accountId: "mock-account" }),
+}));
+
+vi.mock("./bot.js", () => ({
+  handleFeishuMessage: vi.fn(),
+}));
+
+const sendCardFeishuMock = vi.hoisted(() => vi.fn());
+vi.mock("./send.js", () => ({
+  sendCardFeishu: sendCardFeishuMock,
+  sendMessageFeishu: vi.fn(),
+  updateCardFeishu: vi.fn(),
+  buildMarkdownCard: vi.fn().mockReturnValue({ schema: "2.0" }),
+}));
+
+import { handleFeishuMessage } from "./bot.js";
+
+describe("Feishu Card Update Integration", () => {
+  const cfg: ClawdbotConfig = {};
+  const runtime = createRuntimeEnv();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetProcessedFeishuCardActionTokensForTests();
+    resetCardUpdateRegistryForTests();
+  });
+
+  it("full flow: card click -> processing state -> agent update", async () => {
+    // Step 1: User clicks card button
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok_integration",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "update",
+          a: "feishu.card.update.generate",
+          m: {
+            messageId: "msg_original_456",
+            prompt: "Generate a summary report",
+            command: "/report",
+          },
+          c: { u: "u123", h: "chat1", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    // Step 2: Handle card action
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    // Step 3: Verify card updated to processing
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    const processingCall = sendCardFeishuMock.mock.calls[0][0];
+    expect(processingCall.card.header.title.content).toBe("Processing...");
+
+    // Step 4: Verify agent was dispatched
+    expect(handleFeishuMessage).toHaveBeenCalledTimes(1);
+    const dispatchCall = (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const messageContent = JSON.parse(dispatchCall.event.message.content);
+
+    // Extract updateId from dispatched message
+    const updateIdMatch = messageContent.text.match(/updateId: (cu_\w+)/);
+    expect(updateIdMatch).toBeTruthy();
+    const updateId = updateIdMatch![1];
+
+    // Step 5: Verify update is registered
+    const pending = getPendingCardUpdate(updateId);
+    expect(pending).toBeTruthy();
+    expect(pending?.messageId).toBe("msg_original_456");
+    expect(pending?.originalEnvelope.a).toBe("feishu.card.update.generate");
+  });
+
+  it("preserves chat type context through the update flow", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u456", user_id: "uid2", union_id: "un2" },
+      token: "tok_p2p_flow",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "update",
+          a: "feishu.card.update.translate",
+          m: {
+            messageId: "msg_p2p_789",
+            prompt: "Translate to Spanish",
+          },
+          c: { u: "u456", h: "p2p_chat_xyz", t: "p2p", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u456", user_id: "uid2", chat_id: "p2p_chat_xyz" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    // Verify processing card sent
+    expect(sendCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:p2p_chat_xyz",
+      }),
+    );
+
+    // Verify dispatch preserves p2p chat type
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            chat_type: "p2p",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("registers pending update with correct account context", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u789", user_id: "uid3", union_id: "un3" },
+      token: "tok_account_flow",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "update",
+          a: "feishu.card.update.analyze",
+          m: {
+            messageId: "msg_account_test",
+            command: "/analyze",
+          },
+          c: { u: "u789", h: "chat_account", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u789", user_id: "uid3", chat_id: "chat_account" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime, accountId: "custom-account" });
+
+    // Extract updateId from dispatched message
+    const dispatchCall = (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const messageContent = JSON.parse(dispatchCall.event.message.content);
+    const updateIdMatch = messageContent.text.match(/updateId: (cu_\w+)/);
+    const updateId = updateIdMatch![1];
+
+    // Verify pending update has correct account
+    const pending = getPendingCardUpdate(updateId);
+    expect(pending?.accountId).toBe("mock-account");
+    expect(pending?.chatId).toBe("chat_account");
+  });
+
+  it("handles duplicate card action tokens in update flow", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u999", user_id: "uid4", union_id: "un4" },
+      token: "tok_duplicate",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "update",
+          a: "feishu.card.update.refresh",
+          m: {
+            messageId: "msg_duplicate_test",
+            prompt: "Refresh data",
+          },
+          c: { u: "u999", h: "chat_dup", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u999", user_id: "uid4", chat_id: "chat_dup" },
+    };
+
+    // First call should succeed
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    // Second call with same token should be dropped
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    // Should only dispatch once
+    expect(handleFeishuMessage).toHaveBeenCalledTimes(1);
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects update action missing messageId", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u111", user_id: "uid5", union_id: "un5" },
+      token: "tok_missing_msg",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "update",
+          a: "feishu.card.update.test",
+          m: {
+            // messageId intentionally omitted
+            prompt: "Test without message ID",
+          },
+          c: { u: "u111", h: "chat_missing", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u111", user_id: "uid5", chat_id: "chat_missing" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    // Should not dispatch to agent
+    expect(handleFeishuMessage).not.toHaveBeenCalled();
+    // Should send error notice
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("includes prompt and command in processing card when available", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u222", user_id: "uid6", union_id: "un6" },
+      token: "tok_with_metadata",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "update",
+          a: "feishu.card.update.execute",
+          m: {
+            messageId: "msg_with_meta",
+            prompt: "Execute the analysis",
+            command: "/analyze --deep",
+          },
+          c: { u: "u222", h: "chat_meta", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u222", user_id: "uid6", chat_id: "chat_meta" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    // Verify processing card includes the prompt
+    const processingCall = sendCardFeishuMock.mock.calls[0][0];
+    const elements = processingCall.card.body.elements;
+    const hasPromptElement = elements.some(
+      (el: { tag: string; content?: string }) =>
+        el.tag === "markdown" && el.content?.includes("Execute the analysis"),
+    );
+    expect(hasPromptElement).toBe(true);
+
+    // Verify dispatched message includes all metadata
+    const dispatchCall = (handleFeishuMessage as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const messageContent = JSON.parse(dispatchCall.event.message.content);
+    expect(messageContent.text).toContain("prompt: Execute the analysis");
+    expect(messageContent.text).toContain("command: /analyze --deep");
+    expect(messageContent.text).toContain("action: feishu.card.update.execute");
+  });
+});

--- a/extensions/feishu/src/card-interaction.test.ts
+++ b/extensions/feishu/src/card-interaction.test.ts
@@ -126,4 +126,32 @@ describe("feishu card interaction decoder", () => {
 
     expect(result).toEqual({ kind: "invalid", reason: "malformed" });
   });
+
+  it("decodes update action payloads", () => {
+    const result = decodeFeishuCardAction({
+      now: 1_700_000_000_000,
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: {
+          value: createFeishuCardInteractionEnvelope({
+            k: "update",
+            a: "feishu.card.update.submit",
+            m: { messageId: "msg_abc123", cardSchema: "2.0" },
+            c: { u: "u123", h: "chat1", t: "group", e: 1_700_000_060_000 },
+          }),
+        },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "structured",
+        envelope: expect.objectContaining({
+          k: "update",
+          a: "feishu.card.update.submit",
+        }),
+      }),
+    );
+  });
 });

--- a/extensions/feishu/src/card-interaction.ts
+++ b/extensions/feishu/src/card-interaction.ts
@@ -1,6 +1,6 @@
 export const FEISHU_CARD_INTERACTION_VERSION = "ocf1";
 
-export type FeishuCardInteractionKind = "button" | "quick" | "meta";
+export type FeishuCardInteractionKind = "button" | "quick" | "meta" | "update";
 export type FeishuCardInteractionReason =
   | "malformed"
   | "stale"
@@ -58,7 +58,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isInteractionKind(value: unknown): value is FeishuCardInteractionKind {
-  return value === "button" || value === "quick" || value === "meta";
+  return value === "button" || value === "quick" || value === "meta" || value === "update";
 }
 
 function isMetadataValue(value: unknown): value is string | number | boolean | null | undefined {

--- a/extensions/feishu/src/card-update.test.ts
+++ b/extensions/feishu/src/card-update.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  registerPendingCardUpdate,
+  getPendingCardUpdate,
+  completeCardUpdate,
+  resetCardUpdateRegistryForTests,
+} from "./card-update.js";
+
+describe("card update registry", () => {
+  beforeEach(() => {
+    resetCardUpdateRegistryForTests();
+  });
+
+  it("registers and retrieves a pending card update", () => {
+    const updateId = registerPendingCardUpdate({
+      accountId: "test-account",
+      messageId: "msg_123",
+      chatId: "chat_abc",
+      originalEnvelope: { oc: "ocf1", k: "update", a: "test" },
+    });
+
+    expect(updateId).toBeTruthy();
+
+    const pending = getPendingCardUpdate(updateId);
+    expect(pending).toEqual(
+      expect.objectContaining({
+        accountId: "test-account",
+        messageId: "msg_123",
+        chatId: "chat_abc",
+      }),
+    );
+  });
+
+  it("returns null for unknown update id", () => {
+    const pending = getPendingCardUpdate("unknown-id");
+    expect(pending).toBeNull();
+  });
+
+  it("marks update as completed", () => {
+    const updateId = registerPendingCardUpdate({
+      accountId: "test-account",
+      messageId: "msg_123",
+      chatId: "chat_abc",
+      originalEnvelope: { oc: "ocf1", k: "update", a: "test" },
+    });
+
+    completeCardUpdate(updateId);
+
+    const pending = getPendingCardUpdate(updateId);
+    expect(pending).toBeNull();
+  });
+
+  it("prunes expired entries", () => {
+    const updateId = registerPendingCardUpdate(
+      {
+        accountId: "test-account",
+        messageId: "msg_123",
+        chatId: "chat_abc",
+        originalEnvelope: { oc: "ocf1", k: "update", a: "test" },
+      },
+      Date.now() - 16 * 60 * 1000, // expired 16 minutes ago (TTL is 15 min)
+    );
+
+    const pending = getPendingCardUpdate(updateId, Date.now());
+    expect(pending).toBeNull();
+  });
+});

--- a/extensions/feishu/src/card-update.ts
+++ b/extensions/feishu/src/card-update.ts
@@ -1,0 +1,80 @@
+import type { FeishuCardInteractionEnvelope } from "./card-interaction.js";
+
+export type PendingCardUpdate = {
+  accountId: string;
+  messageId: string;
+  chatId: string;
+  originalEnvelope: FeishuCardInteractionEnvelope;
+  registeredAt: number;
+};
+
+const FEISHU_CARD_UPDATE_TTL_MS = 15 * 60 * 1000; // 15 minutes
+
+const pendingUpdates = new Map<string, PendingCardUpdate>();
+
+function generateUpdateId(): string {
+  return `cu_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+}
+
+function pruneExpiredEntries(now: number): void {
+  for (const [id, entry] of pendingUpdates.entries()) {
+    if (entry.registeredAt + FEISHU_CARD_UPDATE_TTL_MS < now) {
+      pendingUpdates.delete(id);
+    }
+  }
+}
+
+/**
+ * Register a new pending card update.
+ * Returns the update ID that can be used to later update the card.
+ */
+export function registerPendingCardUpdate(
+  params: Omit<PendingCardUpdate, "registeredAt">,
+  now?: number,
+): string {
+  const currentTime = now ?? Date.now();
+  pruneExpiredEntries(currentTime);
+
+  const id = generateUpdateId();
+  pendingUpdates.set(id, {
+    ...params,
+    registeredAt: currentTime,
+  });
+
+  return id;
+}
+
+/**
+ * Get a pending card update by ID.
+ * Returns null if not found or expired.
+ */
+export function getPendingCardUpdate(id: string, now?: number): PendingCardUpdate | null {
+  const currentTime = now ?? Date.now();
+  pruneExpiredEntries(currentTime);
+
+  const entry = pendingUpdates.get(id);
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.registeredAt + FEISHU_CARD_UPDATE_TTL_MS < currentTime) {
+    pendingUpdates.delete(id);
+    return null;
+  }
+
+  return entry;
+}
+
+/**
+ * Mark a card update as completed (removes from registry).
+ */
+export function completeCardUpdate(id: string): void {
+  pendingUpdates.delete(id);
+}
+
+/**
+ * Reset registry for tests.
+ */
+export function resetCardUpdateRegistryForTests(): void {
+  pendingUpdates.clear();
+}

--- a/extensions/feishu/src/channel.runtime.ts
+++ b/extensions/feishu/src/channel.runtime.ts
@@ -24,6 +24,7 @@ import {
   getMessageFeishu as getMessageFeishuImpl,
   sendCardFeishu as sendCardFeishuImpl,
   sendMessageFeishu as sendMessageFeishuImpl,
+  updateCardFeishu as updateCardFeishuImpl,
 } from "./send.js";
 
 export const feishuChannelRuntime = {
@@ -44,4 +45,5 @@ export const feishuChannelRuntime = {
   getMessageFeishu: getMessageFeishuImpl,
   sendCardFeishu: sendCardFeishuImpl,
   sendMessageFeishu: sendMessageFeishuImpl,
+  updateCardFeishu: updateCardFeishuImpl,
 };

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -13,12 +13,18 @@ import {
   type RuntimeEnv,
 } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { completeCardUpdate } from "./card-update.js";
 import { createFeishuClient } from "./client.js";
 import { sendMediaFeishu } from "./media.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedCardContent } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMessageFeishu, sendStructuredCardFeishu, type CardHeaderConfig } from "./send.js";
+import {
+  sendMessageFeishu,
+  sendStructuredCardFeishu,
+  updateCardFeishu,
+  type CardHeaderConfig,
+} from "./send.js";
 import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
@@ -87,6 +93,11 @@ export type CreateFeishuReplyDispatcherParams = {
   mentionTargets?: MentionTarget[];
   accountId?: string;
   identity?: OutboundIdentity;
+  cardUpdate?: {
+    updateId: string;
+    messageId: string;
+    accountId: string;
+  } | null;
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
@@ -106,6 +117,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     mentionTargets,
     accountId,
     identity,
+    cardUpdate,
   } = params;
   const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
   const threadReplyMode = threadReply === true;
@@ -196,6 +208,22 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
+  let cardUpdateCompleted = false;
+  const buildCardUpdateResultCard = (text: string) => ({
+    schema: "2.0",
+    header: {
+      title: { content: "Done", tag: "plain_text" },
+      template: "green",
+    },
+    body: {
+      elements: [
+        {
+          tag: "markdown",
+          content: text || "Done",
+        },
+      ],
+    },
+  });
   type StreamTextUpdateMode = "snapshot" | "delta";
 
   const formatReasoningPrefix = (thinking: string): string => {
@@ -370,6 +398,22 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         const shouldDeliverText = hasText && !skipTextForDuplicateFinal;
 
         if (!shouldDeliverText && !hasMedia) {
+          return;
+        }
+
+        if (cardUpdate && info?.kind === "final" && shouldDeliverText && !cardUpdateCompleted) {
+          await updateCardFeishu({
+            cfg,
+            messageId: cardUpdate.messageId,
+            card: buildCardUpdateResultCard(text),
+            accountId: cardUpdate.accountId,
+          });
+          completeCardUpdate(cardUpdate.updateId);
+          cardUpdateCompleted = true;
+          deliveredFinalTexts.add(text);
+          if (hasMedia) {
+            await sendMediaReplies(payload);
+          }
           return;
         }
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -383,7 +383,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
       onReplyStart: async () => {
         deliveredFinalTexts.clear();
-        if (streamingEnabled && renderMode === "card") {
+        if (streamingEnabled && renderMode === "card" && !cardUpdate) {
           startStreaming();
         }
         await typingCallbacks?.onReplyStart?.();
@@ -417,13 +417,23 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           return;
         }
 
+        // Card update already completed — suppress any additional text replies.
+        // Only allow media through.
+        if (cardUpdate && cardUpdateCompleted) {
+          if (hasMedia) {
+            await sendMediaReplies(payload);
+          }
+          return;
+        }
+
         if (shouldDeliverText) {
           const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
           if (info?.kind === "block") {
             // Drop internal block chunks unless we can safely consume them as
             // streaming-card fallback content.
-            if (!(streamingEnabled && useCard)) {
+            // When cardUpdate is active, skip streaming — reply goes via card update path.
+            if (!(streamingEnabled && useCard) || cardUpdate) {
               return;
             }
             startStreaming();
@@ -432,7 +442,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
           }
 
-          if (info?.kind === "final" && streamingEnabled && useCard) {
+          if (info?.kind === "final" && streamingEnabled && useCard && !cardUpdate) {
             startStreaming();
             if (streamingStartPromise) {
               await streamingStartPromise;
@@ -524,26 +534,28 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
       disableBlockStreaming: true,
-      onPartialReply: streamingEnabled
-        ? (payload: ReplyPayload) => {
-            if (!payload.text) {
-              return;
+      onPartialReply:
+        streamingEnabled && !cardUpdate
+          ? (payload: ReplyPayload) => {
+              if (!payload.text) {
+                return;
+              }
+              queueStreamingUpdate(payload.text, {
+                dedupeWithLastPartial: true,
+                mode: "snapshot",
+              });
             }
-            queueStreamingUpdate(payload.text, {
-              dedupeWithLastPartial: true,
-              mode: "snapshot",
-            });
-          }
-        : undefined,
-      onReasoningStream: streamingEnabled
-        ? (payload: ReplyPayload) => {
-            if (!payload.text) {
-              return;
+          : undefined,
+      onReasoningStream:
+        streamingEnabled && !cardUpdate
+          ? (payload: ReplyPayload) => {
+              if (!payload.text) {
+                return;
+              }
+              startStreaming();
+              queueReasoningUpdate(payload.text);
             }
-            startStreaming();
-            queueReasoningUpdate(payload.text);
-          }
-        : undefined,
+          : undefined,
       onReasoningEnd: streamingEnabled ? () => {} : undefined,
     },
     markDispatchIdle,

--- a/extensions/signal/src/runtime-api.ts
+++ b/extensions/signal/src/runtime-api.ts
@@ -19,15 +19,14 @@ export {
 export { formatCliCommand, formatDocsLink } from "openclaw/plugin-sdk/setup-tools";
 export { chunkText } from "openclaw/plugin-sdk/reply-runtime";
 export {
-  ChannelPlugin,
   PAIRING_APPROVED_MESSAGE,
-  SignalAccountConfig,
   SignalConfigSchema,
   looksLikeSignalTargetId,
   normalizeE164,
   normalizeSignalMessagingTarget,
   resolveChannelMediaMaxBytes,
 } from "openclaw/plugin-sdk/signal-core";
+export type { ChannelPlugin, SignalAccountConfig } from "openclaw/plugin-sdk/signal-core";
 export { detectBinary, installSignalCli } from "openclaw/plugin-sdk/setup-tools";
 export {
   resolveAllowlistProviderRuntimeGroupPolicy,

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -185,6 +185,7 @@
   "secret-input",
   "signal",
   "signal-account",
+  "signal-core",
   "signal-surface",
   "channel-status",
   "slack",


### PR DESCRIPTION
## Summary
- update interactive Feishu cards in place after button clicks instead of sending extra follow-up replies
- suppress duplicate final text delivery after a card update completes
- avoid typing-indicator reactions on synthetic card-action message ids
- fix a related type-only re-export in Signal runtime API so `pnpm build` passes again

## What changed
### Feishu card update flow
- guard streaming-card paths when `cardUpdate` is active so the reply stays on the original card update path
- once a card update completes, suppress any later text payloads from the same reply pipeline and only allow media through
- skip typing indicator attachment for synthetic `card-action-*` message ids

### Build fix
- convert `ChannelPlugin` and `SignalAccountConfig` to `export type` in `extensions/signal/src/runtime-api.ts`

## Validation
- sent an interactive Feishu card via real bot account and clicked a callback button
- verified the original card is updated in place to the final result card
- verified gateway dispatch logs show `replies=1` for the card-update request
- ran `pnpm build`
