### PR TITLE
fix(exec): scrub child env secrets and preserve approval routing

### DIFF
--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -151,7 +151,9 @@ Think of the suites as “increasing realism” (and increasing flakiness/cost):
   - Not CI-stable by design (real networks, real provider policies, quotas, outages)
   - Costs money / uses rate limits
   - Prefer running narrowed subsets instead of “everything”
-- Live runs will source `~/.profile` to pick up missing API keys
+- Live runs source `~/.profile` to pick up missing API keys.
+- By default, live runs still isolate `HOME` and copy config/auth material into a temp test home so unit fixtures cannot mutate your real `~/.openclaw`.
+- Set `OPENCLAW_LIVE_USE_REAL_HOME=1` only when you intentionally need live tests to use your real home directory.
 - `pnpm test:live` now defaults to a quieter mode: it keeps `[live] ...` progress output, but suppresses the extra `~/.profile` notice and mutes gateway bootstrap logs/Bonjour chatter. Set `OPENCLAW_LIVE_TEST_QUIET=0` if you want the full startup logs back.
 - API key rotation (provider-specific): set `*_API_KEYS` with comma/semicolon format or `*_API_KEY_1`, `*_API_KEY_2` (for example `OPENAI_API_KEYS`, `ANTHROPIC_API_KEYS`, `GEMINI_API_KEYS`) or per-live override via `OPENCLAW_LIVE_*_KEY`; tests retry on rate limit responses.
 - Progress/heartbeat output:
@@ -452,6 +454,7 @@ Live tests discover credentials the same way the CLI does. Practical implication
 
 - Profile store: `~/.openclaw/credentials/` (preferred; what “profile keys” means in the tests)
 - Config: `~/.openclaw/openclaw.json` (or `OPENCLAW_CONFIG_PATH`)
