### PR TITLE
feat: IPv6 listening and custom user avatar support

### DIFF
--- a/src/agents/identity-avatar.ts
+++ b/src/agents/identity-avatar.ts
@@ -86,33 +86,13 @@ export function resolveAgentAvatar(cfg: OpenClawConfig, agentId: string): AgentA
     if (isAvatarDataUrl(userAvatar)) {
       return { kind: "data", url: userAvatar };
     }
-    // Treat relative user avatar paths as relative to the default workspace's avatars dir.
-    // This mirrors how agent avatars are stored (in their workspace/avatars/).
+    // Resolve relative to the default workspace root (mirrors agent avatar handling)
     const defaultWorkspace = cfg.agents?.defaults?.workspace || process.cwd();
-    const workspaceDir = resolveExistingPath(defaultWorkspace);
-    const resolved =
-      userAvatar.startsWith("~") || path.isAbsolute(userAvatar)
-        ? resolveUserPath(userAvatar)
-        : path.resolve(workspaceDir, "avatars", userAvatar);
-    const realPath = resolveExistingPath(resolved);
-    if (!isPathWithinRoot(workspaceDir, realPath)) {
-      return { kind: "none", reason: "outside_workspace" };
+    const resolved = resolveLocalAvatarPath({ raw: userAvatar, workspaceDir: defaultWorkspace });
+    if (!resolved.ok) {
+      return { kind: "none", reason: resolved.reason };
     }
-    if (!isSupportedLocalAvatarExtension(realPath)) {
-      return { kind: "none", reason: "unsupported_extension" };
-    }
-    try {
-      const stat = fs.statSync(realPath);
-      if (!stat.isFile()) {
-        return { kind: "none", reason: "missing" };
-      }
-      if (stat.size > AVATAR_MAX_BYTES) {
-        return { kind: "none", reason: "too_large" };
-      }
-    } catch {
-      return { kind: "none", reason: "missing" };
-    }
-    return { kind: "local", filePath: realPath };
+    return { kind: "local", filePath: resolved.filePath };
   }
 
   const source = resolveAvatarSource(cfg, agentId);

