### PR TITLE
Fail closed on ambiguous gateway agent errors

### DIFF
--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -134,6 +134,20 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it("fails closed on gateway request timeout for agent instead of falling back to embedded", async () => {
+    await withTempStore(async () => {
+      vi.mocked(callGateway).mockRejectedValue(new Error("gateway request timeout for agent"));
+      mockLocalAgentReply();
+
+      await expect(agentCliCommand({ message: "hi", to: "+1555" }, runtime)).rejects.toThrow(
+        /without embedded fallback/i,
+      );
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(agentCommand).not.toHaveBeenCalled();
+    });
+  });
+
   it("fails closed on gateway closed instead of falling back to embedded", async () => {
     await withTempStore(async () => {
       vi.mocked(callGateway).mockRejectedValue(new Error("gateway closed (1006 abnormal closure)"));

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -107,7 +107,7 @@ describe("agentCliCommand", () => {
     });
   });
 
-  it("falls back to embedded agent when gateway fails", async () => {
+  it("falls back to embedded agent when gateway fails with a recoverable error", async () => {
     await withTempStore(async () => {
       vi.mocked(callGateway).mockRejectedValue(new Error("gateway not connected"));
       mockLocalAgentReply();
@@ -117,6 +117,34 @@ describe("agentCliCommand", () => {
       expect(callGateway).toHaveBeenCalledTimes(1);
       expect(agentCommand).toHaveBeenCalledTimes(1);
       expect(runtime.log).toHaveBeenCalledWith("local");
+    });
+  });
+
+  it("fails closed on gateway timeout instead of falling back to embedded", async () => {
+    await withTempStore(async () => {
+      vi.mocked(callGateway).mockRejectedValue(new Error("gateway timeout after 930000ms"));
+      mockLocalAgentReply();
+
+      await expect(agentCliCommand({ message: "hi", to: "+1555" }, runtime)).rejects.toThrow(
+        /without embedded fallback/i,
+      );
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(agentCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  it("fails closed on gateway closed instead of falling back to embedded", async () => {
+    await withTempStore(async () => {
+      vi.mocked(callGateway).mockRejectedValue(new Error("gateway closed (1006 abnormal closure)"));
+      mockLocalAgentReply();
+
+      await expect(agentCliCommand({ message: "hi", to: "+1555" }, runtime)).rejects.toThrow(
+        /without embedded fallback/i,
+      );
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(agentCommand).not.toHaveBeenCalled();
     });
   });
 

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -185,7 +185,11 @@ function shouldFailClosedAgentGatewayError(err: unknown): boolean {
       : err instanceof Error
         ? err.message.toLowerCase()
         : "";
-  return message.includes("gateway timeout") || message.includes("gateway closed");
+  return (
+    message.includes("gateway timeout") ||
+    message.includes("gateway request timeout") ||
+    message.includes("gateway closed")
+  );
 }
 
 export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, deps?: CliDeps) {

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -178,6 +178,16 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
   return response;
 }
 
+function shouldFailClosedAgentGatewayError(err: unknown): boolean {
+  const message =
+    typeof err === "string"
+      ? err.toLowerCase()
+      : err instanceof Error
+        ? err.message.toLowerCase()
+        : "";
+  return message.includes("gateway timeout") || message.includes("gateway closed");
+}
+
 export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, deps?: CliDeps) {
   const localOpts = {
     ...opts,
@@ -191,6 +201,12 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
   try {
     return await agentViaGatewayCommand(opts, runtime);
   } catch (err) {
+    if (shouldFailClosedAgentGatewayError(err)) {
+      throw new Error(
+        `Gateway agent failed without embedded fallback because the request may still be active remotely: ${String(err)}`,
+        { cause: err },
+      );
+    }
     runtime.error?.(`Gateway agent failed; falling back to embedded: ${String(err)}`);
     return await agentCommand(localOpts, runtime, deps);
   }


### PR DESCRIPTION
## Summary
- fail closed for `openclaw agent` when the gateway error indicates the remote request may still be active
- keep embedded fallback for recoverable gateway errors like "gateway not connected"
- add focused tests for timeout/closed fail-closed behavior

## Why
In real ClawTeam/OpenClaw unattended runs, a gateway timeout could be followed by an immediate embedded fallback on the same session. If the gateway-side turn was still alive and holding the session write lock, the embedded retry would contend on the same `.jsonl.lock` and turn a real in-flight run into a misleading session-lock failure.

This change makes the CLI fail closed for ambiguous gateway errors instead of re-entering locally on the same session.

## Validation
- `pnpm -C /Users/zky/.openclaw/workspace/openclaw-src test src/commands/agent-via-gateway.test.ts`
- real local CLI check against a bad gateway URL now returns an explicit "without embedded fallback" error instead of falling back to embedded
