### PR TITLE
fix(signal): forward quote metadata to agent context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -567,6 +567,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Signal: forward visible signal-cli quote IDs and authors into inbound `ReplyTo*` context, including quoted media replies with empty quote text, while keeping blocked quote metadata hidden and clearing stale quote fields across debounced merges. (#56791) Thanks @svv2014.
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -534,7 +534,12 @@ describe("signal createSignalEventHandler inbound context", () => {
       createSignalReceiveEvent({
         dataMessage: {
           message: "",
-          quote: { text: "quoted context", author: "+15550002222" },
+          quote: {
+            id: 9001,
+            text: "quoted context",
+            author: "123e4567-e89b-12d3-a456-426614174000",
+            authorNumber: "+15550002222",
+          },
           groupInfo: { groupId: "g1", groupName: "Test Group" },
           attachments: [],
         },
@@ -543,9 +548,118 @@ describe("signal createSignalEventHandler inbound context", () => {
 
     const context = requireCapturedContext();
     expect(context.BodyForAgent).toBe("quoted context");
+    expect(context.ReplyToId).toBe("9001");
     expect(context.ReplyToBody).toBe("quoted context");
     expect(context.ReplyToSender).toBe("+15550002222");
     expect(context.ReplyToIsQuote).toBe(true);
+  });
+
+  it("does not expose blocked quote metadata alongside visible group text", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 } },
+          channels: {
+            signal: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+15550001111"],
+              contextVisibility: "allowlist",
+            },
+          },
+        },
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["+15550001111"],
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "visible message",
+          quote: { id: 9002, text: "blocked quote", authorNumber: "+15550002222" },
+          groupInfo: { groupId: "g1", groupName: "Test Group" },
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.BodyForAgent).toBe("visible message");
+    expect(capture.ctx?.ReplyToId).toBeUndefined();
+    expect(capture.ctx?.ReplyToBody).toBeUndefined();
+    expect(capture.ctx?.ReplyToSender).toBeUndefined();
+    expect(capture.ctx?.ReplyToIsQuote).toBeUndefined();
+  });
+
+  it("keeps visible quote id and sender metadata when quote text is empty", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 } },
+          channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+        },
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "replying to media",
+          quote: { id: 9003, text: "", authorNumber: "+15550002222" },
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.BodyForAgent).toBe("replying to media");
+    expect(capture.ctx?.ReplyToId).toBe("9003");
+    expect(capture.ctx?.ReplyToBody).toBeUndefined();
+    expect(capture.ctx?.ReplyToSender).toBe("+15550002222");
+    expect(capture.ctx?.ReplyToIsQuote).toBe(true);
+  });
+
+  it("clears quote metadata when debounced Signal messages are merged", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 50 } },
+          channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+        },
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        timestamp: 1700000000001,
+        dataMessage: {
+          message: "first",
+          quote: { id: 9004, text: "quoted context", authorNumber: "+15550002222" },
+          attachments: [],
+        },
+      }),
+    );
+    await handler(
+      createSignalReceiveEvent({
+        timestamp: 1700000000002,
+        dataMessage: {
+          message: "second",
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));
+
+    expect(capture.ctx?.BodyForAgent).toBe("first\nsecond");
+    expect(capture.ctx?.ReplyToId).toBeUndefined();
+    expect(capture.ctx?.ReplyToBody).toBeUndefined();
+    expect(capture.ctx?.ReplyToSender).toBeUndefined();
+    expect(capture.ctx?.ReplyToIsQuote).toBeUndefined();
   });
 
   it("forwards all fetched attachments via MediaPaths/MediaTypes", async () => {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -414,6 +414,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         mediaType: undefined,
         mediaPaths: undefined,
         mediaTypes: undefined,
+        replyToId: undefined,
+        replyToBody: undefined,
+        replyToSender: undefined,
+        replyToIsQuote: undefined,
       });
     },
     onError: (err) => {
@@ -900,8 +904,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
-      replyToId:
-        dataMessage?.quote?.id != null ? String(dataMessage.quote.id) : undefined,
+      replyToId: visibleQuoteText && dataMessage?.quote?.id != null
+        ? String(dataMessage.quote.id)
+        : undefined,
       replyToBody: visibleQuoteText || undefined,
       replyToSender: visibleQuoteSender,
       replyToIsQuote: visibleQuoteText ? true : undefined,

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -882,16 +882,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const messageId =
       typeof envelope.timestamp === "number" ? String(envelope.timestamp) : undefined;
 
-    // Extract quote metadata for reply context (mirrors Telegram's describeReplyTarget)
-    const signalQuote = dataMessage.quote
-      ? {
-          id: dataMessage.quote.id != null ? String(dataMessage.quote.id) : undefined,
-          author:
-            dataMessage.quote.author ?? dataMessage.quote.authorNumber ?? undefined,
-          text: dataMessage.quote.text?.trim() || undefined,
-        }
-      : undefined;
-
     await inboundDebouncer.enqueue({
       senderName,
       senderDisplay,

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -403,7 +403,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       const combinedText = entries
         .map((entry) => entry.bodyText)
         .filter(Boolean)
-        .join("\\n");
+        .join("\n");
       if (!combinedText.trim()) {
         return;
       }
@@ -579,14 +579,20 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       groupId,
     });
     const quoteText = normalizeOptionalString(dataMessage?.quote?.text) ?? "";
-    const { contextVisibilityMode, quoteSenderAllowed, visibleQuoteText, visibleQuoteSender } =
-      resolveSignalQuoteContext({
-        cfg: deps.cfg,
-        accountId: deps.accountId,
-        isGroup,
-        dataMessage,
-        effectiveGroupAllow,
-      });
+    const {
+      contextVisibilityMode,
+      quoteSenderAllowed,
+      visibleQuoteId,
+      visibleQuoteText,
+      visibleQuoteSender,
+      visibleQuoteIsQuote,
+    } = resolveSignalQuoteContext({
+      cfg: deps.cfg,
+      accountId: deps.accountId,
+      isGroup,
+      dataMessage,
+      effectiveGroupAllow,
+    });
     if (quoteText && !visibleQuoteText && isGroup) {
       logVerbose(
         `signal: drop quote context (mode=${contextVisibilityMode}, sender_allowed=${quoteSenderAllowed ? "yes" : "no"})`,
@@ -904,12 +910,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
-      replyToId: visibleQuoteText && dataMessage?.quote?.id != null
-        ? String(dataMessage.quote.id)
-        : undefined,
+      replyToId: visibleQuoteId,
       replyToBody: visibleQuoteText || undefined,
       replyToSender: visibleQuoteSender,
-      replyToIsQuote: visibleQuoteText ? true : undefined,
+      replyToIsQuote: visibleQuoteIsQuote,
     });
   };
 }

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -123,6 +123,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     mediaTypes?: string[];
     commandAuthorized: boolean;
     wasMentioned?: boolean;
