### PR TITLE
perf: hoist billing error normalization to module level

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -21,6 +21,10 @@ import {
 } from "../../pi-embedded-utils.js";
 import { isLikelyMutatingToolName } from "../../tool-mutation.js";
 
+// Pre-compute normalized billing error text — this is a static constant that
+// doesn't need to be re-normalized on every call to buildEmbeddedRunPayloads.
+const NORMALIZED_BILLING_ERROR_TEXT = normalizeTextForComparison(BILLING_ERROR_USER_MESSAGE);
+
 type ToolMetaEntry = { toolName: string; meta?: string };
 type LastToolError = {
   toolName: string;
@@ -156,7 +160,7 @@ export function buildEmbeddedRunPayloads(params: {
     ? normalizeTextForComparison(rawErrorMessage)
     : null;
   const normalizedErrorText = errorText ? normalizeTextForComparison(errorText) : null;
-  const normalizedGenericBillingErrorText = normalizeTextForComparison(BILLING_ERROR_USER_MESSAGE);
+  const normalizedGenericBillingErrorText = NORMALIZED_BILLING_ERROR_TEXT;
   const genericErrorText = "The AI service returned an error. Please try again.";
   if (errorText) {
     replyItems.push({ text: errorText, isError: true });


### PR DESCRIPTION
## Summary

Hoist the normalization of `BILLING_ERROR_USER_MESSAGE` from inside `buildEmbeddedRunPayloads` to a module-level constant. This avoids re-normalizing a static string (trim, lowercase, strip emoji, collapse whitespace) on every turn.

## Changes

- Add `NORMALIZED_BILLING_ERROR_TEXT` as a module-level `const` computed once at import time
- Replace the per-call `normalizeTextForComparison(BILLING_ERROR_USER_MESSAGE)` with the pre-computed value

## Why this matters

`buildEmbeddedRunPayloads` runs on every turn completion. `normalizeTextForComparison` includes a Unicode emoji regex (`/\p{Emoji_Presentation}|\p{Extended_Pictographic}/gu`) that requires V8 to consult Unicode category tables. Running this on a constant string every turn is pure waste.

## Test plan

- No behavior change — `BILLING_ERROR_USER_MESSAGE` is a module-level constant; `normalizeTextForComparison` is pure
- The pre-computed value is identical to what was computed per-call