### PR TITLE
telegram: improve polling outage detection and recovery after network loss

### DIFF
--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -9,7 +9,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { TelegramExecApprovalHandler } from "./exec-approvals-handler.js";
-import { resolveTelegramTransport } from "./fetch.js";
+import { resolveTelegramApiBase, resolveTelegramTransport } from "./fetch.js";
 import {
   isRecoverableTelegramNetworkError,
   isTelegramPollingNetworkError,
@@ -202,6 +202,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       log,
       telegramTransport,
       createTelegramTransport: createTelegramTransportForPolling,
+      apiBase: resolveTelegramApiBase(account.config.apiRoot?.trim() || undefined),
     });
     await pollingSession.runUntilAbort();
   } finally {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -14,6 +14,14 @@ vi.mock("./bot.js", () => ({
   createTelegramBot: createTelegramBotMock,
 }));
 
+vi.mock("./fetch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./fetch.js")>();
+  return {
+    ...actual,
+    resolveTelegramApiBase: vi.fn((apiRoot?: string) => apiRoot ?? "https://api.telegram.org"),
+  };
+});
+
 vi.mock("./network-errors.js", () => ({
   isRecoverableTelegramNetworkError: isRecoverableTelegramNetworkErrorMock,
 }));

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -7,7 +7,7 @@ import {
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
-import { type TelegramTransport } from "./fetch.js";
+import { resolveTelegramApiBase, type TelegramTransport } from "./fetch.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { TelegramPollingTransportState } from "./polling-transport-state.js";
 
@@ -21,6 +21,10 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;
+const SUPERVISOR_UPDATES_STALE_THRESHOLD_MS = 90_000;
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const HEARTBEAT_TIMEOUT_MS = 10_000;
+const HEARTBEAT_FAIL_THRESHOLD = 3;
 
 const waitForGracefulStop = async (stop: () => Promise<void>) => {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -56,6 +60,8 @@ type TelegramPollingSessionOpts = {
   telegramTransport?: TelegramTransport;
   /** Rebuild Telegram transport after stall/network recovery when marked dirty. */
   createTelegramTransport?: () => TelegramTransport;
+  /** Pre-resolved API base for lightweight heartbeat probes. */
+  apiBase?: string;
 };
 
 export class TelegramPollingSession {
@@ -215,7 +221,6 @@ export class TelegramPollingSession {
     let lastGetUpdatesError: string | null = null;
     let lastGetUpdatesOffset: number | null = null;
     let inFlightGetUpdates = 0;
-    let stopSequenceLogged = false;
     let stallDiagLoggedAt = 0;
 
     bot.api.config.use(async (prev, method, payload, signal) => {
@@ -334,6 +339,37 @@ export class TelegramPollingSession {
           ? lastApiActivityAt
           : Math.max(lastApiActivityAt, latestInFlightApiStartedAt);
       const apiElapsed = now - apiLivenessAt;
+      const updatesElapsed = now - (lastGetUpdatesFinishedAt ?? lastGetUpdatesAt);
+      const updatesStale =
+        updatesElapsed > SUPERVISOR_UPDATES_STALE_THRESHOLD_MS &&
+        inFlightGetUpdates === 0 &&
+        apiElapsed > SUPERVISOR_UPDATES_STALE_THRESHOLD_MS;
+
+      if (updatesStale && runner.isRunning()) {
+        if (stallDiagLoggedAt && now - stallDiagLoggedAt < POLL_STALL_THRESHOLD_MS / 2) {
+          return;
+        }
+        stallDiagLoggedAt = now;
+        this.#transportState.markDirty();
+        stalledRestart = true;
+        this.opts.log(
+          `[telegram] Polling freshness check failed (no successful getUpdates for ${formatDurationPrecise(updatesElapsed)} with no in-flight request); forcing restart. [diag inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}]`,
+        );
+        void stopRunner();
+        void stopBot();
+        if (!forceCycleTimer) {
+          forceCycleTimer = setTimeout(() => {
+            if (this.opts.abortSignal?.aborted) {
+              return;
+            }
+            this.opts.log(
+              `[telegram] Polling runner stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)}; forcing restart cycle.`,
+            );
+            forceCycleResolve?.();
+          }, POLL_STOP_GRACE_MS);
+        }
+        return;
+      }
 
       // Treat recent non-getUpdates success and recent non-getUpdates start as
       // the same liveness signal. Slow delivery should suppress the watchdog,
@@ -373,8 +409,22 @@ export class TelegramPollingSession {
     }, POLL_WATCHDOG_INTERVAL_MS);
 
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+
+    // Cycle-scoped abort: cancelled in finally{} so the heartbeat loop
+    // does not leak across polling cycle restarts.
+    const cycleAbort = new AbortController();
+
+    // Start heartbeat supervisor alongside the polling runner.
+    const heartbeatPromise = this.#runHeartbeatSupervisor({
+      runner,
+      stopRunner,
+      stopBot,
+      forceCycleResolve,
+      cycleSignal: cycleAbort.signal,
+    });
+
     try {
-      await Promise.race([runner.task(), forceCyclePromise]);
+      await Promise.race([runner.task(), forceCyclePromise, heartbeatPromise]);
       if (this.opts.abortSignal?.aborted) {
         return "exit";
       }
@@ -417,6 +467,8 @@ export class TelegramPollingSession {
       );
       return shouldRestart ? "continue" : "exit";
     } finally {
+      // Stop the heartbeat supervisor for this cycle.
+      cycleAbort.abort();
       clearInterval(watchdog);
       if (forceCycleTimer) {
         clearTimeout(forceCycleTimer);
@@ -430,6 +482,110 @@ export class TelegramPollingSession {
         this.#activeFetchAbort = undefined;
       }
     }
+  }
+
+  /**
+   * Lightweight heartbeat probe using the same network path as polling
+   * (respects proxy/transport config). Returns true on success, false on failure.
+   */
+  /**
+   * @param cycleSignal - AbortSignal scoped to the current polling cycle;
+   *   aborted when the cycle ends (restart, stall, or session shutdown).
+   */
+  async #probeHeartbeatOnce(cycleSignal: AbortSignal): Promise<boolean> {
+    const apiBase = this.opts.apiBase ?? resolveTelegramApiBase(undefined);
+    const url = `${apiBase}/bot${this.opts.token}/getMe`;
+    // Use the transport-level fetch so heartbeat traverses the same network
+    // path as getUpdates (respects forceIpv4, DNS tuning, proxy, sticky
+    // fallback, etc.).
+    const transport = this.#transportState.currentTransport();
+    const fetchImpl = transport?.fetch ?? this.opts.proxyFetch ?? globalThis.fetch;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), HEARTBEAT_TIMEOUT_MS);
+    timeout.unref?.();
+    const onCycleAbort = () => controller.abort();
+    cycleSignal.addEventListener("abort", onCycleAbort, { once: true });
+    try {
+      const response = await fetchImpl(url, {
+        method: "POST",
+        signal: controller.signal,
+      });
+      return response.ok;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timeout);
+      cycleSignal.removeEventListener("abort", onCycleAbort);
+    }
+  }
+
+  /**
+   * Heartbeat supervisor: periodically probes Telegram connectivity.
+   * After HEARTBEAT_FAIL_THRESHOLD consecutive failures, stops the polling
+   * runner and waits for heartbeat recovery before allowing a new cycle.
+   *
+   * Returns "stalled" if polling was stopped due to heartbeat failures,
+   * or resolves to "ok" / "aborted" otherwise. The caller (runPollingCycle)
+   * races this against the runner task.
+   */
+  async #runHeartbeatSupervisor(params: {
+    runner: { isRunning: () => boolean };
+    stopRunner: () => Promise<void>;
+    stopBot: () => Promise<void>;
+    forceCycleResolve: (() => void) | undefined;
+    /** Aborted when the current polling cycle ends — stops this loop cleanly. */
+    cycleSignal: AbortSignal;
+  }): Promise<"stalled" | "aborted"> {
+    let consecutiveFailures = 0;
+    const isAborted = () => this.opts.abortSignal?.aborted || params.cycleSignal.aborted;
+
+    while (!isAborted()) {
+      await sleepWithAbort(HEARTBEAT_INTERVAL_MS, params.cycleSignal).catch(() => {});
+      if (isAborted()) {
+        return "aborted";
+      }
+
+      const ok = await this.#probeHeartbeatOnce(params.cycleSignal);
+      if (ok) {
+        if (consecutiveFailures > 0) {
+          this.opts.log(`[telegram] Heartbeat recovered after ${consecutiveFailures} failure(s).`);
+        }
+        consecutiveFailures = 0;
+        continue;
+      }
+
+      consecutiveFailures += 1;
+      if (consecutiveFailures < HEARTBEAT_FAIL_THRESHOLD) {
+        this.opts.log(
+          `[telegram][diag] Heartbeat failed (${consecutiveFailures}/${HEARTBEAT_FAIL_THRESHOLD}).`,
+        );
+        continue;
+      }
+
+      // Threshold reached — stop polling and wait for recovery.
+      this.opts.log(
+        `[telegram] Heartbeat failed ${consecutiveFailures} consecutive times; stopping polling and waiting for recovery.`,
+      );
+      this.#transportState.markDirty();
+      void params.stopRunner();
+      void params.stopBot();
+      params.forceCycleResolve?.();
+
+      // Wait silently for heartbeat to recover.
+      while (!isAborted()) {
+        await sleepWithAbort(HEARTBEAT_INTERVAL_MS, params.cycleSignal).catch(() => {});
+        if (isAborted()) {
+          return "aborted";
+        }
+        const recovered = await this.#probeHeartbeatOnce(params.cycleSignal);
+        if (recovered) {
+          this.opts.log(`[telegram] Heartbeat recovered; polling will restart on next cycle.`);
+          return "stalled";
+        }
+      }
+      return "aborted";
+    }
+    return "aborted";
   }
 }
 

