### PR TITLE
fix(plugins): dedupe tool registration and preserve plugin tool config

### DIFF
--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -151,7 +151,9 @@ Think of the suites as “increasing realism” (and increasing flakiness/cost):
   - Not CI-stable by design (real networks, real provider policies, quotas, outages)
   - Costs money / uses rate limits
   - Prefer running narrowed subsets instead of “everything”
-- Live runs will source `~/.profile` to pick up missing API keys
+- Live runs source `~/.profile` to pick up missing API keys.
+- By default, live runs still isolate `HOME` and copy config/auth material into a temp test home so unit fixtures cannot mutate your real `~/.openclaw`.
+- Set `OPENCLAW_LIVE_USE_REAL_HOME=1` only when you intentionally need live tests to use your real home directory.
 - `pnpm test:live` now defaults to a quieter mode: it keeps `[live] ...` progress output, but suppresses the extra `~/.profile` notice and mutes gateway bootstrap logs/Bonjour chatter. Set `OPENCLAW_LIVE_TEST_QUIET=0` if you want the full startup logs back.
 - API key rotation (provider-specific): set `*_API_KEYS` with comma/semicolon format or `*_API_KEY_1`, `*_API_KEY_2` (for example `OPENAI_API_KEYS`, `ANTHROPIC_API_KEYS`, `GEMINI_API_KEYS`) or per-live override via `OPENCLAW_LIVE_*_KEY`; tests retry on rate limit responses.
 - Progress/heartbeat output:
@@ -452,6 +454,7 @@ Live tests discover credentials the same way the CLI does. Practical implication
 
 - Profile store: `~/.openclaw/credentials/` (preferred; what “profile keys” means in the tests)
 - Config: `~/.openclaw/openclaw.json` (or `OPENCLAW_CONFIG_PATH`)
+- Live local runs copy the active config plus auth stores into a temp test home by default; `agents.*.workspace` / `agentDir` path overrides are stripped in that staged copy so probes stay off your real host workspace.
 
 If you want to rely on env keys (e.g. exported in your `~/.profile`), run local tests after `source ~/.profile`, or use the Docker runners below (they can mount `~/.profile` into the container).
 

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2245,6 +2245,38 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
     expect(loaded?.error).not.toContain("api.registerHttpHandler(...) was removed");
   });
 
+  it("deduplicates repeated tool registration for the same plugin", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "duplicate-tool-registration",
+      filename: "duplicate-tool-registration.cjs",
+      body: `module.exports = { id: "duplicate-tool-registration", register(api) {
+  const tool = {
+    name: "duplicate_tool",
+    description: "duplicate tool",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [], details: {} };
+    },
+  };
+  api.registerTool(tool, { name: "duplicate_tool" });
+  api.registerTool(tool, { name: "duplicate_tool" });
+} };`,
+    });
+
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["duplicate-tool-registration"],
+      },
+    });
+
+    expect(registry.tools).toHaveLength(1);
+    expect(
+      registry.plugins.find((entry) => entry.id === "duplicate-tool-registration")?.toolNames,
+    ).toEqual(["duplicate_tool"]);
+  });
+
   it("enforces plugin http route validation and conflict rules", () => {
     useNoBundledPlugins();
     const scenarios = [
@@ -3561,8 +3593,8 @@ describe("getCompatibleActivePluginRegistry", () => {
         allowGatewaySubagentBinding: true,
       },
     };
-    const { cacheKey } = __testing.resolvePluginLoadCacheContext(loadOptions);
-    setActivePluginRegistry(registry, cacheKey);
+    const { cacheKey, cacheKeyParts } = __testing.resolvePluginLoadCacheContext(loadOptions);
+    setActivePluginRegistry(registry, cacheKey, cacheKeyParts);
 
     expect(__testing.getCompatibleActivePluginRegistry(loadOptions)).toBe(registry);
     expect(
@@ -3582,7 +3614,55 @@ describe("getCompatibleActivePluginRegistry", () => {
         ...loadOptions,
         runtimeOptions: undefined,
       }),
+    ).toBe(registry);
+    expect(
+      __testing.getCompatibleActivePluginRegistry({
+        ...loadOptions,
+        runtimeOptions: {
+          subagent: {
+            run: async () => ({ runId: "subagent-run" }),
+            waitForRun: async () => ({ status: "ok" }),
+            getSessionMessages: async () => ({ messages: [] }),
+            getSession: async () => ({ messages: [] }),
+            deleteSession: async () => undefined,
+          },
+        },
+      }),
     ).toBeUndefined();
+  });
+
+  it("reuses a gateway-bindable active registry for default runtime requests", () => {
+    const registry = createEmptyPluginRegistry();
+    const startupLoadOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+          load: { paths: ["/tmp/demo.js"] },
+        },
+      },
+      workspaceDir: "/tmp/workspace-a",
+      coreGatewayHandlers: {
+        "plugins.demo": async () => undefined,
+      },
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+    };
+    const { cacheKey, cacheKeyParts } = __testing.resolvePluginLoadCacheContext(startupLoadOptions);
+    setActivePluginRegistry(registry, cacheKey, cacheKeyParts);
+
+    expect(
+      __testing.getCompatibleActivePluginRegistry({
+        config: startupLoadOptions.config,
+        workspaceDir: startupLoadOptions.workspaceDir,
+      }),
+    ).toBe(registry);
+    expect(
+      resolveRuntimePluginRegistry({
+        config: startupLoadOptions.config,
+        workspaceDir: startupLoadOptions.workspaceDir,
+      }),
+    ).toBe(registry);
   });
 
   it("falls back to the current active runtime when no compatibility-shaping inputs are supplied", () => {
@@ -3606,8 +3686,8 @@ describe("getCompatibleActivePluginRegistry", () => {
         "sessions.get": () => undefined,
       },
     };
-    const { cacheKey } = __testing.resolvePluginLoadCacheContext(loadOptions);
-    setActivePluginRegistry(registry, cacheKey);
+    const { cacheKey, cacheKeyParts } = __testing.resolvePluginLoadCacheContext(loadOptions);
+    setActivePluginRegistry(registry, cacheKey, cacheKeyParts);
 
     expect(__testing.getCompatibleActivePluginRegistry(loadOptions)).toBe(registry);
     expect(
@@ -3633,8 +3713,8 @@ describe("resolveRuntimePluginRegistry", () => {
       },
       workspaceDir: "/tmp/workspace-a",
     };
-    const { cacheKey } = __testing.resolvePluginLoadCacheContext(loadOptions);
-    setActivePluginRegistry(registry, cacheKey);
+    const { cacheKey, cacheKeyParts } = __testing.resolvePluginLoadCacheContext(loadOptions);
+    setActivePluginRegistry(registry, cacheKey, cacheKeyParts);
 
     expect(resolveRuntimePluginRegistry(loadOptions)).toBe(registry);
   });

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2277,6 +2277,44 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
     ).toEqual(["duplicate_tool"]);
   });
 
