### PR TITLE
fix: log Feishu tool registration only once

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -2,6 +2,7 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
+import { logFeishuRegistrationOnce } from "./register-log-once.js";
 import { createFeishuToolClient } from "./tool-account.js";
 
 // ============ Helpers ============
@@ -729,5 +730,9 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     },
   });
 
-  api.logger.info?.("feishu_bitable: Registered bitable tools");
+  logFeishuRegistrationOnce(
+    api.logger,
+    "feishu_bitable",
+    "feishu_bitable: Registered bitable tools",
+  );
 }

--- a/extensions/feishu/src/chat.test.ts
+++ b/extensions/feishu/src/chat.test.ts
@@ -13,6 +13,7 @@ vi.mock("./client.js", () => ({
 }));
 
 let registerFeishuChatTools: typeof import("./chat.js").registerFeishuChatTools;
+let resetFeishuRegistrationLogOnceForTests: typeof import("./register-log-once.js").resetFeishuRegistrationLogOnceForTests;
 
 describe("registerFeishuChatTools", () => {
   function createChatToolApi(params: {
@@ -46,6 +47,8 @@ describe("registerFeishuChatTools", () => {
 
   beforeEach(async () => {
     ({ registerFeishuChatTools } = await import("./chat.js"));
+    ({ resetFeishuRegistrationLogOnceForTests } = await import("./register-log-once.js"));
+    resetFeishuRegistrationLogOnceForTests();
   });
 
   it("registers feishu_chat and handles info/members actions", async () => {
@@ -139,5 +142,31 @@ describe("registerFeishuChatTools", () => {
       }),
     );
     expect(registerTool).not.toHaveBeenCalled();
+  });
+
+  it("emits the registration info log only once across repeated registrations", () => {
+    const registerTool = vi.fn();
+    const info = vi.fn();
+    const api = createChatToolApi({
+      config: {
+        channels: {
+          feishu: {
+            enabled: true,
+            appId: "app_id",
+            appSecret: "app_secret", // pragma: allowlist secret
+            tools: { chat: true },
+          },
+        },
+      },
+      registerTool,
+    });
+    api.logger.info = info;
+
+    registerFeishuChatTools(api);
+    registerFeishuChatTools(api);
+
+    expect(registerTool).toHaveBeenCalledTimes(2);
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenCalledWith("feishu_chat: Registered feishu_chat tool");
   });
 });

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -3,6 +3,7 @@ import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuChatSchema, type FeishuChatParams } from "./chat-schema.js";
 import { createFeishuClient } from "./client.js";
+import { logFeishuRegistrationOnce } from "./register-log-once.js";
 import { resolveToolsConfig } from "./tools-config.js";
 
 function json(data: unknown) {
@@ -188,5 +189,5 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
     { name: "feishu_chat" },
   );
 
-  api.logger.info?.("feishu_chat: Registered feishu_chat tool");
+  logFeishuRegistrationOnce(api.logger, "feishu_chat", "feishu_chat: Registered feishu_chat tool");
 }

--- a/extensions/feishu/src/docx.registration-log.test.ts
+++ b/extensions/feishu/src/docx.registration-log.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "../runtime-api.js";
+
+describe("registerFeishuDocTools registration logging", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("logs registration only once per module load while still registering tools", async () => {
+    const { registerFeishuDocTools } = await import("./docx.js");
+    const registerTool = vi.fn();
+    const logger = {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const api = {
+      config: {
+        channels: {
+          feishu: {
+            enabled: true,
+            appId: "app_id",
+            appSecret: "app_secret",
+            tools: {
+              doc: true,
+              chat: false,
+              wiki: false,
+              drive: false,
+              perm: false,
+              scopes: true,
+            },
+          },
+        },
+      },
+      logger,
+      registerTool,
+    } as unknown as OpenClawPluginApi;
+
+    registerFeishuDocTools(api);
+    registerFeishuDocTools(api);
+
+    expect(registerTool).toHaveBeenCalledTimes(4);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      "feishu_doc: Registered feishu_doc, feishu_app_scopes",
+    );
+  });
+});

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -18,6 +18,7 @@ import {
   mergeTableCells,
 } from "./docx-table-ops.js";
 import type { FeishuDocxBlock, FeishuDocxBlockChild } from "./docx-types.js";
+import { logFeishuRegistrationOnce } from "./register-log-once.js";
 import { getFeishuRuntime } from "./runtime.js";
 import {
   createFeishuToolClient,
@@ -1575,6 +1576,10 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
   }
 
   if (registered.length > 0) {
-    api.logger.info?.(`feishu_doc: Registered ${registered.join(", ")}`);
+    logFeishuRegistrationOnce(
+      api.logger,
+      "feishu_doc",
+      `feishu_doc: Registered ${registered.join(", ")}`,
+    );
   }
 }

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -2,6 +2,7 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuDriveSchema, type FeishuDriveParams } from "./drive-schema.js";
+import { logFeishuRegistrationOnce } from "./register-log-once.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import {
   jsonToolResult,
@@ -239,5 +240,9 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
     { name: "feishu_drive" },
   );
 
-  api.logger.info?.(`feishu_drive: Registered feishu_drive tool`);
+  logFeishuRegistrationOnce(
+    api.logger,
+    "feishu_drive",
+    "feishu_drive: Registered feishu_drive tool",
+  );
 }

--- a/extensions/feishu/src/register-log-once.ts
+++ b/extensions/feishu/src/register-log-once.ts
@@ -1,0 +1,17 @@
+const emittedRegistrationLogs = new Set<string>();
+
+export function logFeishuRegistrationOnce(
+  logger: { info?: (message: string) => void },
+  key: string,
+  message: string,
+) {
+  if (emittedRegistrationLogs.has(key)) {
+    return;
+  }
+  emittedRegistrationLogs.add(key);
+  logger.info?.(message);
+}
+
+export function resetFeishuRegistrationLogOnceForTests() {
+  emittedRegistrationLogs.clear();
+}

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -1,6 +1,7 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
+import { logFeishuRegistrationOnce } from "./register-log-once.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import {
   jsonToolResult,
@@ -228,5 +229,5 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
     { name: "feishu_wiki" },
   );
 
-  api.logger.info?.(`feishu_wiki: Registered feishu_wiki tool`);
+  logFeishuRegistrationOnce(api.logger, "feishu_wiki", "feishu_wiki: Registered feishu_wiki tool");
 }


### PR DESCRIPTION
## Summary\n- centralize a per-process one-time registration logger for Feishu tools\n- keep tool registration behavior unchanged while suppressing repeated info-level log spam on later dispatches\n- add focused tests for repeated chat/doc tool registration logging\n\n## Testing\n- pnpm exec vitest run extensions/feishu/src/chat.test.ts extensions/feishu/src/docx.registration-log.test.ts\n\nFixes #56695