--- a/extensions/telegram/src/polling-transport-state.ts
+++ b/extensions/telegram/src/polling-transport-state.ts
@@ -18,6 +18,11 @@ export class TelegramPollingTransportState {
     this.#transportDirty = true;
   }
 
+  /** Returns the current transport without rebuilding (read-only access for heartbeat). */
+  currentTransport(): TelegramTransport | undefined {
+    return this.#telegramTransport;
+  }
+
   acquireForNextCycle(): TelegramTransport | undefined {
     const shouldCreateTransport = this.#transportDirty || !this.#telegramTransport;
     const nextTransport = shouldCreateTransport


### PR DESCRIPTION
## Background

In real-world network interruption tests, the current Telegram polling recovery path is not sensitive enough to connection loss.

After repeated observation on a local OpenClaw deployment, we saw cases where Telegram connectivity had already been broken for a long time, but the process did not emit a meaningful error log until much later. In some runs, the gap was well over 15 minutes before a clear failure signal appeared in the logs.

This PR adjusts Telegram polling supervision to make outage detection and recovery more responsive under real network interruptions.

## What changed

### 1. Heartbeat supervisor

A lightweight heartbeat loop runs alongside each polling cycle:

- Periodically probes Telegram with `getMe` requests through the **same proxy/transport path** as `getUpdates` (respects user-configured proxies and custom API endpoints).
- Tracks consecutive heartbeat failures.
- After reaching the failure threshold (3 consecutive failures), **stops the current polling instance** and enters a quiet wait state.
- While waiting, continues probing without logging noise — no repeated restart loops.
- Once heartbeat recovers, signals the polling cycle to restart cleanly.

The heartbeat API base is resolved once at construction time from the account's `apiRoot` config, so deployments using a custom Telegram Bot API server are correctly handled.

### 2. `getUpdates` freshness check

Adds a secondary staleness signal inside the existing watchdog interval:

- Tracks the timestamp of the last successful `getUpdates` completion.
- If `getUpdates` has not completed for longer than the stale threshold **and** no `getUpdates` is currently in-flight **and** no other API calls have been active recently (`apiElapsed` guard), triggers a restart.
- The `apiElapsed` guard ensures we do not falsely restart when the connection is demonstrably alive (e.g. `sendMessage` calls are succeeding).

## Behavior summary

- If polling is healthy, both the heartbeat and the watchdog stay idle.
- If heartbeat failures accumulate past the threshold, the current polling instance is stopped. The session waits quietly for heartbeat recovery before restarting.
- If `getUpdates` becomes stale with no other API liveness signals, the watchdog forces a restart (existing behavior, now augmented with the freshness check).
- Recovery after either path triggers a clean transport rebuild and fresh polling cycle.

## Implementation notes

- `apiBase` is resolved from `account.config.apiRoot` and passed via `TelegramPollingSessionOpts`, matching how `token` is passed.
- Heartbeat uses `this.opts.proxyFetch` (falling back to `globalThis.fetch`) so it traverses the same network path as all other Telegram API calls.
- Heartbeat has its own timeout (`HEARTBEAT_TIMEOUT_MS = 10s`) independent of the session abort signal.
- `HEARTBEAT_INTERVAL_MS = 30s`, `HEARTBEAT_FAIL_THRESHOLD = 3` — configurable via constants.
- `SUPERVISOR_UPDATES_STALE_THRESHOLD_MS = 90s` for the freshness check.

## Testing

Based on repeated local outage/recovery experiments where an external Telegram probe detected failures much earlier than the in-process polling path. Validated:

- Earlier detection of broken Telegram connectivity via heartbeat
- Correct stop behavior after repeated heartbeat failures
- Quiet wait state without noisy restart loops
- Successful restart after heartbeat recovery
- No false-positive restarts when non-getUpdates API traffic is active
