### PR TITLE
fix(docs): remove broken Xfinity SSL troubleshooting links from FAQ

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -266,8 +266,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
 
   <Accordion title="Cannot access docs.openclaw.ai (SSL error)">
     Some Comcast/Xfinity connections incorrectly block `docs.openclaw.ai` via Xfinity
-    Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry. More
-    detail: [Troubleshooting](/help/faq#cannot-access-docsopenclaw-ai-ssl-error).
+    Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry.
     Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
 
     If you still can't reach the site, the docs are mirrored on GitHub:

--- a/docs/zh-CN/help/faq.md
+++ b/docs/zh-CN/help/faq.md
@@ -427,7 +427,7 @@ https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md
 
 ### 无法访问 docs.openclaw.ai（SSL 错误），怎么办
 
-一些 Comcast/Xfinity 连接通过 Xfinity Advanced Security 错误地拦截了 `docs.openclaw.ai`。禁用该功能或将 `docs.openclaw.ai` 加入白名单，然后重试。更多详情：[故障排除](/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity)。
+一些 Comcast/Xfinity 连接通过 Xfinity Advanced Security 错误地拦截了 `docs.openclaw.ai`。禁用该功能或将 `docs.openclaw.ai` 加入白名单，然后重试。
 请帮助我们在此处报告以解除封锁：https://spa.xfinity.com/check_url_status。
 
 如果仍然无法访问该网站，文档在 GitHub 上有镜像：


### PR DESCRIPTION
## Summary

- Remove circular self-link in English FAQ (`docs/help/faq.md` line 270) that pointed back to the same accordion section
- Remove dead anchor reference in zh-CN FAQ (`docs/zh-CN/help/faq.md` line 430) that pointed to a non-existent troubleshooting section
- Both FAQ sections already contain the full Xfinity/SSL workaround inline — the cross-references added no value

## Root Cause

`docs/help/troubleshooting.md` never had an Xfinity/SSL section. The broken links were introduced in the original authoring — not from a later removal.

## Change Type

- [x] Bug fix
- [x] Docs

Fixes #36970