### PR TITLE
Fix HTTP OpenAI-compatible routes missing operator.write scope checks

### DIFF
--- a/src/gateway/http-endpoint-helpers.test.ts
+++ b/src/gateway/http-endpoint-helpers.test.ts
@@ -76,7 +76,6 @@ describe("handleGatewayPostJsonEndpoint", () => {
   it("returns body when auth succeeds and JSON parsing succeeds", async () => {
     vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(true);
     vi.mocked(readJsonBodyOrError).mockResolvedValue({ hello: "world" });
-    vi.mocked(authorizeOperatorScopesForMethod).mockReturnValue({ allowed: true });
     const result = await handleGatewayPostJsonEndpoint(
       {
         url: "/v1/ok",

--- a/src/gateway/http-endpoint-helpers.test.ts
+++ b/src/gateway/http-endpoint-helpers.test.ts
@@ -6,18 +6,28 @@ import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 vi.mock("./http-auth-helpers.js", () => {
   return {
     authorizeGatewayBearerRequestOrReply: vi.fn(),
+    resolveGatewayRequestedOperatorScopes: vi.fn(),
   };
 });
 
 vi.mock("./http-common.js", () => {
   return {
     readJsonBodyOrError: vi.fn(),
+    sendJson: vi.fn(),
     sendMethodNotAllowed: vi.fn(),
   };
 });
 
+vi.mock("./method-scopes.js", () => {
+  return {
+    authorizeOperatorScopesForMethod: vi.fn(),
+  };
+});
+
 const { authorizeGatewayBearerRequestOrReply } = await import("./http-auth-helpers.js");
-const { readJsonBodyOrError, sendMethodNotAllowed } = await import("./http-common.js");
+const { resolveGatewayRequestedOperatorScopes } = await import("./http-auth-helpers.js");
+const { readJsonBodyOrError, sendJson, sendMethodNotAllowed } = await import("./http-common.js");
+const { authorizeOperatorScopesForMethod } = await import("./method-scopes.js");
 
 describe("handleGatewayPostJsonEndpoint", () => {
   it("returns false when path does not match", async () => {
@@ -66,6 +76,7 @@ describe("handleGatewayPostJsonEndpoint", () => {
   it("returns body when auth succeeds and JSON parsing succeeds", async () => {
     vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(true);
     vi.mocked(readJsonBodyOrError).mockResolvedValue({ hello: "world" });
+    vi.mocked(authorizeOperatorScopesForMethod).mockReturnValue({ allowed: true });
     const result = await handleGatewayPostJsonEndpoint(
       {
         url: "/v1/ok",
@@ -76,5 +87,49 @@ describe("handleGatewayPostJsonEndpoint", () => {
       { pathname: "/v1/ok", auth: {} as unknown as ResolvedGatewayAuth, maxBodyBytes: 123 },
     );
     expect(result).toEqual({ body: { hello: "world" } });
+  });
+
+  it("returns undefined and replies when required operator scope is missing", async () => {
+    vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(true);
+    vi.mocked(resolveGatewayRequestedOperatorScopes).mockReturnValue(["operator.approvals"]);
+    vi.mocked(authorizeOperatorScopesForMethod).mockReturnValue({
+      allowed: false,
+      missingScope: "operator.write",
+    });
+    const mockedSendJson = vi.mocked(sendJson);
+    mockedSendJson.mockClear();
+    vi.mocked(readJsonBodyOrError).mockClear();
+
+    const result = await handleGatewayPostJsonEndpoint(
+      {
+        url: "/v1/ok",
+        method: "POST",
+        headers: { host: "localhost" },
+      } as unknown as IncomingMessage,
+      {} as unknown as ServerResponse,
+      {
+        pathname: "/v1/ok",
+        auth: {} as unknown as ResolvedGatewayAuth,
+        maxBodyBytes: 123,
+        requiredOperatorMethod: "chat.send",
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(vi.mocked(authorizeOperatorScopesForMethod)).toHaveBeenCalledWith("chat.send", [
+      "operator.approvals",
+    ]);
+    expect(mockedSendJson).toHaveBeenCalledWith(
+      expect.anything(),
+      403,
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({
+          type: "forbidden",
+          message: "missing scope: operator.write",
+        }),
+      }),
+    );
+    expect(vi.mocked(readJsonBodyOrError)).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/http-endpoint-helpers.ts
+++ b/src/gateway/http-endpoint-helpers.ts
@@ -1,8 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { authorizeGatewayBearerRequestOrReply } from "./http-auth-helpers.js";
-import { readJsonBodyOrError, sendMethodNotAllowed } from "./http-common.js";
+import {
+  authorizeGatewayBearerRequestOrReply,
+  resolveGatewayRequestedOperatorScopes,
+} from "./http-auth-helpers.js";
+import { readJsonBodyOrError, sendJson, sendMethodNotAllowed } from "./http-common.js";
+import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 
 export async function handleGatewayPostJsonEndpoint(
   req: IncomingMessage,
@@ -14,6 +18,7 @@ export async function handleGatewayPostJsonEndpoint(
     trustedProxies?: string[];
     allowRealIpFallback?: boolean;
     rateLimiter?: AuthRateLimiter;
+    requiredOperatorMethod?: string;
   },
 ): Promise<false | { body: unknown } | undefined> {
   const url = new URL(req.url ?? "/", `http://${req.headers.host || "localhost"}`);
@@ -36,6 +41,24 @@ export async function handleGatewayPostJsonEndpoint(
   });
   if (!authorized) {
     return undefined;
+  }
+
+  if (opts.requiredOperatorMethod) {
+    const requestedScopes = resolveGatewayRequestedOperatorScopes(req);
+    const scopeAuth = authorizeOperatorScopesForMethod(
+      opts.requiredOperatorMethod,
+      requestedScopes,
+    );
+    if (!scopeAuth.allowed) {
+      sendJson(res, 403, {
+        ok: false,
+        error: {
+          type: "forbidden",
+          message: `missing scope: ${scopeAuth.missingScope}`,
+        },
+      });
+      return undefined;
+    }
   }
 
   const body = await readJsonBodyOrError(req, res, opts.maxBodyBytes);

--- a/src/gateway/http-endpoint-helpers.ts
+++ b/src/gateway/http-endpoint-helpers.ts
@@ -18,7 +18,7 @@ export async function handleGatewayPostJsonEndpoint(
     trustedProxies?: string[];
     allowRealIpFallback?: boolean;
     rateLimiter?: AuthRateLimiter;
-    requiredOperatorMethod?: string;
+    requiredOperatorMethod?: "chat.send" | (string & Record<never, never>);
   },
 ): Promise<false | { body: unknown } | undefined> {
   const url = new URL(req.url ?? "/", `http://${req.headers.host || "localhost"}`);

--- a/src/gateway/openai-http.message-channel.test.ts
+++ b/src/gateway/openai-http.message-channel.test.ts
@@ -20,6 +20,7 @@ async function runOpenAiMessageChannelRequest(params?: { messageChannelHeader?: 
       const headers: Record<string, string> = {
         "content-type": "application/json",
         authorization: "Bearer secret",
+        "x-openclaw-scopes": "operator.write",
       };
       if (params?.messageChannelHeader) {
         headers["x-openclaw-message-channel"] = params.messageChannelHeader;

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -62,6 +62,7 @@ async function postChatCompletions(port: number, body: unknown, headers?: Record
     headers: {
       "content-type": "application/json",
       authorization: "Bearer secret",
+      "x-openclaw-scopes": "operator.write",
       ...headers,
     },
     body: JSON.stringify(body),

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -416,6 +416,7 @@ export async function handleOpenAiHttpRequest(
   const limits = resolveOpenAiChatCompletionsLimits(opts.config);
   const handled = await handleGatewayPostJsonEndpoint(req, res, {
     pathname: "/v1/chat/completions",
+    requiredOperatorMethod: "chat.send",
     auth: opts.auth,
     trustedProxies: opts.trustedProxies,
     allowRealIpFallback: opts.allowRealIpFallback,

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -71,6 +71,7 @@ async function postResponses(port: number, body: unknown, headers?: Record<strin
     headers: {
       "content-type": "application/json",
       authorization: "Bearer secret",
+      "x-openclaw-scopes": "operator.write",
       ...headers,
     },
     body: JSON.stringify(body),

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -452,6 +452,7 @@ export async function handleOpenResponsesHttpRequest(
       : Math.max(limits.maxBodyBytes, limits.files.maxBytes * 2, limits.images.maxBytes * 2));
   const handled = await handleGatewayPostJsonEndpoint(req, res, {
     pathname: "/v1/responses",
+    requiredOperatorMethod: "chat.send",
     auth: opts.auth,
     trustedProxies: opts.trustedProxies,
     allowRealIpFallback: opts.allowRealIpFallback,

--- a/src/gateway/server.openai-compatible-http-write-scope-bypass.poc.test.ts
+++ b/src/gateway/server.openai-compatible-http-write-scope-bypass.poc.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "vitest";
+import {
+  agentCommand,
+  connectReq,
+  installGatewayTestHooks,
+  rpcReq,
+  startServerWithClient,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+describe("gateway OpenAI-compatible HTTP write-scope bypass PoC", () => {
+  test("operator.approvals is denied by chat.send and /v1/chat/completions without operator.write", async () => {
+    const started = await startServerWithClient("secret", {
+      openAiChatCompletionsEnabled: true,
+    });
+
+    try {
+      const connect = await connectReq(started.ws, {
+        token: "secret",
+        scopes: ["operator.approvals"],
+      });
+      expect(connect.ok).toBe(true);
+
+      const wsSend = await rpcReq(started.ws, "chat.send", {
+        sessionKey: "main",
+        message: "hi",
+      });
+      expect(wsSend.ok).toBe(false);
+      expect(wsSend.error?.message).toBe("missing scope: operator.write");
+
+      agentCommand.mockClear();
+      const httpRes = await fetch(`http://127.0.0.1:${started.port}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+          "x-openclaw-scopes": "operator.approvals",
+        },
+        body: JSON.stringify({
+          model: "openclaw",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+
+      expect(httpRes.status).toBe(403);
+      const body = (await httpRes.json()) as {
+        error?: { type?: string; message?: string };
+      };
+      expect(body.error?.type).toBe("forbidden");
+      expect(body.error?.message).toBe("missing scope: operator.write");
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+    } finally {
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+
+  test("operator.write can still use /v1/chat/completions", async () => {
+    const started = await startServerWithClient("secret", {
+      openAiChatCompletionsEnabled: true,
+    });
+
+    try {
+      agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
+
+      const httpRes = await fetch(`http://127.0.0.1:${started.port}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+          "x-openclaw-scopes": "operator.write",
+        },
+        body: JSON.stringify({
+          model: "openclaw",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+
+      expect(httpRes.status).toBe(200);
+      const body = (await httpRes.json()) as {
+        object?: string;
+        choices?: Array<{ message?: { content?: string } }>;
+      };
+      expect(body.object).toBe("chat.completion");
+      expect(body.choices?.[0]?.message?.content).toBe("hello");
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    } finally {
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+
+  test("operator.approvals is denied by chat.send and /v1/responses without operator.write", async () => {
+    const started = await startServerWithClient("secret", {
+      openResponsesEnabled: true,
+    });
+
+    try {
+      const connect = await connectReq(started.ws, {
+        token: "secret",
+        scopes: ["operator.approvals"],
+      });
+      expect(connect.ok).toBe(true);
+
+      const wsSend = await rpcReq(started.ws, "chat.send", {
+        sessionKey: "main",
+        message: "hi",
+      });
+      expect(wsSend.ok).toBe(false);
+      expect(wsSend.error?.message).toBe("missing scope: operator.write");
+
+      agentCommand.mockClear();
+      const httpRes = await fetch(`http://127.0.0.1:${started.port}/v1/responses`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+          "x-openclaw-scopes": "operator.approvals",
+        },
+        body: JSON.stringify({
+          stream: false,
+          model: "openclaw",
+          input: "hi",
+        }),
+      });
+
+      expect(httpRes.status).toBe(403);
+      const body = (await httpRes.json()) as {
+        error?: { type?: string; message?: string };
+      };
+      expect(body.error?.type).toBe("forbidden");
+      expect(body.error?.message).toBe("missing scope: operator.write");
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+    } finally {
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+
+  test("operator.write can still use /v1/responses", async () => {
+    const started = await startServerWithClient("secret", {
+      openResponsesEnabled: true,
+    });
+
+    try {
+      agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
+
+      const httpRes = await fetch(`http://127.0.0.1:${started.port}/v1/responses`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+          "x-openclaw-scopes": "operator.write",
+        },
+        body: JSON.stringify({
+          stream: false,
+          model: "openclaw",
+          input: "hi",
+        }),
+      });
+
+      expect(httpRes.status).toBe(200);
+      const body = (await httpRes.json()) as {
+        object?: string;
+        status?: string;
+        output?: Array<{
+          type?: string;
+          role?: string;
+          content?: Array<{ type?: string; text?: string }>;
+        }>;
+      };
+      expect(body.object).toBe("response");
+      expect(body.status).toBe("completed");
+      expect(body.output?.[0]?.type).toBe("message");
+      expect(body.output?.[0]?.role).toBe("assistant");
+      expect(body.output?.[0]?.content?.[0]?.type).toBe("output_text");
+      expect(body.output?.[0]?.content?.[0]?.text).toBe("hello");
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    } finally {
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+});

--- a/src/gateway/server.openai-compatible-http-write-scope-bypass.poc.test.ts
+++ b/src/gateway/server.openai-compatible-http-write-scope-bypass.poc.test.ts
@@ -50,6 +50,27 @@ describe("gateway OpenAI-compatible HTTP write-scope bypass PoC", () => {
       expect(body.error?.type).toBe("forbidden");
       expect(body.error?.message).toBe("missing scope: operator.write");
       expect(agentCommand).toHaveBeenCalledTimes(0);
+
+      agentCommand.mockClear();
+      const missingHeaderRes = await fetch(`http://127.0.0.1:${started.port}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "openclaw",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+
+      expect(missingHeaderRes.status).toBe(403);
+      const missingHeaderBody = (await missingHeaderRes.json()) as {
+        error?: { type?: string; message?: string };
+      };
+      expect(missingHeaderBody.error?.type).toBe("forbidden");
+      expect(missingHeaderBody.error?.message).toBe("missing scope: operator.write");
+      expect(agentCommand).toHaveBeenCalledTimes(0);
     } finally {
       started.ws.close();
       await started.server.close();


### PR DESCRIPTION
## Summary

- Problem: the OpenAI-compatible HTTP send routes authenticated bearer requests but did not enforce the operator method scopes that already gate equivalent WS send methods.
- Why it matters: a caller limited to `operator.approvals` could be rejected for `chat.send` over WS but still submit prompts through `/v1/chat/completions` and `/v1/responses`.
- What changed: `src/gateway/http-endpoint-helpers.ts` now supports an optional `requiredOperatorMethod` gate, and both `src/gateway/openai-http.ts` and `src/gateway/openresponses-http.ts` require `chat.send` scope parity before reading the request body. Existing HTTP route tests were updated to declare `x-openclaw-scopes: operator.write`, and a new gateway-level regression file locks in the cross-surface denial/success cases.
- What did NOT change (scope boundary): no changes to WS authorization rules, no changes to embeddings, and no changes to the meaning of `x-openclaw-scopes` beyond applying the already-established HTTP scope pattern to the two send-like routes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the shared POST endpoint helper only validated bearer auth and JSON parsing, while the HTTP send routes invoked agent ingress directly without applying `authorizeOperatorScopesForMethod(...)`.
- Missing detection / guardrail: no gateway-level regression compared WS `chat.send` denial against the two OpenAI-compatible HTTP send surfaces under the same weaker scope set.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `src/gateway/server-methods.ts` already enforces operator method scopes for WS, and `src/gateway/sessions-history-http.ts` already uses `x-openclaw-scopes` plus `authorizeOperatorScopesForMethod(...)` for HTTP parity.
- Why this regressed now: the OpenAI-compatible routes were added on top of shared bearer-auth plumbing without reusing the existing HTTP least-privilege scope pattern.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server.openai-compatible-http-write-scope-bypass.poc.test.ts`
- Scenario the test should lock in: a caller scoped only to `operator.approvals` is denied by WS `chat.send` and by both OpenAI-compatible HTTP send routes, while `operator.write` still succeeds.
- Why this is the smallest reliable guardrail: the bug is a transport-parity mismatch across real gateway auth, scope headers, and HTTP request routing into agent ingress.
- Existing test that already covers this (if any): `src/gateway/openai-http.test.ts` and `src/gateway/openresponses-http.test.ts` already cover successful authenticated requests but not scope parity against WS.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `/v1/chat/completions` now returns HTTP 403 with `missing scope: operator.write` when the caller’s declared `x-openclaw-scopes` does not include write access.
- `/v1/responses` now returns the same HTTP 403 under the same insufficient-scope condition.
- Existing authenticated callers now need to declare `x-openclaw-scopes: operator.write` for these send routes, matching the WS gateway boundary.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation:
  - Mitigation narrows the HTTP send surface so it no longer bypasses the established `operator.write` boundary for prompt submission.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: `node:22-bookworm` container with an in-container writable copy of the worktree and symlinked dependency tree from the repo checkout
- Model/provider: mocked gateway agent command in test harness
- Integration/channel (if any): gateway WS auth plus OpenAI-compatible HTTP routes
- Relevant config (redacted): gateway token auth `"secret"`, OpenAI-compatible endpoints enabled per test

### Steps

1. Connect over WS with `operator.approvals` only and confirm `chat.send` is rejected.
2. Send the same logical prompt over `/v1/chat/completions` and `/v1/responses` with `x-openclaw-scopes: operator.approvals`.
3. Retry both HTTP routes with `x-openclaw-scopes: operator.write`.

### Expected

- The weaker scope set is rejected consistently across WS and HTTP.
- The write-scoped caller still succeeds on both HTTP routes.

### Actual

- Focused container tests passed for the helper, both route suites, the message-channel test, and the new gateway PoC.
- `build` was attempted but blocked by an unrelated network-dependent bundled plugin runtime staging step for `extensions/diffs`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - HTTP send routes now enforce `chat.send` scope parity through the shared POST helper
  - `operator.approvals` is denied on both OpenAI-compatible HTTP routes with the same `missing scope: operator.write` message family
  - `operator.write` still succeeds on both OpenAI-compatible HTTP routes
  - existing route tests still pass once they declare `x-openclaw-scopes: operator.write`
- Edge cases checked:
  - helper-level scope denial happens before JSON body parsing
  - message-channel forwarding still works under explicit write scope
- What you did **not** verify:
  - full `pnpm check`
  - a fully green `build`, due the unrelated bundled runtime staging network failure described below

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the `requiredOperatorMethod` gate wiring for the two HTTP send routes and the related test/header updates.
- Files/config to restore:
  - `src/gateway/http-endpoint-helpers.ts`
  - `src/gateway/openai-http.ts`
  - `src/gateway/openresponses-http.ts`
  - `src/gateway/http-endpoint-helpers.test.ts`
  - `src/gateway/openai-http.test.ts`
  - `src/gateway/openresponses-http.test.ts`
  - `src/gateway/openai-http.message-channel.test.ts`
  - `src/gateway/server.openai-compatible-http-write-scope-bypass.poc.test.ts`
- Known bad symptoms reviewers should watch for:
  - authenticated HTTP callers receiving 403 on `/v1/chat/completions` or `/v1/responses` because they are missing or misdeclaring `x-openclaw-scopes`

## Risks and Mitigations

- Risk: existing HTTP clients that relied on bearer auth alone may now fail until they add the write scope header.
  - Mitigation: this matches the already-documented HTTP least-privilege pattern used by other gateway routes and aligns HTTP send behavior with existing WS authorization.
