### PR TITLE
Sandbox: add actionable guidance when python3 is missing

### DIFF
--- a/src/agents/sandbox/fs-bridge.shell.test.ts
+++ b/src/agents/sandbox/fs-bridge.shell.test.ts
@@ -5,6 +5,7 @@ import {
   createSandbox,
   createSandboxFsBridge,
   createSeededSandboxFsBridge,
+  getDockerScript,
   getScriptsFromCalls,
   installFsBridgeTestHarness,
   mockedExecDockerRaw,
@@ -138,6 +139,35 @@ describe("sandbox fs bridge shell compatibility", () => {
     expect(scripts.some((script) => script.includes('cat >"$1"'))).toBe(false);
     expect(scripts.some((script) => script.includes('cat >"$tmp"'))).toBe(false);
     expect(scripts.some((script) => script.includes("os.replace("))).toBe(true);
+  });
+
+  it("surfaces actionable guidance when sandbox python3 is missing", async () => {
+    const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
+    const baseImpl = mockedExecDockerRaw.getMockImplementation();
+    mockedExecDockerRaw.mockImplementation(async (...callArgs) => {
+      const args = callArgs[0] as string[];
+      if (getDockerScript(args).includes("operation = sys.argv[1]")) {
+        const message = "moltbot-sandbox-fs: 2: python3: not found";
+        const err = Object.assign(new Error(message), {
+          code: 127,
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.from(message),
+        });
+        throw err;
+      }
+      if (baseImpl) {
+        return await baseImpl(...callArgs);
+      }
+      return {
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      };
+    });
+
+    await expect(bridge.writeFile({ filePath: "b.txt", data: "hello" })).rejects.toThrow(
+      /requires `python3` inside the sandbox container/i,
+    );
   });
 
   it("routes mkdirp, remove, and rename through the pinned mutation helper", async () => {

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -14,6 +14,7 @@ import {
   resolveSandboxFsPathWithMounts,
   type SandboxResolvedFsPath,
 } from "./fs-paths.js";
+import { toFriendlySandboxMutationError } from "./mutation-errors.js";
 import type { SandboxContext, SandboxWorkspaceAccess } from "./types.js";
 
 type RunCommandOptions = {
@@ -286,12 +287,19 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     if (plan.recheckBeforeCommand) {
       await this.pathGuard.assertPathChecks(plan.checks);
     }
-    return await this.runCommand(plan.script, {
-      args: plan.args,
-      stdin: plan.stdin,
-      allowFailure: plan.allowFailure,
-      signal: plan.signal,
-    });
+    try {
+      return await this.runCommand(plan.script, {
+        args: plan.args,
+        stdin: plan.stdin,
+        allowFailure: plan.allowFailure,
+        signal: plan.signal,
+      });
+    } catch (error) {
+      if (plan.script.includes("python3 /dev/fd/3")) {
+        throw toFriendlySandboxMutationError(error);
+      }
+      throw error;
+    }
   }
 
   private async runPlannedCommand(

--- a/src/agents/sandbox/mutation-errors.ts
+++ b/src/agents/sandbox/mutation-errors.ts
@@ -1,0 +1,17 @@
+const PYTHON3_MISSING_RE = /\bpython3:\s*not found\b/i;
+
+/**
+ * Provide actionable guidance when mutation helpers fail because the sandbox image
+ * is missing Python. This keeps write/edit errors from surfacing as opaque shell
+ * stderr blobs.
+ */
+export function toFriendlySandboxMutationError(error: unknown): Error {
+  const rawMessage = error instanceof Error ? error.message : String(error);
+  if (!PYTHON3_MISSING_RE.test(rawMessage)) {
+    return error instanceof Error ? error : new Error(rawMessage);
+  }
+  return new Error(
+    "Sandbox write/edit requires `python3` inside the sandbox container, but it is missing in the active image. Rebuild or update the sandbox image (or configure a custom sandbox image that includes `python3`). Original error: " +
+      rawMessage,
+  );
+}

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -4,6 +4,7 @@ import type { SandboxBackendCommandParams, SandboxBackendCommandResult } from ".
 import { SANDBOX_PINNED_MUTATION_PYTHON } from "./fs-bridge-mutation-helper.js";
 import { createWritableRenameTargetResolver } from "./fs-bridge-rename-targets.js";
 import type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./fs-bridge.js";
+import { toFriendlySandboxMutationError } from "./mutation-errors.js";
 import {
   isPathInsideContainerRoot,
   normalizeContainerPath as normalizeSandboxContainerPath,
@@ -472,18 +473,22 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     signal?: AbortSignal;
     allowFailure?: boolean;
   }) {
-    await this.runRemoteScript({
-      script: [
-        "set -eu",
-        "python3 /dev/fd/3 \"$@\" 3<<'PY'",
-        SANDBOX_PINNED_MUTATION_PYTHON,
-        "PY",
-      ].join("\n"),
-      args: params.args,
-      stdin: params.stdin,
-      signal: params.signal,
-      allowFailure: params.allowFailure,
-    });
+    try {
+      await this.runRemoteScript({
+        script: [
+          "set -eu",
+          "python3 /dev/fd/3 \"$@\" 3<<'PY'",
+          SANDBOX_PINNED_MUTATION_PYTHON,
+          "PY",
+        ].join("\n"),
+        args: params.args,
+        stdin: params.stdin,
+        signal: params.signal,
+        allowFailure: params.allowFailure,
+      });
+    } catch (error) {
+      throw toFriendlySandboxMutationError(error);
+    }
   }
 
   private async runRemoteScript(params: {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: when sandbox mutation helpers fail with `python3: not found`, users only see a raw shell error and cannot quickly recover.
- Why it matters: write/edit flows fail with opaque errors, which looks like silent tool breakage and blocks normal agent workflows.
- What changed: mutation execution paths now translate missing-`python3` failures into actionable guidance that tells users to rebuild/update or configure a sandbox image with Python.
- What did NOT change (scope boundary): no mutation protocol changes, no Docker image build logic changes, and no change to successful write/edit behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45108
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: mutation helper execution assumes `python3` exists inside the sandbox container; when missing, raw stderr bubbles up without actionable remediation guidance.
- Missing detection / guardrail: no error translation layer for known sandbox dependency failures.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #45108 reports repeated `moltbot-sandbox-fs: 2: python3: not found` failures during write/edit.
- Why this regressed now: slim/older sandbox images can miss Python even though mutation helpers require it.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/sandbox/fs-bridge.shell.test.ts`
- Scenario the test should lock in: when mutation helper stderr contains `python3: not found`, writeFile rejects with actionable guidance instead of opaque stderr.
- Why this is the smallest reliable guardrail: the regression is in error mapping around sandbox command execution and is deterministic with mocked backend failures.
- Existing test that already covers this (if any): existing fs bridge shell tests validate command shape, not dependency-failure messaging.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Write/edit failures caused by missing `python3` now include explicit recovery guidance about sandbox image requirements.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[write/edit] -> [python3 missing] -> [raw shell error]

After:
[write/edit] -> [python3 missing] -> [friendly actionable error + recovery guidance]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): sandbox write/edit path
- Relevant config (redacted): default sandbox test harness

### Steps

1. Simulate sandbox mutation helper failure with stderr containing `python3: not found`.
2. Trigger `writeFile` through fs bridge.
3. Verify thrown error message contains actionable python3/image guidance.

### Expected

- Error tells the operator exactly how to recover (image with python3), not just raw shell stderr.

### Actual

- Both local and remote fs bridge mutation paths now wrap this failure with friendly guidance.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test -- src/agents/sandbox/fs-bridge.shell.test.ts` passes (9 tests).
`pnpm check` passes.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: mocked mutation failure surfaces friendly guidance; non-matching errors still propagate normally.
- Edge cases checked: wrapper applies in both standard fs bridge and remote shell fs bridge mutation paths.
- What you did **not** verify: live docker runtime with intentionally missing python3 image during manual interactive chat.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: broad regex could accidentally match unrelated stderr lines containing `python3: not found`.
  - Mitigation: mapping only applies in mutation helper execution path where python3 is a required dependency.

Made with [Cursor](https://cursor.com)