### PR TITLE
fix(bluebubbles): guard debounce flush against null text

### DIFF
--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -11,6 +11,23 @@ type BlueBubblesDebounceEntry = {
   target: WebhookTarget;
 };
 
+function normalizeDebounceMessageText(text: unknown): string {
+  return typeof text === "string" ? text : "";
+}
+
+function sanitizeDebounceEntry(entry: BlueBubblesDebounceEntry): BlueBubblesDebounceEntry {
+  if (typeof entry.message.text === "string") {
+    return entry;
+  }
+  return {
+    ...entry,
+    message: {
+      ...entry.message,
+      text: "",
+    },
+  };
+}
+
 export type BlueBubblesDebouncer = {
   enqueue: (item: BlueBubblesDebounceEntry) => Promise<void>;
   flushKey: (key: string) => Promise<void>;
@@ -48,7 +65,7 @@ function combineDebounceEntries(entries: BlueBubblesDebounceEntry[]): Normalized
   const textParts: string[] = [];
 
   for (const entry of entries) {
-    const text = entry.message.text.trim();
+    const text = normalizeDebounceMessageText(entry.message.text).trim();
     if (!text) {
       continue;
     }
@@ -120,7 +137,7 @@ export function createBlueBubblesDebounceRegistry(params: {
       }
 
       const { account, config, runtime, core } = target;
-      const debouncer = core.channel.debounce.createInboundDebouncer<BlueBubblesDebounceEntry>({
+      const baseDebouncer = core.channel.debounce.createInboundDebouncer<BlueBubblesDebounceEntry>({
         debounceMs: resolveBlueBubblesDebounceMs(config, core),
         buildKey: (entry) => {
           const msg = entry.message;
@@ -194,6 +211,13 @@ export function createBlueBubblesDebounceRegistry(params: {
           );
         },
       });
+
+      const debouncer: BlueBubblesDebouncer = {
+        enqueue: async (item) => {
+          await baseDebouncer.enqueue(sanitizeDebounceEntry(item));
+        },
+        flushKey: (key) => baseDebouncer.flushKey(key),
+      };
 
       targetDebouncers.set(target, debouncer);
       return debouncer;

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -27,6 +27,8 @@ import {
   resetBlueBubblesParticipantContactNameCacheForTest,
   setBlueBubblesParticipantContactDepsForTest,
 } from "./participant-contact-names.js";
+import { createBlueBubblesDebounceRegistry } from "./monitor-debounce.js";
+import type { NormalizedWebhookMessage } from "./monitor-normalize.js";
 import type { OpenClawConfig, PluginRuntime } from "./runtime-api.js";
 
 // Mock dependencies
@@ -145,6 +147,73 @@ function getFirstDispatchCall(): DispatchReplyParams {
     throw new Error("expected dispatch call arguments");
   }
   return callArgs;
+}
+
+function installTimingAwareInboundDebouncer(core: PluginRuntime) {
+  // Use a timing-aware debouncer test double that respects debounceMs/buildKey/shouldDebounce.
+  // oxlint-disable-next-line typescript/no-explicit-any
+  core.channel.debounce.createInboundDebouncer = vi.fn((params: any) => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    type Item = any;
+    const buckets = new Map<string, { items: Item[]; timer: ReturnType<typeof setTimeout> | null }>();
+
+    const flush = async (key: string) => {
+      const bucket = buckets.get(key);
+      if (!bucket) {
+        return;
+      }
+      if (bucket.timer) {
+        clearTimeout(bucket.timer);
+        bucket.timer = null;
+      }
+      const items = bucket.items;
+      bucket.items = [];
+      if (items.length > 0) {
+        try {
+          await params.onFlush(items);
+        } catch (err) {
+          params.onError?.(err);
+          throw err;
+        }
+      }
+    };
+
+    return {
+      enqueue: async (item: Item) => {
+        if (params.shouldDebounce && !params.shouldDebounce(item)) {
+          await params.onFlush([item]);
+          return;
+        }
+
+        const key = params.buildKey(item);
+        const existing = buckets.get(key);
+        const bucket = existing ?? { items: [], timer: null };
+        bucket.items.push(item);
+        if (bucket.timer) {
+          clearTimeout(bucket.timer);
+        }
+        bucket.timer = setTimeout(async () => {
+          await flush(key);
+        }, params.debounceMs);
+        buckets.set(key, bucket);
+      },
+      flushKey: vi.fn(async (key: string) => {
+        await flush(key);
+      }),
+    };
+  }) as unknown as PluginRuntime["channel"]["debounce"]["createInboundDebouncer"];
+}
+
+function createDebounceTestMessage(
+  overrides: Partial<NormalizedWebhookMessage> = {},
+): NormalizedWebhookMessage {
+  return {
+    text: "hello",
+    senderId: "+15551234567",
+    senderIdExplicit: true,
+    isGroup: false,
+    ...overrides,
+  };
 }
 
 describe("BlueBubbles webhook monitor", () => {
@@ -724,62 +793,7 @@ describe("BlueBubbles webhook monitor", () => {
       vi.useFakeTimers();
       try {
         const core = createMockRuntime();
-
-        // Use a timing-aware debouncer test double that respects debounceMs/buildKey/shouldDebounce.
-        // oxlint-disable-next-line typescript/no-explicit-any
-        core.channel.debounce.createInboundDebouncer = vi.fn((params: any) => {
-          // oxlint-disable-next-line typescript/no-explicit-any
-          type Item = any;
-          const buckets = new Map<
-            string,
-            { items: Item[]; timer: ReturnType<typeof setTimeout> | null }
-          >();
-
-          const flush = async (key: string) => {
-            const bucket = buckets.get(key);
-            if (!bucket) {
-              return;
-            }
-            if (bucket.timer) {
-              clearTimeout(bucket.timer);
-              bucket.timer = null;
-            }
-            const items = bucket.items;
-            bucket.items = [];
-            if (items.length > 0) {
-              try {
-                await params.onFlush(items);
-              } catch (err) {
-                params.onError?.(err);
-                throw err;
-              }
-            }
-          };
-
-          return {
-            enqueue: async (item: Item) => {
-              if (params.shouldDebounce && !params.shouldDebounce(item)) {
-                await params.onFlush([item]);
-                return;
-              }
-
-              const key = params.buildKey(item);
-              const existing = buckets.get(key);
-              const bucket = existing ?? { items: [], timer: null };
-              bucket.items.push(item);
-              if (bucket.timer) {
-                clearTimeout(bucket.timer);
-              }
-              bucket.timer = setTimeout(async () => {
-                await flush(key);
-              }, params.debounceMs);
-              buckets.set(key, bucket);
-            },
-            flushKey: vi.fn(async (key: string) => {
-              await flush(key);
-            }),
-          };
-        }) as unknown as PluginRuntime["channel"]["debounce"]["createInboundDebouncer"];
+        installTimingAwareInboundDebouncer(core);
 
         const registration = trackWebhookRegistrationForTest(
           setupWebhookTargetForTest({
@@ -828,6 +842,61 @@ describe("BlueBubbles webhook monitor", () => {
         const callArgs = getFirstDispatchCall();
         expect(callArgs.ctx.MediaPaths).toEqual(["/tmp/test-media.jpg"]);
         expect(callArgs.ctx.Body).toContain("hello");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("skips null-text entries during flush and still delivers the valid message", async () => {
+      vi.useFakeTimers();
+      try {
+        const core = createMockRuntime();
+        installTimingAwareInboundDebouncer(core);
+
+        const processMessage = vi.fn().mockResolvedValue(undefined);
+        const registry = createBlueBubblesDebounceRegistry({ processMessage });
+        const account = createMockAccount();
+        const target = {
+          account,
+          config: {},
+          runtime: { log: vi.fn(), error: vi.fn() },
+          core,
+          path: "/bluebubbles-webhook",
+        };
+        const debouncer = registry.getOrCreateDebouncer(target);
+
+        await debouncer.enqueue({
+          message: {
+            ...createDebounceTestMessage({
+              messageId: "msg-null",
+              chatGuid: "iMessage;-;+15551234567",
+            }),
+            text: null,
+          } as unknown as NormalizedWebhookMessage,
+          target,
+        });
+
+        await vi.advanceTimersByTimeAsync(300);
+
+        await debouncer.enqueue({
+          message: createDebounceTestMessage({
+            text: "hello from valid entry",
+            messageId: "msg-null",
+            chatGuid: "iMessage;-;+15551234567",
+          }),
+          target,
+        });
+
+        await vi.advanceTimersByTimeAsync(600);
+
+        expect(processMessage).toHaveBeenCalledTimes(1);
+        expect(processMessage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: "hello from valid entry",
+          }),
+          target,
+        );
+        expect(target.runtime.error).not.toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
       }


### PR DESCRIPTION
## Summary

- Sanitize message text at debounce enqueue boundary — coerce null/undefined to empty string
- Add independent guard in `combineDebounceEntries()` for entries already queued
- Prevents `TypeError: Cannot read properties of null (reading 'trim')` during debounce flush

## Root Cause

`combineDebounceEntries()` in `extensions/bluebubbles/src/monitor-debounce.ts:67` calls `entry.message.text.trim()` without null guard. When a webhook delivers a message with null text (e.g. tapback/reaction-only), the multi-entry flush path crashes.

## Change Type

- [x] Bug fix

## Testing

18 test suites, 363 tests pass. New regression test:
- Enqueue null-text entry + valid entry with same messageId
- Advance timers to force flush
- Verify no error thrown
- Verify valid message is delivered to processMessage

Fixes #35777