### PR TITLE
fix: suppress Discord reconnect-exhausted during stale-socket restarts

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -849,10 +849,51 @@ describe("runDiscordGatewayLifecycle", () => {
     abortController.abort();
 
     await expect(lifecyclePromise).resolves.toBeUndefined();
-    expect(runtimeLog).not.toHaveBeenCalledWith(
+    expect(runtimeLog).toHaveBeenCalledWith(
       expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
     );
-    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("Max reconnect attempts"));
+    expect(runtimeError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Max reconnect attempts"),
+    );
+  });
+
+  it("suppresses reconnect-exhausted delivered through the active lifecycle after abort", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const abortController = new AbortController();
+
+    const emitter = new EventEmitter();
+    const gateway: MockGateway = {
+      isConnected: true,
+      options: { intents: 0, reconnect: { maxAttempts: 50 } } as GatewayPlugin["options"],
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      emitter,
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    waitForDiscordGatewayStopMock.mockImplementationOnce(
+      async (waitParams: WaitForDiscordGatewayStopParams) => {
+        abortController.abort();
+        const decision = waitParams.onGatewayEvent?.(
+          createGatewayEvent(
+            "reconnect-exhausted",
+            "Max reconnect attempts (0) reached after code 1005",
+          ),
+        );
+        expect(decision).toBe("stop");
+      },
+    );
+
+    const { lifecycleParams, runtimeLog, runtimeError } = createLifecycleHarness({ gateway });
+    lifecycleParams.abortSignal = abortController.signal;
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
+    );
+    expect(runtimeError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Max reconnect attempts"),
+    );
   });
 
   it("rejects reconnect-exhausted queued before startup when shutdown has not begun", async () => {

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -66,8 +66,13 @@ export async function runDiscordGatewayLifecycle(params: {
     }
     // When we deliberately set maxAttempts=0 and disconnected (health-monitor
     // stale-socket restart), Carbon fires "Max reconnect attempts (0)". This
-    // is expected — log at info instead of error to avoid false alarms.
-    if (lifecycleStopping && event.type === "reconnect-exhausted") {
+    // can race with abort-driven shutdown before finally() flips
+    // `lifecycleStopping`, so also treat an already-aborted lifecycle as an
+    // expected stop instead of surfacing an uncaught failure.
+    if (
+      event.type === "reconnect-exhausted" &&
+      (lifecycleStopping || params.abortSignal?.aborted === true)
+    ) {
       params.runtime.log?.(
         `discord: ignoring expected reconnect-exhausted during shutdown: ${event.message}`,
       );


### PR DESCRIPTION
## Summary
- suppress expected Discord gateway reconnect-exhausted events once abort-driven shutdown has started
- cover both queued and actively-delivered reconnect-exhausted races during health-monitor stale-socket restarts
- keep the fix surgical in the Discord lifecycle handler without broad reconnect refactors

## Testing
- pnpm exec vitest run ./extensions/discord/src/monitor/provider.lifecycle.test.ts ./extensions/discord/src/monitor/gateway-supervisor.test.ts
- repo hooks/checks triggered by git commit (pnpm check subset + lint)