### PR TITLE
fix(discord): prevent gateway crash on reconnect-exhausted from health-monitor restart

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -1,8 +1,28 @@
 import { EventEmitter } from "node:events";
-import type { Client } from "@buape/carbon";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayPlugin } from "@buape/carbon/gateway";
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import type { RuntimeEnv } from "../../../../src/runtime.js";
 import type { WaitForDiscordGatewayStopParams } from "../monitor.gateway.js";
+import type { MutableDiscordGateway } from "./gateway-handle.js";
+import type { DiscordGatewayEvent } from "./gateway-supervisor.js";
+
+type LifecycleParams = Parameters<
+  typeof import("./provider.lifecycle.js").runDiscordGatewayLifecycle
+>[0];
+type MockGateway = {
+  isConnected: boolean;
+  options: GatewayPlugin["options"];
+  disconnect: Mock<() => void>;
+  connect: Mock<(resume?: boolean) => void>;
+  state?: {
+    sessionId?: string | null;
+    resumeGatewayUrl?: string | null;
+    sequence?: number | null;
+  };
+  sequence?: number | null;
+  emitter: EventEmitter;
+  ws?: EventEmitter & { terminate?: () => void };
+};
 
 const {
   attachDiscordGatewayLoggingMock,
@@ -42,6 +62,7 @@ vi.mock("./gateway-registry.js", () => ({
 
 describe("runDiscordGatewayLifecycle", () => {
   beforeEach(() => {
+    vi.resetModules();
     attachDiscordGatewayLoggingMock.mockClear();
     getDiscordGatewayEmitterMock.mockClear();
     waitForDiscordGatewayStopMock.mockClear();
@@ -55,28 +76,42 @@ describe("runDiscordGatewayLifecycle", () => {
     start?: () => Promise<void>;
     stop?: () => Promise<void>;
     isDisallowedIntentsError?: (err: unknown) => boolean;
-    pendingGatewayErrors?: unknown[];
-    gateway?: {
-      isConnected?: boolean;
-      options?: Record<string, unknown>;
-      disconnect?: () => void;
-      connect?: (resume?: boolean) => void;
-      state?: {
-        sessionId?: string | null;
-        resumeGatewayUrl?: string | null;
-        sequence?: number | null;
-      };
-      sequence?: number | null;
-      emitter?: EventEmitter;
-    };
+    pendingGatewayEvents?: DiscordGatewayEvent[];
+    gateway?: MockGateway;
   }) => {
+    const gateway =
+      params?.gateway ??
+      (() => {
+        const defaultGateway = createGatewayHarness().gateway;
+        defaultGateway.isConnected = true;
+        return defaultGateway;
+      })();
     const start = vi.fn(params?.start ?? (async () => undefined));
     const stop = vi.fn(params?.stop ?? (async () => undefined));
     const threadStop = vi.fn();
     const runtimeLog = vi.fn();
     const runtimeError = vi.fn();
     const runtimeExit = vi.fn();
-    const releaseEarlyGatewayErrorGuard = vi.fn();
+    const pendingGatewayEvents = params?.pendingGatewayEvents ?? [];
+    const gatewaySupervisor = {
+      attachLifecycle: vi.fn(),
+      detachLifecycle: vi.fn(),
+      drainPending: vi.fn((handler: (event: DiscordGatewayEvent) => "continue" | "stop") => {
+        if (pendingGatewayEvents.length === 0) {
+          return "continue";
+        }
+        const queued = [...pendingGatewayEvents];
+        pendingGatewayEvents.length = 0;
+        for (const event of queued) {
+          if (handler(event) === "stop") {
+            return "stop";
+          }
+        }
+        return "continue";
+      }),
+      dispose: vi.fn(),
+      emitter: gateway.emitter,
+    };
     const statusSink = vi.fn();
     const runtime: RuntimeEnv = {
       log: runtimeLog,
@@ -89,24 +124,21 @@ describe("runDiscordGatewayLifecycle", () => {
       threadStop,
       runtimeLog,
       runtimeError,
-      releaseEarlyGatewayErrorGuard,
+      gatewaySupervisor,
       statusSink,
       lifecycleParams: {
         accountId: params?.accountId ?? "default",
-        client: {
-          getPlugin: vi.fn((name: string) => (name === "gateway" ? params?.gateway : undefined)),
-        } as unknown as Client,
+        gateway: gateway as unknown as MutableDiscordGateway,
         runtime,
         isDisallowedIntentsError: params?.isDisallowedIntentsError ?? (() => false),
         voiceManager: null,
         voiceManagerRef: { current: null },
         execApprovalsHandler: { start, stop },
         threadBindings: { stop: threadStop },
-        pendingGatewayErrors: params?.pendingGatewayErrors,
-        releaseEarlyGatewayErrorGuard,
+        gatewaySupervisor,
         statusSink,
         abortSignal: undefined as AbortSignal | undefined,
-      },
+      } satisfies LifecycleParams,
     };
   };
 
@@ -115,7 +147,7 @@ describe("runDiscordGatewayLifecycle", () => {
     stop: ReturnType<typeof vi.fn>;
     threadStop: ReturnType<typeof vi.fn>;
     waitCalls: number;
-    releaseEarlyGatewayErrorGuard: ReturnType<typeof vi.fn>;
+    gatewaySupervisor: { detachLifecycle: ReturnType<typeof vi.fn> };
   }) {
     expect(params.start).toHaveBeenCalledTimes(1);
     expect(params.stop).toHaveBeenCalledTimes(1);
@@ -123,7 +155,7 @@ describe("runDiscordGatewayLifecycle", () => {
     expect(unregisterGatewayMock).toHaveBeenCalledWith("default");
     expect(stopGatewayLoggingMock).toHaveBeenCalledTimes(1);
     expect(params.threadStop).toHaveBeenCalledTimes(1);
-    expect(params.releaseEarlyGatewayErrorGuard).toHaveBeenCalledTimes(1);
+    expect(params.gatewaySupervisor.detachLifecycle).toHaveBeenCalledTimes(1);
   }
 
   function createGatewayHarness(params?: {
@@ -133,15 +165,17 @@ describe("runDiscordGatewayLifecycle", () => {
       sequence?: number | null;
     };
     sequence?: number | null;
-  }) {
+    ws?: EventEmitter & { terminate?: () => void };
+  }): { emitter: EventEmitter; gateway: MockGateway } {
     const emitter = new EventEmitter();
-    const gateway = {
+    const gateway: MockGateway = {
       isConnected: false,
-      options: {},
+      options: { intents: 0 } as GatewayPlugin["options"],
       disconnect: vi.fn(),
       connect: vi.fn(),
       ...(params?.state ? { state: params.state } : {}),
       ...(params?.sequence !== undefined ? { sequence: params.sequence } : {}),
+      ...(params?.ws ? { ws: params.ws } : {}),
       emitter,
     };
     return { emitter, gateway };
@@ -152,14 +186,43 @@ describe("runDiscordGatewayLifecycle", () => {
     await vi.advanceTimersByTimeAsync(delayMs);
   }
 
+  function createGatewayEvent(
+    type: DiscordGatewayEvent["type"],
+    message: string,
+  ): DiscordGatewayEvent {
+    const err = new Error(message);
+    return {
+      type,
+      err,
+      message: String(err),
+      shouldStopLifecycle: type !== "other",
+    };
+  }
+
+  function expectGatewaySessionStateCleared(gateway: {
+    state?: {
+      sessionId?: string | null;
+      resumeGatewayUrl?: string | null;
+      sequence?: number | null;
+    };
+    sequence?: number | null;
+  }) {
+    if (!gateway.state) {
+      throw new Error("gateway state was not initialized");
+    }
+    expect(gateway.state.sessionId).toBeNull();
+    expect(gateway.state.resumeGatewayUrl).toBeNull();
+    expect(gateway.state.sequence).toBeNull();
+    expect(gateway.sequence).toBeNull();
+  }
+
   it("cleans up thread bindings when exec approvals startup fails", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-    const { lifecycleParams, start, stop, threadStop, releaseEarlyGatewayErrorGuard } =
-      createLifecycleHarness({
-        start: async () => {
-          throw new Error("startup failed");
-        },
-      });
+    const { lifecycleParams, start, stop, threadStop, gatewaySupervisor } = createLifecycleHarness({
+      start: async () => {
+        throw new Error("startup failed");
+      },
+    });
 
     await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow("startup failed");
 
@@ -168,14 +231,14 @@ describe("runDiscordGatewayLifecycle", () => {
       stop,
       threadStop,
       waitCalls: 0,
-      releaseEarlyGatewayErrorGuard,
+      gatewaySupervisor,
     });
   });
 
   it("cleans up when gateway wait fails after startup", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
     waitForDiscordGatewayStopMock.mockRejectedValueOnce(new Error("gateway wait failed"));
-    const { lifecycleParams, start, stop, threadStop, releaseEarlyGatewayErrorGuard } =
+    const { lifecycleParams, start, stop, threadStop, gatewaySupervisor } =
       createLifecycleHarness();
 
     await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow(
@@ -187,13 +250,13 @@ describe("runDiscordGatewayLifecycle", () => {
       stop,
       threadStop,
       waitCalls: 1,
-      releaseEarlyGatewayErrorGuard,
+      gatewaySupervisor,
     });
   });
 
   it("cleans up after successful gateway wait", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-    const { lifecycleParams, start, stop, threadStop, releaseEarlyGatewayErrorGuard } =
+    const { lifecycleParams, start, stop, threadStop, gatewaySupervisor } =
       createLifecycleHarness();
 
     await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
@@ -203,7 +266,7 @@ describe("runDiscordGatewayLifecycle", () => {
       stop,
       threadStop,
       waitCalls: 1,
-      releaseEarlyGatewayErrorGuard,
+      gatewaySupervisor,
     });
   });
 
@@ -220,12 +283,14 @@ describe("runDiscordGatewayLifecycle", () => {
       const patch = (call[0] ?? {}) as Record<string, unknown>;
       return patch.connected === true;
     });
-    expect(connectedCall).toBeDefined();
-    expect(connectedCall![0]).toMatchObject({
+    if (!connectedCall) {
+      throw new Error("connected status update was not emitted");
+    }
+    expect(connectedCall[0]).toMatchObject({
       connected: true,
       lastDisconnect: null,
     });
-    expect(connectedCall![0].lastConnectedAt).toBeTypeOf("number");
+    expect(connectedCall[0].lastConnectedAt).toBeTypeOf("number");
   });
 
   it("forces a fresh reconnect when startup never reaches READY, then recovers", async () => {
@@ -256,13 +321,229 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
+  it("clears resume state and suppresses socket-driven auto-resume during forced startup reconnects", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const pendingGatewayEvents: DiscordGatewayEvent[] = [];
+      const socket = new EventEmitter();
+      const { emitter, gateway } = createGatewayHarness({
+        state: {
+          sessionId: "stale-session",
+          resumeGatewayUrl: "wss://gateway.discord.gg",
+          sequence: 123,
+        },
+        sequence: 123,
+        ws: socket,
+      });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+      socket.on("error", (err) => {
+        pendingGatewayEvents.push({
+          type: "other",
+          err,
+          message: String(err),
+          shouldStopLifecycle: false,
+        });
+      });
+      socket.on("close", () => {
+        gateway.connect(true);
+      });
+      gateway.disconnect.mockImplementation(() => {
+        setTimeout(() => {
+          socket.emit(
+            "error",
+            new Error("WebSocket was closed before the connection was established"),
+          );
+          socket.emit("close", 1006, "");
+        }, 1);
+      });
+      gateway.connect.mockImplementation((resume?: boolean) => {
+        if (resume === false) {
+          setTimeout(() => {
+            gateway.isConnected = true;
+          }, 1_000);
+        }
+      });
+
+      const { lifecycleParams, runtimeError } = createLifecycleHarness({
+        gateway,
+        pendingGatewayEvents,
+      });
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      await vi.advanceTimersByTimeAsync(17_000);
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+
+      expect(gateway.connect).toHaveBeenCalledTimes(1);
+      expect(gateway.connect).toHaveBeenCalledWith(false);
+      expect(runtimeError).not.toHaveBeenCalledWith(
+        expect.stringContaining("WebSocket was closed before the connection was established"),
+      );
+      expectGatewaySessionStateCleared(gateway);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for forced terminate to close the old socket before reconnecting", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const socket = Object.assign(new EventEmitter(), {
+        terminate: vi.fn(() => {
+          setTimeout(() => {
+            socket.emit(
+              "error",
+              new Error("WebSocket was closed before the connection was established"),
+            );
+            socket.emit("close", 1006, "");
+          }, 1);
+        }),
+      });
+      const { emitter, gateway } = createGatewayHarness({ ws: socket });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+      gateway.connect.mockImplementation((_resume?: boolean) => {
+        setTimeout(() => {
+          gateway.isConnected = true;
+        }, 1_000);
+      });
+
+      const { lifecycleParams, runtimeError } = createLifecycleHarness({ gateway });
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      await vi.advanceTimersByTimeAsync(15_000 + 5_000 + 1_500);
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+
+      expect(socket.terminate).toHaveBeenCalledTimes(1);
+      expect(gateway.connect).toHaveBeenCalledTimes(1);
+      expect(gateway.connect).toHaveBeenCalledWith(false);
+      expect(runtimeError).toHaveBeenCalledWith(
+        expect.stringContaining("attempting forced terminate before giving up"),
+      );
+      expect(runtimeError).not.toHaveBeenCalledWith(
+        expect.stringContaining("WebSocket was closed before the connection was established"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails closed when forced terminate still does not close the old socket", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const socket = Object.assign(new EventEmitter(), {
+        terminate: vi.fn(() => {
+          setTimeout(() => {
+            socket.emit(
+              "error",
+              new Error("WebSocket was closed before the connection was established"),
+            );
+          }, 1);
+        }),
+      });
+      const { emitter, gateway } = createGatewayHarness({ ws: socket });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+      const { lifecycleParams, start, stop, threadStop, runtimeError, gatewaySupervisor } =
+        createLifecycleHarness({ gateway });
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      lifecyclePromise.catch(() => {});
+      await vi.advanceTimersByTimeAsync(15_000 + 5_000 + 1_500);
+      await expect(lifecyclePromise).rejects.toThrow(
+        "discord gateway socket did not close within 5000ms before reconnect",
+      );
+
+      expect(socket.terminate).toHaveBeenCalledTimes(1);
+      expect(gateway.connect).not.toHaveBeenCalled();
+      expect(runtimeError).toHaveBeenCalledWith(
+        expect.stringContaining("force-stopping instead of opening a parallel socket"),
+      );
+      expect(runtimeError).not.toHaveBeenCalledWith(
+        expect.stringContaining("WebSocket was closed before the connection was established"),
+      );
+      expectLifecycleCleanup({
+        start,
+        stop,
+        threadStop,
+        waitCalls: 0,
+        gatewaySupervisor,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not reconnect after lifecycle shutdown begins during socket drain", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const socket = new EventEmitter();
+      const { emitter, gateway } = createGatewayHarness({ ws: socket });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+      gateway.disconnect.mockImplementation(() => {
+        setTimeout(() => {
+          socket.emit("close", 1000, "");
+        }, 1_000);
+      });
+
+      const abortController = new AbortController();
+      const { lifecycleParams } = createLifecycleHarness({ gateway });
+      lifecycleParams.abortSignal = abortController.signal;
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      await vi.advanceTimersByTimeAsync(15_100);
+      abortController.abort();
+      await vi.advanceTimersByTimeAsync(2_000);
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+
+      expect(gateway.connect).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("treats drain timeout as a graceful stop after lifecycle abort", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const socket = new EventEmitter();
+      const { emitter, gateway } = createGatewayHarness({ ws: socket });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+      const abortController = new AbortController();
+      const { lifecycleParams, start, stop, threadStop, runtimeError, gatewaySupervisor } =
+        createLifecycleHarness({ gateway });
+      lifecycleParams.abortSignal = abortController.signal;
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      await vi.advanceTimersByTimeAsync(15_100);
+      abortController.abort();
+      await vi.advanceTimersByTimeAsync(5_500);
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+
+      expect(gateway.connect).not.toHaveBeenCalled();
+      expect(runtimeError).not.toHaveBeenCalledWith(
+        expect.stringContaining("gateway socket did not close within 5000ms before reconnect"),
+      );
+      expectLifecycleCleanup({
+        start,
+        stop,
+        threadStop,
+        waitCalls: 1,
+        gatewaySupervisor,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("fails fast when startup never reaches READY after a forced reconnect", async () => {
     vi.useFakeTimers();
     try {
       const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
       const { emitter, gateway } = createGatewayHarness();
       getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
-      const { lifecycleParams, start, stop, threadStop, releaseEarlyGatewayErrorGuard } =
+      const { lifecycleParams, start, stop, threadStop, gatewaySupervisor } =
         createLifecycleHarness({ gateway });
 
       const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
@@ -280,7 +561,7 @@ describe("runDiscordGatewayLifecycle", () => {
         stop,
         threadStop,
         waitCalls: 0,
-        releaseEarlyGatewayErrorGuard,
+        gatewaySupervisor,
       });
     } finally {
       vi.useRealTimers();
@@ -289,17 +570,13 @@ describe("runDiscordGatewayLifecycle", () => {
 
   it("handles queued disallowed intents errors without waiting for gateway events", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-    const {
-      lifecycleParams,
-      start,
-      stop,
-      threadStop,
-      runtimeError,
-      releaseEarlyGatewayErrorGuard,
-    } = createLifecycleHarness({
-      pendingGatewayErrors: [new Error("Fatal Gateway error: 4014")],
-      isDisallowedIntentsError: (err) => String(err).includes("4014"),
-    });
+    const { lifecycleParams, start, stop, threadStop, runtimeError, gatewaySupervisor } =
+      createLifecycleHarness({
+        pendingGatewayEvents: [
+          createGatewayEvent("disallowed-intents", "Fatal Gateway error: 4014"),
+        ],
+        isDisallowedIntentsError: (err) => String(err).includes("4014"),
+      });
 
     await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
 
@@ -311,16 +588,36 @@ describe("runDiscordGatewayLifecycle", () => {
       stop,
       threadStop,
       waitCalls: 0,
-      releaseEarlyGatewayErrorGuard,
+      gatewaySupervisor,
+    });
+  });
+
+  it("logs queued non-fatal startup gateway errors and continues", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { lifecycleParams, start, stop, threadStop, runtimeError, gatewaySupervisor } =
+      createLifecycleHarness({
+        pendingGatewayEvents: [createGatewayEvent("other", "transient startup error")],
+      });
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("discord gateway error: Error: transient startup error"),
+    );
+    expectLifecycleCleanup({
+      start,
+      stop,
+      threadStop,
+      waitCalls: 1,
+      gatewaySupervisor,
     });
   });
 
   it("throws queued non-disallowed fatal gateway errors", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-    const { lifecycleParams, start, stop, threadStop, releaseEarlyGatewayErrorGuard } =
-      createLifecycleHarness({
-        pendingGatewayErrors: [new Error("Fatal Gateway error: 4000")],
-      });
+    const { lifecycleParams, start, stop, threadStop, gatewaySupervisor } = createLifecycleHarness({
+      pendingGatewayEvents: [createGatewayEvent("fatal", "Fatal Gateway error: 4000")],
+    });
 
     await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow(
       "Fatal Gateway error: 4000",
@@ -331,7 +628,7 @@ describe("runDiscordGatewayLifecycle", () => {
       stop,
       threadStop,
       waitCalls: 0,
-      releaseEarlyGatewayErrorGuard,
+      gatewaySupervisor,
     });
   });
 
@@ -339,23 +636,17 @@ describe("runDiscordGatewayLifecycle", () => {
     vi.useFakeTimers();
     try {
       const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-      const pendingGatewayErrors: unknown[] = [];
+      const pendingGatewayEvents: DiscordGatewayEvent[] = [];
       const { emitter, gateway } = createGatewayHarness();
       getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
-      const {
-        lifecycleParams,
-        start,
-        stop,
-        threadStop,
-        runtimeError,
-        releaseEarlyGatewayErrorGuard,
-      } = createLifecycleHarness({
-        gateway,
-        pendingGatewayErrors,
-      });
+      const { lifecycleParams, start, stop, threadStop, runtimeError, gatewaySupervisor } =
+        createLifecycleHarness({
+          gateway,
+          pendingGatewayEvents,
+        });
 
       setTimeout(() => {
-        pendingGatewayErrors.push(new Error("Fatal Gateway error: 4001"));
+        pendingGatewayEvents.push(createGatewayEvent("fatal", "Fatal Gateway error: 4001"));
       }, 1_000);
 
       const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
@@ -373,7 +664,7 @@ describe("runDiscordGatewayLifecycle", () => {
         stop,
         threadStop,
         waitCalls: 0,
-        releaseEarlyGatewayErrorGuard,
+        gatewaySupervisor,
       });
     } finally {
       vi.useRealTimers();
@@ -409,11 +700,7 @@ describe("runDiscordGatewayLifecycle", () => {
       expect(gateway.connect).toHaveBeenNthCalledWith(1, true);
       expect(gateway.connect).toHaveBeenNthCalledWith(2, true);
       expect(gateway.connect).toHaveBeenNthCalledWith(3, false);
-      expect(gateway.state).toBeDefined();
-      expect(gateway.state?.sessionId).toBeNull();
-      expect(gateway.state?.resumeGatewayUrl).toBeNull();
-      expect(gateway.state?.sequence).toBeNull();
-      expect(gateway.sequence).toBeNull();
+      expectGatewaySessionStateCleared(gateway);
     } finally {
       vi.useRealTimers();
     }
@@ -526,12 +813,115 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
+  it("suppresses reconnect-exhausted already queued before shutdown", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const pendingGatewayEvents: DiscordGatewayEvent[] = [];
+    const abortController = new AbortController();
+
+    const emitter = new EventEmitter();
+    const gateway: MockGateway = {
+      isConnected: true,
+      options: { intents: 0, reconnect: { maxAttempts: 50 } } as GatewayPlugin["options"],
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      emitter,
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const { lifecycleParams, runtimeLog, runtimeError } = createLifecycleHarness({
+      gateway,
+      pendingGatewayEvents,
+    });
+    lifecycleParams.abortSignal = abortController.signal;
+
+    // Start lifecycle; it yields at execApprovalsHandler.start(). We then
+    // queue a reconnect-exhausted event and abort. The lifecycle resumes and
+    // drains the queued event before shutdown teardown flips lifecycleStopping,
+    // so drainPending must treat it as a graceful stop.
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    pendingGatewayEvents.push(
+      createGatewayEvent(
+        "reconnect-exhausted",
+        "Max reconnect attempts (0) reached after code 1005",
+      ),
+    );
+    abortController.abort();
+
+    await expect(lifecyclePromise).resolves.toBeUndefined();
+    expect(runtimeLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
+    );
+    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("Max reconnect attempts"));
+  });
+
+  it("gracefully stops on reconnect-exhausted from deliberate maxAttempts=0 even before shutdown", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const pendingGatewayEvents: DiscordGatewayEvent[] = [];
+
+    const emitter = new EventEmitter();
+    const gateway: MockGateway = {
+      isConnected: true,
+      options: { intents: 0, reconnect: { maxAttempts: 50 } } as GatewayPlugin["options"],
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      emitter,
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const { lifecycleParams } = createLifecycleHarness({
+      gateway,
+      pendingGatewayEvents,
+    });
+
+    pendingGatewayEvents.push(
+      createGatewayEvent(
+        "reconnect-exhausted",
+        "Max reconnect attempts (0) reached after code 1005",
+      ),
+    );
+
+    // Deliberate maxAttempts=0 disconnect should not crash the gateway
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.not.toThrow();
+  });
+
+  it("rejects reconnect-exhausted with non-zero maxAttempts when shutdown has not begun", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const pendingGatewayEvents: DiscordGatewayEvent[] = [];
+
+    const emitter = new EventEmitter();
+    const gateway: MockGateway = {
+      isConnected: true,
+      options: { intents: 0, reconnect: { maxAttempts: 50 } } as GatewayPlugin["options"],
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      emitter,
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const { lifecycleParams } = createLifecycleHarness({
+      gateway,
+      pendingGatewayEvents,
+    });
+
+    pendingGatewayEvents.push(
+      createGatewayEvent(
+        "reconnect-exhausted",
+        "Max reconnect attempts (50) reached after code 1005",
+      ),
+    );
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow(
+      "Max reconnect attempts",
+    );
+  });
+
   it("does not push connected: true when abortSignal is already aborted", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
     const emitter = new EventEmitter();
-    const gateway = {
+    const gateway: MockGateway = {
       isConnected: true,
-      options: { reconnect: { maxAttempts: 3 } },
+      options: { intents: 0, reconnect: { maxAttempts: 3 } } as GatewayPlugin["options"],
       disconnect: vi.fn(),
       connect: vi.fn(),
       emitter,
@@ -554,7 +944,7 @@ describe("runDiscordGatewayLifecycle", () => {
 
     // onAbort should have pushed connected: false
     const connectedFalse = statusUpdates.find((s) => s.connected === false);
-    expect(connectedFalse).toBeDefined();
+    expect(connectedFalse).toEqual(expect.objectContaining({ connected: false }));
 
     // No connected: true should appear — the isConnected check must be
     // guarded by !lifecycleStopping to avoid contradicting the abort.

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -1,13 +1,12 @@
-import type { Client } from "@buape/carbon";
-import type { GatewayPlugin } from "@buape/carbon/gateway";
-import { createArmableStallWatchdog } from "openclaw/plugin-sdk/channel-lifecycle";
-import { createConnectedChannelStatusPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { attachDiscordGatewayLogging } from "../gateway-logging.js";
 import { getDiscordGatewayEmitter, waitForDiscordGatewayStop } from "../monitor.gateway.js";
 import type { DiscordVoiceManager } from "../voice/manager.js";
+import type { MutableDiscordGateway } from "./gateway-handle.js";
 import { registerGateway, unregisterGateway } from "./gateway-registry.js";
+import type { DiscordGatewayEvent, DiscordGatewaySupervisor } from "./gateway-supervisor.js";
+import { createDiscordGatewayReconnectController } from "./provider.lifecycle.reconnect.js";
 import type { DiscordMonitorStatusSink } from "./status.js";
 
 type ExecApprovalsHandler = {
@@ -15,40 +14,9 @@ type ExecApprovalsHandler = {
   stop: () => Promise<void>;
 };
 
-const DISCORD_GATEWAY_READY_TIMEOUT_MS = 15_000;
-const DISCORD_GATEWAY_READY_POLL_MS = 250;
-
-type GatewayReadyWaitResult = "ready" | "timeout" | "stopped";
-
-async function waitForDiscordGatewayReady(params: {
-  gateway?: Pick<GatewayPlugin, "isConnected">;
-  abortSignal?: AbortSignal;
-  timeoutMs: number;
-  beforePoll?: () => Promise<"continue" | "stop"> | "continue" | "stop";
-}): Promise<GatewayReadyWaitResult> {
-  const deadlineAt = Date.now() + params.timeoutMs;
-  while (!params.abortSignal?.aborted) {
-    const pollDecision = await params.beforePoll?.();
-    if (pollDecision === "stop") {
-      return "stopped";
-    }
-    if (params.gateway?.isConnected) {
-      return "ready";
-    }
-    if (Date.now() >= deadlineAt) {
-      return "timeout";
-    }
-    await new Promise<void>((resolve) => {
-      const timeout = setTimeout(resolve, DISCORD_GATEWAY_READY_POLL_MS);
-      timeout.unref?.();
-    });
-  }
-  return "stopped";
-}
-
 export async function runDiscordGatewayLifecycle(params: {
   accountId: string;
-  client: Client;
+  gateway?: MutableDiscordGateway;
   runtime: RuntimeEnv;
   abortSignal?: AbortSignal;
   isDisallowedIntentsError: (err: unknown) => boolean;
@@ -56,263 +24,79 @@ export async function runDiscordGatewayLifecycle(params: {
   voiceManagerRef: { current: DiscordVoiceManager | null };
   execApprovalsHandler: ExecApprovalsHandler | null;
   threadBindings: { stop: () => void };
-  pendingGatewayErrors?: unknown[];
-  releaseEarlyGatewayErrorGuard?: () => void;
+  gatewaySupervisor: DiscordGatewaySupervisor;
   statusSink?: DiscordMonitorStatusSink;
 }) {
-  const HELLO_TIMEOUT_MS = 30000;
-  const HELLO_CONNECTED_POLL_MS = 250;
-  const MAX_CONSECUTIVE_HELLO_STALLS = 3;
-  const RECONNECT_STALL_TIMEOUT_MS = 5 * 60_000;
-  const gateway = params.client.getPlugin<GatewayPlugin>("gateway");
+  const gateway = params.gateway;
   if (gateway) {
     registerGateway(params.accountId, gateway);
   }
-  const gatewayEmitter = getDiscordGatewayEmitter(gateway);
+  const gatewayEmitter = params.gatewaySupervisor.emitter ?? getDiscordGatewayEmitter(gateway);
   const stopGatewayLogging = attachDiscordGatewayLogging({
     emitter: gatewayEmitter,
     runtime: params.runtime,
   });
   let lifecycleStopping = false;
-  let forceStopHandler: ((err: unknown) => void) | undefined;
-  let queuedForceStopError: unknown;
 
   const pushStatus = (patch: Parameters<DiscordMonitorStatusSink>[0]) => {
     params.statusSink?.(patch);
   };
-
-  const triggerForceStop = (err: unknown) => {
-    if (forceStopHandler) {
-      forceStopHandler(err);
-      return;
-    }
-    queuedForceStopError = err;
-  };
-
-  const reconnectStallWatchdog = createArmableStallWatchdog({
-    label: `discord:${params.accountId}:reconnect`,
-    timeoutMs: RECONNECT_STALL_TIMEOUT_MS,
-    abortSignal: params.abortSignal,
+  const reconnectController = createDiscordGatewayReconnectController({
+    accountId: params.accountId,
+    gateway,
     runtime: params.runtime,
-    onTimeout: () => {
-      if (params.abortSignal?.aborted || lifecycleStopping) {
-        return;
-      }
-      const at = Date.now();
-      const error = new Error(
-        `discord reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms`,
-      );
-      pushStatus({
-        connected: false,
-        lastEventAt: at,
-        lastDisconnect: {
-          at,
-          error: error.message,
-        },
-        lastError: error.message,
-      });
-      params.runtime.error?.(
-        danger(
-          `discord: reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms; force-stopping monitor task`,
-        ),
-      );
-      triggerForceStop(error);
-    },
+    abortSignal: params.abortSignal,
+    pushStatus,
+    isLifecycleStopping: () => lifecycleStopping,
+    drainPendingGatewayErrors: () => drainPendingGatewayErrors(),
   });
-
-  const onAbort = () => {
-    lifecycleStopping = true;
-    reconnectStallWatchdog.disarm();
-    const at = Date.now();
-    pushStatus({ connected: false, lastEventAt: at });
-    if (!gateway) {
-      return;
-    }
-    gatewayEmitter?.once("error", () => {});
-    gateway.options.reconnect = { maxAttempts: 0 };
-    gateway.disconnect();
-  };
-
-  if (params.abortSignal?.aborted) {
-    onAbort();
-  } else {
-    params.abortSignal?.addEventListener("abort", onAbort, { once: true });
-  }
-
-  let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
-  let helloConnectedPollId: ReturnType<typeof setInterval> | undefined;
-  let consecutiveHelloStalls = 0;
-  const clearHelloWatch = () => {
-    if (helloTimeoutId) {
-      clearTimeout(helloTimeoutId);
-      helloTimeoutId = undefined;
-    }
-    if (helloConnectedPollId) {
-      clearInterval(helloConnectedPollId);
-      helloConnectedPollId = undefined;
-    }
-  };
-  const resetHelloStallCounter = () => {
-    consecutiveHelloStalls = 0;
-  };
-  const parseGatewayCloseCode = (message: string): number | undefined => {
-    const match = /code\s+(\d{3,5})/i.exec(message);
-    if (!match?.[1]) {
-      return undefined;
-    }
-    const code = Number.parseInt(match[1], 10);
-    return Number.isFinite(code) ? code : undefined;
-  };
-  const clearResumeState = () => {
-    const mutableGateway = gateway as
-      | (GatewayPlugin & {
-          state?: {
-            sessionId?: string | null;
-            resumeGatewayUrl?: string | null;
-            sequence?: number | null;
-          };
-          sequence?: number | null;
-        })
-      | undefined;
-    if (!mutableGateway?.state) {
-      return;
-    }
-    mutableGateway.state.sessionId = null;
-    mutableGateway.state.resumeGatewayUrl = null;
-    mutableGateway.state.sequence = null;
-    mutableGateway.sequence = null;
-  };
-  const onGatewayDebug = (msg: unknown) => {
-    const message = String(msg);
-    const at = Date.now();
-    pushStatus({ lastEventAt: at });
-    if (message.includes("WebSocket connection closed")) {
-      // Carbon marks `isConnected` true only after READY/RESUMED and flips it
-      // false during reconnect handling after this debug line is emitted.
-      if (gateway?.isConnected) {
-        resetHelloStallCounter();
-      }
-      reconnectStallWatchdog.arm(at);
-      pushStatus({
-        connected: false,
-        lastDisconnect: {
-          at,
-          status: parseGatewayCloseCode(message),
-        },
-      });
-      clearHelloWatch();
-      return;
-    }
-    if (!message.includes("WebSocket connection opened")) {
-      return;
-    }
-    reconnectStallWatchdog.disarm();
-    clearHelloWatch();
-
-    let sawConnected = gateway?.isConnected === true;
-    if (sawConnected) {
-      pushStatus({
-        ...createConnectedChannelStatusPatch(at),
-        lastDisconnect: null,
-      });
-    }
-    helloConnectedPollId = setInterval(() => {
-      if (!gateway?.isConnected) {
-        return;
-      }
-      sawConnected = true;
-      resetHelloStallCounter();
-      const connectedAt = Date.now();
-      reconnectStallWatchdog.disarm();
-      pushStatus({
-        ...createConnectedChannelStatusPatch(connectedAt),
-        lastDisconnect: null,
-      });
-      if (helloConnectedPollId) {
-        clearInterval(helloConnectedPollId);
-        helloConnectedPollId = undefined;
-      }
-    }, HELLO_CONNECTED_POLL_MS);
-
-    helloTimeoutId = setTimeout(() => {
-      if (helloConnectedPollId) {
-        clearInterval(helloConnectedPollId);
-        helloConnectedPollId = undefined;
-      }
-      if (sawConnected || gateway?.isConnected) {
-        resetHelloStallCounter();
-      } else {
-        consecutiveHelloStalls += 1;
-        const forceFreshIdentify = consecutiveHelloStalls >= MAX_CONSECUTIVE_HELLO_STALLS;
-        const stalledAt = Date.now();
-        reconnectStallWatchdog.arm(stalledAt);
-        pushStatus({
-          connected: false,
-          lastEventAt: stalledAt,
-          lastDisconnect: {
-            at: stalledAt,
-            error: "hello-timeout",
-          },
-        });
-        params.runtime.log?.(
-          danger(
-            forceFreshIdentify
-              ? `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); forcing fresh identify`
-              : `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); retrying resume`,
-          ),
-        );
-        if (forceFreshIdentify) {
-          clearResumeState();
-          resetHelloStallCounter();
-        }
-        gateway?.disconnect();
-        gateway?.connect(!forceFreshIdentify);
-      }
-      helloTimeoutId = undefined;
-    }, HELLO_TIMEOUT_MS);
-  };
+  const onGatewayDebug = reconnectController.onGatewayDebug;
   gatewayEmitter?.on("debug", onGatewayDebug);
 
   let sawDisallowedIntents = false;
-  const logGatewayError = (err: unknown) => {
-    if (params.isDisallowedIntentsError(err)) {
+  const handleGatewayEvent = (event: DiscordGatewayEvent): "continue" | "stop" => {
+    if (event.type === "disallowed-intents") {
       sawDisallowedIntents = true;
       params.runtime.error?.(
         danger(
           "discord: gateway closed with code 4014 (missing privileged gateway intents). Enable the required intents in the Discord Developer Portal or disable them in config.",
         ),
       );
-      return;
+      return "stop";
     }
-    params.runtime.error?.(danger(`discord gateway error: ${String(err)}`));
-  };
-  const shouldStopOnGatewayError = (err: unknown) => {
-    const message = String(err);
-    return (
-      message.includes("Max reconnect attempts") ||
-      message.includes("Fatal Gateway error") ||
-      params.isDisallowedIntentsError(err)
-    );
-  };
-  const drainPendingGatewayErrors = (): "continue" | "stop" => {
-    const pendingGatewayErrors = params.pendingGatewayErrors ?? [];
-    if (pendingGatewayErrors.length === 0) {
-      return "continue";
+    // When we deliberately set maxAttempts=0 and disconnected (health-monitor
+    // stale-socket restart), Carbon fires "Max reconnect attempts (0)". This
+    // is expected — log at info instead of error to avoid false alarms.
+    if (lifecycleStopping && event.type === "reconnect-exhausted") {
+      params.runtime.log?.(
+        `discord: ignoring expected reconnect-exhausted during shutdown: ${event.message}`,
+      );
+      return "stop";
     }
-    const queuedErrors = [...pendingGatewayErrors];
-    pendingGatewayErrors.length = 0;
-    for (const err of queuedErrors) {
-      logGatewayError(err);
-      if (!shouldStopOnGatewayError(err)) {
-        continue;
+    params.runtime.error?.(danger(`discord gateway error: ${event.message}`));
+    return event.shouldStopLifecycle ? "stop" : "continue";
+  };
+  const drainPendingGatewayErrors = (): "continue" | "stop" =>
+    params.gatewaySupervisor.drainPending((event) => {
+      const decision = handleGatewayEvent(event);
+      if (decision !== "stop") {
+        return "continue";
       }
-      if (params.isDisallowedIntentsError(err)) {
+      // Don't throw for expected shutdown events. `reconnect-exhausted` can be
+      // queued just before an abort-driven shutdown flips `lifecycleStopping`,
+      // so suppress it when shutdown is underway or when the exhaustion came
+      // from a deliberate maxAttempts=0 disconnect (health-monitor restart).
+      if (
+        event.type === "disallowed-intents" ||
+        (event.type === "reconnect-exhausted" &&
+          (lifecycleStopping ||
+            params.abortSignal?.aborted === true ||
+            event.message.includes("(0)")))
+      ) {
         return "stop";
       }
-      throw err;
-    }
-    return "continue";
-  };
+      throw event.err;
+    });
   try {
     if (params.execApprovalsHandler) {
       await params.execApprovalsHandler.start();
@@ -323,96 +107,22 @@ export async function runDiscordGatewayLifecycle(params: {
       return;
     }
 
-    // Carbon starts the gateway during client construction, before OpenClaw can
-    // attach lifecycle listeners. Require a READY/RESUMED-connected gateway
-    // before continuing so the monitor does not look healthy while silently
-    // missing inbound events.
-    if (gateway && !gateway.isConnected && !lifecycleStopping) {
-      const initialReady = await waitForDiscordGatewayReady({
-        gateway,
-        abortSignal: params.abortSignal,
-        timeoutMs: DISCORD_GATEWAY_READY_TIMEOUT_MS,
-        beforePoll: drainPendingGatewayErrors,
-      });
-      if (initialReady === "stopped" || lifecycleStopping) {
-        return;
-      }
-      if (initialReady === "timeout" && !lifecycleStopping) {
-        params.runtime.error?.(
-          danger(
-            `discord: gateway was not ready after ${DISCORD_GATEWAY_READY_TIMEOUT_MS}ms; forcing a fresh reconnect`,
-          ),
-        );
-        const startupRetryAt = Date.now();
-        pushStatus({
-          connected: false,
-          lastEventAt: startupRetryAt,
-          lastDisconnect: {
-            at: startupRetryAt,
-            error: "startup-not-ready",
-          },
-        });
-        gateway?.disconnect();
-        gateway?.connect(false);
-        const reconnected = await waitForDiscordGatewayReady({
-          gateway,
-          abortSignal: params.abortSignal,
-          timeoutMs: DISCORD_GATEWAY_READY_TIMEOUT_MS,
-          beforePoll: drainPendingGatewayErrors,
-        });
-        if (reconnected === "stopped" || lifecycleStopping) {
-          return;
-        }
-        if (reconnected === "timeout" && !lifecycleStopping) {
-          const error = new Error(
-            `discord gateway did not reach READY within ${DISCORD_GATEWAY_READY_TIMEOUT_MS}ms after a forced reconnect`,
-          );
-          const startupFailureAt = Date.now();
-          pushStatus({
-            connected: false,
-            lastEventAt: startupFailureAt,
-            lastDisconnect: {
-              at: startupFailureAt,
-              error: "startup-reconnect-timeout",
-            },
-            lastError: error.message,
-          });
-          throw error;
-        }
-      }
-    }
+    await reconnectController.ensureStartupReady();
 
-    // If the gateway is already connected when the lifecycle starts (or becomes
-    // connected during the startup readiness guard), push the initial connected
-    // status now. Guard against lifecycleStopping: if the abortSignal was
-    // already aborted, onAbort() ran synchronously above and pushed connected:
-    // false, so don't contradict it with a spurious connected: true.
-    if (gateway?.isConnected && !lifecycleStopping) {
-      const at = Date.now();
-      pushStatus({
-        ...createConnectedChannelStatusPatch(at),
-        lastDisconnect: null,
-      });
+    if (drainPendingGatewayErrors() === "stop") {
+      return;
     }
 
     await waitForDiscordGatewayStop({
       gateway: gateway
         ? {
-            emitter: gatewayEmitter,
             disconnect: () => gateway.disconnect(),
           }
         : undefined,
       abortSignal: params.abortSignal,
-      onGatewayError: logGatewayError,
-      shouldStopOnError: shouldStopOnGatewayError,
-      registerForceStop: (forceStop) => {
-        forceStopHandler = forceStop;
-        if (queuedForceStopError !== undefined) {
-          const queued = queuedForceStopError;
-          queuedForceStopError = undefined;
-          forceStop(queued);
-        }
-      },
+      gatewaySupervisor: params.gatewaySupervisor,
+      onGatewayEvent: handleGatewayEvent,
+      registerForceStop: reconnectController.registerForceStop,
     });
   } catch (err) {
     if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
@@ -420,13 +130,11 @@ export async function runDiscordGatewayLifecycle(params: {
     }
   } finally {
     lifecycleStopping = true;
-    params.releaseEarlyGatewayErrorGuard?.();
+    params.gatewaySupervisor.detachLifecycle();
     unregisterGateway(params.accountId);
     stopGatewayLogging();
-    reconnectStallWatchdog.stop();
-    clearHelloWatch();
+    reconnectController.dispose();
     gatewayEmitter?.removeListener("debug", onGatewayDebug);
-    params.abortSignal?.removeEventListener("abort", onAbort);
     if (params.voiceManager) {
       await params.voiceManager.destroy();
       params.voiceManagerRef.current = null;

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -64,9 +64,9 @@ export async function runDiscordGatewayLifecycle(params: {
       );
       return "stop";
     }
-    // When we deliberately set maxAttempts=0 and disconnected (health-monitor
-    // stale-socket restart), Carbon fires "Max reconnect attempts (0)". This
-    // is expected — log at info instead of error to avoid false alarms.
+    // Any reconnect-exhausted that arrives on the live event path while a
+    // shutdown is already in progress is expected noise. Log at info level
+    // rather than error to avoid false alarms.
     if (lifecycleStopping && event.type === "reconnect-exhausted") {
       params.runtime.log?.(
         `discord: ignoring expected reconnect-exhausted during shutdown: ${event.message}`,
@@ -91,7 +91,10 @@ export async function runDiscordGatewayLifecycle(params: {
         (event.type === "reconnect-exhausted" &&
           (lifecycleStopping ||
             params.abortSignal?.aborted === true ||
-            event.message.includes("(0)")))
+            // Carbon formats this as "Max reconnect attempts (N) reached …".
+            // When N=0 the disconnect was deliberate (health-monitor restart);
+            // suppress the throw so the gateway exits gracefully.
+            /\(0\)/.test(event.message)))
       ) {
         return "stop";
       }


### PR DESCRIPTION
## Summary

- When the health-monitor restarts a stale Discord socket, it sets `maxAttempts=0` and disconnects. Carbon fires `"Max reconnect attempts (0)"` which can be buffered in the supervisor before `lifecycleStopping` flips.
- `drainPendingGatewayErrors` would throw this as an uncaught exception, crashing the entire gateway process.
- Fix: also suppress `reconnect-exhausted` events from deliberate `maxAttempts=0` disconnects (identified by `"(0)"` in the error message), in addition to existing shutdown/abort checks.
- Non-zero exhaustion events still throw to surface genuine reconnection failures.

## Test plan

- [x] Updated existing test: `reconnect-exhausted` with `(0)` now resolves gracefully
- [x] Added new test: `reconnect-exhausted` with non-zero `(50)` still rejects

Fixes #56588

🤖 Generated with [Claude Code](https://claude.com/claude-code)