### PR TITLE
docs: add HRR Fact Memory to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -46,6 +46,22 @@ file messages via any DingTalk client.
 openclaw plugins install @largezhou/ddingtalk
 ```
 
+### HRR Fact Memory
+
+Structured fact recall using Holographic Reduced Representations. Complements
+RAG-based `memory_search` with instant <2ms factual lookups — no embeddings,
+no vector database, zero external dependencies. Parses MEMORY.md into
+`(subject, relation, object)` triples and answers questions like
+"What is Alice's timezone?" in under 2 milliseconds. Optional observation
+layer tracks belief changes over time.
+
+- **npm:** `openclaw-hrr-memory`
+- **repo:** [github.com/Joncik91/openclaw-hrr-memory](https://github.com/Joncik91/openclaw-hrr-memory)
+
+```bash
+openclaw plugins install openclaw-hrr-memory
+```
+
 ### Lossless Claw (LCM)
 
 Lossless Context Management plugin for OpenClaw. DAG-based conversation


### PR DESCRIPTION
## Summary

- Adds [openclaw-hrr-memory](https://github.com/Joncik91/openclaw-hrr-memory) to the community plugins listing
- Structured fact recall using Holographic Reduced Representations — complements RAG with instant <2ms factual lookups
- Published on npm as `openclaw-hrr-memory`, installable via `openclaw plugins install openclaw-hrr-memory`

## What the plugin does

Parses agent MEMORY.md files into `(subject, relation, object)` triples and stores them in an HRR index. Agents use `fact_lookup` and `fact_ask` for direct factual questions (who, what, where, which) before falling back to `memory_search` for fuzzy/semantic queries.

RAG handles 80% of memory queries well. The other 20% — exact fact recall like "What is Alice's timezone?" — is where HRR fills the gap.

## Quality bar checklist

- [x] Published on npm (`openclaw-hrr-memory@1.0.1`)
- [x] Public GitHub repo with docs ([Joncik91/openclaw-hrr-memory](https://github.com/Joncik91/openclaw-hrr-memory))
- [x] Setup and usage docs (`docs/setup.md`, `docs/tools.md`, `docs/how-it-works.md`)
- [x] Active maintenance
- [x] Standalone library ecosystem: [hrr-memory](https://github.com/Joncik91/hrr-memory) (npm) + [hrr-memory-obs](https://github.com/Joncik91/hrr-memory-obs) (npm)