### PR TITLE
fix: replace duplicate clamp and isRecord with shared utils imports

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -10,6 +10,7 @@ import {
   writeFileWithinRoot,
 } from "../infra/fs-safe.js";
 import { trySafeFileURLToPath } from "../infra/local-file-access.js";
+import { clamp } from "../utils.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
@@ -60,10 +61,6 @@ type ReadTruncationDetails = {
 
 const READ_CONTINUATION_NOTICE_RE =
   /\n\n\[(?:Showing lines [^\]]*?Use offset=\d+ to continue\.|\d+ more lines in file\. Use offset=\d+ to continue\.)\]\s*$/;
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
 
 function resolveAdaptiveReadMaxBytes(options?: OpenClawReadToolOptions): number {
   const contextWindowTokens = options?.modelContextWindowTokens;

--- a/src/commands/doctor-legacy-config.ts
+++ b/src/commands/doctor-legacy-config.ts
@@ -13,6 +13,7 @@ import {
 import { migrateLegacyWebSearchConfig } from "../config/legacy-web-search.js";
 import { LEGACY_TALK_PROVIDER_ID, normalizeTalkSection } from "../config/talk.js";
 import { DEFAULT_GOOGLE_API_BASE_URL } from "../infra/google-api-base-url.js";
+import { isRecord } from "../utils.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 
 export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
@@ -23,9 +24,6 @@ export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
   const NANO_BANANA_SKILL_KEY = "nano-banana-pro";
   const NANO_BANANA_MODEL = "google/gemini-3-pro-image-preview";
   let next: OpenClawConfig = cfg;
-
-  const isRecord = (value: unknown): value is Record<string, unknown> =>
-    Boolean(value) && typeof value === "object" && !Array.isArray(value);
 
   const normalizeDmAliases = (params: {
     provider: "slack" | "discord";


### PR DESCRIPTION
## Summary

Remove two duplicate utility functions that are identical to shared exports in `src/utils.ts`:

- **`clamp`** in `pi-tools.read.ts:64` — `Math.max(min, Math.min(max, value))`, identical to `clampNumber` in `utils.ts:30` (which is already re-exported as `clamp` at line 39)
- **`isRecord`** in `doctor-legacy-config.ts:27` — type guard using `Boolean(value) && typeof value === "object" && !Array.isArray(value)`, functionally identical to `isRecord` in `utils.ts:65` which uses `value !== null` instead of `Boolean(value)` (equivalent for the `typeof === "object"` guard since `null` is the only falsy object)

Both local copies are file-scoped (not exported) with no external consumers.

## Changes

- `src/agents/pi-tools.read.ts`: Delete local `clamp`, add `import { clamp } from "../utils.js"`
- `src/commands/doctor-legacy-config.ts`: Delete local `isRecord`, add `import { isRecord } from "../utils.js"`

## Test plan

- No behavior change — both replacements are functionally identical
- Existing tests cover both call sites