### PR TITLE
fix: mark gpt-5.4-mini as vision-capable

### DIFF
--- a/extensions/matrix/CHANGELOG.md
+++ b/extensions/matrix/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Include Matrix poll events in `read` (poll start/response/end) so agents can compute poll results from timeline.
+
 ## 2026.2.22
 
 ### Changes

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -1,8 +1,8 @@
+import { POLL_EVENT_TYPES } from "../poll-types.js";
 import { resolveMatrixRoomId, sendMessageMatrix } from "../send.js";
 import { resolveActionClient } from "./client.js";
 import { resolveMatrixActionLimit } from "./limits.js";
 import { summarizeMatrixRawEvent } from "./summary.js";
-import { POLL_EVENT_TYPES } from "../poll-types.js";
 import {
   EventType,
   MsgType,
@@ -111,10 +111,11 @@ export async function readMatrixMessages(
       },
     )) as { chunk: MatrixRawEvent[]; start?: string; end?: string };
     const messages = res.chunk
-      .filter((event) =>
-        event.type === EventType.RoomMessage ||
-        // Polls (MSC3381): include so clients/agents can read poll questions + responses
-        POLL_EVENT_TYPES.includes(event.type),
+      .filter(
+        (event) =>
+          event.type === EventType.RoomMessage ||
+          // Polls (MSC3381): include so clients/agents can read poll questions + responses
+          POLL_EVENT_TYPES.includes(event.type),
       )
       .filter((event) => !event.unsigned?.redacted_because)
       .map(summarizeMatrixRawEvent);

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -115,7 +115,7 @@ export async function readMatrixMessages(
         (event) =>
           event.type === EventType.RoomMessage ||
           // Polls (MSC3381): include so clients/agents can read poll questions + responses
-          POLL_EVENT_TYPES.includes(event.type),
+          POLL_EVENT_TYPES.includes(event.type as (typeof POLL_EVENT_TYPES)[number]),
       )
       .filter((event) => !event.unsigned?.redacted_because)
       .map(summarizeMatrixRawEvent);

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -2,6 +2,7 @@ import { resolveMatrixRoomId, sendMessageMatrix } from "../send.js";
 import { resolveActionClient } from "./client.js";
 import { resolveMatrixActionLimit } from "./limits.js";
 import { summarizeMatrixRawEvent } from "./summary.js";
+import { POLL_EVENT_TYPES } from "../poll-types.js";
 import {
   EventType,
   MsgType,
@@ -110,7 +111,11 @@ export async function readMatrixMessages(
       },
     )) as { chunk: MatrixRawEvent[]; start?: string; end?: string };
     const messages = res.chunk
