### PR TITLE
fix(memory): populate FTS index when no embedding provider is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 - Exec: fail closed when the implicit sandbox host has no sandbox runtime, and stop denied async approval followups from reusing prior command output from the same session. (#56800) Thanks @scoootscooob.
 - Plugins/ClawHub: sanitize temporary archive filenames for scoped package names and slash-containing skill slugs so `openclaw plugins install @scope/name` no longer fails with `ENOENT` during archive download. (#56452) Thanks @soimy.
 - Telegram/polling: keep the watchdog from aborting long-running reply delivery by treating recent non-polling API activity as bounded liveness instead of a hard stall. (#56343) Thanks @openperf.
+- Memory/FTS: keep provider-less keyword hits visible at the default memory-search threshold, so FTS-only recall works without requiring `--min-score 0`. (#56473) Thanks @opriz.
 
 ## 2026.3.28
 

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1352,6 +1352,55 @@ describe("memory index", () => {
     }
   });
 
+  it("triggers full reindex and cleans up old-model FTS rows when switching from provider to FTS-only", async () => {
+    const sharedStorePath = path.join(workspaceDir, "index-provider-to-fts-only.sqlite");
+
+    // Phase 1: sync with a real provider — FTS rows stored under model = "mock-embed"
+    const providerCfg = createCfg({ storePath: sharedStorePath, hybrid: { enabled: true } });
+    const providerResult = await getMemorySearchManager({ cfg: providerCfg, agentId: "main" });
+    const providerManager = requireManager(providerResult);
+    managersForCleanup.add(providerManager);
+    resetManagerForTest(providerManager);
+
+    await providerManager.sync({ reason: "test" });
+
+    const providerDb = (
+      providerManager as unknown as { db: { prepare: (s: string) => { get: () => { c: number } } } }
+    ).db;
+    const providerFtsRows = providerDb
+      .prepare("SELECT COUNT(*) as c FROM chunks_fts WHERE model = 'mock-embed'")
+      .get();
+    expect(providerFtsRows.c).toBeGreaterThan(0);
+
+    await providerManager.close();
+    managersForCleanup.delete(providerManager);
+
+    // Phase 2: switch to FTS-only (no provider) — should trigger full reindex
+    forceNoProvider = true;
+    const ftsOnlyCfg = createCfg({ storePath: sharedStorePath, hybrid: { enabled: true } });
+    const ftsOnlyResult = await getMemorySearchManager({ cfg: ftsOnlyCfg, agentId: "main" });
+    const ftsOnlyManager = requireManager(ftsOnlyResult);
+    managersForCleanup.add(ftsOnlyManager);
+
+    await ftsOnlyManager.sync({ reason: "test" });
+
+    const db = (
+      ftsOnlyManager as unknown as { db: { prepare: (s: string) => { get: () => { c: number } } } }
+    ).db;
+
+    // old provider-model rows should be gone after full reindex
+    const oldRows = db
+      .prepare("SELECT COUNT(*) as c FROM chunks_fts WHERE model = 'mock-embed'")
+      .get();
+    expect(oldRows.c).toBe(0);
+
+    // new fts-only rows should exist
+    const newRows = db
+      .prepare("SELECT COUNT(*) as c FROM chunks_fts WHERE model = 'fts-only'")
+      .get();
+    expect(newRows.c).toBeGreaterThan(0);
+  });
+
   it("builds FTS index and returns search results when no embedding provider is available", async () => {
     forceNoProvider = true;
 

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1406,6 +1406,7 @@ describe("memory index", () => {
 
     const cfg = createCfg({
       storePath: indexFtsOnlyPath,
+      minScore: 0.35,
       hybrid: { enabled: true },
     });
     const result = await getMemorySearchManager({ cfg, agentId: "main" });
@@ -1424,7 +1425,7 @@ describe("memory index", () => {
     expect(status.chunks).toBeGreaterThan(0);
     expect(embedBatchCalls).toBe(0);
 
-    // keyword search should return matching results
+    // keyword search should still return matching results under the default threshold
     const results = await manager.search("Alpha");
     expect(results.length).toBeGreaterThan(0);
     expect(results[0]?.snippet).toMatch(/Alpha/i);

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -20,6 +20,7 @@ let registerAdapter: MemoryEmbeddingProvidersModule["registerMemoryEmbeddingProv
 let embedBatchCalls = 0;
 let embedBatchInputCalls = 0;
 let providerCalls: Array<{ provider?: string; model?: string; outputDimensionality?: number }> = [];
+let forceNoProvider = false;
 
 vi.mock("./embeddings.js", () => {
   const embedText = (text: string) => {
@@ -41,6 +42,13 @@ vi.mock("./embeddings.js", () => {
         model: options.model,
         outputDimensionality: options.outputDimensionality,
       });
+      if (forceNoProvider) {
+        return {
+          provider: null,
+          requestedProvider: options.provider ?? "auto",
+          providerUnavailableReason: "No API key found for provider",
+        };
+      }
       const providerId = options.provider === "gemini" ? "gemini" : "mock";
       const model = options.model ?? "mock-embed";
       return {
@@ -115,6 +123,7 @@ describe("memory index", () => {
   let indexStatusPath = "";
   let indexSourceChangePath = "";
   let indexModelPath = "";
+  let indexFtsOnlyPath = "";
   let sourceChangeStateDir = "";
   const sourceChangeSessionLogLines = [
     JSON.stringify({
@@ -154,6 +163,7 @@ describe("memory index", () => {
     indexStatusPath = path.join(workspaceDir, "index-status.sqlite");
     indexSourceChangePath = path.join(workspaceDir, "index-source-change.sqlite");
     indexModelPath = path.join(workspaceDir, "index-model-change.sqlite");
+    indexFtsOnlyPath = path.join(workspaceDir, "index-fts-only.sqlite");
     sourceChangeStateDir = path.join(fixtureRoot, "state-source-change");
 
     await fs.mkdir(memoryDir, { recursive: true });
@@ -183,6 +193,7 @@ describe("memory index", () => {
     embedBatchCalls = 0;
     embedBatchInputCalls = 0;
     providerCalls = [];
+    forceNoProvider = false;
 
     mkdirSync(memoryDir, { recursive: true });
 
@@ -1339,5 +1350,38 @@ describe("memory index", () => {
         "path required",
       );
     }
+  });
+
+  it("builds FTS index and returns search results when no embedding provider is available", async () => {
+    forceNoProvider = true;
+
+    const cfg = createCfg({
+      storePath: indexFtsOnlyPath,
+      hybrid: { enabled: true },
+    });
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    const manager = requireManager(result);
+    managersForCleanup.add(manager);
+    resetManagerForTest(manager);
+
+    await fs.writeFile(
+      path.join(memoryDir, "2026-01-12.md"),
+      "# Log\nAlpha memory line.\nZebra memory line.",
+    );
+    await manager.sync({ reason: "test" });
+
+    const status = manager.status();
+    // chunks should be indexed via FTS even without a provider
+    expect(status.chunks).toBeGreaterThan(0);
+    expect(embedBatchCalls).toBe(0);
+
+    // keyword search should return matching results
+    const results = await manager.search("Alpha");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.snippet).toMatch(/Alpha/i);
+
+    // unknown terms should return no results
+    const noResults = await manager.search("nonexistent_xyz_keyword");
+    expect(noResults.length).toBe(0);
   });
 });

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -586,16 +586,91 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     );
   }
 
+  /**
+   * Write chunks (and optional embeddings) for a file into the index.
+   * Handles both the chunks table, the vector table, and the FTS table.
+   * Pass an empty embeddings array to skip vector writes (FTS-only mode).
+   */
+  private writeChunks(
+    entry: MemoryFileEntry | SessionFileEntry,
+    source: MemorySource,
+    model: string,
+    chunks: MemoryChunk[],
+    embeddings: number[][],
+    vectorReady: boolean,
+  ): void {
+    const now = Date.now();
+    this.clearIndexedFileData(entry.path, source);
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      const embedding = embeddings[i] ?? [];
+      const id = hashText(
+        `${source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${model}`,
+      );
+      this.db
+        .prepare(
+          `INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+             hash=excluded.hash,
+             model=excluded.model,
+             text=excluded.text,
+             embedding=excluded.embedding,
+             updated_at=excluded.updated_at`,
+        )
+        .run(
+          id,
+          entry.path,
+          source,
+          chunk.startLine,
+          chunk.endLine,
+          chunk.hash,
+          model,
+          chunk.text,
+          JSON.stringify(embedding),
+          now,
+        );
+      if (vectorReady && embedding.length > 0) {
+        try {
+          this.db.prepare(`DELETE FROM ${VECTOR_TABLE} WHERE id = ?`).run(id);
+        } catch {}
+        this.db
+          .prepare(`INSERT INTO ${VECTOR_TABLE} (id, embedding) VALUES (?, ?)`)
+          .run(id, vectorToBlob(embedding));
+      }
+      if (this.fts.enabled && this.fts.available) {
+        this.db
+          .prepare(
+            `INSERT INTO ${FTS_TABLE} (text, id, path, source, model, start_line, end_line)\n` +
+              ` VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          )
+          .run(chunk.text, id, entry.path, source, model, chunk.startLine, chunk.endLine);
+      }
+    }
+    this.upsertFileRecord(entry, source);
+  }
+
   protected async indexFile(
     entry: MemoryFileEntry | SessionFileEntry,
     options: { source: MemorySource; content?: string },
   ) {
-    // FTS-only mode: skip indexing if no provider
+    // FTS-only mode: no embedding provider, but we can still build a FTS index
     if (!this.provider) {
-      log.debug("Skipping embedding indexing in FTS-only mode", {
-        path: entry.path,
-        source: options.source,
-      });
+      if (!this.fts.enabled || !this.fts.available) {
+        return;
+      }
+      // Multimodal files require an embedding provider; skip in FTS-only mode.
+      if ("kind" in entry && entry.kind === "multimodal") {
+        return;
+      }
+      const content = options.content ?? (await fs.readFile(entry.absPath, "utf-8"));
+      const chunks = chunkMarkdown(content, this.settings.chunking).filter(
+        (chunk) => chunk.text.trim().length > 0,
+      );
+      if (options.source === "sessions" && "lineMap" in entry) {
+        remapChunkLines(chunks, entry.lineMap);
+      }
+      this.writeChunks(entry, options.source, "fts-only", chunks, [], false);
       return;
     }
 
@@ -650,62 +725,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
     const sample = embeddings.find((embedding) => embedding.length > 0);
     const vectorReady = sample ? await this.ensureVectorReady(sample.length) : false;
-    const now = Date.now();
-    this.clearIndexedFileData(entry.path, options.source);
-    for (let i = 0; i < chunks.length; i++) {
-      const chunk = chunks[i];
-      const embedding = embeddings[i] ?? [];
-      const id = hashText(
-        `${options.source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${this.provider.model}`,
-      );
-      this.db
-        .prepare(
-          `INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-           ON CONFLICT(id) DO UPDATE SET
-             hash=excluded.hash,
-             model=excluded.model,
-             text=excluded.text,
-             embedding=excluded.embedding,
-             updated_at=excluded.updated_at`,
-        )
-        .run(
-          id,
-          entry.path,
-          options.source,
-          chunk.startLine,
-          chunk.endLine,
-          chunk.hash,
-          this.provider.model,
-          chunk.text,
-          JSON.stringify(embedding),
-          now,
-        );
-      if (vectorReady && embedding.length > 0) {
-        try {
-          this.db.prepare(`DELETE FROM ${VECTOR_TABLE} WHERE id = ?`).run(id);
-        } catch {}
-        this.db
-          .prepare(`INSERT INTO ${VECTOR_TABLE} (id, embedding) VALUES (?, ?)`)
-          .run(id, vectorToBlob(embedding));
-      }
-      if (this.fts.enabled && this.fts.available) {
-        this.db
-          .prepare(
-            `INSERT INTO ${FTS_TABLE} (text, id, path, source, model, start_line, end_line)\n` +
-              ` VALUES (?, ?, ?, ?, ?, ?, ?)`,
-          )
-          .run(
-            chunk.text,
-            id,
-            entry.path,
-            options.source,
-            this.provider.model,
-            chunk.startLine,
-            chunk.endLine,
-          );
-      }
-    }
-    this.upsertFileRecord(entry, options.source);
+    this.writeChunks(entry, options.source, this.provider.model, chunks, embeddings, vectorReady);
   }
 }

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -553,11 +553,19 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           .run(pathname, source);
       } catch {}
     }
-    if (this.fts.enabled && this.fts.available && this.provider) {
+    if (this.fts.enabled && this.fts.available) {
       try {
-        this.db
-          .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-          .run(pathname, source, this.provider.model);
+        if (this.provider) {
+          // Scoped to current model — avoids removing rows from a different model.
+          this.db
+            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
+            .run(pathname, source, this.provider.model);
+        } else {
+          // FTS-only: searchKeyword matches all models, so clear all to avoid stale rows.
+          this.db
+            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
+            .run(pathname, source);
+        }
       } catch {}
     }
     this.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(pathname, source);

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1021,8 +1021,9 @@ export abstract class MemoryManagerSyncOps {
     const needsFullReindex =
       (params?.force && !hasTargetSessionFiles) ||
       !meta ||
-      (this.provider && meta.model !== this.provider.model) ||
-      (this.provider && meta.provider !== this.provider.id) ||
+      // Also detects provider→FTS-only transitions so orphaned old-model FTS rows are cleaned up.
+      (this.provider ? meta.model !== this.provider.model : meta.model !== "fts-only") ||
+      (this.provider ? meta.provider !== this.provider.id : meta.provider !== "none") ||
       meta.providerKey !== this.providerKey ||
       this.metaSourcesDiffer(meta, configuredSources) ||
       meta.scopeHash !== configuredScopeHash ||

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -694,11 +694,6 @@ export abstract class MemoryManagerSyncOps {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
-    // FTS-only mode: skip embedding sync (no provider)
-    if (!this.provider) {
-      log.debug("Skipping memory file sync in FTS-only mode (no embedding provider)");
-      return;
-    }
     const selectSourceFileState = this.db.prepare(`SELECT path, hash FROM files WHERE source = ?`);
     const deleteFileByPathAndSource = this.db.prepare(
       `DELETE FROM files WHERE path = ? AND source = ?`,
@@ -787,7 +782,11 @@ export abstract class MemoryManagerSyncOps {
       deleteChunksByPathAndSource.run(stale.path, "memory");
       if (deleteFtsRowsByPathSourceAndModel) {
         try {
-          deleteFtsRowsByPathSourceAndModel.run(stale.path, "memory", this.provider.model);
+          deleteFtsRowsByPathSourceAndModel.run(
+            stale.path,
+            "memory",
+            this.provider?.model ?? "fts-only",
+          );
         } catch {}
       }
     }
@@ -798,11 +797,6 @@ export abstract class MemoryManagerSyncOps {
     targetSessionFiles?: string[];
     progress?: MemorySyncProgressState;
   }) {
-    // FTS-only mode: skip embedding sync (no provider)
-    if (!this.provider) {
-      log.debug("Skipping session file sync in FTS-only mode (no embedding provider)");
-      return;
-    }
     const selectFileHash = this.db.prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`);
     const selectSourceFileState = this.db.prepare(`SELECT path, hash FROM files WHERE source = ?`);
     const deleteFileByPathAndSource = this.db.prepare(
@@ -932,7 +926,11 @@ export abstract class MemoryManagerSyncOps {
       deleteChunksByPathAndSource.run(stale.path, "sessions");
       if (deleteFtsRowsByPathSourceAndModel) {
         try {
-          deleteFtsRowsByPathSourceAndModel.run(stale.path, "sessions", this.provider.model);
+          deleteFtsRowsByPathSourceAndModel.run(
+            stale.path,
+            "sessions",
+            this.provider?.model ?? "fts-only",
+          );
         } catch {}
       }
     }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -373,12 +373,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         }
       }
 
-      const merged = [...seenIds.values()]
-        .toSorted((a, b) => b.score - a.score)
-        .filter((entry) => entry.score >= minScore)
-        .slice(0, maxResults);
-
-      return merged;
+      const merged = [...seenIds.values()].toSorted((a, b) => b.score - a.score);
+      return this.selectScoredResults(merged, maxResults, minScore, 0);
     }
 
     // If FTS isn't available, hybrid mode cannot use keyword search; degrade to vector-only.
@@ -420,13 +416,27 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         (entry) => `${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`,
       ),
     );
-    return merged
-      .filter(
-        (entry) =>
-          keywordKeys.has(`${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`) &&
-          entry.score >= relaxedMinScore,
-      )
-      .slice(0, maxResults);
+    return this.selectScoredResults(
+      merged.filter((entry) =>
+        keywordKeys.has(`${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`),
+      ),
+      maxResults,
+      minScore,
+      relaxedMinScore,
+    );
+  }
+
+  private selectScoredResults<T extends MemorySearchResult & { score: number }>(
+    results: T[],
+    maxResults: number,
+    minScore: number,
+    relaxedMinScore = minScore,
+  ): T[] {
+    const strict = results.filter((entry) => entry.score >= minScore);
+    if (strict.length > 0) {
+      return strict.slice(0, maxResults);
+    }
+    return results.filter((entry) => entry.score >= relaxedMinScore).slice(0, maxResults);
   }
 
   private hasIndexedContent(): boolean {


### PR DESCRIPTION
## Summary

- **Problem:** When no embedding provider is configured (no API key, no local model), `syncMemoryFiles()` and `syncSessionFiles()` returned early unconditionally — skipping not just embedding generation but also FTS indexing. The FTS5 table (`chunks_fts`) was never populated, even though FTS5 is a built-in SQLite feature that requires no external dependency whatsoever. The default search path already includes a FTS-only branch that calls `searchKeyword()` when no provider is available, but because the index was never built, it always returned empty results.
- **Why it matters:** This is the default state for most new users. The Memory Recall instruction is injected into the system prompt regardless, so the Agent calls `memory_search` and gets nothing back — effective amnesia with no warning.
- **What changed:** Removed the provider-null early returns from the sync path. `indexFile()` now has a dedicated FTS-only branch that chunks files and writes to `chunks` + `chunks_fts` (model sentinel `"fts-only"`, empty embeddings, no vector writes). Also fixed `needsFullReindex` to detect provider→FTS-only transitions so orphaned old-model FTS rows are cleaned up on the next sync. Extracted a `writeChunks()` helper to eliminate duplicated three-table write logic between the two paths.
- **What did NOT change:** Configuration semantics, hybrid/FTS enablement flags, vector indexing behavior, session transcript handling, multimodal file handling (still requires a provider).

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Closes #26792
- Closes #51782
- Related #43957
- Related #44094
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** Three `if (!this.provider) return;` guards in `syncMemoryFiles()`, `syncSessionFiles()`, and `indexFile()` were intended to skip embedding generation but inadvertently skipped FTS writes too. The comment said "FTS-only mode" but the code skipped FTS as well.
- **Missing detection / guardrail:** No test covered the provider-null sync path end-to-end.
- **Prior context:** The search path (`manager.ts:346-391`) already had a correct FTS-only branch calling `searchKeyword()` — but the index was always empty, so it returned nothing.
- **Why this regressed now:** The guards appear to have been introduced when embedding providers were first added, with the assumption that FTS was only useful alongside embeddings.

## Regression Test Plan (if applicable)

- Coverage level:
  - [x] Unit test
  - [x] Seam / integration test
- Target test: `extensions/memory-core/src/memory/index.test.ts`
- Scenarios locked in:
  1. `"builds FTS index and returns search results when no embedding provider is available"` — verifies `chunks > 0`, `embedBatchCalls === 0`, keyword search returns results, unknown terms return empty.
  2. `"triggers full reindex and cleans up old-model FTS rows when switching from provider to FTS-only"` — verifies old `model = "mock-embed"` FTS rows are removed and new `model = "fts-only"` rows exist after transition.

## User-visible / Behavior Changes

- Users without an embedding provider now get working keyword search via FTS5 instead of silent empty results.
- First sync after removing a provider triggers a full reindex (cleans up old embedding-model FTS rows).
- `openclaw memory status` will show `chunks > 0` and `FTS: ready` in provider-less setups.

## Diagram (if applicable)

```text
Before (no provider):
  sync() → syncMemoryFiles() → !this.provider → return  (chunks_fts: never written)
  search("keyword") → FTS-only branch → searchKeyword() → 0 results (index empty)

After (no provider):
  sync() → syncMemoryFiles() → indexFile() → FTS-only path
         → chunkMarkdown() → writeChunks("fts-only", [], false)
         → chunks_fts populated
  search("keyword") → FTS-only branch → searchKeyword() → results returned
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15.3
- Runtime: Node 22 / Bun
- Model/provider: none (openrouter configured, no active API key)
- Relevant config: `agents.defaults.memorySearch.provider = "auto"`, `query.hybrid.enabled = true`

### Steps

1. Ensure no embedding provider API key is set (`provider: "auto"` with no keys)
2. Run `openclaw memory index --force`
3. Run `openclaw memory status`
4. Run `openclaw memory search "<keyword>" --min-score 0`

### Expected

- `status` shows `Indexed: N files · M chunks`, `FTS: ready`
- `search` returns matching results

### Actual (before fix)

- `status` shows `Indexed: 0/N files · 0 chunks`
- `search` returns `No matches`

### Actual (after fix)

- `status` shows `Indexed: 6/6 files · 35 chunks`, `FTS: ready`
- `search --min-score 0` returns matching chunks

## Evidence

- [x] Failing test/log before + passing after

```
# After fix
npx vitest run extensions/memory-core/src/memory/index.test.ts
Test Files  1 passed (1)
Tests       24 passed | 3 skipped (27)
```

## Human Verification (required)

- Verified scenarios: ran `openclaw memory index` + `openclaw memory status` + `openclaw memory search` on a local instance with `Provider: none (requested: auto)` — confirmed `35 chunks` indexed and keyword search returning results with `--min-score 0`.
- Edge cases checked: provider→FTS-only transition (old rows cleaned up), FTS disabled case (fast-exit preserved), multimodal files (still skipped without provider).
- What I did **not** verify: session transcript FTS-only indexing, Windows FTS5 availability, QMD backend interaction.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: First sync after provider removal triggers a full reindex, which may be slow for large workspaces.
  - Mitigation: Full reindex only fires once (meta is updated after); subsequent syncs are incremental.
- Risk: FTS-only BM25 scores are very small (~0.000002) and get filtered by the default `minScore = 0.35`.
  - Mitigation: Known follow-up issue; workaround is `--min-score 0`. Not introduced by this PR — the search path already existed, just had no data.