### PR TITLE
fix(security): audit web search keys for all bundled providers

### DIFF
--- a/scripts/check-web-search-provider-boundaries.mjs
+++ b/scripts/check-web-search-provider-boundaries.mjs
@@ -53,6 +53,7 @@ const providerIds = new Set([
 const allowedGenericFiles = new Set([
   "src/agents/tools/web-search.ts",
   "src/commands/onboard-search.ts",
+  "src/plugins/bundled-web-search-registry.ts",
   "src/secrets/runtime-web-tools.ts",
   "src/web-search/runtime.ts",
 ]);

--- a/src/plugins/bundled-web-search-registry.ts
+++ b/src/plugins/bundled-web-search-registry.ts
@@ -1,0 +1,31 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveBundledPluginWebSearchProviders } from "./web-search-providers.js";
+
+function hasConfiguredCredentialValue(value: unknown): boolean {
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  return value !== undefined && value !== null;
+}
+
+export function hasBundledWebSearchCredential(params: {
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  searchConfig?: Record<string, unknown>;
+}): boolean {
+  const searchConfig =
+    params.searchConfig ?? (params.config.tools?.web?.search as Record<string, unknown> | undefined);
+  return resolveBundledPluginWebSearchProviders({
+    config: params.config,
+    env: params.env,
+    bundledAllowlistCompat: true,
+  }).some((provider) => {
+    const configuredCredential =
+      provider.getConfiguredCredentialValue?.(params.config) ??
+      provider.getCredentialValue(searchConfig);
+    if (hasConfiguredCredentialValue(configuredCredential)) {
+      return true;
+    }
+    return provider.envVars.some((envVar) => hasConfiguredCredentialValue(params.env?.[envVar]));
+  });
+}

--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { collectAttackSurfaceSummaryFindings } from "./audit-extra.sync.js";
+import {
+  collectAttackSurfaceSummaryFindings,
+  collectSmallModelRiskFindings,
+} from "./audit-extra.sync.js";
 import { safeEqualSecret } from "./secret-equal.js";
 
 describe("collectAttackSurfaceSummaryFindings", () => {
@@ -43,5 +46,62 @@ describe("safeEqualSecret", () => {
     [null, "secret", false],
   ] as const)("compares %o and %o", (left, right, expected) => {
     expect(safeEqualSecret(left, right)).toBe(expected);
+  });
+});
+
+describe("collectSmallModelRiskFindings", () => {
+  const baseCfg = {
+    agents: { defaults: { model: { primary: "ollama/mistral-8b" } } },
+    browser: { enabled: false },
+    tools: { web: { fetch: { enabled: false } } },
+  } satisfies OpenClawConfig;
+
+  it.each([
+    {
+      name: "gemini plugin config",
+      cfg: {
+        ...baseCfg,
+        plugins: {
+          entries: {
+            google: { enabled: true, config: { webSearch: { apiKey: "AIza-test" } } },
+          },
+        },
+      } satisfies OpenClawConfig,
+      env: {},
+    },
+    {
+      name: "gemini env key",
+      cfg: baseCfg,
+      env: { GEMINI_API_KEY: "AIza-test" },
+    },
+    {
+      name: "grok env key",
+      cfg: baseCfg,
+      env: { XAI_API_KEY: "xai-test" },
+    },
+    {
+      name: "kimi env key",
+      cfg: baseCfg,
+      env: { KIMI_API_KEY: "sk-kimi-test" },
+    },
+    {
+      name: "moonshot env key",
+      cfg: baseCfg,
+      env: { MOONSHOT_API_KEY: "sk-moonshot-test" },
+    },
+    {
+      name: "openrouter env fallback",
+      cfg: baseCfg,
+      env: { OPENROUTER_API_KEY: "sk-or-v1-test" },
+    },
+  ])("$name", ({ cfg, env }) => {
+    const [finding] = collectSmallModelRiskFindings({
+      cfg,
+      env,
+    });
+
+    expect(finding?.checkId).toBe("models.small_params");
+    expect(finding?.severity).toBe("critical");
+    expect(finding?.detail).toContain("web_search");
   });
 });

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -23,6 +23,7 @@ import {
   DEFAULT_DANGEROUS_NODE_COMMANDS,
   resolveNodeCommandAllowlist,
 } from "../gateway/node-command-policy.js";
+import { hasBundledWebSearchCredential } from "../plugins/bundled-web-search-registry.js";
 import { resolveBrowserConfig } from "../plugin-sdk/browser-runtime.js";
 import { inferParamBFromIdOrName } from "../shared/model-param-b.js";
 import { pickSandboxToolPolicy } from "./audit-tool-policy.js";
@@ -326,10 +327,7 @@ function resolveToolPolicies(params: {
 }
 
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
-  const search = cfg.tools?.web?.search;
-  return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
-  );
+  return hasBundledWebSearchCredential({ config: cfg, env });
 }
 
 function isWebSearchEnabled(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {


### PR DESCRIPTION
## Summary

- `hasWebSearchKey()` was hardcoded to only check Brave and Perplexity credentials
- Replace with provider-aware check using `resolveBundledPluginWebSearchProviders()`
- Gemini, Grok/XAI, Kimi, Moonshot, and OpenRouter credentials are now recognized by the audit
- Add focused regression tests for each provider

## Root Cause

The audit function `hasWebSearchKey()` in `src/security/audit-extra.sync.ts` was still hardcoded to legacy surfaces (Brave config/env + Perplexity config/env). Web search has moved to provider-owned metadata and plugin config paths, so newer providers were invisible to the audit.

## Change Type

- [x] Bug fix
- [x] Security hardening

## Testing

All 15 tests pass including 6 new regression tests:
- Gemini plugin config
- Gemini env key (`GEMINI_API_KEY`)
- Grok env key (`XAI_API_KEY`)
- Kimi env key (`KIMI_API_KEY`)
- Moonshot env key (`MOONSHOT_API_KEY`)
- OpenRouter env fallback (`OPENROUTER_API_KEY`)

Fixes #34509