### PR TITLE
fix(line): normalize canonical ACP targets

### DIFF
--- a/extensions/line/src/bot-message-context.test.ts
+++ b/extensions/line/src/bot-message-context.test.ts
@@ -335,6 +335,43 @@ describe("buildLineMessageContext", () => {
     });
   });
 
+  it("normalizes canonical LINE targets through the plugin bindings surface", async () => {
+    const compiled = linePlugin.bindings?.compileConfiguredBinding({
+      binding: {
+        type: "acp",
+        agentId: "codex",
+        match: { channel: "line", accountId: "default", peer: { kind: "direct", id: "unused" } },
+      } as AgentBinding,
+      conversationId: "line:U1234567890abcdef1234567890abcdef",
+    });
+
+    expect(compiled).toEqual({
+      conversationId: "U1234567890abcdef1234567890abcdef",
+    });
+    expect(
+      linePlugin.bindings?.resolveCommandConversation?.({
+        accountId: "default",
+        originatingTo: "line:U1234567890abcdef1234567890abcdef",
+      }),
+    ).toEqual({
+      conversationId: "U1234567890abcdef1234567890abcdef",
+    });
+    expect(
+      linePlugin.bindings?.matchInboundConversation({
+        binding: {
+          type: "acp",
+          agentId: "codex",
+          match: { channel: "line", accountId: "default", peer: { kind: "direct", id: "unused" } },
+        } as AgentBinding,
+        compiledBinding: compiled!,
+        conversationId: "U1234567890abcdef1234567890abcdef",
+      }),
+    ).toEqual({
+      conversationId: "U1234567890abcdef1234567890abcdef",
+      matchPriority: 2,
+    });
+  });
+
   it("routes LINE conversations through active ACP session bindings", async () => {
     const userId = "U1234567890abcdef1234567890abcdef";
     await getSessionBindingService().bind({

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -17,7 +17,7 @@ function normalizeLineConversationId(raw?: string | null): string | null {
   if (!trimmed) {
     return null;
   }
-  const prefixed = trimmed.match(/^line:(?:user|group|room):(.+)$/i)?.[1];
+  const prefixed = trimmed.match(/^line:(?:(?:user|group|room):)?(.+)$/i)?.[1];
   return (prefixed ?? trimmed).trim() || null;
 }
 

--- a/src/auto-reply/reply/commands-acp/context.test.ts
+++ b/src/auto-reply/reply/commands-acp/context.test.ts
@@ -201,6 +201,24 @@ describe("commands-acp context", () => {
     });
   });
 
+  it("resolves LINE conversation ids from canonical line targets", () => {
+    const params = buildCommandTestParams("/acp status", baseCfg, {
+      Provider: "line",
+      Surface: "line",
+      OriginatingChannel: "line",
+      OriginatingTo: "line:U1234567890abcdef1234567890abcdef",
+      AccountId: "work",
+    });
+
+    expect(resolveAcpCommandBindingContext(params)).toEqual({
+      channel: "line",
+      accountId: "work",
+      threadId: undefined,
+      conversationId: "U1234567890abcdef1234567890abcdef",
+    });
+    expect(resolveAcpCommandConversationId(params)).toBe("U1234567890abcdef1234567890abcdef");
+  });
+
   it("resolves Matrix thread context from the current room and thread root", () => {
     const params = buildCommandTestParams("/acp status", baseCfg, {
       Provider: "matrix",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the LINE ACP binding normalizer stripped `line:user:` / `line:group:` / `line:room:` prefixes but left canonical `line:<id>` targets unchanged.
- Why it matters: LINE inbound DM context commonly uses `line:<id>`, so configured ACP bindings and command/current-conversation binding resolution could normalize to `line:U...` on one path and bare `U...` on another, causing binding follow-up mismatches.
- What changed: broadened LINE conversation normalization to strip plain `line:` as well, and added focused regression tests for canonical LINE targets on both the plugin binding surface and ACP command-context resolution.
- What did NOT change (scope boundary): no ACP spawn/runtime logic changes, no backend changes, and no non-LINE channel behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #56700
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: LINE used two valid target encodings (`line:<id>` and bare/typed ids), but the channel binding normalizer only canonicalized the typed prefixes, leaving plain `line:` targets out of parity.
- Missing detection / guardrail: existing LINE ACP tests covered bare ids and typed `line:user/group/room:` prefixes, but not canonical `line:<id>` targets.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this is a follow-up to the merged LINE ACP parity work in #56700.
- Why this regressed now: the parity work added LINE binding surfaces, but one target-shape normalization path remained narrower than the actual LINE inbound address format.
- If unknown, what was ruled out: ruled out ACP session-binding service issues; the mismatch is in LINE target normalization only.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/line/src/bot-message-context.test.ts`, `src/auto-reply/reply/commands-acp/context.test.ts`
- Scenario the test should lock in: canonical `line:<id>` targets normalize to the same LINE conversation id as bare and typed LINE targets across plugin binding and ACP command-context resolution.
- Why this is the smallest reliable guardrail: the bug is a pure normalization mismatch on the LINE channel surface.
- Existing test that already covers this (if any): tests already covered bare ids and typed prefixes, but not plain `line:`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- LINE ACP configured bindings and current-conversation follow-up routing now treat canonical `line:<id>` targets the same as bare LINE ids.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Integration/channel (if any): LINE ACP binding normalization

### Steps

1. Resolve a LINE ACP command/binding context using `line:<id>` as the LINE target.
2. Compare it with the bare LINE id and typed `line:user:<id>` path.
3. Run the focused LINE tests and typecheck.

### Expected

- All LINE target forms normalize to the same conversation id.

### Actual

- Verified after the patch with focused tests; before the patch plain `line:<id>` remained unnormalized on the plugin binding path.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused LINE plugin binding normalization, LINE ACP command-context normalization, standalone `pnpm tsgo`, and commit-hook `pnpm check`.
- Edge cases checked: canonical `line:<id>`, typed `line:user:<id>`, and bare LINE ids.
- What you did **not** verify: live LINE smoke test.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Risks and Mitigations

- Risk: low; this broadens LINE normalization to an already-valid target encoding and could only affect callers that depended on preserving the `line:` prefix internally.
  - Mitigation: the rest of the LINE messaging surface already normalizes `line:` targets to bare ids, and the new tests lock in parity across the relevant ACP entry points.
