### PR TITLE
Discord: relax listener timeout and reconnect stall watchdog

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.reconnect.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.reconnect.ts
@@ -12,7 +12,8 @@ const DISCORD_GATEWAY_FORCE_TERMINATE_CLOSE_TIMEOUT_MS = 1_000;
 const DISCORD_GATEWAY_HELLO_TIMEOUT_MS = 30_000;
 const DISCORD_GATEWAY_HELLO_CONNECTED_POLL_MS = 250;
 const DISCORD_GATEWAY_MAX_CONSECUTIVE_HELLO_STALLS = 3;
-const DISCORD_GATEWAY_RECONNECT_STALL_TIMEOUT_MS = 5 * 60_000;
+// Allow slow Discord gateway recovery before force-stopping the monitor (#45485, #44227).
+const DISCORD_GATEWAY_RECONNECT_STALL_TIMEOUT_MS = 10 * 60_000;
 
 type GatewayReadyWaitResult = "ready" | "timeout" | "stopped";
 

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -771,7 +771,7 @@ describe("runDiscordGatewayLifecycle", () => {
       lifecyclePromise.catch(() => {});
       emitter.emit("debug", "WebSocket connection closed with code 1006");
 
-      await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_000);
+      await vi.advanceTimersByTimeAsync(10 * 60_000 + 1_000);
       await expect(lifecyclePromise).rejects.toThrow("reconnect watchdog timeout");
     } finally {
       vi.useRealTimers();
@@ -801,7 +801,7 @@ describe("runDiscordGatewayLifecycle", () => {
 
       gateway.isConnected = true;
       emitter.emit("debug", "WebSocket connection opened");
-      await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_000);
+      await vi.advanceTimersByTimeAsync(10 * 60_000 + 1_000);
 
       expect(runtimeLog).not.toHaveBeenCalledWith(
         expect.stringContaining("reconnect watchdog timeout"),

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -27,6 +27,7 @@ import {
   registerDiscordListener,
 } from "./listeners.js";
 import { resolveDiscordPresenceUpdate } from "./presence.js";
+import { DISCORD_DEFAULT_LISTENER_TIMEOUT_MS } from "./timeouts.js";
 
 type DiscordAutoPresenceController = ReturnType<typeof createDiscordAutoPresenceController>;
 type DiscordListenerConfig = {
@@ -96,10 +97,9 @@ export function createDiscordMonitorClient(params: {
   }
 
   // Pass eventQueue config to Carbon so the gateway listener budget can be tuned.
-  // Default listenerTimeout is 120s (Carbon defaults to 30s, which is too short for some
-  // Discord normalization/enqueue work).
+  // Carbon's own default is shorter; OpenClaw raises the floor via DISCORD_DEFAULT_LISTENER_TIMEOUT_MS.
   const eventQueueOpts = {
-    listenerTimeout: 120_000,
+    listenerTimeout: DISCORD_DEFAULT_LISTENER_TIMEOUT_MS,
     ...params.discordConfig.eventQueue,
   };
   const readyListener = createDiscordStatusReadyListener({

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -510,14 +510,15 @@ describe("monitorDiscordProvider", () => {
     expect(drained[0]?.message).toContain("4014");
   });
 
-  it("passes default eventQueue.listenerTimeout of 120s to Carbon Client", async () => {
+  it("passes default eventQueue.listenerTimeout to Carbon Client", async () => {
     await monitorDiscordProvider({
       config: baseConfig(),
       runtime: baseRuntime(),
     });
 
     const eventQueue = getConstructedEventQueue();
-    expect(eventQueue).toEqual({ listenerTimeout: 120_000 });
+    expect(eventQueue).toBeDefined();
+    expect(eventQueue?.listenerTimeout).toBe(600_000);
   });
 
   it("forwards custom eventQueue config from discord config to Carbon Client", async () => {
@@ -734,7 +735,7 @@ describe("monitorDiscordProvider", () => {
     });
 
     expect(clientHandleDeployRequestMock).toHaveBeenCalledTimes(1);
-    expect(getConstructedClientOptions().eventQueue?.listenerTimeout).toBe(120_000);
+    expect(getConstructedClientOptions().eventQueue?.listenerTimeout).toBe(600_000);
   });
 
   it("reports connected status on startup and shutdown", async () => {

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -79,6 +79,7 @@ import { resolveDiscordRestFetch } from "./rest-fetch.js";
 import { formatDiscordStartupStatusMessage } from "./startup-status.js";
 import type { DiscordMonitorStatusSink } from "./status.js";
 import { formatThreadBindingDurationLabel } from "./thread-bindings.messages.js";
+import { DISCORD_DEFAULT_LISTENER_TIMEOUT_MS } from "./timeouts.js";
 
 export type MonitorDiscordOpts = {
   token?: string;

--- a/extensions/discord/src/monitor/timeouts.ts
+++ b/extensions/discord/src/monitor/timeouts.ts
@@ -1,7 +1,8 @@
 const MAX_DISCORD_TIMEOUT_MS = 2_147_483_647;
 
-// 10 minutes: quiet gateways + Carbon's event-queue listener budget previously
-// defaulted to 2 minutes, which could churn reconnects on low-traffic bots (see #45485).
+// 10 minutes: quiet gateways can churn reconnects on low-traffic bots when the
+// listener budget is too tight. OpenClaw previously capped this at 2 minutes (Carbon's
+// own default is ~30 s); raising to 10 minutes reduces false-positive recycle loops (see #45485).
 export const DISCORD_DEFAULT_LISTENER_TIMEOUT_MS = 600_000;
 export const DISCORD_DEFAULT_INBOUND_WORKER_TIMEOUT_MS = 30 * 60_000;
 

--- a/extensions/discord/src/monitor/timeouts.ts
+++ b/extensions/discord/src/monitor/timeouts.ts
@@ -1,6 +1,8 @@
 const MAX_DISCORD_TIMEOUT_MS = 2_147_483_647;
 
-export const DISCORD_DEFAULT_LISTENER_TIMEOUT_MS = 120_000;
+// 10 minutes: quiet gateways + Carbon's event-queue listener budget previously
+// defaulted to 2 minutes, which could churn reconnects on low-traffic bots (see #45485).
+export const DISCORD_DEFAULT_LISTENER_TIMEOUT_MS = 600_000;
 export const DISCORD_DEFAULT_INBOUND_WORKER_TIMEOUT_MS = 30 * 60_000;
 
 function clampDiscordTimeoutMs(timeoutMs: number, minimumMs: number): number {

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -362,7 +362,7 @@ export type DiscordAccountConfig = {
    * It does not control the lifetime of queued inbound agent turns.
    */
   eventQueue?: {
-    /** Max time (ms) a single listener can run before being killed. Default: 120000. */
+    /** Max time (ms) a single listener can run before being killed. Default: 600000. */
     listenerTimeout?: number;
     /** Max events queued before backpressure is applied. Default: 10000. */
     maxQueueSize?: number;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord monitor can churn into periodic restart loops around reconnect/listener time budgets, matching the timeout cluster in #45485.
- Why it matters: bots appear disconnected or repeatedly recycled during slower reconnect windows.
- What changed: default listener timeout is increased to 10 minutes and reconnect stall watchdog budget is also extended to 10 minutes.
- What did NOT change (scope boundary): no protocol-level rewrite of discord.js/carbon reconnect internals.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45485
- Related #44227
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: timeout budgets for listener and reconnect-stall paths were too aggressive for slower/unstable reconnect windows.
- Missing detection / guardrail: defaults did not leave enough margin for normal reconnect variability before forced recycle.
- Prior context (`git blame`, prior PR, issue, or refactor if known): recurring timeout reports in #45485 and related reconnect issues.
- Why this regressed now: production environments with more jitter expose strict timeout defaults.
- If unknown, what was ruled out: deeper transport-layer causes may still exist; this change addresses high-confidence budget pressure.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/provider.lifecycle.test.ts`, `extensions/discord/src/monitor/provider.test.ts`
- Scenario the test should lock in: monitor does not prematurely stall/recycle under extended reconnect/listener windows.
- Why this is the smallest reliable guardrail: behavior is concentrated in monitor timeout constants and lifecycle logic.
- Existing test that already covers this (if any): lifecycle/provider monitor tests extended in this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Fewer false-positive Discord reconnect timeout/stall cycles under slower network conditions.

## Diagram (if applicable)

```text
Before:
[slow reconnect] -> timeout budget expires early -> forced recycle loop

After:
[slow reconnect] -> larger budget window -> stable recovery path
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Discord integration monitor
- Relevant config (redacted): default discord monitor config

### Steps

1. Simulate/trace reconnect + listener timeout paths in monitor tests.
2. Verify extended budgets are applied by defaults.
3. Ensure lifecycle tests reflect expected non-premature watchdog behavior.

### Expected

- Monitor tolerates slower reconnect windows without immediate forced recycle.

### Actual

- Defaults and lifecycle behavior now use 10-minute budgets for listener/stall windows.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `vitest run --config vitest.channels.config.ts extensions/discord/src/monitor/provider.lifecycle.test.ts --pool=forks`

## Human Verification (required)

- Verified scenarios: reconnect stall/watchdog timing behavior with new defaults.
- Edge cases checked: provider timeout defaults and lifecycle budget assertions.
- What you did **not** verify: live Discord production traffic soak after the change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: longer timeout windows can delay detection of genuinely stuck reconnect states.
  - Mitigation: watchdog remains active; only default thresholds are relaxed to reduce false positives.

Made with [Cursor](https://cursor.com)