### PR TITLE
feat(openresponses): return reasoning/thinking content in /v1/responses output

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -367,11 +367,14 @@ export function handleMessageEnd(
     text: ctx.stripBlockTags(rawText, { thinking: false, final: false }),
     messagingToolSentTexts: ctx.state.messagingToolSentTexts,
   });
+  // Always extract raw thinking so HTTP listeners (OpenResponses) can capture
+  // it even when the channel reasoning mode is off.
   const rawThinking =
-    ctx.state.includeReasoning || ctx.state.streamReasoning
-      ? extractAssistantThinking(assistantMessage) || extractThinkingFromTaggedText(rawText)
+    extractAssistantThinking(assistantMessage) || extractThinkingFromTaggedText(rawText);
+  const formattedReasoning =
+    rawThinking && (ctx.state.includeReasoning || ctx.state.streamReasoning)
+      ? formatReasoningMessage(rawThinking)
       : "";
-  const formattedReasoning = rawThinking ? formatReasoningMessage(rawThinking) : "";
   const trimmedText = text.trim();
   const parsedText = trimmedText ? parseReplyDirectives(stripTrailingDirective(trimmedText)) : null;
   let cleanedText = parsedText?.text ?? "";

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -194,8 +194,7 @@ export function handleMessageUpdate(
       delta: thinkingDelta,
       content: thinkingContent,
     });
-    if (ctx.state.streamReasoning) {
-      // Prefer full partial-message thinking when available; fall back to event payloads.
+    {
       const partialThinking = extractAssistantThinking(msg);
       ctx.emitReasoningStream(partialThinking || thinkingContent || thinkingDelta);
     }
@@ -253,10 +252,7 @@ export function handleMessageUpdate(
     }
   }
 
