### PR TITLE
fix: prevent infinite retry loop when provider returns 401

### DIFF
--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -49,6 +49,11 @@ export async function checkInboundAccessControl(params: {
   messageTimestampMs?: number;
   connectedAtMs?: number;
   pairingGraceMs?: number;
+  /** True when processing a Baileys "append" upsert (history/offline catch-up).
+   *  Pairing challenges must never fire for append messages — they are replays,
+   *  not real-time inbound DMs. Without this guard, reconnect loops cause
+   *  unsolicited pairing codes to be sent to contacts (#56448). */
+  isAppend?: boolean;
   sock: {
     sendMessage: (jid: string, content: { text: string }) => Promise<unknown>;
   };
@@ -79,9 +84,13 @@ export async function checkInboundAccessControl(params: {
       ? params.pairingGraceMs
       : PAIRING_REPLY_HISTORY_GRACE_MS;
   const suppressPairingReply =
-    typeof params.connectedAtMs === "number" &&
+    // Suppress for append (history/offline) messages — these are replays from
+    // Baileys, not real-time DMs. Sending pairing codes for replayed messages
+    // during reconnect cycles sends unsolicited messages to contacts (#56448).
+    params.isAppend === true ||
+    (typeof params.connectedAtMs === "number" &&
     typeof params.messageTimestampMs === "number" &&
-    params.messageTimestampMs < params.connectedAtMs - pairingGraceMs;
+    params.messageTimestampMs < params.connectedAtMs - pairingGraceMs);
 
   // Group policy filtering:
   // - "open": groups bypass allowFrom, only mention-gating applies

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -207,6 +207,7 @@ export async function monitorWebInbox(options: {
 
   const normalizeInboundMessage = async (
     msg: WAMessage,
+    opts?: { isAppend?: boolean },
   ): Promise<NormalizedInboundMessage | null> => {
     const id = msg.key?.id ?? undefined;
     const remoteJid = msg.key?.remoteJid;
@@ -271,6 +272,7 @@ export async function monitorWebInbox(options: {
       isFromMe: Boolean(msg.key?.fromMe),
       messageTimestampMs,
       connectedAtMs,
+      isAppend: opts?.isAppend,
       sock: { sendMessage: (jid, content) => sendTrackedMessage(jid, content) },
       remoteJid,
     });
@@ -463,21 +465,19 @@ export async function monitorWebInbox(options: {
     if (upsert.type !== "notify" && upsert.type !== "append") {
       return;
     }
+    const isAppend = upsert.type === "append";
     for (const msg of upsert.messages ?? []) {
       recordChannelActivity({
         channel: "whatsapp",
         accountId: options.accountId,
         direction: "inbound",
       });
-      const inbound = await normalizeInboundMessage(msg);
-      if (!inbound) {
-        continue;
-      }
 
-      await maybeMarkInboundAsRead(inbound);
-
-      // If this is history/offline catch-up, mark read above but skip auto-reply.
-      if (upsert.type === "append") {
+      // Skip old history BEFORE access control to prevent pairing challenges
+      // from firing on replayed messages during reconnect cycles (#56448).
+      // Without this guard, 408 reconnect loops cause unsolicited pairing
+      // codes to be sent to the user's contacts.
+      if (isAppend) {
         const APPEND_RECENT_GRACE_MS = 60_000;
         const msgTsRaw = msg.messageTimestamp;
         const msgTsNum = msgTsRaw != null ? Number(msgTsRaw) : NaN;
@@ -486,6 +486,13 @@ export async function monitorWebInbox(options: {
           continue;
         }
       }
+
+      const inbound = await normalizeInboundMessage(msg, { isAppend });
+      if (!inbound) {
+        continue;
+      }
+
+      await maybeMarkInboundAsRead(inbound);
 
       const enriched = await enrichInboundMessage(msg);
       if (!enriched) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -228,6 +228,10 @@ export async function runEmbeddedPiAgent(
       let lastProfileId: string | undefined;
       let runtimeAuthState: RuntimeAuthState | null = null;
       let runtimeAuthRefreshCancelled = false;
+      // Track providers that failed with auth errors this run to prevent the
+      // live session model switch from switching back to a provider that just
+      // returned 401, which creates an infinite retry loop (#56501).
+      const authFailedProviders = new Set<string>();
       const resolveCurrentLiveSelection = () => ({
         provider,
         model: modelId,
@@ -451,10 +455,20 @@ export async function runEmbeddedPiAgent(
           runLoopIterations += 1;
           const nextSelection = resolvePersistedLiveSelection();
           if (hasDifferentLiveSessionModelSelection(resolveCurrentLiveSelection(), nextSelection)) {
-            log.info(
-              `live session model switch detected before attempt for ${params.sessionId}: ${provider}/${modelId} -> ${nextSelection.provider}/${nextSelection.model}`,
-            );
-            throw new LiveSessionModelSwitchError(nextSelection);
+            // Do NOT switch back to a provider that failed with auth error
+            // this run. Otherwise the system oscillates: failed provider ->
+            // fallback -> live switch back to failed -> 401 -> fallback ->
+            // live switch -> ... (#56501).
+            if (authFailedProviders.has(nextSelection.provider)) {
+              log.info(
+                `suppressing live session model switch to ${nextSelection.provider}/${nextSelection.model} — provider has auth failure this run`,
+              );
+            } else {
+              log.info(
+                `live session model switch detected before attempt for ${params.sessionId}: ${provider}/${modelId} -> ${nextSelection.provider}/${nextSelection.model}`,
+              );
+              throw new LiveSessionModelSwitchError(nextSelection);
+            }
           }
           const runtimeAuthRetry = authRetryPending;
           authRetryPending = false;
@@ -1072,6 +1086,9 @@ export async function runEmbeddedPiAgent(
             // Throw FailoverError for prompt-side failover reasons when fallbacks
             // are configured so outer model fallback can continue on overload,
             // rate-limit, auth, or billing failures.
+            if (promptFailoverReason === "auth" || promptFailoverReason === "auth_permanent") {
+              authFailedProviders.add(provider);
+            }
             if (fallbackConfigured && promptFailoverFailure) {
               const status = resolveFailoverStatus(promptFailoverReason ?? "unknown");
               logPromptFailoverDecision("fallback_model", { status });

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
+import { extractToolCallsFromAssistant, extractToolResultId, sanitizeToolCallId } from "./tool-call-id.js";
 
 const TOOL_CALL_NAME_MAX_CHARS = 64;
 const TOOL_CALL_NAME_RE = /^[A-Za-z0-9_-]+$/;
@@ -408,6 +408,18 @@ export function repairToolUseResultPairing(
 
     const toolCallIds = new Set(toolCalls.map((t) => t.id));
     const toolCallNamesById = new Map(toolCalls.map((t) => [t.id, t.name] as const));
+    // Build a sanitized-to-original ID map so we can match tool results whose
+    // IDs were normalized (e.g. by sanitizeToolCallIds for the Anthropic API)
+    // against raw JSONL IDs that contain underscores/hyphens (#52604).
+    const sanitizedToOriginalId = new Map<string, string>();
+    for (const t of toolCalls) {
+      if (t.id) {
+        const sanitized = sanitizeToolCallId(t.id);
+        if (sanitized !== t.id) {
+          sanitizedToOriginalId.set(sanitized, t.id);
+        }
+      }
+    }
 
     const spanResultsById = new Map<string, Extract<AgentMessage, { role: "toolResult" }>>();
     const remainder: AgentMessage[] = [];
@@ -427,7 +439,13 @@ export function repairToolUseResultPairing(
 
       if (nextRole === "toolResult") {
         const toolResult = next as Extract<AgentMessage, { role: "toolResult" }>;
-        const id = extractToolResultId(toolResult);
+        const rawId = extractToolResultId(toolResult);
+        // Match against raw ID first; fall back to sanitized ID for
+        // cross-model sessions where tool results were saved with sanitized
+        // IDs but tool calls retain the original format (#52604).
+        const id = rawId && toolCallIds.has(rawId)
+          ? rawId
+          : rawId ? (sanitizedToOriginalId.get(rawId) ?? sanitizedToOriginalId.get(sanitizeToolCallId(rawId))) : undefined;
         if (id && toolCallIds.has(id)) {
           if (seenToolResultIds.has(id)) {
             droppedDuplicateCount += 1;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -592,7 +592,12 @@ export async function onTimer(state: CronServiceState) {
     const dueJobs = await locked(state, async () => {
       await ensureLoaded(state, { forceReload: true, skipRecompute: true });
       const dueCheckNow = state.deps.nowMs();
-      const due = collectRunnableJobs(state, dueCheckNow);
+      // skipAtIfAlreadyRan prevents one-shot "at" jobs from re-triggering
+      // when their scheduled time is in the past but deleteAfterRun cleanup
+      // hasn't persisted yet (e.g. after crash or slow persist) (#56488).
+      const due = collectRunnableJobs(state, dueCheckNow, {
+        skipAtIfAlreadyRan: true,
+      });
 
       if (due.length === 0) {
         // Use maintenance-only recompute to avoid advancing past-due nextRunAtMs
@@ -998,7 +1003,7 @@ export async function runDueJobs(state: CronServiceState) {
     return;
   }
   const now = state.deps.nowMs();
-  const due = collectRunnableJobs(state, now);
+  const due = collectRunnableJobs(state, now, { skipAtIfAlreadyRan: true });
   for (const job of due) {
     await executeJob(state, job, now, { forced: false });
   }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -451,8 +451,32 @@ export async function startGatewayServer(
     params: { reason: "startup" | "reload" | "restart-check"; activate: boolean },
   ) =>
     await runWithSecretsActivationLock(async () => {
+      // Retry with exponential backoff at startup to prevent crash-loops that
+      // exhaust secret provider rate limits (e.g. 1Password daily quota).
+      // Without backoff, a transient failure causes: crash → OS restart → crash
+      // → restart, burning N `op read` calls per cycle (#56217).
+      const STARTUP_MAX_RETRIES = 3;
+      const STARTUP_BASE_DELAY_MS = 2_000;
+
+      const attemptResolve = async (attempt: number): Promise<Awaited<ReturnType<typeof prepareSecretsRuntimeSnapshot>>> => {
+        try {
+          return await prepareSecretsRuntimeSnapshot({ config });
+        } catch (err) {
+          if (params.reason !== "startup" || attempt >= STARTUP_MAX_RETRIES) {
+            throw err;
+          }
+          const delayMs = STARTUP_BASE_DELAY_MS * Math.pow(2, attempt);
+          logSecrets.warn(
+            `[SECRETS_STARTUP_RETRY] Attempt ${attempt + 1}/${STARTUP_MAX_RETRIES} failed, ` +
+            `retrying in ${delayMs}ms: ${String(err)}`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          return attemptResolve(attempt + 1);
+        }
+      };
+
       try {
-        const prepared = await prepareSecretsRuntimeSnapshot({ config });
+        const prepared = await attemptResolve(0);
         if (params.activate) {
           activateSecretsRuntimeSnapshot(prepared);
           logGatewayAuthSurfaceDiagnostics(prepared);
@@ -484,9 +508,12 @@ export async function startGatewayServer(
         }
         secretsDegraded = true;
         if (params.reason === "startup") {
-          throw new Error(`Startup failed: required secrets are unavailable. ${details}`, {
-            cause: err,
-          });
+          throw new Error(
+            `Startup failed: required secrets are unavailable after ${STARTUP_MAX_RETRIES} ` +
+            `retries with exponential backoff. If using 1Password, check that your service ` +
+            `account token is valid and the account has not exceeded its daily rate limit. ${details}`,
+            { cause: err },
+          );
         }
         throw err;
       }

--- a/src/infra/host-env-security.ts
+++ b/src/infra/host-env-security.ts
@@ -1,5 +1,6 @@
 import HOST_ENV_SECURITY_POLICY_JSON from "./host-env-security-policy.json" with { type: "json" };
 import { markOpenClawExecEnv } from "./openclaw-exec-env.js";
+import { listKnownProviderAuthEnvVarNames } from "../secrets/provider-env-vars.js";
 
 const PORTABLE_ENV_VAR_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const WINDOWS_COMPAT_OVERRIDE_ENV_VAR_KEY = /^[A-Za-z_][A-Za-z0-9_()]*$/;
@@ -185,9 +186,20 @@ export function sanitizeHostExecEnvWithDiagnostics(params?: {
 }): HostExecEnvSanitizationResult {
   const baseEnv = params?.baseEnv ?? process.env;
 
+  // Strip provider API keys so they don't leak to child processes spawned
+  // by the exec tool. Keys like OPENAI_API_KEY, ANTHROPIC_API_KEY, etc. are
+  // injected into process.env for in-process SDK usage but must not be
+  // inherited by untrusted binaries (#56441).
+  const providerKeyBlocklist = new Set(
+    listKnownProviderAuthEnvVarNames().map((k) => k.toUpperCase()),
+  );
+
   const merged: Record<string, string> = {};
   for (const [key, value] of listNormalizedEnvEntries(baseEnv)) {
     if (isDangerousHostEnvVarName(key)) {
+      continue;
+    }
+    if (providerKeyBlocklist.has(key.toUpperCase())) {
       continue;
     }
     merged[key] = value;


### PR DESCRIPTION
## Problem

Fixes #56501

When a provider returns HTTP 401 (invalid/expired API key), the agent enters an infinite retry loop generating ~1500+ ERROR entries per minute:

```
moonshot/kimi-k2.5 → 401 auth error
  → failover to modelstudio/qwen3.5-plus
    → live session model switch check reads persisted preference → moonshot/kimi-k2.5
    → "different from current" → throws LiveSessionModelSwitchError
      → outer loop catches, switches back to moonshot/kimi-k2.5
        → 401 auth error again → ...infinite loop
```

## Root Cause

Three systems interact to create the oscillation:

1. **Model fallback** (`model-fallback.ts`): Correctly switches from moonshot to modelstudio on 401
2. **Persisted session store** (`live-model-switch.ts`): Still says `providerOverride: "moonshot"` (never cleared on auth failure)
3. **Live switch check** (`run.ts:452-458`): Sees current=modelstudio vs persisted=moonshot, throws `LiveSessionModelSwitchError` which forces the outer loop back to moonshot

The model fallback system has auth cooldown logic (`resolveCooldownDecision`), but the `LiveSessionModelSwitchError` path completely bypasses it.

## Fix

Track providers that fail with auth errors in a per-run `Set<string>`. Before honoring a `LiveSessionModelSwitchError`, check whether the target provider is in the auth-failed set. If it is, log the suppression and let the fallback model proceed.

```
moonshot/kimi-k2.5 → 401 → authFailedProviders.add("moonshot")
  → failover to modelstudio/qwen3.5-plus
    → live switch check: persisted = moonshot
    → authFailedProviders.has("moonshot")? YES
    → suppress switch, continue with modelstudio ✓
```

21 lines in 1 file. The auth-failed set is scoped to the current run, so it resets on fresh agent invocations (allowing recovery after the user fixes their API key).