### PR TITLE
fix(ollama): properly handle abort signal during streaming

### DIFF
--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -615,29 +615,47 @@ export function buildAssistantMessage(
 
 export async function* parseNdjsonStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
+  signal?: AbortSignal,
 ): AsyncGenerator<OllamaChatResponse> {
   const decoder = new TextDecoder();
   let buffer = "";
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      break;
-    }
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n");
-    buffer = lines.pop() ?? "";
+  if (signal) {
+    signal.addEventListener(
+      "abort",
+      () => {
+        reader.cancel().catch(() => {});
+      },
+      { once: true },
+    );
+  }
 
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed) {
-        continue;
+  while (true) {
+    try {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
       }
-      try {
-        yield parseJsonPreservingUnsafeIntegers(trimmed) as OllamaChatResponse;
-      } catch {
-        log.warn(`Skipping malformed NDJSON line: ${trimmed.slice(0, 120)}`);
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        try {
+          yield parseJsonPreservingUnsafeIntegers(trimmed) as OllamaChatResponse;
+        } catch {
+          log.warn(`Skipping malformed NDJSON line: ${trimmed.slice(0, 120)}`);
+        }
       }
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") {
+        break;
+      }
+      throw err;
     }
   }
 
@@ -752,7 +770,7 @@ export function createOllamaStreamFn(
           });
         };
 
-        for await (const chunk of parseNdjsonStream(reader)) {
+        for await (const chunk of parseNdjsonStream(reader, options?.signal)) {
           if (chunk.message?.content) {
             const delta = chunk.message.content;
 


### PR DESCRIPTION
## Summary

- Fixes the issue where OpenClaw hangs/timeouts with larger Ollama models (>3GB)
- When a timeout occurs, the abort signal now properly cancels the reader stream instead of hanging indefinitely

## Changes

- Pass signal to `parseNdjsonStream` function
- Add abort event listener to cancel reader when signal fires  
- Handle AbortError to break out of stream loop cleanly
- Updated call site to pass `options.signal` to the stream parser

## Testing

- All 31 existing unit tests pass
- Lint passes with 0 warnings and 0 errors