### PR TITLE
feat: emit llm_event JSONL entries per completed LLM call

### DIFF
--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -14,6 +14,7 @@ import {
   resolveModelRefFromString,
 } from "./model-selection.js";
 import { resolveModel } from "./pi-embedded-runner/model.js";
+import { emitLlmEvent } from "../observability/event-emitter.js";
 
 type SimpleCompletionAuthStorage = {
   setRuntimeApiKey: (provider: string, apiKey: string) => void;
@@ -237,9 +238,48 @@ export async function completeWithPreparedSimpleCompletionModel(params: {
   auth: ResolvedProviderAuth;
   context: Parameters<typeof complete>[1];
   options?: Omit<Parameters<typeof complete>[2], "apiKey">;
+  /** Optional session key for observability; falls back to 'unknown'. */
+  sessionKey?: string;
 }) {
-  return await complete(params.model, params.context, {
-    ...params.options,
-    apiKey: params.auth.apiKey,
-  });
+  const startTime = performance.now();
+  let response: Awaited<ReturnType<typeof complete>> | undefined;
+
+  try {
+    response = await complete(params.model, params.context, {
+      ...params.options,
+      apiKey: params.auth.apiKey,
+    });
+
+    emitLlmEvent({
+      level: "info",
+      model: response.model ?? params.model.id ?? "unknown",
+      provider: response.provider ?? params.model.provider ?? "unknown",
+      sessionKey: params.sessionKey ?? "unknown",
+      startTime,
+      tokensIn: response.usage?.input,
+      tokensOut: response.usage?.output,
+    });
+
+    return response;
+  } catch (err) {
+    // Only emit if the API responded with usage data.
+    // Zero usage = network failure / request never reached API = do NOT emit.
+    const hasUsage =
+      (response?.usage?.input ?? 0) > 0 || (response?.usage?.output ?? 0) > 0;
+
+    if (hasUsage) {
+      emitLlmEvent({
+        level: "error",
+        model: response?.model ?? params.model.id ?? "unknown",
+        provider: response?.provider ?? params.model.provider ?? "unknown",
+        sessionKey: params.sessionKey ?? "unknown",
+        startTime,
+        tokensIn: response?.usage?.input,
+        tokensOut: response?.usage?.output,
+        error: err,
+      });
+    }
+
+    throw err;
+  }
 }

--- a/src/observability/event-emitter.test.ts
+++ b/src/observability/event-emitter.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── fs mock (hoisted so it's available before module load) ───────────────────
+const appendFileSyncMock = vi.hoisted(() => vi.fn());
+const mkdirSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      appendFileSync: appendFileSyncMock,
+      mkdirSync: mkdirSyncMock,
+    },
+    appendFileSync: appendFileSyncMock,
+    mkdirSync: mkdirSyncMock,
+  };
+});
+
+// ── Logger mock: return predictable log file path ────────────────────────────
+vi.mock('../logging/logger.js', () => ({
+  getResolvedLoggerSettings: () => ({
+    file: '/tmp/openclaw/openclaw-2026-03-28.log',
+    level: 'info',
+    maxFileBytes: 500 * 1024 * 1024,
+  }),
+}));
+
+describe('emitLlmEvent', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    appendFileSyncMock.mockReset();
+    mkdirSyncMock.mockReset();
+  });
+
+  // ── Test 1: Anthropic success response ───────────────────────────────────
+  it('emits correct JSONL for Anthropic success response', async () => {
+    const { emitLlmEvent } = await import('./event-emitter.js');
+    const startTime = performance.now() - 2340;
+
+    emitLlmEvent({
+      level: 'info',
+      model: 'claude-sonnet-4-6-20250613',
+      provider: 'anthropic',
+      sessionKey: 'agent:conductor',
+      startTime,
+      tokensIn: 1500,
+      tokensOut: 800,
+    });
+
+    expect(appendFileSyncMock).toHaveBeenCalledOnce();
+    const [filePath, written] = appendFileSyncMock.mock.calls[0] as [string, string];
+
+    // File path must be the log file
+    expect(filePath).toBe('/tmp/openclaw/openclaw-2026-03-28.log');
+
+    const parsed = JSON.parse((written as string).trim());
+
+    // Required fields
+    expect(parsed.event).toBe('llm_event');
+    expect(parsed.level).toBe('info');
+    expect(parsed.type).toBe('openclaw');   // ← critical for Logstash routing
+    expect(parsed.sessionKey).toBe('agent:conductor');
+    expect(parsed.model).toBe('claude-sonnet-4-6-20250613');
+    expect(parsed.provider).toBe('anthropic');
+    expect(parsed.tokens_in).toBe(1500);
+    expect(parsed.tokens_out).toBe(800);
+    expect(typeof parsed.duration_ms).toBe('number');
+    expect(parsed.duration_ms).toBeGreaterThan(0);
+    expect(typeof parsed.time).toBe('string');
+
+    // Must NOT have tslog envelope fields
+    expect(parsed['0']).toBeUndefined();
+    expect(parsed['_meta']).toBeUndefined();
+
+    // Must NOT have error fields on success
+    expect(parsed.error_type).toBeUndefined();
+    expect(parsed.error_message).toBeUndefined();
+  });
+
+  // ── Test 2: Gemini success response ──────────────────────────────────────
+  it('emits correct JSONL for Gemini success response', async () => {
+    const { emitLlmEvent } = await import('./event-emitter.js');
+
+    emitLlmEvent({
+      level: 'info',
+      model: 'gemini-3-pro-preview',
+      provider: 'google-gemini-cli',
+      sessionKey: 'agent:main',
+      startTime: performance.now() - 1200,
+      tokensIn: 2048,
+      tokensOut: 512,
+    });
+
+    expect(appendFileSyncMock).toHaveBeenCalledOnce();
+    const [, written] = appendFileSyncMock.mock.calls[0] as [string, string];
+    const parsed = JSON.parse((written as string).trim());
+
+    expect(parsed.provider).toBe('google-gemini-cli');
+    expect(parsed.tokens_in).toBe(2048);
+    expect(parsed.tokens_out).toBe(512);
+    expect(parsed.type).toBe('openclaw');
+  });
+
+  // ── Test 3: Error event shape ─────────────────────────────────────────────
+  it('emits error event with error_type and error_message', async () => {
+    const { emitLlmEvent } = await import('./event-emitter.js');
+
+    emitLlmEvent({
+      level: 'error',
+      model: 'claude-sonnet-4-6-20250613',
+      provider: 'anthropic',
+      sessionKey: 'agent:main',
+      startTime: performance.now() - 500,
+      tokensIn: 800,
+      tokensOut: 0,
+      error: new Error('rate limit exceeded: 429 Too Many Requests'),
+    });
+
+    expect(appendFileSyncMock).toHaveBeenCalledOnce();
+    const [, written] = appendFileSyncMock.mock.calls[0] as [string, string];
+    const parsed = JSON.parse((written as string).trim());
+
+    expect(parsed.level).toBe('error');
+    expect(parsed.error_type).toBe('rate_limit');
+    expect(typeof parsed.error_message).toBe('string');
+    expect(parsed.error_message.length).toBeLessThanOrEqual(500);
+    expect(parsed.tokens_in).toBe(800);
+    // tokens_out omitted when 0
+    expect(parsed.tokens_out).toBeUndefined();
+  });
+
+  // ── Test 4: No emit on network failure (zero token usage gate) ────────────
+  it('does NOT emit when usage.input === 0 && usage.output === 0 (network failure)', async () => {
+    const { emitLlmEvent } = await import('./event-emitter.js');
+
+    // Simulate the caller guard in completeWithPreparedSimpleCompletionModel:
+    const networkFailureUsage = { input: 0, output: 0 };
+    const hasUsage = networkFailureUsage.input > 0 || networkFailureUsage.output > 0;
+
+    if (hasUsage) {
+      emitLlmEvent({
+        level: 'error',
+        model: 'claude-sonnet-4-6',
+        provider: 'anthropic',
+        sessionKey: 'agent:main',
+        startTime: performance.now(),
+        error: new Error('ECONNREFUSED'),
+      });
+    }
+
+    // emitLlmEvent must not have been called
+    expect(appendFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  // ── Test 5: Token field omission when 0 ──────────────────────────────────
+  it('omits tokens_in and tokens_out entirely when 0 (not null, not undefined-from-absence)', async () => {
+    const { emitLlmEvent } = await import('./event-emitter.js');
+
+    emitLlmEvent({
+      level: 'info',
+      model: 'test-model',
+      provider: 'test',
+      sessionKey: 'agent:test',
+      startTime: performance.now(),
+      tokensIn: 0,
+      tokensOut: 0,
+    });
+
+    expect(appendFileSyncMock).toHaveBeenCalledOnce();
+    const [, written] = appendFileSyncMock.mock.calls[0] as [string, string];
+    const parsed = JSON.parse((written as string).trim());
+
+    // Fields must be absent (not present as null or 0)
+    expect('tokens_in' in parsed).toBe(false);
+    expect('tokens_out' in parsed).toBe(false);
+  });
+
+  // ── Test 6: sessionKey fallback ───────────────────────────────────────────
+  it('uses "unknown" sessionKey when empty or missing', async () => {
+    const { emitLlmEvent } = await import('./event-emitter.js');
+
+    emitLlmEvent({
+      level: 'info',
+      model: 'test-model',
+      provider: 'test',
+      sessionKey: '',
+      startTime: performance.now(),
+      tokensIn: 100,
+      tokensOut: 50,
+    });
+
+    expect(appendFileSyncMock).toHaveBeenCalledOnce();
+    const [, written] = appendFileSyncMock.mock.calls[0] as [string, string];
+    const parsed = JSON.parse((written as string).trim());
+    expect(parsed.sessionKey).toBe('unknown');
+  });
+});

--- a/src/observability/event-emitter.ts
+++ b/src/observability/event-emitter.ts
@@ -1,0 +1,106 @@
+/**
+ * LLM usage event emitter for gateway observability.
+ *
+ * Writes JSONL directly to the gateway's rolling log file (same file Logstash ingests).
+ * Bypasses tslog deliberately — tslog wraps arguments in a nested logObj envelope,
+ * but Logstash requires all fields at document root (type: "openclaw" routing).
+ *
+ * All errors are swallowed silently. Observability failures MUST NOT affect callers.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { getResolvedLoggerSettings } from '../logging/logger.js';
+import type { LlmEventPayload } from './types.js';
+
+// ─── Log file path resolution ────────────────────────────────────────────────
+// Uses the same rolling-file path as the gateway logger via getResolvedLoggerSettings().
+// This stays in sync with any runtime override (e.g. custom path in openclaw.json).
+
+function resolveLogFilePath(): string {
+  try {
+    return getResolvedLoggerSettings().file;
+  } catch {
+    // Fallback: derive today's rolling path directly
+    const dir = '/tmp/openclaw';
+    const d = new Date();
+    const ymd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    return path.join(dir, `openclaw-${ymd}.log`);
+  }
+}
+
+// ─── Error classification ────────────────────────────────────────────────────
+
+function classifyError(err: unknown): string {
+  const msg = String((err as Error)?.message ?? err).toLowerCase();
+  if (msg.includes('rate limit') || msg.includes('429')) return 'rate_limit';
+  if (msg.includes('context length') || msg.includes('context window') || msg.includes('max_tokens'))
+    return 'context_length';
+  if (msg.includes('timeout') || msg.includes('timed out')) return 'timeout';
+  if (msg.includes('network') || msg.includes('econnrefused') || msg.includes('enotfound'))
+    return 'network';
+  if (msg.includes('auth') || msg.includes('403') || msg.includes('401')) return 'auth';
+  return 'unknown';
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Build and emit an LLM usage event to the gateway log file.
+ *
+ * Call this from the LLM dispatch wrapper immediately after complete() resolves
+ * (success path) or in the catch block when usage data is present (error path).
+ *
+ * Do NOT call when: an error was thrown AND tokensIn === 0 && tokensOut === 0
+ * (network failure — no API response was received, no tokens were processed).
+ */
+export function emitLlmEvent(opts: {
+  level: 'info' | 'error';
+  model: string;
+  provider: string;
+  sessionKey: string;
+  startTime: number;           // performance.now() at request dispatch
+  tokensIn?: number;
+  tokensOut?: number;
+  error?: unknown;
+}): void {
+  try {
+    const duration_ms = Math.round(performance.now() - opts.startTime);
+
+    const payload: LlmEventPayload = {
+      event: 'llm_event',
+      level: opts.level,
+      type: 'openclaw',
+      time: new Date().toISOString(),
+      sessionKey: opts.sessionKey || 'unknown',
+      model: opts.model || 'unknown',
+      provider: opts.provider || 'unknown',
+      duration_ms,
+    };
+
+    // Omit token fields entirely when 0 — never set to null
+    if (typeof opts.tokensIn === 'number' && opts.tokensIn > 0) {
+      payload.tokens_in = opts.tokensIn;
+    }
+    if (typeof opts.tokensOut === 'number' && opts.tokensOut > 0) {
+      payload.tokens_out = opts.tokensOut;
+    }
+
+    // Error fields only on error events
+    if (opts.level === 'error' && opts.error !== undefined) {
+      payload.error_type = classifyError(opts.error);
+      payload.error_message = String((opts.error as Error)?.message ?? opts.error).slice(0, 500);
+    }
+
+    const line = JSON.stringify(payload) + '\n';
+    const logFile = resolveLogFilePath();
+
+    // Ensure directory exists (should already be created by gateway startup)
+    fs.mkdirSync(path.dirname(logFile), { recursive: true });
+    fs.appendFileSync(logFile, line, { encoding: 'utf8' });
+  } catch {
+    // Swallow all errors — observability failures must never surface to callers
+    try {
+      process.stderr.write('[observability] Failed to emit llm_event\n');
+    } catch { /* nothing */ }
+  }
+}

--- a/src/observability/types.ts
+++ b/src/observability/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Observability types — LLM usage events.
+ * All fields flat (top-level) for Logstash compatibility.
+ */
+export interface LlmEventPayload {
+  event: 'llm_event';
+  level: 'info' | 'error';
+  /** Always "openclaw" — required for Logstash routing */
+  type: 'openclaw';
+  /** ISO-8601 timestamp stamped at emission */
+  time: string;
+  /** Caller session key; fallback: 'unknown' */
+  sessionKey: string;
+  /** Model identifier from API response (e.g. "claude-sonnet-4-6-20250613") */
+  model: string;
+  /** Provider identifier (e.g. "anthropic", "google-gemini-cli") */
+  provider: string;
+  /** Input token count — omit entirely if 0 */
+  tokens_in?: number;
+  /** Output token count — omit entirely if 0 */
+  tokens_out?: number;
+  /** Wall-clock duration from request dispatch to final response/error */
+  duration_ms: number;
+  /** Error classifier — present only when level === 'error' */
+  error_type?: string;
+  /** Human-readable error message (<=500 chars) — present only when level === 'error' */
+  error_message?: string;
+}


### PR DESCRIPTION
## Summary

Adds LLM token usage observability to the gateway. Emits one `llm_event` JSONL log entry per completed LLM API call (success + error paths with usage data) to the same rolling log file Logstash already ingests.

## Event shape
```jsonl
{"event":"llm_event","level":"info","type":"openclaw","time":"2026-03-28T20:25:56.711Z","sessionKey":"agent:conductor","model":"claude-sonnet-4-6-20250613","provider":"anthropic","tokens_in":1500,"tokens_out":800,"duration_ms":2340}
```

## Changes
- `src/observability/types.ts` — `LlmEventPayload` TypeScript interface
- `src/observability/event-emitter.ts` — `emitLlmEvent()` with direct `fs.appendFileSync` (bypasses tslog nesting)
- `src/observability/event-emitter.test.ts` — 6 Vitest unit tests
- `src/agents/simple-completion-runtime.ts` — hook `completeWithPreparedSimpleCompletionModel` with timing + emit

## Why direct appendFileSync
tslog wraps logged objects in a `logObj` envelope (`"0"`, `_meta`, etc.) which would nest all fields — breaking Logstash routing that requires `type: "openclaw"` at document root.

## Downstream (no changes needed)
- Logstash config already routes `type: "openclaw"` → `openclaw_logs`
- Grafana `openclaw-application.json` "Token Usage" row panels already wired
- MongoDB 30-day TTL index already in place

Closes bodegus/openclaw-deployment-test#382