### PR TITLE
feat: Add opt-in ACP parent completion notify for sessions_spawn

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -304,8 +304,15 @@ Interface details:
 - `cwd` (optional): requested runtime working directory (validated by backend/runtime policy).
 - `label` (optional): operator-facing label used in session/banner text.
 - `resumeSessionId` (optional): resume an existing ACP session instead of creating a new one. The agent replays its conversation history via `session/load`. Requires `runtime: "acp"`.
-- `streamTo` (optional): `"parent"` streams initial ACP run progress summaries back to the requester session as system events.
+- `streamTo` (optional): `"parent"` streams initial ACP run progress summaries back to the requester session.
   - When available, accepted responses include `streamLogPath` pointing to a session-scoped JSONL log (`<sessionId>.acp-stream.jsonl`) you can tail for full relay history.
+- `parentUpdates` (optional): controls how ACP `mode: "run"` spawns report back to the requester session.
+  - `system` is the default behavior and preserves the current relay path.
+  - `notify` is opt-in and changes terminal completion routing so the finished ACP task is announced back into the parent session like a subagent completion.
+  - `notify` requires `mode: "run"` and an active requester session context.
+  - `streamTo: "parent"` remains the switch for progress relay. When both are set, progress stays on the lightweight relay path while terminal completion uses the announce path.
+  - This split is intentional: progress updates are frequent, best-effort status signals, while announce is better suited to one terminal completion message with final outcome metadata.
+  - If the notify path is unavailable, OpenClaw falls back to the normal parent-session system-event completion notice.
 
 ### Resume an existing session
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -310,6 +310,7 @@ Interface details:
   - `system` is the default behavior and preserves the current relay path.
   - `notify` is opt-in and changes terminal completion routing so the finished ACP task is announced back into the parent session like a subagent completion.
   - `notify` requires `mode: "run"` and an active requester session context.
+  - When `notify` owns terminal delivery, OpenClaw suppresses child inline external delivery so the parent session remains the only user-facing completion path.
   - `streamTo: "parent"` remains the switch for progress relay. When both are set, progress stays on the lightweight relay path while terminal completion uses the announce path.
   - This split is intentional: progress updates are frequent, best-effort status signals, while announce is better suited to one terminal completion message with final outcome metadata.
   - If the notify path is unavailable, OpenClaw falls back to the normal parent-session system-event completion notice.

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -1,11 +1,17 @@
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mergeMockedModule } from "../test-utils/vitest-module-mocks.js";
 
 const enqueueSystemEventMock = vi.fn();
 const requestHeartbeatNowMock = vi.fn();
 const readAcpSessionEntryMock = vi.fn();
+const loadConfigMock = vi.fn();
+const loadSessionStoreMock = vi.fn();
+const resolveStorePathMock = vi.fn();
 const resolveSessionFilePathMock = vi.fn();
 const resolveSessionFilePathOptionsMock = vi.fn();
+const queueEmbeddedPiMessageMock = vi.fn();
+const runSubagentAnnounceFlowMock = vi.fn();
 
 vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
@@ -24,9 +30,26 @@ vi.mock("../acp/runtime/session-meta.js", () => ({
   readAcpSessionEntry: (...args: unknown[]) => readAcpSessionEntryMock(...args),
 }));
 
+vi.mock("../config/config.js", () => ({
+  loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: (...args: unknown[]) => loadSessionStoreMock(...args),
+  resolveStorePath: (...args: unknown[]) => resolveStorePathMock(...args),
+}));
+
 vi.mock("../config/sessions/paths.js", () => ({
   resolveSessionFilePath: (...args: unknown[]) => resolveSessionFilePathMock(...args),
   resolveSessionFilePathOptions: (...args: unknown[]) => resolveSessionFilePathOptionsMock(...args),
+}));
+
+vi.mock("./pi-embedded.js", () => ({
+  queueEmbeddedPiMessage: (...args: unknown[]) => queueEmbeddedPiMessageMock(...args),
+}));
+
+vi.mock("./subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: (...args: unknown[]) => runSubagentAnnounceFlowMock(...args),
 }));
 
 let emitAgentEvent: typeof import("../infra/agent-events.js").emitAgentEvent;
