### PR TITLE
fix: read tool false-positive warning for 'file' and 'filePath' params

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -352,7 +352,11 @@ export async function handleToolExecutionStart(
         ? record.path
         : typeof record.file_path === "string"
           ? record.file_path
-          : "";
+          : typeof record.file === "string"
+            ? record.file
+            : typeof record.filePath === "string"
+              ? record.filePath
+              : "";
     const filePath = filePathValue.trim();
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;


### PR DESCRIPTION
## Description

The embedded agent runtime emits a false-positive warning `read tool called without path` whenever the LLM calls the `read` tool using `file` or `filePath` as the parameter name instead of `path` or `file_path`.

## Root Cause

In `src/agents/pi-embedded-subscribe.handlers.tools.ts`, the path extraction logic only checked for `path` and `file_path`, but the read tool schema also accepts `file` and `filePath`.

## Fix

Updated the path extraction to check all 4 accepted parameter names:

```ts
const filePathValue =
  typeof record.path === "string"
    ? record.path
    : typeof record.file_path === "string"
      ? record.file_path
      : typeof record.file === "string"
        ? record.file
        : typeof record.filePath === "string"
          ? record.filePath
          : "";
```

## Testing

Before: Warning emitted for `file` and `filePath` parameters
After: No warning emitted — parameters correctly resolved

Fixes #56694