### PR TITLE
Add time-based session maintenance modes

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -532,7 +532,12 @@ async function agentCommandInternal(
     if (sessionStore && sessionKey) {
       const entry = sessionStore[sessionKey] ??
         sessionEntry ?? { sessionId, updatedAt: Date.now() };
-      const next: SessionEntry = { ...entry, sessionId, updatedAt: Date.now() };
+      const next: SessionEntry = {
+        ...entry,
+        sessionId,
+        updatedAt: Date.now(),
+        lastUserMessageAt: Date.now(),
+      };
       if (thinkOverride) {
         next.thinkingLevel = thinkOverride;
       }

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -509,14 +509,15 @@ async function agentCommandInternal(
       : sessionEntry?.skillsSnapshot;
 
     if (skillsSnapshot && sessionStore && sessionKey && needsSkillsSnapshot) {
+      const now = Date.now();
       const current = sessionEntry ?? {
         sessionId,
-        updatedAt: Date.now(),
+        updatedAt: now,
       };
       const next: SessionEntry = {
         ...current,
         sessionId,
-        updatedAt: Date.now(),
+        updatedAt: now,
         skillsSnapshot,
       };
       await persistSessionEntry({
@@ -530,13 +531,13 @@ async function agentCommandInternal(
 
     // Persist explicit /command overrides to the session store when we have a key.
     if (sessionStore && sessionKey) {
-      const entry = sessionStore[sessionKey] ??
-        sessionEntry ?? { sessionId, updatedAt: Date.now() };
+      const now = Date.now();
+      const entry = sessionStore[sessionKey] ?? sessionEntry ?? { sessionId, updatedAt: now };
       const next: SessionEntry = {
         ...entry,
         sessionId,
-        updatedAt: Date.now(),
-        lastUserMessageAt: Date.now(),
+        updatedAt: now,
+        lastUserMessageAt: now,
       };
       if (thinkOverride) {
         next.thinkingLevel = thinkOverride;

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -61,15 +61,16 @@ export async function updateSessionStoreAfterAgentRun(params: {
       allowAsyncLoad: false,
     }) ?? DEFAULT_CONTEXT_TOKENS;
 
+  const now = Date.now();
   const entry = sessionStore[sessionKey] ?? {
     sessionId,
-    updatedAt: Date.now(),
+    updatedAt: now,
   };
   const next: SessionEntry = {
     ...entry,
     sessionId,
-    updatedAt: Date.now(),
-    lastAssistantMessageAt: Date.now(),
+    updatedAt: now,
+    lastAssistantMessageAt: now,
     contextTokens,
   };
   const cacheTtlMs = resolveCacheTtlMs({

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -5,11 +5,13 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import { setCliSessionBinding, setCliSessionId } from "../cli-session.js";
 import { resolveContextTokensForModel } from "../context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { isCliProvider } from "../model-selection.js";
+import { resolveCacheTtlMs } from "../pi-embedded-runner/cache-ttl.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../usage.js";
 
 type RunResult = Awaited<ReturnType<(typeof import("../pi-embedded.js"))["runEmbeddedPiAgent"]>>;
@@ -67,8 +69,19 @@ export async function updateSessionStoreAfterAgentRun(params: {
     ...entry,
     sessionId,
     updatedAt: Date.now(),
+    lastAssistantMessageAt: Date.now(),
     contextTokens,
   };
+  const cacheTtlMs = resolveCacheTtlMs({
+    config: cfg,
+    provider: providerUsed,
+    modelId: modelUsed,
+    agentId: resolveAgentIdFromSessionKey(sessionKey),
+  });
+  if (cacheTtlMs != null) {
+    next.lastCacheTouchAt = next.updatedAt;
+    next.lastIdleCompactionForCacheTouchAt = undefined;
+  }
   setSessionRuntimeModel(next, {
     provider: providerUsed,
     model: modelUsed,

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -81,7 +81,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
   });
   if (cacheTtlMs != null) {
     next.lastCacheTouchAt = next.updatedAt;
-    next.lastIdleCompactionForCacheTouchAt = undefined;
+    next.lastIdleCompactionForAssistantMessageAt = undefined;
   }
   setSessionRuntimeModel(next, {
     provider: providerUsed,

--- a/src/agents/pi-embedded-runner/cache-ttl.test.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.test.ts
@@ -19,20 +19,21 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
   },
 }));
 
-import { isCacheTtlEligibleProvider } from "./cache-ttl.js";
+import { isCacheTtlEligibleProvider, resolveCacheTtlMs } from "./cache-ttl.js";
+import { log } from "./logger.js";
 
 describe("isCacheTtlEligibleProvider", () => {
   it("allows anthropic", () => {
     expect(isCacheTtlEligibleProvider("anthropic", "claude-sonnet-4-20250514")).toBe(true);
   });
 
-  it("allows moonshot and zai providers", () => {
-    expect(isCacheTtlEligibleProvider("moonshot", "kimi-k2.5")).toBe(true);
+  it("uses provider-specific native eligibility rules", () => {
+    expect(isCacheTtlEligibleProvider("moonshot", "kimi-k2.5")).toBe(false);
     expect(isCacheTtlEligibleProvider("zai", "glm-5")).toBe(true);
   });
 
-  it("is case-insensitive for native providers", () => {
-    expect(isCacheTtlEligibleProvider("Moonshot", "Kimi-K2.5")).toBe(true);
+  it("normalizes native eligibility rules case-insensitively", () => {
+    expect(isCacheTtlEligibleProvider("Moonshot", "Kimi-K2.5")).toBe(false);
     expect(isCacheTtlEligibleProvider("ZAI", "GLM-5")).toBe(true);
   });
 
@@ -46,5 +47,128 @@ describe("isCacheTtlEligibleProvider", () => {
   it("rejects unsupported providers and models", () => {
     expect(isCacheTtlEligibleProvider("openai", "gpt-4o")).toBe(false);
     expect(isCacheTtlEligibleProvider("openrouter", "openai/gpt-4o")).toBe(false);
+  });
+});
+
+describe("resolveCacheTtlMs", () => {
+  it("uses sessionCacheTtl when configured", () => {
+    expect(
+      resolveCacheTtlMs({
+        config: {
+          agents: {
+            defaults: {
+              models: {
+                "anthropic/claude-sonnet-4": {
+                  params: {
+                    sessionCacheTtl: "45m",
+                    timeBasedContextCompact: "compact",
+                  },
+                },
+              },
+            },
+          },
+        },
+        provider: "anthropic",
+        modelId: "claude-sonnet-4",
+      }),
+    ).toBe(45 * 60_000);
+  });
+
+  it("returns null when sessionCacheTtl is unset", () => {
+    expect(
+      resolveCacheTtlMs({
+        config: {
+          agents: {
+            defaults: {
+              models: {
+                "anthropic/claude-haiku-4": {
+                  params: { cacheRetention: "long" },
+                },
+              },
+            },
+          },
+        },
+        provider: "anthropic",
+        modelId: "claude-haiku-4",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when timeBasedContextCompact is unset", () => {
+    expect(
+      resolveCacheTtlMs({
+        config: {
+          agents: {
+            defaults: {
+              models: {
+                "anthropic/claude-haiku-4": {
+                  params: { sessionCacheTtl: "1h" },
+                },
+              },
+            },
+          },
+        },
+        provider: "anthropic",
+        modelId: "claude-haiku-4",
+      }),
+    ).toBeNull();
+  });
+
+  it("still uses sessionCacheTtl when cacheRetention disables model caching", () => {
+    expect(
+      resolveCacheTtlMs({
+        config: {
+          agents: {
+            defaults: {
+              models: {
+                "anthropic/claude-sonnet-4": {
+                  params: {
+                    cacheRetention: "none",
+                    sessionCacheTtl: "1h",
+                    timeBasedContextCompact: "reset",
+                  },
+                },
+              },
+            },
+          },
+        },
+        provider: "anthropic",
+        modelId: "claude-sonnet-4",
+      }),
+    ).toBe(60 * 60_000);
+  });
+
+  it("warns when sessionCacheTtl exceeds an explicit model cache ttl", () => {
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    expect(
+      resolveCacheTtlMs({
+        config: {
+          agents: {
+            defaults: {
+              models: {
+                "anthropic/claude-opus-4": {
+                  params: {
+                    cacheRetention: "short",
+                    sessionCacheTtl: "1h",
+                    timeBasedContextCompact: "reset",
+                  },
+                },
+              },
+            },
+          },
+        },
+        provider: "anthropic",
+        modelId: "claude-opus-4",
+      }),
+    ).toBe(60 * 60_000);
+
+    expect(warnSpy).toHaveBeenCalledWith("sessionCacheTtl exceeds explicit model cache ttl", {
+      provider: "anthropic",
+      modelId: "claude-opus-4",
+      sessionCacheTtlMs: 60 * 60_000,
+      explicitModelCacheTtlMs: 5 * 60_000,
+    });
+    warnSpy.mockRestore();
   });
 });

--- a/src/agents/pi-embedded-runner/cache-ttl.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.ts
@@ -1,4 +1,9 @@
+import { parseDurationMs } from "../../cli/parse-duration.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { resolveProviderCacheTtlEligibility } from "../../plugins/provider-runtime.js";
+import { resolveCacheRetention } from "./anthropic-stream-wrappers.js";
+import { resolveExtraParams } from "./extra-params.js";
+import { log } from "./logger.js";
 
 type CustomEntryLike = { type?: unknown; customType?: unknown; data?: unknown };
 
@@ -9,6 +14,14 @@ export type CacheTtlEntryData = {
   provider?: string;
   modelId?: string;
 };
+
+const CACHE_RETENTION_TTL_MS = {
+  short: 5 * 60_000,
+  long: 60 * 60_000,
+} as const;
+const warnedSessionCacheTtlMismatchKeys = new Set<string>();
+
+export type TimeBasedContextCompactMode = "none" | "compact" | "reset";
 
 export function isCacheTtlEligibleProvider(provider: string, modelId: string): boolean {
   const normalizedProvider = provider.toLowerCase();
@@ -64,4 +77,122 @@ export function appendCacheTtlTimestamp(sessionManager: unknown, data: CacheTtlE
   } catch {
     // ignore persistence failures
   }
+}
+
+export function resolveCacheRetentionTtlMs(
+  cacheRetention: "none" | "short" | "long" | undefined,
+): number | null {
+  if (!cacheRetention || cacheRetention === "none") {
+    return null;
+  }
+  return CACHE_RETENTION_TTL_MS[cacheRetention];
+}
+
+function parsePositiveDuration(value: unknown): number | null {
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+  try {
+    const ttlMs = parseDurationMs(value.trim(), { defaultUnit: "m" });
+    return ttlMs > 0 ? ttlMs : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveConfiguredSessionCacheTtlMs(
+  extraParams: Record<string, unknown> | undefined,
+): number | null {
+  return parsePositiveDuration(extraParams?.sessionCacheTtl);
+}
+
+export function resolveTimeBasedContextCompactMode(
+  extraParams: Record<string, unknown> | undefined,
+): TimeBasedContextCompactMode {
+  const mode = extraParams?.timeBasedContextCompact;
+  return mode === "compact" || mode === "reset" ? mode : "none";
+}
+
+function resolveExplicitModelCacheTtlMs(
+  extraParams: Record<string, unknown> | undefined,
+  provider: string,
+): number | null {
+  if (!extraParams) {
+    return null;
+  }
+  if (Object.hasOwn(extraParams, "cacheRetention")) {
+    const cacheRetention = resolveCacheRetention(extraParams, provider);
+    if (cacheRetention === "none") {
+      return null;
+    }
+    return resolveCacheRetentionTtlMs(cacheRetention);
+  }
+  if (Object.hasOwn(extraParams, "cacheControlTtl")) {
+    return parsePositiveDuration(extraParams.cacheControlTtl);
+  }
+  return null;
+}
+
+function maybeWarnSessionCacheTtlMismatch(params: {
+  provider: string;
+  modelId: string;
+  sessionCacheTtlMs: number;
+  explicitModelCacheTtlMs: number;
+}) {
+  const warningKey = [
+    params.provider,
+    params.modelId,
+    params.sessionCacheTtlMs,
+    params.explicitModelCacheTtlMs,
+  ].join(":");
+  if (warnedSessionCacheTtlMismatchKeys.has(warningKey)) {
+    return;
+  }
+  warnedSessionCacheTtlMismatchKeys.add(warningKey);
+  log.warn("sessionCacheTtl exceeds explicit model cache ttl", {
+    provider: params.provider,
+    modelId: params.modelId,
+    sessionCacheTtlMs: params.sessionCacheTtlMs,
+    explicitModelCacheTtlMs: params.explicitModelCacheTtlMs,
+  });
+}
+
+export function resolveCacheTtlMs(params: {
+  config?: OpenClawConfig;
+  provider: string;
+  modelId: string;
+  agentId?: string;
+}): number | null {
+  if (!isCacheTtlEligibleProvider(params.provider, params.modelId)) {
+    return null;
+  }
+
+  const resolvedExtraParams = resolveExtraParams({
+    cfg: params.config,
+    provider: params.provider,
+    modelId: params.modelId,
+    agentId: params.agentId,
+  });
+  const timeBasedContextCompact = resolveTimeBasedContextCompactMode(resolvedExtraParams);
+  if (timeBasedContextCompact === "none") {
+    return null;
+  }
+  const sessionCacheTtlMs = resolveConfiguredSessionCacheTtlMs(resolvedExtraParams);
+  if (sessionCacheTtlMs == null) {
+    return null;
+  }
+
+  const explicitModelCacheTtlMs = resolveExplicitModelCacheTtlMs(
+    resolvedExtraParams,
+    params.provider,
+  );
+  if (explicitModelCacheTtlMs != null && sessionCacheTtlMs > explicitModelCacheTtlMs) {
+    maybeWarnSessionCacheTtlMismatch({
+      provider: params.provider,
+      modelId: params.modelId,
+      sessionCacheTtlMs,
+      explicitModelCacheTtlMs,
+    });
+  }
+  return sessionCacheTtlMs;
 }

--- a/src/agents/pi-embedded-runner/cache-ttl.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.ts
@@ -19,6 +19,7 @@ const CACHE_RETENTION_TTL_MS = {
   short: 5 * 60_000,
   long: 60 * 60_000,
 } as const;
+const MAX_WARNED_SESSION_CACHE_TTL_MISMATCH_KEYS = 1_000;
 const warnedSessionCacheTtlMismatchKeys = new Set<string>();
 
 export type TimeBasedContextCompactMode = "none" | "compact" | "reset";
@@ -147,6 +148,9 @@ function maybeWarnSessionCacheTtlMismatch(params: {
   ].join(":");
   if (warnedSessionCacheTtlMismatchKeys.has(warningKey)) {
     return;
+  }
+  if (warnedSessionCacheTtlMismatchKeys.size >= MAX_WARNED_SESSION_CACHE_TTL_MISMATCH_KEYS) {
+    warnedSessionCacheTtlMismatchKeys.clear();
   }
   warnedSessionCacheTtlMismatchKeys.add(warningKey);
   log.warn("sessionCacheTtl exceeds explicit model cache ttl", {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -539,6 +539,7 @@ export async function runReplyAgent(params: {
       cliSessionId,
       cliSessionBinding,
       usageIsContextSnapshot: isCliProvider(providerUsed, cfg),
+      recordAssistantActivity: !isHeartbeat,
     });
 
     // Drain any late tool/block deliveries before deciding there's "nothing to send".

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -299,6 +299,7 @@ export function createFollowupRunner(params: {
             queued.run.config,
           ),
           logLabel: "followup",
+          recordAssistantActivity: true,
         });
       }
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -217,6 +217,7 @@ export async function getReplyFromConfig(
     ctx: finalized,
     cfg,
     commandAuthorized,
+    isHeartbeat: opts?.isHeartbeat === true,
   });
   let {
     sessionCtx,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -1,4 +1,5 @@
 import { setCliSessionBinding, setCliSessionId } from "../../agents/cli-session.js";
+import { resolveCacheTtlMs } from "../../agents/pi-embedded-runner/cache-ttl.js";
 import {
   deriveSessionTotalTokens,
   hasNonzeroUsage,
@@ -12,6 +13,7 @@ import {
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 
 function applyCliSessionIdToSessionPatch(
@@ -89,6 +91,7 @@ export async function persistSessionUsageUpdate(params: {
   cliSessionId?: string;
   cliSessionBinding?: import("../../config/sessions.js").CliSessionBinding;
   logLabel?: string;
+  recordAssistantActivity?: boolean;
 }): Promise<void> {
   const { storePath, sessionKey } = params;
   if (!storePath || !sessionKey) {
@@ -111,6 +114,7 @@ export async function persistSessionUsageUpdate(params: {
         storePath,
         sessionKey,
         update: async (entry) => {
+          const now = Date.now();
           const resolvedContextTokens = params.contextTokensUsed ?? entry.contextTokens;
           // Use last-call usage for totalTokens when available. The accumulated
           // `usage.input` sums input tokens from every API call in the run
@@ -138,8 +142,25 @@ export async function persistSessionUsageUpdate(params: {
             model: params.modelUsed ?? entry.model,
             contextTokens: resolvedContextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
-            updatedAt: Date.now(),
+            updatedAt: now,
           };
+          if (params.recordAssistantActivity) {
+            patch.lastAssistantMessageAt = now;
+            const providerForCache = params.providerUsed ?? entry.modelProvider;
+            const modelForCache = params.modelUsed ?? entry.model;
+            if (providerForCache && modelForCache) {
+              const cacheTtlMs = resolveCacheTtlMs({
+                config: cfg,
+                provider: providerForCache,
+                modelId: modelForCache,
+                agentId: resolveAgentIdFromSessionKey(sessionKey),
+              });
+              if (cacheTtlMs != null) {
+                patch.lastCacheTouchAt = now;
+                patch.lastIdleCompactionForCacheTouchAt = undefined;
+              }
+            }
+          }
           if (hasUsage) {
             patch.inputTokens = params.usage?.input ?? 0;
             patch.outputTokens = params.usage?.output ?? 0;
@@ -173,13 +194,31 @@ export async function persistSessionUsageUpdate(params: {
         storePath,
         sessionKey,
         update: async (entry) => {
+          const now = Date.now();
           const patch: Partial<SessionEntry> = {
             modelProvider: params.providerUsed ?? entry.modelProvider,
             model: params.modelUsed ?? entry.model,
             contextTokens: params.contextTokensUsed ?? entry.contextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
-            updatedAt: Date.now(),
+            updatedAt: now,
           };
+          if (params.recordAssistantActivity) {
+            patch.lastAssistantMessageAt = now;
+            const providerForCache = params.providerUsed ?? entry.modelProvider;
+            const modelForCache = params.modelUsed ?? entry.model;
+            if (providerForCache && modelForCache) {
+              const cacheTtlMs = resolveCacheTtlMs({
+                config: cfg,
+                provider: providerForCache,
+                modelId: modelForCache,
+                agentId: resolveAgentIdFromSessionKey(sessionKey),
+              });
+              if (cacheTtlMs != null) {
+                patch.lastCacheTouchAt = now;
+                patch.lastIdleCompactionForCacheTouchAt = undefined;
+              }
+            }
+          }
           return applyCliSessionIdToSessionPatch(params, entry, patch);
         },
       });

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -157,7 +157,7 @@ export async function persistSessionUsageUpdate(params: {
               });
               if (cacheTtlMs != null) {
                 patch.lastCacheTouchAt = now;
-                patch.lastIdleCompactionForCacheTouchAt = undefined;
+                patch.lastIdleCompactionForAssistantMessageAt = undefined;
               }
             }
           }
@@ -215,7 +215,7 @@ export async function persistSessionUsageUpdate(params: {
               });
               if (cacheTtlMs != null) {
                 patch.lastCacheTouchAt = now;
-                patch.lastIdleCompactionForCacheTouchAt = undefined;
+                patch.lastIdleCompactionForAssistantMessageAt = undefined;
               }
             }
           }

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -5,7 +5,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import * as bootstrapCache from "../../agents/bootstrap-cache.js";
 import { setDefaultChannelPluginRegistryForTests } from "../../commands/channel-test-helpers.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { SessionEntry } from "../../config/sessions.js";
+import { loadSessionStore, type SessionEntry } from "../../config/sessions.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
 import {
   __testing as sessionBindingTesting,
@@ -2446,5 +2446,33 @@ describe("initSessionState internal channel routing preservation", () => {
     expect(result.sessionEntry.lastTo).toBe("+15555550123");
     expect(result.sessionEntry.deliveryContext?.channel).toBe("whatsapp");
     expect(result.sessionEntry.deliveryContext?.to).toBe("+15555550123");
+  });
+
+  it("does not refresh lastUserMessageAt for heartbeat turns", async () => {
+    const storePath = await createStorePath("heartbeat-preserves-last-user-");
+    const sessionKey = "agent:main:discord:channel:heartbeat";
+    const initialUserAt = 1_234;
+    const updatedAt = Date.now();
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: "sess-heartbeat",
+        updatedAt,
+        lastUserMessageAt: initialUserAt,
+      },
+    });
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    await initSessionState({
+      ctx: {
+        Body: "heartbeat",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+      isHeartbeat: true,
+    });
+
+    const stored = loadSessionStore(storePath, { skipCache: true });
+    expect(stored[sessionKey]?.lastUserMessageAt).toBe(initialUserAt);
   });
 });

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -184,6 +184,7 @@ export async function initSessionState(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
   commandAuthorized: boolean;
+  isHeartbeat?: boolean;
 }): Promise<SessionInitResult> {
   const { ctx, cfg, commandAuthorized } = params;
   const conversationBindingContext = resolveSessionConversationBindingContext(cfg, ctx);
@@ -467,11 +468,12 @@ export async function initSessionState(params: {
   const lastTo = deliveryFields.lastTo ?? lastToRaw;
   const lastAccountId = deliveryFields.lastAccountId ?? lastAccountIdRaw;
   const lastThreadId = deliveryFields.lastThreadId ?? lastThreadIdRaw;
+  const updatedAt = Date.now();
   sessionEntry = {
     ...baseEntry,
     sessionId,
-    updatedAt: Date.now(),
-    lastUserMessageAt: Date.now(),
+    updatedAt,
+    lastUserMessageAt: params.isHeartbeat === true ? baseEntry?.lastUserMessageAt : updatedAt,
     systemSent,
     abortedLastRun,
     // Persist previously stored thinking/verbose levels when present.

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -471,6 +471,7 @@ export async function initSessionState(params: {
     ...baseEntry,
     sessionId,
     updatedAt: Date.now(),
+    lastUserMessageAt: Date.now(),
     systemSent,
     abortedLastRun,
     // Persist previously stored thinking/verbose levels when present.
@@ -585,6 +586,9 @@ export async function initSessionState(params: {
   });
   sessionEntry = resolvedSessionFile.sessionEntry;
   if (isNewSession) {
+    sessionEntry.lastAssistantMessageAt = undefined;
+    sessionEntry.lastCacheTouchAt = undefined;
+    sessionEntry.lastIdleCompactionForCacheTouchAt = undefined;
     sessionEntry.compactionCount = 0;
     sessionEntry.memoryFlushCompactionCount = undefined;
     sessionEntry.memoryFlushAt = undefined;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -590,7 +590,7 @@ export async function initSessionState(params: {
   if (isNewSession) {
     sessionEntry.lastAssistantMessageAt = undefined;
     sessionEntry.lastCacheTouchAt = undefined;
-    sessionEntry.lastIdleCompactionForCacheTouchAt = undefined;
+    sessionEntry.lastIdleCompactionForAssistantMessageAt = undefined;
     sessionEntry.compactionCount = 0;
     sessionEntry.memoryFlushCompactionCount = undefined;
     sessionEntry.memoryFlushAt = undefined;

--- a/src/config/config.pruning-defaults.test.ts
+++ b/src/config/config.pruning-defaults.test.ts
@@ -75,9 +75,15 @@ describe("config pruning defaults", () => {
     expect(
       cfg.agents?.defaults?.models?.["anthropic/claude-opus-4-5"]?.params?.cacheRetention,
     ).toBe("short");
+    expect(
+      cfg.agents?.defaults?.models?.["anthropic/claude-opus-4-5"]?.params?.sessionCacheTtl,
+    ).toBe("1h");
+    expect(
+      cfg.agents?.defaults?.models?.["anthropic/claude-opus-4-5"]?.params?.timeBasedContextCompact,
+    ).toBeUndefined();
   });
 
-  it("adds cacheRetention defaults for dated Anthropic primary model refs", async () => {
+  it("adds cacheRetention and sessionCacheTtl defaults for dated Anthropic primary model refs", async () => {
     const cfg = await loadConfigForHome({
       auth: {
         profiles: {
@@ -95,9 +101,16 @@ describe("config pruning defaults", () => {
     expect(
       cfg.agents?.defaults?.models?.["anthropic/claude-sonnet-4-20250514"]?.params?.cacheRetention,
     ).toBe("short");
+    expect(
+      cfg.agents?.defaults?.models?.["anthropic/claude-sonnet-4-20250514"]?.params?.sessionCacheTtl,
+    ).toBe("1h");
+    expect(
+      cfg.agents?.defaults?.models?.["anthropic/claude-sonnet-4-20250514"]?.params
+        ?.timeBasedContextCompact,
+    ).toBeUndefined();
   });
 
-  it("adds default cacheRetention for Anthropic Claude models on Bedrock", async () => {
+  it("adds default cacheRetention and sessionCacheTtl for Anthropic Claude models on Bedrock", async () => {
     const cfg = await loadConfigForHome({
       auth: {
         profiles: {
@@ -115,6 +128,14 @@ describe("config pruning defaults", () => {
       cfg.agents?.defaults?.models?.["amazon-bedrock/us.anthropic.claude-opus-4-6-v1"]?.params
         ?.cacheRetention,
     ).toBe("short");
+    expect(
+      cfg.agents?.defaults?.models?.["amazon-bedrock/us.anthropic.claude-opus-4-6-v1"]?.params
+        ?.sessionCacheTtl,
+    ).toBe("1h");
+    expect(
+      cfg.agents?.defaults?.models?.["amazon-bedrock/us.anthropic.claude-opus-4-6-v1"]?.params
+        ?.timeBasedContextCompact,
+    ).toBeUndefined();
   });
 
   it("does not add default cacheRetention for non-Anthropic Bedrock models", async () => {
@@ -134,6 +155,40 @@ describe("config pruning defaults", () => {
     expect(
       cfg.agents?.defaults?.models?.["amazon-bedrock/amazon.nova-micro-v1:0"]?.params
         ?.cacheRetention,
+    ).toBeUndefined();
+    expect(
+      cfg.agents?.defaults?.models?.["amazon-bedrock/amazon.nova-micro-v1:0"]?.params
+        ?.sessionCacheTtl,
+    ).toBeUndefined();
+  });
+
+  it("adds sessionCacheTtl even when cacheRetention is explicitly configured", async () => {
+    const cfg = await loadConfigForHome({
+      auth: {
+        profiles: {
+          "anthropic:api": { provider: "anthropic", mode: "api_key" },
+        },
+      },
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-5" },
+          models: {
+            "anthropic/claude-opus-4-5": {
+              params: { cacheRetention: "long" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      cfg.agents?.defaults?.models?.["anthropic/claude-opus-4-5"]?.params?.cacheRetention,
+    ).toBe("long");
+    expect(
+      cfg.agents?.defaults?.models?.["anthropic/claude-opus-4-5"]?.params?.sessionCacheTtl,
+    ).toBe("1h");
+    expect(
+      cfg.agents?.defaults?.models?.["anthropic/claude-opus-4-5"]?.params?.timeBasedContextCompact,
     ).toBeUndefined();
   });
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -487,12 +487,22 @@ export function applyContextPruningDefaults(cfg: OpenClawConfig): OpenClawConfig
       }
       const current = entry ?? {};
       const params = (current as { params?: Record<string, unknown> }).params ?? {};
-      if (typeof params.cacheRetention === "string") {
+      const nextParams = { ...params };
+      let paramsMutated = false;
+      if (typeof params.cacheRetention !== "string") {
+        nextParams.cacheRetention = "short";
+        paramsMutated = true;
+      }
+      if (typeof params.sessionCacheTtl !== "string") {
+        nextParams.sessionCacheTtl = "1h";
+        paramsMutated = true;
+      }
+      if (!paramsMutated) {
         continue;
       }
       nextModels[key] = {
         ...(current as Record<string, unknown>),
-        params: { ...params, cacheRetention: "short" },
+        params: nextParams,
       };
       modelsMutated = true;
     }
@@ -507,10 +517,20 @@ export function applyContextPruningDefaults(cfg: OpenClawConfig): OpenClawConfig
         const entry = nextModels[key];
         const current = entry ?? {};
         const params = (current as { params?: Record<string, unknown> }).params ?? {};
+        const nextParams = { ...params };
+        let paramsMutated = false;
         if (typeof params.cacheRetention !== "string") {
+          nextParams.cacheRetention = "short";
+          paramsMutated = true;
+        }
+        if (typeof params.sessionCacheTtl !== "string") {
+          nextParams.sessionCacheTtl = "1h";
+          paramsMutated = true;
+        }
+        if (paramsMutated) {
           nextModels[key] = {
             ...(current as Record<string, unknown>),
-            params: { ...params, cacheRetention: "short" },
+            params: nextParams,
           };
           modelsMutated = true;
         }

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -82,6 +82,17 @@ export type SessionEntry = {
   lastHeartbeatSentAt?: number;
   sessionId: string;
   updatedAt: number;
+  /** Timestamp (ms) of the latest inbound user turn recorded for this session. */
+  lastUserMessageAt?: number;
+  /** Timestamp (ms) of the latest completed assistant turn recorded for this session. */
+  lastAssistantMessageAt?: number;
+  /** Timestamp (ms) when this session last touched the model prompt cache. */
+  lastCacheTouchAt?: number;
+  /**
+   * Cache-touch timestamp already serviced by idle cache-warming compaction.
+   * Prevents retrying the same idle compaction every maintenance sweep.
+   */
+  lastIdleCompactionForCacheTouchAt?: number;
   sessionFile?: string;
   /** Parent session key that spawned this session (used for sandbox session-tool scoping). */
   spawnedBy?: string;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -89,10 +89,11 @@ export type SessionEntry = {
   /** Timestamp (ms) when this session last touched the model prompt cache. */
   lastCacheTouchAt?: number;
   /**
-   * Cache-touch timestamp already serviced by idle cache-warming compaction.
-   * Prevents retrying the same idle compaction every maintenance sweep.
+   * Assistant-turn timestamp already serviced by idle cache-warming compaction.
+   * Prevents retrying idle compaction more than once for the same
+   * assistant-waiting-for-user window.
    */
-  lastIdleCompactionForCacheTouchAt?: number;
+  lastIdleCompactionForAssistantMessageAt?: number;
   sessionFile?: string;
   /** Parent session key that spawned this session (used for sandbox session-tool scoping). */
   spawnedBy?: string;

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -11,6 +11,7 @@ import {
 import type { DedupeEntry } from "./server-shared.js";
 import { formatError } from "./server-utils.js";
 import { setBroadcastHealthUpdate } from "./server/health-state.js";
+import { runSessionCacheMaintenanceSweep } from "./session-cache-maintenance.js";
 
 export function startGatewayMaintenanceTimers(params: {
   broadcast: (
@@ -76,6 +77,7 @@ export function startGatewayMaintenanceTimers(params: {
     .catch((err) => params.logHealth.error(`initial refresh failed: ${formatError(err)}`));
 
   // dedupe cache cleanup
+  let sessionCacheMaintenanceInFlight: Promise<void> | null = null;
   const dedupeCleanup = setInterval(() => {
     const AGENT_RUN_SEQ_MAX = 10_000;
     const now = Date.now();
@@ -150,6 +152,15 @@ export function startGatewayMaintenanceTimers(params: {
       params.chatRunBuffers.delete(runId);
       params.chatDeltaSentAt.delete(runId);
       params.chatDeltaLastBroadcastLen.delete(runId);
+    }
+
+    if (!sessionCacheMaintenanceInFlight) {
+      sessionCacheMaintenanceInFlight = runSessionCacheMaintenanceSweep().catch((err) => {
+        params.logHealth.error(`session cache maintenance failed: ${formatError(err)}`);
+      });
+      void sessionCacheMaintenanceInFlight.finally(() => {
+        sessionCacheMaintenanceInFlight = null;
+      });
     }
   }, 60_000);
 

--- a/src/gateway/session-cache-maintenance.sweep.test.ts
+++ b/src/gateway/session-cache-maintenance.sweep.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { loadSessionStore } from "../config/sessions.js";
+
+const ONE_HOUR_MS = 60 * 60_000;
+const { compactEmbeddedPiSessionMock, isEmbeddedPiRunActiveMock } = vi.hoisted(() => ({
+  compactEmbeddedPiSessionMock: vi.fn(),
+  isEmbeddedPiRunActiveMock: vi.fn(() => false),
+}));
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  compactEmbeddedPiSession: compactEmbeddedPiSessionMock,
+  isEmbeddedPiRunActive: isEmbeddedPiRunActiveMock,
+}));
+
+vi.mock("../agents/pi-embedded-runner/cache-ttl.js", async () => {
+  const actual = await vi.importActual<typeof import("../agents/pi-embedded-runner/cache-ttl.js")>(
+    "../agents/pi-embedded-runner/cache-ttl.js",
+  );
+  return {
+    ...actual,
+    resolveCacheTtlMs: vi.fn(() => ONE_HOUR_MS),
+    resolveTimeBasedContextCompactMode: vi.fn(() => "compact"),
+  };
+});
+
+describe("runSessionCacheMaintenanceSweep", () => {
+  const tempRoots: string[] = [];
+
+  afterEach(async () => {
+    compactEmbeddedPiSessionMock.mockReset();
+    isEmbeddedPiRunActiveMock.mockReset();
+    isEmbeddedPiRunActiveMock.mockReturnValue(false);
+    await Promise.all(
+      tempRoots.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("retries idle compaction when the previous sweep did not compact", async () => {
+    const { runSessionCacheMaintenanceSweep } = await import("./session-cache-maintenance.js");
+
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-cache-maint-"));
+    tempRoots.push(root);
+    const storePath = path.join(root, "sessions.json");
+    const sessionFile = path.join(root, "session.jsonl");
+    const sessionKey = "agent:main:test:compact-retry";
+    const cacheTouchAt = 5_000;
+    const now = cacheTouchAt + ONE_HOUR_MS - 60_000;
+
+    await fs.writeFile(sessionFile, "", "utf-8");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sess-compact-retry",
+          sessionFile,
+          updatedAt: cacheTouchAt,
+          lastUserMessageAt: cacheTouchAt,
+          lastAssistantMessageAt: cacheTouchAt,
+          lastCacheTouchAt: cacheTouchAt,
+          totalTokens: 25_000,
+          totalTokensFresh: true,
+        },
+      }),
+      "utf-8",
+    );
+
+    compactEmbeddedPiSessionMock.mockResolvedValue({
+      ok: true,
+      compacted: false,
+      reason: "nothing to compact",
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    await runSessionCacheMaintenanceSweep({
+      cfg,
+      nowMs: () => now,
+    });
+    await runSessionCacheMaintenanceSweep({
+      cfg,
+      nowMs: () => now,
+    });
+
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(2);
+    const stored = loadSessionStore(storePath, { skipCache: true });
+    expect(stored[sessionKey]?.lastIdleCompactionForCacheTouchAt).toBeUndefined();
+  });
+});

--- a/src/gateway/session-cache-maintenance.sweep.test.ts
+++ b/src/gateway/session-cache-maintenance.sweep.test.ts
@@ -87,6 +87,58 @@ describe("runSessionCacheMaintenanceSweep", () => {
 
     expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(2);
     const stored = loadSessionStore(storePath, { skipCache: true });
-    expect(stored[sessionKey]?.lastIdleCompactionForCacheTouchAt).toBeUndefined();
+    expect(stored[sessionKey]?.lastIdleCompactionForAssistantMessageAt).toBeUndefined();
+  });
+
+  it("does not compact twice during the same assistant idle window", async () => {
+    const { runSessionCacheMaintenanceSweep } = await import("./session-cache-maintenance.js");
+
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-cache-once-"));
+    tempRoots.push(root);
+    const storePath = path.join(root, "sessions.json");
+    const sessionFile = path.join(root, "session.jsonl");
+    const sessionKey = "agent:main:test:compact-once";
+    const assistantReplyAt = 5_000;
+    const firstNow = assistantReplyAt + ONE_HOUR_MS - 60_000;
+    const secondNow = firstNow + ONE_HOUR_MS - 60_000;
+
+    await fs.writeFile(sessionFile, "", "utf-8");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sess-compact-once",
+          sessionFile,
+          updatedAt: assistantReplyAt,
+          lastUserMessageAt: assistantReplyAt,
+          lastAssistantMessageAt: assistantReplyAt,
+          lastCacheTouchAt: assistantReplyAt,
+          totalTokens: 25_000,
+          totalTokensFresh: true,
+        },
+      }),
+      "utf-8",
+    );
+
+    compactEmbeddedPiSessionMock.mockResolvedValue({
+      ok: true,
+      compacted: true,
+      result: { tokensAfter: 10_000 },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    await runSessionCacheMaintenanceSweep({
+      cfg,
+      nowMs: () => firstNow,
+    });
+    await runSessionCacheMaintenanceSweep({
+      cfg,
+      nowMs: () => secondNow,
+    });
+
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    const stored = loadSessionStore(storePath, { skipCache: true });
+    expect(stored[sessionKey]?.lastIdleCompactionForAssistantMessageAt).toBe(assistantReplyAt);
   });
 });

--- a/src/gateway/session-cache-maintenance.test.ts
+++ b/src/gateway/session-cache-maintenance.test.ts
@@ -28,14 +28,14 @@ describe("session cache maintenance helpers", () => {
     ).toBe(true);
   });
 
-  it("does not warm when the current cache-touch window was already serviced", () => {
+  it("does not warm when the current assistant idle window was already serviced", () => {
     expect(
       shouldRunIdleCacheCompaction({
         entry: {
           lastUserMessageAt: 1_000,
           lastAssistantMessageAt: 2_000,
           lastCacheTouchAt: 2_000,
-          lastIdleCompactionForCacheTouchAt: 2_000,
+          lastIdleCompactionForAssistantMessageAt: 2_000,
         },
         policy: {
           mode: "compact",

--- a/src/gateway/session-cache-maintenance.test.ts
+++ b/src/gateway/session-cache-maintenance.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldResetExpiredSession,
+  shouldRunIdleCacheCompaction,
+} from "./session-cache-maintenance.js";
+
+const ONE_HOUR_MS = 60 * 60_000;
+const ONE_MINUTE_MS = 60_000;
+
+describe("session cache maintenance helpers", () => {
+  it("warms idle long sessions shortly before cache expiry", () => {
+    expect(
+      shouldRunIdleCacheCompaction({
+        entry: {
+          lastUserMessageAt: 1_000,
+          lastAssistantMessageAt: 2_000,
+          lastCacheTouchAt: 2_000,
+        },
+        policy: {
+          mode: "compact",
+          cacheTtlMs: ONE_HOUR_MS,
+          idleCompactionMinTokens: 20_000,
+          idleCompactionLeadMs: ONE_MINUTE_MS,
+        },
+        now: 2_000 + ONE_HOUR_MS - ONE_MINUTE_MS,
+        totalTokens: 25_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not warm when the current cache-touch window was already serviced", () => {
+    expect(
+      shouldRunIdleCacheCompaction({
+        entry: {
+          lastUserMessageAt: 1_000,
+          lastAssistantMessageAt: 2_000,
+          lastCacheTouchAt: 2_000,
+          lastIdleCompactionForCacheTouchAt: 2_000,
+        },
+        policy: {
+          mode: "compact",
+          cacheTtlMs: ONE_HOUR_MS,
+          idleCompactionMinTokens: 20_000,
+          idleCompactionLeadMs: ONE_MINUTE_MS,
+        },
+        now: 2_000 + ONE_HOUR_MS - ONE_MINUTE_MS,
+        totalTokens: 25_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not warm short sessions below the default token floor", () => {
+    expect(
+      shouldRunIdleCacheCompaction({
+        entry: {
+          lastUserMessageAt: 1_000,
+          lastAssistantMessageAt: 2_000,
+          lastCacheTouchAt: 2_000,
+        },
+        policy: {
+          mode: "compact",
+          cacheTtlMs: ONE_HOUR_MS,
+          idleCompactionMinTokens: 20_000,
+          idleCompactionLeadMs: ONE_MINUTE_MS,
+        },
+        now: 2_000 + ONE_HOUR_MS - ONE_MINUTE_MS,
+        totalTokens: 19_999,
+      }),
+    ).toBe(false);
+  });
+
+  it("resets expired sessions once cache ttl is exceeded", () => {
+    expect(
+      shouldResetExpiredSession({
+        entry: {
+          lastUserMessageAt: 1_000,
+          lastAssistantMessageAt: 2_000,
+          lastCacheTouchAt: 2_000,
+        },
+        policy: {
+          mode: "reset",
+          cacheTtlMs: ONE_HOUR_MS,
+          idleCompactionMinTokens: 20_000,
+          idleCompactionLeadMs: ONE_MINUTE_MS,
+        },
+        now: 2_000 + ONE_HOUR_MS,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not reset while waiting on a newer user message", () => {
+    expect(
+      shouldResetExpiredSession({
+        entry: {
+          lastUserMessageAt: 3_000,
+          lastAssistantMessageAt: 2_000,
+          lastCacheTouchAt: 2_000,
+        },
+        policy: {
+          mode: "reset",
+          cacheTtlMs: ONE_HOUR_MS,
+          idleCompactionMinTokens: 20_000,
+          idleCompactionLeadMs: ONE_MINUTE_MS,
+        },
+        now: 2_000 + ONE_HOUR_MS,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not reset in compact mode", () => {
+    expect(
+      shouldResetExpiredSession({
+        entry: {
+          lastUserMessageAt: 1_000,
+          lastAssistantMessageAt: 2_000,
+          lastCacheTouchAt: 2_000,
+        },
+        policy: {
+          mode: "compact",
+          cacheTtlMs: ONE_HOUR_MS,
+          idleCompactionMinTokens: 20_000,
+          idleCompactionLeadMs: ONE_MINUTE_MS,
+        },
+        now: 2_000 + ONE_HOUR_MS,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not compact in reset mode", () => {
+    expect(
+      shouldRunIdleCacheCompaction({
+        entry: {
+          lastUserMessageAt: 1_000,
+          lastAssistantMessageAt: 2_000,
+          lastCacheTouchAt: 2_000,
+        },
+        policy: {
+          mode: "reset",
+          cacheTtlMs: ONE_HOUR_MS,
+          idleCompactionMinTokens: 20_000,
+          idleCompactionLeadMs: ONE_MINUTE_MS,
+        },
+        now: 2_000 + ONE_HOUR_MS - ONE_MINUTE_MS,
+        totalTokens: 25_000,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/gateway/session-cache-maintenance.test.ts
+++ b/src/gateway/session-cache-maintenance.test.ts
@@ -49,6 +49,26 @@ describe("session cache maintenance helpers", () => {
     ).toBe(false);
   });
 
+  it("still treats equal user and assistant timestamps as awaiting user reply", () => {
+    expect(
+      shouldRunIdleCacheCompaction({
+        entry: {
+          lastUserMessageAt: 2_000,
+          lastAssistantMessageAt: 2_000,
+          lastCacheTouchAt: 2_000,
+        },
+        policy: {
+          mode: "compact",
+          cacheTtlMs: ONE_HOUR_MS,
+          idleCompactionMinTokens: 20_000,
+          idleCompactionLeadMs: ONE_MINUTE_MS,
+        },
+        now: 2_000 + ONE_HOUR_MS - ONE_MINUTE_MS,
+        totalTokens: 25_000,
+      }),
+    ).toBe(true);
+  });
+
   it("does not warm short sessions below the default token floor", () => {
     expect(
       shouldRunIdleCacheCompaction({

--- a/src/gateway/session-cache-maintenance.ts
+++ b/src/gateway/session-cache-maintenance.ts
@@ -43,7 +43,7 @@ type SessionCacheTimingState = Pick<
   | "lastUserMessageAt"
   | "lastAssistantMessageAt"
   | "lastCacheTouchAt"
-  | "lastIdleCompactionForCacheTouchAt"
+  | "lastIdleCompactionForAssistantMessageAt"
 >;
 
 function resolvePositiveTimestamp(value: number | undefined): number | null {
@@ -55,6 +55,10 @@ function resolveCacheTouchAt(entry: SessionCacheTimingState): number | null {
     resolvePositiveTimestamp(entry.lastCacheTouchAt) ??
     resolvePositiveTimestamp(entry.lastAssistantMessageAt)
   );
+}
+
+function resolveAssistantReplyAt(entry: SessionCacheTimingState): number | null {
+  return resolvePositiveTimestamp(entry.lastAssistantMessageAt);
 }
 
 function isAwaitingUserReply(entry: SessionCacheTimingState): boolean {
@@ -102,11 +106,12 @@ export function shouldRunIdleCacheCompaction(params: {
     return false;
   }
   const cacheTouchAt = resolveCacheTouchAt(params.entry);
+  const assistantReplyAt = resolveAssistantReplyAt(params.entry);
   const idleThresholdMs = resolveIdleCompactionThresholdMs(params.policy);
-  if (cacheTouchAt == null || idleThresholdMs == null) {
+  if (cacheTouchAt == null || assistantReplyAt == null || idleThresholdMs == null) {
     return false;
   }
-  if (params.entry.lastIdleCompactionForCacheTouchAt === cacheTouchAt) {
+  if (params.entry.lastIdleCompactionForAssistantMessageAt === assistantReplyAt) {
     return false;
   }
   if (params.now - cacheTouchAt >= (params.policy.cacheTtlMs ?? 0)) {
@@ -219,7 +224,8 @@ async function maybeCompactIdleSession(params: {
   totalTokens: number;
 }): Promise<boolean> {
   const cacheTouchAt = resolveCacheTouchAt(params.entry);
-  if (cacheTouchAt == null || !params.entry.sessionFile) {
+  const assistantReplyAt = resolveAssistantReplyAt(params.entry);
+  if (cacheTouchAt == null || assistantReplyAt == null || !params.entry.sessionFile) {
     return false;
   }
   const agentId =
@@ -243,7 +249,7 @@ async function maybeCompactIdleSession(params: {
 
   const patch: Partial<SessionEntry> = {};
   if (result.ok && result.compacted) {
-    patch.lastIdleCompactionForCacheTouchAt = cacheTouchAt;
+    patch.lastIdleCompactionForAssistantMessageAt = assistantReplyAt;
     patch.compactionCount = (params.entry.compactionCount ?? 0) + 1;
     patch.lastCacheTouchAt = params.now;
     if (typeof result.result?.tokensAfter === "number" && result.result.tokensAfter > 0) {

--- a/src/gateway/session-cache-maintenance.ts
+++ b/src/gateway/session-cache-maintenance.ts
@@ -1,0 +1,339 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import {
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
+import { estimateMessagesTokens } from "../agents/compaction.js";
+import {
+  resolveCacheTtlMs,
+  resolveTimeBasedContextCompactMode,
+  type TimeBasedContextCompactMode,
+} from "../agents/pi-embedded-runner/cache-ttl.js";
+import { resolveExtraParams } from "../agents/pi-embedded-runner/extra-params.js";
+import { compactEmbeddedPiSession, isEmbeddedPiRunActive } from "../agents/pi-embedded.js";
+import { type OpenClawConfig, loadConfig } from "../config/config.js";
+import {
+  loadSessionStore,
+  resolveAllAgentSessionStoreTargetsSync,
+  resolveFreshSessionTotalTokens,
+  type SessionEntry,
+  type SessionStoreTarget,
+  updateSessionStore,
+} from "../config/sessions.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { performGatewaySessionReset } from "./session-reset-service.js";
+import { readSessionMessages, resolveSessionModelRef } from "./session-utils.js";
+
+const log = createSubsystemLogger("gateway/session-cache-maintenance");
+
+const DEFAULT_IDLE_COMPACTION_MIN_TOKENS = 20_000;
+const DEFAULT_IDLE_COMPACTION_LEAD_MS = 60_000;
+
+type SessionCacheMaintenancePolicy = {
+  mode: TimeBasedContextCompactMode;
+  cacheTtlMs: number | null;
+  idleCompactionMinTokens: number;
+  idleCompactionLeadMs: number;
+};
+
+type SessionCacheTimingState = Pick<
+  SessionEntry,
+  | "lastUserMessageAt"
+  | "lastAssistantMessageAt"
+  | "lastCacheTouchAt"
+  | "lastIdleCompactionForCacheTouchAt"
+>;
+
+function resolvePositiveTimestamp(value: number | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function resolveCacheTouchAt(entry: SessionCacheTimingState): number | null {
+  return (
+    resolvePositiveTimestamp(entry.lastCacheTouchAt) ??
+    resolvePositiveTimestamp(entry.lastAssistantMessageAt)
+  );
+}
+
+function isAwaitingUserReply(entry: SessionCacheTimingState): boolean {
+  const lastAssistant = resolvePositiveTimestamp(entry.lastAssistantMessageAt);
+  if (lastAssistant == null) {
+    return false;
+  }
+  const lastUser = resolvePositiveTimestamp(entry.lastUserMessageAt);
+  return lastUser == null || lastAssistant > lastUser;
+}
+
+function resolveIdleCompactionThresholdMs(policy: SessionCacheMaintenancePolicy): number | null {
+  if (policy.cacheTtlMs == null) {
+    return null;
+  }
+  const thresholdMs = policy.cacheTtlMs - policy.idleCompactionLeadMs;
+  return thresholdMs > 0 ? thresholdMs : null;
+}
+
+export function shouldResetExpiredSession(params: {
+  entry: SessionCacheTimingState;
+  policy: SessionCacheMaintenancePolicy;
+  now: number;
+}): boolean {
+  if (!isAwaitingUserReply(params.entry) || params.policy.cacheTtlMs == null) {
+    return false;
+  }
+  if (params.policy.mode !== "reset") {
+    return false;
+  }
+  const cacheTouchAt = resolveCacheTouchAt(params.entry);
+  return cacheTouchAt != null && params.now - cacheTouchAt >= params.policy.cacheTtlMs;
+}
+
+export function shouldRunIdleCacheCompaction(params: {
+  entry: SessionCacheTimingState;
+  policy: SessionCacheMaintenancePolicy;
+  now: number;
+  totalTokens?: number;
+}): boolean {
+  if (!isAwaitingUserReply(params.entry)) {
+    return false;
+  }
+  if (params.policy.mode !== "compact") {
+    return false;
+  }
+  const cacheTouchAt = resolveCacheTouchAt(params.entry);
+  const idleThresholdMs = resolveIdleCompactionThresholdMs(params.policy);
+  if (cacheTouchAt == null || idleThresholdMs == null) {
+    return false;
+  }
+  if (params.entry.lastIdleCompactionForCacheTouchAt === cacheTouchAt) {
+    return false;
+  }
+  if (params.now - cacheTouchAt >= (params.policy.cacheTtlMs ?? 0)) {
+    return false;
+  }
+  if (params.now - cacheTouchAt < idleThresholdMs) {
+    return false;
+  }
+  return (params.totalTokens ?? 0) >= params.policy.idleCompactionMinTokens;
+}
+
+function resolveSessionCacheMaintenancePolicy(params: {
+  cfg: OpenClawConfig;
+  entry: SessionEntry;
+  sessionKey: string;
+  target: SessionStoreTarget;
+}): SessionCacheMaintenancePolicy {
+  const agentId =
+    params.target.agentId ||
+    resolveAgentIdFromSessionKey(params.sessionKey) ||
+    resolveDefaultAgentId(params.cfg);
+  const { provider, model } = resolveSessionModelRef(params.cfg, params.entry, agentId);
+  const extraParams = resolveExtraParams({
+    cfg: params.cfg,
+    provider,
+    modelId: model,
+    agentId,
+  });
+  return {
+    mode: resolveTimeBasedContextCompactMode(extraParams),
+    cacheTtlMs: resolveCacheTtlMs({
+      config: params.cfg,
+      provider,
+      modelId: model,
+      agentId,
+    }),
+    idleCompactionMinTokens: DEFAULT_IDLE_COMPACTION_MIN_TOKENS,
+    idleCompactionLeadMs: DEFAULT_IDLE_COMPACTION_LEAD_MS,
+  };
+}
+
+function estimateSessionTotalTokens(params: {
+  entry: SessionEntry;
+  target: SessionStoreTarget;
+}): number | undefined {
+  const freshTokens = resolveFreshSessionTotalTokens(params.entry);
+  if (typeof freshTokens === "number" && freshTokens > 0) {
+    return freshTokens;
+  }
+  const fallbackTokens =
+    typeof params.entry.totalTokens === "number" && params.entry.totalTokens > 0
+      ? params.entry.totalTokens
+      : undefined;
+  if (fallbackTokens !== undefined) {
+    return fallbackTokens;
+  }
+  if (!params.entry.sessionId) {
+    return undefined;
+  }
+  try {
+    const messages = readSessionMessages(
+      params.entry.sessionId,
+      params.target.storePath,
+      params.entry.sessionFile,
+    );
+    if (messages.length === 0) {
+      return undefined;
+    }
+    const estimated = estimateMessagesTokens(messages as AgentMessage[]);
+    return Number.isFinite(estimated) && estimated > 0 ? Math.ceil(estimated) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function persistSessionMaintenancePatch(params: {
+  target: SessionStoreTarget;
+  sessionKey: string;
+  patch: Partial<SessionEntry>;
+}) {
+  await updateSessionStore(params.target.storePath, (store) => {
+    const current = store[params.sessionKey];
+    if (!current) {
+      return;
+    }
+    store[params.sessionKey] = {
+      ...current,
+      ...params.patch,
+    };
+  });
+}
+
+async function maybeCompactIdleSession(params: {
+  cfg: OpenClawConfig;
+  entry: SessionEntry;
+  sessionKey: string;
+  target: SessionStoreTarget;
+  now: number;
+  totalTokens: number;
+}): Promise<boolean> {
+  const cacheTouchAt = resolveCacheTouchAt(params.entry);
+  if (cacheTouchAt == null || !params.entry.sessionFile) {
+    return false;
+  }
+  const agentId =
+    params.target.agentId ||
+    resolveAgentIdFromSessionKey(params.sessionKey) ||
+    resolveDefaultAgentId(params.cfg);
+  const { provider, model } = resolveSessionModelRef(params.cfg, params.entry, agentId);
+  const result = await compactEmbeddedPiSession({
+    sessionId: params.entry.sessionId,
+    sessionKey: params.sessionKey,
+    sessionFile: params.entry.sessionFile,
+    workspaceDir: resolveAgentWorkspaceDir(params.cfg, agentId),
+    agentDir: resolveAgentDir(params.cfg, agentId),
+    config: params.cfg,
+    skillsSnapshot: params.entry.skillsSnapshot,
+    provider,
+    model,
+    trigger: "manual",
+    currentTokenCount: params.totalTokens,
+  });
+
+  const patch: Partial<SessionEntry> = {
+    lastIdleCompactionForCacheTouchAt: cacheTouchAt,
+  };
+  if (result.ok && result.compacted) {
+    patch.compactionCount = (params.entry.compactionCount ?? 0) + 1;
+    patch.lastCacheTouchAt = params.now;
+    if (typeof result.result?.tokensAfter === "number" && result.result.tokensAfter > 0) {
+      patch.totalTokens = result.result.tokensAfter;
+      patch.totalTokensFresh = true;
+    }
+    log.info("idle cache-warming compaction completed", {
+      sessionKey: params.sessionKey,
+      provider,
+      model,
+      tokensBefore: params.totalTokens,
+      tokensAfter: result.result?.tokensAfter,
+    });
+  } else {
+    log.info("idle cache-warming compaction skipped", {
+      sessionKey: params.sessionKey,
+      provider,
+      model,
+      reason: result.reason ?? "not_compacted",
+      tokens: params.totalTokens,
+    });
+  }
+  await persistSessionMaintenancePatch({
+    target: params.target,
+    sessionKey: params.sessionKey,
+    patch,
+  });
+  return true;
+}
+
+async function maybeResetExpiredSession(params: { sessionKey: string }): Promise<boolean> {
+  const result = await performGatewaySessionReset({
+    key: params.sessionKey,
+    reason: "reset",
+    commandSource: "gateway:session-cache-maintenance",
+  });
+  if (!result.ok) {
+    log.warn(`expired-session reset skipped for ${params.sessionKey}: ${result.error.message}`);
+    return false;
+  }
+  log.info("expired-session reset completed", { sessionKey: params.sessionKey });
+  return true;
+}
+
+export async function runSessionCacheMaintenanceSweep(
+  params: {
+    cfg?: OpenClawConfig;
+    nowMs?: () => number;
+  } = {},
+): Promise<void> {
+  const cfg = params.cfg ?? loadConfig();
+  const now = params.nowMs?.() ?? Date.now();
+  const targets = resolveAllAgentSessionStoreTargetsSync(cfg);
+
+  for (const target of targets) {
+    const store = loadSessionStore(target.storePath);
+    for (const [sessionKey, entry] of Object.entries(store)) {
+      if (!entry?.sessionId || isEmbeddedPiRunActive(entry.sessionId)) {
+        continue;
+      }
+
+      const policy = resolveSessionCacheMaintenancePolicy({
+        cfg,
+        entry,
+        sessionKey,
+        target,
+      });
+      if (policy.cacheTtlMs == null) {
+        continue;
+      }
+
+      if (
+        shouldResetExpiredSession({
+          entry,
+          policy,
+          now,
+        })
+      ) {
+        await maybeResetExpiredSession({ sessionKey });
+        continue;
+      }
+
+      const totalTokens = estimateSessionTotalTokens({ entry, target });
+      if (
+        shouldRunIdleCacheCompaction({
+          entry,
+          policy,
+          now,
+          totalTokens,
+        })
+      ) {
+        await maybeCompactIdleSession({
+          cfg,
+          entry,
+          sessionKey,
+          target,
+          now,
+          totalTokens: totalTokens ?? 0,
+        });
+      }
+    }
+  }
+}

--- a/src/gateway/session-cache-maintenance.ts
+++ b/src/gateway/session-cache-maintenance.ts
@@ -63,7 +63,7 @@ function isAwaitingUserReply(entry: SessionCacheTimingState): boolean {
     return false;
   }
   const lastUser = resolvePositiveTimestamp(entry.lastUserMessageAt);
-  return lastUser == null || lastAssistant > lastUser;
+  return lastUser == null || lastAssistant >= lastUser;
 }
 
 function resolveIdleCompactionThresholdMs(policy: SessionCacheMaintenancePolicy): number | null {
@@ -116,6 +116,17 @@ export function shouldRunIdleCacheCompaction(params: {
     return false;
   }
   return (params.totalTokens ?? 0) >= params.policy.idleCompactionMinTokens;
+}
+
+function shouldCheckIdleCacheCompactionWindow(params: {
+  entry: SessionCacheTimingState;
+  policy: SessionCacheMaintenancePolicy;
+  now: number;
+}): boolean {
+  return shouldRunIdleCacheCompaction({
+    ...params,
+    totalTokens: params.policy.idleCompactionMinTokens,
+  });
 }
 
 function resolveSessionCacheMaintenancePolicy(params: {
@@ -226,14 +237,13 @@ async function maybeCompactIdleSession(params: {
     skillsSnapshot: params.entry.skillsSnapshot,
     provider,
     model,
-    trigger: "manual",
+    trigger: "budget",
     currentTokenCount: params.totalTokens,
   });
 
-  const patch: Partial<SessionEntry> = {
-    lastIdleCompactionForCacheTouchAt: cacheTouchAt,
-  };
+  const patch: Partial<SessionEntry> = {};
   if (result.ok && result.compacted) {
+    patch.lastIdleCompactionForCacheTouchAt = cacheTouchAt;
     patch.compactionCount = (params.entry.compactionCount ?? 0) + 1;
     patch.lastCacheTouchAt = params.now;
     if (typeof result.result?.tokensAfter === "number" && result.result.tokensAfter > 0) {
@@ -256,12 +266,14 @@ async function maybeCompactIdleSession(params: {
       tokens: params.totalTokens,
     });
   }
-  await persistSessionMaintenancePatch({
-    target: params.target,
-    sessionKey: params.sessionKey,
-    patch,
-  });
-  return true;
+  if (Object.keys(patch).length > 0) {
+    await persistSessionMaintenancePatch({
+      target: params.target,
+      sessionKey: params.sessionKey,
+      patch,
+    });
+  }
+  return result.ok && result.compacted;
 }
 
 async function maybeResetExpiredSession(params: { sessionKey: string }): Promise<boolean> {
@@ -316,23 +328,32 @@ export async function runSessionCacheMaintenanceSweep(
         continue;
       }
 
-      const totalTokens = estimateSessionTotalTokens({ entry, target });
       if (
-        shouldRunIdleCacheCompaction({
+        policy.mode === "compact" &&
+        shouldCheckIdleCacheCompactionWindow({
           entry,
           policy,
           now,
-          totalTokens,
         })
       ) {
-        await maybeCompactIdleSession({
-          cfg,
-          entry,
-          sessionKey,
-          target,
-          now,
-          totalTokens: totalTokens ?? 0,
-        });
+        const totalTokens = estimateSessionTotalTokens({ entry, target });
+        if (
+          shouldRunIdleCacheCompaction({
+            entry,
+            policy,
+            now,
+            totalTokens,
+          })
+        ) {
+          await maybeCompactIdleSession({
+            cfg,
+            entry,
+            sessionKey,
+            target,
+            now,
+            totalTokens: totalTokens ?? 0,
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- add time-based session maintenance settings using `sessionCacheTtl` plus `timeBasedContextCompact`
- support explicit `compact` and `reset` maintenance modes instead of implicitly coupling both behaviors together
- track session idle/cache timestamps and run gateway maintenance sweeps to apply the selected policy

## Why
This change adds two time-based session maintenance workflows for long-lived sessions:

1. `compact`
   - Purpose: reduce the chance of a cold cache miss after a long idle period by proactively compacting an idle session shortly before the configured timeout.
   - Good fit: long research or coding threads where the user may come back later and continue from the same context.

2. `reset`
   - Purpose: aggressively clear stale sessions once they have been idle past the configured timeout instead of carrying old context forward.
   - Good fit: workflows where stale context is more harmful than helpful, or where keeping expired sessions around only increases cost and surprise.

The new behavior is controlled explicitly per model:
- `sessionCacheTtl` defines the timeout window
- `timeBasedContextCompact` chooses the maintenance algorithm: `none`, `compact`, or `reset`

`cacheRetention` remains a model prompt-cache setting and is no longer used to enable or disable these new maintenance features.

## Implementation notes
- keep Anthropic API-key smart defaults at `cacheRetention: "short"`
- add `sessionCacheTtl: "1h"` as a defaulted timeout value without auto-enabling maintenance mode
- warn when `sessionCacheTtl` exceeds an explicitly configured model cache TTL
- record `lastUserMessageAt`, `lastAssistantMessageAt`, `lastCacheTouchAt`, and `lastIdleCompactionForCacheTouchAt` in session state
- run the maintenance sweep from gateway server maintenance without overlapping runs

## Validation
- `pnpm exec vitest run src/gateway/session-cache-maintenance.test.ts src/gateway/server-maintenance.test.ts src/config/config.pruning-defaults.test.ts src/agents/pi-embedded-runner/cache-ttl.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.cache-ttl.test.ts src/agents/pi-embedded-runner/extra-params.cache-retention-default.test.ts src/commands/agent/session-store.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc -p tsconfig.json --noEmit`
