### PR TITLE
feat(matrix): add explicit channels.matrix.proxy config (#56930)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Agents/LLM: add a configurable idle-stream timeout for embedded runner requests so stalled model streams abort cleanly instead of hanging until the broader run timeout fires. (#55072) Thanks @liuy.
 - OpenAI/Responses: forward configured `text.verbosity` across Responses HTTP and WebSocket transports, surface it in `/status`, and keep per-agent verbosity precedence aligned with runtime behavior. (#47106) Thanks @merc1305 and @vincentkoc.
 - Android/notifications: add notification-forwarding controls with package filtering, quiet hours, rate limiting, and safer picker behavior for forwarded notification events. (#40175) Thanks @nimbleenigma.
+- Matrix/network: add explicit `channels.matrix.proxy` config for routing Matrix traffic through an HTTP(S) proxy, including account-level overrides and matching probe/runtime behavior. (#56931) thanks @patrick-yingxi-pan.
 
 ### Fixes
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -679,6 +679,25 @@ openclaw matrix account add \
 This opt-in only allows trusted private/internal targets. Public cleartext homeservers such as
 `http://matrix.example.org:8008` remain blocked. Prefer `https://` whenever possible.
 
+## Proxying Matrix traffic
+
+If your Matrix deployment needs an explicit outbound HTTP(S) proxy, set `channels.matrix.proxy`:
+
+```json5
+{
+  channels: {
+    matrix: {
+      homeserver: "https://matrix.example.org",
+      accessToken: "syt_bot_xxx",
+      proxy: "http://127.0.0.1:7890",
+    },
+  },
+}
+```
+
+Named accounts can override the top-level default with `channels.matrix.accounts.<id>.proxy`.
+OpenClaw uses the same proxy setting for runtime Matrix traffic and account status probes.
+
 ## Target resolution
 
 Matrix accepts these target forms anywhere OpenClaw asks you for a room or user target:
@@ -700,6 +719,7 @@ Live directory lookup uses the logged-in Matrix account:
 - `defaultAccount`: preferred account ID when multiple Matrix accounts are configured.
 - `homeserver`: homeserver URL, for example `https://matrix.example.org`.
 - `allowPrivateNetwork`: allow this Matrix account to connect to private/internal homeservers. Enable this when the homeserver resolves to `localhost`, a LAN/Tailscale IP, or an internal host such as `matrix-synapse`.
+- `proxy`: optional HTTP(S) proxy URL for Matrix traffic. Named accounts can override the top-level default with their own `proxy`.
 - `userId`: full Matrix user ID, for example `@bot:example.org`.
 - `accessToken`: access token for token-based auth. Plaintext values and SecretRef values are supported for `channels.matrix.accessToken` and `channels.matrix.accounts.<id>.accessToken` across env/file/exec providers. See [Secrets Management](/gateway/secrets).
 - `password`: password for password-based login. Plaintext values and SecretRef values are supported.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -571,6 +571,45 @@ exec ssh -T gateway-host imsg "$@"
 
 </Accordion>
 
+### Matrix
+
+Matrix is extension-backed and configured under `channels.matrix`.
+
+```json5
+{
+  channels: {
+    matrix: {
+      enabled: true,
+      homeserver: "https://matrix.example.org",
+      accessToken: "syt_bot_xxx",
+      proxy: "http://127.0.0.1:7890",
+      encryption: true,
+      initialSyncLimit: 20,
+      defaultAccount: "ops",
+      accounts: {
+        ops: {
+          name: "Ops",
+          userId: "@ops:example.org",
+          accessToken: "syt_ops_xxx",
+        },
+        alerts: {
+          userId: "@alerts:example.org",
+          password: "secret",
+          proxy: "http://127.0.0.1:7891",
+        },
+      },
+    },
+  },
+}
+```
+
+- Token auth uses `accessToken`; password auth uses `userId` + `password`.
+- `channels.matrix.proxy` routes Matrix HTTP traffic through an explicit HTTP(S) proxy. Named accounts can override it with `channels.matrix.accounts.<id>.proxy`.
+- `channels.matrix.allowPrivateNetwork` allows private/internal homeservers. `proxy` and `allowPrivateNetwork` are independent controls.
+- `channels.matrix.defaultAccount` selects the preferred account in multi-account setups.
+- Matrix status probes and live directory lookups use the same proxy policy as runtime traffic.
+- Full Matrix configuration, targeting rules, and setup examples are documented in [Matrix](/channels/matrix).
+
 ### Microsoft Teams
 
 Microsoft Teams is extension-backed and configured under `channels.msteams`.

--- a/extensions/matrix/src/channel.setup.test.ts
+++ b/extensions/matrix/src/channel.setup.test.ts
@@ -240,13 +240,14 @@ describe("matrix setup post-write bootstrap", () => {
     );
   });
 
-  it("clears allowPrivateNetwork when deleting the default Matrix account config", () => {
+  it("clears allowPrivateNetwork and proxy when deleting the default Matrix account config", () => {
     const updated = matrixPlugin.config.deleteAccount?.({
       cfg: {
         channels: {
           matrix: {
             homeserver: "http://localhost.localdomain:8008",
             allowPrivateNetwork: true,
+            proxy: "http://127.0.0.1:7890",
             accounts: {
               ops: {
                 enabled: true,

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -154,6 +154,7 @@ const matrixConfigAdapter = createScopedChannelConfigAdapter<
     "name",
     "homeserver",
     "allowPrivateNetwork",
+    "proxy",
     "userId",
     "accessToken",
     "password",
@@ -439,6 +440,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
               accountId: account.accountId,
               allowPrivateNetwork: auth.allowPrivateNetwork,
               ssrfPolicy: auth.ssrfPolicy,
+              dispatcherPolicy: auth.dispatcherPolicy,
             });
           } catch (err) {
             return {

--- a/extensions/matrix/src/cli.ts
+++ b/extensions/matrix/src/cli.ts
@@ -158,6 +158,7 @@ async function addMatrixAccount(params: {
   name?: string;
   avatarUrl?: string;
   homeserver?: string;
+  proxy?: string;
   userId?: string;
   accessToken?: string;
   password?: string;
@@ -177,6 +178,7 @@ async function addMatrixAccount(params: {
     avatarUrl: params.avatarUrl,
     homeserver: params.homeserver,
     allowPrivateNetwork: params.allowPrivateNetwork,
+    proxy: params.proxy,
     userId: params.userId,
     accessToken: params.accessToken,
     password: params.password,
@@ -675,6 +677,7 @@ export function registerMatrixCli(params: { program: Command }): void {
     .option("--name <name>", "Optional display name for this account")
     .option("--avatar-url <url>", "Optional Matrix avatar URL (mxc:// or http(s) URL)")
     .option("--homeserver <url>", "Matrix homeserver URL")
+    .option("--proxy <url>", "Optional HTTP(S) proxy URL for Matrix requests")
     .option(
       "--allow-private-network",
       "Allow Matrix homeserver traffic to private/internal hosts for this account",
@@ -696,6 +699,7 @@ export function registerMatrixCli(params: { program: Command }): void {
         name?: string;
         avatarUrl?: string;
         homeserver?: string;
+        proxy?: string;
         allowPrivateNetwork?: boolean;
         userId?: string;
         accessToken?: string;
@@ -715,6 +719,7 @@ export function registerMatrixCli(params: { program: Command }): void {
               name: options.name,
               avatarUrl: options.avatarUrl,
               homeserver: options.homeserver,
+              proxy: options.proxy,
               allowPrivateNetwork: options.allowPrivateNetwork === true,
               userId: options.userId,
               accessToken: options.accessToken,

--- a/extensions/matrix/src/config-schema.ts
+++ b/extensions/matrix/src/config-schema.ts
@@ -53,6 +53,7 @@ export const MatrixConfigSchema = z.object({
   markdown: MarkdownConfigSchema,
   homeserver: z.string().optional(),
   allowPrivateNetwork: z.boolean().optional(),
+  proxy: z.string().optional(),
   userId: z.string().optional(),
   accessToken: buildSecretInputSchema().optional(),
   password: buildSecretInputSchema().optional(),

--- a/extensions/matrix/src/directory-live.test.ts
+++ b/extensions/matrix/src/directory-live.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { requestJsonMock } = vi.hoisted(() => ({
+const { matrixAuthedHttpClientCtorMock, requestJsonMock } = vi.hoisted(() => ({
+  matrixAuthedHttpClientCtorMock: vi.fn(),
   requestJsonMock: vi.fn(),
 }));
 
@@ -10,6 +11,10 @@ vi.mock("./matrix/client.js", () => ({
 
 vi.mock("./matrix/sdk/http-client.js", () => ({
   MatrixAuthedHttpClient: class {
+    constructor(params: unknown) {
+      matrixAuthedHttpClientCtorMock(params);
+    }
+
     requestJson(params: unknown) {
       return requestJsonMock(params);
     }
@@ -35,6 +40,7 @@ describe("matrix directory live", () => {
       userId: "@bot:example.org",
       accessToken: "test-token",
     });
+    matrixAuthedHttpClientCtorMock.mockReset();
     requestJsonMock.mockReset();
     requestJsonMock.mockResolvedValue({ results: [] });
   });
@@ -59,6 +65,35 @@ describe("matrix directory live", () => {
     });
 
     expect(resolveMatrixAuth).toHaveBeenCalledWith({ cfg, accountId: "assistant" });
+  });
+
+  it("passes dispatcherPolicy through to the live directory client", async () => {
+    vi.mocked(resolveMatrixAuth).mockResolvedValue({
+      accountId: "assistant",
+      homeserver: "https://matrix.example.org",
+      userId: "@bot:example.org",
+      accessToken: "test-token",
+      dispatcherPolicy: {
+        mode: "explicit-proxy",
+        proxyUrl: "http://proxy.internal:8080",
+      },
+    });
+
+    await listMatrixDirectoryPeersLive({
+      cfg,
+      accountId: "assistant",
+      query: "alice",
+    });
+
+    expect(matrixAuthedHttpClientCtorMock).toHaveBeenCalledWith({
+      homeserver: "https://matrix.example.org",
+      accessToken: "test-token",
+      ssrfPolicy: undefined,
+      dispatcherPolicy: {
+        mode: "explicit-proxy",
+        proxyUrl: "http://proxy.internal:8080",
+      },
+    });
   });
 
   it("returns no peer results for empty query without resolving auth", async () => {

--- a/extensions/matrix/src/directory-live.ts
+++ b/extensions/matrix/src/directory-live.ts
@@ -46,7 +46,12 @@ function resolveMatrixDirectoryLimit(limit?: number | null): number {
 }
 
 function createMatrixDirectoryClient(auth: MatrixResolvedAuth): MatrixAuthedHttpClient {
-  return new MatrixAuthedHttpClient(auth.homeserver, auth.accessToken, auth.ssrfPolicy);
+  return new MatrixAuthedHttpClient({
+    homeserver: auth.homeserver,
+    accessToken: auth.accessToken,
+    ssrfPolicy: auth.ssrfPolicy,
+    dispatcherPolicy: auth.dispatcherPolicy,
+  });
 }
 
 async function resolveMatrixDirectoryContext(params: MatrixDirectoryLiveParams): Promise<{

--- a/extensions/matrix/src/matrix/client.test.ts
+++ b/extensions/matrix/src/matrix/client.test.ts
@@ -542,6 +542,51 @@ describe("resolveMatrixConfig", () => {
     ).toBe("http://matrix-synapse:8008");
   });
 
+  it("resolves an explicit proxy dispatcher from top-level Matrix config", () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          accessToken: "tok-123",
+          proxy: "http://127.0.0.1:7890",
+        },
+      },
+    } as CoreConfig;
+
+    const resolved = resolveMatrixConfig(cfg, {} as NodeJS.ProcessEnv);
+
+    expect(resolved.dispatcherPolicy).toEqual({
+      mode: "explicit-proxy",
+      proxyUrl: "http://127.0.0.1:7890",
+    });
+  });
+
+  it("prefers account proxy overrides over top-level Matrix proxy config", () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          accessToken: "base-token",
+          proxy: "http://127.0.0.1:7890",
+          accounts: {
+            ops: {
+              homeserver: "https://matrix.ops.example.org",
+              accessToken: "ops-token",
+              proxy: "http://127.0.0.1:7891",
+            },
+          },
+        },
+      },
+    } as CoreConfig;
+
+    const resolved = resolveMatrixConfigForAccount(cfg, "ops", {} as NodeJS.ProcessEnv);
+
+    expect(resolved.dispatcherPolicy).toEqual({
+      mode: "explicit-proxy",
+      proxyUrl: "http://127.0.0.1:7891",
+    });
+  });
+
   it("rejects public http homeservers even when private-network access is enabled", async () => {
     await expect(
       resolveValidatedMatrixHomeserverUrl("http://matrix.example.org:8008", {

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -1,3 +1,4 @@
+import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import {
   coerceSecretRef,
   resolveConfiguredSecretInputString,
@@ -292,13 +293,19 @@ const MATRIX_HTTP_HOMESERVER_ERROR =
 
 function buildMatrixNetworkFields(
   allowPrivateNetwork: boolean | undefined,
-): Pick<MatrixResolvedConfig, "allowPrivateNetwork" | "ssrfPolicy"> {
-  if (!allowPrivateNetwork) {
+  proxy?: string,
+): Pick<MatrixResolvedConfig, "allowPrivateNetwork" | "ssrfPolicy" | "dispatcherPolicy"> {
+  const dispatcherPolicy: PinnedDispatcherPolicy | undefined = proxy
+    ? { mode: "explicit-proxy", proxyUrl: proxy }
+    : undefined;
+  if (!allowPrivateNetwork && !dispatcherPolicy) {
     return {};
   }
   return {
-    allowPrivateNetwork: true,
-    ssrfPolicy: ssrfPolicyFromAllowPrivateNetwork(true),
+    ...(allowPrivateNetwork
+      ? { allowPrivateNetwork: true, ssrfPolicy: ssrfPolicyFromAllowPrivateNetwork(true) }
+      : {}),
+    ...(dispatcherPolicy ? { dispatcherPolicy } : {}),
   };
 }
 
@@ -492,7 +499,7 @@ export function resolveMatrixConfig(
     deviceName: resolvedStrings.deviceName || undefined,
     initialSyncLimit,
     encryption,
-    ...buildMatrixNetworkFields(allowPrivateNetwork),
+    ...buildMatrixNetworkFields(allowPrivateNetwork, matrix.proxy),
   };
 }
 
@@ -562,7 +569,7 @@ export function resolveMatrixConfigForAccount(
     deviceName: resolvedStrings.deviceName || undefined,
     initialSyncLimit,
     encryption,
-    ...buildMatrixNetworkFields(allowPrivateNetwork),
+    ...buildMatrixNetworkFields(allowPrivateNetwork, account.proxy ?? matrix.proxy),
   };
 }
 
@@ -662,6 +669,7 @@ export async function resolveMatrixAuth(params?: {
       ensureMatrixSdkLoggingConfigured();
       const tempClient = new MatrixClient(homeserver, accessToken, undefined, undefined, {
         ssrfPolicy: resolved.ssrfPolicy,
+        dispatcherPolicy: resolved.dispatcherPolicy,
       });
       const whoami = (await tempClient.doRequest("GET", "/_matrix/client/v3/account/whoami")) as {
         user_id?: string;
@@ -710,7 +718,12 @@ export async function resolveMatrixAuth(params?: {
       deviceName: resolved.deviceName,
       initialSyncLimit: resolved.initialSyncLimit,
       encryption: resolved.encryption,
-      ...buildMatrixNetworkFields(resolved.allowPrivateNetwork),
+      ...buildMatrixNetworkFields(
+        resolved.allowPrivateNetwork,
+        resolved.dispatcherPolicy?.mode === "explicit-proxy"
+          ? resolved.dispatcherPolicy.proxyUrl
+          : undefined,
+      ),
     };
   }
 
@@ -727,7 +740,12 @@ export async function resolveMatrixAuth(params?: {
       deviceName: resolved.deviceName,
       initialSyncLimit: resolved.initialSyncLimit,
       encryption: resolved.encryption,
-      ...buildMatrixNetworkFields(resolved.allowPrivateNetwork),
+      ...buildMatrixNetworkFields(
+        resolved.allowPrivateNetwork,
+        resolved.dispatcherPolicy?.mode === "explicit-proxy"
+          ? resolved.dispatcherPolicy.proxyUrl
+          : undefined,
+      ),
     };
   }
 
@@ -752,6 +770,7 @@ export async function resolveMatrixAuth(params?: {
   ensureMatrixSdkLoggingConfigured();
   const loginClient = new MatrixClient(homeserver, "", undefined, undefined, {
     ssrfPolicy: resolved.ssrfPolicy,
+    dispatcherPolicy: resolved.dispatcherPolicy,
   });
   const login = (await loginClient.doRequest("POST", "/_matrix/client/v3/login", undefined, {
     type: "m.login.password",
@@ -780,7 +799,12 @@ export async function resolveMatrixAuth(params?: {
     deviceName: resolved.deviceName,
     initialSyncLimit: resolved.initialSyncLimit,
     encryption: resolved.encryption,
-    ...buildMatrixNetworkFields(resolved.allowPrivateNetwork),
+    ...buildMatrixNetworkFields(
+      resolved.allowPrivateNetwork,
+      resolved.dispatcherPolicy?.mode === "explicit-proxy"
+        ? resolved.dispatcherPolicy.proxyUrl
+        : undefined,
+    ),
   };
 
   const { saveMatrixCredentials } = await loadCredentialsWriter();

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -1,8 +1,8 @@
-import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import {
   coerceSecretRef,
   resolveConfiguredSecretInputString,
 } from "openclaw/plugin-sdk/config-runtime";
+import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import {
   requiresExplicitMatrixDefaultAccount,
   resolveMatrixDefaultOrOnlyAccountId,
@@ -291,18 +291,19 @@ function clampMatrixInitialSyncLimit(value: unknown): number | undefined {
 const MATRIX_HTTP_HOMESERVER_ERROR =
   "Matrix homeserver must use https:// unless it targets a private or loopback host";
 
-function buildMatrixNetworkFields(
-  allowPrivateNetwork: boolean | undefined,
-  proxy?: string,
-): Pick<MatrixResolvedConfig, "allowPrivateNetwork" | "ssrfPolicy" | "dispatcherPolicy"> {
-  const dispatcherPolicy: PinnedDispatcherPolicy | undefined = proxy
-    ? { mode: "explicit-proxy", proxyUrl: proxy }
-    : undefined;
-  if (!allowPrivateNetwork && !dispatcherPolicy) {
+function buildMatrixNetworkFields(params: {
+  allowPrivateNetwork: boolean | undefined;
+  proxy?: string;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+}): Pick<MatrixResolvedConfig, "allowPrivateNetwork" | "ssrfPolicy" | "dispatcherPolicy"> {
+  const dispatcherPolicy: PinnedDispatcherPolicy | undefined =
+    params.dispatcherPolicy ??
+    (params.proxy ? { mode: "explicit-proxy", proxyUrl: params.proxy } : undefined);
+  if (!params.allowPrivateNetwork && !dispatcherPolicy) {
     return {};
   }
   return {
-    ...(allowPrivateNetwork
+    ...(params.allowPrivateNetwork
       ? { allowPrivateNetwork: true, ssrfPolicy: ssrfPolicyFromAllowPrivateNetwork(true) }
       : {}),
     ...(dispatcherPolicy ? { dispatcherPolicy } : {}),
@@ -499,7 +500,7 @@ export function resolveMatrixConfig(
     deviceName: resolvedStrings.deviceName || undefined,
     initialSyncLimit,
     encryption,
-    ...buildMatrixNetworkFields(allowPrivateNetwork, matrix.proxy),
+    ...buildMatrixNetworkFields({ allowPrivateNetwork, proxy: matrix.proxy }),
   };
 }
 
@@ -569,7 +570,10 @@ export function resolveMatrixConfigForAccount(
     deviceName: resolvedStrings.deviceName || undefined,
     initialSyncLimit,
     encryption,
-    ...buildMatrixNetworkFields(allowPrivateNetwork, account.proxy ?? matrix.proxy),
+    ...buildMatrixNetworkFields({
+      allowPrivateNetwork,
+      proxy: account.proxy ?? matrix.proxy,
+    }),
   };
 }
 
@@ -718,12 +722,10 @@ export async function resolveMatrixAuth(params?: {
       deviceName: resolved.deviceName,
       initialSyncLimit: resolved.initialSyncLimit,
       encryption: resolved.encryption,
-      ...buildMatrixNetworkFields(
-        resolved.allowPrivateNetwork,
-        resolved.dispatcherPolicy?.mode === "explicit-proxy"
-          ? resolved.dispatcherPolicy.proxyUrl
-          : undefined,
-      ),
+      ...buildMatrixNetworkFields({
+        allowPrivateNetwork: resolved.allowPrivateNetwork,
+        dispatcherPolicy: resolved.dispatcherPolicy,
+      }),
     };
   }
 
@@ -740,12 +742,10 @@ export async function resolveMatrixAuth(params?: {
       deviceName: resolved.deviceName,
       initialSyncLimit: resolved.initialSyncLimit,
       encryption: resolved.encryption,
-      ...buildMatrixNetworkFields(
-        resolved.allowPrivateNetwork,
-        resolved.dispatcherPolicy?.mode === "explicit-proxy"
-          ? resolved.dispatcherPolicy.proxyUrl
-          : undefined,
-      ),
+      ...buildMatrixNetworkFields({
+        allowPrivateNetwork: resolved.allowPrivateNetwork,
+        dispatcherPolicy: resolved.dispatcherPolicy,
+      }),
     };
   }
 
@@ -799,12 +799,10 @@ export async function resolveMatrixAuth(params?: {
     deviceName: resolved.deviceName,
     initialSyncLimit: resolved.initialSyncLimit,
     encryption: resolved.encryption,
-    ...buildMatrixNetworkFields(
-      resolved.allowPrivateNetwork,
-      resolved.dispatcherPolicy?.mode === "explicit-proxy"
-        ? resolved.dispatcherPolicy.proxyUrl
-        : undefined,
-    ),
+    ...buildMatrixNetworkFields({
+      allowPrivateNetwork: resolved.allowPrivateNetwork,
+      dispatcherPolicy: resolved.dispatcherPolicy,
+    }),
   };
 
   const { saveMatrixCredentials } = await loadCredentialsWriter();

--- a/extensions/matrix/src/matrix/client/create-client.ts
+++ b/extensions/matrix/src/matrix/client/create-client.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import type { SsrFPolicy } from "../../runtime-api.js";
 import { MatrixClient } from "../sdk.js";
 import { resolveValidatedMatrixHomeserverUrl } from "./config.js";
@@ -22,6 +23,7 @@ export async function createMatrixClient(params: {
   autoBootstrapCrypto?: boolean;
   allowPrivateNetwork?: boolean;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
 }): Promise<MatrixClient> {
   ensureMatrixSdkLoggingConfigured();
   const env = process.env;
@@ -68,5 +70,6 @@ export async function createMatrixClient(params: {
     cryptoDatabasePrefix,
     autoBootstrapCrypto: params.autoBootstrapCrypto,
     ssrfPolicy: params.ssrfPolicy,
+    dispatcherPolicy: params.dispatcherPolicy,
   });
 }

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -230,4 +230,33 @@ describe("resolveSharedMatrixClient", () => {
       }),
     ).rejects.toThrow("Matrix shared client account mismatch");
   });
+
+  it("recreates the shared client when dispatcherPolicy changes", async () => {
+    const firstAuth = {
+      ...authFor("main"),
+      dispatcherPolicy: {
+        mode: "explicit-proxy" as const,
+        proxyUrl: "http://127.0.0.1:7890",
+      },
+    };
+    const secondAuth = {
+      ...authFor("main"),
+      dispatcherPolicy: {
+        mode: "explicit-proxy" as const,
+        proxyUrl: "http://127.0.0.1:7891",
+      },
+    };
+    const firstClient = createMockClient("main-first");
+    const secondClient = createMockClient("main-second");
+
+    resolveMatrixAuthMock.mockResolvedValueOnce(firstAuth).mockResolvedValueOnce(secondAuth);
+    createMatrixClientMock.mockResolvedValueOnce(firstClient).mockResolvedValueOnce(secondClient);
+
+    const first = await resolveSharedMatrixClient({ accountId: "main", startClient: false });
+    const second = await resolveSharedMatrixClient({ accountId: "main", startClient: false });
+
+    expect(first).toBe(firstClient);
+    expect(second).toBe(secondClient);
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -18,6 +18,10 @@ type SharedMatrixClientState = {
 const sharedClientStates = new Map<string, SharedMatrixClientState>();
 const sharedClientPromises = new Map<string, Promise<SharedMatrixClientState>>();
 
+function serializeDispatcherPolicyKey(auth: MatrixAuth): string {
+  return JSON.stringify(auth.dispatcherPolicy ?? null);
+}
+
 function buildSharedClientKey(auth: MatrixAuth): string {
   return [
     auth.homeserver,
@@ -25,6 +29,7 @@ function buildSharedClientKey(auth: MatrixAuth): string {
     auth.accessToken,
     auth.encryption ? "e2ee" : "plain",
     auth.allowPrivateNetwork ? "private-net" : "strict-net",
+    serializeDispatcherPolicyKey(auth),
     auth.accountId,
   ].join("|");
 }

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -45,6 +45,7 @@ async function createSharedMatrixClient(params: {
     accountId: params.auth.accountId,
     allowPrivateNetwork: params.auth.allowPrivateNetwork,
     ssrfPolicy: params.auth.ssrfPolicy,
+    dispatcherPolicy: params.auth.dispatcherPolicy,
   });
   return {
     client,

--- a/extensions/matrix/src/matrix/client/types.ts
+++ b/extensions/matrix/src/matrix/client/types.ts
@@ -1,3 +1,4 @@
+import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import type { SsrFPolicy } from "../../runtime-api.js";
 
 export type MatrixResolvedConfig = {
@@ -11,6 +12,7 @@ export type MatrixResolvedConfig = {
   encryption?: boolean;
   allowPrivateNetwork?: boolean;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
 };
 
 /**
@@ -33,6 +35,7 @@ export type MatrixAuth = {
   encryption?: boolean;
   allowPrivateNetwork?: boolean;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
 };
 
 export type MatrixStoragePaths = {

--- a/extensions/matrix/src/matrix/config-update.test.ts
+++ b/extensions/matrix/src/matrix/config-update.test.ts
@@ -73,7 +73,7 @@ describe("updateMatrixAccountConfig", () => {
     });
   });
 
-  it("stores and clears Matrix allowBots and allowPrivateNetwork settings", () => {
+  it("stores and clears Matrix allowBots, allowPrivateNetwork, and proxy settings", () => {
     const cfg = {
       channels: {
         matrix: {
@@ -81,6 +81,7 @@ describe("updateMatrixAccountConfig", () => {
             default: {
               allowBots: true,
               allowPrivateNetwork: true,
+              proxy: "http://127.0.0.1:7890",
             },
           },
         },
@@ -90,12 +91,14 @@ describe("updateMatrixAccountConfig", () => {
     const updated = updateMatrixAccountConfig(cfg, "default", {
       allowBots: "mentions",
       allowPrivateNetwork: null,
+      proxy: null,
     });
 
     expect(updated.channels?.["matrix"]?.accounts?.default).toMatchObject({
       allowBots: "mentions",
     });
     expect(updated.channels?.["matrix"]?.accounts?.default?.allowPrivateNetwork).toBeUndefined();
+    expect(updated.channels?.["matrix"]?.accounts?.default?.proxy).toBeUndefined();
   });
 
   it("normalizes account id and defaults account enabled=true", () => {

--- a/extensions/matrix/src/matrix/config-update.ts
+++ b/extensions/matrix/src/matrix/config-update.ts
@@ -10,6 +10,7 @@ export type MatrixAccountPatch = {
   enabled?: boolean;
   homeserver?: string | null;
   allowPrivateNetwork?: boolean | null;
+  proxy?: string | null;
   userId?: string | null;
   accessToken?: MatrixConfig["accessToken"] | null;
   password?: MatrixConfig["password"] | null;
@@ -171,6 +172,7 @@ export function updateMatrixAccountConfig(
   }
 
   applyNullableStringField(nextAccount, "homeserver", patch.homeserver);
+  applyNullableStringField(nextAccount, "proxy", patch.proxy);
   applyNullableStringField(nextAccount, "userId", patch.userId);
   applyNullableSecretInputField(
     nextAccount,

--- a/extensions/matrix/src/matrix/probe.test.ts
+++ b/extensions/matrix/src/matrix/probe.test.ts
@@ -69,6 +69,29 @@ describe("probeMatrix", () => {
     });
   });
 
+  it("passes dispatcherPolicy through to client creation", async () => {
+    await probeMatrix({
+      homeserver: "https://matrix.example.org",
+      accessToken: "tok",
+      timeoutMs: 500,
+      dispatcherPolicy: {
+        mode: "explicit-proxy",
+        proxyUrl: "http://127.0.0.1:7890",
+      },
+    });
+
+    expect(createMatrixClientMock).toHaveBeenCalledWith({
+      homeserver: "https://matrix.example.org",
+      userId: undefined,
+      accessToken: "tok",
+      localTimeoutMs: 500,
+      dispatcherPolicy: {
+        mode: "explicit-proxy",
+        proxyUrl: "http://127.0.0.1:7890",
+      },
+    });
+  });
+
   it("returns client validation errors for insecure public http homeservers", async () => {
     createMatrixClientMock.mockRejectedValue(
       new Error("Matrix homeserver must use https:// unless it targets a private or loopback host"),

--- a/extensions/matrix/src/matrix/probe.ts
+++ b/extensions/matrix/src/matrix/probe.ts
@@ -1,3 +1,4 @@
+import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import type { SsrFPolicy } from "../runtime-api.js";
 import type { BaseProbeResult } from "../runtime-api.js";
 import { createMatrixClient, isBunRuntime } from "./client.js";
@@ -16,6 +17,7 @@ export async function probeMatrix(params: {
   accountId?: string | null;
   allowPrivateNetwork?: boolean;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
 }): Promise<MatrixProbe> {
   const started = Date.now();
   const result: MatrixProbe = {
@@ -55,6 +57,7 @@ export async function probeMatrix(params: {
       accountId: params.accountId,
       allowPrivateNetwork: params.allowPrivateNetwork,
       ssrfPolicy: params.ssrfPolicy,
+      dispatcherPolicy: params.dispatcherPolicy,
     });
     // The client wrapper resolves user ID via whoami when needed.
     const userId = await client.getUserId();

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -11,6 +11,7 @@ import {
 } from "matrix-js-sdk/lib/matrix.js";
 import { VerificationMethod } from "matrix-js-sdk/lib/types.js";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/core";
+import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import type { SsrFPolicy } from "../runtime-api.js";
 import { resolveMatrixRoomKeyBackupReadinessError } from "./backup-health.js";
 import { FileBackedMatrixSyncStore } from "./client/file-sync-store.js";
@@ -221,9 +222,15 @@ export class MatrixClient {
       cryptoDatabasePrefix?: string;
       autoBootstrapCrypto?: boolean;
       ssrfPolicy?: SsrFPolicy;
+      dispatcherPolicy?: PinnedDispatcherPolicy;
     } = {},
   ) {
-    this.httpClient = new MatrixAuthedHttpClient(homeserver, accessToken, opts.ssrfPolicy);
+    this.httpClient = new MatrixAuthedHttpClient(
+      homeserver,
+      accessToken,
+      opts.ssrfPolicy,
+      opts.dispatcherPolicy,
+    );
     this.localTimeoutMs = Math.max(1, opts.localTimeoutMs ?? 60_000);
     this.initialSyncLimit = opts.initialSyncLimit;
     this.encryptionEnabled = opts.encryption === true;
@@ -244,7 +251,10 @@ export class MatrixClient {
       deviceId: opts.deviceId,
       logger: createMatrixJsSdkClientLogger("MatrixClient"),
       localTimeoutMs: this.localTimeoutMs,
-      fetchFn: createMatrixGuardedFetch({ ssrfPolicy: opts.ssrfPolicy }),
+      fetchFn: createMatrixGuardedFetch({
+        ssrfPolicy: opts.ssrfPolicy,
+        dispatcherPolicy: opts.dispatcherPolicy,
+      }),
       store: this.syncStore,
       cryptoCallbacks: cryptoCallbacks as never,
       verificationMethods: [

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -225,12 +225,12 @@ export class MatrixClient {
       dispatcherPolicy?: PinnedDispatcherPolicy;
     } = {},
   ) {
-    this.httpClient = new MatrixAuthedHttpClient(
+    this.httpClient = new MatrixAuthedHttpClient({
       homeserver,
       accessToken,
-      opts.ssrfPolicy,
-      opts.dispatcherPolicy,
-    );
+      ssrfPolicy: opts.ssrfPolicy,
+      dispatcherPolicy: opts.dispatcherPolicy,
+    });
     this.localTimeoutMs = Math.max(1, opts.localTimeoutMs ?? 60_000);
     this.initialSyncLimit = opts.initialSyncLimit;
     this.encryptionEnabled = opts.encryption === true;

--- a/extensions/matrix/src/matrix/sdk/http-client.test.ts
+++ b/extensions/matrix/src/matrix/sdk/http-client.test.ts
@@ -27,8 +27,16 @@ describe("MatrixAuthedHttpClient", () => {
       buffer: Buffer.from('{"ok":true}', "utf8"),
     });
 
-    const client = new MatrixAuthedHttpClient("https://matrix.example.org", "token", {
-      allowPrivateNetwork: true,
+    const client = new MatrixAuthedHttpClient({
+      homeserver: "https://matrix.example.org",
+      accessToken: "token",
+      ssrfPolicy: {
+        allowPrivateNetwork: true,
+      },
+      dispatcherPolicy: {
+        mode: "explicit-proxy",
+        proxyUrl: "http://proxy.internal:8080",
+      },
     });
     const result = await client.requestJson({
       method: "GET",
@@ -44,6 +52,10 @@ describe("MatrixAuthedHttpClient", () => {
         endpoint: "https://matrix.example.org/_matrix/client/v3/account/whoami",
         allowAbsoluteEndpoint: true,
         ssrfPolicy: { allowPrivateNetwork: true },
+        dispatcherPolicy: {
+          mode: "explicit-proxy",
+          proxyUrl: "http://proxy.internal:8080",
+        },
       }),
     );
   });
@@ -58,7 +70,10 @@ describe("MatrixAuthedHttpClient", () => {
       buffer: Buffer.from("pong", "utf8"),
     });
 
-    const client = new MatrixAuthedHttpClient("https://matrix.example.org", "token");
+    const client = new MatrixAuthedHttpClient({
+      homeserver: "https://matrix.example.org",
+      accessToken: "token",
+    });
     const result = await client.requestJson({
       method: "GET",
       endpoint: "/_matrix/client/v3/ping",
@@ -76,7 +91,10 @@ describe("MatrixAuthedHttpClient", () => {
       buffer: payload,
     });
 
-    const client = new MatrixAuthedHttpClient("https://matrix.example.org", "token");
+    const client = new MatrixAuthedHttpClient({
+      homeserver: "https://matrix.example.org",
+      accessToken: "token",
+    });
     const result = await client.requestRaw({
       method: "GET",
       endpoint: "/_matrix/media/v3/download/example/id",
@@ -96,7 +114,10 @@ describe("MatrixAuthedHttpClient", () => {
       buffer: Buffer.from(JSON.stringify({ error: "forbidden" }), "utf8"),
     });
 
-    const client = new MatrixAuthedHttpClient("https://matrix.example.org", "token");
+    const client = new MatrixAuthedHttpClient({
+      homeserver: "https://matrix.example.org",
+      accessToken: "token",
+    });
     await expect(
       client.requestJson({
         method: "GET",

--- a/extensions/matrix/src/matrix/sdk/http-client.ts
+++ b/extensions/matrix/src/matrix/sdk/http-client.ts
@@ -3,13 +3,25 @@ import type { SsrFPolicy } from "../../runtime-api.js";
 import { buildHttpError } from "./event-helpers.js";
 import { type HttpMethod, type QueryParams, performMatrixRequest } from "./transport.js";
 
+type MatrixAuthedHttpClientParams = {
+  homeserver: string;
+  accessToken: string;
+  ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+};
+
 export class MatrixAuthedHttpClient {
-  constructor(
-    private readonly homeserver: string,
-    private readonly accessToken: string,
-    private readonly ssrfPolicy?: SsrFPolicy,
-    private readonly dispatcherPolicy?: PinnedDispatcherPolicy,
-  ) {}
+  private readonly homeserver: string;
+  private readonly accessToken: string;
+  private readonly ssrfPolicy?: SsrFPolicy;
+  private readonly dispatcherPolicy?: PinnedDispatcherPolicy;
+
+  constructor(params: MatrixAuthedHttpClientParams) {
+    this.homeserver = params.homeserver;
+    this.accessToken = params.accessToken;
+    this.ssrfPolicy = params.ssrfPolicy;
+    this.dispatcherPolicy = params.dispatcherPolicy;
+  }
 
   async requestJson(params: {
     method: HttpMethod;

--- a/extensions/matrix/src/matrix/sdk/http-client.ts
+++ b/extensions/matrix/src/matrix/sdk/http-client.ts
@@ -1,3 +1,4 @@
+import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import type { SsrFPolicy } from "../../runtime-api.js";
 import { buildHttpError } from "./event-helpers.js";
 import { type HttpMethod, type QueryParams, performMatrixRequest } from "./transport.js";
@@ -7,6 +8,7 @@ export class MatrixAuthedHttpClient {
     private readonly homeserver: string,
     private readonly accessToken: string,
     private readonly ssrfPolicy?: SsrFPolicy,
+    private readonly dispatcherPolicy?: PinnedDispatcherPolicy,
   ) {}
 
   async requestJson(params: {
@@ -26,6 +28,7 @@ export class MatrixAuthedHttpClient {
       body: params.body,
       timeoutMs: params.timeoutMs,
       ssrfPolicy: this.ssrfPolicy,
+      dispatcherPolicy: this.dispatcherPolicy,
       allowAbsoluteEndpoint: params.allowAbsoluteEndpoint,
     });
     if (!response.ok) {
@@ -61,6 +64,7 @@ export class MatrixAuthedHttpClient {
       maxBytes: params.maxBytes,
       readIdleTimeoutMs: params.readIdleTimeoutMs,
       ssrfPolicy: this.ssrfPolicy,
+      dispatcherPolicy: this.dispatcherPolicy,
       allowAbsoluteEndpoint: params.allowAbsoluteEndpoint,
     });
     if (!response.ok) {

--- a/extensions/matrix/src/matrix/sdk/transport.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.ts
@@ -1,3 +1,4 @@
+import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import {
   buildTimeoutAbortSignal,
   closeDispatcher,
@@ -88,6 +89,7 @@ async function fetchWithMatrixGuardedRedirects(params: {
   signal?: AbortSignal;
   timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
 }): Promise<{ response: Response; release: () => Promise<void>; finalUrl: string }> {
   let currentUrl = new URL(params.url);
   let method = (params.init?.method ?? "GET").toUpperCase();
@@ -106,7 +108,7 @@ async function fetchWithMatrixGuardedRedirects(params: {
       const pinned = await resolvePinnedHostnameWithPolicy(currentUrl.hostname, {
         policy: params.ssrfPolicy,
       });
-      dispatcher = createPinnedDispatcher(pinned, undefined, params.ssrfPolicy);
+      dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy, params.ssrfPolicy);
       const response = await fetch(currentUrl.toString(), {
         ...params.init,
         method,
@@ -184,7 +186,10 @@ async function fetchWithMatrixGuardedRedirects(params: {
   throw new Error(`Too many redirects while requesting ${params.url}`);
 }
 
-export function createMatrixGuardedFetch(params: { ssrfPolicy?: SsrFPolicy }): typeof fetch {
+export function createMatrixGuardedFetch(params: {
+  ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+}): typeof fetch {
   return (async (resource: RequestInfo | URL, init?: RequestInit) => {
     const url = toFetchUrl(resource);
     const { signal, ...requestInit } = init ?? {};
@@ -193,6 +198,7 @@ export function createMatrixGuardedFetch(params: { ssrfPolicy?: SsrFPolicy }): t
       init: requestInit,
       signal: signal ?? undefined,
       ssrfPolicy: params.ssrfPolicy,
+      dispatcherPolicy: params.dispatcherPolicy,
     });
 
     try {
@@ -220,6 +226,7 @@ export async function performMatrixRequest(params: {
   maxBytes?: number;
   readIdleTimeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
   allowAbsoluteEndpoint?: boolean;
 }): Promise<{ response: Response; text: string; buffer: Buffer }> {
   const isAbsoluteEndpoint =
@@ -264,6 +271,7 @@ export async function performMatrixRequest(params: {
     },
     timeoutMs: params.timeoutMs,
     ssrfPolicy: params.ssrfPolicy,
+    dispatcherPolicy: params.dispatcherPolicy,
   });
 
   try {

--- a/extensions/matrix/src/setup-config.ts
+++ b/extensions/matrix/src/setup-config.ts
@@ -208,6 +208,7 @@ export function applyMatrixSetupAccountConfig(params: {
       enabled: true,
       homeserver: null,
       allowPrivateNetwork: null,
+      proxy: null,
       userId: null,
       accessToken: null,
       password: null,
@@ -226,6 +227,7 @@ export function applyMatrixSetupAccountConfig(params: {
       typeof params.input.allowPrivateNetwork === "boolean"
         ? params.input.allowPrivateNetwork
         : undefined,
+    proxy: params.input.proxy?.trim() || undefined,
     userId: password && !userId ? null : userId,
     accessToken: accessToken || (password ? null : undefined),
     password: password || (accessToken ? null : undefined),

--- a/extensions/matrix/src/setup-core.test.ts
+++ b/extensions/matrix/src/setup-core.test.ts
@@ -52,6 +52,7 @@ describe("matrixSetupAdapter", () => {
             ops: {
               name: "Ops",
               homeserver: "https://matrix.example.org",
+              proxy: "http://127.0.0.1:7890",
               userId: "@ops:example.org",
               accessToken: "ops-token",
               password: "secret",
@@ -77,10 +78,30 @@ describe("matrixSetupAdapter", () => {
       enabled: true,
     });
     expect(next.channels?.matrix?.accounts?.ops?.homeserver).toBeUndefined();
+    expect(next.channels?.matrix?.accounts?.ops?.proxy).toBeUndefined();
     expect(next.channels?.matrix?.accounts?.ops?.userId).toBeUndefined();
     expect(next.channels?.matrix?.accounts?.ops?.accessToken).toBeUndefined();
     expect(next.channels?.matrix?.accounts?.ops?.password).toBeUndefined();
     expect(next.channels?.matrix?.accounts?.ops?.deviceId).toBeUndefined();
     expect(next.channels?.matrix?.accounts?.ops?.deviceName).toBeUndefined();
+  });
+
+  it("stores proxy in account setup updates", () => {
+    const next = matrixSetupAdapter.applyAccountConfig({
+      cfg: {} as CoreConfig,
+      accountId: "ops",
+      input: {
+        homeserver: "https://matrix.example.org",
+        accessToken: "ops-token",
+        proxy: "http://127.0.0.1:7890",
+      },
+    }) as CoreConfig;
+
+    expect(next.channels?.matrix?.accounts?.ops).toMatchObject({
+      enabled: true,
+      homeserver: "https://matrix.example.org",
+      accessToken: "ops-token",
+      proxy: "http://127.0.0.1:7890",
+    });
   });
 });

--- a/extensions/matrix/src/setup-core.ts
+++ b/extensions/matrix/src/setup-core.ts
@@ -4,7 +4,6 @@ import {
   prepareScopedSetupConfig,
   type ChannelSetupAdapter,
 } from "openclaw/plugin-sdk/setup";
-import { updateMatrixAccountConfig } from "./matrix/config-update.js";
 import { applyMatrixSetupAccountConfig, validateMatrixSetupInput } from "./setup-config.js";
 import type { CoreConfig } from "./types.js";
 
@@ -12,32 +11,6 @@ const channel = "matrix" as const;
 
 function resolveMatrixSetupAccountId(params: { accountId?: string; name?: string }): string {
   return normalizeAccountId(params.accountId?.trim() || params.name?.trim() || DEFAULT_ACCOUNT_ID);
-}
-
-export function buildMatrixConfigUpdate(
-  cfg: CoreConfig,
-  input: {
-    homeserver?: string;
-    allowPrivateNetwork?: boolean;
-    proxy?: string;
-    userId?: string;
-    accessToken?: string;
-    password?: string;
-    deviceName?: string;
-    initialSyncLimit?: number;
-  },
-): CoreConfig {
-  return updateMatrixAccountConfig(cfg, DEFAULT_ACCOUNT_ID, {
-    enabled: true,
-    homeserver: input.homeserver,
-    allowPrivateNetwork: input.allowPrivateNetwork,
-    proxy: input.proxy,
-    userId: input.userId,
-    accessToken: input.accessToken,
-    password: input.password,
-    deviceName: input.deviceName,
-    initialSyncLimit: input.initialSyncLimit,
-  });
 }
 
 export const matrixSetupAdapter: ChannelSetupAdapter = {

--- a/extensions/matrix/src/setup-core.ts
+++ b/extensions/matrix/src/setup-core.ts
@@ -19,6 +19,7 @@ export function buildMatrixConfigUpdate(
   input: {
     homeserver?: string;
     allowPrivateNetwork?: boolean;
+    proxy?: string;
     userId?: string;
     accessToken?: string;
     password?: string;
@@ -30,6 +31,7 @@ export function buildMatrixConfigUpdate(
     enabled: true,
     homeserver: input.homeserver,
     allowPrivateNetwork: input.allowPrivateNetwork,
+    proxy: input.proxy,
     userId: input.userId,
     accessToken: input.accessToken,
     password: input.password,

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -70,6 +70,8 @@ export type MatrixConfig = {
   homeserver?: string;
   /** Allow Matrix homeserver traffic to private/internal hosts. */
   allowPrivateNetwork?: boolean;
+  /** Optional HTTP(S) proxy URL for Matrix connections (e.g. http://127.0.0.1:7890). */
+  proxy?: string;
   /** Matrix user id (@user:server). */
   userId?: string;
   /** Matrix access token. */

--- a/src/agents/skills.test-helpers.ts
+++ b/src/agents/skills.test-helpers.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { Skill } from "@mariozechner/pi-coding-agent";
+import { createSyntheticSourceInfo, type Skill } from "@mariozechner/pi-coding-agent";
 
 export async function writeSkill(params: {
   dir: string;
@@ -37,6 +37,12 @@ export function createCanonicalFixtureSkill(params: {
     filePath: params.filePath,
     baseDir: params.baseDir,
     source: params.source,
+    sourceInfo: createSyntheticSourceInfo(params.filePath, {
+      source: params.source,
+      baseDir: params.baseDir,
+      scope: "project",
+      origin: "top-level",
+    }),
     disableModelInvocation: params.disableModelInvocation ?? false,
   };
 }

--- a/src/agents/skills.test-helpers.ts
+++ b/src/agents/skills.test-helpers.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createSyntheticSourceInfo, type Skill } from "@mariozechner/pi-coding-agent";
+import type { Skill } from "@mariozechner/pi-coding-agent";
 
 export async function writeSkill(params: {
   dir: string;
@@ -37,12 +37,6 @@ export function createCanonicalFixtureSkill(params: {
     filePath: params.filePath,
     baseDir: params.baseDir,
     source: params.source,
-    sourceInfo: createSyntheticSourceInfo(params.filePath, {
-      source: params.source,
-      baseDir: params.baseDir,
-      scope: "project",
-      origin: "top-level",
-    }),
     disableModelInvocation: params.disableModelInvocation ?? false,
   };
 }

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -83,6 +83,7 @@ export type ChannelSetupInput = {
   useEnv?: boolean;
   homeserver?: string;
   allowPrivateNetwork?: boolean;
+  proxy?: string;
   userId?: string;
   accessToken?: string;
   password?: string;


### PR DESCRIPTION
## Summary

Adds `channels.matrix.proxy?: string` — an explicit HTTP(S) proxy URL for Matrix connections. Mirrors the existing `channels.telegram.proxy` pattern.

## Motivation

The Matrix channel lacks an explicit proxy configuration option. Unlike other channels (e.g., Telegram with `channels.telegram.proxy`), there was no supported way to configure an HTTP(S) proxy for Matrix connections through the config file.

## Changes

### Core
- **`src/plugin-sdk/infra-runtime.ts`** — Re-export `PinnedDispatcherPolicy` type so extensions can import from `openclaw/plugin-sdk/infra-runtime`

### Matrix channel
- **`extensions/matrix/src/types.ts`** — `proxy?: string` on `MatrixConfig`
- **`extensions/matrix/src/config-schema.ts`** — `proxy: z.string().optional()` on `MatrixConfigSchema`
- **`extensions/matrix/src/matrix/client/types.ts`** — `dispatcherPolicy?: PinnedDispatcherPolicy` on `MatrixResolvedConfig` + `MatrixAuth`
- **`extensions/matrix/src/matrix/client/config.ts`** — `buildMatrixNetworkFields` builds `PinnedDispatcherPolicy` from proxy string (`mode: "explicit-proxy"`); plumbed through all call sites
- **`extensions/matrix/src/matrix/sdk.ts`** — `MatrixClient` opts accept + forward `dispatcherPolicy`
- **`extensions/matrix/src/matrix/sdk/http-client.ts`** — `MatrixAuthedHttpClient` accepts + forwards `dispatcherPolicy`
- **`extensions/matrix/src/matrix/sdk/transport.ts`** — All fetch functions accept + forward `dispatcherPolicy` to `createPinnedDispatcher`
- **`extensions/matrix/src/matrix/client/create-client.ts`** — Thread `dispatcherPolicy` through `createMatrixClient`
- **`extensions/matrix/src/matrix/client/shared.ts`** — Thread `dispatcherPolicy` through shared client creation

### SSRF layer
- **`src/infra/net/ssrf.ts`** — Remove env var auto-detect fallback from `createPinnedDispatcher` for `mode: "direct"` (explicit config is now the intended path)

## Usage

```yaml
channels:
  matrix:
    proxy: http://127.0.0.1:7890
```

## Testing

- All existing Matrix channel tests pass
- `pnpm check` passes with 0 warnings/errors
- Verified locally: gateway Matrix traffic routes through configured proxy

Closes #56930