### PR TITLE
fix: sweep orphaned toolStartData entries to prevent memory leak

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -34,6 +34,13 @@ type ToolStartRecord = {
 /** Track tool execution start data for after_tool_call hook. */
 const toolStartData = new Map<string, ToolStartRecord>();
 
+/**
+ * Maximum age (ms) for entries in toolStartData before they are considered
+ * orphaned. Tool calls that start but never complete (abort, crash, network
+ * failure) leave entries that would otherwise accumulate indefinitely.
+ */
+const TOOL_START_DATA_MAX_AGE_MS = 5 * 60_000; // 5 minutes
+
 function buildToolStartKey(runId: string, toolCallId: string): string {
   return `${runId}:${toolCallId}`;
 }
@@ -344,6 +351,16 @@ export async function handleToolExecutionStart(
 
   // Track start time and args for after_tool_call hook
   toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: Date.now(), args });
+
+  // Sweep orphaned entries from aborted/crashed tool calls to prevent unbounded growth
+  if (toolStartData.size > 50) {
+    const now = Date.now();
+    for (const [key, record] of toolStartData) {
+      if (now - record.startTime > TOOL_START_DATA_MAX_AGE_MS) {
+        toolStartData.delete(key);
+      }
+    }
+  }
 
   if (toolName === "read") {
     const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -34,14 +34,18 @@ type ToolStartRecord = {
 /** Track tool execution start data for after_tool_call hook. */
 const toolStartData = new Map<string, ToolStartRecord>();
 
-/** Track last tool-call activity per runId to distinguish active runs from orphaned ones. */
+/**
+ * Track last tool-call activity per runId. Updated on both tool start and tool
+ * end so that a run with a single long-running tool call stays marked active.
+ * Cleaned up when a run has no remaining entries in toolStartData.
+ */
 const lastRunActivity = new Map<string, number>();
 
 /**
  * Maximum idle time (ms) for a run before its entries are considered orphaned.
  * Only entries from runs with no tool-call activity within this window are swept.
- * This protects long-running tool calls (e.g., exec commands) as long as their
- * run is still producing new tool calls.
+ * This protects long-running tool calls (e.g., exec commands) because tool-end
+ * also refreshes the activity timestamp.
  */
 const RUN_IDLE_SWEEP_MS = 5 * 60_000; // 5 minutes
 
@@ -359,13 +363,11 @@ export async function handleToolExecutionStart(
   lastRunActivity.set(runId, now);
 
   // Sweep orphaned entries from runs that have gone completely idle.
-  // Only entries whose entire run has had no tool-call activity within the
-  // idle window are removed — this protects long-running tool calls (e.g.,
-  // exec commands that take >5 min) as long as the run is still active.
-  if (toolStartData.size > 50) {
+  // Gate on lastRunActivity.size (not toolStartData.size) so that run
+  // tracking entries are also cleaned up in the normal start/end cycle.
+  if (lastRunActivity.size > 20) {
     for (const [entryRunId, lastActivity] of lastRunActivity) {
       if (now - lastActivity > RUN_IDLE_SWEEP_MS) {
-        // Remove all entries for this idle run
         for (const key of toolStartData.keys()) {
           if (key.startsWith(entryRunId + ":")) {
             toolStartData.delete(key);
@@ -500,6 +502,21 @@ export async function handleToolExecutionEnd(
   const toolStartKey = buildToolStartKey(runId, toolCallId);
   const startData = toolStartData.get(toolStartKey);
   toolStartData.delete(toolStartKey);
+
+  // Refresh run activity on tool end so single long-running tool calls stay
+  // marked active. Also clean up the run activity entry when no more entries
+  // remain for this run (prevents lastRunActivity from growing unbounded).
+  lastRunActivity.set(runId, Date.now());
+  let hasRemainingEntries = false;
+  for (const key of toolStartData.keys()) {
+    if (key.startsWith(runId + ":")) {
+      hasRemainingEntries = true;
+      break;
+    }
+  }
+  if (!hasRemainingEntries) {
+    lastRunActivity.delete(runId);
+  }
   const callSummary = ctx.state.toolMetaById.get(toolCallId);
   const meta = callSummary?.meta;
   ctx.state.toolMetas.push({ toolName, meta });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -34,12 +34,16 @@ type ToolStartRecord = {
 /** Track tool execution start data for after_tool_call hook. */
 const toolStartData = new Map<string, ToolStartRecord>();
 
+/** Track last tool-call activity per runId to distinguish active runs from orphaned ones. */
+const lastRunActivity = new Map<string, number>();
+
 /**
- * Maximum age (ms) for entries in toolStartData before they are considered
- * orphaned. Tool calls that start but never complete (abort, crash, network
- * failure) leave entries that would otherwise accumulate indefinitely.
+ * Maximum idle time (ms) for a run before its entries are considered orphaned.
+ * Only entries from runs with no tool-call activity within this window are swept.
+ * This protects long-running tool calls (e.g., exec commands) as long as their
+ * run is still producing new tool calls.
  */
-const TOOL_START_DATA_MAX_AGE_MS = 5 * 60_000; // 5 minutes
+const RUN_IDLE_SWEEP_MS = 5 * 60_000; // 5 minutes
 
 function buildToolStartKey(runId: string, toolCallId: string): string {
   return `${runId}:${toolCallId}`;
@@ -350,14 +354,24 @@ export async function handleToolExecutionStart(
   const runId = ctx.params.runId;
 
   // Track start time and args for after_tool_call hook
-  toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: Date.now(), args });
+  const now = Date.now();
+  toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: now, args });
+  lastRunActivity.set(runId, now);
 
-  // Sweep orphaned entries from aborted/crashed tool calls to prevent unbounded growth
+  // Sweep orphaned entries from runs that have gone completely idle.
+  // Only entries whose entire run has had no tool-call activity within the
+  // idle window are removed — this protects long-running tool calls (e.g.,
+  // exec commands that take >5 min) as long as the run is still active.
   if (toolStartData.size > 50) {
-    const now = Date.now();
-    for (const [key, record] of toolStartData) {
-      if (now - record.startTime > TOOL_START_DATA_MAX_AGE_MS) {
-        toolStartData.delete(key);
+    for (const [entryRunId, lastActivity] of lastRunActivity) {
+      if (now - lastActivity > RUN_IDLE_SWEEP_MS) {
+        // Remove all entries for this idle run
+        for (const key of toolStartData.keys()) {
+          if (key.startsWith(entryRunId + ":")) {
+            toolStartData.delete(key);
+          }
+        }
+        lastRunActivity.delete(entryRunId);
       }
     }
   }


### PR DESCRIPTION
## Summary

The module-level `toolStartData` Map tracks tool call start times keyed by `${runId}:${toolCallId}`. Entries are set on tool start and deleted on tool result. If a tool call starts but never completes (abort, crash, network failure), the entry is never deleted. Each orphaned entry holds the full `args` object, which can be large (file contents, code blocks).

Over hours/days in gateway/daemon mode, this accumulates unbounded.

## Fix

Add a periodic sweep when the map exceeds 50 entries: delete any entry older than 5 minutes. The sweep runs at insert time (amortized cost), only when the map is large enough to matter.

The threshold of 50 avoids sweeping during normal operation (most sessions have <10 concurrent tool calls). The 5-minute TTL is generous — tool calls that take longer than 5 minutes are vanishingly rare, and even if one is swept prematurely, the only effect is a missing `after_tool_call` hook duration field.

## Test plan

- No behavior change for tool calls that complete normally (set + delete path unchanged)
- Orphaned entries are cleaned up within one sweep cycle after the map exceeds 50 entries