### PR TITLE
docs: update CONTRIBUTING Discord invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Welcome to the lobster tank! 🦞
 
 - **GitHub:** https://github.com/openclaw/openclaw
 - **Vision:** [`VISION.md`](VISION.md)
-- **Discord:** https://discord.gg/qkhbAGHRBT
+- **Discord:** https://discord.gg/clawd
 - **X/Twitter:** [@steipete](https://x.com/steipete) / [@openclaw](https://x.com/openclaw)
 
 ## Maintainers


### PR DESCRIPTION
## Summary\n- update the Discord invite in  to match the current  link already used in the README and docs\n\n## Why\n- keeps contributor-facing entry points consistent\n- avoids sending contributors to a stale or different invite URL\n\n## Validation\n- searched the repository for Discord invite references and confirmed README/docs already use \n- verified the change is docs-only and limited to \n