### PR TITLE
fix: accept all read path aliases in tool-start warning

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -60,14 +60,19 @@ function createTestContext(): {
 }
 
 describe("handleToolExecutionStart read path checks", () => {
-  it("does not warn when read tool uses file_path alias", async () => {
+  it.each([
+    { label: "path", args: { path: "/tmp/example.txt" } },
+    { label: "file_path", args: { file_path: "/tmp/example.txt" } },
+    { label: "file", args: { file: "/tmp/example.txt" } },
+    { label: "filePath", args: { filePath: "/tmp/example.txt" } },
+  ])("does not warn when read tool uses $label alias", async ({ args }) => {
     const { ctx, warn, onBlockReplyFlush } = createTestContext();
 
     const evt: ToolExecutionStartEvent = {
       type: "tool_execution_start",
       toolName: "read",
       toolCallId: "tool-1",
-      args: { file_path: "/tmp/example.txt" },
+      args,
     };
 
     await handleToolExecutionStart(ctx, evt);
@@ -76,7 +81,7 @@ describe("handleToolExecutionStart read path checks", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it("warns when read tool has neither path nor file_path", async () => {
+  it("warns when read tool has none of the supported path aliases", async () => {
     const { ctx, warn } = createTestContext();
 
     const evt: ToolExecutionStartEvent = {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -4,6 +4,7 @@ import {
   buildExecApprovalPendingReplyPayload,
   buildExecApprovalUnavailableReplyPayload,
 } from "../infra/exec-approval-reply.js";
+import { readSnakeCaseParamRaw } from "../param-key.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
@@ -76,6 +77,20 @@ function extendExecMeta(toolName: string, args: unknown, meta?: string): string 
   }
   const suffix = flags.join(" · ");
   return meta ? `${meta} · ${suffix}` : suffix;
+}
+
+function readReadToolPathArg(args: unknown): string {
+  if (!args || typeof args !== "object") {
+    return "";
+  }
+  const record = args as Record<string, unknown>;
+  for (const key of ["path", "filePath", "file"] as const) {
+    const value = readSnakeCaseParamRaw(record, key);
+    if (typeof value === "string") {
+      return value.trim();
+    }
+  }
+  return "";
 }
 
 function pushUniqueMediaUrl(urls: string[], seen: Set<string>, value: unknown): void {
@@ -346,14 +361,7 @@ export async function handleToolExecutionStart(
   toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: Date.now(), args });
 
   if (toolName === "read") {
-    const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-    const filePathValue =
-      typeof record.path === "string"
-        ? record.path
-        : typeof record.file_path === "string"
-          ? record.file_path
-          : "";
-    const filePath = filePathValue.trim();
+    const filePath = readReadToolPathArg(args);
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;
       ctx.log.warn(


### PR DESCRIPTION
## Summary
- treat `file` and `filePath` as valid read-tool path aliases in embedded tool-start diagnostics
- keep the warning only for calls that truly omit all supported path fields
- extend the focused test coverage for all supported aliases

## Testing
- pnpm exec vitest run src/agents/pi-embedded-subscribe.handlers.tools.test.ts

Fixes #56694