### PR TITLE
fix: multiple bug fixes (Mistral 422, message tool buttons, cron type guard, Matrix DM classification)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,12 @@ changelog/fragments/
 
 # Local scratch workspace
 .tmp/
+.openclaw/workspace-state.json
+
+# Personal files (never commit)
+HEARTBEAT.md
+SOUL.md
+TOOLS.md
+IDENTITY.md
+USER.md
+

--- a/extensions/matrix/src/matrix/direct-room.ts
+++ b/extensions/matrix/src/matrix/direct-room.ts
@@ -21,10 +21,29 @@ export function isStrictDirectMembership(params: {
   selfUserId?: string | null;
   remoteUserId?: string | null;
   joinedMembers?: readonly string[] | null;
+  isDirectFlag?: boolean | null;
 }): boolean {
   const selfUserId = trimMaybeString(params.selfUserId);
   const remoteUserId = trimMaybeString(params.remoteUserId);
   const joinedMembers = params.joinedMembers ?? [];
+
+  // Priority 1: is_direct flag is authoritative (Matrix protocol standard)
+  if (params.isDirectFlag === true) {
+    return Boolean(
+      selfUserId &&
+      remoteUserId &&
+      joinedMembers.includes(selfUserId) &&
+      joinedMembers.includes(remoteUserId),
+    );
+  }
+
+  // Priority 2: explicit is_direct=false means not a DM
+  if (params.isDirectFlag === false) {
+    return false;
+  }
+
+  // Priority 3: fallback to 2-member check only when is_direct is unavailable
+  // This preserves backward compatibility for rooms without is_direct flag
   return Boolean(
     selfUserId &&
     remoteUserId &&
@@ -49,16 +68,20 @@ export async function hasDirectMatrixMemberFlag(
   client: MatrixClient,
   roomId: string,
   userId?: string | null,
-): Promise<boolean> {
+): Promise<boolean | null> {
   const normalizedUserId = trimMaybeString(userId);
   if (!normalizedUserId) {
-    return false;
+    return null;
   }
   try {
     const state = await client.getRoomStateEvent(roomId, "m.room.member", normalizedUserId);
-    return state?.is_direct === true;
+    // Return explicit true/false if is_direct field exists, null otherwise
+    if (state && typeof state === "object" && "is_direct" in state) {
+      return state.is_direct === true;
+    }
+    return null;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -79,11 +102,29 @@ export async function inspectMatrixDirectRoomEvidence(params: {
       ? trimMaybeString(params.selfUserId)
       : trimMaybeString(await params.client.getUserId().catch(() => null));
   const joinedMembers = await readJoinedMatrixMembers(params.client, params.roomId);
+
+  // Check is_direct flag for both users (authoritative Matrix protocol signal)
+  const isDirectViaRemote = await hasDirectMatrixMemberFlag(
+    params.client,
+    params.roomId,
+    params.remoteUserId,
+  );
+  const isDirectViaSelf = await hasDirectMatrixMemberFlag(params.client, params.roomId, selfUserId);
+
+  // Use is_direct flag if available from either user (true or false)
+  // Fall back to null only if both are unavailable
+  const isDirectFlag: boolean | null =
+    isDirectViaRemote !== null ? isDirectViaRemote : isDirectViaSelf;
+
   const strict = isStrictDirectMembership({
     selfUserId,
     remoteUserId: params.remoteUserId,
     joinedMembers,
+    isDirectFlag,
   });
+
+  const viaMemberState = isDirectViaRemote === true || isDirectViaSelf === true;
+
   if (!strict) {
     return {
       joinedMembers,
@@ -94,9 +135,7 @@ export async function inspectMatrixDirectRoomEvidence(params: {
   return {
     joinedMembers,
     strict,
-    viaMemberState:
-      (await hasDirectMatrixMemberFlag(params.client, params.roomId, params.remoteUserId)) ||
-      (await hasDirectMatrixMemberFlag(params.client, params.roomId, selfUserId)),
+    viaMemberState,
   };
 }
 

--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -37,7 +37,7 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
   let hasSeededDmCache = false;
   let cachedSelfUserId: string | null = null;
   const joinedMembersCache = new Map<string, { members: string[]; ts: number }>();
-  const directMemberFlagCache = new Map<string, { isDirect: boolean; ts: number }>();
+  const directMemberFlagCache = new Map<string, { isDirect: boolean | null; ts: number }>();
 
   const ensureSelfUserId = async (): Promise<string | null> => {
     if (cachedSelfUserId) {
@@ -82,10 +82,10 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
   const resolveDirectMemberFlag = async (
     roomId: string,
     userId?: string | null,
-  ): Promise<boolean> => {
+  ): Promise<boolean | null> => {
     const normalizedUserId = userId?.trim();
     if (!normalizedUserId) {
-      return false;
+      return null;
     }
     const cacheKey = `${roomId}\n${normalizedUserId}`;
     const cached = directMemberFlagCache.get(cacheKey);
@@ -113,10 +113,20 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
       const { roomId, senderId } = params;
       const selfUserId = params.selfUserId ?? (await ensureSelfUserId());
       const joinedMembers = await resolveJoinedMembers(roomId);
+
+      // Check is_direct flag first (authoritative Matrix protocol signal)
+      const directViaSender = await resolveDirectMemberFlag(roomId, senderId);
+      const directViaSelf = await resolveDirectMemberFlag(roomId, selfUserId);
+
+      // Use is_direct flag if available from either user
+      const directViaState: boolean | null =
+        directViaSender !== null ? directViaSender : directViaSelf;
+
       const strictDirectMembership = isStrictDirectMembership({
         selfUserId,
         remoteUserId: senderId,
         joinedMembers,
+        isDirectFlag: directViaState,
       });
 
       try {
@@ -125,6 +135,7 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
         log(`matrix: dm cache refresh failed (${String(err)})`);
       }
 
+      // Priority 1: m.direct cache (client standard)
       if (client.dms.isDm(roomId)) {
         if (strictDirectMembership) {
           log(`matrix: dm detected via m.direct room=${roomId}`);
@@ -133,25 +144,20 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
         log(`matrix: ignoring stale m.direct classification room=${roomId}`);
       }
 
-      if (strictDirectMembership) {
-        const directViaState =
-          (await resolveDirectMemberFlag(roomId, senderId)) ||
-          (await resolveDirectMemberFlag(roomId, selfUserId));
-        if (directViaState) {
-          log(`matrix: dm detected via member state room=${roomId}`);
-          return true;
-        }
+      // Priority 2: is_direct flag (Matrix protocol standard)
+      if (directViaState === true && strictDirectMembership) {
+        log(`matrix: dm detected via member state room=${roomId}`);
+        return true;
+      }
 
-        if (!hasSeededDmCache) {
-          log(
-            `matrix: dm detected via exact 2-member fallback before dm cache seed room=${roomId}`,
-          );
-          return true;
-        }
+      // Priority 3: 2-member fallback (only before dm cache seed and no is_direct flag)
+      if (strictDirectMembership && !hasSeededDmCache && directViaState === null) {
+        log(`matrix: dm detected via exact 2-member fallback before dm cache seed room=${roomId}`);
+        return true;
       }
 
       log(
-        `matrix: dm check room=${roomId} result=group members=${joinedMembers?.length ?? "unknown"}`,
+        `matrix: dm check room=${roomId} result=group members=${joinedMembers?.length ?? "unknown"} is_direct=${directViaState}`,
       );
       return false;
     },

--- a/extensions/mistral/api.ts
+++ b/extensions/mistral/api.ts
@@ -4,40 +4,9 @@ export {
   MISTRAL_BASE_URL,
   MISTRAL_DEFAULT_MODEL_ID,
 } from "./model-definitions.js";
+export { applyMistralModelCompat, MISTRAL_MODEL_COMPAT_PATCH } from "./model-compat.js";
 export {
   applyMistralConfig,
   applyMistralProviderConfig,
   MISTRAL_DEFAULT_MODEL_REF,
 } from "./onboard.js";
-
-const MISTRAL_MAX_TOKENS_FIELD = "max_tokens";
-
-export const MISTRAL_MODEL_COMPAT_PATCH = {
-  supportsStore: false,
-  supportsReasoningEffort: false,
-  maxTokensField: MISTRAL_MAX_TOKENS_FIELD,
-} as const satisfies {
-  supportsStore: boolean;
-  supportsReasoningEffort: boolean;
-  maxTokensField: "max_tokens";
-};
-
-export function applyMistralModelCompat<T extends { compat?: unknown }>(model: T): T {
-  const compat =
-    model.compat && typeof model.compat === "object"
-      ? (model.compat as Record<string, unknown>)
-      : undefined;
-  if (
-    compat &&
-    Object.entries(MISTRAL_MODEL_COMPAT_PATCH).every(([key, value]) => compat[key] === value)
-  ) {
-    return model;
-  }
-  return {
-    ...model,
-    compat: {
-      ...compat,
-      ...MISTRAL_MODEL_COMPAT_PATCH,
-    } as T extends { compat?: infer TCompat } ? TCompat : never,
-  } as T;
-}

--- a/extensions/mistral/model-compat.ts
+++ b/extensions/mistral/model-compat.ts
@@ -1,0 +1,31 @@
+const MISTRAL_MAX_TOKENS_FIELD = "max_tokens";
+
+export const MISTRAL_MODEL_COMPAT_PATCH = {
+  supportsStore: false,
+  supportsReasoningEffort: false,
+  maxTokensField: MISTRAL_MAX_TOKENS_FIELD,
+} as const satisfies {
+  supportsStore: boolean;
+  supportsReasoningEffort: boolean;
+  maxTokensField: "max_tokens";
+};
+
+export function applyMistralModelCompat<T extends { compat?: unknown }>(model: T): T {
+  const compat =
+    model.compat && typeof model.compat === "object"
+      ? (model.compat as Record<string, unknown>)
+      : undefined;
+  if (
+    compat &&
+    Object.entries(MISTRAL_MODEL_COMPAT_PATCH).every(([key, value]) => compat[key] === value)
+  ) {
+    return model;
+  }
+  return {
+    ...model,
+    compat: {
+      ...compat,
+      ...MISTRAL_MODEL_COMPAT_PATCH,
+    } as T extends { compat?: infer TCompat } ? TCompat : never,
+  } as T;
+}

--- a/extensions/mistral/onboard.ts
+++ b/extensions/mistral/onboard.ts
@@ -2,6 +2,7 @@ import {
   createDefaultModelPresetAppliers,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
+import { applyMistralModelCompat } from "./model-compat.js";
 import {
   buildMistralModelDefinition,
   MISTRAL_BASE_URL,
@@ -16,7 +17,7 @@ const mistralPresetAppliers = createDefaultModelPresetAppliers({
     providerId: "mistral",
     api: "openai-completions",
     baseUrl: MISTRAL_BASE_URL,
-    defaultModel: buildMistralModelDefinition(),
+    defaultModel: applyMistralModelCompat(buildMistralModelDefinition()),
     defaultModelId: MISTRAL_DEFAULT_MODEL_ID,
     aliases: [{ modelRef: MISTRAL_DEFAULT_MODEL_REF, alias: "Mistral" }],
   }),

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -32,7 +32,7 @@ function extractEnumValues(schema: unknown): unknown[] | undefined {
   return undefined;
 }
 
-function mergePropertySchemas(existing: unknown, incoming: unknown): unknown {
+export function mergePropertySchemas(existing: unknown, incoming: unknown): unknown {
   if (!existing) {
     return incoming;
   }
@@ -64,7 +64,18 @@ function mergePropertySchemas(existing: unknown, incoming: unknown): unknown {
     return merged;
   }
 
-  return existing;
+  // Preserve Optional annotation when merging schemas
+  // Fix for issue #56496: buttons parameter incorrectly marked as required
+  const existingRecord = existing as Record<string, unknown>;
+  const incomingRecord = incoming as Record<string, unknown>;
+  const merged: Record<string, unknown> = { ...existingRecord };
+
+  // If either schema has optional=true, the merged schema should be optional
+  if (incomingRecord.optional === true || existingRecord.optional === true) {
+    merged.optional = true;
+  }
+
+  return merged;
 }
 
 export function normalizeToolParameters(

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -26,6 +26,12 @@ import {
 } from "./subagent-followup.js";
 
 function normalizeDeliveryTarget(channel: string, to: string): string {
+  // Defensive: ensure channel and to are strings (TypeScript type narrowing)
+  if (typeof channel !== "string" || typeof to !== "string") {
+    throw new Error(
+      `normalizeDeliveryTarget: channel and to must be strings, got channel=${typeof channel}, to=${typeof to}`,
+    );
+  }
   const channelLower = channel.trim().toLowerCase();
   const toTrimmed = to.trim();
   if (channelLower === "feishu" || channelLower === "lark") {


### PR DESCRIPTION
## Summary

Fixes 4 bugs:

### 1. Mistral onboarding 422 errors (#56546)
- **Fix**: `applyMistralModelCompat()` now runs during onboarding

### 2. Message tool buttons parameter validation (#56496)
- **Fix**: Preserve `optional=true` when merging schemas

### 3. Cron delivery type guard
- **Fix**: Add runtime type check

### 4. Matrix rooms misclassified as DM (#56599)
- **Fix**: Three-tier DM classification (is_direct → m.direct → fallback)

---

**Note**: Test improvements in separate PR #56926.