### PR TITLE
fix(msteams): accept strict Bot Framework and Entra service tokens

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -196,4 +196,94 @@ describe("msteams monitor handler authz", () => {
       meta: { name: "New User" },
     });
   });
+
+  it("logs an info drop reason when dmPolicy allowlist rejects a sender", async () => {
+    const { deps } = createDeps({
+      channels: {
+        msteams: {
+          dmPolicy: "allowlist",
+          allowFrom: ["trusted-aad"],
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler({
+      activity: {
+        id: "msg-drop-dm",
+        type: "message",
+        text: "hello",
+        from: {
+          id: "attacker-id",
+          aadObjectId: "attacker-aad",
+          name: "Attacker",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "a:personal-chat",
+          conversationType: "personal",
+        },
+        channelData: {},
+        attachments: [],
+      },
+      sendActivity: vi.fn(async () => undefined),
+    } as unknown as Parameters<typeof handler>[0]);
+
+    expect(deps.log.info).toHaveBeenCalledWith(
+      "dropping dm (not allowlisted)",
+      expect.objectContaining({
+        sender: "attacker-aad",
+        dmPolicy: "allowlist",
+        reason: "dmPolicy=allowlist (not allowlisted)",
+      }),
+    );
+  });
+
+  it("logs an info drop reason when group policy has an empty allowlist", async () => {
+    const { deps } = createDeps({
+      channels: {
+        msteams: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler({
+      activity: {
+        id: "msg-drop-group",
+        type: "message",
+        text: "hello",
+        from: {
+          id: "attacker-id",
+          aadObjectId: "attacker-aad",
+          name: "Attacker",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "19:group@thread.tacv2",
+          conversationType: "groupChat",
+        },
+        channelData: {},
+        attachments: [],
+      },
+      sendActivity: vi.fn(async () => undefined),
+    } as unknown as Parameters<typeof handler>[0]);
+
+    expect(deps.log.info).toHaveBeenCalledWith(
+      "dropping group message (groupPolicy: allowlist, no allowlist)",
+      expect.objectContaining({
+        conversationId: "19:group@thread.tacv2",
+      }),
+    );
+  });
 });

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -153,6 +153,10 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
 
     if (isDirectMessage && msteamsCfg && access.decision !== "allow") {
       if (access.reason === "dmPolicy=disabled") {
+        log.info("dropping dm (dms disabled)", {
+          sender: senderId,
+          label: senderName,
+        });
         log.debug?.("dropping dm (dms disabled)");
         return;
       }
@@ -179,11 +183,25 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         label: senderName,
         allowlistMatch: formatAllowlistMatchMeta(allowMatch),
       });
+      log.info("dropping dm (not allowlisted)", {
+        sender: senderId,
+        label: senderName,
+        dmPolicy,
+        reason: access.reason,
+        allowlistMatch: formatAllowlistMatchMeta(allowMatch),
+      });
       return;
     }
 
     if (!isDirectMessage && msteamsCfg) {
       if (channelGate.allowlistConfigured && !channelGate.allowed) {
+        log.info("dropping group message (not in team/channel allowlist)", {
+          conversationId,
+          teamKey: channelGate.teamKey ?? "none",
+          channelKey: channelGate.channelKey ?? "none",
+          channelMatchKey: channelGate.channelMatchKey ?? "none",
+          channelMatchSource: channelGate.channelMatchSource ?? "none",
+        });
         log.debug?.("dropping group message (not in team/channel allowlist)", {
           conversationId,
           teamKey: channelGate.teamKey ?? "none",
@@ -207,12 +225,18 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       });
 
       if (!senderGroupAccess.allowed && senderGroupAccess.reason === "disabled") {
+        log.info("dropping group message (groupPolicy: disabled)", {
+          conversationId,
+        });
         log.debug?.("dropping group message (groupPolicy: disabled)", {
           conversationId,
         });
         return;
       }
       if (!senderGroupAccess.allowed && senderGroupAccess.reason === "empty_allowlist") {
+        log.info("dropping group message (groupPolicy: allowlist, no allowlist)", {
+          conversationId,
+        });
         log.debug?.("dropping group message (groupPolicy: allowlist, no allowlist)", {
           conversationId,
         });
@@ -226,6 +250,11 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
           allowNameMatching,
         });
         log.debug?.("dropping group message (not in groupAllowFrom)", {
+          sender: senderId,
+          label: senderName,
+          allowlistMatch: formatAllowlistMatchMeta(allowMatch),
+        });
+        log.info("dropping group message (not in groupAllowFrom)", {
           sender: senderId,
           label: senderName,
           allowlistMatch: formatAllowlistMatchMeta(allowMatch),

--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -1,11 +1,45 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createMSTeamsAdapter, type MSTeamsTeamsSdk } from "./sdk.js";
+import {
+  createBotFrameworkJwtValidator,
+  createMSTeamsAdapter,
+  type MSTeamsTeamsSdk,
+} from "./sdk.js";
 import type { MSTeamsCredentials } from "./token.js";
+
+const jwtValidatorState = vi.hoisted(() => ({
+  instances: [] as Array<{ config: Record<string, unknown> }>,
+  behaviorByJwks: new Map<string, "success" | "null" | "throw">(),
+  calls: [] as Array<{ jwksUri: string; token: string; overrideOptions?: unknown }>,
+}));
+
+vi.mock("@microsoft/teams.apps/dist/middleware/auth/jwt-validator.js", () => ({
+  JwtValidator: class JwtValidator {
+    private readonly config: Record<string, unknown>;
+
+    constructor(config: Record<string, unknown>) {
+      this.config = config;
+      jwtValidatorState.instances.push({ config });
+    }
+
+    async validateAccessToken(token: string, overrideOptions?: unknown): Promise<object | null> {
+      const jwksUri = String((this.config.jwksUriOptions as { uri?: string })?.uri ?? "");
+      jwtValidatorState.calls.push({ jwksUri, token, overrideOptions });
+      const behavior = jwtValidatorState.behaviorByJwks.get(jwksUri) ?? "null";
+      if (behavior === "throw") {
+        throw new Error("validator error");
+      }
+      return behavior === "success" ? { sub: "ok" } : null;
+    }
+  },
+}));
 
 const originalFetch = globalThis.fetch;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  jwtValidatorState.instances.length = 0;
+  jwtValidatorState.calls.length = 0;
+  jwtValidatorState.behaviorByJwks.clear();
   vi.restoreAllMocks();
 });
 
@@ -75,5 +109,83 @@ describe("createMSTeamsAdapter", () => {
         }),
       }),
     );
