### PR TITLE
fix(slack): pre-set shuttingDown before app.stop() to prevent orphaned ping intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -610,6 +610,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/forum topics: keep native `/new` and `/reset` routed to the active topic by preserving the topic target on forum-thread command context. (#35963)
 - Status/port diagnostics: treat single-process dual-stack loopback gateway listeners as healthy in `openclaw status --all`, suppressing false "port already in use" conflict warnings. (#53398) Thanks @DanWebb1949.
 - CLI/Docker: treat loopback private-host CLI gateway connects as local for silent pairing auto-approval, while keeping remote backend and public-host CLI connects behind pairing. (#55113) Thanks @sar618.
+- Slack/socket mode: mark the underlying socket client as shutting down before provider stop paths call Bolt teardown so stale-socket restarts stop leaking orphaned ping reconnect loops. (#56646) Thanks @hsiaoa.
 
 ## 2026.3.24
 

--- a/extensions/slack/src/monitor/provider.reconnect.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect.test.ts
@@ -104,4 +104,18 @@ describe("slack socket reconnect helpers", () => {
       error: err,
     });
   });
+
+  it("marks the socket client as shutting down before stop runs", async () => {
+    const app = {
+      receiver: { client: { shuttingDown: false } },
+      stop: vi.fn().mockImplementation(async () => {
+        expect(app.receiver.client.shuttingDown).toBe(true);
+      }),
+    };
+
+    await __testing.gracefulStopSlackApp(app);
+
+    expect(app.stop).toHaveBeenCalledTimes(1);
+    expect(app.receiver.client.shuttingDown).toBe(true);
+  });
 });

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -59,6 +59,9 @@ type SlackBoltResolvedExports = {
   App: SlackAppConstructor;
   HTTPReceiver: SlackHttpReceiverConstructor;
 };
+type SlackSocketShutdownClient = {
+  shuttingDown?: boolean;
+};
 type Constructor = abstract new (...args: never[]) => unknown;
 
 function isConstructorFunction<T extends Constructor>(value: unknown): value is T {
@@ -169,6 +172,29 @@ function publishSlackDisconnectedStatus(
     lastDisconnect: message ? { at, error: message } : { at },
     lastError: message ?? null,
   });
+}
+
+function resolveSlackSocketShutdownClient(app: unknown): SlackSocketShutdownClient | undefined {
+  if (!app || typeof app !== "object") {
+    return undefined;
+  }
+  const receiver = Reflect.get(app, "receiver");
+  if (!receiver || typeof receiver !== "object") {
+    return undefined;
+  }
+  const client = Reflect.get(receiver, "client");
+  if (!client || typeof client !== "object") {
+    return undefined;
+  }
+  return client as SlackSocketShutdownClient;
+}
+
+async function gracefulStopSlackApp(app: { stop: () => unknown }) {
+  const socketClient = resolveSlackSocketShutdownClient(app);
+  if (socketClient) {
+    socketClient.shuttingDown = true;
+  }
+  await Promise.resolve(app.stop()).catch(() => undefined);
 }
 
 function formatSlackResolvedLabel(params: {
@@ -319,6 +345,15 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           clientOptions,
         },
   );
+
+  // Pre-set shuttingDown on the SocketModeClient before app.stop() to prevent
+  // a race where the library's internal ping timeout fires disconnect() before
+  // shuttingDown is set, causing orphaned reconnects with leaked ping intervals.
+  // See: openclaw/openclaw#56508
+  const gracefulStop = async () => {
+    await gracefulStopSlackApp(app);
+  };
+
   const slackHttpHandler =
     slackMode === "http" && receiver
       ? async (req: IncomingMessage, res: ServerResponse) => {
@@ -529,7 +564,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
 
   const stopOnAbort = () => {
     if (opts.abortSignal?.aborted && slackMode === "socket") {
-      void app.stop();
+      void gracefulStop();
     }
   };
   opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
@@ -607,7 +642,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
             disconnect.error ? ` (${formatUnknownError(disconnect.error)})` : ""
           }`,
         );
-        await app.stop().catch(() => undefined);
+        await gracefulStop();
         try {
           await sleepWithAbort(delayMs, opts.abortSignal);
         } catch {
@@ -628,7 +663,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     opts.abortSignal?.removeEventListener("abort", stopOnAbort);
     unregisterHttpHandler?.();
     await execApprovalsHandler?.stop().catch(() => undefined);
-    await app.stop().catch(() => undefined);
+    await gracefulStop();
   }
 }
 
@@ -641,6 +676,8 @@ export const __testing = {
   formatSlackUserResolved,
   publishSlackConnectedStatus,
   publishSlackDisconnectedStatus,
+  resolveSlackSocketShutdownClient,
+  gracefulStopSlackApp,
   resolveSlackRuntimeGroupPolicy: resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   resolveSlackBoltInterop,

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -228,7 +228,6 @@ function formatSlackUserResolved(entry: SlackUserResolution): string {
     extra: entry.note ? [entry.note] : [],
   });
 }
-
 export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const cfg = opts.config ?? loadConfig();
   const runtime: RuntimeEnv = opts.runtime ?? createNonExitingRuntime();


### PR DESCRIPTION
Fixes #56508

## Problem

When the health monitor restarts a stale Slack socket-mode connection, a race condition in `@slack/socket-mode@2.0.5` can leave orphaned ping intervals running indefinitely:

1. Health monitor detects stale socket → calls `stopChannel()` → aborts → `app.stop()`
2. `app.stop()` → `SocketModeClient.disconnect()` sets `shuttingDown = true`
3. **Race**: the library's internal ping interval fires `SlackWebSocket.disconnect()` → `terminate()` → emits `close` BEFORE step 2 sets `shuttingDown`
4. The `close` handler sees `shuttingDown === false` → schedules `delayReconnectAttempt(this.start)`
5. Orphaned connection's ping interval keeps firing, logging `"A pong wasn't received..."` every ~1.6s and leaking file descriptors

Impact: `gateway.err.log` grows unbounded (~3 warnings/1.6s per account), FD accumulation over time.

## Fix

Introduce `gracefulStop()` that sets `shuttingDown = true` on the `SocketModeClient` BEFORE calling `app.stop()`, closing the race window. Applied to all three stop paths:

- `stopOnAbort` handler (health monitor restart)
- Reconnect loop (disconnect recovery)
- `finally` block (provider teardown)

## Why not fix upstream?

`@slack/socket-mode@2.0.6` has no fix for this (only cosmetic async/await changes). The proper upstream fix would be to clear ping intervals in `SocketModeClient.disconnect()` before calling `websocket.disconnect()`, but that requires a library release. This workaround is safe because `shuttingDown` is a simple boolean sentinel — setting it early just makes the close handler skip the reconnect, which is exactly what we want.

## Testing

- Verified on macOS with 1 Slack account in socket mode
- Health monitor `stale-socket` restarts no longer produce orphaned pong warnings
- `gateway.err.log` stays clean after restart cycles

## AI Disclosure

🤖 AI-assisted (Kiro CLI). Root cause analysis from issue #56508, fix verified against `@slack/socket-mode` source.