### PR TITLE
fix: lower xai bootstrap fallback log noise

### DIFF
--- a/src/agents/models-config.providers.secrets.ts
+++ b/src/agents/models-config.providers.secrets.ts
@@ -440,7 +440,7 @@ function resolveConfigBackedProviderAuth(params: { provider: string; config?: Op
   const apiKey = synthetic?.apiKey?.trim();
   if (!apiKey) {
     if (shouldTraceProviderAuth(params.provider)) {
-      log.info("[xai-auth] bootstrap config fallback: no config-backed key found");
+      log.debug("[xai-auth] bootstrap config fallback: no config-backed key found");
     }
     return undefined;
   }


### PR DESCRIPTION
## Summary
- downgrade the `[xai-auth]` bootstrap fallback message from INFO to DEBUG when no config-backed key exists

## Why
Users who do not configure xAI should not see an INFO-level startup message for an optional provider. This keeps gateway startup logs quieter without removing the trace entirely for debug sessions.

Closes #56884