-      .filter((event) => event.type === EventType.RoomMessage)
+      .filter((event) =>
+        event.type === EventType.RoomMessage ||
+        // Polls (MSC3381): include so clients/agents can read poll questions + responses
+        POLL_EVENT_TYPES.includes(event.type),
+      )
       .filter((event) => !event.unsigned?.redacted_because)
       .map(summarizeMatrixRawEvent);
     return {

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -1,4 +1,5 @@
 import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
+import { POLL_END_TYPES, POLL_RESPONSE_TYPES } from "../poll-types.js";
 import {
   EventType,
   type MatrixMessageSummary,
@@ -7,31 +8,100 @@ import {
   type RoomPinnedEventsEventContent,
 } from "./types.js";
 
-export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSummary {
-  const content = event.content as RoomMessageEventContent;
-  const relates = content["m.relates_to"];
+function getRelatesTo(content: Record<string, unknown>): MatrixMessageSummary["relatesTo"] {
+  const relates = content["m.relates_to"] as
+    | {
+        rel_type?: string;
+        event_id?: string;
+        key?: string;
+        "m.in_reply_to"?: { event_id?: string };
+      }
+    | undefined;
+
   let relType: string | undefined;
   let eventId: string | undefined;
+  let key: string | undefined;
+
   if (relates) {
-    if ("rel_type" in relates) {
-      relType = relates.rel_type;
-      eventId = relates.event_id;
-    } else if ("m.in_reply_to" in relates) {
-      eventId = relates["m.in_reply_to"]?.event_id;
-    }
+    relType = relates.rel_type;
+    eventId = relates.event_id ?? relates["m.in_reply_to"]?.event_id;
+    key = relates.key;
   }
-  const relatesTo =
-    relType || eventId
-      ? {
-          relType,
-          eventId,
-        }
-      : undefined;
+
+  return relType || eventId || key
+    ? {
+        relType,
+        eventId,
+        key,
+      }
+    : undefined;
+}
+
+function summarizePollResponse(event: MatrixRawEvent): { body: string; msgtype: string } {
+  const content = event.content as Record<string, unknown>;
+
+  // Responses can be legacy key ("m.poll.response") or MSC key (event.type)
+  const responseObj =
+    (content[event.type] as { answers?: unknown } | undefined) ??
+    (content["m.poll.response"] as { answers?: unknown } | undefined) ??
+    (content["org.matrix.msc3381.poll.response"] as { answers?: unknown } | undefined);
+
+  const answers = Array.isArray(responseObj?.answers)
+    ? responseObj?.answers.filter((x): x is string => typeof x === "string")
+    : [];
+
+  const answersText = answers.length ? answers.join(", ") : "(no answers)";
+  return {
+    body: `[Poll vote] ${answersText}`,
+    msgtype: "m.poll.response",
+  };
+}
+
+export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSummary {
+  const content = event.content as Record<string, unknown>;
+  const relatesTo = getRelatesTo(content);
+
+  // Most events are m.room.message and have {body,msgtype}. Poll response/end events do not.
+  const maybeRoomMsg = content as unknown as Partial<RoomMessageEventContent>;
+  if (typeof maybeRoomMsg.body === "string" && typeof maybeRoomMsg.msgtype === "string") {
+    return {
+      eventId: event.event_id,
+      sender: event.sender,
+      body: maybeRoomMsg.body,
+      msgtype: maybeRoomMsg.msgtype,
+      timestamp: event.origin_server_ts,
+      relatesTo,
+    };
+  }
+
+  if (POLL_RESPONSE_TYPES.includes(event.type)) {
+    const summarized = summarizePollResponse(event);
+    return {
+      eventId: event.event_id,
+      sender: event.sender,
+      body: summarized.body,
+      msgtype: summarized.msgtype,
+      timestamp: event.origin_server_ts,
+      relatesTo,
+    };
+  }
+
+  if (POLL_END_TYPES.includes(event.type)) {
+    return {
+      eventId: event.event_id,
+      sender: event.sender,
+      body: "[Poll ended]",
+      msgtype: "m.poll.end",
+      timestamp: event.origin_server_ts,
+      relatesTo,
+    };
+  }
+
   return {
     eventId: event.event_id,
     sender: event.sender,
-    body: content.body,
-    msgtype: content.msgtype,
+    body: `[${event.type}]`,
+    msgtype: event.type,
     timestamp: event.origin_server_ts,
     relatesTo,
   };

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -74,7 +74,7 @@ export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSum
     };
   }
 
-  if (POLL_RESPONSE_TYPES.includes(event.type)) {
+  if (POLL_RESPONSE_TYPES.includes(event.type as (typeof POLL_RESPONSE_TYPES)[number])) {
     const summarized = summarizePollResponse(event);
     return {
       eventId: event.event_id,
@@ -86,7 +86,7 @@ export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSum
     };
   }
 
-  if (POLL_END_TYPES.includes(event.type)) {
+  if (POLL_END_TYPES.includes(event.type as (typeof POLL_END_TYPES)[number])) {
     return {
       eventId: event.event_id,
       sender: event.sender,

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
-import { __setModelCatalogImportForTest, loadModelCatalog } from "./model-catalog.js";
+import {
+  __setModelCatalogImportForTest,
+  loadModelCatalog,
+  modelSupportsVision,
+} from "./model-catalog.js";
 import {
   installModelCatalogTestHooks,
   mockCatalogImportFailThenRecover,
@@ -102,5 +106,33 @@ describe("loadModelCatalog", () => {
     const spark = result.find((entry) => entry.id === "gpt-5.3-codex-spark");
     expect(spark?.name).toBe("gpt-5.3-codex-spark");
     expect(spark?.reasoning).toBe(true);
+  });
+
+  it("marks gpt-5.4-mini as vision-capable for openai-codex", async () => {
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          AuthStorage: class {},
+          ModelRegistry: class {
+            getAll() {
+              return [
+                {
+                  id: "gpt-5.4-mini",
+                  provider: "openai-codex",
+                  name: "GPT-5.4 Mini",
+                  reasoning: true,
+                  contextWindow: 272000,
+                  input: ["text"],
+                },
+              ];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+    const model = result.find((entry) => entry.id === "gpt-5.4-mini");
+    expect(model?.input).toContain("image");
+    expect(modelSupportsVision(model)).toBe(true);
   });
 });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -59,6 +59,24 @@ function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
   });
 }
 
+const OPENAI_CODEX_NATIVE_VISION_MODEL_IDS = new Set(["gpt-5.4", "gpt-5.4-mini"]);
+
+function applyOpenAICodexNativeVisionFallback(models: ModelCatalogEntry[]): void {
+  for (const entry of models) {
+    if (entry.provider !== CODEX_PROVIDER) {
+      continue;
+    }
+    if (!OPENAI_CODEX_NATIVE_VISION_MODEL_IDS.has(entry.id.toLowerCase())) {
+      continue;
+    }
+    const input = new Set(entry.input ?? ["text"]);
+    if (!input.has("image")) {
+      input.add("image");
+      entry.input = Array.from(input) as Array<"text" | "image">;
+    }
+  }
+}
+
 export function resetModelCatalogCacheForTest() {
   modelCatalogPromise = null;
   hasLoggedModelCatalogError = false;
@@ -143,6 +161,7 @@ export async function loadModelCatalog(params?: {
         models.push({ id, name, provider, contextWindow, reasoning, input });
       }
       applyOpenAICodexSparkFallback(models);
+      applyOpenAICodexNativeVisionFallback(models);
 
       if (models.length === 0) {
         // If we found nothing, don't cache this result so we can try again.


### PR DESCRIPTION
## Summary

- Problem: `openai-codex` `gpt-5.4-mini` was getting treated as text-only in the model catalog, so Hermes fell back to the separate vision tool path.
- Why it matters: Matrix chats using `gpt-5.4-mini` should use native image input when available instead of an extra vision step.
- What changed: Added a Codex-native vision fallback in `src/agents/model-catalog.ts` that marks `gpt-5.4` / `gpt-5.4-mini` as image-capable, plus a regression test.
- What did NOT change (scope boundary): No provider/auth config changes, no gateway protocol changes, no new tools.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

`openai-codex` `gpt-5.4-mini` now routes as vision-capable in the catalog, so native image injection can be used instead of `vision_analyze`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: None.

## Repro + Verification

### Environment

- OS: Fedora
- Runtime/container: local dev checkout
- Model/provider: `openai-codex` / `gpt-5.4-mini`
- Integration/channel (if any): Matrix gateway
- Relevant config (redacted): `model.provider: openai-codex`, `model.default: gpt-5.4-mini`

### Steps

1. Load model catalog with an `openai-codex` `gpt-5.4-mini` entry whose `input` only contains `text`.
2. Confirm the fallback adds `image` and `modelSupportsVision()` returns true.
3. Run the focused Vitest suite.

### Expected

- `gpt-5.4-mini` is treated as vision-capable.
- No fallback to the separate vision analyzer for that model.

### Actual

- Before the fix, `gpt-5.4-mini` was routed as text-only and fell back to the vision tool path.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Added regression test and ran `pnpm vitest run --config vitest.unit.config.ts src/agents/model-catalog.test.ts`.
- Edge cases checked: Existing Codex spark fallback still works.
- What you did not verify: Live Matrix image routing end-to-end with an actual attachment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: None.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit or remove the Codex native-vision fallback block in `src/agents/model-catalog.ts`.
- Files/config to restore: `src/agents/model-catalog.ts`, `src/agents/model-catalog.test.ts`
- Known bad symptoms reviewers should watch for: Unexpectedly treating other Codex models as image-capable.

## Risks and Mitigations

- Risk: Over-broad model-id matching could mark an unsupported Codex model as vision-capable.
  - Mitigation: The fallback is narrowly scoped to `gpt-5.4` and `gpt-5.4-mini`, and is covered by a regression test.
