### PR TITLE
TTS: ignore inline literal directive examples

### DIFF
--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -106,21 +106,16 @@ export function parseTtsDirectives(
 
   const overrides: TtsDirectiveOverrides = {};
   const warnings: string[] = [];
-  let cleanedText = text;
+  let cleanedText = text.replace(/\s+$/, "");
   let hasDirective = false;
 
-  const blockRegex = /\[\[tts:text\]\]([\s\S]*?)\[\[\/tts:text\]\]/gi;
-  cleanedText = cleanedText.replace(blockRegex, (_match, inner: string) => {
-    hasDirective = true;
-    if (policy.allowText && overrides.ttsText == null) {
-      overrides.ttsText = inner.trim();
+  const consumeDirectiveLine = (): boolean => {
+    const match = /(?:^|\n)([ \t]*)\[\[tts:([^\]]+)\]\][ \t]*$/i.exec(cleanedText);
+    if (!match) {
+      return false;
     }
-    return "";
-  });
-
-  const directiveRegex = /\[\[tts:([^\]]+)\]\]/gi;
-  cleanedText = cleanedText.replace(directiveRegex, (_match, body: string) => {
     hasDirective = true;
+    const body = match[2] ?? "";
     const tokens = body.split(/\s+/).filter(Boolean);
     for (const token of tokens) {
       const eqIndex = token.indexOf("=");
@@ -313,8 +308,35 @@ export function parseTtsDirectives(
         warnings.push((err as Error).message);
       }
     }
-    return "";
-  });
+    cleanedText = cleanedText.slice(0, match.index).replace(/\s+$/, "");
+    return true;
+  };
+
+  const consumeTextBlock = (): boolean => {
+    const closeMatch = /\[\[\/tts:text\]\][ \t]*$/i.exec(cleanedText);
+    if (!closeMatch) {
+      return false;
+    }
+    const beforeClose = cleanedText.slice(0, closeMatch.index);
+    const openIndex = beforeClose.toLowerCase().lastIndexOf("[[tts:text]]");
+    if (openIndex === -1) {
+      return false;
+    }
+    const lineStart = beforeClose.lastIndexOf("\n", openIndex - 1) + 1;
+    if (beforeClose.slice(lineStart, openIndex).trim() !== "") {
+      return false;
+    }
+    hasDirective = true;
+    if (policy.allowText && overrides.ttsText == null) {
+      overrides.ttsText = beforeClose.slice(openIndex + "[[tts:text]]".length).trim();
+    }
+    cleanedText = cleanedText.slice(0, lineStart).replace(/\s+$/, "");
+    return true;
+  };
+
+  while (consumeDirectiveLine() || consumeTextBlock()) {
+    // Consume a trailing standalone TTS directive section only.
+  }
 
   return {
     cleanedText,

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -185,14 +185,15 @@ describe("tts", () => {
   });
 
   describe("parseTtsDirectives", () => {
-    it("extracts overrides and strips directives when enabled", () => {
+    it("extracts overrides from a trailing directive section", () => {
       const policy = resolveModelOverridePolicy({ enabled: true });
       const input =
-        "Hello [[tts:provider=elevenlabs voiceId=pMsXgVXv3BLzUgSXRplE stability=0.4 speed=1.1]] world\n\n" +
+        "Hello world\n\n" +
+        "[[tts:provider=elevenlabs voiceId=pMsXgVXv3BLzUgSXRplE stability=0.4 speed=1.1]]\n" +
         "[[tts:text]](laughs) Read the song once more.[[/tts:text]]";
       const result = parseTtsDirectives(input, policy);
 
-      expect(result.cleanedText).not.toContain("[[tts:");
+      expect(result.cleanedText).toBe("Hello world");
       expect(result.ttsText).toBe("(laughs) Read the song once more.");
       expect(result.overrides.provider).toBe("elevenlabs");
       expect(result.overrides.elevenlabs?.voiceId).toBe("pMsXgVXv3BLzUgSXRplE");
@@ -200,12 +201,25 @@ describe("tts", () => {
       expect(result.overrides.elevenlabs?.voiceSettings?.speed).toBe(1.1);
     });
 
-    it("accepts edge as provider override", () => {
+    it("accepts a standalone trailing provider override", () => {
       const policy = resolveModelOverridePolicy({ enabled: true });
-      const input = "Hello [[tts:provider=edge]] world";
+      const input = "Hello world\n\n[[tts:provider=edge]]";
       const result = parseTtsDirectives(input, policy);
 
+      expect(result.cleanedText).toBe("Hello world");
       expect(result.overrides.provider).toBe("edge");
+    });
+
+    it("keeps inline literal directive examples as visible text", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true });
+      const input =
+        "This reply mentions [[tts:voice=alloy]] and [[tts:text]]hello[[/tts:text]] as plain text examples.";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.cleanedText).toBe(input);
+      expect(result.hasDirective).toBe(false);
+      expect(result.ttsText).toBeUndefined();
+      expect(result.overrides.openai?.voice).toBeUndefined();
     });
 
     it("keeps text intact when overrides are disabled", () => {
@@ -586,6 +600,39 @@ describe("tts", () => {
 
       expect(result.mediaUrl).toBeDefined();
       expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      globalThis.fetch = originalFetch;
+      process.env.OPENCLAW_TTS_PREFS = prevPrefs;
+    });
+
+    it("does not trigger tagged auto-TTS for inline literal tag examples", async () => {
+      const prevPrefs = process.env.OPENCLAW_TTS_PREFS;
+      process.env.OPENCLAW_TTS_PREFS = `/tmp/tts-test-${Date.now()}.json`;
+      const originalFetch = globalThis.fetch;
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(1),
+      }));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const cfg = {
+        ...baseCfg,
+        messages: {
+          ...baseCfg.messages,
+          tts: { ...baseCfg.messages.tts, auto: "tagged" },
+        },
+      };
+
+      const input =
+        "This reply mentions [[tts:voice=alloy]] and [[tts:text]]hello[[/tts:text]] as plain text examples.";
+      const result = await maybeApplyTtsToPayload({
+        payload: { text: input },
+        cfg,
+        kind: "final",
+      });
+
+      expect(result).toEqual({ text: input });
+      expect(fetchMock).not.toHaveBeenCalled();
 
       globalThis.fetch = originalFetch;
       process.env.OPENCLAW_TTS_PREFS = prevPrefs;


### PR DESCRIPTION
Closes #56680

#### Summary
This keeps `parseTtsDirectives()` from treating literal inline `[[tts:...]]` and `[[tts:text]]...[[/tts:text]]` examples inside normal prose as active TTS directives.

#### Repro Steps
1. Configure `messages.tts.auto: tagged`.
2. Send a normal reply that mentions `[[tts:voice=alloy]]` or `[[tts:text]]hello[[/tts:text]]` as plain text examples.
3. Observe that current code strips the examples and can route the reply into the TTS path.

#### Root Cause
`parseTtsDirectives()` scanned the entire reply body for matching TTS tags, so inline literal examples were parsed the same way as real directive markup.

#### Behavior Changes
- Only a trailing standalone TTS directive section is parsed.
- Inline literal tag examples remain visible reply text.
- `tagged` auto-TTS no longer triggers on inline examples.
- Existing trailing standalone TTS directives continue to work.

#### Codebase and GitHub Search
- Searched the codebase for `parseTtsDirectives`, `[[tts:text]]`, and `[[tts:` to confirm where tagged-mode activation happens and what syntax is currently documented.
- Reviewed issue #56680 and reproduced the reported behavior against current `main` before changing the parser.
- Confirmed the existing docs example already uses a trailing standalone directive section, which matches the updated parser behavior.

#### Tests
- `pnpm test:fast -- src/tts/tts.test.ts src/tts/prepare-text.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm test`

#### Evidence
- Reproduced on current `main`: inline literal examples were stripped from visible text, and a long enough inline `[[tts:...]]` example triggered tagged auto-TTS unexpectedly.
- Added parser coverage for trailing standalone directives vs inline literal examples.
- Added tagged-mode coverage to confirm inline examples no longer synthesize audio.

lobster-biscuit

**Sign-Off**

- Models used: GPT-5.4 via Cursor
- Submitter effort: verified repro, implemented focused parser fix, and ran the requested validation commands
- Agent notes: AI-assisted change; details kept focused here with verification grounded in current-code repros and test runs