--- a/src/agents/identity-avatar.ts
+++ b/src/agents/identity-avatar.ts
@@ -74,27 +74,6 @@ function resolveLocalAvatarPath(params: {
 }
 
 export function resolveAgentAvatar(cfg: OpenClawConfig, agentId: string): AgentAvatarResolution {
-  // Special case: "user" refers to the user avatar override from ui.userAvatar
-  if (agentId === "user") {
-    const userAvatar = normalizeAvatarValue(cfg.ui?.userAvatar);
-    if (!userAvatar) {
-      return { kind: "none", reason: "missing" };
-    }
-    if (isAvatarHttpUrl(userAvatar)) {
-      return { kind: "remote", url: userAvatar };
-    }
-    if (isAvatarDataUrl(userAvatar)) {
-      return { kind: "data", url: userAvatar };
-    }
-    // Resolve relative to the default workspace root (mirrors agent avatar handling)
-    const defaultWorkspace = cfg.agents?.defaults?.workspace || process.cwd();
-    const resolved = resolveLocalAvatarPath({ raw: userAvatar, workspaceDir: defaultWorkspace });
-    if (!resolved.ok) {
-      return { kind: "none", reason: resolved.reason };
-    }
-    return { kind: "local", filePath: resolved.filePath };
-  }
-
   const source = resolveAvatarSource(cfg, agentId);
   if (!source) {
     return { kind: "none", reason: "missing" };

--- a/src/agents/identity-avatar.ts
+++ b/src/agents/identity-avatar.ts
@@ -91,3 +91,5 @@ export function resolveAgentAvatar(cfg: OpenClawConfig, agentId: string): AgentA
   }
   return { kind: "local", filePath: resolved.filePath };
 }
+
+export { resolveLocalAvatarPath };

--- a/src/agents/identity-avatar.ts
+++ b/src/agents/identity-avatar.ts
@@ -74,6 +74,47 @@ function resolveLocalAvatarPath(params: {
 }
 
 export function resolveAgentAvatar(cfg: OpenClawConfig, agentId: string): AgentAvatarResolution {
+  // Special case: "user" refers to the user avatar override from ui.userAvatar
+  if (agentId === "user") {
+    const userAvatar = normalizeAvatarValue(cfg.ui?.userAvatar);
+    if (!userAvatar) {
+      return { kind: "none", reason: "missing" };
+    }
+    if (isAvatarHttpUrl(userAvatar)) {
+      return { kind: "remote", url: userAvatar };
+    }
+    if (isAvatarDataUrl(userAvatar)) {
+      return { kind: "data", url: userAvatar };
+    }
+    // Treat relative user avatar paths as relative to the default workspace's avatars dir.
+    // This mirrors how agent avatars are stored (in their workspace/avatars/).
+    const defaultWorkspace = cfg.agents?.defaults?.workspace || process.cwd();
+    const workspaceDir = resolveExistingPath(defaultWorkspace);
+    const resolved =
+      userAvatar.startsWith("~") || path.isAbsolute(userAvatar)
+        ? resolveUserPath(userAvatar)
+        : path.resolve(workspaceDir, "avatars", userAvatar);
+    const realPath = resolveExistingPath(resolved);
+    if (!isPathWithinRoot(workspaceDir, realPath)) {
+      return { kind: "none", reason: "outside_workspace" };
+    }
+    if (!isSupportedLocalAvatarExtension(realPath)) {
+      return { kind: "none", reason: "unsupported_extension" };
+    }
+    try {
+      const stat = fs.statSync(realPath);
+      if (!stat.isFile()) {
+        return { kind: "none", reason: "missing" };
+      }
+      if (stat.size > AVATAR_MAX_BYTES) {
+        return { kind: "none", reason: "too_large" };
+      }
+    } catch {
+      return { kind: "none", reason: "missing" };
+    }
+    return { kind: "local", filePath: realPath };
+  }
+
   const source = resolveAvatarSource(cfg, agentId);
   if (!source) {
     return { kind: "none", reason: "missing" };

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -513,6 +513,10 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
             type: "string",
             pattern: "^#?[0-9a-fA-F]{6}$",
           },
+          userAvatar: {
+            type: "string",
+            maxLength: 200,
+          },
           assistant: {
             type: "object",
             properties: {

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -85,6 +85,8 @@ export type OpenClawConfig = {
   ui?: {
     /** Accent color for OpenClaw UI chrome (hex). */
     seamColor?: string;
+    /** User avatar override for Control UI (URL, path, or data URI). */
+    userAvatar?: string;
     assistant?: {
       /** Assistant display name for UI surfaces. */
       name?: string;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -417,7 +417,7 @@ export const OpenClawSchema = z
     ui: z
       .object({
         seamColor: HexColorSchema.optional(),
-        userAvatar: z.string().optional(),
+        userAvatar: z.string().max(200).optional(),
         assistant: z
           .object({
             name: z.string().max(50).optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -417,6 +417,7 @@ export const OpenClawSchema = z
     ui: z
       .object({
         seamColor: HexColorSchema.optional(),
+        userAvatar: z.string().optional(),
         assistant: z
           .object({
             name: z.string().max(50).optional(),

--- a/src/gateway/assistant-identity.test.ts
+++ b/src/gateway/assistant-identity.test.ts
@@ -53,9 +53,9 @@ describe("resolveUserAvatar", () => {
     expect(resolveUserAvatar(cfg)).toBeNull();
   });
 
-  it("keeps valid short text avatar", () => {
+  it("rejects short text avatars (UI cannot render)", () => {
     const cfg: OpenClawConfig = { ui: { userAvatar: "U" } };
-    expect(resolveUserAvatar(cfg)).toBe("U");
+    expect(resolveUserAvatar(cfg)).toBeNull();
   });
 
   it("keeps valid avatar path", () => {

--- a/src/gateway/assistant-identity.test.ts
+++ b/src/gateway/assistant-identity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity } from "./assistant-identity.js";
+import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity, resolveUserAvatar } from "./assistant-identity.js";
 
 describe("resolveAssistantIdentity avatar normalization", () => {
   it("drops sentence-like avatar placeholders", () => {
@@ -39,5 +39,37 @@ describe("resolveAssistantIdentity avatar normalization", () => {
     };
 
     expect(resolveAssistantIdentity({ cfg, workspaceDir: "" }).avatar).toBe("avatars/openclaw.png");
+  });
+});
+
+describe("resolveUserAvatar", () => {
+  it("returns null when userAvatar not set", () => {
+    const cfg: OpenClawConfig = {};
+    expect(resolveUserAvatar(cfg)).toBeNull();
+  });
+
+  it("returns null when userAvatar is empty string", () => {
+    const cfg: OpenClawConfig = { ui: { userAvatar: "" } };
+    expect(resolveUserAvatar(cfg)).toBeNull();
+  });
+
+  it("keeps valid short text avatar", () => {
+    const cfg: OpenClawConfig = { ui: { userAvatar: "U" } };
+    expect(resolveUserAvatar(cfg)).toBe("U");
+  });
+
+  it("keeps valid avatar path", () => {
+    const cfg: OpenClawConfig = { ui: { userAvatar: "avatars/user.png" } };
+    expect(resolveUserAvatar(cfg)).toBe("avatars/user.png");
+  });
+
+  it("drops sentence-like avatar (too long with spaces)", () => {
+    const cfg: OpenClawConfig = { ui: { userAvatar: "this is a sentence" } };
+    expect(resolveUserAvatar(cfg)).toBeNull();
+  });
+
+  it("keeps URL avatars", () => {
+    const cfg: OpenClawConfig = { ui: { userAvatar: "https://example.com/avatar.png" } };
+    expect(resolveUserAvatar(cfg)).toBe("https://example.com/avatar.png");
   });
 });

--- a/src/gateway/assistant-identity.ts
+++ b/src/gateway/assistant-identity.ts
@@ -120,7 +120,8 @@ export function resolveAssistantIdentity(params: {
 
 /**
  * Resolve user avatar from config.ui.userAvatar.
- * Validates the avatar value using the same policy as assistant avatars.
+ * Only URL-like (http/https/data:image) or path-like values are accepted.
+ * Short text/emojis are rejected to align with UI rendering behavior.
  *
  * @param cfg - OpenClaw configuration
  * @returns User avatar string if valid, otherwise null
@@ -130,7 +131,14 @@ export function resolveUserAvatar(cfg: OpenClawConfig): string | null {
   if (!raw) {
     return null;
   }
-  const coerced = coerceIdentityValue(raw, MAX_USER_AVATAR);
-  const normalized = normalizeAvatarValue(coerced);
-  return normalized ?? null;
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  // Accept only HTTP URLs, data URLs, or file paths (containing path separators or image extensions)
+  if (isAvatarHttpUrl(trimmed) || isAvatarImageDataUrl(trimmed) || looksLikeAvatarPath(trimmed)) {
+    return trimmed;
+  }
+  // Reject short text/emojis
+  return null;
 }

--- a/src/gateway/assistant-identity.ts
+++ b/src/gateway/assistant-identity.ts
@@ -13,6 +13,7 @@ import {
 const MAX_ASSISTANT_NAME = 50;
 const MAX_ASSISTANT_AVATAR = 200;
 const MAX_ASSISTANT_EMOJI = 16;
+const MAX_USER_AVATAR = 200;
 
 export const DEFAULT_ASSISTANT_IDENTITY: AssistantIdentity = {
   agentId: "main",
@@ -115,4 +116,21 @@ export function resolveAssistantIdentity(params: {
   const emoji = emojiCandidates.map((candidate) => normalizeEmojiValue(candidate)).find(Boolean);
 
   return { agentId, name, avatar, emoji };
+}
+
+/**
+ * Resolve user avatar from config.ui.userAvatar.
+ * Validates the avatar value using the same policy as assistant avatars.
+ *
+ * @param cfg - OpenClaw configuration
+ * @returns User avatar string if valid, otherwise null
+ */
+export function resolveUserAvatar(cfg: OpenClawConfig): string | null {
+  const raw = cfg.ui?.userAvatar;
+  if (!raw) {
+    return null;
+  }
+  const coerced = coerceIdentityValue(raw, MAX_USER_AVATAR);
+  const normalized = normalizeAvatarValue(coerced);
+  return normalized ?? null;
 }

--- a/src/gateway/assistant-identity.ts
+++ b/src/gateway/assistant-identity.ts
@@ -13,7 +13,6 @@ import {
 const MAX_ASSISTANT_NAME = 50;
 const MAX_ASSISTANT_AVATAR = 200;
 const MAX_ASSISTANT_EMOJI = 16;
-const MAX_USER_AVATAR = 200;
 
 export const DEFAULT_ASSISTANT_IDENTITY: AssistantIdentity = {
   agentId: "main",

--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -5,5 +5,6 @@ export type ControlUiBootstrapConfig = {
   assistantName: string;
   assistantAvatar: string;
   assistantAgentId: string;
+  userAvatar?: string | null;
   serverVersion?: string;
 };

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -248,7 +248,8 @@ describe("handleControlUiHttpRequest", () => {
         );
         expect(handled).toBe(true);
         const parsed = parseBootstrapPayload(end);
-        expect(parsed.userAvatar).toBe("user-custom.png");
+        // userAvatar is now resolved through resolveAssistantAvatarUrl (agentId "user")
+        expect(parsed.userAvatar).toBe("/avatar/user");
       },
     });
   });

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -28,6 +28,7 @@ describe("handleControlUiHttpRequest", () => {
       assistantName: string;
       assistantAvatar: string;
       assistantAgentId: string;
+      userAvatar?: string | null;
     };
   }
 
@@ -223,6 +224,31 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.assistantName).toBe("Ops");
         expect(parsed.assistantAvatar).toBe("/openclaw/avatar/main");
         expect(parsed.assistantAgentId).toBe("main");
+      },
+    });
+  });
+
+  it("includes userAvatar in bootstrap config when set", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { res, end } = makeMockHttpResponse();
+        const handled = handleControlUiHttpRequest(
+          { url: CONTROL_UI_BOOTSTRAP_CONFIG_PATH, method: "GET" } as IncomingMessage,
+          res,
+          {
+            root: { kind: "resolved", path: tmp },
+            config: {
+              agents: { defaults: { workspace: tmp } },
+              ui: {
+                assistant: { name: "Assistant", avatar: "assistant.png" },
+                userAvatar: "user-custom.png",
+              },
+            },
+          },
+        );
+        expect(handled).toBe(true);
+        const parsed = parseBootstrapPayload(end);
+        expect(parsed.userAvatar).toBe("user-custom.png");
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -354,7 +354,17 @@ export function handleControlUiHttpRequest(
       agentId: identity.agentId,
       basePath,
     });
-    const userAvatar = config ? resolveUserAvatar(config) : null;
+
+    // Resolve user avatar with same URL transformation as assistant avatar.
+    // Use a fixed agentId "user" for user avatar path resolution.
+    const rawUserAvatar = config ? resolveUserAvatar(config) : null;
+    const userAvatar = rawUserAvatar
+      ? resolveAssistantAvatarUrl({
+          avatar: rawUserAvatar,
+          agentId: "user",
+          basePath,
+        })
+      : null;
     if (req.method === "HEAD") {
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/json; charset=utf-8");

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -11,7 +11,7 @@ import { isWithinDir } from "../infra/path-safety.js";
 import { openVerifiedFileSync } from "../infra/safe-open-sync.js";
 import { AVATAR_MAX_BYTES } from "../shared/avatar-policy.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
-import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity } from "./assistant-identity.js";
+import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity, resolveUserAvatar } from "./assistant-identity.js";
 import {
   CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
   type ControlUiBootstrapConfig,
@@ -354,6 +354,7 @@ export function handleControlUiHttpRequest(
       agentId: identity.agentId,
       basePath,
     });
+    const userAvatar = config ? resolveUserAvatar(config) : null;
     if (req.method === "HEAD") {
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/json; charset=utf-8");
@@ -366,6 +367,7 @@ export function handleControlUiHttpRequest(
       assistantName: identity.name,
       assistantAvatar: avatarValue ?? identity.avatar,
       assistantAgentId: identity.agentId,
+      userAvatar,
       serverVersion: resolveRuntimeServiceVersion(process.env),
     } satisfies ControlUiBootstrapConfig);
     return true;

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -312,13 +312,29 @@ export async function resolveGatewayListenHosts(
   bindHost: string,
   opts?: { canBindToHost?: (host: string) => Promise<boolean> },
 ): Promise<string[]> {
-  if (bindHost !== "127.0.0.1") {
+  // If bindHost is not loopback IPv4, keep existing logic
+  if (bindHost !== "127.0.0.1" && bindHost !== "0.0.0.0") {
     return [bindHost];
   }
+
   const canBind = opts?.canBindToHost ?? canBindToHost;
-  if (await canBind("::1")) {
-    return [bindHost, "::1"];
+
+  // For 0.0.0.0 (bind all IPv4), also try to bind to :: (all IPv6) if available
+  if (bindHost === "0.0.0.0") {
+    if (await canBind("::")) {
+      return ["0.0.0.0", "::"];
+    }
+    return ["0.0.0.0"];
   }
+
+  // For 127.0.0.1, try to add ::1 for IPv6 loopback
+  if (bindHost === "127.0.0.1") {
+    if (await canBind("::1")) {
+      return [bindHost, "::1"];
+    }
+    return [bindHost];
+  }
+
   return [bindHost];
 }
 

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -319,13 +319,27 @@ export async function resolveGatewayListenHosts(
 
   const canBind = opts?.canBindToHost ?? canBindToHost;
 
-  // For 0.0.0.0 (bind all IPv4), if IPv6 is available, bind to :: only.
-  // :: accepts both IPv4 and IPv6 connections on most systems (dual-stack).
+  // For 0.0.0.0 (bind all IPv4), we want to ensure both IPv4 and IPv6 connectivity.
+  // On systems with dual-stack (default Linux/macOS, net.ipv6only=0), binding to ::
+  // automatically accepts IPv4-mapped addresses, and binding to 0.0.0.0 afterwards would
+  // fail with EADDRINUSE. On IPv6-only systems (net.ipv6only=1), :: does NOT accept
+  // IPv4, so we must bind both 0.0.0.0 and :: separately.
   if (bindHost === "0.0.0.0") {
-    if (await canBind("::")) {
-      return ["::"];
+    const ipv6Available = await canBind("::");
+    if (!ipv6Available) {
+      return ["0.0.0.0"]; // IPv6 not available, IPv4 only
     }
-    return ["0.0.0.0"];
+
+    // Check if :: and 0.0.0.0 conflict (dual-stack case).
+    // If 0.0.0.0 can still bind after ::, then they are independent (IPv6-only).
+    // We test by attempting to bind 0.0.0.0 IN ISOLATION (not after ::).
+    const ipv4Independent = await canBind("0.0.0.0");
+    if (ipv4Independent) {
+      // System is IPv6-only or custom config; bind both to keep IPv4 reachable.
+      return ["0.0.0.0", "::"];
+    }
+    // Dual-stack: :: covers both IPv4 and IPv6, just bind it.
+    return ["::"];
   }
 
   // For 127.0.0.1, try to add ::1 for IPv6 loopback

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -319,10 +319,11 @@ export async function resolveGatewayListenHosts(
 
   const canBind = opts?.canBindToHost ?? canBindToHost;
 
-  // For 0.0.0.0 (bind all IPv4), also try to bind to :: (all IPv6) if available
+  // For 0.0.0.0 (bind all IPv4), if IPv6 is available, bind to :: only.
+  // :: accepts both IPv4 and IPv6 connections on most systems (dual-stack).
   if (bindHost === "0.0.0.0") {
     if (await canBind("::")) {
-      return ["0.0.0.0", "::"];
+      return ["::"];
     }
     return ["0.0.0.0"];
   }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -17,6 +17,12 @@ import { handleSlackHttpRequest } from "../plugin-sdk/slack.js";
 import { resolveHookExternalContentSource as resolveHookExternalContentSourceFromSession } from "../security/external-content.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import {
+  isAvatarDataUrl,
+  isAvatarHttpUrl,
+} from "../shared/avatar-policy.js";
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { resolveLocalAvatarPath } from "../agents/identity-avatar.js";
+import {
   AUTH_RATE_LIMIT_SCOPE_HOOK_AUTH,
   createAuthRateLimiter,
   normalizeRateLimitClientIp,
@@ -959,9 +965,28 @@ export function createGatewayHttpServer(opts: {
           run: () =>
             handleControlUiAvatarRequest(req, res, {
               basePath: controlUiBasePath,
-              resolveAvatar: (agentId) => resolveAgentAvatar(configSnapshot, agentId),
+              resolveAvatar: (agentId) => {
+                if (agentId === "user") {
+                  // Resolve user avatar from config.ui.userAvatar
+                  const raw = configSnapshot.ui?.userAvatar?.trim();
+                  if (!raw) {
+                    return { kind: "none", reason: "missing" };
+                  }
+                  if (isAvatarHttpUrl(raw) || isAvatarDataUrl(raw)) {
+                    return { kind: isAvatarHttpUrl(raw) ? "remote" : "data", url: raw };
+                  }
+                  // Resolve relative to the default workspace (same as agent avatars)
+                  const workspaceDir = resolveAgentWorkspaceDir(configSnapshot, "default");
+                  const resolved = resolveLocalAvatarPath({ raw, workspaceDir });
+                  if (!resolved.ok) {
+                    return { kind: "none", reason: resolved.reason };
+                  }
+                  return { kind: "local", filePath: resolved.filePath };
+                }
+                return resolveAgentAvatar(configSnapshot, agentId);
+              },
             }),
-        });
+            });
         requestStages.push({
           name: "control-ui-http",
           run: () =>

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -9,6 +9,7 @@ import { createServer as createHttpsServer } from "node:https";
 import type { TlsOptions } from "node:tls";
 import type { WebSocketServer } from "ws";
 import { resolveAgentAvatar } from "../agents/identity-avatar.js";
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { CANVAS_WS_PATH, handleA2uiHttpRequest } from "../canvas-host/a2ui.js";
 import type { CanvasHostHandler } from "../canvas-host/server.js";
 import { loadConfig } from "../config/config.js";
@@ -20,8 +21,6 @@ import {
   isAvatarDataUrl,
   isAvatarHttpUrl,
 } from "../shared/avatar-policy.js";
-import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
-import { resolveLocalAvatarPath } from "../agents/identity-avatar.js";
 import {
   AUTH_RATE_LIMIT_SCOPE_HOOK_AUTH,
   createAuthRateLimiter,
@@ -967,7 +966,7 @@ export function createGatewayHttpServer(opts: {
               basePath: controlUiBasePath,
               resolveAvatar: (agentId) => {
                 if (agentId === "user") {
-                  // Resolve user avatar from config.ui.userAvatar
+                  // Resolve user avatar from config.ui.userAvatar using the same workspace resolution as agents
                   const raw = configSnapshot.ui?.userAvatar?.trim();
                   if (!raw) {
                     return { kind: "none", reason: "missing" };
@@ -975,18 +974,19 @@ export function createGatewayHttpServer(opts: {
                   if (isAvatarHttpUrl(raw) || isAvatarDataUrl(raw)) {
                     return { kind: isAvatarHttpUrl(raw) ? "remote" : "data", url: raw };
                   }
-                  // Resolve relative to the default workspace (same as agent avatars)
+                  // Resolve relative path using default workspace (same as resolveAgentAvatar does)
                   const workspaceDir = resolveAgentWorkspaceDir(configSnapshot, "default");
-                  const resolved = resolveLocalAvatarPath({ raw, workspaceDir });
-                  if (!resolved.ok) {
-                    return { kind: "none", reason: resolved.reason };
-                  }
-                  return { kind: "local", filePath: resolved.filePath };
+                  const resolved = resolveAgentAvatar(configSnapshot, "default") as
+                    | { kind: "local"; filePath: string }
+                    | { kind: "none"; reason: string };
+                  // For simplicity, we try to construct the path directly; validation will be done by the handler
+                  const filePath = path.resolve(workspaceDir, raw);
+                  return { kind: "local", filePath };
                 }
                 return resolveAgentAvatar(configSnapshot, agentId);
               },
             }),
-            });
+        });
         requestStages.push({
           name: "control-ui-http",
           run: () =>

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -6,6 +6,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
+import path from "node:path";
 import type { TlsOptions } from "node:tls";
 import type { WebSocketServer } from "ws";
 import { resolveAgentAvatar } from "../agents/identity-avatar.js";

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -11,6 +11,7 @@ import type { TlsOptions } from "node:tls";
 import type { WebSocketServer } from "ws";
 import { resolveAgentAvatar } from "../agents/identity-avatar.js";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { resolveLocalAvatarPath } from "../agents/identity-avatar.js";
 import { CANVAS_WS_PATH, handleA2uiHttpRequest } from "../canvas-host/a2ui.js";
 import type { CanvasHostHandler } from "../canvas-host/server.js";
 import { loadConfig } from "../config/config.js";
@@ -967,7 +968,7 @@ export function createGatewayHttpServer(opts: {
               basePath: controlUiBasePath,
               resolveAvatar: (agentId) => {
                 if (agentId === "user") {
-                  // Resolve user avatar from config.ui.userAvatar using the same workspace resolution as agents
+                  // Resolve user avatar from config.ui.userAvatar with same validation as agents
                   const raw = configSnapshot.ui?.userAvatar?.trim();
                   if (!raw) {
                     return { kind: "none", reason: "missing" };
@@ -975,14 +976,13 @@ export function createGatewayHttpServer(opts: {
                   if (isAvatarHttpUrl(raw) || isAvatarDataUrl(raw)) {
                     return { kind: isAvatarHttpUrl(raw) ? "remote" : "data", url: raw };
                   }
-                  // Resolve relative path using default workspace (same as resolveAgentAvatar does)
+                  // Resolve relative path using default workspace and validate
                   const workspaceDir = resolveAgentWorkspaceDir(configSnapshot, "default");
-                  const resolved = resolveAgentAvatar(configSnapshot, "default") as
-                    | { kind: "local"; filePath: string }
-                    | { kind: "none"; reason: string };
-                  // For simplicity, we try to construct the path directly; validation will be done by the handler
-                  const filePath = path.resolve(workspaceDir, raw);
-                  return { kind: "local", filePath };
+                  const resolved = resolveLocalAvatarPath({ raw, workspaceDir });
+                  if (!resolved.ok) {
+                    return { kind: "none", reason: resolved.reason };
+                  }
+                  return { kind: "local", filePath: resolved.filePath };
                 }
                 return resolveAgentAvatar(configSnapshot, agentId);
               },

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -6,7 +6,6 @@ import {
   type ServerResponse,
 } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
-import path from "node:path";
 import type { TlsOptions } from "node:tls";
 import type { WebSocketServer } from "ws";
 import { resolveAgentAvatar } from "../agents/identity-avatar.js";

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -28,6 +28,7 @@ type LifecycleHost = {
   assistantName: string;
   assistantAvatar: string | null;
   assistantAgentId: string | null;
+  userAvatar?: string | null;
   serverVersion: string | null;
   chatHasAutoScrolled: boolean;
   chatManualRefreshInFlight: boolean;

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -28,7 +28,7 @@ type LifecycleHost = {
   assistantName: string;
   assistantAvatar: string | null;
   assistantAgentId: string | null;
-  userAvatar?: string | null;
+  userAvatar: string | null;
   serverVersion: string | null;
   chatHasAutoScrolled: boolean;
   chatManualRefreshInFlight: boolean;

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -63,7 +63,7 @@ function extractImages(message: unknown): ImageBlock[] {
 export function renderReadingIndicatorGroup(assistant?: AssistantIdentity, basePath?: string) {
   return html`
     <div class="chat-group assistant">
-      ${renderAvatar("assistant", assistant, basePath)}
+      ${renderAvatar("assistant", assistant, undefined, basePath)}
       <div class="chat-group-messages">
         <div class="chat-bubble chat-reading-indicator" aria-hidden="true">
           <span class="chat-reading-indicator__dots">
@@ -90,7 +90,7 @@ export function renderStreamingGroup(
 
   return html`
     <div class="chat-group assistant">
-      ${renderAvatar("assistant", assistant, basePath)}
+      ${renderAvatar("assistant", assistant, undefined, basePath)}
       <div class="chat-group-messages">
         ${renderGroupedMessage(
           {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -118,6 +118,7 @@ export function renderMessageGroup(
     showToolCalls?: boolean;
     assistantName?: string;
     assistantAvatar?: string | null;
+    userAvatar?: string | null;
     basePath?: string;
     contextWindow?: number | null;
     onDelete?: () => void;
@@ -158,6 +159,7 @@ export function renderMessageGroup(
           name: assistantName,
           avatar: opts.assistantAvatar ?? null,
         },
+        opts.userAvatar ?? null,
         opts.basePath,
       )}
       <div class="chat-group-messages">
@@ -437,6 +439,7 @@ function renderTtsButton(group: MessageGroup) {
 function renderAvatar(
   role: string,
   assistant?: Pick<AssistantIdentity, "name" | "avatar">,
+  userAvatar?: string | null,
   basePath?: string,
 ) {
   const normalized = normalizeRoleForGrouping(role);
@@ -487,6 +490,14 @@ function renderAvatar(
         : normalized === "tool"
           ? "tool"
           : "other";
+
+  // User avatar override (from config)
+  if (userAvatar && normalized === "user") {
+    if (isAvatarUrl(userAvatar)) {
+      return html`<img class="chat-avatar ${className}" src="${userAvatar}" alt="You" />`;
+    }
+    // Non-URL avatar: fall back to initial
+  }
 
   if (assistantAvatar && normalized === "assistant") {
     if (isAvatarUrl(assistantAvatar)) {

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -23,6 +23,7 @@ describe("loadControlUiBootstrapConfig", () => {
       assistantName: "Assistant",
       assistantAvatar: null,
       assistantAgentId: null,
+      userAvatar: null,
       serverVersion: null,
     };
 
@@ -49,6 +50,7 @@ describe("loadControlUiBootstrapConfig", () => {
       assistantName: "Assistant",
       assistantAvatar: null,
       assistantAgentId: null,
+      userAvatar: null,
       serverVersion: null,
     };
 
@@ -72,6 +74,7 @@ describe("loadControlUiBootstrapConfig", () => {
       assistantName: "Assistant",
       assistantAvatar: null,
       assistantAgentId: null,
+      userAvatar: null,
       serverVersion: null,
     };
 

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -10,6 +10,7 @@ export type ControlUiBootstrapState = {
   assistantName: string;
   assistantAvatar: string | null;
   assistantAgentId: string | null;
+  userAvatar: string | null;
   serverVersion: string | null;
 };
 
@@ -44,6 +45,7 @@ export async function loadControlUiBootstrapConfig(state: ControlUiBootstrapStat
     state.assistantName = normalized.name;
     state.assistantAvatar = normalized.avatar;
     state.assistantAgentId = normalized.agentId ?? null;
+    state.userAvatar = parsed.userAvatar ?? null;
     state.serverVersion = parsed.serverVersion ?? null;
   } catch {
     // Ignore bootstrap failures; UI will update identity after connecting.

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -82,6 +82,7 @@ export type ChatProps = {
   splitRatio?: number;
   assistantName: string;
   assistantAvatar: string | null;
+  userAvatar?: string | null;
   attachments?: ChatAttachment[];
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
   showNewMessages?: boolean;
@@ -1022,6 +1023,7 @@ export function renderChat(props: ChatProps) {
                 showToolCalls: props.showToolCalls,
                 assistantName: props.assistantName,
                 assistantAvatar: assistantIdentity.avatar,
+                userAvatar: props.userAvatar ?? null,
                 basePath: props.basePath,
                 contextWindow:
                   activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null,


### PR DESCRIPTION
- net: resolveGatewayListenHosts now binds to both 0.0.0.0 (IPv4) and :: (IPv6) when gateway.bind="lan" and IPv6 is available. Falls back gracefully if IPv6 disabled.

- ui: Add ui.userAvatar config option to override user avatar in Control UI.

  * assistant-identity.ts: add resolveUserAvatar() helper
  * control-ui-contract.ts: add userAvatar to bootstrap config
  * control-ui.ts: include userAvatar in bootstrap response
  * control-ui-bootstrap.ts: consume userAvatar into UI state

- Tests: Updated related test files to reflect new interfaces.