+- Live local runs copy the active config plus auth stores into a temp test home by default; `agents.*.workspace` / `agentDir` path overrides are stripped in that staged copy so probes stay off your real host workspace.
 
 If you want to rely on env keys (e.g. exported in your `~/.profile`), run local tests after `source ~/.profile`, or use the Docker runners below (they can mount `~/.profile` into the container).
 

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -1,3 +1,4 @@
+import { INTERNAL_MESSAGE_CHANNEL, isInternalMessageChannel } from "../utils/message-channel.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 type ExecApprovalFollowupParams = {
@@ -39,6 +40,8 @@ export async function sendExecApprovalFollowup(
     params.turnSourceThreadId != null && params.turnSourceThreadId !== ""
       ? String(params.turnSourceThreadId)
       : undefined;
+  const isInternal = isInternalMessageChannel(channel);
+  const hasExplicitExternalPair = Boolean(channel && to) && !isInternal;
 
   await callGatewayTool(
     "agent",
@@ -46,12 +49,18 @@ export async function sendExecApprovalFollowup(
     {
       sessionKey,
       message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: true,
+      deliver: !isInternal,
       bestEffortDeliver: true,
-      channel: channel && to ? channel : undefined,
-      to: channel && to ? to : undefined,
-      accountId: channel && to ? params.turnSourceAccountId?.trim() || undefined : undefined,
-      threadId: channel && to ? threadId : undefined,
+      channel: hasExplicitExternalPair
+        ? channel
+        : isInternal
+          ? INTERNAL_MESSAGE_CHANNEL
+          : undefined,
+      to: hasExplicitExternalPair ? to : undefined,
+      accountId: hasExplicitExternalPair
+        ? params.turnSourceAccountId?.trim() || undefined
+        : undefined,
+      threadId: hasExplicitExternalPair ? threadId : undefined,
       idempotencyKey: `exec-approval-followup:${params.approvalId}`,
     },
     { expectFinal: true },

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -336,6 +336,7 @@ export async function processGatewayAllowlist(
         initiatingSurface,
         sentApproverDms,
         unavailableReason,
+        turnSourceChannel: params.turnSourceChannel,
       }),
     };
   }

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -374,6 +374,7 @@ export async function executeNodeHostCommand(
       sentApproverDms,
       unavailableReason,
       nodeId,
+      turnSourceChannel: params.turnSourceChannel,
     });
   }
 

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -349,6 +349,7 @@ export function buildExecApprovalPendingToolResult(params: {
   sentApproverDms: boolean;
   unavailableReason: ExecApprovalUnavailableReason | null;
   nodeId?: string;
+  turnSourceChannel?: string;
 }): AgentToolResult<ExecToolDetails> {
   return {
     content: [
@@ -370,6 +371,7 @@ export function buildExecApprovalPendingToolResult(params: {
                 cwd: params.cwd,
                 host: params.host,
                 nodeId: params.nodeId,
+                turnSourceChannel: params.turnSourceChannel,
               }),
       },
     ],

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -7,6 +7,7 @@ import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
 import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { isInternalMessageChannel } from "../utils/message-channel.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -279,6 +280,7 @@ export function buildApprovalPendingMessage(params: {
   cwd: string;
   host: "gateway" | "node";
   nodeId?: string;
+  turnSourceChannel?: string;
 }) {
   let fence = "```";
   while (params.command.includes(fence)) {
@@ -300,7 +302,14 @@ export function buildApprovalPendingMessage(params: {
   lines.push(commandBlock);
   lines.push("Mode: foreground (interactive approvals available).");
   lines.push("Background mode requires pre-approved policy (allow-always or ask=off).");
-  lines.push(`Reply with: /approve ${params.approvalSlug} allow-once|allow-always|deny`);
+  if (isInternalMessageChannel(params.turnSourceChannel)) {
+    lines.push(
+      "Use the exec approval buttons (Allow once, Always allow, or Deny) in the Control UI.",
+    );
+    lines.push(`Alternatively: /approve ${params.approvalSlug} allow-once|allow-always|deny`);
+  } else {
+    lines.push(`Reply with: /approve ${params.approvalSlug} allow-once|allow-always|deny`);
+  }
   lines.push("If the short code is ambiguous, use the full id in /approve.");
   return lines.join("\n");
 }

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -449,6 +449,71 @@ describe("exec approvals", () => {
     );
   });
 
+  it("routes exec follow-ups back to webchat without external delivery", async () => {
+    const agentCalls: Array<Record<string, unknown>> = [];
+
+    mockAcceptedApprovalFlow({
+      onAgent: (params) => {
+        agentCalls.push(params);
+      },
+    });
+
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "always",
+      approvalRunningNoticeMs: 0,
+      sessionKey: "agent:main:webchat",
+      messageProvider: "webchat",
+      elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
+    });
+
+    const result = await tool.execute("call-gw-followup-webchat", {
+      command: "echo ok",
+      workdir: process.cwd(),
+      gatewayUrl: undefined,
+      gatewayToken: undefined,
+    });
+
+    expect(result.details.status).toBe("approval-pending");
+    await expect.poll(() => agentCalls.length, { timeout: 3_000, interval: 20 }).toBe(1);
+    expect(agentCalls[0]).toEqual(
+      expect.objectContaining({
+        sessionKey: "agent:main:webchat",
+        deliver: false,
+        channel: "webchat",
+        idempotencyKey: expect.stringContaining("exec-approval-followup:"),
+      }),
+    );
+    expect(agentCalls[0]?.to).toBeUndefined();
+  });
+
+  it("shows Control UI approval guidance for webchat-sourced approvals", async () => {
+    mockPendingApprovalRegistration();
+
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "always",
+      approvalRunningNoticeMs: 0,
+      messageProvider: " Webchat ",
+      elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
+    });
+
+    const result = await tool.execute("call-webchat-pending-copy", {
+      command: "echo ok",
+      elevated: true,
+    });
+
+    expect(result.details.status).toBe("approval-pending");
+    const pendingText = getResultText(result);
+    const details = result.details as { approvalSlug: string };
+    expect(pendingText).toContain(
+      "Use the exec approval buttons (Allow once, Always allow, or Deny) in the Control UI.",
+    );
+    expect(pendingText).toContain(
+      `Alternatively: /approve ${details.approvalSlug} allow-once|allow-always|deny`,
+    );
+  });
+
   it("requires a separate approval for each elevated command after allow-once", async () => {
     const requestCommands: string[] = [];
     const requestIds: string[] = [];

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -449,7 +449,7 @@ export function buildAgentSystemPrompt(params: {
     "Keep narration brief and value-dense; avoid repeating obvious steps.",
     "Use plain human language for narration unless in a technical context.",
     "When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.",
-    "When exec returns approval-pending, include the concrete /approve command from tool output (with allow-once|allow-always|deny) and do not ask for a different or rotated code.",
+    "When exec returns approval-pending, include the approval instructions from tool output (Control UI buttons when available, or the /approve command with allow-once|allow-always|deny) and do not ask for a different or rotated code.",
     "Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.",
     "When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run.",
     "",

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -202,7 +202,7 @@ export function createExecApprovalHandlers(
         }
       }
 
-      if (!hasExecApprovalClients && !forwarded) {
+      if (!twoPhase && !hasExecApprovalClients && !forwarded) {
         manager.expire(record.id, "no-approval-route");
         respond(
           true,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -966,7 +966,48 @@ describe("exec approval handlers", () => {
     }
   });
 
-  it("fast-fails approvals when no approver clients and no forwarding targets", async () => {
+  it("keeps two-phase approvals pending when no approver clients and no forwarding targets", async () => {
+    vi.useFakeTimers();
+    try {
+      const { manager, handlers, forwarder, respond, context } =
+        createForwardingExecApprovalFixture();
+      const expireSpy = vi.spyOn(manager, "expire");
+
+      const requestPromise = requestExecApproval({
+        handlers,
+        respond,
+        context,
+        params: {
+          timeoutMs: 60_000,
+          id: "approval-two-phase-no-clients",
+          host: "gateway",
+          twoPhase: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(forwarder.handleRequested).toHaveBeenCalledTimes(1);
+      expect(expireSpy).not.toHaveBeenCalled();
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          status: "accepted",
+          id: "approval-two-phase-no-clients",
+        }),
+        undefined,
+      );
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await requestPromise;
+
+      expect(expireSpy).toHaveBeenCalledWith("approval-two-phase-no-clients");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fast-fails single-phase approvals when no approver clients and no forwarding targets", async () => {
     const { manager, handlers, forwarder, respond, context } =
       createForwardingExecApprovalFixture();
     const expireSpy = vi.spyOn(manager, "expire");

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -250,6 +250,23 @@ describe("sanitizeHostExecEnv", () => {
       "ProgramFiles(x86)": "C:\\Program Files (x86)",
     });
   });
+
+  it("strips provider auth env vars from inherited host env case-insensitively", () => {
+    const env = sanitizeHostExecEnv({
+      baseEnv: {
+        PATH: "/usr/bin:/bin",
+        OPENAI_API_KEY: "openai-secret",
+        anthropic_api_key: "anthropic-secret",
+        SAFE: "1",
+      },
+    });
+
+    expect(env.PATH).toBe("/usr/bin:/bin");
+    expect(env.OPENCLAW_CLI).toBe(OPENCLAW_CLI_ENV_VALUE);
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.anthropic_api_key).toBeUndefined();
+    expect(env.SAFE).toBe("1");
+  });
 });
 
 describe("isDangerousHostEnvOverrideVarName", () => {

--- a/src/infra/host-env-security.ts
+++ b/src/infra/host-env-security.ts
@@ -1,3 +1,4 @@
+import { listKnownProviderAuthEnvVarNames } from "../secrets/provider-env-vars.js";
 import HOST_ENV_SECURITY_POLICY_JSON from "./host-env-security-policy.json" with { type: "json" };
 import { markOpenClawExecEnv } from "./openclaw-exec-env.js";
 
@@ -41,6 +42,9 @@ export const HOST_DANGEROUS_OVERRIDE_ENV_KEYS = new Set<string>(
 );
 export const HOST_SHELL_WRAPPER_ALLOWED_OVERRIDE_ENV_KEYS = new Set<string>(
   HOST_SHELL_WRAPPER_ALLOWED_OVERRIDE_ENV_KEY_VALUES,
+);
+const HOST_PROVIDER_AUTH_ENV_KEYS = new Set(
+  listKnownProviderAuthEnvVarNames().map((key) => key.toUpperCase()),
 );
 
 export type HostExecEnvSanitizationResult = {
@@ -188,6 +192,9 @@ export function sanitizeHostExecEnvWithDiagnostics(params?: {
   const merged: Record<string, string> = {};
   for (const [key, value] of listNormalizedEnvEntries(baseEnv)) {
     if (isDangerousHostEnvVarName(key)) {
+      continue;
+    }
+    if (HOST_PROVIDER_AUTH_ENV_KEYS.has(key.toUpperCase())) {
       continue;
     }
     merged[key] = value;

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -1,0 +1,139 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { installTestEnv } from "./test-env.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+const tempDirs = new Set<string>();
+const cleanupFns: Array<() => void> = [];
+
+function restoreProcessEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) {
+      delete process.env[key];
+    }
+  }
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function writeFile(targetPath: string, content: string): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, content, "utf8");
+}
+
+function createTempHome(): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-env-real-home-"));
+  tempDirs.add(tempDir);
+  return tempDir;
+}
+
+afterEach(() => {
+  while (cleanupFns.length > 0) {
+    cleanupFns.pop()?.();
+  }
+  restoreProcessEnv();
+  for (const tempDir of tempDirs) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+describe("installTestEnv", () => {
+  it("keeps live tests on a temp HOME while copying config and auth state", () => {
+    const realHome = createTempHome();
+    writeFile(path.join(realHome, ".profile"), "export TEST_PROFILE_ONLY=from-profile\n");
+    writeFile(
+      path.join(realHome, "custom-openclaw.json5"),
+      `{
+        // Preserve provider config, strip host-bound paths.
+        agents: {
+          defaults: {
+            workspace: "/Users/peter/Projects",
+            agentDir: "/Users/peter/.openclaw/agents/main/agent",
+          },
+          list: [
+            {
+              id: "dev",
+              workspace: "/Users/peter/dev-workspace",
+              agentDir: "/Users/peter/.openclaw/agents/dev/agent",
+            },
+          ],
+        },
+        models: {
+          providers: {
+            custom: { baseUrl: "https://example.test/v1" },
+          },
+        },
+      }`,
+    );
+    writeFile(path.join(realHome, ".openclaw", "credentials", "token.txt"), "secret\n");
+    writeFile(
+      path.join(realHome, ".openclaw", "agents", "main", "agent", "auth-profiles.json"),
+      JSON.stringify({ version: 1, profiles: { default: { provider: "openai" } } }, null, 2),
+    );
+    writeFile(path.join(realHome, ".claude", ".credentials.json"), '{"accessToken":"token"}\n');
+
+    process.env.HOME = realHome;
+    process.env.USERPROFILE = realHome;
+    process.env.OPENCLAW_LIVE_TEST = "1";
+    process.env.OPENCLAW_LIVE_TEST_QUIET = "1";
+    process.env.OPENCLAW_CONFIG_PATH = "~/custom-openclaw.json5";
+
+    const testEnv = installTestEnv();
+    cleanupFns.push(testEnv.cleanup);
+
+    expect(testEnv.tempHome).not.toBe(realHome);
+    expect(process.env.HOME).toBe(testEnv.tempHome);
+    expect(process.env.OPENCLAW_TEST_HOME).toBe(testEnv.tempHome);
+    expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
+
+    const copiedConfigPath = path.join(testEnv.tempHome, ".openclaw", "openclaw.json");
+    const copiedConfig = JSON.parse(fs.readFileSync(copiedConfigPath, "utf8")) as {
+      agents?: {
+        defaults?: Record<string, unknown>;
+        list?: Array<Record<string, unknown>>;
+      };
+      models?: { providers?: Record<string, unknown> };
+    };
+    expect(copiedConfig.models?.providers?.custom).toEqual({ baseUrl: "https://example.test/v1" });
+    expect(copiedConfig.agents?.defaults?.workspace).toBeUndefined();
+    expect(copiedConfig.agents?.defaults?.agentDir).toBeUndefined();
+    expect(copiedConfig.agents?.list?.[0]?.workspace).toBeUndefined();
+    expect(copiedConfig.agents?.list?.[0]?.agentDir).toBeUndefined();
+
+    expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".openclaw", "credentials", "token.txt")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(testEnv.tempHome, ".openclaw", "agents", "main", "agent", "auth-profiles.json"),
+      ),
+    ).toBe(true);
+    expect(fs.existsSync(path.join(testEnv.tempHome, ".claude", ".credentials.json"))).toBe(true);
+  });
+
+  it("allows explicit live runs against the real HOME", () => {
+    const realHome = createTempHome();
+    writeFile(path.join(realHome, ".profile"), "export TEST_PROFILE_ONLY=from-profile\n");
+
+    process.env.HOME = realHome;
+    process.env.USERPROFILE = realHome;
+    process.env.OPENCLAW_LIVE_TEST = "1";
+    process.env.OPENCLAW_LIVE_USE_REAL_HOME = "1";
+    process.env.OPENCLAW_LIVE_TEST_QUIET = "1";
+
+    const testEnv = installTestEnv();
+
+    expect(testEnv.tempHome).toBe(realHome);
+    expect(process.env.HOME).toBe(realHome);
+    expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
+  });
+});

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { installTestEnv } from "./test-env.js";
+import { __testing, installTestEnv } from "./test-env.js";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -135,5 +135,22 @@ describe("installTestEnv", () => {
     expect(testEnv.tempHome).toBe(realHome);
     expect(process.env.HOME).toBe(realHome);
     expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
+  });
+
+  it("parses simple exported profile vars without relying on bash", () => {
+    expect(
+      __testing.parseSimpleProfileEnv(
+        [
+          "# comment",
+          "export TEST_PROFILE_ONLY=from-profile",
+          "QUOTED_VALUE='hello world'",
+          'DOUBLE_QUOTED="quoted"',
+        ].join("\n"),
+      ),
+    ).toEqual([
+      { key: "TEST_PROFILE_ONLY", value: "from-profile" },
+      { key: "QUOTED_VALUE", value: "hello world" },
+      { key: "DOUBLE_QUOTED", value: "quoted" },
+    ]);
   });
 });

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -2,8 +2,11 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import JSON5 from "json5";
 
 type RestoreEntry = { key: string; value: string | undefined };
+
+const LIVE_EXTERNAL_AUTH_DIRS = [".claude", ".codex", ".minimax"] as const;
 
 function isTruthyEnvValue(value: string | undefined): boolean {
   if (!value) {
@@ -31,8 +34,19 @@ function restoreEnv(entries: RestoreEntry[]): void {
   }
 }
 
-function loadProfileEnv(): void {
-  const profilePath = path.join(os.homedir(), ".profile");
+function resolveHomeRelativePath(input: string, homeDir: string): string {
+  const trimmed = input.trim();
+  if (trimmed === "~") {
+    return homeDir;
+  }
+  if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    return path.join(homeDir, trimmed.slice(2));
+  }
+  return path.resolve(trimmed);
+}
+
+function loadProfileEnv(homeDir = os.homedir()): void {
+  const profilePath = path.join(homeDir, ".profile");
   if (!fs.existsSync(profilePath)) {
     return;
   }
@@ -67,20 +81,8 @@ function loadProfileEnv(): void {
   }
 }
 
-export function installTestEnv(): { cleanup: () => void; tempHome: string } {
-  const live =
-    process.env.LIVE === "1" ||
-    process.env.OPENCLAW_LIVE_TEST === "1" ||
-    process.env.OPENCLAW_LIVE_GATEWAY === "1";
-
-  // Live tests must use the real user environment (keys, profiles, config).
-  // The default test env isolates HOME to avoid touching real state.
-  if (live) {
-    loadProfileEnv();
-    return { cleanup: () => {}, tempHome: process.env.HOME ?? "" };
-  }
-
-  const restore: RestoreEntry[] = [
+function resolveRestoreEntries(): RestoreEntry[] {
+  return [
     { key: "OPENCLAW_TEST_FAST", value: process.env.OPENCLAW_TEST_FAST },
     { key: "HOME", value: process.env.HOME },
     { key: "USERPROFILE", value: process.env.USERPROFILE },
@@ -96,6 +98,8 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
     { key: "OPENCLAW_BRIDGE_PORT", value: process.env.OPENCLAW_BRIDGE_PORT },
     { key: "OPENCLAW_CANVAS_HOST_PORT", value: process.env.OPENCLAW_CANVAS_HOST_PORT },
     { key: "OPENCLAW_TEST_HOME", value: process.env.OPENCLAW_TEST_HOME },
+    { key: "OPENCLAW_AGENT_DIR", value: process.env.OPENCLAW_AGENT_DIR },
+    { key: "PI_CODING_AGENT_DIR", value: process.env.PI_CODING_AGENT_DIR },
     { key: "TELEGRAM_BOT_TOKEN", value: process.env.TELEGRAM_BOT_TOKEN },
     { key: "DISCORD_BOT_TOKEN", value: process.env.DISCORD_BOT_TOKEN },
     { key: "SLACK_BOT_TOKEN", value: process.env.SLACK_BOT_TOKEN },
@@ -106,7 +110,12 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
     { key: "GITHUB_TOKEN", value: process.env.GITHUB_TOKEN },
     { key: "NODE_OPTIONS", value: process.env.NODE_OPTIONS },
   ];
+}
 
+function createIsolatedTestHome(restore: RestoreEntry[]): {
+  cleanup: () => void;
+  tempHome: string;
+} {
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-home-"));
 
   process.env.HOME = tempHome;
@@ -118,6 +127,8 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
   delete process.env.OPENCLAW_CONFIG_PATH;
   // Prefer deriving state dir from HOME so nested tests that change HOME also isolate correctly.
   delete process.env.OPENCLAW_STATE_DIR;
+  delete process.env.OPENCLAW_AGENT_DIR;
+  delete process.env.PI_CODING_AGENT_DIR;
   // Prefer test-controlled ports over developer overrides (avoid port collisions across tests/workers).
   delete process.env.OPENCLAW_GATEWAY_PORT;
   delete process.env.OPENCLAW_BRIDGE_ENABLED;
@@ -156,6 +167,132 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
   };
 
   return { cleanup, tempHome };
+}
+
+function ensureParentDir(targetPath: string): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+}
+
+function copyDirIfExists(sourcePath: string, targetPath: string): void {
+  if (!fs.existsSync(sourcePath)) {
+    return;
+  }
+  fs.mkdirSync(targetPath, { recursive: true });
+  fs.cpSync(sourcePath, targetPath, {
+    recursive: true,
+    force: true,
+  });
+}
+
+function copyFileIfExists(sourcePath: string, targetPath: string): void {
+  if (!fs.existsSync(sourcePath)) {
+    return;
+  }
+  ensureParentDir(targetPath);
+  fs.copyFileSync(sourcePath, targetPath);
+}
+
+function sanitizeLiveConfig(raw: string): string {
+  try {
+    const parsed = JSON5.parse(raw) as {
+      agents?: {
+        defaults?: Record<string, unknown>;
+        list?: Array<Record<string, unknown>>;
+      };
+    };
+    if (!parsed || typeof parsed !== "object") {
+      return raw;
+    }
+    if (parsed.agents?.defaults && typeof parsed.agents.defaults === "object") {
+      delete parsed.agents.defaults.workspace;
+      delete parsed.agents.defaults.agentDir;
+    }
+    if (Array.isArray(parsed.agents?.list)) {
+      parsed.agents.list = parsed.agents.list.map((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return entry;
+        }
+        const nextEntry = { ...entry };
+        delete nextEntry.workspace;
+        delete nextEntry.agentDir;
+        return nextEntry;
+      });
+    }
+    return `${JSON.stringify(parsed, null, 2)}\n`;
+  } catch {
+    return raw;
+  }
+}
+
+function copyLiveAuthProfiles(realStateDir: string, tempStateDir: string): void {
+  const agentsDir = path.join(realStateDir, "agents");
+  if (!fs.existsSync(agentsDir)) {
+    return;
+  }
+  for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const sourcePath = path.join(agentsDir, entry.name, "agent", "auth-profiles.json");
+    const targetPath = path.join(tempStateDir, "agents", entry.name, "agent", "auth-profiles.json");
+    copyFileIfExists(sourcePath, targetPath);
+  }
+}
+
+function stageLiveTestState(params: {
+  env: NodeJS.ProcessEnv;
+  realHome: string;
+  tempHome: string;
+}): void {
+  const realStateDir = params.env.OPENCLAW_STATE_DIR?.trim()
+    ? resolveHomeRelativePath(params.env.OPENCLAW_STATE_DIR, params.realHome)
+    : path.join(params.realHome, ".openclaw");
+  const tempStateDir = path.join(params.tempHome, ".openclaw");
+  fs.mkdirSync(tempStateDir, { recursive: true });
+
+  const realConfigPath = params.env.OPENCLAW_CONFIG_PATH?.trim()
+    ? resolveHomeRelativePath(params.env.OPENCLAW_CONFIG_PATH, params.realHome)
+    : path.join(realStateDir, "openclaw.json");
+  if (fs.existsSync(realConfigPath)) {
+    const rawConfig = fs.readFileSync(realConfigPath, "utf8");
+    fs.writeFileSync(
+      path.join(tempStateDir, "openclaw.json"),
+      sanitizeLiveConfig(rawConfig),
+      "utf8",
+    );
+  }
+
+  copyDirIfExists(path.join(realStateDir, "credentials"), path.join(tempStateDir, "credentials"));
+  copyLiveAuthProfiles(realStateDir, tempStateDir);
+
+  for (const authDir of LIVE_EXTERNAL_AUTH_DIRS) {
+    copyDirIfExists(path.join(params.realHome, authDir), path.join(params.tempHome, authDir));
+  }
+}
+
+export function installTestEnv(): { cleanup: () => void; tempHome: string } {
+  const live =
+    process.env.LIVE === "1" ||
+    process.env.OPENCLAW_LIVE_TEST === "1" ||
+    process.env.OPENCLAW_LIVE_GATEWAY === "1";
+  const allowRealHome = isTruthyEnvValue(process.env.OPENCLAW_LIVE_USE_REAL_HOME);
+  const realHome = process.env.HOME ?? os.homedir();
+  const liveEnvSnapshot = { ...process.env };
+
+  loadProfileEnv(realHome);
+
+  if (live && allowRealHome) {
+    return { cleanup: () => {}, tempHome: realHome };
+  }
+
+  const restore = resolveRestoreEntries();
+  const testEnv = createIsolatedTestHome(restore);
+
+  if (live) {
+    stageLiveTestState({ env: liveEnvSnapshot, realHome, tempHome: testEnv.tempHome });
+  }
+
+  return testEnv;
 }
 
 export function withIsolatedTestHome(): { cleanup: () => void; tempHome: string } {

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import JSON5 from "json5";
 
 type RestoreEntry = { key: string; value: string | undefined };
+type ProfileEnvEntry = { key: string; value: string };
 
 const LIVE_EXTERNAL_AUTH_DIRS = [".claude", ".codex", ".minimax"] as const;
 
@@ -45,41 +46,96 @@ function resolveHomeRelativePath(input: string, homeDir: string): string {
   return path.resolve(trimmed);
 }
 
+function stripWrappingQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' || first === "'") && first === last) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
+function applyProfileEnvEntries(entries: Iterable<ProfileEnvEntry>): number {
+  let applied = 0;
+  for (const entry of entries) {
+    if (!entry.key || (process.env[entry.key] ?? "") !== "") {
+      continue;
+    }
+    process.env[entry.key] = entry.value;
+    applied += 1;
+  }
+  return applied;
+}
+
+function parseSimpleProfileEnv(content: string): ProfileEnvEntry[] {
+  const entries: ProfileEnvEntry[] = [];
+  for (const rawLine of content.split(/\r?\n/u)) {
+    const trimmed = rawLine.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/u.exec(trimmed);
+    if (!match) {
+      continue;
+    }
+    const [, key, rawValue] = match;
+    entries.push({ key, value: stripWrappingQuotes(rawValue) });
+  }
+  return entries;
+}
+
 function loadProfileEnv(homeDir = os.homedir()): void {
   const profilePath = path.join(homeDir, ".profile");
   if (!fs.existsSync(profilePath)) {
     return;
   }
+  let applied = 0;
+  let loadedFromShell = false;
   try {
-    const output = execFileSync(
-      "/bin/bash",
-      ["-lc", `set -a; source "${profilePath}" >/dev/null 2>&1; env -0`],
-      { encoding: "utf8" },
-    );
-    const entries = output.split("\0");
-    let applied = 0;
-    for (const entry of entries) {
-      if (!entry) {
+    const shellCandidates =
+      process.platform === "win32" ? ["bash", "/bin/bash"] : ["/bin/bash", "bash"];
+    for (const shellCommand of shellCandidates) {
+      try {
+        const output = execFileSync(
+          shellCommand,
+          ["-lc", `set -a; source "${profilePath}" >/dev/null 2>&1; env -0`],
+          { encoding: "utf8" },
+        );
+        const entries: ProfileEnvEntry[] = [];
+        for (const entry of output.split("\0")) {
+          if (!entry) {
+            continue;
+          }
+          const idx = entry.indexOf("=");
+          if (idx <= 0) {
+            continue;
+          }
+          entries.push({ key: entry.slice(0, idx), value: entry.slice(idx + 1) });
+        }
+        applied = applyProfileEnvEntries(entries);
+        loadedFromShell = true;
+        break;
+      } catch {
         continue;
       }
-      const idx = entry.indexOf("=");
-      if (idx <= 0) {
-        continue;
-      }
-      const key = entry.slice(0, idx);
-      if (!key || (process.env[key] ?? "") !== "") {
-        continue;
-      }
-      process.env[key] = entry.slice(idx + 1);
-      applied += 1;
     }
-    if (applied > 0 && !isTruthyEnvValue(process.env.OPENCLAW_LIVE_TEST_QUIET)) {
-      console.log(`[live] loaded ${applied} env vars from ~/.profile`);
+    if (!loadedFromShell) {
+      applied = applyProfileEnvEntries(parseSimpleProfileEnv(fs.readFileSync(profilePath, "utf8")));
     }
   } catch {
     // ignore profile load failures
   }
+  if (applied > 0 && !isTruthyEnvValue(process.env.OPENCLAW_LIVE_TEST_QUIET)) {
+    console.log(`[live] loaded ${applied} env vars from ~/.profile`);
+  }
 }
+
+export const __testing = {
+  parseSimpleProfileEnv,
+};
 
 function resolveRestoreEntries(): RestoreEntry[] {
   return [


### PR DESCRIPTION
## Summary
- strip provider auth env vars from exec child environments so provider API keys do not leak into spawned processes
- keep two-phase exec approvals pending when no approver client is connected instead of expiring them immediately
- route webchat approval followups back to the internal channel and show Control UI approval guidance in pending copy

## Why
- addresses the unowned security gap in #56441
- integrates the approval-state-machine fix from #56398
- integrates the webchat approval UX and routing fixes from #56445
- intentionally does not pull unrelated commits from #56506

## Validation
- `./node_modules/.bin/vitest run --config vitest.config.ts --pool=threads --maxWorkers=1 src/gateway/server-methods/server-methods.test.ts -t 'keeps two-phase approvals pending when no approver clients and no forwarding targets|fast-fails single-phase approvals when no approver clients and no forwarding targets'`\n- `./node_modules/.bin/vitest run --config vitest.config.ts --pool=threads --maxWorkers=1 src/infra/host-env-security.test.ts -t 'strips provider auth env vars from inherited host env case-insensitively'`\n- `./node_modules/.bin/vitest run --config vitest.config.ts --pool=threads --maxWorkers=1 src/agents/bash-tools.exec.approval-id.test.ts -t 'starts a direct agent follow-up after approved gateway exec completes|routes exec follow-ups back to webchat without external delivery|shows Control UI approval guidance for webchat-sourced approvals'`\n- `pnpm check`