### PR TITLE
perf: reuse char estimate cache in tool result context guard

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -161,7 +161,7 @@ function enforceToolResultContextBudgetInPlace(params: {
   messages: AgentMessage[];
   contextBudgetChars: number;
   maxSingleToolResultChars: number;
-}): void {
+}): MessageCharEstimateCache {
   const { messages, contextBudgetChars, maxSingleToolResultChars } = params;
   const estimateCache = createMessageCharEstimateCache();
 
@@ -176,7 +176,7 @@ function enforceToolResultContextBudgetInPlace(params: {
 
   let currentChars = estimateContextChars(messages, estimateCache);
   if (currentChars <= contextBudgetChars) {
-    return;
+    return estimateCache;
   }
 
   // Compact oldest tool outputs first until the context is back under budget.
@@ -185,6 +185,8 @@ function enforceToolResultContextBudgetInPlace(params: {
     charsNeeded: currentChars - contextBudgetChars,
     cache: estimateCache,
   });
+
+  return estimateCache;
 }
 
 export function installToolResultContextGuard(params: {
@@ -218,7 +220,7 @@ export function installToolResultContextGuard(params: {
       : messages;
 
     const contextMessages = Array.isArray(transformed) ? transformed : messages;
-    enforceToolResultContextBudgetInPlace({
+    const enforcementCache = enforceToolResultContextBudgetInPlace({
       messages: contextMessages,
       contextBudgetChars,
       maxSingleToolResultChars,
@@ -228,9 +230,10 @@ export function installToolResultContextGuard(params: {
     // If it does, non-tool-result content dominates and only full LLM-based session
     // compaction can reduce context size. Throwing a context overflow error triggers
     // the existing overflow recovery cascade in run.ts.
+    // Reuse the cache from enforcement to avoid re-estimating every message.
     const postEnforcementChars = estimateContextChars(
       contextMessages,
-      createMessageCharEstimateCache(),
+      enforcementCache,
     );
     if (postEnforcementChars > preemptiveOverflowChars) {
       throw new Error(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);


### PR DESCRIPTION
## Summary

Reuse the `MessageCharEstimateCache` from `enforceToolResultContextBudgetInPlace` instead of creating a second cache for the post-enforcement size check. This avoids re-estimating every message's character count twice per turn.

## The issue

In `installToolResultContextGuard`, the `transformContext` handler:
1. Calls `enforceToolResultContextBudgetInPlace`, which creates a `MessageCharEstimateCache` (WeakMap) and populates it while iterating all messages
2. Discards that cache when the function returns
3. Creates a **new** `createMessageCharEstimateCache()` at line 233 for the `estimateContextChars` call
4. Re-iterates all messages to re-estimate their sizes from scratch

## The fix

- Change `enforceToolResultContextBudgetInPlace` to return its cache (return type `void` -> `MessageCharEstimateCache`)
- Reuse the returned cache for the post-enforcement `estimateContextChars` call

## Impact

For a session with N messages, this eliminates N redundant character estimations per turn. The estimation involves iterating message content blocks and computing string lengths, so the savings scale with conversation length.

## Test plan

- No behavior change — the cache is a WeakMap that maps messages to their estimated char counts. Since `enforceToolResultContextBudgetInPlace` may mutate messages (truncation/compaction), the cache entries for mutated messages are invalidated via `invalidateMessageCharsCacheEntry`. The post-enforcement `estimateContextChars` call will re-estimate only the mutated messages and use cached values for the rest.