### PR TITLE
fix(google): resolve Gemini 3.1 models for all Google provider aliases

### DIFF
--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -241,7 +241,11 @@ export default definePluginEntry({
         normalizeGoogleProviderConfig(provider, providerConfig),
       normalizeModelId: ({ modelId }) => normalizeGoogleModelId(modelId),
       resolveDynamicModel: (ctx) =>
-        resolveGoogle31ForwardCompatModel({ providerId: "google", ctx }),
+        resolveGoogle31ForwardCompatModel({
+          providerId: ctx.provider,
+          templateProviderId: GOOGLE_GEMINI_CLI_PROVIDER_ID,
+          ctx,
+        }),
       wrapStreamFn: (ctx) => createGoogleThinkingPayloadWrapper(ctx.streamFn, ctx.thinkingLevel),
       isModernModelRef: ({ modelId }) => isModernGoogleModel(modelId),
     });

--- a/extensions/google/provider-models.test.ts
+++ b/extensions/google/provider-models.test.ts
@@ -1,0 +1,117 @@
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import type {
+  ProviderResolveDynamicModelContext,
+  ProviderRuntimeModel,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { resolveGoogle31ForwardCompatModel } from "./provider-models.js";
+
+function createTemplateModel(
+  provider: string,
+  id: string,
+  overrides: Partial<ProviderRuntimeModel> = {},
+): ProviderRuntimeModel {
+  return {
+    id,
+    name: id,
+    provider,
+    api: provider === "google-gemini-cli" ? "google-gemini-cli" : "google-generative-ai",
+    baseUrl:
+      provider === "google-gemini-cli"
+        ? "https://cloudcode-pa.googleapis.com"
+        : "https://generativelanguage.googleapis.com/v1beta",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 64_000,
+    ...overrides,
+  } as ProviderRuntimeModel;
+}
+
+function createContext(params: {
+  provider: string;
+  modelId: string;
+  models: ProviderRuntimeModel[];
+}): ProviderResolveDynamicModelContext {
+  return {
+    provider: params.provider,
+    modelId: params.modelId,
+    modelRegistry: {
+      find(providerId: string, modelId: string) {
+        return (
+          params.models.find(
+            (model) =>
+              model.provider === providerId && model.id.toLowerCase() === modelId.toLowerCase(),
+          ) ?? null
+        );
+      },
+    } as ModelRegistry,
+  };
+}
+
+describe("resolveGoogle31ForwardCompatModel", () => {
+  it("resolves gemini 3.1 pro for google aliases via an alternate template provider", () => {
+    const model = resolveGoogle31ForwardCompatModel({
+      providerId: "google-vertex",
+      templateProviderId: "google-gemini-cli",
+      ctx: createContext({
+        provider: "google-vertex",
+        modelId: "gemini-3.1-pro-preview",
+        models: [createTemplateModel("google-gemini-cli", "gemini-3-pro-preview")],
+      }),
+    });
+
+    expect(model).toMatchObject({
+      provider: "google-vertex",
+      id: "gemini-3.1-pro-preview",
+      api: "google-gemini-cli",
+      reasoning: true,
+    });
+  });
+
+  it("resolves gemini 3.1 flash from direct google templates", () => {
+    const model = resolveGoogle31ForwardCompatModel({
+      providerId: "google",
+      templateProviderId: "google-gemini-cli",
+      ctx: createContext({
+        provider: "google",
+        modelId: "gemini-3.1-flash-preview",
+        models: [createTemplateModel("google", "gemini-3-flash-preview")],
+      }),
+    });
+
+    expect(model).toMatchObject({
+      provider: "google",
+      id: "gemini-3.1-flash-preview",
+      api: "google-generative-ai",
+      reasoning: true,
+    });
+  });
+
+  it("prefers the flash-lite template before the broader flash prefix", () => {
+    const model = resolveGoogle31ForwardCompatModel({
+      providerId: "google-vertex",
+      templateProviderId: "google-gemini-cli",
+      ctx: createContext({
+        provider: "google-vertex",
+        modelId: "gemini-3.1-flash-lite-preview",
+        models: [
+          createTemplateModel("google-gemini-cli", "gemini-3-flash-preview", {
+            contextWindow: 128_000,
+          }),
+          createTemplateModel("google-gemini-cli", "gemini-3.1-flash-lite-preview", {
+            contextWindow: 1_048_576,
+          }),
+        ],
+      }),
+    });
+
+    expect(model).toMatchObject({
+      provider: "google-vertex",
+      id: "gemini-3.1-flash-lite-preview",
+      contextWindow: 1_048_576,
+      reasoning: true,
+    });
+  });
+});

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -5,12 +5,51 @@ import type {
 import { cloneFirstTemplateModel } from "openclaw/plugin-sdk/provider-model-shared";
 
 const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
+const GEMINI_3_1_FLASH_LITE_PREFIX = "gemini-3.1-flash-lite";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
 const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
+const GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS = [
+  "gemini-3.1-flash-lite-preview",
+] as const;
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
+
+function cloneFirstGoogleTemplateModel(params: {
+  providerId: string;
+  templateProviderId?: string;
+  modelId: string;
+  templateIds: readonly string[];
+  ctx: ProviderResolveDynamicModelContext;
+  patch?: Partial<ProviderRuntimeModel>;
+}): ProviderRuntimeModel | undefined {
+  const templateProviderIds = [
+    params.providerId,
+    params.templateProviderId,
+  ]
+    .map((providerId) => providerId?.trim())
+    .filter((providerId): providerId is string => Boolean(providerId));
+
+  for (const templateProviderId of new Set(templateProviderIds)) {
+    const model = cloneFirstTemplateModel({
+      providerId: templateProviderId,
+      modelId: params.modelId,
+      templateIds: params.templateIds,
+      ctx: params.ctx,
+      patch: {
+        ...params.patch,
+        provider: params.providerId,
+      },
+    });
+    if (model) {
+      return model;
+    }
+  }
+
+  return undefined;
+}
 
 export function resolveGoogle31ForwardCompatModel(params: {
   providerId: string;
+  templateProviderId?: string;
   ctx: ProviderResolveDynamicModelContext;
 }): ProviderRuntimeModel | undefined {
   const trimmed = params.ctx.modelId.trim();
@@ -19,14 +58,17 @@ export function resolveGoogle31ForwardCompatModel(params: {
   let templateIds: readonly string[];
   if (lower.startsWith(GEMINI_3_1_PRO_PREFIX)) {
     templateIds = GEMINI_3_1_PRO_TEMPLATE_IDS;
+  } else if (lower.startsWith(GEMINI_3_1_FLASH_LITE_PREFIX)) {
+    templateIds = GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS;
   } else if (lower.startsWith(GEMINI_3_1_FLASH_PREFIX)) {
     templateIds = GEMINI_3_1_FLASH_TEMPLATE_IDS;
   } else {
     return undefined;
   }
 
-  return cloneFirstTemplateModel({
+  return cloneFirstGoogleTemplateModel({
     providerId: params.providerId,
+    templateProviderId: params.templateProviderId,
     modelId: trimmed,
     templateIds,
     ctx: params.ctx,


### PR DESCRIPTION
## Summary

- The forward-compat resolver hardcoded `"google"` as the provider ID for template lookup, so alias providers (`google-vertex`, `google-gemini-cli`) could not find matching templates
- Pass actual provider ID from runtime context + add `templateProviderId` fallback for cross-provider template resolution
- Fix flash-lite prefix ordering: check `gemini-3.1-flash-lite` before `gemini-3.1-flash` to prevent misclassification
- Add regression tests for pro, flash, and flash-lite across provider aliases

## Root Cause

`resolveGoogle31ForwardCompatModel()` in `extensions/google/provider-models.ts` was called with hardcoded `providerId: "google"` from `extensions/google/index.ts:243`. When users configured `google-vertex` or other aliases, the template lookup failed because no templates existed under that provider ID.

Secondary bug: `gemini-3.1-flash-lite` starts with `gemini-3.1-flash`, so without explicit ordering it matched the wrong branch.

## Change Type

- [x] Bug fix

## Testing

24 tests pass across 3 test files including new regression coverage for:
- Gemini 3.1 Pro via google-vertex alias
- Gemini 3.1 Flash via direct google provider  
- Gemini 3.1 Flash-Lite prefix ordering

Fixes #36111