### PR TITLE
fix(whatsapp): support quoted outbound replies

### DIFF
--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -6,6 +6,7 @@ export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
   fileName?: string;
+  replyToId?: string;
 };
 
 export type ActiveWebListener = {

--- a/extensions/whatsapp/src/channel.test.ts
+++ b/extensions/whatsapp/src/channel.test.ts
@@ -164,6 +164,40 @@ describe("whatsappPlugin outbound sendMedia", () => {
     );
     expect(result).toMatchObject({ channel: "whatsapp", messageId: "msg-1" });
   });
+
+  it("forwards replyToId to sendMessageWhatsApp", async () => {
+    const sendWhatsApp = vi.fn(async () => ({
+      messageId: "msg-1",
+      toJid: "15551234567@s.whatsapp.net",
+    }));
+
+    const outbound = whatsappPlugin.outbound;
+    if (!outbound?.sendText) {
+      throw new Error("whatsapp outbound sendText is unavailable");
+    }
+
+    const result = await outbound.sendText({
+      cfg: {} as never,
+      to: "whatsapp:+15551234567",
+      text: "reply body",
+      replyToId: "wa-msg-1",
+      accountId: "default",
+      deps: { sendWhatsApp },
+      gifPlayback: false,
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledWith(
+      "whatsapp:+15551234567",
+      "reply body",
+      expect.objectContaining({
+        verbose: false,
+        accountId: "default",
+        gifPlayback: false,
+        replyToId: "wa-msg-1",
+      }),
+    );
+    expect(result).toMatchObject({ channel: "whatsapp", messageId: "msg-1" });
+  });
 });
 
 describe("whatsappPlugin outbound sendPoll", () => {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -25,6 +25,7 @@ import {
 } from "./extract.js";
 import { attachEmitterListener, closeInboundMonitorSocket } from "./lifecycle.js";
 import { downloadInboundMedia } from "./media.js";
+import { getRecentWhatsAppMessage, rememberRecentWhatsAppMessage } from "./recent-messages.js";
 import { createWebSendApi } from "./send-api.js";
 import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
 
@@ -150,6 +151,11 @@ export async function monitorWebInbox(options: {
     if (!messageId) {
       return;
     }
+    rememberRecentWhatsAppMessage({
+      accountId: options.accountId,
+      remoteJid,
+      message: result as WAMessage,
+    });
     rememberRecentOutboundMessage({
       accountId: options.accountId,
       remoteJid,
@@ -157,8 +163,14 @@ export async function monitorWebInbox(options: {
     });
   };
 
-  const sendTrackedMessage = async (jid: string, content: AnyMessageContent) => {
-    const result = await sock.sendMessage(jid, content);
+  const sendTrackedMessage = async (
+    jid: string,
+    content: AnyMessageContent,
+    sendOptions?: { quoted?: WAMessage },
+  ) => {
+    const result = sendOptions
+      ? await sock.sendMessage(jid, content, sendOptions)
+      : await sock.sendMessage(jid, content);
     rememberOutboundMessage(jid, result);
     return result;
   };
@@ -473,6 +485,11 @@ export async function monitorWebInbox(options: {
       if (!inbound) {
         continue;
       }
+      rememberRecentWhatsAppMessage({
+        accountId: options.accountId,
+        remoteJid: inbound.remoteJid,
+        message: msg,
+      });
 
       await maybeMarkInboundAsRead(inbound);
 
@@ -533,10 +550,16 @@ export async function monitorWebInbox(options: {
 
   const sendApi = createWebSendApi({
     sock: {
-      sendMessage: (jid: string, content: AnyMessageContent) => sendTrackedMessage(jid, content),
+      sendMessage: (
+        jid: string,
+        content: AnyMessageContent,
+        sendOptions?: { quoted?: WAMessage },
+      ) => sendTrackedMessage(jid, content, sendOptions),
       sendPresenceUpdate: (presence, jid?: string) => sock.sendPresenceUpdate(presence, jid),
     },
     defaultAccountId: options.accountId,
+    resolveQuotedMessage: ({ accountId, remoteJid, messageId }) =>
+      getRecentWhatsAppMessage({ accountId, remoteJid, messageId }),
   });
 
   return {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -155,6 +155,7 @@ export async function monitorWebInbox(options: {
       accountId: options.accountId,
       remoteJid,
       message: result as WAMessage,
+      authDir: options.authDir,
     });
     rememberRecentOutboundMessage({
       accountId: options.accountId,
@@ -489,6 +490,7 @@ export async function monitorWebInbox(options: {
         accountId: options.accountId,
         remoteJid: inbound.remoteJid,
         message: msg,
+        authDir: options.authDir,
       });
 
       await maybeMarkInboundAsRead(inbound);
@@ -559,7 +561,7 @@ export async function monitorWebInbox(options: {
     },
     defaultAccountId: options.accountId,
     resolveQuotedMessage: ({ accountId, remoteJid, messageId }) =>
-      getRecentWhatsAppMessage({ accountId, remoteJid, messageId }),
+      getRecentWhatsAppMessage({ accountId, remoteJid, messageId, authDir: options.authDir }),
   });
 
   return {

--- a/extensions/whatsapp/src/inbound/recent-messages.test.ts
+++ b/extensions/whatsapp/src/inbound/recent-messages.test.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getRecentWhatsAppMessage,
+  rememberRecentWhatsAppMessage,
+  resetRecentWhatsAppMessages,
+} from "./recent-messages.js";
+
+describe("recent WhatsApp messages", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    resetRecentWhatsAppMessages();
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("matches device-scoped direct JIDs against normalized outbound JIDs", () => {
+    rememberRecentWhatsAppMessage({
+      accountId: "main",
+      remoteJid: "15551234567:12@s.whatsapp.net",
+      message: {
+        key: {
+          id: "msg-1",
+          remoteJid: "15551234567:12@s.whatsapp.net",
+        },
+        message: { conversation: "hello" },
+      },
+    });
+
+    expect(
+      getRecentWhatsAppMessage({
+        accountId: "main",
+        remoteJid: "15551234567@s.whatsapp.net",
+        messageId: "msg-1",
+      }),
+    ).toMatchObject({
+      key: expect.objectContaining({ id: "msg-1" }),
+      message: { conversation: "hello" },
+    });
+  });
+
+  it("matches LID-backed chats against normalized outbound JIDs when authDir is available", () => {
+    const authDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-lid-"));
+    tempDirs.push(authDir);
+    fs.writeFileSync(
+      path.join(authDir, "lid-mapping-123_reverse.json"),
+      JSON.stringify("+15557654321"),
+    );
+
+    rememberRecentWhatsAppMessage({
+      accountId: "main",
+      remoteJid: "123@lid",
+      authDir,
+      message: {
+        key: {
+          id: "msg-2",
+          remoteJid: "123@lid",
+        },
+        message: { conversation: "hello from lid" },
+      },
+    });
+
+    expect(
+      getRecentWhatsAppMessage({
+        accountId: "main",
+        remoteJid: "15557654321@s.whatsapp.net",
+        messageId: "msg-2",
+        authDir,
+      }),
+    ).toMatchObject({
+      key: expect.objectContaining({ id: "msg-2" }),
+      message: { conversation: "hello from lid" },
+    });
+  });
+});

--- a/extensions/whatsapp/src/inbound/recent-messages.ts
+++ b/extensions/whatsapp/src/inbound/recent-messages.ts
@@ -1,4 +1,6 @@
 import type { WAMessage } from "@whiskeysockets/baileys";
+import { jidToE164, toWhatsappJid } from "openclaw/plugin-sdk/text-runtime";
+import { normalizeDeviceScopedJid } from "../identity.js";
 
 const RECENT_WHATSAPP_MESSAGE_TTL_MS = 20 * 60_000;
 const RECENT_WHATSAPP_MESSAGE_MAX = 5000;
@@ -25,9 +27,10 @@ function buildMessageKey(params: {
   accountId: string;
   remoteJid: string;
   messageId: string | null | undefined;
+  authDir?: string;
 }): string | null {
   const accountId = params.accountId.trim();
-  const remoteJid = params.remoteJid.trim();
+  const remoteJid = canonicalizeRecentMessageJid(params.remoteJid, params.authDir);
   const messageId = params.messageId?.trim() || "";
   if (!accountId || !remoteJid || !messageId || messageId === "unknown") {
     return null;
@@ -35,12 +38,28 @@ function buildMessageKey(params: {
   return `${accountId}:${remoteJid}:${messageId}`;
 }
 
+function canonicalizeRecentMessageJid(remoteJid: string, authDir?: string): string {
+  const normalizedJid = normalizeDeviceScopedJid(remoteJid)?.trim() || "";
+  if (!normalizedJid) {
+    return "";
+  }
+  const e164 = jidToE164(normalizedJid, authDir ? { authDir } : undefined);
+  return e164 ? toWhatsappJid(e164) : normalizedJid;
+}
+
 function pruneRecentMessages(now: number): void {
-  const cutoff = now - RECENT_WHATSAPP_MESSAGE_TTL_MS;
-  for (const [key, entry] of state.messages) {
-    if (entry.seenAt < cutoff) {
-      state.messages.delete(key);
+  while (true) {
+    const oldest = state.messages.entries().next().value as
+      | [string, RecentMessageEntry]
+      | undefined;
+    if (!oldest) {
+      break;
     }
+    const [oldestKey, oldestEntry] = oldest;
+    if (now - oldestEntry.seenAt < RECENT_WHATSAPP_MESSAGE_TTL_MS) {
+      break;
+    }
+    state.messages.delete(oldestKey);
   }
   while (state.messages.size > RECENT_WHATSAPP_MESSAGE_MAX) {
     const oldestKey = state.messages.keys().next().value;
@@ -55,12 +74,14 @@ export function rememberRecentWhatsAppMessage(params: {
   accountId: string;
   remoteJid: string;
   message: WAMessage | null | undefined;
+  authDir?: string;
   now?: number;
 }): void {
   const key = buildMessageKey({
     accountId: params.accountId,
     remoteJid: params.remoteJid,
     messageId: params.message?.key?.id,
+    authDir: params.authDir,
   });
   if (!key || !params.message?.message) {
     return;
@@ -82,6 +103,7 @@ export function getRecentWhatsAppMessage(params: {
   accountId: string;
   remoteJid: string;
   messageId: string;
+  authDir?: string;
   now?: number;
 }): WAMessage | null {
   const key = buildMessageKey(params);

--- a/extensions/whatsapp/src/inbound/recent-messages.ts
+++ b/extensions/whatsapp/src/inbound/recent-messages.ts
@@ -1,0 +1,105 @@
+import type { WAMessage } from "@whiskeysockets/baileys";
+
+const RECENT_WHATSAPP_MESSAGE_TTL_MS = 20 * 60_000;
+const RECENT_WHATSAPP_MESSAGE_MAX = 5000;
+const RECENT_WHATSAPP_MESSAGE_STATE_KEY = Symbol.for("openclaw.whatsapp.recentMessageState");
+
+type RecentMessageEntry = {
+  message: WAMessage;
+  seenAt: number;
+};
+
+type RecentMessageState = {
+  messages: Map<string, RecentMessageEntry>;
+};
+
+const g = globalThis as unknown as Record<symbol, RecentMessageState | undefined>;
+if (!g[RECENT_WHATSAPP_MESSAGE_STATE_KEY]) {
+  g[RECENT_WHATSAPP_MESSAGE_STATE_KEY] = {
+    messages: new Map<string, RecentMessageEntry>(),
+  };
+}
+const state = g[RECENT_WHATSAPP_MESSAGE_STATE_KEY]!;
+
+function buildMessageKey(params: {
+  accountId: string;
+  remoteJid: string;
+  messageId: string | null | undefined;
+}): string | null {
+  const accountId = params.accountId.trim();
+  const remoteJid = params.remoteJid.trim();
+  const messageId = params.messageId?.trim() || "";
+  if (!accountId || !remoteJid || !messageId || messageId === "unknown") {
+    return null;
+  }
+  return `${accountId}:${remoteJid}:${messageId}`;
+}
+
+function pruneRecentMessages(now: number): void {
+  const cutoff = now - RECENT_WHATSAPP_MESSAGE_TTL_MS;
+  for (const [key, entry] of state.messages) {
+    if (entry.seenAt < cutoff) {
+      state.messages.delete(key);
+    }
+  }
+  while (state.messages.size > RECENT_WHATSAPP_MESSAGE_MAX) {
+    const oldestKey = state.messages.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    state.messages.delete(oldestKey);
+  }
+}
+
+export function rememberRecentWhatsAppMessage(params: {
+  accountId: string;
+  remoteJid: string;
+  message: WAMessage | null | undefined;
+  now?: number;
+}): void {
+  const key = buildMessageKey({
+    accountId: params.accountId,
+    remoteJid: params.remoteJid,
+    messageId: params.message?.key?.id,
+  });
+  if (!key || !params.message?.message) {
+    return;
+  }
+  const seenAt = params.now ?? Date.now();
+  const message = {
+    ...params.message,
+    key: {
+      ...params.message.key,
+      remoteJid: params.message.key?.remoteJid ?? params.remoteJid,
+    },
+  } satisfies WAMessage;
+  state.messages.delete(key);
+  state.messages.set(key, { message, seenAt });
+  pruneRecentMessages(seenAt);
+}
+
+export function getRecentWhatsAppMessage(params: {
+  accountId: string;
+  remoteJid: string;
+  messageId: string;
+  now?: number;
+}): WAMessage | null {
+  const key = buildMessageKey(params);
+  if (!key) {
+    return null;
+  }
+  const entry = state.messages.get(key);
+  if (!entry) {
+    return null;
+  }
+  const now = params.now ?? Date.now();
+  if (now - entry.seenAt >= RECENT_WHATSAPP_MESSAGE_TTL_MS) {
+    state.messages.delete(key);
+    return null;
+  }
+  return entry.message;
+}
+
+export function resetRecentWhatsAppMessages(): void {
+  state.messages.clear();
+}

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -18,7 +18,6 @@ describe("createWebSendApi", () => {
   }));
   const sendPresenceUpdate = vi.fn(async () => {});
   const resolveQuotedMessage = vi.fn();
-  const rememberMessage = vi.fn();
   let api: ReturnType<typeof createWebSendApi>;
 
   beforeEach(async () => {
@@ -29,7 +28,6 @@ describe("createWebSendApi", () => {
       sock: { sendMessage, sendPresenceUpdate },
       defaultAccountId: "main",
       resolveQuotedMessage,
-      rememberMessage,
     });
   });
 
@@ -153,23 +151,6 @@ describe("createWebSendApi", () => {
     });
     const res = await api.sendMessage("+1555", "hello");
     expect(res.messageId).toBe("unknown");
-  });
-
-  it("remembers sent messages for later quoted replies", async () => {
-    await api.sendMessage("+1555", "hello");
-
-    expect(rememberMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accountId: "main",
-        remoteJid: "1555@s.whatsapp.net",
-        message: expect.objectContaining({
-          key: expect.objectContaining({
-            id: "msg-1",
-            remoteJid: "1555@s.whatsapp.net",
-          }),
-        }),
-      }),
-    );
   });
 
   it("sends polls and records outbound activity", async () => {

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -12,8 +12,13 @@ vi.mock("openclaw/plugin-sdk/channel-runtime", async (importOriginal) => {
 });
 
 describe("createWebSendApi", () => {
-  const sendMessage = vi.fn(async () => ({ key: { id: "msg-1" } }));
+  const sendMessage = vi.fn(async () => ({
+    key: { id: "msg-1" },
+    message: { conversation: "sent" },
+  }));
   const sendPresenceUpdate = vi.fn(async () => {});
+  const resolveQuotedMessage = vi.fn();
+  const rememberMessage = vi.fn();
   let api: ReturnType<typeof createWebSendApi>;
 
   beforeEach(async () => {
@@ -23,6 +28,8 @@ describe("createWebSendApi", () => {
     api = createWebSendApi({
       sock: { sendMessage, sendPresenceUpdate },
       defaultAccountId: "main",
+      resolveQuotedMessage,
+      rememberMessage,
     });
   });
 
@@ -67,6 +74,31 @@ describe("createWebSendApi", () => {
       accountId: "main",
       direction: "outbound",
     });
+  });
+
+  it("uses quoted message options when replyToId resolves", async () => {
+    const quoted = {
+      key: { id: "reply-1", remoteJid: "1555@s.whatsapp.net", fromMe: false },
+      message: { conversation: "original" },
+    };
+    resolveQuotedMessage.mockReturnValueOnce(quoted);
+
+    await api.sendMessage("+1555", "hello", undefined, undefined, { replyToId: "reply-1" });
+
+    expect(resolveQuotedMessage).toHaveBeenCalledWith({
+      accountId: "main",
+      remoteJid: "1555@s.whatsapp.net",
+      messageId: "reply-1",
+    });
+    expect(sendMessage).toHaveBeenCalledWith("1555@s.whatsapp.net", { text: "hello" }, { quoted });
+  });
+
+  it("falls back to a plain send when replyToId cannot be resolved", async () => {
+    resolveQuotedMessage.mockReturnValueOnce(null);
+
+    await api.sendMessage("+1555", "hello", undefined, undefined, { replyToId: "missing" });
+
+    expect(sendMessage).toHaveBeenCalledWith("1555@s.whatsapp.net", { text: "hello" });
   });
 
   it("supports image media with caption", async () => {
@@ -115,9 +147,29 @@ describe("createWebSendApi", () => {
   });
 
   it("falls back to unknown messageId if Baileys result does not expose key.id", async () => {
-    sendMessage.mockResolvedValueOnce({ key: {} as { id: string } });
+    sendMessage.mockResolvedValueOnce({
+      key: {} as { id: string },
+      message: { conversation: "sent" },
+    });
     const res = await api.sendMessage("+1555", "hello");
     expect(res.messageId).toBe("unknown");
+  });
+
+  it("remembers sent messages for later quoted replies", async () => {
+    await api.sendMessage("+1555", "hello");
+
+    expect(rememberMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "main",
+        remoteJid: "1555@s.whatsapp.net",
+        message: expect.objectContaining({
+          key: expect.objectContaining({
+            id: "msg-1",
+            remoteJid: "1555@s.whatsapp.net",
+          }),
+        }),
+      }),
+    );
   });
 
   it("sends polls and records outbound activity", async () => {

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -1,4 +1,4 @@
-import type { AnyMessageContent, WAPresence } from "@whiskeysockets/baileys";
+import type { AnyMessageContent, WAMessage, WAPresence } from "@whiskeysockets/baileys";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-runtime";
 import { toWhatsappJid } from "openclaw/plugin-sdk/text-runtime";
 import type { ActiveWebSendOptions } from "../active-listener.js";
@@ -19,11 +19,39 @@ function resolveOutboundMessageId(result: unknown): string {
 
 export function createWebSendApi(params: {
   sock: {
-    sendMessage: (jid: string, content: AnyMessageContent) => Promise<unknown>;
+    sendMessage: (
+      jid: string,
+      content: AnyMessageContent,
+      options?: { quoted?: WAMessage },
+    ) => Promise<unknown>;
     sendPresenceUpdate: (presence: WAPresence, jid?: string) => Promise<unknown>;
   };
   defaultAccountId: string;
+  resolveQuotedMessage?: (params: {
+    accountId: string;
+    remoteJid: string;
+    messageId: string;
+  }) => WAMessage | null;
+  rememberMessage?: (params: { accountId: string; remoteJid: string; message: WAMessage }) => void;
 }) {
+  function coerceTrackedMessage(result: unknown, remoteJid: string): WAMessage | null {
+    if (!result || typeof result !== "object") {
+      return null;
+    }
+    const message = result as WAMessage;
+    const messageId = message.key?.id?.trim();
+    if (!messageId || !message.message) {
+      return null;
+    }
+    return {
+      ...message,
+      key: {
+        ...message.key,
+        remoteJid: message.key?.remoteJid ?? remoteJid,
+      },
+    } satisfies WAMessage;
+  }
+
   return {
     sendMessage: async (
       to: string,
@@ -63,8 +91,26 @@ export function createWebSendApi(params: {
       } else {
         payload = { text };
       }
-      const result = await params.sock.sendMessage(jid, payload);
       const accountId = sendOptions?.accountId ?? params.defaultAccountId;
+      const replyToId = sendOptions?.replyToId?.trim() || undefined;
+      const quoted =
+        replyToId &&
+        params.resolveQuotedMessage?.({
+          accountId,
+          remoteJid: jid,
+          messageId: replyToId,
+        });
+      const result = quoted
+        ? await params.sock.sendMessage(jid, payload, { quoted })
+        : await params.sock.sendMessage(jid, payload);
+      const trackedMessage = coerceTrackedMessage(result, jid);
+      if (trackedMessage) {
+        params.rememberMessage?.({
+          accountId,
+          remoteJid: jid,
+          message: trackedMessage,
+        });
+      }
       recordWhatsAppOutbound(accountId);
       const messageId = resolveOutboundMessageId(result);
       return { messageId };

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -32,26 +32,7 @@ export function createWebSendApi(params: {
     remoteJid: string;
     messageId: string;
   }) => WAMessage | null;
-  rememberMessage?: (params: { accountId: string; remoteJid: string; message: WAMessage }) => void;
 }) {
-  function coerceTrackedMessage(result: unknown, remoteJid: string): WAMessage | null {
-    if (!result || typeof result !== "object") {
-      return null;
-    }
-    const message = result as WAMessage;
-    const messageId = message.key?.id?.trim();
-    if (!messageId || !message.message) {
-      return null;
-    }
-    return {
-      ...message,
-      key: {
-        ...message.key,
-        remoteJid: message.key?.remoteJid ?? remoteJid,
-      },
-    } satisfies WAMessage;
-  }
-
   return {
     sendMessage: async (
       to: string,
@@ -93,24 +74,16 @@ export function createWebSendApi(params: {
       }
       const accountId = sendOptions?.accountId ?? params.defaultAccountId;
       const replyToId = sendOptions?.replyToId?.trim() || undefined;
-      const quoted =
-        replyToId &&
-        params.resolveQuotedMessage?.({
-          accountId,
-          remoteJid: jid,
-          messageId: replyToId,
-        });
-      const result = quoted
-        ? await params.sock.sendMessage(jid, payload, { quoted })
+      const resolvedQuoted = replyToId
+        ? (params.resolveQuotedMessage?.({
+            accountId,
+            remoteJid: jid,
+            messageId: replyToId,
+          }) ?? null)
+        : null;
+      const result = resolvedQuoted
+        ? await params.sock.sendMessage(jid, payload, { quoted: resolvedQuoted })
         : await params.sock.sendMessage(jid, payload);
-      const trackedMessage = coerceTrackedMessage(result, jid);
-      if (trackedMessage) {
-        params.rememberMessage?.({
-          accountId,
-          remoteJid: jid,
-          message: trackedMessage,
-        });
-      }
       recordWhatsAppOutbound(accountId);
       const messageId = resolveOutboundMessageId(result);
       return { messageId };

--- a/extensions/whatsapp/src/outbound-adapter.sendpayload.test.ts
+++ b/extensions/whatsapp/src/outbound-adapter.sendpayload.test.ts
@@ -20,6 +20,26 @@ describe("whatsappOutbound sendPayload", () => {
     });
   });
 
+  it("forwards replyToId for direct text sends", async () => {
+    const sendWhatsApp = vi.fn(async () => ({ messageId: "wa-1", toJid: "jid" }));
+
+    await whatsappOutbound.sendText!({
+      cfg: {},
+      to: "5511999999999@c.us",
+      text: "hello",
+      replyToId: "wa-msg-1",
+      deps: { sendWhatsApp },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledWith("5511999999999@c.us", "hello", {
+      verbose: false,
+      cfg: {},
+      accountId: undefined,
+      gifPlayback: undefined,
+      replyToId: "wa-msg-1",
+    });
+  });
+
   it("trims leading whitespace for direct media captions", async () => {
     const sendWhatsApp = vi.fn(async () => ({ messageId: "wa-1", toJid: "jid" }));
 

--- a/extensions/whatsapp/src/outbound-adapter.ts
+++ b/extensions/whatsapp/src/outbound-adapter.ts
@@ -45,7 +45,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
   },
   ...createAttachedChannelResultAdapter({
     channel: "whatsapp",
-    sendText: async ({ cfg, to, text, accountId, deps, gifPlayback }) => {
+    sendText: async ({ cfg, to, text, accountId, deps, gifPlayback, replyToId }) => {
       const normalizedText = trimLeadingWhitespace(text);
       if (!normalizedText) {
         return createEmptyChannelResult("whatsapp");
@@ -58,6 +58,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
         cfg,
         accountId: accountId ?? undefined,
         gifPlayback,
+        replyToId: replyToId ?? undefined,
       });
     },
     sendMedia: async ({
@@ -69,6 +70,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
       accountId,
       deps,
       gifPlayback,
+      replyToId,
     }) => {
       const normalizedText = trimLeadingWhitespace(text);
       const send =
@@ -81,6 +83,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
         mediaLocalRoots,
         accountId: accountId ?? undefined,
         gifPlayback,
+        replyToId: replyToId ?? undefined,
       });
     },
     sendPoll: async ({ cfg, to, poll, accountId }) =>

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -58,6 +58,18 @@ describe("web outbound", () => {
     expect(sendMessage).toHaveBeenCalledWith("+1555", "hi", undefined, undefined);
   });
 
+  it("forwards replyToId to the active listener", async () => {
+    await sendMessageWhatsApp("+1555", "reply", {
+      verbose: false,
+      replyToId: "wa-msg-1",
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith("+1555", "reply", undefined, undefined, {
+      replyToId: "wa-msg-1",
+      accountId: undefined,
+    });
+  });
+
   it("trims leading whitespace before sending text and captions", async () => {
     await sendMessageWhatsApp("+1555", "\n \thello", { verbose: false });
     expect(sendMessage).toHaveBeenLastCalledWith("+1555", "hello", undefined, undefined);

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -24,6 +24,7 @@ export async function sendMessageWhatsApp(
     mediaLocalRoots?: readonly string[];
     gifPlayback?: boolean;
     accountId?: string;
+    replyToId?: string;
   },
 ): Promise<{ messageId: string; toJid: string }> {
   let text = body.trimStart();
@@ -59,6 +60,7 @@ export async function sendMessageWhatsApp(
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
     let documentFileName: string | undefined;
+    const replyToId = options.replyToId?.trim() || undefined;
     if (options.mediaUrl) {
       const media = await loadWebMedia(options.mediaUrl, {
         maxBytes: resolveWhatsAppMediaMaxBytes(account),
@@ -88,10 +90,11 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId || documentFileName
+      options.gifPlayback || accountId || documentFileName || replyToId
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
             ...(documentFileName ? { fileName: documentFileName } : {}),
+            ...(replyToId ? { replyToId } : {}),
             accountId,
           }
         : undefined;

--- a/src/channels/plugins/whatsapp-shared.ts
+++ b/src/channels/plugins/whatsapp-shared.ts
@@ -63,7 +63,7 @@ export function createWhatsAppOutboundBase({
     resolveTarget,
     ...createAttachedChannelResultAdapter({
       channel: "whatsapp",
-      sendText: async ({ cfg, to, text, accountId, deps, gifPlayback }) => {
+      sendText: async ({ cfg, to, text, accountId, deps, gifPlayback, replyToId }) => {
         const normalizedText = normalizeText(text);
         if (skipEmptyText && !normalizedText) {
           return { messageId: "" };
@@ -75,6 +75,7 @@ export function createWhatsAppOutboundBase({
           cfg,
           accountId: accountId ?? undefined,
           gifPlayback,
+          replyToId: replyToId ?? undefined,
         });
       },
       sendMedia: async ({
@@ -86,6 +87,7 @@ export function createWhatsAppOutboundBase({
         accountId,
         deps,
         gifPlayback,
+        replyToId,
       }) => {
         const send =
           resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp") ?? sendMessageWhatsApp;
@@ -96,6 +98,7 @@ export function createWhatsAppOutboundBase({
           mediaLocalRoots,
           accountId: accountId ?? undefined,
           gifPlayback,
+          replyToId: replyToId ?? undefined,
         });
       },
       sendPoll: async ({ cfg, to, poll, accountId }) =>

--- a/src/plugins/runtime/runtime-whatsapp-surface.ts
+++ b/src/plugins/runtime/runtime-whatsapp-surface.ts
@@ -180,6 +180,7 @@ export type WhatsAppHeavyRuntimeModule = {
       mediaLocalRoots?: readonly string[];
       gifPlayback?: boolean;
       accountId?: string;
+      replyToId?: string;
     },
   ) => Promise<{ messageId: string; toJid: string }>;
   sendPollWhatsApp: (


### PR DESCRIPTION
## Summary

- Problem: WhatsApp outbound sends already carry `replyToId` through the generic delivery pipeline, but the WhatsApp adapters dropped it before the Baileys send call, so replies were always sent as new messages.
- Why it matters: group follow-ups and confirmations lose the native quoted-reply bubble, which makes automated replies much harder to follow in busy chats.
- What changed: forwarded `replyToId` through both WhatsApp outbound adapter paths, added a bounded recent-message cache for inbound/outbound `WAMessage`s, and used Baileys `quoted` sends when the target message is still available; added regression tests around forwarding and quoted-send behavior.
- What did NOT change (scope boundary): no new config knobs, no changes to inbound reply parsing, and no attempt to reconstruct quoted replies for messages outside the recent cache window.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #56465
- Related #56465
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `replyToId` reached the WhatsApp outbound surface, but neither `src/channels/plugins/whatsapp-shared.ts` nor `extensions/whatsapp/src/outbound-adapter.ts` forwarded it into `sendMessageWhatsApp`, and the WhatsApp send API never resolved a Baileys `quoted` message.
- Missing detection / guardrail: there was no regression test that asserted WhatsApp preserved `replyToId` all the way into the final socket send options.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the generic outbound plumbing and inbound reply-context extraction already supported `replyToId`; the gap was specific to the WhatsApp outbound implementation.
- Why this regressed now: it appears to be a longstanding omission rather than a newly introduced regression.
- If unknown, what was ruled out: ruled out the generic reply plumbing because `replyToId` is already preserved before the WhatsApp-specific send boundary.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/inbound/send-api.test.ts`, `extensions/whatsapp/src/send.test.ts`, `extensions/whatsapp/src/outbound-adapter.sendpayload.test.ts`, `extensions/whatsapp/src/channel.test.ts`
- Scenario the test should lock in: a WhatsApp send with `replyToId` forwards the id through the adapter stack and emits a Baileys send with `{ quoted }` when the referenced message is still cached.
- Why this is the smallest reliable guardrail: the bug lived at the WhatsApp-specific send seam, so the fastest durable coverage is to assert the final outbound call shape and fallback behavior there.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- WhatsApp sends that include `replyToId` now produce native quoted replies when the referenced message is still available in the recent-message cache.
- If the target message is no longer available, the send still succeeds as a normal unquoted message instead of failing.

## Diagram (if applicable)

```text
Before:
replyToId -> WhatsApp outbound adapter -> sendMessageWhatsApp -> plain Baileys send -> new standalone message

After:
replyToId -> WhatsApp outbound adapter -> sendMessageWhatsApp -> resolve cached WAMessage -> Baileys quoted send -> native quoted reply
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.3
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): WhatsApp / Baileys
- Relevant config (redacted): default local test config

### Steps

1. Send a WhatsApp message into a chat or group and capture its message id.
2. Send an outbound WhatsApp message through OpenClaw with `replyTo` / `replyToId` pointing at that id.
3. Observe whether WhatsApp renders the outbound message as a native quoted reply.

### Expected

- WhatsApp renders the outbound send as a native quoted reply to the referenced message.

### Actual

- Before this change, the outbound send was delivered as a new standalone message because the final WhatsApp send path dropped reply metadata.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `pnpm test -- extensions/whatsapp/src/inbound/send-api.test.ts extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/outbound-adapter.sendpayload.test.ts extensions/whatsapp/src/channel.test.ts`, `pnpm test:extension whatsapp`, and `pnpm test:contracts:channels`.
- Edge cases checked: whitespace-only `replyToId` trimming, fallback to plain send when the referenced message is not cached, and forwarding through both WhatsApp outbound adapter paths.
- What you did **not** verify: a live WhatsApp device roundtrip was not run. Repo-wide `pnpm build`, `pnpm check`, and `pnpm test` are currently blocked by unrelated pre-existing `sourceInfo` typing failures under `src/agents/skills*` and `src/security/audit-extra.async.ts`, which this PR does not touch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: quoted replies only work while the referenced message is still present in the recent-message cache.
  - Mitigation: the send path falls back to a normal unquoted message instead of failing, and the cache is bounded by TTL and max entries.

## Additional Notes

- AI assistance: prepared with an AI coding assistant and then manually reviewed, adjusted, and verified.

Made with [Cursor](https://cursor.com)