### PR TITLE
fix(mistral): use mistral-conversations API instead of openai-completions

### DIFF
--- a/extensions/mistral/onboard.test.ts
+++ b/extensions/mistral/onboard.test.ts
@@ -20,7 +20,7 @@ describe("mistral onboard", () => {
     const cfg = applyMistralConfig({});
     expect(cfg.models?.providers?.mistral).toMatchObject({
       baseUrl: "https://api.mistral.ai/v1",
-      api: "openai-completions",
+      api: "mistral-conversations",
     });
     expect(resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)).toBe(
       MISTRAL_DEFAULT_MODEL_REF,
@@ -38,7 +38,7 @@ describe("mistral onboard", () => {
     );
 
     expect(cfg.models?.providers?.mistral?.baseUrl).toBe("https://api.mistral.ai/v1");
-    expect(cfg.models?.providers?.mistral?.api).toBe("openai-completions");
+    expect(cfg.models?.providers?.mistral?.api).toBe("mistral-conversations");
     expect(cfg.models?.providers?.mistral?.apiKey).toBe("old-key");
     expect(cfg.models?.providers?.mistral?.models.map((m) => m.id)).toEqual([
       "custom-model",

--- a/extensions/mistral/onboard.ts
+++ b/extensions/mistral/onboard.ts
@@ -14,7 +14,7 @@ const mistralPresetAppliers = createDefaultModelPresetAppliers({
   primaryModelRef: MISTRAL_DEFAULT_MODEL_REF,
   resolveParams: (_cfg: OpenClawConfig) => ({
     providerId: "mistral",
-    api: "openai-completions",
+    api: "mistral-conversations",
     baseUrl: MISTRAL_BASE_URL,
     defaultModel: buildMistralModelDefinition(),
     defaultModelId: MISTRAL_DEFAULT_MODEL_ID,

--- a/extensions/mistral/provider-catalog.ts
+++ b/extensions/mistral/provider-catalog.ts
@@ -4,7 +4,7 @@ import { buildMistralCatalogModels, MISTRAL_BASE_URL } from "./model-definitions
 export function buildMistralProvider(): ModelProviderConfig {
   return {
     baseUrl: MISTRAL_BASE_URL,
-    api: "openai-completions",
+    api: "mistral-conversations",
     models: buildMistralCatalogModels(),
   };
 }


### PR DESCRIPTION
## Summary

The Mistral onboarding wizard (`openclaw onboard --auth-choice mistral-api-key`) configured the provider with `api: "openai-completions"`, causing every agent request to fail with **HTTP 422** because Mistral rejects OpenAI-specific parameters:

- `store: false` → `Extra inputs are not permitted`
- `max_completion_tokens` → `Extra inputs are not permitted`

## Root Cause

`extensions/mistral/onboard.ts` and `extensions/mistral/provider-catalog.ts` both hardcoded `api: "openai-completions"`. The codebase already has a native Mistral API (`mistral-conversations`) that uses the official Mistral SDK and sends only parameters Mistral supports, but the onboarding flow wasn't using it.

## Changes

- `extensions/mistral/onboard.ts`: `api: "openai-completions"` → `"mistral-conversations"`
- `extensions/mistral/provider-catalog.ts`: same change
- `extensions/mistral/onboard.test.ts`: updated assertions

Fixes #56546