### PR TITLE
fix(feishu): add botName to per-account config schema

### DIFF
--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -192,6 +192,7 @@ export const FeishuAccountConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
     name: z.string().optional(), // Display name for this account
+    botName: z.string().optional(), // User-facing bot display name override
     appId: z.string().optional(),
     appSecret: buildSecretInputSchema().optional(),
     encryptKey: buildSecretInputSchema().optional(),


### PR DESCRIPTION
lobster-biscuit

Closes #56942

## Problem

After upgrading to v2026.3.28, gateway fails to start with:
`Config validation failed: channels.feishu.accounts.main: must NOT have additional properties`

Users with `botName` in their per-account Feishu config (documented in the Feishu channel setup guide) are blocked from starting the gateway.

## Root cause

`extensions/feishu/src/config-schema.ts:191-206` — `FeishuAccountConfigSchema` uses `.strict()` but does not include `botName`. The runtime reads `botName` from config at `bot.ts:225` and passes it through to `parseFeishuMessageEvent()`.

The schema was tightened with `.strict()` during the config-schema migration but `botName` was missed.

## User impact

Gateway startup blocked for any Feishu user with `botName` in per-account config. No workaround except editing config to remove `botName`.

## Fix

Add `botName: z.string().optional()` to `FeishuAccountConfigSchema`. 1 file, +1 line.

## How to verify

1. Set `channels.feishu.accounts.main.botName: "MyBot"`
2. `openclaw gateway start`
3. Before: "must NOT have additional properties". After: starts normally.

## Tests

Schema-only change — existing Feishu config tests validate the schema shape. The new field is optional and does not affect any existing valid config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)