### PR TITLE
fix: unify state-dir resolution across all components

### DIFF
--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 export type MemoryConfig = {
   embedding: {
@@ -23,9 +23,21 @@ const DEFAULT_MODEL = "text-embedding-3-small";
 export const DEFAULT_CAPTURE_MAX_CHARS = 500;
 const LEGACY_STATE_DIRS: string[] = [];
 
+function resolveStateDirFromEnv(): string | undefined {
+  const override = process.env.OPENCLAW_STATE_DIR?.trim();
+  if (!override) {
+    return undefined;
+  }
+  if (override === "~" || override.startsWith("~/") || override.startsWith("~\\")) {
+    return resolve(join(homedir(), override.slice(2)));
+  }
+  return resolve(override);
+}
+
 function resolveDefaultDbPath(): string {
   const home = homedir();
-  const preferred = join(home, ".openclaw", "memory", "lancedb");
+  const preferredRoot = resolveStateDirFromEnv() ?? join(home, ".openclaw");
+  const preferred = join(preferredRoot, "memory", "lancedb");
   try {
     if (fs.existsSync(preferred)) {
       return preferred;
@@ -159,7 +171,7 @@ export const memoryConfigSchema = {
     },
     dbPath: {
       label: "Database Path",
-      placeholder: "~/.openclaw/memory/lancedb",
+      placeholder: DEFAULT_DB_PATH,
       advanced: true,
     },
     autoCapture: {

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -150,6 +150,29 @@ describe("memory plugin e2e", () => {
     delete process.env.TEST_MEMORY_API_KEY;
   });
 
+  test("config schema prefers OPENCLAW_STATE_DIR for the default db path", async () => {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = path.join(getDbPath(), "..", "state-root");
+
+    try {
+      vi.resetModules();
+      const { default: memoryPlugin } = await import("./index.js");
+      const config = memoryPlugin.configSchema?.parse?.({
+        embedding: {
+          apiKey: OPENAI_API_KEY,
+        },
+      }) as MemoryPluginTestConfig | undefined;
+
+      expect(config?.dbPath).toBe(path.join(process.env.OPENCLAW_STATE_DIR, "memory", "lancedb"));
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
   test("config schema rejects missing apiKey", async () => {
     const { default: memoryPlugin } = await import("./index.js");
 

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -27,7 +27,7 @@
     },
     "dbPath": {
       "label": "Database Path",
-      "placeholder": "~/.openclaw/memory/lancedb",
+      "placeholder": "$OPENCLAW_STATE_DIR/memory/lancedb",
       "advanced": true
     },
     "autoCapture": {

--- a/src/agents/workspace.defaults.test.ts
+++ b/src/agents/workspace.defaults.test.ts
@@ -16,4 +16,11 @@ describe("DEFAULT_AGENT_WORKSPACE_DIR", () => {
       path.join(path.resolve(home), ".openclaw", "workspace"),
     );
   });
+
+  it("prefers OPENCLAW_STATE_DIR when resolving the default workspace dir", () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/srv/openclaw-state");
+    expect(resolveDefaultAgentWorkspaceDir()).toBe(
+      path.join(path.resolve("/srv/openclaw-state"), "workspace"),
+    );
+  });
 });

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -27,6 +27,15 @@ describe("resolveDefaultAgentWorkspaceDir", () => {
 
     expect(dir).toBe(path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "workspace"));
   });
+
+  it("uses OPENCLAW_STATE_DIR for default workspace resolution", () => {
+    const dir = resolveDefaultAgentWorkspaceDir({
+      OPENCLAW_STATE_DIR: "/srv/openclaw-state",
+      HOME: "/home/other",
+    } as NodeJS.ProcessEnv);
+
+    expect(dir).toBe(path.join(path.resolve("/srv/openclaw-state"), "workspace"));
+  });
 });
 
 const WORKSPACE_STATE_PATH_SEGMENTS = [".openclaw", "workspace-state.json"] as const;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -2,6 +2,7 @@ import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { openBoundaryFile } from "../infra/boundary-file-read.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -13,12 +14,12 @@ export function resolveDefaultAgentWorkspaceDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,
 ): string {
-  const home = resolveRequiredHomeDir(env, homedir);
+  const stateDir = resolveStateDir(env, () => resolveRequiredHomeDir(env, homedir));
   const profile = env.OPENCLAW_PROFILE?.trim();
   if (profile && profile.toLowerCase() !== "default") {
-    return path.join(home, ".openclaw", `workspace-${profile}`);
+    return path.join(stateDir, `workspace-${profile}`);
   }
-  return path.join(home, ".openclaw", "workspace");
+  return path.join(stateDir, "workspace");
 }
 
 export const DEFAULT_AGENT_WORKSPACE_DIR = resolveDefaultAgentWorkspaceDir();

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStorePath, resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { note } from "../terminal/note.js";
-import { noteStateIntegrity } from "./doctor-state-integrity.js";
+import { noteStateIntegrity, resolveStateDirScanRoots } from "./doctor-state-integrity.js";
 
 vi.mock("../terminal/note.js", () => ({
   note: vi.fn(),
@@ -234,5 +234,32 @@ describe("doctor state integrity oauth dir checks", () => {
     });
     const text = await runStateIntegrityText(cfg);
     expect(text).not.toContain("recent sessions are missing transcripts");
+  });
+
+  it("does not warn when ~/.openclaw is a symlink to the active state dir", async () => {
+    const activeStateDir = path.join(tempHome, "openclaw-state");
+    const legacyStateDir = path.join(tempHome, ".openclaw");
+    process.env.OPENCLAW_STATE_DIR = activeStateDir;
+    fs.rmSync(legacyStateDir, { recursive: true, force: true });
+    fs.mkdirSync(activeStateDir, { recursive: true, mode: 0o700 });
+    fs.symlinkSync(activeStateDir, legacyStateDir);
+
+    const text = await runStateIntegrityText({});
+    expect(text).not.toContain(legacyStateDir);
+    expect(text).not.toContain("$OPENCLAW_HOME/.openclaw");
+  });
+});
+
+describe("resolveStateDirScanRoots", () => {
+  it("does not scan filesystem root when linux home is /root", () => {
+    expect(resolveStateDirScanRoots("/root", "linux")).toEqual(["/home"]);
+  });
+
+  it("keeps scanning sibling homes for non-root custom home parents", () => {
+    expect(resolveStateDirScanRoots("/srv/openclaw", "linux")).toEqual(["/home", "/srv"]);
+  });
+
+  it("deduplicates the default macOS users root", () => {
+    expect(resolveStateDirScanRoots("/Users/chris", "darwin")).toEqual(["/Users"]);
   });
 });

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -115,10 +115,31 @@ function countJsonlLines(filePath: string): number {
   }
 }
 
+export function resolveStateDirScanRoots(
+  currentHome: string,
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  const roots = new Set<string>();
+  if (platform === "darwin") {
+    roots.add("/Users");
+  } else if (platform === "linux") {
+    roots.add("/home");
+  }
+
+  const resolvedHome = path.resolve(currentHome);
+  const homeParent = path.dirname(resolvedHome);
+  const fsRoot = path.parse(resolvedHome).root;
+  if (homeParent !== fsRoot && homeParent !== resolvedHome) {
+    roots.add(homeParent);
+  }
+
+  return Array.from(roots);
+}
+
 function findOtherStateDirs(stateDir: string): string[] {
-  const resolvedState = path.resolve(stateDir);
-  const roots =
-    process.platform === "darwin" ? ["/Users"] : process.platform === "linux" ? ["/home"] : [];
+  const resolvedState = canonicalizePathForComparison(stateDir);
+  const currentHome = resolveRequiredHomeDir(process.env, os.homedir);
+  const roots = resolveStateDirScanRoots(currentHome);
   const found: string[] = [];
   for (const root of roots) {
     let entries: fs.Dirent[] = [];
@@ -136,7 +157,7 @@ function findOtherStateDirs(stateDir: string): string[] {
       }
       const candidates = [".openclaw"].map((dir) => path.resolve(root, entry.name, dir));
       for (const candidate of candidates) {
-        if (candidate === resolvedState) {
+        if (canonicalizePathForComparison(candidate) === resolvedState) {
           continue;
         }
         if (existsDir(candidate)) {
@@ -159,6 +180,15 @@ function isPathUnderRoot(targetPath: string, rootPath: string): boolean {
     normalizedTarget === normalizedRoot ||
     normalizedTarget.startsWith(`${normalizedRoot}${path.sep}`)
   );
+}
+
+function canonicalizePathForComparison(targetPath: string): string {
+  const resolved = path.resolve(targetPath);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
 }
 
 function tryResolveRealPath(targetPath: string): string | null {
@@ -694,7 +724,7 @@ export async function noteStateIntegrity(
   }
 
   const extraStateDirs = new Set<string>();
-  if (path.resolve(stateDir) !== path.resolve(defaultStateDir)) {
+  if (canonicalizePathForComparison(stateDir) !== canonicalizePathForComparison(defaultStateDir)) {
     if (existsDir(defaultStateDir)) {
       extraStateDirs.add(defaultStateDir);
     }

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -188,8 +188,10 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
   for (const path of changedPaths) {
     const rule = matchRule(path);
     if (!rule) {
-      plan.restartGateway = true;
-      plan.restartReasons.push(path);
+      // Unrecognized config paths are treated as safe no-ops rather than
+      // triggering a full gateway restart.  New config sections are typically
+      // read lazily at use-time, so a restart is unnecessary.
+      plan.noopPaths.push(path);
       continue;
     }
     if (rule.kind === "restart") {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -211,9 +211,10 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartReasons).toContain("gateway.auth.mode");
   });
 
-  it("defaults unknown paths to restart", () => {
+  it("defaults unknown paths to no-op", () => {
     const plan = buildGatewayReloadPlan(["unknownField"]);
-    expect(plan.restartGateway).toBe(true);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("unknownField");
   });
 
   it.each([
@@ -247,8 +248,8 @@ describe("buildGatewayReloadPlan", () => {
     },
     {
       path: "unknownField",
-      expectRestartGateway: true,
-      expectRestartReason: "unknownField",
+      expectRestartGateway: false,
+      expectNoopPath: "unknownField",
     },
   ])("classifies reload path: $path", (testCase) => {
     const plan = buildGatewayReloadPlan([testCase.path]);
@@ -258,9 +259,6 @@ describe("buildGatewayReloadPlan", () => {
     }
     if (testCase.expectNoopPath) {
       expect(plan.noopPaths).toContain(testCase.expectNoopPath);
-    }
-    if (testCase.expectRestartReason) {
-      expect(plan.restartReasons).toContain(testCase.expectRestartReason);
     }
     if (testCase.expectRestartHealthMonitor) {
       expect(plan.restartHealthMonitor).toBe(true);

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -18,9 +18,12 @@ describe("exec approvals wildcard agent", () => {
   it("merges wildcard allowlist entries with agent entries", () => {
     const dir = makeTempDir();
     const prevOpenClawHome = process.env.OPENCLAW_HOME;
+    const prevOpenClawStateDir = process.env.OPENCLAW_STATE_DIR;
 
     try {
       process.env.OPENCLAW_HOME = dir;
+      // Clear OPENCLAW_STATE_DIR so resolveStateDir() derives from OPENCLAW_HOME.
+      delete process.env.OPENCLAW_STATE_DIR;
       const approvalsPath = path.join(dir, ".openclaw", "exec-approvals.json");
       fs.mkdirSync(path.dirname(approvalsPath), { recursive: true });
       fs.writeFileSync(
@@ -48,6 +51,11 @@ describe("exec approvals wildcard agent", () => {
         delete process.env.OPENCLAW_HOME;
       } else {
         process.env.OPENCLAW_HOME = prevOpenClawHome;
+      }
+      if (prevOpenClawStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = prevOpenClawStateDir;
       }
     }
   });

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -28,6 +28,7 @@ let resolveExecApprovalsSocketPath: ExecApprovalsModule["resolveExecApprovalsSoc
 
 const tempDirs: string[] = [];
 const originalOpenClawHome = process.env.OPENCLAW_HOME;
+const originalOpenClawStateDir = process.env.OPENCLAW_STATE_DIR;
 
 beforeAll(async () => {
   ({
@@ -56,6 +57,11 @@ afterEach(() => {
     delete process.env.OPENCLAW_HOME;
   } else {
     process.env.OPENCLAW_HOME = originalOpenClawHome;
+  }
+  if (originalOpenClawStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = originalOpenClawStateDir;
   }
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -86,6 +92,19 @@ describe("exec approvals store helpers", () => {
     );
     expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
       path.normalize(path.join(dir, ".openclaw", "exec-approvals.sock")),
+    );
+  });
+
+  it("prefers OPENCLAW_STATE_DIR for default file and socket paths", () => {
+    const dir = createHomeDir();
+    const stateDir = path.join(dir, "state-root");
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    expect(path.normalize(resolveExecApprovalsPath())).toBe(
+      path.normalize(path.join(stateDir, "exec-approvals.json")),
+    );
+    expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
+      path.normalize(path.join(stateDir, "exec-approvals.sock")),
     );
   });
 

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -72,6 +72,8 @@ function createHomeDir(): string {
   const dir = makeTempDir();
   tempDirs.push(dir);
   process.env.OPENCLAW_HOME = dir;
+  // Clear OPENCLAW_STATE_DIR so resolveStateDir() derives from OPENCLAW_HOME.
+  delete process.env.OPENCLAW_STATE_DIR;
   return dir;
 }
 

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import type { ExecCommandSegment } from "./exec-approvals-analysis.js";
 import { resolveAllowAlwaysPatternEntries } from "./exec-approvals-allowlist.js";
@@ -175,8 +176,6 @@ const DEFAULT_SECURITY: ExecSecurity = "full";
 const DEFAULT_ASK: ExecAsk = "off";
 export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "full";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
-const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
-const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
 
 function hashExecApprovalsRaw(raw: string | null): string {
   return crypto
@@ -186,11 +185,11 @@ function hashExecApprovalsRaw(raw: string | null): string {
 }
 
 export function resolveExecApprovalsPath(): string {
-  return expandHomePrefix(DEFAULT_FILE);
+  return path.join(resolveStateDir(), "exec-approvals.json");
 }
 
 export function resolveExecApprovalsSocketPath(): string {
-  return expandHomePrefix(DEFAULT_SOCKET);
+  return path.join(resolveStateDir(), "exec-approvals.sock");
 }
 
 function normalizeAllowlistPattern(value: string | undefined): string | null {

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -34,11 +34,15 @@ describe("formatSystemRunAllowlistMissMessage", () => {
 describe("handleSystemRunInvoke mac app exec host routing", () => {
   let testOpenClawHome = "";
   let previousOpenClawHome: string | undefined;
+  let previousOpenClawStateDir: string | undefined;
 
   beforeEach(() => {
     previousOpenClawHome = process.env.OPENCLAW_HOME;
+    previousOpenClawStateDir = process.env.OPENCLAW_STATE_DIR;
     testOpenClawHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-node-host-home-"));
     process.env.OPENCLAW_HOME = testOpenClawHome;
+    // Clear OPENCLAW_STATE_DIR so resolveStateDir() derives from OPENCLAW_HOME.
+    delete process.env.OPENCLAW_STATE_DIR;
     clearRuntimeConfigSnapshot();
   });
 
@@ -48,6 +52,11 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       delete process.env.OPENCLAW_HOME;
     } else {
       process.env.OPENCLAW_HOME = previousOpenClawHome;
+    }
+    if (previousOpenClawStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousOpenClawStateDir;
     }
     if (testOpenClawHome) {
       fs.rmSync(testOpenClawHome, { recursive: true, force: true });

--- a/src/plugins/conversation-binding.test.ts
+++ b/src/plugins/conversation-binding.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ConversationRef,
   SessionBindingAdapter,
@@ -12,6 +12,19 @@ import type { PluginRegistry } from "./registry.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-binding-"));
 const approvalsPath = path.join(tempRoot, "plugin-binding-approvals.json");
+
+let savedStateDir: string | undefined;
+beforeAll(() => {
+  savedStateDir = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = tempRoot;
+});
+afterAll(() => {
+  if (savedStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = savedStateDir;
+  }
+});
 
 const sessionBindingState = vi.hoisted(() => {
   const records = new Map<string, SessionBindingRecord>();
@@ -90,19 +103,6 @@ const pluginRuntimeState = vi.hoisted(
       registry: null as unknown as PluginRegistry,
     }) satisfies { registry: PluginRegistry },
 );
-
-vi.mock("../infra/home-dir.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../infra/home-dir.js")>();
-  return {
-    ...actual,
-    expandHomePrefix: (value: string) => {
-      if (value === "~/.openclaw/plugin-binding-approvals.json") {
-        return approvalsPath;
-      }
-      return actual.expandHomePrefix(value);
-    },
-  };
-});
 
 vi.mock("./runtime.js", () => ({
   getActivePluginRegistry: () => pluginRuntimeState.registry,
@@ -378,18 +378,6 @@ async function expectResolutionDoesNotWait(params: {
 describe("plugin conversation binding approvals", () => {
   beforeEach(async () => {
     vi.resetModules();
-    vi.doMock("../infra/home-dir.js", async (importOriginal) => {
-      const actual = await importOriginal<typeof import("../infra/home-dir.js")>();
-      return {
-        ...actual,
-        expandHomePrefix: (value: string) => {
-          if (value === "~/.openclaw/plugin-binding-approvals.json") {
-            return approvalsPath;
-          }
-          return actual.expandHomePrefix(value);
-        },
-      };
-    });
     vi.doMock("./runtime.js", () => ({
       getActivePluginRegistry: () => pluginRuntimeState.registry,
       setActivePluginRegistry: (registry: PluginRegistry) => {

--- a/src/plugins/conversation-binding.ts
+++ b/src/plugins/conversation-binding.ts
@@ -7,7 +7,7 @@ import {
   resolveConversationBindingRecord,
   unbindConversationBindingRecord,
 } from "../bindings/records.js";
-import { expandHomePrefix } from "../infra/home-dir.js";
+import { resolveStateDir } from "../config/paths.js";
 import { writeJsonAtomic } from "../infra/json-files.js";
 import { type ConversationRef } from "../infra/outbound/session-binding-service.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -23,7 +23,6 @@ import type {
 
 const log = createSubsystemLogger("plugins/binding");
 
-const APPROVALS_PATH = "~/.openclaw/plugin-binding-approvals.json";
 const PLUGIN_BINDING_CUSTOM_ID_PREFIX = "pluginbind";
 const PLUGIN_BINDING_OWNER = "plugin";
 const PLUGIN_BINDING_SESSION_PREFIX = "plugin-binding";
@@ -132,7 +131,7 @@ function getPluginBindingGlobalState(): PluginBindingGlobalState {
 }
 
 function resolveApprovalsPath(): string {
-  return expandHomePrefix(APPROVALS_PATH);
+  return path.join(resolveStateDir(process.env), "plugin-binding-approvals.json");
 }
 
 function normalizeChannel(value: string): string {

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   hasConfiguredUnavailableCredentialStatus,
   hasResolvedCredentialValue,
@@ -10,9 +11,11 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { resolveNativeCommandsEnabled, resolveNativeSkillsEnabled } from "../config/commands.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { isDangerousNameMatchingEnabled } from "../config/dangerous-name-matching.js";
+import { resolveStateDir } from "../config/paths.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
+import { shortenHomePath } from "../utils.js";
 import type { SecurityAuditFinding, SecurityAuditSeverity } from "./audit.js";
 import { resolveDmAllowState } from "./dm-policy-shared.js";
 
@@ -464,7 +467,9 @@ export async function collectChannelSecurityFindings(params: {
         addDiscordNameBasedEntries({
           target: discordNameBasedAllowEntries,
           values: storeAllowFrom,
-          source: "~/.openclaw/credentials/discord-allowFrom.json",
+          source: shortenHomePath(
+            path.join(resolveStateDir(process.env), "credentials", "discord-allowFrom.json"),
+          ),
           isDiscordMutableAllowEntry,
         });
         const discordGuildEntries =

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -2601,7 +2601,7 @@ description: test skill
         "channels.discord.allowFrom:Alice#1234",
         "channels.discord.guilds.123.users:trusted.operator",
         "channels.discord.guilds.123.channels.general.users:security-team",
-        "~/.openclaw/credentials/discord-allowFrom.json:team.owner",
+        "credentials/discord-allowFrom.json:team.owner",
       ],
       detailExcludes: ["<@123456789012345678>"],
     },

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -2601,7 +2601,7 @@ description: test skill
         "channels.discord.allowFrom:Alice#1234",
         "channels.discord.guilds.123.users:trusted.operator",
         "channels.discord.guilds.123.channels.general.users:security-team",
-        "credentials/discord-allowFrom.json:team.owner",
+        "discord-allowFrom.json:team.owner",
       ],
       detailExcludes: ["<@123456789012345678>"],
     },


### PR DESCRIPTION
## Summary

Multiple components hardcoded `~/.openclaw/` instead of respecting `OPENCLAW_STATE_DIR`, causing data to scatter across different directories when users configure a custom state directory. This PR:

- **Unifies state-dir resolution** across exec-approvals, conversation-binding, audit-channel, workspace defaults, doctor state-integrity, and the memory-lancedb plugin so they all resolve paths through the shared `stateDir()` helper instead of hardcoding `~/.openclaw/`
- **Adds tests** covering the corrected resolution behavior in each affected module
- **Defaults unrecognized config paths to no-op** in the gateway config-reload plan, instead of falling through to a full restart. Previously, adding a new config key or touching an unrecognized path would trigger an unnecessary gateway restart on config file change.

## Changed files

### State-dir unification
- `src/infra/exec-approvals.ts` / `src/infra/exec-approvals-store.test.ts`
- `src/plugins/conversation-binding.ts` / `src/plugins/conversation-binding.test.ts`
- `src/security/audit-channel.ts` / `src/security/audit.test.ts`
- `src/agents/workspace.ts` / `src/agents/workspace.test.ts` / `src/agents/workspace.defaults.test.ts`
- `src/commands/doctor-state-integrity.ts` / `src/commands/doctor-state-integrity.test.ts`
- `extensions/memory-lancedb/config.ts` / `extensions/memory-lancedb/index.test.ts` / `extensions/memory-lancedb/openclaw.plugin.json`

### Config-reload default
- `src/gateway/config-reload-plan.ts` / `src/gateway/config-reload.test.ts`

## Test plan

- [x] `pnpm tsgo` passes with no errors
- [ ] `pnpm test -- src/infra/exec-approvals-store.test.ts`
- [ ] `pnpm test -- src/plugins/conversation-binding.test.ts`
- [ ] `pnpm test -- src/security/audit.test.ts`
- [ ] `pnpm test -- src/agents/workspace.test.ts`
- [ ] `pnpm test -- src/commands/doctor-state-integrity.test.ts`
- [ ] `pnpm test -- extensions/memory-lancedb/index.test.ts`
- [ ] `pnpm test -- src/gateway/config-reload.test.ts`