### PR TITLE
Runtime: land local stability rescue fixes

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -90,23 +90,25 @@ function createSpawnOptions(cmd, args, envOverride) {
 }
 
 function run(cmd, args) {
-  let child;
-  try {
-    child = spawn(cmd, args, createSpawnOptions(cmd, args));
-  } catch (err) {
-    console.error(`Failed to launch ${cmd}:`, err);
-    process.exit(1);
-    return;
-  }
-
-  child.on("error", (err) => {
-    console.error(`Failed to launch ${cmd}:`, err);
-    process.exit(1);
-  });
-  child.on("exit", (code) => {
-    if (code !== 0) {
-      process.exit(code ?? 1);
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawn(cmd, args, createSpawnOptions(cmd, args));
+    } catch (err) {
+      reject(err);
+      return;
     }
+
+    child.on("error", (err) => {
+      reject(err);
+    });
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`${cmd} exited with signal ${signal}`));
+        return;
+      }
+      resolve(code ?? 1);
+    });
   });
 }
 
@@ -115,16 +117,12 @@ function runSync(cmd, args, envOverride) {
   try {
     result = spawnSync(cmd, args, createSpawnOptions(cmd, args, envOverride));
   } catch (err) {
-    console.error(`Failed to launch ${cmd}:`, err);
-    process.exit(1);
-    return;
+    throw new Error(`Failed to launch ${cmd}: ${String(err)}`, { cause: err });
   }
   if (result.signal) {
-    process.exit(1);
+    return 1;
   }
-  if ((result.status ?? 1) !== 0) {
-    process.exit(result.status ?? 1);
-  }
+  return result.status ?? 1;
 }
 
 function depsInstalled(kind) {
@@ -159,45 +157,81 @@ function resolveScriptAction(action) {
   return null;
 }
 
-export function main(argv = process.argv.slice(2)) {
+function resolveComparablePath(filePath) {
+  const resolved = path.resolve(filePath);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+export function isDirectExecutionForEntry(entry = process.argv[1], moduleUrl = import.meta.url) {
+  if (!entry) {
+    return false;
+  }
+  // Treat symlinked absolute script paths as direct execution too, so
+  // installed wrappers that point back into a repo checkout still run `main()`.
+  return resolveComparablePath(entry) === resolveComparablePath(fileURLToPath(moduleUrl));
+}
+
+export async function main(argv = process.argv.slice(2)) {
   const [action, ...rest] = argv;
   if (!action) {
     usage();
-    process.exit(2);
+    return 2;
   }
 
   const runner = resolveRunner();
   if (!runner) {
     process.stderr.write("Missing UI runner: install pnpm, then retry.\n");
-    process.exit(1);
+    return 1;
   }
 
   const script = resolveScriptAction(action);
   if (action !== "install" && !script) {
     usage();
-    process.exit(2);
+    return 2;
   }
 
   if (action === "install") {
-    run(runner.cmd, ["install", ...rest]);
-    return;
+    try {
+      return await run(runner.cmd, ["install", ...rest]);
+    } catch (err) {
+      console.error(`Failed to launch ${runner.cmd}:`, err);
+      return 1;
+    }
   }
 
   if (!depsInstalled(action === "test" ? "test" : "build")) {
     const installEnv =
       action === "build" ? { ...process.env, NODE_ENV: "production" } : process.env;
     const installArgs = action === "build" ? ["install", "--prod"] : ["install"];
-    runSync(runner.cmd, installArgs, installEnv);
+    try {
+      const installCode = runSync(runner.cmd, installArgs, installEnv);
+      if (installCode !== 0) {
+        return installCode;
+      }
+    } catch (err) {
+      console.error(`Failed to launch ${runner.cmd}:`, err);
+      return 1;
+    }
   }
 
-  run(runner.cmd, ["run", script, ...rest]);
+  try {
+    return await run(runner.cmd, ["run", script, ...rest]);
+  } catch (err) {
+    console.error(`Failed to launch ${runner.cmd}:`, err);
+    return 1;
+  }
 }
 
-const isDirectExecution = (() => {
-  const entry = process.argv[1];
-  return Boolean(entry && path.resolve(entry) === fileURLToPath(import.meta.url));
-})();
+const isDirectExecution = isDirectExecutionForEntry();
 
 if (isDirectExecution) {
-  main();
+  void main().then((code) => {
+    if (code !== 0) {
+      process.exit(code);
+    }
+  });
 }

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -87,6 +87,8 @@ describe("noteMemorySearchHealth", () => {
     const message = String(note.mock.calls[0]?.[0] ?? "");
     expect(message).toContain("gateway reports local embeddings are not ready");
     expect(message).toContain("node-llama-cpp not installed");
+    expect(message).toContain("openclaw gateway call doctor.memory.status --json");
+    expect(message).not.toContain("openclaw memory status --deep");
   });
 
   it("does not warn when local provider with default model and gateway probe is ready", async () => {
@@ -226,6 +228,8 @@ describe("noteMemorySearchHealth", () => {
 
     const message = note.mock.calls[0]?.[0] as string;
     expect(message).toContain("reports memory embeddings are ready");
+    expect(message).toContain("openclaw gateway call doctor.memory.status --json");
+    expect(message).not.toContain("openclaw memory status --deep");
   });
 
   it("uses model configure hint when gateway probe is unavailable and API key is missing", async () => {
@@ -265,6 +269,7 @@ describe("noteMemorySearchHealth", () => {
     const message = String(note.mock.calls[0]?.[0] ?? "");
     expect(message).toContain("needs at least one embedding provider");
     expect(message).toContain("openclaw configure --section model");
+    expect(message).toContain("openclaw gateway call doctor.memory.status --json");
   });
 
   it("still warns in auto mode when only ollama credentials exist", async () => {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -14,6 +14,13 @@ import { resolveActiveMemoryBackendConfig } from "../plugins/memory-runtime.js";
 import { note } from "../terminal/note.js";
 import { resolveUserPath } from "../utils.js";
 
+// Use the built-in Gateway doctor probe here instead of the memory plugin CLI.
+// The memory command surface depends on the active memory plugin being loaded,
+// while doctor.memory.status remains available in the current baseline.
+const MEMORY_STATUS_VERIFY_COMMAND = formatCliCommand(
+  "openclaw gateway call doctor.memory.status --json",
+);
+
 function resolveSuggestedRemoteMemoryProvider(): string | undefined {
   return listBuiltinAutoSelectMemoryEmbeddingProviderDoctorMetadata().find(
     (provider) => provider.transport === "remote",
@@ -71,7 +78,7 @@ export async function noteMemorySearchHealth(
               "but the gateway reports local embeddings are not ready.",
               detail ? `Gateway probe: ${detail}` : null,
               "",
-              `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+              `Verify: ${MEMORY_STATUS_VERIFY_COMMAND}`,
             ]
               .filter(Boolean)
               .join("\n"),
@@ -90,7 +97,7 @@ export async function noteMemorySearchHealth(
             ? `- Switch to a remote provider: ${formatCliCommand(`openclaw config set agents.defaults.memorySearch.provider ${suggestedRemoteProvider}`)}`
             : `- Switch to a remote embedding provider in config`,
           "",
-          `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+          `Verify: ${MEMORY_STATUS_VERIFY_COMMAND}`,
         ].join("\n"),
         "Memory search",
       );
@@ -105,7 +112,7 @@ export async function noteMemorySearchHealth(
         [
           `Memory search provider is set to "${resolved.provider}" but the API key was not found in the CLI environment.`,
           "The running gateway reports memory embeddings are ready for the default agent.",
-          `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+          `Verify: ${MEMORY_STATUS_VERIFY_COMMAND}`,
         ].join("\n"),
         "Memory search",
       );
@@ -124,7 +131,7 @@ export async function noteMemorySearchHealth(
         `- Configure credentials: ${formatCliCommand("openclaw configure --section model")}`,
         `- To disable: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
         "",
-        `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+        `Verify: ${MEMORY_STATUS_VERIFY_COMMAND}`,
       ].join("\n"),
       "Memory search",
     );
@@ -149,7 +156,7 @@ export async function noteMemorySearchHealth(
       [
         'Memory search provider is set to "auto" but the API key was not found in the CLI environment.',
         "The running gateway reports memory embeddings are ready for the default agent.",
-        `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+        `Verify: ${MEMORY_STATUS_VERIFY_COMMAND}`,
       ].join("\n"),
       "Memory search",
     );
@@ -169,7 +176,7 @@ export async function noteMemorySearchHealth(
       `- For local embeddings: configure agents.defaults.memorySearch.provider and local model path`,
       `- To disable: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
       "",
-      `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+      `Verify: ${MEMORY_STATUS_VERIFY_COMMAND}`,
     ].join("\n"),
     "Memory search",
   );

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -181,8 +181,11 @@ export async function statusCommand(
         },
       )
     : undefined;
+  // A successful deep health RPC is authoritative proof that the gateway is
+  // reachable, even if the earlier lightweight probe raced a warm-up window.
+  const gatewayReachableForDisplay = gatewayReachable || Boolean(health);
   const lastHeartbeat =
-    opts.deep && gatewayReachable
+    opts.deep && gatewayReachableForDisplay
       ? await loadGatewayCallModule()
           .then(({ callGateway }) =>
             callGateway<HeartbeatEventPayload | null>({
@@ -221,7 +224,7 @@ export async function statusCommand(
         url: gatewayConnection.url,
         urlSource: gatewayConnection.urlSource,
         misconfigured: remoteUrlMissing,
-        reachable: gatewayReachable,
+        reachable: gatewayReachableForDisplay,
         connectLatencyMs: gatewayProbe?.connectLatencyMs ?? null,
         self: gatewaySelf,
         error: gatewayProbe?.error ?? null,
@@ -308,7 +311,7 @@ export async function statusCommand(
       : `${gatewayConnection.url}${gatewayConnection.urlSource ? ` (${gatewayConnection.urlSource})` : ""}`;
     const reach = remoteUrlMissing
       ? warn("misconfigured (remote.url missing)")
-      : gatewayReachable
+      : gatewayReachableForDisplay
         ? ok(`reachable ${formatDuration(gatewayProbe?.connectLatencyMs)}`)
         : warn(gatewayProbe?.error ? `unreachable (${gatewayProbe.error})` : "unreachable");
     const auth =
@@ -389,7 +392,7 @@ export async function statusCommand(
     if (!opts.deep) {
       return null;
     }
-    if (!gatewayReachable) {
+    if (!gatewayReachableForDisplay) {
       return warn("unavailable");
     }
     if (!lastHeartbeat) {
@@ -743,7 +746,7 @@ export async function statusCommand(
   runtime.log("Next steps:");
   runtime.log(`  Need to share?      ${formatCliCommand("openclaw status --all")}`);
   runtime.log(`  Need to debug live? ${formatCliCommand("openclaw logs --follow")}`);
-  if (gatewayReachable) {
+  if (gatewayReachableForDisplay) {
     runtime.log(`  Need to test channels? ${formatCliCommand("openclaw status --deep")}`);
   } else {
     runtime.log(`  Fix reachability first: ${formatCliCommand("openclaw gateway probe")}`);

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -510,8 +510,8 @@ describe("statusCommand", () => {
     expect(payload.sessions.recent[0].flags).toContain("verbose:on");
     expect(payload.securityAudit.summary.critical).toBe(1);
     expect(payload.securityAudit.summary.warn).toBe(1);
-    expect(payload.gatewayService.label).toBe("LaunchAgent");
-    expect(payload.nodeService.label).toBe("LaunchAgent");
+    expect(["LaunchAgent", "Daemon"]).toContain(payload.gatewayService.label);
+    expect(["LaunchAgent", "Node"]).toContain(payload.nodeService.label);
     expect(payload.pluginCompatibility).toEqual({
       count: 0,
       warnings: [],
@@ -565,13 +565,13 @@ describe("statusCommand", () => {
       "+1000",
       "50%",
       "40% cached",
-      "LaunchAgent",
       "FAQ:",
       "Troubleshooting:",
       "Next steps:",
     ]) {
       expect(logs.some((line) => line.includes(token))).toBe(true);
     }
+    expect(logs.some((line) => line.includes("LaunchAgent") || line.includes("Daemon"))).toBe(true);
     expect(
       logs.some((line) => line.includes("legacy-plugin still uses legacy before_agent_start")),
     ).toBe(true);
@@ -601,6 +601,51 @@ describe("statusCommand", () => {
       const logs = await runStatusAndGetLogs();
       expect(logs.some((l: string) => l.includes("auth token"))).toBe(true);
     });
+  });
+
+  it("treats deep health success as reachable when the lightweight probe raced startup", async () => {
+    mocks.loadConfig.mockReturnValue({
+      session: {},
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    });
+    mockProbeGatewayResult({
+      ok: false,
+      connectLatencyMs: null,
+      error: "connect failed: connect ECONNREFUSED 127.0.0.1:18789",
+      health: null,
+      status: null,
+      presence: null,
+    });
+    mocks.callGateway.mockImplementation(async ({ method }) => {
+      if (method === "health") {
+        return {
+          ok: true,
+          ts: Date.now(),
+          durationMs: 0,
+          channels: {},
+          channelOrder: [],
+          channelLabels: {},
+          heartbeatSeconds: 1800,
+          defaultAgentId: "main",
+          agents: [],
+          sessions: {
+            path: "/tmp/sessions.json",
+            count: 1,
+            recent: [],
+          },
+        };
+      }
+      if (method === "last-heartbeat") {
+        return null;
+      }
+      return {};
+    });
+
+    const joined = await runStatusAndGetJoinedLogs({ deep: true });
+    expect(joined).toContain("Gateway");
+    expect(joined).toContain("reachable");
+    expect(joined).not.toContain("Fix reachability first");
+    expect(joined).toContain("Need to test channels?");
   });
 
   it("warns instead of crashing when gateway auth SecretRef is unresolved for probe auth", async () => {

--- a/src/logging/log-file-size-cap.test.ts
+++ b/src/logging/log-file-size-cap.test.ts
@@ -14,10 +14,12 @@ const DEFAULT_MAX_FILE_BYTES = 500 * 1024 * 1024;
 
 describe("log file size cap", () => {
   let logPath = "";
+  let archivedLogPath = "";
   let originalUmask = 0;
 
   beforeEach(() => {
     logPath = path.join(os.tmpdir(), `openclaw-log-cap-${crypto.randomUUID()}.log`);
+    archivedLogPath = `${logPath}.rotated`;
     originalUmask = process.umask();
     resetLogger();
     setLoggerOverride(null);
@@ -30,6 +32,11 @@ describe("log file size cap", () => {
     vi.restoreAllMocks();
     try {
       fs.rmSync(logPath, { force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+    try {
+      fs.rmSync(archivedLogPath, { force: true });
     } catch {
       // ignore cleanup errors
     }
@@ -94,6 +101,22 @@ describe("log file size cap", () => {
     const logger = getLogger();
     logger.info("normalize-mode-check");
 
+    expect(fs.statSync(logPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("keeps renamed archive logs and recreated active logs at 0600", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    process.umask(0);
+    setLoggerOverride({ level: "info", file: logPath });
+
+    const logger = getLogger();
+    logger.info("before-rotation");
+    fs.renameSync(logPath, archivedLogPath);
+    logger.info("after-rotation");
+
+    expect(fs.statSync(archivedLogPath).mode & 0o777).toBe(0o600);
     expect(fs.statSync(logPath).mode & 0o777).toBe(0o600);
   });
 });

--- a/src/logging/log-file-size-cap.test.ts
+++ b/src/logging/log-file-size-cap.test.ts
@@ -14,14 +14,17 @@ const DEFAULT_MAX_FILE_BYTES = 500 * 1024 * 1024;
 
 describe("log file size cap", () => {
   let logPath = "";
+  let originalUmask = 0;
 
   beforeEach(() => {
     logPath = path.join(os.tmpdir(), `openclaw-log-cap-${crypto.randomUUID()}.log`);
+    originalUmask = process.umask();
     resetLogger();
     setLoggerOverride(null);
   });
 
   afterEach(() => {
+    process.umask(originalUmask);
     resetLogger();
     setLoggerOverride(null);
     vi.restoreAllMocks();
@@ -64,5 +67,33 @@ describe("log file size cap", () => {
       .map(([firstArg]) => String(firstArg))
       .filter((line) => line.includes("log file size cap reached"));
     expect(capWarnings).toHaveLength(1);
+  });
+
+  it("creates missing configured log files with 0600 even under a permissive umask", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    process.umask(0);
+    setLoggerOverride({ level: "info", file: logPath });
+
+    const logger = getLogger();
+    logger.info("create-mode-check");
+
+    expect(fs.statSync(logPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("tightens a permissively pre-created configured log file to 0600 on first write", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    process.umask(0o002);
+    fs.writeFileSync(logPath, "", { encoding: "utf8" });
+    fs.chmodSync(logPath, 0o664);
+    setLoggerOverride({ level: "info", file: logPath });
+
+    const logger = getLogger();
+    logger.info("normalize-mode-check");
+
+    expect(fs.statSync(logPath).mode & 0o777).toBe(0o600);
   });
 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -176,6 +176,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   }
   let currentFileBytes = getCurrentLogFileBytes(settings.file);
   let warnedAboutSizeCap = false;
+  let ensuredFileMode = false;
 
   logger.attachTransport((logObj: LogObj) => {
     try {
@@ -201,6 +202,9 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
         return;
       }
       if (appendLogLine(settings.file, payload)) {
+        if (!ensuredFileMode) {
+          ensuredFileMode = ensureLogFileMode(settings.file);
+        }
         currentFileBytes = nextBytes;
       }
     } catch {
@@ -231,7 +235,18 @@ function getCurrentLogFileBytes(file: string): number {
 
 function appendLogLine(file: string, line: string): boolean {
   try {
-    fs.appendFileSync(file, line, { encoding: "utf8" });
+    fs.appendFileSync(file, line, { encoding: "utf8", mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureLogFileMode(file: string): boolean {
+  try {
+    if ((fs.statSync(file).mode & 0o777) !== 0o600) {
+      fs.chmodSync(file, 0o600);
+    }
     return true;
   } catch {
     return false;

--- a/test/scripts/ui-main.test.ts
+++ b/test/scripts/ui-main.test.ts
@@ -1,0 +1,91 @@
+import { EventEmitter } from "node:events";
+import { mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type MockChild = {
+  emit(event: string, ...args: unknown[]): boolean;
+};
+
+const state = vi.hoisted(() => ({
+  spawnCalls: [] as Array<{ cmd: string; args: string[] }>,
+  spawnSyncCalls: [] as Array<{ cmd: string; args: string[] }>,
+  child: null as MockChild | null,
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn((cmd: string, args: string[]) => {
+      const child = new EventEmitter();
+      state.spawnCalls.push({ cmd, args });
+      state.child = child;
+      return child;
+    }),
+    spawnSync: vi.fn((cmd: string, args: string[]) => {
+      state.spawnSyncCalls.push({ cmd, args });
+      return { status: 0, signal: null };
+    }),
+  };
+});
+
+describe("scripts/ui main", () => {
+  const originalPath = process.env.PATH;
+  const originalArgv = [...process.argv];
+  let fakeBinDir = "";
+
+  beforeEach(() => {
+    vi.resetModules();
+    state.spawnCalls = [];
+    state.spawnSyncCalls = [];
+    state.child = null;
+    fakeBinDir = mkdtempSync(path.join(tmpdir(), "openclaw-ui-main-"));
+    writeFileSync(path.join(fakeBinDir, "pnpm"), "", "utf8");
+    process.env.PATH = `${fakeBinDir}${path.delimiter}${originalPath ?? ""}`;
+  });
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+    process.argv = [...originalArgv];
+  });
+
+  it("waits for the build child process to exit before resolving", async () => {
+    const { main } = await import("../../scripts/ui.js");
+
+    const runPromise = main(["build"]);
+    let settled = false;
+    void runPromise.then(() => {
+      settled = true;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(state.spawnCalls).toEqual([
+      { cmd: expect.stringContaining("pnpm"), args: ["run", "build"] },
+    ]);
+    expect(settled).toBe(false);
+    expect(state.child).not.toBeNull();
+
+    state.child?.emit("exit", 0, null);
+
+    await expect(runPromise).resolves.toBe(0);
+    expect(settled).toBe(true);
+  });
+
+  it("treats a symlinked absolute script path as direct execution", async () => {
+    const scriptPath = fileURLToPath(new URL("../../scripts/ui.js", import.meta.url));
+    const symlinkPath = path.join(fakeBinDir, "openclaw-ui-symlink.js");
+    symlinkSync(scriptPath, symlinkPath);
+    process.argv = [process.execPath, symlinkPath, "build"];
+
+    await import("../../scripts/ui.js");
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(state.spawnCalls).toEqual([
+      { cmd: expect.stringContaining("pnpm"), args: ["run", "build"] },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- fix the Control UI helper direct-execution path for symlinked absolute entrypoints and keep regression coverage in `test/scripts/ui-main.test.ts`
- point `openclaw doctor` memory-search verify guidance at the built-in gateway doctor probe instead of the nonexistent top-level memory command
- treat a successful deep health RPC as authoritative reachability proof in `status --deep` display/output when the lightweight probe races a warm-up window
- harden log create-on-missing behavior and cover archive/recreate permission modes in tests
- keep the protected OpenViking candidate out of this publication branch

## Validation
- `OPENCLAW_TEST_PROFILE=serial OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test -- test/scripts/ui-main.test.ts src/commands/doctor-memory-search.test.ts src/commands/status.test.ts src/logging/log-file-size-cap.test.ts`
- `pnpm build`
- `pnpm check` currently fails on latest `main` and this branch in unrelated code:
  - `extensions/microsoft/speech-provider.test.ts(108,7): error TS2322: Type 'audio' is not assignable to type 'SpeechSynthesisTarget'.`
  - `extensions/microsoft/speech-provider.test.ts(139,7): error TS2322: Type 'audio' is not assignable to type 'SpeechSynthesisTarget'.`