### PR TITLE
fix: command poll backoff skips first tier after output reset

### DIFF
--- a/src/agents/command-poll-backoff.test.ts
+++ b/src/agents/command-poll-backoff.test.ts
@@ -70,10 +70,10 @@ describe("command-poll-backoff", () => {
       recordCommandPoll(state, "cmd-123", false);
       expect(state.commandPollCounts?.get("cmd-123")?.count).toBe(2); // 3 polls = index 2
 
-      // New output resets count
+      // New output resets count to -1 so the next no-output poll lands on index 0 (5s)
       const retryMs = recordCommandPoll(state, "cmd-123", true);
       expect(retryMs).toBe(5000); // Back to first poll delay
-      expect(state.commandPollCounts?.get("cmd-123")?.count).toBe(0);
+      expect(state.commandPollCounts?.get("cmd-123")?.count).toBe(-1);
     });
 
     it("tracks different commands independently", () => {

--- a/src/agents/command-poll-backoff.ts
+++ b/src/agents/command-poll-backoff.ts
@@ -32,7 +32,10 @@ export function recordCommandPoll(
   const now = Date.now();
 
   if (hasNewOutput) {
-    state.commandPollCounts.set(commandId, { count: 0, lastPollAt: now });
+    // Reset to -1 so the next no-output poll increments to 0 (first backoff tier).
+    // Using 0 here would cause the next no-output poll to compute (0 + 1) = 1,
+    // skipping the 5s tier and jumping straight to 10s.
+    state.commandPollCounts.set(commandId, { count: -1, lastPollAt: now });
     return BACKOFF_SCHEDULE_MS[0] ?? 5000;
   }
 

--- a/src/agents/command-poll-backoff.ts
+++ b/src/agents/command-poll-backoff.ts
@@ -57,7 +57,7 @@ export function getCommandPollSuggestion(
   if (!pollData) {
     return undefined;
   }
-  return calculateBackoffMs(pollData.count);
+  return calculateBackoffMs(Math.max(0, pollData.count));
 }
 
 /**


### PR DESCRIPTION
## Summary

Fix an off-by-one in command poll backoff that causes agents to skip the first backoff tier (5s) after a command produces output then goes quiet.

## The bug

When `hasNewOutput` is true, `recordCommandPoll` resets `count` to `0`. On the next call with `hasNewOutput: false`:

```
newCount = (existing?.count ?? -1) + 1 = (0 ?? -1) + 1 = 0 + 1 = 1
```

`calculateBackoffMs(1)` returns `BACKOFF_SCHEDULE_MS[1]` = 10,000ms (10s), skipping the first tier (5s).

Compare with a brand-new command (no existing entry):

```
newCount = (undefined?.count ?? -1) + 1 = -1 + 1 = 0
```

This correctly gets `BACKOFF_SCHEDULE_MS[0]` = 5,000ms (5s).

## The fix

Reset `count` to `-1` instead of `0` when output is received. The next no-output poll then computes `(-1) + 1 = 0`, correctly landing on the first backoff tier.

## Impact

After this fix, commands that produce output then go quiet will poll at 5s -> 10s -> 30s -> 60s instead of 10s -> 30s -> 60s. This improves responsiveness for background commands.