### PR TITLE
fix(edit): show best matching region on mismatch instead of raw file head

### DIFF
--- a/src/agents/pi-tools.host-edit.fuzzy-hint.test.ts
+++ b/src/agents/pi-tools.host-edit.fuzzy-hint.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import { wrapEditToolWithRecovery } from "./pi-tools.host-edit.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+function createMockEditTool(errorMessage: string): AnyAgentTool {
+  return {
+    name: "edit",
+    label: "edit",
+    description: "test edit tool",
+    parameters: {},
+    execute: vi.fn(async () => {
+      throw new Error(errorMessage);
+    }),
+  } as unknown as AnyAgentTool;
+}
+
+describe("edit tool fuzzy match hint", () => {
+  it("shows best matching region when oldText partially matches", async () => {
+    const fileContent = [
+      "function hello() {",
+      '  console.log("hello");',
+      '  console.log("world");',
+      "}",
+      "",
+      "function goodbye() {",
+      '  console.log("goodbye");',
+      "}",
+    ].join("\n");
+
+    const base = createMockEditTool("Could not find the exact text in test.ts");
+    const wrapped = wrapEditToolWithRecovery(base, {
+      root: "/tmp",
+      readFile: async () => fileContent,
+    });
+
+    const error = await wrapped
+      .execute(
+        "call-1",
+        {
+          path: "test.ts",
+          // Slightly wrong oldText — extra space before console.log
+          oldText: 'function hello() {\n   console.log("hello");\n  console.log("world");\n}',
+          newText: "replacement",
+        },
+        undefined,
+      )
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    const msg = (error as Error).message;
+    expect(msg).toContain("Best matching region");
+    expect(msg).toContain("near line");
+    expect(msg).toContain("similar");
+    expect(msg).toContain("Hint:");
+  });
+
+  it("falls back to file contents when no similar region found", async () => {
+    const fileContent = "alpha bravo charlie\ndelta echo foxtrot\n";
+
+    const base = createMockEditTool("Could not find the exact text in test.ts");
+    const wrapped = wrapEditToolWithRecovery(base, {
+      root: "/tmp",
+      readFile: async () => fileContent,
+    });
+
+    const error = await wrapped
+      .execute(
+        "call-1",
+        {
+          path: "test.ts",
+          oldText: "zzz yyy xxx www\nvvv uuu ttt sss\nrrr qqq ppp ooo",
+          newText: "replacement",
+        },
+        undefined,
+      )
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    const msg = (error as Error).message;
+    expect(msg).toContain("Current file contents:");
+    expect(msg).toContain("alpha bravo charlie");
+  });
+
+  it("finds single-line partial match via substring", async () => {
+    const fileContent = [
+      "import { foo } from './foo';",
+      "import { bar } from './bar';",
+      "",
+      "export function main() {",
+      "  return foo() + bar();",
+      "}",
+    ].join("\n");
+
+    const base = createMockEditTool("Could not find the exact text in main.ts");
+    const wrapped = wrapEditToolWithRecovery(base, {
+      root: "/tmp",
+      readFile: async () => fileContent,
+    });
+
+    const error = await wrapped
+      .execute(
+        "call-1",
+        {
+          path: "main.ts",
+          // Model wrote the import without quotes matching
+          oldText: "return foo() + bar()",
+          newText: "return foo() * bar()",
+        },
+        undefined,
+      )
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    const msg = (error as Error).message;
+    expect(msg).toContain("Best matching region");
+    expect(msg).toContain("line 5");
+  });
+
+  it("includes line numbers in the snippet", async () => {
+    const lines = Array.from({ length: 50 }, (_, i) => `line ${i + 1} content`);
+    const fileContent = lines.join("\n");
+
+    const base = createMockEditTool("Could not find the exact text in big.ts");
+    const wrapped = wrapEditToolWithRecovery(base, {
+      root: "/tmp",
+      readFile: async () => fileContent,
+    });
+
+    const error = await wrapped
+      .execute(
+        "call-1",
+        {
+          path: "big.ts",
+          // Multi-line oldText that partially matches around line 30
+          oldText: "line 30 content\nline 31 WRONG\nline 32 content",
+          newText: "replacement",
+        },
+        undefined,
+      )
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    const msg = (error as Error).message;
+    // Should contain numbered lines in the snippet
+    expect(msg).toMatch(/\d+\|/);
+    expect(msg).toContain("Best matching region");
+  });
+
+  it("preserves original error when oldText is missing", async () => {
+    const fileContent = "some content";
+
+    const base = createMockEditTool("Could not find the exact text in test.ts");
+    const wrapped = wrapEditToolWithRecovery(base, {
+      root: "/tmp",
+      readFile: async () => fileContent,
+    });
+
+    const error = await wrapped
+      .execute(
+        "call-1",
+        {
+          path: "test.ts",
+          newText: "replacement",
+        },
+        undefined,
+      )
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    const msg = (error as Error).message;
+    expect(msg).toContain("Current file contents:");
+  });
+});

--- a/src/agents/pi-tools.host-edit.ts
+++ b/src/agents/pi-tools.host-edit.ts
@@ -105,12 +105,109 @@ function shouldAddMismatchHint(error: unknown) {
   return error instanceof Error && error.message.includes(EDIT_MISMATCH_MESSAGE);
 }
 
