### PR TITLE
feat(matrix): add group chat history context for agent triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,13 @@ Docs: https://docs.openclaw.ai
 - Agents/LLM: add a configurable idle-stream timeout for embedded runner requests so stalled model streams abort cleanly instead of hanging until the broader run timeout fires. (#55072) Thanks @liuy.
 - OpenAI/Responses: forward configured `text.verbosity` across Responses HTTP and WebSocket transports, surface it in `/status`, and keep per-agent verbosity precedence aligned with runtime behavior. (#47106) Thanks @merc1305 and @vincentkoc.
 - Android/notifications: add notification-forwarding controls with package filtering, quiet hours, rate limiting, and safer picker behavior for forwarded notification events. (#40175) Thanks @nimbleenigma.
+<<<<<<< HEAD
+- Matrix/history: add optional room history context for Matrix group triggers via `channels.matrix.historyLimit`, with per-agent watermarks and retry-safe snapshots so failed trigger retries do not drift into newer room messages. (#57022) thanks @chain710.
 - Matrix/network: add explicit `channels.matrix.proxy` config for routing Matrix traffic through an HTTP(S) proxy, including account-level overrides and matching probe/runtime behavior. (#56931) thanks @patrick-yingxi-pan.
 - Background tasks: turn tasks into a real shared background-run control plane instead of ACP-only bookkeeping by unifying ACP, subagent, cron, and background CLI execution under one SQLite-backed ledger, routing detached lifecycle updates through the executor seam, adding audit/maintenance/status visibility, tightening auto-cleanup and lost-run recovery, improving task awareness in internal status/tool surfaces, and clarifying the split between heartbeat/main-session automation and detached scheduled runs. Thanks @vincentkoc and @mbelinky.
 - Flows/tasks: add a minimal SQLite-backed flow registry plus task-to-flow linkage scaffolding, so orchestrated work can start gaining a first-class parent record without changing current task delivery behavior.
 - Flows/tasks: route one-task ACP and subagent updates through a parent flow owner context, so detached work can emerge back through the intended parent thread/session instead of speaking only as a raw child task.
+- Matrix/history: add optional room history context for Matrix group triggers via `channels.matrix.historyLimit`, with per-agent watermarks and retry-safe snapshots so failed trigger retries do not drift into newer room messages. (#57022) thanks @chain710.
 
 ### Fixes
 

--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -22372,6 +22372,16 @@
       "hasChildren": false
     },
     {
+      "path": "channels.matrix.historyLimit",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.matrix.homeserver",
       "kind": "channel",
       "type": "string",

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5593}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5594}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1993,6 +1993,7 @@
 {"recordType":"path","path":"channels.matrix.groups.*.tools.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.groups.*.users","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.matrix.groups.*.users.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.matrix.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.homeserver","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.initialSyncLimit","kind":"channel","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.markdown","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -581,7 +581,9 @@ Current behavior:
 
 - `channels.matrix.historyLimit` controls how many recent room messages are included as `InboundHistory` when a Matrix room message triggers the agent.
 - It falls back to `messages.groupChat.historyLimit`. Set `0` to disable.
+- Matrix room history is room-only. DMs keep using normal session history.
 - Matrix room history is pending-only: OpenClaw buffers room messages that did not trigger a reply yet, then snapshots that window when a mention or other trigger arrives.
+- The current trigger message is not included in `InboundHistory`; it stays in the main inbound body for that turn.
 - Retries of the same Matrix event reuse the original history snapshot instead of drifting forward to newer room messages.
 
 ## DM and room policy example

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -577,6 +577,13 @@ Current behavior:
 - `reactionNotifications: "off"` disables reaction system events.
 - Reaction removals are still not synthesized into system events because Matrix surfaces those as redactions, not as standalone `m.reaction` removals.
 
+## History context
+
+- `channels.matrix.historyLimit` controls how many recent room messages are included as `InboundHistory` when a Matrix room message triggers the agent.
+- It falls back to `messages.groupChat.historyLimit`. Set `0` to disable.
+- Matrix room history is pending-only: OpenClaw buffers room messages that did not trigger a reply yet, then snapshots that window when a mention or other trigger arrives.
+- Retries of the same Matrix event reuse the original history snapshot instead of drifting forward to newer room messages.
+
 ## DM and room policy example
 
 ```json5
@@ -732,6 +739,7 @@ Live directory lookup uses the logged-in Matrix account:
 - `groupPolicy`: `open`, `allowlist`, or `disabled`.
 - `groupAllowFrom`: allowlist of user IDs for room traffic.
 - `groupAllowFrom` entries should be full Matrix user IDs. Unresolved names are ignored at runtime.
+- `historyLimit`: max room messages to include as group history context. Falls back to `messages.groupChat.historyLimit`. Set `0` to disable.
 - `replyToMode`: `off`, `first`, or `all`.
 - `streaming`: `off` (default) or `partial`. `partial` enables single-message draft previews with edit-in-place updates.
 - `threadReplies`: `off`, `inbound`, or `always`.

--- a/extensions/matrix/src/config-schema.ts
+++ b/extensions/matrix/src/config-schema.ts
@@ -80,6 +80,7 @@ export const MatrixConfigSchema = z.object({
   startupVerification: z.enum(["off", "if-unverified"]).optional(),
   startupVerificationCooldownHours: z.number().optional(),
   mediaMaxMb: z.number().optional(),
+  historyLimit: z.number().int().min(0).optional(),
   autoJoin: z.enum(["always", "allowlist", "off"]).optional(),
   autoJoinAllowlist: AllowFromListSchema,
   groupAllowFrom: AllowFromListSchema,

--- a/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
@@ -60,6 +60,14 @@ beforeEach(() => {
   installMatrixMonitorTestRuntime();
 });
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe("matrix group chat history — scenario 1: basic accumulation", () => {
   it("pending messages appear in InboundHistory; trigger itself does not", async () => {
     const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
@@ -183,6 +191,39 @@ describe("matrix group chat history — scenario 1: basic accumulation", () => {
     const ctx = finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>;
     const history = ctx["InboundHistory"] as Array<unknown> | undefined;
     expect(history ?? []).toHaveLength(0);
+  });
+
+  it("historyLimit=0 does not serialize same-room ingress", async () => {
+    const firstUserId = deferred<string>();
+    let getUserIdCalls = 0;
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 0,
+      groupPolicy: "open",
+      isDirectMessage: false,
+      client: {
+        getUserId: async () => {
+          getUserIdCalls += 1;
+          if (getUserIdCalls === 1) {
+            return await firstUserId.promise;
+          }
+          return "@bot:example.org";
+        },
+      },
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+    });
+
+    const first = handler(DEFAULT_ROOM, makeRoomTriggerEvent({ eventId: "$a", body: "first" }));
+    await Promise.resolve();
+    const second = handler(DEFAULT_ROOM, makeRoomTriggerEvent({ eventId: "$b", body: "second" }));
+    await Promise.resolve();
+
+    expect(getUserIdCalls).toBe(2);
+
+    firstUserId.resolve("@bot:example.org");
+    await Promise.all([first, second]);
   });
 
   it("DMs do not accumulate history (group chat only)", async () => {

--- a/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
@@ -372,6 +372,72 @@ describe("matrix group chat history — scenario 2: race condition safety", () =
     }
   });
 
+  it("retrying the same failed trigger reuses the original history window", async () => {
+    let capturedOnError:
+      | ((err: unknown, info: { kind: "tool" | "block" | "final" }) => void)
+      | undefined;
+
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 20,
+      groupPolicy: "open",
+      isDirectMessage: false,
+      finalizeInboundContext,
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+      createReplyDispatcherWithTyping: (params?: {
+        onError?: (err: unknown, info: { kind: "tool" | "block" | "final" }) => void;
+      }) => {
+        capturedOnError = params?.onError;
+        return {
+          dispatcher: {},
+          replyOptions: {},
+          markDispatchIdle: () => {},
+          markRunComplete: () => {},
+        };
+      },
+      withReplyDispatcher: async <T>(params: {
+        dispatcher: { markComplete?: () => void; waitForIdle?: () => Promise<void> };
+        run: () => Promise<T>;
+        onSettled?: () => void | Promise<void>;
+      }) => {
+        const result = await params.run();
+        capturedOnError?.(new Error("simulated delivery failure"), { kind: "final" });
+        params.dispatcher.markComplete?.();
+        await params.dispatcher.waitForIdle?.();
+        await params.onSettled?.();
+        return result;
+      },
+    });
+
+    await handler(
+      DEFAULT_ROOM,
+      makeRoomPlainEvent({ eventId: "$p", body: "pending msg", ts: 1000 }),
+    );
+
+    await handler(
+      DEFAULT_ROOM,
+      makeRoomTriggerEvent({ eventId: "$same", body: "trigger", ts: 2000 }),
+    );
+    await handler(
+      DEFAULT_ROOM,
+      makeRoomTriggerEvent({ eventId: "$same", body: "trigger", ts: 2000 }),
+    );
+
+    expect(finalizeInboundContext).toHaveBeenCalledTimes(2);
+    const firstHistory = (finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>)[
+      "InboundHistory"
+    ] as Array<{ body: string }>;
+    const retryHistory = (finalizeInboundContext.mock.calls[1]?.[0] as Record<string, unknown>)[
+      "InboundHistory"
+    ] as Array<{ body: string }>;
+
+    expect(firstHistory.map((entry) => entry.body)).toEqual(["pending msg"]);
+    expect(retryHistory.map((entry) => entry.body)).toEqual(["pending msg"]);
+  });
+
   it("records pending history before sender-name lookup resolves", async () => {
     let resolveFirstName: (() => void) | undefined;
     let firstNameLookupStarted = false;
@@ -417,5 +483,53 @@ describe("matrix group chat history — scenario 2: race condition safety", () =
     const ctx = finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>;
     const history = ctx["InboundHistory"] as Array<{ body: string }> | undefined;
     expect(history?.some((entry) => entry.body.includes("plain before trigger"))).toBe(true);
+  });
+
+  it("preserves arrival order when a plain message starts before a later trigger", async () => {
+    let releaseFirstGetUserId: (() => void) | undefined;
+    let getUserIdCalls = 0;
+
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 20,
+      groupPolicy: "open",
+      isDirectMessage: false,
+      client: {
+        async getUserId() {
+          getUserIdCalls += 1;
+          if (getUserIdCalls === 1) {
+            await new Promise<void>((resolve) => {
+              releaseFirstGetUserId = resolve;
+            });
+          }
+          return "@bot:example.org";
+        },
+        getEvent: async () => ({ sender: "@bot:example.org" }),
+      },
+      finalizeInboundContext,
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+    });
+
+    const plainPromise = handler(
+      DEFAULT_ROOM,
+      makeRoomPlainEvent({ eventId: "$a", body: "msg A", ts: 1000 }),
+    );
+    await vi.waitFor(() => {
+      expect(releaseFirstGetUserId).toBeTypeOf("function");
+    });
+    const triggerPromise = handler(
+      DEFAULT_ROOM,
+      makeRoomTriggerEvent({ eventId: "$b", body: "msg B", ts: 2000 }),
+    );
+
+    releaseFirstGetUserId?.();
+    await Promise.all([plainPromise, triggerPromise]);
+
+    const ctx = finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>;
+    const history = ctx["InboundHistory"] as Array<{ body: string }>;
+    expect(history.map((entry) => entry.body)).toEqual(["msg A"]);
   });
 });

--- a/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Tests for Matrix group chat history accumulation.
+ *
+ * Covers two key scenarios:
+ *
+ * Scenario 1 — basic accumulation across agents:
+ *   user: msg A              (no mention, accumulates)
+ *   user: @agent_a msg B     (triggers agent_a; agent_a sees [A] in history, not B itself)
+ *   user: @agent_b msg C     (triggers agent_b; agent_b sees [A, B] — independent watermark)
+ *   user: @agent_b msg D     (triggers agent_b; agent_b sees [] — A/B/C were consumed)
+ *
+ * Scenario 2 — race condition safety:
+ *   user: @agent_a msg A     (triggers agent_a; agent starts processing, not yet replied)
+ *   user: msg B              (no mention, arrives during processing — must not be lost)
+ *   agent_a: reply           (watermark advances to just after A, not after B)
+ *   user: @agent_a msg C     (triggers agent_a; agent_a sees [B] in history)
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { installMatrixMonitorTestRuntime } from "../../test-runtime.js";
+import {
+  createMatrixHandlerTestHarness,
+  createMatrixRoomMessageEvent,
+  createMatrixTextMessageEvent,
+} from "./handler.test-helpers.js";
+import { EventType, type MatrixRawEvent } from "./types.js";
+
+const DEFAULT_ROOM = "!room:example.org";
+
+function makeRoomTriggerEvent(params: { eventId: string; body: string; ts?: number }) {
+  // Use @room mention to trigger the bot without requiring agent-specific mention regexes
+  return createMatrixTextMessageEvent({
+    eventId: params.eventId,
+    body: `@room ${params.body}`,
+    originServerTs: params.ts ?? Date.now(),
+    mentions: { room: true },
+  });
+}
+
+function makeRoomPlainEvent(params: { eventId: string; body: string; ts?: number }) {
+  return createMatrixTextMessageEvent({
+    eventId: params.eventId,
+    body: params.body,
+    originServerTs: params.ts ?? Date.now(),
+  });
+}
+
+function makeDevRoute(agentId: string) {
+  return {
+    agentId,
+    channel: "matrix" as const,
+    accountId: "ops",
+    sessionKey: `agent:${agentId}:main`,
+    mainSessionKey: `agent:${agentId}:main`,
+    matchedBy: "binding.account" as const,
+  };
+}
+
+beforeEach(() => {
+  installMatrixMonitorTestRuntime();
+});
+
+describe("matrix group chat history — scenario 1: basic accumulation", () => {
+  it("pending messages appear in InboundHistory; trigger itself does not", async () => {
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 20,
+      groupPolicy: "open",
+      isDirectMessage: false,
+      finalizeInboundContext,
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+    });
+
+    // Non-trigger message A — should not dispatch
+    await handler(DEFAULT_ROOM, makeRoomPlainEvent({ eventId: "$a", body: "msg A", ts: 1000 }));
+    expect(finalizeInboundContext).not.toHaveBeenCalled();
+
+    // Trigger B — history must contain [msg A] only, not the trigger itself
+    await handler(DEFAULT_ROOM, makeRoomTriggerEvent({ eventId: "$b", body: "msg B", ts: 2000 }));
+    expect(finalizeInboundContext).toHaveBeenCalledOnce();
+    const ctx = finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>;
+    const history = ctx["InboundHistory"] as Array<{ body: string; sender: string }>;
+    expect(history).toHaveLength(1);
+    expect(history[0]?.body).toContain("msg A");
+  });
+
+  it("multi-agent: each agent has an independent watermark", async () => {
+    let currentAgentId = "agent_a";
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 20,
+      groupPolicy: "open",
+      isDirectMessage: false,
+      finalizeInboundContext,
+      resolveAgentRoute: vi.fn(() => makeDevRoute(currentAgentId)),
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+    });
+
+    // msg A accumulates for all agents
+    await handler(DEFAULT_ROOM, makeRoomPlainEvent({ eventId: "$a", body: "msg A", ts: 1000 }));
+
+    // @agent_a trigger B — agent_a sees [msg A]
+    currentAgentId = "agent_a";
+    await handler(DEFAULT_ROOM, makeRoomTriggerEvent({ eventId: "$b", body: "msg B", ts: 2000 }));
+    {
+      const ctx = finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>;
+      const history = ctx["InboundHistory"] as Array<{ body: string }>;
+      expect(history).toHaveLength(1);
+      expect(history[0]?.body).toContain("msg A");
+    }
+
+    // @agent_b trigger C — agent_b watermark is 0, so it sees [msg A, msg B]
+    currentAgentId = "agent_b";
+    await handler(DEFAULT_ROOM, makeRoomTriggerEvent({ eventId: "$c", body: "msg C", ts: 3000 }));
+    {
+      const ctx = finalizeInboundContext.mock.calls[1]?.[0] as Record<string, unknown>;
+      const history = ctx["InboundHistory"] as Array<{ body: string }>;
+      expect(history).toHaveLength(2);
+      expect(history.map((h) => h.body).some((b) => b.includes("msg A"))).toBe(true);
+      expect(history.map((h) => h.body).some((b) => b.includes("msg B"))).toBe(true);
+    }
+
+    // @agent_b trigger D — A/B/C consumed; history is empty
+    currentAgentId = "agent_b";
+    await handler(DEFAULT_ROOM, makeRoomTriggerEvent({ eventId: "$d", body: "msg D", ts: 4000 }));
+    {
+      const ctx = finalizeInboundContext.mock.calls[2]?.[0] as Record<string, unknown>;
+      const history = ctx["InboundHistory"] as Array<unknown> | undefined;
+      expect(history ?? []).toHaveLength(0);
+    }
+  });
+
+  it("respects historyLimit: caps to the most recent N entries", async () => {
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 2,
+      groupPolicy: "open",
+      isDirectMessage: false,
+      finalizeInboundContext,
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+    });
+
+    for (let i = 1; i <= 4; i++) {
+      await handler(
+        DEFAULT_ROOM,
+        makeRoomPlainEvent({ eventId: `$p${i}`, body: `pending ${i}`, ts: i * 1000 }),
+      );
+    }
+
+    await handler(DEFAULT_ROOM, makeRoomTriggerEvent({ eventId: "$t", body: "trigger", ts: 5000 }));
+    const ctx = finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>;
+    const history = ctx["InboundHistory"] as Array<{ body: string }>;
+    expect(history).toHaveLength(2);
+    expect(history[0]?.body).toContain("pending 3");
+    expect(history[1]?.body).toContain("pending 4");
+  });
+
+  it("historyLimit=0 disables history accumulation entirely", async () => {
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 0,
+      groupPolicy: "open",
+      isDirectMessage: false,
+      finalizeInboundContext,
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+    });
+
+    await handler(DEFAULT_ROOM, makeRoomPlainEvent({ eventId: "$p", body: "pending" }));
+    await handler(DEFAULT_ROOM, makeRoomTriggerEvent({ eventId: "$t", body: "trigger" }));
+
+    const ctx = finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>;
+    const history = ctx["InboundHistory"] as Array<unknown> | undefined;
+    expect(history ?? []).toHaveLength(0);
+  });
+
+  it("DMs do not accumulate history (group chat only)", async () => {
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 20,
+      isDirectMessage: true,
+      finalizeInboundContext,
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+    });
+
+    await handler(DEFAULT_ROOM, makeRoomPlainEvent({ eventId: "$dm1", body: "dm message 1" }));
+    await handler(DEFAULT_ROOM, makeRoomPlainEvent({ eventId: "$dm2", body: "dm message 2" }));
+
+    expect(finalizeInboundContext).toHaveBeenCalledTimes(2);
+    for (const call of finalizeInboundContext.mock.calls) {
+      const ctx = call[0] as Record<string, unknown>;
+      const history = ctx["InboundHistory"] as Array<unknown> | undefined;
+      expect(history ?? []).toHaveLength(0);
+    }
+  });
+
+  it("includes skipped media-only room messages in next trigger history", async () => {
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 20,
+      groupPolicy: "open",
+      isDirectMessage: false,
+      finalizeInboundContext,
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+    });
+
+    // Unmentioned media-only message should be buffered as pending history context.
+    await handler(
+      DEFAULT_ROOM,
+      createMatrixRoomMessageEvent({
+        eventId: "$media-a",
+        originServerTs: 1000,
+        content: {
+          msgtype: "m.image",
+          body: "",
+          url: "mxc://example.org/media-a",
+        },
+      }) as MatrixRawEvent,
+    );
+    expect(finalizeInboundContext).not.toHaveBeenCalled();
+
+    await handler(
+      DEFAULT_ROOM,
+      makeRoomTriggerEvent({ eventId: "$trigger-media", body: "trigger", ts: 2000 }),
+    );
+    expect(finalizeInboundContext).toHaveBeenCalledOnce();
+    const ctx = finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>;
+    const history = ctx["InboundHistory"] as Array<{ body: string }> | undefined;
+    expect(history?.some((entry) => entry.body.includes("[matrix image attachment]"))).toBe(true);
+  });
+});
+
+describe("matrix group chat history — scenario 2: race condition safety", () => {
+  it("messages arriving during agent processing are visible on the next trigger", async () => {
+    let resolveFirstDispatch: (() => void) | undefined;
+    let firstDispatchStarted = false;
+
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const dispatchReplyFromConfig = vi.fn(async () => {
+      if (!firstDispatchStarted) {
+        firstDispatchStarted = true;
+        await new Promise<void>((resolve) => {
+          resolveFirstDispatch = resolve;
+        });
+      }
+      return { queuedFinal: true, counts: { final: 1, block: 0, tool: 0 } };
+    });
+
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 20,
+      groupPolicy: "open",
+      isDirectMessage: false,
+      finalizeInboundContext,
+      dispatchReplyFromConfig,
+    });
+
+    // Step 1: trigger msg A — don't await, let it block in dispatch
+    const firstHandlerDone = handler(
+      DEFAULT_ROOM,
+      makeRoomTriggerEvent({ eventId: "$a", body: "msg A", ts: 1000 }),
+    );
+
+    // Step 2: wait until dispatch is in-flight
+    await vi.waitFor(() => {
+      expect(firstDispatchStarted).toBe(true);
+    });
+
+    // Step 3: msg B arrives while agent is processing — must not be lost
+    await handler(DEFAULT_ROOM, makeRoomPlainEvent({ eventId: "$b", body: "msg B", ts: 2000 }));
+
+    // Step 4: unblock dispatch and complete
+    resolveFirstDispatch!();
+    await firstHandlerDone;
+    // watermark advances to snapshot taken at dispatch time (just after msg A), not to queue end
+
+    // Step 5: trigger msg C — should see [msg B] in history (msg A was consumed)
+    await handler(DEFAULT_ROOM, makeRoomTriggerEvent({ eventId: "$c", body: "msg C", ts: 3000 }));
+
+    expect(finalizeInboundContext).toHaveBeenCalledTimes(2);
+    const ctxForC = finalizeInboundContext.mock.calls[1]?.[0] as Record<string, unknown>;
+    const history = ctxForC["InboundHistory"] as Array<{ body: string }>;
+    expect(history.some((h) => h.body.includes("msg B"))).toBe(true);
+    expect(history.every((h) => !h.body.includes("msg A"))).toBe(true);
+  });
+
+  it("watermark does not advance when final reply delivery fails (retry sees same history)", async () => {
+    // Capture the onError callback so we can fire a simulated final delivery failure
+    let capturedOnError:
+      | ((err: unknown, info: { kind: "tool" | "block" | "final" }) => void)
+      | undefined;
+
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 20,
+      groupPolicy: "open",
+      isDirectMessage: false,
+      finalizeInboundContext,
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+      createReplyDispatcherWithTyping: (params?: {
+        onError?: (err: unknown, info: { kind: "tool" | "block" | "final" }) => void;
+      }) => {
+        capturedOnError = params?.onError;
+        return {
+          dispatcher: {},
+          replyOptions: {},
+          markDispatchIdle: () => {},
+          markRunComplete: () => {},
+        };
+      },
+      withReplyDispatcher: async <T>(params: {
+        dispatcher: { markComplete?: () => void; waitForIdle?: () => Promise<void> };
+        run: () => Promise<T>;
+        onSettled?: () => void | Promise<void>;
+      }) => {
+        const result = await params.run();
+        capturedOnError?.(new Error("simulated delivery failure"), { kind: "final" });
+        params.dispatcher.markComplete?.();
+        await params.dispatcher.waitForIdle?.();
+        await params.onSettled?.();
+        return result;
+      },
+    });
+
+    await handler(
+      DEFAULT_ROOM,
+      makeRoomPlainEvent({ eventId: "$p", body: "pending msg", ts: 1000 }),
+    );
+
+    // First trigger — delivery fails; watermark must NOT advance
+    await handler(
+      DEFAULT_ROOM,
+      makeRoomTriggerEvent({ eventId: "$t1", body: "trigger 1", ts: 2000 }),
+    );
+    expect(finalizeInboundContext).toHaveBeenCalledOnce();
+    {
+      const ctx = finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>;
+      const history = ctx["InboundHistory"] as Array<{ body: string }>;
+      expect(history).toHaveLength(1);
+      expect(history[0]?.body).toContain("pending msg");
+    }
+
+    // Second trigger — pending msg must still be visible (watermark not advanced)
+    await handler(
+      DEFAULT_ROOM,
+      makeRoomTriggerEvent({ eventId: "$t2", body: "trigger 2", ts: 3000 }),
+    );
+    expect(finalizeInboundContext).toHaveBeenCalledTimes(2);
+    {
+      const ctx = finalizeInboundContext.mock.calls[1]?.[0] as Record<string, unknown>;
+      const history = ctx["InboundHistory"] as Array<{ body: string }> | undefined;
+      expect(history?.some((h) => h.body.includes("pending msg"))).toBe(true);
+    }
+  });
+
+  it("records pending history before sender-name lookup resolves", async () => {
+    let resolveFirstName: (() => void) | undefined;
+    let firstNameLookupStarted = false;
+    const getMemberDisplayName = vi.fn(async () => {
+      firstNameLookupStarted = true;
+      await new Promise<void>((resolve) => {
+        resolveFirstName = resolve;
+      });
+      return "sender";
+    });
+
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 20,
+      groupPolicy: "open",
+      isDirectMessage: false,
+      getMemberDisplayName,
+      finalizeInboundContext,
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+    });
+
+    // Unmentioned message should be buffered without waiting for async sender-name lookup.
+    await handler(
+      DEFAULT_ROOM,
+      makeRoomPlainEvent({ eventId: "$slow-name", body: "plain before trigger", ts: 1000 }),
+    );
+    expect(firstNameLookupStarted).toBe(false);
+
+    // Trigger reads pending history first, then can await sender-name lookup later.
+    const triggerDone = handler(
+      DEFAULT_ROOM,
+      makeRoomTriggerEvent({ eventId: "$trigger-after-slow-name", body: "trigger", ts: 2000 }),
+    );
+    await vi.waitFor(() => {
+      expect(firstNameLookupStarted).toBe(true);
+    });
+    resolveFirstName?.();
+    await triggerDone;
+
+    const ctx = finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>;
+    const history = ctx["InboundHistory"] as Array<{ body: string }> | undefined;
+    expect(history?.some((entry) => entry.body.includes("plain before trigger"))).toBe(true);
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
@@ -286,6 +286,71 @@ describe("matrix group chat history — scenario 1: basic accumulation", () => {
     const history = ctx["InboundHistory"] as Array<{ body: string }> | undefined;
     expect(history?.some((entry) => entry.body.includes("[matrix image attachment]"))).toBe(true);
   });
+
+  it("includes skipped poll updates in next trigger history", async () => {
+    const getEvent = vi.fn(async () => ({
+      event_id: "$poll",
+      sender: "@user:example.org",
+      type: "m.poll.start",
+      origin_server_ts: Date.now(),
+      content: {
+        "m.poll.start": {
+          question: { "m.text": "Lunch?" },
+          kind: "m.poll.disclosed",
+          max_selections: 1,
+          answers: [{ id: "a1", "m.text": "Pizza" }],
+        },
+      },
+    }));
+    const getRelations = vi.fn(async () => ({
+      events: [],
+      nextBatch: null,
+      prevBatch: null,
+    }));
+    const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 20,
+      groupPolicy: "open",
+      isDirectMessage: false,
+      client: {
+        getEvent,
+        getRelations,
+      },
+      finalizeInboundContext,
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+    });
+
+    await handler(DEFAULT_ROOM, {
+      type: "m.poll.response",
+      sender: "@user:example.org",
+      event_id: "$poll-response-1",
+      origin_server_ts: 1000,
+      content: {
+        "m.poll.response": {
+          answers: ["a1"],
+        },
+        "m.relates_to": {
+          rel_type: "m.reference",
+          event_id: "$poll",
+        },
+      },
+    } as MatrixRawEvent);
+    expect(finalizeInboundContext).not.toHaveBeenCalled();
+
+    await handler(
+      DEFAULT_ROOM,
+      makeRoomTriggerEvent({ eventId: "$trigger-poll", body: "trigger", ts: 2000 }),
+    );
+
+    expect(getEvent).toHaveBeenCalledOnce();
+    expect(getRelations).toHaveBeenCalledOnce();
+    const ctx = finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>;
+    const history = ctx["InboundHistory"] as Array<{ body: string }> | undefined;
+    expect(history?.some((entry) => entry.body.includes("Lunch?"))).toBe(true);
+  });
 });
 
 describe("matrix group chat history — scenario 2: race condition safety", () => {

--- a/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
@@ -249,6 +249,46 @@ describe("matrix group chat history — scenario 1: basic accumulation", () => {
     }
   });
 
+  it("history-enabled rooms do not serialize DM ingress heavy work", async () => {
+    let resolveFirstName: (() => void) | undefined;
+    let nameLookupCalls = 0;
+    const getMemberDisplayName = vi.fn(async () => {
+      nameLookupCalls += 1;
+      if (nameLookupCalls === 1) {
+        await new Promise<void>((resolve) => {
+          resolveFirstName = resolve;
+        });
+      }
+      return "sender";
+    });
+
+    const { handler } = createMatrixHandlerTestHarness({
+      historyLimit: 20,
+      isDirectMessage: true,
+      getMemberDisplayName,
+      dispatchReplyFromConfig: async () => ({
+        queuedFinal: true,
+        counts: { final: 1, block: 0, tool: 0 },
+      }),
+    });
+
+    const first = handler(DEFAULT_ROOM, makeRoomPlainEvent({ eventId: "$dm-a", body: "first dm" }));
+    await vi.waitFor(() => {
+      expect(resolveFirstName).toBeTypeOf("function");
+    });
+
+    const second = handler(
+      DEFAULT_ROOM,
+      makeRoomPlainEvent({ eventId: "$dm-b", body: "second dm" }),
+    );
+    await vi.waitFor(() => {
+      expect(nameLookupCalls).toBe(2);
+    });
+
+    resolveFirstName?.();
+    await Promise.all([first, second]);
+  });
+
   it("includes skipped media-only room messages in next trigger history", async () => {
     const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
     const { handler } = createMatrixHandlerTestHarness({

--- a/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
@@ -40,6 +40,7 @@ type MatrixHandlerTestHarnessOptions = {
   dropPreStartupMessages?: boolean;
   needsRoomAliasesForConfig?: boolean;
   isDirectMessage?: boolean;
+  historyLimit?: number;
   readAllowFromStore?: MatrixMonitorHandlerParams["core"]["channel"]["pairing"]["readAllowFromStore"];
   upsertPairingRequest?: MatrixMonitorHandlerParams["core"]["channel"]["pairing"]["upsertPairingRequest"];
   buildPairingReply?: () => string;
@@ -225,6 +226,7 @@ export function createMatrixHandlerTestHarness(
     getRoomInfo: options.getRoomInfo ?? (async () => ({ altAliases: [] })),
     getMemberDisplayName: options.getMemberDisplayName ?? (async () => "sender"),
     needsRoomAliasesForConfig: options.needsRoomAliasesForConfig ?? false,
+    historyLimit: options.historyLimit ?? 0,
   });
 
   return {

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -892,6 +892,7 @@ describe("matrix monitor handler pairing account scope", () => {
       dmPolicy: "open",
       textLimit: 8_000,
       mediaMaxBytes: 10_000_000,
+      historyLimit: 0,
       startupMs: 0,
       startupGraceMs: 0,
       directTracker: {

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -223,6 +223,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     logVerboseMessage,
   });
   const roomHistoryTracker = createRoomHistoryTracker();
+  const roomIngressTails = new Map<string, Promise<void>>();
 
   const readStoreAllowFrom = async (): Promise<string[]> => {
     const now = Date.now();
@@ -263,6 +264,25 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     return true;
   };
 
+  const runRoomIngress = async <T>(roomId: string, task: () => Promise<T>): Promise<T> => {
+    const previous = roomIngressTails.get(roomId) ?? Promise.resolve();
+    let releaseCurrent!: () => void;
+    const current = new Promise<void>((resolve) => {
+      releaseCurrent = resolve;
+    });
+    const chain = previous.catch(() => {}).then(() => current);
+    roomIngressTails.set(roomId, chain);
+    await previous.catch(() => {});
+    try {
+      return await task();
+    } finally {
+      releaseCurrent();
+      if (roomIngressTails.get(roomId) === chain) {
+        roomIngressTails.delete(roomId);
+      }
+    }
+  };
+
   return async (roomId: string, event: MatrixRawEvent) => {
     const eventId = typeof event.event_id === "string" ? event.event_id.trim() : "";
     let claimedInboundEvent = false;
@@ -298,10 +318,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       if (!senderId) {
         return;
       }
-      const selfUserId = await client.getUserId();
-      if (senderId === selfUserId) {
-        return;
-      }
       const eventTs = event.origin_server_ts;
       const eventAge = event.unsigned?.age;
       const commitInboundEventIfClaimed = async () => {
@@ -311,216 +327,222 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         await inboundDeduper.commitEvent({ roomId, eventId });
         claimedInboundEvent = false;
       };
-      if (dropPreStartupMessages) {
-        if (typeof eventTs === "number" && eventTs < startupMs - startupGraceMs) {
+      const ingressResult = await runRoomIngress(roomId, async () => {
+        const selfUserId = await client.getUserId();
+        if (senderId === selfUserId) {
           return;
         }
-        if (
-          typeof eventTs !== "number" &&
-          typeof eventAge === "number" &&
-          eventAge > startupGraceMs
-        ) {
-          return;
-        }
-      }
-
-      let content = event.content as RoomMessageEventContent;
-
-      if (
-        eventType === EventType.RoomMessage &&
-        isMatrixVerificationRoomMessage({
-          msgtype: (content as { msgtype?: unknown }).msgtype,
-          body: content.body,
-        })
-      ) {
-        logVerboseMessage(`matrix: skip verification/system room message room=${roomId}`);
-        return;
-      }
-
-      const locationPayload: MatrixLocationPayload | null = resolveMatrixLocation({
-        eventType,
-        content: content as LocationMessageEventContent,
-      });
-
-      const relates = content["m.relates_to"];
-      if (relates && "rel_type" in relates) {
-        if (relates.rel_type === RelationType.Replace) {
-          return;
-        }
-      }
-      if (eventId && inboundDeduper) {
-        claimedInboundEvent = inboundDeduper.claimEvent({ roomId, eventId });
-        if (!claimedInboundEvent) {
-          logVerboseMessage(`matrix: skip duplicate inbound event room=${roomId} id=${eventId}`);
-          return;
-        }
-      }
-
-      const isDirectMessage = await directTracker.isDirectMessage({
-        roomId,
-        senderId,
-        selfUserId,
-      });
-      const isRoom = !isDirectMessage;
-
-      if (isRoom && groupPolicy === "disabled") {
-        await commitInboundEventIfClaimed();
-        return;
-      }
-
-      const roomInfoForConfig =
-        isRoom && needsRoomAliasesForConfig
-          ? await getRoomInfo(roomId, { includeAliases: true })
-          : undefined;
-      const roomAliasesForConfig = roomInfoForConfig
-        ? [roomInfoForConfig.canonicalAlias ?? "", ...roomInfoForConfig.altAliases].filter(Boolean)
-        : [];
-      const roomConfigInfo = isRoom
-        ? resolveMatrixRoomConfig({
-            rooms: roomsConfig,
-            roomId,
-            aliases: roomAliasesForConfig,
-          })
-        : undefined;
-      const roomConfig = roomConfigInfo?.config;
-      const allowBotsMode = resolveMatrixAllowBotsMode(roomConfig?.allowBots ?? accountAllowBots);
-      const isConfiguredBotSender = configuredBotUserIds.has(senderId);
-      const roomMatchMeta = roomConfigInfo
-        ? `matchKey=${roomConfigInfo.matchKey ?? "none"} matchSource=${
-            roomConfigInfo.matchSource ?? "none"
-          }`
-        : "matchKey=none matchSource=none";
-
-      if (isConfiguredBotSender && allowBotsMode === "off") {
-        logVerboseMessage(
-          `matrix: drop configured bot sender=${senderId} (allowBots=false${isDirectMessage ? "" : `, ${roomMatchMeta}`})`,
-        );
-        await commitInboundEventIfClaimed();
-        return;
-      }
-
-      if (isRoom && roomConfig && !roomConfigInfo?.allowed) {
-        logVerboseMessage(`matrix: room disabled room=${roomId} (${roomMatchMeta})`);
-        await commitInboundEventIfClaimed();
-        return;
-      }
-      if (isRoom && groupPolicy === "allowlist") {
-        if (!roomConfigInfo?.allowlistConfigured) {
-          logVerboseMessage(`matrix: drop room message (no allowlist, ${roomMatchMeta})`);
-          await commitInboundEventIfClaimed();
-          return;
-        }
-        if (!roomConfig) {
-          logVerboseMessage(`matrix: drop room message (not in allowlist, ${roomMatchMeta})`);
-          await commitInboundEventIfClaimed();
-          return;
-        }
-      }
-
-      let senderNamePromise: Promise<string> | null = null;
-      const getSenderName = async (): Promise<string> => {
-        senderNamePromise ??= getMemberDisplayName(roomId, senderId).catch(() => senderId);
-        return await senderNamePromise;
-      };
-      const storeAllowFrom = await readStoreAllowFrom();
-      const roomUsers = roomConfig?.users ?? [];
-      const accessState = resolveMatrixMonitorAccessState({
-        allowFrom,
-        storeAllowFrom,
-        groupAllowFrom,
-        roomUsers,
-        senderId,
-        isRoom,
-      });
-      const {
-        effectiveAllowFrom,
-        effectiveGroupAllowFrom,
-        effectiveRoomUsers,
-        groupAllowConfigured,
-        directAllowMatch,
-        roomUserMatch,
-        groupAllowMatch,
-        commandAuthorizers,
-      } = accessState;
-
-      if (isDirectMessage) {
-        if (!dmEnabled || dmPolicy === "disabled") {
-          await commitInboundEventIfClaimed();
-          return;
-        }
-        if (dmPolicy !== "open") {
-          const allowMatchMeta = formatAllowlistMatchMeta(directAllowMatch);
-          if (!directAllowMatch.allowed) {
-            if (!isReactionEvent && dmPolicy === "pairing") {
-              const senderName = await getSenderName();
-              const { code, created } = await core.channel.pairing.upsertPairingRequest({
-                channel: "matrix",
-                id: senderId,
-                accountId,
-                meta: { name: senderName },
-              });
-              if (shouldSendPairingReply(senderId, created)) {
-                const pairingReply = core.channel.pairing.buildPairingReply({
-                  channel: "matrix",
-                  idLine: `Your Matrix user id: ${senderId}`,
-                  code,
-                });
-                logVerboseMessage(
-                  created
-                    ? `matrix pairing request sender=${senderId} name=${senderName ?? "unknown"} (${allowMatchMeta})`
-                    : `matrix pairing reminder sender=${senderId} name=${senderName ?? "unknown"} (${allowMatchMeta})`,
-                );
-                try {
-                  await sendMessageMatrix(
-                    `room:${roomId}`,
-                    created
-                      ? pairingReply
-                      : `${pairingReply}\n\nPairing request is still pending approval. Reusing existing code.`,
-                    {
-                      client,
-                      cfg,
-                      accountId,
-                    },
-                  );
-                  await commitInboundEventIfClaimed();
-                } catch (err) {
-                  logVerboseMessage(`matrix pairing reply failed for ${senderId}: ${String(err)}`);
-                  return;
-                }
-              } else {
-                logVerboseMessage(
-                  `matrix pairing reminder suppressed sender=${senderId} (cooldown)`,
-                );
-                await commitInboundEventIfClaimed();
-              }
-            }
-            if (isReactionEvent || dmPolicy !== "pairing") {
-              logVerboseMessage(
-                `matrix: blocked ${isReactionEvent ? "reaction" : "dm"} sender ${senderId} (dmPolicy=${dmPolicy}, ${allowMatchMeta})`,
-              );
-              await commitInboundEventIfClaimed();
-            }
+        if (dropPreStartupMessages) {
+          if (typeof eventTs === "number" && eventTs < startupMs - startupGraceMs) {
+            return;
+          }
+          if (
+            typeof eventTs !== "number" &&
+            typeof eventAge === "number" &&
+            eventAge > startupGraceMs
+          ) {
             return;
           }
         }
-      }
 
-      if (isRoom && roomUserMatch && !roomUserMatch.allowed) {
-        logVerboseMessage(
-          `matrix: blocked sender ${senderId} (room users allowlist, ${roomMatchMeta}, ${formatAllowlistMatchMeta(
-            roomUserMatch,
-          )})`,
-        );
-        await commitInboundEventIfClaimed();
-        return;
-      }
-      if (
-        isRoom &&
-        groupPolicy === "allowlist" &&
-        effectiveRoomUsers.length === 0 &&
-        groupAllowConfigured
-      ) {
-        if (groupAllowMatch && !groupAllowMatch.allowed) {
+        let content = event.content as RoomMessageEventContent;
+
+        if (
+          eventType === EventType.RoomMessage &&
+          isMatrixVerificationRoomMessage({
+            msgtype: (content as { msgtype?: unknown }).msgtype,
+            body: content.body,
+          })
+        ) {
+          logVerboseMessage(`matrix: skip verification/system room message room=${roomId}`);
+          return;
+        }
+
+        const locationPayload: MatrixLocationPayload | null = resolveMatrixLocation({
+          eventType,
+          content: content as LocationMessageEventContent,
+        });
+
+        const relates = content["m.relates_to"];
+        if (relates && "rel_type" in relates && relates.rel_type === RelationType.Replace) {
+          return;
+        }
+        if (eventId && inboundDeduper) {
+          claimedInboundEvent = inboundDeduper.claimEvent({ roomId, eventId });
+          if (!claimedInboundEvent) {
+            logVerboseMessage(`matrix: skip duplicate inbound event room=${roomId} id=${eventId}`);
+            return;
+          }
+        }
+
+        const isDirectMessage = await directTracker.isDirectMessage({
+          roomId,
+          senderId,
+          selfUserId,
+        });
+        const isRoom = !isDirectMessage;
+
+        if (isRoom && groupPolicy === "disabled") {
+          await commitInboundEventIfClaimed();
+          return;
+        }
+
+        const roomInfoForConfig =
+          isRoom && needsRoomAliasesForConfig
+            ? await getRoomInfo(roomId, { includeAliases: true })
+            : undefined;
+        const roomAliasesForConfig = roomInfoForConfig
+          ? [roomInfoForConfig.canonicalAlias ?? "", ...roomInfoForConfig.altAliases].filter(
+              Boolean,
+            )
+          : [];
+        const roomConfigInfo = isRoom
+          ? resolveMatrixRoomConfig({
+              rooms: roomsConfig,
+              roomId,
+              aliases: roomAliasesForConfig,
+            })
+          : undefined;
+        const roomConfig = roomConfigInfo?.config;
+        const allowBotsMode = resolveMatrixAllowBotsMode(roomConfig?.allowBots ?? accountAllowBots);
+        const isConfiguredBotSender = configuredBotUserIds.has(senderId);
+        const roomMatchMeta = roomConfigInfo
+          ? `matchKey=${roomConfigInfo.matchKey ?? "none"} matchSource=${
+              roomConfigInfo.matchSource ?? "none"
+            }`
+          : "matchKey=none matchSource=none";
+
+        if (isConfiguredBotSender && allowBotsMode === "off") {
+          logVerboseMessage(
+            `matrix: drop configured bot sender=${senderId} (allowBots=false${isDirectMessage ? "" : `, ${roomMatchMeta}`})`,
+          );
+          await commitInboundEventIfClaimed();
+          return;
+        }
+
+        if (isRoom && roomConfig && !roomConfigInfo?.allowed) {
+          logVerboseMessage(`matrix: room disabled room=${roomId} (${roomMatchMeta})`);
+          await commitInboundEventIfClaimed();
+          return;
+        }
+        if (isRoom && groupPolicy === "allowlist") {
+          if (!roomConfigInfo?.allowlistConfigured) {
+            logVerboseMessage(`matrix: drop room message (no allowlist, ${roomMatchMeta})`);
+            await commitInboundEventIfClaimed();
+            return;
+          }
+          if (!roomConfig) {
+            logVerboseMessage(`matrix: drop room message (not in allowlist, ${roomMatchMeta})`);
+            await commitInboundEventIfClaimed();
+            return;
+          }
+        }
+
+        let senderNamePromise: Promise<string> | null = null;
+        const getSenderName = async (): Promise<string> => {
+          senderNamePromise ??= getMemberDisplayName(roomId, senderId).catch(() => senderId);
+          return await senderNamePromise;
+        };
+        const storeAllowFrom = await readStoreAllowFrom();
+        const roomUsers = roomConfig?.users ?? [];
+        const accessState = resolveMatrixMonitorAccessState({
+          allowFrom,
+          storeAllowFrom,
+          groupAllowFrom,
+          roomUsers,
+          senderId,
+          isRoom,
+        });
+        const {
+          effectiveRoomUsers,
+          groupAllowConfigured,
+          directAllowMatch,
+          roomUserMatch,
+          groupAllowMatch,
+          commandAuthorizers,
+        } = accessState;
+
+        if (isDirectMessage) {
+          if (!dmEnabled || dmPolicy === "disabled") {
+            await commitInboundEventIfClaimed();
+            return;
+          }
+          if (dmPolicy !== "open") {
+            const allowMatchMeta = formatAllowlistMatchMeta(directAllowMatch);
+            if (!directAllowMatch.allowed) {
+              if (!isReactionEvent && dmPolicy === "pairing") {
+                const senderName = await getSenderName();
+                const { code, created } = await core.channel.pairing.upsertPairingRequest({
+                  channel: "matrix",
+                  id: senderId,
+                  accountId,
+                  meta: { name: senderName },
+                });
+                if (shouldSendPairingReply(senderId, created)) {
+                  const pairingReply = core.channel.pairing.buildPairingReply({
+                    channel: "matrix",
+                    idLine: `Your Matrix user id: ${senderId}`,
+                    code,
+                  });
+                  logVerboseMessage(
+                    created
+                      ? `matrix pairing request sender=${senderId} name=${senderName ?? "unknown"} (${allowMatchMeta})`
+                      : `matrix pairing reminder sender=${senderId} name=${senderName ?? "unknown"} (${allowMatchMeta})`,
+                  );
+                  try {
+                    await sendMessageMatrix(
+                      `room:${roomId}`,
+                      created
+                        ? pairingReply
+                        : `${pairingReply}\n\nPairing request is still pending approval. Reusing existing code.`,
+                      {
+                        client,
+                        cfg,
+                        accountId,
+                      },
+                    );
+                    await commitInboundEventIfClaimed();
+                  } catch (err) {
+                    logVerboseMessage(
+                      `matrix pairing reply failed for ${senderId}: ${String(err)}`,
+                    );
+                    return;
+                  }
+                } else {
+                  logVerboseMessage(
+                    `matrix pairing reminder suppressed sender=${senderId} (cooldown)`,
+                  );
+                  await commitInboundEventIfClaimed();
+                }
+              }
+              if (isReactionEvent || dmPolicy !== "pairing") {
+                logVerboseMessage(
+                  `matrix: blocked ${isReactionEvent ? "reaction" : "dm"} sender ${senderId} (dmPolicy=${dmPolicy}, ${allowMatchMeta})`,
+                );
+                await commitInboundEventIfClaimed();
+              }
+              return;
+            }
+          }
+        }
+
+        if (isRoom && roomUserMatch && !roomUserMatch.allowed) {
+          logVerboseMessage(
+            `matrix: blocked sender ${senderId} (room users allowlist, ${roomMatchMeta}, ${formatAllowlistMatchMeta(
+              roomUserMatch,
+            )})`,
+          );
+          await commitInboundEventIfClaimed();
+          return;
+        }
+        if (
+          isRoom &&
+          groupPolicy === "allowlist" &&
+          effectiveRoomUsers.length === 0 &&
+          groupAllowConfigured &&
+          groupAllowMatch &&
+          !groupAllowMatch.allowed
+        ) {
           logVerboseMessage(
             `matrix: blocked sender ${senderId} (groupAllowFrom, ${roomMatchMeta}, ${formatAllowlistMatchMeta(
               groupAllowMatch,
@@ -529,373 +551,404 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           await commitInboundEventIfClaimed();
           return;
         }
-      }
-      if (isRoom) {
-        logVerboseMessage(`matrix: allow room ${roomId} (${roomMatchMeta})`);
-      }
+        if (isRoom) {
+          logVerboseMessage(`matrix: allow room ${roomId} (${roomMatchMeta})`);
+        }
 
-      if (isReactionEvent) {
-        const senderName = await getSenderName();
-        await handleInboundMatrixReaction({
-          client,
-          core,
+        if (isReactionEvent) {
+          const senderName = await getSenderName();
+          await handleInboundMatrixReaction({
+            client,
+            core,
+            cfg,
+            accountId,
+            roomId,
+            event,
+            senderId,
+            senderLabel: senderName,
+            selfUserId,
+            isDirectMessage,
+            logVerboseMessage,
+          });
+          await commitInboundEventIfClaimed();
+          return;
+        }
+
+        const mentionPrecheckText = resolveMatrixMentionPrecheckText({
+          eventType,
+          content,
+          locationText: locationPayload?.text,
+        });
+        const contentUrl =
+          "url" in content && typeof content.url === "string" ? content.url : undefined;
+        const contentFile =
+          "file" in content && content.file && typeof content.file === "object"
+            ? content.file
+            : undefined;
+        const mediaUrl = contentUrl ?? contentFile?.url;
+        const pendingHistoryText = resolveMatrixPendingHistoryText({
+          mentionPrecheckText,
+          content,
+          mediaUrl,
+        });
+        if (!mentionPrecheckText && !mediaUrl && !isPollEvent) {
+          await commitInboundEventIfClaimed();
+          return;
+        }
+
+        const _messageId = event.event_id ?? "";
+        const _threadRootId = resolveMatrixThreadRootId({ event, content });
+        const {
+          route: _route,
+          configuredBinding: _configuredBinding,
+          runtimeBindingId: _runtimeBindingId,
+        } = resolveMatrixInboundRoute({
           cfg,
           accountId,
           roomId,
-          event,
           senderId,
-          senderLabel: senderName,
-          selfUserId,
           isDirectMessage,
-          logVerboseMessage,
+          messageId: _messageId,
+          threadRootId: _threadRootId,
+          eventTs: eventTs ?? undefined,
+          resolveAgentRoute: core.channel.routing.resolveAgentRoute,
         });
-        await commitInboundEventIfClaimed();
-        return;
-      }
-
-      const mentionPrecheckText = resolveMatrixMentionPrecheckText({
-        eventType,
-        content,
-        locationText: locationPayload?.text,
-      });
-      const contentUrl =
-        "url" in content && typeof content.url === "string" ? content.url : undefined;
-      const contentFile =
-        "file" in content && content.file && typeof content.file === "object"
-          ? content.file
+        const agentMentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, _route.agentId);
+        const selfDisplayName = content.formatted_body
+          ? await getMemberDisplayName(roomId, selfUserId).catch(() => undefined)
           : undefined;
-      const mediaUrl = contentUrl ?? contentFile?.url;
-      const pendingHistoryText = resolveMatrixPendingHistoryText({
-        mentionPrecheckText,
-        content,
-        mediaUrl,
-      });
-      if (!mentionPrecheckText && !mediaUrl && !isPollEvent) {
-        await commitInboundEventIfClaimed();
-        return;
-      }
-
-      const _messageId = event.event_id ?? "";
-      const _threadRootId = resolveMatrixThreadRootId({ event, content });
-      const {
-        route: _route,
-        configuredBinding: _configuredBinding,
-        runtimeBindingId: _runtimeBindingId,
-      } = resolveMatrixInboundRoute({
-        cfg,
-        accountId,
-        roomId,
-        senderId,
-        isDirectMessage,
-        messageId: _messageId,
-        threadRootId: _threadRootId,
-        eventTs: eventTs ?? undefined,
-        resolveAgentRoute: core.channel.routing.resolveAgentRoute,
-      });
-      const agentMentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, _route.agentId);
-      const selfDisplayName = content.formatted_body
-        ? await getMemberDisplayName(roomId, selfUserId).catch(() => undefined)
-        : undefined;
-      const { wasMentioned, hasExplicitMention } = resolveMentions({
-        content,
-        userId: selfUserId,
-        displayName: selfDisplayName,
-        text: mentionPrecheckText,
-        mentionRegexes: agentMentionRegexes,
-      });
-      if (
-        isConfiguredBotSender &&
-        allowBotsMode === "mentions" &&
-        !isDirectMessage &&
-        !wasMentioned
-      ) {
-        logVerboseMessage(
-          `matrix: drop configured bot sender=${senderId} (allowBots=mentions, missing mention, ${roomMatchMeta})`,
-        );
-        await commitInboundEventIfClaimed();
-        return;
-      }
-      const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
-        cfg,
-        surface: "matrix",
-      });
-      const useAccessGroups = cfg.commands?.useAccessGroups !== false;
-      const hasControlCommandInMessage = core.channel.text.hasControlCommand(
-        mentionPrecheckText,
-        cfg,
-      );
-      const commandGate = resolveControlCommandGate({
-        useAccessGroups,
-        authorizers: commandAuthorizers,
-        allowTextCommands,
-        hasControlCommand: hasControlCommandInMessage,
-      });
-      const commandAuthorized = commandGate.commandAuthorized;
-      if (isRoom && commandGate.shouldBlock) {
-        logInboundDrop({
-          log: logVerboseMessage,
-          channel: "matrix",
-          reason: "control command (unauthorized)",
-          target: senderId,
+        const { wasMentioned, hasExplicitMention } = resolveMentions({
+          content,
+          userId: selfUserId,
+          displayName: selfDisplayName,
+          text: mentionPrecheckText,
+          mentionRegexes: agentMentionRegexes,
         });
-        await commitInboundEventIfClaimed();
-        return;
-      }
-      const shouldRequireMention = isRoom
-        ? roomConfig?.autoReply === true
-          ? false
-          : roomConfig?.autoReply === false
-            ? true
-            : typeof roomConfig?.requireMention === "boolean"
-              ? roomConfig?.requireMention
-              : true
-        : false;
-      const shouldBypassMention =
-        allowTextCommands &&
-        isRoom &&
-        shouldRequireMention &&
-        !wasMentioned &&
-        !hasExplicitMention &&
-        commandAuthorized &&
-        hasControlCommandInMessage;
-      const canDetectMention = agentMentionRegexes.length > 0 || hasExplicitMention;
-      if (isRoom && shouldRequireMention && !wasMentioned && !shouldBypassMention) {
-        // Record in room history so future triggered replies can see this message as context.
-        if (historyLimit > 0 && pendingHistoryText) {
-          const pendingEntry: HistoryEntry = {
-            // Keep skipped-message buffering non-blocking: sender name lookup can be async.
-            sender: senderId,
-            body: pendingHistoryText,
-            timestamp: eventTs ?? undefined,
-          };
-          roomHistoryTracker.recordPending(roomId, pendingEntry);
-        }
-        logger.info("skipping room message", { roomId, reason: "no-mention" });
-        await commitInboundEventIfClaimed();
-        return;
-      }
-
-      if (isPollEvent) {
-        const pollSnapshot = await fetchMatrixPollSnapshot(client, roomId, event).catch((err) => {
+        if (
+          isConfiguredBotSender &&
+          allowBotsMode === "mentions" &&
+          !isDirectMessage &&
+          !wasMentioned
+        ) {
           logVerboseMessage(
-            `matrix: failed resolving poll snapshot room=${roomId} id=${event.event_id ?? "unknown"}: ${String(err)}`,
+            `matrix: drop configured bot sender=${senderId} (allowBots=mentions, missing mention, ${roomMatchMeta})`,
           );
-          return null;
-        });
-        if (!pollSnapshot) {
+          await commitInboundEventIfClaimed();
           return;
         }
-        content = {
-          msgtype: "m.text",
-          body: pollSnapshot.text,
-        } as unknown as RoomMessageEventContent;
-      }
-
-      let media: {
-        path: string;
-        contentType?: string;
-        placeholder: string;
-      } | null = null;
-      let mediaDownloadFailed = false;
-      const finalContentUrl =
-        "url" in content && typeof content.url === "string" ? content.url : undefined;
-      const finalContentFile =
-        "file" in content && content.file && typeof content.file === "object"
-          ? content.file
-          : undefined;
-      const finalMediaUrl = finalContentUrl ?? finalContentFile?.url;
-      const contentBody = typeof content.body === "string" ? content.body.trim() : "";
-      const contentFilename = typeof content.filename === "string" ? content.filename.trim() : "";
-      const originalFilename = contentFilename || contentBody || undefined;
-      const contentInfo =
-        "info" in content && content.info && typeof content.info === "object"
-          ? (content.info as { mimetype?: string; size?: number })
-          : undefined;
-      const contentType = contentInfo?.mimetype;
-      const contentSize = typeof contentInfo?.size === "number" ? contentInfo.size : undefined;
-      if (finalMediaUrl?.startsWith("mxc://")) {
-        try {
-          media = await downloadMatrixMedia({
-            client,
-            mxcUrl: finalMediaUrl,
-            contentType,
-            sizeBytes: contentSize,
-            maxBytes: mediaMaxBytes,
-            file: finalContentFile,
-            originalFilename,
-          });
-        } catch (err) {
-          mediaDownloadFailed = true;
-          const errorText = err instanceof Error ? err.message : String(err);
-          logVerboseMessage(
-            `matrix: media download failed room=${roomId} id=${event.event_id ?? "unknown"} type=${content.msgtype} error=${errorText}`,
-          );
-          logger.warn("matrix media download failed", {
-            roomId,
-            eventId: event.event_id,
-            msgtype: content.msgtype,
-            encrypted: Boolean(finalContentFile),
-            error: errorText,
-          });
-        }
-      }
-
-      const rawBody = locationPayload?.text ?? contentBody;
-      const bodyText = resolveMatrixInboundBodyText({
-        rawBody,
-        filename: typeof content.filename === "string" ? content.filename : undefined,
-        mediaPlaceholder: media?.placeholder,
-        msgtype: content.msgtype,
-        hadMediaUrl: Boolean(finalMediaUrl),
-        mediaDownloadFailed,
-      });
-      if (!bodyText) {
-        await commitInboundEventIfClaimed();
-        return;
-      }
-      const senderName = await getSenderName();
-      const roomInfo = isRoom ? await getRoomInfo(roomId) : undefined;
-      const roomName = roomInfo?.name;
-
-      const replyToEventId = content["m.relates_to"]?.["m.in_reply_to"]?.event_id;
-      const threadTarget = resolveMatrixThreadTarget({
-        threadReplies,
-        messageId: _messageId,
-        threadRootId: _threadRootId,
-        isThreadRoot: false, // Raw event payload does not carry explicit thread-root metadata.
-      });
-      const threadContext = _threadRootId
-        ? await resolveThreadContext({ roomId, threadRootId: _threadRootId })
-        : undefined;
-
-      // Resolve the body and sender of the replied-to message so the agent
-      // can see what is being replied to, not just the event ID.
-      // Note: resolve even when threadTarget is set (e.g. threadReplies: "always")
-      // because the user may still be quoting a specific message within the thread.
-      const replyContext =
-        replyToEventId && replyToEventId === _threadRootId && threadContext?.summary
-          ? {
-              replyToBody: threadContext.summary,
-              replyToSender: threadContext.senderLabel,
-            }
-          : replyToEventId
-            ? await resolveReplyContext({ roomId, eventId: replyToEventId })
-            : undefined;
-
-      if (_configuredBinding) {
-        const ensured = await ensureConfiguredAcpBindingReady({
+        const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
           cfg,
-          configuredBinding: _configuredBinding,
+          surface: "matrix",
         });
-        if (!ensured.ok) {
+        const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+        const hasControlCommandInMessage = core.channel.text.hasControlCommand(
+          mentionPrecheckText,
+          cfg,
+        );
+        const commandGate = resolveControlCommandGate({
+          useAccessGroups,
+          authorizers: commandAuthorizers,
+          allowTextCommands,
+          hasControlCommand: hasControlCommandInMessage,
+        });
+        const commandAuthorized = commandGate.commandAuthorized;
+        if (isRoom && commandGate.shouldBlock) {
           logInboundDrop({
             log: logVerboseMessage,
             channel: "matrix",
-            reason: "configured ACP binding unavailable",
-            target: _configuredBinding.spec.conversationId,
+            reason: "control command (unauthorized)",
+            target: senderId,
           });
+          await commitInboundEventIfClaimed();
           return;
         }
-      }
-      if (_runtimeBindingId) {
-        getSessionBindingService().touch(_runtimeBindingId, eventTs ?? undefined);
-      }
-      const envelopeFrom = isDirectMessage ? senderName : (roomName ?? roomId);
-
-      // Group chat history: read pending history before recording this trigger, then
-      // snapshot the queue position so the watermark can advance to exactly here on reply.
-      const inboundHistory =
-        isRoom && historyLimit > 0
-          ? roomHistoryTracker.getPendingHistory(_route.agentId, roomId, historyLimit)
-          : undefined;
-      const triggerSnapshotIdx =
-        isRoom && historyLimit > 0
-          ? roomHistoryTracker.recordTrigger(roomId, {
-              sender: senderName,
-              body: bodyText,
+        const shouldRequireMention = isRoom
+          ? roomConfig?.autoReply === true
+            ? false
+            : roomConfig?.autoReply === false
+              ? true
+              : typeof roomConfig?.requireMention === "boolean"
+                ? roomConfig?.requireMention
+                : true
+          : false;
+        const shouldBypassMention =
+          allowTextCommands &&
+          isRoom &&
+          shouldRequireMention &&
+          !wasMentioned &&
+          !hasExplicitMention &&
+          commandAuthorized &&
+          hasControlCommandInMessage;
+        const canDetectMention = agentMentionRegexes.length > 0 || hasExplicitMention;
+        if (isRoom && shouldRequireMention && !wasMentioned && !shouldBypassMention) {
+          if (historyLimit > 0 && pendingHistoryText) {
+            const pendingEntry: HistoryEntry = {
+              sender: senderId,
+              body: pendingHistoryText,
               timestamp: eventTs ?? undefined,
-            })
-          : -1;
+              messageId: _messageId,
+            };
+            roomHistoryTracker.recordPending(roomId, pendingEntry);
+          }
+          logger.info("skipping room message", { roomId, reason: "no-mention" });
+          await commitInboundEventIfClaimed();
+          return;
+        }
 
-      const textWithId = `${bodyText}\n[matrix event id: ${_messageId} room: ${roomId}]`;
-      const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
-        agentId: _route.agentId,
-      });
-      const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
-      const previousTimestamp = core.channel.session.readSessionUpdatedAt({
-        storePath,
-        sessionKey: _route.sessionKey,
-      });
-      const body = core.channel.reply.formatAgentEnvelope({
-        channel: "Matrix",
-        from: envelopeFrom,
-        timestamp: eventTs ?? undefined,
-        previousTimestamp,
-        envelope: envelopeOptions,
-        body: textWithId,
-      });
-
-      const groupSystemPrompt = roomConfig?.systemPrompt?.trim() || undefined;
-      const ctxPayload = core.channel.reply.finalizeInboundContext({
-        Body: body,
-        RawBody: bodyText,
-        CommandBody: bodyText,
-        InboundHistory: inboundHistory && inboundHistory.length > 0 ? inboundHistory : undefined,
-        From: isDirectMessage ? `matrix:${senderId}` : `matrix:channel:${roomId}`,
-        To: `room:${roomId}`,
-        SessionKey: _route.sessionKey,
-        AccountId: _route.accountId,
-        ChatType: isDirectMessage ? "direct" : "channel",
-        ConversationLabel: envelopeFrom,
-        SenderName: senderName,
-        SenderId: senderId,
-        SenderUsername: senderId.split(":")[0]?.replace(/^@/, ""),
-        GroupSubject: isRoom ? (roomName ?? roomId) : undefined,
-        GroupId: isRoom ? roomId : undefined,
-        GroupSystemPrompt: isRoom ? groupSystemPrompt : undefined,
-        Provider: "matrix" as const,
-        Surface: "matrix" as const,
-        WasMentioned: isRoom ? wasMentioned : undefined,
-        MessageSid: _messageId,
-        ReplyToId: threadTarget ? undefined : (replyToEventId ?? undefined),
-        ReplyToBody: replyContext?.replyToBody,
-        ReplyToSender: replyContext?.replyToSender,
-        MessageThreadId: threadTarget,
-        ThreadStarterBody: threadContext?.threadStarterBody,
-        Timestamp: eventTs ?? undefined,
-        MediaPath: media?.path,
-        MediaType: media?.contentType,
-        MediaUrl: media?.path,
-        ...locationPayload?.context,
-        CommandAuthorized: commandAuthorized,
-        CommandSource: "text" as const,
-        OriginatingChannel: "matrix" as const,
-        OriginatingTo: `room:${roomId}`,
-      });
-
-      await core.channel.session.recordInboundSession({
-        storePath,
-        sessionKey: ctxPayload.SessionKey ?? _route.sessionKey,
-        ctx: ctxPayload,
-        updateLastRoute: isDirectMessage
-          ? {
-              sessionKey: _route.mainSessionKey,
-              channel: "matrix",
-              to: `room:${roomId}`,
-              accountId: _route.accountId,
-            }
-          : undefined,
-        onRecordError: (err) => {
-          logger.warn("failed updating session meta", {
-            error: String(err),
-            storePath,
-            sessionKey: ctxPayload.SessionKey ?? _route.sessionKey,
+        if (isPollEvent) {
+          const pollSnapshot = await fetchMatrixPollSnapshot(client, roomId, event).catch((err) => {
+            logVerboseMessage(
+              `matrix: failed resolving poll snapshot room=${roomId} id=${event.event_id ?? "unknown"}: ${String(err)}`,
+            );
+            return null;
           });
-        },
-      });
+          if (!pollSnapshot) {
+            return;
+          }
+          content = {
+            msgtype: "m.text",
+            body: pollSnapshot.text,
+          } as unknown as RoomMessageEventContent;
+        }
 
-      const preview = bodyText.slice(0, 200).replace(/\n/g, "\\n");
-      logVerboseMessage(`matrix inbound: room=${roomId} from=${senderId} preview="${preview}"`);
+        let media: {
+          path: string;
+          contentType?: string;
+          placeholder: string;
+        } | null = null;
+        let mediaDownloadFailed = false;
+        const finalContentUrl =
+          "url" in content && typeof content.url === "string" ? content.url : undefined;
+        const finalContentFile =
+          "file" in content && content.file && typeof content.file === "object"
+            ? content.file
+            : undefined;
+        const finalMediaUrl = finalContentUrl ?? finalContentFile?.url;
+        const contentBody = typeof content.body === "string" ? content.body.trim() : "";
+        const contentFilename = typeof content.filename === "string" ? content.filename.trim() : "";
+        const originalFilename = contentFilename || contentBody || undefined;
+        const contentInfo =
+          "info" in content && content.info && typeof content.info === "object"
+            ? (content.info as { mimetype?: string; size?: number })
+            : undefined;
+        const contentType = contentInfo?.mimetype;
+        const contentSize = typeof contentInfo?.size === "number" ? contentInfo.size : undefined;
+        if (finalMediaUrl?.startsWith("mxc://")) {
+          try {
+            media = await downloadMatrixMedia({
+              client,
+              mxcUrl: finalMediaUrl,
+              contentType,
+              sizeBytes: contentSize,
+              maxBytes: mediaMaxBytes,
+              file: finalContentFile,
+              originalFilename,
+            });
+          } catch (err) {
+            mediaDownloadFailed = true;
+            const errorText = err instanceof Error ? err.message : String(err);
+            logVerboseMessage(
+              `matrix: media download failed room=${roomId} id=${event.event_id ?? "unknown"} type=${content.msgtype} error=${errorText}`,
+            );
+            logger.warn("matrix media download failed", {
+              roomId,
+              eventId: event.event_id,
+              msgtype: content.msgtype,
+              encrypted: Boolean(finalContentFile),
+              error: errorText,
+            });
+          }
+        }
+
+        const rawBody = locationPayload?.text ?? contentBody;
+        const bodyText = resolveMatrixInboundBodyText({
+          rawBody,
+          filename: typeof content.filename === "string" ? content.filename : undefined,
+          mediaPlaceholder: media?.placeholder,
+          msgtype: content.msgtype,
+          hadMediaUrl: Boolean(finalMediaUrl),
+          mediaDownloadFailed,
+        });
+        if (!bodyText) {
+          await commitInboundEventIfClaimed();
+          return;
+        }
+        const senderName = await getSenderName();
+        const roomInfo = isRoom ? await getRoomInfo(roomId) : undefined;
+        const roomName = roomInfo?.name;
+
+        const replyToEventId = content["m.relates_to"]?.["m.in_reply_to"]?.event_id;
+        const threadTarget = resolveMatrixThreadTarget({
+          threadReplies,
+          messageId: _messageId,
+          threadRootId: _threadRootId,
+          isThreadRoot: false,
+        });
+        const threadContext = _threadRootId
+          ? await resolveThreadContext({ roomId, threadRootId: _threadRootId })
+          : undefined;
+        const replyContext =
+          replyToEventId && replyToEventId === _threadRootId && threadContext?.summary
+            ? {
+                replyToBody: threadContext.summary,
+                replyToSender: threadContext.senderLabel,
+              }
+            : replyToEventId
+              ? await resolveReplyContext({ roomId, eventId: replyToEventId })
+              : undefined;
+
+        if (_configuredBinding) {
+          const ensured = await ensureConfiguredAcpBindingReady({
+            cfg,
+            configuredBinding: _configuredBinding,
+          });
+          if (!ensured.ok) {
+            logInboundDrop({
+              log: logVerboseMessage,
+              channel: "matrix",
+              reason: "configured ACP binding unavailable",
+              target: _configuredBinding.spec.conversationId,
+            });
+            return;
+          }
+        }
+        if (_runtimeBindingId) {
+          getSessionBindingService().touch(_runtimeBindingId, eventTs ?? undefined);
+        }
+        const envelopeFrom = isDirectMessage ? senderName : (roomName ?? roomId);
+        const preparedTrigger =
+          isRoom && historyLimit > 0
+            ? roomHistoryTracker.prepareTrigger(_route.agentId, roomId, historyLimit, {
+                sender: senderName,
+                body: bodyText,
+                timestamp: eventTs ?? undefined,
+                messageId: _messageId,
+              })
+            : undefined;
+        const inboundHistory = preparedTrigger?.history;
+        const triggerSnapshotIdx = preparedTrigger?.snapshotIdx ?? -1;
+
+        const textWithId = `${bodyText}\n[matrix event id: ${_messageId} room: ${roomId}]`;
+        const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
+          agentId: _route.agentId,
+        });
+        const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
+        const previousTimestamp = core.channel.session.readSessionUpdatedAt({
+          storePath,
+          sessionKey: _route.sessionKey,
+        });
+        const body = core.channel.reply.formatAgentEnvelope({
+          channel: "Matrix",
+          from: envelopeFrom,
+          timestamp: eventTs ?? undefined,
+          previousTimestamp,
+          envelope: envelopeOptions,
+          body: textWithId,
+        });
+
+        const groupSystemPrompt = roomConfig?.systemPrompt?.trim() || undefined;
+        const ctxPayload = core.channel.reply.finalizeInboundContext({
+          Body: body,
+          RawBody: bodyText,
+          CommandBody: bodyText,
+          InboundHistory: inboundHistory && inboundHistory.length > 0 ? inboundHistory : undefined,
+          From: isDirectMessage ? `matrix:${senderId}` : `matrix:channel:${roomId}`,
+          To: `room:${roomId}`,
+          SessionKey: _route.sessionKey,
+          AccountId: _route.accountId,
+          ChatType: isDirectMessage ? "direct" : "channel",
+          ConversationLabel: envelopeFrom,
+          SenderName: senderName,
+          SenderId: senderId,
+          SenderUsername: senderId.split(":")[0]?.replace(/^@/, ""),
+          GroupSubject: isRoom ? (roomName ?? roomId) : undefined,
+          GroupId: isRoom ? roomId : undefined,
+          GroupSystemPrompt: isRoom ? groupSystemPrompt : undefined,
+          Provider: "matrix" as const,
+          Surface: "matrix" as const,
+          WasMentioned: isRoom ? wasMentioned : undefined,
+          MessageSid: _messageId,
+          ReplyToId: threadTarget ? undefined : (replyToEventId ?? undefined),
+          ReplyToBody: replyContext?.replyToBody,
+          ReplyToSender: replyContext?.replyToSender,
+          MessageThreadId: threadTarget,
+          ThreadStarterBody: threadContext?.threadStarterBody,
+          Timestamp: eventTs ?? undefined,
+          MediaPath: media?.path,
+          MediaType: media?.contentType,
+          MediaUrl: media?.path,
+          ...locationPayload?.context,
+          CommandAuthorized: commandAuthorized,
+          CommandSource: "text" as const,
+          OriginatingChannel: "matrix" as const,
+          OriginatingTo: `room:${roomId}`,
+        });
+
+        await core.channel.session.recordInboundSession({
+          storePath,
+          sessionKey: ctxPayload.SessionKey ?? _route.sessionKey,
+          ctx: ctxPayload,
+          updateLastRoute: isDirectMessage
+            ? {
+                sessionKey: _route.mainSessionKey,
+                channel: "matrix",
+                to: `room:${roomId}`,
+                accountId: _route.accountId,
+              }
+            : undefined,
+          onRecordError: (err) => {
+            logger.warn("failed updating session meta", {
+              error: String(err),
+              storePath,
+              sessionKey: ctxPayload.SessionKey ?? _route.sessionKey,
+            });
+          },
+        });
+
+        const preview = bodyText.slice(0, 200).replace(/\n/g, "\\n");
+        logVerboseMessage(`matrix inbound: room=${roomId} from=${senderId} preview="${preview}"`);
+
+        const replyTarget = ctxPayload.To;
+        if (!replyTarget) {
+          runtime.error?.("matrix: missing reply target");
+          return;
+        }
+
+        return {
+          ctxPayload,
+          route: _route,
+          roomConfig,
+          isDirectMessage,
+          isRoom,
+          shouldRequireMention,
+          wasMentioned,
+          shouldBypassMention,
+          canDetectMention,
+          messageId: _messageId,
+          triggerSnapshotIdx,
+          threadTarget,
+          replyTarget,
+        };
+      });
+      if (!ingressResult) {
+        return;
+      }
+
+      const {
+        ctxPayload,
+        route: _route,
+        roomConfig,
+        isDirectMessage,
+        isRoom,
+        shouldRequireMention,
+        wasMentioned,
+        shouldBypassMention,
+        canDetectMention,
+        messageId: _messageId,
+        triggerSnapshotIdx,
+        threadTarget,
+        replyTarget,
+      } = ingressResult;
 
       const { ackReaction, ackReactionScope: ackScope } = resolveMatrixAckReactionConfig({
         cfg,
@@ -920,12 +973,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         reactMatrixMessage(roomId, _messageId, ackReaction, client).catch((err) => {
           logVerboseMessage(`matrix react failed for room ${roomId}: ${String(err)}`);
         });
-      }
-
-      const replyTarget = ctxPayload.To;
-      if (!replyTarget) {
-        runtime.error?.("matrix: missing reply target");
-        return;
       }
 
       if (_messageId) {
@@ -1243,7 +1290,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       // Only advance to the snapshot position — messages added during async processing remain
       // visible for the next trigger.
       if (isRoom && triggerSnapshotIdx >= 0) {
-        roomHistoryTracker.consumeHistory(_route.agentId, roomId, triggerSnapshotIdx);
+        roomHistoryTracker.consumeHistory(_route.agentId, roomId, triggerSnapshotIdx, _messageId);
       }
       if (!queuedFinal) {
         await commitInboundEventIfClaimed();

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -50,7 +50,11 @@ import type { HistoryEntry } from "./room-history.js";
 import { resolveMatrixRoomConfig } from "./rooms.js";
 import { resolveMatrixInboundRoute } from "./route.js";
 import { createMatrixThreadContextResolver } from "./thread-context.js";
-import { resolveMatrixThreadRootId, resolveMatrixThreadTarget } from "./threads.js";
+import {
+  resolveMatrixReplyToEventId,
+  resolveMatrixThreadRootId,
+  resolveMatrixThreadTarget,
+} from "./threads.js";
 import type { MatrixRawEvent, RoomMessageEventContent } from "./types.js";
 import { EventType, RelationType } from "./types.js";
 import { isMatrixVerificationRoomMessage } from "./verification-utils.js";
@@ -806,8 +810,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
 
         return {
           route: _route,
-          configuredBinding: _configuredBinding,
-          runtimeBindingId: _runtimeBindingId,
           roomConfig,
           isDirectMessage,
           isRoom,
@@ -832,8 +834,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
 
       const {
         route: _route,
-        configuredBinding: _configuredBinding,
-        runtimeBindingId: _runtimeBindingId,
         roomConfig,
         isDirectMessage,
         isRoom,
@@ -854,9 +854,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
 
       // Keep the per-room ingress gate focused on ordering-sensitive state updates.
       // Prompt/session enrichment below can run concurrently after the history snapshot is fixed.
-      const replyToEventId = (event.content as RoomMessageEventContent)["m.relates_to"]?.[
-        "m.in_reply_to"
-      ]?.event_id;
+      const replyToEventId = resolveMatrixReplyToEventId(event.content as RoomMessageEventContent);
       const threadTarget = resolveMatrixThreadTarget({
         threadReplies,
         messageId: _messageId,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -21,7 +21,7 @@ import {
   resolveMatrixMessageAttachment,
   resolveMatrixMessageBody,
 } from "../media-text.js";
-import { fetchMatrixPollSnapshot } from "../poll-summary.js";
+import { fetchMatrixPollSnapshot, type MatrixPollSnapshot } from "../poll-summary.js";
 import {
   formatPollAsText,
   isPollEventType,
@@ -583,6 +583,20 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           return;
         }
 
+        let pollSnapshotPromise: Promise<MatrixPollSnapshot | null> | null = null;
+        const getPollSnapshot = async (): Promise<MatrixPollSnapshot | null> => {
+          if (!isPollEvent) {
+            return null;
+          }
+          pollSnapshotPromise ??= fetchMatrixPollSnapshot(client, roomId, event).catch((err) => {
+            logVerboseMessage(
+              `matrix: failed resolving poll snapshot room=${roomId} id=${event.event_id ?? "unknown"}: ${String(err)}`,
+            );
+            return null;
+          });
+          return await pollSnapshotPromise;
+        };
+
         const mentionPrecheckText = resolveMatrixMentionPrecheckText({
           eventType,
           content,
@@ -600,6 +614,10 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           content,
           mediaUrl,
         });
+        const pendingHistoryPollText =
+          !pendingHistoryText && isPollEvent && historyLimit > 0
+            ? (await getPollSnapshot())?.text
+            : "";
         if (!mentionPrecheckText && !mediaUrl && !isPollEvent) {
           await commitInboundEventIfClaimed();
           return;
@@ -690,10 +708,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           hasControlCommandInMessage;
         const canDetectMention = agentMentionRegexes.length > 0 || hasExplicitMention;
         if (isRoom && shouldRequireMention && !wasMentioned && !shouldBypassMention) {
-          if (historyLimit > 0 && pendingHistoryText) {
+          const pendingHistoryBody = pendingHistoryText || pendingHistoryPollText;
+          if (historyLimit > 0 && pendingHistoryBody) {
             const pendingEntry: HistoryEntry = {
               sender: senderId,
-              body: pendingHistoryText,
+              body: pendingHistoryBody,
               timestamp: eventTs ?? undefined,
               messageId: _messageId,
             };
@@ -705,12 +724,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         }
 
         if (isPollEvent) {
-          const pollSnapshot = await fetchMatrixPollSnapshot(client, roomId, event).catch((err) => {
-            logVerboseMessage(
-              `matrix: failed resolving poll snapshot room=${roomId} id=${event.event_id ?? "unknown"}: ${String(err)}`,
-            );
-            return null;
-          });
+          const pollSnapshot = await getPollSnapshot();
           if (!pollSnapshot) {
             return;
           }

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -825,7 +825,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
               })
             : undefined;
         const inboundHistory = preparedTrigger?.history;
-        const triggerSnapshotIdx = preparedTrigger?.snapshotIdx ?? -1;
+        const triggerSnapshot = preparedTrigger;
 
         return {
           route: _route,
@@ -843,7 +843,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           media,
           locationPayload,
           messageId: _messageId,
-          triggerSnapshotIdx,
+          triggerSnapshot,
           threadRootId: _threadRootId,
         };
       });
@@ -867,7 +867,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         media,
         locationPayload,
         messageId: _messageId,
-        triggerSnapshotIdx,
+        triggerSnapshot,
         threadRootId: _threadRootId,
       } = ingressResult;
 
@@ -1319,8 +1319,8 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       // Advance the per-agent watermark now that the reply succeeded (or no reply was needed).
       // Only advance to the snapshot position — messages added during async processing remain
       // visible for the next trigger.
-      if (isRoom && triggerSnapshotIdx >= 0) {
-        roomHistoryTracker.consumeHistory(_route.agentId, roomId, triggerSnapshotIdx, _messageId);
+      if (isRoom && triggerSnapshot) {
+        roomHistoryTracker.consumeHistory(_route.agentId, roomId, triggerSnapshot, _messageId);
       }
       if (!queuedFinal) {
         await commitInboundEventIfClaimed();

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -287,11 +287,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     }
   };
 
-  const runHistoryAwareRoomIngress = async <T>(
-    roomId: string,
-    task: () => Promise<T>,
-  ): Promise<T> => (historyLimit > 0 ? runRoomIngress(roomId, task) : task());
-
   return async (roomId: string, event: MatrixRawEvent) => {
     const eventId = typeof event.event_id === "string" ? event.event_id.trim() : "";
     let claimedInboundEvent = false;
@@ -336,7 +331,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         await inboundDeduper.commitEvent({ roomId, eventId });
         claimedInboundEvent = false;
       };
-      const ingressResult = await runHistoryAwareRoomIngress(roomId, async () => {
+      const readIngressPrefix = async () => {
         const selfUserId = await client.getUserId();
         if (senderId === selfUserId) {
           return;
@@ -389,8 +384,18 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           senderId,
           selfUserId,
         });
+        return { content, isDirectMessage, locationPayload, selfUserId };
+      };
+      const continueIngress = async (params: {
+        content: RoomMessageEventContent;
+        isDirectMessage: boolean;
+        locationPayload: MatrixLocationPayload | null;
+        selfUserId: string;
+      }) => {
+        let content = params.content;
+        const isDirectMessage = params.isDirectMessage;
         const isRoom = !isDirectMessage;
-
+        const { locationPayload, selfUserId } = params;
         if (isRoom && groupPolicy === "disabled") {
           await commitInboundEventIfClaimed();
           return;
@@ -846,8 +851,33 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           triggerSnapshot,
           threadRootId: _threadRootId,
         };
-      });
-      if (!ingressResult) {
+      };
+      const ingressResult =
+        historyLimit > 0
+          ? await runRoomIngress(roomId, async () => {
+              const prefix = await readIngressPrefix();
+              if (!prefix) {
+                return;
+              }
+              if (prefix.isDirectMessage) {
+                return { deferredPrefix: prefix } as const;
+              }
+              return { ingressResult: await continueIngress(prefix) } as const;
+            })
+          : undefined;
+      const resolvedIngressResult =
+        historyLimit > 0
+          ? ingressResult?.deferredPrefix
+            ? await continueIngress(ingressResult.deferredPrefix)
+            : ingressResult?.ingressResult
+          : await (async () => {
+              const prefix = await readIngressPrefix();
+              if (!prefix) {
+                return;
+              }
+              return await continueIngress(prefix);
+            })();
+      if (!resolvedIngressResult) {
         return;
       }
 
@@ -869,7 +899,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         messageId: _messageId,
         triggerSnapshot,
         threadRootId: _threadRootId,
-      } = ingressResult;
+      } = resolvedIngressResult;
 
       // Keep the per-room ingress gate focused on ordering-sensitive state updates.
       // Prompt/session enrichment below can run concurrently after the history snapshot is fixed.

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -287,6 +287,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     }
   };
 
+  const runHistoryAwareRoomIngress = async <T>(
+    roomId: string,
+    task: () => Promise<T>,
+  ): Promise<T> => (historyLimit > 0 ? runRoomIngress(roomId, task) : task());
+
   return async (roomId: string, event: MatrixRawEvent) => {
     const eventId = typeof event.event_id === "string" ? event.event_id.trim() : "";
     let claimedInboundEvent = false;
@@ -331,7 +336,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         await inboundDeduper.commitEvent({ roomId, eventId });
         claimedInboundEvent = false;
       };
-      const ingressResult = await runRoomIngress(roomId, async () => {
+      const ingressResult = await runHistoryAwareRoomIngress(roomId, async () => {
         const selfUserId = await client.getUserId();
         if (senderId === selfUserId) {
           return;

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -15,7 +15,12 @@ import {
 } from "../../runtime-api.js";
 import type { CoreConfig, MatrixRoomConfig, ReplyToMode } from "../../types.js";
 import { createMatrixDraftStream } from "../draft-stream.js";
-import { formatMatrixMediaUnavailableText } from "../media-text.js";
+import {
+  formatMatrixMediaUnavailableText,
+  formatMatrixMessageText,
+  resolveMatrixMessageAttachment,
+  resolveMatrixMessageBody,
+} from "../media-text.js";
 import { fetchMatrixPollSnapshot } from "../poll-summary.js";
 import {
   formatPollAsText,
@@ -40,6 +45,8 @@ import { resolveMentions } from "./mentions.js";
 import { handleInboundMatrixReaction } from "./reaction-events.js";
 import { deliverMatrixReplies } from "./replies.js";
 import { createMatrixReplyContextResolver } from "./reply-context.js";
+import { createRoomHistoryTracker } from "./room-history.js";
+import type { HistoryEntry } from "./room-history.js";
 import { resolveMatrixRoomConfig } from "./rooms.js";
 import { resolveMatrixInboundRoute } from "./route.js";
 import { createMatrixThreadContextResolver } from "./thread-context.js";
@@ -74,6 +81,7 @@ export type MatrixMonitorHandlerParams = {
   dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
   textLimit: number;
   mediaMaxBytes: number;
+  historyLimit: number;
   startupMs: number;
   startupGraceMs: number;
   dropPreStartupMessages: boolean;
@@ -134,6 +142,29 @@ function resolveMatrixInboundBodyText(params: {
   });
 }
 
+function resolveMatrixPendingHistoryText(params: {
+  mentionPrecheckText: string;
+  content: RoomMessageEventContent;
+  mediaUrl?: string;
+}): string {
+  if (params.mentionPrecheckText) {
+    return params.mentionPrecheckText;
+  }
+  if (!params.mediaUrl) {
+    return "";
+  }
+  const body = typeof params.content.body === "string" ? params.content.body.trim() : undefined;
+  const filename =
+    typeof params.content.filename === "string" ? params.content.filename.trim() : undefined;
+  const msgtype = typeof params.content.msgtype === "string" ? params.content.msgtype : undefined;
+  return (
+    formatMatrixMessageText({
+      body: resolveMatrixMessageBody({ body, filename, msgtype }),
+      attachment: resolveMatrixMessageAttachment({ body, filename, msgtype }),
+    }) ?? ""
+  );
+}
+
 function resolveMatrixAllowBotsMode(value?: boolean | "mentions"): MatrixAllowBotsMode {
   if (value === true) {
     return "all";
@@ -166,6 +197,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     dmPolicy,
     textLimit,
     mediaMaxBytes,
+    historyLimit,
     startupMs,
     startupGraceMs,
     dropPreStartupMessages,
@@ -190,6 +222,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     getMemberDisplayName,
     logVerboseMessage,
   });
+  const roomHistoryTracker = createRoomHistoryTracker();
 
   const readStoreAllowFrom = async (): Promise<string[]> => {
     const now = Date.now();
@@ -532,6 +565,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           ? content.file
           : undefined;
       const mediaUrl = contentUrl ?? contentFile?.url;
+      const pendingHistoryText = resolveMatrixPendingHistoryText({
+        mentionPrecheckText,
+        content,
+        mediaUrl,
+      });
       if (!mentionPrecheckText && !mediaUrl && !isPollEvent) {
         await commitInboundEventIfClaimed();
         return;
@@ -622,6 +660,16 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         hasControlCommandInMessage;
       const canDetectMention = agentMentionRegexes.length > 0 || hasExplicitMention;
       if (isRoom && shouldRequireMention && !wasMentioned && !shouldBypassMention) {
+        // Record in room history so future triggered replies can see this message as context.
+        if (historyLimit > 0 && pendingHistoryText) {
+          const pendingEntry: HistoryEntry = {
+            // Keep skipped-message buffering non-blocking: sender name lookup can be async.
+            sender: senderId,
+            body: pendingHistoryText,
+            timestamp: eventTs ?? undefined,
+          };
+          roomHistoryTracker.recordPending(roomId, pendingEntry);
+        }
         logger.info("skipping room message", { roomId, reason: "no-mention" });
         await commitInboundEventIfClaimed();
         return;
@@ -753,6 +801,22 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         getSessionBindingService().touch(_runtimeBindingId, eventTs ?? undefined);
       }
       const envelopeFrom = isDirectMessage ? senderName : (roomName ?? roomId);
+
+      // Group chat history: read pending history before recording this trigger, then
+      // snapshot the queue position so the watermark can advance to exactly here on reply.
+      const inboundHistory =
+        isRoom && historyLimit > 0
+          ? roomHistoryTracker.getPendingHistory(_route.agentId, roomId, historyLimit)
+          : undefined;
+      const triggerSnapshotIdx =
+        isRoom && historyLimit > 0
+          ? roomHistoryTracker.recordTrigger(roomId, {
+              sender: senderName,
+              body: bodyText,
+              timestamp: eventTs ?? undefined,
+            })
+          : -1;
+
       const textWithId = `${bodyText}\n[matrix event id: ${_messageId} room: ${roomId}]`;
       const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
         agentId: _route.agentId,
@@ -776,6 +840,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         Body: body,
         RawBody: bodyText,
         CommandBody: bodyText,
+        InboundHistory: inboundHistory && inboundHistory.length > 0 ? inboundHistory : undefined,
         From: isDirectMessage ? `matrix:${senderId}` : `matrix:channel:${roomId}`,
         To: `room:${roomId}`,
         SessionKey: _route.sessionKey,
@@ -1164,13 +1229,21 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         logVerboseMessage(
           `matrix: final reply delivery failed room=${roomId} id=${_messageId}; leaving event uncommitted`,
         );
+        // Do not advance watermark — the event will be retried and should see the same history.
         return;
       }
       if (!queuedFinal && nonFinalReplyDeliveryFailed) {
         logVerboseMessage(
           `matrix: non-final reply delivery failed room=${roomId} id=${_messageId}; leaving event uncommitted`,
         );
+        // Do not advance watermark — the event will be retried.
         return;
+      }
+      // Advance the per-agent watermark now that the reply succeeded (or no reply was needed).
+      // Only advance to the snapshot position — messages added during async processing remain
+      // visible for the next trigger.
+      if (isRoom && triggerSnapshotIdx >= 0) {
+        roomHistoryTracker.consumeHistory(_route.agentId, roomId, triggerSnapshotIdx);
       }
       if (!queuedFinal) {
         await commitInboundEventIfClaimed();

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -774,29 +774,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           return;
         }
         const senderName = await getSenderName();
-        const roomInfo = isRoom ? await getRoomInfo(roomId) : undefined;
-        const roomName = roomInfo?.name;
-
-        const replyToEventId = content["m.relates_to"]?.["m.in_reply_to"]?.event_id;
-        const threadTarget = resolveMatrixThreadTarget({
-          threadReplies,
-          messageId: _messageId,
-          threadRootId: _threadRootId,
-          isThreadRoot: false,
-        });
-        const threadContext = _threadRootId
-          ? await resolveThreadContext({ roomId, threadRootId: _threadRootId })
-          : undefined;
-        const replyContext =
-          replyToEventId && replyToEventId === _threadRootId && threadContext?.summary
-            ? {
-                replyToBody: threadContext.summary,
-                replyToSender: threadContext.senderLabel,
-              }
-            : replyToEventId
-              ? await resolveReplyContext({ roomId, eventId: replyToEventId })
-              : undefined;
-
         if (_configuredBinding) {
           const ensured = await ensureConfiguredAcpBindingReady({
             cfg,
@@ -815,7 +792,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         if (_runtimeBindingId) {
           getSessionBindingService().touch(_runtimeBindingId, eventTs ?? undefined);
         }
-        const envelopeFrom = isDirectMessage ? senderName : (roomName ?? roomId);
         const preparedTrigger =
           isRoom && historyLimit > 0
             ? roomHistoryTracker.prepareTrigger(_route.agentId, roomId, historyLimit, {
@@ -828,95 +804,10 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         const inboundHistory = preparedTrigger?.history;
         const triggerSnapshotIdx = preparedTrigger?.snapshotIdx ?? -1;
 
-        const textWithId = `${bodyText}\n[matrix event id: ${_messageId} room: ${roomId}]`;
-        const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
-          agentId: _route.agentId,
-        });
-        const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
-        const previousTimestamp = core.channel.session.readSessionUpdatedAt({
-          storePath,
-          sessionKey: _route.sessionKey,
-        });
-        const body = core.channel.reply.formatAgentEnvelope({
-          channel: "Matrix",
-          from: envelopeFrom,
-          timestamp: eventTs ?? undefined,
-          previousTimestamp,
-          envelope: envelopeOptions,
-          body: textWithId,
-        });
-
-        const groupSystemPrompt = roomConfig?.systemPrompt?.trim() || undefined;
-        const ctxPayload = core.channel.reply.finalizeInboundContext({
-          Body: body,
-          RawBody: bodyText,
-          CommandBody: bodyText,
-          InboundHistory: inboundHistory && inboundHistory.length > 0 ? inboundHistory : undefined,
-          From: isDirectMessage ? `matrix:${senderId}` : `matrix:channel:${roomId}`,
-          To: `room:${roomId}`,
-          SessionKey: _route.sessionKey,
-          AccountId: _route.accountId,
-          ChatType: isDirectMessage ? "direct" : "channel",
-          ConversationLabel: envelopeFrom,
-          SenderName: senderName,
-          SenderId: senderId,
-          SenderUsername: senderId.split(":")[0]?.replace(/^@/, ""),
-          GroupSubject: isRoom ? (roomName ?? roomId) : undefined,
-          GroupId: isRoom ? roomId : undefined,
-          GroupSystemPrompt: isRoom ? groupSystemPrompt : undefined,
-          Provider: "matrix" as const,
-          Surface: "matrix" as const,
-          WasMentioned: isRoom ? wasMentioned : undefined,
-          MessageSid: _messageId,
-          ReplyToId: threadTarget ? undefined : (replyToEventId ?? undefined),
-          ReplyToBody: replyContext?.replyToBody,
-          ReplyToSender: replyContext?.replyToSender,
-          MessageThreadId: threadTarget,
-          ThreadStarterBody: threadContext?.threadStarterBody,
-          Timestamp: eventTs ?? undefined,
-          MediaPath: media?.path,
-          MediaType: media?.contentType,
-          MediaUrl: media?.path,
-          ...locationPayload?.context,
-          CommandAuthorized: commandAuthorized,
-          CommandSource: "text" as const,
-          OriginatingChannel: "matrix" as const,
-          OriginatingTo: `room:${roomId}`,
-        });
-
-        await core.channel.session.recordInboundSession({
-          storePath,
-          sessionKey: ctxPayload.SessionKey ?? _route.sessionKey,
-          ctx: ctxPayload,
-          updateLastRoute: isDirectMessage
-            ? {
-                sessionKey: _route.mainSessionKey,
-                channel: "matrix",
-                to: `room:${roomId}`,
-                accountId: _route.accountId,
-              }
-            : undefined,
-          onRecordError: (err) => {
-            logger.warn("failed updating session meta", {
-              error: String(err),
-              storePath,
-              sessionKey: ctxPayload.SessionKey ?? _route.sessionKey,
-            });
-          },
-        });
-
-        const preview = bodyText.slice(0, 200).replace(/\n/g, "\\n");
-        logVerboseMessage(`matrix inbound: room=${roomId} from=${senderId} preview="${preview}"`);
-
-        const replyTarget = ctxPayload.To;
-        if (!replyTarget) {
-          runtime.error?.("matrix: missing reply target");
-          return;
-        }
-
         return {
-          ctxPayload,
           route: _route,
+          configuredBinding: _configuredBinding,
+          runtimeBindingId: _runtimeBindingId,
           roomConfig,
           isDirectMessage,
           isRoom,
@@ -924,10 +815,15 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           wasMentioned,
           shouldBypassMention,
           canDetectMention,
+          commandAuthorized,
+          inboundHistory,
+          senderName,
+          bodyText,
+          media,
+          locationPayload,
           messageId: _messageId,
           triggerSnapshotIdx,
-          threadTarget,
-          replyTarget,
+          threadRootId: _threadRootId,
         };
       });
       if (!ingressResult) {
@@ -935,8 +831,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       }
 
       const {
-        ctxPayload,
         route: _route,
+        configuredBinding: _configuredBinding,
+        runtimeBindingId: _runtimeBindingId,
         roomConfig,
         isDirectMessage,
         isRoom,
@@ -944,11 +841,127 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         wasMentioned,
         shouldBypassMention,
         canDetectMention,
+        commandAuthorized,
+        inboundHistory,
+        senderName,
+        bodyText,
+        media,
+        locationPayload,
         messageId: _messageId,
         triggerSnapshotIdx,
-        threadTarget,
-        replyTarget,
+        threadRootId: _threadRootId,
       } = ingressResult;
+
+      // Keep the per-room ingress gate focused on ordering-sensitive state updates.
+      // Prompt/session enrichment below can run concurrently after the history snapshot is fixed.
+      const replyToEventId = (event.content as RoomMessageEventContent)["m.relates_to"]?.[
+        "m.in_reply_to"
+      ]?.event_id;
+      const threadTarget = resolveMatrixThreadTarget({
+        threadReplies,
+        messageId: _messageId,
+        threadRootId: _threadRootId,
+        isThreadRoot: false,
+      });
+      const threadContext = _threadRootId
+        ? await resolveThreadContext({ roomId, threadRootId: _threadRootId })
+        : undefined;
+      const replyContext =
+        replyToEventId && replyToEventId === _threadRootId && threadContext?.summary
+          ? {
+              replyToBody: threadContext.summary,
+              replyToSender: threadContext.senderLabel,
+            }
+          : replyToEventId
+            ? await resolveReplyContext({ roomId, eventId: replyToEventId })
+            : undefined;
+      const roomInfo = isRoom ? await getRoomInfo(roomId) : undefined;
+      const roomName = roomInfo?.name;
+      const envelopeFrom = isDirectMessage ? senderName : (roomName ?? roomId);
+      const textWithId = `${bodyText}\n[matrix event id: ${_messageId} room: ${roomId}]`;
+      const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
+        agentId: _route.agentId,
+      });
+      const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
+      const previousTimestamp = core.channel.session.readSessionUpdatedAt({
+        storePath,
+        sessionKey: _route.sessionKey,
+      });
+      const body = core.channel.reply.formatAgentEnvelope({
+        channel: "Matrix",
+        from: envelopeFrom,
+        timestamp: eventTs ?? undefined,
+        previousTimestamp,
+        envelope: envelopeOptions,
+        body: textWithId,
+      });
+      const groupSystemPrompt = roomConfig?.systemPrompt?.trim() || undefined;
+      const ctxPayload = core.channel.reply.finalizeInboundContext({
+        Body: body,
+        RawBody: bodyText,
+        CommandBody: bodyText,
+        InboundHistory: inboundHistory && inboundHistory.length > 0 ? inboundHistory : undefined,
+        From: isDirectMessage ? `matrix:${senderId}` : `matrix:channel:${roomId}`,
+        To: `room:${roomId}`,
+        SessionKey: _route.sessionKey,
+        AccountId: _route.accountId,
+        ChatType: isDirectMessage ? "direct" : "channel",
+        ConversationLabel: envelopeFrom,
+        SenderName: senderName,
+        SenderId: senderId,
+        SenderUsername: senderId.split(":")[0]?.replace(/^@/, ""),
+        GroupSubject: isRoom ? (roomName ?? roomId) : undefined,
+        GroupId: isRoom ? roomId : undefined,
+        GroupSystemPrompt: isRoom ? groupSystemPrompt : undefined,
+        Provider: "matrix" as const,
+        Surface: "matrix" as const,
+        WasMentioned: isRoom ? wasMentioned : undefined,
+        MessageSid: _messageId,
+        ReplyToId: threadTarget ? undefined : (replyToEventId ?? undefined),
+        ReplyToBody: replyContext?.replyToBody,
+        ReplyToSender: replyContext?.replyToSender,
+        MessageThreadId: threadTarget,
+        ThreadStarterBody: threadContext?.threadStarterBody,
+        Timestamp: eventTs ?? undefined,
+        MediaPath: media?.path,
+        MediaType: media?.contentType,
+        MediaUrl: media?.path,
+        ...locationPayload?.context,
+        CommandAuthorized: commandAuthorized,
+        CommandSource: "text" as const,
+        OriginatingChannel: "matrix" as const,
+        OriginatingTo: `room:${roomId}`,
+      });
+
+      await core.channel.session.recordInboundSession({
+        storePath,
+        sessionKey: ctxPayload.SessionKey ?? _route.sessionKey,
+        ctx: ctxPayload,
+        updateLastRoute: isDirectMessage
+          ? {
+              sessionKey: _route.mainSessionKey,
+              channel: "matrix",
+              to: `room:${roomId}`,
+              accountId: _route.accountId,
+            }
+          : undefined,
+        onRecordError: (err) => {
+          logger.warn("failed updating session meta", {
+            error: String(err),
+            storePath,
+            sessionKey: ctxPayload.SessionKey ?? _route.sessionKey,
+          });
+        },
+      });
+
+      const preview = bodyText.slice(0, 200).replace(/\n/g, "\\n");
+      logVerboseMessage(`matrix inbound: room=${roomId} from=${senderId} preview="${preview}"`);
+
+      const replyTarget = ctxPayload.To;
+      if (!replyTarget) {
+        runtime.error?.("matrix: missing reply target");
+        return;
+      }
 
       const { ackReaction, ackReactionScope: ackScope } = resolveMatrixAckReactionConfig({
         cfg,

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -196,6 +196,10 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const dmPolicyRaw = dmConfig?.policy ?? "pairing";
   const dmPolicy = allowlistOnly && dmPolicyRaw !== "disabled" ? "allowlist" : dmPolicyRaw;
   const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "matrix", account.accountId);
+  const globalGroupChatHistoryLimit = (
+    cfg.messages as { groupChat?: { historyLimit?: number } } | undefined
+  )?.groupChat?.historyLimit;
+  const historyLimit = Math.max(0, accountConfig.historyLimit ?? globalGroupChatHistoryLimit ?? 0);
   const mediaMaxMb = opts.mediaMaxMb ?? accountConfig.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
   const mediaMaxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
   const streaming: "partial" | "off" =
@@ -232,6 +236,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     dmPolicy,
     textLimit,
     mediaMaxBytes,
+    historyLimit,
     startupMs,
     startupGraceMs,
     dropPreStartupMessages,

--- a/extensions/matrix/src/matrix/monitor/room-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.test.ts
@@ -125,4 +125,29 @@ describe("createRoomHistoryTracker — roomQueues eviction", () => {
     expect(history).toHaveLength(1);
     expect(history[0]?.body).toBe("new msg in room1");
   });
+
+  it("ignores late consumeHistory calls after the room queue was evicted", () => {
+    const tracker = createRoomHistoryTracker(200, 1);
+    const room1 = "!room1:test";
+    const room2 = "!room2:test";
+
+    tracker.recordPending(room1, entry("old msg in room1"));
+    const prepared = tracker.prepareTrigger(AGENT, room1, 100, {
+      sender: "user",
+      body: "trigger in room1",
+      messageId: "$trigger",
+    });
+
+    // room2 creation evicts room1 (maxRoomQueues=1) while the trigger is still in flight.
+    tracker.recordPending(room2, entry("msg in room2"));
+
+    // Late completion for the evicted room must not recreate a stale watermark.
+    tracker.consumeHistory(AGENT, room1, prepared.snapshotIdx, "$trigger");
+
+    // Recreate room1 and add fresh content.
+    tracker.recordPending(room1, entry("new msg in room1"));
+    const history = tracker.getPendingHistory(AGENT, room1, 100);
+    expect(history).toHaveLength(1);
+    expect(history[0]?.body).toBe("new msg in room1");
+  });
 });

--- a/extensions/matrix/src/matrix/monitor/room-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.test.ts
@@ -91,6 +91,41 @@ describe("createRoomHistoryTracker — watermark monotonicity", () => {
     expect(room1History).toHaveLength(1);
     expect(room1History[0]?.body).toBe("new msg in room1");
   });
+
+  it("refreshes prepared-trigger recency before capped eviction on retry hits", () => {
+    const tracker = createRoomHistoryTracker(200, 10, 5000, 2);
+    const room1 = "!room1:test";
+
+    tracker.prepareTrigger(AGENT, room1, 100, {
+      sender: "user",
+      body: "trigger1",
+      messageId: "$trigger1",
+    });
+    tracker.prepareTrigger(AGENT, room1, 100, {
+      sender: "user",
+      body: "trigger2",
+      messageId: "$trigger2",
+    });
+
+    // Retry hit should refresh trigger1 so trigger2 becomes the stale entry.
+    const retried = tracker.prepareTrigger(AGENT, room1, 100, {
+      sender: "user",
+      body: "trigger1",
+      messageId: "$trigger1",
+    });
+    tracker.prepareTrigger(AGENT, room1, 100, {
+      sender: "user",
+      body: "trigger3",
+      messageId: "$trigger3",
+    });
+
+    const reused = tracker.prepareTrigger(AGENT, room1, 100, {
+      sender: "user",
+      body: "trigger1",
+      messageId: "$trigger1",
+    });
+    expect(reused.snapshotIdx).toBe(retried.snapshotIdx);
+  });
 });
 
 describe("createRoomHistoryTracker — roomQueues eviction", () => {

--- a/extensions/matrix/src/matrix/monitor/room-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.test.ts
@@ -204,10 +204,28 @@ describe("createRoomHistoryTracker — roomQueues eviction", () => {
     tracker.recordPending(room2, entry("msg in room2"));
 
     // Late completion for the evicted room must not recreate a stale watermark.
-    tracker.consumeHistory(AGENT, room1, prepared.snapshotIdx, "$trigger");
+    tracker.consumeHistory(AGENT, room1, prepared, "$trigger");
 
     // Recreate room1 and add fresh content.
     tracker.recordPending(room1, entry("new msg in room1"));
+    const history = tracker.getPendingHistory(AGENT, room1, 100);
+    expect(history).toHaveLength(1);
+    expect(history[0]?.body).toBe("new msg in room1");
+  });
+
+  it("rejects stale snapshots after the room queue is recreated", () => {
+    const tracker = createRoomHistoryTrackerForTests(200, 1);
+    const room1 = "!room1:test";
+    const room2 = "!room2:test";
+
+    tracker.recordPending(room1, entry("old msg in room1"));
+    const staleSnapshot = tracker.recordTrigger(room1, entry("trigger in room1"));
+
+    tracker.recordPending(room2, entry("msg in room2")); // evicts room1
+    tracker.recordPending(room1, entry("new msg in room1")); // recreates room1 with new generation
+
+    tracker.consumeHistory(AGENT, room1, staleSnapshot);
+
     const history = tracker.getPendingHistory(AGENT, room1, 100);
     expect(history).toHaveLength(1);
     expect(history[0]?.body).toBe("new msg in room1");

--- a/extensions/matrix/src/matrix/monitor/room-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.test.ts
@@ -42,6 +42,28 @@ describe("createRoomHistoryTracker — watermark monotonicity", () => {
     tracker.consumeHistory(AGENT, ROOM, snap3); // watermark → 7
     expect(tracker.getPendingHistory(AGENT, ROOM, 100)).toHaveLength(0);
   });
+
+  it("prepareTrigger reuses the original history window for a retried event", () => {
+    const tracker = createRoomHistoryTracker();
+
+    tracker.recordPending(ROOM, { sender: "user", body: "msg1", messageId: "$m1" });
+    const first = tracker.prepareTrigger(AGENT, ROOM, 100, {
+      sender: "user",
+      body: "trigger",
+      messageId: "$trigger",
+    });
+
+    tracker.recordPending(ROOM, { sender: "user", body: "msg2", messageId: "$m2" });
+    const retried = tracker.prepareTrigger(AGENT, ROOM, 100, {
+      sender: "user",
+      body: "trigger",
+      messageId: "$trigger",
+    });
+
+    expect(first.history.map((entry) => entry.body)).toEqual(["msg1"]);
+    expect(retried.history.map((entry) => entry.body)).toEqual(["msg1"]);
+    expect(retried.snapshotIdx).toBe(first.snapshotIdx);
+  });
 });
 
 describe("createRoomHistoryTracker — roomQueues eviction", () => {

--- a/extensions/matrix/src/matrix/monitor/room-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.test.ts
@@ -230,4 +230,29 @@ describe("createRoomHistoryTracker — roomQueues eviction", () => {
     expect(history).toHaveLength(1);
     expect(history[0]?.body).toBe("new msg in room1");
   });
+
+  it("preserves newer watermarks when an older snapshot finishes after room recreation", () => {
+    const tracker = createRoomHistoryTrackerForTests(200, 1);
+    const room1 = "!room1:test";
+    const room2 = "!room2:test";
+
+    tracker.recordPending(room1, entry("old msg in room1"));
+    const staleSnapshot = tracker.recordTrigger(room1, entry("old trigger in room1"));
+
+    tracker.recordPending(room2, entry("msg in room2")); // evicts room1
+
+    tracker.recordPending(room1, entry("new msg in room1"));
+    const freshSnapshot = tracker.recordTrigger(room1, entry("new trigger in room1"));
+    tracker.consumeHistory(AGENT, room1, freshSnapshot);
+
+    // Late completion from the old generation must be ignored and must not clear the
+    // watermark already written by the newer trigger.
+    tracker.consumeHistory(AGENT, room1, staleSnapshot);
+
+    tracker.recordPending(room1, entry("fresh msg after consume"));
+
+    const history = tracker.getPendingHistory(AGENT, room1, 100);
+    expect(history).toHaveLength(1);
+    expect(history[0]?.body).toBe("fresh msg after consume");
+  });
 });

--- a/extensions/matrix/src/matrix/monitor/room-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.test.ts
@@ -64,6 +64,33 @@ describe("createRoomHistoryTracker — watermark monotonicity", () => {
     expect(retried.history.map((entry) => entry.body)).toEqual(["msg1"]);
     expect(retried.snapshotIdx).toBe(first.snapshotIdx);
   });
+
+  it("refreshes watermark recency before capped-map eviction", () => {
+    const tracker = createRoomHistoryTracker(200, 10, 2);
+    const room1 = "!room1:test";
+    const room2 = "!room2:test";
+    const room3 = "!room3:test";
+
+    tracker.recordPending(room1, entry("old msg in room1"));
+    const snap1 = tracker.recordTrigger(room1, entry("trigger in room1"));
+    tracker.consumeHistory(AGENT, room1, snap1);
+
+    tracker.recordPending(room2, entry("old msg in room2"));
+    const snap2 = tracker.recordTrigger(room2, entry("trigger in room2"));
+    tracker.consumeHistory(AGENT, room2, snap2);
+
+    // Refresh room1 so room2 becomes the stalest watermark entry.
+    tracker.consumeHistory(AGENT, room1, snap1);
+
+    tracker.recordPending(room3, entry("old msg in room3"));
+    const snap3 = tracker.recordTrigger(room3, entry("trigger in room3"));
+    tracker.consumeHistory(AGENT, room3, snap3);
+
+    tracker.recordPending(room1, entry("new msg in room1"));
+    const room1History = tracker.getPendingHistory(AGENT, room1, 100);
+    expect(room1History).toHaveLength(1);
+    expect(room1History[0]?.body).toBe("new msg in room1");
+  });
 });
 
 describe("createRoomHistoryTracker — roomQueues eviction", () => {

--- a/extensions/matrix/src/matrix/monitor/room-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { createRoomHistoryTracker } from "./room-history.js";
+import { createRoomHistoryTrackerForTests } from "./room-history.js";
 
 const ROOM = "!room:test";
 const AGENT = "agent_a";
@@ -18,7 +18,7 @@ function entry(body: string) {
 
 describe("createRoomHistoryTracker — watermark monotonicity", () => {
   it("consumeHistory is monotone: out-of-order completion does not regress the watermark", () => {
-    const tracker = createRoomHistoryTracker();
+    const tracker = createRoomHistoryTrackerForTests();
 
     // Queue: [msg1, msg2, trigger1, msg3, trigger2]
     tracker.recordPending(ROOM, entry("msg1"));
@@ -44,7 +44,7 @@ describe("createRoomHistoryTracker — watermark monotonicity", () => {
   });
 
   it("prepareTrigger reuses the original history window for a retried event", () => {
-    const tracker = createRoomHistoryTracker();
+    const tracker = createRoomHistoryTrackerForTests();
 
     tracker.recordPending(ROOM, { sender: "user", body: "msg1", messageId: "$m1" });
     const first = tracker.prepareTrigger(AGENT, ROOM, 100, {
@@ -66,7 +66,7 @@ describe("createRoomHistoryTracker — watermark monotonicity", () => {
   });
 
   it("refreshes watermark recency before capped-map eviction", () => {
-    const tracker = createRoomHistoryTracker(200, 10, 2);
+    const tracker = createRoomHistoryTrackerForTests(200, 10, 2);
     const room1 = "!room1:test";
     const room2 = "!room2:test";
     const room3 = "!room3:test";
@@ -93,7 +93,7 @@ describe("createRoomHistoryTracker — watermark monotonicity", () => {
   });
 
   it("refreshes prepared-trigger recency before capped eviction on retry hits", () => {
-    const tracker = createRoomHistoryTracker(200, 10, 5000, 2);
+    const tracker = createRoomHistoryTrackerForTests(200, 10, 5000, 2);
     const room1 = "!room1:test";
 
     tracker.prepareTrigger(AGENT, room1, 100, {
@@ -130,7 +130,7 @@ describe("createRoomHistoryTracker — watermark monotonicity", () => {
 
 describe("createRoomHistoryTracker — roomQueues eviction", () => {
   it("evicts the oldest room (FIFO) when the room count exceeds the cap", () => {
-    const tracker = createRoomHistoryTracker(200, 3);
+    const tracker = createRoomHistoryTrackerForTests(200, 3);
 
     const room1 = "!room1:test";
     const room2 = "!room2:test";
@@ -153,7 +153,7 @@ describe("createRoomHistoryTracker — roomQueues eviction", () => {
   });
 
   it("re-accessing an evicted room starts a fresh empty queue", () => {
-    const tracker = createRoomHistoryTracker(200, 2);
+    const tracker = createRoomHistoryTrackerForTests(200, 2);
 
     const room1 = "!room1:test";
     const room2 = "!room2:test";
@@ -170,7 +170,7 @@ describe("createRoomHistoryTracker — roomQueues eviction", () => {
   });
 
   it("clears stale room watermarks when an evicted room is recreated", () => {
-    const tracker = createRoomHistoryTracker(200, 1);
+    const tracker = createRoomHistoryTrackerForTests(200, 1);
     const room1 = "!room1:test";
     const room2 = "!room2:test";
 
@@ -189,7 +189,7 @@ describe("createRoomHistoryTracker — roomQueues eviction", () => {
   });
 
   it("ignores late consumeHistory calls after the room queue was evicted", () => {
-    const tracker = createRoomHistoryTracker(200, 1);
+    const tracker = createRoomHistoryTrackerForTests(200, 1);
     const room1 = "!room1:test";
     const room2 = "!room2:test";
 

--- a/extensions/matrix/src/matrix/monitor/room-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for createRoomHistoryTracker.
+ *
+ * Covers correctness properties that are hard to observe through the handler harness:
+ * - Monotone watermark advancement (out-of-order consumeHistory must not regress)
+ * - roomQueues FIFO eviction when the room count exceeds the cap
+ */
+
+import { describe, expect, it } from "vitest";
+import { createRoomHistoryTracker } from "./room-history.js";
+
+const ROOM = "!room:test";
+const AGENT = "agent_a";
+
+function entry(body: string) {
+  return { sender: "user", body };
+}
+
+describe("createRoomHistoryTracker — watermark monotonicity", () => {
+  it("consumeHistory is monotone: out-of-order completion does not regress the watermark", () => {
+    const tracker = createRoomHistoryTracker();
+
+    // Queue: [msg1, msg2, trigger1, msg3, trigger2]
+    tracker.recordPending(ROOM, entry("msg1"));
+    tracker.recordPending(ROOM, entry("msg2"));
+    const snap1 = tracker.recordTrigger(ROOM, entry("trigger1")); // snap=3
+    tracker.recordPending(ROOM, entry("msg3"));
+    const snap2 = tracker.recordTrigger(ROOM, entry("trigger2")); // snap=5
+
+    // trigger2 completes first (higher index)
+    tracker.consumeHistory(AGENT, ROOM, snap2); // watermark → 5
+    expect(tracker.getPendingHistory(AGENT, ROOM, 100)).toHaveLength(0);
+
+    // trigger1 completes later (lower index) — must NOT regress to 3
+    tracker.consumeHistory(AGENT, ROOM, snap1);
+    // If regressed: [msg3, trigger2] would be visible (2 entries); must stay at 0
+    expect(tracker.getPendingHistory(AGENT, ROOM, 100)).toHaveLength(0);
+
+    // In-order advancement still works
+    tracker.recordPending(ROOM, entry("msg4"));
+    const snap3 = tracker.recordTrigger(ROOM, entry("trigger3")); // snap=7
+    tracker.consumeHistory(AGENT, ROOM, snap3); // watermark → 7
+    expect(tracker.getPendingHistory(AGENT, ROOM, 100)).toHaveLength(0);
+  });
+});
+
+describe("createRoomHistoryTracker — roomQueues eviction", () => {
+  it("evicts the oldest room (FIFO) when the room count exceeds the cap", () => {
+    const tracker = createRoomHistoryTracker(200, 3);
+
+    const room1 = "!room1:test";
+    const room2 = "!room2:test";
+    const room3 = "!room3:test";
+    const room4 = "!room4:test";
+
+    tracker.recordPending(room1, entry("msg in room1"));
+    tracker.recordPending(room2, entry("msg in room2"));
+    tracker.recordPending(room3, entry("msg in room3"));
+
+    // At cap (3 rooms) — no eviction yet
+    expect(tracker.getPendingHistory(AGENT, room1, 100)).toHaveLength(1);
+
+    // room4 pushes count to 4 > cap=3 → room1 (oldest) evicted
+    tracker.recordPending(room4, entry("msg in room4"));
+    expect(tracker.getPendingHistory(AGENT, room1, 100)).toHaveLength(0);
+    expect(tracker.getPendingHistory(AGENT, room2, 100)).toHaveLength(1);
+    expect(tracker.getPendingHistory(AGENT, room3, 100)).toHaveLength(1);
+    expect(tracker.getPendingHistory(AGENT, room4, 100)).toHaveLength(1);
+  });
+
+  it("re-accessing an evicted room starts a fresh empty queue", () => {
+    const tracker = createRoomHistoryTracker(200, 2);
+
+    const room1 = "!room1:test";
+    const room2 = "!room2:test";
+    const room3 = "!room3:test";
+
+    tracker.recordPending(room1, entry("old msg in room1"));
+    tracker.recordPending(room2, entry("msg in room2"));
+    tracker.recordPending(room3, entry("msg in room3")); // evicts room1
+
+    tracker.recordPending(room1, entry("new msg in room1"));
+    const history = tracker.getPendingHistory(AGENT, room1, 100);
+    expect(history).toHaveLength(1);
+    expect(history[0]?.body).toBe("new msg in room1");
+  });
+
+  it("clears stale room watermarks when an evicted room is recreated", () => {
+    const tracker = createRoomHistoryTracker(200, 1);
+    const room1 = "!room1:test";
+    const room2 = "!room2:test";
+
+    tracker.recordPending(room1, entry("old msg in room1"));
+    const firstSnapshot = tracker.recordTrigger(room1, entry("trigger in room1"));
+    tracker.consumeHistory(AGENT, room1, firstSnapshot);
+
+    // room2 creation evicts room1 (maxRoomQueues=1)
+    tracker.recordPending(room2, entry("msg in room2"));
+
+    // Recreate room1 and add fresh content.
+    tracker.recordPending(room1, entry("new msg in room1"));
+    const history = tracker.getPendingHistory(AGENT, room1, 100);
+    expect(history).toHaveLength(1);
+    expect(history[0]?.body).toBe("new msg in room1");
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/room-history.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.ts
@@ -26,10 +26,14 @@ const MAX_PREPARED_TRIGGER_ENTRIES = 500;
 
 export type { HistoryEntry };
 
+export type HistorySnapshotToken = {
+  snapshotIdx: number;
+  queueGeneration: number;
+};
+
 export type PreparedTriggerResult = {
   history: HistoryEntry[];
-  snapshotIdx: number;
-};
+} & HistorySnapshotToken;
 
 export type RoomHistoryTracker = {
   /**
@@ -57,7 +61,7 @@ export type RoomHistoryTracker = {
   consumeHistory: (
     agentId: string,
     roomId: string,
-    snapshotIdx: number,
+    snapshot: HistorySnapshotToken,
     messageId?: string,
   ) => void;
 };
@@ -71,13 +75,14 @@ export type RoomHistoryTrackerTestApi = RoomHistoryTracker & {
   /**
    * Test-only helper for manually appending a trigger entry and snapshot index.
    */
-  recordTrigger: (roomId: string, entry: HistoryEntry) => number;
+  recordTrigger: (roomId: string, entry: HistoryEntry) => HistorySnapshotToken;
 };
 
 type RoomQueue = {
   entries: HistoryEntry[];
   /** Absolute index of entries[0] — increases as old entries are trimmed. */
   baseIndex: number;
+  generation: number;
   preparedTriggers: Map<string, PreparedTriggerResult>;
 };
 
@@ -90,6 +95,7 @@ function createRoomHistoryTrackerInternal(
   const roomQueues = new Map<string, RoomQueue>();
   /** Maps `${agentId}:${roomId}` → absolute consumed-up-to index */
   const agentWatermarks = new Map<string, number>();
+  let nextQueueGeneration = 1;
 
   function clearRoomWatermarks(roomId: string): void {
     const roomSuffix = `:${roomId}`;
@@ -103,7 +109,12 @@ function createRoomHistoryTrackerInternal(
   function getOrCreateQueue(roomId: string): RoomQueue {
     let queue = roomQueues.get(roomId);
     if (!queue) {
-      queue = { entries: [], baseIndex: 0, preparedTriggers: new Map() };
+      queue = {
+        entries: [],
+        baseIndex: 0,
+        generation: nextQueueGeneration++,
+        preparedTriggers: new Map(),
+      };
       roomQueues.set(roomId, queue);
       // FIFO eviction to prevent unbounded growth across many rooms
       if (roomQueues.size > maxRoomQueues) {
@@ -117,14 +128,17 @@ function createRoomHistoryTrackerInternal(
     return queue;
   }
 
-  function appendToQueue(queue: RoomQueue, entry: HistoryEntry): number {
+  function appendToQueue(queue: RoomQueue, entry: HistoryEntry): HistorySnapshotToken {
     queue.entries.push(entry);
     if (queue.entries.length > maxQueueSize) {
       const overflow = queue.entries.length - maxQueueSize;
       queue.entries.splice(0, overflow);
       queue.baseIndex += overflow;
     }
-    return queue.baseIndex + queue.entries.length;
+    return {
+      snapshotIdx: queue.baseIndex + queue.entries.length,
+      queueGeneration: queue.generation,
+    };
   }
 
   function wmKey(agentId: string, roomId: string): string {
@@ -217,7 +231,7 @@ function createRoomHistoryTrackerInternal(
       }
       const prepared = {
         history: computePendingHistory(queue, agentId, roomId, limit),
-        snapshotIdx: appendToQueue(queue, entry),
+        ...appendToQueue(queue, entry),
       };
       if (retryKey) {
         return rememberPreparedTrigger(queue, retryKey, prepared);
@@ -225,7 +239,7 @@ function createRoomHistoryTrackerInternal(
       return prepared;
     },
 
-    consumeHistory(agentId, roomId, snapshotIdx, messageId) {
+    consumeHistory(agentId, roomId, snapshot, messageId) {
       const key = wmKey(agentId, roomId);
       const queue = roomQueues.get(roomId);
       if (!queue) {
@@ -234,10 +248,16 @@ function createRoomHistoryTrackerInternal(
         agentWatermarks.delete(key);
         return;
       }
+      if (queue.generation !== snapshot.queueGeneration) {
+        // The room was evicted and recreated before this trigger completed. Reject the stale
+        // snapshot so it cannot advance the watermark for the new queue generation.
+        agentWatermarks.delete(key);
+        return;
+      }
       // Monotone write: never regress an already-advanced watermark.
       // Guards against out-of-order completion when two triggers for the same
       // (agentId, roomId) are in-flight concurrently.
-      rememberWatermark(key, snapshotIdx);
+      rememberWatermark(key, snapshot.snapshotIdx);
       const retryKey = preparedTriggerKey(agentId, messageId);
       if (queue && retryKey) {
         queue.preparedTriggers.delete(retryKey);

--- a/extensions/matrix/src/matrix/monitor/room-history.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.ts
@@ -63,7 +63,8 @@ export type RoomHistoryTracker = {
   ) => PreparedTriggerResult;
 
   /**
-   * Advance the agent's watermark to the snapshot index returned by recordTrigger.
+   * Advance the agent's watermark to the snapshot index returned by prepareTrigger
+   * (or the lower-level recordTrigger helper used in tests).
    * Only messages appended after that snapshot remain visible on the next trigger.
    */
   consumeHistory: (

--- a/extensions/matrix/src/matrix/monitor/room-history.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.ts
@@ -85,6 +85,7 @@ type RoomQueue = {
 export function createRoomHistoryTracker(
   maxQueueSize = DEFAULT_MAX_QUEUE_SIZE,
   maxRoomQueues = DEFAULT_MAX_ROOM_QUEUES,
+  maxWatermarkEntries = MAX_WATERMARK_ENTRIES,
 ): RoomHistoryTracker {
   const roomQueues = new Map<string, RoomQueue>();
   /** Maps `${agentId}:${roomId}` → absolute consumed-up-to index */
@@ -135,6 +136,21 @@ export function createRoomHistoryTracker(
       return null;
     }
     return `${agentId}:${messageId.trim()}`;
+  }
+
+  function rememberWatermark(key: string, snapshotIdx: number): void {
+    const nextSnapshotIdx = Math.max(agentWatermarks.get(key) ?? 0, snapshotIdx);
+    if (agentWatermarks.has(key)) {
+      // Refresh insertion order so capped-map eviction removes the stalest pair, not an active one.
+      agentWatermarks.delete(key);
+    }
+    agentWatermarks.set(key, nextSnapshotIdx);
+    if (agentWatermarks.size > maxWatermarkEntries) {
+      const oldest = agentWatermarks.keys().next().value;
+      if (oldest !== undefined) {
+        agentWatermarks.delete(oldest);
+      }
+    }
   }
 
   function computePendingHistory(
@@ -208,17 +224,10 @@ export function createRoomHistoryTracker(
       // Monotone write: never regress an already-advanced watermark.
       // Guards against out-of-order completion when two triggers for the same
       // (agentId, roomId) are in-flight concurrently.
-      agentWatermarks.set(key, Math.max(agentWatermarks.get(key) ?? 0, snapshotIdx));
+      rememberWatermark(key, snapshotIdx);
       const retryKey = preparedTriggerKey(agentId, messageId);
       if (queue && retryKey) {
         queue.preparedTriggers.delete(retryKey);
-      }
-      // LRU-style eviction to prevent unbounded growth
-      if (agentWatermarks.size > MAX_WATERMARK_ENTRIES) {
-        const oldest = agentWatermarks.keys().next().value;
-        if (oldest !== undefined) {
-          agentWatermarks.delete(oldest);
-        }
       }
     },
   };

--- a/extensions/matrix/src/matrix/monitor/room-history.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.ts
@@ -250,8 +250,7 @@ function createRoomHistoryTrackerInternal(
       }
       if (queue.generation !== snapshot.queueGeneration) {
         // The room was evicted and recreated before this trigger completed. Reject the stale
-        // snapshot so it cannot advance the watermark for the new queue generation.
-        agentWatermarks.delete(key);
+        // snapshot so it cannot advance or erase state for the new queue generation.
         return;
       }
       // Monotone write: never regress an already-advanced watermark.

--- a/extensions/matrix/src/matrix/monitor/room-history.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.ts
@@ -198,11 +198,17 @@ export function createRoomHistoryTracker(
 
     consumeHistory(agentId, roomId, snapshotIdx, messageId) {
       const key = wmKey(agentId, roomId);
+      const queue = roomQueues.get(roomId);
+      if (!queue) {
+        // The room was evicted while this trigger was in flight. Keep eviction authoritative
+        // so a late completion cannot recreate a stale watermark against a fresh queue.
+        agentWatermarks.delete(key);
+        return;
+      }
       // Monotone write: never regress an already-advanced watermark.
       // Guards against out-of-order completion when two triggers for the same
       // (agentId, roomId) are in-flight concurrently.
       agentWatermarks.set(key, Math.max(agentWatermarks.get(key) ?? 0, snapshotIdx));
-      const queue = roomQueues.get(roomId);
       const retryKey = preparedTriggerKey(agentId, messageId);
       if (queue && retryKey) {
         queue.preparedTriggers.delete(retryKey);

--- a/extensions/matrix/src/matrix/monitor/room-history.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.ts
@@ -1,0 +1,147 @@
+/**
+ * Per-room group chat history tracking for Matrix.
+ *
+ * Maintains a shared per-room message queue and per-(agentId, roomId) watermarks so
+ * each agent independently tracks which messages it has already consumed. This design
+ * lets multiple agents in the same room see independent history windows:
+ *
+ * - dev replies to @dev msgB (watermark advances to B) → room queue still has [A, B]
+ * - spark replies to @spark msgC → spark watermark starts at 0 and sees [A, B, C]
+ *
+ * Race-condition safety: the watermark only advances to the snapshot index taken at
+ * dispatch time, NOT to the queue's end at reply time.  Messages that land in the queue
+ * while the agent is processing stay visible to the next trigger for that agent.
+ */
+
+import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
+
+/** Maximum entries retained per room (hard cap to bound memory). */
+const DEFAULT_MAX_QUEUE_SIZE = 200;
+/** Maximum number of rooms to retain queues for (FIFO eviction beyond this). */
+const DEFAULT_MAX_ROOM_QUEUES = 1000;
+/** Maximum number of (agentId, roomId) watermark entries to retain. */
+const MAX_WATERMARK_ENTRIES = 5000;
+
+export type { HistoryEntry };
+
+export type RoomHistoryTracker = {
+  /**
+   * Record a non-trigger message for future context.
+   * Call this when a room message arrives but does not mention the bot.
+   */
+  recordPending: (roomId: string, entry: HistoryEntry) => void;
+
+  /**
+   * Get pending history for an agent: all messages in the room since the
+   * agent's last watermark, capped at `limit` most-recent entries.
+   * Call this BEFORE recordTrigger so the trigger itself is not included.
+   */
+  getPendingHistory: (agentId: string, roomId: string, limit: number) => HistoryEntry[];
+
+  /**
+   * Append the trigger message to the room queue and return a snapshot index.
+   * The snapshot index must be passed to consumeHistory after the agent replies.
+   */
+  recordTrigger: (roomId: string, entry: HistoryEntry) => number;
+
+  /**
+   * Advance the agent's watermark to the snapshot index returned by recordTrigger.
+   * Only messages appended after that snapshot remain visible on the next trigger.
+   */
+  consumeHistory: (agentId: string, roomId: string, snapshotIdx: number) => void;
+};
+
+type RoomQueue = {
+  entries: HistoryEntry[];
+  /** Absolute index of entries[0] — increases as old entries are trimmed. */
+  baseIndex: number;
+};
+
+export function createRoomHistoryTracker(
+  maxQueueSize = DEFAULT_MAX_QUEUE_SIZE,
+  maxRoomQueues = DEFAULT_MAX_ROOM_QUEUES,
+): RoomHistoryTracker {
+  const roomQueues = new Map<string, RoomQueue>();
+  /** Maps `${agentId}:${roomId}` → absolute consumed-up-to index */
+  const agentWatermarks = new Map<string, number>();
+
+  function clearRoomWatermarks(roomId: string): void {
+    const roomSuffix = `:${roomId}`;
+    for (const key of agentWatermarks.keys()) {
+      if (key.endsWith(roomSuffix)) {
+        agentWatermarks.delete(key);
+      }
+    }
+  }
+
+  function getOrCreateQueue(roomId: string): RoomQueue {
+    let queue = roomQueues.get(roomId);
+    if (!queue) {
+      queue = { entries: [], baseIndex: 0 };
+      roomQueues.set(roomId, queue);
+      // FIFO eviction to prevent unbounded growth across many rooms
+      if (roomQueues.size > maxRoomQueues) {
+        const oldest = roomQueues.keys().next().value;
+        if (oldest !== undefined) {
+          roomQueues.delete(oldest);
+          clearRoomWatermarks(oldest);
+        }
+      }
+    }
+    return queue;
+  }
+
+  function appendToQueue(queue: RoomQueue, entry: HistoryEntry): number {
+    queue.entries.push(entry);
+    if (queue.entries.length > maxQueueSize) {
+      const overflow = queue.entries.length - maxQueueSize;
+      queue.entries.splice(0, overflow);
+      queue.baseIndex += overflow;
+    }
+    return queue.baseIndex + queue.entries.length;
+  }
+
+  function wmKey(agentId: string, roomId: string): string {
+    return `${agentId}:${roomId}`;
+  }
+
+  return {
+    recordPending(roomId, entry) {
+      const queue = getOrCreateQueue(roomId);
+      appendToQueue(queue, entry);
+    },
+
+    getPendingHistory(agentId, roomId, limit) {
+      if (limit <= 0) return [];
+      const queue = roomQueues.get(roomId);
+      if (!queue || queue.entries.length === 0) return [];
+      const wm = agentWatermarks.get(wmKey(agentId, roomId)) ?? 0;
+      // startAbs: the first absolute index the agent hasn't seen yet
+      const startAbs = Math.max(wm, queue.baseIndex);
+      const startRel = startAbs - queue.baseIndex;
+      const available = queue.entries.slice(startRel);
+      // Cap to the last `limit` entries
+      return limit > 0 && available.length > limit ? available.slice(-limit) : available;
+    },
+
+    recordTrigger(roomId, entry) {
+      const queue = getOrCreateQueue(roomId);
+      return appendToQueue(queue, entry);
+    },
+
+    consumeHistory(agentId, roomId, snapshotIdx) {
+      const key = wmKey(agentId, roomId);
+      // Monotone write: never regress an already-advanced watermark.
+      // Guards against out-of-order completion when two triggers for the same
+      // (agentId, roomId) are in-flight concurrently.
+      agentWatermarks.set(key, Math.max(agentWatermarks.get(key) ?? 0, snapshotIdx));
+      // LRU-style eviction to prevent unbounded growth
+      if (agentWatermarks.size > MAX_WATERMARK_ENTRIES) {
+        const oldest = agentWatermarks.keys().next().value;
+        if (oldest !== undefined) {
+          agentWatermarks.delete(oldest);
+        }
+      }
+    },
+  };
+}

--- a/extensions/matrix/src/matrix/monitor/room-history.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.ts
@@ -21,8 +21,15 @@ const DEFAULT_MAX_QUEUE_SIZE = 200;
 const DEFAULT_MAX_ROOM_QUEUES = 1000;
 /** Maximum number of (agentId, roomId) watermark entries to retain. */
 const MAX_WATERMARK_ENTRIES = 5000;
+/** Maximum prepared trigger snapshots retained per room for retry reuse. */
+const MAX_PREPARED_TRIGGER_ENTRIES = 500;
 
 export type { HistoryEntry };
+
+export type PreparedTriggerResult = {
+  history: HistoryEntry[];
+  snapshotIdx: number;
+};
 
 export type RoomHistoryTracker = {
   /**
@@ -45,16 +52,33 @@ export type RoomHistoryTracker = {
   recordTrigger: (roomId: string, entry: HistoryEntry) => number;
 
   /**
+   * Capture pending history and append the trigger as one idempotent operation.
+   * Retries of the same Matrix event reuse the original prepared history window.
+   */
+  prepareTrigger: (
+    agentId: string,
+    roomId: string,
+    limit: number,
+    entry: HistoryEntry,
+  ) => PreparedTriggerResult;
+
+  /**
    * Advance the agent's watermark to the snapshot index returned by recordTrigger.
    * Only messages appended after that snapshot remain visible on the next trigger.
    */
-  consumeHistory: (agentId: string, roomId: string, snapshotIdx: number) => void;
+  consumeHistory: (
+    agentId: string,
+    roomId: string,
+    snapshotIdx: number,
+    messageId?: string,
+  ) => void;
 };
 
 type RoomQueue = {
   entries: HistoryEntry[];
   /** Absolute index of entries[0] — increases as old entries are trimmed. */
   baseIndex: number;
+  preparedTriggers: Map<string, PreparedTriggerResult>;
 };
 
 export function createRoomHistoryTracker(
@@ -77,7 +101,7 @@ export function createRoomHistoryTracker(
   function getOrCreateQueue(roomId: string): RoomQueue {
     let queue = roomQueues.get(roomId);
     if (!queue) {
-      queue = { entries: [], baseIndex: 0 };
+      queue = { entries: [], baseIndex: 0, preparedTriggers: new Map() };
       roomQueues.set(roomId, queue);
       // FIFO eviction to prevent unbounded growth across many rooms
       if (roomQueues.size > maxRoomQueues) {
@@ -105,6 +129,30 @@ export function createRoomHistoryTracker(
     return `${agentId}:${roomId}`;
   }
 
+  function preparedTriggerKey(agentId: string, messageId?: string): string | null {
+    if (!messageId?.trim()) {
+      return null;
+    }
+    return `${agentId}:${messageId.trim()}`;
+  }
+
+  function computePendingHistory(
+    queue: RoomQueue,
+    agentId: string,
+    roomId: string,
+    limit: number,
+  ): HistoryEntry[] {
+    if (limit <= 0 || queue.entries.length === 0) {
+      return [];
+    }
+    const wm = agentWatermarks.get(wmKey(agentId, roomId)) ?? 0;
+    // startAbs: the first absolute index the agent hasn't seen yet
+    const startAbs = Math.max(wm, queue.baseIndex);
+    const startRel = startAbs - queue.baseIndex;
+    const available = queue.entries.slice(startRel);
+    return available.length > limit ? available.slice(-limit) : available;
+  }
+
   return {
     recordPending(roomId, entry) {
       const queue = getOrCreateQueue(roomId);
@@ -112,16 +160,9 @@ export function createRoomHistoryTracker(
     },
 
     getPendingHistory(agentId, roomId, limit) {
-      if (limit <= 0) return [];
       const queue = roomQueues.get(roomId);
-      if (!queue || queue.entries.length === 0) return [];
-      const wm = agentWatermarks.get(wmKey(agentId, roomId)) ?? 0;
-      // startAbs: the first absolute index the agent hasn't seen yet
-      const startAbs = Math.max(wm, queue.baseIndex);
-      const startRel = startAbs - queue.baseIndex;
-      const available = queue.entries.slice(startRel);
-      // Cap to the last `limit` entries
-      return limit > 0 && available.length > limit ? available.slice(-limit) : available;
+      if (!queue) return [];
+      return computePendingHistory(queue, agentId, roomId, limit);
     },
 
     recordTrigger(roomId, entry) {
@@ -129,12 +170,42 @@ export function createRoomHistoryTracker(
       return appendToQueue(queue, entry);
     },
 
-    consumeHistory(agentId, roomId, snapshotIdx) {
+    prepareTrigger(agentId, roomId, limit, entry) {
+      const queue = getOrCreateQueue(roomId);
+      const retryKey = preparedTriggerKey(agentId, entry.messageId);
+      if (retryKey) {
+        const prepared = queue.preparedTriggers.get(retryKey);
+        if (prepared) {
+          return prepared;
+        }
+      }
+      const prepared = {
+        history: computePendingHistory(queue, agentId, roomId, limit),
+        snapshotIdx: appendToQueue(queue, entry),
+      };
+      if (retryKey) {
+        queue.preparedTriggers.set(retryKey, prepared);
+        if (queue.preparedTriggers.size > MAX_PREPARED_TRIGGER_ENTRIES) {
+          const oldest = queue.preparedTriggers.keys().next().value;
+          if (oldest !== undefined) {
+            queue.preparedTriggers.delete(oldest);
+          }
+        }
+      }
+      return prepared;
+    },
+
+    consumeHistory(agentId, roomId, snapshotIdx, messageId) {
       const key = wmKey(agentId, roomId);
       // Monotone write: never regress an already-advanced watermark.
       // Guards against out-of-order completion when two triggers for the same
       // (agentId, roomId) are in-flight concurrently.
       agentWatermarks.set(key, Math.max(agentWatermarks.get(key) ?? 0, snapshotIdx));
+      const queue = roomQueues.get(roomId);
+      const retryKey = preparedTriggerKey(agentId, messageId);
+      if (queue && retryKey) {
+        queue.preparedTriggers.delete(retryKey);
+      }
       // LRU-style eviction to prevent unbounded growth
       if (agentWatermarks.size > MAX_WATERMARK_ENTRIES) {
         const oldest = agentWatermarks.keys().next().value;

--- a/extensions/matrix/src/matrix/monitor/room-history.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.ts
@@ -86,6 +86,7 @@ export function createRoomHistoryTracker(
   maxQueueSize = DEFAULT_MAX_QUEUE_SIZE,
   maxRoomQueues = DEFAULT_MAX_ROOM_QUEUES,
   maxWatermarkEntries = MAX_WATERMARK_ENTRIES,
+  maxPreparedTriggerEntries = MAX_PREPARED_TRIGGER_ENTRIES,
 ): RoomHistoryTracker {
   const roomQueues = new Map<string, RoomQueue>();
   /** Maps `${agentId}:${roomId}` → absolute consumed-up-to index */
@@ -153,6 +154,25 @@ export function createRoomHistoryTracker(
     }
   }
 
+  function rememberPreparedTrigger(
+    queue: RoomQueue,
+    retryKey: string,
+    prepared: PreparedTriggerResult,
+  ): PreparedTriggerResult {
+    if (queue.preparedTriggers.has(retryKey)) {
+      // Refresh insertion order so capped eviction keeps actively retried events hot.
+      queue.preparedTriggers.delete(retryKey);
+    }
+    queue.preparedTriggers.set(retryKey, prepared);
+    if (queue.preparedTriggers.size > maxPreparedTriggerEntries) {
+      const oldest = queue.preparedTriggers.keys().next().value;
+      if (oldest !== undefined) {
+        queue.preparedTriggers.delete(oldest);
+      }
+    }
+    return prepared;
+  }
+
   function computePendingHistory(
     queue: RoomQueue,
     agentId: string,
@@ -193,7 +213,7 @@ export function createRoomHistoryTracker(
       if (retryKey) {
         const prepared = queue.preparedTriggers.get(retryKey);
         if (prepared) {
-          return prepared;
+          return rememberPreparedTrigger(queue, retryKey, prepared);
         }
       }
       const prepared = {
@@ -201,13 +221,7 @@ export function createRoomHistoryTracker(
         snapshotIdx: appendToQueue(queue, entry),
       };
       if (retryKey) {
-        queue.preparedTriggers.set(retryKey, prepared);
-        if (queue.preparedTriggers.size > MAX_PREPARED_TRIGGER_ENTRIES) {
-          const oldest = queue.preparedTriggers.keys().next().value;
-          if (oldest !== undefined) {
-            queue.preparedTriggers.delete(oldest);
-          }
-        }
+        return rememberPreparedTrigger(queue, retryKey, prepared);
       }
       return prepared;
     },

--- a/extensions/matrix/src/matrix/monitor/room-history.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.ts
@@ -39,19 +39,6 @@ export type RoomHistoryTracker = {
   recordPending: (roomId: string, entry: HistoryEntry) => void;
 
   /**
-   * Get pending history for an agent: all messages in the room since the
-   * agent's last watermark, capped at `limit` most-recent entries.
-   * Call this BEFORE recordTrigger so the trigger itself is not included.
-   */
-  getPendingHistory: (agentId: string, roomId: string, limit: number) => HistoryEntry[];
-
-  /**
-   * Append the trigger message to the room queue and return a snapshot index.
-   * The snapshot index must be passed to consumeHistory after the agent replies.
-   */
-  recordTrigger: (roomId: string, entry: HistoryEntry) => number;
-
-  /**
    * Capture pending history and append the trigger as one idempotent operation.
    * Retries of the same Matrix event reuse the original prepared history window.
    */
@@ -75,6 +62,18 @@ export type RoomHistoryTracker = {
   ) => void;
 };
 
+export type RoomHistoryTrackerTestApi = RoomHistoryTracker & {
+  /**
+   * Test-only helper for inspecting pending room history directly.
+   */
+  getPendingHistory: (agentId: string, roomId: string, limit: number) => HistoryEntry[];
+
+  /**
+   * Test-only helper for manually appending a trigger entry and snapshot index.
+   */
+  recordTrigger: (roomId: string, entry: HistoryEntry) => number;
+};
+
 type RoomQueue = {
   entries: HistoryEntry[];
   /** Absolute index of entries[0] — increases as old entries are trimmed. */
@@ -82,12 +81,12 @@ type RoomQueue = {
   preparedTriggers: Map<string, PreparedTriggerResult>;
 };
 
-export function createRoomHistoryTracker(
+function createRoomHistoryTrackerInternal(
   maxQueueSize = DEFAULT_MAX_QUEUE_SIZE,
   maxRoomQueues = DEFAULT_MAX_ROOM_QUEUES,
   maxWatermarkEntries = MAX_WATERMARK_ENTRIES,
   maxPreparedTriggerEntries = MAX_PREPARED_TRIGGER_ENTRIES,
-): RoomHistoryTracker {
+): RoomHistoryTrackerTestApi {
   const roomQueues = new Map<string, RoomQueue>();
   /** Maps `${agentId}:${roomId}` → absolute consumed-up-to index */
   const agentWatermarks = new Map<string, number>();
@@ -245,4 +244,37 @@ export function createRoomHistoryTracker(
       }
     },
   };
+}
+
+export function createRoomHistoryTracker(
+  maxQueueSize = DEFAULT_MAX_QUEUE_SIZE,
+  maxRoomQueues = DEFAULT_MAX_ROOM_QUEUES,
+  maxWatermarkEntries = MAX_WATERMARK_ENTRIES,
+  maxPreparedTriggerEntries = MAX_PREPARED_TRIGGER_ENTRIES,
+): RoomHistoryTracker {
+  const tracker = createRoomHistoryTrackerInternal(
+    maxQueueSize,
+    maxRoomQueues,
+    maxWatermarkEntries,
+    maxPreparedTriggerEntries,
+  );
+  return {
+    recordPending: tracker.recordPending,
+    prepareTrigger: tracker.prepareTrigger,
+    consumeHistory: tracker.consumeHistory,
+  };
+}
+
+export function createRoomHistoryTrackerForTests(
+  maxQueueSize = DEFAULT_MAX_QUEUE_SIZE,
+  maxRoomQueues = DEFAULT_MAX_ROOM_QUEUES,
+  maxWatermarkEntries = MAX_WATERMARK_ENTRIES,
+  maxPreparedTriggerEntries = MAX_PREPARED_TRIGGER_ENTRIES,
+): RoomHistoryTrackerTestApi {
+  return createRoomHistoryTrackerInternal(
+    maxQueueSize,
+    maxRoomQueues,
+    maxWatermarkEntries,
+    maxPreparedTriggerEntries,
+  );
 }

--- a/extensions/matrix/src/matrix/monitor/threads.ts
+++ b/extensions/matrix/src/matrix/monitor/threads.ts
@@ -1,6 +1,22 @@
 import type { MatrixRawEvent, RoomMessageEventContent } from "./types.js";
 import { RelationType } from "./types.js";
 
+function resolveMatrixRelatedReplyToEventId(relates: unknown): string | undefined {
+  if (!relates || typeof relates !== "object") {
+    return undefined;
+  }
+  if (
+    "m.in_reply_to" in relates &&
+    typeof relates["m.in_reply_to"] === "object" &&
+    relates["m.in_reply_to"] &&
+    "event_id" in relates["m.in_reply_to"] &&
+    typeof relates["m.in_reply_to"].event_id === "string"
+  ) {
+    return relates["m.in_reply_to"].event_id;
+  }
+  return undefined;
+}
+
 export function resolveMatrixThreadTarget(params: {
   threadReplies: "off" | "inbound" | "always";
   messageId: string;
@@ -34,15 +50,11 @@ export function resolveMatrixThreadRootId(params: {
     if ("event_id" in relates && typeof relates.event_id === "string") {
       return relates.event_id;
     }
-    if (
-      "m.in_reply_to" in relates &&
-      typeof relates["m.in_reply_to"] === "object" &&
-      relates["m.in_reply_to"] &&
-      "event_id" in relates["m.in_reply_to"] &&
-      typeof relates["m.in_reply_to"].event_id === "string"
-    ) {
-      return relates["m.in_reply_to"].event_id;
-    }
+    return resolveMatrixRelatedReplyToEventId(relates);
   }
   return undefined;
+}
+
+export function resolveMatrixReplyToEventId(content: RoomMessageEventContent): string | undefined {
+  return resolveMatrixRelatedReplyToEventId(content["m.relates_to"]);
 }

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -123,6 +123,12 @@ export type MatrixConfig = {
   startupVerificationCooldownHours?: number;
   /** Max outbound media size in MB. */
   mediaMaxMb?: number;
+  /**
+   * Number of recent room messages shown to the agent as context when it is mentioned
+   * in a group chat (0 = disabled). Applies to room messages that did not directly
+   * trigger a reply. Default: 0 (disabled).
+   */
+  historyLimit?: number;
   /** Auto-join invites (always|allowlist|off). Default: off. */
   autoJoin?: "always" | "allowlist" | "off";
   /** Allowlist for auto-join invites (room IDs, aliases). */

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -6301,6 +6301,27 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         webhookPath: {
           type: "string",
         },
+        threadBindings: {
+          type: "object",
+          properties: {
+            enabled: {
+              type: "boolean",
+            },
+            idleHours: {
+              type: "number",
+            },
+            maxAgeHours: {
+              type: "number",
+            },
+            spawnSubagentSessions: {
+              type: "boolean",
+            },
+            spawnAcpSessions: {
+              type: "boolean",
+            },
+          },
+          additionalProperties: false,
+        },
         accounts: {
           type: "object",
           propertyNames: {
@@ -6371,6 +6392,27 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               webhookPath: {
                 type: "string",
+              },
+              threadBindings: {
+                type: "object",
+                properties: {
+                  enabled: {
+                    type: "boolean",
+                  },
+                  idleHours: {
+                    type: "number",
+                  },
+                  maxAgeHours: {
+                    type: "number",
+                  },
+                  spawnSubagentSessions: {
+                    type: "boolean",
+                  },
+                  spawnAcpSessions: {
+                    type: "boolean",
+                  },
+                },
+                additionalProperties: false,
               },
               groups: {
                 type: "object",
@@ -6674,6 +6716,17 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           type: "string",
           enum: ["open", "disabled", "allowlist"],
         },
+        streaming: {
+          anyOf: [
+            {
+              type: "string",
+              enum: ["partial", "off"],
+            },
+            {
+              type: "boolean",
+            },
+          ],
+        },
         replyToMode: {
           type: "string",
           enum: ["off", "first", "all"],
@@ -6735,6 +6788,11 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         mediaMaxMb: {
           type: "number",
+        },
+        historyLimit: {
+          type: "integer",
+          minimum: 0,
+          maximum: 9007199254740991,
         },
         autoJoin: {
           type: "string",


### PR DESCRIPTION
## Summary

- **Problem:** When an agent is triggered in a Matrix group chat, it had no visibility into the conversation that preceded the trigger message, making replies lack context.
- **Why it matters:** Group chat users expect the agent to understand the conversation background before the trigger mention; without it, reply quality degrades.
- **What changed:** Added a per-room message queue with per-(agentId, roomId) watermarks. Non-trigger messages accumulate in the shared queue; when an agent is triggered it receives `InboundHistory` of messages since its last watermark (capped at `historyLimit`). The watermark only advances to the snapshot index taken at dispatch time, so messages arriving during async processing remain visible on the next trigger. Multiple agents in the same room each maintain an independent watermark.
- **What did NOT change:** Default behavior is unchanged (`historyLimit` defaults to `0`, disabled). DM flow, allowlist logic, existing routing, and reply mechanics are unmodified.

Configure via `channels.matrix.historyLimit` (or `messages.groupChat.historyLimit`). Default: `0` (disabled).

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A — new feature, not a bug fix.

## Regression Test Plan (if applicable)

N/A — new feature.

New test file added: `extensions/matrix/src/matrix/monitor/handler.group-history.test.ts` (377 lines), covering:
- Independent watermarks per agent in the same room
- Queue overflow trimming and `baseIndex` advancement
- Async race safety (dispatch snapshot vs. messages arriving during processing)
- `historyLimit = 0` disabling behavior
- History entry count capping

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/matrix/src/matrix/monitor/handler.group-history.test.ts`
- Scenario the test should lock in: multi-agent watermark independence, race safety, queue size cap trimming
- Why this is the smallest reliable guardrail: core logic is isolated in `room-history.ts` as pure functions; unit tests fully cover all boundary conditions
- Existing test that already covers this (if any): none (new module)
- If no new test is added, why not: tests are added

## User-visible / Behavior Changes

- New optional config field `channels.matrix.historyLimit` (integer, ≥ 0). Default `0` preserves existing behavior.
- When set to a positive integer, agents triggered in group chat receive up to N recent room messages as `InboundHistory` context.

## Diagram (if applicable)

```text
Before:
[user @bot msg] -> handler -> agent (no prior context)

After (historyLimit > 0):
[user msg A]    -> recordPending(room, A)
[user msg B]    -> recordPending(room, B)
[user @bot C]   -> getPendingHistory(agentId, room) -> [A, B]
                -> recordTrigger(room, C) -> snapshotIdx=3
                -> agent receives InboundHistory([A, B]) + trigger C
                -> consumeHistory(agentId, room, snapshotIdx=3)
                   (watermark=3; messages after C remain visible for next trigger)
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Debian 6.12.74-2, x86_64)
- Runtime/container: Node v24.14.1
- Model/provider: N/A
- Integration/channel: Matrix (Synapse)
- Relevant config (redacted): `channels.matrix.historyLimit: 5`

### Steps

1. Set `channels.matrix.historyLimit: 5`
2. Send several plain messages in a Matrix group room (no bot mention)
3. Send a message that @mentions the bot to trigger the agent

### Expected

- Agent receives the preceding messages as history context (up to 5)

### Actual

- Agent receives history context and replies with conversational continuity

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New unit tests in `handler.group-history.test.ts` all pass, covering core boundary scenarios.

## Human Verification (required)

- Verified scenarios: agent receives correct history context when triggered in a group chat; `historyLimit=0` preserves original behavior; multiple agents maintain independent watermarks correctly.
- Edge cases checked: standard group chat scenarios verified manually on Synapse.
- What you did **not** verify: behavior under very high concurrency; queue hard-cap trimming (200 entries) in production; non-Synapse homeservers (Conduit, Dendrite).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — `historyLimit` defaults to `0`, fully backward compatible
- Config/env changes? `Yes` — new optional field `channels.matrix.historyLimit`
- Migration needed? `No`

## Risks and Mitigations

- Risk: in-memory queue (max 200 entries/room) and watermark table (max 5000 entries) grow with active rooms and agents.
  - Mitigation: hard caps and LRU eviction are already implemented in `room-history.ts`; feature is opt-in (disabled by default).
- Risk: watermarks are in-memory only; after a restart the agent will see the full queue on next trigger.
  - Mitigation: expected behavior — history context is best-effort and does not affect correctness.