@@ -51,10 +74,23 @@ async function loadFreshAcpSpawnParentStreamModulesForTest() {
   vi.doMock("../acp/runtime/session-meta.js", () => ({
     readAcpSessionEntry: (...args: unknown[]) => readAcpSessionEntryMock(...args),
   }));
+  vi.doMock("../config/config.js", () => ({
+    loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+  }));
+  vi.doMock("../config/sessions.js", () => ({
+    loadSessionStore: (...args: unknown[]) => loadSessionStoreMock(...args),
+    resolveStorePath: (...args: unknown[]) => resolveStorePathMock(...args),
+  }));
   vi.doMock("../config/sessions/paths.js", () => ({
     resolveSessionFilePath: (...args: unknown[]) => resolveSessionFilePathMock(...args),
     resolveSessionFilePathOptions: (...args: unknown[]) =>
       resolveSessionFilePathOptionsMock(...args),
+  }));
+  vi.doMock("./pi-embedded.js", () => ({
+    queueEmbeddedPiMessage: (...args: unknown[]) => queueEmbeddedPiMessageMock(...args),
+  }));
+  vi.doMock("./subagent-announce.js", () => ({
+    runSubagentAnnounceFlow: (...args: unknown[]) => runSubagentAnnounceFlowMock(...args),
   }));
   const [agentEvents, relayModule] = await Promise.all([
     import("../infra/agent-events.js"),
@@ -76,9 +112,22 @@ describe("startAcpSpawnParentStreamRelay", () => {
     enqueueSystemEventMock.mockClear();
     requestHeartbeatNowMock.mockClear();
     readAcpSessionEntryMock.mockReset();
+    loadConfigMock.mockReset().mockReturnValue({
+      session: {
+        mainKey: "main",
+      },
+    });
+    loadSessionStoreMock.mockReset().mockReturnValue({
+      "agent:main:main": {
+        sessionId: "parent-session-1",
+      },
+    });
+    resolveStorePathMock.mockReset().mockReturnValue("/tmp/main-sessions.json");
     resolveSessionFilePathMock.mockReset();
     resolveSessionFilePathOptionsMock.mockReset();
     resolveSessionFilePathOptionsMock.mockImplementation((value: unknown) => value);
+    queueEmbeddedPiMessageMock.mockReset().mockReturnValue(false);
+    runSubagentAnnounceFlowMock.mockReset().mockResolvedValue(false);
     ({ emitAgentEvent, resolveAcpSpawnStreamLogPath, startAcpSpawnParentStreamRelay } =
       await loadFreshAcpSpawnParentStreamModulesForTest());
     vi.useFakeTimers();
@@ -131,6 +180,69 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
+  it("queues notify-mode progress updates into the active parent run", () => {
+    queueEmbeddedPiMessageMock.mockReturnValue(true);
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-notify-progress",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-notify-progress",
+      agentId: "codex",
+      parentUpdateMode: "notify",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-notify-progress",
+      stream: "assistant",
+      data: {
+        delta: "hello from child",
+      },
+    });
+    vi.advanceTimersByTime(15);
+
+    expect(queueEmbeddedPiMessageMock).toHaveBeenCalledWith(
+      "parent-session-1",
+      expect.stringContaining("Started codex session"),
+    );
+    expect(queueEmbeddedPiMessageMock).toHaveBeenCalledWith(
+      "parent-session-1",
+      expect.stringContaining("codex: hello from child"),
+    );
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    relay.dispose();
+  });
+
+  it("falls back to system events when notify-mode progress cannot queue into the parent run", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-notify-fallback",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-notify-fallback",
+      agentId: "codex",
+      parentUpdateMode: "notify",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-notify-fallback",
+      stream: "assistant",
+      data: {
+        delta: "hello from child",
+      },
+    });
+    vi.advanceTimersByTime(15);
+
+    const texts = collectedTexts();
+    expect(queueEmbeddedPiMessageMock).toHaveBeenCalled();
+    expect(texts.some((text) => text.includes("Started codex session"))).toBe(true);
+    expect(texts.some((text) => text.includes("codex: hello from child"))).toBe(true);
+    expect(requestHeartbeatNowMock).toHaveBeenCalled();
+    relay.dispose();
+  });
+
   it("emits a no-output notice and a resumed notice when output returns", () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-2",
@@ -168,6 +280,168 @@ describe("startAcpSpawnParentStreamRelay", () => {
         error: "boom",
       },
     });
+    expect(collectedTexts().some((text) => text.includes("run failed: boom"))).toBe(true);
+    relay.dispose();
+  });
+
+  it("uses subagent-style completion announce for notify mode and skips the terminal done system event on success", async () => {
+    runSubagentAnnounceFlowMock.mockResolvedValue(true);
+    queueEmbeddedPiMessageMock.mockReturnValue(true);
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-notify-complete",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-notify-complete",
+      agentId: "codex",
+      parentUpdateMode: "notify",
+      requesterOrigin: {
+        channel: "discord",
+        accountId: "default",
+        to: "channel:parent-channel",
+      },
+      taskLabel: "Analyze issue",
+      emitStartNotice: false,
+      streamFlushMs: 60_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-notify-complete",
+      stream: "assistant",
+      data: {
+        delta: "buffered child output",
+      },
+    });
+    emitAgentEvent({
+      runId: "run-notify-complete",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 1_000,
+        endedAt: 3_100,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(runSubagentAnnounceFlowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childSessionKey: "agent:codex:acp:child-notify-complete",
+        childRunId: "run-notify-complete",
+        requesterSessionKey: "agent:main:main",
+        requesterOrigin: expect.objectContaining({
+          channel: "discord",
+          accountId: "default",
+          to: "channel:parent-channel",
+        }),
+        task: "Analyze issue",
+        label: "Analyze issue",
+        announceType: "acp task",
+        expectsCompletionMessage: true,
+        cleanup: "keep",
+        waitForCompletion: false,
+        spawnMode: "run",
+      }),
+    );
+    expect(queueEmbeddedPiMessageMock).toHaveBeenCalledWith(
+      "parent-session-1",
+      expect.stringContaining("buffered child output"),
+    );
+    expect(collectedTexts()).toEqual([]);
+    expect(collectedTexts().some((text) => text.includes("run completed"))).toBe(false);
+    relay.dispose();
+  });
+
+  it("supports completion-only notify mode without progress relays", async () => {
+    runSubagentAnnounceFlowMock.mockResolvedValue(true);
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-notify-completion-only",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-notify-completion-only",
+      agentId: "codex",
+      relayProgressToParent: false,
+      parentUpdateMode: "notify",
+      emitStartNotice: false,
+    });
+
+    emitAgentEvent({
+      runId: "run-notify-completion-only",
+      stream: "assistant",
+      data: {
+        delta: "progress that should stay local",
+      },
+    });
+    emitAgentEvent({
+      runId: "run-notify-completion-only",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 1_000,
+        endedAt: 3_100,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(runSubagentAnnounceFlowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childSessionKey: "agent:codex:acp:child-notify-completion-only",
+        childRunId: "run-notify-completion-only",
+        announceType: "acp task",
+      }),
+    );
+    expect(queueEmbeddedPiMessageMock).not.toHaveBeenCalled();
+    expect(collectedTexts()).toEqual([]);
+    relay.dispose();
+  });
+
+  it("falls back to terminal done system events when notify-mode completion announce fails", async () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-notify-complete-fallback",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-notify-complete-fallback",
+      agentId: "codex",
+      parentUpdateMode: "notify",
+      emitStartNotice: false,
+    });
+
+    emitAgentEvent({
+      runId: "run-notify-complete-fallback",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 1_000,
+        endedAt: 3_100,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(collectedTexts().some((text) => text.includes("codex run completed in 2s"))).toBe(true);
+    relay.dispose();
+  });
+
+  it("falls back to terminal error system events when notify-mode completion announce fails", async () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-notify-error-fallback",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-notify-error-fallback",
+      agentId: "codex",
+      parentUpdateMode: "notify",
+      emitStartNotice: false,
+    });
+
+    emitAgentEvent({
+      runId: "run-notify-error-fallback",
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        error: "boom",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
     expect(collectedTexts().some((text) => text.includes("run failed: boom"))).toBe(true);
     relay.dispose();
   });
@@ -266,7 +540,12 @@ describe("startAcpSpawnParentStreamRelay", () => {
       childSessionKey: "agent:codex:acp:child-1",
     });
 
