### PR TITLE
Feature Request: Add Feishu Interactive Card Parsing support #48281 

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -1,6 +1,7 @@
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { buildFeishuConversationId } from "./conversation-id.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
+import { parseInteractiveCardPayload } from "./interactive-card.js";
 import { downloadMessageResourceFeishu } from "./media.js";
 import { parsePostContent } from "./post.js";
 import { getFeishuRuntime } from "./runtime.js";
@@ -127,6 +128,9 @@ export function resolveFeishuGroupSession(params: {
 export function parseMessageContent(content: string, messageType: string): string {
   if (messageType === "post") {
     return parsePostContent(content).textContent;
+  }
+  if (messageType === "interactive") {
+    return parseInteractiveCardPayload(content).text;
   }
 
   try {

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -50,6 +50,20 @@ function makeShareChatEvent(content: unknown): FeishuMessageEvent {
   };
 }
 
+function makeInteractiveEvent(content: unknown): FeishuMessageEvent {
+  return {
+    sender: { sender_id: { user_id: "u1", open_id: "ou_sender" } },
+    message: {
+      message_id: "msg_1",
+      chat_id: "oc_chat1",
+      chat_type: "group",
+      message_type: "interactive",
+      content: JSON.stringify(content),
+      mentions: [],
+    },
+  };
+}
+
 describe("parseFeishuMessageEvent – mentionedBot", () => {
   const BOT_OPEN_ID = "ou_bot_123";
 
@@ -189,5 +203,24 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     });
     const ctx = parseFeishuMessageEvent(event, "ou_bot_123");
     expect(ctx.content).toBe("[Forwarded message: sc_abc123]");
+  });
+
+  it("extracts header and element text from interactive cards", () => {
+    const event = makeInteractiveEvent({
+      card: {
+        header: { title: { content: "Weekly Report" }, template: "blue" },
+        body: {
+          elements: [
+            { tag: "markdown", content: "## Progress" },
+            { tag: "div", text: { content: "Finished feature A" } },
+            { tag: "button", text: { content: "Approve" } },
+          ],
+        },
+      },
+    });
+
+    const ctx = parseFeishuMessageEvent(event, "ou_bot_123");
+    expect(ctx.content).toBe("Weekly Report\n## Progress\nFinished feature A\nApprove");
+    expect(ctx.rawContent).toBe(event.message.content);
   });
 });

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2496,4 +2496,68 @@ describe("handleFeishuMessage command authorization", () => {
     await Promise.all([dispatchMessage({ cfg, event }), dispatchMessage({ cfg, event })]);
     expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
+
+  it("fetches full interactive card content and forwards raw card JSON in context", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "msg-interactive-1",
+      chatId: "oc-dm",
+      contentType: "interactive",
+      content: "Weekly Report\nCompleted A\nApprove",
+      rawContent: JSON.stringify({
+        header: { title: { content: "Weekly Report" }, template: "blue" },
+        body: {
+          elements: [
+            { tag: "div", text: { content: "Completed A" } },
+            { tag: "button", text: { content: "Approve" }, value: { action: "approve" } },
+          ],
+        },
+      }),
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-card-user",
+        },
+      },
+      message: {
+        message_id: "msg-interactive-1",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "interactive",
+        content: JSON.stringify({ text: "[Interactive Card]" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockGetMessageFeishu).toHaveBeenCalledWith({
+      cfg,
+      messageId: "msg-interactive-1",
+      accountId: "default",
+    });
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        CommandBody: "Weekly Report\nCompleted A\nApprove",
+        RawBody: JSON.stringify({
+          header: { title: { content: "Weekly Report" }, template: "blue" },
+          body: {
+            elements: [
+              { tag: "div", text: { content: "Completed A" } },
+              { tag: "button", text: { content: "Approve" }, value: { action: "approve" } },
+            ],
+          },
+        }),
+      }),
+    );
+  });
 });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -36,6 +36,7 @@ import { createFeishuClient } from "./client.js";
 import { finalizeFeishuMessageProcessing, tryRecordMessagePersistent } from "./dedup.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
 import { extractMentionTargets, isMentionForwardRequest } from "./mention.js";