+  });
+});
+
+describe("createBotFrameworkJwtValidator", () => {
+  const creds = {
+    appId: "app-id",
+    appPassword: "secret",
+    tenantId: "tenant-id",
+  } satisfies MSTeamsCredentials;
+
+  it("validates with legacy Bot Framework JWKS and issuer first", async () => {
+    jwtValidatorState.behaviorByJwks.set(
+      "https://login.botframework.com/v1/.well-known/keys",
+      "success",
+    );
+
+    const validator = await createBotFrameworkJwtValidator(creds);
+    await expect(validator.validate("Bearer token-1", "https://service.example.com")).resolves.toBe(
+      true,
+    );
+
+    expect(jwtValidatorState.instances).toHaveLength(2);
+    expect(jwtValidatorState.calls).toHaveLength(1);
+    expect(jwtValidatorState.calls[0]).toMatchObject({
+      jwksUri: "https://login.botframework.com/v1/.well-known/keys",
+      token: "token-1",
+      overrideOptions: {
+        validateServiceUrl: { expectedServiceUrl: "https://service.example.com" },
+      },
+    });
+  });
+
+  it("falls back to Entra JWKS when Bot Framework validation fails", async () => {
+    jwtValidatorState.behaviorByJwks.set(
+      "https://login.botframework.com/v1/.well-known/keys",
+      "null",
+    );
+    jwtValidatorState.behaviorByJwks.set(
+      "https://login.microsoftonline.com/common/discovery/v2.0/keys",
+      "success",
+    );
+
+    const validator = await createBotFrameworkJwtValidator(creds);
+    await expect(validator.validate("Bearer token-2")).resolves.toBe(true);
+
+    expect(jwtValidatorState.calls).toHaveLength(2);
+    expect(jwtValidatorState.calls[0]?.jwksUri).toBe(
+      "https://login.botframework.com/v1/.well-known/keys",
+    );
+    expect(jwtValidatorState.calls[1]?.jwksUri).toBe(
+      "https://login.microsoftonline.com/common/discovery/v2.0/keys",
+    );
+
+    const entraConfig = jwtValidatorState.instances
+      .map((instance) => instance.config)
+      .find(
+        (config) =>
+          String((config.jwksUriOptions as { uri?: string })?.uri) ===
+          "https://login.microsoftonline.com/common/discovery/v2.0/keys",
+      );
+    expect(entraConfig).toBeDefined();
+    expect(entraConfig?.validateIssuer).toEqual({ allowedTenantIds: ["tenant-id"] });
+  });
+
+  it("returns false when all validator paths fail", async () => {
+    jwtValidatorState.behaviorByJwks.set(
+      "https://login.botframework.com/v1/.well-known/keys",
+      "throw",
+    );
+
+    const validator = await createBotFrameworkJwtValidator(creds);
+    await expect(validator.validate("Bearer token-3")).resolves.toBe(false);
+  });
+
+  it("returns false for empty bearer token", async () => {
+    const validator = await createBotFrameworkJwtValidator(creds);
+    await expect(validator.validate("Bearer ")).resolves.toBe(false);
+    expect(jwtValidatorState.calls).toHaveLength(0);
   });
 });

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -401,18 +401,43 @@ export async function loadMSTeamsSdkWithAuth(creds: MSTeamsCredentials) {
 }
 
 /**
- * Create a Bot Framework JWT validator using the Teams SDK's built-in
- * JwtValidator pre-configured for Bot Framework signing keys.
+ * Create a Bot Framework JWT validator with strict multi-issuer support.
  *
- * Validates: signature (JWKS), audience (appId), issuer (api.botframework.com),
- * and expiration (5-minute clock tolerance).
+ * During Microsoft's transition, inbound service tokens can be signed by either:
+ * - Legacy Bot Framework issuer/JWKS
+ * - Entra issuer/JWKS
+ *
+ * Security invariants are preserved for both paths:
+ * - signature verification (issuer-specific JWKS)
+ * - audience validation (appId)
+ * - issuer validation (strict allowlist)
+ * - expiration validation (Teams SDK defaults)
  */
 export async function createBotFrameworkJwtValidator(creds: MSTeamsCredentials): Promise<{
   validate: (authHeader: string, serviceUrl?: string) => Promise<boolean>;
 }> {
-  const { createServiceTokenValidator } =
+  const { JwtValidator } =
     await import("@microsoft/teams.apps/dist/middleware/auth/jwt-validator.js");
-  const validator = createServiceTokenValidator(creds.appId, creds.tenantId);
+
+  const botFrameworkValidator = new JwtValidator({
+    clientId: creds.appId,
+    tenantId: creds.tenantId,
+    validateIssuer: { allowedIssuer: "https://api.botframework.com" },
+    jwksUriOptions: {
+      type: "uri",
+      uri: "https://login.botframework.com/v1/.well-known/keys",
+    },
+  });
+
+  const entraValidator = new JwtValidator({
+    clientId: creds.appId,
+    tenantId: creds.tenantId,
+    validateIssuer: { allowedTenantIds: [creds.tenantId] },
+    jwksUriOptions: {
+      type: "uri",
+      uri: "https://login.microsoftonline.com/common/discovery/v2.0/keys",
+    },
+  });
 
   return {
     async validate(authHeader: string, serviceUrl?: string): Promise<boolean> {
@@ -420,12 +445,19 @@ export async function createBotFrameworkJwtValidator(creds: MSTeamsCredentials):
       if (!token) {
         return false;
       }
+
+      const overrides = serviceUrl
+        ? ({ validateServiceUrl: { expectedServiceUrl: serviceUrl } } as const)
+        : undefined;
+
       try {
-        const result = await validator.validateAccessToken(
-          token,
-          serviceUrl ? { validateServiceUrl: { expectedServiceUrl: serviceUrl } } : undefined,
-        );
-        return result != null;
+        const legacyResult = await botFrameworkValidator.validateAccessToken(token, overrides);
+        if (legacyResult != null) {
+          return true;
+        }
+
+        const entraResult = await entraValidator.validateAccessToken(token, overrides);
+        return entraResult != null;
       } catch {
         return false;
       }

--- a/src/types/microsoft-teams-sdk.d.ts
+++ b/src/types/microsoft-teams-sdk.d.ts
@@ -26,6 +26,24 @@ declare module "@microsoft/teams.api" {
 }
 
 declare module "@microsoft/teams.apps/dist/middleware/auth/jwt-validator.js" {
+  export type JwtValidationOptions = {
+    clientId: string;
+    tenantId?: string;
+    jwksUriOptions: { type: "uri"; uri: string } | { type: "tenantId" };
+    validateIssuer?: { allowedIssuer: string } | { allowedTenantIds?: string[] };
+    validateServiceUrl?: { expectedServiceUrl: string };
+  };
+
+  export class JwtValidator {
+    constructor(options: JwtValidationOptions, logger?: unknown);
+    validateAccessToken(
+      token: string,
+      options?: {
+        validateServiceUrl?: { expectedServiceUrl: string } | undefined;
+      },
+    ): Promise<unknown | null>;
+  }
+
   export function createServiceTokenValidator(
     appId: string,
     tenantId?: string,


### PR DESCRIPTION
## Summary
- keep strict Bot Framework token validation with issuer and JWKS checks
- add strict Entra fallback validation for service tokens using common discovery JWKS and tenant issuer allowlist
- preserve serviceUrl validation override behavior
- add focused tests for legacy path, Entra fallback path, and all-fail behavior
- update local Teams SDK type declarations for JwtValidator usage

## Root cause fixed
Webhook auth only validated tokens against the legacy Bot Framework issuer (https://api.botframework.com) and Bot Framework JWKS. Valid Entra-signed service tokens were rejected even with correct signature and audience.

## Testing
- pnpm vitest extensions/msteams/src/sdk.test.ts extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
  - passed (2 files, 10 tests)

Closes #56603