-    expect(resolved).toBe("/tmp/openclaw/agents/codex/sessions/sess-123.acp-stream.jsonl");
+    expect(resolved).toBe(
+      path.join(
+        path.dirname(path.resolve("/tmp/openclaw/agents/codex/sessions/sess-123.jsonl")),
+        "sess-123.acp-stream.jsonl",
+      ),
+    );
     expect(readAcpSessionEntryMock).toHaveBeenCalledWith({
       sessionKey: "agent:codex:acp:child-1",
     });

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -1,18 +1,25 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
+import { loadConfig } from "../config/config.js";
+import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import type { DeliveryContext } from "../utils/delivery-context.js";
+import { queueEmbeddedPiMessage } from "./pi-embedded.js";
 
 const DEFAULT_STREAM_FLUSH_MS = 2_500;
 const DEFAULT_NO_OUTPUT_NOTICE_MS = 60_000;
 const DEFAULT_NO_OUTPUT_POLL_MS = 15_000;
 const DEFAULT_MAX_RELAY_LIFETIME_MS = 6 * 60 * 60 * 1000;
+const DEFAULT_COMPLETION_ANNOUNCE_TIMEOUT_MS = 5_000;
 const STREAM_BUFFER_MAX_CHARS = 4_000;
 const STREAM_SNIPPET_MAX_CHARS = 220;
+
+type AcpParentUpdateMode = "system" | "notify";
 
 function compactWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
