### PR TITLE
fix(discord): improve chunk boundary selection

### DIFF
--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -2,7 +2,83 @@ import { countLines, hasBalancedFences } from "openclaw/plugin-sdk/testing";
 import { describe, expect, it } from "vitest";
 import { chunkDiscordText, chunkDiscordTextWithMode } from "./chunk.js";
 
+function createSeededRand(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 2 ** 32;
+  };
+}
+
+function generateRandomText(
+  rand: () => number,
+  opts: { chars: string[]; maxLen: number; requireNonWhitespace?: boolean },
+) {
+  const len = 1 + Math.floor(rand() * opts.maxLen);
+  let text = "";
+  let hasNonWhitespace = false;
+  for (let i = 0; i < len; i++) {
+    const nextChar = opts.chars[Math.floor(rand() * opts.chars.length)] ?? "a";
+    text += nextChar;
+    if (!/\s/.test(nextChar)) {
+      hasNonWhitespace = true;
+    }
+  }
+  if (opts.requireNonWhitespace && !hasNonWhitespace) {
+    text = `${text.slice(0, -1)}a`;
+  }
+  return text;
+}
+
+function assertChunkBounds(chunks: string[], opts: { maxChars: number; maxLines?: number }) {
+  expect(chunks.length).toBeGreaterThan(0);
+  for (const chunk of chunks) {
+    expect(chunk.length).toBeGreaterThan(0);
+    expect(chunk.length).toBeLessThanOrEqual(opts.maxChars);
+    if (opts.maxLines !== undefined) {
+      expect(countLines(chunk)).toBeLessThanOrEqual(opts.maxLines);
+    }
+  }
+}
+
 describe("chunkDiscordText", () => {
+  it("keeps making progress across a small randomized matrix", () => {
+    const rand = createSeededRand(314159);
+    const chars = ["a", "b", " ", "\n", "`", "~", "t", "x"];
+
+    for (let i = 0; i < 12; i++) {
+      const text = generateRandomText(rand, { chars, maxLen: 20 });
+      const maxChars = 1 + Math.floor(rand() * 12);
+      const chunks = chunkDiscordText(text, { maxChars });
+      assertChunkBounds(chunks, { maxChars });
+    }
+  });
+
+  it("enforces explicit maxLines across a small randomized matrix", () => {
+    const rand = createSeededRand(161803);
+    const chars = ["a", "b", " ", "\n", "t", "x"];
+
+    for (let i = 0; i < 12; i++) {
+      const text = generateRandomText(rand, {
+        chars,
+        maxLen: 24,
+        requireNonWhitespace: true,
+      });
+      const maxChars = 6 + Math.floor(rand() * 16);
+      const maxLines = 1 + Math.floor(rand() * 4);
+      const chunks = chunkDiscordText(text, { maxChars, maxLines });
+      assertChunkBounds(chunks, { maxChars, maxLines });
+    }
+  });
+
+  it("does not split tall messages by default when under the char limit", () => {
+    const text = Array.from({ length: 45 }, (_, i) => `line-${i + 1}`).join("\n");
+    expect(text.length).toBeLessThan(1950);
+
+    const chunks = chunkDiscordText(text);
+    expect(chunks).toEqual([text]);
+  });
+
   it("splits tall messages even when under 2000 chars", () => {
     const text = Array.from({ length: 45 }, (_, i) => `line-${i + 1}`).join("\n");
     expect(text.length).toBeLessThan(2000);
@@ -30,6 +106,54 @@ describe("chunkDiscordText", () => {
     expect(chunks.at(-1)).toContain("Done.");
   });
 
+  it("prefers paragraph breaks before newline or whitespace", () => {
+    const text = ["a".repeat(30), "b".repeat(30), "c".repeat(30)].join("\n\n");
+    const chunks = chunkDiscordText(text, { maxChars: 75 });
+
+    expect(chunks).toEqual([`${"a".repeat(30)}\n\n${"b".repeat(30)}\n\n`, "c".repeat(30)]);
+  });
+
+  it("prefers newline breaks before whitespace", () => {
+    const text = `alpha beta gamma\ndelta epsilon zeta`;
+    const chunks = chunkDiscordText(text, { maxChars: 22 });
+
+    expect(chunks).toEqual(["alpha beta gamma\n", "delta epsilon zeta"]);
+  });
+
+  it("does not exceed maxChars when a preferred newline break starts at the limit", () => {
+    const text = `aaaaa\nbbbbb`;
+    const chunks = chunkDiscordText(text, { maxChars: 5 });
+
+    expect(chunks.join("")).toBe(text);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("does not exceed maxChars when a preferred paragraph break starts at the limit", () => {
+    const text = `aaaaa\n\nbbbbb`;
+    const chunks = chunkDiscordText(text, { maxChars: 5 });
+
+    expect(chunks.join("")).toBe(text);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("prefers whitespace breaks before arbitrary character splits", () => {
+    const text = "alpha beta gamma delta";
+    const chunks = chunkDiscordText(text, { maxChars: 12 });
+
+    expect(chunks).toEqual(["alpha beta ", "gamma delta"]);
+  });
+
+  it("falls back to arbitrary splits when no better boundary exists", () => {
+    const text = "abcdefghijklmnopqrstuvwxyz";
+    const chunks = chunkDiscordText(text, { maxChars: 10 });
+
+    expect(chunks).toEqual(["abcdefghij", "klmnopqrst", "uvwxyz"]);
+  });
+
   it("keeps fenced blocks intact when chunkMode is newline", () => {
     const text = "```js\nconst a = 1;\nconst b = 2;\n```\nAfter";
     const chunks = chunkDiscordTextWithMode(text, {
@@ -48,6 +172,237 @@ describe("chunkDiscordText", () => {
     expect(chunks.length).toBeGreaterThan(1);
     for (const chunk of chunks) {
       expect(chunk.length).toBeLessThanOrEqual(50);
+      expect(hasBalancedFences(chunk)).toBe(true);
+    }
+  });
+
+  it("splits oversized fenced blocks while keeping each chunk balanced", () => {
+    const body = "a".repeat(80);
+    const text = `\`\`\`txt\n${body}\n\`\`\``;
+
+    const chunks = chunkDiscordText(text, { maxChars: 30 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(hasBalancedFences(chunk)).toBe(true);
+      expect(chunk.length).toBeLessThanOrEqual(30);
+    }
+  });
+
+  it("keeps making progress when a split lands inside a long fence opener", () => {
+    const text = `\`\`\`verylonglanguagehint\nconsole.log("hi");\n\`\`\``;
+
+    const chunks = chunkDiscordText(text, { maxChars: 8 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(8);
+    }
+  });
+
+  it("does not loop when maxChars is smaller than the fence closing budget", () => {
+    const text = `\`\`\`txt\nabc\n\`\`\``;
+
+    const chunks = chunkDiscordText(text, { maxChars: 3 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it("keeps making progress when a carry-over would recreate the same fence prefix", () => {
+    const text = `\`\`\`txt\nabcdef\n\`\`\``;
+
+    const chunks = chunkDiscordText(text, { maxChars: 11 });
+    expect(chunks).toEqual(["```txt\n", "abcdef\n```"]);
+  });
+
+  it("does not add an extra newline when reopening a fenced chunk at a newline boundary", () => {
+    const text = `\`\`\`txt\nabc\ndefghij\n\`\`\``;
+
+    const chunks = chunkDiscordText(text, { maxChars: 15 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks.slice(1)) {
+      expect(chunk.startsWith("```txt\n\n")).toBe(false);
+    }
+  });
+
+  it("closes the final chunk when an unterminated fenced block exceeds maxChars", () => {
+    const text = `\`\`\`txt\n${"a".repeat(2100)}`;
+
+    const chunks = chunkDiscordText(text, { maxChars: 2000 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(2000);
+      expect(hasBalancedFences(chunk)).toBe(true);
+    }
+  });
+
+  it("closes an unterminated fenced block that already fits once balanced", () => {
+    const text = `\`\`\`txt\nabc`;
+
+    const chunks = chunkDiscordText(text, { maxChars: 20 });
+    expect(chunks).toEqual(["```txt\nabc\n```"]);
+    expect(hasBalancedFences(chunks[0]!)).toBe(true);
+  });
+
+  it("does not bypass explicit maxLines when balancing a feasible unterminated fenced block", () => {
+    const text = `x\n\`\`\`txt\nabc`;
+
+    const chunks = chunkDiscordText(text, { maxChars: 20, maxLines: 3 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(20);
+      expect(countLines(chunk)).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it("keeps explicit maxLines chunks within maxChars after reopening a malformed fence", () => {
+    const text = `\`\`\`${"x".repeat(1992)}\na`;
+
+    const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 20 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(2000);
+      expect(countLines(chunk)).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it("preserves a fence opener when line mode forces progress after reopening", () => {
+    const text = `\`\`\`${"x".repeat(1992)}\na`;
+
+    const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 20 });
+    expect(chunks).toEqual([`\`\`\`${"x".repeat(1992)}\n\`\`\``, "```\na\n```"]);
+    for (const chunk of chunks) {
+      expect(hasBalancedFences(chunk)).toBe(true);
+    }
+  });
+
+  it("keeps the final balanced chunk within maxChars when closing an unterminated fence", () => {
+    const text = `\`\`\`txt\n${"a".repeat(25)}\n\nrest`;
+
+    const chunks = chunkDiscordText(text, { maxChars: 20 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(20);
+      expect(hasBalancedFences(chunk)).toBe(true);
+    }
+  });
+
+  it("closes a trailing unterminated fence that starts after a leading newline split", () => {
+    const text = `${"a".repeat(11)}\n\`\`\`txt\nabc`;
+
+    const chunks = chunkDiscordText(text, { maxChars: 11 });
+    expect(chunks[0]).toBe("a".repeat(11));
+    for (const chunk of chunks.slice(1)) {
+      expect(chunk.length).toBeLessThanOrEqual(11);
+      expect(hasBalancedFences(chunk)).toBe(true);
+    }
+  });
+
+  it("keeps a conversation-style bullet list in one chunk when under the char limit", () => {
+    const text = [
+      "Yeah, that framing makes sense. Plain text is the obvious fit here.",
+      "",
+      "Reasons this works well:",
+      "- works well with editor plugins",
+      "- easy to inspect and update",
+      "- plain text workflow",
+      "- no weird proprietary format",
+      "",
+      "For this, I'd use a simple text file:",
+      "",
+      "notes.txt",
+    ].join("\n");
+
+    expect(text.length).toBeLessThan(1950);
+    expect(chunkDiscordText(text)).toEqual([text]);
+  });
+
+  it("keeps prose and a short fenced block together when the whole reply fits", () => {
+    const text = [
+      "Here is the command I'd use.",
+      "",
+      "```bash",
+      "printf 'notes' > notes.txt",
+      "```",
+      "",
+      "That keeps the workflow simple.",
+    ].join("\n");
+
+    expect(text.length).toBeLessThan(1950);
+    expect(chunkDiscordText(text)).toEqual([text]);
+  });
+
+  it("splits a prose plus code block reply at the paragraph before the fenced block", () => {
+    const intro = "A".repeat(120);
+    const code = ["```bash", "printf 'notes' > notes.txt", "```"].join("\n");
+    const outro = "B".repeat(40);
+    const text = [intro, code, outro].join("\n\n");
+
+    const chunks = chunkDiscordText(text, { maxChars: 150 });
+    expect(chunks).toEqual([`${intro}\n\n`, `${code}\n\n${outro}`]);
+    expect(hasBalancedFences(chunks[1])).toBe(true);
+  });
+
+  it("prefers splitting before a fenced block when the block itself fits in the next chunk", () => {
+    const intro = "Opening paragraph ".repeat(8).trimEnd();
+    const code = ["```bash", "echo test", "echo second", "```"].join("\n");
+    const trailing = "Closing paragraph.";
+    const text = [intro, code, trailing].join("\n\n");
+
+    const chunks = chunkDiscordText(text, { maxChars: intro.length + 2 });
+    expect(chunks).toEqual([`${intro}\n\n`, `${code}\n\n${trailing}`]);
+  });
+
+  it("splits long advice at paragraph boundaries instead of breaking a bullet list", () => {
+    const intro = "That explanation works. Keeping the structure readable matters here.";
+    const bullets = [
+      "Reasons this layout is useful:",
+      "- easy to scan in chat",
+      "- simple to edit later",
+      "- works with plain text tools",
+      "- avoids unnecessary formatting",
+    ].join("\n");
+    const outro = ["Recommended file:", "", "notes.txt"].join("\n");
+    const text = [intro, bullets, outro].join("\n\n");
+
+    const maxChars = bullets.length + outro.length + 4;
+    expect(maxChars).toBeLessThan(text.length);
+    const chunks = chunkDiscordText(text, { maxChars });
+    expect(chunks).toEqual([`${intro}\n\n`, `${bullets}\n\n${outro}`]);
+  });
+
+  it("prefers paragraph boundaries over an earlier whitespace break", () => {
+    const intro = "alpha beta gamma delta epsilon";
+    const second = "line one\nline two";
+    const third = "omega";
+    const text = [intro, second, third].join("\n\n");
+
+    const chunks = chunkDiscordText(text, { maxChars: intro.length + 3 });
+    expect(chunks).toEqual([`${intro}\n\n`, `${second}\n\n${third}`]);
+  });
+
+  it("keeps a short fenced block with its trailing paragraph when both fit together", () => {
+    const intro = "Preface paragraph that needs its own chunk.";
+    const code = ["```text", "morty", "Need edit note add links.", "```"].join("\n");
+    const trailing = "Those are internal thoughts of the agent.";
+    const text = [intro, code, trailing].join("\n\n");
+
+    const expectedSecondChunk = `${code}\n\n${trailing}`;
+    const maxChars = expectedSecondChunk.length;
+    expect(maxChars).toBeLessThan(text.length);
+    const chunks = chunkDiscordText(text, { maxChars });
+    expect(chunks).toEqual([`${intro}\n\n`, expectedSecondChunk]);
+  });
+
+  it("splits inside a fenced block only when the block cannot fit in one chunk", () => {
+    const code = ["```text", "morty", "a".repeat(80), "```"].join("\n");
+
+    const chunks = chunkDiscordText(code, { maxChars: 35 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(35);
       expect(hasBalancedFences(chunk)).toBe(true);
     }
   });

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -1,26 +1,43 @@
-import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
+import {
+  chunkMarkdownTextWithMode,
+  chunkMarkdownWithBalancedFences,
+  type ChunkMode,
+} from "openclaw/plugin-sdk/reply-chunking";
 
 export type ChunkDiscordTextOpts = {
-  /** Max characters per Discord message. Default: 2000. */
+  /** Max characters per Discord message. Default: 1950. */
   maxChars?: number;
   /**
-   * Soft max line count per message. Default: 17.
+   * Optional soft max line count per message.
    *
-   * Discord clients can clip/collapse very tall messages in the UI; splitting
-   * by lines keeps long multi-paragraph replies readable.
+   * When omitted, Discord chunking prioritizes minimizing message count and
+   * only splits on character limits.
    */
   maxLines?: number;
 };
 
 type OpenFence = {
+  hasInfoString: boolean;
   indent: string;
   markerChar: string;
   markerLen: number;
   openLine: string;
 };
 
-const DEFAULT_MAX_CHARS = 2000;
-const DEFAULT_MAX_LINES = 17;
+type FenceSpan = OpenFence & {
+  closed: boolean;
+  start: number;
+  end: number;
+};
+
+type FenceState = {
+  leadingOpenFence: FenceSpan | null;
+  spans: FenceSpan[];
+  trailingOpenFence: FenceSpan | null;
+};
+
+const DEFAULT_MAX_CHARS = 1950;
+const DEFAULT_MAX_LINES = Number.MAX_SAFE_INTEGER;
 const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
 
 function countLines(text: string) {
@@ -37,7 +54,9 @@ function parseFenceLine(line: string): OpenFence | null {
   }
   const indent = match[1] ?? "";
   const marker = match[2] ?? "";
+  const suffix = match[3] ?? "";
   return {
+    hasInfoString: suffix.trim().length > 0,
     indent,
     markerChar: marker[0] ?? "`",
     markerLen: marker.length,
@@ -61,6 +80,81 @@ function closeFenceIfNeeded(text: string, openFence: OpenFence | null) {
     return `${text}\n${closeLine}`;
   }
   return `${text}${closeLine}`;
+}
+
+function parseFenceSpans(text: string): FenceSpan[] {
+  const spans: FenceSpan[] = [];
+  let openFence: FenceSpan | null = null;
+  let offset = 0;
+  while (offset <= text.length) {
+    const nextNewline = text.indexOf("\n", offset);
+    const lineEnd = nextNewline === -1 ? text.length : nextNewline;
+    const line = text.slice(offset, lineEnd);
+    const fence = parseFenceLine(line);
+    if (fence) {
+      if (!openFence) {
+        openFence = {
+          closed: false,
+          ...fence,
+          start: offset,
+          end: text.length,
+        };
+      } else if (
+        openFence.markerChar === fence.markerChar &&
+        fence.markerLen >= openFence.markerLen
+      ) {
+        openFence.end = lineEnd;
+        openFence.closed = true;
+        spans.push(openFence);
+        openFence = null;
+      }
+    }
+    if (nextNewline === -1) {
+      break;
+    }
+    offset = nextNewline + 1;
+  }
+  if (openFence) {
+    spans.push(openFence);
+  }
+  return spans;
+}
+
+function findTrailingOpenFence(spans: FenceSpan[]): FenceSpan | null {
+  const last = spans.at(-1);
+  if (!last || last.closed) {
+    return null;
+  }
+  return last;
+}
+
+function getFenceState(text: string): FenceState {
+  const spans = parseFenceSpans(text);
+  const trailingOpenFence = findTrailingOpenFence(spans);
+  return {
+    spans,
+    trailingOpenFence,
+    leadingOpenFence: trailingOpenFence?.start === 0 ? trailingOpenFence : null,
+  };
+}
+
+function renderChunkWithFence(text: string, openFence: OpenFence | null): string {
+  return closeFenceIfNeeded(text, openFence);
+}
+
+function getStandaloneChunkFence(text: string, fenceState: FenceState): FenceSpan | null {
+  if (fenceState.leadingOpenFence) {
+    return fenceState.leadingOpenFence;
+  }
+  const trailing = fenceState.trailingOpenFence;
+  if (!trailing) {
+    return null;
+  }
+  if (trailing.hasInfoString || trailing.start === 0) {
+    return trailing;
+  }
+  const trailingBody = text.slice(trailing.start + trailing.openLine.length);
+  return trailingBody.length > 0 ? trailing : null;
 }
 
 function splitLongLine(
@@ -92,7 +186,6 @@ function splitLongLine(
       breakIdx = limit;
     }
     out.push(remaining.slice(0, breakIdx));
-    // Keep the separator for the next segment so words don't get glued together.
     remaining = remaining.slice(breakIdx);
   }
   if (remaining.length) {
@@ -101,11 +194,7 @@ function splitLongLine(
   return out;
 }
 
-/**
- * Chunks outbound Discord text by both character count and (soft) line count,
- * while keeping fenced code blocks balanced across chunks.
- */
-export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}): string[] {
+function chunkDiscordTextByLines(text: string, opts: ChunkDiscordTextOpts): string[] {
   const maxChars = Math.max(1, Math.floor(opts.maxChars ?? DEFAULT_MAX_CHARS));
   const maxLines = Math.max(1, Math.floor(opts.maxLines ?? DEFAULT_MAX_LINES));
 
@@ -114,9 +203,11 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     return [];
   }
 
-  const alreadyOk = body.length <= maxChars && countLines(body) <= maxLines;
+  const bodyFenceState = getFenceState(body);
+  const renderedBody = renderChunkWithFence(body, getStandaloneChunkFence(body, bodyFenceState));
+  const alreadyOk = renderedBody.length <= maxChars && countLines(renderedBody) <= maxLines;
   if (alreadyOk) {
-    return [body];
+    return [renderedBody];
   }
 
   const lines = body.split("\n");
@@ -172,26 +263,39 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     for (let segIndex = 0; segIndex < segments.length; segIndex++) {
       const segment = segments[segIndex];
       const isLineContinuation = segIndex > 0;
-      const delimiter = isLineContinuation ? "" : current.length > 0 ? "\n" : "";
-      const addition = `${delimiter}${segment}`;
-      const nextLen = current.length + addition.length;
-      const nextLines = currentLines + (isLineContinuation ? 0 : 1);
+      while (true) {
+        const delimiter = isLineContinuation ? "" : current.length > 0 ? "\n" : "";
+        const addition = `${delimiter}${segment}`;
+        const nextLen = current.length + addition.length;
+        const nextLines = currentLines + (isLineContinuation ? 0 : 1);
 
-      const wouldExceedChars = nextLen > charLimit;
-      const wouldExceedLines = nextLines > lineLimit;
+        const wouldExceedChars = nextLen > charLimit;
+        const wouldExceedLines = nextLines > lineLimit;
 
-      if ((wouldExceedChars || wouldExceedLines) && current.length > 0) {
-        flush();
-      }
-
-      if (current.length > 0) {
-        current += addition;
-        if (!isLineContinuation) {
-          currentLines += 1;
+        if ((wouldExceedChars || wouldExceedLines) && current.length > 0) {
+          const beforeFlush = current;
+          flush();
+          if (current === beforeFlush) {
+            // Reopening the exact same buffer would loop forever. Keep a minimal
+            // fence marker so following content stays fenced without exceeding
+            // the explicit line-mode char budget.
+            current = nextOpenFence ? closeFenceLine(nextOpenFence) : "";
+            currentLines = current.length > 0 ? 1 : 0;
+            openFence = nextOpenFence;
+          }
+          continue;
         }
-      } else {
-        current = segment;
-        currentLines = 1;
+
+        if (current.length > 0) {
+          current += addition;
+          if (!isLineContinuation) {
+            currentLines += 1;
+          }
+        } else {
+          current = segment;
+          currentLines = 1;
+        }
+        break;
       }
     }
 
@@ -206,6 +310,26 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
   }
 
   return rebalanceReasoningItalics(text, chunks);
+}
+
+export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}): string[] {
+  const maxChars = Math.max(1, Math.floor(opts.maxChars ?? DEFAULT_MAX_CHARS));
+  const maxLines = Math.max(1, Math.floor(opts.maxLines ?? DEFAULT_MAX_LINES));
+  const body = text ?? "";
+  if (!body) {
+    return [];
+  }
+
+  if (maxLines < Number.MAX_SAFE_INTEGER) {
+    return chunkDiscordTextByLines(text, opts);
+  }
+
+  return rebalanceReasoningItalics(
+    text,
+    chunkMarkdownWithBalancedFences(body, {
+      maxChars,
+    }),
+  );
 }
 
 export function chunkDiscordTextWithMode(
@@ -233,10 +357,6 @@ export function chunkDiscordTextWithMode(
   return chunks;
 }
 
-// Keep italics intact for reasoning payloads that are wrapped once with `_…_`.
-// When Discord chunking splits the message, we close italics at the end of
-// each chunk and reopen at the start of the next so every chunk renders
-// consistently.
 function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
   if (chunks.length <= 1) {
     return chunks;
@@ -253,7 +373,6 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
     const isLast = i === adjusted.length - 1;
     const current = adjusted[i];
 
-    // Ensure current chunk closes italics so Discord renders it italicized.
     const needsClosing = !current.trimEnd().endsWith("_");
     if (needsClosing) {
       adjusted[i] = `${current}_`;
@@ -263,7 +382,6 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
       break;
     }
 
-    // Re-open italics on the next chunk if needed.
     const next = adjusted[i + 1];
     const leadingWhitespaceLen = next.length - next.trimStart().length;
     const leadingWhitespace = next.slice(0, leadingWhitespaceLen);

--- a/src/markdown/chunk.test.ts
+++ b/src/markdown/chunk.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import { hasBalancedFences } from "../test-utils/chunk-test-helpers.js";
+import { chunkMarkdownWithBalancedFences } from "./chunk.js";
+
+function expectChunkInvariants(chunks: string[], maxChars: number) {
+  expect(chunks.length).toBeGreaterThan(0);
+  for (const chunk of chunks) {
+    expect(chunk.length).toBeGreaterThan(0);
+    expect(chunk.length).toBeLessThanOrEqual(maxChars);
+  }
+}
+
+describe("chunkMarkdownWithBalancedFences", () => {
+  it("keeps fenced code blocks balanced across chunks", () => {
+    const body = Array.from({ length: 30 }, (_, i) => `console.log(${i});`).join("\n");
+    const text = `Here is code:\n\n\`\`\`js\n${body}\n\`\`\`\n\nDone.`;
+
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 200 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    for (const chunk of chunks) {
+      expect(hasBalancedFences(chunk)).toBe(true);
+      expect(chunk.length).toBeLessThanOrEqual(200);
+    }
+
+    expect(chunks.some((chunk) => chunk.includes("```js"))).toBe(true);
+    expect(chunks.at(-1)).toContain("Done.");
+  });
+
+  it("prefers paragraph breaks before newline or whitespace", () => {
+    const text = ["a".repeat(30), "b".repeat(30), "c".repeat(30)].join("\n\n");
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 75 });
+
+    expect(chunks).toEqual([`${"a".repeat(30)}\n\n${"b".repeat(30)}\n\n`, "c".repeat(30)]);
+  });
+
+  it("prefers newline breaks before whitespace", () => {
+    const text = `alpha beta gamma\ndelta epsilon zeta`;
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 22 });
+
+    expect(chunks).toEqual(["alpha beta gamma\n", "delta epsilon zeta"]);
+  });
+
+  it("prefers whitespace breaks before arbitrary character splits", () => {
+    const text = "alpha beta gamma delta";
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 12 });
+
+    expect(chunks).toEqual(["alpha beta ", "gamma delta"]);
+  });
+
+  it("falls back to arbitrary splits when no better boundary exists", () => {
+    const text = "abcdefghijklmnopqrstuvwxyz";
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 10 });
+
+    expect(chunks).toEqual(["abcdefghij", "klmnopqrst", "uvwxyz"]);
+  });
+
+  it("splits oversized fenced blocks while keeping each chunk balanced", () => {
+    const body = "a".repeat(80);
+    const text = `\`\`\`txt\n${body}\n\`\`\``;
+
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 30 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(hasBalancedFences(chunk)).toBe(true);
+      expect(chunk.length).toBeLessThanOrEqual(30);
+    }
+  });
+
+  it("keeps making progress when a split lands inside a long fence opener", () => {
+    const text = `\`\`\`verylonglanguagehint\nconsole.log("hi");\n\`\`\``;
+
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 8 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(8);
+    }
+  });
+
+  it("does not loop when maxChars is smaller than the fence closing budget", () => {
+    const text = `\`\`\`txt\nabc\n\`\`\``;
+
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 3 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it("keeps making progress when a carry-over would recreate the same fence prefix", () => {
+    const text = `\`\`\`txt\nabcdef\n\`\`\``;
+
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 11 });
+    expect(chunks).toEqual(["```txt\n", "abcdef\n```"]);
+  });
+
+  it("does not add an extra newline when reopening a fenced chunk at a newline boundary", () => {
+    const text = `\`\`\`txt\nabc\ndefghij\n\`\`\``;
+
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 15 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks.slice(1)) {
+      expect(chunk.startsWith("```txt\n\n")).toBe(false);
+    }
+  });
+
+  it("closes the final chunk when an unterminated fenced block exceeds maxChars", () => {
+    const text = `\`\`\`txt\n${"a".repeat(2100)}`;
+
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 2000 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(2000);
+      expect(hasBalancedFences(chunk)).toBe(true);
+    }
+  });
+
+  it("closes an unterminated fenced block that already fits once balanced", () => {
+    const text = `\`\`\`txt\nabc`;
+
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 20 });
+    expect(chunks).toEqual(["```txt\nabc\n```"]);
+    expect(hasBalancedFences(chunks[0])).toBe(true);
+  });
+
+  it("keeps the final balanced chunk within maxChars when closing an unterminated fence", () => {
+    const text = `\`\`\`txt\n${"a".repeat(25)}\n\nrest`;
+
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 20 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(20);
+      expect(hasBalancedFences(chunk)).toBe(true);
+    }
+  });
+
+  it("closes a trailing unterminated fence that starts after a leading newline split", () => {
+    const text = `${"a".repeat(11)}\n\`\`\`txt\nabc`;
+
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 11 });
+    expect(chunks[0]).toBe("a".repeat(11));
+    for (const chunk of chunks.slice(1)) {
+      expect(chunk.length).toBeLessThanOrEqual(11);
+      expect(hasBalancedFences(chunk)).toBe(true);
+    }
+  });
+
+  it("preserves whitespace when splitting long lines", () => {
+    const text = Array.from({ length: 40 }, () => "word").join(" ");
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 20 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("preserves mixed whitespace across chunk boundaries", () => {
+    const text = "alpha  beta\tgamma   delta epsilon  zeta";
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 12 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("keeps leading whitespace when splitting long lines", () => {
+    const text = "    indented line with words that force splits";
+    const chunks = chunkMarkdownWithBalancedFences(text, { maxChars: 14 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("keeps making bounded progress across representative hostile inputs", () => {
+    const cases = [
+      "abcdefghijklmnopqrstuvwxyz",
+      "    indented line with words that force splits",
+      "alpha  beta\tgamma   delta epsilon  zeta",
+      "```txt\nabcdef\n```",
+      "```txt\n01234567890123456789\n```",
+      "```verylonglanguagehint\n01234567890123456789\n```",
+      "```txt\nabc",
+      "aaaaaaaaaaa\n```txt\nabc",
+    ];
+
+    for (const text of cases) {
+      for (let maxChars = 1; maxChars <= 20; maxChars++) {
+        const chunks = chunkMarkdownWithBalancedFences(text, { maxChars });
+        expectChunkInvariants(chunks, maxChars);
+      }
+    }
+  });
+
+  it("does not drop numeric payload bytes across fence reopen adjustments", () => {
+    const text = "```verylonglanguagehint\n01234567890123456789\n```";
+
+    for (let maxChars = 1; maxChars <= 25; maxChars++) {
+      const chunks = chunkMarkdownWithBalancedFences(text, { maxChars });
+      expectChunkInvariants(chunks, maxChars);
+      expect(chunks.join("").replace(/\D/g, "")).toBe("01234567890123456789");
+    }
+  });
+});

--- a/src/markdown/chunk.ts
+++ b/src/markdown/chunk.ts
@@ -1,0 +1,316 @@
+export type MarkdownChunkOptions = {
+  maxChars: number;
+};
+
+type OpenFence = {
+  hasInfoString: boolean;
+  indent: string;
+  markerChar: string;
+  markerLen: number;
+  openLine: string;
+};
+
+type LocalFenceSpan = OpenFence & {
+  closed: boolean;
+  start: number;
+  end: number;
+};
+
+type FenceState = {
+  leadingOpenFence: LocalFenceSpan | null;
+  spans: LocalFenceSpan[];
+  trailingOpenFence: LocalFenceSpan | null;
+};
+
+const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+
+function parseFenceLine(line: string): OpenFence | null {
+  const match = line.match(FENCE_RE);
+  if (!match) {
+    return null;
+  }
+  const indent = match[1] ?? "";
+  const marker = match[2] ?? "";
+  const suffix = match[3] ?? "";
+  return {
+    hasInfoString: suffix.trim().length > 0,
+    indent,
+    markerChar: marker[0] ?? "`",
+    markerLen: marker.length,
+    openLine: line,
+  };
+}
+
+function closeFenceLine(openFence: OpenFence) {
+  return `${openFence.indent}${openFence.markerChar.repeat(openFence.markerLen)}`;
+}
+
+function closeFenceIfNeeded(text: string, openFence: OpenFence | null) {
+  if (!openFence) {
+    return text;
+  }
+  const closeLine = closeFenceLine(openFence);
+  if (!text) {
+    return closeLine;
+  }
+  if (!text.endsWith("\n")) {
+    return `${text}\n${closeLine}`;
+  }
+  return `${text}${closeLine}`;
+}
+
+function parseFenceSpans(text: string): LocalFenceSpan[] {
+  const spans: LocalFenceSpan[] = [];
+  let openFence: LocalFenceSpan | null = null;
+  let offset = 0;
+  while (offset <= text.length) {
+    const nextNewline = text.indexOf("\n", offset);
+    const lineEnd = nextNewline === -1 ? text.length : nextNewline;
+    const line = text.slice(offset, lineEnd);
+    const fence = parseFenceLine(line);
+    if (fence) {
+      if (!openFence) {
+        openFence = {
+          closed: false,
+          ...fence,
+          start: offset,
+          end: text.length,
+        };
+      } else if (
+        openFence.markerChar === fence.markerChar &&
+        fence.markerLen >= openFence.markerLen
+      ) {
+        openFence.end = lineEnd;
+        openFence.closed = true;
+        spans.push(openFence);
+        openFence = null;
+      }
+    }
+    if (nextNewline === -1) {
+      break;
+    }
+    offset = nextNewline + 1;
+  }
+  if (openFence) {
+    spans.push(openFence);
+  }
+  return spans;
+}
+
+function findFenceSpanAt(spans: LocalFenceSpan[], index: number): LocalFenceSpan | null {
+  for (const span of spans) {
+    if (index > span.start && index < span.end) {
+      return span;
+    }
+  }
+  return null;
+}
+
+function findTrailingOpenFence(spans: LocalFenceSpan[]): LocalFenceSpan | null {
+  const last = spans.at(-1);
+  if (!last || last.closed) {
+    return null;
+  }
+  return last;
+}
+
+function getFenceState(text: string): FenceState {
+  const spans = parseFenceSpans(text);
+  const trailingOpenFence = findTrailingOpenFence(spans);
+  return {
+    spans,
+    trailingOpenFence,
+    leadingOpenFence: trailingOpenFence?.start === 0 ? trailingOpenFence : null,
+  };
+}
+
+function renderChunkWithFence(text: string, openFence: OpenFence | null): string {
+  return closeFenceIfNeeded(text, openFence);
+}
+
+function getStandaloneChunkFence(text: string, fenceState: FenceState): LocalFenceSpan | null {
+  if (fenceState.leadingOpenFence) {
+    return fenceState.leadingOpenFence;
+  }
+  const trailing = fenceState.trailingOpenFence;
+  if (!trailing) {
+    return null;
+  }
+  if (trailing.hasInfoString || trailing.start === 0) {
+    return trailing;
+  }
+  const trailingBody = text.slice(trailing.start + trailing.openLine.length);
+  return trailingBody.length > 0 ? trailing : null;
+}
+
+function isSafeFenceBreak(spans: LocalFenceSpan[], index: number): boolean {
+  return findFenceSpanAt(spans, index) === null;
+}
+
+function findWhitespaceBreak(text: string, maxChars: number, spans: LocalFenceSpan[]): number {
+  for (let i = Math.min(maxChars - 1, text.length - 1); i >= 0; i--) {
+    const char = text[i];
+    if (!char || !/\s/.test(char)) {
+      continue;
+    }
+    if (!isSafeFenceBreak(spans, i)) {
+      continue;
+    }
+    return i + 1;
+  }
+  return -1;
+}
+
+function findPreferredBreak(text: string, maxChars: number, spans: LocalFenceSpan[]): number {
+  const paragraphIdx = text.lastIndexOf("\n\n", maxChars);
+  if (paragraphIdx > 0 && paragraphIdx + 2 <= maxChars && isSafeFenceBreak(spans, paragraphIdx)) {
+    return paragraphIdx + 2;
+  }
+
+  const newlineIdx = text.lastIndexOf("\n", maxChars);
+  if (newlineIdx > 0 && newlineIdx + 1 <= maxChars && isSafeFenceBreak(spans, newlineIdx)) {
+    return newlineIdx + 1;
+  }
+
+  const whitespaceIdx = findWhitespaceBreak(text, maxChars, spans);
+  if (whitespaceIdx > 0) {
+    return whitespaceIdx;
+  }
+
+  return Math.min(maxChars, text.length);
+}
+
+function isInsideFenceOpener(span: LocalFenceSpan, index: number): boolean {
+  return index <= span.start + span.openLine.length;
+}
+
+function reopenFenceTail(openFence: OpenFence, tail: string): string {
+  return `${openFence.openLine}${tail.startsWith("\n") ? "" : "\n"}${tail}`;
+}
+
+function renderedChunkExceedsLimit(text: string, maxChars: number, openFence: OpenFence | null) {
+  return text.length > maxChars || renderChunkWithFence(text, openFence).length > maxChars;
+}
+
+function resolveFenceAtBreak(
+  spans: LocalFenceSpan[],
+  breakIdx: number,
+  remainingLength: number,
+  chunkFence: LocalFenceSpan | null,
+) {
+  return findFenceSpanAt(spans, breakIdx) ?? (breakIdx === remainingLength ? chunkFence : null);
+}
+
+function chooseBreakForRemaining(remaining: string, maxChars: number, fenceState: FenceState) {
+  const chunkFence = getStandaloneChunkFence(remaining, fenceState);
+  let effectiveMaxChars = maxChars;
+  let breakIdx = findPreferredBreak(remaining, effectiveMaxChars, fenceState.spans);
+  let fenceAtBreak = resolveFenceAtBreak(fenceState.spans, breakIdx, remaining.length, chunkFence);
+
+  while (fenceAtBreak) {
+    const chunk = remaining.slice(0, breakIdx);
+    const closeLine = closeFenceLine(fenceAtBreak);
+    const reserveChars = closeLine.length + (chunk.endsWith("\n") ? 0 : 1);
+    if (breakIdx + reserveChars <= maxChars) {
+      break;
+    }
+    const nextEffectiveMaxChars = Math.max(1, maxChars - reserveChars);
+    if (nextEffectiveMaxChars >= effectiveMaxChars) {
+      break;
+    }
+    effectiveMaxChars = nextEffectiveMaxChars;
+    breakIdx = findPreferredBreak(remaining, effectiveMaxChars, fenceState.spans);
+    fenceAtBreak = resolveFenceAtBreak(fenceState.spans, breakIdx, remaining.length, chunkFence);
+  }
+
+  return { breakIdx, fenceAtBreak };
+}
+
+function splitRemainingChunk(
+  remaining: string,
+  breakIdx: number,
+  fenceAtBreak: LocalFenceSpan | null,
+  opts: { maxChars: number; trailingOpenFence: LocalFenceSpan | null },
+) {
+  let safeBreakIdx = Math.max(1, Math.min(breakIdx, remaining.length));
+  let carryFence =
+    fenceAtBreak && !isInsideFenceOpener(fenceAtBreak, safeBreakIdx) ? fenceAtBreak : null;
+  let tail = remaining.slice(safeBreakIdx);
+  let nextRemaining = tail;
+  if (carryFence) {
+    let reopened = reopenFenceTail(carryFence, tail);
+    if (
+      reopened.length >= remaining.length &&
+      safeBreakIdx < remaining.length &&
+      renderChunkWithFence(remaining.slice(0, safeBreakIdx + 1), carryFence).length <= opts.maxChars
+    ) {
+      safeBreakIdx += 1;
+      tail = remaining.slice(safeBreakIdx);
+      reopened = reopenFenceTail(carryFence, tail);
+    }
+    if (reopened.length < remaining.length) {
+      nextRemaining = reopened;
+    } else if (
+      opts.trailingOpenFence &&
+      renderChunkWithFence(remaining.slice(0, safeBreakIdx), carryFence).length <= opts.maxChars
+    ) {
+      nextRemaining = tail;
+    } else {
+      carryFence = null;
+    }
+  }
+  if (nextRemaining.length >= remaining.length) {
+    return { breakIdx: safeBreakIdx, carryFence: null, nextRemaining: tail };
+  }
+  return { breakIdx: safeBreakIdx, carryFence, nextRemaining };
+}
+
+export function chunkMarkdownWithBalancedFences(
+  text: string,
+  opts: MarkdownChunkOptions,
+): string[] {
+  const maxChars = Math.max(1, Math.floor(opts.maxChars));
+  const body = text ?? "";
+  if (!body) {
+    return [];
+  }
+
+  const bodyFenceState = getFenceState(body);
+  const renderedBody = renderChunkWithFence(body, getStandaloneChunkFence(body, bodyFenceState));
+  if (renderedBody.length <= maxChars) {
+    return [renderedBody];
+  }
+
+  const chunks: string[] = [];
+  let remaining = body;
+
+  while (true) {
+    const fenceState = getFenceState(remaining);
+    if (
+      !renderedChunkExceedsLimit(
+        remaining,
+        maxChars,
+        getStandaloneChunkFence(remaining, fenceState),
+      )
+    ) {
+      break;
+    }
+    const { breakIdx, fenceAtBreak } = chooseBreakForRemaining(remaining, maxChars, fenceState);
+    const { carryFence, nextRemaining } = splitRemainingChunk(remaining, breakIdx, fenceAtBreak, {
+      maxChars,
+      trailingOpenFence: fenceState.trailingOpenFence,
+    });
+    const chunk = remaining.slice(0, breakIdx);
+    if (chunk.length > 0) {
+      chunks.push(renderChunkWithFence(chunk, carryFence));
+    }
+    remaining = nextRemaining;
+  }
+
+  if (remaining.length) {
+    const fenceState = getFenceState(remaining);
+    chunks.push(renderChunkWithFence(remaining, getStandaloneChunkFence(remaining, fenceState)));
+  }
+
+  return chunks;
+}

--- a/src/plugin-sdk/reply-chunking.ts
+++ b/src/plugin-sdk/reply-chunking.ts
@@ -8,3 +8,4 @@ export {
 export type { ChunkMode } from "../auto-reply/chunk.js";
 export { isSilentReplyText } from "../auto-reply/tokens.js";
 export type { ReplyPayload } from "../auto-reply/types.js";
+export { chunkMarkdownWithBalancedFences } from "../markdown/chunk.js";

--- a/src/plugin-sdk/reply-runtime.ts
+++ b/src/plugin-sdk/reply-runtime.ts
@@ -10,6 +10,7 @@ export {
   resolveTextChunkLimit,
 } from "../auto-reply/chunk.js";
 export type { ChunkMode } from "../auto-reply/chunk.js";
+export { chunkMarkdownWithBalancedFences } from "../markdown/chunk.js";
 export {
   dispatchInboundMessage,
   dispatchInboundMessageWithBufferedDispatcher,

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -279,7 +279,11 @@ describe("plugin-sdk subpath exports", () => {
       "createResolvedApproverActionAuthAdapter",
       "resolveApprovalApprovers",
     ]);
-    expectSourceMentions("reply-chunking", ["chunkText", "chunkTextWithMode"]);
+    expectSourceMentions("reply-chunking", [
+      "chunkMarkdownWithBalancedFences",
+      "chunkText",
+      "chunkTextWithMode",
+    ]);
     expectSourceMentions("reply-history", [
       "buildPendingHistoryContextFromMap",
       "clearHistoryEntriesIfEnabled",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: On `origin/main`, Discord chunking applies a default `maxLines: 17`, so tall replies are split even when the full message is still under Discord's character limit.
- Why it matters: That default increases message count for long multi-paragraph replies, makes responses feel more fragmented, and forces the chunker down fence-handling paths more often than necessary.
- What changed: Discord chunking now defaults to character-first splitting when `maxLines` is omitted, only falls back to paragraph/newline/whitespace boundaries when a split is actually required, and keeps fenced-block handling progressing without exceeding `maxChars`.
- What did NOT change (scope boundary): This PR does not change non-Discord channels, and it does not change explicit `maxLines` or `chunkMode: "newline"` call sites beyond keeping them compatible with the updated chunker.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Discord replies now stay in a single message by default when they are under the character limit, even if they contain many lines or paragraphs.
- When Discord replies do need splitting, chunking still prefers paragraph/newline/whitespace boundaries before arbitrary cuts.
- Preferred delimiter breaks no longer produce chunks larger than `maxChars`, and malformed fenced blocks no longer trigger the length-based splitter to stall.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout, `pnpm test -- extensions/discord/src/chunk.test.ts`
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): default Discord chunking, plus explicit `maxChars` / `maxLines` cases in unit tests

### Steps

1. On `origin/main`, chunk a Discord reply with many paragraphs that is still under the character limit.
2. On this branch, chunk the same reply with default options.
3. Chunk text where `\n` or `\n\n` starts exactly at `maxChars`.
4. Chunk malformed fenced content that previously recreated the same carried prefix or left the final chunk unbalanced.
5. Run the Discord chunking test file.

### Expected

- On `origin/main`, tall under-limit replies split because of the default `maxLines: 17` rule.
- On this branch, under-limit replies stay in one message by default.
- When splitting is required, chunk boundaries prefer paragraph/newline/whitespace only when those breaks still satisfy `maxChars`.
- No chunk exceeds `maxChars`, fenced chunks keep making progress, and malformed unterminated fences are closed when possible.

### Actual

- Before this change, the default Discord path split tall under-limit replies because `maxLines` defaulted to `17`.
- While moving to a character-first default, the length-based splitter also exposed several fence edge cases, including non-progress loops, newline mutation on reopen, and malformed final chunks that were left unbalanced.
- After this change, default Discord chunking minimizes message count first and keeps the fence carry-over path within the expected limits.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: compared the old default behavior in `origin/main` against the new Discord-only implementation and ran `pnpm test -- extensions/discord/src/chunk.test.ts` after the fix.
- Edge cases checked: under-limit multi-paragraph replies; exact-limit newline and paragraph delimiters; oversized fenced blocks; malformed unterminated fences; no-progress fence carry-over; explicit `maxLines`; `chunkMode: "newline"`; reasoning italics rebalancing.
- What you did **not** verify: end-to-end live Discord delivery against the remote API.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or reset the branch to `origin/main`.
- Files/config to restore: `extensions/discord/src/chunk.ts`, `extensions/discord/src/chunk.test.ts`
- Known bad symptoms reviewers should watch for: Discord replies splitting into more chunks than expected, any chunk exceeding the configured character limit, or fenced content rendering incorrectly across chunk boundaries.

## Risks and Mitigations

- Risk: The new default changes exactly where Discord replies split when they exceed the character limit.
  - Mitigation: Added targeted regression coverage for under-limit default behavior, preferred break ordering, exact-boundary delimiter cases, malformed fence handling, and randomized progress/size invariants.
