### PR TITLE
fix(agents): accept read file/filePath aliases

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -110,7 +110,39 @@ describe("handleToolExecutionStart read path checks", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it("warns when read tool has neither path nor file_path", async () => {
+  it("does not warn when read tool uses file alias", async () => {
+    const { ctx, warn, onBlockReplyFlush } = createTestContext();
+
+    const evt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "tool-1b",
+      args: { file: "/tmp/example.txt" },
+    };
+
+    await handleToolExecutionStart(ctx, evt);
+
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when read tool uses filePath alias", async () => {
+    const { ctx, warn, onBlockReplyFlush } = createTestContext();
+
+    const evt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "tool-1c",
+      args: { filePath: "/tmp/example.txt" },
+    };
+
+    await handleToolExecutionStart(ctx, evt);
+
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns when read tool has no supported path aliases", async () => {
     const { ctx, warn } = createTestContext();
 
     const evt: ToolExecutionStartEvent = {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -90,6 +90,7 @@ type ToolStartRecord = {
 
 /** Track tool execution start data for after_tool_call hook. */
 const toolStartData = new Map<string, ToolStartRecord>();
+const READ_TOOL_PATH_ARG_KEYS = ["path", "file_path", "file", "filePath"] as const;
 
 function buildToolStartKey(runId: string, toolCallId: string): string {
   return `${runId}:${toolCallId}`;
@@ -104,6 +105,19 @@ export function countActiveToolExecutions(runId: string): number {
     }
   }
   return count;
+}
+
+function readFirstStringRecordValue(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): string {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return "";
 }
 
 function isCronAddAction(args: unknown): boolean {
@@ -664,17 +678,7 @@ export function handleToolExecutionStart(
 
     if (toolName === "read") {
       const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-      const filePathValue =
-        typeof record.path === "string"
-          ? record.path
-          : typeof record.file_path === "string"
-            ? record.file_path
-            : typeof record.file === "string"
-              ? record.file
-              : typeof record.filePath === "string"
-                ? record.filePath
-                : "";
-      const filePath = filePathValue.trim();
+      const filePath = readFirstStringRecordValue(record, READ_TOOL_PATH_ARG_KEYS).trim();
       if (!filePath) {
         const argsPreview = readStringValue(args)?.slice(0, 200);
         ctx.log.warn(

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -669,7 +669,11 @@ export function handleToolExecutionStart(
           ? record.path
           : typeof record.file_path === "string"
             ? record.file_path
-            : "";
+            : typeof record.file === "string"
+              ? record.file
+              : typeof record.filePath === "string"
+                ? record.filePath
+                : "";
       const filePath = filePathValue.trim();
       if (!filePath) {
         const argsPreview = readStringValue(args)?.slice(0, 200);


### PR DESCRIPTION
## Summary
- Problem: `read` tool path-warning logic only recognized `path` and `file_path`, which raised false warnings for valid `file`/`filePath` argument shapes.
- What changed: `handleToolExecutionStart` now accepts `path`, `file_path`, `file`, and `filePath` as supported read-path aliases.
- Follow-up: the `file` and `filePath` regression tests now also assert `onBlockReplyFlush`, addressing the reviewer note.

## Testing
- `node --experimental-strip-types --check src/agents/pi-embedded-subscribe.handlers.tools.ts`
- `rg -n "READ_TOOL_PATH_ARG_KEYS|filePath|file_path|onBlockReplyFlush" src/agents/pi-embedded-subscribe.handlers.tools.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts`
- `git diff --check origin/main...HEAD`

## Real behavior proof
- **Behavior or issue addressed**: `read` tool starts using `file` or `filePath` no longer hit the missing-path warning path, while the existing block-reply flush behavior remains covered for the aliases.
- **Real environment tested**: Local OpenClaw source checkout on Linux at head `8da5b1223d`, Node `v22.22.0`, pnpm `10.33.2`.
- **Exact steps or command run after this patch**: `node --experimental-strip-types --check src/agents/pi-embedded-subscribe.handlers.tools.ts`; then `rg -n "READ_TOOL_PATH_ARG_KEYS|filePath|file_path|onBlockReplyFlush" src/agents/pi-embedded-subscribe.handlers.tools.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts`.
- **Evidence after fix**: Terminal capture from the patched checkout:

```text
$ node --experimental-strip-types --check src/agents/pi-embedded-subscribe.handlers.tools.ts
$ rg -n "READ_TOOL_PATH_ARG_KEYS|filePath|file_path|onBlockReplyFlush" src/agents/pi-embedded-subscribe.handlers.tools.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts
src/agents/pi-embedded-subscribe.handlers.tools.ts:93:const READ_TOOL_PATH_ARG_KEYS = ["path", "file_path", "file", "filePath"] as const;
src/agents/pi-embedded-subscribe.handlers.tools.ts:681:      const filePath = readFirstStringRecordValue(record, READ_TOOL_PATH_ARG_KEYS).trim();
src/agents/pi-embedded-subscribe.handlers.tools.test.ts:97:  it("does not warn when read tool uses file_path alias", async () => {
src/agents/pi-embedded-subscribe.handlers.tools.test.ts:109:    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
src/agents/pi-embedded-subscribe.handlers.tools.test.ts:129:  it("does not warn when read tool uses filePath alias", async () => {
src/agents/pi-embedded-subscribe.handlers.tools.test.ts:141:    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
```

- **Observed result after fix**: The patched handler parses under Node strip-only checking; the alias list includes `file` and `filePath`, and the tests include flush assertions for the alias paths.
- **What was not tested**: I did not run a full live agent conversation in this local proof; CI remains the supplemental validation for the Vitest suite.

Closes #56694