### PR TITLE
perf: hoist regex patterns to module level in detectImageReferences

### DIFF
--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -38,6 +38,14 @@ const FILE_URL_REGEX_SOURCE = "file://[^\\s<>\"'`\\]]+\\.(?:" + IMAGE_EXTENSION_
 const PATH_REGEX_SOURCE =
   "(?:^|\\s|[\"'`(])((\\.\\.?/|[~/])[^\\s\"'`()\\[\\]]*\\.(?:" + IMAGE_EXTENSION_PATTERN + "))";
 
+// Pre-compiled regex patterns for image reference detection.
+// Patterns with the `g` flag are stateful (lastIndex), so they must be reset before each use.
+const MEDIA_ATTACHED_PATTERN = /\[media attached(?:\s+\d+\/\d+)?:\s*([^\]]+)\]/gi;
+const MEDIA_ATTACHED_PATH_PATTERN = new RegExp(MEDIA_ATTACHED_PATH_REGEX_SOURCE, "i");
+const MESSAGE_IMAGE_PATTERN = new RegExp(MESSAGE_IMAGE_REGEX_SOURCE, "gi");
+const FILE_URL_PATTERN = new RegExp(FILE_URL_REGEX_SOURCE, "gi");
+const PATH_PATTERN = new RegExp(PATH_REGEX_SOURCE, "gi");
+
 /**
  * Result of detecting an image reference in text.
  */
@@ -118,16 +126,17 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     refs.push({ raw: trimmed, type: "path", resolved });
   };
 
+  // Reset stateful regex patterns (g flag maintains lastIndex between calls)
+  MEDIA_ATTACHED_PATTERN.lastIndex = 0;
+  MESSAGE_IMAGE_PATTERN.lastIndex = 0;
+  FILE_URL_PATTERN.lastIndex = 0;
+  PATH_PATTERN.lastIndex = 0;
+
   // Pattern for [media attached: path (type) | url] or [media attached N/M: path (type) | url] format
   // Each bracket = ONE file. The | separates path from URL, not multiple files.
   // Multi-file format uses separate brackets on separate lines.
-  const mediaAttachedPattern = /\[media attached(?:\s+\d+\/\d+)?:\s*([^\]]+)\]/gi;
-  const mediaAttachedPathPattern = new RegExp(MEDIA_ATTACHED_PATH_REGEX_SOURCE, "i");
-  const messageImagePattern = new RegExp(MESSAGE_IMAGE_REGEX_SOURCE, "gi");
-  const fileUrlPattern = new RegExp(FILE_URL_REGEX_SOURCE, "gi");
-  const pathPattern = new RegExp(PATH_REGEX_SOURCE, "gi");
   let match: RegExpExecArray | null;
-  while ((match = mediaAttachedPattern.exec(prompt)) !== null) {
+  while ((match = MEDIA_ATTACHED_PATTERN.exec(prompt)) !== null) {
     const content = match[1];
 
     // Skip "[media attached: N files]" header lines
@@ -139,14 +148,14 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     // Format is: path (type) | url  OR  just: path (type)
     // Path may contain spaces (e.g., "ChatGPT Image Apr 21.png")
     // Use non-greedy .+? to stop at first image extension
-    const pathMatch = content.match(mediaAttachedPathPattern);
+    const pathMatch = content.match(MEDIA_ATTACHED_PATH_PATTERN);
     if (pathMatch?.[1]) {
       addPathRef(pathMatch[1].trim());
     }
   }
 
   // Pattern for [Image: source: /path/...] format from messaging systems
-  while ((match = messageImagePattern.exec(prompt)) !== null) {
+  while ((match = MESSAGE_IMAGE_PATTERN.exec(prompt)) !== null) {
     const raw = match[1]?.trim();
     if (raw) {
       addPathRef(raw);
@@ -156,7 +165,7 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
   // Remote HTTP(S) URLs are intentionally ignored. Native image injection is local-only.
 
   // Pattern for file:// URLs - treat as paths since loadWebMedia handles them
-  while ((match = fileUrlPattern.exec(prompt)) !== null) {
+  while ((match = FILE_URL_PATTERN.exec(prompt)) !== null) {
     const raw = match[0];
     const dedupeKey = normalizeRefForDedupe(raw);
     if (seen.has(dedupeKey)) {
@@ -178,7 +187,7 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
   // - ./relative/path.ext
   // - ../parent/path.ext
   // - ~/home/path.ext
-  while ((match = pathPattern.exec(prompt)) !== null) {
+  while ((match = PATH_PATTERN.exec(prompt)) !== null) {
     // Use capture group 1 (the path without delimiter prefix); skip if undefined
     if (match[1]) {
       addPathRef(match[1]);


### PR DESCRIPTION
## Summary

Hoist 5 regex patterns from inside `detectImageReferences()` to module-level constants. These patterns are built from static strings (`IMAGE_EXTENSION_NAMES`) that never change, but were being recompiled via `new RegExp(...)` on every function call.

## Changes

- Move `mediaAttachedPattern`, `mediaAttachedPathPattern`, `messageImagePattern`, `fileUrlPattern`, and `pathPattern` to module scope as `MEDIA_ATTACHED_PATTERN`, `MEDIA_ATTACHED_PATH_PATTERN`, `MESSAGE_IMAGE_PATTERN`, `FILE_URL_PATTERN`, and `PATH_PATTERN`
- Add `lastIndex = 0` resets at the top of the function for the four `g`-flag patterns (stateful regex objects maintain `lastIndex` between `exec()` calls)
- `MEDIA_ATTACHED_PATH_PATTERN` uses the `i` flag only (no `g`), so no reset needed — `.match()` is stateless

## Why this matters

`detectImageReferences` is called on every user turn via `detectAndLoadPromptImages`. Regex compilation from strings (especially patterns with alternation across 10 image extensions) is measurably more expensive than a `lastIndex = 0` reset.

## Test plan

- No behavior change — same patterns, same matching logic
- The `lastIndex` resets ensure correct behavior across multiple calls (prevents stale `lastIndex` from a previous invocation affecting the next)