### PR TITLE
fix: stop bundled Feishu schema from rejecting valid plugin config

### DIFF
--- a/extensions/feishu/openclaw.plugin.json
+++ b/extensions/feishu/openclaw.plugin.json
@@ -4,7 +4,6 @@
   "skills": ["./skills"],
   "configSchema": {
     "type": "object",
-    "additionalProperties": false,
-    "properties": {}
+    "additionalProperties": true
   }
 }


### PR DESCRIPTION
## Summary
- make the bundled Feishu channel config schema permissive instead of rejecting unknown keys up front
- defer validation to the Feishu plugin's runtime schema, which already knows the real supported fields

## Why
The bundled metadata currently exposes an empty strict object, so core startup validation rejects valid Feishu options like `footer.elapsed` / `footer.status` before the plugin can parse them. Making the bundled schema permissive restores compatibility with the plugin's actual config surface.

Closes #56882
Closes #56883