-function appendMismatchHint(error: Error, currentContent: string): Error {
+/**
+ * Find the most similar region in the file to the given oldText using
+ * line-level similarity scoring. Returns the best matching line range
+ * with a context snippet so the model can self-correct.
+ */
+function findBestMatchRegion(
+  content: string,
+  oldText: string,
+): { lineStart: number; snippet: string; score: number } | null {
+  const contentLines = content.split("\n");
+  const oldLines = oldText.split("\n");
+  if (oldLines.length === 0 || contentLines.length === 0) {
+    return null;
+  }
+
+  let bestScore = 0;
+  let bestStart = 0;
+
+  // Slide a window the size of oldText lines across the file
+  const windowSize = oldLines.length;
+  for (let start = 0; start <= contentLines.length - windowSize; start++) {
+    let matching = 0;
+    for (let j = 0; j < windowSize; j++) {
+      const contentLine = contentLines[start + j].trimEnd();
+      const oldLine = oldLines[j].trimEnd();
+      if (contentLine === oldLine) {
+        matching++;
+      } else if (
+        contentLine.trim() === oldLine.trim() ||
+        contentLine.includes(oldLine.trim()) ||
+        oldLine.includes(contentLine.trim())
+      ) {
+        matching += 0.5;
+      }
+    }
+    const score = matching / windowSize;
+    if (score > bestScore) {
+      bestScore = score;
+      bestStart = start;
+    }
+  }
+
+  // Also try single-line match for single-line oldText in multi-line files
+  if (windowSize === 1) {
+    const trimmedOld = oldLines[0].trim();
+    if (trimmedOld.length > 0) {
+      for (let i = 0; i < contentLines.length; i++) {
+        if (contentLines[i].includes(trimmedOld)) {
+          return {
+            lineStart: i + 1,
+            snippet: contentLines
+              .slice(Math.max(0, i - 1), i + 2)
+              .map((l, idx) => `${Math.max(1, i) + idx}| ${l}`)
+              .join("\n"),
+            score: 0.9,
+          };
+        }
+      }
+    }
+  }
+
+  // Only return if the match is somewhat meaningful (>20% line overlap)
+  if (bestScore < 0.2) {
+    return null;
+  }
+
+  const contextStart = Math.max(0, bestStart - 1);
+  const contextEnd = Math.min(contentLines.length, bestStart + windowSize + 1);
+  const snippet = contentLines
+    .slice(contextStart, contextEnd)
+    .map((l, idx) => `${contextStart + idx + 1}| ${l}`)
+    .join("\n");
+
+  return { lineStart: bestStart + 1, snippet, score: bestScore };
+}
+
+function appendMismatchHint(error: Error, currentContent: string, oldText?: string): Error {
+  const parts: string[] = [error.message];
+
+  // Try to find the most similar region if oldText is available
+  if (oldText && oldText.length > 0) {
+    const match = findBestMatchRegion(normalizeToLF(currentContent), normalizeToLF(oldText));
+    if (match) {
+      const pct = Math.round(match.score * 100);
+      parts.push(
+        `\nBest matching region (${pct}% similar) near line ${match.lineStart}:\n${match.snippet}`,
+      );
+      parts.push(
+        "\nHint: check for whitespace differences, extra/missing lines, or outdated content in your oldText.",
+      );
+      const enhanced = new Error(parts.join(""));
+      enhanced.stack = error.stack;
+      return enhanced;
+    }
+  }
+
+  // Fall back to showing file head if no similar region found
   const snippet =
     currentContent.length <= EDIT_MISMATCH_HINT_LIMIT
       ? currentContent
       : `${currentContent.slice(0, EDIT_MISMATCH_HINT_LIMIT)}\n... (truncated)`;
-  const enhanced = new Error(`${error.message}\nCurrent file contents:\n${snippet}`);
+  parts.push(`\nCurrent file contents:\n${snippet}`);
+  const enhanced = new Error(parts.join(""));
   enhanced.stack = error.stack;
   return enhanced;
 }
@@ -177,7 +274,7 @@ export function wrapEditToolWithRecovery(
           err instanceof Error &&
           shouldAddMismatchHint(err)
         ) {
-          throw appendMismatchHint(err, currentContent);
+          throw appendMismatchHint(err, currentContent, oldText);
         }
 
         throw err;


### PR DESCRIPTION
## Problem

When the edit tool's `oldText` doesn't match, the error currently shows the first 800 characters of the file. For large files where the intended edit target is deep in the content, this is unhelpful — the model has to re-read the file and guess where the mismatch occurred.

## Solution

Replace the raw file-head fallback with a **best-match region finder** that uses line-level sliding window comparison:

- **Multi-line oldText**: slides a window of the same line count across the file, scoring each position by line-level overlap (exact match = 1.0, whitespace-only diff = 0.5)
- **Single-line oldText**: falls back to substring search across all lines
- **Below 20% similarity**: preserves the original file-head behavior as fallback

### Example error output (before)
```
Could not find the exact text in src/foo.ts.
Current file contents:
import { ... } from '...';
... (truncated after 800 chars)
```

### Example error output (after)
```
Could not find the exact text in src/foo.ts.
Best matching region (66% similar) near line 42:
41| function hello() {
42|   console.log("hello");
43|   console.log("world");
44| }
Hint: check for whitespace differences, extra/missing lines, or outdated content in your oldText.
```

## Changes

- `src/agents/pi-tools.host-edit.ts`: Added `findBestMatchRegion()` and updated `appendMismatchHint()` to pass `oldText` and use region matching
- `src/agents/pi-tools.host-edit.fuzzy-hint.test.ts`: 5 new tests covering partial match, fallback, single-line match, line numbers, and missing oldText

## Testing

All 5 new tests pass. Existing edit tool tests unaffected — this only enhances error messages on mismatch.