### PR TITLE
Gateway/UI: clarify insecure-context device-auth errors

### DIFF
--- a/src/gateway/protocol/connect-error-details.test.ts
+++ b/src/gateway/protocol/connect-error-details.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
+  CONTROL_UI_DEVICE_IDENTITY_INSECURE_CONTEXT_MESSAGE,
   readConnectErrorDetailCode,
   readConnectErrorRecoveryAdvice,
 } from "./connect-error-details.js";
+
+describe("CONTROL_UI_DEVICE_IDENTITY_INSECURE_CONTEXT_MESSAGE", () => {
+  it("keeps a stable prefix for handshake and UI copy", () => {
+    expect(CONTROL_UI_DEVICE_IDENTITY_INSECURE_CONTEXT_MESSAGE).toMatch(
+      /^control ui requires device identity:/,
+    );
+    expect(CONTROL_UI_DEVICE_IDENTITY_INSECURE_CONTEXT_MESSAGE).toContain("allowInsecureAuth");
+  });
+});
 
 describe("readConnectErrorDetailCode", () => {
   it("reads structured detail codes", () => {

--- a/src/gateway/protocol/connect-error-details.ts
+++ b/src/gateway/protocol/connect-error-details.ts
@@ -1,3 +1,11 @@
+/**
+ * Explains why Control UI on plain HTTP from a non-localhost address cannot use
+ * device identity (browser WebCrypto secure-context requirement). Keep the
+ * leading phrase stable: gateway and UI tests match on "control ui requires device identity".
+ */
+export const CONTROL_UI_DEVICE_IDENTITY_INSECURE_CONTEXT_MESSAGE =
+  "control ui requires device identity: browsers expose WebCrypto only on HTTPS or localhost; use HTTPS, an SSH tunnel to 127.0.0.1:18789, or gateway.controlUi.dangerouslyDisableDeviceAuth on trusted networks (see docs). gateway.controlUi.allowInsecureAuth applies only on localhost HTTP.";
+
 export const ConnectErrorDetailCodes = {
   AUTH_REQUIRED: "AUTH_REQUIRED",
   AUTH_UNAUTHORIZED: "AUTH_UNAUTHORIZED",

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -44,6 +44,7 @@ import { checkBrowserOrigin } from "../../origin-check.js";
 import { GATEWAY_CLIENT_IDS } from "../../protocol/client-info.js";
 import {
   ConnectErrorDetailCodes,
+  CONTROL_UI_DEVICE_IDENTITY_INSECURE_CONTEXT_MESSAGE,
   resolveDeviceAuthConnectErrorDetailCode,
   resolveAuthConnectErrorDetailCode,
 } from "../../protocol/connect-error-details.js";
@@ -542,15 +543,14 @@ export function attachGatewayWsMessageHandler(params: {
           }
 
           if (decision.kind === "reject-control-ui-insecure-auth") {
-            const errorMessage =
-              "control ui requires device identity (use HTTPS or localhost secure context)";
+            const errorMessage = CONTROL_UI_DEVICE_IDENTITY_INSECURE_CONTEXT_MESSAGE;
             markHandshakeFailure("control-ui-insecure-auth", {
               insecureAuthConfigured: controlUiAuthPolicy.allowInsecureAuthConfigured,
             });
             sendHandshakeErrorResponse(ErrorCodes.INVALID_REQUEST, errorMessage, {
               details: { code: ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED },
             });
-            close(1008, errorMessage);
+            close(1008, truncateCloseReason(errorMessage));
             return false;
           }
 

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -117,7 +117,8 @@ export const en: TranslationMap = {
     },
     insecure: {
       hint: "This page is HTTP, so the browser blocks device identity. Use HTTPS (Tailscale Serve) or open {url} on the gateway host.",
-      stayHttp: "If you must stay on HTTP, set {config} (token-only).",
+      stayHttp:
+        "On localhost HTTP only, set {config} (token-only). Remote plain HTTP cannot use device identity—use HTTPS, an SSH tunnel to localhost, or read the insecure HTTP docs.",
     },
     connection: {
       title: "How to connect",

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -302,7 +302,7 @@ describe("connectGateway", () => {
     });
 
     expect(host.lastErrorCode).toBe(ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED);
-    expect(host.lastError).toContain("device identity required");
+    expect(host.lastError).toContain("control ui requires device identity");
   });
 
   it("maps generic fetch failures to actionable origin guidance", () => {

--- a/ui/src/ui/connect-error.test.ts
+++ b/ui/src/ui/connect-error.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../src/gateway/protocol/connect-error-details.js";
+import { formatConnectError } from "./connect-error.js";
+
+describe("formatConnectError", () => {
+  it("formats CONTROL_UI_DEVICE_IDENTITY_REQUIRED with secure-context guidance", () => {
+    const text = formatConnectError({
+      message: "connect failed",
+      details: { code: ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED },
+    });
+    expect(text).toContain("control ui requires device identity");
+    expect(text).toContain("allowInsecureAuth applies only on localhost HTTP");
+    expect(text).toContain("dangerouslyDisableDeviceAuth");
+  });
+});

--- a/ui/src/ui/connect-error.ts
+++ b/ui/src/ui/connect-error.ts
@@ -1,4 +1,7 @@
-import { ConnectErrorDetailCodes } from "../../../src/gateway/protocol/connect-error-details.js";
+import {
+  ConnectErrorDetailCodes,
+  CONTROL_UI_DEVICE_IDENTITY_INSECURE_CONTEXT_MESSAGE,
+} from "../../../src/gateway/protocol/connect-error-details.js";
 import { resolveGatewayErrorDetailCode } from "./gateway.ts";
 
 type ErrorWithMessageAndDetails = {
@@ -30,7 +33,7 @@ function formatErrorFromMessageAndDetails(error: ErrorWithMessageAndDetails): st
     case ConnectErrorDetailCodes.PAIRING_REQUIRED:
       return "gateway pairing required";
     case ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED:
-      return "device identity required (use HTTPS/localhost or allow insecure auth explicitly)";
+      return CONTROL_UI_DEVICE_IDENTITY_INSECURE_CONTEXT_MESSAGE;
     case ConnectErrorDetailCodes.CONTROL_UI_ORIGIN_NOT_ALLOWED:
       return "origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)";
     case ConnectErrorDetailCodes.AUTH_TOKEN_MISSING:

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -597,7 +597,7 @@ describe("abortChatRun", () => {
       sessionKey: "main",
       runId: "run-1",
     });
-    expect(state.lastError).toContain("device identity required");
+    expect(state.lastError).toContain("control ui requires device identity");
   });
 });
 

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -239,7 +239,8 @@ export class GatewayBrowserClient {
 
     // crypto.subtle is only available in secure contexts (HTTPS, localhost).
     // Over plain HTTP, we skip device identity and fall back to token-only auth.
-    // Gateways may reject this unless gateway.controlUi.allowInsecureAuth is enabled.
+    // The gateway allows that path for localhost Control UI when
+    // gateway.controlUi.allowInsecureAuth is enabled; remote plain HTTP is still rejected.
     const isSecureContext = typeof crypto !== "undefined" && !!crypto.subtle;
 
     const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];

--- a/ui/src/ui/views/overview-hints.ts
+++ b/ui/src/ui/views/overview-hints.ts
@@ -85,5 +85,9 @@ export function shouldShowInsecureContextHint(
     return INSECURE_CONTEXT_CODES.has(lastErrorCode);
   }
   const lower = lastError.toLowerCase();
-  return lower.includes("secure context") || lower.includes("device identity required");
+  return (
+    lower.includes("secure context") ||
+    lower.includes("device identity required") ||
+    lower.includes("requires device identity")
+  );
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI error/hint copy around device identity and insecure auth can mislead users into expecting remote plain-HTTP flows to work with `allowInsecureAuth`.
- Why it matters: users spend time on non-working paths and misdiagnose expected secure-context policy as random failures.
- What changed: unified and clarified device-identity insecure-context messaging across gateway protocol and UI hints/tests.
- What did NOT change (scope boundary): secure-context/device-auth policy behavior itself is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32473
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: messaging did not clearly separate localhost-only insecure-auth relaxation from remote secure-context requirements for device identity.
- Missing detection / guardrail: inconsistent wording across protocol/UI surfaces.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #32473 discussion repeatedly conflates policy with configuration toggle behavior.
- Why this regressed now: increased remote homelab/docker usage exposed messaging ambiguity.
- If unknown, what was ruled out: policy bug was ruled out; underlying behavior is intentional security design.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/protocol/connect-error-details.test.ts`, `ui/src/ui/connect-error.test.ts`, `ui/src/ui/app-gateway.node.test.ts`
- Scenario the test should lock in: error prefix and UI mapping remain consistent and explicit for insecure-context/device-identity failures.
- Why this is the smallest reliable guardrail: change is copy/mapping logic across protocol and UI.
- Existing test that already covers this (if any): extended existing connect-error and gateway-node tests.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Error guidance now explicitly clarifies that remote plain HTTP cannot satisfy browser device-identity secure-context requirements.

## Diagram (if applicable)

```text
Before:
remote HTTP + allowInsecureAuth -> ambiguous error/hints

After:
remote HTTP + allowInsecureAuth -> clear message: secure context still required for device identity
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Control UI connect/auth path
- Relevant config (redacted): insecure-context/device-auth settings

### Steps

1. Trigger device-identity required path from non-secure remote context.
2. Observe protocol close reason and UI hint rendering.
3. Verify copy points users to secure-context-compatible options.

### Expected

- Consistent, explicit secure-context guidance across protocol and UI surfaces.

### Actual

- Messaging now uses a canonical phrasing and updated UI hints/tests.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `pnpm exec vitest run src/gateway/protocol/connect-error-details.test.ts src/gateway/server/ws-connection/connect-policy.test.ts`
- `pnpm exec vitest run --config ui/vitest.config.ts --project unit src/ui/connect-error.test.ts`

## Human Verification (required)

- Verified scenarios: device-identity insecure-context errors map to clearer guidance in both gateway and UI layers.
- Edge cases checked: prefix compatibility retained for existing control-ui auth suite expectations.
- What you did **not** verify: full browser manual matrix on multiple remote topologies.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: wording changes could break tests that match exact text.
  - Mitigation: canonical message constant + updated tests preserve stable expected prefix.

Made with [Cursor](https://cursor.com)