### PR TITLE
fix(telegram): preserve forum topic routing for /new and /reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: restore completion announce delivery for extension channels like BlueBubbles. (#56348)
 - Plugins/Matrix: load bundled `@matrix-org/matrix-sdk-crypto-nodejs` through `createRequire(...)` so E2EE media send and receive keep the package-local native binding lookup working in packaged ESM builds. (#54566) thanks @joelnishanth.
 - Plugins/Matrix: encrypt E2EE image thumbnails with `thumbnail_file` while keeping unencrypted-room previews on `thumbnail_url`, so encrypted Matrix image events keep thumbnail metadata without leaking plaintext previews. (#54711) thanks @frischeDaten.
+- Telegram/forum topics: keep native `/new` and `/reset` routed to the active topic by preserving the topic target on forum-thread command context. (#35963)
 
 ## 2026.3.24
 

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -643,6 +643,41 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     );
   });
 
+  it.each(["new", "reset"] as const)(
+    "preserves the topic-qualified origin target for native /%s in forum topics",
+    async (commandName) => {
+      const { handler } = registerAndResolveCommandHandler({
+        commandName,
+        cfg: {},
+        allowFrom: ["200"],
+        groupAllowFrom: ["200"],
+        useAccessGroups: true,
+      });
+      await handler(createTelegramTopicCommandContext());
+
+      const dispatchCall = (
+        replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+          [
+            {
+              ctx?: {
+                CommandTargetSessionKey?: string;
+                MessageThreadId?: number;
+                OriginatingTo?: string;
+              };
+            },
+          ]
+        >
+      )[0]?.[0];
+      expect(dispatchCall?.ctx).toEqual(
+        expect.objectContaining({
+          CommandTargetSessionKey: "agent:main:telegram:group:-1001234567890:topic:42",
+          MessageThreadId: 42,
+          OriginatingTo: "telegram:-1001234567890:topic:42",
+        }),
+      );
+    },
+  );
+
   it("aborts native command dispatch when configured ACP topic binding cannot initialize", async () => {
     const boundSessionKey = "agent:codex:acp:binding:telegram:default:feedface";
     persistentBindingMocks.resolveConfiguredBindingRoute.mockImplementation(({ route }) =>

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -62,6 +62,7 @@ import { TelegramUpdateKeyContext } from "./bot-updates.js";
 import { TelegramBotOptions } from "./bot.js";
 import { deliverReplies } from "./bot/delivery.js";
 import {
+  buildTelegramRoutingTarget,
   buildTelegramThreadParams,
   buildSenderName,
   buildTelegramGroupFrom,
@@ -642,6 +643,7 @@ export const registerTelegramNativeCommands = ({
         }
         const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } = runtimeContext;
         const threadParams = buildTelegramThreadParams(threadSpec) ?? {};
+        const originatingTo = buildTelegramRoutingTarget(chatId, threadSpec);
         const executionCfg = getRuntimeConfigSnapshot() ?? cfg;
 
         const commandDefinition = findCommandByNativeName(command.name, "telegram");
@@ -768,7 +770,7 @@ export const registerTelegramNativeCommands = ({
           IsForum: isForum,
           // Originating context for sub-agent announce routing
           OriginatingChannel: "telegram" as const,
-          OriginatingTo: `telegram:${chatId}`,
+          OriginatingTo: originatingTo,
         });
 
         await recordInboundSessionMetaSafe({

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -1,6 +1,7 @@
 import type { Message } from "grammy/types";
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildTelegramRoutingTarget,
   buildTelegramThreadParams,
   buildTypingThreadParams,
   describeReplyTarget,
@@ -89,6 +90,31 @@ describe("buildTelegramThreadParams", () => {
     { input: { id: 0, scope: "none" as const }, expected: { message_thread_id: 0 } },
   ])("builds thread params", ({ input, expected }) => {
     expect(buildTelegramThreadParams(input)).toEqual(expected);
+  });
+});
+
+describe("buildTelegramRoutingTarget", () => {
+  it.each([
+    {
+      name: "keeps General forum topic chat-scoped",
+      chatId: -100123,
+      thread: { id: 1, scope: "forum" as const },
+      expected: "telegram:-100123",
+    },
+    {
+      name: "includes real forum topic ids",
+      chatId: -100123,
+      thread: { id: 42, scope: "forum" as const },
+      expected: "telegram:-100123:topic:42",
+    },
+    {
+      name: "falls back to bare chat when thread is missing",
+      chatId: -100123,
+      thread: null,
+      expected: "telegram:-100123",
+    },
+  ])("$name", ({ chatId, thread, expected }) => {
+    expect(buildTelegramRoutingTarget(chatId, thread)).toBe(expected);
   });
 });
 

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -204,6 +204,26 @@ export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
 }
 
 /**
+ * Build a Telegram routing target that keeps real topic/thread ids in-band.
+ *
+ * This is used by generic reply plumbing that may not always carry a separate
+ * `threadId` field through every hop. General forum topic stays chat-scoped
+ * because Telegram rejects `message_thread_id=1` for message sends.
+ */
+export function buildTelegramRoutingTarget(
+  chatId: number | string,
+  thread?: TelegramThreadSpec | null,
+): string {
+  const base = `telegram:${chatId}`;
+  const threadParams = buildTelegramThreadParams(thread);
+  const messageThreadId = threadParams?.message_thread_id;
+  if (typeof messageThreadId !== "number") {
+    return base;
+  }
+  return `${base}:topic:${messageThreadId}`;
+}
+
+/**
  * Build thread params for typing indicators (sendChatAction).
  * Empirically, General topic (id=1) needs message_thread_id for typing to appear.
  */


### PR DESCRIPTION
## Summary

- Build topic-qualified routing target (`telegram:<chatId>:topic:<threadId>`) for native commands in forum groups
- `/new` and `/reset` now stay scoped to the active topic instead of falling back to General
- General topic (threadId=1) correctly falls through to base chat target
- Add `buildTelegramRoutingTarget()` helper in `bot/helpers.ts`

## Root Cause

Native Telegram commands in `bot-native-commands.ts` flattened the origin reply target to the bare chat ID. In forum topics, any reset/hook/reply path that fell back to `OriginatingTo` lost the topic context and routed to General.

## Change Type

- [x] Bug fix

## Testing

1115 tests pass across 76 Telegram test files. New tests:
- `/new` and `/reset` in forum topic preserve `CommandTargetSessionKey`, `MessageThreadId`, and `OriginatingTo`
- `buildTelegramRoutingTarget` unit tests: threadId=1 → base, threadId=42 → topic-qualified, null → base

Fixes #35963