### PR TITLE
Onboard: persist default workspace as portable ~/.openclaw path

### DIFF
--- a/src/agents/workspace.defaults.test.ts
+++ b/src/agents/workspace.defaults.test.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
+import {
+  portableDefaultAgentWorkspacePath,
+  resolveDefaultAgentWorkspaceDir,
+  workspaceResolvedDirToConfigValue,
+} from "./workspace.js";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -14,6 +18,21 @@ describe("DEFAULT_AGENT_WORKSPACE_DIR", () => {
 
     expect(resolveDefaultAgentWorkspaceDir()).toBe(
       path.join(path.resolve(home), ".openclaw", "workspace"),
+    );
+  });
+
+  it("portableDefaultAgentWorkspacePath reflects OPENCLAW_PROFILE", () => {
+    vi.stubEnv("OPENCLAW_PROFILE", "dev");
+    expect(portableDefaultAgentWorkspacePath()).toBe("~/.openclaw/workspace-dev");
+    vi.stubEnv("OPENCLAW_PROFILE", "default");
+    expect(portableDefaultAgentWorkspacePath()).toBe("~/.openclaw/workspace");
+  });
+
+  it("workspaceResolvedDirToConfigValue uses portable path only for the default workspace dir", () => {
+    const def = resolveDefaultAgentWorkspaceDir();
+    expect(workspaceResolvedDirToConfigValue(def)).toBe("~/.openclaw/workspace");
+    expect(workspaceResolvedDirToConfigValue(path.join(def, "extra"))).toBe(
+      path.join(def, "extra"),
     );
   });
 });

--- a/src/agents/workspace.defaults.test.ts
+++ b/src/agents/workspace.defaults.test.ts
@@ -35,4 +35,13 @@ describe("DEFAULT_AGENT_WORKSPACE_DIR", () => {
       path.join(def, "extra"),
     );
   });
+
+  it("workspaceResolvedDirToConfigValue uses portable profile path for default profile workspace", () => {
+    vi.stubEnv("OPENCLAW_PROFILE", "staging");
+    const def = resolveDefaultAgentWorkspaceDir();
+    expect(workspaceResolvedDirToConfigValue(def)).toBe("~/.openclaw/workspace-staging");
+    expect(workspaceResolvedDirToConfigValue(path.join(def, "extra"))).toBe(
+      path.join(def, "extra"),
+    );
+  });
 });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -21,6 +21,35 @@ export function resolveDefaultAgentWorkspaceDir(
   return path.join(home, ".openclaw", "workspace");
 }
 
+/**
+ * Home-relative path to store in config when the user keeps the default workspace, so
+ * `openclaw.json` stays portable across machines (see onboarding / issue #51429).
+ */
+export function portableDefaultAgentWorkspacePath(env: NodeJS.ProcessEnv = process.env): string {
+  const profile = env.OPENCLAW_PROFILE?.trim();
+  if (profile && profile.toLowerCase() !== "default") {
+    return `~/.openclaw/workspace-${profile}`;
+  }
+  return "~/.openclaw/workspace";
+}
+
+/**
+ * If `resolvedDir` is the canonical default workspace for this environment, return
+ * {@link portableDefaultAgentWorkspacePath}; otherwise return `resolvedDir` unchanged.
+ */
+export function workspaceResolvedDirToConfigValue(
+  resolvedDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string {
+  const normalized = path.normalize(resolvedDir);
+  const defaultDir = path.normalize(resolveDefaultAgentWorkspaceDir(env, homedir));
+  if (normalized === defaultDir) {
+    return portableDefaultAgentWorkspacePath(env);
+  }
+  return resolvedDir;
+}
+
 export const DEFAULT_AGENT_WORKSPACE_DIR = resolveDefaultAgentWorkspaceDir();
 export const DEFAULT_AGENTS_FILENAME = "AGENTS.md";
 export const DEFAULT_SOUL_FILENAME = "SOUL.md";

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -1,5 +1,6 @@
 import fsPromises from "node:fs/promises";
 import nodePath from "node:path";
+import { workspaceResolvedDirToConfigValue } from "../agents/workspace.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { readConfigFileSnapshot, resolveGatewayPort, writeConfigFile } from "../config/config.js";
@@ -395,7 +396,7 @@ export async function runConfigureWizard(
           ...nextConfig.agents,
           defaults: {
             ...nextConfig.agents?.defaults,
-            workspace: workspaceDir,
+            workspace: workspaceResolvedDirToConfigValue(workspaceDir),
           },
         },
       };

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { inspect } from "node:util";
 import { cancel, isCancel } from "@clack/prompts";
