### PR TITLE
fix: dedupe hook-injected bootstrap files by path

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -7,6 +7,7 @@ import {
   type AgentBootstrapHookContext,
 } from "../hooks/internal-hooks.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
+import { clearAllBootstrapSnapshots } from "./bootstrap-cache.js";
 import { resolveBootstrapContextForRun, resolveBootstrapFilesForRun } from "./bootstrap-files.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
@@ -52,9 +53,44 @@ function registerMalformedBootstrapFileHook() {
   });
 }
 
+function registerDuplicateBootstrapFileHook() {
+  registerInternalHook("agent:bootstrap", (event) => {
+    const context = event.context as AgentBootstrapHookContext;
+    const duplicateDir = path.join(context.workspaceDir, "extras");
+    const duplicatePath = path.join(duplicateDir, "SELF_IMPROVEMENT_REMINDER.md");
+    context.bootstrapFiles = [
+      ...context.bootstrapFiles,
+      {
+        name: "SELF_IMPROVEMENT_REMINDER.md",
+        path: `${duplicateDir}${path.sep}.${path.sep}SELF_IMPROVEMENT_REMINDER.md`,
+        content: "first",
+        missing: false,
+      } as unknown as WorkspaceBootstrapFile,
+      {
+        name: "SELF_IMPROVEMENT_REMINDER.md",
+        path: duplicatePath,
+        content: "second",
+        missing: false,
+      } as unknown as WorkspaceBootstrapFile,
+      {
+        name: "SELF_IMPROVEMENT_REMINDER.md",
+        path: path.join(context.workspaceDir, "other", "SELF_IMPROVEMENT_REMINDER.md"),
+        content: "third",
+        missing: false,
+      } as unknown as WorkspaceBootstrapFile,
+    ];
+  });
+}
+
 describe("resolveBootstrapFilesForRun", () => {
-  beforeEach(() => clearInternalHooks());
-  afterEach(() => clearInternalHooks());
+  beforeEach(() => {
+    clearInternalHooks();
+    clearAllBootstrapSnapshots();
+  });
+  afterEach(() => {
+    clearInternalHooks();
+    clearAllBootstrapSnapshots();
+  });
 
   it("applies bootstrap hook overrides", async () => {
     registerExtraBootstrapFileHook();
@@ -81,11 +117,56 @@ describe("resolveBootstrapFilesForRun", () => {
     expect(warnings).toHaveLength(3);
     expect(warnings[0]).toContain('missing or invalid "path" field');
   });
+
+  it("deduplicates hook-injected bootstrap files by normalized path while preserving order", async () => {
+    registerDuplicateBootstrapFileHook();
+
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const files = await resolveBootstrapFilesForRun({ workspaceDir });
+    const duplicates = files.filter((file) => file.path.endsWith("SELF_IMPROVEMENT_REMINDER.md"));
+
+    expect(duplicates).toHaveLength(2);
+    expect(duplicates[0]?.path).toBe(
+      `${path.join(workspaceDir, "extras")}${path.sep}.${path.sep}SELF_IMPROVEMENT_REMINDER.md`,
+    );
+    expect(duplicates[0]?.content).toBe("first");
+    expect(duplicates[1]?.path).toBe(
+      path.join(workspaceDir, "other", "SELF_IMPROVEMENT_REMINDER.md"),
+    );
+  });
+
+  it("does not accumulate duplicate hook-injected files across cached runs", async () => {
+    registerInternalHook("agent:bootstrap", (event) => {
+      const context = event.context as AgentBootstrapHookContext;
+      context.bootstrapFiles.push({
+        name: "EXTRA.md",
+        path: path.join(context.workspaceDir, "EXTRA.md"),
+        content: "extra",
+        missing: false,
+      } as unknown as WorkspaceBootstrapFile);
+    });
+
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const sessionKey = "agent:main:main";
+    const injectedPath = path.join(workspaceDir, "EXTRA.md");
+
+    const first = await resolveBootstrapFilesForRun({ workspaceDir, sessionKey });
+    const second = await resolveBootstrapFilesForRun({ workspaceDir, sessionKey });
+
+    expect(first.filter((file) => file.path === injectedPath)).toHaveLength(1);
+    expect(second.filter((file) => file.path === injectedPath)).toHaveLength(1);
+  });
 });
 
 describe("resolveBootstrapContextForRun", () => {
-  beforeEach(() => clearInternalHooks());
-  afterEach(() => clearInternalHooks());
+  beforeEach(() => {
+    clearInternalHooks();
+    clearAllBootstrapSnapshots();
+  });
+  afterEach(() => {
+    clearInternalHooks();
+    clearAllBootstrapSnapshots();
+  });
 
   it("returns context files for hook-adjusted bootstrap files", async () => {
     registerExtraBootstrapFileHook();

--- a/src/agents/bootstrap-hooks.ts
+++ b/src/agents/bootstrap-hooks.ts
@@ -1,8 +1,38 @@
+import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import type { AgentBootstrapHookContext } from "../hooks/internal-hooks.js";
 import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
+
+function cloneBootstrapFiles(files: WorkspaceBootstrapFile[]): WorkspaceBootstrapFile[] {
+  return files.map((file) => ({ ...file }));
+}
+
+function normalizeBootstrapFilePath(filePath: string): string {
+  return path.normalize(filePath.trim()).replace(/\\/g, "/");
+}
+
+function dedupeBootstrapFilesByNormalizedPath(
+  files: WorkspaceBootstrapFile[],
+): WorkspaceBootstrapFile[] {
+  const deduped: WorkspaceBootstrapFile[] = [];
+  const seenPaths = new Set<string>();
+  for (const file of files) {
+    const pathValue = typeof file.path === "string" ? file.path.trim() : "";
+    if (!pathValue) {
+      deduped.push({ ...file });
+      continue;
+    }
+    const normalizedPath = normalizeBootstrapFilePath(pathValue);
+    if (seenPaths.has(normalizedPath)) {
+      continue;
+    }
+    seenPaths.add(normalizedPath);
+    deduped.push({ ...file, path: pathValue });
+  }
+  return deduped;
+}
 
 export async function applyBootstrapHookOverrides(params: {
   files: WorkspaceBootstrapFile[];
@@ -18,7 +48,7 @@ export async function applyBootstrapHookOverrides(params: {
     (params.sessionKey ? resolveAgentIdFromSessionKey(params.sessionKey) : undefined);
   const context: AgentBootstrapHookContext = {
     workspaceDir: params.workspaceDir,
-    bootstrapFiles: params.files,
+    bootstrapFiles: cloneBootstrapFiles(params.files),
     cfg: params.config,
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
@@ -27,5 +57,8 @@ export async function applyBootstrapHookOverrides(params: {
   const event = createInternalHookEvent("agent", "bootstrap", sessionKey, context);
   await triggerInternalHook(event);
   const updated = (event.context as AgentBootstrapHookContext).bootstrapFiles;
-  return Array.isArray(updated) ? updated : params.files;
+  if (!Array.isArray(updated)) {
+    return cloneBootstrapFiles(params.files);
+  }
+  return dedupeBootstrapFilesByNormalizedPath(updated);
 }


### PR DESCRIPTION
## Summary\n- normalize and deduplicate hook-adjusted bootstrap files by path before prompt assembly\n- preserve first-seen order while trimming path aliases so repeated restarts do not accumulate duplicate injected files\n- cover duplicate and cached-run behavior with focused bootstrap tests\n\n## Testing\n- pnpm exec vitest run src/agents/bootstrap-files.test.ts src/agents/bootstrap-hooks.test.ts\n\nFixes #56698