### PR TITLE
fix(discord): await async gateway plugin registration after Client construction

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -239,12 +239,27 @@ function createGatewayPlugin(params: {
 }): carbonGateway.GatewayPlugin {
   class SafeGatewayPlugin extends carbonGateway.GatewayPlugin {
     private gatewayInfoUsedFallback = false;
+    /**
+     * Promise that resolves when the async registerClient completes.
+     * Carbon's Client constructor calls registerClient synchronously
+     * (fire-and-forget), so this must be awaited after construction
+     * to ensure the gateway actually connects (#56492).
+     */
+    registrationReady: Promise<void> | null = null;
 
     constructor() {
       super(params.options);
     }
 
     override async registerClient(
+      client: Parameters<carbonGateway.GatewayPlugin["registerClient"]>[0],
+    ) {
+      const work = this._registerClientAsync(client);
+      this.registrationReady = work;
+      return work;
+    }
+
+    private async _registerClientAsync(
       client: Parameters<carbonGateway.GatewayPlugin["registerClient"]>[0],
     ) {
       if (!this.gatewayInfo || this.gatewayInfoUsedFallback) {

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -66,7 +66,7 @@ export function createDiscordStatusReadyListener(params: {
   })();
 }
 
-export function createDiscordMonitorClient(params: {
+export async function createDiscordMonitorClient(params: {
   accountId: string;
   applicationId: string;
   token: string;
@@ -125,6 +125,15 @@ export function createDiscordMonitorClient(params: {
     clientPlugins,
   );
   const gateway = client.getPlugin<GatewayPlugin>("gateway") as MutableDiscordGateway | undefined;
+
+  // Carbon's Client constructor calls plugin.registerClient() synchronously,
+  // but SafeGatewayPlugin.registerClient is async (fetches gateway metadata).
+  // The constructor drops the promise, so we must await it explicitly (#56492).
+  const gatewayWithRegistration = gateway as (MutableDiscordGateway & { registrationReady?: Promise<void> | null }) | undefined;
+  if (gatewayWithRegistration?.registrationReady) {
+    await gatewayWithRegistration.registrationReady;
+  }
+
   const gatewaySupervisor = params.createGatewaySupervisor({
     gateway,
     isDisallowedIntentsError: params.isDisallowedIntentsError,

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -894,7 +894,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       gatewaySupervisor: createdGatewaySupervisor,
       autoPresenceController: createdAutoPresenceController,
       eventQueueOpts,
-    } = createDiscordMonitorClient({
+    } = await createDiscordMonitorClient({
       accountId: account.accountId,
       applicationId,
       token,


### PR DESCRIPTION
## Problem

Fixes #56492

Discord gateway frequently fails to connect on startup. The gateway's `isConnected` stays `false` permanently, and the lifecycle code waits forever.

## Root Cause

Carbon's `Client` constructor iterates plugins synchronously:

```js
// @buape/carbon Client.js:121-124
for (const plugin of plugins) {
    plugin.registerClient?.(this);   // fire-and-forget: async not awaited
    plugin.registerRoutes?.(this);
    this.plugins.push({ id: plugin.id, plugin });
}
```

OpenClaw's `SafeGatewayPlugin.registerClient()` is `async` because it fetches gateway metadata from Discord's API before establishing the WebSocket connection. The constructor cannot await (it's a constructor), so the promise is dropped. The gateway fetch starts but nobody waits for it to finish.

```
new Client(config, handlers, [SafeGatewayPlugin])
  └─ constructor calls plugin.registerClient(this)  ← SYNC, drops promise
     └─ SafeGatewayPlugin.registerClient starts async fetch...
        └─ ...promise dropped, nobody awaits
           └─ gateway.isConnected === false forever
```

## Fix

Two changes:

**1. `gateway-plugin.ts`:** Store the async work as a `registrationReady` promise on `SafeGatewayPlugin`. The `registerClient` override captures the promise before returning, so the fire-and-forget call in Carbon's constructor still starts the work, but the promise is accessible externally.

**2. `provider.startup.ts`:** Make `createDiscordMonitorClient` async. After constructing the Carbon `Client`, explicitly await `gateway.registrationReady` to ensure the metadata fetch and WebSocket connection complete before proceeding.

```
new Client(config, handlers, [SafeGatewayPlugin])
  └─ constructor calls plugin.registerClient(this)
     └─ SafeGatewayPlugin stores promise as registrationReady
await gateway.registrationReady   ← NEW: ensures connection completes
  └─ gateway.isConnected === true ✓
```

26 lines across 3 files.