### PR TITLE
feat(extensions): add databricks skill pack scaffold

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -242,14 +242,14 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/byteplus/**"
-"extensions: deepseek":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "extensions/deepseek/**"
 "extensions: databricks":
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/databricks/**"
+"extensions: deepseek":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/deepseek/**"
 "extensions: anthropic":
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -246,6 +246,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/deepseek/**"
+"extensions: databricks":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/databricks/**"
 "extensions: anthropic":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/databricks/README.md
+++ b/extensions/databricks/README.md
@@ -1,6 +1,6 @@
 # Databricks (plugin)
 
-Adds a Databricks skill bundle for analytics engineering, SQL operations, and job orchestration workflows.
+Adds a Databricks plugin with a minimal runtime capability and a skill bundle.
 
 ## Install
 
@@ -24,8 +24,32 @@ Restart the gateway after enabling.
 
 ## What you get
 
+- Runtime tool: `databricks_sql_readonly`
+  - Executes a single SQL statement through Databricks SQL Statements API
+  - Enforces read-only policy: only `SELECT` or `WITH ... SELECT`
+  - Blocks mutating SQL and multiple statements
 - `databricks` skill available to the agent
-- Practical playbook for:
-  - SQL warehouse analysis and optimization
-  - notebook/job run planning and post-run checks
-  - Unity Catalog aware data governance checklists
+
+## Required config
+
+Configure `plugins.entries.databricks.config` with:
+
+- `host`
+- `token`
+- `warehouseId`
+- optional `timeoutMs` (default `30000`)
+- optional `retryCount` (default `1`)
+- optional `readOnly` (default `true`, and must remain `true` in this iteration)
+
+Environment fallbacks are supported:
+
+- `DATABRICKS_HOST`
+- `DATABRICKS_TOKEN`
+- `DATABRICKS_WAREHOUSE_ID`
+- `DATABRICKS_READ_ONLY`
+
+## Current limits (intentional)
+
+- No Jobs API execution yet
+- No Unity Catalog/lineage API integration yet
+- No mutating SQL operations in this iteration

--- a/extensions/databricks/README.md
+++ b/extensions/databricks/README.md
@@ -27,6 +27,7 @@ Restart the gateway after enabling.
 - Runtime tool: `databricks_sql_readonly`
   - Executes a single SQL statement through Databricks SQL Statements API
   - Polls statement status when Databricks responds `PENDING`/`RUNNING`/`QUEUED`
+  - Retries transient polling failures (`429`/`5xx`) with bounded backoff inside `maxPollingWaitMs`
   - Enforces read-only policy: only `SELECT` or `WITH ... SELECT`
   - Blocks mutating SQL and multiple statements
   - Supports optional catalog/schema allowlists
@@ -60,4 +61,6 @@ Environment fallbacks are supported:
 - No Unity Catalog/lineage API integration yet
 - No mutating SQL operations in this iteration
 - Allowlist checks are conservative:
-  - if an allowlist is configured and target catalog/schema cannot be determined safely, the query is rejected (fail-closed)
+  - if an allowlist is configured and query targets cannot be determined safely from SQL, the query is rejected (fail-closed)
+  - single-part table references (for example `FROM orders`) are treated as ambiguous when allowlists are active
+  - explicit `catalog`/`schema` request parameters do not bypass SQL target validation

--- a/extensions/databricks/README.md
+++ b/extensions/databricks/README.md
@@ -61,6 +61,9 @@ Environment fallbacks are supported:
 - No Unity Catalog/lineage API integration yet
 - No mutating SQL operations in this iteration
 - Allowlist checks are conservative:
+  - target extraction supports only explicit and safe `FROM`/`JOIN` references in `schema.table` or `catalog.schema.table` form, including backtick-quoted identifiers
+  - queries with leading `WITH` and derived subqueries are supported conservatively: only explicit physical targets are extracted, CTE aliases are never treated as physical tables
   - if an allowlist is configured and query targets cannot be determined safely from SQL, the query is rejected (fail-closed)
+  - malformed quoting, unbalanced parentheses, ambiguous syntax, or unsupported statement shapes resolve to no targets (fail-closed)
   - single-part table references (for example `FROM orders`) are treated as ambiguous when allowlists are active
   - explicit `catalog`/`schema` request parameters do not bypass SQL target validation

--- a/extensions/databricks/README.md
+++ b/extensions/databricks/README.md
@@ -26,8 +26,10 @@ Restart the gateway after enabling.
 
 - Runtime tool: `databricks_sql_readonly`
   - Executes a single SQL statement through Databricks SQL Statements API
+  - Polls statement status when Databricks responds `PENDING`/`RUNNING`/`QUEUED`
   - Enforces read-only policy: only `SELECT` or `WITH ... SELECT`
   - Blocks mutating SQL and multiple statements
+  - Supports optional catalog/schema allowlists
 - `databricks` skill available to the agent
 
 ## Required config
@@ -39,6 +41,10 @@ Configure `plugins.entries.databricks.config` with:
 - `warehouseId`
 - optional `timeoutMs` (default `30000`)
 - optional `retryCount` (default `1`)
+- optional `pollingIntervalMs` (default `1000`)
+- optional `maxPollingWaitMs` (default `30000`)
+- optional `allowedCatalogs` (empty by default)
+- optional `allowedSchemas` (empty by default)
 - optional `readOnly` (default `true`, and must remain `true` in this iteration)
 
 Environment fallbacks are supported:
@@ -53,3 +59,5 @@ Environment fallbacks are supported:
 - No Jobs API execution yet
 - No Unity Catalog/lineage API integration yet
 - No mutating SQL operations in this iteration
+- Allowlist checks are conservative:
+  - if an allowlist is configured and target catalog/schema cannot be determined safely, the query is rejected (fail-closed)

--- a/extensions/databricks/README.md
+++ b/extensions/databricks/README.md
@@ -5,7 +5,7 @@ Adds a Databricks skill bundle for analytics engineering, SQL operations, and jo
 ## Install
 
 ```bash
-openclaw plugins install @kansodata/databricks
+openclaw plugins install @openclaw/databricks
 ```
 
 ## Enable

--- a/extensions/databricks/README.md
+++ b/extensions/databricks/README.md
@@ -1,0 +1,31 @@
+# Databricks (plugin)
+
+Adds a Databricks skill bundle for analytics engineering, SQL operations, and job orchestration workflows.
+
+## Install
+
+```bash
+openclaw plugins install @kansodata/databricks
+```
+
+## Enable
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "databricks": { "enabled": true }
+    }
+  }
+}
+```
+
+Restart the gateway after enabling.
+
+## What you get
+
+- `databricks` skill available to the agent
+- Practical playbook for:
+  - SQL warehouse analysis and optimization
+  - notebook/job run planning and post-run checks
+  - Unity Catalog aware data governance checklists

--- a/extensions/databricks/index.ts
+++ b/extensions/databricks/index.ts
@@ -1,0 +1,10 @@
+import { definePluginEntry, type OpenClawPluginApi } from "./runtime-api.js";
+
+export default definePluginEntry({
+  id: "databricks",
+  name: "Databricks",
+  description: "Plugin-shipped Databricks skills bundle",
+  register(_api: OpenClawPluginApi) {
+    // This plugin currently ships skills only.
+  },
+});

--- a/extensions/databricks/index.ts
+++ b/extensions/databricks/index.ts
@@ -1,10 +1,11 @@
-import { definePluginEntry, type OpenClawPluginApi } from "./runtime-api.js";
+import { definePluginEntry } from "./runtime-api.js";
+import { createDatabricksSqlReadOnlyTool } from "./src/operations/sql.js";
 
 export default definePluginEntry({
   id: "databricks",
   name: "Databricks",
-  description: "Plugin-shipped Databricks skills bundle",
-  register(_api: OpenClawPluginApi) {
-    // This plugin currently ships skills only.
+  description: "Databricks read-only SQL runtime + skills bundle",
+  register(api) {
+    api.registerTool(createDatabricksSqlReadOnlyTool(api));
   },
 });

--- a/extensions/databricks/openclaw.plugin.json
+++ b/extensions/databricks/openclaw.plugin.json
@@ -1,11 +1,66 @@
 {
   "id": "databricks",
   "name": "Databricks",
-  "description": "Databricks skill pack for SQL operations, jobs orchestration, and Unity Catalog governance workflows.",
+  "description": "Databricks runtime plugin with read-only SQL statement execution and skill guidance.",
   "skills": ["./skills"],
+  "providerAuthEnvVars": {
+    "databricks": ["DATABRICKS_HOST", "DATABRICKS_TOKEN", "DATABRICKS_WAREHOUSE_ID"]
+  },
+  "contracts": {
+    "tools": ["databricks_sql_readonly"]
+  },
+  "uiHints": {
+    "host": {
+      "label": "Databricks Host",
+      "help": "Workspace host URL, for example https://dbc-xxxx.cloud.databricks.com."
+    },
+    "token": {
+      "label": "Databricks Token",
+      "help": "Access token for SQL statement execution.",
+      "sensitive": true,
+      "placeholder": "dapi..."
+    },
+    "warehouseId": {
+      "label": "Warehouse ID",
+      "help": "Default SQL warehouse ID used by databricks_sql_readonly."
+    },
+    "readOnly": {
+      "label": "Read-Only Mode",
+      "help": "Must remain enabled in this iteration."
+    }
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "host": {
+        "type": ["string", "object"],
+        "description": "Databricks workspace host URL (for example: https://dbc-xxxx.cloud.databricks.com)."
+      },
+      "token": {
+        "type": ["string", "object"],
+        "description": "Databricks access token (supports secret input resolution)."
+      },
+      "warehouseId": {
+        "type": ["string", "object"],
+        "description": "Default Databricks SQL warehouse ID for statement execution."
+      },
+      "timeoutMs": {
+        "type": "number",
+        "minimum": 1000,
+        "maximum": 120000,
+        "description": "HTTP timeout for Databricks requests in milliseconds."
+      },
+      "retryCount": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 3,
+        "description": "Retry attempts for transient Databricks request failures."
+      },
+      "readOnly": {
+        "type": "boolean",
+        "description": "Must stay true in this iteration. Mutating SQL operations are blocked."
+      }
+    }
   }
 }

--- a/extensions/databricks/openclaw.plugin.json
+++ b/extensions/databricks/openclaw.plugin.json
@@ -24,6 +24,22 @@
       "label": "Warehouse ID",
       "help": "Default SQL warehouse ID used by databricks_sql_readonly."
     },
+    "allowedCatalogs": {
+      "label": "Allowed Catalogs",
+      "help": "Optional read-only allowlist. When set, SQL calls must provide a catalog in this list."
+    },
+    "allowedSchemas": {
+      "label": "Allowed Schemas",
+      "help": "Optional read-only allowlist. When set, SQL calls must provide a schema in this list."
+    },
+    "pollingIntervalMs": {
+      "label": "Polling Interval (ms)",
+      "help": "Polling interval for pending/running Databricks statements."
+    },
+    "maxPollingWaitMs": {
+      "label": "Max Polling Wait (ms)",
+      "help": "Maximum total wait time for statement polling."
+    },
     "readOnly": {
       "label": "Read-Only Mode",
       "help": "Must remain enabled in this iteration."
@@ -56,6 +72,28 @@
         "minimum": 0,
         "maximum": 3,
         "description": "Retry attempts for transient Databricks request failures."
+      },
+      "pollingIntervalMs": {
+        "type": "number",
+        "minimum": 200,
+        "maximum": 5000,
+        "description": "Polling interval used while statement status is PENDING/RUNNING/QUEUED."
+      },
+      "maxPollingWaitMs": {
+        "type": "number",
+        "minimum": 1000,
+        "maximum": 120000,
+        "description": "Maximum total elapsed wait time for statement polling."
+      },
+      "allowedCatalogs": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Optional allowlist of permitted catalogs for read-only SQL."
+      },
+      "allowedSchemas": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Optional allowlist of permitted schemas for read-only SQL."
       },
       "readOnly": {
         "type": "boolean",

--- a/extensions/databricks/openclaw.plugin.json
+++ b/extensions/databricks/openclaw.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "databricks",
+  "name": "Databricks",
+  "description": "Databricks skill pack for SQL operations, jobs orchestration, and Unity Catalog governance workflows.",
+  "skills": ["./skills"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/databricks/package.json
+++ b/extensions/databricks/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@kansodata/databricks",
-  "version": "0.0.1",
+  "name": "@openclaw/databricks",
+  "version": "2026.3.27",
   "private": true,
   "description": "Databricks skill pack plugin for OpenClaw.",
   "type": "module",

--- a/extensions/databricks/package.json
+++ b/extensions/databricks/package.json
@@ -2,7 +2,7 @@
   "name": "@openclaw/databricks",
   "version": "2026.3.27",
   "private": true,
-  "description": "Databricks skill pack plugin for OpenClaw.",
+  "description": "Databricks read-only SQL runtime + skill pack plugin for OpenClaw.",
   "type": "module",
   "openclaw": {
     "extensions": [

--- a/extensions/databricks/package.json
+++ b/extensions/databricks/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@kansodata/databricks",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Databricks skill pack plugin for OpenClaw.",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/databricks/runtime-api.ts
+++ b/extensions/databricks/runtime-api.ts
@@ -1,0 +1,2 @@
+export { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+export type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";

--- a/extensions/databricks/runtime-api.ts
+++ b/extensions/databricks/runtime-api.ts
@@ -1,2 +1,3 @@
 export { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+export type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 export type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";

--- a/extensions/databricks/skills/databricks/SKILL.md
+++ b/extensions/databricks/skills/databricks/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: databricks
+description: Plan and execute Databricks workflows for SQL analytics, jobs orchestration, and Unity Catalog governance follow-up.
+---
+
+Use this skill when the user asks to work with Databricks SQL, notebooks, jobs, or catalog governance tasks.
+
+## Scope
+
+- Convert analysis requests into runnable Databricks SQL drafts.
+- Prepare job and workflow execution plans with pre-run and post-run checks.
+- Build governance and access review checklists for Unity Catalog objects.
+
+## Inputs to request early
+
+- Workspace URL and target environment (`dev`, `staging`, or `prod`).
+- SQL warehouse name or cluster policy constraints.
+- Catalog, schema, and table scope.
+- Job identifiers, schedules, and retry expectations.
+
+## Output format defaults
+
+- Keep outputs copy-paste ready for tickets and runbooks.
+- Include:
+  - short objective line
+  - step-by-step execution plan
+  - SQL draft or pseudo-query blocks when needed
+  - risk notes, validation checks, and rollback signals
+
+## SQL analysis template
+
+When preparing SQL work, produce this structure:
+
+1. Objective
+2. Data scope and assumptions
+3. Query draft
+4. Cost and performance considerations
+5. Validation checklist
+
+## Job orchestration template
+
+When preparing Databricks job execution:
+
+1. Trigger mode (manual, scheduled, or event-based)
+2. Task graph and dependencies
+3. Runtime parameters and secrets handling notes
+4. Failure and retry behavior
+5. Post-run verification steps
+
+## Governance follow-up template
+
+For Unity Catalog and permissions follow-up:
+
+1. Assets in scope (catalogs, schemas, tables, volumes)
+2. Current access model summary
+3. Proposed permission changes
+4. Audit logging checks
+5. Sign-off and monitoring plan

--- a/extensions/databricks/skills/databricks/SKILL.md
+++ b/extensions/databricks/skills/databricks/SKILL.md
@@ -17,6 +17,7 @@ Use this skill when the user asks to work with Databricks SQL, notebooks, jobs, 
   - mutating statements blocked
   - multi-statement SQL blocked
   - optional catalog/schema allowlists enforced conservatively (fail-closed)
+  - SQL target resolution is conservative; ambiguous targets are rejected when allowlists are active
 
 ## Not implemented yet
 
@@ -27,7 +28,8 @@ Use this skill when the user asks to work with Databricks SQL, notebooks, jobs, 
 ## Allowlist note
 
 If `allowedCatalogs` and/or `allowedSchemas` are configured, pass `catalog` and `schema` explicitly in tool requests.
-When the target cannot be determined safely, execution is rejected.
+The runtime still validates target references from SQL text itself and does not allow parameter-only bypass.
+When target resolution is ambiguous (for example single-part table references), execution is rejected.
 
 ## Scope
 

--- a/extensions/databricks/skills/databricks/SKILL.md
+++ b/extensions/databricks/skills/databricks/SKILL.md
@@ -11,16 +11,23 @@ Use this skill when the user asks to work with Databricks SQL, notebooks, jobs, 
 - Real execution support:
   - single-statement `SELECT`
   - single-statement `WITH ... SELECT`
+  - status polling for `PENDING` / `RUNNING` / `QUEUED` until terminal state or max wait
 - Enforced limits:
   - read-only only
   - mutating statements blocked
   - multi-statement SQL blocked
+  - optional catalog/schema allowlists enforced conservatively (fail-closed)
 
 ## Not implemented yet
 
 - Jobs API execution
 - Unity Catalog or lineage API calls
 - Mutating SQL workflows
+
+## Allowlist note
+
+If `allowedCatalogs` and/or `allowedSchemas` are configured, pass `catalog` and `schema` explicitly in tool requests.
+When the target cannot be determined safely, execution is rejected.
 
 ## Scope
 

--- a/extensions/databricks/skills/databricks/SKILL.md
+++ b/extensions/databricks/skills/databricks/SKILL.md
@@ -1,15 +1,32 @@
 ---
 name: databricks
-description: Plan and execute Databricks workflows for SQL analytics, jobs orchestration, and Unity Catalog governance follow-up.
+description: Plan and execute Databricks workflows with OpenClaw's current runtime support for read-only SQL statement execution, plus guidance for jobs and governance planning.
 ---
 
 Use this skill when the user asks to work with Databricks SQL, notebooks, jobs, or catalog governance tasks.
 
+## Runtime support in this iteration
+
+- Available runtime tool: `databricks_sql_readonly`
+- Real execution support:
+  - single-statement `SELECT`
+  - single-statement `WITH ... SELECT`
+- Enforced limits:
+  - read-only only
+  - mutating statements blocked
+  - multi-statement SQL blocked
+
+## Not implemented yet
+
+- Jobs API execution
+- Unity Catalog or lineage API calls
+- Mutating SQL workflows
+
 ## Scope
 
-- Convert analysis requests into runnable Databricks SQL drafts.
-- Prepare job and workflow execution plans with pre-run and post-run checks.
-- Build governance and access review checklists for Unity Catalog objects.
+- Execute read-only SQL via the runtime tool when the request fits allowed policy.
+- Convert broader requests into safe, copy-paste ready plans when runtime support is not implemented yet.
+- Prepare job/workflow and governance checklists as planning output only.
 
 ## Inputs to request early
 
@@ -33,13 +50,13 @@ When preparing SQL work, produce this structure:
 
 1. Objective
 2. Data scope and assumptions
-3. Query draft
+3. Query draft (read-only)
 4. Cost and performance considerations
 5. Validation checklist
 
 ## Job orchestration template
 
-When preparing Databricks job execution:
+When preparing Databricks job execution (planning only in this iteration):
 
 1. Trigger mode (manual, scheduled, or event-based)
 2. Task graph and dependencies
@@ -49,7 +66,7 @@ When preparing Databricks job execution:
 
 ## Governance follow-up template
 
-For Unity Catalog and permissions follow-up:
+For Unity Catalog and permissions follow-up (planning only in this iteration):
 
 1. Assets in scope (catalogs, schemas, tables, volumes)
 2. Current access model summary

--- a/extensions/databricks/src/client.test.ts
+++ b/extensions/databricks/src/client.test.ts
@@ -1,0 +1,124 @@
+import type { PluginLogger } from "openclaw/plugin-sdk/core";
+import { describe, expect, it, vi } from "vitest";
+import { DatabricksSqlClient } from "./client.js";
+
+function createLogger(): PluginLogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe("databricks sql client", () => {
+  it("sends auth header and statement payload", async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("Authorization")).toBe("Bearer dapi-test");
+      expect(headers.get("Content-Type")).toBe("application/json");
+      const body = JSON.parse(String(init?.body));
+      expect(body.statement).toBe("SELECT 1");
+      expect(body.warehouse_id).toBe("wh-1");
+      return new Response(
+        JSON.stringify({ statement_id: "stmt-1", status: { state: "SUCCEEDED" } }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+
+    const client = new DatabricksSqlClient({
+      config: {
+        host: "https://dbc-example.cloud.databricks.com",
+        token: "dapi-test",
+        warehouseId: "wh-1",
+        timeoutMs: 10_000,
+        retryCount: 0,
+        readOnly: true,
+      },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    const result = await client.executeStatement({
+      statement: "SELECT 1",
+      warehouseId: "wh-1",
+    });
+    expect(result).toEqual({ statement_id: "stmt-1", status: { state: "SUCCEEDED" } });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries transient http failures", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "try again" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ statement_id: "stmt-2" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const client = new DatabricksSqlClient({
+      config: {
+        host: "https://dbc-example.cloud.databricks.com",
+        token: "dapi-test",
+        warehouseId: "wh-1",
+        timeoutMs: 10_000,
+        retryCount: 1,
+        readOnly: true,
+      },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    const result = await client.executeStatement({
+      statement: "SELECT 1",
+      warehouseId: "wh-1",
+    });
+    expect(result).toEqual({ statement_id: "stmt-2" });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("raises timeout error when request aborts", async () => {
+    const fetchImpl = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal;
+      return new Promise<Response>((_resolve, reject) => {
+        if (signal?.aborted) {
+          reject(new DOMException("aborted", "AbortError"));
+          return;
+        }
+        signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+      });
+    });
+
+    const client = new DatabricksSqlClient({
+      config: {
+        host: "https://dbc-example.cloud.databricks.com",
+        token: "dapi-test",
+        warehouseId: "wh-1",
+        timeoutMs: 20,
+        retryCount: 0,
+        readOnly: true,
+      },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    await expect(
+      client.executeStatement({
+        statement: "SELECT 1",
+        warehouseId: "wh-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "TIMEOUT",
+    });
+  });
+});

--- a/extensions/databricks/src/client.test.ts
+++ b/extensions/databricks/src/client.test.ts
@@ -36,6 +36,10 @@ describe("databricks sql client", () => {
         warehouseId: "wh-1",
         timeoutMs: 10_000,
         retryCount: 0,
+        pollingIntervalMs: 1_000,
+        maxPollingWaitMs: 30_000,
+        allowedCatalogs: [],
+        allowedSchemas: [],
         readOnly: true,
       },
       logger: createLogger(),
@@ -73,6 +77,10 @@ describe("databricks sql client", () => {
         warehouseId: "wh-1",
         timeoutMs: 10_000,
         retryCount: 1,
+        pollingIntervalMs: 1_000,
+        maxPollingWaitMs: 30_000,
+        allowedCatalogs: [],
+        allowedSchemas: [],
         readOnly: true,
       },
       logger: createLogger(),
@@ -106,6 +114,10 @@ describe("databricks sql client", () => {
         warehouseId: "wh-1",
         timeoutMs: 20,
         retryCount: 0,
+        pollingIntervalMs: 1_000,
+        maxPollingWaitMs: 30_000,
+        allowedCatalogs: [],
+        allowedSchemas: [],
         readOnly: true,
       },
       logger: createLogger(),
@@ -118,7 +130,131 @@ describe("databricks sql client", () => {
         warehouseId: "wh-1",
       }),
     ).rejects.toMatchObject({
-      code: "TIMEOUT",
+      code: "STATEMENT_TIMEOUT",
+    });
+  });
+
+  it("polls until statement reaches terminal status", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-3",
+            status: { state: "PENDING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-3",
+            status: { state: "RUNNING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-3",
+            status: { state: "SUCCEEDED" },
+            result: { data_array: [[1]] },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+
+    const client = new DatabricksSqlClient({
+      config: {
+        host: "https://dbc-example.cloud.databricks.com",
+        token: "dapi-test",
+        warehouseId: "wh-1",
+        timeoutMs: 10_000,
+        retryCount: 0,
+        pollingIntervalMs: 1,
+        maxPollingWaitMs: 5_000,
+        allowedCatalogs: [],
+        allowedSchemas: [],
+        readOnly: true,
+      },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    const result = await client.executeStatement({
+      statement: "SELECT 1",
+      warehouseId: "wh-1",
+    });
+    expect(result).toEqual({
+      statement_id: "stmt-3",
+      status: { state: "SUCCEEDED" },
+      result: { data_array: [[1]] },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails when statement remains pending past max wait", async () => {
+    const fetchImpl = vi.fn();
+    fetchImpl.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          statement_id: "stmt-4",
+          status: { state: "PENDING" },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    fetchImpl.mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          statement_id: "stmt-4",
+          status: { state: "RUNNING" },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+
+    const client = new DatabricksSqlClient({
+      config: {
+        host: "https://dbc-example.cloud.databricks.com",
+        token: "dapi-test",
+        warehouseId: "wh-1",
+        timeoutMs: 10_000,
+        retryCount: 0,
+        pollingIntervalMs: 1,
+        maxPollingWaitMs: 1,
+        allowedCatalogs: [],
+        allowedSchemas: [],
+        readOnly: true,
+      },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    await expect(
+      client.executeStatement({
+        statement: "SELECT 1",
+        warehouseId: "wh-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "STATEMENT_PENDING_MAX_WAIT",
     });
   });
 });

--- a/extensions/databricks/src/client.test.ts
+++ b/extensions/databricks/src/client.test.ts
@@ -257,4 +257,276 @@ describe("databricks sql client", () => {
       code: "STATEMENT_PENDING_MAX_WAIT",
     });
   });
+
+  it("recovers from transient 429 during polling", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-5",
+            status: { state: "PENDING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "rate limited" }), {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-5",
+            status: { state: "SUCCEEDED" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+
+    const client = new DatabricksSqlClient({
+      config: {
+        host: "https://dbc-example.cloud.databricks.com",
+        token: "dapi-test",
+        warehouseId: "wh-1",
+        timeoutMs: 10_000,
+        retryCount: 0,
+        pollingIntervalMs: 1,
+        maxPollingWaitMs: 5_000,
+        allowedCatalogs: [],
+        allowedSchemas: [],
+        readOnly: true,
+      },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    const result = await client.executeStatement({
+      statement: "SELECT 1",
+      warehouseId: "wh-1",
+    });
+    expect(result).toEqual({
+      statement_id: "stmt-5",
+      status: { state: "SUCCEEDED" },
+    });
+  });
+
+  it("recovers from transient 5xx during polling", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-6",
+            status: { state: "RUNNING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "temporary backend error" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-6",
+            status: { state: "SUCCEEDED" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+
+    const client = new DatabricksSqlClient({
+      config: {
+        host: "https://dbc-example.cloud.databricks.com",
+        token: "dapi-test",
+        warehouseId: "wh-1",
+        timeoutMs: 10_000,
+        retryCount: 0,
+        pollingIntervalMs: 1,
+        maxPollingWaitMs: 5_000,
+        allowedCatalogs: [],
+        allowedSchemas: [],
+        readOnly: true,
+      },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    const result = await client.executeStatement({
+      statement: "SELECT 1",
+      warehouseId: "wh-1",
+    });
+    expect(result).toEqual({
+      statement_id: "stmt-6",
+      status: { state: "SUCCEEDED" },
+    });
+  });
+
+  it("fails with pending-max-wait when statement never reaches terminal state", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-7",
+            status: { state: "RUNNING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+      .mockImplementation(async () => {
+        return new Response(
+          JSON.stringify({
+            statement_id: "stmt-7",
+            status: { state: "RUNNING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      });
+
+    const client = new DatabricksSqlClient({
+      config: {
+        host: "https://dbc-example.cloud.databricks.com",
+        token: "dapi-test",
+        warehouseId: "wh-1",
+        timeoutMs: 10_000,
+        retryCount: 0,
+        pollingIntervalMs: 500,
+        maxPollingWaitMs: 300,
+        allowedCatalogs: [],
+        allowedSchemas: [],
+        readOnly: true,
+      },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    await expect(
+      client.executeStatement({
+        statement: "SELECT 1",
+        warehouseId: "wh-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "STATEMENT_PENDING_MAX_WAIT",
+    });
+  });
+
+  it("fails with polling-timeout when transient polling errors consume budget", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-7b",
+            status: { state: "RUNNING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+      .mockImplementation(async () => {
+        return new Response(JSON.stringify({ message: "rate limited" }), {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        });
+      });
+
+    const client = new DatabricksSqlClient({
+      config: {
+        host: "https://dbc-example.cloud.databricks.com",
+        token: "dapi-test",
+        warehouseId: "wh-1",
+        timeoutMs: 10_000,
+        retryCount: 0,
+        pollingIntervalMs: 500,
+        maxPollingWaitMs: 300,
+        allowedCatalogs: [],
+        allowedSchemas: [],
+        readOnly: true,
+      },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    await expect(
+      client.executeStatement({
+        statement: "SELECT 1",
+        warehouseId: "wh-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "POLLING_TIMEOUT",
+    });
+  });
+
+  it("fails with polling timeout when transient polling timeouts consume budget", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-8",
+            status: { state: "PENDING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+      .mockImplementation(async () => {
+        throw new DOMException("aborted", "AbortError");
+      });
+
+    const client = new DatabricksSqlClient({
+      config: {
+        host: "https://dbc-example.cloud.databricks.com",
+        token: "dapi-test",
+        warehouseId: "wh-1",
+        timeoutMs: 1_000,
+        retryCount: 0,
+        pollingIntervalMs: 500,
+        maxPollingWaitMs: 300,
+        allowedCatalogs: [],
+        allowedSchemas: [],
+        readOnly: true,
+      },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    await expect(
+      client.executeStatement({
+        statement: "SELECT 1",
+        warehouseId: "wh-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "POLLING_TIMEOUT",
+    });
+  });
 });

--- a/extensions/databricks/src/client.ts
+++ b/extensions/databricks/src/client.ts
@@ -1,6 +1,11 @@
 import type { PluginLogger } from "openclaw/plugin-sdk/core";
 import type { ResolvedDatabricksRuntimeConfig } from "./config.js";
-import { DatabricksHttpError, normalizeDatabricksError, isRetryableStatus } from "./errors.js";
+import {
+  DatabricksError,
+  DatabricksHttpError,
+  normalizeDatabricksError,
+  isRetryableStatus,
+} from "./errors.js";
 import { logDatabricks } from "./logger.js";
 
 type DatabricksFetch = typeof fetch;
@@ -10,6 +15,16 @@ type DatabricksSqlRequest = {
   warehouseId: string;
   catalog?: string;
   schema?: string;
+};
+
+type DatabricksSqlStatus = "PENDING" | "RUNNING" | "QUEUED" | "SUCCEEDED" | "FAILED" | "CANCELED";
+
+type DatabricksStatementPayload = {
+  statement_id?: string;
+  status?: {
+    state?: string;
+  };
+  [key: string]: unknown;
 };
 
 type RetryOptions = {
@@ -79,6 +94,32 @@ function buildBackoffMs(attempt: number, retry: RetryOptions): number {
   return Math.min(exponential, 2_000);
 }
 
+function getStatementStatus(payload: unknown): DatabricksSqlStatus | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const statusValue = (payload as DatabricksStatementPayload).status?.state;
+  if (typeof statusValue !== "string") {
+    return null;
+  }
+  const normalized = statusValue.toUpperCase();
+  if (
+    normalized === "PENDING" ||
+    normalized === "RUNNING" ||
+    normalized === "QUEUED" ||
+    normalized === "SUCCEEDED" ||
+    normalized === "FAILED" ||
+    normalized === "CANCELED"
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+function isPendingStatus(status: DatabricksSqlStatus | null): boolean {
+  return status === "PENDING" || status === "RUNNING" || status === "QUEUED";
+}
+
 export class DatabricksSqlClient {
   private readonly fetchImpl: DatabricksFetch;
   private readonly sleep: (ms: number) => Promise<void>;
@@ -144,12 +185,19 @@ export class DatabricksSqlClient {
           }
           throw error;
         }
-        return payload;
+        return this.resolveFinalStatementPayload(payload);
       } catch (error) {
         const normalized = normalizeDatabricksError(
           error,
           `Databricks SQL request timed out after ${this.config.timeoutMs}ms.`,
         );
+        if (normalized.code === "TIMEOUT") {
+          throw new DatabricksError({
+            code: "STATEMENT_TIMEOUT",
+            message: normalized.message,
+            retryable: normalized.retryable,
+          });
+        }
         if (shouldRetry({ attempt, retry }) && normalized.retryable) {
           const delayMs = buildBackoffMs(attempt, retry);
           logDatabricks(this.logger, "warn", "Retrying SQL API request after transient error.", {
@@ -170,6 +218,100 @@ export class DatabricksSqlClient {
       message: "Databricks SQL request exhausted retry attempts.",
       retryable: false,
     });
+  }
+
+  private async pollStatement(statementId: string): Promise<unknown> {
+    const startedAt = Date.now();
+    const endpoint = `${this.config.host}/api/2.0/sql/statements/${encodeURIComponent(statementId)}`;
+
+    while (Date.now() - startedAt <= this.config.maxPollingWaitMs) {
+      const elapsedMs = Date.now() - startedAt;
+      const remainingMs = this.config.maxPollingWaitMs - elapsedMs;
+      const requestTimeoutMs = Math.max(1_000, Math.min(this.config.timeoutMs, remainingMs));
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+      try {
+        const response = await this.fetchImpl(endpoint, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${this.config.token}`,
+          },
+          signal: controller.signal,
+        });
+        const payload = await parseResponsePayload(response);
+        if (!response.ok) {
+          const message = toErrorMessage(
+            payload,
+            `Databricks statement polling failed with status ${response.status}.`,
+          );
+          throw new DatabricksHttpError({
+            statusCode: response.status,
+            message,
+          });
+        }
+
+        const status = getStatementStatus(payload);
+        if (!isPendingStatus(status)) {
+          return payload;
+        }
+
+        const delayMs = Math.min(this.config.pollingIntervalMs, Math.max(0, remainingMs));
+        logDatabricks(this.logger, "debug", "Polling Databricks statement status.", {
+          statementId,
+          status,
+          delayMs,
+          elapsedMs,
+        });
+        await this.sleep(delayMs);
+      } catch (error) {
+        const normalized = normalizeDatabricksError(
+          error,
+          `Databricks statement polling timed out after ${requestTimeoutMs}ms.`,
+        );
+        if (normalized.code === "TIMEOUT") {
+          throw new DatabricksError({
+            code: "POLLING_TIMEOUT",
+            message: normalized.message,
+            retryable: true,
+          });
+        }
+        throw normalized;
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+
+    throw new DatabricksError({
+      code: "STATEMENT_PENDING_MAX_WAIT",
+      message: `Databricks statement is still pending after ${this.config.maxPollingWaitMs}ms.`,
+      retryable: false,
+      details: {
+        maxPollingWaitMs: this.config.maxPollingWaitMs,
+        pollingIntervalMs: this.config.pollingIntervalMs,
+      },
+    });
+  }
+
+  private async resolveFinalStatementPayload(initialPayload: unknown): Promise<unknown> {
+    const status = getStatementStatus(initialPayload);
+    if (!isPendingStatus(status)) {
+      return initialPayload;
+    }
+
+    const statementId =
+      initialPayload && typeof initialPayload === "object"
+        ? (initialPayload as DatabricksStatementPayload).statement_id
+        : undefined;
+    if (!statementId || typeof statementId !== "string") {
+      throw new DatabricksError({
+        code: "POLLING_TIMEOUT",
+        message: "Databricks statement is pending, but statement_id is missing for polling.",
+        retryable: false,
+      });
+    }
+
+    return this.pollStatement(statementId);
   }
 }
 

--- a/extensions/databricks/src/client.ts
+++ b/extensions/databricks/src/client.ts
@@ -120,6 +120,16 @@ function isPendingStatus(status: DatabricksSqlStatus | null): boolean {
   return status === "PENDING" || status === "RUNNING" || status === "QUEUED";
 }
 
+function buildTransientPollingDelayMs(params: {
+  attempt: number;
+  pollingIntervalMs: number;
+  remainingMs: number;
+}): number {
+  const base = Math.max(200, params.pollingIntervalMs);
+  const delayMs = Math.min(base * 2 ** Math.max(0, params.attempt - 1), 2_000);
+  return Math.max(0, Math.min(delayMs, params.remainingMs));
+}
+
 export class DatabricksSqlClient {
   private readonly fetchImpl: DatabricksFetch;
   private readonly sleep: (ms: number) => Promise<void>;
@@ -222,11 +232,16 @@ export class DatabricksSqlClient {
 
   private async pollStatement(statementId: string): Promise<unknown> {
     const startedAt = Date.now();
+    let transientAttempt = 0;
+    let exhaustedByTransientErrors = false;
     const endpoint = `${this.config.host}/api/2.0/sql/statements/${encodeURIComponent(statementId)}`;
 
     while (Date.now() - startedAt <= this.config.maxPollingWaitMs) {
       const elapsedMs = Date.now() - startedAt;
       const remainingMs = this.config.maxPollingWaitMs - elapsedMs;
+      if (remainingMs <= 0) {
+        break;
+      }
       const requestTimeoutMs = Math.max(1_000, Math.min(this.config.timeoutMs, remainingMs));
 
       const controller = new AbortController();
@@ -245,13 +260,41 @@ export class DatabricksSqlClient {
             payload,
             `Databricks statement polling failed with status ${response.status}.`,
           );
-          throw new DatabricksHttpError({
+          const error = new DatabricksHttpError({
             statusCode: response.status,
             message,
           });
+          if (error.retryable) {
+            transientAttempt += 1;
+            exhaustedByTransientErrors = true;
+            const delayMs = buildTransientPollingDelayMs({
+              attempt: transientAttempt,
+              pollingIntervalMs: this.config.pollingIntervalMs,
+              remainingMs,
+            });
+            if (delayMs <= 0) {
+              throw new DatabricksError({
+                code: "POLLING_TIMEOUT",
+                message:
+                  "Databricks statement polling exceeded time budget while handling transient errors.",
+                retryable: false,
+              });
+            }
+            logDatabricks(this.logger, "warn", "Transient polling HTTP error; retrying.", {
+              statementId,
+              statusCode: response.status,
+              transientAttempt,
+              delayMs,
+            });
+            await this.sleep(delayMs);
+            continue;
+          }
+          throw error;
         }
 
         const status = getStatementStatus(payload);
+        transientAttempt = 0;
+        exhaustedByTransientErrors = false;
         if (!isPendingStatus(status)) {
           return payload;
         }
@@ -269,17 +312,44 @@ export class DatabricksSqlClient {
           error,
           `Databricks statement polling timed out after ${requestTimeoutMs}ms.`,
         );
-        if (normalized.code === "TIMEOUT") {
-          throw new DatabricksError({
-            code: "POLLING_TIMEOUT",
-            message: normalized.message,
-            retryable: true,
+        if (normalized.retryable) {
+          transientAttempt += 1;
+          exhaustedByTransientErrors = true;
+          const delayMs = buildTransientPollingDelayMs({
+            attempt: transientAttempt,
+            pollingIntervalMs: this.config.pollingIntervalMs,
+            remainingMs,
           });
+          if (delayMs <= 0) {
+            throw new DatabricksError({
+              code: "POLLING_TIMEOUT",
+              message:
+                "Databricks statement polling exceeded time budget while handling transient errors.",
+              retryable: false,
+            });
+          }
+          logDatabricks(this.logger, "warn", "Transient polling error; retrying.", {
+            statementId,
+            code: normalized.code,
+            transientAttempt,
+            delayMs,
+          });
+          await this.sleep(delayMs);
+          continue;
         }
         throw normalized;
       } finally {
         clearTimeout(timeout);
       }
+    }
+
+    if (exhaustedByTransientErrors) {
+      throw new DatabricksError({
+        code: "POLLING_TIMEOUT",
+        message:
+          "Databricks statement polling exceeded time budget while handling transient errors.",
+        retryable: false,
+      });
     }
 
     throw new DatabricksError({

--- a/extensions/databricks/src/client.ts
+++ b/extensions/databricks/src/client.ts
@@ -1,0 +1,182 @@
+import type { PluginLogger } from "openclaw/plugin-sdk/core";
+import type { ResolvedDatabricksRuntimeConfig } from "./config.js";
+import { DatabricksHttpError, normalizeDatabricksError, isRetryableStatus } from "./errors.js";
+import { logDatabricks } from "./logger.js";
+
+type DatabricksFetch = typeof fetch;
+
+type DatabricksSqlRequest = {
+  statement: string;
+  warehouseId: string;
+  catalog?: string;
+  schema?: string;
+};
+
+type RetryOptions = {
+  maxAttempts: number;
+  minDelayMs: number;
+};
+
+type DatabricksClientDeps = {
+  fetchImpl?: DatabricksFetch;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+function toErrorMessage(payload: unknown, fallback: string): string {
+  if (payload && typeof payload === "object") {
+    const asRecord = payload as Record<string, unknown>;
+    const message = asRecord.message;
+    if (typeof message === "string" && message.trim()) {
+      return message.trim();
+    }
+    const errorMessage = asRecord.error_message;
+    if (typeof errorMessage === "string" && errorMessage.trim()) {
+      return errorMessage.trim();
+    }
+  }
+  return fallback;
+}
+
+async function parseResponsePayload(response: Response): Promise<unknown> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.toLowerCase().includes("application/json")) {
+    return response.json();
+  }
+  const text = await response.text();
+  if (!text.trim()) {
+    return {};
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { message: text };
+  }
+}
+
+function buildRetryOptions(retryCount: number): RetryOptions {
+  return {
+    maxAttempts: Math.max(1, retryCount + 1),
+    minDelayMs: 250,
+  };
+}
+
+function shouldRetry(params: {
+  statusCode?: number;
+  attempt: number;
+  retry: RetryOptions;
+}): boolean {
+  if (params.attempt >= params.retry.maxAttempts) {
+    return false;
+  }
+  if (params.statusCode === undefined) {
+    return true;
+  }
+  return isRetryableStatus(params.statusCode);
+}
+
+function buildBackoffMs(attempt: number, retry: RetryOptions): number {
+  const exponential = retry.minDelayMs * 2 ** Math.max(0, attempt - 1);
+  return Math.min(exponential, 2_000);
+}
+
+export class DatabricksSqlClient {
+  private readonly fetchImpl: DatabricksFetch;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly config: ResolvedDatabricksRuntimeConfig;
+  private readonly logger: PluginLogger;
+
+  constructor(params: {
+    config: ResolvedDatabricksRuntimeConfig;
+    logger: PluginLogger;
+    deps?: DatabricksClientDeps;
+  }) {
+    this.config = params.config;
+    this.logger = params.logger;
+    this.fetchImpl = params.deps?.fetchImpl ?? fetch;
+    this.sleep =
+      params.deps?.sleep ??
+      ((ms: number) => new Promise((resolve) => setTimeout(resolve, Math.max(0, ms))));
+  }
+
+  async executeStatement(request: DatabricksSqlRequest): Promise<unknown> {
+    const retry = buildRetryOptions(this.config.retryCount);
+    const endpoint = `${this.config.host}/api/2.0/sql/statements`;
+    const body = {
+      statement: request.statement,
+      warehouse_id: request.warehouseId,
+      disposition: "INLINE",
+      ...(request.catalog ? { catalog: request.catalog } : {}),
+      ...(request.schema ? { schema: request.schema } : {}),
+    };
+
+    for (let attempt = 1; attempt <= retry.maxAttempts; attempt += 1) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), this.config.timeoutMs);
+      try {
+        const response = await this.fetchImpl(endpoint, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${this.config.token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+        const payload = await parseResponsePayload(response);
+        if (!response.ok) {
+          const message = toErrorMessage(
+            payload,
+            `Databricks SQL API request failed with status ${response.status}.`,
+          );
+          const error = new DatabricksHttpError({
+            statusCode: response.status,
+            message,
+          });
+          if (shouldRetry({ statusCode: response.status, attempt, retry })) {
+            const delayMs = buildBackoffMs(attempt, retry);
+            logDatabricks(this.logger, "warn", "Retrying SQL API request after HTTP error.", {
+              statusCode: response.status,
+              attempt,
+              delayMs,
+            });
+            await this.sleep(delayMs);
+            continue;
+          }
+          throw error;
+        }
+        return payload;
+      } catch (error) {
+        const normalized = normalizeDatabricksError(
+          error,
+          `Databricks SQL request timed out after ${this.config.timeoutMs}ms.`,
+        );
+        if (shouldRetry({ attempt, retry }) && normalized.retryable) {
+          const delayMs = buildBackoffMs(attempt, retry);
+          logDatabricks(this.logger, "warn", "Retrying SQL API request after transient error.", {
+            code: normalized.code,
+            attempt,
+            delayMs,
+          });
+          await this.sleep(delayMs);
+          continue;
+        }
+        throw normalized;
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+    throw new DatabricksHttpError({
+      statusCode: 500,
+      message: "Databricks SQL request exhausted retry attempts.",
+      retryable: false,
+    });
+  }
+}
+
+export function createDatabricksSqlClient(params: {
+  config: ResolvedDatabricksRuntimeConfig;
+  logger: PluginLogger;
+  deps?: DatabricksClientDeps;
+}): DatabricksSqlClient {
+  return new DatabricksSqlClient(params);
+}

--- a/extensions/databricks/src/config.test.ts
+++ b/extensions/databricks/src/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { resolveDatabricksRuntimeConfig } from "./config.js";
+import { DatabricksConfigError } from "./errors.js";
+
+describe("databricks config", () => {
+  it("resolves required config and defaults", () => {
+    const resolved = resolveDatabricksRuntimeConfig({
+      rawConfig: {
+        host: "dbc-example.cloud.databricks.com",
+        token: "dapi-test-token",
+        warehouseId: "abc123",
+      },
+      env: {},
+    });
+
+    expect(resolved.host).toBe("https://dbc-example.cloud.databricks.com");
+    expect(resolved.timeoutMs).toBe(30_000);
+    expect(resolved.retryCount).toBe(1);
+    expect(resolved.readOnly).toBe(true);
+  });
+
+  it("uses environment fallback values", () => {
+    const resolved = resolveDatabricksRuntimeConfig({
+      rawConfig: {},
+      env: {
+        DATABRICKS_HOST: "https://dbc-env.cloud.databricks.com",
+        DATABRICKS_TOKEN: "dapi-env",
+        DATABRICKS_WAREHOUSE_ID: "wh-env",
+      },
+    });
+
+    expect(resolved.host).toBe("https://dbc-env.cloud.databricks.com");
+    expect(resolved.token).toBe("dapi-env");
+    expect(resolved.warehouseId).toBe("wh-env");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() =>
+      resolveDatabricksRuntimeConfig({
+        rawConfig: {
+          host: "https://dbc-example.cloud.databricks.com",
+          warehouseId: "abc123",
+        },
+        env: {},
+      }),
+    ).toThrow(DatabricksConfigError);
+  });
+
+  it("rejects readOnly=false", () => {
+    expect(() =>
+      resolveDatabricksRuntimeConfig({
+        rawConfig: {
+          host: "https://dbc-example.cloud.databricks.com",
+          token: "dapi-test-token",
+          warehouseId: "abc123",
+          readOnly: false,
+        },
+        env: {},
+      }),
+    ).toThrow("Only readOnly=true is supported");
+  });
+});

--- a/extensions/databricks/src/config.test.ts
+++ b/extensions/databricks/src/config.test.ts
@@ -16,6 +16,10 @@ describe("databricks config", () => {
     expect(resolved.host).toBe("https://dbc-example.cloud.databricks.com");
     expect(resolved.timeoutMs).toBe(30_000);
     expect(resolved.retryCount).toBe(1);
+    expect(resolved.pollingIntervalMs).toBe(1_000);
+    expect(resolved.maxPollingWaitMs).toBe(30_000);
+    expect(resolved.allowedCatalogs).toEqual([]);
+    expect(resolved.allowedSchemas).toEqual([]);
     expect(resolved.readOnly).toBe(true);
   });
 
@@ -58,5 +62,21 @@ describe("databricks config", () => {
         env: {},
       }),
     ).toThrow("Only readOnly=true is supported");
+  });
+
+  it("normalizes allowlists", () => {
+    const resolved = resolveDatabricksRuntimeConfig({
+      rawConfig: {
+        host: "https://dbc-example.cloud.databricks.com",
+        token: "dapi-test-token",
+        warehouseId: "abc123",
+        allowedCatalogs: ["Main", " analytics "],
+        allowedSchemas: ["Public"],
+      },
+      env: {},
+    });
+
+    expect(resolved.allowedCatalogs).toEqual(["main", "analytics"]);
+    expect(resolved.allowedSchemas).toEqual(["public"]);
   });
 });

--- a/extensions/databricks/src/config.ts
+++ b/extensions/databricks/src/config.ts
@@ -8,6 +8,8 @@ import { DatabricksConfigError } from "./errors.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_RETRY_COUNT = 1;
+const DEFAULT_POLLING_INTERVAL_MS = 1_000;
+const DEFAULT_MAX_POLLING_WAIT_MS = 30_000;
 
 const DatabricksRuntimeConfigSchema = z.object({
   host: z.string().min(1, { error: "host is required" }),
@@ -23,6 +25,18 @@ const DatabricksRuntimeConfigSchema = z.object({
     .int({ error: "retryCount must be an integer between 0 and 3" })
     .min(0, { error: "retryCount must be >= 0" })
     .max(3, { error: "retryCount must be <= 3" }),
+  pollingIntervalMs: z
+    .number({ error: "pollingIntervalMs must be a number between 200 and 5000" })
+    .int({ error: "pollingIntervalMs must be an integer between 200 and 5000" })
+    .min(200, { error: "pollingIntervalMs must be >= 200" })
+    .max(5_000, { error: "pollingIntervalMs must be <= 5000" }),
+  maxPollingWaitMs: z
+    .number({ error: "maxPollingWaitMs must be a number between 1000 and 120000" })
+    .int({ error: "maxPollingWaitMs must be an integer between 1000 and 120000" })
+    .min(1_000, { error: "maxPollingWaitMs must be >= 1000" })
+    .max(120_000, { error: "maxPollingWaitMs must be <= 120000" }),
+  allowedCatalogs: z.array(z.string().min(1)).default([]),
+  allowedSchemas: z.array(z.string().min(1)).default([]),
   readOnly: z.literal(true, {
     error: "Only readOnly=true is supported in this Databricks runtime iteration.",
   }),
@@ -36,6 +50,10 @@ type DatabricksPluginConfig = {
   warehouseId?: unknown;
   timeoutMs?: unknown;
   retryCount?: unknown;
+  pollingIntervalMs?: unknown;
+  maxPollingWaitMs?: unknown;
+  allowedCatalogs?: unknown;
+  allowedSchemas?: unknown;
   readOnly?: unknown;
 };
 
@@ -78,6 +96,30 @@ function normalizeTimeoutMs(value: unknown): number {
   return Math.floor(value);
 }
 
+function normalizePollingIntervalMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_POLLING_INTERVAL_MS;
+  }
+  return Math.floor(value);
+}
+
+function normalizeMaxPollingWaitMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_MAX_POLLING_WAIT_MS;
+  }
+  return Math.floor(value);
+}
+
+function normalizeAllowlistValues(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+}
+
 export function resolveDatabricksPluginRawConfig(
   config?: OpenClawConfig,
 ): DatabricksPluginConfig | undefined {
@@ -118,6 +160,10 @@ export function resolveDatabricksRuntimeConfig(params: {
 
   const timeoutMs = normalizeTimeoutMs(candidate?.timeoutMs);
   const retryCount = normalizeRetryCount(candidate?.retryCount);
+  const pollingIntervalMs = normalizePollingIntervalMs(candidate?.pollingIntervalMs);
+  const maxPollingWaitMs = normalizeMaxPollingWaitMs(candidate?.maxPollingWaitMs);
+  const allowedCatalogs = normalizeAllowlistValues(candidate?.allowedCatalogs);
+  const allowedSchemas = normalizeAllowlistValues(candidate?.allowedSchemas);
   const readOnly =
     typeof candidate?.readOnly === "boolean"
       ? candidate.readOnly
@@ -129,6 +175,10 @@ export function resolveDatabricksRuntimeConfig(params: {
     warehouseId: warehouseId ?? "",
     timeoutMs,
     retryCount,
+    pollingIntervalMs,
+    maxPollingWaitMs,
+    allowedCatalogs,
+    allowedSchemas,
     readOnly,
   });
   if (!parsed.success) {

--- a/extensions/databricks/src/config.ts
+++ b/extensions/databricks/src/config.ts
@@ -1,0 +1,139 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  normalizeResolvedSecretInputString,
+  normalizeSecretInput,
+} from "openclaw/plugin-sdk/secret-input";
+import { z } from "zod";
+import { DatabricksConfigError } from "./errors.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_RETRY_COUNT = 1;
+
+const DatabricksRuntimeConfigSchema = z.object({
+  host: z.string().min(1, { error: "host is required" }),
+  token: z.string().min(1, { error: "token is required" }),
+  warehouseId: z.string().min(1, { error: "warehouseId is required" }),
+  timeoutMs: z
+    .number({ error: "timeoutMs must be a number between 1000 and 120000" })
+    .int({ error: "timeoutMs must be an integer between 1000 and 120000" })
+    .min(1_000, { error: "timeoutMs must be >= 1000" })
+    .max(120_000, { error: "timeoutMs must be <= 120000" }),
+  retryCount: z
+    .number({ error: "retryCount must be a number between 0 and 3" })
+    .int({ error: "retryCount must be an integer between 0 and 3" })
+    .min(0, { error: "retryCount must be >= 0" })
+    .max(3, { error: "retryCount must be <= 3" }),
+  readOnly: z.literal(true, {
+    error: "Only readOnly=true is supported in this Databricks runtime iteration.",
+  }),
+});
+
+export type ResolvedDatabricksRuntimeConfig = z.infer<typeof DatabricksRuntimeConfigSchema>;
+
+type DatabricksPluginConfig = {
+  host?: unknown;
+  token?: unknown;
+  warehouseId?: unknown;
+  timeoutMs?: unknown;
+  retryCount?: unknown;
+  readOnly?: unknown;
+};
+
+function normalizeOptionalString(value: unknown, path: string): string | undefined {
+  const resolved = normalizeResolvedSecretInputString({ value, path });
+  return normalizeSecretInput(resolved) || undefined;
+}
+
+function normalizeHost(rawHost: string): string {
+  const prefixed = /^https?:\/\//i.test(rawHost) ? rawHost : `https://${rawHost}`;
+  let url: URL;
+  try {
+    url = new URL(prefixed);
+  } catch {
+    throw new DatabricksConfigError("Invalid databricks host URL.");
+  }
+  if (url.protocol !== "https:") {
+    throw new DatabricksConfigError("Databricks host must use HTTPS.");
+  }
+  if (url.pathname && url.pathname !== "/") {
+    throw new DatabricksConfigError("Databricks host must not include a path.");
+  }
+  url.pathname = "";
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/+$/u, "");
+}
+
+function normalizeRetryCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_RETRY_COUNT;
+  }
+  return Math.floor(value);
+}
+
+function normalizeTimeoutMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+  return Math.floor(value);
+}
+
+export function resolveDatabricksPluginRawConfig(
+  config?: OpenClawConfig,
+): DatabricksPluginConfig | undefined {
+  const entry = config?.plugins?.entries?.databricks?.config;
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return undefined;
+  }
+  return entry as DatabricksPluginConfig;
+}
+
+export function resolveDatabricksRuntimeConfig(params: {
+  rawConfig?: unknown;
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): ResolvedDatabricksRuntimeConfig {
+  const env = params.env ?? process.env;
+  const fromOpenClawConfig = resolveDatabricksPluginRawConfig(params.config);
+  const candidate =
+    params.rawConfig && typeof params.rawConfig === "object" && !Array.isArray(params.rawConfig)
+      ? (params.rawConfig as DatabricksPluginConfig)
+      : fromOpenClawConfig;
+
+  const host =
+    normalizeOptionalString(candidate?.host, "plugins.entries.databricks.config.host") ||
+    normalizeSecretInput(env.DATABRICKS_HOST || "") ||
+    undefined;
+  const token =
+    normalizeOptionalString(candidate?.token, "plugins.entries.databricks.config.token") ||
+    normalizeSecretInput(env.DATABRICKS_TOKEN || "") ||
+    undefined;
+  const warehouseId =
+    normalizeOptionalString(
+      candidate?.warehouseId,
+      "plugins.entries.databricks.config.warehouseId",
+    ) ||
+    normalizeSecretInput(env.DATABRICKS_WAREHOUSE_ID || "") ||
+    undefined;
+
+  const timeoutMs = normalizeTimeoutMs(candidate?.timeoutMs);
+  const retryCount = normalizeRetryCount(candidate?.retryCount);
+  const readOnly =
+    typeof candidate?.readOnly === "boolean"
+      ? candidate.readOnly
+      : normalizeSecretInput(env.DATABRICKS_READ_ONLY || "").toLowerCase() !== "false";
+
+  const parsed = DatabricksRuntimeConfigSchema.safeParse({
+    host: host ? normalizeHost(host) : "",
+    token: token ?? "",
+    warehouseId: warehouseId ?? "",
+    timeoutMs,
+    retryCount,
+    readOnly,
+  });
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw new DatabricksConfigError(issue?.message ?? "Invalid Databricks plugin configuration.");
+  }
+  return parsed.data;
+}

--- a/extensions/databricks/src/errors.test.ts
+++ b/extensions/databricks/src/errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  DatabricksAllowlistError,
   DatabricksError,
   DatabricksHttpError,
   isRetryableStatus,
@@ -39,5 +40,11 @@ describe("databricks errors", () => {
     });
     const normalized = normalizeDatabricksError(original, "fallback");
     expect(normalized).toBe(original);
+  });
+
+  it("creates allowlist violation error", () => {
+    const error = new DatabricksAllowlistError("catalog blocked");
+    expect(error.code).toBe("ALLOWLIST_VIOLATION");
+    expect(error.retryable).toBe(false);
   });
 });

--- a/extensions/databricks/src/errors.test.ts
+++ b/extensions/databricks/src/errors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  DatabricksError,
+  DatabricksHttpError,
+  isRetryableStatus,
+  normalizeDatabricksError,
+} from "./errors.js";
+
+describe("databricks errors", () => {
+  it("maps retryable status codes", () => {
+    expect(isRetryableStatus(429)).toBe(true);
+    expect(isRetryableStatus(503)).toBe(true);
+    expect(isRetryableStatus(400)).toBe(false);
+  });
+
+  it("creates typed http errors", () => {
+    const error = new DatabricksHttpError({
+      statusCode: 401,
+      message: "Unauthorized",
+    });
+    expect(error.code).toBe("UNAUTHORIZED");
+    expect(error.retryable).toBe(false);
+    expect(error.statusCode).toBe(401);
+  });
+
+  it("normalizes abort errors into TIMEOUT", () => {
+    const error = normalizeDatabricksError(
+      new DOMException("The operation was aborted.", "AbortError"),
+      "timeout",
+    );
+    expect(error.code).toBe("TIMEOUT");
+    expect(error.retryable).toBe(true);
+  });
+
+  it("passes through DatabricksError instances", () => {
+    const original = new DatabricksError({
+      code: "POLICY_VIOLATION",
+      message: "blocked",
+    });
+    const normalized = normalizeDatabricksError(original, "fallback");
+    expect(normalized).toBe(original);
+  });
+});

--- a/extensions/databricks/src/errors.ts
+++ b/extensions/databricks/src/errors.ts
@@ -1,8 +1,12 @@
 export type DatabricksErrorCode =
   | "CONFIG_ERROR"
   | "POLICY_VIOLATION"
+  | "ALLOWLIST_VIOLATION"
   | "REQUEST_ERROR"
   | "TIMEOUT"
+  | "STATEMENT_TIMEOUT"
+  | "POLLING_TIMEOUT"
+  | "STATEMENT_PENDING_MAX_WAIT"
   | "UNAUTHORIZED"
   | "RATE_LIMIT"
   | "HTTP_ERROR"
@@ -52,6 +56,18 @@ export class DatabricksPolicyError extends DatabricksError {
       details,
     });
     this.name = "DatabricksPolicyError";
+  }
+}
+
+export class DatabricksAllowlistError extends DatabricksError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super({
+      code: "ALLOWLIST_VIOLATION",
+      message,
+      retryable: false,
+      details,
+    });
+    this.name = "DatabricksAllowlistError";
   }
 }
 

--- a/extensions/databricks/src/errors.ts
+++ b/extensions/databricks/src/errors.ts
@@ -1,0 +1,124 @@
+export type DatabricksErrorCode =
+  | "CONFIG_ERROR"
+  | "POLICY_VIOLATION"
+  | "REQUEST_ERROR"
+  | "TIMEOUT"
+  | "UNAUTHORIZED"
+  | "RATE_LIMIT"
+  | "HTTP_ERROR"
+  | "TRANSIENT_ERROR"
+  | "UNKNOWN_ERROR";
+
+export class DatabricksError extends Error {
+  readonly code: DatabricksErrorCode;
+  readonly statusCode?: number;
+  readonly retryable: boolean;
+  readonly details?: Record<string, unknown>;
+
+  constructor(params: {
+    code: DatabricksErrorCode;
+    message: string;
+    retryable?: boolean;
+    statusCode?: number;
+    details?: Record<string, unknown>;
+  }) {
+    super(params.message);
+    this.name = "DatabricksError";
+    this.code = params.code;
+    this.retryable = params.retryable ?? false;
+    this.statusCode = params.statusCode;
+    this.details = params.details;
+  }
+}
+
+export class DatabricksConfigError extends DatabricksError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super({
+      code: "CONFIG_ERROR",
+      message,
+      retryable: false,
+      details,
+    });
+    this.name = "DatabricksConfigError";
+  }
+}
+
+export class DatabricksPolicyError extends DatabricksError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super({
+      code: "POLICY_VIOLATION",
+      message,
+      retryable: false,
+      details,
+    });
+    this.name = "DatabricksPolicyError";
+  }
+}
+
+export class DatabricksHttpError extends DatabricksError {
+  constructor(params: {
+    statusCode: number;
+    message: string;
+    retryable?: boolean;
+    details?: Record<string, unknown>;
+  }) {
+    const code = mapStatusToErrorCode(params.statusCode);
+    super({
+      code,
+      message: params.message,
+      statusCode: params.statusCode,
+      retryable: params.retryable ?? isRetryableStatus(params.statusCode),
+      details: params.details,
+    });
+    this.name = "DatabricksHttpError";
+  }
+}
+
+export function isRetryableStatus(statusCode: number): boolean {
+  return statusCode === 429 || statusCode === 408 || statusCode >= 500;
+}
+
+function mapStatusToErrorCode(statusCode: number): DatabricksErrorCode {
+  if (statusCode === 401 || statusCode === 403) {
+    return "UNAUTHORIZED";
+  }
+  if (statusCode === 429) {
+    return "RATE_LIMIT";
+  }
+  if (statusCode === 408 || statusCode >= 500) {
+    return "TRANSIENT_ERROR";
+  }
+  return "HTTP_ERROR";
+}
+
+function isAbortError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.name === "AbortError" || /aborted|abort/i.test(error.message);
+}
+
+export function normalizeDatabricksError(error: unknown, fallbackMessage: string): DatabricksError {
+  if (error instanceof DatabricksError) {
+    return error;
+  }
+  if (isAbortError(error)) {
+    return new DatabricksError({
+      code: "TIMEOUT",
+      message: fallbackMessage,
+      retryable: true,
+    });
+  }
+  if (error instanceof Error) {
+    return new DatabricksError({
+      code: "UNKNOWN_ERROR",
+      message: error.message || fallbackMessage,
+      retryable: false,
+    });
+  }
+  return new DatabricksError({
+    code: "UNKNOWN_ERROR",
+    message: fallbackMessage,
+    retryable: false,
+  });
+}

--- a/extensions/databricks/src/logger.ts
+++ b/extensions/databricks/src/logger.ts
@@ -1,0 +1,76 @@
+import type { PluginLogger } from "openclaw/plugin-sdk/core";
+
+function redactToken(value: string): string {
+  if (!value) {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length <= 8) {
+    return "***";
+  }
+  return `${trimmed.slice(0, 4)}***${trimmed.slice(-3)}`;
+}
+
+function redactBearerTokens(value: string): string {
+  return value.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, (match) => {
+    const token = match.replace(/^Bearer\s+/i, "");
+    return `Bearer ${redactToken(token)}`;
+  });
+}
+
+function sanitizeString(value: string, token?: string): string {
+  let sanitized = redactBearerTokens(value);
+  if (token) {
+    sanitized = sanitized.split(token).join(redactToken(token));
+  }
+  return sanitized;
+}
+
+export function sanitizeLogValue(value: unknown, token?: string): unknown {
+  if (typeof value === "string") {
+    return sanitizeString(value, token);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeLogValue(entry, token));
+  }
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      const lowerKey = key.toLowerCase();
+      if (lowerKey.includes("token") || lowerKey.includes("authorization")) {
+        result[key] = "***";
+      } else {
+        result[key] = sanitizeLogValue(nested, token);
+      }
+    }
+    return result;
+  }
+  return value;
+}
+
+export function formatLogMessage(
+  message: string,
+  context?: Record<string, unknown>,
+  token?: string,
+): string {
+  const safeMessage = sanitizeString(message, token);
+  if (!context || Object.keys(context).length === 0) {
+    return safeMessage;
+  }
+  return `${safeMessage} ${JSON.stringify(sanitizeLogValue(context, token))}`;
+}
+
+export function logDatabricks(
+  logger: PluginLogger,
+  level: "debug" | "info" | "warn" | "error",
+  message: string,
+  context?: Record<string, unknown>,
+  token?: string,
+) {
+  const payload = `[databricks] ${formatLogMessage(message, context, token)}`;
+  if (level === "debug") {
+    logger.debug?.(payload);
+    return;
+  }
+  logger[level](payload);
+}

--- a/extensions/databricks/src/operations/sql.ts
+++ b/extensions/databricks/src/operations/sql.ts
@@ -10,6 +10,7 @@ import { resolveDatabricksRuntimeConfig } from "../config.js";
 import { DatabricksPolicyError } from "../errors.js";
 import { logDatabricks } from "../logger.js";
 import { assertAllowlistTarget, assertReadOnlySqlStatement } from "../security-policy.js";
+import { resolveSqlTargets } from "../sql-target-resolution.js";
 
 const DatabricksReadOnlySqlToolSchema = Type.Object(
   {
@@ -76,11 +77,11 @@ export function createDatabricksSqlReadOnlyTool(api: OpenClawPluginApi): AnyAgen
       }
 
       const safeSql = assertReadOnlySqlStatement(sql);
+      const targets = resolveSqlTargets(safeSql);
       assertAllowlistTarget({
         allowedCatalogs: config.allowedCatalogs,
         allowedSchemas: config.allowedSchemas,
-        catalog,
-        schema,
+        targets,
       });
       const client = createDatabricksSqlClient({
         config: {

--- a/extensions/databricks/src/operations/sql.ts
+++ b/extensions/databricks/src/operations/sql.ts
@@ -9,7 +9,7 @@ import { createDatabricksSqlClient } from "../client.js";
 import { resolveDatabricksRuntimeConfig } from "../config.js";
 import { DatabricksPolicyError } from "../errors.js";
 import { logDatabricks } from "../logger.js";
-import { assertReadOnlySqlStatement } from "../security-policy.js";
+import { assertAllowlistTarget, assertReadOnlySqlStatement } from "../security-policy.js";
 
 const DatabricksReadOnlySqlToolSchema = Type.Object(
   {
@@ -76,6 +76,12 @@ export function createDatabricksSqlReadOnlyTool(api: OpenClawPluginApi): AnyAgen
       }
 
       const safeSql = assertReadOnlySqlStatement(sql);
+      assertAllowlistTarget({
+        allowedCatalogs: config.allowedCatalogs,
+        allowedSchemas: config.allowedSchemas,
+        catalog,
+        schema,
+      });
       const client = createDatabricksSqlClient({
         config: {
           ...config,

--- a/extensions/databricks/src/operations/sql.ts
+++ b/extensions/databricks/src/operations/sql.ts
@@ -1,0 +1,113 @@
+import { Type } from "@sinclair/typebox";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-search";
+import type { AnyAgentTool, OpenClawPluginApi } from "../../runtime-api.js";
+import { createDatabricksSqlClient } from "../client.js";
+import { resolveDatabricksRuntimeConfig } from "../config.js";
+import { DatabricksPolicyError } from "../errors.js";
+import { logDatabricks } from "../logger.js";
+import { assertReadOnlySqlStatement } from "../security-policy.js";
+
+const DatabricksReadOnlySqlToolSchema = Type.Object(
+  {
+    sql: Type.String({
+      description: "Single read-only SQL statement. Only SELECT or WITH ... SELECT are allowed.",
+      minLength: 1,
+    }),
+    warehouse_id: Type.Optional(
+      Type.String({
+        description: "Optional warehouse override. Defaults to plugin config warehouseId.",
+      }),
+    ),
+    catalog: Type.Optional(
+      Type.String({
+        description: "Optional catalog override used during SQL statement execution.",
+      }),
+    ),
+    schema: Type.Optional(
+      Type.String({
+        description: "Optional schema override used during SQL statement execution.",
+      }),
+    ),
+    timeout_ms: Type.Optional(
+      Type.Number({
+        description: "Per-call timeout override in milliseconds (1000-120000).",
+        minimum: 1000,
+        maximum: 120000,
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export function createDatabricksSqlReadOnlyTool(api: OpenClawPluginApi): AnyAgentTool {
+  return {
+    name: "databricks_sql_readonly",
+    label: "Databricks SQL Read-Only",
+    description:
+      "Execute a single read-only Databricks SQL statement. This runtime only supports SELECT and WITH ... SELECT.",
+    parameters: DatabricksReadOnlySqlToolSchema,
+    execute: async (_toolCallId, rawParams) => {
+      const sql = readStringParam(rawParams, "sql", { required: true });
+      const warehouseOverride = normalizeOptionalString(readStringParam(rawParams, "warehouse_id"));
+      const catalog = normalizeOptionalString(readStringParam(rawParams, "catalog"));
+      const schema = normalizeOptionalString(readStringParam(rawParams, "schema"));
+      const timeoutOverride = readNumberParam(rawParams, "timeout_ms", { integer: true });
+
+      const config = resolveDatabricksRuntimeConfig({
+        rawConfig: api.pluginConfig,
+        config: api.config,
+      });
+      if (!config.readOnly) {
+        throw new DatabricksPolicyError(
+          "Databricks plugin is running in non-read-only mode, but this iteration only supports readOnly=true.",
+        );
+      }
+
+      const safeSql = assertReadOnlySqlStatement(sql);
+      const client = createDatabricksSqlClient({
+        config: {
+          ...config,
+          ...(typeof timeoutOverride === "number" ? { timeoutMs: timeoutOverride } : {}),
+        },
+        logger: api.logger,
+      });
+
+      const startedAt = Date.now();
+      const payload = await client.executeStatement({
+        statement: safeSql,
+        warehouseId: warehouseOverride ?? config.warehouseId,
+        catalog,
+        schema,
+      });
+      const tookMs = Date.now() - startedAt;
+      logDatabricks(api.logger, "info", "Executed read-only Databricks SQL statement.", {
+        tookMs,
+        warehouseId: warehouseOverride ?? config.warehouseId,
+      });
+
+      return jsonResult({
+        provider: "databricks",
+        mode: "read-only",
+        tookMs,
+        request: {
+          warehouseId: warehouseOverride ?? config.warehouseId,
+          catalog,
+          schema,
+        },
+        response: payload,
+      });
+    },
+  };
+}

--- a/extensions/databricks/src/security-policy.test.ts
+++ b/extensions/databricks/src/security-policy.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { DatabricksPolicyError } from "./errors.js";
+import { assertReadOnlySqlStatement } from "./security-policy.js";
+
+describe("databricks read-only sql policy", () => {
+  it("accepts SELECT", () => {
+    const sql = assertReadOnlySqlStatement("SELECT id, name FROM analytics.users;");
+    expect(sql).toBe("SELECT id, name FROM analytics.users");
+  });
+
+  it("accepts WITH ... SELECT", () => {
+    const sql = assertReadOnlySqlStatement(
+      "WITH recent AS (SELECT * FROM events) SELECT * FROM recent",
+    );
+    expect(sql).toContain("WITH recent");
+  });
+
+  it("rejects mutating statement", () => {
+    expect(() => assertReadOnlySqlStatement("SELECT * FROM users; DELETE FROM users")).toThrow(
+      DatabricksPolicyError,
+    );
+  });
+
+  it("rejects non-select statement", () => {
+    expect(() => assertReadOnlySqlStatement("SHOW TABLES")).toThrow(
+      "Read-only SQL must start with SELECT or WITH ... SELECT",
+    );
+  });
+
+  it("rejects insert keyword even when prefixed by with", () => {
+    expect(() =>
+      assertReadOnlySqlStatement("WITH x AS (SELECT 1) INSERT INTO t VALUES (1)"),
+    ).toThrow("disallowed keyword: INSERT");
+  });
+});

--- a/extensions/databricks/src/security-policy.test.ts
+++ b/extensions/databricks/src/security-policy.test.ts
@@ -58,8 +58,14 @@ describe("databricks allowlist policy", () => {
       assertAllowlistTarget({
         allowedCatalogs: ["main"],
         allowedSchemas: ["public"],
-        catalog: "MAIN",
-        schema: "Public",
+        targets: [
+          {
+            catalog: "main",
+            schema: "public",
+            table: "orders",
+            raw: "main.public.orders",
+          },
+        ],
       }),
     ).not.toThrow();
   });
@@ -69,6 +75,7 @@ describe("databricks allowlist policy", () => {
       assertAllowlistTarget({
         allowedCatalogs: ["main"],
         allowedSchemas: [],
+        targets: [],
       }),
     ).toThrow(DatabricksAllowlistError);
   });
@@ -78,8 +85,30 @@ describe("databricks allowlist policy", () => {
       assertAllowlistTarget({
         allowedCatalogs: [],
         allowedSchemas: ["public"],
-        schema: "private",
+        targets: [
+          {
+            schema: "private",
+            table: "events",
+            raw: "private.events",
+          },
+        ],
       }),
     ).toThrow('Schema "private" is not in the configured allowlist');
+  });
+
+  it("rejects schema.table target when catalog allowlist is configured", () => {
+    expect(() =>
+      assertAllowlistTarget({
+        allowedCatalogs: ["main"],
+        allowedSchemas: [],
+        targets: [
+          {
+            schema: "public",
+            table: "events",
+            raw: "public.events",
+          },
+        ],
+      }),
+    ).toThrow("has no explicit catalog");
   });
 });

--- a/extensions/databricks/src/security-policy.test.ts
+++ b/extensions/databricks/src/security-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { DatabricksPolicyError } from "./errors.js";
-import { assertReadOnlySqlStatement } from "./security-policy.js";
+import { DatabricksAllowlistError, DatabricksPolicyError } from "./errors.js";
+import { assertAllowlistTarget, assertReadOnlySqlStatement } from "./security-policy.js";
 
 describe("databricks read-only sql policy", () => {
   it("accepts SELECT", () => {
@@ -31,5 +31,55 @@ describe("databricks read-only sql policy", () => {
     expect(() =>
       assertReadOnlySqlStatement("WITH x AS (SELECT 1) INSERT INTO t VALUES (1)"),
     ).toThrow("disallowed keyword: INSERT");
+  });
+
+  it("accepts sql with comments and unusual whitespace", () => {
+    const sql = assertReadOnlySqlStatement(
+      "  /* lead */\nWITH t AS (\n  SELECT 1 AS id -- row\n)\nSELECT\t*\nFROM t  ; ",
+    );
+    expect(sql).toContain("WITH t AS");
+  });
+
+  it("ignores mutating keywords inside string literals", () => {
+    const sql = assertReadOnlySqlStatement("SELECT 'drop table users' AS note");
+    expect(sql).toBe("SELECT 'drop table users' AS note");
+  });
+
+  it("rejects multiple statements with comments", () => {
+    expect(() => assertReadOnlySqlStatement("SELECT 1; -- comment\nSELECT 2")).toThrow(
+      "single SQL statement",
+    );
+  });
+});
+
+describe("databricks allowlist policy", () => {
+  it("accepts targets inside allowlist", () => {
+    expect(() =>
+      assertAllowlistTarget({
+        allowedCatalogs: ["main"],
+        allowedSchemas: ["public"],
+        catalog: "MAIN",
+        schema: "Public",
+      }),
+    ).not.toThrow();
+  });
+
+  it("fails closed when catalog is required but missing", () => {
+    expect(() =>
+      assertAllowlistTarget({
+        allowedCatalogs: ["main"],
+        allowedSchemas: [],
+      }),
+    ).toThrow(DatabricksAllowlistError);
+  });
+
+  it("rejects non-allowlisted schema", () => {
+    expect(() =>
+      assertAllowlistTarget({
+        allowedCatalogs: [],
+        allowedSchemas: ["public"],
+        schema: "private",
+      }),
+    ).toThrow('Schema "private" is not in the configured allowlist');
   });
 });

