### PR TITLE
fix(acp): repair stale bindings after runtime exits

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -265,6 +265,7 @@ export async function spawnAndCollect(
   stdout: string;
   stderr: string;
   code: number | null;
+  signal: NodeJS.Signals | null;
   error: Error | null;
 }> {
   if (runtime?.signal?.aborted) {
@@ -272,6 +273,7 @@ export async function spawnAndCollect(
       stdout: "",
       stderr: "",
       code: null,
+      signal: null,
       error: createAbortError(),
     };
   }
@@ -316,6 +318,7 @@ export async function spawnAndCollect(
       stdout,
       stderr,
       code: exit.code,
+      signal: exit.signal,
       error: aborted ? createAbortError() : exit.error,
     };
   } finally {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -535,6 +535,31 @@ describe("AcpxRuntime", () => {
     expect(logs.find((entry) => entry.kind === "status")).toBeDefined();
   });
 
+  it("surfaces signal-only status exits as control command failures", async () => {
+    const previousSignal = process.env.MOCK_ACPX_STATUS_SIGNAL;
+    process.env.MOCK_ACPX_STATUS_SIGNAL = "SIGTERM";
+
+    try {
+      const { runtime } = await createMockRuntimeFixture();
+      const handle = await runtime.ensureSession({
+        sessionKey: "agent:codex:acp:controls-signal",
+        agent: "codex",
+        mode: "persistent",
+      });
+
+      await expect(runtime.getStatus({ handle })).rejects.toMatchObject({
+        code: "ACP_TURN_FAILED",
+        message: "acpx exited with signal SIGTERM",
+      });
+    } finally {
+      if (previousSignal === undefined) {
+        delete process.env.MOCK_ACPX_STATUS_SIGNAL;
+      } else {
+        process.env.MOCK_ACPX_STATUS_SIGNAL = previousSignal;
+      }
+    }
+  });
+
   it("routes ACPX commands through an MCP proxy agent when MCP servers are configured", async () => {
     process.env.MOCK_ACPX_CONFIG_SHOW_AGENTS = JSON.stringify({
       codex: {
@@ -666,6 +691,23 @@ describe("AcpxRuntime", () => {
     }
     await missingCommandRuntime.probeAvailability();
     expect(missingCommandRuntime.isHealthy()).toBe(false);
+  });
+
+  it("marks runtime unhealthy when the help check exits on a signal", async () => {
+    const previousSignal = process.env.MOCK_ACPX_HELP_SIGNAL;
+    process.env.MOCK_ACPX_HELP_SIGNAL = "SIGTERM";
+
+    try {
+      const { runtime } = await createMockRuntimeFixture();
+      await runtime.probeAvailability();
+      expect(runtime.isHealthy()).toBe(false);
+    } finally {
+      if (previousSignal === undefined) {
+        delete process.env.MOCK_ACPX_HELP_SIGNAL;
+      } else {
+        process.env.MOCK_ACPX_HELP_SIGNAL = previousSignal;
+      }
+    }
   });
 
   it("logs ACPX spawn resolution once per command policy", async () => {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -175,6 +175,42 @@ describe("AcpxRuntime", () => {
     expect(promptArgs).toContain("--approve-all");
   });
 
+  it("surfaces signal-only prompt exits as runtime errors", async () => {
+    const previousSignal = process.env.MOCK_ACPX_PROMPT_SIGNAL;
+    process.env.MOCK_ACPX_PROMPT_SIGNAL = "SIGTERM";
+
+    try {
+      const { runtime } = await createMockRuntimeFixture();
+      const handle = await runtime.ensureSession({
+        sessionKey: "agent:codex:acp:signal-exit",
+        agent: "codex",
+        mode: "persistent",
+      });
+
+      const events = [];
+      for await (const event of runtime.runTurn({
+        handle,
+        text: "signal-only-exit",
+        mode: "prompt",
+        requestId: "req-signal",
+      })) {
+        events.push(event);
+      }
+
+      expect(events).toContainEqual({
+        type: "error",
+        message: "acpx exited with signal SIGTERM",
+      });
+      expect(events.some((event) => event.type === "done")).toBe(false);
+    } finally {
+      if (previousSignal === undefined) {
+        delete process.env.MOCK_ACPX_PROMPT_SIGNAL;
+      } else {
+        process.env.MOCK_ACPX_PROMPT_SIGNAL = previousSignal;
+      }
+    }
+  });
+
   it("uses sessions new with --resume-session when resumeSessionId is provided", async () => {
     const { runtime, logPath } = await createMockRuntimeFixture();
     const resumeSessionId = "sid-resume-123";

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -641,7 +641,8 @@ export class AcpxRuntime implements AcpRuntime {
         throw new AcpRuntimeError("ACP_TURN_FAILED", exit.error.message, { cause: exit.error });
       }
 
-      if ((exit.code ?? 0) !== 0 && !sawError) {
+      const exitedWithFailure = exit.code !== null ? exit.code !== 0 : exit.signal !== null;
+      if (exitedWithFailure && !sawError) {
         yield {
           type: "error",
           message: formatAcpxExitMessage({

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -99,6 +99,15 @@ function formatAcpxExitMessage(params: {
   return `acpx exited with code ${params.exitCode ?? "unknown"}`;
 }
 
+function didAcpxProcessExitWithFailure(params: {
+  exitCode: number | null | undefined;
+  signal?: NodeJS.Signals | null;
+}): boolean {
+  return params.exitCode !== null && params.exitCode !== undefined
+    ? params.exitCode !== 0
+    : params.signal !== null && params.signal !== undefined;
+}
+
 function summarizeLogText(text: string, maxChars = 240): string {
   const normalized = text.trim().replace(/\s+/g, " ");
   if (!normalized) {
@@ -250,7 +259,13 @@ export class AcpxRuntime implements AcpRuntime {
 
     try {
       const result = await this.runHelpCheck();
-      if (result.error != null || (result.code ?? 0) !== 0) {
+      if (
+        result.error != null ||
+        didAcpxProcessExitWithFailure({
+          exitCode: result.code,
+          signal: result.signal,
+        })
+      ) {
         return {
           ok: false,
           failure: {
@@ -641,7 +656,10 @@ export class AcpxRuntime implements AcpRuntime {
         throw new AcpRuntimeError("ACP_TURN_FAILED", exit.error.message, { cause: exit.error });
       }
 
-      const exitedWithFailure = exit.code !== null ? exit.code !== 0 : exit.signal !== null;
+      const exitedWithFailure = didAcpxProcessExitWithFailure({
+        exitCode: exit.code,
+        signal: exit.signal,
+      });
       if (exitedWithFailure && !sawError) {
         yield {
           type: "error",
@@ -1008,7 +1026,12 @@ export class AcpxRuntime implements AcpRuntime {
       );
     }
 
-    if ((result.code ?? 0) !== 0) {
+    if (
+      didAcpxProcessExitWithFailure({
+        exitCode: result.code,
+        signal: result.signal,
+      })
+    ) {
       throw new AcpRuntimeError(
         params.fallbackCode,
         formatAcpxExitMessage({

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -80,6 +80,7 @@ function formatPermissionModeGuidance(): string {
 function formatAcpxExitMessage(params: {
   stderr: string;
   exitCode: number | null | undefined;
+  signal?: NodeJS.Signals | null;
 }): string {
   const stderr = params.stderr.trim();
   if (params.exitCode === ACPX_EXIT_CODE_PERMISSION_DENIED) {
@@ -89,7 +90,13 @@ function formatAcpxExitMessage(params: {
       formatPermissionModeGuidance(),
     ].join(" ");
   }
-  return stderr || `acpx exited with code ${params.exitCode ?? "unknown"}`;
+  if (stderr) {
+    return stderr;
+  }
+  if (params.signal) {
+    return `acpx exited with signal ${params.signal}`;
+  }
+  return `acpx exited with code ${params.exitCode ?? "unknown"}`;
 }
 
 function summarizeLogText(text: string, maxChars = 240): string {
@@ -640,6 +647,7 @@ export class AcpxRuntime implements AcpRuntime {
           message: formatAcpxExitMessage({
             stderr,
             exitCode: exit.code,
+            signal: exit.signal,
           }),
         };
         return;
@@ -1005,6 +1013,7 @@ export class AcpxRuntime implements AcpRuntime {
         formatAcpxExitMessage({
           stderr: result.stderr,
           exitCode: result.code,
+          signal: result.signal,
         }),
       );
     }

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -270,6 +270,10 @@ if (command === "prompt") {
     process.exit(5);
   }
 
+  if (process.env.MOCK_ACPX_PROMPT_SIGNAL) {
+    process.kill(process.pid, process.env.MOCK_ACPX_PROMPT_SIGNAL);
+  }
+
   if (stdinText.includes("split-spacing")) {
     emitUpdate(sessionFromOption, {
       sessionUpdate: "agent_message_chunk",

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -41,6 +41,9 @@ if (args.includes("--version")) {
 }
 
 if (args.includes("--help")) {
+  if (process.env.MOCK_ACPX_HELP_SIGNAL) {
+    process.kill(process.pid, process.env.MOCK_ACPX_HELP_SIGNAL);
+  }
   process.stdout.write("mock-acpx help\\n");
   process.exit(0);
 }
@@ -184,6 +187,9 @@ if (command === "set") {
 
 if (command === "status") {
   writeLog({ kind: "status", agent, args, sessionName: sessionFromOption });
+  if (process.env.MOCK_ACPX_STATUS_SIGNAL) {
+    process.kill(process.pid, process.env.MOCK_ACPX_STATUS_SIGNAL);
+  }
   const status = process.env.MOCK_ACPX_STATUS_STATUS || (sessionFromOption ? "alive" : "no-session");
   const summary = process.env.MOCK_ACPX_STATUS_SUMMARY || "";
   emitJson({

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1473,7 +1473,7 @@ export class AcpSessionManager {
   }
 
   private isRecoverableAcpxExitError(message: string): boolean {
-    return /^acpx exited with code \d+/i.test(message.trim());
+    return /^acpx exited with (code \d+|signal [a-z0-9]+)/i.test(message.trim());
   }
 
   private async evictIdleRuntimeHandles(params: { cfg: OpenClawConfig }): Promise<void> {

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1422,6 +1422,47 @@ describe("AcpSessionManager", () => {
     expect(states).not.toContain("error");
   });
 
+  it("retries once with a fresh runtime handle after an early acpx signal exit", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+    runtimeState.runTurn
+      .mockImplementationOnce(async function* () {
+        yield {
+          type: "error" as const,
+          message: "acpx exited with signal SIGTERM",
+        };
+      })
+      .mockImplementationOnce(async function* () {
+        yield { type: "done" as const };
+      });
+
+    const manager = new AcpSessionManager();
+    await expect(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
+    const states = extractStatesFromUpserts();
+    expect(states).toContain("running");
+    expect(states).toContain("idle");
+    expect(states).not.toContain("error");
+  });
+
   it("persists runtime mode changes through setSessionRuntimeMode", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -480,6 +480,32 @@ describe("tryDispatchAcpReply", () => {
     expect(bindingServiceMocks.unbind).not.toHaveBeenCalled();
   });
 
+  it("does not unbind stale bindings when ACP dispatch is disabled by policy", async () => {
+    managerMocks.resolveSession.mockReturnValue({
+      kind: "stale",
+      sessionKey,
+      error: new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP metadata is missing."),
+    });
+    policyMocks.resolveAcpDispatchPolicyError.mockReturnValue(
+      new AcpRuntimeError("ACP_DISPATCH_DISABLED", "ACP dispatch is disabled by policy."),
+    );
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "test",
+      dispatcher,
+    });
+
+    expect(managerMocks.runTurn).not.toHaveBeenCalled();
+    expect(bindingServiceMocks.unbind).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isError: true,
+        text: expect.stringContaining("ACP dispatch is disabled by policy."),
+      }),
+    );
+  });
+
   it("unbinds stale bound conversations before surfacing stale ACP resolution errors", async () => {
     managerMocks.resolveSession.mockReturnValue({
       kind: "stale",

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -628,6 +628,80 @@ describe("tryDispatchAcpReply", () => {
     );
   });
 
+  it("uses canonical session keys for bound-session identity notices", async () => {
+    const aliasSessionKey = "main";
+    const canonicalSessionKey = "agent:main:main";
+    managerMocks.resolveSession.mockReturnValue({
+      kind: "ready",
+      sessionKey: canonicalSessionKey,
+      meta: createAcpSessionMeta({
+        identity: {
+          state: "pending",
+          source: "ensure",
+          lastUpdatedAt: Date.now(),
+          acpxRecordId: "rec-main",
+        },
+      }),
+    });
+    bindingServiceMocks.listBySession.mockImplementation((targetSessionKey: string) =>
+      targetSessionKey === canonicalSessionKey
+        ? [
+            {
+              bindingId: "discord:default:thread-1",
+              targetSessionKey: canonicalSessionKey,
+              targetKind: "session",
+              conversation: {
+                channel: "discord",
+                accountId: "default",
+                conversationId: "thread-1",
+              },
+              status: "active",
+              boundAt: 0,
+            },
+          ]
+        : [],
+    );
+    sessionMetaMocks.readAcpSessionEntry.mockImplementation(
+      (params: { sessionKey: string; cfg?: OpenClawConfig }) =>
+        params.sessionKey === canonicalSessionKey
+          ? {
+              cfg: params.cfg ?? createAcpTestConfig(),
+              storePath: "/tmp/openclaw-session-store.json",
+              sessionKey: canonicalSessionKey,
+              storeSessionKey: canonicalSessionKey,
+              acp: createAcpSessionMeta({
+                identity: {
+                  state: "resolved",
+                  source: "status",
+                  lastUpdatedAt: Date.now(),
+                  acpxSessionId: "acpx-main",
+                },
+              }),
+            }
+          : null,
+    );
+    managerMocks.runTurn.mockResolvedValue(undefined);
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "test",
+      dispatcher,
+      sessionKeyOverride: aliasSessionKey,
+    });
+
+    expect(bindingServiceMocks.listBySession).toHaveBeenCalledWith(canonicalSessionKey);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("Session ids resolved."),
+      }),
+    );
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("acpx session id: acpx-main"),
+      }),
+    );
+  });
+
   it("does not deliver final fallback text when routed block text was already visible", async () => {
     setReadyAcpResolution();
     ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -107,18 +107,20 @@ async function runDispatch(params: {
   shouldRouteToOriginating?: boolean;
   onReplyStart?: () => void;
   ctxOverrides?: Record<string, unknown>;
+  sessionKeyOverride?: string;
 }) {
+  const targetSessionKey = params.sessionKeyOverride ?? sessionKey;
   return tryDispatchAcpReply({
     ctx: buildTestCtx({
       Provider: "discord",
       Surface: "discord",
-      SessionKey: sessionKey,
+      SessionKey: targetSessionKey,
       BodyForAgent: params.bodyForAgent,
       ...params.ctxOverrides,
     }),
     cfg: params.cfg ?? createAcpTestConfig(),
     dispatcher: params.dispatcher ?? createDispatcher().dispatcher,
-    sessionKey,
+    sessionKey: targetSessionKey,
     inboundAudio: false,
     shouldRouteToOriginating: params.shouldRouteToOriginating ?? false,
     ...(params.shouldRouteToOriginating
@@ -507,15 +509,17 @@ describe("tryDispatchAcpReply", () => {
   });
 
   it("unbinds stale bound conversations before surfacing stale ACP resolution errors", async () => {
+    const aliasSessionKey = "main";
+    const canonicalSessionKey = "agent:main:main";
     managerMocks.resolveSession.mockReturnValue({
       kind: "stale",
-      sessionKey,
+      sessionKey: canonicalSessionKey,
       error: new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP metadata is missing."),
     });
     bindingServiceMocks.unbind.mockResolvedValueOnce([
       {
         bindingId: "discord:default:thread-1",
-        targetSessionKey: sessionKey,
+        targetSessionKey: canonicalSessionKey,
         targetKind: "session",
         conversation: {
           channel: "discord",
@@ -531,12 +535,13 @@ describe("tryDispatchAcpReply", () => {
     await runDispatch({
       bodyForAgent: "test",
       dispatcher,
+      sessionKeyOverride: aliasSessionKey,
     });
 
     expect(managerMocks.runTurn).not.toHaveBeenCalled();
     expect(bindingServiceMocks.unbind).toHaveBeenCalledTimes(1);
     expect(bindingServiceMocks.unbind).toHaveBeenCalledWith({
-      targetSessionKey: sessionKey,
+      targetSessionKey: canonicalSessionKey,
       reason: "acp-session-init-failed",
     });
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
@@ -574,18 +579,24 @@ describe("tryDispatchAcpReply", () => {
   });
 
   it("unbinds stale bindings on ACP runTurn missing-metadata failures", async () => {
-    setReadyAcpResolution();
+    const aliasSessionKey = "main";
+    const canonicalSessionKey = "agent:main:main";
+    managerMocks.resolveSession.mockReturnValue({
+      kind: "ready",
+      sessionKey: canonicalSessionKey,
+      meta: createAcpSessionMeta(),
+    });
     const { AcpRuntimeError: FreshAcpRuntimeError } = await import("../../acp/runtime/errors.js");
     managerMocks.runTurn.mockRejectedValueOnce(
       new FreshAcpRuntimeError(
         "ACP_SESSION_INIT_FAILED",
-        `ACP metadata is missing for ${sessionKey}. Recreate this ACP session with /acp spawn and rebind the thread.`,
+        `ACP metadata is missing for ${canonicalSessionKey}. Recreate this ACP session with /acp spawn and rebind the thread.`,
       ),
     );
     bindingServiceMocks.unbind.mockResolvedValueOnce([
       {
         bindingId: "discord:default:thread-1",
-        targetSessionKey: sessionKey,
+        targetSessionKey: canonicalSessionKey,
         targetKind: "session",
         conversation: {
           channel: "discord",
@@ -601,11 +612,12 @@ describe("tryDispatchAcpReply", () => {
     await runDispatch({
       bodyForAgent: "test",
       dispatcher,
+      sessionKeyOverride: aliasSessionKey,
     });
 
     expect(bindingServiceMocks.unbind).toHaveBeenCalledTimes(1);
     expect(bindingServiceMocks.unbind).toHaveBeenCalledWith({
-      targetSessionKey: sessionKey,
+      targetSessionKey: canonicalSessionKey,
       reason: "acp-session-init-failed",
     });
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -508,6 +508,7 @@ describe("tryDispatchAcpReply", () => {
     });
 
     expect(managerMocks.runTurn).not.toHaveBeenCalled();
+    expect(bindingServiceMocks.unbind).toHaveBeenCalledTimes(1);
     expect(bindingServiceMocks.unbind).toHaveBeenCalledWith({
       targetSessionKey: sessionKey,
       reason: "acp-session-init-failed",
@@ -520,7 +521,7 @@ describe("tryDispatchAcpReply", () => {
     );
   });
 
-  it("unbinds stale bindings on ACP runTurn init failure", async () => {
+  it("does not unbind valid bindings on generic ACP runTurn init failure", async () => {
     setReadyAcpResolution();
     // Match the post-reset module instance so dispatch-acp preserves the ACP error code.
     const { AcpRuntimeError: FreshAcpRuntimeError } = await import("../../acp/runtime/errors.js");
@@ -528,6 +529,31 @@ describe("tryDispatchAcpReply", () => {
       new FreshAcpRuntimeError(
         "ACP_SESSION_INIT_FAILED",
         "Could not initialize ACP session runtime.",
+      ),
+    );
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "test",
+      dispatcher,
+    });
+
+    expect(bindingServiceMocks.unbind).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isError: true,
+        text: expect.stringContaining("Could not initialize ACP session runtime."),
+      }),
+    );
+  });
+
+  it("unbinds stale bindings on ACP runTurn missing-metadata failures", async () => {
+    setReadyAcpResolution();
+    const { AcpRuntimeError: FreshAcpRuntimeError } = await import("../../acp/runtime/errors.js");
+    managerMocks.runTurn.mockRejectedValueOnce(
+      new FreshAcpRuntimeError(
+        "ACP_SESSION_INIT_FAILED",
+        `ACP metadata is missing for ${sessionKey}. Recreate this ACP session with /acp spawn and rebind the thread.`,
       ),
     );
     bindingServiceMocks.unbind.mockResolvedValueOnce([
@@ -551,6 +577,7 @@ describe("tryDispatchAcpReply", () => {
       dispatcher,
     });
 
+    expect(bindingServiceMocks.unbind).toHaveBeenCalledTimes(1);
     expect(bindingServiceMocks.unbind).toHaveBeenCalledWith({
       targetSessionKey: sessionKey,
       reason: "acp-session-init-failed",
@@ -558,7 +585,7 @@ describe("tryDispatchAcpReply", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
       expect.objectContaining({
         isError: true,
-        text: expect.stringContaining("Could not initialize ACP session runtime."),
+        text: expect.stringContaining("ACP metadata is missing"),
       }),
     );
   });

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -42,6 +42,10 @@ const ttsMocks = vi.hoisted(() => ({
   resolveTtsConfig: vi.fn((_cfg: OpenClawConfig) => ({ mode: "final" })),
 }));
 
+const mediaUnderstandingMocks = vi.hoisted(() => ({
+  applyMediaUnderstanding: vi.fn(async (_params: unknown) => undefined),
+}));
+
 const sessionMetaMocks = vi.hoisted(() => ({
   readAcpSessionEntry: vi.fn<
     (params: { sessionKey: string; cfg?: OpenClawConfig }) => AcpSessionStoreEntry | null
@@ -50,6 +54,7 @@ const sessionMetaMocks = vi.hoisted(() => ({
 
 const bindingServiceMocks = vi.hoisted(() => ({
   listBySession: vi.fn<(sessionKey: string) => SessionBindingRecord[]>(() => []),
+  unbind: vi.fn<(input: unknown) => Promise<SessionBindingRecord[]>>(async () => []),
 }));
 
 const sessionKey = "agent:codex-acp:session-1";
@@ -232,6 +237,10 @@ describe("tryDispatchAcpReply", () => {
       maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
       resolveTtsConfig: (cfg: OpenClawConfig) => ttsMocks.resolveTtsConfig(cfg),
     }));
+    vi.doMock("../../media-understanding/apply.js", () => ({
+      applyMediaUnderstanding: (params: unknown) =>
+        mediaUnderstandingMocks.applyMediaUnderstanding(params),
+    }));
     vi.doMock("../../acp/runtime/session-meta.js", () => ({
       readAcpSessionEntry: (params: { sessionKey: string; cfg?: OpenClawConfig }) =>
         sessionMetaMocks.readAcpSessionEntry(params),
@@ -240,6 +249,7 @@ describe("tryDispatchAcpReply", () => {
       getSessionBindingService: () => ({
         listBySession: (targetSessionKey: string) =>
           bindingServiceMocks.listBySession(targetSessionKey),
+        unbind: (input: unknown) => bindingServiceMocks.unbind(input),
       }),
     }));
     ({ tryDispatchAcpReply } = await import("./dispatch-acp.js"));
@@ -261,10 +271,14 @@ describe("tryDispatchAcpReply", () => {
     ttsMocks.maybeApplyTtsToPayload.mockClear();
     ttsMocks.resolveTtsConfig.mockReset();
     ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
+    mediaUnderstandingMocks.applyMediaUnderstanding.mockReset();
+    mediaUnderstandingMocks.applyMediaUnderstanding.mockResolvedValue(undefined);
     sessionMetaMocks.readAcpSessionEntry.mockReset();
     sessionMetaMocks.readAcpSessionEntry.mockReturnValue(null);
     bindingServiceMocks.listBySession.mockReset();
     bindingServiceMocks.listBySession.mockReturnValue([]);
+    bindingServiceMocks.unbind.mockReset();
+    bindingServiceMocks.unbind.mockResolvedValue([]);
   });
 
   it("routes ACP block output to originating channel", async () => {
@@ -461,6 +475,90 @@ describe("tryDispatchAcpReply", () => {
       expect.objectContaining({
         isError: true,
         text: expect.stringContaining("ACP dispatch is disabled by policy."),
+      }),
+    );
+    expect(bindingServiceMocks.unbind).not.toHaveBeenCalled();
+  });
+
+  it("unbinds stale bound conversations before surfacing stale ACP resolution errors", async () => {
+    managerMocks.resolveSession.mockReturnValue({
+      kind: "stale",
+      sessionKey,
+      error: new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP metadata is missing."),
+    });
+    bindingServiceMocks.unbind.mockResolvedValueOnce([
+      {
+        bindingId: "discord:default:thread-1",
+        targetSessionKey: sessionKey,
+        targetKind: "session",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "thread-1",
+        },
+        status: "active",
+        boundAt: 0,
+      },
+    ]);
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "test",
+      dispatcher,
+    });
+
+    expect(managerMocks.runTurn).not.toHaveBeenCalled();
+    expect(bindingServiceMocks.unbind).toHaveBeenCalledWith({
+      targetSessionKey: sessionKey,
+      reason: "acp-session-init-failed",
+    });
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isError: true,
+        text: expect.stringContaining("ACP metadata is missing."),
+      }),
+    );
+  });
+
+  it("unbinds stale bindings on ACP runTurn init failure", async () => {
+    setReadyAcpResolution();
+    // Match the post-reset module instance so dispatch-acp preserves the ACP error code.
+    const { AcpRuntimeError: FreshAcpRuntimeError } = await import("../../acp/runtime/errors.js");
+    managerMocks.runTurn.mockRejectedValueOnce(
+      new FreshAcpRuntimeError(
+        "ACP_SESSION_INIT_FAILED",
+        "Could not initialize ACP session runtime.",
+      ),
+    );
+    bindingServiceMocks.unbind.mockResolvedValueOnce([
+      {
+        bindingId: "discord:default:thread-1",
+        targetSessionKey: sessionKey,
+        targetKind: "session",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "thread-1",
+        },
+        status: "active",
+        boundAt: 0,
+      },
+    ]);
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "test",
+      dispatcher,
+    });
+
+    expect(bindingServiceMocks.unbind).toHaveBeenCalledWith({
+      targetSessionKey: sessionKey,
+      reason: "acp-session-init-failed",
+    });
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isError: true,
+        text: expect.stringContaining("Could not initialize ACP session runtime."),
       }),
     );
   });

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -199,7 +199,7 @@ function isStaleSessionInitError(params: { code: string; message: string }): boo
 }
 
 async function maybeUnbindStaleBoundConversations(params: {
-  sessionKey: string;
+  targetSessionKey: string;
   error: { code: string; message: string };
 }): Promise<void> {
   if (!isStaleSessionInitError(params.error)) {
@@ -207,17 +207,17 @@ async function maybeUnbindStaleBoundConversations(params: {
   }
   try {
     const removed = await getSessionBindingService().unbind({
-      targetSessionKey: params.sessionKey,
+      targetSessionKey: params.targetSessionKey,
       reason: ACP_STALE_BINDING_UNBIND_REASON,
     });
     if (removed.length > 0) {
       logVerbose(
-        `dispatch-acp: removed ${removed.length} stale bound conversation(s) for ${params.sessionKey} after ${params.error.code}: ${params.error.message}`,
+        `dispatch-acp: removed ${removed.length} stale bound conversation(s) for ${params.targetSessionKey} after ${params.error.code}: ${params.error.message}`,
       );
     }
   } catch (error) {
     logVerbose(
-      `dispatch-acp: failed to unbind stale bound conversations for ${params.sessionKey}: ${error instanceof Error ? error.message : String(error)}`,
+      `dispatch-acp: failed to unbind stale bound conversations for ${params.targetSessionKey}: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 }
@@ -335,6 +335,7 @@ export async function tryDispatchAcpReply(params: {
   if (acpResolution.kind === "none") {
     return null;
   }
+  const canonicalSessionKey = acpResolution.sessionKey;
 
   let queuedFinal = false;
   const delivery = createAcpDispatchDeliveryCoordinator({
@@ -386,7 +387,7 @@ export async function tryDispatchAcpReply(params: {
     }
     if (acpResolution.kind === "stale") {
       await maybeUnbindStaleBoundConversations({
-        sessionKey,
+        targetSessionKey: canonicalSessionKey,
         error: acpResolution.error,
       });
       const delivered = await delivery.deliver("final", {
@@ -480,7 +481,7 @@ export async function tryDispatchAcpReply(params: {
       fallbackMessage: "ACP turn failed before completion.",
     });
     await maybeUnbindStaleBoundConversations({
-      sessionKey,
+      targetSessionKey: canonicalSessionKey,
       error: acpError,
     });
     const delivered = await delivery.deliver("final", {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -379,31 +379,31 @@ export async function tryDispatchAcpReply(params: {
   });
 
   const acpDispatchStartedAt = Date.now();
-  if (acpResolution.kind === "stale") {
-    await maybeUnbindStaleBoundConversations({
-      sessionKey,
-      error: acpResolution.error,
-    });
-    const delivered = await delivery.deliver("final", {
-      text: formatAcpRuntimeErrorText(acpResolution.error),
-      isError: true,
-    });
-    const counts = params.dispatcher.getQueuedCounts();
-    delivery.applyRoutedCounts(counts);
-    const acpStats = acpManager.getObservabilitySnapshot(params.cfg);
-    logVerbose(
-      `acp-dispatch: session=${sessionKey} outcome=error code=${acpResolution.error.code} latencyMs=${Date.now() - acpDispatchStartedAt} queueDepth=${acpStats.turns.queueDepth} activeRuntimes=${acpStats.runtimeCache.activeSessions}`,
-    );
-    params.recordProcessed("completed", {
-      reason: `acp_error:${acpResolution.error.code.toLowerCase()}`,
-    });
-    params.markIdle("message_completed");
-    return { queuedFinal: delivered, counts };
-  }
   try {
     const dispatchPolicyError = resolveAcpDispatchPolicyError(params.cfg);
     if (dispatchPolicyError) {
       throw dispatchPolicyError;
+    }
+    if (acpResolution.kind === "stale") {
+      await maybeUnbindStaleBoundConversations({
+        sessionKey,
+        error: acpResolution.error,
+      });
+      const delivered = await delivery.deliver("final", {
+        text: formatAcpRuntimeErrorText(acpResolution.error),
+        isError: true,
+      });
+      const counts = params.dispatcher.getQueuedCounts();
+      delivery.applyRoutedCounts(counts);
+      const acpStats = acpManager.getObservabilitySnapshot(params.cfg);
+      logVerbose(
+        `acp-dispatch: session=${sessionKey} outcome=error code=${acpResolution.error.code} latencyMs=${Date.now() - acpDispatchStartedAt} queueDepth=${acpStats.turns.queueDepth} activeRuntimes=${acpStats.runtimeCache.activeSessions}`,
+      );
+      params.recordProcessed("completed", {
+        reason: `acp_error:${acpResolution.error.code.toLowerCase()}`,
+      });
+      params.markIdle("message_completed");
+      return { queuedFinal: delivered, counts };
     }
     const agentPolicyError = resolveAcpAgentPolicyError(params.cfg, resolvedAcpAgent);
     if (agentPolicyError) {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -358,7 +358,7 @@ export async function tryDispatchAcpReply(params: {
     identityPendingBeforeTurn &&
     (Boolean(params.ctx.MessageThreadId != null && String(params.ctx.MessageThreadId).trim()) ||
       hasBoundConversationForSession({
-        sessionKey,
+        sessionKey: canonicalSessionKey,
         channelRaw: params.ctx.OriginatingChannel ?? params.ctx.Surface ?? params.ctx.Provider,
         accountIdRaw: params.ctx.AccountId,
       }));
@@ -368,9 +368,9 @@ export async function tryDispatchAcpReply(params: {
       ? (
           acpResolution.meta.agent?.trim() ||
           params.cfg.acp?.defaultAgent?.trim() ||
-          resolveAgentIdFromSessionKey(sessionKey)
+          resolveAgentIdFromSessionKey(canonicalSessionKey)
         ).trim()
-      : resolveAgentIdFromSessionKey(sessionKey);
+      : resolveAgentIdFromSessionKey(canonicalSessionKey);
   const projector = createAcpReplyProjector({
     cfg: params.cfg,
     shouldSendToolSummaries: params.shouldSendToolSummaries,
@@ -443,7 +443,7 @@ export async function tryDispatchAcpReply(params: {
 
     await acpManager.runTurn({
       cfg: params.cfg,
-      sessionKey,
+      sessionKey: canonicalSessionKey,
       text: promptText,
       attachments: attachments.length > 0 ? attachments : undefined,
       mode: "prompt",
@@ -456,7 +456,7 @@ export async function tryDispatchAcpReply(params: {
     queuedFinal =
       (await finalizeAcpTurnOutput({
         cfg: params.cfg,
-        sessionKey,
+        sessionKey: canonicalSessionKey,
         delivery,
         inboundAudio: params.inboundAudio,
         sessionTtsAuto: params.sessionTtsAuto,

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -189,11 +189,20 @@ export type AcpDispatchAttemptResult = {
 
 const ACP_STALE_BINDING_UNBIND_REASON = "acp-session-init-failed";
 
+function isStaleSessionInitError(params: { code: string; message: string }): boolean {
+  if (params.code !== "ACP_SESSION_INIT_FAILED") {
+    return false;
+  }
+  return /(ACP (session )?metadata is missing|missing ACP metadata|Session is not ACP-enabled|Resource not found)/i.test(
+    params.message,
+  );
+}
+
 async function maybeUnbindStaleBoundConversations(params: {
   sessionKey: string;
   error: { code: string; message: string };
 }): Promise<void> {
-  if (params.error.code !== "ACP_SESSION_INIT_FAILED") {
+  if (!isStaleSessionInitError(params.error)) {
     return;
   }
   try {
@@ -370,17 +379,31 @@ export async function tryDispatchAcpReply(params: {
   });
 
   const acpDispatchStartedAt = Date.now();
+  if (acpResolution.kind === "stale") {
+    await maybeUnbindStaleBoundConversations({
+      sessionKey,
+      error: acpResolution.error,
+    });
+    const delivered = await delivery.deliver("final", {
+      text: formatAcpRuntimeErrorText(acpResolution.error),
+      isError: true,
+    });
+    const counts = params.dispatcher.getQueuedCounts();
+    delivery.applyRoutedCounts(counts);
+    const acpStats = acpManager.getObservabilitySnapshot(params.cfg);
+    logVerbose(
+      `acp-dispatch: session=${sessionKey} outcome=error code=${acpResolution.error.code} latencyMs=${Date.now() - acpDispatchStartedAt} queueDepth=${acpStats.turns.queueDepth} activeRuntimes=${acpStats.runtimeCache.activeSessions}`,
+    );
+    params.recordProcessed("completed", {
+      reason: `acp_error:${acpResolution.error.code.toLowerCase()}`,
+    });
+    params.markIdle("message_completed");
+    return { queuedFinal: delivered, counts };
+  }
   try {
     const dispatchPolicyError = resolveAcpDispatchPolicyError(params.cfg);
     if (dispatchPolicyError) {
       throw dispatchPolicyError;
-    }
-    if (acpResolution.kind === "stale") {
-      await maybeUnbindStaleBoundConversations({
-        sessionKey,
-        error: acpResolution.error,
-      });
-      throw acpResolution.error;
     }
     const agentPolicyError = resolveAcpAgentPolicyError(params.cfg, resolvedAcpAgent);
     if (agentPolicyError) {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -187,6 +187,32 @@ export type AcpDispatchAttemptResult = {
   counts: Record<ReplyDispatchKind, number>;
 };
 
+const ACP_STALE_BINDING_UNBIND_REASON = "acp-session-init-failed";
+
+async function maybeUnbindStaleBoundConversations(params: {
+  sessionKey: string;
+  error: { code: string; message: string };
+}): Promise<void> {
+  if (params.error.code !== "ACP_SESSION_INIT_FAILED") {
+    return;
+  }
+  try {
+    const removed = await getSessionBindingService().unbind({
+      targetSessionKey: params.sessionKey,
+      reason: ACP_STALE_BINDING_UNBIND_REASON,
+    });
+    if (removed.length > 0) {
+      logVerbose(
+        `dispatch-acp: removed ${removed.length} stale bound conversation(s) for ${params.sessionKey} after ${params.error.code}: ${params.error.message}`,
+      );
+    }
+  } catch (error) {
+    logVerbose(
+      `dispatch-acp: failed to unbind stale bound conversations for ${params.sessionKey}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
 async function finalizeAcpTurnOutput(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -350,6 +376,10 @@ export async function tryDispatchAcpReply(params: {
       throw dispatchPolicyError;
     }
     if (acpResolution.kind === "stale") {
+      await maybeUnbindStaleBoundConversations({
+        sessionKey,
+        error: acpResolution.error,
+      });
       throw acpResolution.error;
     }
     const agentPolicyError = resolveAcpAgentPolicyError(params.cfg, resolvedAcpAgent);
@@ -425,6 +455,10 @@ export async function tryDispatchAcpReply(params: {
       error: err,
       fallbackCode: "ACP_TURN_FAILED",
       fallbackMessage: "ACP turn failed before completion.",
+    });
+    await maybeUnbindStaleBoundConversations({
+      sessionKey,
+      error: acpError,
     });
     const delivered = await delivery.deliver("final", {
       text: formatAcpRuntimeErrorText(acpError),


### PR DESCRIPTION
## Summary
- preserve ACPX signal exits so SIGTERM-triggered runtime failures are recognized as recoverable and retried with a fresh handle
- unbind stale bound conversations when ACP session initialization fails before surfacing the final error reply
- isolate dispatch ACP unit tests from media-understanding runtime so the stale-binding regressions are exercised deterministically

## Testing
- PATH=/Users/termtek/.nvm/versions/node/v22.18.0/bin:$PATH corepack pnpm test -- src/auto-reply/reply/dispatch-acp.test.ts
- PATH=/Users/termtek/.nvm/versions/node/v22.18.0/bin:$PATH corepack pnpm test -- src/acp/control-plane/manager.test.ts -t 'retries once with a fresh runtime handle after an early acpx (exit|signal exit)'\n- PATH=/Users/termtek/.nvm/versions/node/v22.18.0/bin:$PATH corepack pnpm tsgo --noEmit  # fails on latest main baseline: src/agents/bedrock-discovery.test.ts(222,13)\n