### PR TITLE
fix(media): add Content-Disposition for active content types and Cache-Control

### DIFF
--- a/src/media/server.test.ts
+++ b/src/media/server.test.ts
@@ -202,4 +202,50 @@ describe("media server", () => {
   ] as const)("%#", async (testCase) => {
     await expectFetchedMediaCase(testCase);
   });
+
+  describe("content-disposition hardening", () => {
+    it("forces download for HTML files", async () => {
+      await writeMediaFile("page.html", "<script>alert(1)</script>");
+      const res = await realFetch(mediaUrl("page.html"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-disposition")).toMatch(/^attachment/);
+    });
+
+    it("forces download for SVG files", async () => {
+      await writeMediaFile(
+        "icon.svg",
+        '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+      );
+      const res = await realFetch(mediaUrl("icon.svg"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-disposition")).toMatch(/^attachment/);
+    });
+
+    it("does not force download for JPEG images", async () => {
+      // Minimal JFIF header so file-type detects image/jpeg
+      const jpegHeader = Buffer.from([
+        0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00,
+        0x01, 0x00, 0x01, 0x00, 0x00,
+      ]);
+      const file = path.join(MEDIA_DIR, "photo.jpg");
+      await fs.writeFile(file, jpegHeader);
+      const res = await realFetch(mediaUrl("photo.jpg"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-disposition")).toBeNull();
+    });
+
+    it("forces download for PDF files", async () => {
+      await writeMediaFile("doc.pdf", "%PDF-1.4 fake");
+      const res = await realFetch(mediaUrl("doc.pdf"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-disposition")).toMatch(/^attachment/);
+    });
+
+    it("sets Cache-Control: no-store on all media responses", async () => {
+      await writeMediaFile("cached.txt", "data");
+      const res = await realFetch(mediaUrl("cached.txt"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("cache-control")).toBe("no-store");
+    });
+  });
 });

--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import type { Server } from "node:http";
+import path from "node:path";
 import express, { type Express } from "express";
 import { danger } from "../globals.js";
 import { SafeOpenError, readFileWithinRoot } from "../infra/fs-safe.js";
@@ -11,6 +12,26 @@ const DEFAULT_TTL_MS = 2 * 60 * 1000;
 const MAX_MEDIA_ID_CHARS = 200;
 const MEDIA_ID_PATTERN = /^[\p{L}\p{N}._-]+$/u;
 const MAX_MEDIA_BYTES = MEDIA_MAX_BYTES;
+
+/**
+ * MIME types that are safe to render inline in the browser.  Everything else
+ * gets a `Content-Disposition: attachment` header so the browser never
+ * interprets potentially active content (HTML, SVG+script, XML, etc.) inside
+ * the gateway origin.
+ */
+const INLINE_SAFE_MIME_PREFIXES: readonly string[] = ["image/", "audio/", "video/"];
+
+function shouldForceDownload(mime: string | undefined): boolean {
+  if (!mime) {
+    return true;
+  }
+  // SVG can carry embedded scripts, so it must not render inline even though
+  // it starts with "image/".
+  if (mime === "image/svg+xml") {
+    return true;
+  }
+  return !INLINE_SAFE_MIME_PREFIXES.some((prefix) => mime.startsWith(prefix));
+}
 
 const isValidMediaId = (id: string) => {
   if (!id) {
@@ -34,6 +55,7 @@ export function attachMediaRoutes(
 
   app.get("/media/:id", async (req, res) => {
     res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Cache-Control", "no-store");
     const id = req.params.id;
     if (!isValidMediaId(id)) {
       res.status(400).send("invalid path");
@@ -58,6 +80,16 @@ export function attachMediaRoutes(
       if (mime) {
         res.type(mime);
       }
+
+      // Force download for any MIME type that could carry active content
+      // (HTML, SVG, XML, PDF with JS, etc.) to prevent XSS in the gateway
+      // origin.  Safe media types (images, audio, video) render inline.
+      if (shouldForceDownload(mime)) {
+        const ext = path.extname(id) || "";
+        const safeFilename = `download${ext}`;
+        res.setHeader("Content-Disposition", `attachment; filename="${safeFilename}"`);
+      }
+
       res.send(data);
       // best-effort single-use cleanup after response ends
       res.on("finish", () => {


### PR DESCRIPTION
## Problem

The media server endpoint at `/media/:id` serves user-uploaded files without a `Content-Disposition` header. Files with active content MIME types (HTML, SVG, XML, PDF with embedded JavaScript) render inline in the browser, which means scripts within those files execute in the gateway origin context. This is a stored XSS vector.

Additionally, media files are ephemeral (single-use, auto-deleted after serving) but responses lack `Cache-Control: no-store`, so browser and proxy caches may retain sensitive content beyond its intended lifetime.

## Fix

- Add a `shouldForceDownload()` guard that checks the detected MIME type against a safe-list of passive media prefixes (`image/*`, `audio/*`, `video/*`).
- Explicitly exclude `image/svg+xml` from the safe-list since SVG can embed `<script>` elements.
- Any MIME type not on the safe-list gets `Content-Disposition: attachment` so the browser downloads rather than renders it.
- Set `Cache-Control: no-store` on all media responses to prevent caching of ephemeral files.

## Testing

Added tests covering:
- HTML files receive `Content-Disposition: attachment`
- SVG files receive `Content-Disposition: attachment`
- JPEG images do **not** receive forced download (inline rendering is fine)
- PDF files receive `Content-Disposition: attachment`
- All media responses include `Cache-Control: no-store`

All existing tests continue to pass.