### PR TITLE
fix: prevent input/toggle overlap in Overview access section at narrow widths

### DIFF
--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -225,7 +225,7 @@ export function renderOverview(props: OverviewProps) {
                     <input
                       type=${props.showGatewayToken ? "text" : "password"}
                       autocomplete="off"
-                      style="flex: 1;"
+                      style="flex: 1; min-width: 0;"
                       .value=${props.settings.token}
                       @input=${(e: Event) => {
                         const v = (e.target as HTMLInputElement).value;
@@ -236,7 +236,7 @@ export function renderOverview(props: OverviewProps) {
                     <button
                       type="button"
                       class="btn btn--icon ${props.showGatewayToken ? "active" : ""}"
-                      style="width: 36px; height: 36px;"
+                      style="width: 36px; height: 36px; flex-shrink: 0;"
                       title=${props.showGatewayToken ? "Hide token" : "Show token"}
                       aria-label="Toggle token visibility"
                       aria-pressed=${props.showGatewayToken}
@@ -252,7 +252,7 @@ export function renderOverview(props: OverviewProps) {
                     <input
                       type=${props.showGatewayPassword ? "text" : "password"}
                       autocomplete="off"
-                      style="flex: 1;"
+                      style="flex: 1; min-width: 0;"
                       .value=${props.password}
                       @input=${(e: Event) => {
                         const v = (e.target as HTMLInputElement).value;
@@ -263,7 +263,7 @@ export function renderOverview(props: OverviewProps) {
                     <button
                       type="button"
                       class="btn btn--icon ${props.showGatewayPassword ? "active" : ""}"
-                      style="width: 36px; height: 36px;"
+                      style="width: 36px; height: 36px; flex-shrink: 0;"
                       title=${props.showGatewayPassword ? "Hide password" : "Show password"}
                       aria-label="Toggle password visibility"
                       aria-pressed=${props.showGatewayPassword}


### PR DESCRIPTION
## Summary

At narrow browser widths (~400px), the token and password visibility toggle buttons overlap with their respective input fields in the Control UI Overview access section.

## Root Cause

The flex container did not constrain the input to shrink properly — flex items default to `min-width: auto`, preventing them from shrinking below their content size. The toggle button was pushed on top of the input at narrow widths.

## Changes

- Added `min-width: 0` to both token and password input fields so they can shrink within the flex container
- Added `flex-shrink: 0` to both toggle buttons so they maintain their fixed 36x36px dimensions and are never squeezed

## Testing

Visual fix verified by inspecting the layout. Existing tests pass.

Fixes openclaw/openclaw#56921