+    replyToId?: string;
     replyToBody?: string;
     replyToSender?: string;
     replyToIsQuote?: boolean;
@@ -217,6 +218,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       Provider: "signal" as const,
       Surface: "signal" as const,
       MessageSid: entry.messageId,
+      ReplyToId: entry.replyToId,
       ReplyToBody: entry.replyToBody,
       ReplyToSender: entry.replyToSender,
       ReplyToIsQuote: entry.replyToIsQuote,
@@ -879,6 +881,17 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const senderName = envelope.sourceName ?? senderDisplay;
     const messageId =
       typeof envelope.timestamp === "number" ? String(envelope.timestamp) : undefined;
+
+    // Extract quote metadata for reply context (mirrors Telegram's describeReplyTarget)
+    const signalQuote = dataMessage.quote
+      ? {
+          id: dataMessage.quote.id != null ? String(dataMessage.quote.id) : undefined,
+          author:
+            dataMessage.quote.author ?? dataMessage.quote.authorNumber ?? undefined,
+          text: dataMessage.quote.text?.trim() || undefined,
+        }
+      : undefined;
+
     await inboundDebouncer.enqueue({
       senderName,
       senderDisplay,
@@ -897,6 +910,8 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
+      replyToId:
+        dataMessage?.quote?.id != null ? String(dataMessage.quote.id) : undefined,
       replyToBody: visibleQuoteText || undefined,
       replyToSender: visibleQuoteSender,
       replyToIsQuote: visibleQuoteText ? true : undefined,

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -38,9 +38,11 @@ export type SignalDataMessage = {
     groupName?: string | null;
   } | null;
   quote?: {
+    id?: number | null;
     text?: string | null;
     author?: string | null;
     authorUuid?: string | null;
+    authorNumber?: string | null;
   } | null;
   reaction?: SignalReactionMessage | null;
 };

--- a/extensions/signal/src/monitor/inbound-context.ts
+++ b/extensions/signal/src/monitor/inbound-context.ts
@@ -3,7 +3,7 @@ import {
   evaluateSupplementalContextVisibility,
   type ContextVisibilityDecision,
 } from "openclaw/plugin-sdk/security-runtime";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   formatSignalSenderDisplay,
   isSignalSenderAllowed,

--- a/extensions/signal/src/monitor/inbound-context.ts
+++ b/extensions/signal/src/monitor/inbound-context.ts
@@ -33,8 +33,8 @@ export function resolveSignalQuoteContext(params: {
   });
   const quoteText = normalizeOptionalString(params.dataMessage?.quote?.text) ?? "";
   const quoteSender = resolveSignalSender({
-    sourceNumber: params.dataMessage?.quote?.author ?? null,
-    sourceUuid: params.dataMessage?.quote?.authorUuid ?? null,
+    sourceNumber: params.dataMessage?.quote?.authorNumber ?? null,
+    sourceUuid: params.dataMessage?.quote?.authorUuid ?? params.dataMessage?.quote?.author ?? null,
   });
   const quoteSenderAllowed =
     !params.isGroup || params.effectiveGroupAllow.length === 0

--- a/extensions/signal/src/monitor/inbound-context.ts
+++ b/extensions/signal/src/monitor/inbound-context.ts
@@ -7,6 +7,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import {
   formatSignalSenderDisplay,
   isSignalSenderAllowed,
+  looksLikeUuid,
   resolveSignalSender,
 } from "../identity.js";
 import type { SignalDataMessage } from "./event-handler.types.js";
@@ -32,9 +33,10 @@ export function resolveSignalQuoteContext(params: {
     accountId: params.accountId,
   });
   const quoteText = normalizeOptionalString(params.dataMessage?.quote?.text) ?? "";
+  const quoteAuthor = params.dataMessage?.quote?.author ?? null;
   const quoteSender = resolveSignalSender({
-    sourceNumber: params.dataMessage?.quote?.authorNumber ?? null,
-    sourceUuid: params.dataMessage?.quote?.authorUuid ?? params.dataMessage?.quote?.author ?? null,
+    sourceNumber: params.dataMessage?.quote?.authorNumber ?? (quoteAuthor && !looksLikeUuid(quoteAuthor) ? quoteAuthor : null),
+    sourceUuid: params.dataMessage?.quote?.authorUuid ?? (quoteAuthor && looksLikeUuid(quoteAuthor) ? quoteAuthor : null),
   });
   const quoteSenderAllowed =
     !params.isGroup || params.effectiveGroupAllow.length === 0

--- a/extensions/signal/src/monitor/inbound-context.ts
+++ b/extensions/signal/src/monitor/inbound-context.ts
@@ -16,8 +16,10 @@ type SignalQuoteContext = {
   contextVisibilityMode: ReturnType<typeof resolveChannelContextVisibilityMode>;
   decision: ContextVisibilityDecision;
   quoteSenderAllowed: boolean;
+  visibleQuoteId?: string;
   visibleQuoteText: string;
   visibleQuoteSender?: string;
+  visibleQuoteIsQuote?: boolean;
 };
 
 export function resolveSignalQuoteContext(params: {
@@ -35,9 +37,15 @@ export function resolveSignalQuoteContext(params: {
   const quoteText = normalizeOptionalString(params.dataMessage?.quote?.text) ?? "";
   const quoteAuthor = params.dataMessage?.quote?.author ?? null;
   const quoteSender = resolveSignalSender({
-    sourceNumber: params.dataMessage?.quote?.authorNumber ?? (quoteAuthor && !looksLikeUuid(quoteAuthor) ? quoteAuthor : null),
-    sourceUuid: params.dataMessage?.quote?.authorUuid ?? (quoteAuthor && looksLikeUuid(quoteAuthor) ? quoteAuthor : null),
+    sourceNumber:
+      params.dataMessage?.quote?.authorNumber ??
+      (quoteAuthor && !looksLikeUuid(quoteAuthor) ? quoteAuthor : null),
+    sourceUuid:
+      params.dataMessage?.quote?.authorUuid ??
+      (quoteAuthor && looksLikeUuid(quoteAuthor) ? quoteAuthor : null),
   });
+  const quoteId =
+    params.dataMessage?.quote?.id != null ? String(params.dataMessage.quote.id) : undefined;
   const quoteSenderAllowed =
     !params.isGroup || params.effectiveGroupAllow.length === 0
       ? true
@@ -49,13 +57,17 @@ export function resolveSignalQuoteContext(params: {
     kind: "quote",
     senderAllowed: quoteSenderAllowed,
   });
+  const hasQuoteMetadata = Boolean(quoteId || quoteText || quoteSender);
+  const includeQuoteMetadata = decision.include && hasQuoteMetadata;
 
   return {
     contextVisibilityMode,
     decision,
     quoteSenderAllowed,
+    visibleQuoteId: includeQuoteMetadata ? quoteId : undefined,
     visibleQuoteText: decision.include ? quoteText : "",
     visibleQuoteSender:
-      decision.include && quoteSender ? formatSignalSenderDisplay(quoteSender) : undefined,
+      includeQuoteMetadata && quoteSender ? formatSignalSenderDisplay(quoteSender) : undefined,
+    visibleQuoteIsQuote: includeQuoteMetadata ? true : undefined,
   };
 }


### PR DESCRIPTION
## Summary

Signal quoted replies (using the native reply/quote feature) arrive with `dataMessage.quote` containing `id`, `author`, and `text` from signal-cli, but only `quote.text` was being extracted — `id` and `author` were silently dropped, and none of the `ReplyTo*` context fields were populated in `finalizeInboundContext()`.

This means agents receiving Signal messages cannot tell what message a user was replying to, even though the data is available. The reply text itself arrives fine, but the quote context (which message was being replied to, who wrote it) is lost.

Telegram already handles this correctly via `describeReplyTarget()` which populates `ReplyToId`, `ReplyToBody`, `ReplyToSender`, and `ReplyToIsQuote`. This PR mirrors that behavior for Signal.

## Changes

- **`event-handler.types.ts`**: Expand `SignalDataMessage.quote` type to include `id`, `author`, `authorNumber` fields (matching signal-cli JSON-RPC protocol)
- **`event-handler.ts`**: 
  - Add `signalQuote` field to `SignalInboundEntry` type
  - Extract quote metadata from `dataMessage.quote` before debouncer enqueue
  - Set `ReplyToId`, `ReplyToBody`, `ReplyToSender`, `ReplyToIsQuote` in inbound context payload

## Before / After

**Before:** Agent receives `Body: "yes that sounds good"` — no indication this was a reply to a specific message.

**After:** Agent receives:
- `Body: "yes that sounds good"` 
- `ReplyToId: "1774743992672"` (timestamp of quoted message)
- `ReplyToBody: "Should we deploy the fix tonight?"` (original message text)
- `ReplyToSender: "+1234567890"` (who wrote the original)
- `ReplyToIsQuote: true`

## Test plan

- [ ] Send a normal (non-reply) Signal message → verify no ReplyTo fields set
- [ ] Send a quoted reply → verify ReplyToId, ReplyToBody, ReplyToSender, ReplyToIsQuote populated
- [ ] Send a reply with no new text (quote-only) → verify bodyText falls back to quote text, ReplyTo fields still set
- [ ] Send a message in a group with a quote → verify same behavior in group context
- [ ] Verify Telegram reply behavior unchanged