+import { isInteractiveCardPlaceholder, parseInteractiveCardPayload } from "./interactive-card.js";
 import {
   resolveFeishuGroupConfig,
   resolveFeishuReplyPolicy,
@@ -159,6 +160,7 @@ export function parseFeishuMessageEvent(
     parentId: event.message.parent_id || undefined,
     threadId: event.message.thread_id || undefined,
     content,
+    rawContent: event.message.content,
     contentType: event.message.message_type,
   };
 
@@ -177,7 +179,8 @@ export function buildFeishuAgentBody(params: {
   ctx: Pick<
     FeishuMessageContext,
     "content" | "senderName" | "senderOpenId" | "mentionTargets" | "messageId" | "hasAnyMention"
-  >;
+  > &
+    Partial<Pick<FeishuMessageContext, "contentType" | "rawContent">>;
   quotedContent?: string;
   permissionErrorForAgent?: FeishuPermissionError;
   botOpenId?: string;
@@ -205,6 +208,11 @@ export function buildFeishuAgentBody(params: {
   if (ctx.mentionTargets && ctx.mentionTargets.length > 0) {
     const targetNames = ctx.mentionTargets.map((t) => t.name).join(", ");
     messageBody += `\n\n[System: Your reply will automatically @mention: ${targetNames}. Do not write @xxx yourself.]`;
+  }
+  if (ctx.contentType === "interactive" && ctx.rawContent) {
+    messageBody +=
+      "\n\n[System: Raw Feishu interactive card JSON follows. Parse this JSON for card metadata/actions when needed.]\n" +
+      ctx.rawContent;
   }
 
   // Keep message_id on its own line so shared message-id hint stripping can parse it reliably.
@@ -293,6 +301,30 @@ export async function handleFeishuMessage(params: {
     } catch (err) {
       log(`feishu[${account.accountId}]: merge_forward fetch failed: ${String(err)}`);
       ctx = { ...ctx, content: "[Merged and Forwarded Message - fetch error]" };
+    }
+  }
+  if (event.message.message_type === "interactive") {
+    try {
+      const interactive = await getMessageFeishu({
+        cfg,
+        messageId: event.message.message_id,
+        accountId: account.accountId,
+      });
+      if (interactive?.contentType === "interactive") {
+        const nextContent =
+          !isInteractiveCardPlaceholder(interactive.content) || isInteractiveCardPlaceholder(ctx.content)
+            ? interactive.content
+            : ctx.content;
+        const parsed = parseInteractiveCardPayload(interactive.rawContent ?? "");
+        const nextRawCardJson = parsed.rawCardJson ?? interactive.rawContent ?? ctx.rawContent;
+        ctx = {
+          ...ctx,
+          content: nextContent,
+          rawContent: nextRawCardJson ?? ctx.rawContent,
+        };
+      }
+    } catch (err) {
+      log(`feishu[${account.accountId}]: interactive card fetch failed: ${String(err)}`);
     }
   }
 
@@ -907,7 +939,7 @@ export async function handleFeishuMessage(params: {
         InboundHistory: inboundHistory,
         ReplyToId: ctx.parentId,
         RootMessageId: ctx.rootId,
-        RawBody: ctx.content,
+        RawBody: ctx.rawContent ?? ctx.content,
         CommandBody: ctx.content,
         From: feishuFrom,
         To: feishuTo,

--- a/extensions/feishu/src/interactive-card.test.ts
+++ b/extensions/feishu/src/interactive-card.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { parseInteractiveCardPayload } from "./interactive-card.js";
+
+describe("parseInteractiveCardPayload", () => {
+  it("falls back to raw_card_content when card is a non-JSON string", () => {
+    const payload = JSON.stringify({
+      card: "[Interactive Card]",
+      raw_card_content: {
+        header: { title: { content: "Weekly Report" } },
+        body: {
+          elements: [{ tag: "div", text: { content: "Finished A" } }],
+        },
+      },
+    });
+
+    const parsed = parseInteractiveCardPayload(payload);
+    expect(parsed.text).toBe("Weekly Report\nFinished A");
+    expect(parsed.rawCardJson).toBe(
+      JSON.stringify({
+        header: { title: { content: "Weekly Report" } },
+        body: {
+          elements: [{ tag: "div", text: { content: "Finished A" } }],
+        },
+      }),
+    );
+  });
+
+  it("ignores malformed i18n_elements.zh_cn object values without throwing", () => {
+    const payload = JSON.stringify({
+      header: { title: { content: "Title" } },
+      i18n_elements: {
+        zh_cn: { invalid: true },
+      },
+      body: {
+        elements: [{ tag: "markdown", content: "Body" }],
+      },
+    });
+
+    const parsed = parseInteractiveCardPayload(payload);
+    expect(parsed.text).toBe("Title\nBody");
+  });
+
+  it("caps recursive parsing depth to avoid stack overflow on deeply nested cards", () => {
+    let nested: Record<string, unknown> = { tag: "div", text: { content: "leaf" } };
+    for (let i = 0; i < 100; i++) {
+      nested = { tag: "div", elements: [nested] };
+    }
+    const payload = JSON.stringify({ body: { elements: [nested] } });
+
+    const parsed = parseInteractiveCardPayload(payload);
+    expect(parsed.text).toBe("[Interactive Card]");
+  });
+});
+

--- a/extensions/feishu/src/interactive-card.test.ts
+++ b/extensions/feishu/src/interactive-card.test.ts
@@ -40,6 +40,18 @@ describe("parseInteractiveCardPayload", () => {
     expect(parsed.text).toBe("Title\nBody");
   });
 
+  it("extracts i18n element text from non-zh locales", () => {
+    const payload = JSON.stringify({
+      header: { title: { content: "Weekly Report" } },
+      i18n_elements: {
+        en_us: [{ tag: "markdown", content: "Delivered in English locale" }],
+      },
+    });
+
+    const parsed = parseInteractiveCardPayload(payload);
+    expect(parsed.text).toBe("Weekly Report\nDelivered in English locale");
+  });
+
   it("caps recursive parsing depth to avoid stack overflow on deeply nested cards", () => {
     let nested: Record<string, unknown> = { tag: "div", text: { content: "leaf" } };
     for (let i = 0; i < 100; i++) {
@@ -51,4 +63,3 @@ describe("parseInteractiveCardPayload", () => {
     expect(parsed.text).toBe("[Interactive Card]");
   });
 });
-

--- a/extensions/feishu/src/interactive-card.ts
+++ b/extensions/feishu/src/interactive-card.ts
@@ -1,6 +1,7 @@
 type InteractiveCardObject = Record<string, unknown>;
 
 const INTERACTIVE_CARD_PLACEHOLDER = "[Interactive Card]";
+const MAX_CARD_PARSE_DEPTH = 20;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -34,7 +35,10 @@ function resolveCardObject(parsed: unknown): InteractiveCardObject | undefined {
     return asRecord.card as InteractiveCardObject;
   }
   if (typeof asRecord.card === "string") {
-    return parseJsonObject(asRecord.card);
+    const parsedCard = parseJsonObject(asRecord.card);
+    if (parsedCard) {
+      return parsedCard;
+    }
   }
 
   if (isRecord(asRecord.raw_card_content)) {
@@ -63,8 +67,8 @@ function pushText(out: string[], value: unknown): void {
   }
 }
 
-function collectElementText(node: unknown, out: string[]): void {
-  if (!node) {
+function collectElementText(node: unknown, out: string[], depth = 0): void {
+  if (!node || depth > MAX_CARD_PARSE_DEPTH) {
     return;
   }
   if (typeof node === "string") {
@@ -95,37 +99,37 @@ function collectElementText(node: unknown, out: string[]): void {
   const note = obj.note;
   if (Array.isArray(note)) {
     for (const item of note) {
-      collectElementText(item, out);
+      collectElementText(item, out, depth + 1);
     }
   } else {
-    collectElementText(note, out);
+    collectElementText(note, out, depth + 1);
   }
 
   const fields = obj.fields;
   if (Array.isArray(fields)) {
     for (const field of fields) {
-      collectElementText(field, out);
+      collectElementText(field, out, depth + 1);
     }
   }
 
   const options = obj.options;
   if (Array.isArray(options)) {
     for (const option of options) {
-      collectElementText(option, out);
+      collectElementText(option, out, depth + 1);
     }
   }
 
   const actions = obj.actions;
   if (Array.isArray(actions)) {
     for (const action of actions) {
-      collectElementText(action, out);
+      collectElementText(action, out, depth + 1);
     }
   }
 
   const children = obj.elements;
   if (Array.isArray(children)) {
     for (const child of children) {
-      collectElementText(child, out);
+      collectElementText(child, out, depth + 1);
     }
   }
 }
@@ -148,7 +152,8 @@ function collectCardText(card: InteractiveCardObject): string[] {
       ? ((card.body as Record<string, unknown>).elements as unknown[])
       : [];
   const i18nElements =
-    isRecord(card.i18n_elements) && isRecord((card.i18n_elements as Record<string, unknown>).zh_cn)
+    isRecord(card.i18n_elements) &&
+    Array.isArray((card.i18n_elements as Record<string, unknown>).zh_cn)
       ? ((card.i18n_elements as Record<string, unknown>).zh_cn as unknown[])
       : [];
 
@@ -210,4 +215,3 @@ export function parseInteractiveCardPayload(rawContent: string): {
 export function isInteractiveCardPlaceholder(value: string): boolean {
   return value.trim() === INTERACTIVE_CARD_PLACEHOLDER;
 }
-

--- a/extensions/feishu/src/interactive-card.ts
+++ b/extensions/feishu/src/interactive-card.ts
@@ -151,11 +151,15 @@ function collectCardText(card: InteractiveCardObject): string[] {
     isRecord(card.body) && Array.isArray((card.body as Record<string, unknown>).elements)
       ? ((card.body as Record<string, unknown>).elements as unknown[])
       : [];
-  const i18nElements =
-    isRecord(card.i18n_elements) &&
-    Array.isArray((card.i18n_elements as Record<string, unknown>).zh_cn)
-      ? ((card.i18n_elements as Record<string, unknown>).zh_cn as unknown[])
-      : [];
+  const i18nElements: unknown[] = [];
+  if (isRecord(card.i18n_elements)) {
+    const i18n = card.i18n_elements as Record<string, unknown>;
+    for (const localeElements of Object.values(i18n)) {
+      if (Array.isArray(localeElements)) {
+        i18nElements.push(...localeElements);
+      }
+    }
+  }
 
   for (const element of [...topLevelElements, ...bodyElements, ...i18nElements]) {
     collectElementText(element, lines);

--- a/extensions/feishu/src/interactive-card.ts
+++ b/extensions/feishu/src/interactive-card.ts
@@ -1,0 +1,213 @@
+type InteractiveCardObject = Record<string, unknown>;
+
+const INTERACTIVE_CARD_PLACEHOLDER = "[Interactive Card]";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseJsonObject(value: string): InteractiveCardObject | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveCardObject(parsed: unknown): InteractiveCardObject | undefined {
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+
+  const asRecord = parsed as InteractiveCardObject;
+
+  if (isRecord(asRecord.card)) {
+    return asRecord.card as InteractiveCardObject;
+  }
+  if (typeof asRecord.card === "string") {
+    return parseJsonObject(asRecord.card);
+  }
+
+  if (isRecord(asRecord.raw_card_content)) {
+    return asRecord.raw_card_content as InteractiveCardObject;
+  }
+  if (typeof asRecord.raw_card_content === "string") {
+    return parseJsonObject(asRecord.raw_card_content);
+  }
+
+  if (
+    Array.isArray(asRecord.elements) ||
+    isRecord(asRecord.body) ||
+    isRecord(asRecord.header) ||
+    typeof asRecord.schema === "string"
+  ) {
+    return asRecord;
+  }
+
+  return undefined;
+}
+
+function pushText(out: string[], value: unknown): void {
+  const text = readNonEmptyString(value);
+  if (text) {
+    out.push(text);
+  }
+}
+
+function collectElementText(node: unknown, out: string[]): void {
+  if (!node) {
+    return;
+  }
+  if (typeof node === "string") {
+    pushText(out, node);
+    return;
+  }
+  if (!isRecord(node)) {
+    return;
+  }
+
+  const obj = node as Record<string, unknown>;
+  const textField = obj.text;
+  if (isRecord(textField)) {
+    pushText(out, textField.content);
+  } else {
+    pushText(out, textField);
+  }
+  pushText(out, obj.content);
+
+  const title = obj.title;
+  if (isRecord(title)) {
+    pushText(out, title.content);
+    pushText(out, title.text);
+  } else {
+    pushText(out, title);
+  }
+
+  const note = obj.note;
+  if (Array.isArray(note)) {
+    for (const item of note) {
+      collectElementText(item, out);
+    }
+  } else {
+    collectElementText(note, out);
+  }
+
+  const fields = obj.fields;
+  if (Array.isArray(fields)) {
+    for (const field of fields) {
+      collectElementText(field, out);
+    }
+  }
+
+  const options = obj.options;
+  if (Array.isArray(options)) {
+    for (const option of options) {
+      collectElementText(option, out);
+    }
+  }
+
+  const actions = obj.actions;
+  if (Array.isArray(actions)) {
+    for (const action of actions) {
+      collectElementText(action, out);
+    }
+  }
+
+  const children = obj.elements;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      collectElementText(child, out);
+    }
+  }
+}
+
+function collectCardText(card: InteractiveCardObject): string[] {
+  const lines: string[] = [];
+
+  if (isRecord(card.header)) {
+    const header = card.header as Record<string, unknown>;
+    if (isRecord(header.title)) {
+      const title = header.title as Record<string, unknown>;
+      pushText(lines, title.content);
+      pushText(lines, title.text);
+    }
+  }
+
+  const topLevelElements = Array.isArray(card.elements) ? card.elements : [];
+  const bodyElements =
+    isRecord(card.body) && Array.isArray((card.body as Record<string, unknown>).elements)
+      ? ((card.body as Record<string, unknown>).elements as unknown[])
+      : [];
+  const i18nElements =
+    isRecord(card.i18n_elements) && isRecord((card.i18n_elements as Record<string, unknown>).zh_cn)
+      ? ((card.i18n_elements as Record<string, unknown>).zh_cn as unknown[])
+      : [];
+
+  for (const element of [...topLevelElements, ...bodyElements, ...i18nElements]) {
+    collectElementText(element, lines);
+  }
+
+  return lines;
+}
+
+function dedupeLines(lines: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const line of lines) {
+    const normalized = line.trim();
+    if (!normalized) {
+      continue;
+    }
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    out.push(normalized);
+  }
+  return out;
+}
+
+export function parseInteractiveCardPayload(rawContent: string): {
+  text: string;
+  card?: InteractiveCardObject;
+  rawCardJson?: string;
+} {
+  if (!rawContent) {
+    return { text: INTERACTIVE_CARD_PLACEHOLDER };
+  }
+
+  const parsed = parseJsonObject(rawContent);
+  if (!parsed) {
+    return { text: rawContent };
+  }
+
+  const card = resolveCardObject(parsed);
+  if (!card) {
+    const textValue = readNonEmptyString(parsed.text);
+    if (textValue) {
+      return { text: textValue };
+    }
+    return { text: INTERACTIVE_CARD_PLACEHOLDER };
+  }
+
+  const text = dedupeLines(collectCardText(card)).join("\n");
+  return {
+    text: text || INTERACTIVE_CARD_PLACEHOLDER,
+    card,
+    rawCardJson: JSON.stringify(card),
+  };
+}
+
+export function isInteractiveCardPlaceholder(value: string): boolean {
+  return value.trim() === INTERACTIVE_CARD_PLACEHOLDER;
+}
+

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -1,6 +1,7 @@
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/config-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-runtime";
 import type { ClawdbotConfig } from "../runtime-api.js";
+import { parseInteractiveCardPayload } from "./interactive-card.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import type { MentionTarget } from "./mention.js";
@@ -97,6 +98,11 @@ type FeishuGetMessageResponse = {
   };
 };
 
+type FeishuMessageGetRequestWithRawCard = {
+  path: { message_id: string };
+  params?: { raw_card_content?: boolean };
+};
+
 /** Send a direct message as a fallback when a reply target is unavailable. */
 async function sendFallbackDirect(
   client: FeishuCreateMessageClient,
@@ -176,43 +182,6 @@ async function sendReplyOrFallbackDirect(
   return toFeishuSendResult(response, params.directParams.receiveId);
 }
 
-function parseInteractiveCardContent(parsed: unknown): string {
-  if (!parsed || typeof parsed !== "object") {
-    return "[Interactive Card]";
-  }
-
-  // Support both schema 1.0 (top-level `elements`) and 2.0 (`body.elements`).
-  const candidate = parsed as { elements?: unknown; body?: { elements?: unknown } };
-  const elements = Array.isArray(candidate.elements)
-    ? candidate.elements
-    : Array.isArray(candidate.body?.elements)
-      ? candidate.body!.elements
-      : null;
-  if (!elements) {
-    return "[Interactive Card]";
-  }
-
-  const texts: string[] = [];
-  for (const element of elements) {
-    if (!element || typeof element !== "object") {
-      continue;
-    }
-    const item = element as {
-      tag?: string;
-      content?: string;
-      text?: { content?: string };
-    };
-    if (item.tag === "div" && typeof item.text?.content === "string") {
-      texts.push(item.text.content);
-      continue;
-    }
-    if (item.tag === "markdown" && typeof item.content === "string") {
-      texts.push(item.content);
-    }
-  }
-  return texts.join("\n").trim() || "[Interactive Card]";
-}
-
 function parseFeishuMessageContent(rawContent: string, msgType: string): string {
   if (!rawContent) {
     return "";
@@ -235,7 +204,7 @@ function parseFeishuMessageContent(rawContent: string, msgType: string): string 
   }
 
   if (msgType === "interactive") {
-    return parseInteractiveCardContent(parsed);
+    return parseInteractiveCardPayload(rawContent).text;
   }
 
   if (typeof parsed === "string") {
@@ -272,6 +241,7 @@ function parseFeishuMessageItem(
     senderOpenId: item.sender?.id_type === "open_id" ? item.sender?.id : undefined,
     senderType: item.sender?.sender_type,
     content: parseFeishuMessageContent(rawContent, msgType),
+    rawContent,
     contentType: msgType,
     createTime: item.create_time ? parseInt(String(item.create_time), 10) : undefined,
     threadId: item.thread_id || undefined,
@@ -294,11 +264,15 @@ export async function getMessageFeishu(params: {
   }
 
   const client = createFeishuClient(account);
+  const getMessageWithRawCard = client.im.message.get as unknown as (
+    opts: FeishuMessageGetRequestWithRawCard,
+  ) => Promise<FeishuGetMessageResponse>;
 
   try {
-    const response = (await client.im.message.get({
+    const response = await getMessageWithRawCard({
       path: { message_id: messageId },
-    })) as FeishuGetMessageResponse;
+      params: { raw_card_content: true },
+    });
 
     if (response.code !== 0) {
       return null;

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -50,6 +50,7 @@ export type FeishuMessageContext = {
   parentId?: string;
   threadId?: string;
   content: string;
+  rawContent?: string;
   contentType: string;
   /** Mention forward targets (excluding the bot itself) */
   mentionTargets?: MentionTarget[];
@@ -70,6 +71,7 @@ export type FeishuMessageInfo = {
   senderOpenId?: string;
   senderType?: string;
   content: string;
+  rawContent?: string;
   contentType: string;
   createTime?: number;
   /** Feishu thread ID (omt_xxx) — present when the message belongs to a topic thread. */


### PR DESCRIPTION
## Summary

- Problem: Feishu inbound `interactive` messages were parsed as `[Interactive Card]` only, so card header/elements/actions were not available to the agent.
- Why it matters: Blocks card-based workflows (weekly reports, approvals, form-like actions) because the bot cannot read card content.
- What changed: Added interactive card parsing for inbound events, fetches richer card payload via `raw_card_content`, extracts readable text, and forwards raw card JSON to context for advanced parsing.
- What did NOT change (scope boundary): No outbound card rendering/protocol changes, no new Feishu permissions, no changes to non-Feishu channels.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48281
- Related #55466
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Inbound Feishu `interactive` payloads were not parsed beyond placeholder text in the inbound event path.
- Missing detection / guardrail: No focused inbound interactive-card test asserting extracted content + raw card payload propagation.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Existing parsing focused on text/post + outbound card sending.
- Why this regressed now: N/A (feature gap / missing implementation rather than a recent regression).
- If unknown, what was ruled out: Confirmed issue is in inbound parse path, not outbound send path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/feishu/src/bot.checkBotMentioned.test.ts`
  - `extensions/feishu/src/bot.test.ts`
  - `extensions/feishu/src/send.test.ts`
- Scenario the test should lock in: Inbound interactive card -> extracted readable text + raw card JSON available in inbound context (`RawBody`).
- Why this is the smallest reliable guardrail: Covers both parser behavior and message-handling wiring without requiring live Feishu infra.
- Existing test that already covers this (if any): `send.test.ts` had partial interactive extraction coverage; extended/leveraged.
- If no new test is added, why not: N/A (new tests added).

## User-visible / Behavior Changes

- Incoming Feishu interactive cards are now readable by the bot (header + element text extraction).
- Inbound context now includes raw interactive card JSON for advanced card/action parsing.
- Placeholder-only behavior for interactive cards is no longer the default when card payload is available.

```text
Before:
[user sends Feishu interactive card] -> [bot sees "[Interactive Card]"] -> [cannot analyze real card content]

After:
[user sends Feishu interactive card] -> [fetch + parse full card payload] -> [text extracted + raw card JSON attached] -> [bot can analyze/report/action]

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
   Added targeted Feishu message fetch for inbound interactive messages to obtain richer card payload.
  Mitigation: Uses existing authenticated Feishu client and existing message scope; no new credentials/privileges introduced.

## Repro + Verification

### Environment

OS: Windows (PowerShell)
Runtime/container: Node 22 + pnpm (corepack)
Model/provider: N/A
Integration/channel (if any): Feishu extension
Relevant config (redacted): channels.feishu.dmPolicy=open (test/mocked configs)

### Steps

1 Send an inbound Feishu interactive message/card to the bot.
2 Observe parsed inbound content/context in Feishu handling path.
3 Run targeted tests listed below.

### Expected

Card text content is extracted (header + elements).
Raw card JSON is available in context (RawBody) for advanced parsing.
-

### Actual

-Verified as expected; targeted tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  Targeted tests pass for interactive parsing and context propagation:
  corepack pnpm test -- extensions/feishu/src/send.test.ts -t interactive
  corepack pnpm test -- extensions/feishu/src/bot.checkBotMentioned.test.ts -t interactive
  corepack pnpm test -- extensions/feishu/src/bot.test.ts -t "fetches full interactive card content and forwards raw card JSON in context"
  Type-check passed: corepack pnpm tsgo

- Edge cases checked:
  Placeholder fallback path
  Card header + mixed element extraction
  Raw card payload forwarding

- What you did **not** verify:
   Live Feishu tenant end-to-end in production workspace (manual real-tenant validation still recommended).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: (N/A)

## Risks and Mitigations

Risk: Unexpected card schemas may still produce partial text extraction.
Mitigation: Conservative fallback to placeholder/raw content path and centralized parser for future schema extension.
Risk: Extra Feishu API call for inbound interactive messages can increase latency slightly.
Mitigation: Call is scoped to interactive type only and uses existing client/retry/error handling paths.


