### PR TITLE
fix(moonshot): inherit native chat base URL for Kimi web search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 - Cron: replay interrupted recurring jobs on the first gateway restart instead of waiting for a second restart. (#60583) Thanks @joelnishanth.
 - Plugins/media understanding: enable bundled Groq and Deepgram providers by default so configured transcription models work without extra plugin activation config. (#59982) Thanks @yxjsxy.
 - Plugins/Kimi Coding: parse tagged tool calls and keep Anthropic-native tool payloads so Kimi coding endpoints execute tools instead of echoing raw markup. (#60051, #60391)
+- Tools/web_search (Kimi): when `tools.web.search.kimi.baseUrl` is unset, inherit native Moonshot chat `baseUrl` (`.ai` / `.cn`) so China console keys authenticate on the same host as chat. Fixes #44851. (#56769) Thanks @tonga54.
 - Plugins/marketplace: block remote marketplace symlink escapes without breaking ordinary local marketplace install paths. (#60556) Thanks @eleqtrizit.
 - Plugins/install: preserve unsafe override flags across linked plugin and hook-pack probes so local `--link` installs honor the documented override behavior. (#60624) Thanks @JerrettDavis.
 - Config/All Settings: keep the raw config view intact when sensitive fields are blank instead of corrupting or dropping the rendered snapshot. (#28214) Thanks @solodmd.

--- a/docs/tools/kimi-search.md
+++ b/docs/tools/kimi-search.md
@@ -53,6 +53,13 @@ to produce AI-synthesized answers with citations.
 }
 ```
 
+If you use the China API host for chat (`models.providers.moonshot.baseUrl`:
+`https://api.moonshot.cn/v1`), OpenClaw reuses that same host for Kimi
+`web_search` when `tools.web.search.kimi.baseUrl` is omitted, so keys from
+[platform.moonshot.cn](https://platform.moonshot.cn/) do not hit the
+international endpoint by mistake (which often returns HTTP 401). Override
+with `tools.web.search.kimi.baseUrl` when you need a different search base URL.
+
 **Environment alternative:** set `KIMI_API_KEY` or `MOONSHOT_API_KEY` in the
 Gateway environment. For a gateway install, put it in `~/.openclaw/.env`.
 

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -1,3 +1,4 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
 import { withEnv } from "openclaw/plugin-sdk/testing";
 import { describe, expect, it } from "vitest";
 import { __testing } from "./kimi-web-search-provider.js";
@@ -12,6 +13,40 @@ describe("kimi web search provider", () => {
     expect(__testing.resolveKimiBaseUrl({ baseUrl: "https://kimi.example/v1" })).toBe(
       "https://kimi.example/v1",
     );
+  });
+
+  it("inherits native Moonshot chat baseUrl when kimi baseUrl is unset", () => {
+    const cnConfig = {
+      models: { providers: { moonshot: { baseUrl: "https://api.moonshot.cn/v1" } } },
+    } as unknown as OpenClawConfig;
+    const cnConfigWithTrailingSlash = {
+      models: { providers: { moonshot: { baseUrl: "https://api.moonshot.cn/v1/" } } },
+    } as unknown as OpenClawConfig;
+
+    expect(__testing.resolveKimiBaseUrl(undefined, cnConfig)).toBe("https://api.moonshot.cn/v1");
+    expect(__testing.resolveKimiBaseUrl(undefined, cnConfigWithTrailingSlash)).toBe(
+      "https://api.moonshot.cn/v1",
+    );
+  });
+
+  it("does not inherit non-native Moonshot baseUrl for web search", () => {
+    const proxyConfig = {
+      models: { providers: { moonshot: { baseUrl: "https://proxy.example/v1" } } },
+    } as unknown as OpenClawConfig;
+
+    expect(__testing.resolveKimiBaseUrl(undefined, proxyConfig)).toBe(
+      "https://api.moonshot.ai/v1",
+    );
+  });
+
+  it("keeps explicit kimi baseUrl over models.providers.moonshot.baseUrl", () => {
+    const moonshotConfig = {
+      models: { providers: { moonshot: { baseUrl: "https://api.moonshot.cn/v1" } } },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      __testing.resolveKimiBaseUrl({ baseUrl: "https://api.moonshot.ai/v1" }, moonshotConfig),
+    ).toBe("https://api.moonshot.ai/v1");
   });
 
   it("extracts unique citations from search results and tool call arguments", () => {

--- a/extensions/moonshot/src/kimi-web-search-provider.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
 import {
   buildSearchCacheKey,
   buildUnsupportedSearchFilterResponse,
@@ -95,9 +96,28 @@ function resolveKimiModel(kimi?: KimiConfig): string {
   return model || DEFAULT_KIMI_SEARCH_MODEL;
 }
 
-function resolveKimiBaseUrl(kimi?: KimiConfig): string {
-  const baseUrl = typeof kimi?.baseUrl === "string" ? kimi.baseUrl.trim() : "";
-  return baseUrl || DEFAULT_KIMI_BASE_URL;
+function trimTrailingSlashes(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function resolveKimiBaseUrl(kimi?: KimiConfig, openClawConfig?: OpenClawConfig): string {
+  const explicitBaseUrl = typeof kimi?.baseUrl === "string" ? kimi.baseUrl.trim() : "";
+  if (explicitBaseUrl) {
+    return trimTrailingSlashes(explicitBaseUrl) || DEFAULT_KIMI_BASE_URL;
+  }
+
+  const moonshotBaseUrl = openClawConfig?.models?.providers?.moonshot?.baseUrl;
+  if (typeof moonshotBaseUrl === "string") {
+    const normalizedMoonshotBaseUrl = trimTrailingSlashes(moonshotBaseUrl.trim());
+    if (
+      normalizedMoonshotBaseUrl &&
+      isNativeMoonshotBaseUrl(normalizedMoonshotBaseUrl)
+    ) {
+      return normalizedMoonshotBaseUrl;
+    }
+  }
+
+  return DEFAULT_KIMI_BASE_URL;
 }
 
 function extractKimiMessageText(message: KimiMessage | undefined): string | undefined {
@@ -259,7 +279,8 @@ function createKimiSchema() {
 }
 
 function createKimiToolDefinition(
-  searchConfig?: SearchConfigRecord,
+  searchConfig: SearchConfigRecord | undefined,
+  openClawConfig: OpenClawConfig | undefined,
 ): WebSearchProviderToolDefinition {
   return {
     description:
@@ -289,7 +310,7 @@ function createKimiToolDefinition(
         searchConfig?.maxResults ??
         undefined;
       const model = resolveKimiModel(kimiConfig);
-      const baseUrl = resolveKimiBaseUrl(kimiConfig);
+      const baseUrl = resolveKimiBaseUrl(kimiConfig, openClawConfig);
       const cacheKey = buildSearchCacheKey([
         "kimi",
         query,
@@ -445,6 +466,7 @@ export function createKimiWebSearchProvider(): WebSearchProviderPlugin {
           "kimi",
           resolveProviderWebSearchPluginConfig(ctx.config, "moonshot"),
         ) as SearchConfigRecord | undefined,
+        ctx.config,
       ),
   };
 }


### PR DESCRIPTION
## Summary

- Problem: Kimi web search defaulted to `api.moonshot.ai` when `tools.web.search.kimi.baseUrl` was unset, even when chat was configured against native Moonshot CN host (`api.moonshot.cn`).
- Why it matters: CN console keys could work for chat but fail for web search with auth mismatch symptoms (HTTP 401 invalid authentication).
- What changed: when Kimi search base URL is unset, inherit native Moonshot chat base URL (`.ai` / `.cn`) from `models.providers.moonshot`; keep explicit Kimi base URL precedence; avoid inheriting non-native/proxy model base URLs; add tests and docs note.
- What did NOT change (scope boundary): no change to explicit `tools.web.search.kimi.baseUrl`, no change to non-native proxy inheritance behavior, no provider-wide auth contract changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44851
- Related # none
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: host-selection mismatch between Kimi web search default and Moonshot chat provider base URL in CN deployments.
- Missing detection / guardrail: no focused test asserting base-URL inheritance/precedence rules for Kimi search.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Moonshot provider already supports native `.ai` and `.cn` host handling for chat paths.
- Why this regressed now: surfaced as usage increased on CN-hosted Moonshot setups.
- If unknown, what was ruled out: explicit Kimi base URL override and non-native proxy handling were intentionally preserved.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/moonshot/src/kimi-web-search-provider.test.ts`
- Scenario the test should lock in:
  - inherit native `.cn` model base URL when Kimi base URL is unset
  - keep explicit Kimi base URL precedence
  - avoid inheriting non-native proxy model hosts
- Why this is the smallest reliable guardrail: behavior is pure base-URL resolution logic with deterministic input/output.
- Existing test that already covers this (if any): existing provider tests covered citation and env behavior; host inheritance coverage added here.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- CN Moonshot users no longer need duplicated base URL config for Kimi web search in the common native-host case.
- Explicit `tools.web.search.kimi.baseUrl` continues to override inherited values.
- Non-native/proxy model hosts are still not auto-inherited by Kimi search.

## Diagram (if applicable)

```text
Before:
[chat uses moonshot.cn] + [kimi search unset] -> [search calls moonshot.ai] -> [401 auth mismatch]

After:
[chat uses moonshot.cn] + [kimi search unset] -> [search inherits moonshot.cn] -> [auth host parity]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: host selection may route search calls to native `.cn` endpoint when configured for Moonshot chat; inheritance is restricted to native Moonshot hosts and explicit Kimi override still wins.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local CLI runtime
- Model/provider: Moonshot/Kimi
- Integration/channel (if any): tools.web.search provider `kimi`
- Relevant config (redacted): `models.providers.moonshot.baseUrl=https://api.moonshot.cn/v1`, `tools.web.search.kimi.baseUrl` unset

### Steps

1. Configure Moonshot model base URL to native CN host.
2. Leave `tools.web.search.kimi.baseUrl` unset and trigger Kimi search path.
3. Validate resolved search base URL in provider logic/tests.

### Expected

- Kimi search inherits native CN Moonshot host when explicit Kimi base URL is absent.
- Explicit Kimi base URL remains highest precedence.

### Actual

- Implemented and covered by focused provider tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - native CN host inheritance
  - explicit override precedence
  - non-native host non-inheritance
- Edge cases checked:
  - trailing slash normalization
  - `.ai` and `.cn` native host handling
- What you did **not** verify:
  - live external Kimi rate-limit behavior (429 paths remain provider-side)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: unintended host inheritance if model base URL points to non-Moonshot endpoints.
  - Mitigation: inheritance is explicitly limited to native Moonshot hosts only; all other hosts require explicit Kimi base URL.