### PR TITLE
feat(extensions): add jira-cloud skill pack scaffold

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -261,6 +261,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/kilocode/**"
+"extensions: jira-cloud":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/jira-cloud/**"
 "extensions: openai":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/jira-cloud/README.md
+++ b/extensions/jira-cloud/README.md
@@ -1,31 +1,97 @@
-# Jira Cloud (plugin)
+# Jira Cloud Plugin (Bundled)
 
-Adds a Jira Cloud skill bundle for issue triage, planning, and release follow-up.
+`extensions/jira-cloud` is a bundled/internal OpenClaw plugin that provides a real Jira Cloud runtime integration plus a Jira workflow skill.
 
-## Install
+## Packaging and Availability
 
-```bash
-openclaw plugins install @openclaw/jira-cloud
-```
+- Package name: `@openclaw/jira-cloud`
+- Current state: `"private": true` in this repo
+- Distribution: bundled/internal (not documented as a public npm install flow)
 
-## Enable
+## Configuration
+
+Configure under `plugins.entries.jira-cloud.config`:
 
 ```json
 {
   "plugins": {
     "entries": {
-      "jira-cloud": { "enabled": true }
+      "jira-cloud": {
+        "enabled": true,
+        "config": {
+          "siteUrl": "https://your-org.atlassian.net",
+          "email": "bot@your-org.com",
+          "apiToken": "your-atlassian-api-token",
+          "defaultProjectKey": "OPS",
+          "defaultIssueType": "Task",
+          "requestTimeoutMs": 15000,
+          "retryCount": 2
+        }
+      }
     }
   }
 }
 ```
 
-Restart the gateway after enabling.
+Required:
+- `siteUrl` (or `baseUrl`) must be an HTTPS Jira Cloud URL (`*.atlassian.net`)
+- `email`
+- `apiToken`
 
-## What you get
+Optional:
+- `defaultProjectKey`
+- `defaultIssueType`
+- `requestTimeoutMs`
+- `retryCount`
+- `userAgent`
 
-- `jira-cloud` skill available to the agent
-- Practical playbook for:
-  - issue triage from raw bug reports
-  - sprint planning from backlog state
-  - release follow-up and verification checklist generation
+Environment fallback is supported:
+- `JIRA_CLOUD_SITE_URL`
+- `JIRA_CLOUD_EMAIL`
+- `JIRA_CLOUD_API_TOKEN`
+- `JIRA_CLOUD_REQUEST_TIMEOUT_MS`
+- `JIRA_CLOUD_RETRY_COUNT`
+- `JIRA_CLOUD_USER_AGENT`
+
+## Tools Exposed
+
+The plugin registers these tools:
+
+1. `jira_healthcheck`
+2. `jira_list_projects`
+3. `jira_search_issues`
+4. `jira_get_issue`
+5. `jira_create_issue`
+6. `jira_add_comment`
+7. `jira_list_transitions`
+8. `jira_transition_issue`
+9. `jira_assign_issue`
+10. `jira_get_create_metadata`
+
+## Supported Operations
+
+- Validate Jira connectivity/authentication.
+- List accessible projects.
+- Search issues with JQL.
+- Read issue details.
+- Create issues.
+- Add comments.
+- List transitions.
+- Transition issues.
+- Assign issues.
+- Fetch minimal create metadata.
+
+## Security and Hardening
+
+- Fail-closed when required credentials are missing.
+- API token is never intentionally returned in tool output.
+- Error normalization sanitizes secrets.
+- Timeout and conservative retry logic for 429/5xx/transient failures.
+- Tool input validation for keys, required fields, and bounded result sizes.
+- Field selection is allowlisted for search/detail tools.
+
+## Known Limits
+
+- Metadata endpoints differ across Jira Cloud tenants; this plugin uses a conservative subset and returns best-effort metadata.
+- Custom fields are not fully modeled by static types and are returned as generic field payloads where needed.
+- Issue description/comment bodies are sent as plain-text ADF documents.

--- a/extensions/jira-cloud/README.md
+++ b/extensions/jira-cloud/README.md
@@ -1,0 +1,31 @@
+# Jira Cloud (plugin)
+
+Adds a Jira Cloud skill bundle for issue triage, planning, and release follow-up.
+
+## Install
+
+```bash
+openclaw plugins install @kansodata/jira-cloud
+```
+
+## Enable
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "jira-cloud": { "enabled": true }
+    }
+  }
+}
+```
+
+Restart the gateway after enabling.
+
+## What you get
+
+- `jira-cloud` skill available to the agent
+- Practical playbook for:
+  - issue triage from raw bug reports
+  - sprint planning from backlog state
+  - release follow-up and verification checklist generation

--- a/extensions/jira-cloud/README.md
+++ b/extensions/jira-cloud/README.md
@@ -81,6 +81,13 @@ The plugin registers these tools:
 - Assign issues.
 - Fetch minimal create metadata.
 
+## Text Field Handling (ADF)
+
+- `summary` is sent as a plain Jira string field.
+- `description` (issue create) is converted from plain text to minimal Atlassian Document Format (ADF).
+- `comment` (add comment and optional transition comment) is converted from plain text to minimal ADF.
+- The plugin intentionally supports only conservative/minimal ADF generation, not arbitrary complex ADF payload composition.
+
 ## Security and Hardening
 
 - Fail-closed when required credentials are missing.
@@ -93,5 +100,15 @@ The plugin registers these tools:
 ## Known Limits
 
 - Metadata endpoints differ across Jira Cloud tenants; this plugin uses a conservative subset and returns best-effort metadata.
+- `jira_get_create_metadata` is explicitly best-effort: some tenants/permission sets return partial metadata; in that case the tool returns stable partial output plus warnings.
 - Custom fields are not fully modeled by static types and are returned as generic field payloads where needed.
 - Issue description/comment bodies are sent as plain-text ADF documents.
+
+## Common Error Outcomes
+
+- `401 Unauthorized`: invalid credentials or token mismatch.
+- `403 Forbidden`: authenticated but lacking permission in project/resource.
+- `404 Not Found`: issue/project/resource not found or not visible.
+- `409 Conflict`: workflow/state conflict (for example transitions).
+- `429 Too Many Requests`: rate limit; retry uses conservative backoff and honors `Retry-After` when available.
+- `timeout/transient`: normalized to consistent upstream timeout/request-failed errors.

--- a/extensions/jira-cloud/README.md
+++ b/extensions/jira-cloud/README.md
@@ -5,7 +5,7 @@ Adds a Jira Cloud skill bundle for issue triage, planning, and release follow-up
 ## Install
 
 ```bash
-openclaw plugins install @kansodata/jira-cloud
+openclaw plugins install @openclaw/jira-cloud
 ```
 
 ## Enable

--- a/extensions/jira-cloud/index.ts
+++ b/extensions/jira-cloud/index.ts
@@ -1,10 +1,13 @@
 import { definePluginEntry, type OpenClawPluginApi } from "./runtime-api.js";
+import { createJiraCloudTools } from "./src/tools.js";
 
 export default definePluginEntry({
   id: "jira-cloud",
   name: "Jira Cloud",
-  description: "Plugin-shipped Jira Cloud skills bundle",
-  register(_api: OpenClawPluginApi) {
-    // This plugin currently ships skills only.
+  description: "Jira Cloud tools and skills for issue workflows.",
+  register(api: OpenClawPluginApi) {
+    for (const tool of createJiraCloudTools(api)) {
+      api.registerTool(tool);
+    }
   },
 });

--- a/extensions/jira-cloud/index.ts
+++ b/extensions/jira-cloud/index.ts
@@ -1,0 +1,10 @@
+import { definePluginEntry, type OpenClawPluginApi } from "./runtime-api.js";
+
+export default definePluginEntry({
+  id: "jira-cloud",
+  name: "Jira Cloud",
+  description: "Plugin-shipped Jira Cloud skills bundle",
+  register(_api: OpenClawPluginApi) {
+    // This plugin currently ships skills only.
+  },
+});

--- a/extensions/jira-cloud/openclaw.plugin.json
+++ b/extensions/jira-cloud/openclaw.plugin.json
@@ -38,8 +38,6 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "required": ["email", "apiToken"],
-    "anyOf": [{ "required": ["siteUrl"] }, { "required": ["baseUrl"] }],
     "properties": {
       "siteUrl": {
         "type": "string",

--- a/extensions/jira-cloud/openclaw.plugin.json
+++ b/extensions/jira-cloud/openclaw.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "jira-cloud",
+  "name": "Jira Cloud",
+  "description": "Jira Cloud skill pack for triage, planning, and release follow-up workflows.",
+  "skills": ["./skills"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/jira-cloud/openclaw.plugin.json
+++ b/extensions/jira-cloud/openclaw.plugin.json
@@ -1,11 +1,83 @@
 {
   "id": "jira-cloud",
   "name": "Jira Cloud",
-  "description": "Jira Cloud skill pack for triage, planning, and release follow-up workflows.",
+  "description": "Jira Cloud tools and skill pack for issue management workflows.",
   "skills": ["./skills"],
+  "providerAuthEnvVars": {
+    "jira-cloud": ["JIRA_CLOUD_SITE_URL", "JIRA_CLOUD_EMAIL", "JIRA_CLOUD_API_TOKEN"]
+  },
+  "uiHints": {
+    "siteUrl": {
+      "label": "Jira Site URL",
+      "help": "Your Jira Cloud site URL, for example https://example.atlassian.net"
+    },
+    "email": {
+      "label": "Jira Email",
+      "help": "Atlassian account email for API token auth."
+    },
+    "apiToken": {
+      "label": "Jira API Token",
+      "help": "Atlassian API token used with email for Basic auth.",
+      "sensitive": true
+    }
+  },
+  "contracts": {
+    "tools": [
+      "jira_healthcheck",
+      "jira_list_projects",
+      "jira_search_issues",
+      "jira_get_issue",
+      "jira_create_issue",
+      "jira_add_comment",
+      "jira_list_transitions",
+      "jira_transition_issue",
+      "jira_assign_issue",
+      "jira_get_create_metadata"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "required": ["email", "apiToken"],
+    "anyOf": [{ "required": ["siteUrl"] }, { "required": ["baseUrl"] }],
+    "properties": {
+      "siteUrl": {
+        "type": "string",
+        "pattern": "^https://[A-Za-z0-9.-]+\\.atlassian\\.net/?$"
+      },
+      "baseUrl": {
+        "type": "string",
+        "pattern": "^https://[A-Za-z0-9.-]+\\.atlassian\\.net/?$"
+      },
+      "email": {
+        "type": "string",
+        "minLength": 3
+      },
+      "apiToken": {
+        "type": ["string", "object"]
+      },
+      "defaultProjectKey": {
+        "type": "string",
+        "pattern": "^[A-Za-z][A-Za-z0-9_]{0,49}$"
+      },
+      "defaultIssueType": {
+        "type": "string",
+        "minLength": 1
+      },
+      "requestTimeoutMs": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 60000
+      },
+      "retryCount": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 5
+      },
+      "userAgent": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
   }
 }

--- a/extensions/jira-cloud/package.json
+++ b/extensions/jira-cloud/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@kansodata/jira-cloud",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Jira Cloud skill pack plugin for OpenClaw.",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/jira-cloud/package.json
+++ b/extensions/jira-cloud/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@kansodata/jira-cloud",
-  "version": "0.0.1",
+  "name": "@openclaw/jira-cloud",
+  "version": "2026.3.27",
   "private": true,
   "description": "Jira Cloud skill pack plugin for OpenClaw.",
   "type": "module",

--- a/extensions/jira-cloud/plugin-registration.test.ts
+++ b/extensions/jira-cloud/plugin-registration.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+
+describe("jira-cloud plugin registration", () => {
+  it("registers jira tools", () => {
+    const toolNames: string[] = [];
+    const mockApi = {
+      registerTool(tool: { name: string }) {
+        toolNames.push(tool.name);
+      },
+      config: {
+        plugins: {
+          entries: {
+            "jira-cloud": {
+              config: {
+                siteUrl: "https://example.atlassian.net",
+                email: "bot@example.com",
+                apiToken: "secret-token",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    plugin.register(mockApi as never);
+
+    expect(plugin.id).toBe("jira-cloud");
+    expect(toolNames).toHaveLength(10);
+    expect(toolNames).toContain("jira_healthcheck");
+    expect(toolNames).toContain("jira_transition_issue");
+  });
+});
+

--- a/extensions/jira-cloud/runtime-api.ts
+++ b/extensions/jira-cloud/runtime-api.ts
@@ -1,0 +1,2 @@
+export { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+export type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";

--- a/extensions/jira-cloud/runtime-api.ts
+++ b/extensions/jira-cloud/runtime-api.ts
@@ -1,2 +1,11 @@
 export { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 export type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+export type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+export type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+export { Type } from "@sinclair/typebox";
+export {
+  jsonResult,
+  readNumberParam,
+  readStringArrayParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-search";

--- a/extensions/jira-cloud/skills/jira-cloud/SKILL.md
+++ b/extensions/jira-cloud/skills/jira-cloud/SKILL.md
@@ -1,62 +1,78 @@
 ---
 name: jira-cloud
-description: Plan and execute Jira Cloud workflows for triage, sprint prep, and release follow-up.
+description: Execute Jira Cloud read/write workflows safely with explicit tool selection and confirmation.
 metadata: { "openclaw": { "emoji": "🎫" } }
 ---
 
-Use this skill when the user asks to work with Jira Cloud issues, backlog planning, or release tracking.
+Use this skill when the user asks to work with Jira Cloud issues, projects, comments, transitions, assignment, or creation workflows.
 
-## Scope
+## Operating Modes
 
-- Convert unstructured bug reports into actionable Jira issue drafts.
-- Propose sprint-ready backlog slices with clear acceptance criteria.
-- Build release follow-up checklists from sets of Jira issues.
+1. Exploration / Read-only
+- Validate integration and permissions with `jira_healthcheck`.
+- Discover projects with `jira_list_projects`.
+- Search with JQL via `jira_search_issues`.
+- Inspect issue details via `jira_get_issue`.
+- Inspect available status moves via `jira_list_transitions`.
+- Inspect creation metadata via `jira_get_create_metadata`.
 
-## Inputs to request early
+2. Creation
+- Draft ticket content first (summary, description, issue type, labels, priority).
+- Confirm target project key and issue type before creating.
+- Execute with `jira_create_issue`.
 
-- Jira project key (example: `OPS`).
-- Issue type (`Bug`, `Task`, `Story`, `Epic`).
-- Priority and severity expectations.
-- Sprint or release target.
+3. Update
+- Confirm issue key before write operations.
+- Add comments with `jira_add_comment`.
+- Assign ownership with `jira_assign_issue`.
 
-## Output format defaults
+4. Transition
+- Query allowed transitions first with `jira_list_transitions`.
+- Confirm transition intent before executing `jira_transition_issue`.
 
-- Keep outputs copy-paste ready for Jira fields.
-- Include:
-  - short summary line
-  - detailed description
-  - acceptance criteria
-  - labels/components suggestion
-  - risk notes and verification steps
+## Safety Rules
 
-## Triage template
+- Never reveal credentials, auth headers, or secrets.
+- Never assume `projectKey` when ambiguous; ask the user.
+- Before mutating Jira state (create/comment/transition/assign), summarize planned action and confirm.
+- If user intent is unclear, ask one precise clarification question before writing.
+- Prefer bounded result sets and concise summaries for large searches.
 
-When triaging, produce this structure:
+## Tool Selection Guide
 
-1. Problem statement
-2. Impact and affected users
-3. Reproduction steps
-4. Expected vs actual behavior
-5. Technical hypothesis
-6. Proposed fix direction
-7. Suggested Jira fields
+- "Is Jira configured correctly?" -> `jira_healthcheck`
+- "List available projects" -> `jira_list_projects`
+- "Find issues assigned to me" -> `jira_search_issues`
+- "Show details for OPS-123" -> `jira_get_issue`
+- "Create a bug ticket" -> draft first, then `jira_create_issue`
+- "Comment on OPS-123" -> `jira_add_comment`
+- "Move OPS-123 to In Progress" -> `jira_list_transitions` then `jira_transition_issue`
+- "Assign OPS-123 to account X" -> `jira_assign_issue`
 
-## Sprint planning template
+## Good Usage Examples
 
-When planning a sprint from a backlog slice:
+1. Busca issues abiertos asignados a mí
+- First propose JQL: `assignee = currentUser() AND statusCategory != Done ORDER BY updated DESC`
+- Run `jira_search_issues` with bounded `maxResults`.
+- Summarize key issues.
 
-1. Objectives
-2. Candidate issues grouped by theme
-3. Dependency/risk map
-4. Suggested execution order
-5. Definition-of-done checks
+2. Crea un bug
+- Draft summary/description/labels/priority.
+- Confirm `projectKey` and `issueType`.
+- Execute `jira_create_issue`.
+- Return created key/url plus short status.
 
-## Release follow-up template
+3. Comenta este ticket
+- Confirm issue key and comment text.
+- Execute `jira_add_comment`.
+- Return confirmation with comment id/url when available.
 
-After release or cut candidate:
+4. Mueve este issue a In Progress
+- Run `jira_list_transitions` first.
+- Match transition id by name with user confirmation.
+- Execute `jira_transition_issue`.
 
-1. Included issues summary
-2. Validation matrix
-3. Rollback signals
-4. Monitoring checklist
-5. Post-release actions
+5. Asigna este ticket a alguien
+- Confirm exact accountId.
+- Execute `jira_assign_issue`.
+- Return resulting assignee information.

--- a/extensions/jira-cloud/skills/jira-cloud/SKILL.md
+++ b/extensions/jira-cloud/skills/jira-cloud/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: jira-cloud
+description: Plan and execute Jira Cloud workflows for triage, sprint prep, and release follow-up.
+metadata: { "openclaw": { "emoji": "🎫" } }
+---
+
+Use this skill when the user asks to work with Jira Cloud issues, backlog planning, or release tracking.
+
+## Scope
+
+- Convert unstructured bug reports into actionable Jira issue drafts.
+- Propose sprint-ready backlog slices with clear acceptance criteria.
+- Build release follow-up checklists from sets of Jira issues.
+
+## Inputs to request early
+
+- Jira project key (example: `OPS`).
+- Issue type (`Bug`, `Task`, `Story`, `Epic`).
+- Priority and severity expectations.
+- Sprint or release target.
+
+## Output format defaults
+
+- Keep outputs copy-paste ready for Jira fields.
+- Include:
+  - short summary line
+  - detailed description
+  - acceptance criteria
+  - labels/components suggestion
+  - risk notes and verification steps
+
+## Triage template
+
+When triaging, produce this structure:
+
+1. Problem statement
+2. Impact and affected users
+3. Reproduction steps
+4. Expected vs actual behavior
+5. Technical hypothesis
+6. Proposed fix direction
+7. Suggested Jira fields
+
+## Sprint planning template
+
+When planning a sprint from a backlog slice:
+
+1. Objectives
+2. Candidate issues grouped by theme
+3. Dependency/risk map
+4. Suggested execution order
+5. Definition-of-done checks
+
+## Release follow-up template
+
+After release or cut candidate:
+
+1. Included issues summary
+2. Validation matrix
+3. Rollback signals
+4. Monitoring checklist
+5. Post-release actions

--- a/extensions/jira-cloud/skills/jira-cloud/SKILL.md
+++ b/extensions/jira-cloud/skills/jira-cloud/SKILL.md
@@ -37,6 +37,8 @@ Use this skill when the user asks to work with Jira Cloud issues, projects, comm
 - Before mutating Jira state (create/comment/transition/assign), summarize planned action and confirm.
 - If user intent is unclear, ask one precise clarification question before writing.
 - Prefer bounded result sets and concise summaries for large searches.
+- Draft before create: propose summary/description/labels/priority first, then execute only after confirmation.
+- Do not assume create metadata is complete; treat `jira_get_create_metadata` as best-effort and proceed with explicit fallback questions when fields are missing.
 
 ## Tool Selection Guide
 
@@ -48,6 +50,13 @@ Use this skill when the user asks to work with Jira Cloud issues, projects, comm
 - "Comment on OPS-123" -> `jira_add_comment`
 - "Move OPS-123 to In Progress" -> `jira_list_transitions` then `jira_transition_issue`
 - "Assign OPS-123 to account X" -> `jira_assign_issue`
+
+## Error Interpretation Quick Guide
+
+- `403` -> permission problem, not credential format.
+- `404` -> issue/project/resource does not exist or is not visible to current account.
+- `409` -> state/workflow conflict; re-check transitions/current status.
+- `429` -> rate-limited; wait/retry conservatively, avoid rapid retries.
 
 ## Good Usage Examples
 

--- a/extensions/jira-cloud/src/adf.test.ts
+++ b/extensions/jira-cloud/src/adf.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { toMinimalAdfTextDocument } from "./adf.js";
+
+describe("adf helper", () => {
+  it("converts plain text into minimal adf document", () => {
+    expect(toMinimalAdfTextDocument("Hello Jira")).toEqual({
+      type: "doc",
+      version: 1,
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello Jira" }],
+        },
+      ],
+    });
+  });
+
+  it("splits non-empty lines into paragraphs", () => {
+    const doc = toMinimalAdfTextDocument("line 1\n\nline 2");
+    expect(doc.content).toHaveLength(2);
+    expect(doc.content[1]?.content[0]?.text).toBe("line 2");
+  });
+});
+

--- a/extensions/jira-cloud/src/adf.ts
+++ b/extensions/jira-cloud/src/adf.ts
@@ -1,0 +1,42 @@
+export type AdfTextNode = {
+  type: "text";
+  text: string;
+};
+
+export type AdfParagraphNode = {
+  type: "paragraph";
+  content: AdfTextNode[];
+};
+
+export type AdfDocument = {
+  type: "doc";
+  version: 1;
+  content: AdfParagraphNode[];
+};
+
+export function toMinimalAdfTextDocument(text: string): AdfDocument {
+  const normalized = text.replace(/\r\n/g, "\n").trim();
+  if (!normalized) {
+    throw new Error("ADF text content must not be empty.");
+  }
+
+  const paragraphs = normalized
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => ({
+      type: "paragraph" as const,
+      content: [{ type: "text" as const, text: line }],
+    }));
+
+  if (paragraphs.length === 0) {
+    throw new Error("ADF text content must include at least one paragraph.");
+  }
+
+  return {
+    type: "doc",
+    version: 1,
+    content: paragraphs,
+  };
+}
+

--- a/extensions/jira-cloud/src/client.test.ts
+++ b/extensions/jira-cloud/src/client.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import type { JiraCloudConfig } from "./config.js";
+import { JiraCloudClient } from "./client.js";
+
+function buildConfig(overrides: Partial<JiraCloudConfig> = {}): JiraCloudConfig {
+  return {
+    siteUrl: "https://example.atlassian.net",
+    email: "bot@example.com",
+    apiToken: "secret-token",
+    requestTimeoutMs: 5_000,
+    retryCount: 2,
+    userAgent: "openclaw-jira-cloud/test",
+    ...overrides,
+  };
+}
+
+describe("jira client", () => {
+  it("adds auth headers and parses successful json", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const client = new JiraCloudClient(buildConfig(), { fetchImpl: fetchImpl as never });
+    const payload = await client.request<{ ok: boolean }>("/rest/api/3/myself");
+
+    const call = fetchImpl.mock.calls[0] as unknown as [RequestInfo | URL, RequestInit];
+    expect(String(call[0])).toContain("/rest/api/3/myself");
+    const headers = call[1].headers as Headers;
+    expect(headers.get("Authorization")).toContain("Basic ");
+    expect(payload.ok).toBe(true);
+  });
+
+  it("retries on 429 and then succeeds", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ errorMessages: ["slow down"] }), {
+          status: 429,
+          headers: { "content-type": "application/json", "retry-after": "0" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const sleep = vi.fn(async () => {});
+    const client = new JiraCloudClient(buildConfig(), {
+      fetchImpl: fetchImpl as never,
+      sleep,
+    });
+    const payload = await client.request<{ ok: boolean }>("/rest/api/3/project/search");
+    expect(payload.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps auth failures without leaking secrets", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(JSON.stringify({ errorMessages: ["invalid token"] }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const client = new JiraCloudClient(buildConfig(), { fetchImpl: fetchImpl as never });
+
+    await expect(client.request("/rest/api/3/myself")).rejects.toMatchObject({
+      code: "jira_auth_failed",
+      status: 401,
+    });
+  });
+});

--- a/extensions/jira-cloud/src/client.test.ts
+++ b/extensions/jira-cloud/src/client.test.ts
@@ -68,8 +68,94 @@ describe("jira client", () => {
     const client = new JiraCloudClient(buildConfig(), { fetchImpl: fetchImpl as never });
 
     await expect(client.request("/rest/api/3/myself")).rejects.toMatchObject({
-      code: "jira_auth_failed",
+      code: "jira_unauthorized",
       status: 401,
+    });
+  });
+
+  it("maps 403, 404 and 409 with explicit codes", async () => {
+    const run = async (status: number) => {
+      const fetchImpl = vi.fn(async () => {
+        return new Response(JSON.stringify({ errorMessages: ["failure"] }), {
+          status,
+          headers: { "content-type": "application/json" },
+        });
+      });
+      const client = new JiraCloudClient(buildConfig({ retryCount: 0 }), {
+        fetchImpl: fetchImpl as never,
+      });
+      try {
+        await client.request("/rest/api/3/issue/OPS-1");
+      } catch (error) {
+        return error as { code?: string; status?: number };
+      }
+      throw new Error("Expected request to fail");
+    };
+
+    await expect(run(403)).resolves.toMatchObject({ code: "jira_forbidden", status: 403 });
+    await expect(run(404)).resolves.toMatchObject({ code: "jira_not_found", status: 404 });
+    await expect(run(409)).resolves.toMatchObject({ code: "jira_conflict", status: 409 });
+  });
+
+  it("uses retry-after when 429 provides it", async () => {
+    const sleep = vi.fn(async () => {});
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ errorMessages: ["slow down"] }), {
+          status: 429,
+          headers: { "content-type": "application/json", "retry-after": "2" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const client = new JiraCloudClient(buildConfig(), {
+      fetchImpl: fetchImpl as never,
+      sleep,
+    });
+    await client.request("/rest/api/3/project/search");
+    expect(sleep).toHaveBeenCalledWith(2000);
+  });
+
+  it("applies fallback backoff when 429 has no retry-after", async () => {
+    const sleep = vi.fn(async () => {});
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ errorMessages: ["slow down"] }), {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const client = new JiraCloudClient(buildConfig(), {
+      fetchImpl: fetchImpl as never,
+      sleep,
+    });
+    await client.request("/rest/api/3/project/search");
+    const firstSleepArg = (sleep.mock.calls as unknown as Array<[number]>)[0]?.[0];
+    expect(Number(firstSleepArg)).toBeGreaterThanOrEqual(250);
+  });
+
+  it("maps timeout errors explicitly", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new DOMException("timed out", "AbortError");
+    });
+    const client = new JiraCloudClient(buildConfig({ retryCount: 0 }), {
+      fetchImpl: fetchImpl as never,
+    });
+
+    await expect(client.request("/rest/api/3/myself")).rejects.toMatchObject({
+      code: "jira_timeout",
     });
   });
 });

--- a/extensions/jira-cloud/src/client.ts
+++ b/extensions/jira-cloud/src/client.ts
@@ -124,17 +124,41 @@ export class JiraCloudClient {
 
   private async buildHttpError(response: Response, retryable: boolean): Promise<JiraApiError> {
     const detail = await this.readResponseDetail(response);
-    if (response.status === 401 || response.status === 403) {
+    if (response.status === 401) {
       return new JiraApiError(
-        `Jira authentication failed (${response.status}).`,
-        "jira_auth_failed",
+        "Jira authentication failed (401 Unauthorized). Verify email/apiToken.",
+        "jira_unauthorized",
         response.status,
         false,
       );
     }
-    if (response.status === 400 || response.status === 404 || response.status === 409) {
+    if (response.status === 403) {
       return new JiraApiError(
-        `Jira validation failed (${response.status}): ${detail}`,
+        "Jira request forbidden (403). The account is authenticated but lacks permissions.",
+        "jira_forbidden",
+        response.status,
+        false,
+      );
+    }
+    if (response.status === 404) {
+      return new JiraApiError(
+        `Jira resource not found (404): ${detail}`,
+        "jira_not_found",
+        response.status,
+        false,
+      );
+    }
+    if (response.status === 409) {
+      return new JiraApiError(
+        `Jira conflict (409): ${detail}`,
+        "jira_conflict",
+        response.status,
+        false,
+      );
+    }
+    if (response.status === 400) {
+      return new JiraApiError(
+        `Jira validation failed (400): ${detail}`,
         "jira_validation_failed",
         response.status,
         false,
@@ -192,10 +216,17 @@ export class JiraCloudClient {
     if (retryAfter) {
       const asNumber = Number(retryAfter);
       if (Number.isFinite(asNumber) && asNumber > 0) {
-        return Math.min(2_000, Math.floor(asNumber * 1_000));
+        return Math.min(10_000, Math.floor(asNumber * 1_000));
+      }
+      const asDate = Date.parse(retryAfter);
+      if (!Number.isNaN(asDate)) {
+        const delta = asDate - Date.now();
+        if (delta > 0) {
+          return Math.min(10_000, delta);
+        }
       }
     }
-    return Math.min(2_000, 200 * 2 ** Math.max(0, attempt - 1));
+    return Math.min(10_000, 250 * 2 ** Math.max(0, attempt - 1));
   }
 
   private isRetryableTransportError(error: unknown): boolean {
@@ -216,4 +247,3 @@ export class JiraCloudClient {
     );
   }
 }
-

--- a/extensions/jira-cloud/src/client.ts
+++ b/extensions/jira-cloud/src/client.ts
@@ -1,0 +1,219 @@
+import type { JiraCloudConfig } from "./config.js";
+import { JiraApiError } from "./errors.js";
+
+type HttpMethod = "GET" | "POST" | "PUT";
+
+type JiraRequestOptions = {
+  method?: HttpMethod;
+  query?: Record<string, string | number | boolean | undefined>;
+  body?: unknown;
+  timeoutMs?: number;
+};
+
+type JiraClientDependencies = {
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+export class JiraCloudClient {
+  private readonly fetchImpl: typeof fetch;
+  private readonly sleepImpl: (ms: number) => Promise<void>;
+  private readonly authHeader: string;
+
+  constructor(
+    private readonly config: JiraCloudConfig,
+    deps: JiraClientDependencies = {},
+  ) {
+    this.fetchImpl = deps.fetchImpl ?? fetch;
+    this.sleepImpl = deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.authHeader = `Basic ${Buffer.from(`${config.email}:${config.apiToken}`).toString("base64")}`;
+  }
+
+  getSiteUrl(): string {
+    return this.config.siteUrl;
+  }
+
+  getSecrets(): string[] {
+    return [this.config.apiToken, `${this.config.email}:${this.config.apiToken}`, this.authHeader];
+  }
+
+  async request<T>(path: string, options: JiraRequestOptions = {}): Promise<T> {
+    const method = options.method ?? "GET";
+    const url = this.buildUrl(path, options.query);
+    const maxAttempts = this.config.retryCount + 1;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      const controller = new AbortController();
+      const timeoutMs = options.timeoutMs ?? this.config.requestTimeoutMs;
+      const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await this.fetchImpl(url, {
+          method,
+          signal: controller.signal,
+          headers: this.buildHeaders(options.body !== undefined),
+          body: options.body === undefined ? undefined : JSON.stringify(options.body),
+        });
+
+        if (response.ok) {
+          if (response.status === 204) {
+            return undefined as T;
+          }
+          return (await response.json()) as T;
+        }
+
+        const retryable = response.status === 429 || response.status >= 500;
+        const error = await this.buildHttpError(response, retryable);
+        if (!retryable || attempt >= maxAttempts) {
+          throw error;
+        }
+
+        await this.sleepImpl(this.resolveBackoffMs(attempt, response));
+      } catch (error) {
+        if (!this.isRetryableTransportError(error) || attempt >= maxAttempts) {
+          if (error instanceof JiraApiError) {
+            throw error;
+          }
+          if (error instanceof DOMException && error.name === "AbortError") {
+            throw new JiraApiError(
+              `Jira request timed out after ${timeoutMs}ms.`,
+              "jira_timeout",
+              undefined,
+              true,
+            );
+          }
+          throw new JiraApiError(
+            `Jira request failed: ${error instanceof Error ? error.message : String(error)}`,
+            "jira_request_failed",
+            undefined,
+            false,
+          );
+        }
+        await this.sleepImpl(this.resolveBackoffMs(attempt));
+      } finally {
+        clearTimeout(timeoutHandle);
+      }
+    }
+
+    throw new JiraApiError("Unexpected Jira client state.", "jira_request_failed", undefined, false);
+  }
+
+  private buildUrl(path: string, query: JiraRequestOptions["query"]): string {
+    const safePath = path.startsWith("/") ? path : `/${path}`;
+    const url = new URL(`${this.config.siteUrl}${safePath}`);
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value === undefined || value === null) {
+          continue;
+        }
+        url.searchParams.set(key, String(value));
+      }
+    }
+    return url.toString();
+  }
+
+  private buildHeaders(hasBody: boolean): Headers {
+    const headers = new Headers();
+    headers.set("Accept", "application/json");
+    headers.set("Authorization", this.authHeader);
+    headers.set("User-Agent", this.config.userAgent);
+    if (hasBody) {
+      headers.set("Content-Type", "application/json");
+    }
+    return headers;
+  }
+
+  private async buildHttpError(response: Response, retryable: boolean): Promise<JiraApiError> {
+    const detail = await this.readResponseDetail(response);
+    if (response.status === 401 || response.status === 403) {
+      return new JiraApiError(
+        `Jira authentication failed (${response.status}).`,
+        "jira_auth_failed",
+        response.status,
+        false,
+      );
+    }
+    if (response.status === 400 || response.status === 404 || response.status === 409) {
+      return new JiraApiError(
+        `Jira validation failed (${response.status}): ${detail}`,
+        "jira_validation_failed",
+        response.status,
+        false,
+      );
+    }
+    if (response.status === 429) {
+      return new JiraApiError(
+        `Jira rate limited the request (429): ${detail}`,
+        "jira_rate_limited",
+        response.status,
+        true,
+      );
+    }
+    return new JiraApiError(
+      `Jira request failed (${response.status}): ${detail}`,
+      "jira_request_failed",
+      response.status,
+      retryable,
+    );
+  }
+
+  private async readResponseDetail(response: Response): Promise<string> {
+    try {
+      const body = (await response.json()) as {
+        message?: string;
+        errorMessages?: string[];
+        errors?: Record<string, string>;
+      };
+      const messages: string[] = [];
+      if (typeof body.message === "string" && body.message.trim()) {
+        messages.push(body.message.trim());
+      }
+      if (Array.isArray(body.errorMessages)) {
+        for (const message of body.errorMessages) {
+          if (typeof message === "string" && message.trim()) {
+            messages.push(message.trim());
+          }
+        }
+      }
+      if (body.errors && typeof body.errors === "object") {
+        for (const [field, message] of Object.entries(body.errors)) {
+          if (message) {
+            messages.push(`${field}: ${message}`);
+          }
+        }
+      }
+      return messages.join("; ") || response.statusText || "Unknown Jira error";
+    } catch {
+      return response.statusText || "Unknown Jira error";
+    }
+  }
+
+  private resolveBackoffMs(attempt: number, response?: Response): number {
+    const retryAfter = response?.headers.get("retry-after");
+    if (retryAfter) {
+      const asNumber = Number(retryAfter);
+      if (Number.isFinite(asNumber) && asNumber > 0) {
+        return Math.min(2_000, Math.floor(asNumber * 1_000));
+      }
+    }
+    return Math.min(2_000, 200 * 2 ** Math.max(0, attempt - 1));
+  }
+
+  private isRetryableTransportError(error: unknown): boolean {
+    if (error instanceof JiraApiError) {
+      return error.retryable;
+    }
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return true;
+    }
+    if (!(error instanceof Error)) {
+      return false;
+    }
+    return (
+      error.name.includes("Timeout") ||
+      error.message.includes("ECONNRESET") ||
+      error.message.includes("ENOTFOUND") ||
+      error.message.includes("network")
+    );
+  }
+}
+

--- a/extensions/jira-cloud/src/config.test.ts
+++ b/extensions/jira-cloud/src/config.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { resolveAllowedJiraFields, resolveJiraCloudConfig } from "./config.js";
+
+describe("jira cloud config", () => {
+  it("resolves strict config and defaults", () => {
+    const cfg = resolveJiraCloudConfig({
+      cfg: {
+        plugins: {
+          entries: {
+            "jira-cloud": {
+              config: {
+                siteUrl: "https://example.atlassian.net/",
+                email: "bot@example.com",
+                apiToken: "top-secret-token",
+                defaultProjectKey: "ops",
+              },
+            },
+          },
+        },
+      } as never,
+      env: {},
+    });
+
+    expect(cfg.siteUrl).toBe("https://example.atlassian.net");
+    expect(cfg.defaultProjectKey).toBe("OPS");
+    expect(cfg.requestTimeoutMs).toBe(15_000);
+    expect(cfg.retryCount).toBe(2);
+  });
+
+  it("supports env fallbacks and fails closed without credentials", () => {
+    const cfg = resolveJiraCloudConfig({
+      cfg: {} as never,
+      env: {
+        JIRA_CLOUD_SITE_URL: "https://env.atlassian.net",
+        JIRA_CLOUD_EMAIL: "env@example.com",
+        JIRA_CLOUD_API_TOKEN: "env-token",
+      } as NodeJS.ProcessEnv,
+    });
+    expect(cfg.siteUrl).toBe("https://env.atlassian.net");
+
+    expect(() =>
+      resolveJiraCloudConfig({
+        cfg: {} as never,
+        env: {},
+      }),
+    ).toThrow(/siteUrl\/baseUrl, email, and apiToken are required/);
+  });
+
+  it("only returns allowlisted fields", () => {
+    expect(resolveAllowedJiraFields(["summary", "status", "drop_table", ""])).toEqual([
+      "summary",
+      "status",
+    ]);
+  });
+});
+

--- a/extensions/jira-cloud/src/config.ts
+++ b/extensions/jira-cloud/src/config.ts
@@ -1,0 +1,213 @@
+import type { OpenClawConfig } from "../runtime-api.js";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_RETRY_COUNT = 2;
+const MIN_TIMEOUT_MS = 1_000;
+const MAX_TIMEOUT_MS = 60_000;
+const MAX_RETRY_COUNT = 5;
+
+export type JiraCloudConfig = {
+  siteUrl: string;
+  email: string;
+  apiToken: string;
+  defaultProjectKey?: string;
+  defaultIssueType?: string;
+  requestTimeoutMs: number;
+  retryCount: number;
+  userAgent: string;
+};
+
+export const JIRA_FIELDS_ALLOWLIST = [
+  "summary",
+  "status",
+  "priority",
+  "assignee",
+  "reporter",
+  "issuetype",
+  "project",
+  "labels",
+  "created",
+  "updated",
+  "description",
+  "comment",
+] as const;
+
+export const DEFAULT_SEARCH_FIELDS: readonly string[] = [
+  "summary",
+  "status",
+  "priority",
+  "assignee",
+  "issuetype",
+  "project",
+  "updated",
+];
+
+export function getRawJiraPluginConfig(cfg?: OpenClawConfig): Record<string, unknown> {
+  const entries = cfg?.plugins?.entries;
+  if (!entries || typeof entries !== "object") {
+    return {};
+  }
+  const pluginEntry = (entries as Record<string, unknown>)["jira-cloud"];
+  if (!pluginEntry || typeof pluginEntry !== "object") {
+    return {};
+  }
+  const rawConfig = (pluginEntry as { config?: unknown }).config;
+  if (!rawConfig || typeof rawConfig !== "object" || Array.isArray(rawConfig)) {
+    return {};
+  }
+  return rawConfig as Record<string, unknown>;
+}
+
+function normalizeSiteUrl(raw: unknown): string | null {
+  if (typeof raw !== "string") {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "https:") {
+      return null;
+    }
+    if (!url.hostname.endsWith(".atlassian.net")) {
+      return null;
+    }
+    url.pathname = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return null;
+  }
+}
+
+function parseString(raw: unknown): string | undefined {
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed || undefined;
+}
+
+function parseNumber(raw: unknown): number | undefined {
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return raw;
+  }
+  if (typeof raw === "string" && raw.trim()) {
+    const parsed = Number(raw.trim());
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function normalizeProjectKey(raw: unknown): string | undefined {
+  const value = parseString(raw);
+  if (!value) {
+    return undefined;
+  }
+  if (!/^[A-Z][A-Z0-9_]{0,49}$/i.test(value)) {
+    throw new Error("jira-cloud config: defaultProjectKey must match Jira project key format.");
+  }
+  return value.toUpperCase();
+}
+
+function normalizeIssueType(raw: unknown): string | undefined {
+  const value = parseString(raw);
+  return value || undefined;
+}
+
+function normalizeEmail(raw: unknown): string | undefined {
+  const value = parseString(raw);
+  if (!value) {
+    return undefined;
+  }
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(value)) {
+    throw new Error("jira-cloud config: email must be a valid email address.");
+  }
+  return value;
+}
+
+function normalizeBoundedNumber(params: {
+  value: unknown;
+  fallback: number;
+  min: number;
+  max: number;
+  label: string;
+}): number {
+  const parsed = parseNumber(params.value);
+  if (parsed === undefined) {
+    return params.fallback;
+  }
+  const floored = Math.floor(parsed);
+  if (floored < params.min || floored > params.max) {
+    throw new Error(
+      `jira-cloud config: ${params.label} must be between ${params.min} and ${params.max}.`,
+    );
+  }
+  return floored;
+}
+
+export function resolveJiraCloudConfig(params: {
+  cfg?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): JiraCloudConfig {
+  const rawConfig = getRawJiraPluginConfig(params.cfg);
+  const env = params.env ?? process.env;
+
+  const siteUrl =
+    normalizeSiteUrl(rawConfig.siteUrl ?? rawConfig.baseUrl ?? env.JIRA_CLOUD_SITE_URL) ?? null;
+  const email = normalizeEmail(rawConfig.email ?? env.JIRA_CLOUD_EMAIL);
+  const apiToken = parseString(rawConfig.apiToken ?? env.JIRA_CLOUD_API_TOKEN);
+
+  if (!siteUrl || !email || !apiToken) {
+    throw new Error(
+      "jira-cloud config invalid: siteUrl/baseUrl, email, and apiToken are required (config or JIRA_CLOUD_* env vars).",
+    );
+  }
+
+  const requestTimeoutMs = normalizeBoundedNumber({
+    value: rawConfig.requestTimeoutMs ?? env.JIRA_CLOUD_REQUEST_TIMEOUT_MS,
+    fallback: DEFAULT_TIMEOUT_MS,
+    min: MIN_TIMEOUT_MS,
+    max: MAX_TIMEOUT_MS,
+    label: "requestTimeoutMs",
+  });
+
+  const retryCount = normalizeBoundedNumber({
+    value: rawConfig.retryCount ?? env.JIRA_CLOUD_RETRY_COUNT,
+    fallback: DEFAULT_RETRY_COUNT,
+    min: 0,
+    max: MAX_RETRY_COUNT,
+    label: "retryCount",
+  });
+
+  const userAgent =
+    parseString(rawConfig.userAgent ?? env.JIRA_CLOUD_USER_AGENT) ?? "openclaw-jira-cloud/1.0";
+
+  return {
+    siteUrl,
+    email,
+    apiToken,
+    defaultProjectKey: normalizeProjectKey(rawConfig.defaultProjectKey),
+    defaultIssueType: normalizeIssueType(rawConfig.defaultIssueType),
+    requestTimeoutMs,
+    retryCount,
+    userAgent,
+  };
+}
+
+export function resolveAllowedJiraFields(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const allowlist = new Set<string>(JIRA_FIELDS_ALLOWLIST);
+  return raw
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0 && allowlist.has(value));
+}
+

--- a/extensions/jira-cloud/src/errors.test.ts
+++ b/extensions/jira-cloud/src/errors.test.ts
@@ -4,11 +4,14 @@ import { JiraApiError, normalizeJiraError, sanitizeJiraErrorMessage } from "./er
 describe("jira errors", () => {
   it("sanitizes token and authorization values", () => {
     const message = sanitizeJiraErrorMessage({
-      message: "failed with token super-secret and Authorization: Basic abc123",
+      message:
+        "failed with token super-secret and Authorization: Basic abc123 and Authorization: Bearer my-token and x-api-key: key-123",
       secrets: ["super-secret"],
     });
     expect(message).not.toContain("super-secret");
     expect(message).not.toContain("abc123");
+    expect(message).not.toContain("my-token");
+    expect(message).not.toContain("key-123");
     expect(message).toContain("[REDACTED]");
   });
 
@@ -33,5 +36,16 @@ describe("jira errors", () => {
     expect(payload.code).toBe("jira_validation_failed");
     expect(payload.retryable).toBe(false);
   });
-});
 
+  it("redacts embedded basic token and apiToken in upstream-like text", () => {
+    const payload = normalizeJiraError(
+      new Error("upstream echoed Authorization: Basic ZXhhbXBsZTpzZWNyZXQ= apiToken=abc123"),
+      {
+        secrets: ["abc123"],
+      },
+    );
+    expect(payload.message).not.toContain("ZXhhbXBsZTpzZWNyZXQ=");
+    expect(payload.message).not.toContain("abc123");
+    expect(payload.message).toContain("[REDACTED]");
+  });
+});

--- a/extensions/jira-cloud/src/errors.test.ts
+++ b/extensions/jira-cloud/src/errors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { JiraApiError, normalizeJiraError, sanitizeJiraErrorMessage } from "./errors.js";
+
+describe("jira errors", () => {
+  it("sanitizes token and authorization values", () => {
+    const message = sanitizeJiraErrorMessage({
+      message: "failed with token super-secret and Authorization: Basic abc123",
+      secrets: ["super-secret"],
+    });
+    expect(message).not.toContain("super-secret");
+    expect(message).not.toContain("abc123");
+    expect(message).toContain("[REDACTED]");
+  });
+
+  it("normalizes JiraApiError preserving code and status", () => {
+    const payload = normalizeJiraError(
+      new JiraApiError("too many requests", "jira_rate_limited", 429, true),
+    );
+    expect(payload).toEqual({
+      ok: false,
+      code: "jira_rate_limited",
+      status: 429,
+      retryable: true,
+      message: "too many requests",
+    });
+  });
+
+  it("normalizes unknown errors with fallback code", () => {
+    const payload = normalizeJiraError(new Error("boom"), {
+      fallbackCode: "jira_validation_failed",
+    });
+    expect(payload.ok).toBe(false);
+    expect(payload.code).toBe("jira_validation_failed");
+    expect(payload.retryable).toBe(false);
+  });
+});
+

--- a/extensions/jira-cloud/src/errors.ts
+++ b/extensions/jira-cloud/src/errors.ts
@@ -1,0 +1,70 @@
+import { redactSecrets, truncate } from "./sanitize.js";
+
+export type JiraErrorCode =
+  | "jira_timeout"
+  | "jira_rate_limited"
+  | "jira_auth_failed"
+  | "jira_request_failed"
+  | "jira_validation_failed"
+  | "jira_polling_timeout";
+
+export type JiraErrorPayload = {
+  ok: false;
+  code: JiraErrorCode;
+  message: string;
+  status?: number;
+  retryable: boolean;
+};
+
+export class JiraApiError extends Error {
+  constructor(
+    message: string,
+    public readonly code: JiraErrorCode,
+    public readonly status?: number,
+    public readonly retryable: boolean = false,
+  ) {
+    super(message);
+    this.name = "JiraApiError";
+  }
+}
+
+export function sanitizeJiraErrorMessage(params: {
+  message: string;
+  secrets?: string[];
+  maxLength?: number;
+}): string {
+  const redacted = redactSecrets(params.message, params.secrets ?? []);
+  return truncate(redacted, params.maxLength ?? 1_000);
+}
+
+export function normalizeJiraError(
+  error: unknown,
+  options: { secrets?: string[]; fallbackCode?: JiraErrorCode } = {},
+): JiraErrorPayload {
+  const fallbackCode = options.fallbackCode ?? "jira_request_failed";
+
+  if (error instanceof JiraApiError) {
+    return {
+      ok: false,
+      code: error.code,
+      status: error.status,
+      retryable: error.retryable,
+      message: sanitizeJiraErrorMessage({
+        message: error.message,
+        secrets: options.secrets,
+      }),
+    };
+  }
+
+  const rawMessage = error instanceof Error ? error.message : String(error);
+  return {
+    ok: false,
+    code: fallbackCode,
+    retryable: false,
+    message: sanitizeJiraErrorMessage({
+      message: rawMessage,
+      secrets: options.secrets,
+    }),
+  };
+}
+

--- a/extensions/jira-cloud/src/errors.ts
+++ b/extensions/jira-cloud/src/errors.ts
@@ -3,7 +3,10 @@ import { redactSecrets, truncate } from "./sanitize.js";
 export type JiraErrorCode =
   | "jira_timeout"
   | "jira_rate_limited"
-  | "jira_auth_failed"
+  | "jira_unauthorized"
+  | "jira_forbidden"
+  | "jira_not_found"
+  | "jira_conflict"
   | "jira_request_failed"
   | "jira_validation_failed"
   | "jira_polling_timeout";
@@ -67,4 +70,3 @@ export function normalizeJiraError(
     }),
   };
 }
-

--- a/extensions/jira-cloud/src/jira-service.test.ts
+++ b/extensions/jira-cloud/src/jira-service.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { JiraApiError } from "./errors.js";
+import { createJiraService } from "./jira-service.js";
+
+describe("jira service", () => {
+  it("converts create issue description from plain text to minimal adf", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "1001", key: "OPS-1" })
+      .mockResolvedValueOnce({
+        key: "OPS-1",
+        fields: { summary: "A", status: { name: "To Do" } },
+      });
+    const service = createJiraService({
+      request,
+      getSiteUrl: () => "https://example.atlassian.net",
+    } as never);
+
+    await service.createIssue({
+      projectKey: "OPS",
+      issueType: "Bug",
+      summary: "Broken",
+      description: "line1\nline2",
+    });
+
+    const createBody = request.mock.calls[0]?.[1]?.body as { fields?: Record<string, unknown> };
+    expect(createBody.fields?.description).toEqual({
+      type: "doc",
+      version: 1,
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "line1" }] },
+        { type: "paragraph", content: [{ type: "text", text: "line2" }] },
+      ],
+    });
+  });
+
+  it("converts add comment plain text to minimal adf", async () => {
+    const request = vi.fn().mockResolvedValue({ id: "2002" });
+    const service = createJiraService({
+      request,
+      getSiteUrl: () => "https://example.atlassian.net",
+    } as never);
+
+    await service.addComment("OPS-2", "hello");
+    const commentBody = request.mock.calls[0]?.[1]?.body as { body?: unknown };
+    expect(commentBody.body).toEqual({
+      type: "doc",
+      version: 1,
+      content: [{ type: "paragraph", content: [{ type: "text", text: "hello" }] }],
+    });
+  });
+
+  it("converts transition comment plain text to minimal adf", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ key: "OPS-3", fields: { status: { name: "In Progress" } } });
+    const service = createJiraService({
+      request,
+      getSiteUrl: () => "https://example.atlassian.net",
+    } as never);
+
+    await service.transitionIssue({
+      issueKey: "OPS-3",
+      transitionId: "31",
+      comment: "moving now",
+    });
+
+    const transitionBody = request.mock.calls[0]?.[1]?.body as { update?: unknown };
+    expect(transitionBody.update).toEqual({
+      comment: [
+        {
+          add: {
+            body: {
+              type: "doc",
+              version: 1,
+              content: [{ type: "paragraph", content: [{ type: "text", text: "moving now" }] }],
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it("returns stable complete metadata when available", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        values: [{ id: "1", key: "OPS", name: "Operations" }],
+      })
+      .mockResolvedValueOnce({
+        issueTypes: [{ id: "100", name: "Bug", subtask: false, description: "desc" }],
+      })
+      .mockResolvedValueOnce({
+        fields: {
+          summary: { name: "Summary", required: true, schema: { type: "string" } },
+          customfield_10000: {
+            name: "Customer",
+            required: false,
+            schema: { custom: "com.atlassian.jira.plugin.system.customfieldtypes:select" },
+            allowedValues: [{ value: "A" }, { value: "B" }],
+          },
+        },
+      });
+    const service = createJiraService({
+      request,
+      getSiteUrl: () => "https://example.atlassian.net",
+    } as never);
+
+    const payload = await service.getCreateMetadata({ projectKey: "OPS", issueType: "Bug" });
+    expect(payload.bestEffort).toBe(true);
+    expect(payload.projects).toHaveLength(1);
+    expect(payload.issueTypes).toHaveLength(1);
+    expect(payload.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "summary", required: true, schemaType: "string" }),
+        expect.objectContaining({
+          id: "customfield_10000",
+          hasAllowedValues: true,
+          allowedValues: ["A", "B"],
+        }),
+      ]),
+    );
+  });
+
+  it("returns stable partial metadata under restricted tenants", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        values: [{ id: "1", key: "OPS", name: "Operations" }],
+      })
+      .mockRejectedValueOnce(new JiraApiError("forbidden", "jira_forbidden", 403))
+      .mockRejectedValueOnce(new JiraApiError("forbidden", "jira_forbidden", 403));
+    const service = createJiraService({
+      request,
+      getSiteUrl: () => "https://example.atlassian.net",
+    } as never);
+
+    const payload = await service.getCreateMetadata({ projectKey: "OPS", issueType: "Bug" });
+    expect(payload.bestEffort).toBe(true);
+    expect(payload.issueTypes).toEqual([]);
+    expect(payload.fields).toEqual([]);
+    expect(payload.warnings.length).toBeGreaterThan(0);
+  });
+});

--- a/extensions/jira-cloud/src/jira-service.ts
+++ b/extensions/jira-cloud/src/jira-service.ts
@@ -1,0 +1,293 @@
+import { DEFAULT_SEARCH_FIELDS } from "./config.js";
+import type { JiraCloudClient } from "./client.js";
+
+export type JiraIssueSummary = {
+  id?: string;
+  key: string;
+  summary?: string;
+  status?: string;
+  issueType?: string;
+  assignee?: string;
+  priority?: string;
+  updated?: string;
+};
+
+type JiraIssueLike = {
+  id?: string;
+  key?: string;
+  fields?: Record<string, unknown>;
+};
+
+function toAdfDocument(text: string): Record<string, unknown> {
+  return {
+    type: "doc",
+    version: 1,
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text }],
+      },
+    ],
+  };
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function summarizeIssue(issue: JiraIssueLike): JiraIssueSummary {
+  const fields = issue.fields ?? {};
+  const status = readString((fields.status as { name?: unknown } | undefined)?.name);
+  const issueType = readString((fields.issuetype as { name?: unknown } | undefined)?.name);
+  const assignee = readString((fields.assignee as { displayName?: unknown } | undefined)?.displayName);
+  const priority = readString((fields.priority as { name?: unknown } | undefined)?.name);
+  return {
+    id: readString(issue.id),
+    key: readString(issue.key) ?? "",
+    summary: readString(fields.summary),
+    status,
+    issueType,
+    assignee,
+    priority,
+    updated: readString(fields.updated),
+  };
+}
+
+function safeIssueUrl(siteUrl: string, issueKey: string): string {
+  return `${siteUrl}/browse/${issueKey}`;
+}
+
+export function createJiraService(client: JiraCloudClient) {
+  return {
+    async healthcheck() {
+      const myself = await client.request<{
+        accountId?: string;
+        displayName?: string;
+        emailAddress?: string;
+      }>("/rest/api/3/myself");
+      return {
+        site: client.getSiteUrl(),
+        status: "ok",
+        timestamp: new Date().toISOString(),
+        authenticatedUser: {
+          accountId: readString(myself.accountId),
+          displayName: readString(myself.displayName),
+          emailAddress: readString(myself.emailAddress),
+        },
+      };
+    },
+
+    async listProjects(maxResults: number) {
+      const payload = await client.request<{
+        values?: Array<{
+          id?: string;
+          key?: string;
+          name?: string;
+          simplified?: boolean;
+          projectTypeKey?: string;
+        }>;
+      }>("/rest/api/3/project/search", {
+        query: { maxResults },
+      });
+      return {
+        projects: (payload.values ?? []).map((project) => ({
+          id: readString(project.id),
+          key: readString(project.key),
+          name: readString(project.name),
+          simplified: project.simplified === true,
+          projectTypeKey: readString(project.projectTypeKey),
+        })),
+      };
+    },
+
+    async searchIssues(params: {
+      jql: string;
+      maxResults: number;
+      fields?: string[];
+      startAt?: number;
+    }) {
+      const payload = await client.request<{
+        startAt?: number;
+        maxResults?: number;
+        total?: number;
+        issues?: JiraIssueLike[];
+      }>("/rest/api/3/search", {
+        method: "POST",
+        body: {
+          jql: params.jql,
+          maxResults: params.maxResults,
+          startAt: params.startAt ?? 0,
+          fields: params.fields?.length ? params.fields : DEFAULT_SEARCH_FIELDS,
+        },
+      });
+      return {
+        total: payload.total ?? 0,
+        startAt: payload.startAt ?? 0,
+        maxResults: payload.maxResults ?? params.maxResults,
+        issues: (payload.issues ?? []).map((issue) => summarizeIssue(issue)),
+      };
+    },
+
+    async getIssue(issueKey: string, fields?: string[]) {
+      const issue = await client.request<JiraIssueLike>(`/rest/api/3/issue/${encodeURIComponent(issueKey)}`, {
+        query: {
+          fields: fields?.length ? fields.join(",") : DEFAULT_SEARCH_FIELDS.join(","),
+        },
+      });
+      return {
+        issue: {
+          ...summarizeIssue(issue),
+          fields: issue.fields ?? {},
+          url: safeIssueUrl(client.getSiteUrl(), issueKey),
+        },
+      };
+    },
+
+    async createIssue(params: {
+      projectKey: string;
+      issueType: string;
+      summary: string;
+      description?: string;
+      priority?: string;
+      labels?: string[];
+      assigneeAccountId?: string;
+    }) {
+      const fields: Record<string, unknown> = {
+        project: { key: params.projectKey },
+        issuetype: { name: params.issueType },
+        summary: params.summary,
+      };
+      if (params.description) {
+        fields.description = toAdfDocument(params.description);
+      }
+      if (params.priority) {
+        fields.priority = { name: params.priority };
+      }
+      if (params.labels?.length) {
+        fields.labels = params.labels;
+      }
+      if (params.assigneeAccountId) {
+        fields.assignee = { accountId: params.assigneeAccountId };
+      }
+
+      const created = await client.request<{ id?: string; key?: string }>("/rest/api/3/issue", {
+        method: "POST",
+        body: { fields },
+      });
+      const key = readString(created.key) ?? "";
+      const detail = key
+        ? await this.getIssue(key, ["summary", "status", "issuetype", "assignee", "project"])
+        : null;
+      return {
+        id: readString(created.id),
+        key,
+        url: key ? safeIssueUrl(client.getSiteUrl(), key) : undefined,
+        summary: detail?.issue.summary,
+        status: detail?.issue.status,
+      };
+    },
+
+    async addComment(issueKey: string, comment: string) {
+      const payload = await client.request<{ id?: string }>("/rest/api/3/issue/" + encodeURIComponent(issueKey) + "/comment", {
+        method: "POST",
+        body: { body: toAdfDocument(comment) },
+      });
+      const commentId = readString(payload.id);
+      return {
+        issueKey,
+        commentId,
+        url: commentId
+          ? `${safeIssueUrl(client.getSiteUrl(), issueKey)}?focusedCommentId=${commentId}`
+          : safeIssueUrl(client.getSiteUrl(), issueKey),
+      };
+    },
+
+    async listTransitions(issueKey: string) {
+      const payload = await client.request<{
+        transitions?: Array<{ id?: string; name?: string; to?: { name?: string } }>;
+      }>(`/rest/api/3/issue/${encodeURIComponent(issueKey)}/transitions`);
+      return {
+        issueKey,
+        transitions: (payload.transitions ?? []).map((transition) => ({
+          id: readString(transition.id),
+          name: readString(transition.name),
+          toStatus: readString(transition.to?.name),
+        })),
+      };
+    },
+
+    async transitionIssue(params: { issueKey: string; transitionId: string; comment?: string }) {
+      const body: Record<string, unknown> = {
+        transition: { id: params.transitionId },
+      };
+      if (params.comment) {
+        body.update = {
+          comment: [{ add: { body: toAdfDocument(params.comment) } }],
+        };
+      }
+      await client.request<void>(`/rest/api/3/issue/${encodeURIComponent(params.issueKey)}/transitions`, {
+        method: "POST",
+        body,
+      });
+      const detail = await this.getIssue(params.issueKey, ["status", "summary"]);
+      return {
+        issueKey: params.issueKey,
+        transitioned: true,
+        status: detail.issue.status,
+      };
+    },
+
+    async assignIssue(params: { issueKey: string; accountId: string }) {
+      await client.request<void>(`/rest/api/3/issue/${encodeURIComponent(params.issueKey)}/assignee`, {
+        method: "PUT",
+        body: { accountId: params.accountId },
+      });
+      const detail = await this.getIssue(params.issueKey, ["assignee"]);
+      return {
+        issueKey: params.issueKey,
+        assigned: true,
+        assignee: detail.issue.assignee,
+      };
+    },
+
+    async getCreateMetadata(params: { projectKey?: string; issueType?: string }) {
+      const projectKey = params.projectKey;
+      const issueTypesPayload = projectKey
+        ? await client.request<{ issueTypes?: Array<{ id?: string; name?: string }> }>(
+            `/rest/api/3/issue/createmeta/${encodeURIComponent(projectKey)}/issuetypes`,
+          )
+        : { issueTypes: [] };
+      const issueTypes = (issueTypesPayload.issueTypes ?? []).map((issueType) => ({
+        id: readString(issueType.id),
+        name: readString(issueType.name),
+      }));
+
+      let issueTypeFields: unknown = undefined;
+      if (projectKey && params.issueType) {
+        const matchedIssueType = issueTypes.find(
+          (entry) =>
+            entry.id === params.issueType ||
+            entry.name?.toLowerCase() === params.issueType?.toLowerCase(),
+        );
+        if (matchedIssueType?.id) {
+          issueTypeFields = await client.request<Record<string, unknown>>(
+            `/rest/api/3/issue/createmeta/${encodeURIComponent(projectKey)}/issuetypes/${encodeURIComponent(
+              matchedIssueType.id,
+            )}`,
+          );
+        }
+      }
+
+      return {
+        projectKey,
+        issueTypes,
+        issueTypeFields,
+      };
+    },
+  };
+}
+

--- a/extensions/jira-cloud/src/jira-service.ts
+++ b/extensions/jira-cloud/src/jira-service.ts
@@ -1,5 +1,7 @@
 import { DEFAULT_SEARCH_FIELDS } from "./config.js";
 import type { JiraCloudClient } from "./client.js";
+import { JiraApiError } from "./errors.js";
+import { toMinimalAdfTextDocument } from "./adf.js";
 
 export type JiraIssueSummary = {
   id?: string;
@@ -17,19 +19,6 @@ type JiraIssueLike = {
   key?: string;
   fields?: Record<string, unknown>;
 };
-
-function toAdfDocument(text: string): Record<string, unknown> {
-  return {
-    type: "doc",
-    version: 1,
-    content: [
-      {
-        type: "paragraph",
-        content: [{ type: "text", text }],
-      },
-    ],
-  };
-}
 
 function readString(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -59,6 +48,92 @@ function summarizeIssue(issue: JiraIssueLike): JiraIssueSummary {
 
 function safeIssueUrl(siteUrl: string, issueKey: string): string {
   return `${siteUrl}/browse/${issueKey}`;
+}
+
+function summarizeAllowedValue(value: unknown): string {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const asRecord = value as Record<string, unknown>;
+    const fromValue = readString(asRecord.value);
+    if (fromValue) {
+      return fromValue;
+    }
+    const fromName = readString(asRecord.name);
+    if (fromName) {
+      return fromName;
+    }
+    const fromId = readString(asRecord.id);
+    if (fromId) {
+      return fromId;
+    }
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  return String(value);
+}
+
+function summarizeMetadataFields(fields: unknown) {
+  if (!fields || typeof fields !== "object" || Array.isArray(fields)) {
+    return [];
+  }
+  return Object.entries(fields as Record<string, unknown>).map(([id, raw]) => {
+    const field = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
+    const fieldRecord = field as Record<string, unknown>;
+    const allowedValues = Array.isArray(fieldRecord.allowedValues)
+      ? fieldRecord.allowedValues.slice(0, 10).map(summarizeAllowedValue)
+      : [];
+    const schema = fieldRecord.schema;
+    const schemaRecord =
+      schema && typeof schema === "object" && !Array.isArray(schema)
+        ? (schema as Record<string, unknown>)
+        : undefined;
+    return {
+      id,
+      name: readString(fieldRecord.name) ?? id,
+      required: fieldRecord.required === true,
+      schemaType: readString(schemaRecord?.type) ?? readString(schemaRecord?.custom),
+      hasAllowedValues: allowedValues.length > 0,
+      allowedValues,
+    };
+  });
+}
+
+async function requestCreateIssueTypesBestEffort(client: JiraCloudClient, projectKey: string) {
+  try {
+    return await client.request<{
+      issueTypes?: Array<{ id?: string; name?: string; subtask?: boolean; description?: string }>;
+    }>(`/rest/api/3/issue/createmeta/${encodeURIComponent(projectKey)}/issuetypes`);
+  } catch (error) {
+    if (
+      error instanceof JiraApiError &&
+      (error.code === "jira_forbidden" || error.code === "jira_not_found")
+    ) {
+      return { issueTypes: [] };
+    }
+    throw error;
+  }
+}
+
+async function requestCreateIssueTypeDetailBestEffort(
+  client: JiraCloudClient,
+  projectKey: string,
+  issueTypeId: string,
+) {
+  try {
+    return await client.request<Record<string, unknown>>(
+      `/rest/api/3/issue/createmeta/${encodeURIComponent(projectKey)}/issuetypes/${encodeURIComponent(
+        issueTypeId,
+      )}`,
+    );
+  } catch (error) {
+    if (
+      error instanceof JiraApiError &&
+      (error.code === "jira_forbidden" || error.code === "jira_not_found")
+    ) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 export function createJiraService(client: JiraCloudClient) {
@@ -162,7 +237,7 @@ export function createJiraService(client: JiraCloudClient) {
         summary: params.summary,
       };
       if (params.description) {
-        fields.description = toAdfDocument(params.description);
+        fields.description = toMinimalAdfTextDocument(params.description);
       }
       if (params.priority) {
         fields.priority = { name: params.priority };
@@ -194,7 +269,7 @@ export function createJiraService(client: JiraCloudClient) {
     async addComment(issueKey: string, comment: string) {
       const payload = await client.request<{ id?: string }>("/rest/api/3/issue/" + encodeURIComponent(issueKey) + "/comment", {
         method: "POST",
-        body: { body: toAdfDocument(comment) },
+        body: { body: toMinimalAdfTextDocument(comment) },
       });
       const commentId = readString(payload.id);
       return {
@@ -226,7 +301,7 @@ export function createJiraService(client: JiraCloudClient) {
       };
       if (params.comment) {
         body.update = {
-          comment: [{ add: { body: toAdfDocument(params.comment) } }],
+          comment: [{ add: { body: toMinimalAdfTextDocument(params.comment) } }],
         };
       }
       await client.request<void>(`/rest/api/3/issue/${encodeURIComponent(params.issueKey)}/transitions`, {
@@ -256,14 +331,26 @@ export function createJiraService(client: JiraCloudClient) {
 
     async getCreateMetadata(params: { projectKey?: string; issueType?: string }) {
       const projectKey = params.projectKey;
+      const warnings: string[] = [];
+      const projectsPayload = await client.request<{
+        values?: Array<{ id?: string; key?: string; name?: string }>;
+      }>("/rest/api/3/project/search", {
+        query: { maxResults: 25 },
+      });
+      const projects = (projectsPayload.values ?? []).map((project) => ({
+        id: readString(project.id),
+        key: readString(project.key),
+        name: readString(project.name),
+      }));
+
       const issueTypesPayload = projectKey
-        ? await client.request<{ issueTypes?: Array<{ id?: string; name?: string }> }>(
-            `/rest/api/3/issue/createmeta/${encodeURIComponent(projectKey)}/issuetypes`,
-          )
+        ? await requestCreateIssueTypesBestEffort(client, projectKey)
         : { issueTypes: [] };
       const issueTypes = (issueTypesPayload.issueTypes ?? []).map((issueType) => ({
         id: readString(issueType.id),
         name: readString(issueType.name),
+        subtask: issueType.subtask === true,
+        description: readString(issueType.description),
       }));
 
       let issueTypeFields: unknown = undefined;
@@ -274,20 +361,37 @@ export function createJiraService(client: JiraCloudClient) {
             entry.name?.toLowerCase() === params.issueType?.toLowerCase(),
         );
         if (matchedIssueType?.id) {
-          issueTypeFields = await client.request<Record<string, unknown>>(
-            `/rest/api/3/issue/createmeta/${encodeURIComponent(projectKey)}/issuetypes/${encodeURIComponent(
-              matchedIssueType.id,
-            )}`,
+          issueTypeFields = await requestCreateIssueTypeDetailBestEffort(
+            client,
+            projectKey,
+            matchedIssueType.id,
           );
+          if (!issueTypeFields) {
+            warnings.push(
+              "Issue type metadata was not fully available for this tenant or permission set.",
+            );
+          }
+        } else {
+          warnings.push("Requested issueType was not found in current create metadata response.");
         }
+      } else if (projectKey && issueTypes.length === 0) {
+        warnings.push(
+          "Create metadata for issue types is not available for this project in this tenant context.",
+        );
       }
 
       return {
+        bestEffort: true,
         projectKey,
+        projects,
         issueTypes,
-        issueTypeFields,
+        fields: summarizeMetadataFields(
+          issueTypeFields && typeof issueTypeFields === "object"
+            ? (issueTypeFields as Record<string, unknown>).fields
+            : undefined,
+        ),
+        warnings,
       };
     },
   };
 }
-

--- a/extensions/jira-cloud/src/sanitize.ts
+++ b/extensions/jira-cloud/src/sanitize.ts
@@ -11,7 +11,10 @@ export function redactSecrets(value: string, secrets: string[]): string {
     sanitized = redactSecret(sanitized, secret);
   }
   sanitized = sanitized.replace(/authorization:\s*basic\s+[a-z0-9+/=]+/gi, "authorization: [REDACTED]");
+  sanitized = sanitized.replace(/authorization:\s*bearer\s+[a-z0-9\-._~+/=]+/gi, "authorization: [REDACTED]");
+  sanitized = sanitized.replace(/\b(x-)?api[-_ ]?key\s*[:=]?\s*[^\s,;]+/gi, "$1api-key [REDACTED]");
   sanitized = sanitized.replace(/\b(api[-_ ]?token|token)\s*[:=]?\s*[^\s,;]+/gi, "$1 [REDACTED]");
+  sanitized = sanitized.replace(/\bbasic\s+[a-z0-9+/=]{12,}\b/gi, "basic [REDACTED]");
   return sanitized;
 }
 

--- a/extensions/jira-cloud/src/sanitize.ts
+++ b/extensions/jira-cloud/src/sanitize.ts
@@ -1,0 +1,23 @@
+export function redactSecret(value: string, secret: string): string {
+  if (!secret) {
+    return value;
+  }
+  return value.split(secret).join("[REDACTED]");
+}
+
+export function redactSecrets(value: string, secrets: string[]): string {
+  let sanitized = value;
+  for (const secret of secrets) {
+    sanitized = redactSecret(sanitized, secret);
+  }
+  sanitized = sanitized.replace(/authorization:\s*basic\s+[a-z0-9+/=]+/gi, "authorization: [REDACTED]");
+  sanitized = sanitized.replace(/\b(api[-_ ]?token|token)\s*[:=]?\s*[^\s,;]+/gi, "$1 [REDACTED]");
+  return sanitized;
+}
+
+export function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength)}…`;
+}

--- a/extensions/jira-cloud/src/tools.test.ts
+++ b/extensions/jira-cloud/src/tools.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveJiraCloudConfig = vi.hoisted(() => vi.fn());
+const JiraCloudClient = vi.hoisted(() =>
+  vi.fn().mockImplementation(function MockedJiraCloudClient() {
+    return {
+      getSecrets: () => ["secret-token"],
+    };
+  }),
+);
+const createJiraService = vi.hoisted(() => vi.fn());
+
+vi.mock("./config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./config.js")>();
+  return {
+    ...actual,
+    resolveJiraCloudConfig,
+  };
+});
+
+vi.mock("./client.js", () => ({
+  JiraCloudClient,
+}));
+
+vi.mock("./jira-service.js", () => ({
+  createJiraService,
+}));
+
+describe("jira tools", () => {
+  beforeEach(() => {
+    resolveJiraCloudConfig.mockReset();
+    JiraCloudClient.mockClear();
+    createJiraService.mockReset();
+    resolveJiraCloudConfig.mockReturnValue({
+      siteUrl: "https://example.atlassian.net",
+      email: "bot@example.com",
+      apiToken: "secret-token",
+      defaultProjectKey: "OPS",
+      defaultIssueType: "Task",
+      requestTimeoutMs: 15_000,
+      retryCount: 2,
+      userAgent: "openclaw-jira-cloud/test",
+    });
+    createJiraService.mockReturnValue({
+      healthcheck: vi.fn(async () => ({ status: "ok" })),
+      listProjects: vi.fn(async () => ({ projects: [] })),
+      searchIssues: vi.fn(async () => ({ issues: [], total: 0, startAt: 0, maxResults: 20 })),
+      getIssue: vi.fn(async () => ({ issue: { key: "OPS-1" } })),
+      createIssue: vi.fn(async () => ({ key: "OPS-2" })),
+      addComment: vi.fn(async () => ({ issueKey: "OPS-2", commentId: "10100" })),
+      listTransitions: vi.fn(async () => ({ transitions: [] })),
+      transitionIssue: vi.fn(async () => ({ transitioned: true })),
+      assignIssue: vi.fn(async () => ({ assigned: true })),
+      getCreateMetadata: vi.fn(async () => ({ issueTypes: [] })),
+    });
+  });
+
+  it("registers all jira tools", async () => {
+    const { createJiraCloudTools } = await import("./tools.js");
+    const tools = createJiraCloudTools({ config: {} } as never);
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "jira_healthcheck",
+      "jira_list_projects",
+      "jira_search_issues",
+      "jira_get_issue",
+      "jira_create_issue",
+      "jira_add_comment",
+      "jira_list_transitions",
+      "jira_transition_issue",
+      "jira_assign_issue",
+      "jira_get_create_metadata",
+    ]);
+  });
+
+  it("validates issue keys on mutating tools", async () => {
+    const { createJiraCloudTools } = await import("./tools.js");
+    const tools = createJiraCloudTools({ config: {} } as never);
+    const addCommentTool = tools.find((tool) => tool.name === "jira_add_comment");
+    if (!addCommentTool?.execute) {
+      throw new Error("jira_add_comment tool missing");
+    }
+
+    const result = (await addCommentTool.execute("1", {
+      issueKey: "invalid",
+      comment: "hello",
+    })) as { details?: { code?: string }; content?: Array<{ text?: string }> };
+    expect(result.details).toMatchObject({
+      code: "jira_validation_failed",
+    });
+  });
+
+  it("returns sanitized failures when config is missing", async () => {
+    resolveJiraCloudConfig.mockImplementation(() => {
+      throw new Error("token secret-token missing");
+    });
+    const { createJiraCloudTools } = await import("./tools.js");
+    const tools = createJiraCloudTools({ config: {} } as never);
+    const healthTool = tools.find((tool) => tool.name === "jira_healthcheck");
+    if (!healthTool?.execute) {
+      throw new Error("jira_healthcheck tool missing");
+    }
+    const result = (await healthTool.execute("1", {})) as { details?: { message?: string } };
+    expect(result.details?.message).not.toContain("secret-token");
+  });
+});

--- a/extensions/jira-cloud/src/tools.ts
+++ b/extensions/jira-cloud/src/tools.ts
@@ -1,0 +1,319 @@
+import type { AnyAgentTool, OpenClawPluginApi } from "../runtime-api.js";
+import {
+  Type,
+  jsonResult,
+  readNumberParam,
+  readStringArrayParam,
+  readStringParam,
+} from "../runtime-api.js";
+import { resolveAllowedJiraFields, resolveJiraCloudConfig } from "./config.js";
+import { JiraCloudClient } from "./client.js";
+import { createJiraService } from "./jira-service.js";
+import { JiraApiError, normalizeJiraError } from "./errors.js";
+
+const ISSUE_KEY_RE = /^[A-Z][A-Z0-9_]+-\d+$/i;
+const PROJECT_KEY_RE = /^[A-Z][A-Z0-9_]{0,49}$/i;
+
+const DEFAULT_MAX_RESULTS = 20;
+const MAX_MAX_RESULTS = 50;
+
+function optionalStringArray(description: string) {
+  return Type.Optional(Type.Array(Type.String(), { description }));
+}
+
+function validateIssueKey(issueKey: string): string {
+  const normalized = issueKey.trim().toUpperCase();
+  if (!ISSUE_KEY_RE.test(normalized)) {
+    throw new JiraApiError(
+      "issueKey must be a valid Jira key (e.g. PROJ-123).",
+      "jira_validation_failed",
+      400,
+      false,
+    );
+  }
+  return normalized;
+}
+
+function validateProjectKey(projectKey: string): string {
+  const normalized = projectKey.trim().toUpperCase();
+  if (!PROJECT_KEY_RE.test(normalized)) {
+    throw new JiraApiError(
+      "projectKey must be a valid Jira project key.",
+      "jira_validation_failed",
+      400,
+      false,
+    );
+  }
+  return normalized;
+}
+
+function normalizeMaxResults(rawParams: Record<string, unknown>): number {
+  const value = readNumberParam(rawParams, "maxResults", { integer: true }) ?? DEFAULT_MAX_RESULTS;
+  return Math.max(1, Math.min(MAX_MAX_RESULTS, value));
+}
+
+function createToolSchemas() {
+  return {
+    healthcheck: Type.Object({}, { additionalProperties: false }),
+    listProjects: Type.Object(
+      {
+        maxResults: Type.Optional(Type.Number({ minimum: 1, maximum: MAX_MAX_RESULTS })),
+      },
+      { additionalProperties: false },
+    ),
+    searchIssues: Type.Object(
+      {
+        jql: Type.String({ minLength: 1 }),
+        maxResults: Type.Optional(Type.Number({ minimum: 1, maximum: MAX_MAX_RESULTS })),
+        fields: optionalStringArray("Optional Jira fields allowlist."),
+      },
+      { additionalProperties: false },
+    ),
+    getIssue: Type.Object(
+      {
+        issueKey: Type.String({ minLength: 1 }),
+        fields: optionalStringArray("Optional Jira fields allowlist."),
+      },
+      { additionalProperties: false },
+    ),
+    createIssue: Type.Object(
+      {
+        projectKey: Type.Optional(Type.String({ minLength: 1 })),
+        issueType: Type.Optional(Type.String({ minLength: 1 })),
+        summary: Type.String({ minLength: 1 }),
+        description: Type.Optional(Type.String()),
+        priority: Type.Optional(Type.String()),
+        labels: optionalStringArray("Issue labels."),
+        assigneeAccountId: Type.Optional(Type.String()),
+      },
+      { additionalProperties: false },
+    ),
+    addComment: Type.Object(
+      {
+        issueKey: Type.String({ minLength: 1 }),
+        comment: Type.String({ minLength: 1 }),
+      },
+      { additionalProperties: false },
+    ),
+    listTransitions: Type.Object(
+      {
+        issueKey: Type.String({ minLength: 1 }),
+      },
+      { additionalProperties: false },
+    ),
+    transitionIssue: Type.Object(
+      {
+        issueKey: Type.String({ minLength: 1 }),
+        transitionId: Type.String({ minLength: 1 }),
+        comment: Type.Optional(Type.String()),
+      },
+      { additionalProperties: false },
+    ),
+    assignIssue: Type.Object(
+      {
+        issueKey: Type.String({ minLength: 1 }),
+        accountId: Type.String({ minLength: 1 }),
+      },
+      { additionalProperties: false },
+    ),
+    getCreateMetadata: Type.Object(
+      {
+        projectKey: Type.Optional(Type.String()),
+        issueType: Type.Optional(Type.String()),
+      },
+      { additionalProperties: false },
+    ),
+  };
+}
+
+type JiraToolExecutionContext = {
+  config: ReturnType<typeof resolveJiraCloudConfig>;
+  client: JiraCloudClient;
+  service: ReturnType<typeof createJiraService>;
+};
+
+type JiraToolResult = ReturnType<typeof jsonResult>;
+
+type JiraToolExecutor = (
+  toolCallId: string,
+  rawParams: Record<string, unknown>,
+  context: JiraToolExecutionContext,
+) => Promise<JiraToolResult>;
+
+function createExecutionContext(api: OpenClawPluginApi): JiraToolExecutionContext {
+  const config = resolveJiraCloudConfig({ cfg: api.config });
+  const client = new JiraCloudClient(config);
+  const service = createJiraService(client);
+  return { config, client, service };
+}
+
+function wrapToolExecution(
+  api: OpenClawPluginApi,
+  execute: JiraToolExecutor,
+): (toolCallId: string, rawParams: Record<string, unknown>) => Promise<JiraToolResult> {
+  return async (toolCallId: string, rawParams: Record<string, unknown>) => {
+    let context: JiraToolExecutionContext | null = null;
+    try {
+      context = createExecutionContext(api);
+      return await execute(toolCallId, rawParams, context);
+    } catch (error) {
+      const errorName =
+        error && typeof error === "object" && "name" in error ? String(error.name) : "";
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const validationLike =
+        errorName === "ToolInputError" ||
+        /required|issuekey|projectkey|invalid/i.test(errorMessage);
+      const payload = normalizeJiraError(error, {
+        secrets: context?.client.getSecrets() ?? [],
+        fallbackCode: validationLike ? "jira_validation_failed" : "jira_request_failed",
+      });
+      return jsonResult(payload);
+    }
+  };
+}
+
+export function createJiraCloudTools(api: OpenClawPluginApi): AnyAgentTool[] {
+  const schemas = createToolSchemas();
+
+  const tools: AnyAgentTool[] = [
+    {
+      name: "jira_healthcheck",
+      label: "Jira Healthcheck",
+      description: "Validate Jira Cloud authentication and connectivity.",
+      parameters: schemas.healthcheck,
+      execute: wrapToolExecution(api, async (_toolCallId, _rawParams, context) =>
+        jsonResult(await context.service.healthcheck()),
+      ),
+    },
+    {
+      name: "jira_list_projects",
+      label: "Jira List Projects",
+      description: "List Jira projects accessible with the configured account.",
+      parameters: schemas.listProjects,
+      execute: wrapToolExecution(api, async (_toolCallId, rawParams, context) => {
+        const payload = await context.service.listProjects(normalizeMaxResults(rawParams));
+        return jsonResult(payload);
+      }),
+    },
+    {
+      name: "jira_search_issues",
+      label: "Jira Search Issues",
+      description: "Search Jira issues using JQL.",
+      parameters: schemas.searchIssues,
+      execute: wrapToolExecution(api, async (_toolCallId, rawParams, context) => {
+        const jql = readStringParam(rawParams, "jql", { required: true });
+        const fields = resolveAllowedJiraFields(readStringArrayParam(rawParams, "fields"));
+        const payload = await context.service.searchIssues({
+          jql,
+          maxResults: normalizeMaxResults(rawParams),
+          fields: fields.length ? fields : undefined,
+        });
+        return jsonResult(payload);
+      }),
+    },
+    {
+      name: "jira_get_issue",
+      label: "Jira Get Issue",
+      description: "Get detailed information for one Jira issue key.",
+      parameters: schemas.getIssue,
+      execute: wrapToolExecution(api, async (_toolCallId, rawParams, context) => {
+        const issueKey = validateIssueKey(readStringParam(rawParams, "issueKey", { required: true }));
+        const fields = resolveAllowedJiraFields(readStringArrayParam(rawParams, "fields"));
+        return jsonResult(await context.service.getIssue(issueKey, fields.length ? fields : undefined));
+      }),
+    },
+    {
+      name: "jira_create_issue",
+      label: "Jira Create Issue",
+      description: "Create a Jira issue in the target project.",
+      parameters: schemas.createIssue,
+      execute: wrapToolExecution(api, async (_toolCallId, rawParams, context) => {
+        const summary = readStringParam(rawParams, "summary", { required: true });
+        const projectKey = validateProjectKey(
+          readStringParam(rawParams, "projectKey") ?? context.config.defaultProjectKey ?? "",
+        );
+        const issueType = readStringParam(rawParams, "issueType") ?? context.config.defaultIssueType;
+        if (!issueType) {
+          throw new Error(
+            "issueType is required when defaultIssueType is not configured in jira-cloud config.",
+          );
+        }
+        const description = readStringParam(rawParams, "description");
+        const priority = readStringParam(rawParams, "priority");
+        const labels = readStringArrayParam(rawParams, "labels");
+        const assigneeAccountId = readStringParam(rawParams, "assigneeAccountId");
+        return jsonResult(
+          await context.service.createIssue({
+            projectKey,
+            issueType,
+            summary,
+            description,
+            priority,
+            labels,
+            assigneeAccountId,
+          }),
+        );
+      }),
+    },
+    {
+      name: "jira_add_comment",
+      label: "Jira Add Comment",
+      description: "Add a comment to a Jira issue.",
+      parameters: schemas.addComment,
+      execute: wrapToolExecution(api, async (_toolCallId, rawParams, context) => {
+        const issueKey = validateIssueKey(readStringParam(rawParams, "issueKey", { required: true }));
+        const comment = readStringParam(rawParams, "comment", { required: true });
+        return jsonResult(await context.service.addComment(issueKey, comment));
+      }),
+    },
+    {
+      name: "jira_list_transitions",
+      label: "Jira List Transitions",
+      description: "List available transitions for a Jira issue.",
+      parameters: schemas.listTransitions,
+      execute: wrapToolExecution(api, async (_toolCallId, rawParams, context) => {
+        const issueKey = validateIssueKey(readStringParam(rawParams, "issueKey", { required: true }));
+        return jsonResult(await context.service.listTransitions(issueKey));
+      }),
+    },
+    {
+      name: "jira_transition_issue",
+      label: "Jira Transition Issue",
+      description: "Transition a Jira issue to a new workflow state.",
+      parameters: schemas.transitionIssue,
+      execute: wrapToolExecution(api, async (_toolCallId, rawParams, context) => {
+        const issueKey = validateIssueKey(readStringParam(rawParams, "issueKey", { required: true }));
+        const transitionId = readStringParam(rawParams, "transitionId", { required: true });
+        const comment = readStringParam(rawParams, "comment");
+        return jsonResult(await context.service.transitionIssue({ issueKey, transitionId, comment }));
+      }),
+    },
+    {
+      name: "jira_assign_issue",
+      label: "Jira Assign Issue",
+      description: "Assign a Jira issue to an accountId.",
+      parameters: schemas.assignIssue,
+      execute: wrapToolExecution(api, async (_toolCallId, rawParams, context) => {
+        const issueKey = validateIssueKey(readStringParam(rawParams, "issueKey", { required: true }));
+        const accountId = readStringParam(rawParams, "accountId", { required: true });
+        return jsonResult(await context.service.assignIssue({ issueKey, accountId }));
+      }),
+    },
+    {
+      name: "jira_get_create_metadata",
+      label: "Jira Get Create Metadata",
+      description: "Fetch issue-type metadata for issue creation.",
+      parameters: schemas.getCreateMetadata,
+      execute: wrapToolExecution(api, async (_toolCallId, rawParams, context) => {
+        const projectKeyRaw = readStringParam(rawParams, "projectKey");
+        const issueType = readStringParam(rawParams, "issueType");
+        const projectKey = projectKeyRaw
+          ? validateProjectKey(projectKeyRaw)
+          : context.config.defaultProjectKey;
+        return jsonResult(await context.service.getCreateMetadata({ projectKey, issueType }));
+      }),
+    },
+  ];
+
+  return tools;
+}


### PR DESCRIPTION
## Summary
- add a new plugin scaffold `@kansodata/jira-cloud` under `extensions/jira-cloud`
- register a packaged skill at `skills/jira-cloud/SKILL.md`
- expose plugin metadata through `openclaw.plugin.json` and extension entrypoint
- add labeler mapping for the new extension path

## Why
- `openclaw skills install` currently validates slugs and does not accept scoped names like `@kansodata/...`
- plugin installation supports scoped packages, so this path enables user installation via `@kansodata`

## Validation
- verified repo state is clean after scaffold creation
- verified `.github/labeler.yml` includes `extensions: jira-cloud` mapping