### PR TITLE
Doctor: skip workspace plugin status during update-mode health checks

### DIFF
--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -30,6 +30,7 @@ vi.mock("../plugins/status.js", () => ({
 async function runNoteWorkspaceStatusForTest(
   loadResult: ReturnType<typeof createPluginLoadResult>,
   compatibilityWarnings: string[] = [],
+  options?: Parameters<(typeof import("./doctor-workspace-status.js"))["noteWorkspaceStatus"]>[1],
 ) {
   resolveDefaultAgentIdMock.mockReturnValue("default");
   resolveAgentWorkspaceDirMock.mockReturnValue("/workspace");
@@ -44,7 +45,7 @@ async function runNoteWorkspaceStatusForTest(
 
   const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
   const { noteWorkspaceStatus } = await import("./doctor-workspace-status.js");
-  noteWorkspaceStatus({});
+  noteWorkspaceStatus({}, options);
   return noteSpy;
 }
 
@@ -153,6 +154,30 @@ describe("noteWorkspaceStatus", () => {
       expect(String(compatibilityCalls[0]?.[0])).toContain(
         "legacy-plugin still uses legacy before_agent_start",
       );
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
+  it("skips plugin status loading when includePluginStatus is false", async () => {
+    const noteSpy = await runNoteWorkspaceStatusForTest(
+      createPluginLoadResult({
+        plugins: [
+          createPluginRecord({
+            id: "modern-plugin",
+            name: "Modern Plugin",
+            providerIds: ["modern"],
+          }),
+        ],
+      }),
+      [],
+      { includePluginStatus: false },
+    );
+    try {
+      expect(buildPluginStatusReportMock).not.toHaveBeenCalled();
+      expect(buildPluginCompatibilityWarningsMock).not.toHaveBeenCalled();
+      expect(noteSpy.mock.calls.some(([, title]) => title === "Plugins")).toBe(false);
+      expect(noteSpy.mock.calls.some(([, title]) => title === "Plugin compatibility")).toBe(false);
     } finally {
       noteSpy.mockRestore();
     }

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -5,7 +5,12 @@ import { buildPluginCompatibilityWarnings, buildPluginStatusReport } from "../pl
 import { note } from "../terminal/note.js";
 import { detectLegacyWorkspaceDirs, formatLegacyWorkspaceWarning } from "./doctor-workspace.js";
 
-export function noteWorkspaceStatus(cfg: OpenClawConfig) {
+export function noteWorkspaceStatus(
+  cfg: OpenClawConfig,
+  options: {
+    includePluginStatus?: boolean;
+  } = {},
+) {
   const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
   const legacyWorkspace = detectLegacyWorkspaceDirs({ workspaceDir });
   if (legacyWorkspace.legacyDirs.length > 0) {
@@ -24,6 +29,10 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig) {
     ].join("\n"),
     "Skills status",
   );
+
+  if (options.includePluginStatus === false) {
+    return { workspaceDir };
+  }
 
   const pluginRegistry = buildPluginStatusReport({
     config: cfg,

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -379,7 +379,9 @@ async function runSystemdLingerHealth(ctx: DoctorHealthFlowContext): Promise<voi
 }
 
 async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Promise<void> {
-  noteWorkspaceStatus(ctx.cfg);
+  const skipPluginStatus =
+    ctx.options.nonInteractive === true && process.env.OPENCLAW_UPDATE_IN_PROGRESS === "1";
+  noteWorkspaceStatus(ctx.cfg, { includePluginStatus: !skipPluginStatus });
 }
 
 async function runBootstrapSizeHealth(ctx: DoctorHealthFlowContext): Promise<void> {


### PR DESCRIPTION
## Summary
- skip plugin status loading inside `openclaw doctor` when it runs in non-interactive update mode (`OPENCLAW_UPDATE_IN_PROGRESS=1`)
- keep normal doctor behavior unchanged outside update-mode runs
- add a unit test covering the new `includePluginStatus: false` path in `noteWorkspaceStatus`

## Problem This Fix Addresses
During `openclaw update`, the health-check step runs:

`node openclaw.mjs doctor --non-interactive --fix`

In that mode, `doctor` always executed workspace plugin status loading. On affected installs this caused:
- the health check to hang seemingly indefinitely
- repeated plugin loader failures (for example Signal/Telegram stack overflows)
- update flow getting stuck at the final safety check instead of completing

This change removes that blocking plugin-status load specifically for update-mode doctor runs, so the health check can finish and report real issues promptly.

## Validation
- Added unit test: `src/commands/doctor-workspace-status.test.ts` (`includePluginStatus: false` skips plugin status/compatibility loaders)
- Manual repro command no longer hangs at plugin-status loading path:
  - `OPENCLAW_UPDATE_IN_PROGRESS=1 node openclaw.mjs doctor --non-interactive --fix`
  - now exits quickly instead of stalling in workspace plugin status load

## Scope
- `src/flows/doctor-health-contributions.ts`
- `src/commands/doctor-workspace-status.ts`
- `src/commands/doctor-workspace-status.test.ts`