### PR TITLE
fix(cli): include dashboard token URL in gateway status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Docs: https://docs.openclaw.ai
 - Agents/MCP: dispose bundled MCP runtimes after one-shot `openclaw agent --local` runs finish, while preserving bundled MCP state across in-run retries so local JSON runs exit cleanly without restarting stateful MCP tools mid-run.
 - Gateway/OpenAI HTTP: restore default operator scopes for bearer-authenticated requests that omit `x-openclaw-scopes`, so headless `/v1/chat/completions` and session-history callers work again after the recent method-scope hardening. (#57596) Thanks @openperf.
 - Gateway/attachments: offload large inbound images without leaking `media://` markers into text-only runs, preserve mixed attachment order for model input/transcripts, and fail closed when model image capability cannot be resolved. (#55513) Thanks @Syysean.
+- Gateway/status: print the Control UI dashboard URL with the same `#token=…` fragment as `openclaw dashboard` when the gateway token resolves locally (SecretRef-managed tokens stay unembedded), and strip the token from `gateway status --json` output. Reduces `token_missing` WebChat handshake failures when users open the bare loopback URL from status output. (#45471)
 
 ## 2026.3.28
 

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -247,6 +247,7 @@ describe("gatherDaemonStatus", () => {
     });
 
     expect(status.gateway?.controlUiAccessHint).toContain("SecretRef-managed");
+    expect(status.gateway?.controlUiAccessHint).toContain("openclaw dashboard");
   });
 
   it("keeps unresolved-ref hint with resolution guidance", async () => {

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ControlUiAccessUrlResult } from "../../commands/control-ui-access-url.js";
 import { createMockGatewayService } from "../../daemon/service.test-helpers.js";
 import { captureEnv } from "../../test-utils/env.js";
 import type { GatewayRestartSnapshot } from "./restart-health.js";
@@ -69,6 +70,14 @@ let cliLoadedConfig: Record<string, unknown> = {
     bind: "loopback",
   },
 };
+const resolveControlUiAccessUrl = vi.fn<(_params?: unknown) => Promise<ControlUiAccessUrlResult>>(
+  async (_params?: unknown) => ({
+    httpUrl: "http://127.0.0.1:19001/",
+    dashboardUrl: "http://127.0.0.1:19001/",
+    tokenFragmentEmbedded: false,
+    tokenSecretRefConfigured: false,
+  }),
+);
 
 vi.mock("../../config/config.js", () => ({
   createConfigIO: ({ configPath }: { configPath: string }) => {
@@ -91,6 +100,10 @@ vi.mock("../../config/config.js", () => ({
 
 vi.mock("../../daemon/diagnostics.js", () => ({
   readLastGatewayErrorLine: (env: NodeJS.ProcessEnv) => readLastGatewayErrorLine(env),
+}));
+
+vi.mock("../../commands/control-ui-access-url.js", () => ({
+  resolveControlUiAccessUrl: (params: unknown) => resolveControlUiAccessUrl(params),
 }));
 
 vi.mock("../../daemon/inspect.js", () => ({
@@ -156,6 +169,13 @@ describe("gatherDaemonStatus", () => {
     delete process.env.OPENCLAW_GATEWAY_PASSWORD;
     delete process.env.DAEMON_GATEWAY_TOKEN;
     delete process.env.DAEMON_GATEWAY_PASSWORD;
+    resolveControlUiAccessUrl.mockReset();
+    resolveControlUiAccessUrl.mockResolvedValue({
+      httpUrl: "http://127.0.0.1:19001/",
+      dashboardUrl: "http://127.0.0.1:19001/",
+      tokenFragmentEmbedded: false,
+      tokenSecretRefConfigured: false,
+    });
     callGatewayStatusProbe.mockClear();
     loadGatewayTlsRuntime.mockClear();
     inspectGatewayRestart.mockClear();
@@ -195,6 +215,57 @@ describe("gatherDaemonStatus", () => {
     expect(status.gateway?.probeUrl).toBe("wss://127.0.0.1:19001");
     expect(status.rpc?.url).toBe("wss://127.0.0.1:19001");
     expect(status.rpc?.ok).toBe(true);
+  });
+
+  it("uses runtime daemon port when resolving dashboard access URL", async () => {
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: false,
+      deep: false,
+    });
+
+    expect(resolveControlUiAccessUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resolvedPort: 19001,
+      }),
+    );
+    expect(status.gateway?.controlUiAccessUrl).toBe("http://127.0.0.1:19001/");
+  });
+
+  it("surfaces SecretRef hint when token URL embedding is intentionally disabled", async () => {
+    resolveControlUiAccessUrl.mockResolvedValueOnce({
+      httpUrl: "http://127.0.0.1:19001/",
+      dashboardUrl: "http://127.0.0.1:19001/",
+      tokenFragmentEmbedded: false,
+      tokenSecretRefConfigured: true,
+    });
+
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: false,
+      deep: false,
+    });
+
+    expect(status.gateway?.controlUiAccessHint).toContain("SecretRef-managed");
+  });
+
+  it("keeps unresolved-ref hint with resolution guidance", async () => {
+    resolveControlUiAccessUrl.mockResolvedValueOnce({
+      httpUrl: "http://127.0.0.1:19001/",
+      dashboardUrl: "http://127.0.0.1:19001/",
+      tokenFragmentEmbedded: false,
+      tokenSecretRefConfigured: false,
+      unresolvedRefReason: "provider unavailable",
+    });
+
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: false,
+      deep: false,
+    });
+
+    expect(status.gateway?.controlUiAccessHint).toContain("provider unavailable");
+    expect(status.gateway?.controlUiAccessHint).toContain("openclaw dashboard");
   });
 
   it("forwards requireRpc and configPath to the daemon probe", async () => {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -1,3 +1,4 @@
+import { resolveControlUiAccessUrl } from "../../commands/control-ui-access-url.js";
 import {
   createConfigIO,
   resolveConfigPath,
@@ -51,6 +52,9 @@ type GatewayStatusSummary = {
   portSource: "service args" | "env/config";
   probeUrl: string;
   probeNote?: string;
+  /** Dashboard URL with optional `#token=` (matches `openclaw dashboard`). */
+  controlUiAccessUrl?: string;
+  controlUiAccessHint?: string;
 };
 
 type PortStatusSummary = {
@@ -312,13 +316,36 @@ export async function gatherDaemonStatus(
     daemonConfigSummary,
     configMismatch,
   } = await loadDaemonConfigContext(command?.environment);
-  const { gateway, daemonPort, cliPort, probeUrlOverride } = await resolveGatewayStatusSummary({
+  const {
+    gateway: gatewayBase,
+    daemonPort,
+    cliPort,
+    probeUrlOverride,
+  } = await resolveGatewayStatusSummary({
     cliCfg,
     daemonCfg,
     mergedDaemonEnv,
     commandProgramArguments: command?.programArguments,
     rpcUrlOverride: opts.rpc.url,
   });
+  let gateway: GatewayStatusSummary = gatewayBase;
+  try {
+    const access = await resolveControlUiAccessUrl({
+      cfg: daemonCfg,
+      env: mergedDaemonEnv as NodeJS.ProcessEnv,
+    });
+    gateway = {
+      ...gatewayBase,
+      controlUiAccessUrl: access.dashboardUrl,
+      ...(access.unresolvedRefReason
+        ? {
+            controlUiAccessHint: `URL omits token (${access.unresolvedRefReason}). Run \`openclaw dashboard\` with credentials in your shell, or paste the token in Control UI settings.`,
+          }
+        : {}),
+    };
+  } catch {
+    // Keep gateway summary without dashboard URL hints if token resolution fails.
+  }
   const { portStatus, portCliStatus } = await inspectDaemonPortStatuses({
     daemonPort,
     cliPort,

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -333,15 +333,17 @@ export async function gatherDaemonStatus(
     const access = await resolveControlUiAccessUrl({
       cfg: daemonCfg,
       env: mergedDaemonEnv as NodeJS.ProcessEnv,
+      resolvedPort: gatewayBase.port,
     });
+    const controlUiAccessHint = access.unresolvedRefReason
+      ? `URL omits token (${access.unresolvedRefReason}). Run \`openclaw dashboard\` with credentials in your shell, or paste the token in Control UI settings.`
+      : access.tokenSecretRefConfigured
+        ? "Token auto-auth is disabled for SecretRef-managed `gateway.auth.token`; use your external token source if prompted."
+        : undefined;
     gateway = {
       ...gatewayBase,
       controlUiAccessUrl: access.dashboardUrl,
-      ...(access.unresolvedRefReason
-        ? {
-            controlUiAccessHint: `URL omits token (${access.unresolvedRefReason}). Run \`openclaw dashboard\` with credentials in your shell, or paste the token in Control UI settings.`,
-          }
-        : {}),
+      ...(controlUiAccessHint ? { controlUiAccessHint } : {}),
     };
   } catch {
     // Keep gateway summary without dashboard URL hints if token resolution fails.

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -338,7 +338,7 @@ export async function gatherDaemonStatus(
     const controlUiAccessHint = access.unresolvedRefReason
       ? `URL omits token (${access.unresolvedRefReason}). Run \`openclaw dashboard\` with credentials in your shell, or paste the token in Control UI settings.`
       : access.tokenSecretRefConfigured
-        ? "Token auto-auth is disabled for SecretRef-managed `gateway.auth.token`; use your external token source if prompted."
+        ? `Token omitted because \`gateway.auth.token\` is SecretRef-managed. Run \`openclaw dashboard\` with your external token source if prompted.`
         : undefined;
     gateway = {
       ...gatewayBase,

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -4,6 +4,7 @@ import { formatCliCommand } from "../command-format.js";
 const runtime = vi.hoisted(() => ({
   log: vi.fn<(line: string) => void>(),
   error: vi.fn<(line: string) => void>(),
+  writeJson: vi.fn<(value: unknown) => void>(),
 }));
 
 vi.mock("../../runtime.js", () => ({
@@ -75,6 +76,7 @@ describe("printDaemonStatus", () => {
   beforeEach(() => {
     runtime.log.mockReset();
     runtime.error.mockReset();
+    runtime.writeJson.mockReset();
   });
 
   it("prints stale gateway pid guidance when runtime does not own the listener", () => {
@@ -120,5 +122,34 @@ describe("printDaemonStatus", () => {
     expect(runtime.error).toHaveBeenCalledWith(
       expect.stringContaining(formatCliCommand("openclaw gateway restart")),
     );
+  });
+
+  it("redacts dashboard token fragment from JSON status output", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "systemd",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+        },
+        gateway: {
+          bindMode: "loopback",
+          bindHost: "127.0.0.1",
+          port: 18789,
+          portSource: "env/config",
+          probeUrl: "ws://127.0.0.1:18789",
+          controlUiAccessUrl: "http://127.0.0.1:18789/#token=supersecret",
+        },
+        extraServices: [],
+      },
+      { json: true },
+    );
+
+    expect(runtime.writeJson).toHaveBeenCalledTimes(1);
+    const payload = runtime.writeJson.mock.calls[0][0] as {
+      gateway?: { controlUiAccessUrl?: string };
+    };
+    expect(payload.gateway?.controlUiAccessUrl).toBe("http://127.0.0.1:18789/");
   });
 });

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -32,23 +32,50 @@ import {
   resolvePortListeningAddresses,
 } from "./status.gather.js";
 
+function redactControlUiAccessUrlForJson(url: string): string {
+  const hashIdx = url.indexOf("#");
+  if (hashIdx < 0) {
+    return url;
+  }
+  const base = url.slice(0, hashIdx);
+  const frag = url.slice(hashIdx + 1);
+  const params = new URLSearchParams(frag);
+  if (!params.has("token")) {
+    return url;
+  }
+  params.delete("token");
+  const next = params.toString();
+  return next ? `${base}#${next}` : base;
+}
+
 function sanitizeDaemonStatusForJson(status: DaemonStatus): DaemonStatus {
   const command = status.service.command;
-  if (!command?.environment) {
-    return status;
+  let next: DaemonStatus = status;
+  if (command?.environment) {
+    const safeEnv = filterDaemonEnv(command.environment);
+    const nextCommand = {
+      ...command,
+      environment: Object.keys(safeEnv).length > 0 ? safeEnv : undefined,
+    };
+    next = {
+      ...status,
+      service: {
+        ...status.service,
+        command: nextCommand,
+      },
+    };
   }
-  const safeEnv = filterDaemonEnv(command.environment);
-  const nextCommand = {
-    ...command,
-    environment: Object.keys(safeEnv).length > 0 ? safeEnv : undefined,
-  };
-  return {
-    ...status,
-    service: {
-      ...status.service,
-      command: nextCommand,
-    },
-  };
+  const gw = next.gateway?.controlUiAccessUrl;
+  if (gw) {
+    return {
+      ...next,
+      gateway: {
+        ...next.gateway!,
+        controlUiAccessUrl: redactControlUiAccessUrlForJson(gw),
+      },
+    };
+  }
+  return next;
 }
 
 export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean }) {
@@ -159,7 +186,13 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
         customBindHost: status.gateway.customBindHost,
         basePath: status.config?.daemon?.controlUi?.basePath,
       });
-      defaultRuntime.log(`${label("Dashboard:")} ${infoText(links.httpUrl)}`);
+      const dashboardUrl = status.gateway.controlUiAccessUrl ?? links.httpUrl;
+      defaultRuntime.log(`${label("Dashboard:")} ${infoText(dashboardUrl)}`);
+      if (status.gateway.controlUiAccessHint) {
+        defaultRuntime.log(
+          `${label("Dashboard note:")} ${warnText(status.gateway.controlUiAccessHint)}`,
+        );
+      }
     }
     if (status.gateway.probeNote) {
       defaultRuntime.log(`${label("Probe note:")} ${infoText(status.gateway.probeNote)}`);

--- a/src/commands/control-ui-access-url.test.ts
+++ b/src/commands/control-ui-access-url.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveControlUiAccessUrl } from "./control-ui-access-url.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveConfiguredSecretInputWithFallback: vi.fn(),
+  resolveGatewayPort: vi.fn(() => 18789),
+  resolveControlUiLinks: vi.fn(() => ({
+    httpUrl: "http://127.0.0.1:18789/",
+    wsUrl: "ws://127.0.0.1:18789",
+  })),
+}));
+
+vi.mock("../config/config.js", () => ({
+  resolveGatewayPort: mocks.resolveGatewayPort,
+}));
+
+vi.mock("../gateway/resolve-configured-secret-input-string.js", () => ({
+  resolveConfiguredSecretInputWithFallback: mocks.resolveConfiguredSecretInputWithFallback,
+}));
+
+vi.mock("./onboard-helpers.js", () => ({
+  resolveControlUiLinks: mocks.resolveControlUiLinks,
+}));
+
+describe("resolveControlUiAccessUrl", () => {
+  beforeEach(() => {
+    mocks.resolveConfiguredSecretInputWithFallback.mockReset();
+    mocks.resolveGatewayPort.mockClear();
+    mocks.resolveControlUiLinks.mockClear();
+  });
+
+  it("embeds token in URL fragment when token resolves and SecretRef is not used", async () => {
+    mocks.resolveConfiguredSecretInputWithFallback.mockResolvedValue({
+      value: "tok-secret",
+      secretRefConfigured: false,
+    });
+
+    const res = await resolveControlUiAccessUrl({
+      cfg: { gateway: { auth: { token: "x" } } },
+      env: {},
+    });
+
+    expect(res.httpUrl).toBe("http://127.0.0.1:18789/");
+    expect(res.dashboardUrl).toBe("http://127.0.0.1:18789/#token=tok-secret");
+    expect(res.tokenFragmentEmbedded).toBe(true);
+    expect(res.tokenSecretRefConfigured).toBe(false);
+    expect(res.authToken).toBe("tok-secret");
+  });
+
+  it("does not embed token when SecretRef-backed", async () => {
+    mocks.resolveConfiguredSecretInputWithFallback.mockResolvedValue({
+      value: "from-ref",
+      secretRefConfigured: true,
+    });
+
+    const res = await resolveControlUiAccessUrl({
+      cfg: { gateway: {} },
+      env: {},
+    });
+
+    expect(res.dashboardUrl).toBe("http://127.0.0.1:18789/");
+    expect(res.tokenFragmentEmbedded).toBe(false);
+    expect(res.tokenSecretRefConfigured).toBe(true);
+    expect(res.authToken).toBe("from-ref");
+  });
+
+  it("maps lan bind to loopback for links", async () => {
+    mocks.resolveConfiguredSecretInputWithFallback.mockResolvedValue({
+      secretRefConfigured: false,
+    });
+
+    await resolveControlUiAccessUrl({
+      cfg: { gateway: { bind: "lan" } },
+      env: {},
+    });
+
+    expect(mocks.resolveControlUiLinks).toHaveBeenCalledWith(
+      expect.objectContaining({ bind: "loopback" }),
+    );
+  });
+});

--- a/src/commands/control-ui-access-url.test.ts
+++ b/src/commands/control-ui-access-url.test.ts
@@ -64,6 +64,23 @@ describe("resolveControlUiAccessUrl", () => {
     expect(res.authToken).toBe("from-ref");
   });
 
+  it("uses runtime-resolved port override when provided", async () => {
+    mocks.resolveConfiguredSecretInputWithFallback.mockResolvedValue({
+      secretRefConfigured: false,
+    });
+
+    await resolveControlUiAccessUrl({
+      cfg: { gateway: {} },
+      env: {},
+      resolvedPort: 19001,
+    });
+
+    expect(mocks.resolveControlUiLinks).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 19001 }),
+    );
+    expect(mocks.resolveGatewayPort).not.toHaveBeenCalled();
+  });
+
   it("maps lan bind to loopback for links", async () => {
     mocks.resolveConfiguredSecretInputWithFallback.mockResolvedValue({
       secretRefConfigured: false,

--- a/src/commands/control-ui-access-url.ts
+++ b/src/commands/control-ui-access-url.ts
@@ -1,0 +1,63 @@
+import { resolveGatewayPort } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { readGatewayTokenEnv } from "../gateway/credentials.js";
+import { resolveConfiguredSecretInputWithFallback } from "../gateway/resolve-configured-secret-input-string.js";
+import { resolveControlUiLinks } from "./onboard-helpers.js";
+
+export type ControlUiAccessUrlResult = {
+  /** Base HTTP URL for the Control UI (no auth fragment). */
+  httpUrl: string;
+  /** Same as `httpUrl`, or with `#token=…` when token auth can be embedded safely. */
+  dashboardUrl: string;
+  tokenFragmentEmbedded: boolean;
+  /** True when `gateway.auth.token` is SecretRef-backed (token is never embedded in URLs). */
+  tokenSecretRefConfigured: boolean;
+  /** Resolved gateway token when present (plain config, env, or resolved SecretRef). */
+  authToken?: string;
+  unresolvedRefReason?: string;
+};
+
+/**
+ * Resolves the Control UI HTTP URL and, when allowed, the dashboard deep link with
+ * `#token=…` (same rules as `openclaw dashboard`). SecretRef-managed tokens are
+ * never embedded.
+ */
+export async function resolveControlUiAccessUrl(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): Promise<ControlUiAccessUrlResult> {
+  const env = params.env ?? process.env;
+  const port = resolveGatewayPort(params.cfg, env);
+  const bind = params.cfg.gateway?.bind ?? "loopback";
+  const basePath = params.cfg.gateway?.controlUi?.basePath;
+  const customBindHost = params.cfg.gateway?.customBindHost;
+  const links = resolveControlUiLinks({
+    port,
+    bind: bind === "lan" ? "loopback" : bind,
+    customBindHost,
+    basePath,
+  });
+
+  const resolved = await resolveConfiguredSecretInputWithFallback({
+    config: params.cfg,
+    env,
+    value: params.cfg.gateway?.auth?.token,
+    path: "gateway.auth.token",
+    readFallback: () => readGatewayTokenEnv(env),
+  });
+
+  const token = resolved.value ?? "";
+  const includeTokenInUrl = token.length > 0 && !resolved.secretRefConfigured;
+  const dashboardUrl = includeTokenInUrl
+    ? `${links.httpUrl}#token=${encodeURIComponent(token)}`
+    : links.httpUrl;
+
+  return {
+    httpUrl: links.httpUrl,
+    dashboardUrl,
+    tokenFragmentEmbedded: includeTokenInUrl,
+    tokenSecretRefConfigured: resolved.secretRefConfigured,
+    ...(token.length > 0 ? { authToken: token } : {}),
+    ...(resolved.unresolvedRefReason ? { unresolvedRefReason: resolved.unresolvedRefReason } : {}),
+  };
+}

--- a/src/commands/control-ui-access-url.ts
+++ b/src/commands/control-ui-access-url.ts
@@ -25,9 +25,14 @@ export type ControlUiAccessUrlResult = {
 export async function resolveControlUiAccessUrl(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  /**
+   * Optional runtime-resolved gateway port (for example from service args).
+   * When provided, this takes precedence over config/env derivation.
+   */
+  resolvedPort?: number;
 }): Promise<ControlUiAccessUrlResult> {
   const env = params.env ?? process.env;
-  const port = resolveGatewayPort(params.cfg, env);
+  const port = params.resolvedPort ?? resolveGatewayPort(params.cfg, env);
   const bind = params.cfg.gateway?.bind ?? "loopback";
   const basePath = params.cfg.gateway?.controlUi?.basePath;
   const customBindHost = params.cfg.gateway?.customBindHost;

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,51 +1,13 @@
 import { readConfigFileSnapshot, resolveGatewayPort } from "../config/config.js";
-import type { OpenClawConfig } from "../config/types.js";
-import { readGatewayTokenEnv } from "../gateway/credentials.js";
-import { resolveConfiguredSecretInputWithFallback } from "../gateway/resolve-configured-secret-input-string.js";
 import { copyToClipboard } from "../infra/clipboard.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
-import {
-  detectBrowserOpenSupport,
-  formatControlUiSshHint,
-  openUrl,
-  resolveControlUiLinks,
-} from "./onboard-helpers.js";
+import { resolveControlUiAccessUrl } from "./control-ui-access-url.js";
+import { detectBrowserOpenSupport, formatControlUiSshHint, openUrl } from "./onboard-helpers.js";
 
 type DashboardOptions = {
   noOpen?: boolean;
 };
-
-async function resolveDashboardToken(
-  cfg: OpenClawConfig,
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<{
-  token?: string;
-  source?: "config" | "env" | "secretRef";
-  unresolvedRefReason?: string;
-  tokenSecretRefConfigured: boolean;
-}> {
-  const resolved = await resolveConfiguredSecretInputWithFallback({
-    config: cfg,
-    env,
-    value: cfg.gateway?.auth?.token,
-    path: "gateway.auth.token",
-    readFallback: () => readGatewayTokenEnv(env),
-  });
-  return {
-    token: resolved.value,
-    source:
-      resolved.source === "config"
-        ? "config"
-        : resolved.source === "secretRef"
-          ? "secretRef"
-          : resolved.source === "fallback"
-            ? "env"
-            : undefined,
-    unresolvedRefReason: resolved.unresolvedRefReason,
-    tokenSecretRefConfigured: resolved.secretRefConfigured,
-  };
-}
 
 export async function dashboardCommand(
   runtime: RuntimeEnv = defaultRuntime,
@@ -54,35 +16,20 @@ export async function dashboardCommand(
   const snapshot = await readConfigFileSnapshot();
   const cfg = snapshot.valid ? (snapshot.sourceConfig ?? snapshot.config) : {};
   const port = resolveGatewayPort(cfg);
-  const bind = cfg.gateway?.bind ?? "loopback";
   const basePath = cfg.gateway?.controlUi?.basePath;
-  const customBindHost = cfg.gateway?.customBindHost;
-  const resolvedToken = await resolveDashboardToken(cfg, process.env);
-  const token = resolvedToken.token ?? "";
-
-  // LAN URLs fail secure-context checks in browsers.
-  // Coerce only lan->loopback and preserve other bind modes.
-  const links = resolveControlUiLinks({
-    port,
-    bind: bind === "lan" ? "loopback" : bind,
-    customBindHost,
-    basePath,
-  });
-  // Avoid embedding externally managed SecretRef tokens in terminal/clipboard/browser args.
-  const includeTokenInUrl = token.length > 0 && !resolvedToken.tokenSecretRefConfigured;
-  // Prefer URL fragment to avoid leaking auth tokens via query params.
-  const dashboardUrl = includeTokenInUrl
-    ? `${links.httpUrl}#token=${encodeURIComponent(token)}`
-    : links.httpUrl;
+  const access = await resolveControlUiAccessUrl({ cfg, env: process.env });
+  const dashboardUrl = access.dashboardUrl;
+  const includeTokenInUrl = access.tokenFragmentEmbedded;
+  const token = access.authToken ?? "";
 
   runtime.log(`Dashboard URL: ${dashboardUrl}`);
-  if (resolvedToken.tokenSecretRefConfigured && token) {
+  if (access.tokenSecretRefConfigured && token) {
     runtime.log(
       "Token auto-auth is disabled for SecretRef-managed gateway.auth.token; use your external token source if prompted.",
     );
   }
-  if (resolvedToken.unresolvedRefReason) {
-    runtime.log(`Token auto-auth unavailable: ${resolvedToken.unresolvedRefReason}`);
+  if (access.unresolvedRefReason) {
+    runtime.log(`Token auto-auth unavailable: ${access.unresolvedRefReason}`);
     runtime.log(
       "Set OPENCLAW_GATEWAY_TOKEN in this shell or resolve your secret provider, then rerun `openclaw dashboard`.",
     );
@@ -102,7 +49,7 @@ export async function dashboardCommand(
       hint = formatControlUiSshHint({
         port,
         basePath,
-        token: includeTokenInUrl ? token || undefined : undefined,
+        token: includeTokenInUrl ? token : undefined,
       });
     }
   } else {


### PR DESCRIPTION
## Summary

- Problem: `openclaw gateway status` printed a bare Control UI URL while `openclaw dashboard` could include `#token=...`, so token-auth setups could open the UI in an unauthenticated state (`token_missing`).
- Why it matters: users opening the dashboard from status output could see a stuck/non-functional chat surface and assume UI breakage.
- What changed: added a shared Control UI access URL resolver; `gateway status` now prints `gateway.controlUiAccessUrl` with safe token-fragment embedding parity with `openclaw dashboard`; added a SecretRef hint path; redacted token fragments in `gateway status --json`; added focused tests.
- What did NOT change (scope boundary): no change to gateway auth mode semantics, no SecretRef token embedding in URLs, no new auth provider behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45471
- Related # none
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: status output and dashboard command used different URL-generation paths, causing token-fragment behavior drift.
- Missing detection / guardrail: no test asserted token-fragment parity and JSON redaction in daemon status output.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `openclaw dashboard` already resolved token-aware URLs; status path used raw link generation.
- Why this regressed now: long-standing parity gap became visible in token-auth usage patterns.
- If unknown, what was ruled out: ruled out changing auth mode or SecretRef behavior as the fix target.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/commands/control-ui-access-url.test.ts`
  - `src/cli/daemon-cli/status.print.test.ts`
  - `src/cli/daemon-cli/status.gather.test.ts`
  - `src/commands/dashboard.test.ts`
- Scenario the test should lock in: status/dashboard URL parity for token embedding rules and token redaction in JSON output.
- Why this is the smallest reliable guardrail: behavior is deterministic command-layer logic with no external dependency required.
- Existing test that already covers this (if any): `dashboard` tests covered command behavior; status coverage was added here.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw gateway status` now prints a token-fragment dashboard URL when local token resolution allows it (same safety rules as `openclaw dashboard`).
- `openclaw gateway status --json` redacts token fragments from `gateway.controlUiAccessUrl`.
- SecretRef-backed tokens continue to avoid URL embedding and now include a clearer hint.

## Diagram (if applicable)

```text
Before:
[user runs `openclaw gateway status`] -> [sees bare URL] -> [opens Control UI] -> [token missing / auth prompt]

After:
[user runs `openclaw gateway status`] -> [sees safe tokenized URL when allowed] -> [opens Control UI] -> [authenticated dashboard]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: token handling now explicitly redacts token fragments in JSON output and still refuses embedding for SecretRef-managed tokens.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local CLI runtime
- Model/provider: N/A
- Integration/channel (if any): Web Control UI + gateway auth token mode
- Relevant config (redacted): `gateway.auth.mode=token`, `gateway.auth.token` set (plain token and SecretRef scenarios)

### Steps

1. Configure token auth and run `openclaw gateway status`.
2. Open dashboard URL from status output.
3. Run `openclaw gateway status --json` and inspect `gateway.controlUiAccessUrl`.

### Expected

- Status URL follows dashboard token-embedding rules.
- JSON output does not leak `#token=...`.

### Actual

- Implemented and verified in tests + local checks.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - token-fragment URL generation parity between status and dashboard
  - SecretRef non-embedding path + hint
  - JSON token redaction
- Edge cases checked:
  - unresolved token references
  - LAN bind coercion path used by dashboard links
- What you did **not** verify:
  - full end-user browser flow on every OS variant (validated command/test layer)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: token-bearing URLs shown in terminal output when local token resolution is allowed.
  - Mitigation: preserve SecretRef non-embedding behavior and redact token fragments from JSON output.