### PR TITLE
fix: trigger failover on terminated transport errors

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -655,6 +655,10 @@ describe("isFailoverErrorMessage", () => {
     ]);
   });
 
+  it("matches terminated transport errors as timeout", () => {
+    expectTimeoutFailoverSamples(["terminated", "rawError=terminated"]);
+  });
+
   it("does not classify MALFORMED_FUNCTION_CALL as timeout", () => {
     const sample = "Unhandled stop reason: MALFORMED_FUNCTION_CALL";
     expect(isTimeoutErrorMessage(sample)).toBe(false);

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -39,6 +39,7 @@ const ERROR_PATTERNS = {
     "connection reset",
   ],
   timeout: [
+    "terminated",
     "timeout",
     "timed out",
     "service unavailable",


### PR DESCRIPTION
## Summary
- classify plain `terminated` transport failures as retryable timeout errors
- add regression coverage for `terminated` and `rawError=terminated` samples

## Why
Proxy-backed providers can surface abrupt upstream disconnects as `terminated`, but this currently bypasses the fallback chain entirely. Mapping it to the existing timeout bucket restores expected model failover behavior for a common transient failure mode.

Closes #56875
