### PR TITLE
fix(memory): retry transient embedding transport failures

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -1,5 +1,11 @@
 import fs from "node:fs/promises";
 import {
+  collectErrorGraphCandidates,
+  extractErrorCode,
+  formatErrorMessage,
+  readErrorName,
+} from "openclaw/plugin-sdk/error-runtime";
+import {
   enforceEmbeddingMaxInputTokens,
   estimateStructuredEmbeddingInputBytes,
   estimateUtf8Bytes,
@@ -34,10 +40,127 @@ const EMBEDDING_QUERY_TIMEOUT_LOCAL_MS = 5 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_REMOTE_MS = 2 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_LOCAL_MS = 10 * 60_000;
 
+const TRANSIENT_NETWORK_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "ESOCKETTIMEDOUT",
+  "ECONNABORTED",
+  "EPIPE",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "EAI_AGAIN",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_DNS_RESOLVE_FAILED",
+  "UND_ERR_CONNECT",
+  "UND_ERR_SOCKET",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "EPROTO",
+  "ERR_SSL_WRONG_VERSION_NUMBER",
+  "ERR_SSL_PROTOCOL_RETURNED_AN_ERROR",
+]);
+
+const TRANSIENT_NETWORK_ERROR_NAMES = new Set([
+  "AbortError",
+  "ConnectTimeoutError",
+  "HeadersTimeoutError",
+  "BodyTimeoutError",
+  "TimeoutError",
+]);
+
+const TRANSIENT_NETWORK_MESSAGE_CODE_RE =
+  /\b(ECONNRESET|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ESOCKETTIMEDOUT|ECONNABORTED|EPIPE|EHOSTUNREACH|ENETUNREACH|EAI_AGAIN|EPROTO|UND_ERR_CONNECT_TIMEOUT|UND_ERR_DNS_RESOLVE_FAILED|UND_ERR_CONNECT|UND_ERR_SOCKET|UND_ERR_HEADERS_TIMEOUT|UND_ERR_BODY_TIMEOUT)\b/i;
+
+const TRANSIENT_NETWORK_MESSAGE_SNIPPETS = [
+  "getaddrinfo",
+  "socket hang up",
+  "client network socket disconnected before secure tls connection was established",
+  "network error",
+  "network is unreachable",
+  "temporary failure in name resolution",
+  "upstream connect error",
+  "disconnect/reset before headers",
+  "tlsv1 alert",
+  "ssl routines",
+  "packet length too long",
+  "write eproto",
+];
+
 const vectorToBlob = (embedding: number[]): Buffer =>
   Buffer.from(new Float32Array(embedding).buffer);
 
 const log = createSubsystemLogger("memory");
+
+function isWrappedFetchFailedMessage(message: string): boolean {
+  if (message === "fetch failed") {
+    return true;
+  }
+  return /:\s*fetch failed$/.test(message);
+}
+
+function extractErrorCodeOrErrno(err: unknown): string | undefined {
+  const code = extractErrorCode(err);
+  if (code) {
+    return code.trim().toUpperCase();
+  }
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const errno = (err as { errno?: unknown }).errno;
+  if (typeof errno === "string" && errno.trim()) {
+    return errno.trim().toUpperCase();
+  }
+  if (typeof errno === "number" && Number.isFinite(errno)) {
+    return String(errno);
+  }
+  return undefined;
+}
+
+function isTransientEmbeddingNetworkError(err: unknown): boolean {
+  if (!err) {
+    return false;
+  }
+  for (const candidate of collectErrorGraphCandidates(err, (current) => {
+    const nested: Array<unknown> = [
+      current.cause,
+      current.reason,
+      current.original,
+      current.error,
+      current.data,
+    ];
+    if (Array.isArray(current.errors)) {
+      nested.push(...current.errors);
+    }
+    return nested;
+  })) {
+    const code = extractErrorCodeOrErrno(candidate);
+    if (code && TRANSIENT_NETWORK_CODES.has(code)) {
+      return true;
+    }
+
+    const name = readErrorName(candidate);
+    if (name && TRANSIENT_NETWORK_ERROR_NAMES.has(name)) {
+      return true;
+    }
+
+    const message = formatErrorMessage(candidate).trim().toLowerCase();
+    if (!message) {
+      continue;
+    }
+    if (TRANSIENT_NETWORK_MESSAGE_CODE_RE.test(message)) {
+      return true;
+    }
+    if (isWrappedFetchFailedMessage(message)) {
+      return true;
+    }
+    if (TRANSIENT_NETWORK_MESSAGE_SNIPPETS.some((snippet) => message.includes(snippet))) {
+      return true;
+    }
+  }
+  return false;
+}
 
 export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   protected abstract batchFailureCount: number;
