### PR TITLE
fix: prevent media understanding and speech provider resolution from replacing global hook runner

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -331,7 +331,7 @@ export function resolveRuntimePluginRegistry(
   if (!options || !hasExplicitCompatibilityInputs(options)) {
     return getCompatibleActivePluginRegistry();
   }
-  return getCompatibleActivePluginRegistry(options) ?? loadOpenClawPlugins(options);
+  return getCompatibleActivePluginRegistry(options) ?? loadOpenClawPlugins({ ...options, ...(getActivePluginRegistry() ? { activate: false, cache: false } : {}) });
 }
 
 function validatePluginConfig(params: {


### PR DESCRIPTION
Fixes #56835

# Fix: prevent media understanding provider resolution from replacing global hook runner

## Summary

Inbound media messages (photos, stickers, audio, video) silently and permanently break all plugin hooks (`agent_end`, `before_agent_start`, etc.) for the lifetime of the gateway process. Once triggered, hook-driven plugins (memory, analytics, guardrails) stop functioning. Only a full process restart recovers.

The root cause: `applyMediaUnderstanding` calls `buildProviderRegistry` without passing `cfg`, causing `buildMediaUnderstandingRegistry` to call `loadOpenClawPlugins({ config: undefined })`. This creates a near-empty registry (only extension-dir plugins) and **activates it** by default, replacing the global hook runner with one that has none of the user's plugin hooks.

## Problem

When a media message arrives, the pipeline calls `applyMediaUnderstanding` to process attachments. This calls `buildProviderRegistry(params.providers)`, passing provider overrides but **not** `cfg` (the gateway config). Inside `buildMediaUnderstandingRegistry`, when no media understanding providers exist in the active registry, it falls through to:

```ts
loadOpenClawPlugins({ config: cfg }) // cfg is undefined!
```

Because `activate` defaults to `true`, this:
1. Creates a fresh plugin registry from `config: undefined` (no `plugins.allow`, no `plugins.load.paths`)
2. Discovers only extension-dir plugins
3. **Replaces the global active registry** via `setActivePluginRegistry()`
4. **Replaces the global hook runner** via `initializeGlobalHookRunner()`

All hook-driven functionality (memory capture, analytics, guardrails) is silently dead from this point forward.

## Root cause call chain

```
dispatchInboundMessage
  -> applyMediaUnderstanding (src/media-understanding/apply.ts)
    -> buildProviderRegistry(params.providers)        <- cfg NOT passed
      -> buildMediaUnderstandingRegistry(overrides, undefined)
        -> loadOpenClawPlugins({ config: undefined })
          -> activatePluginRegistry()                 <- replaces hook runner
```

## Fix

One line, one file: `src/plugins/loader.ts`, function `resolveRuntimePluginRegistry`.

```diff
-  return getCompatibleActivePluginRegistry(options) ?? loadOpenClawPlugins(options);
+  return getCompatibleActivePluginRegistry(options)
+    ?? loadOpenClawPlugins({
+      ...options,
+      ...(getActivePluginRegistry()
+        ? { activate: false, cache: false }
+        : {}),
+    });
```

All five call sites identified during investigation (`apply.ts`, `provider-registry.ts`, `runner.ts`, `audio-transcription-runner.ts`, `tts/provider-registry.ts`) funnel through this shared helper. Three of the original per-site fixes were already merged into `main`. The remaining two were refactored into `resolveRuntimePluginRegistry`. So the five-site bug collapses to a single-line fix at the shared chokepoint.

### Why the guard is conditional

`resolveRuntimePluginRegistry` is called by two categories of callers:

**Provider-resolution callers** (media understanding, speech, capabilities, tools) that just need to read plugin entries. These pass transformed config whose cache key won't match the active registry, triggering the fallback. They should never activate.

**Bootstrap callers** (`ensureRuntimePluginsLoaded`, `ensureMemoryRuntime`, `maybeBootstrapChannelPlugin`) that depend on the fallback to initialize global state during cold start.

The conditional guard handles both: when `getActivePluginRegistry()` returns a registry (normal operation after startup), provider callers get a read-only snapshot without wiping hooks. When it returns null (cold start), bootstrap callers initialize normally because `activate` defaults to `true`.

One caveat: `maybeBootstrapChannelPlugin` safety depends on the main gateway bootstrap having already set a compatible active registry. That's true today but is a runtime observation, not a structural guarantee. Worth covering with a test that `maybeBootstrapChannelPlugin` still activates when called before the main bootstrap.

## Reproduction

1. Configure a gateway with any plugin using `agent_end` or `before_agent_start` hooks via `plugins.load.paths`
2. Start the gateway, verify hooks fire on text messages
3. Send a photo to any channel that triggers `applyMediaUnderstanding`
4. Hooks stop firing for all subsequent messages
5. Check logs for `plugins.allow is empty; discovered non-bundled plugins may auto-load`

## Who is affected

Any deployment that loads plugins via `plugins.load.paths` and receives media messages. This is a silent data-loss bug: memory plugins stop capturing, guardrail plugins stop enforcing. No error or crash to alert the operator.

## Testing

Tested on a live OpenClaw 2026.3.24 gateway with 7 agents, `openclaw-mem0` and `lossless-claw` plugins.

**Before fix:** Send photo -> `plugins.allow is empty` -> hooks permanently dead
**After fix:** Send photo -> no warning -> hooks survive. Multiple photos across multiple restarts, zero occurrences.

Note: `resolveRuntimePluginRegistry` does not exist in v2026.3.24 (introduced after that version). We patched five individual call sites in our production dist, which has been stable. This PR consolidates those into the single source-level fix.

## Related issues

- **#47625**: Same root cause class. `loadOpenClawPlugins` secondary call overwrites active plugin registry.
- **#30674**: Identical trigger (Telegram stops working after receiving image).
- **#5513**: Plugin hooks never invoked. Consistent with hook runner replacement.
- **#23452**: Vision/image recognition broken. Same `buildMediaUnderstandingRegistry` code path.

## Design note

The broader issue is that `loadOpenClawPlugins` defaults to `activate: true`, making it a footgun for any caller that just needs to read plugin data. Consider separating "load plugins" from "activate registry" into distinct functions, or adding a runtime assertion that `activate: true` is only called during startup.
