### PR TITLE
feat(cron): add agent-turn mode for failure alerts

### DIFF
--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -77,7 +77,7 @@ export function registerCronEditCommand(cron: Command) {
       )
       .option("--failure-alert-to <dest>", "Failure alert destination")
       .option("--failure-alert-cooldown <duration>", "Minimum time between alerts (e.g. 1h, 30m)")
-      .option("--failure-alert-mode <mode>", "Failure alert delivery mode (announce or webhook)")
+      .option("--failure-alert-mode <mode>", "Failure alert delivery mode (announce, webhook, or agent-turn)")
       .option(
         "--failure-alert-account-id <id>",
         "Account ID for failure alert channel (multi-account setups)",

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -16,7 +16,7 @@ export type CronFailureAlertConfig = {
   enabled?: boolean;
   after?: number;
   cooldownMs?: number;
-  mode?: "announce" | "webhook";
+  mode?: "announce" | "webhook" | "agent-turn";
   accountId?: string;
 };
 
@@ -24,7 +24,7 @@ export type CronFailureDestinationConfig = {
   channel?: string;
   to?: string;
   accountId?: string;
-  mode?: "announce" | "webhook";
+  mode?: "announce" | "webhook" | "agent-turn";
 };
 
 export type CronConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -556,7 +556,7 @@ export const OpenClawSchema = z
             enabled: z.boolean().optional(),
             after: z.number().int().min(1).optional(),
             cooldownMs: z.number().int().min(0).optional(),
-            mode: z.enum(["announce", "webhook"]).optional(),
+            mode: z.enum(["announce", "webhook", "agent-turn"]).optional(),
             accountId: z.string().optional(),
           })
           .strict()
@@ -566,7 +566,7 @@ export const OpenClawSchema = z
             channel: z.string().optional(),
             to: z.string().optional(),
             accountId: z.string().optional(),
-            mode: z.enum(["announce", "webhook"]).optional(),
+            mode: z.enum(["announce", "webhook", "agent-turn"]).optional(),
           })
           .strict()
           .optional(),

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -118,7 +118,7 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
 }
 
 export type CronFailureDeliveryPlan = {
-  mode: "announce" | "webhook";
+  mode: "announce" | "webhook" | "agent-turn";
   channel?: CronMessageChannel;
   to?: string;
   accountId?: string;
@@ -128,15 +128,15 @@ export type CronFailureDestinationInput = {
   channel?: CronMessageChannel;
   to?: string;
   accountId?: string;
-  mode?: "announce" | "webhook";
+  mode?: "announce" | "webhook" | "agent-turn";
 };
 
-function normalizeFailureMode(value: unknown): "announce" | "webhook" | undefined {
+function normalizeFailureMode(value: unknown): "announce" | "webhook" | "agent-turn" | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
   const trimmed = value.trim().toLowerCase();
-  if (trimmed === "announce" || trimmed === "webhook") {
+  if (trimmed === "announce" || trimmed === "webhook" || trimmed === "agent-turn") {
     return trimmed;
   }
   return undefined;

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -153,7 +153,7 @@ export function resolveFailureDestination(
   let channel: CronMessageChannel | undefined;
   let to: string | undefined;
   let accountId: string | undefined;
-  let mode: "announce" | "webhook" | undefined;
+  let mode: "announce" | "webhook" | "agent-turn" | undefined;
 
   // Start with global config as base
   if (globalConfig) {
@@ -204,6 +204,11 @@ export function resolveFailureDestination(
   }
 
   const resolvedMode = mode ?? "announce";
+
+  // agent-turn mode is handled directly by timer.ts via enqueueSystemEvent
+  if (resolvedMode === "agent-turn") {
+    return null;
+  }
 
   // Webhook mode requires a URL
   if (resolvedMode === "webhook" && !to) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -300,7 +300,7 @@ function resolveFailureAlert(
   cooldownMs: number;
   channel: CronMessageChannel;
   to?: string;
-  mode?: "announce" | "webhook";
+  mode?: "announce" | "webhook" | "agent-turn";
   accountId?: string;
 } | null {
   const globalConfig = state.deps.cronConfig?.failureAlert;
@@ -340,7 +340,7 @@ function emitFailureAlert(
     consecutiveErrors: number;
     channel: CronMessageChannel;
     to?: string;
-    mode?: "announce" | "webhook";
+    mode?: "announce" | "webhook" | "agent-turn";
     accountId?: string;
   },
 ) {
@@ -350,6 +350,12 @@ function emitFailureAlert(
     `Cron job "${safeJobName}" failed ${params.consecutiveErrors} times`,
     `Last error: ${truncatedError}`,
   ].join("\n");
+
+  if (params.mode === "agent-turn") {
+    state.deps.enqueueSystemEvent(text, { agentId: params.job.agentId });
+    state.deps.requestHeartbeatNow({ reason: `cron:${params.job.id}:failure-alert` });
+    return;
+  }
 
   if (state.deps.sendCronFailureAlert) {
     void state.deps

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -38,7 +38,7 @@ export type CronFailureDestination = {
   channel?: CronMessageChannel;
   to?: string;
   accountId?: string;
-  mode?: "announce" | "webhook";
+  mode?: "announce" | "webhook" | "agent-turn";
 };
 
 export type CronDeliveryPatch = Partial<CronDelivery>;
@@ -75,8 +75,8 @@ export type CronFailureAlert = {
   channel?: CronMessageChannel;
   to?: string;
   cooldownMs?: number;
-  /** Delivery mode: announce (via messaging channels) or webhook (HTTP POST). */
-  mode?: "announce" | "webhook";
+  /** Delivery mode: announce (via messaging channels), webhook (HTTP POST), or agent-turn (inject into agent session). */
+  mode?: "announce" | "webhook" | "agent-turn";
   /** Account ID for multi-account channel configurations. */
   accountId?: string;
 };

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -303,6 +303,11 @@ export function buildGatewayCronService(params: {
       });
     },
     sendCronFailureAlert: async ({ job, text, channel, to, mode, accountId }) => {
+      // agent-turn mode is handled directly in timer.ts via enqueueSystemEvent;
+      // it should never reach here, but guard just in case.
+      if (mode === "agent-turn") {
+        return;
+      }
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       const webhookToken = trimToOptionalString(params.cfg.cron?.webhookToken);
 


### PR DESCRIPTION
Closes #56521

## What

Adds a new `agent-turn` mode for cron job `failureAlert` that injects the error as a system event into the agent session instead of sending an outbound notification (Telegram/etc).

## Why

When cron jobs fail, the current `announce` mode sends a notification to the user's chat. But the agent (main session) is unaware of the failure — the human has to relay the error manually.

With `agent-turn` mode, the failure alert triggers the agent directly via `enqueueSystemEvent` + `requestHeartbeatNow`, allowing the agent to:
- Diagnose the error autonomously
- Attempt a fix if possible
- Report the outcome to the human

## How

- New `failureAlert.mode: 'agent-turn'` option
- In `emitFailureAlert`, when mode is `agent-turn`, bypasses `sendCronFailureAlert` and uses the existing `enqueueSystemEvent` + `requestHeartbeatNow` path
- CLI: `openclaw cron edit <id> --failure-alert-mode agent-turn`

## Usage

```bash
openclaw cron edit <job-id> --failure-alert-mode agent-turn
```

Or in config:
```json
{
  "failureAlert": {
    "mode": "agent-turn",
    "after": 1
  }
}
```