-import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
+import { ensureAgentWorkspace, portableDefaultAgentWorkspacePath } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH } from "../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
@@ -297,7 +297,7 @@ function summarizeError(err: unknown): string {
   return line.length > 120 ? `${line.slice(0, 119)}…` : line;
 }
 
-export const DEFAULT_WORKSPACE = DEFAULT_AGENT_WORKSPACE_DIR;
+export const DEFAULT_WORKSPACE = portableDefaultAgentWorkspacePath();
 
 export function resolveControlUiLinks(params: {
   port: number;

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -1,3 +1,4 @@
+import { workspaceResolvedDirToConfigValue } from "../../agents/workspace.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveGatewayPort, writeConfigFile } from "../../config/config.js";
@@ -81,7 +82,10 @@ export async function runNonInteractiveLocalSetup(params: {
     defaultWorkspaceDir: DEFAULT_WORKSPACE,
   });
 
-  let nextConfig: OpenClawConfig = applyLocalSetupWorkspaceConfig(baseConfig, workspaceDir);
+  let nextConfig: OpenClawConfig = applyLocalSetupWorkspaceConfig(
+    baseConfig,
+    workspaceResolvedDirToConfigValue(workspaceDir),
+  );
 
   const inferredAuthChoice = inferAuthChoiceFromFlags(opts);
   if (!opts.authChoice && inferredAuthChoice.matches.length > 1) {

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -20,6 +20,7 @@ describe("setupCommand", () => {
 
       expect(raw).toContain('"mode": "local"');
       expect(raw).toContain('"workspace"');
+      expect(raw).toContain("~/.openclaw/workspace");
     });
   });
 

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,13 +1,17 @@
 import fs from "node:fs/promises";
 import JSON5 from "json5";
 import { z } from "zod";
-import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
+import {
+  ensureAgentWorkspace,
+  portableDefaultAgentWorkspacePath,
+  workspaceResolvedDirToConfigValue,
+} from "../agents/workspace.js";
 import { type OpenClawConfig, createConfigIO, writeConfigFile } from "../config/config.js";
 import { formatConfigPath, logConfigUpdated } from "../config/logging.js";
 import { resolveSessionTranscriptsDir } from "../config/sessions.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
-import { shortenHomePath } from "../utils.js";
+import { resolveUserPath, shortenHomePath } from "../utils.js";
 import { safeParseWithSchema } from "../utils/zod-parse.js";
 
 const JsonRecordSchema = z.record(z.string(), z.unknown());
@@ -40,7 +44,12 @@ export async function setupCommand(
   const cfg = existingRaw.parsed;
   const defaults = cfg.agents?.defaults ?? {};
 
-  const workspace = desiredWorkspace ?? defaults.workspace ?? DEFAULT_AGENT_WORKSPACE_DIR;
+  const rawWorkspace =
+    desiredWorkspace?.trim() ||
+    (typeof defaults.workspace === "string" ? defaults.workspace.trim() : "") ||
+    portableDefaultAgentWorkspacePath();
+  const resolvedWorkspace = resolveUserPath(rawWorkspace);
+  const workspace = workspaceResolvedDirToConfigValue(resolvedWorkspace);
 
   const next: OpenClawConfig = {
     ...cfg,

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -45,11 +45,14 @@ export async function setupCommand(
   const defaults = cfg.agents?.defaults ?? {};
 
   const rawWorkspace =
-    desiredWorkspace?.trim() ||
+    desiredWorkspace ||
     (typeof defaults.workspace === "string" ? defaults.workspace.trim() : "") ||
     portableDefaultAgentWorkspacePath();
   const resolvedWorkspace = resolveUserPath(rawWorkspace);
-  const workspace = workspaceResolvedDirToConfigValue(resolvedWorkspace);
+  // For the default workspace, store the portable ~/.openclaw/workspace form;
+  // for custom paths, preserve the user's original text (e.g. ~/my-workspace).
+  const resolvedDefault = workspaceResolvedDirToConfigValue(resolvedWorkspace);
+  const workspace = resolvedDefault !== resolvedWorkspace ? resolvedDefault : rawWorkspace;
 
   const next: OpenClawConfig = {
     ...cfg,

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -1,3 +1,4 @@
+import { workspaceResolvedDirToConfigValue } from "../agents/workspace.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type {
   GatewayAuthChoice,
@@ -477,7 +478,10 @@ export async function runSetupWizard(
   const workspaceDir = resolveUserPath(workspaceInput.trim() || onboardHelpers.DEFAULT_WORKSPACE);
 
   const { applyLocalSetupWorkspaceConfig } = await import("../commands/onboard-config.js");
-  let nextConfig: OpenClawConfig = applyLocalSetupWorkspaceConfig(baseConfig, workspaceDir);
+  let nextConfig: OpenClawConfig = applyLocalSetupWorkspaceConfig(
+    baseConfig,
+    workspaceResolvedDirToConfigValue(workspaceDir),
+  );
 
   const { ensureAuthProfileStore } = await import("../agents/auth-profiles.runtime.js");
   const { promptAuthChoiceGrouped } = await import("../commands/auth-choice-prompt.js");


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: onboarding/setup could persist resolved absolute default workspace paths in config, which can look like hardcoded host-specific paths when config is migrated/synced across machines.
- Why it matters: config portability suffers and users can see confusing foreign absolute paths.
- What changed: when workspace matches canonical default, config now stores portable `~/.openclaw/workspace` (profile-aware) instead of absolute home path.
- What did NOT change (scope boundary): runtime filesystem operations still resolve to absolute paths at execution time.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #51429
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: onboarding/configure/setup resolved default workspace to absolute path and wrote it directly to `agents.defaults.workspace`.
- Missing detection / guardrail: no canonical mapping back to portable default string for persisted config.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #51429 reports apparent hardcoded path behavior from config baking.
- Why this regressed now: portability issues become visible when configs are reused across hosts.
- If unknown, what was ruled out: actual hardcoded username path in source was ruled out.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/workspace.defaults.test.ts`, `src/commands/setup.test.ts`
- Scenario the test should lock in: default workspace persistence remains portable (`~/.openclaw/...`) while runtime still resolves absolute path correctly.
- Why this is the smallest reliable guardrail: bug is in config serialization for default workspace value.
- Existing test that already covers this (if any): setup/onboard tests extended for persisted value expectations.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Config files now store portable default workspace strings for default path cases.

## Diagram (if applicable)

```text
Before:
default workspace -> resolve absolute path -> persist /Users/<name>/.openclaw/workspace

After:
default workspace -> detect canonical default -> persist ~/.openclaw/workspace
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): onboarding/setup/configure flows
- Relevant config (redacted): default workspace settings

### Steps

1. Run setup/onboard/configure with default workspace value.
2. Inspect saved `agents.defaults.workspace` in config.
3. Confirm persisted value is portable `~/.openclaw/...` and runtime still resolves correctly.

### Expected

- Portable default path in config for canonical default workspace.

### Actual

- Config now stores `~/.openclaw/workspace` (or profile-specific variant) for default-path cases.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `pnpm test -- src/agents/workspace.defaults.test.ts src/commands/setup.test.ts src/commands/onboard-config.test.ts`
- `pnpm test -- src/wizard/setup.test.ts`

## Human Verification (required)

- Verified scenarios: setup/onboard/configure persist portable defaults when using canonical workspace.
- Edge cases checked: profile-aware default workspace suffix behavior.
- What you did **not** verify: full interactive onboarding matrix across all shells/platforms manually.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: users relying on absolute default path serialization may notice config text changes.
  - Mitigation: runtime path resolution remains unchanged; only persisted default representation becomes portable.

Made with [Cursor](https://cursor.com)