### PR TITLE
fix: allow microphone access in Permissions-Policy for web UI voice input

### DIFF
--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -115,6 +115,10 @@ function applyControlUiSecurityHeaders(res: ServerResponse) {
   res.setHeader("Content-Security-Policy", buildControlUiCspHeader());
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Referrer-Policy", "no-referrer");
+  // Allow same-origin microphone access for the Control UI voice input (STT).
+  // The baseline Permissions-Policy in http-common.ts blocks microphone for all
+  // responses; override here so the chat UI can use the Web Speech API.
+  res.setHeader("Permissions-Policy", "camera=(), microphone=(self), geolocation=()");
 }
 
 function sendJson(res: ServerResponse, status: number, body: unknown) {

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -14,7 +14,7 @@ export function setDefaultSecurityHeaders(
 ) {
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Referrer-Policy", "no-referrer");
-  res.setHeader("Permissions-Policy", "camera=(), microphone=(self), geolocation=()");
+  res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
   const strictTransportSecurity = opts?.strictTransportSecurity;
   if (typeof strictTransportSecurity === "string" && strictTransportSecurity.length > 0) {
     res.setHeader("Strict-Transport-Security", strictTransportSecurity);

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -14,7 +14,7 @@ export function setDefaultSecurityHeaders(
 ) {
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Referrer-Policy", "no-referrer");
-  res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  res.setHeader("Permissions-Policy", "camera=(), microphone=(self), geolocation=()");
   const strictTransportSecurity = opts?.strictTransportSecurity;
   if (typeof strictTransportSecurity === "string" && strictTransportSecurity.length > 0) {
     res.setHeader("Strict-Transport-Security", strictTransportSecurity);


### PR DESCRIPTION
## Summary
- The Control UI includes a voice input (STT) button that uses the Web Speech API
- The gateway's `Permissions-Policy` header sets `microphone=()` which blocks all microphone access
- This causes Chrome to reject mic permission with "Permissions policy violation: microphone is not allowed in this document" even on HTTPS
- Changed to `microphone=(self)` to allow same-origin mic access while still blocking third-party iframes

## Test plan
- [ ] Start gateway with TLS enabled (`gateway.tls.enabled: true`)
- [ ] Open Control UI in Chrome
- [ ] Click the mic button in the chat input
- [ ] Verify Chrome prompts for microphone permission
- [ ] Verify voice input transcribes speech into the message box

🤖 Generated with [Claude Code](https://claude.com/claude-code)