### PR TITLE
test: refresh bundled plugin metadata

### DIFF
--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -7947,6 +7947,27 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               webhookPath: {
                 type: "string",
               },
+              threadBindings: {
+                type: "object",
+                properties: {
+                  enabled: {
+                    type: "boolean",
+                  },
+                  idleHours: {
+                    type: "number",
+                  },
+                  maxAgeHours: {
+                    type: "number",
+                  },
+                  spawnSubagentSessions: {
+                    type: "boolean",
+                  },
+                  spawnAcpSessions: {
+                    type: "boolean",
+                  },
+                },
+                additionalProperties: false,
+              },
               accounts: {
                 type: "object",
                 propertyNames: {
@@ -8017,6 +8038,27 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     },
                     webhookPath: {
                       type: "string",
+                    },
+                    threadBindings: {
+                      type: "object",
+                      properties: {
+                        enabled: {
+                          type: "boolean",
+                        },
+                        idleHours: {
+                          type: "number",
+                        },
+                        maxAgeHours: {
+                          type: "number",
+                        },
+                        spawnSubagentSessions: {
+                          type: "boolean",
+                        },
+                        spawnAcpSessions: {
+                          type: "boolean",
+                        },
+                      },
+                      additionalProperties: false,
                     },
                     groups: {
                       type: "object",


### PR DESCRIPTION
## Summary\n- refresh the generated bundled plugin metadata snapshot\n- include the current LINE plugin threadBindings schema in the generated artifact\n- unbreak the stale metadata snapshot failure seen in CI after #56707\n\n## Testing\n- node scripts/test-parallel.mjs --collect-failures --files src/plugins/bundled-plugin-metadata.test.ts\n- pnpm check:bundled-plugin-metadata\n- bun x vitest run --config vitest.unit.config.ts --pool=forks --isolate=false src/plugins/bundled-plugin-metadata.test.ts