@@ -330,8 +453,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           `memory embeddings batch timed out after ${Math.round(timeoutMs / 1000)}s`,
         );
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        if (!this.isRetryableEmbeddingError(message) || attempt >= EMBEDDING_RETRY_MAX_ATTEMPTS) {
+        if (!this.isRetryableEmbeddingError(err) || attempt >= EMBEDDING_RETRY_MAX_ATTEMPTS) {
           throw err;
         }
         await this.waitForEmbeddingRetry(delayMs, "retrying");
@@ -364,8 +486,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           `memory embeddings batch timed out after ${Math.round(timeoutMs / 1000)}s`,
         );
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        if (!this.isRetryableEmbeddingError(message) || attempt >= EMBEDDING_RETRY_MAX_ATTEMPTS) {
+        if (!this.isRetryableEmbeddingError(err) || attempt >= EMBEDDING_RETRY_MAX_ATTEMPTS) {
           throw err;
         }
         await this.waitForEmbeddingRetry(delayMs, "retrying structured batch");
@@ -380,11 +501,15 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       EMBEDDING_RETRY_MAX_DELAY_MS,
       Math.round(delayMs * (1 + Math.random() * 0.2)),
     );
-    log.warn(`memory embeddings rate limited; ${action} in ${waitMs}ms`);
+    log.warn(`memory embeddings transient failure; ${action} in ${waitMs}ms`);
     await new Promise((resolve) => setTimeout(resolve, waitMs));
   }
 
