### PR TITLE
memory-lancedb: add configurable timeout/retry for embedding calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,10 +173,10 @@ Docs: https://docs.openclaw.ai
 - Memory-core: treat exhausted file watcher limits as non-fatal for builtin memory auto-sync while preserving fatal handling for unrelated disk-full errors. (#73357) Thanks @solodmd.
 - Providers/Ollama: restore catalog context-window forwarding as `num_ctx` for native `/api/chat` requests; fixes tool selection and context truncation regressions on models with catalog entries (qwen3, llama3, gemma3, …) when no explicit `params.num_ctx` was configured. Fixes #76117. (#76181) Thanks @openperf.
 - Plugins/install: pin npm plugin installs to the verified resolved version and reject package-lock version or integrity drift, so mutable tags cannot race integrity checks into accepting a different artifact. Thanks @Lucenx9.
-
 - Plugins/providers: preserve scoped cold-load fallback for enabled external manifest-contract capability providers missing from the startup registry, so providers such as Fish Audio can resolve on request without requiring `activation.onStartup` for correctness. (#76536) Thanks @Conan-Scott.
 - Gateway/update: carry `continuationMessage` from `update.run` into successful restart sentinels so session-scoped self-updates can resume one follow-up turn after the Gateway restarts. Refs #71178. (#74362) Thanks @100menotu001, @HeilbronAILabs, and @artnking.
 - Agents/fallback: suppress duplicate current-turn user-message transcript writes after embedded fallback retries while still sending the retry prompt to the model. (#63696) Thanks @dashhuang.
+- Plugins/memory-lancedb: add configurable `embedding.timeoutMs` and `embedding.maxRetries` for OpenAI-compatible embedding requests, validated and clamped to safe ranges with silent fallback to SDK defaults on out-of-bounds input. (#56532) Thanks @amittell.
 
 ## 2026.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,6 +378,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: report tool-only child progress during timeout summaries instead of showing no visible output.
 - Telegram/ACP: preserve explicit `:topic:` conversation suffixes when inbound ACP targets do not carry a separate thread id.
 - Browser/proxy: bypass the managed proxy for the exact local managed Chrome CDP readiness and DevTools WebSocket endpoints, so `openclaw browser start` works when the operator proxy blocks loopback egress. (#83255) Thanks @lightcap.
+- Plugins/memory-lancedb: add configurable `embedding.timeoutMs` and `embedding.maxRetries` for OpenAI-compatible embedding requests, validated and clamped to safe ranges with silent fallback to SDK defaults on out-of-bounds input. (#56532) Thanks @amittell.
 - Ollama: bypass the managed proxy for configured local embedding origins while keeping SSRF guardrails on unconfigured targets. Thanks @Kaspre.
 - OpenAI/images: route Codex API-key image generation through the native OpenAI Images API instead of the Codex OAuth streaming backend, avoiding 401s from valid API keys.
 - Agents/OpenAI completions: omit empty tool payload fields for proxy-like OpenAI-compatible endpoints so strict vLLM-style servers accept tool-free turns. (#85835) Thanks @rendrag-git.

--- a/extensions/memory-lancedb/config.test.ts
+++ b/extensions/memory-lancedb/config.test.ts
@@ -173,7 +173,7 @@ describe("memory-lancedb config", () => {
 
   it("falls back to undefined for non-finite or negative timeoutMs", () => {
     const nan = memoryConfigSchema.parse({
-      embedding: { apiKey: "sk-test", timeoutMs: NaN },
+      embedding: { apiKey: "sk-test", timeoutMs: Number.NaN },
     });
     expect(nan.embedding.timeoutMs).toBeUndefined();
 
@@ -207,7 +207,7 @@ describe("memory-lancedb config", () => {
     expect(frac.embedding.maxRetries).toBeUndefined();
 
     const nan = memoryConfigSchema.parse({
-      embedding: { apiKey: "sk-test", maxRetries: NaN },
+      embedding: { apiKey: "sk-test", maxRetries: Number.NaN },
     });
     expect(nan.embedding.maxRetries).toBeUndefined();
 

--- a/extensions/memory-lancedb/config.test.ts
+++ b/extensions/memory-lancedb/config.test.ts
@@ -132,4 +132,131 @@ describe("memory-lancedb config", () => {
       });
     }).toThrow("dreaming config must be an object");
   });
+
+  it("accepts valid timeoutMs and maxRetries", () => {
+    const parsed = memoryConfigSchema.parse({
+      embedding: {
+        apiKey: "sk-test",
+        timeoutMs: 15_000,
+        maxRetries: 3,
+      },
+    });
+    expect(parsed.embedding.timeoutMs).toBe(15_000);
+    expect(parsed.embedding.maxRetries).toBe(3);
+  });
+
+  it("accepts boundary values for timeoutMs and maxRetries", () => {
+    const low = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: 1000, maxRetries: 0 },
+    });
+    expect(low.embedding.timeoutMs).toBe(1000);
+    expect(low.embedding.maxRetries).toBe(0);
+
+    const high = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: 60_000, maxRetries: 5 },
+    });
+    expect(high.embedding.timeoutMs).toBe(60_000);
+    expect(high.embedding.maxRetries).toBe(5);
+  });
+
+  it("falls back to undefined for out-of-bounds timeoutMs", () => {
+    const tooLow = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: 500 },
+    });
+    expect(tooLow.embedding.timeoutMs).toBeUndefined();
+
+    const tooHigh = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: 120_000 },
+    });
+    expect(tooHigh.embedding.timeoutMs).toBeUndefined();
+  });
+
+  it("falls back to undefined for non-finite or negative timeoutMs", () => {
+    const nan = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: NaN },
+    });
+    expect(nan.embedding.timeoutMs).toBeUndefined();
+
+    const inf = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: Infinity },
+    });
+    expect(inf.embedding.timeoutMs).toBeUndefined();
+
+    const neg = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: -1000 },
+    });
+    expect(neg.embedding.timeoutMs).toBeUndefined();
+  });
+
+  it("falls back to undefined for out-of-bounds maxRetries", () => {
+    const neg = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", maxRetries: -1 },
+    });
+    expect(neg.embedding.maxRetries).toBeUndefined();
+
+    const tooHigh = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", maxRetries: 10 },
+    });
+    expect(tooHigh.embedding.maxRetries).toBeUndefined();
+  });
+
+  it("falls back to undefined for non-integer or non-finite maxRetries", () => {
+    const frac = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", maxRetries: 2.5 },
+    });
+    expect(frac.embedding.maxRetries).toBeUndefined();
+
+    const nan = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", maxRetries: NaN },
+    });
+    expect(nan.embedding.maxRetries).toBeUndefined();
+
+    const inf = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", maxRetries: Infinity },
+    });
+    expect(inf.embedding.maxRetries).toBeUndefined();
+  });
+
+  it("accepts timeoutMs and maxRetries through the manifest schema", () => {
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "memory-lancedb.manifest.timeout-retries",
+      value: {
+        embedding: {
+          apiKey: "sk-test",
+          timeoutMs: 10_000,
+          maxRetries: 2,
+        },
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects out-of-range timeoutMs in the manifest schema", () => {
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "memory-lancedb.manifest.timeout-oob",
+      value: {
+        embedding: {
+          apiKey: "sk-test",
+          timeoutMs: 500,
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects out-of-range maxRetries in the manifest schema", () => {
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "memory-lancedb.manifest.retries-oob",
+      value: {
+        embedding: {
+          apiKey: "sk-test",
+          maxRetries: 10,
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
+  });
 });

--- a/extensions/memory-lancedb/config.test.ts
+++ b/extensions/memory-lancedb/config.test.ts
@@ -253,7 +253,7 @@ describe("memory-lancedb config", () => {
 
   it("falls back to undefined for non-finite or negative timeoutMs", () => {
     const nan = memoryConfigSchema.parse({
-      embedding: { apiKey: "sk-test", timeoutMs: NaN },
+      embedding: { apiKey: "sk-test", timeoutMs: Number.NaN },
     });
     expect(nan.embedding.timeoutMs).toBeUndefined();
 
@@ -287,7 +287,7 @@ describe("memory-lancedb config", () => {
     expect(frac.embedding.maxRetries).toBeUndefined();
 
     const nan = memoryConfigSchema.parse({
-      embedding: { apiKey: "sk-test", maxRetries: NaN },
+      embedding: { apiKey: "sk-test", maxRetries: Number.NaN },
     });
     expect(nan.embedding.maxRetries).toBeUndefined();
 

--- a/extensions/memory-lancedb/config.test.ts
+++ b/extensions/memory-lancedb/config.test.ts
@@ -212,4 +212,131 @@ describe("memory-lancedb config", () => {
       });
     }).toThrow("dreaming config must be an object");
   });
+
+  it("accepts valid timeoutMs and maxRetries", () => {
+    const parsed = memoryConfigSchema.parse({
+      embedding: {
+        apiKey: "sk-test",
+        timeoutMs: 15_000,
+        maxRetries: 3,
+      },
+    });
+    expect(parsed.embedding.timeoutMs).toBe(15_000);
+    expect(parsed.embedding.maxRetries).toBe(3);
+  });
+
+  it("accepts boundary values for timeoutMs and maxRetries", () => {
+    const low = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: 1000, maxRetries: 0 },
+    });
+    expect(low.embedding.timeoutMs).toBe(1000);
+    expect(low.embedding.maxRetries).toBe(0);
+
+    const high = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: 60_000, maxRetries: 5 },
+    });
+    expect(high.embedding.timeoutMs).toBe(60_000);
+    expect(high.embedding.maxRetries).toBe(5);
+  });
+
+  it("falls back to undefined for out-of-bounds timeoutMs", () => {
+    const tooLow = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: 500 },
+    });
+    expect(tooLow.embedding.timeoutMs).toBeUndefined();
+
+    const tooHigh = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: 120_000 },
+    });
+    expect(tooHigh.embedding.timeoutMs).toBeUndefined();
+  });
+
+  it("falls back to undefined for non-finite or negative timeoutMs", () => {
+    const nan = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: NaN },
+    });
+    expect(nan.embedding.timeoutMs).toBeUndefined();
+
+    const inf = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: Infinity },
+    });
+    expect(inf.embedding.timeoutMs).toBeUndefined();
+
+    const neg = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", timeoutMs: -1000 },
+    });
+    expect(neg.embedding.timeoutMs).toBeUndefined();
+  });
+
+  it("falls back to undefined for out-of-bounds maxRetries", () => {
+    const neg = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", maxRetries: -1 },
+    });
+    expect(neg.embedding.maxRetries).toBeUndefined();
+
+    const tooHigh = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", maxRetries: 10 },
+    });
+    expect(tooHigh.embedding.maxRetries).toBeUndefined();
+  });
+
+  it("falls back to undefined for non-integer or non-finite maxRetries", () => {
+    const frac = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", maxRetries: 2.5 },
+    });
+    expect(frac.embedding.maxRetries).toBeUndefined();
+
+    const nan = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", maxRetries: NaN },
+    });
+    expect(nan.embedding.maxRetries).toBeUndefined();
+
+    const inf = memoryConfigSchema.parse({
+      embedding: { apiKey: "sk-test", maxRetries: Infinity },
+    });
+    expect(inf.embedding.maxRetries).toBeUndefined();
+  });
+
+  it("accepts timeoutMs and maxRetries through the manifest schema", () => {
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "memory-lancedb.manifest.timeout-retries",
+      value: {
+        embedding: {
+          apiKey: "sk-test",
+          timeoutMs: 10_000,
+          maxRetries: 2,
+        },
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects out-of-range timeoutMs in the manifest schema", () => {
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "memory-lancedb.manifest.timeout-oob",
+      value: {
+        embedding: {
+          apiKey: "sk-test",
+          timeoutMs: 500,
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects out-of-range maxRetries in the manifest schema", () => {
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "memory-lancedb.manifest.retries-oob",
+      value: {
+        embedding: {
+          apiKey: "sk-test",
+          maxRetries: 10,
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
+  });
 });

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -9,6 +9,8 @@ export type MemoryConfig = {
     apiKey?: string;
     baseUrl?: string;
     dimensions?: number;
+    timeoutMs?: number;
+    maxRetries?: number;
   };
   dreaming?: Record<string, unknown>;
   dbPath?: string;
@@ -58,7 +60,15 @@ const EMBEDDING_DIMENSIONS: Record<string, number> = {
   "text-embedding-3-small": 1536,
   "text-embedding-3-large": 3072,
 };
-const EMBEDDING_CONFIG_KEYS = ["provider", "apiKey", "model", "baseUrl", "dimensions"] as const;
+const EMBEDDING_CONFIG_KEYS = [
+  "provider",
+  "apiKey",
+  "model",
+  "baseUrl",
+  "dimensions",
+  "timeoutMs",
+  "maxRetries",
+] as const;
 
 function assertAllowedKeys(value: Record<string, unknown>, allowed: string[], label: string) {
   const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
@@ -170,6 +180,28 @@ export const memoryConfigSchema = {
       }
     }
 
+    // Clamp timeoutMs to [1000, 60000]; fall back to undefined (uses SDK default) if invalid
+    const rawTimeoutMs = typeof embedding.timeoutMs === "number" ? embedding.timeoutMs : undefined;
+    const timeoutMs =
+      rawTimeoutMs !== undefined &&
+      Number.isFinite(rawTimeoutMs) &&
+      rawTimeoutMs >= 1000 &&
+      rawTimeoutMs <= 60_000
+        ? rawTimeoutMs
+        : undefined;
+
+    // Clamp maxRetries to integer in [0, 5]; fall back to undefined (uses SDK default) if invalid
+    const rawMaxRetries =
+      typeof embedding.maxRetries === "number" ? embedding.maxRetries : undefined;
+    const maxRetries =
+      rawMaxRetries !== undefined &&
+      Number.isFinite(rawMaxRetries) &&
+      Number.isInteger(rawMaxRetries) &&
+      rawMaxRetries >= 0 &&
+      rawMaxRetries <= 5
+        ? rawMaxRetries
+        : undefined;
+
     return {
       embedding: {
         provider,
@@ -178,6 +210,8 @@ export const memoryConfigSchema = {
         baseUrl:
           typeof embedding.baseUrl === "string" ? resolveEnvVars(embedding.baseUrl) : undefined,
         dimensions: typeof embedding.dimensions === "number" ? embedding.dimensions : undefined,
+        timeoutMs,
+        maxRetries,
       },
       dreaming,
       dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : DEFAULT_DB_PATH,
@@ -216,6 +250,18 @@ export const memoryConfigSchema = {
       label: "Embedding Model",
       placeholder: DEFAULT_MODEL,
       help: "OpenAI embedding model to use",
+    },
+    "embedding.timeoutMs": {
+      label: "Timeout (ms)",
+      placeholder: "10000",
+      help: "Timeout for embedding API requests in milliseconds",
+      advanced: true,
+    },
+    "embedding.maxRetries": {
+      label: "Max Retries",
+      placeholder: "1",
+      help: "Maximum number of retries for failed embedding requests",
+      advanced: true,
     },
     dbPath: {
       label: "Database Path",

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -10,6 +10,8 @@ export type MemoryConfig = {
     apiKey?: string;
     baseUrl?: string;
     dimensions?: number;
+    timeoutMs?: number;
+    maxRetries?: number;
   };
   dreaming?: Record<string, unknown>;
   dbPath?: string;
@@ -60,7 +62,15 @@ const EMBEDDING_DIMENSIONS: Record<string, number> = {
   "text-embedding-3-small": 1536,
   "text-embedding-3-large": 3072,
 };
-const EMBEDDING_CONFIG_KEYS = ["provider", "apiKey", "model", "baseUrl", "dimensions"] as const;
+const EMBEDDING_CONFIG_KEYS = [
+  "provider",
+  "apiKey",
+  "model",
+  "baseUrl",
+  "dimensions",
+  "timeoutMs",
+  "maxRetries",
+] as const;
 
 function assertAllowedKeys(value: Record<string, unknown>, allowed: string[], label: string) {
   const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
@@ -234,6 +244,28 @@ export const memoryConfigSchema = {
       }
     }
 
+    // Clamp timeoutMs to [1000, 60000]; fall back to undefined (uses SDK default) if invalid
+    const rawTimeoutMs = typeof embedding.timeoutMs === "number" ? embedding.timeoutMs : undefined;
+    const timeoutMs =
+      rawTimeoutMs !== undefined &&
+      Number.isFinite(rawTimeoutMs) &&
+      rawTimeoutMs >= 1000 &&
+      rawTimeoutMs <= 60_000
+        ? rawTimeoutMs
+        : undefined;
+
+    // Clamp maxRetries to integer in [0, 5]; fall back to undefined (uses SDK default) if invalid
+    const rawMaxRetries =
+      typeof embedding.maxRetries === "number" ? embedding.maxRetries : undefined;
+    const maxRetries =
+      rawMaxRetries !== undefined &&
+      Number.isFinite(rawMaxRetries) &&
+      Number.isInteger(rawMaxRetries) &&
+      rawMaxRetries >= 0 &&
+      rawMaxRetries <= 5
+        ? rawMaxRetries
+        : undefined;
+
     return {
       embedding: {
         provider,
@@ -242,6 +274,8 @@ export const memoryConfigSchema = {
         baseUrl:
           typeof embedding.baseUrl === "string" ? resolveEnvVars(embedding.baseUrl) : undefined,
         dimensions,
+        timeoutMs,
+        maxRetries,
       },
       dreaming,
       dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : DEFAULT_DB_PATH,
@@ -281,6 +315,18 @@ export const memoryConfigSchema = {
       label: "Embedding Model",
       placeholder: DEFAULT_MODEL,
       help: "OpenAI embedding model to use",
+    },
+    "embedding.timeoutMs": {
+      label: "Timeout (ms)",
+      placeholder: "10000",
+      help: "Timeout for embedding API requests in milliseconds",
+      advanced: true,
+    },
+    "embedding.maxRetries": {
+      label: "Max Retries",
+      placeholder: "1",
+      help: "Maximum number of retries for failed embedding requests",
+      advanced: true,
     },
     dbPath: {
       label: "Database Path",

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -441,7 +441,14 @@ async function runWithTimeout<T>(params: {
 function createEmbeddings(api: OpenClawPluginApi, cfg: MemoryConfig): Embeddings {
   const { provider, model, dimensions, apiKey, baseUrl, timeoutMs, maxRetries } = cfg.embedding;
   if (provider === "openai" && apiKey) {
-    return new OpenAiCompatibleEmbeddings(apiKey, model, baseUrl, dimensions, timeoutMs, maxRetries);
+    return new OpenAiCompatibleEmbeddings(
+      apiKey,
+      model,
+      baseUrl,
+      dimensions,
+      timeoutMs,
+      maxRetries,
+    );
   }
   return new ProviderAdapterEmbeddings(api, cfg.embedding);
 }

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -309,6 +309,9 @@ class MemoryDB {
 // Embeddings
 // ============================================================================
 
+const DEFAULT_EMBEDDING_TIMEOUT_MS = 10_000;
+const DEFAULT_EMBEDDING_MAX_RETRIES = 1;
+
 type Embeddings = {
   embed(text: string, options?: { timeoutMs?: number }): Promise<number[]>;
 };
@@ -321,8 +324,15 @@ class OpenAiCompatibleEmbeddings implements Embeddings {
     private model: string,
     baseUrl?: string,
     private dimensions?: number,
+    timeoutMs?: number,
+    maxRetries?: number,
   ) {
-    this.client = new OpenAI({ apiKey, baseURL: baseUrl });
+    this.client = new OpenAI({
+      apiKey,
+      baseURL: baseUrl,
+      timeout: timeoutMs ?? DEFAULT_EMBEDDING_TIMEOUT_MS,
+      maxRetries: maxRetries ?? DEFAULT_EMBEDDING_MAX_RETRIES,
+    });
   }
 
   async embed(text: string, options?: { timeoutMs?: number }): Promise<number[]> {
@@ -429,9 +439,9 @@ async function runWithTimeout<T>(params: {
 }
 
 function createEmbeddings(api: OpenClawPluginApi, cfg: MemoryConfig): Embeddings {
-  const { provider, model, dimensions, apiKey, baseUrl } = cfg.embedding;
+  const { provider, model, dimensions, apiKey, baseUrl, timeoutMs, maxRetries } = cfg.embedding;
   if (provider === "openai" && apiKey) {
-    return new OpenAiCompatibleEmbeddings(apiKey, model, baseUrl, dimensions);
+    return new OpenAiCompatibleEmbeddings(apiKey, model, baseUrl, dimensions, timeoutMs, maxRetries);
   }
   return new ProviderAdapterEmbeddings(api, cfg.embedding);
 }

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -357,9 +357,21 @@ class OpenAiCompatibleEmbeddings implements Embeddings {
     private model: string,
     baseUrl?: string,
     private dimensions?: number,
+    timeoutMs?: number,
+    maxRetries?: number,
   ) {
     this.clientPromise = loadOpenAiModule().then(
-      ({ default: OpenAI }) => new OpenAI({ apiKey, baseURL: baseUrl }) as OpenAiEmbeddingClient,
+      ({ default: OpenAI }) =>
+        // Only pass timeout/maxRetries through when the operator explicitly
+        // configured them. Leaving them unset preserves the OpenAI SDK defaults
+        // (600000ms timeout, 2 retries) so upgrading installs with slow-but-
+        // working embedding endpoints do not silently start failing.
+        new OpenAI({
+          apiKey,
+          baseURL: baseUrl,
+          ...(timeoutMs !== undefined ? { timeout: timeoutMs } : {}),
+          ...(maxRetries !== undefined ? { maxRetries } : {}),
+        }) as OpenAiEmbeddingClient,
     );
   }
 
@@ -471,9 +483,9 @@ async function runWithTimeout<T>(params: {
 }
 
 function createEmbeddings(api: OpenClawPluginApi, cfg: MemoryConfig): Embeddings {
-  const { provider, model, dimensions, apiKey, baseUrl } = cfg.embedding;
+  const { provider, model, dimensions, apiKey, baseUrl, timeoutMs, maxRetries } = cfg.embedding;
   if (provider === "openai" && apiKey) {
-    return new OpenAiCompatibleEmbeddings(apiKey, model, baseUrl, dimensions);
+    return new OpenAiCompatibleEmbeddings(apiKey, model, baseUrl, dimensions, timeoutMs, maxRetries);
   }
   return new ProviderAdapterEmbeddings(api, cfg.embedding);
 }

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -485,7 +485,14 @@ async function runWithTimeout<T>(params: {
 function createEmbeddings(api: OpenClawPluginApi, cfg: MemoryConfig): Embeddings {
   const { provider, model, dimensions, apiKey, baseUrl, timeoutMs, maxRetries } = cfg.embedding;
   if (provider === "openai" && apiKey) {
-    return new OpenAiCompatibleEmbeddings(apiKey, model, baseUrl, dimensions, timeoutMs, maxRetries);
+    return new OpenAiCompatibleEmbeddings(
+      apiKey,
+      model,
+      baseUrl,
+      dimensions,
+      timeoutMs,
+      maxRetries,
+    );
   }
   return new ProviderAdapterEmbeddings(api, cfg.embedding);
 }

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -36,6 +36,18 @@
       "help": "Vector dimensions for custom models (required for non-standard models)",
       "advanced": true
     },
+    "embedding.timeoutMs": {
+      "label": "Timeout (ms)",
+      "placeholder": "10000",
+      "help": "Timeout for embedding API requests in milliseconds",
+      "advanced": true
+    },
+    "embedding.maxRetries": {
+      "label": "Max Retries",
+      "placeholder": "1",
+      "help": "Maximum number of retries for failed embedding requests",
+      "advanced": true
+    },
     "dbPath": {
       "label": "Database Path",
       "placeholder": "~/.openclaw/memory/lancedb",
@@ -95,6 +107,16 @@
           },
           "dimensions": {
             "type": "number"
+          },
+          "timeoutMs": {
+            "type": "number",
+            "minimum": 1000,
+            "maximum": 60000
+          },
+          "maxRetries": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 5
           }
         }
       },

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -40,6 +40,18 @@
       "help": "Vector dimensions for custom models (required for non-standard models)",
       "advanced": true
     },
+    "embedding.timeoutMs": {
+      "label": "Timeout (ms)",
+      "placeholder": "10000",
+      "help": "Timeout for embedding API requests in milliseconds",
+      "advanced": true
+    },
+    "embedding.maxRetries": {
+      "label": "Max Retries",
+      "placeholder": "1",
+      "help": "Maximum number of retries for failed embedding requests",
+      "advanced": true
+    },
     "dbPath": {
       "label": "Database Path",
       "placeholder": "~/.openclaw/memory/lancedb",
@@ -105,6 +117,16 @@
           "dimensions": {
             "type": "integer",
             "minimum": 1
+          },
+          "timeoutMs": {
+            "type": "number",
+            "minimum": 1000,
+            "maximum": 60000
+          },
+          "maxRetries": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 5
           }
         }
       },


### PR DESCRIPTION
Replaces #56517 (closed, could not reopen).

- Add embedding.timeoutMs (default 10s) and embedding.maxRetries (default 1) to memory-lancedb plugin config
- Prevents cascading Connection error failures during API rate-limit storms
- Also bumps LaunchAgent ThrottleInterval from 1s to 10s

## Real behavior proof

- **Behavior or issue addressed**: `memory-lancedb`'s OpenAI-SDK embedding client had no operator-tunable timeout/retry budget. A hung or 5xx-storming embedding backend blocks on the SDK default (600000ms) and stalls every agent turn that triggers auto-recall. This PR lets operators bound it via `embedding.timeoutMs` / `embedding.maxRetries`. Per ClawSweeper review, the bounds now apply ONLY when explicitly configured; unset installs keep the SDK defaults (no upgrade behavior change).
- **Real environment tested**: local `openclaw` checkout (upgrade onto current upstream/main) with the bundled `openai` SDK the plugin loads at runtime, exercised against a blackhole TCP endpoint that accepts the connection but never responds (simulating a hung embedding backend).
- **Exact steps or command run after this patch**:
  ```bash
  # blackhole server + the same OpenAI client the plugin constructs, with the
  # configured bound applied:
  node ./embed-timeout-proof.mjs   # full script in PR discussion
  # core: new OpenAI({ baseURL: <blackhole>, timeout: 2000, maxRetries: 1 })
  #         .embeddings.create({ model, input })
  ```
- **Evidence after fix**: captured live from the blackhole run via `node` against the bundled `openai` SDK in `~/.openclaw`/local checkout:
  ```
  blackhole embedding endpoint listening at http://127.0.0.1:60765/v1 (never responds)
  configured timeoutMs=2000 maxRetries=1: failed after 4520ms — APIConnectionTimeoutError: Request timed out.
  ```
  The configured bound aborts at 2000ms, retries once, and surfaces `APIConnectionTimeoutError` after ~4.5s total — instead of hanging on the SDK default 600000ms. The deployed wiring in `extensions/memory-lancedb/index.ts` now spreads `timeout`/`maxRetries` into the `new OpenAI({...})` constructor only when set (`...(timeoutMs !== undefined ? { timeout: timeoutMs } : {})`), so unconfigured installs retain SDK defaults.
- **Observed result after fix**: With `embedding.timeoutMs` set, a hung endpoint fails fast at the configured bound. With it unset, the OpenAI SDK default (600000ms / 2 retries) is preserved unchanged — no regression for installs with slow-but-working endpoints (the upgrade risk ClawSweeper flagged). Config-layer clamping still rejects out-of-range values (`timeoutMs` to [1000, 60000], `maxRetries` to [0, 5]).
- **What was not tested**: A real upstream OpenAI 5xx wave (used a local blackhole to deterministically reproduce the hang). Behavior on a partially-responsive endpoint that sends headers then stalls mid-body (the SDK's bodyTimeout governs that path, unchanged by this PR).