+  it("keeps non-conflicting tool registrations when advertised names only partially overlap", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "partial-overlap-tool-registration",
+      filename: "partial-overlap-tool-registration.cjs",
+      body: `module.exports = { id: "partial-overlap-tool-registration", register(api) {
+  api.registerTool({
+    name: "tool_a",
+    description: "tool a",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [], details: { tool: "a" } };
+    },
+  }, { names: ["tool_a", "shared_name"] });
+  api.registerTool({
+    name: "tool_c",
+    description: "tool c",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [], details: { tool: "c" } };
+    },
+  }, { names: ["shared_name", "tool_c"] });
+} };`,
+    });
+
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["partial-overlap-tool-registration"],
+      },
+    });
+
+    expect(registry.tools).toHaveLength(2);
+    expect(
+      registry.plugins.find((entry) => entry.id === "partial-overlap-tool-registration")?.toolNames,
+    ).toEqual(["tool_a", "shared_name", "tool_c"]);
+  });
+
   it("enforces plugin http route validation and conflict rules", () => {
     useNoBundledPlugins();
     const scenarios = [
@@ -3663,6 +3701,38 @@ describe("getCompatibleActivePluginRegistry", () => {
         workspaceDir: startupLoadOptions.workspaceDir,
       }),
     ).toBe(registry);
+  });
+
+  it("does not reuse a gateway-bindable active registry when core gateway method names differ", () => {
+    const registry = createEmptyPluginRegistry();
+    const startupLoadOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+          load: { paths: ["/tmp/demo.js"] },
+        },
+      },
+      workspaceDir: "/tmp/workspace-a",
+      coreGatewayHandlers: {
+        "plugins.demo": async () => undefined,
+      },
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+    };
+    const { cacheKey, cacheKeyParts } = __testing.resolvePluginLoadCacheContext(startupLoadOptions);
+    setActivePluginRegistry(registry, cacheKey, cacheKeyParts);
+
+    expect(
+      __testing.getCompatibleActivePluginRegistry({
+        config: startupLoadOptions.config,
+        workspaceDir: startupLoadOptions.workspaceDir,
+        coreGatewayHandlers: {
+          "plugins.demo": async () => undefined,
+          "plugins.demo.extra": async () => undefined,
+        },
+      }),
+    ).toBeUndefined();
   });
 
   it("falls back to the current active runtime when no compatibility-shaping inputs are supplied", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -40,6 +40,7 @@ import { resolvePluginCacheInputs } from "./roots.js";
 import {
   getActivePluginRegistry,
   getActivePluginRegistryKey,
+  getActivePluginRegistryKeyParts,
   setActivePluginRegistry,
 } from "./runtime.js";
 import type { CreatePluginRuntimeOptions } from "./runtime/index.js";
@@ -206,6 +207,22 @@ function buildCacheKey(params: {
   pluginSdkResolution?: PluginSdkResolutionPreference;
   coreGatewayMethodNames?: string[];
 }): string {
+  const parts = buildCacheKeyParts(params);
+  return `${parts.pluginInputKey}::${parts.scopeKey}::${parts.setupOnlyKey}::${parts.startupChannelMode}::${parts.runtimeSubagentMode}::${parts.pluginSdkResolution}::${parts.gatewayMethodsKey}`;
+}
+
+function buildCacheKeyParts(params: {
+  workspaceDir?: string;
+  plugins: ReturnType<typeof normalizePluginsConfig>;
+  installs?: Record<string, PluginInstallRecord>;
+  env: NodeJS.ProcessEnv;
+  onlyPluginIds?: string[];
+  includeSetupOnlyChannelPlugins?: boolean;
+  preferSetupRuntimeForChannelPlugins?: boolean;
+  runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
+  pluginSdkResolution?: PluginSdkResolutionPreference;
+  coreGatewayMethodNames?: string[];
+}) {
   const { roots, loadPaths } = resolvePluginCacheInputs({
     workspaceDir: params.workspaceDir,
     loadPaths: params.plugins.loadPaths,
@@ -232,11 +249,21 @@ function buildCacheKey(params: {
   const startupChannelMode =
     params.preferSetupRuntimeForChannelPlugins === true ? "prefer-setup" : "full";
   const gatewayMethodsKey = JSON.stringify(params.coreGatewayMethodNames ?? []);
-  return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
-    ...params.plugins,
-    installs,
-    loadPaths,
-  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${params.runtimeSubagentMode ?? "default"}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}`;
+  return {
+    pluginInputKey: `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify(
+      {
+        ...params.plugins,
+        installs,
+        loadPaths,
+      },
+    )}`,
+    scopeKey,
+    setupOnlyKey,
+    startupChannelMode,
+    runtimeSubagentMode: params.runtimeSubagentMode ?? "default",
+    pluginSdkResolution: params.pluginSdkResolution ?? "auto",
+    gatewayMethodsKey,
+  };
 }
 
 function normalizeScopedPluginIds(ids?: string[]): string[] | undefined {
@@ -293,6 +320,18 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     pluginSdkResolution: options.pluginSdkResolution,
     coreGatewayMethodNames,
   });
+  const cacheKeyParts = buildCacheKeyParts({
+    workspaceDir: options.workspaceDir,
+    plugins: normalized,
+    installs: cfg.plugins?.installs,
+    env,
+    onlyPluginIds,
+    includeSetupOnlyChannelPlugins,
+    preferSetupRuntimeForChannelPlugins,
+    runtimeSubagentMode: resolveRuntimeSubagentMode(options.runtimeOptions),
+    pluginSdkResolution: options.pluginSdkResolution,
+    coreGatewayMethodNames,
+  });
   return {
     env,
     cfg,
@@ -302,6 +341,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     preferSetupRuntimeForChannelPlugins,
     shouldActivate: options.activate !== false,
     cacheKey,
+    cacheKeyParts,
   };
 }
 
@@ -316,12 +356,27 @@ function getCompatibleActivePluginRegistry(
     return activeRegistry;
   }
   const activeCacheKey = getActivePluginRegistryKey();
+  const activeCacheKeyParts = getActivePluginRegistryKeyParts();
   if (!activeCacheKey) {
     return undefined;
   }
-  return resolvePluginLoadCacheContext(options).cacheKey === activeCacheKey
-    ? activeRegistry
-    : undefined;
+  const { cacheKey: requestCacheKey, cacheKeyParts: requestCacheKeyParts } =
+    resolvePluginLoadCacheContext(options);
+  if (requestCacheKey === activeCacheKey) {
+    return activeRegistry;
+  }
+  if (
+    requestCacheKeyParts.runtimeSubagentMode === "default" &&
+    activeCacheKeyParts?.runtimeSubagentMode === "gateway-bindable" &&
+    requestCacheKeyParts.pluginInputKey === activeCacheKeyParts.pluginInputKey &&
+    requestCacheKeyParts.scopeKey === activeCacheKeyParts.scopeKey &&
+    requestCacheKeyParts.setupOnlyKey === activeCacheKeyParts.setupOnlyKey &&
+    requestCacheKeyParts.startupChannelMode === activeCacheKeyParts.startupChannelMode &&
+    requestCacheKeyParts.pluginSdkResolution === activeCacheKeyParts.pluginSdkResolution
+  ) {
+    return activeRegistry;
+  }
+  return undefined;
 }
 
 export function resolveRuntimePluginRegistry(
@@ -768,8 +823,12 @@ function warnAboutUntrackedLoadedPlugins(params: {
   }
 }
 
-function activatePluginRegistry(registry: PluginRegistry, cacheKey: string): void {
-  setActivePluginRegistry(registry, cacheKey);
+function activatePluginRegistry(
+  registry: PluginRegistry,
+  cacheKey: string,
+  cacheKeyParts: ReturnType<typeof resolvePluginLoadCacheContext>["cacheKeyParts"],
+): void {
+  setActivePluginRegistry(registry, cacheKey, cacheKeyParts);
   initializeGlobalHookRunner(registry);
 }
 
@@ -790,6 +849,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     preferSetupRuntimeForChannelPlugins,
     shouldActivate,
     cacheKey,
+    cacheKeyParts,
   } = resolvePluginLoadCacheContext(options);
   const logger = options.logger ?? defaultLogger();
   const validateOnly = options.mode === "validate";
@@ -805,7 +865,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         runtime: cached.memoryRuntime,
       });
       if (shouldActivate) {
-        activatePluginRegistry(cached.registry, cacheKey);
+        activatePluginRegistry(cached.registry, cacheKey, cacheKeyParts);
       }
       return cached.registry;
     }
@@ -1396,7 +1456,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     });
   }
   if (shouldActivate) {
-    activatePluginRegistry(registry, cacheKey);
+    activatePluginRegistry(registry, cacheKey, cacheKeyParts);
   }
   return registry;
 }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -16,7 +16,6 @@ import {
   normalizePluginsConfig,
   resolveEffectiveEnableState,
   resolveMemorySlotDecision,
-  type NormalizedPluginsConfig,
 } from "./config-state.js";
 import { discoverOpenClawPlugins } from "./discovery.js";
 import { initializeGlobalHookRunner } from "./hook-runner-global.js";
@@ -195,19 +194,7 @@ function setCachedPluginRegistry(cacheKey: string, state: CachedPluginState): vo
   }
 }
 
-function buildCacheKey(params: {
-  workspaceDir?: string;
-  plugins: NormalizedPluginsConfig;
-  installs?: Record<string, PluginInstallRecord>;
-  env: NodeJS.ProcessEnv;
-  onlyPluginIds?: string[];
-  includeSetupOnlyChannelPlugins?: boolean;
-  preferSetupRuntimeForChannelPlugins?: boolean;
-  runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
-  pluginSdkResolution?: PluginSdkResolutionPreference;
-  coreGatewayMethodNames?: string[];
-}): string {
-  const parts = buildCacheKeyParts(params);
+function buildCacheKeyFromParts(parts: ReturnType<typeof buildCacheKeyParts>): string {
   return `${parts.pluginInputKey}::${parts.scopeKey}::${parts.setupOnlyKey}::${parts.startupChannelMode}::${parts.runtimeSubagentMode}::${parts.pluginSdkResolution}::${parts.gatewayMethodsKey}`;
 }
 
@@ -308,18 +295,6 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const includeSetupOnlyChannelPlugins = options.includeSetupOnlyChannelPlugins === true;
   const preferSetupRuntimeForChannelPlugins = options.preferSetupRuntimeForChannelPlugins === true;
   const coreGatewayMethodNames = Object.keys(options.coreGatewayHandlers ?? {}).toSorted();
-  const cacheKey = buildCacheKey({
-    workspaceDir: options.workspaceDir,
-    plugins: normalized,
-    installs: cfg.plugins?.installs,
-    env,
-    onlyPluginIds,
-    includeSetupOnlyChannelPlugins,
-    preferSetupRuntimeForChannelPlugins,
-    runtimeSubagentMode: resolveRuntimeSubagentMode(options.runtimeOptions),
-    pluginSdkResolution: options.pluginSdkResolution,
-    coreGatewayMethodNames,
-  });
   const cacheKeyParts = buildCacheKeyParts({
     workspaceDir: options.workspaceDir,
     plugins: normalized,
@@ -332,6 +307,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     pluginSdkResolution: options.pluginSdkResolution,
     coreGatewayMethodNames,
   });
+  const cacheKey = buildCacheKeyFromParts(cacheKeyParts);
   return {
     env,
     cfg,
@@ -372,7 +348,9 @@ function getCompatibleActivePluginRegistry(
     requestCacheKeyParts.scopeKey === activeCacheKeyParts.scopeKey &&
     requestCacheKeyParts.setupOnlyKey === activeCacheKeyParts.setupOnlyKey &&
     requestCacheKeyParts.startupChannelMode === activeCacheKeyParts.startupChannelMode &&
-    requestCacheKeyParts.pluginSdkResolution === activeCacheKeyParts.pluginSdkResolution
+    requestCacheKeyParts.pluginSdkResolution === activeCacheKeyParts.pluginSdkResolution &&
+    (options.coreGatewayHandlers === undefined ||
+      requestCacheKeyParts.gatewayMethodsKey === activeCacheKeyParts.gatewayMethodsKey)
   ) {
     return activeRegistry;
   }

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -79,6 +79,24 @@ export type PluginToolRegistration = {
   pluginConfig?: Record<string, unknown>;
 };
 
+function hasExactRegisteredToolMatch(params: {
+  existing: PluginToolRegistration;
+  pluginId: string;
+  normalizedNames: string[];
+  optional: boolean;
+  source: string;
+  rootDir?: string;
+}): boolean {
+  return (
+    params.existing.pluginId === params.pluginId &&
+    params.existing.optional === params.optional &&
+    params.existing.source === params.source &&
+    params.existing.rootDir === params.rootDir &&
+    params.existing.names.length === params.normalizedNames.length &&
+    params.existing.names.every((name, index) => name === params.normalizedNames[index])
+  );
+}
+
 export type PluginCliRegistration = {
   pluginId: string;
   pluginName?: string;
@@ -294,17 +312,22 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
 
     const normalized = Array.from(new Set(names.map((name) => name.trim()).filter(Boolean)));
     if (normalized.length > 0) {
-      const alreadyRegistered = registry.tools.some(
-        (existing) =>
-          existing.pluginId === record.id &&
-          existing.names.some((name) => normalized.includes(name)),
+      const alreadyRegistered = registry.tools.some((existing) =>
+        hasExactRegisteredToolMatch({
+          existing,
+          pluginId: record.id,
+          normalizedNames: normalized,
+          optional,
+          source: record.source,
+          rootDir: record.rootDir,
+        }),
       );
       if (alreadyRegistered) {
         return;
       }
     }
     if (normalized.length > 0) {
-      record.toolNames.push(...normalized);
+      record.toolNames = Array.from(new Set([...record.toolNames, ...normalized]));
     }
     registry.tools.push({
       pluginId: record.id,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -76,6 +76,7 @@ export type PluginToolRegistration = {
   optional: boolean;
   source: string;
   rootDir?: string;
+  pluginConfig?: Record<string, unknown>;
 };
 
 export type PluginCliRegistration = {
@@ -280,6 +281,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     record: PluginRecord,
     tool: AnyAgentTool | OpenClawPluginToolFactory,
     opts?: { name?: string; names?: string[]; optional?: boolean },
+    pluginConfig?: Record<string, unknown>,
   ) => {
     const names = opts?.names ?? (opts?.name ? [opts.name] : []);
     const optional = opts?.optional === true;
@@ -290,7 +292,17 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       names.push(tool.name);
     }
 
-    const normalized = names.map((name) => name.trim()).filter(Boolean);
+    const normalized = Array.from(new Set(names.map((name) => name.trim()).filter(Boolean)));
+    if (normalized.length > 0) {
+      const alreadyRegistered = registry.tools.some(
+        (existing) =>
+          existing.pluginId === record.id &&
+          existing.names.some((name) => normalized.includes(name)),
+      );
+      if (alreadyRegistered) {
+        return;
+      }
+    }
     if (normalized.length > 0) {
       record.toolNames.push(...normalized);
     }
@@ -302,6 +314,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       optional,
       source: record.source,
       rootDir: record.rootDir,
+      pluginConfig,
     });
   };
 
@@ -975,7 +988,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       handlers: {
         ...(registrationMode === "full"
           ? {
-              registerTool: (tool, opts) => registerTool(record, tool, opts),
+              registerTool: (tool, opts) => registerTool(record, tool, opts, params.pluginConfig),
               registerHook: (events, handler, opts) =>
                 registerHook(record, events, handler, opts, params.config),
               registerHttpRoute: (routeParams) => registerHttpRoute(record, routeParams),

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -15,6 +15,15 @@ type RegistryState = {
   httpRoute: RegistrySurfaceState;
   channel: RegistrySurfaceState;
   key: string | null;
+  keyParts: {
+    pluginInputKey: string;
+    scopeKey: string;
+    setupOnlyKey: string;
+    startupChannelMode: string;
+    runtimeSubagentMode: string;
+    pluginSdkResolution: string;
+    gatewayMethodsKey: string;
+  } | null;
 };
 
 const state: RegistryState = (() => {
@@ -36,6 +45,7 @@ const state: RegistryState = (() => {
         version: 0,
       },
       key: null,
+      keyParts: null,
     };
   }
   return globalState[REGISTRY_STATE];
@@ -71,12 +81,17 @@ function syncTrackedSurface(
   installSurfaceRegistry(surface, registry, false);
 }
 
-export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
+export function setActivePluginRegistry(
+  registry: PluginRegistry,
+  cacheKey?: string,
+  cacheKeyParts?: RegistryState["keyParts"],
+) {
   state.activeRegistry = registry;
   state.activeVersion += 1;
   syncTrackedSurface(state.httpRoute, registry, true);
   syncTrackedSurface(state.channel, registry, true);
   state.key = cacheKey ?? null;
+  state.keyParts = cacheKeyParts ?? null;
 }
 
 export function getActivePluginRegistry(): PluginRegistry | null {
@@ -175,6 +190,10 @@ export function getActivePluginRegistryKey(): string | null {
   return state.key;
 }
 
+export function getActivePluginRegistryKeyParts(): RegistryState["keyParts"] {
+  return state.keyParts;
+}
+
 export function getActivePluginRegistryVersion(): number {
   return state.activeVersion;
 }
@@ -185,4 +204,5 @@ export function resetPluginRuntimeStateForTest(): void {
   installSurfaceRegistry(state.httpRoute, null, false);
   installSurfaceRegistry(state.channel, null, false);
   state.key = null;
+  state.keyParts = null;
 }

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -5,6 +5,7 @@ type MockRegistryToolEntry = {
   optional: boolean;
   source: string;
   factory: (ctx: unknown) => unknown;
+  pluginConfig?: Record<string, unknown>;
 };
 
 const loadOpenClawPluginsMock = vi.fn();
@@ -214,6 +215,31 @@ describe("resolvePluginTools optional tools", () => {
     const tools = resolveOptionalDemoTools();
 
     expect(tools).toHaveLength(0);
+  });
+
+  it("passes pluginConfig through to plugin tool factories", () => {
+    const seenContexts: unknown[] = [];
+    setRegistry([
+      {
+        pluginId: "optional-demo",
+        optional: false,
+        source: "/tmp/optional-demo.js",
+        pluginConfig: { tenant: "workspace-a", token: "masked" },
+        factory: (ctx) => {
+          seenContexts.push(ctx);
+          return makeTool("plugin_config_tool");
+        },
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["plugin_config_tool"]);
+    expect(seenContexts[0]).toEqual(
+      expect.objectContaining({
+        pluginConfig: { tenant: "workspace-a", token: "masked" },
+      }),
+    );
   });
 
   it.each([

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -111,7 +111,7 @@ export function resolvePluginTools(params: {
     }
     let resolved: AnyAgentTool | AnyAgentTool[] | null | undefined = null;
     try {
-      resolved = entry.factory(params.context);
+      resolved = entry.factory({ ...params.context, pluginConfig: entry.pluginConfig });
     } catch (err) {
       log.error(`plugin tool failed (${entry.pluginId}): ${String(err)}`);
       continue;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -114,6 +114,7 @@ export type OpenClawPluginConfigSchema = {
 /** Trusted execution context passed to plugin-owned agent tool factories. */
 export type OpenClawPluginToolContext = {
   config?: OpenClawConfig;
+  pluginConfig?: Record<string, unknown>;
   workspaceDir?: string;
   agentDir?: string;
   agentId?: string;

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -1,0 +1,139 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { installTestEnv } from "./test-env.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+const tempDirs = new Set<string>();
+const cleanupFns: Array<() => void> = [];
+
+function restoreProcessEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) {
+      delete process.env[key];
+    }
+  }
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function writeFile(targetPath: string, content: string): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, content, "utf8");
+}
+
+function createTempHome(): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-env-real-home-"));
+  tempDirs.add(tempDir);
+  return tempDir;
+}
+
+afterEach(() => {
+  while (cleanupFns.length > 0) {
+    cleanupFns.pop()?.();
+  }
+  restoreProcessEnv();
+  for (const tempDir of tempDirs) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+describe("installTestEnv", () => {
+  it("keeps live tests on a temp HOME while copying config and auth state", () => {
+    const realHome = createTempHome();
+    writeFile(path.join(realHome, ".profile"), "export TEST_PROFILE_ONLY=from-profile\n");
+    writeFile(
+      path.join(realHome, "custom-openclaw.json5"),
+      `{
+        // Preserve provider config, strip host-bound paths.
+        agents: {
+          defaults: {
+            workspace: "/Users/peter/Projects",
+            agentDir: "/Users/peter/.openclaw/agents/main/agent",
+          },
+          list: [
+            {
+              id: "dev",
+              workspace: "/Users/peter/dev-workspace",
+              agentDir: "/Users/peter/.openclaw/agents/dev/agent",
+            },
+          ],
+        },
+        models: {
+          providers: {
+            custom: { baseUrl: "https://example.test/v1" },
+          },
+        },
+      }`,
+    );
+    writeFile(path.join(realHome, ".openclaw", "credentials", "token.txt"), "secret\n");
+    writeFile(
+      path.join(realHome, ".openclaw", "agents", "main", "agent", "auth-profiles.json"),
+      JSON.stringify({ version: 1, profiles: { default: { provider: "openai" } } }, null, 2),
+    );
+    writeFile(path.join(realHome, ".claude", ".credentials.json"), '{"accessToken":"token"}\n');
+
+    process.env.HOME = realHome;
+    process.env.USERPROFILE = realHome;
+    process.env.OPENCLAW_LIVE_TEST = "1";
+    process.env.OPENCLAW_LIVE_TEST_QUIET = "1";
+    process.env.OPENCLAW_CONFIG_PATH = "~/custom-openclaw.json5";
+
+    const testEnv = installTestEnv();
+    cleanupFns.push(testEnv.cleanup);
+
+    expect(testEnv.tempHome).not.toBe(realHome);
+    expect(process.env.HOME).toBe(testEnv.tempHome);
+    expect(process.env.OPENCLAW_TEST_HOME).toBe(testEnv.tempHome);
+    expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
+
+    const copiedConfigPath = path.join(testEnv.tempHome, ".openclaw", "openclaw.json");
+    const copiedConfig = JSON.parse(fs.readFileSync(copiedConfigPath, "utf8")) as {
+      agents?: {
+        defaults?: Record<string, unknown>;
+        list?: Array<Record<string, unknown>>;
+      };
+      models?: { providers?: Record<string, unknown> };
+    };
+    expect(copiedConfig.models?.providers?.custom).toEqual({ baseUrl: "https://example.test/v1" });
+    expect(copiedConfig.agents?.defaults?.workspace).toBeUndefined();
+    expect(copiedConfig.agents?.defaults?.agentDir).toBeUndefined();
+    expect(copiedConfig.agents?.list?.[0]?.workspace).toBeUndefined();
+    expect(copiedConfig.agents?.list?.[0]?.agentDir).toBeUndefined();
+
+    expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".openclaw", "credentials", "token.txt")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(testEnv.tempHome, ".openclaw", "agents", "main", "agent", "auth-profiles.json"),
+      ),
+    ).toBe(true);
+    expect(fs.existsSync(path.join(testEnv.tempHome, ".claude", ".credentials.json"))).toBe(true);
+  });
+
+  it("allows explicit live runs against the real HOME", () => {
+    const realHome = createTempHome();
+    writeFile(path.join(realHome, ".profile"), "export TEST_PROFILE_ONLY=from-profile\n");
+
+    process.env.HOME = realHome;
+    process.env.USERPROFILE = realHome;
+    process.env.OPENCLAW_LIVE_TEST = "1";
+    process.env.OPENCLAW_LIVE_USE_REAL_HOME = "1";
+    process.env.OPENCLAW_LIVE_TEST_QUIET = "1";
+
+    const testEnv = installTestEnv();
+
+    expect(testEnv.tempHome).toBe(realHome);
+    expect(process.env.HOME).toBe(realHome);
+    expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
+  });
+});

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { installTestEnv } from "./test-env.js";
+import { __testing, installTestEnv } from "./test-env.js";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -135,5 +135,22 @@ describe("installTestEnv", () => {
     expect(testEnv.tempHome).toBe(realHome);
     expect(process.env.HOME).toBe(realHome);
     expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
+  });
+
+  it("parses simple exported profile vars without relying on bash", () => {
+    expect(
+      __testing.parseSimpleProfileEnv(
+        [
+          "# comment",
+          "export TEST_PROFILE_ONLY=from-profile",
+          "QUOTED_VALUE='hello world'",
+          'DOUBLE_QUOTED="quoted"',
+        ].join("\n"),
+      ),
+    ).toEqual([
+      { key: "TEST_PROFILE_ONLY", value: "from-profile" },
+      { key: "QUOTED_VALUE", value: "hello world" },
+      { key: "DOUBLE_QUOTED", value: "quoted" },
+    ]);
   });
 });

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -2,8 +2,11 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import JSON5 from "json5";
 
 type RestoreEntry = { key: string; value: string | undefined };
+
+const LIVE_EXTERNAL_AUTH_DIRS = [".claude", ".codex", ".minimax"] as const;
 
 function isTruthyEnvValue(value: string | undefined): boolean {
   if (!value) {
@@ -31,8 +34,19 @@ function restoreEnv(entries: RestoreEntry[]): void {
   }
 }
 
-function loadProfileEnv(): void {
-  const profilePath = path.join(os.homedir(), ".profile");
+function resolveHomeRelativePath(input: string, homeDir: string): string {
+  const trimmed = input.trim();
+  if (trimmed === "~") {
+    return homeDir;
+  }
+  if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    return path.join(homeDir, trimmed.slice(2));
+  }
+  return path.resolve(trimmed);
+}
+
+function loadProfileEnv(homeDir = os.homedir()): void {
+  const profilePath = path.join(homeDir, ".profile");
   if (!fs.existsSync(profilePath)) {
     return;
   }
@@ -67,20 +81,8 @@ function loadProfileEnv(): void {
   }
 }
 
-export function installTestEnv(): { cleanup: () => void; tempHome: string } {
-  const live =
-    process.env.LIVE === "1" ||
-    process.env.OPENCLAW_LIVE_TEST === "1" ||
-    process.env.OPENCLAW_LIVE_GATEWAY === "1";
-
-  // Live tests must use the real user environment (keys, profiles, config).
-  // The default test env isolates HOME to avoid touching real state.
-  if (live) {
-    loadProfileEnv();
-    return { cleanup: () => {}, tempHome: process.env.HOME ?? "" };
-  }
-
-  const restore: RestoreEntry[] = [
+function resolveRestoreEntries(): RestoreEntry[] {
+  return [
     { key: "OPENCLAW_TEST_FAST", value: process.env.OPENCLAW_TEST_FAST },
     { key: "HOME", value: process.env.HOME },
     { key: "USERPROFILE", value: process.env.USERPROFILE },
@@ -96,6 +98,8 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
     { key: "OPENCLAW_BRIDGE_PORT", value: process.env.OPENCLAW_BRIDGE_PORT },
     { key: "OPENCLAW_CANVAS_HOST_PORT", value: process.env.OPENCLAW_CANVAS_HOST_PORT },
     { key: "OPENCLAW_TEST_HOME", value: process.env.OPENCLAW_TEST_HOME },
+    { key: "OPENCLAW_AGENT_DIR", value: process.env.OPENCLAW_AGENT_DIR },
+    { key: "PI_CODING_AGENT_DIR", value: process.env.PI_CODING_AGENT_DIR },
     { key: "TELEGRAM_BOT_TOKEN", value: process.env.TELEGRAM_BOT_TOKEN },
     { key: "DISCORD_BOT_TOKEN", value: process.env.DISCORD_BOT_TOKEN },
     { key: "SLACK_BOT_TOKEN", value: process.env.SLACK_BOT_TOKEN },
@@ -106,7 +110,12 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
     { key: "GITHUB_TOKEN", value: process.env.GITHUB_TOKEN },
     { key: "NODE_OPTIONS", value: process.env.NODE_OPTIONS },
   ];
+}
 
+function createIsolatedTestHome(restore: RestoreEntry[]): {
+  cleanup: () => void;
+  tempHome: string;
+} {
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-home-"));
 
   process.env.HOME = tempHome;
@@ -118,6 +127,8 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
   delete process.env.OPENCLAW_CONFIG_PATH;
   // Prefer deriving state dir from HOME so nested tests that change HOME also isolate correctly.
   delete process.env.OPENCLAW_STATE_DIR;
+  delete process.env.OPENCLAW_AGENT_DIR;
+  delete process.env.PI_CODING_AGENT_DIR;
   // Prefer test-controlled ports over developer overrides (avoid port collisions across tests/workers).
   delete process.env.OPENCLAW_GATEWAY_PORT;
   delete process.env.OPENCLAW_BRIDGE_ENABLED;
@@ -156,6 +167,132 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
   };
 
   return { cleanup, tempHome };
+}
+
+function ensureParentDir(targetPath: string): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+}
+
+function copyDirIfExists(sourcePath: string, targetPath: string): void {
+  if (!fs.existsSync(sourcePath)) {
+    return;
+  }
+  fs.mkdirSync(targetPath, { recursive: true });
+  fs.cpSync(sourcePath, targetPath, {
+    recursive: true,
+    force: true,
+  });
+}
+
+function copyFileIfExists(sourcePath: string, targetPath: string): void {
+  if (!fs.existsSync(sourcePath)) {
+    return;
+  }
+  ensureParentDir(targetPath);
+  fs.copyFileSync(sourcePath, targetPath);
+}
+
+function sanitizeLiveConfig(raw: string): string {
+  try {
+    const parsed = JSON5.parse(raw) as {
+      agents?: {
+        defaults?: Record<string, unknown>;
+        list?: Array<Record<string, unknown>>;
+      };
+    };
+    if (!parsed || typeof parsed !== "object") {
+      return raw;
+    }
+    if (parsed.agents?.defaults && typeof parsed.agents.defaults === "object") {
+      delete parsed.agents.defaults.workspace;
+      delete parsed.agents.defaults.agentDir;
+    }
+    if (Array.isArray(parsed.agents?.list)) {
+      parsed.agents.list = parsed.agents.list.map((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return entry;
+        }
+        const nextEntry = { ...entry };
+        delete nextEntry.workspace;
+        delete nextEntry.agentDir;
+        return nextEntry;
+      });
+    }
+    return `${JSON.stringify(parsed, null, 2)}\n`;
+  } catch {
+    return raw;
+  }
+}
+
+function copyLiveAuthProfiles(realStateDir: string, tempStateDir: string): void {
+  const agentsDir = path.join(realStateDir, "agents");
+  if (!fs.existsSync(agentsDir)) {
+    return;
+  }
+  for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const sourcePath = path.join(agentsDir, entry.name, "agent", "auth-profiles.json");
+    const targetPath = path.join(tempStateDir, "agents", entry.name, "agent", "auth-profiles.json");
+    copyFileIfExists(sourcePath, targetPath);
+  }
+}
+
+function stageLiveTestState(params: {
+  env: NodeJS.ProcessEnv;
+  realHome: string;
+  tempHome: string;
+}): void {
+  const realStateDir = params.env.OPENCLAW_STATE_DIR?.trim()
+    ? resolveHomeRelativePath(params.env.OPENCLAW_STATE_DIR, params.realHome)
+    : path.join(params.realHome, ".openclaw");
+  const tempStateDir = path.join(params.tempHome, ".openclaw");
+  fs.mkdirSync(tempStateDir, { recursive: true });
+
+  const realConfigPath = params.env.OPENCLAW_CONFIG_PATH?.trim()
+    ? resolveHomeRelativePath(params.env.OPENCLAW_CONFIG_PATH, params.realHome)
+    : path.join(realStateDir, "openclaw.json");
+  if (fs.existsSync(realConfigPath)) {
+    const rawConfig = fs.readFileSync(realConfigPath, "utf8");
+    fs.writeFileSync(
+      path.join(tempStateDir, "openclaw.json"),
+      sanitizeLiveConfig(rawConfig),
+      "utf8",
+    );
+  }
+
+  copyDirIfExists(path.join(realStateDir, "credentials"), path.join(tempStateDir, "credentials"));
+  copyLiveAuthProfiles(realStateDir, tempStateDir);
+
+  for (const authDir of LIVE_EXTERNAL_AUTH_DIRS) {
+    copyDirIfExists(path.join(params.realHome, authDir), path.join(params.tempHome, authDir));
+  }
+}
+
+export function installTestEnv(): { cleanup: () => void; tempHome: string } {
+  const live =
+    process.env.LIVE === "1" ||
+    process.env.OPENCLAW_LIVE_TEST === "1" ||
+    process.env.OPENCLAW_LIVE_GATEWAY === "1";
+  const allowRealHome = isTruthyEnvValue(process.env.OPENCLAW_LIVE_USE_REAL_HOME);
+  const realHome = process.env.HOME ?? os.homedir();
+  const liveEnvSnapshot = { ...process.env };
+
+  loadProfileEnv(realHome);
+
+  if (live && allowRealHome) {
+    return { cleanup: () => {}, tempHome: realHome };
+  }
+
+  const restore = resolveRestoreEntries();
+  const testEnv = createIsolatedTestHome(restore);
+
+  if (live) {
+    stageLiveTestState({ env: liveEnvSnapshot, realHome, tempHome: testEnv.tempHome });
+  }
+
+  return testEnv;
 }
 
 export function withIsolatedTestHome(): { cleanup: () => void; tempHome: string } {

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import JSON5 from "json5";
 
 type RestoreEntry = { key: string; value: string | undefined };
+type ProfileEnvEntry = { key: string; value: string };
 
 const LIVE_EXTERNAL_AUTH_DIRS = [".claude", ".codex", ".minimax"] as const;
 
@@ -45,41 +46,96 @@ function resolveHomeRelativePath(input: string, homeDir: string): string {
   return path.resolve(trimmed);
 }
 
+function stripWrappingQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' || first === "'") && first === last) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
+function applyProfileEnvEntries(entries: Iterable<ProfileEnvEntry>): number {
+  let applied = 0;
+  for (const entry of entries) {
+    if (!entry.key || (process.env[entry.key] ?? "") !== "") {
+      continue;
+    }
+    process.env[entry.key] = entry.value;
+    applied += 1;
+  }
+  return applied;
+}
+
+function parseSimpleProfileEnv(content: string): ProfileEnvEntry[] {
+  const entries: ProfileEnvEntry[] = [];
+  for (const rawLine of content.split(/\r?\n/u)) {
+    const trimmed = rawLine.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/u.exec(trimmed);
+    if (!match) {
+      continue;
+    }
+    const [, key, rawValue] = match;
+    entries.push({ key, value: stripWrappingQuotes(rawValue) });
+  }
+  return entries;
+}
+
 function loadProfileEnv(homeDir = os.homedir()): void {
   const profilePath = path.join(homeDir, ".profile");
   if (!fs.existsSync(profilePath)) {
     return;
   }
+  let applied = 0;
+  let loadedFromShell = false;
   try {
-    const output = execFileSync(
-      "/bin/bash",
-      ["-lc", `set -a; source "${profilePath}" >/dev/null 2>&1; env -0`],
-      { encoding: "utf8" },
-    );
-    const entries = output.split("\0");
-    let applied = 0;
-    for (const entry of entries) {
-      if (!entry) {
+    const shellCandidates =
+      process.platform === "win32" ? ["bash", "/bin/bash"] : ["/bin/bash", "bash"];
+    for (const shellCommand of shellCandidates) {
+      try {
+        const output = execFileSync(
+          shellCommand,
+          ["-lc", `set -a; source "${profilePath}" >/dev/null 2>&1; env -0`],
+          { encoding: "utf8" },
+        );
+        const entries: ProfileEnvEntry[] = [];
+        for (const entry of output.split("\0")) {
+          if (!entry) {
+            continue;
+          }
+          const idx = entry.indexOf("=");
+          if (idx <= 0) {
+            continue;
+          }
+          entries.push({ key: entry.slice(0, idx), value: entry.slice(idx + 1) });
+        }
+        applied = applyProfileEnvEntries(entries);
+        loadedFromShell = true;
+        break;
+      } catch {
         continue;
       }
-      const idx = entry.indexOf("=");
-      if (idx <= 0) {
-        continue;
-      }
-      const key = entry.slice(0, idx);
-      if (!key || (process.env[key] ?? "") !== "") {
-        continue;
-      }
-      process.env[key] = entry.slice(idx + 1);
-      applied += 1;
     }
-    if (applied > 0 && !isTruthyEnvValue(process.env.OPENCLAW_LIVE_TEST_QUIET)) {
-      console.log(`[live] loaded ${applied} env vars from ~/.profile`);
+    if (!loadedFromShell) {
+      applied = applyProfileEnvEntries(parseSimpleProfileEnv(fs.readFileSync(profilePath, "utf8")));
     }
   } catch {
     // ignore profile load failures
   }
+  if (applied > 0 && !isTruthyEnvValue(process.env.OPENCLAW_LIVE_TEST_QUIET)) {
+    console.log(`[live] loaded ${applied} env vars from ~/.profile`);
+  }
 }
+
+export const __testing = {
+  parseSimpleProfileEnv,
+};
 
 function resolveRestoreEntries(): RestoreEntry[] {
   return [


### PR DESCRIPTION
## Summary
- dedupe repeated per-plugin tool registration in the registry instead of patching Feishu locally
- preserve `plugins.entries.<id>.config` when plugin tool factories are invoked
- reuse a compatible gateway-bindable active registry for default runtime requests without widening reuse across unrelated load contexts

## Why
- addresses the root cause behind repeated Feishu tool registration during startup (#56494)
- integrates the plugin tool factory context fix from #56474
- integrates the gateway-bindable default-runtime compatibility fix from #56353
- supersedes the duplicate-registration approach in #56358

## Validation
- `./node_modules/.bin/vitest run --config vitest.config.ts --pool=threads --maxWorkers=1 src/plugins/loader.test.ts src/plugins/tools.optional.test.ts -t 'deduplicates repeated tool registration for the same plugin|reuses the active registry only when the load context cache key matches|reuses a gateway-bindable active registry for default runtime requests|does not reuse the active registry when core gateway method names differ|reuses the compatible active registry before attempting a fresh load|passes pluginConfig through to plugin tool factories'`\n- `pnpm check`