### PR TITLE
fix(plugins): rescue bundled channels from allowlist exclusion

### DIFF
--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -302,7 +302,9 @@ export function resolveEffectiveEnableState(params: {
   const base = resolveEnableState(params.id, params.origin, params.config, params.enabledByDefault);
   if (
     !base.enabled &&
-    base.reason === "bundled (disabled by default)" &&
+    (base.reason === "bundled (disabled by default)" ||
+      base.reason === "not in allowlist") &&
+    params.origin === "bundled" &&
     isBundledChannelEnabledByChannelConfig(params.rootConfig, params.id)
   ) {
     return { enabled: true };


### PR DESCRIPTION
lobster-biscuit

Closes #56426

## Problem

Setting `plugins.allow: ["duckduckgo", "google"]` silently breaks Telegram (and other configured bundled channels). The channel stops loading with no error.

## Root cause

`src/plugins/config-state.ts:305` — `resolveEffectiveEnableState()` rescues bundled plugins disabled by the default-off heuristic (`reason === "bundled (disabled by default)"`), but does NOT rescue those disabled by the allowlist (`reason === "not in allowlist"`).

When `plugins.allow` is set, bundled channels not listed get `reason: "not in allowlist"`. The rescue at line 303-308 only checks for `"bundled (disabled by default)"`, so it misses them.

`isBundledChannelEnabledByChannelConfig()` (line 276) already correctly checks whether the channel is explicitly configured (e.g. `channels.telegram.enabled: true`). This should trump the allowlist for bundled channels.

## User impact

Any user who sets `plugins.allow` to restrict third-party plugins will silently lose all bundled channel plugins (Telegram, Discord, Slack, etc.) that aren't listed. No error message — channels just stop working.

## Fix

Extend the rescue condition to also match `reason === "not in allowlist"` for bundled-origin plugins. Added `params.origin === "bundled"` guard to prevent rescuing external plugins the user intentionally excluded.

1 file, +3/-1.

## How to verify

1. Set `plugins.allow: ["duckduckgo"]` + `channels.telegram.enabled: true`
2. Before: Telegram silently disabled. After: Telegram loads correctly.

## Tests

`resolveEffectiveEnableState` is tested in `config-state.test.ts`. The fix adds one additional OR condition to the existing rescue path. Existing tests for the "bundled (disabled by default)" rescue remain valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)