--- a/extensions/databricks/src/security-policy.ts
+++ b/extensions/databricks/src/security-policy.ts
@@ -1,4 +1,5 @@
 import { DatabricksAllowlistError, DatabricksPolicyError } from "./errors.js";
+import type { ResolvedSqlTarget } from "./sql-target-resolution.js";
 
 const MUTATING_KEYWORDS = [
   "INSERT",
@@ -120,41 +121,46 @@ export function assertReadOnlySqlStatement(rawSql: string): string {
 export function assertAllowlistTarget(params: {
   allowedCatalogs: readonly string[];
   allowedSchemas: readonly string[];
-  catalog?: string;
-  schema?: string;
+  targets: readonly ResolvedSqlTarget[];
 }) {
   const allowedCatalogs = params.allowedCatalogs.map((entry) => entry.toLowerCase());
   const allowedSchemas = params.allowedSchemas.map((entry) => entry.toLowerCase());
-  const targetCatalog = params.catalog?.trim().toLowerCase();
-  const targetSchema = params.schema?.trim().toLowerCase();
 
   if (allowedCatalogs.length === 0 && allowedSchemas.length === 0) {
     return;
   }
 
-  if (allowedCatalogs.length > 0) {
-    if (!targetCatalog) {
-      throw new DatabricksAllowlistError(
-        "Catalog allowlist is configured, but the query target catalog could not be determined safely.",
-      );
-    }
-    if (!allowedCatalogs.includes(targetCatalog)) {
-      throw new DatabricksAllowlistError(
-        `Catalog "${params.catalog}" is not in the configured allowlist.`,
-      );
-    }
+  if (params.targets.length === 0) {
+    throw new DatabricksAllowlistError(
+      "Allowlist is configured, but query targets could not be determined safely.",
+    );
   }
 
-  if (allowedSchemas.length > 0) {
-    if (!targetSchema) {
-      throw new DatabricksAllowlistError(
-        "Schema allowlist is configured, but the query target schema could not be determined safely.",
-      );
+  for (const target of params.targets) {
+    if (allowedCatalogs.length > 0) {
+      if (!target.catalog) {
+        throw new DatabricksAllowlistError(
+          `Catalog allowlist is configured, but target "${target.raw}" has no explicit catalog.`,
+        );
+      }
+      if (!allowedCatalogs.includes(target.catalog)) {
+        throw new DatabricksAllowlistError(
+          `Catalog "${target.catalog}" is not in the configured allowlist.`,
+        );
+      }
     }
-    if (!allowedSchemas.includes(targetSchema)) {
-      throw new DatabricksAllowlistError(
-        `Schema "${params.schema}" is not in the configured allowlist.`,
-      );
+
+    if (allowedSchemas.length > 0) {
+      if (!target.schema) {
+        throw new DatabricksAllowlistError(
+          `Schema allowlist is configured, but target "${target.raw}" has no explicit schema.`,
+        );
+      }
+      if (!allowedSchemas.includes(target.schema)) {
+        throw new DatabricksAllowlistError(
+          `Schema "${target.schema}" is not in the configured allowlist.`,
+        );
+      }
     }
   }
 }

--- a/extensions/databricks/src/security-policy.ts
+++ b/extensions/databricks/src/security-policy.ts
@@ -1,0 +1,118 @@
+import { DatabricksPolicyError } from "./errors.js";
+
+const MUTATING_KEYWORDS = [
+  "INSERT",
+  "UPDATE",
+  "DELETE",
+  "MERGE",
+  "ALTER",
+  "DROP",
+  "TRUNCATE",
+  "CREATE",
+  "GRANT",
+  "REVOKE",
+  "CALL",
+  "COPY",
+  "REPLACE",
+] as const;
+
+function stripSqlCommentsAndLiterals(sql: string): string {
+  let result = "";
+  let index = 0;
+
+  while (index < sql.length) {
+    const current = sql[index];
+    const next = sql[index + 1];
+
+    if (current === "'" || current === '"' || current === "`") {
+      const quote = current;
+      result += " ";
+      index += 1;
+      while (index < sql.length) {
+        const ch = sql[index];
+        const peek = sql[index + 1];
+        if (ch === quote) {
+          if (quote === "'" && peek === "'") {
+            index += 2;
+            continue;
+          }
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    if (current === "-" && next === "-") {
+      index += 2;
+      while (index < sql.length && sql[index] !== "\n") {
+        index += 1;
+      }
+      result += " ";
+      continue;
+    }
+
+    if (current === "/" && next === "*") {
+      index += 2;
+      while (index < sql.length) {
+        if (sql[index] === "*" && sql[index + 1] === "/") {
+          index += 2;
+          break;
+        }
+        index += 1;
+      }
+      result += " ";
+      continue;
+    }
+
+    result += current;
+    index += 1;
+  }
+
+  return result;
+}
+
+function assertSingleStatement(sql: string) {
+  const withoutComments = stripSqlCommentsAndLiterals(sql);
+  const trimmed = withoutComments.trim().replace(/;+\s*$/u, "");
+  if (trimmed.includes(";")) {
+    throw new DatabricksPolicyError("Only a single SQL statement is allowed in read-only mode.");
+  }
+}
+
+function assertAllowedStartingClause(sql: string) {
+  const normalized = sql.trim().replace(/\s+/gu, " ").toUpperCase();
+  if (normalized.startsWith("SELECT ")) {
+    return;
+  }
+  if (normalized.startsWith("WITH ") && /\bSELECT\b/u.test(normalized)) {
+    return;
+  }
+  throw new DatabricksPolicyError(
+    "Read-only SQL must start with SELECT or WITH ... SELECT in this Databricks runtime iteration.",
+  );
+}
+
+function assertNoMutatingKeyword(sql: string) {
+  const normalized = stripSqlCommentsAndLiterals(sql).toUpperCase();
+  for (const keyword of MUTATING_KEYWORDS) {
+    const pattern = new RegExp(`\\b${keyword}\\b`, "u");
+    if (pattern.test(normalized)) {
+      throw new DatabricksPolicyError(
+        `Read-only SQL policy rejected statement because it contains disallowed keyword: ${keyword}.`,
+      );
+    }
+  }
+}
+
+export function assertReadOnlySqlStatement(rawSql: string): string {
+  const sql = rawSql.trim();
+  if (!sql) {
+    throw new DatabricksPolicyError("SQL statement is required.");
+  }
+  assertSingleStatement(sql);
+  assertAllowedStartingClause(sql);
+  assertNoMutatingKeyword(sql);
+  return sql.replace(/;+\s*$/u, "");
+}

--- a/extensions/databricks/src/security-policy.ts
+++ b/extensions/databricks/src/security-policy.ts
@@ -1,4 +1,4 @@
-import { DatabricksPolicyError } from "./errors.js";
+import { DatabricksAllowlistError, DatabricksPolicyError } from "./errors.js";
 
 const MUTATING_KEYWORDS = [
   "INSERT",
@@ -16,7 +16,7 @@ const MUTATING_KEYWORDS = [
   "REPLACE",
 ] as const;
 
-function stripSqlCommentsAndLiterals(sql: string): string {
+export function stripSqlCommentsAndLiterals(sql: string): string {
   let result = "";
   let index = 0;
 
@@ -82,7 +82,7 @@ function assertSingleStatement(sql: string) {
 }
 
 function assertAllowedStartingClause(sql: string) {
-  const normalized = sql.trim().replace(/\s+/gu, " ").toUpperCase();
+  const normalized = stripSqlCommentsAndLiterals(sql).trim().replace(/\s+/gu, " ").toUpperCase();
   if (normalized.startsWith("SELECT ")) {
     return;
   }
@@ -115,4 +115,46 @@ export function assertReadOnlySqlStatement(rawSql: string): string {
   assertAllowedStartingClause(sql);
   assertNoMutatingKeyword(sql);
   return sql.replace(/;+\s*$/u, "");
+}
+
+export function assertAllowlistTarget(params: {
+  allowedCatalogs: readonly string[];
+  allowedSchemas: readonly string[];
+  catalog?: string;
+  schema?: string;
+}) {
+  const allowedCatalogs = params.allowedCatalogs.map((entry) => entry.toLowerCase());
+  const allowedSchemas = params.allowedSchemas.map((entry) => entry.toLowerCase());
+  const targetCatalog = params.catalog?.trim().toLowerCase();
+  const targetSchema = params.schema?.trim().toLowerCase();
+
+  if (allowedCatalogs.length === 0 && allowedSchemas.length === 0) {
+    return;
+  }
+
+  if (allowedCatalogs.length > 0) {
+    if (!targetCatalog) {
+      throw new DatabricksAllowlistError(
+        "Catalog allowlist is configured, but the query target catalog could not be determined safely.",
+      );
+    }
+    if (!allowedCatalogs.includes(targetCatalog)) {
+      throw new DatabricksAllowlistError(
+        `Catalog "${params.catalog}" is not in the configured allowlist.`,
+      );
+    }
+  }
+
+  if (allowedSchemas.length > 0) {
+    if (!targetSchema) {
+      throw new DatabricksAllowlistError(
+        "Schema allowlist is configured, but the query target schema could not be determined safely.",
+      );
+    }
+    if (!allowedSchemas.includes(targetSchema)) {
+      throw new DatabricksAllowlistError(
+        `Schema "${params.schema}" is not in the configured allowlist.`,
+      );
+    }
+  }
 }

--- a/extensions/databricks/src/sql-target-resolution.test.ts
+++ b/extensions/databricks/src/sql-target-resolution.test.ts
@@ -3,72 +3,156 @@ import { resolveSqlTargets } from "./sql-target-resolution.js";
 
 describe("sql target resolution", () => {
   it("resolves catalog.schema.table references", () => {
-    const targets = resolveSqlTargets(
-      "SELECT * FROM main.analytics.orders o JOIN main.analytics.customers c ON o.id = c.id",
-    );
-    expect(targets).toEqual([
-      {
-        catalog: "main",
-        schema: "analytics",
-        table: "orders",
-        raw: "main.analytics.orders",
-      },
-      {
-        catalog: "main",
-        schema: "analytics",
-        table: "customers",
-        raw: "main.analytics.customers",
-      },
-    ]);
-  });
-
-  it("resolves schema.table references with odd whitespace", () => {
-    const targets = resolveSqlTargets("SELECT * FROM analytics   .   events");
-    expect(targets).toEqual([
-      {
-        schema: "analytics",
-        table: "events",
-        raw: "analytics.events",
-      },
-    ]);
-  });
-
-  it("handles CTEs and subqueries without breaking extraction", () => {
-    const targets = resolveSqlTargets(
-      "WITH x AS (SELECT * FROM main.sales.orders) SELECT * FROM x JOIN main.sales.customers c ON x.id = c.id",
-    );
-    expect(targets).toEqual([
+    expect(resolveSqlTargets("select * from main.sales.orders")).toEqual([
       {
         catalog: "main",
         schema: "sales",
         table: "orders",
         raw: "main.sales.orders",
       },
+    ]);
+  });
+
+  it("resolves schema.table references", () => {
+    expect(resolveSqlTargets("select * from sales.orders")).toEqual([
+      {
+        schema: "sales",
+        table: "orders",
+        raw: "sales.orders",
+      },
+    ]);
+  });
+
+  it("resolves quoted catalog.schema.table references", () => {
+    expect(resolveSqlTargets("select * from `main`.`sales`.`orders`")).toEqual([
       {
         catalog: "main",
         schema: "sales",
-        table: "customers",
-        raw: "main.sales.customers",
+        table: "orders",
+        raw: "main.sales.orders",
       },
     ]);
   });
 
-  it("ignores strings and comments with fake table references", () => {
-    const targets = resolveSqlTargets(
-      "SELECT 'from x.y.z' AS note /* from bad.schema.table */ FROM main.prod.logs",
-    );
-    expect(targets).toEqual([
+  it("resolves mixed quoted and bare identifiers when unambiguous", () => {
+    expect(resolveSqlTargets("select * from `main`.sales.`orders`")).toEqual([
       {
         catalog: "main",
-        schema: "prod",
-        table: "logs",
-        raw: "main.prod.logs",
+        schema: "sales",
+        table: "orders",
+        raw: "main.sales.orders",
       },
     ]);
   });
 
-  it("fails closed naturally by returning empty when references are ambiguous", () => {
-    const targets = resolveSqlTargets("SELECT * FROM orders");
-    expect(targets).toEqual([]);
+  it("deduplicates and resolves multiple join targets", () => {
+    expect(
+      resolveSqlTargets(
+        "select * from sales.orders o join core.customers c on o.id = c.id join sales.orders o2 on o2.id = c.id",
+      ),
+    ).toEqual([
+      {
+        schema: "sales",
+        table: "orders",
+        raw: "sales.orders",
+      },
+      {
+        schema: "core",
+        table: "customers",
+        raw: "core.customers",
+      },
+    ]);
+  });
+
+  it("extracts physical targets from WITH CTE and ignores cte aliases", () => {
+    expect(resolveSqlTargets("with c as (select * from sales.orders) select * from c")).toEqual([
+      {
+        schema: "sales",
+        table: "orders",
+        raw: "sales.orders",
+      },
+    ]);
+  });
+
+  it("extracts quoted targets from WITH CTE", () => {
+    expect(
+      resolveSqlTargets("with c as (select * from `main`.`sales`.`orders`) select * from c"),
+    ).toEqual([
+      {
+        catalog: "main",
+        schema: "sales",
+        table: "orders",
+        raw: "main.sales.orders",
+      },
+    ]);
+  });
+
+  it("extracts targets from subquery in FROM", () => {
+    expect(resolveSqlTargets("select * from (select * from sales.orders) x")).toEqual([
+      {
+        schema: "sales",
+        table: "orders",
+        raw: "sales.orders",
+      },
+    ]);
+  });
+
+  it("extracts targets across multiple CTEs", () => {
+    expect(
+      resolveSqlTargets(
+        "with c as (select * from sales.orders), d as (select * from core.customers) select * from c join d on c.id = d.id",
+      ),
+    ).toEqual([
+      {
+        schema: "sales",
+        table: "orders",
+        raw: "sales.orders",
+      },
+      {
+        schema: "core",
+        table: "customers",
+        raw: "core.customers",
+      },
+    ]);
+  });
+
+  it("returns empty when CTEs do not reference physical targets", () => {
+    expect(resolveSqlTargets("with c as (select 1) select * from c")).toEqual([]);
+  });
+
+  it("returns empty when subquery does not reference physical targets", () => {
+    expect(resolveSqlTargets("select * from (select 1) x")).toEqual([]);
+  });
+
+  it("returns empty for ambiguous single-part references", () => {
+    expect(resolveSqlTargets("select * from foo")).toEqual([]);
+  });
+
+  it("fails closed on broken quoted identifiers", () => {
+    expect(resolveSqlTargets("select * from `main.sales.orders")).toEqual([]);
+  });
+
+  it("fails closed on unbalanced parentheses", () => {
+    expect(resolveSqlTargets("select * from (select * from sales.orders")).toEqual([]);
+  });
+
+  it("ignores fake from/join tokens inside strings and comments", () => {
+    expect(
+      resolveSqlTargets(
+        "select 'from fake.schema.table' as note /* join bad.schema.table */ from sales.orders",
+      ),
+    ).toEqual([
+      {
+        schema: "sales",
+        table: "orders",
+        raw: "sales.orders",
+      },
+    ]);
+  });
+
+  it("returns empty for multi-statement sql", () => {
+    expect(resolveSqlTargets("select * from sales.orders; select * from core.customers")).toEqual(
+      [],
+    );
   });
 });

--- a/extensions/databricks/src/sql-target-resolution.test.ts
+++ b/extensions/databricks/src/sql-target-resolution.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { resolveSqlTargets } from "./sql-target-resolution.js";
+
+describe("sql target resolution", () => {
+  it("resolves catalog.schema.table references", () => {
+    const targets = resolveSqlTargets(
+      "SELECT * FROM main.analytics.orders o JOIN main.analytics.customers c ON o.id = c.id",
+    );
+    expect(targets).toEqual([
+      {
+        catalog: "main",
+        schema: "analytics",
+        table: "orders",
+        raw: "main.analytics.orders",
+      },
+      {
+        catalog: "main",
+        schema: "analytics",
+        table: "customers",
+        raw: "main.analytics.customers",
+      },
+    ]);
+  });
+
+  it("resolves schema.table references with odd whitespace", () => {
+    const targets = resolveSqlTargets("SELECT * FROM analytics   .   events");
+    expect(targets).toEqual([
+      {
+        schema: "analytics",
+        table: "events",
+        raw: "analytics.events",
+      },
+    ]);
+  });
+
+  it("handles CTEs and subqueries without breaking extraction", () => {
+    const targets = resolveSqlTargets(
+      "WITH x AS (SELECT * FROM main.sales.orders) SELECT * FROM x JOIN main.sales.customers c ON x.id = c.id",
+    );
+    expect(targets).toEqual([
+      {
+        catalog: "main",
+        schema: "sales",
+        table: "orders",
+        raw: "main.sales.orders",
+      },
+      {
+        catalog: "main",
+        schema: "sales",
+        table: "customers",
+        raw: "main.sales.customers",
+      },
+    ]);
+  });
+
+  it("ignores strings and comments with fake table references", () => {
+    const targets = resolveSqlTargets(
+      "SELECT 'from x.y.z' AS note /* from bad.schema.table */ FROM main.prod.logs",
+    );
+    expect(targets).toEqual([
+      {
+        catalog: "main",
+        schema: "prod",
+        table: "logs",
+        raw: "main.prod.logs",
+      },
+    ]);
+  });
+
+  it("fails closed naturally by returning empty when references are ambiguous", () => {
+    const targets = resolveSqlTargets("SELECT * FROM orders");
+    expect(targets).toEqual([]);
+  });
+});

--- a/extensions/databricks/src/sql-target-resolution.ts
+++ b/extensions/databricks/src/sql-target-resolution.ts
@@ -1,0 +1,58 @@
+import { stripSqlCommentsAndLiterals } from "./security-policy.js";
+
+export type ResolvedSqlTarget = {
+  catalog?: string;
+  schema?: string;
+  table: string;
+  raw: string;
+};
+
+function normalizeIdentifier(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function parseQualifiedReference(value: string): ResolvedSqlTarget | null {
+  const compact = value.replace(/\s*\.\s*/gu, ".");
+  const parts = compact.split(".").map((part) => normalizeIdentifier(part));
+  if (parts.length === 2) {
+    const [schema, table] = parts;
+    if (!schema || !table) {
+      return null;
+    }
+    return { schema, table, raw: compact };
+  }
+  if (parts.length === 3) {
+    const [catalog, schema, table] = parts;
+    if (!catalog || !schema || !table) {
+      return null;
+    }
+    return { catalog, schema, table, raw: compact };
+  }
+  return null;
+}
+
+export function resolveSqlTargets(rawSql: string): ResolvedSqlTarget[] {
+  const sanitized = stripSqlCommentsAndLiterals(rawSql);
+  const references = new Set<string>();
+  const targets: ResolvedSqlTarget[] = [];
+  const pattern = /\b(?:from|join)\s+((?:[A-Za-z_][\w$]*)(?:\s*\.\s*[A-Za-z_][\w$]*){1,2})\b/giu;
+
+  for (const match of sanitized.matchAll(pattern)) {
+    const rawReference = match[1];
+    if (!rawReference) {
+      continue;
+    }
+    const target = parseQualifiedReference(rawReference);
+    if (!target) {
+      continue;
+    }
+    const key = `${target.catalog ?? ""}|${target.schema ?? ""}|${target.table}`;
+    if (references.has(key)) {
+      continue;
+    }
+    references.add(key);
+    targets.push(target);
+  }
+
+  return targets;
+}

--- a/extensions/databricks/src/sql-target-resolution.ts
+++ b/extensions/databricks/src/sql-target-resolution.ts
@@ -1,5 +1,3 @@
-import { stripSqlCommentsAndLiterals } from "./security-policy.js";
-
 export type ResolvedSqlTarget = {
   catalog?: string;
   schema?: string;
@@ -7,51 +5,351 @@ export type ResolvedSqlTarget = {
   raw: string;
 };
 
+type SqlToken = {
+  kind: "identifier" | "symbol" | "keyword";
+  value: string;
+};
+
+type ParseQualifiedResult = {
+  nextIndex: number;
+  malformed: boolean;
+  target?: ResolvedSqlTarget;
+};
+
 function normalizeIdentifier(value: string): string {
   return value.trim().toLowerCase();
 }
 
-function parseQualifiedReference(value: string): ResolvedSqlTarget | null {
-  const compact = value.replace(/\s*\.\s*/gu, ".");
-  const parts = compact.split(".").map((part) => normalizeIdentifier(part));
+function stripSqlCommentsAndStringLiterals(sql: string): string {
+  let result = "";
+  for (let index = 0; index < sql.length; ) {
+    const current = sql[index];
+    const next = sql[index + 1];
+    if (!current) {
+      break;
+    }
+
+    if (current === "'" || current === '"') {
+      const quote = current;
+      result += " ";
+      index += 1;
+      while (index < sql.length) {
+        const char = sql[index];
+        const peek = sql[index + 1];
+        if (char === quote) {
+          if (quote === "'" && peek === "'") {
+            index += 2;
+            continue;
+          }
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    if (current === "-" && next === "-") {
+      index += 2;
+      while (index < sql.length && sql[index] !== "\n") {
+        index += 1;
+      }
+      result += " ";
+      continue;
+    }
+
+    if (current === "/" && next === "*") {
+      index += 2;
+      while (index < sql.length) {
+        if (sql[index] === "*" && sql[index + 1] === "/") {
+          index += 2;
+          break;
+        }
+        index += 1;
+      }
+      result += " ";
+      continue;
+    }
+
+    result += current;
+    index += 1;
+  }
+
+  return result;
+}
+
+function buildResolvedTarget(parts: string[]): ResolvedSqlTarget | null {
   if (parts.length === 2) {
     const [schema, table] = parts;
     if (!schema || !table) {
       return null;
     }
-    return { schema, table, raw: compact };
+    return { schema, table, raw: `${schema}.${table}` };
   }
   if (parts.length === 3) {
     const [catalog, schema, table] = parts;
     if (!catalog || !schema || !table) {
       return null;
     }
-    return { catalog, schema, table, raw: compact };
+    return { catalog, schema, table, raw: `${catalog}.${schema}.${table}` };
   }
   return null;
 }
 
+function isIdentifierStart(char: string): boolean {
+  return /[A-Za-z_]/u.test(char);
+}
+
+function isIdentifierPart(char: string): boolean {
+  return /[A-Za-z0-9_$]/u.test(char);
+}
+
+function tokenizeSql(sql: string): { tokens: SqlToken[]; malformed: boolean } {
+  const tokens: SqlToken[] = [];
+  for (let index = 0; index < sql.length; ) {
+    const char = sql[index];
+    if (!char) {
+      break;
+    }
+
+    if (/\s/u.test(char)) {
+      index += 1;
+      continue;
+    }
+
+    if (char === "`") {
+      let cursor = index + 1;
+      let value = "";
+      let closed = false;
+      while (cursor < sql.length) {
+        const current = sql[cursor];
+        if (current === "`") {
+          if (sql[cursor + 1] === "`") {
+            value += "`";
+            cursor += 2;
+            continue;
+          }
+          closed = true;
+          break;
+        }
+        value += current;
+        cursor += 1;
+      }
+      if (!closed) {
+        return { tokens: [], malformed: true };
+      }
+      const normalized = normalizeIdentifier(value);
+      if (!normalized) {
+        return { tokens: [], malformed: true };
+      }
+      tokens.push({ kind: "identifier", value: normalized });
+      index = cursor + 1;
+      continue;
+    }
+
+    if (isIdentifierStart(char)) {
+      let cursor = index + 1;
+      while (cursor < sql.length && isIdentifierPart(sql[cursor] ?? "")) {
+        cursor += 1;
+      }
+      const value = sql.slice(index, cursor);
+      const upper = value.toUpperCase();
+      if (upper === "FROM" || upper === "JOIN" || upper === "WITH" || upper === "AS") {
+        tokens.push({ kind: "keyword", value: upper });
+      } else {
+        tokens.push({ kind: "identifier", value: normalizeIdentifier(value) });
+      }
+      index = cursor;
+      continue;
+    }
+
+    if (char === "." || char === "(" || char === ")" || char === "," || char === ";") {
+      tokens.push({ kind: "symbol", value: char });
+      index += 1;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return { tokens, malformed: false };
+}
+
+function validateBalancedParentheses(tokens: SqlToken[]): boolean {
+  let depth = 0;
+  for (const token of tokens) {
+    if (token.kind !== "symbol") {
+      continue;
+    }
+    if (token.value === "(") {
+      depth += 1;
+    } else if (token.value === ")") {
+      depth -= 1;
+      if (depth < 0) {
+        return false;
+      }
+    }
+  }
+  return depth === 0;
+}
+
+function parseQualifiedReference(tokens: SqlToken[], startIndex: number): ParseQualifiedResult {
+  const first = tokens[startIndex];
+  if (!first || first.kind !== "identifier") {
+    return { nextIndex: startIndex, malformed: false };
+  }
+
+  const parts = [first.value];
+  let cursor = startIndex + 1;
+
+  while (true) {
+    const dot = tokens[cursor];
+    if (!dot || dot.kind !== "symbol" || dot.value !== ".") {
+      break;
+    }
+    const next = tokens[cursor + 1];
+    if (!next || next.kind !== "identifier") {
+      return { nextIndex: cursor + 1, malformed: true };
+    }
+    parts.push(next.value);
+    cursor += 2;
+    if (parts.length > 3) {
+      return { nextIndex: cursor, malformed: true };
+    }
+  }
+
+  const target = buildResolvedTarget(parts);
+  if (!target && parts.length >= 2) {
+    return { nextIndex: cursor, malformed: true };
+  }
+  return {
+    nextIndex: cursor,
+    malformed: false,
+    ...(target ? { target } : {}),
+  };
+}
+
+function parseLeadingWithClause(tokens: SqlToken[]): boolean {
+  if (tokens.length === 0) {
+    return true;
+  }
+  if (tokens[0]?.kind !== "keyword" || tokens[0].value !== "WITH") {
+    return true;
+  }
+
+  let cursor = 1;
+  while (cursor < tokens.length) {
+    const cteName = tokens[cursor];
+    if (!cteName || cteName.kind !== "identifier") {
+      return false;
+    }
+    cursor += 1;
+
+    if (tokens[cursor]?.kind === "symbol" && tokens[cursor]?.value === "(") {
+      let depth = 1;
+      cursor += 1;
+      while (cursor < tokens.length && depth > 0) {
+        const token = tokens[cursor];
+        if (token?.kind === "symbol" && token.value === "(") {
+          depth += 1;
+        } else if (token?.kind === "symbol" && token.value === ")") {
+          depth -= 1;
+        }
+        cursor += 1;
+      }
+      if (depth !== 0) {
+        return false;
+      }
+    }
+
+    const asToken = tokens[cursor];
+    if (!asToken || asToken.kind !== "keyword" || asToken.value !== "AS") {
+      return false;
+    }
+    cursor += 1;
+
+    if (tokens[cursor]?.kind !== "symbol" || tokens[cursor]?.value !== "(") {
+      return false;
+    }
+    let subqueryDepth = 1;
+    cursor += 1;
+    while (cursor < tokens.length && subqueryDepth > 0) {
+      const token = tokens[cursor];
+      if (token?.kind === "symbol" && token.value === "(") {
+        subqueryDepth += 1;
+      } else if (token?.kind === "symbol" && token.value === ")") {
+        subqueryDepth -= 1;
+      }
+      cursor += 1;
+    }
+    if (subqueryDepth !== 0) {
+      return false;
+    }
+
+    if (tokens[cursor]?.kind === "symbol" && tokens[cursor].value === ",") {
+      cursor += 1;
+      continue;
+    }
+    break;
+  }
+
+  return true;
+}
+
 export function resolveSqlTargets(rawSql: string): ResolvedSqlTarget[] {
-  const sanitized = stripSqlCommentsAndLiterals(rawSql);
+  const sanitized = stripSqlCommentsAndStringLiterals(rawSql);
+  const { tokens, malformed } = tokenizeSql(sanitized);
+  if (malformed) {
+    return [];
+  }
+  if (!validateBalancedParentheses(tokens)) {
+    return [];
+  }
+  if (!parseLeadingWithClause(tokens)) {
+    return [];
+  }
+  if (tokens.some((token) => token.kind === "symbol" && token.value === ";")) {
+    return [];
+  }
+
   const references = new Set<string>();
   const targets: ResolvedSqlTarget[] = [];
-  const pattern = /\b(?:from|join)\s+((?:[A-Za-z_][\w$]*)(?:\s*\.\s*[A-Za-z_][\w$]*){1,2})\b/giu;
 
-  for (const match of sanitized.matchAll(pattern)) {
-    const rawReference = match[1];
-    if (!rawReference) {
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!token || token.kind !== "keyword") {
       continue;
     }
-    const target = parseQualifiedReference(rawReference);
-    if (!target) {
+    if (token.value !== "FROM" && token.value !== "JOIN") {
       continue;
     }
-    const key = `${target.catalog ?? ""}|${target.schema ?? ""}|${target.table}`;
+
+    const next = tokens[index + 1];
+    if (!next) {
+      continue;
+    }
+    if (next.kind === "symbol" && next.value === "(") {
+      continue;
+    }
+    if (next.kind !== "identifier") {
+      continue;
+    }
+
+    const parsed = parseQualifiedReference(tokens, index + 1);
+    if (parsed.malformed) {
+      return [];
+    }
+    if (!parsed.target) {
+      continue;
+    }
+    index = parsed.nextIndex - 1;
+
+    const key = `${parsed.target.catalog ?? ""}|${parsed.target.schema ?? ""}|${parsed.target.table}`;
     if (references.has(key)) {
       continue;
     }
     references.add(key);
-    targets.push(target);
+    targets.push(parsed.target);
   }
 
   return targets;

--- a/src/plugins/bundled-provider-auth-env-vars.generated.ts
+++ b/src/plugins/bundled-provider-auth-env-vars.generated.ts
@@ -6,6 +6,7 @@ export const BUNDLED_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
   byteplus: ["BYTEPLUS_API_KEY"],
   chutes: ["CHUTES_API_KEY", "CHUTES_OAUTH_TOKEN"],
   "cloudflare-ai-gateway": ["CLOUDFLARE_AI_GATEWAY_API_KEY"],
+  databricks: ["DATABRICKS_HOST", "DATABRICKS_TOKEN", "DATABRICKS_WAREHOUSE_ID"],
   deepseek: ["DEEPSEEK_API_KEY"],
   exa: ["EXA_API_KEY"],
   fal: ["FAL_KEY"],

--- a/test/scripts/test-planner.executor-fallback.test.ts
+++ b/test/scripts/test-planner.executor-fallback.test.ts
@@ -27,9 +27,11 @@ describe("test planner executor", () => {
       kill: vi.fn(),
     });
     const spawnMock = vi.fn(() => {
-      setTimeout(() => {
+      queueMicrotask(() => {
+        stdout.end();
+        stderr.end();
         fakeChild.emit("exit", 0, null);
-      }, 0);
+      });
       return fakeChild;
     });
     const artifacts = createExecutionArtifacts({ OPENCLAW_TEST_CLOSE_GRACE_MS: "10" });
@@ -75,15 +77,17 @@ describe("test planner executor", () => {
     const spawnMock = vi.fn(() => {
       const child = children[childIndex];
       childIndex += 1;
-      setTimeout(() => {
+      queueMicrotask(() => {
         child.stdout.write(
           child.index === 0
             ? " ❯ src/alpha.test.ts (1 test | 1 failed)\n"
             : " ❯ src/beta.test.ts (1 test | 1 failed)\n",
         );
+        child.stdout.end();
+        child.stderr.end();
         child.emit("exit", 1, null);
         child.emit("close", 1, null);
-      }, 0);
+      });
       return child;
     });
     const artifacts = createExecutionArtifacts({});
@@ -140,10 +144,12 @@ describe("test planner executor", () => {
     let capturedEnv;
     const spawnMock = vi.fn((_command, _args, options) => {
       capturedEnv = options?.env;
-      setTimeout(() => {
+      queueMicrotask(() => {
+        stdout.end();
+        stderr.end();
         fakeChild.emit("exit", 0, null);
         fakeChild.emit("close", 0, null);
-      }, 0);
+      });
       return fakeChild;
     });
     const artifacts = createExecutionArtifacts({
@@ -190,3 +196,5 @@ describe("test planner executor", () => {
     artifacts.cleanupTempArtifacts();
   });
 });
+
+


### PR DESCRIPTION
## Summary
- add a new plugin scaffold `@kansodata/databricks` under `extensions/databricks`
- register a packaged skill at `skills/databricks/SKILL.md`
- expose plugin metadata through `openclaw.plugin.json` and extension entrypoint
- add labeler mapping for the new extension path

## Why
- this enables installation using a scoped package (`@kansodata/databricks`)
- keeps the contribution as a first-party, self-initiated plugin-based skill pack

## Validation
- pre-commit checks ran during commit
- repo is clean after scaffold and branch split