-  if (ctx.state.streamReasoning) {
-    // Handle partial <think> tags: stream whatever reasoning is visible so far.
-    ctx.emitReasoningStream(extractThinkingFromTaggedStream(ctx.state.deltaBuffer));
-  }
+  ctx.emitReasoningStream(extractThinkingFromTaggedStream(ctx.state.deltaBuffer));
 
   const next = ctx
     .stripBlockTags(ctx.state.deltaBuffer, {
@@ -516,7 +512,7 @@ export function handleMessageEnd(
   if (!shouldEmitReasoningBeforeAnswer) {
     maybeEmitReasoning();
   }
-  if (!ctx.params.silentExpected && ctx.state.streamReasoning && rawThinking) {
+  if (rawThinking) {
     ctx.emitReasoningStream(rawThinking);
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -23,6 +23,8 @@ import {
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
 
+const THINKING_TAG_CHUNK_RE = /<\s*\/?\s*(?:think(?:ing)?|thought|antthinking)\s*>/i;
+
 const stripTrailingDirective = (text: string): string => {
   const openIndex = text.lastIndexOf("[[");
   if (openIndex < 0) {
@@ -252,7 +254,14 @@ export function handleMessageUpdate(
     }
   }
 
-  ctx.emitReasoningStream(extractThinkingFromTaggedStream(ctx.state.deltaBuffer));
+  const chunkMayChangeTaggedThinking = Boolean(chunk && THINKING_TAG_CHUNK_RE.test(chunk));
+  if (
+    ctx.state.streamReasoning ||
+    ctx.state.partialBlockState.thinking ||
+    chunkMayChangeTaggedThinking
+  ) {
+    ctx.emitReasoningStream(extractThinkingFromTaggedStream(ctx.state.deltaBuffer));
+  }
 
   const next = ctx
     .stripBlockTags(ctx.state.deltaBuffer, {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -52,6 +52,7 @@ export type EmbeddedPiSubscribeState = {
   lastStreamedAssistantCleaned?: string;
   emittedAssistantUpdate: boolean;
   lastStreamedReasoning?: string;
+  lastStreamedReasoningRaw?: string;
   lastBlockReplyText?: string;
   reasoningStreamOpen: boolean;
   assistantMessageIndex: number;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
+import { onAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.js";
 import {
   THINKING_TAG_CASES,
   createStubSessionHarness,
@@ -259,6 +260,50 @@ describe("subscribeEmbeddedPiSession", () => {
     emitAssistantTextDelta(emit, " files</think>\nFinal answer");
 
     expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets raw reasoning dedupe state between assistant messages", () => {
+    resetAgentEventsForTest();
+    const runId = "run-raw-reset";
+    const rawDeltas: string[] = [];
+    const unsubscribe = onAgentEvent((evt) => {
+      if (evt.runId !== runId || evt.stream !== "thinking-raw") {
+        return;
+      }
+      const rawDelta = typeof evt.data?.rawDelta === "string" ? evt.data.rawDelta : "";
+      if (rawDelta) {
+        rawDeltas.push(rawDelta);
+      }
+    });
+
+    const { emit } = createSubscribedHarness({
+      runId,
+      reasoningMode: "off",
+    });
+    const repeatedThinkingMessage = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "Shared prefix" }],
+    } as AssistantMessage;
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: repeatedThinkingMessage,
+      assistantMessageEvent: { type: "thinking_delta", delta: "Shared prefix" },
+    });
+    emit({ type: "message_end", message: repeatedThinkingMessage });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: repeatedThinkingMessage,
+      assistantMessageEvent: { type: "thinking_delta", delta: "Shared prefix" },
+    });
+    emit({ type: "message_end", message: repeatedThinkingMessage });
+
+    expect(rawDeltas).toEqual(["Shared prefix", "Shared prefix"]);
+    unsubscribe();
+    resetAgentEventsForTest();
   });
 
   it("emits delta chunks in agent events for streaming assistant text", () => {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -577,52 +577,40 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       return;
     }
 
-    // Always broadcast raw thinking via agent events so HTTP listeners
-    // (e.g. OpenResponses /v1/responses) can capture reasoning content
-    // even when the channel-specific streamReasoning mode is off.
     const rawPrior = state.lastStreamedReasoningRaw ?? "";
     const rawDelta = text.startsWith(rawPrior) ? text.slice(rawPrior.length) : text;
     state.lastStreamedReasoningRaw = text;
 
-    emitAgentEvent({
-      runId: params.runId,
-      stream: "thinking",
-      data: {
-        rawText: text,
-        rawDelta,
-      },
-    });
-
-    if (!state.streamReasoning) {
-      return;
-    }
-
+    // Compute formatted text and delta for channel consumers.
     const formatted = formatReasoningMessage(text);
-    if (!formatted) {
-      return;
+    const formattedPrior = state.lastStreamedReasoning ?? "";
+    const formattedDelta =
+      formatted && formatted !== formattedPrior
+        ? formatted.startsWith(formattedPrior)
+          ? formatted.slice(formattedPrior.length)
+          : formatted
+        : undefined;
+    if (formatted && formatted !== formattedPrior) {
+      state.lastStreamedReasoning = formatted;
     }
-    if (formatted === state.lastStreamedReasoning) {
-      return;
-    }
-    const prior = state.lastStreamedReasoning ?? "";
-    const delta = formatted.startsWith(prior) ? formatted.slice(prior.length) : formatted;
-    state.lastStreamedReasoning = formatted;
 
-    // Re-emit with formatted text for channel-specific consumers
+    // Single event with both raw and formatted fields. HTTP listeners
+    // use rawText; channel-specific consumers use text/delta.
     emitAgentEvent({
       runId: params.runId,
       stream: "thinking",
       data: {
-        text: formatted,
-        delta,
+        ...(formatted ? { text: formatted, delta: formattedDelta } : {}),
         rawText: text,
         rawDelta,
       },
     });
 
-    void params.onReasoningStream?.({
-      text: formatted,
-    });
+    if (state.streamReasoning && formatted) {
+      void params.onReasoningStream?.({
+        text: formatted,
+      });
+    }
   };
 
   const resetForCompactionRetry = () => {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -141,6 +141,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.emittedAssistantUpdate = false;
     state.lastBlockReplyText = undefined;
     state.lastStreamedReasoning = undefined;
+    state.lastStreamedReasoningRaw = undefined;
     state.lastReasoningSent = undefined;
     state.reasoningStreamOpen = false;
     state.suppressBlockChunks = false;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -581,41 +581,43 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     const rawDelta = text.startsWith(rawPrior) ? text.slice(rawPrior.length) : text;
     state.lastStreamedReasoningRaw = text;
 
-    // Compute formatted text and delta for channel consumers.
-    const formatted = formatReasoningMessage(text);
-    const formattedPrior = state.lastStreamedReasoning ?? "";
-    const formattedDelta =
-      formatted && formatted !== formattedPrior
-        ? formatted.startsWith(formattedPrior)
-          ? formatted.slice(formattedPrior.length)
-          : formatted
-        : undefined;
-    if (formatted && formatted !== formattedPrior) {
-      state.lastStreamedReasoning = formatted;
-    }
-
-    // Skip if nothing actually changed.
-    if (!rawDelta && !formattedDelta) {
+    if (!rawDelta) {
       return;
     }
 
-    // Single event with both raw and formatted fields. HTTP listeners
-    // use rawText; channel-specific consumers use text/delta.
+    // Always emit a non-broadcast raw event for HTTP listeners (e.g.
+    // OpenResponses /v1/responses). Uses "thinking-raw" so the generic
+    // WS broadcast path does not forward it to Control UI / channel clients.
+    emitAgentEvent({
+      runId: params.runId,
+      stream: "thinking-raw",
+      data: { rawText: text, rawDelta },
+    });
+
+    if (!state.streamReasoning) {
+      return;
+    }
+
+    const formatted = formatReasoningMessage(text);
+    if (!formatted) {
+      return;
+    }
+    if (formatted === state.lastStreamedReasoning) {
+      return;
+    }
+    const prior = state.lastStreamedReasoning ?? "";
+    const delta = formatted.startsWith(prior) ? formatted.slice(prior.length) : formatted;
+    state.lastStreamedReasoning = formatted;
+
     emitAgentEvent({
       runId: params.runId,
       stream: "thinking",
-      data: {
-        ...(formatted ? { text: formatted, delta: formattedDelta } : {}),
-        rawText: text,
-        rawDelta,
-      },
+      data: { text: formatted, delta, rawText: text, rawDelta },
     });
 
-    if (state.streamReasoning && formatted && formattedDelta) {
-      void params.onReasoningStream?.({
-        text: formatted,
-      });
-    }
+    void params.onReasoningStream?.({
+      text: formatted,
+    });
   };
 
   const resetForCompactionRetry = () => {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -573,9 +573,30 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (params.silentExpected) {
       return;
     }
-    if (!state.streamReasoning || !params.onReasoningStream) {
+    if (!text) {
       return;
     }
+
+    // Always broadcast raw thinking via agent events so HTTP listeners
+    // (e.g. OpenResponses /v1/responses) can capture reasoning content
+    // even when the channel-specific streamReasoning mode is off.
+    const rawPrior = state.lastStreamedReasoningRaw ?? "";
+    const rawDelta = text.startsWith(rawPrior) ? text.slice(rawPrior.length) : text;
+    state.lastStreamedReasoningRaw = text;
+
+    emitAgentEvent({
+      runId: params.runId,
+      stream: "thinking",
+      data: {
+        rawText: text,
+        rawDelta,
+      },
+    });
+
+    if (!state.streamReasoning) {
+      return;
+    }
+
     const formatted = formatReasoningMessage(text);
     if (!formatted) {
       return;
@@ -583,23 +604,23 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (formatted === state.lastStreamedReasoning) {
       return;
     }
-    // Compute delta: new text since the last emitted reasoning.
-    // Guard against non-prefix changes (e.g. trim/format altering earlier content).
     const prior = state.lastStreamedReasoning ?? "";
     const delta = formatted.startsWith(prior) ? formatted.slice(prior.length) : formatted;
     state.lastStreamedReasoning = formatted;
 
-    // Broadcast thinking event to WebSocket clients in real-time
+    // Re-emit with formatted text for channel-specific consumers
     emitAgentEvent({
       runId: params.runId,
       stream: "thinking",
       data: {
         text: formatted,
         delta,
+        rawText: text,
+        rawDelta,
       },
     });
 
-    void params.onReasoningStream({
+    void params.onReasoningStream?.({
       text: formatted,
     });
   };

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -594,6 +594,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       state.lastStreamedReasoning = formatted;
     }
 
+    // Skip if nothing actually changed.
+    if (!rawDelta && !formattedDelta) {
+      return;
+    }
+
     // Single event with both raw and formatted fields. HTTP listeners
     // use rawText; channel-specific consumers use text/delta.
     emitAgentEvent({
@@ -606,7 +611,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       },
     });
 
-    if (state.streamReasoning && formatted) {
+    if (state.streamReasoning && formatted && formattedDelta) {
       void params.onReasoningStream?.({
         text: formatted,
       });

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -348,6 +348,18 @@ export const OutputTextDoneEventSchema = z.object({
   text: z.string(),
 });
 
+export const ReasoningDeltaEventSchema = z.object({
+  type: z.literal("response.reasoning.delta"),
+  item_id: z.string(),
+  text: z.string(),
+});
+
+export const ReasoningDoneEventSchema = z.object({
+  type: z.literal("response.reasoning.done"),
+  item_id: z.string(),
+  text: z.string(),
+});
+
 export type StreamingEvent =
   | z.infer<typeof ResponseCreatedEventSchema>
   | z.infer<typeof ResponseInProgressEventSchema>
@@ -358,4 +370,6 @@ export type StreamingEvent =
   | z.infer<typeof ContentPartAddedEventSchema>
   | z.infer<typeof ContentPartDoneEventSchema>
   | z.infer<typeof OutputTextDeltaEventSchema>
-  | z.infer<typeof OutputTextDoneEventSchema>;
+  | z.infer<typeof OutputTextDoneEventSchema>
+  | z.infer<typeof ReasoningDeltaEventSchema>
+  | z.infer<typeof ReasoningDoneEventSchema>;

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -351,7 +351,7 @@ export const OutputTextDoneEventSchema = z.object({
 export const ReasoningDeltaEventSchema = z.object({
   type: z.literal("response.reasoning.delta"),
   item_id: z.string(),
-  text: z.string(),
+  delta: z.string(),
 });
 
 export const ReasoningDoneEventSchema = z.object({

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -740,6 +740,53 @@ describe("OpenResponses HTTP API (e2e)", () => {
     await ensureResponseConsumed(res);
   });
 
+  it("preserves non-stream reasoning segment boundaries when snapshots share prefixes", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "thinking-raw",
+        data: { rawText: "Shared prefix", rawDelta: "Shared prefix" },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "thinking-raw",
+        data: {
+          rawText: "Shared prefix and second segment",
+          rawDelta: "Shared prefix and second segment",
+        },
+      });
+      return {
+        payloads: [{ text: "Final answer." }],
+      };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: false,
+      model: "openclaw",
+      input: "explain this",
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      status?: string;
+      output?: Array<Record<string, unknown>>;
+    };
+    expect(json.status).toBe("completed");
+    expect(json.output?.map((item) => item.type)).toEqual(["reasoning", "message"]);
+    expect((json.output?.[0]?.content as string | undefined) ?? "").toBe(
+      "Shared prefix\n\nShared prefix and second segment",
+    );
+    expect(
+      ((json.output?.[1]?.content as Array<Record<string, unknown>> | undefined)?.[0]?.text as
+        | string
+        | undefined) ?? "",
+    ).toBe("Final answer.");
+    await ensureResponseConsumed(res);
+  });
+
   it("falls back to payload text for streamed function_call responses", async () => {
     const port = enabledPort;
     agentCommand.mockClear();
@@ -790,7 +837,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(events.some((event) => event.data === "[DONE]")).toBe(true);
   });
 
-  it("streams incremental reasoning deltas and emits reasoning.done before output_item.done in tool-call mode", async () => {
+  it("streams reset-aware reasoning deltas and emits a single reasoning.done in tool-call mode", async () => {
     const port = enabledPort;
     agentCommand.mockClear();
     agentCommand.mockImplementationOnce((async (opts: unknown) => {
@@ -798,12 +845,21 @@ describe("OpenResponses HTTP API (e2e)", () => {
       emitAgentEvent({
         runId,
         stream: "thinking-raw",
-        data: { rawText: "First segment", rawDelta: "First segment" },
+        data: { rawText: "Shared prefix", rawDelta: "Shared prefix" },
       });
       emitAgentEvent({
         runId,
         stream: "thinking-raw",
-        data: { rawText: "Second segment", rawDelta: "Second segment" },
+        data: {
+          rawText: "Shared prefix and second segment",
+          rawDelta: "Shared prefix and second segment",
+        },
+      });
+      // Simulate providers that emit lifecycle end before the command returns.
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end" },
       });
       return {
         payloads: [{ text: "Let me check that." }],
@@ -835,9 +891,12 @@ describe("OpenResponses HTTP API (e2e)", () => {
       .filter((event) => event.event === "response.reasoning.delta")
       .map((event) => JSON.parse(event.data) as { delta?: string });
     expect(reasoningDeltas.map((event) => event.delta)).toEqual([
-      "First segment",
-      "\n\nSecond segment",
+      "Shared prefix",
+      "\n\nShared prefix and second segment",
     ]);
+
+    const reasoningDoneEvents = events.filter((event) => event.event === "response.reasoning.done");
+    expect(reasoningDoneEvents).toHaveLength(1);
 
     const reasoningDoneIndex = events.findIndex(
       (event) => event.event === "response.reasoning.done",
@@ -849,9 +908,9 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(firstOutputItemDoneIndex).toBeGreaterThanOrEqual(0);
     expect(reasoningDoneIndex).toBeLessThan(firstOutputItemDoneIndex);
 
-    const reasoningDone = events[reasoningDoneIndex];
+    const reasoningDone = reasoningDoneEvents[0];
     expect((JSON.parse(reasoningDone?.data ?? "{}") as { text?: string }).text).toBe(
-      "First segment\n\nSecond segment",
+      "Shared prefix\n\nShared prefix and second segment",
     );
     expect(events.some((event) => event.data === "[DONE]")).toBe(true);
   });

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -790,6 +790,72 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(events.some((event) => event.data === "[DONE]")).toBe(true);
   });
 
+  it("streams incremental reasoning deltas and emits reasoning.done before output_item.done in tool-call mode", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "thinking-raw",
+        data: { rawText: "First segment", rawDelta: "First segment" },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "thinking-raw",
+        data: { rawText: "Second segment", rawDelta: "Second segment" },
+      });
+      return {
+        payloads: [{ text: "Let me check that." }],
+        meta: {
+          stopReason: "tool_calls",
+          pendingToolCalls: [
+            {
+              id: "call_1",
+              name: "get_weather",
+              arguments: '{"city":"Taipei"}',
+            },
+          ],
+        },
+      };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "check the weather",
+      tools: WEATHER_TOOL,
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const events = parseSseEvents(text);
+
+    const reasoningDeltas = events
+      .filter((event) => event.event === "response.reasoning.delta")
+      .map((event) => JSON.parse(event.data) as { delta?: string });
+    expect(reasoningDeltas.map((event) => event.delta)).toEqual([
+      "First segment",
+      "\n\nSecond segment",
+    ]);
+
+    const reasoningDoneIndex = events.findIndex(
+      (event) => event.event === "response.reasoning.done",
+    );
+    const firstOutputItemDoneIndex = events.findIndex(
+      (event) => event.event === "response.output_item.done",
+    );
+    expect(reasoningDoneIndex).toBeGreaterThanOrEqual(0);
+    expect(firstOutputItemDoneIndex).toBeGreaterThanOrEqual(0);
+    expect(reasoningDoneIndex).toBeLessThan(firstOutputItemDoneIndex);
+
+    const reasoningDone = events[reasoningDoneIndex];
+    expect((JSON.parse(reasoningDone?.data ?? "{}") as { text?: string }).text).toBe(
+      "First segment\n\nSecond segment",
+    );
+    expect(events.some((event) => event.data === "[DONE]")).toBe(true);
+  });
+
   it("reuses the prior session when previous_response_id is provided", async () => {
     const port = enabledPort;
     agentCommand.mockClear();

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -847,6 +847,12 @@ describe("OpenResponses HTTP API (e2e)", () => {
         stream: "thinking-raw",
         data: { rawText: "Shared prefix", rawDelta: "Shared prefix" },
       });
+      // Simulate providers that emit lifecycle end before the command returns.
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end" },
+      });
       emitAgentEvent({
         runId,
         stream: "thinking-raw",
@@ -854,12 +860,6 @@ describe("OpenResponses HTTP API (e2e)", () => {
           rawText: "Shared prefix and second segment",
           rawDelta: "Shared prefix and second segment",
         },
-      });
-      // Simulate providers that emit lifecycle end before the command returns.
-      emitAgentEvent({
-        runId,
-        stream: "lifecycle",
-        data: { phase: "end" },
       });
       return {
         payloads: [{ text: "Let me check that." }],
@@ -901,11 +901,17 @@ describe("OpenResponses HTTP API (e2e)", () => {
     const reasoningDoneIndex = events.findIndex(
       (event) => event.event === "response.reasoning.done",
     );
+    const lastReasoningDeltaIndex = events.reduce(
+      (latest, event, index) => (event.event === "response.reasoning.delta" ? index : latest),
+      -1,
+    );
     const firstOutputItemDoneIndex = events.findIndex(
       (event) => event.event === "response.output_item.done",
     );
+    expect(lastReasoningDeltaIndex).toBeGreaterThanOrEqual(0);
     expect(reasoningDoneIndex).toBeGreaterThanOrEqual(0);
     expect(firstOutputItemDoneIndex).toBeGreaterThanOrEqual(0);
+    expect(lastReasoningDeltaIndex).toBeLessThan(reasoningDoneIndex);
     expect(reasoningDoneIndex).toBeLessThan(firstOutputItemDoneIndex);
 
     const reasoningDone = reasoningDoneEvents[0];

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1154,6 +1154,13 @@ export async function handleOpenResponsesHttpRequest(
           output: toolCallOutput,
           usage,
         });
+        if (accumulatedThinking) {
+          writeSseEvent(res, {
+            type: "response.reasoning.done",
+            item_id: reasoningItemId,
+            text: accumulatedThinking,
+          });
+        }
         closed = true;
         unsubscribe();
         rememberResponseSession();

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1063,6 +1063,20 @@ export async function handleOpenResponsesHttpRequest(
         pendingToolCalls &&
         pendingToolCalls.length > 0
       ) {
+        // Flush any pending thinking segment before closing the stream.
+        if (currentStreamThinkingSegment) {
+          if (
+            !accumulatedThinking ||
+            !currentStreamThinkingSegment.startsWith(accumulatedThinking)
+          ) {
+            accumulatedThinking +=
+              (accumulatedThinking ? "\n\n" : "") + currentStreamThinkingSegment;
+          } else {
+            accumulatedThinking = currentStreamThinkingSegment;
+          }
+          currentStreamThinkingSegment = "";
+        }
+
         const functionCall = pendingToolCalls[0];
         const usage = finalUsage ?? createEmptyUsage();
         const finalText =

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -971,20 +971,23 @@ export async function handleOpenResponsesHttpRequest(
 
     if (evt.stream === "thinking-raw") {
       const raw = typeof evt.data?.rawText === "string" ? evt.data.rawText : "";
-      if (!raw) {
+      const rawDelta = typeof evt.data?.rawDelta === "string" ? evt.data.rawDelta : "";
+      if (!raw || !rawDelta) {
         return;
       }
+      let delta = rawDelta;
       if (currentStreamThinkingSegment && !raw.startsWith(currentStreamThinkingSegment)) {
         accumulatedThinking += (accumulatedThinking ? "\n\n" : "") + currentStreamThinkingSegment;
+        // New thinking segment starts; preserve the same separator used in
+        // final aggregated reasoning output.
+        delta = `\n\n${rawDelta}`;
       }
       currentStreamThinkingSegment = raw;
 
       writeSseEvent(res, {
         type: "response.reasoning.delta",
         item_id: reasoningItemId,
-        text: accumulatedThinking
-          ? accumulatedThinking + "\n\n" + currentStreamThinkingSegment
-          : currentStreamThinkingSegment,
+        delta,
       });
       return;
     }
@@ -1102,6 +1105,13 @@ export async function handleOpenResponsesHttpRequest(
           content_index: 0,
           part: { type: "output_text", text: finalText },
         });
+        if (accumulatedThinking) {
+          writeSseEvent(res, {
+            type: "response.reasoning.done",
+            item_id: reasoningItemId,
+            text: accumulatedThinking,
+          });
+        }
 
         const completedItem = createAssistantOutputItem({
           id: outputItemId,
@@ -1154,13 +1164,6 @@ export async function handleOpenResponsesHttpRequest(
           output: toolCallOutput,
           usage,
         });
-        if (accumulatedThinking) {
-          writeSseEvent(res, {
-            type: "response.reasoning.done",
-            item_id: reasoningItemId,
-            text: accumulatedThinking,
-          });
-        }
         closed = true;
         unsubscribe();
         rememberResponseSession();

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -895,7 +895,9 @@ export async function handleOpenResponsesHttpRequest(
       item: completedItem,
     });
 
-    const completedOutput: OutputItem[] = [];
+    // Keep assistant at output_index 0 (matching the streamed events) and
+    // append reasoning after so clients reconciling by index stay consistent.
+    const completedOutput: OutputItem[] = [completedItem];
     if (accumulatedThinking) {
       completedOutput.push({
         type: "reasoning",
@@ -903,7 +905,6 @@ export async function handleOpenResponsesHttpRequest(
         content: accumulatedThinking,
       });
     }
-    completedOutput.push(completedItem);
 
     const finalResponse = createResponseResource({
       id: responseId,

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -693,6 +693,23 @@ export async function handleOpenResponsesHttpRequest(
       : undefined;
 
   if (!stream) {
+    let collectedThinking = "";
+    let currentThinkingSegment = "";
+    const unsubThinking = onAgentEvent((evt) => {
+      if (evt.runId !== responseId || evt.stream !== "thinking") {
+        return;
+      }
+      const raw = typeof evt.data?.rawText === "string" ? evt.data.rawText : "";
+      if (!raw) {
+        return;
+      }
+      if (currentThinkingSegment) {
+        collectedThinking += (collectedThinking ? "\n\n" : "") + currentThinkingSegment;
+        currentThinkingSegment = "";
+      }
+      currentThinkingSegment = raw;
+    });
+
     try {
       const result = await runResponsesAgentCommand({
         message: prompt.message,
@@ -707,7 +724,12 @@ export async function handleOpenResponsesHttpRequest(
         deps,
       });
 
-      const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
+      unsubThinking();
+      if (currentThinkingSegment) {
+        collectedThinking += (collectedThinking ? "\n\n" : "") + currentThinkingSegment;
+        currentThinkingSegment = "";
+      }
+
       const usage = extractUsageFromResult(result);
       const meta = (result as { meta?: unknown } | null)?.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
@@ -717,6 +739,7 @@ export async function handleOpenResponsesHttpRequest(
         const functionCall = pendingToolCalls[0];
         const functionCallItemId = `call_${randomUUID()}`;
 
+        const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
         const assistantText =
           Array.isArray(payloads) && payloads.length > 0
             ? payloads
@@ -726,6 +749,13 @@ export async function handleOpenResponsesHttpRequest(
             : "";
 
         const output: OutputItem[] = [];
+        if (collectedThinking) {
+          output.push({
+            type: "reasoning",
+            id: `reasoning_${randomUUID()}`,
+            content: collectedThinking,
+          });
+        }
         if (assistantText) {
           output.push(
             createAssistantOutputItem({
@@ -756,27 +786,41 @@ export async function handleOpenResponsesHttpRequest(
         return true;
       }
 
+      const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
       const content =
         Array.isArray(payloads) && payloads.length > 0
           ? payloads
               .map((p) => (typeof p.text === "string" ? p.text : ""))
               .filter(Boolean)
               .join("\n\n")
-          : "No response from OpenClaw.";
+          : "";
+      const text = content || collectedThinking || "No response from OpenClaw.";
+
+      const output: OutputItem[] = [];
+      if (collectedThinking) {
+        output.push({
+          type: "reasoning",
+          id: `reasoning_${randomUUID()}`,
+          content: collectedThinking,
+        });
+      }
+      output.push(createAssistantOutputItem({ id: outputItemId, text, status: "completed" }));
 
       const response = createResponseResource({
         id: responseId,
         model,
         status: "completed",
-        output: [
-          createAssistantOutputItem({ id: outputItemId, text: content, status: "completed" }),
-        ],
+        output,
         usage,
       });
 
       rememberResponseSession();
       sendJson(res, 200, response);
     } catch (err) {
+      unsubThinking();
+      if (currentThinkingSegment) {
+        collectedThinking += (collectedThinking ? "\n\n" : "") + currentThinkingSegment;
+      }
       logWarn(`openresponses: non-stream response failed: ${String(err)}`);
       const response = createResponseResource({
         id: responseId,
@@ -798,11 +842,14 @@ export async function handleOpenResponsesHttpRequest(
   setSseHeaders(res);
 
   let accumulatedText = "";
+  let accumulatedThinking = "";
+  let currentStreamThinkingSegment = "";
   let sawAssistantDelta = false;
   let closed = false;
   let unsubscribe = () => {};
   let finalUsage: Usage | undefined;
   let finalizeRequested: { status: ResponseResource["status"]; text: string } | null = null;
+  const reasoningItemId = `reasoning_${randomUUID()}`;
 
   const maybeFinalize = () => {
     if (closed) {
@@ -910,6 +957,27 @@ export async function handleOpenResponsesHttpRequest(
       return;
     }
 
+    if (evt.stream === "thinking") {
+      const raw = typeof evt.data?.rawText === "string" ? evt.data.rawText : "";
+      if (!raw) {
+        return;
+      }
+      if (currentStreamThinkingSegment) {
+        accumulatedThinking += (accumulatedThinking ? "\n\n" : "") + currentStreamThinkingSegment;
+        currentStreamThinkingSegment = "";
+      }
+      currentStreamThinkingSegment = raw;
+
+      writeSseEvent(res, {
+        type: "response.reasoning.delta",
+        item_id: reasoningItemId,
+        text: accumulatedThinking
+          ? accumulatedThinking + "\n\n" + currentStreamThinkingSegment
+          : currentStreamThinkingSegment,
+      });
+      return;
+    }
+
     if (evt.stream === "assistant") {
       const content = resolveAssistantStreamDeltaText(evt);
       if (!content) {
@@ -932,9 +1000,20 @@ export async function handleOpenResponsesHttpRequest(
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
-        const finalText = accumulatedText || "No response from OpenClaw.";
+        if (currentStreamThinkingSegment) {
+          accumulatedThinking += (accumulatedThinking ? "\n\n" : "") + currentStreamThinkingSegment;
+          currentStreamThinkingSegment = "";
+        }
+        if (accumulatedThinking) {
+          writeSseEvent(res, {
+            type: "response.reasoning.done",
+            item_id: reasoningItemId,
+            text: accumulatedThinking,
+          });
+        }
+        const fallback = accumulatedText || accumulatedThinking || "No response from OpenClaw.";
         const finalStatus = phase === "error" ? "failed" : "completed";
-        requestFinalize(finalStatus, finalText);
+        requestFinalize(finalStatus, fallback);
       }
     }
   });
@@ -1066,9 +1145,10 @@ export async function handleOpenResponsesHttpRequest(
                 .map((p) => (typeof p.text === "string" ? p.text : ""))
                 .filter(Boolean)
                 .join("\n\n")
-            : "No response from OpenClaw.";
+            : "";
 
-        accumulatedText = content;
+        const fallback = content || accumulatedThinking || "No response from OpenClaw.";
+        accumulatedText = fallback;
         sawAssistantDelta = true;
 
         writeSseEvent(res, {
@@ -1076,7 +1156,7 @@ export async function handleOpenResponsesHttpRequest(
           item_id: outputItemId,
           output_index: 0,
           content_index: 0,
-          delta: content,
+          delta: fallback,
         });
       }
     } catch (err) {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -696,7 +696,7 @@ export async function handleOpenResponsesHttpRequest(
     let collectedThinking = "";
     let currentThinkingSegment = "";
     const unsubThinking = onAgentEvent((evt) => {
-      if (evt.runId !== responseId || evt.stream !== "thinking") {
+      if (evt.runId !== responseId || evt.stream !== "thinking-raw") {
         return;
       }
       const raw = typeof evt.data?.rawText === "string" ? evt.data.rawText : "";
@@ -969,7 +969,7 @@ export async function handleOpenResponsesHttpRequest(
       return;
     }
 
-    if (evt.stream === "thinking") {
+    if (evt.stream === "thinking-raw") {
       const raw = typeof evt.data?.rawText === "string" ? evt.data.rawText : "";
       if (!raw) {
         return;
@@ -1125,11 +1125,19 @@ export async function handleOpenResponsesHttpRequest(
           item: completedFunctionCallItem,
         });
 
+        const toolCallOutput: OutputItem[] = [completedItem, functionCallItem];
+        if (accumulatedThinking) {
+          toolCallOutput.push({
+            type: "reasoning",
+            id: reasoningItemId,
+            content: accumulatedThinking,
+          });
+        }
         const incompleteResponse = createResponseResource({
           id: responseId,
           model,
           status: "incomplete",
-          output: [completedItem, functionCallItem],
+          output: toolCallOutput,
           usage,
         });
         closed = true;

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -899,6 +899,20 @@ export async function handleOpenResponsesHttpRequest(
     });
     reasoningDoneEmitted = true;
   };
+  const buildThinkingTextWithPendingSegment = () =>
+    currentStreamThinkingSegment
+      ? accumulatedThinking
+        ? `${accumulatedThinking}\n\n${currentStreamThinkingSegment}`
+        : currentStreamThinkingSegment
+      : accumulatedThinking;
+  const buildFinalizeText = () =>
+    accumulatedText || buildThinkingTextWithPendingSegment() || "No response from OpenClaw.";
+  const refreshFinalizeText = () => {
+    if (!finalizeRequested) {
+      return;
+    }
+    finalizeRequested.text = buildFinalizeText();
+  };
 
   const maybeFinalize = () => {
     if (closed) {
@@ -910,7 +924,11 @@ export async function handleOpenResponsesHttpRequest(
     if (!finalUsage) {
       return;
     }
+    flushCurrentStreamThinkingSegment();
+    refreshFinalizeText();
+    emitReasoningDoneOnce();
     const usage = finalUsage;
+    const finalText = finalizeRequested.text;
 
     closed = true;
     unsubscribe();
@@ -920,7 +938,7 @@ export async function handleOpenResponsesHttpRequest(
       item_id: outputItemId,
       output_index: 0,
       content_index: 0,
-      text: finalizeRequested.text,
+      text: finalText,
     });
 
     writeSseEvent(res, {
@@ -928,12 +946,12 @@ export async function handleOpenResponsesHttpRequest(
       item_id: outputItemId,
       output_index: 0,
       content_index: 0,
-      part: { type: "output_text", text: finalizeRequested.text },
+      part: { type: "output_text", text: finalText },
     });
 
     const completedItem = createAssistantOutputItem({
       id: outputItemId,
-      text: finalizeRequested.text,
+      text: finalText,
       status: "completed",
     });
 
@@ -1028,6 +1046,7 @@ export async function handleOpenResponsesHttpRequest(
         flushCurrentStreamThinkingSegment();
       }
       currentStreamThinkingSegment = raw;
+      refreshFinalizeText();
 
       let delta = rawDelta ?? raw;
       if (startsNewSegment) {
@@ -1052,6 +1071,7 @@ export async function handleOpenResponsesHttpRequest(
 
       sawAssistantDelta = true;
       accumulatedText += content;
+      refreshFinalizeText();
 
       writeSseEvent(res, {
         type: "response.output_text.delta",
@@ -1066,11 +1086,8 @@ export async function handleOpenResponsesHttpRequest(
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
-        flushCurrentStreamThinkingSegment();
-        emitReasoningDoneOnce();
-        const fallback = accumulatedText || accumulatedThinking || "No response from OpenClaw.";
         const finalStatus = phase === "error" ? "failed" : "completed";
-        requestFinalize(finalStatus, fallback);
+        requestFinalize(finalStatus, buildFinalizeText());
       }
     }
   });
@@ -1219,6 +1236,7 @@ export async function handleOpenResponsesHttpRequest(
         const fallback = content || accumulatedThinking || "No response from OpenClaw.";
         accumulatedText = fallback;
         sawAssistantDelta = true;
+        refreshFinalizeText();
 
         writeSseEvent(res, {
           type: "response.output_text.delta",

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -703,9 +703,10 @@ export async function handleOpenResponsesHttpRequest(
       if (!raw) {
         return;
       }
-      if (currentThinkingSegment) {
+      // rawText is cumulative within a block. Only flush the previous segment
+      // when the new value does NOT extend it (indicates a new thinking block).
+      if (currentThinkingSegment && !raw.startsWith(currentThinkingSegment)) {
         collectedThinking += (collectedThinking ? "\n\n" : "") + currentThinkingSegment;
-        currentThinkingSegment = "";
       }
       currentThinkingSegment = raw;
     });
@@ -894,11 +895,21 @@ export async function handleOpenResponsesHttpRequest(
       item: completedItem,
     });
 
+    const completedOutput: OutputItem[] = [];
+    if (accumulatedThinking) {
+      completedOutput.push({
+        type: "reasoning",
+        id: reasoningItemId,
+        content: accumulatedThinking,
+      });
+    }
+    completedOutput.push(completedItem);
+
     const finalResponse = createResponseResource({
       id: responseId,
       model,
       status: finalizeRequested.status,
-      output: [completedItem],
+      output: completedOutput,
       usage,
     });
 
@@ -962,9 +973,8 @@ export async function handleOpenResponsesHttpRequest(
       if (!raw) {
         return;
       }
-      if (currentStreamThinkingSegment) {
+      if (currentStreamThinkingSegment && !raw.startsWith(currentStreamThinkingSegment)) {
         accumulatedThinking += (accumulatedThinking ? "\n\n" : "") + currentStreamThinkingSegment;
-        currentStreamThinkingSegment = "";
       }
       currentStreamThinkingSegment = raw;
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -695,18 +695,35 @@ export async function handleOpenResponsesHttpRequest(
   if (!stream) {
     let collectedThinking = "";
     let currentThinkingSegment = "";
+    const flushCurrentThinkingSegment = () => {
+      if (!currentThinkingSegment) {
+        return;
+      }
+      collectedThinking += (collectedThinking ? "\n\n" : "") + currentThinkingSegment;
+      currentThinkingSegment = "";
+    };
+    const isNewThinkingSegment = (raw: string, rawDelta?: string) => {
+      if (!currentThinkingSegment) {
+        return false;
+      }
+      // rawDelta===raw means upstream reset the snapshot baseline, so this is
+      // a new segment even when the next segment shares a prefix.
+      if (rawDelta && rawDelta === raw) {
+        return true;
+      }
+      return !raw.startsWith(currentThinkingSegment);
+    };
     const unsubThinking = onAgentEvent((evt) => {
       if (evt.runId !== responseId || evt.stream !== "thinking-raw") {
         return;
       }
       const raw = typeof evt.data?.rawText === "string" ? evt.data.rawText : "";
+      const rawDelta = typeof evt.data?.rawDelta === "string" ? evt.data.rawDelta : undefined;
       if (!raw) {
         return;
       }
-      // rawText is cumulative within a block. Only flush the previous segment
-      // when the new value does NOT extend it (indicates a new thinking block).
-      if (currentThinkingSegment && !raw.startsWith(currentThinkingSegment)) {
-        collectedThinking += (collectedThinking ? "\n\n" : "") + currentThinkingSegment;
+      if (isNewThinkingSegment(raw, rawDelta)) {
+        flushCurrentThinkingSegment();
       }
       currentThinkingSegment = raw;
     });
@@ -726,10 +743,7 @@ export async function handleOpenResponsesHttpRequest(
       });
 
       unsubThinking();
-      if (currentThinkingSegment) {
-        collectedThinking += (collectedThinking ? "\n\n" : "") + currentThinkingSegment;
-        currentThinkingSegment = "";
-      }
+      flushCurrentThinkingSegment();
 
       const usage = extractUsageFromResult(result);
       const meta = (result as { meta?: unknown } | null)?.meta;
@@ -819,9 +833,7 @@ export async function handleOpenResponsesHttpRequest(
       sendJson(res, 200, response);
     } catch (err) {
       unsubThinking();
-      if (currentThinkingSegment) {
-        collectedThinking += (collectedThinking ? "\n\n" : "") + currentThinkingSegment;
-      }
+      flushCurrentThinkingSegment();
       logWarn(`openresponses: non-stream response failed: ${String(err)}`);
       const response = createResponseResource({
         id: responseId,
@@ -851,6 +863,42 @@ export async function handleOpenResponsesHttpRequest(
   let finalUsage: Usage | undefined;
   let finalizeRequested: { status: ResponseResource["status"]; text: string } | null = null;
   const reasoningItemId = `reasoning_${randomUUID()}`;
+  let reasoningDoneEmitted = false;
+  const appendThinkingSegment = (segment: string) => {
+    if (!segment) {
+      return;
+    }
+    accumulatedThinking += (accumulatedThinking ? "\n\n" : "") + segment;
+  };
+  const flushCurrentStreamThinkingSegment = () => {
+    if (!currentStreamThinkingSegment) {
+      return;
+    }
+    appendThinkingSegment(currentStreamThinkingSegment);
+    currentStreamThinkingSegment = "";
+  };
+  const isNewStreamThinkingSegment = (raw: string, rawDelta?: string) => {
+    if (!currentStreamThinkingSegment) {
+      return false;
+    }
+    // rawDelta===raw means upstream reset the snapshot baseline, so this is
+    // a new segment even when the next segment shares a prefix.
+    if (rawDelta && rawDelta === raw) {
+      return true;
+    }
+    return !raw.startsWith(currentStreamThinkingSegment);
+  };
+  const emitReasoningDoneOnce = () => {
+    if (!accumulatedThinking || reasoningDoneEmitted) {
+      return;
+    }
+    writeSseEvent(res, {
+      type: "response.reasoning.done",
+      item_id: reasoningItemId,
+      text: accumulatedThinking,
+    });
+    reasoningDoneEmitted = true;
+  };
 
   const maybeFinalize = () => {
     if (closed) {
@@ -971,18 +1019,22 @@ export async function handleOpenResponsesHttpRequest(
 
     if (evt.stream === "thinking-raw") {
       const raw = typeof evt.data?.rawText === "string" ? evt.data.rawText : "";
-      const rawDelta = typeof evt.data?.rawDelta === "string" ? evt.data.rawDelta : "";
-      if (!raw || !rawDelta) {
+      const rawDelta = typeof evt.data?.rawDelta === "string" ? evt.data.rawDelta : undefined;
+      if (!raw) {
         return;
       }
-      let delta = rawDelta;
-      if (currentStreamThinkingSegment && !raw.startsWith(currentStreamThinkingSegment)) {
-        accumulatedThinking += (accumulatedThinking ? "\n\n" : "") + currentStreamThinkingSegment;
-        // New thinking segment starts; preserve the same separator used in
-        // final aggregated reasoning output.
-        delta = `\n\n${rawDelta}`;
+      const startsNewSegment = isNewStreamThinkingSegment(raw, rawDelta);
+      if (startsNewSegment) {
+        flushCurrentStreamThinkingSegment();
       }
       currentStreamThinkingSegment = raw;
+
+      let delta = rawDelta ?? raw;
+      if (startsNewSegment) {
+        // New thinking segment starts; preserve the same separator used in
+        // final aggregated reasoning output.
+        delta = `\n\n${delta}`;
+      }
 
       writeSseEvent(res, {
         type: "response.reasoning.delta",
@@ -1014,17 +1066,8 @@ export async function handleOpenResponsesHttpRequest(
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
-        if (currentStreamThinkingSegment) {
-          accumulatedThinking += (accumulatedThinking ? "\n\n" : "") + currentStreamThinkingSegment;
-          currentStreamThinkingSegment = "";
-        }
-        if (accumulatedThinking) {
-          writeSseEvent(res, {
-            type: "response.reasoning.done",
-            item_id: reasoningItemId,
-            text: accumulatedThinking,
-          });
-        }
+        flushCurrentStreamThinkingSegment();
+        emitReasoningDoneOnce();
         const fallback = accumulatedText || accumulatedThinking || "No response from OpenClaw.";
         const finalStatus = phase === "error" ? "failed" : "completed";
         requestFinalize(finalStatus, fallback);
@@ -1067,18 +1110,8 @@ export async function handleOpenResponsesHttpRequest(
         pendingToolCalls.length > 0
       ) {
         // Flush any pending thinking segment before closing the stream.
-        if (currentStreamThinkingSegment) {
-          if (
-            !accumulatedThinking ||
-            !currentStreamThinkingSegment.startsWith(accumulatedThinking)
-          ) {
-            accumulatedThinking +=
-              (accumulatedThinking ? "\n\n" : "") + currentStreamThinkingSegment;
-          } else {
-            accumulatedThinking = currentStreamThinkingSegment;
-          }
-          currentStreamThinkingSegment = "";
-        }
+        flushCurrentStreamThinkingSegment();
+        emitReasoningDoneOnce();
 
         const functionCall = pendingToolCalls[0];
         const usage = finalUsage ?? createEmptyUsage();
@@ -1105,13 +1138,6 @@ export async function handleOpenResponsesHttpRequest(
           content_index: 0,
           part: { type: "output_text", text: finalText },
         });
-        if (accumulatedThinking) {
-          writeSseEvent(res, {
-            type: "response.reasoning.done",
-            item_id: reasoningItemId,
-            text: accumulatedThinking,
-          });
-        }
 
         const completedItem = createAssistantOutputItem({
           id: outputItemId,

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -626,6 +626,47 @@ describe("agent event handler", () => {
     resetAgentRunContextForTest();
   });
 
+  it("does not broadcast thinking-raw events to agent or node subscribers", () => {
+    const { broadcast, nodeSendToSession, agentRunSeq, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-thinking-raw",
+    });
+    registerAgentRunContext("run-thinking-raw", {
+      sessionKey: "session-thinking-raw",
+      verboseLevel: "off",
+    });
+
+    handler({
+      runId: "run-thinking-raw",
+      seq: 1,
+      stream: "thinking-raw",
+      ts: Date.now(),
+      data: { rawText: "step one", rawDelta: "step one" },
+    });
+
+    expect(broadcast).not.toHaveBeenCalled();
+    expect(nodeSendToSession).not.toHaveBeenCalled();
+    expect(agentRunSeq.get("run-thinking-raw")).toBe(1);
+
+    // Follow-up events should not trigger seq-gap errors after a hidden thinking-raw event.
+    handler({
+      runId: "run-thinking-raw",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "final answer" },
+    });
+
+    const agentCalls = broadcast.mock.calls.filter(([event]) => event === "agent");
+    expect(agentCalls).toHaveLength(1);
+    const firstAgentPayload = agentCalls[0] ? (agentCalls[0][1] as { stream?: string }) : undefined;
+    expect(firstAgentPayload?.stream).toBe("assistant");
+    const seqGapErrors = agentCalls.filter(
+      ([, payload]) => (payload as { stream?: string }).stream === "error",
+    );
+    expect(seqGapErrors).toHaveLength(0);
+    resetAgentRunContextForTest();
+  });
+
   it("broadcasts tool events to WS recipients even when verbose is off, but skips node send", () => {
     const { broadcastToConnIds, nodeSendToSession, toolEventRecipients, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-1",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -730,6 +730,7 @@ export function createAgentEventHandler({
     const agentPayload = sessionKey ? { ...eventForClients, sessionKey } : eventForClients;
     const last = agentRunSeq.get(evt.runId) ?? 0;
     const isToolEvent = evt.stream === "tool";
+    const isRawThinkingEvent = evt.stream === "thinking-raw";
     const toolVerbose = isToolEvent ? resolveToolVerboseLevel(evt.runId, sessionKey) : "off";
     // Build tool payload: strip result/partialResult unless verbose=full
     const toolPayload =
@@ -792,7 +793,7 @@ export function createAgentEventHandler({
           );
         }
       }
-    } else {
+    } else if (!isRawThinkingEvent) {
       broadcast("agent", agentPayload);
     }
 
@@ -802,7 +803,7 @@ export function createAgentEventHandler({
     if (isControlUiVisible && sessionKey) {
       // Send tool events to node/channel subscribers only when verbose is enabled;
       // WS clients already received the event above via broadcastToConnIds.
-      if (!isToolEvent || toolVerbose !== "off") {
+      if (!isRawThinkingEvent && (!isToolEvent || toolVerbose !== "off")) {
         nodeSendToSession(
           sessionKey,
           "agent",


### PR DESCRIPTION
## Summary

- **Problem:** The `/v1/responses` endpoint does not return model reasoning/thinking content. When models produce chain-of-thought reasoning (Anthropic Claude, OpenAI o-series, Gemini thinking, Ollama thinking models), the reasoning output is silently discarded by the HTTP API. Callers have no way to observe model reasoning through the OpenResponses interface.
- **Why it matters:** The [Open Responses spec](https://www.openresponses.org/reference) defines `type: "reasoning"` as a first-class output item (`ReasoningBody`) and `response.reasoning.delta`/`response.reasoning.done` as streaming events. Not implementing these means OpenClaw's OpenResponses endpoint is incomplete relative to the spec, and API callers (dashboards, orchestrators, observability tools) cannot access reasoning data.
- **What changed:** The endpoint now captures reasoning content from agent thinking events and returns it as `type: "reasoning"` output items (non-stream) or `response.reasoning.delta`/`response.reasoning.done` SSE events (stream). When no assistant text is produced but reasoning exists, the reasoning text is used as a fallback response to avoid empty replies from thinking-only models.
- **What did NOT change (scope boundary):** No config changes required. No new dependencies. Existing behavior for non-reasoning models is unchanged. The `onReasoningStream` callback path for channel-specific reasoning delivery (Discord, Telegram, etc.) is unmodified. This change only adds reasoning to the HTTP API surface.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #54496
- Related #44513
- Related #8364
- Partially addresses #31449 (OpenResponses reasoning output/events only; full tool I/O/context parity still pending)
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A — this is a new feature implementing an existing spec item.

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

### Non-streaming responses

When reasoning is produced, the response `output` array now includes a `type: "reasoning"` item before the assistant message:

```json
{
  "output": [
    {
      "type": "reasoning",
      "id": "reasoning_abc123",
      "content": "Let me think about this step by step..."
    },
    {
      "type": "message",
      "role": "assistant",
      "content": [{ "type": "output_text", "text": "The answer is 42." }]
    }
  ]
}
```

### Streaming responses

Two new SSE event types are emitted during streaming:

- `response.reasoning.delta` — cumulative reasoning text as it streams
- `response.reasoning.done` — final reasoning text when complete

### Fallback behavior

When a model produces reasoning but no assistant text (common with thinking-only model configurations), the reasoning content is used as the response text instead of returning "No response from OpenClaw."

## Diagram (if applicable)

```
Model produces reasoning + answer:

  [thinking events] ──→ collect reasoning ──→ output[0]: reasoning item
  [assistant events] ──→ collect text     ──→ output[1]: assistant message

Model produces reasoning only (no assistant text):

  [thinking events] ──→ collect reasoning ──→ output[0]: reasoning item
  (no assistant text)                     ──→ output[1]: assistant = reasoning fallback
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — reasoning content was already produced by the model, it was just being discarded

## Repro + Verification

### Environment

- OS: macOS 15.4 (Apple Silicon)
- Runtime: Node 22, Bun 1.2
- Model: any reasoning-capable model (Claude, o-series, Gemini thinking)

### Steps

1. Send a POST to `/v1/responses` with a reasoning-capable model
2. Observe the response `output` array

### Expected

Reasoning content appears as `type: "reasoning"` output item.

### Actual

Same as expected.

## Evidence

- [x] `pnpm build` green
- [x] `pnpm check` green (lint, format, types)
- [x] `src/gateway/openresponses-http.test.ts` — 12/12 tests pass
- [x] `src/agents/pi-embedded-subscribe.*` — 21/30 pass (9 pre-existing upstream failures, verified same count on clean `upstream/main`)

## Human Verification (required)

- Verified: non-stream reasoning collection, stream reasoning events, fallback from thinking to text, cleanup on error
- Edge cases: no reasoning produced (no-op), reasoning-only response (fallback), tool-call + reasoning combined output
- Not verified: production load, all provider-specific thinking formats

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — adds new output items, does not remove or change existing ones
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: reasoning content could be large (10k+ chars) for complex prompts, increasing response payload size
  - Mitigation: This mirrors the model's actual output; callers can ignore the reasoning item if not needed
- Risk: double `emitAgentEvent` calls (raw + formatted) for channel-streaming reasoning mode
  - Mitigation: The raw-only event fires first for HTTP capture; the formatted event fires only when `streamReasoning` is active. HTTP consumers filter by `rawText` presence.


Made with [Cursor](https://cursor.com)


