### PR TITLE
fix(clawhub): sanitize archive temp filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/agents: auto-load agent workspace files on initial Files panel open, and populate overview model/workspace/fallbacks from effective runtime agent metadata so defaulted models no longer show as `Not set`. (#56637) Thanks @dxsx84.
 - Control UI/slash commands: make `/steer` and `/redirect` work from the chat command palette with visible pending state for active-run `/steer`, correct redirected-run tracking, and a single canonical `/steer` entry in the command menu. (#54625) Thanks @fuller-stack-dev.
 - Exec: fail closed when the implicit sandbox host has no sandbox runtime, and stop denied async approval followups from reusing prior command output from the same session. (#56800) Thanks @scoootscooob.
+- Plugins/ClawHub: sanitize temporary archive filenames for scoped package names and slash-containing skill slugs so `openclaw plugins install @scope/name` no longer fails with `ENOENT` during archive download. (#56452) Thanks @soimy.
 
 ## 2026.3.28
 

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -3,6 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  downloadClawHubPackageArchive,
+  downloadClawHubSkillArchive,
   parseClawHubPluginSpec,
   resolveClawHubAuthToken,
   searchClawHubSkills,
@@ -163,5 +165,41 @@ describe("clawhub helpers", () => {
     };
 
     await expect(searchClawHubSkills({ query: "calendar", fetchImpl })).resolves.toEqual([]);
+  });
+
+  it("writes scoped package archives to a safe temp file name", async () => {
+    const archive = await downloadClawHubPackageArchive({
+      name: "@soimy/dingtalk",
+      fetchImpl: async () =>
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "application/zip" },
+        }),
+    });
+
+    try {
+      expect(path.basename(archive.archivePath)).toBe("@soimy__dingtalk.zip");
+      await expect(fs.readFile(archive.archivePath)).resolves.toEqual(Buffer.from([1, 2, 3]));
+    } finally {
+      await fs.rm(path.dirname(archive.archivePath), { recursive: true, force: true });
+    }
+  });
+
+  it("writes skill archives to a safe temp file name when slugs contain separators", async () => {
+    const archive = await downloadClawHubSkillArchive({
+      slug: "ops/calendar",
+      fetchImpl: async () =>
+        new Response(new Uint8Array([4, 5, 6]), {
+          status: 200,
+          headers: { "content-type": "application/zip" },
+        }),
+    });
+
+    try {
+      expect(path.basename(archive.archivePath)).toBe("ops__calendar.zip");
+      await expect(fs.readFile(archive.archivePath)).resolves.toEqual(Buffer.from([4, 5, 6]));
+    } finally {
+      await fs.rm(path.dirname(archive.archivePath), { recursive: true, force: true });
+    }
   });
 });

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { safeDirName } from "./install-safe-path.js";
 import { isAtLeast, parseSemver } from "./runtime-guard.js";
 import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
 
@@ -580,7 +581,7 @@ export async function downloadClawHubPackageArchive(params: {
   }
   const bytes = new Uint8Array(await response.arrayBuffer());
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-clawhub-package-"));
-  const archivePath = path.join(tmpDir, `${params.name}.zip`);
+  const archivePath = path.join(tmpDir, `${safeDirName(params.name)}.zip`);
   await fs.writeFile(archivePath, bytes);
   return {
     archivePath,
@@ -618,7 +619,7 @@ export async function downloadClawHubSkillArchive(params: {
   }
   const bytes = new Uint8Array(await response.arrayBuffer());
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-clawhub-skill-"));
-  const archivePath = path.join(tmpDir, `${params.slug}.zip`);
+  const archivePath = path.join(tmpDir, `${safeDirName(params.slug)}.zip`);
   await fs.writeFile(archivePath, bytes);
   return {
     archivePath,


### PR DESCRIPTION
## Summary

- Problem: `downloadClawHubPackageArchive()` built the temp zip path from the raw package name, so scoped names like `@soimy/dingtalk` turned into `<tmp>/@soimy/dingtalk.zip` and failed with `ENOENT` before extraction.
- Why it matters: the documented ClawHub-first `openclaw plugins install <package>` flow was blocked for scoped plugin packages.
- What changed: reuse `safeDirName()` for ClawHub package and skill archive temp filenames, add focused unit coverage for slash-containing package names and slugs, and note the user-visible fix in `CHANGELOG.md`.
- What did NOT change (scope boundary): no changes to ClawHub resolution, extraction, verification, install-dir layout, or plugin manifest handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #56452
- Related #55805
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `src/infra/clawhub.ts` used `path.join(tmpDir, `${params.name}.zip`)` and `path.join(tmpDir, `${params.slug}.zip`)`, so slash-containing identifiers were treated as nested directories instead of temp file basenames.
- Missing detection / guardrail: there was no unit test that exercised archive downloads for slash-containing package names or skill slugs.
- Prior context (`git blame`, prior PR, issue, or refactor if known): OpenClaw already used `safeDirName()` in `src/plugins/install.ts` for install-directory naming, but the ClawHub temp archive path missed that normalization.
- Why this regressed now: ClawHub package resolution supports scoped package names, but the local archive write path still assumed identifiers never contain separators.
- If unknown, what was ruled out: ruled out ClawHub lookup/auth failures because the failure happens after download bytes are available and exactly at the local `fs.writeFile()` call.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/clawhub.test.ts`
- Scenario the test should lock in: slash-containing package names and skill slugs are written to sanitized temp zip filenames instead of nested paths.
- Why this is the smallest reliable guardrail: the bug is entirely in the local archive-path construction logic, so a focused unit test catches it without needing live ClawHub/network setup.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw plugins install @scope/name` no longer fails during the ClawHub archive download step just because the package name contains `/`.

## Diagram (if applicable)

```text
Before:
openclaw plugins install @soimy/dingtalk
-> download bytes from ClawHub
-> write <tmp>/@soimy/dingtalk.zip
-> ENOENT

After:
openclaw plugins install @soimy/dingtalk
-> download bytes from ClawHub
-> write <tmp>/@soimy__dingtalk.zip
-> continue to extraction/install
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (local verification), issue also reports Ubuntu 22.04
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): ClawHub plugin install flow
- Relevant config (redacted): N/A

### Steps

1. Start from a build before this fix.
2. Run `openclaw plugins install @soimy/dingtalk`.
3. Observe the local archive write fail before extraction.

### Expected

- The downloaded archive is written to a valid temp zip file path and install continues.

### Actual

- The archive path includes the raw scoped package slash and fails with `ENOENT` during `fs.writeFile()`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: added regression tests for `@soimy/dingtalk` and `ops/calendar`; confirmed they fail before the fix with `ENOENT` and pass after the fix.
- Edge cases checked: package names and skill slugs containing `/` now map to safe temp zip basenames using the repo's existing `safeDirName()` convention.
- What you did **not** verify: a live end-to-end install against ClawHub with a real published package.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: temp archive basenames now differ from the raw ClawHub identifier.
  - Mitigation: these files are internal ephemeral temp artifacts only, and the sanitization matches the existing install-path naming helper already used elsewhere in plugin install code.
