### PR TITLE
fix: strip terminal dangling anthropic tool uses

### DIFF
--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -463,23 +463,57 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     ]);
   });
 
-  it("should not modify messages when next is not user", () => {
+  it("should not modify messages when next is a non-user message", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Use tool" }] },
       {
         role: "assistant",
         content: [{ type: "toolUse", id: "tool-1", name: "test", input: {} }],
       },
-      // Next is assistant, not user - should not strip
+      // Next is assistant, not user - keep as-is because the assistant turn is not terminal.
       { role: "assistant", content: [{ type: "text", text: "Continue" }] },
     ]);
 
     const result = validateAnthropicTurns(msgs);
 
     expect(result).toHaveLength(3);
-    // Original tool_use should be preserved
     const assistantContent = (result[1] as { content?: unknown[] }).content;
     expect(assistantContent).toEqual([{ type: "toolUse", id: "tool-1", name: "test", input: {} }]);
+  });
+
+  it("strips dangling tool_use blocks from a terminal assistant message", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolUse", id: "tool-1", name: "test", input: {} },
+          { type: "text", text: "I'll check that" },
+        ],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(2);
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([{ type: "text", text: "I'll check that" }]);
+  });
+
+  it("inserts fallback text when terminal assistant content is only dangling tool_use", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolUse", id: "tool-1", name: "test", input: {} }],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(2);
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([{ type: "text", text: "[tool calls omitted]" }]);
   });
 
   it("is replay-safe across repeated validation passes", () => {

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -40,14 +40,18 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
         ? ((nextMsg as { role?: unknown }).role as string | undefined)
         : undefined;
 
-    // If next message is not user, keep the assistant message as-is
+    // If there is no following user message, any tool_use blocks in this final
+    // assistant turn are necessarily dangling and must be stripped before replaying
+    // the transcript back to Anthropic.
     if (nextMsgRole !== "user") {
-      result.push(msg);
-      continue;
+      if (nextMsgRole !== undefined) {
+        result.push(msg);
+        continue;
+      }
     }
 
     // Collect tool_use_ids from the next user message's tool_result blocks
-    const nextUserMsg = nextMsg as {
+    const nextUserMsg = (nextMsg ?? {}) as {
       content?: AnthropicContentBlock[];
     };
     const validToolUseIds = new Set<string>();


### PR DESCRIPTION
## Summary
- strip dangling Anthropic `toolUse` blocks when the assistant message is the terminal turn in history
- preserve the existing behavior for non-terminal assistant messages followed by another assistant/system turn
- add regression coverage for terminal dangling-tool cases, including fallback placeholder behavior

## Testing
- pnpm exec vitest run src/agents/pi-embedded-helpers.validate-turns.test.ts

Closes #56757