@@ -22,10 +29,10 @@ function truncate(value: string, maxChars: number): string {
   if (value.length <= maxChars) {
     return value;
   }
-  if (maxChars <= 1) {
+  if (maxChars <= 3) {
     return value.slice(0, maxChars);
   }
-  return `${value.slice(0, maxChars - 1)}…`;
+  return `${value.slice(0, maxChars - 3)}...`;
 }
 
 function toTrimmedString(value: unknown): string | undefined {
@@ -40,9 +47,40 @@ function toFiniteNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
+function summarizeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message || "error";
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return "error";
+}
+
 function resolveAcpStreamLogPathFromSessionFile(sessionFile: string, sessionId: string): string {
   const baseDir = path.dirname(path.resolve(sessionFile));
   return path.join(baseDir, `${sessionId}.acp-stream.jsonl`);
+}
+
+let subagentAnnounceModulePromise: Promise<typeof import("./subagent-announce.js")> | null = null;
+
+async function loadSubagentAnnounceModule() {
+  subagentAnnounceModulePromise ??= import("./subagent-announce.js");
+  return await subagentAnnounceModulePromise;
+}
+
+function loadParentSessionEntry(sessionKey: string) {
+  const normalizedSessionKey = sessionKey.trim();
+  if (!normalizedSessionKey) {
+    return undefined;
+  }
+  const cfg = loadConfig();
+  const agentId = normalizedSessionKey.startsWith("agent:")
+    ? normalizedSessionKey.split(":")[1]?.trim() || undefined
+    : undefined;
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+  const store = loadSessionStore(storePath);
+  return store[normalizedSessionKey];
 }
 
 export function resolveAcpSpawnStreamLogPath(params: {
@@ -84,6 +122,10 @@ export function startAcpSpawnParentStreamRelay(params: {
   noOutputPollMs?: number;
   maxRelayLifetimeMs?: number;
   emitStartNotice?: boolean;
+  relayProgressToParent?: boolean;
+  parentUpdateMode?: AcpParentUpdateMode;
+  requesterOrigin?: DeliveryContext;
+  taskLabel?: string;
 }): AcpSpawnParentRelayHandle {
   const runId = params.runId.trim();
   const parentSessionKey = params.parentSessionKey.trim();
@@ -94,6 +136,8 @@ export function startAcpSpawnParentStreamRelay(params: {
     };
   }
 
+  const parentUpdateMode = params.parentUpdateMode === "notify" ? "notify" : "system";
+  const relayProgressToParent = params.relayProgressToParent !== false;
   const streamFlushMs =
     typeof params.streamFlushMs === "number" && Number.isFinite(params.streamFlushMs)
       ? Math.max(0, Math.floor(params.streamFlushMs))
@@ -112,6 +156,7 @@ export function startAcpSpawnParentStreamRelay(params: {
       : DEFAULT_MAX_RELAY_LIFETIME_MS;
 
   const relayLabel = truncate(compactWhitespace(params.agentId), 40) || "ACP child";
+  const relayTaskLabel = compactWhitespace(params.taskLabel ?? "") || `${relayLabel} task`;
   const contextPrefix = `acp-spawn:${runId}`;
   const logPath = toTrimmedString(params.logPath);
   let logDirReady = false;
@@ -185,7 +230,7 @@ export function startAcpSpawnParentStreamRelay(params: {
       }),
     );
   };
-  const emit = (text: string, contextKey: string) => {
+  const emitSystemEvent = (text: string, contextKey: string) => {
     const cleaned = text.trim();
     if (!cleaned) {
       return;
@@ -194,14 +239,119 @@ export function startAcpSpawnParentStreamRelay(params: {
     enqueueSystemEvent(cleaned, { sessionKey: parentSessionKey, contextKey });
     wake();
   };
+  let cachedParentSessionId: string | undefined;
+  const resolveParentSessionId = () => {
+    if (cachedParentSessionId) {
+      return cachedParentSessionId;
+    }
+    try {
+      cachedParentSessionId = toTrimmedString(loadParentSessionEntry(parentSessionKey)?.sessionId);
+      return cachedParentSessionId;
+    } catch (error) {
+      logEvent("notify_parent_lookup_failed", {
+        error: summarizeError(error),
+      });
+      return undefined;
+    }
+  };
+  const tryNotifyParentRun = (text: string, contextKey: string) => {
+    if (parentUpdateMode !== "notify") {
+      return false;
+    }
+    const cleaned = text.trim();
+    if (!cleaned) {
+      return false;
+    }
+    const parentSessionId = resolveParentSessionId();
+    if (!parentSessionId) {
+      logEvent("notify_parent_unavailable", {
+        contextKey,
+        reason: "missing_parent_session_id",
+        text: cleaned,
+      });
+      return false;
+    }
+    const queued = queueEmbeddedPiMessage(parentSessionId, cleaned);
+    logEvent(queued ? "notify_parent_queued" : "notify_parent_unavailable", {
+      contextKey,
+      sessionId: parentSessionId,
+      reason: queued ? undefined : "queue_rejected",
+      text: cleaned,
+    });
+    return queued;
+  };
+  const emitProgressUpdate = (text: string, contextKey: string) => {
+    if (!relayProgressToParent) {
+      return;
+    }
+    const cleaned = text.trim();
+    if (!cleaned) {
+      return;
+    }
+    if (tryNotifyParentRun(cleaned, contextKey)) {
+      return;
+    }
+    emitSystemEvent(cleaned, contextKey);
+  };
+  const announceCompletionToParent = async (completion: {
+    phase: "end" | "error";
+    startedAt?: number;
+    endedAt?: number;
+    errorText?: string;
+  }) => {
+    if (parentUpdateMode !== "notify") {
+      return false;
+    }
+    try {
+      const { runSubagentAnnounceFlow } = await loadSubagentAnnounceModule();
+      const didAnnounce = await runSubagentAnnounceFlow({
+        childSessionKey: params.childSessionKey,
+        childRunId: runId,
+        requesterSessionKey: parentSessionKey,
+        requesterOrigin: params.requesterOrigin,
+        requesterDisplayKey: parentSessionKey,
+        task: relayTaskLabel,
+        timeoutMs: DEFAULT_COMPLETION_ANNOUNCE_TIMEOUT_MS,
+        cleanup: "keep",
+        waitForCompletion: false,
+        startedAt: completion.startedAt,
+        endedAt: completion.endedAt,
+        label: relayTaskLabel,
+        outcome:
+          completion.phase === "error"
+            ? {
+                status: "error",
+                error: completion.errorText,
+              }
+            : {
+                status: "ok",
+              },
+        announceType: "acp task",
+        expectsCompletionMessage: true,
+        spawnMode: "run",
+      });
+      logEvent("completion_announce", {
+        phase: completion.phase,
+        delivered: didAnnounce,
+      });
+      return didAnnounce;
+    } catch (error) {
+      logEvent("completion_announce_failed", {
+        phase: completion.phase,
+        error: summarizeError(error),
+      });
+      return false;
+    }
+  };
   const emitStartNotice = () => {
-    emit(
+    emitProgressUpdate(
       `Started ${relayLabel} session ${params.childSessionKey}. Streaming progress updates to parent session.`,
       `${contextPrefix}:start`,
     );
   };
 
   let disposed = false;
+  let terminalPhaseHandling = false;
   let pendingText = "";
   let lastProgressAt = Date.now();
   let stallNotified = false;
@@ -228,16 +378,20 @@ export function startAcpSpawnParentStreamRelay(params: {
     if (!pendingText) {
       return;
     }
+    if (!relayProgressToParent) {
+      pendingText = "";
+      return;
+    }
     const snippet = truncate(compactWhitespace(pendingText), STREAM_SNIPPET_MAX_CHARS);
     pendingText = "";
     if (!snippet) {
       return;
     }
-    emit(`${relayLabel}: ${snippet}`, `${contextPrefix}:progress`);
+    emitProgressUpdate(`${relayLabel}: ${snippet}`, `${contextPrefix}:progress`);
   };
 
   const scheduleFlush = () => {
-    if (disposed || flushTimer || streamFlushMs <= 0) {
+    if (disposed || terminalPhaseHandling || flushTimer || streamFlushMs <= 0) {
       return;
     }
     flushTimer = setTimeout(() => {
@@ -247,7 +401,7 @@ export function startAcpSpawnParentStreamRelay(params: {
   };
 
   const noOutputWatcherTimer = setInterval(() => {
-    if (disposed || noOutputNoticeMs <= 0) {
+    if (disposed || terminalPhaseHandling || !relayProgressToParent || noOutputNoticeMs <= 0) {
       return;
     }
     if (stallNotified) {
@@ -257,7 +411,7 @@ export function startAcpSpawnParentStreamRelay(params: {
       return;
     }
     stallNotified = true;
-    emit(
+    emitProgressUpdate(
       `${relayLabel} has produced no output for ${Math.round(noOutputNoticeMs / 1000)}s. It may be waiting for interactive input.`,
       `${contextPrefix}:stall`,
     );
@@ -265,10 +419,10 @@ export function startAcpSpawnParentStreamRelay(params: {
   noOutputWatcherTimer.unref?.();
 
   relayLifetimeTimer = setTimeout(() => {
-    if (disposed) {
+    if (disposed || terminalPhaseHandling) {
       return;
     }
-    emit(
+    emitSystemEvent(
       `${relayLabel} stream relay timed out after ${Math.max(1, Math.round(maxRelayLifetimeMs / 1000))}s without completion.`,
       `${contextPrefix}:timeout`,
     );
@@ -281,7 +435,7 @@ export function startAcpSpawnParentStreamRelay(params: {
   }
 
   const unsubscribe = onAgentEvent((event) => {
-    if (disposed || event.runId !== runId) {
+    if (disposed || terminalPhaseHandling || event.runId !== runId) {
       return;
     }
 
@@ -295,10 +449,13 @@ export function startAcpSpawnParentStreamRelay(params: {
         return;
       }
       logEvent("assistant_delta", { delta });
+      if (!relayProgressToParent) {
+        return;
+      }
 
       if (stallNotified) {
         stallNotified = false;
-        emit(`${relayLabel} resumed output.`, `${contextPrefix}:resumed`);
+        emitProgressUpdate(`${relayLabel} resumed output.`, `${contextPrefix}:resumed`);
       }
 
       lastProgressAt = Date.now();
@@ -321,7 +478,6 @@ export function startAcpSpawnParentStreamRelay(params: {
     const phase = toTrimmedString((event.data as { phase?: unknown } | undefined)?.phase);
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
     if (phase === "end") {
-      flushPending();
       const startedAt = toFiniteNumber(
         (event.data as { startedAt?: unknown } | undefined)?.startedAt,
       );
@@ -330,27 +486,74 @@ export function startAcpSpawnParentStreamRelay(params: {
         startedAt != null && endedAt != null && endedAt >= startedAt
           ? endedAt - startedAt
           : undefined;
-      if (durationMs != null) {
-        emit(
-          `${relayLabel} run completed in ${Math.max(1, Math.round(durationMs / 1000))}s.`,
-          `${contextPrefix}:done`,
-        );
-      } else {
-        emit(`${relayLabel} run completed.`, `${contextPrefix}:done`);
+      flushPending();
+      if (parentUpdateMode !== "notify") {
+        if (durationMs != null) {
+          emitSystemEvent(
+            `${relayLabel} run completed in ${Math.max(1, Math.round(durationMs / 1000))}s.`,
+            `${contextPrefix}:done`,
+          );
+        } else {
+          emitSystemEvent(`${relayLabel} run completed.`, `${contextPrefix}:done`);
+        }
+        dispose();
+        return;
       }
-      dispose();
+      terminalPhaseHandling = true;
+      clearRelayLifetimeTimer();
+      clearInterval(noOutputWatcherTimer);
+      void (async () => {
+        const announced = await announceCompletionToParent({
+          phase: "end",
+          startedAt,
+          endedAt,
+        });
+        if (!announced) {
+          flushPending();
+          if (durationMs != null) {
+            emitSystemEvent(
+              `${relayLabel} run completed in ${Math.max(1, Math.round(durationMs / 1000))}s.`,
+              `${contextPrefix}:done`,
+            );
+          } else {
+            emitSystemEvent(`${relayLabel} run completed.`, `${contextPrefix}:done`);
+          }
+        }
+        dispose();
+      })();
       return;
     }
 
     if (phase === "error") {
-      flushPending();
       const errorText = toTrimmedString((event.data as { error?: unknown } | undefined)?.error);
-      if (errorText) {
-        emit(`${relayLabel} run failed: ${errorText}`, `${contextPrefix}:error`);
-      } else {
-        emit(`${relayLabel} run failed.`, `${contextPrefix}:error`);
+      if (parentUpdateMode !== "notify") {
+        flushPending();
+        if (errorText) {
+          emitSystemEvent(`${relayLabel} run failed: ${errorText}`, `${contextPrefix}:error`);
+        } else {
+          emitSystemEvent(`${relayLabel} run failed.`, `${contextPrefix}:error`);
+        }
+        dispose();
+        return;
       }
-      dispose();
+      terminalPhaseHandling = true;
+      clearRelayLifetimeTimer();
+      clearInterval(noOutputWatcherTimer);
+      void (async () => {
+        const announced = await announceCompletionToParent({
+          phase: "error",
+          errorText,
+        });
+        if (!announced) {
+          flushPending();
+          if (errorText) {
+            emitSystemEvent(`${relayLabel} run failed: ${errorText}`, `${contextPrefix}:error`);
+          } else {
+            emitSystemEvent(`${relayLabel} run failed.`, `${contextPrefix}:error`);
+          }
+        }
+        dispose();
+      })();
     }
   });
 
@@ -368,7 +571,12 @@ export function startAcpSpawnParentStreamRelay(params: {
 
   return {
     dispose,
-    notifyStarted: emitStartNotice,
+    notifyStarted: () => {
+      if (disposed) {
+        return;
+      }
+      emitStartNotice();
+    },
   };
 }
 

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -760,6 +760,13 @@ describe("spawnAcpDirect", () => {
         agentId: "codex",
         logPath: "/tmp/sess-main.acp-stream.jsonl",
         emitStartNotice: false,
+        parentUpdateMode: "system",
+        requesterOrigin: expect.objectContaining({
+          channel: "discord",
+          accountId: "default",
+          to: "channel:parent-channel",
+        }),
+        taskLabel: "Investigate flaky tests",
       }),
     );
     const relayRuns = hoisted.startAcpSpawnParentStreamRelayMock.mock.calls.map(
@@ -773,6 +780,87 @@ describe("spawnAcpDirect", () => {
     expect(firstHandle.dispose).toHaveBeenCalledTimes(1);
     expect(firstHandle.notifyStarted).not.toHaveBeenCalled();
     expect(secondHandle.notifyStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes parentUpdates="notify" through to the parent relay', async () => {
+    const relayHandle = createRelayHandle();
+    hoisted.startAcpSpawnParentStreamRelayMock.mockReset().mockReturnValue(relayHandle);
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        label: "Flaky tests",
+        agentId: "codex",
+        streamTo: "parent",
+        parentUpdates: "notify",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.startAcpSpawnParentStreamRelayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        relayProgressToParent: true,
+        parentUpdateMode: "notify",
+        requesterOrigin: expect.objectContaining({
+          channel: "discord",
+          accountId: "default",
+          to: "channel:parent-channel",
+        }),
+        taskLabel: "Flaky tests",
+      }),
+    );
+  });
+
+  it('starts a completion-only parent relay when parentUpdates="notify" is used without streamTo="parent"', async () => {
+    const relayHandle = createRelayHandle();
+    hoisted.startAcpSpawnParentStreamRelayMock.mockReset().mockReturnValue(relayHandle);
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        parentUpdates: "notify",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.mode).toBe("run");
+    expect(hoisted.startAcpSpawnParentStreamRelayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        relayProgressToParent: false,
+        parentUpdateMode: "notify",
+        parentSessionKey: "agent:main:main",
+      }),
+    );
+  });
+
+  it('rejects parentUpdates="notify" for ACP mode="session"', async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+        parentUpdates: "notify",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain('parentUpdates="notify"');
+    expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
+    expect(hoisted.startAcpSpawnParentStreamRelayMock).not.toHaveBeenCalled();
   });
 
   it("implicitly streams mode=run ACP spawns for subagent requester sessions", async () => {

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -820,6 +820,7 @@ describe("spawnAcpDirect", () => {
   it('starts a completion-only parent relay when parentUpdates="notify" is used without streamTo="parent"', async () => {
     const relayHandle = createRelayHandle();
     hoisted.startAcpSpawnParentStreamRelayMock.mockReset().mockReturnValue(relayHandle);
+    const requesterContext = createRequesterContext();
 
     const result = await spawnAcpDirect(
       {
@@ -827,9 +828,7 @@ describe("spawnAcpDirect", () => {
         agentId: "codex",
         parentUpdates: "notify",
       },
-      {
-        agentSessionKey: "agent:main:main",
-      },
+      requesterContext,
     );
 
     expect(result.status).toBe("accepted");
@@ -838,9 +837,15 @@ describe("spawnAcpDirect", () => {
       expect.objectContaining({
         relayProgressToParent: false,
         parentUpdateMode: "notify",
-        parentSessionKey: "agent:main:main",
+        parentSessionKey: requesterContext.agentSessionKey,
       }),
     );
+    expectAgentGatewayCall({
+      deliver: false,
+      channel: undefined,
+      to: undefined,
+      threadId: undefined,
+    });
   });
 
   it('rejects parentUpdates="notify" for ACP mode="session"', async () => {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -64,6 +64,8 @@ export const ACP_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
 export type SpawnAcpSandboxMode = (typeof ACP_SPAWN_SANDBOX_MODES)[number];
 export const ACP_SPAWN_STREAM_TARGETS = ["parent"] as const;
 export type SpawnAcpStreamTarget = (typeof ACP_SPAWN_STREAM_TARGETS)[number];
+export const ACP_PARENT_UPDATE_MODES = ["system", "notify"] as const;
+export type SpawnAcpParentUpdateMode = (typeof ACP_PARENT_UPDATE_MODES)[number];
 
 export type SpawnAcpParams = {
   task: string;
@@ -75,6 +77,7 @@ export type SpawnAcpParams = {
   thread?: boolean;
   sandbox?: SpawnAcpSandboxMode;
   streamTo?: SpawnAcpStreamTarget;
+  parentUpdates?: SpawnAcpParentUpdateMode;
 };
 
 export type SpawnAcpContext = {
@@ -704,7 +707,19 @@ export async function spawnAcpDirect(
     };
   }
   const streamToParentRequested = params.streamTo === "parent";
+  const requestedParentUpdates =
+    params.parentUpdates === "notify"
+      ? "notify"
+      : params.parentUpdates === "system"
+        ? "system"
+        : undefined;
   const parentSessionKey = ctx.agentSessionKey?.trim();
+  if (requestedParentUpdates === "notify" && !parentSessionKey) {
+    return {
+      status: "error",
+      error: 'sessions_spawn parentUpdates="notify" requires an active requester session context.',
+    };
+  }
   if (streamToParentRequested && !parentSessionKey) {
     return {
       status: "error",
@@ -736,6 +751,12 @@ export async function spawnAcpDirect(
       error: 'mode="session" requires thread=true so the ACP session can stay bound to a thread.',
     };
   }
+  if (requestedParentUpdates === "notify" && spawnMode !== "run") {
+    return {
+      status: "error",
+      error: 'sessions_spawn parentUpdates="notify" is only supported for ACP mode="run".',
+    };
+  }
 
   const requesterState = resolveAcpSpawnRequesterState({
     cfg,
@@ -748,6 +769,8 @@ export async function spawnAcpDirect(
     streamToParentRequested,
     requester: requesterState,
   });
+  const effectiveParentUpdates =
+    requestedParentUpdates === "notify" ? "notify" : effectiveStreamToParent ? "system" : undefined;
 
   const targetAgentResult = resolveTargetAcpAgentId({
     requestedAgentId: params.agentId,
@@ -846,14 +869,17 @@ export async function spawnAcpDirect(
   });
   const childIdem = crypto.randomUUID();
   let childRunId: string = childIdem;
+  const taskLabel = params.label?.trim() || params.task.trim() || targetAgentId;
   const streamLogPath =
     effectiveStreamToParent && parentSessionKey
       ? resolveAcpSpawnStreamLogPath({
           childSessionKey: sessionKey,
         })
       : undefined;
+  const shouldStartParentRelay =
+    Boolean(parentSessionKey) && (effectiveStreamToParent || effectiveParentUpdates === "notify");
   let parentRelay: AcpSpawnParentRelayHandle | undefined;
-  if (effectiveStreamToParent && parentSessionKey) {
+  if (shouldStartParentRelay && parentSessionKey) {
     // Register relay before dispatch so fast lifecycle failures are not missed.
     parentRelay = startAcpSpawnParentStreamRelay({
       runId: childIdem,
@@ -862,6 +888,10 @@ export async function spawnAcpDirect(
       agentId: targetAgentId,
       logPath: streamLogPath,
       emitStartNotice: false,
+      relayProgressToParent: effectiveStreamToParent,
+      parentUpdateMode: effectiveParentUpdates,
+      requesterOrigin: requesterState.origin,
+      taskLabel,
     });
   }
   try {
@@ -898,7 +928,7 @@ export async function spawnAcpDirect(
     };
   }
 
-  if (effectiveStreamToParent && parentSessionKey) {
+  if (shouldStartParentRelay && parentSessionKey) {
     if (parentRelay && childRunId !== childIdem) {
       parentRelay.dispose();
       // Defensive fallback if gateway returns a runId that differs from idempotency key.
@@ -909,6 +939,10 @@ export async function spawnAcpDirect(
         agentId: targetAgentId,
         logPath: streamLogPath,
         emitStartNotice: false,
+        relayProgressToParent: effectiveStreamToParent,
+        parentUpdateMode: effectiveParentUpdates,
+        requesterOrigin: requesterState.origin,
+        taskLabel,
       });
     }
     parentRelay?.notifyStarted();

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -646,6 +646,7 @@ function resolveAcpSpawnBootstrapDeliveryPlan(params: {
   spawnMode: SpawnAcpMode;
   requestThreadBinding: boolean;
   effectiveStreamToParent: boolean;
+  completionHandledByParent: boolean;
   requester: AcpSpawnRequesterState;
   binding: SessionBindingRecord | null;
 }): AcpSpawnBootstrapDeliveryPlan {
@@ -675,10 +676,12 @@ function resolveAcpSpawnBootstrapDeliveryPlan(params: {
   // Run-mode spawns use stream-to-parent when the requester is a subagent
   // orchestrator with an active heartbeat relay route. For all other run-mode
   // spawns from non-subagent requester sessions, fall back to inline delivery
-  // so the result reaches the originating channel.
+  // so the result reaches the originating channel. When parent notify mode
+  // takes ownership of terminal delivery, suppress the child inline path.
   const useInlineDelivery =
     hasDeliveryTarget &&
     !params.effectiveStreamToParent &&
+    !params.completionHandledByParent &&
     (params.spawnMode === "session" ||
       (!params.requester.isSubagentSession && !params.requestThreadBinding));
 
@@ -864,6 +867,7 @@ export async function spawnAcpDirect(
     spawnMode,
     requestThreadBinding,
     effectiveStreamToParent,
+    completionHandledByParent: effectiveParentUpdates === "notify",
     requester: requesterState,
     binding,
   });

--- a/src/agents/internal-events.ts
+++ b/src/agents/internal-events.ts
@@ -2,7 +2,7 @@ export type AgentInternalEventType = "task_completion";
 
 export type AgentTaskCompletionInternalEvent = {
   type: "task_completion";
-  source: "subagent" | "cron";
+  source: "subagent" | "cron" | "acp";
   childSessionKey: string;
   childSessionId?: string;
   announceType: string;

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -36,8 +36,13 @@ import "./test-helpers/fast-core-tools.js";
 import { __testing as openClawToolsTesting, createOpenClawTools } from "./openclaw-tools.js";
 import { __testing as subagentControlTesting } from "./subagent-control.js";
 import { __testing as agentStepTesting } from "./tools/agent-step.js";
+import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
+import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { __testing as sessionsResolutionTesting } from "./tools/sessions-resolution.js";
+import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 import { __testing as sessionsSendA2ATesting } from "./tools/sessions-send-tool.a2a.js";
+import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
+import { createSubagentsTool } from "./tools/subagents-tool.js";
 
 const TEST_CONFIG = {
   session: {
@@ -88,7 +93,29 @@ describe("sessions tools", () => {
   });
 
   it("uses number (not integer) in tool schemas for Gemini compatibility", () => {
-    const tools = createOpenClawTools();
+    const tools = [
+      createSessionsHistoryTool({
+        agentSessionKey: "agent:main:main",
+        config: TEST_CONFIG,
+        callGateway: (opts: unknown) => callGatewayMock(opts),
+      }),
+      createSessionsListTool({
+        agentSessionKey: "agent:main:main",
+        config: TEST_CONFIG,
+        callGateway: (opts: unknown) => callGatewayMock(opts),
+      }),
+      createSessionsSendTool({
+        agentSessionKey: "agent:main:main",
+        config: TEST_CONFIG,
+        callGateway: (opts: unknown) => callGatewayMock(opts),
+      }),
+      createSessionsSpawnTool({
+        agentSessionKey: "agent:main:main",
+      }),
+      createSubagentsTool({
+        agentSessionKey: "agent:main:main",
+      }),
+    ];
     const byName = (name: string) => {
       const tool = tools.find((candidate) => candidate.name === name);
       expect(tool).toBeDefined();
@@ -128,6 +155,7 @@ describe("sessions tools", () => {
     expect(schemaProp("sessions_spawn", "mode").type).toBe("string");
     expect(schemaProp("sessions_spawn", "sandbox").type).toBe("string");
     expect(schemaProp("sessions_spawn", "streamTo").type).toBe("string");
+    expect(schemaProp("sessions_spawn", "parentUpdates").type).toBe("string");
     expect(schemaProp("sessions_spawn", "runtime").type).toBe("string");
     expect(schemaProp("sessions_spawn", "cwd").type).toBe("string");
     expect(schemaProp("subagents", "recentMinutes").type).toBe("number");

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -157,7 +157,7 @@ export function buildSubagentSystemPrompt(params: {
 export { captureSubagentCompletionReply } from "./subagent-announce-output.js";
 export type { SubagentRunOutcome } from "./subagent-announce-output.js";
 
-export type SubagentAnnounceType = "subagent task" | "cron job";
+export type SubagentAnnounceType = "subagent task" | "cron job" | "acp task";
 
 function buildAnnounceReplyInstruction(params: {
   requesterIsSubagent: boolean;
@@ -543,7 +543,12 @@ export async function runSubagentAnnounceFlow(params: {
     const internalEvents: AgentInternalEvent[] = [
       {
         type: "task_completion",
-        source: announceType === "cron job" ? "cron" : "subagent",
+        source:
+          announceType === "cron job"
+            ? "cron"
+            : announceType === "acp task"
+              ? "acp"
+              : "subagent",
         childSessionKey: params.childSessionKey,
         childSessionId: announceSessionId,
         announceType,

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -15,6 +15,7 @@ vi.mock("../subagent-spawn.js", () => ({
 }));
 
 vi.mock("../acp-spawn.js", () => ({
+  ACP_PARENT_UPDATE_MODES: ["system", "notify"],
   ACP_SPAWN_MODES: ["run", "session"],
   ACP_SPAWN_STREAM_TARGETS: ["parent"],
   spawnAcpDirect: (...args: unknown[]) => hoisted.spawnAcpDirectMock(...args),
@@ -29,6 +30,7 @@ async function loadFreshSessionsSpawnToolModuleForTest() {
     spawnSubagentDirect: (...args: unknown[]) => hoisted.spawnSubagentDirectMock(...args),
   }));
   vi.doMock("../acp-spawn.js", () => ({
+    ACP_PARENT_UPDATE_MODES: ["system", "notify"],
     ACP_SPAWN_MODES: ["run", "session"],
     ACP_SPAWN_STREAM_TARGETS: ["parent"],
     spawnAcpDirect: (...args: unknown[]) => hoisted.spawnAcpDirectMock(...args),
@@ -178,6 +180,30 @@ describe("sessions_spawn tool", () => {
     );
   });
 
+  it("passes parentUpdates through to ACP spawns", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await tool.execute("call-2parent", {
+      runtime: "acp",
+      task: "resume prior work",
+      agentId: "codex",
+      streamTo: "parent",
+      parentUpdates: "notify",
+    });
+
+    expect(hoisted.spawnAcpDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "resume prior work",
+        agentId: "codex",
+        streamTo: "parent",
+        parentUpdates: "notify",
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("passes resumeSessionId through to ACP spawns", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
@@ -236,6 +262,52 @@ describe("sessions_spawn tool", () => {
     const details = result.details as { error?: string };
     expect(details.error).toContain("attachments are currently unsupported for runtime=acp");
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects parentUpdates when runtime is not "acp"', async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    const result = await tool.execute("call-3aa", {
+      runtime: "subagent",
+      task: "analyze file",
+      streamTo: "parent",
+      parentUpdates: "notify",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "error",
+    });
+    const details = result.details as { error?: string };
+    expect(details.error).toContain("parentUpdates is only supported for runtime=acp");
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
+  it('passes parentUpdates through even without streamTo="parent"', async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    const result = await tool.execute("call-3ab", {
+      runtime: "acp",
+      task: "analyze file",
+      parentUpdates: "notify",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+    });
+    expect(hoisted.spawnAcpDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "analyze file",
+        parentUpdates: "notify",
+        streamTo: undefined,
+      }),
+      expect.any(Object),
+    );
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -1,6 +1,5 @@
 import { Type } from "@sinclair/typebox";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
-import { ACP_SPAWN_MODES, ACP_SPAWN_STREAM_TARGETS, spawnAcpDirect } from "../acp-spawn.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import type { SpawnedToolContext } from "../spawned-context.js";
 import { SUBAGENT_SPAWN_MODES, spawnSubagentDirect } from "../subagent-spawn.js";
@@ -9,6 +8,9 @@ import { jsonResult, readStringParam, ToolInputError } from "./common.js";
 
 const SESSIONS_SPAWN_RUNTIMES = ["subagent", "acp"] as const;
 const SESSIONS_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
+const ACP_SESSIONS_SPAWN_MODES = ["run", "session"] as const;
+const ACP_SESSIONS_SPAWN_STREAM_TARGETS = ["parent"] as const;
+const ACP_SESSIONS_PARENT_UPDATE_MODES = ["system", "notify"] as const;
 const UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS = [
   "target",
   "transport",
@@ -41,7 +43,8 @@ const SessionsSpawnToolSchema = Type.Object({
   mode: optionalStringEnum(SUBAGENT_SPAWN_MODES),
   cleanup: optionalStringEnum(["delete", "keep"] as const),
   sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
-  streamTo: optionalStringEnum(ACP_SPAWN_STREAM_TARGETS),
+  streamTo: optionalStringEnum(ACP_SESSIONS_SPAWN_STREAM_TARGETS),
+  parentUpdates: optionalStringEnum(ACP_SESSIONS_PARENT_UPDATE_MODES),
 
   // Inline attachments (snapshot-by-value).
   // NOTE: Attachment contents are redacted from transcript persistence by sanitizeToolCallInputs.
@@ -106,6 +109,12 @@ export function createSessionsSpawnTool(
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
       const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const parentUpdates =
+        params.parentUpdates === "notify"
+          ? "notify"
+          : params.parentUpdates === "system"
+            ? "system"
+            : undefined;
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
         typeof params.runTimeoutSeconds === "number"
@@ -126,6 +135,13 @@ export function createSessionsSpawnTool(
             mimeType?: string;
           }>)
         : undefined;
+
+      if (parentUpdates && runtime !== "acp") {
+        return jsonResult({
+          status: "error",
+          error: `parentUpdates is only supported for runtime=acp; got runtime=${runtime}`,
+        });
+      }
 
       if (streamTo && runtime !== "acp") {
         return jsonResult({
@@ -149,6 +165,7 @@ export function createSessionsSpawnTool(
               "attachments are currently unsupported for runtime=acp; use runtime=subagent or remove attachments",
           });
         }
+        const { spawnAcpDirect } = await import("../acp-spawn.js");
         const result = await spawnAcpDirect(
           {
             task,
@@ -156,10 +173,11 @@ export function createSessionsSpawnTool(
             agentId: requestedAgentId,
             resumeSessionId,
             cwd,
-            mode: mode && ACP_SPAWN_MODES.includes(mode) ? mode : undefined,
+            mode: mode && ACP_SESSIONS_SPAWN_MODES.includes(mode) ? mode : undefined,
             thread,
             sandbox,
             streamTo,
+            parentUpdates,
           },
           {
             agentSessionKey: opts?.agentSessionKey,

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -4,7 +4,7 @@ import { InputProvenanceSchema, NonEmptyString, SessionLabelString } from "./pri
 export const AgentInternalEventSchema = Type.Object(
   {
     type: Type.Literal("task_completion"),
-    source: Type.String({ enum: ["subagent", "cron"] }),
+    source: Type.String({ enum: ["subagent", "cron", "acp"] }),
     childSessionKey: Type.String(),
     childSessionId: Type.Optional(Type.String()),
     announceType: Type.String(),


### PR DESCRIPTION
## What changed

This adds an opt-in ACP parent update mode for `sessions_spawn` so ACP `mode:"run"` completions can return to the parent session like subagent completions, instead of only surfacing as parent-side system events.

Key behavior changes:

- adds `parentUpdates?: "system" | "notify"` for ACP spawns
- keeps the default behavior unchanged
- allows `parentUpdates:"notify"` for ACP `mode:"run"` even without `streamTo:"parent"`
- keeps `streamTo:"parent"` as the progress relay switch
- routes terminal completion/error through the existing subagent-style announce flow when `parentUpdates:"notify"` is enabled
- falls back to the existing system-event path if notify/announce is unavailable

## Why

Today, ACP `sessions_spawn` run completions only surface to the parent session as system events.

That lets the parent session observe that work finished internally, but the completion signal primarily rides the heartbeat/internal relay path instead of a normal completion delivery path. In practice, channel-facing completion notifications can be missing or incomplete, and final result details are often lost.

This change fixes that gap by adding an explicit, non-default completion routing mode for ACP run spawns.

## Design

This intentionally splits progress relay from terminal completion routing:

- `streamTo:"parent"` continues to control progress relay
- `parentUpdates:"notify"` controls terminal completion announce

That split keeps progress on the lightweight best-effort relay path while reusing the existing announce/completion machinery for final outcomes.

## Compatibility

- default behavior remains unchanged
- ACP / ACPX execution flow is unchanged
- only parent reporting / relay / completion routing is updated

## Validation

Passed:

- `corepack pnpm test -- src/agents/acp-spawn-parent-stream.test.ts src/agents/acp-spawn.test.ts src/agents/tools/sessions-spawn-tool.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc -p tsconfig.json --noEmit --pretty false`

Note:

- `src/agents/openclaw-tools.sessions.test.ts` still has unrelated existing local failures:
  - `sessions_list filters kinds and includes messages` timeout
  - `sessions_send supports fire-and-forget and wait` expects `historyOnlyCalls` length 8 but gets 9
