### PR TITLE
fix(dev): rebuild dist after HEAD changes

### DIFF
--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -211,10 +211,10 @@ const shouldBuild = (deps) => {
 
   const currentHead = resolveGitHead(deps);
   if (currentHead && !stamp.head) {
-    return hasSourceMtimeChanged(stamp.mtime, deps);
+    return true;
   }
   if (currentHead && stamp.head && currentHead !== stamp.head) {
-    return hasSourceMtimeChanged(stamp.mtime, deps);
+    return true;
   }
   if (currentHead) {
     const dirty = hasDirtySourceTree(deps);

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -319,6 +319,27 @@ describe("run-node script", () => {
     });
   });
 
+  it("rebuilds when git HEAD changes even if source mtimes do not exceed the old build stamp", async () => {
+    await withTempDir(async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+        },
+        oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE],
+        buildPaths: [DIST_ENTRY, BUILD_STAMP],
+      });
+
+      const { spawnCalls, spawn, spawnSync } = createSpawnRecorder({
+        gitHead: "def456\n",
+        gitStatus: "",
+      });
+      const exitCode = await runStatusCommand({ tmp, spawn, spawnSync });
+
+      expect(exitCode).toBe(0);
+      expect(spawnCalls).toEqual([expectedBuildSpawn(), statusCommandSpawn()]);
+    });
+  });
+
   it("skips rebuilding when extension package metadata is newer than the build stamp", async () => {
     await withTempDir(async (tmp) => {
       await setupTrackedProject(tmp, {


### PR DESCRIPTION
## Summary
- rebuild `dist` whenever the stamped Git `HEAD` differs from the current checkout
- add a regression test covering the rebase/checkout case where source mtimes do not exceed the old build stamp

## Verification
- `pnpm vitest run src/infra/run-node.test.ts src/infra/watch-node.test.ts src/infra/tsdown-config.test.ts`