### PR TITLE
CLI: improve device pairing timeout diagnostics and defaults

### DIFF
--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -298,6 +298,19 @@ describe("devices cli local fallback", () => {
 });
 
 describe("devices cli list", () => {
+  it("uses an extended default gateway RPC timeout for pairing-heavy calls", async () => {
+    callGateway.mockResolvedValueOnce({ pending: [], paired: [] });
+
+    await runDevicesCommand(["list"]);
+
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "device.pair.list",
+        timeoutMs: 30_000,
+      }),
+    );
+  });
+
   it("renders pending scopes when present", async () => {
     callGateway.mockResolvedValueOnce({
       pending: [

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -64,12 +64,19 @@ type DevicePairingList = {
 
 const FALLBACK_NOTICE = "Direct scope access failed; using local fallback.";
 
+/** Device pairing RPCs can wait on busy gateways (Pi, Docker, LAN); keep above generic CLI defaults. */
+const DEVICES_GATEWAY_DEFAULT_TIMEOUT_MS = 30_000;
+
 const devicesCallOpts = (cmd: Command, defaults?: { timeoutMs?: number }) =>
   cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (password auth)")
-    .option("--timeout <ms>", "Timeout in ms", String(defaults?.timeoutMs ?? 10_000))
+    .option(
+      "--timeout <ms>",
+      "Timeout in ms",
+      String(defaults?.timeoutMs ?? DEVICES_GATEWAY_DEFAULT_TIMEOUT_MS),
+    )
     .option("--json", "Output JSON", false);
 
 const callGatewayCli = async (method: string, opts: DevicesRpcOpts, params?: unknown) =>
@@ -86,7 +93,7 @@ const callGatewayCli = async (method: string, opts: DevicesRpcOpts, params?: unk
         password: opts.password,
         method,
         params,
-        timeoutMs: Number(opts.timeout ?? 10_000),
+        timeoutMs: Number(opts.timeout ?? DEVICES_GATEWAY_DEFAULT_TIMEOUT_MS),
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
       }),

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -193,7 +193,13 @@ export async function runCli(argv: string[] = process.argv) {
       }
     }
 
-    await program.parseAsync(parseArgv);
+    try {
+      await program.parseAsync(parseArgv);
+    } catch (error) {
+      // Commander async actions reject here; avoid surfacing them as "Failed to start CLI" from entry.ts.
+      console.error("[openclaw] Error:", formatUncaughtError(error));
+      process.exitCode = 1;
+    }
   } finally {
     await closeCliMemoryManagers();
   }

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -487,6 +487,7 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.url).toBe(expectedUrl);
     expect(details.urlSource).toBe("local loopback");
     expect(details.bindDetail).toBe("Bind: lan");
+    expect(details.message).toContain("OPENCLAW_GATEWAY_URL");
   });
 
   it("prefers remote url when configured", () => {

--- a/src/gateway/connection-details.ts
+++ b/src/gateway/connection-details.ts
@@ -70,6 +70,13 @@ export function buildGatewayConnectionDetailsWithResolvers(
   const remoteFallbackNote = remoteMisconfigured
     ? "Warn: gateway.mode=remote but gateway.remote.url is missing; set gateway.remote.url or switch gateway.mode=local."
     : undefined;
+  // Local mode always targets 127.0.0.1 on *this* OS instance. When the gateway is bound beyond
+  // loopback (LAN/custom/tailnet/auto), operators often run the CLI in Docker or on another host
+  // and hit confusing pairing or RPC timeouts (issue #45753).
+  const loopbackTargetHint =
+    !urlOverride && !remoteUrl && bindMode !== "loopback"
+      ? "Note: local-mode CLI uses 127.0.0.1 on this machine. If the gateway runs on the Docker host or another host, set OPENCLAW_GATEWAY_URL (or pass --url)."
+      : undefined;
 
   const allowPrivateWs = process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS === "1";
   if (!isSecureWebSocketUrl(url, { allowPrivateWs })) {
@@ -98,6 +105,7 @@ export function buildGatewayConnectionDetailsWithResolvers(
     `Config: ${configPath}`,
     bindDetail,
     remoteFallbackNote,
+    loopbackTargetHint,
   ]
     .filter(Boolean)
     .join("\n");


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw devices list` timeout reports can be confusing in pairing flows, especially when loopback URL assumptions are wrong in container/LAN setups.
- Why it matters: users get generic timeout/startup failures instead of actionable guidance.
- What changed: increased default devices RPC timeout (10s -> 30s), added non-loopback targeting hint, and improved CLI error labeling.
- What did NOT change (scope boundary): no changes to pairing protocol or device auth semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45753
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: timeout budget and error messaging in CLI path were too strict/opaque for slower or mis-targeted gateway setups.
- Missing detection / guardrail: defaults and connection hints did not guide users when bind mode and loopback target diverged.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #45753 reports timeout failures in pairing/device list workflows.
- Why this regressed now: containerized and LAN-hosted setups increased cases where `127.0.0.1` is not the correct endpoint from the caller context.
- If unknown, what was ruled out: no protocol-level pairing failure required to reproduce these UX failures.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/devices-cli.test.ts`, `src/gateway/call.test.ts`
- Scenario the test should lock in: devices CLI uses 30s default timeout and connection details include non-loopback guidance.
- Why this is the smallest reliable guardrail: issue is localized to timeout default + connection detail reporting.
- Existing test that already covers this (if any): existing devices/call test suites extended with new assertions.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `devices` CLI operations wait longer by default and provide clearer guidance for non-loopback gateway binds.

## Diagram (if applicable)

```text
Before:
devices list -> 10s timeout -> generic failure

After:
devices list -> 30s timeout + bind mismatch hint -> actionable troubleshooting
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): CLI devices + gateway call path
- Relevant config (redacted): bind mode and gateway URL defaults

### Steps

1. Run `openclaw devices list` in a non-loopback/bind-divergent setup.
2. Observe timeout behavior and connection diagnostics.
3. Validate improved hinting and default timeout.

### Expected

- Better tolerance for slower environments and clearer URL/bind guidance.

### Actual

- 30s default timeout and improved gateway connection details are applied.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `pnpm test -- src/cli/devices-cli.test.ts`
- `pnpm test -- src/gateway/call.test.ts -t "buildGatewayConnectionDetails"`
- `pnpm check`

## Human Verification (required)

- Verified scenarios: devices timeout default and connection-details hint behavior.
- Edge cases checked: command failure path no longer reports misleading startup text.
- What you did **not** verify: live remote pairing across all deployment topologies.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: longer timeout increases wait time for genuinely unreachable endpoints.
  - Mitigation: improved diagnostic hints reduce blind waiting and guide endpoint correction.

Made with [Cursor](https://cursor.com)