### PR TITLE
fix(sandbox): add CJK fonts to browser image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Memory/QMD: honor `memory.qmd.update.embedInterval` even when regular QMD update cadence is disabled or slower by arming a dedicated embed-cadence maintenance timer, while avoiding redundant timers when regular updates are already frequent enough. (#37326) Thanks @barronlroth.
 - Agents/memory flush: keep daily memory flush files append-only during embedded attempts so compaction writes do not overwrite earlier notes. (#53725) Thanks @HPluseven.
 - Web UI/markdown: stop bare auto-links from swallowing adjacent CJK text while preserving valid mixed-script path and query characters in rendered links. (#48410) Thanks @jnuyao.
+- Sandbox/browser: install `fonts-noto-cjk` in the sandbox browser image so screenshots render Chinese, Japanese, and Korean text correctly instead of tofu boxes. Fixes #35597. Thanks @carrotRakko and @vincentkoc.
 - Memory/FTS: add configurable trigram tokenization plus short-CJK substring fallback so memory search can find Chinese, Japanese, and Korean text without breaking mixed long-and-short queries. Thanks @carrotRakko.
 - Hooks/config: accept runtime channel plugin ids in `hooks.mappings[].channel` (for example `feishu`) instead of rejecting non-core channels during config validation. (#56226) Thanks @AiKrai001.
 - TUI/chat: keep optimistic outbound user messages visible during active runs by deferring local-run binding until the first gateway chat event reveals the real run id, preventing premature history reloads from wiping pending local sends. (#54722) Thanks @seanturner001.

--- a/Dockerfile.sandbox-browser
+++ b/Dockerfile.sandbox-browser
@@ -14,6 +14,7 @@ RUN --mount=type=cache,id=openclaw-sandbox-bookworm-apt-cache,target=/var/cache/
     chromium \
     curl \
     fonts-liberation \
+    fonts-noto-cjk \
     fonts-noto-color-emoji \
     git \
     jq \


### PR DESCRIPTION
## Summary

- Problem: `Dockerfile.sandbox-browser` installs Latin and emoji fonts, but not CJK system fonts.
- Why it matters: browser-tool screenshots of Chinese, Japanese, and Korean pages render tofu boxes instead of readable text.
- What changed: added `fonts-noto-cjk` to the sandbox browser image package list.
- What did NOT change (scope boundary): no sandbox runtime behavior, browser logic, or screenshot code paths changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #35597
- Related #35597
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the sandbox browser container image lacked any installed CJK font family.
- Missing detection / guardrail: no image-level validation exists for non-Latin screenshot rendering.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue report from @carrotRakko identified the missing package directly.
- Why this regressed now: not a new regression; it is a longstanding image gap.
- If unknown, what was ruled out: ruled out screenshot code-path issues because the image package list only included `fonts-liberation` and `fonts-noto-color-emoji`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: N/A
- Scenario the test should lock in: container image contains fallback CJK fonts for browser screenshots.
- Why this is the smallest reliable guardrail: this is a Docker package-list fix; there is no existing small automated font-render test seam here.
- Existing test that already covers this (if any): none
- If no new test is added, why not: meaningful validation would require building the image and rendering CJK content inside the sandbox browser container.

## User-visible / Behavior Changes

Browser tool screenshots from the sandbox browser image now render Chinese, Japanese, and Korean text with system fonts instead of tofu boxes.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: `Dockerfile.sandbox-browser`
- Model/provider: N/A
- Integration/channel (if any): browser sandbox image
- Relevant config (redacted): N/A

### Steps

1. Inspect `Dockerfile.sandbox-browser` package list.
2. Confirm the image installs `fonts-liberation` and `fonts-noto-color-emoji`, but no CJK font package.
3. Add `fonts-noto-cjk`.

### Expected

- The sandbox browser image includes a CJK-capable fallback font family for screenshots.

### Actual

- Before this patch, the image lacked a CJK fallback font package.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: inspected the sandbox browser Docker package list before/after; confirmed the requested package is now installed in the image definition.
- Edge cases checked: kept the change limited to the base `fonts-noto-cjk` package rather than the larger `fonts-noto-cjk-extra` variant.
- What you did **not** verify: I did not build the full Docker image or run a live screenshot render in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: slightly larger sandbox browser image size.
  - Mitigation: use the base `fonts-noto-cjk` package only, not `fonts-noto-cjk-extra`.