-  private isRetryableEmbeddingError(message: string): boolean {
+  private isRetryableEmbeddingError(err: unknown): boolean {
+    if (isTransientEmbeddingNetworkError(err)) {
+      return true;
+    }
+    const message = formatErrorMessage(err);
     return /(rate[_ ]limit|too many requests|429|resource has been exhausted|5\d\d|cloudflare|tokens per day)/i.test(
       message,
     );

--- a/extensions/memory-core/src/memory/manager.embedding-batches.test.ts
+++ b/extensions/memory-core/src/memory/manager.embedding-batches.test.ts
@@ -124,6 +124,28 @@ describe("memory embedding batches", () => {
     expect(calls).toBe(3);
   }, 10000);
 
+  it("retries embeddings on transient fetch failures with network causes", async () => {
+    const memoryDir = fx.getMemoryDir();
+    const managerSmall = fx.getManagerSmall();
+    const line = "f".repeat(120);
+    const content = Array.from({ length: 4 }, () => line).join("\n");
+    await fs.writeFile(path.join(memoryDir, "2026-01-09.md"), content);
+
+    let calls = 0;
+    fx.embedBatch.mockImplementation(async (texts: string[]) => {
+      calls += 1;
+      if (calls === 1) {
+        const cause = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+        throw Object.assign(new TypeError("fetch failed"), { cause });
+      }
+      return texts.map(() => [0, 1, 0]);
+    });
+
+    await expectSyncWithFastTimeouts(managerSmall);
+
+    expect(calls).toBe(2);
+  }, 10000);
+
   it("retries embeddings on too-many-tokens-per-day rate limits", async () => {
     const memoryDir = fx.getMemoryDir();
     const managerSmall = fx.getManagerSmall();

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 import { type FSWatcher } from "chokidar";
+import { formatUncaughtError } from "openclaw/plugin-sdk/error-runtime";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -305,7 +306,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return;
     }
     void this.sync({ reason: "session-start" }).catch((err) => {
-      log.warn(`memory sync failed (session-start): ${String(err)}`);
+      log.warn(`memory sync failed (session-start): ${formatUncaughtError(err)}`);
     });
     if (key) {
       this.sessionWarm.add(key);
@@ -327,7 +328,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     void this.warmSession(opts?.sessionKey);
     if (this.settings.sync.onSearch && (this.dirty || this.sessionsDirty)) {
       void this.sync({ reason: "search" }).catch((err) => {
-        log.warn(`memory sync failed (search): ${String(err)}`);
+        log.warn(`memory sync failed (search): ${formatUncaughtError(err)}`);
       });
     }
     const hasIndexedContent = this.hasIndexedContent();

--- a/packages/memory-host-sdk/src/host/post-json.test.ts
+++ b/packages/memory-host-sdk/src/host/post-json.test.ts
@@ -56,4 +56,26 @@ describe("postJson", () => {
       status: 502,
     });
   });
+
+  it("wraps transport errors with prefix and cause details", async () => {
+    const cause = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+    const fetchError = Object.assign(new TypeError("fetch failed"), { cause });
+    remoteHttpMock.mockRejectedValueOnce(fetchError);
+
+    try {
+      await postJson({
+        url: "https://memory.example/v1/post",
+        headers: {},
+        body: {},
+        errorPrefix: "post failed",
+        parse: () => ({}),
+      });
+      throw new Error("expected postJson to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain("post failed: fetch failed");
+      expect((err as Error).message).toContain("cause: ECONNRESET socket hang up");
+      expect((err as Error & { cause?: unknown }).cause).toBe(fetchError);
+    }
+  });
 });

--- a/packages/memory-host-sdk/src/host/post-json.ts
+++ b/packages/memory-host-sdk/src/host/post-json.ts
@@ -1,5 +1,26 @@
+import { extractErrorCode, formatErrorMessage } from "../../../../src/infra/errors.js";
 import type { SsrFPolicy } from "../../../../src/infra/net/ssrf.js";
 import { withRemoteHttpResponse } from "./remote-http.js";
+
+function formatPostJsonCause(err: unknown): string {
+  if (!err || typeof err !== "object") {
+    return "";
+  }
+  const cause = (err as { cause?: unknown }).cause;
+  if (!cause) {
+    return "";
+  }
+  const parts: string[] = [];
+  const code = extractErrorCode(cause);
+  if (code) {
+    parts.push(code);
+  }
+  const message = formatErrorMessage(cause);
+  if (message && !parts.includes(message)) {
+    parts.push(message);
+  }
+  return parts.length > 0 ? ` (cause: ${parts.join(" ")})` : "";
+}
 
 export async function postJson<T>(params: {
   url: string;
@@ -10,26 +31,36 @@ export async function postJson<T>(params: {
   attachStatus?: boolean;
   parse: (payload: unknown) => T | Promise<T>;
 }): Promise<T> {
-  return await withRemoteHttpResponse({
-    url: params.url,
-    ssrfPolicy: params.ssrfPolicy,
-    init: {
-      method: "POST",
-      headers: params.headers,
-      body: JSON.stringify(params.body),
-    },
-    onResponse: async (res) => {
-      if (!res.ok) {
-        const text = await res.text();
-        const err = new Error(`${params.errorPrefix}: ${res.status} ${text}`) as Error & {
-          status?: number;
-        };
-        if (params.attachStatus) {
-          err.status = res.status;
+  try {
+    return await withRemoteHttpResponse({
+      url: params.url,
+      ssrfPolicy: params.ssrfPolicy,
+      init: {
+        method: "POST",
+        headers: params.headers,
+        body: JSON.stringify(params.body),
+      },
+      onResponse: async (res) => {
+        if (!res.ok) {
+          const text = await res.text();
+          const err = new Error(`${params.errorPrefix}: ${res.status} ${text}`) as Error & {
+            status?: number;
+          };
+          if (params.attachStatus) {
+            err.status = res.status;
+          }
+          throw err;
         }
-        throw err;
-      }
-      return await params.parse(await res.json());
-    },
-  });
+        return await params.parse(await res.json());
+      },
+    });
+  } catch (err) {
+    const message = formatErrorMessage(err);
+    if (message.startsWith(`${params.errorPrefix}:`)) {
+      throw err;
+    }
+    throw new Error(`${params.errorPrefix}: ${message}${formatPostJsonCause(err)}`, {
+      cause: err,
+    });
+  }
 }


### PR DESCRIPTION
## Summary

- Problem: memory indexing/search treated transient embedding transport failures like `fetch failed`, `ECONNRESET`, and `ENOTFOUND` as terminal errors.
- Why it matters: a single network blip could abort memory indexing, while logs often only showed a flattened `fetch failed` message.
- What changed: memory embedding retries now recognize transient transport failures, remote POST errors preserve prefix/cause detail, and async memory sync warnings use `formatUncaughtError(...)`.
- Scope boundary: this does not add checkpoint/resume for atomic reindexing or change rollback semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Related #56815
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: memory retry logic only matched rate-limit / 5xx-style messages, so transient transport-layer failures were not retried.
- Missing detection / guardrail: the memory path did not inspect nested `cause`/`errno`/undici-style transient network errors, and transport failures from `postJson` were not wrapped with provider context.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the memory engine moved behind the plugin/host split, but the retry heuristic remained message-string based.
- Why this regressed now: remote embedding failures can surface as transport exceptions instead of only HTTP status errors.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file:
  - `packages/memory-host-sdk/src/host/post-json.test.ts`
  - `packages/memory-host-sdk/src/host/embeddings-remote-fetch.test.ts`
  - `extensions/memory-core/src/memory/manager.embedding-batches.test.ts`
- Scenario the test should lock in: retry a transient `TypeError("fetch failed")` with `cause.code = "ECONNRESET"` and preserve wrapped error detail.

## User-visible / Behavior Changes

- Memory embeddings now retry on transient transport/network failures such as `fetch failed`, `ECONNRESET`, `ENOTFOUND`, and undici timeout/socket errors.
- Memory sync warnings for `session-start` and `search` now include stack/cause detail instead of flattening to `String(err)`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 + pnpm
- Model/provider: `openai` memory embeddings against a local fake `/v1/embeddings` endpoint
- Relevant config (redacted):
  - `agents.defaults.memorySearch.provider = "openai"`
  - `agents.defaults.memorySearch.model = "text-embedding-3-small"`
  - `agents.defaults.memorySearch.remote.baseUrl = "http://127.0.0.1:8765/v1"`
  - `agents.defaults.memorySearch.remote.apiKey = "dummy-key"`

### Steps

1. Start a fake embeddings server that drops the first `/v1/embeddings` request and succeeds on the second.
2. Run `openclaw memory index --force --verbose`.
3. Run `openclaw memory search "retry embeddings" --json`.

### Expected

- The first transient transport failure is retried automatically.
- Memory indexing completes successfully.
- Memory search returns the indexed `MEMORY.md` content.

### Actual

- Observed `memory embeddings transient failure; retrying in 555ms`.
- Fake server received `request #1` and `request #2`.
- `memory index --force --verbose` completed successfully.
- `memory search "retry embeddings" --json` returned the expected `MEMORY.md` result.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios:
  - Manual smoke with a fake embeddings server that intentionally drops the first request and succeeds on the second.
  - `memory index --force --verbose` completed after the retry.
  - `memory search --json` returned the indexed `MEMORY.md` snippet.
- Edge cases checked:
  - Existing retry behavior for rate-limit / 5xx errors still passes.
  - Existing remote fetch mapping still passes.
- What you did **not** verify:
  - Full long-running reindex against a large real remote provider.
  - Checkpoint/resume behavior after fatal non-retryable failures.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: some transport-shaped errors may now retry before failing.
  - Mitigation: retries are still bounded by the existing backoff / max-attempt limits.
- Risk: async memory sync warnings are now more verbose.
  - Mitigation: the change is limited to `session-start` / `search` warning paths, and secret redaction still applies.
