### PR TITLE
fix: keep subagents list active while run cleanup is pending

### DIFF
--- a/src/agents/subagent-control.ts
+++ b/src/agents/subagent-control.ts
@@ -193,7 +193,11 @@ export function isActiveSubagentRun(
   entry: SubagentRunRecord,
   pendingDescendantCount: (sessionKey: string) => number,
 ) {
-  return !entry.endedAt || pendingDescendantCount(entry.childSessionKey) > 0;
+  return (
+    !entry.endedAt ||
+    (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) ||
+    pendingDescendantCount(entry.childSessionKey) > 0
+  );
 }
 
 function resolveLatestAssistantReplySnapshot(messages: unknown[]): {
@@ -225,6 +229,10 @@ function resolveRunStatus(entry: SubagentRunRecord, options?: { pendingDescendan
   }
   if (!entry.endedAt) {
     return "running";
+  }
+  // Run ended but cleanup (announce/descendant settle) is still in progress.
+  if (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) {
+    return "completing";
   }
   const status = entry.outcome?.status ?? "done";
   if (status === "ok") {

--- a/src/agents/subagent-control.ts
+++ b/src/agents/subagent-control.ts
@@ -195,7 +195,7 @@ export function isActiveSubagentRun(
 ) {
   return (
     !entry.endedAt ||
-    (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) ||
+    (!entry.cleanupCompletedAt && !entry.suppressAnnounceReason) ||
     pendingDescendantCount(entry.childSessionKey) > 0
   );
 }
@@ -231,7 +231,7 @@ function resolveRunStatus(entry: SubagentRunRecord, options?: { pendingDescendan
     return "running";
   }
   // Run ended but cleanup (announce/descendant settle) is still in progress.
-  if (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) {
+  if (!entry.cleanupCompletedAt && !entry.suppressAnnounceReason) {
     return "completing";
   }
   const status = entry.outcome?.status ?? "done";

--- a/src/agents/subagent-registry-queries.test.ts
+++ b/src/agents/subagent-registry-queries.test.ts
@@ -239,7 +239,9 @@ describe("subagent registry query regressions", () => {
       }),
     );
 
-    expect(countActiveRunsForSessionFromRuns(runs, "agent:main:main")).toBe(0);
+    // Parent run still has cleanupCompletedAt=undefined and cleanupHandled not set,
+    // so it remains active even after all descendants are done.
+    expect(countActiveRunsForSessionFromRuns(runs, "agent:main:main")).toBe(1);
   });
 
   it("dedupes stale and current rows for the same child session when counting active runs", () => {

--- a/src/agents/subagent-registry-queries.ts
+++ b/src/agents/subagent-registry-queries.ts
@@ -153,11 +153,7 @@ export function countActiveRunsForSessionFromRuns(
       count += 1;
       continue;
     }
-    if (
-      typeof entry.cleanupCompletedAt !== "number" &&
-      !entry.cleanupHandled &&
-      !entry.suppressAnnounceReason
-    ) {
+    if (typeof entry.cleanupCompletedAt !== "number" && !entry.suppressAnnounceReason) {
       count += 1;
       continue;
     }

--- a/src/agents/subagent-registry-queries.ts
+++ b/src/agents/subagent-registry-queries.ts
@@ -153,6 +153,14 @@ export function countActiveRunsForSessionFromRuns(
       count += 1;
       continue;
     }
+    if (
+      typeof entry.cleanupCompletedAt !== "number" &&
+      !entry.cleanupHandled &&
+      !entry.suppressAnnounceReason
+    ) {
+      count += 1;
+      continue;
+    }
     if (pendingDescendantCount(entry.childSessionKey) > 0) {
       count += 1;
     }

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -193,7 +193,7 @@ export async function buildStatusReply(params: {
       const active = runs.filter(
         (entry) =>
           !entry.endedAt ||
-          (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) ||
+          (!entry.cleanupCompletedAt && !entry.suppressAnnounceReason) ||
           countPendingDescendantRuns(entry.childSessionKey) > 0,
       );
       const done = runs.length - active.length;

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -191,7 +191,10 @@ export async function buildStatusReply(params: {
     const verboseEnabled = resolvedVerboseLevel && resolvedVerboseLevel !== "off";
     if (runs.length > 0) {
       const active = runs.filter(
-        (entry) => !entry.endedAt || countPendingDescendantRuns(entry.childSessionKey) > 0,
+        (entry) =>
+          !entry.endedAt ||
+          (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) ||
+          countPendingDescendantRuns(entry.childSessionKey) > 0,
       );
       const done = runs.length - active.length;
       if (verboseEnabled) {

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -211,7 +211,7 @@ export function resolveSubagentTarget(
     label: (entry) => formatRunLabel(entry),
     isActive: (entry) =>
       !entry.endedAt ||
-      (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) ||
+      (!entry.cleanupCompletedAt && !entry.suppressAnnounceReason) ||
       Math.max(0, countPendingDescendantRuns(entry.childSessionKey)) > 0,
     errors: {
       missingTarget: "Missing subagent id.",

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -210,7 +210,9 @@ export function resolveSubagentTarget(
     recentWindowMinutes: RECENT_WINDOW_MINUTES,
     label: (entry) => formatRunLabel(entry),
     isActive: (entry) =>
-      !entry.endedAt || Math.max(0, countPendingDescendantRuns(entry.childSessionKey)) > 0,
+      !entry.endedAt ||
+      (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) ||
+      Math.max(0, countPendingDescendantRuns(entry.childSessionKey)) > 0,
     errors: {
       missingTarget: "Missing subagent id.",
       invalidIndex: (value) => `Invalid subagent index: ${value}`,

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -361,10 +361,39 @@ describe("subagents utils", () => {
 
   it("formats run status from outcome and timestamps", () => {
     expect(formatRunStatus({ ...baseRun })).toBe("running");
-    expect(formatRunStatus({ ...baseRun, endedAt: 2000, outcome: { status: "ok" } })).toBe("done");
-    expect(formatRunStatus({ ...baseRun, endedAt: 2000, outcome: { status: "timeout" } })).toBe(
-      "timeout",
+    expect(
+      formatRunStatus({
+        ...baseRun,
+        endedAt: 2000,
+        cleanupCompletedAt: 2100,
+        outcome: { status: "ok" },
+      }),
+    ).toBe("done");
+    expect(
+      formatRunStatus({
+        ...baseRun,
+        endedAt: 2000,
+        cleanupCompletedAt: 2100,
+        outcome: { status: "timeout" },
+      }),
+    ).toBe("timeout");
+  });
+
+  it("returns completing when cleanup is pending and not yet handled", () => {
+    expect(formatRunStatus({ ...baseRun, endedAt: 2000, outcome: { status: "ok" } })).toBe(
+      "completing",
     );
+  });
+
+  it("returns done when cleanup is handled but cleanupCompletedAt is missing (legacy state)", () => {
+    expect(
+      formatRunStatus({
+        ...baseRun,
+        endedAt: 2000,
+        cleanupHandled: true,
+        outcome: { status: "ok" },
+      }),
+    ).toBe("done");
   });
 
   it("formats duration compact for seconds and minutes", () => {

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -385,12 +385,23 @@ describe("subagents utils", () => {
     );
   });
 
-  it("returns done when cleanup is handled but cleanupCompletedAt is missing (legacy state)", () => {
+  it("returns completing when cleanup is in progress (cleanupHandled but not completed)", () => {
     expect(
       formatRunStatus({
         ...baseRun,
         endedAt: 2000,
         cleanupHandled: true,
+        outcome: { status: "ok" },
+      }),
+    ).toBe("completing");
+  });
+
+  it("returns done when suppressAnnounceReason is set (steer-restart/killed)", () => {
+    expect(
+      formatRunStatus({
+        ...baseRun,
+        endedAt: 2000,
+        suppressAnnounceReason: "steer-restart",
         outcome: { status: "ok" },
       }),
     ).toBe("done");

--- a/src/auto-reply/reply/subagents-utils.ts
+++ b/src/auto-reply/reply/subagents-utils.ts
@@ -19,6 +19,9 @@ export function formatRunStatus(entry: SubagentRunRecord) {
   if (!entry.endedAt) {
     return "running";
   }
+  if (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) {
+    return "completing";
+  }
   const status = entry.outcome?.status ?? "done";
   return status === "ok" ? "done" : status;
 }
@@ -69,7 +72,11 @@ export function resolveSubagentTargetFromRuns(params: {
   if (trimmed === "last") {
     return { entry: deduped[0] };
   }
-  const isActive = params.isActive ?? ((entry: SubagentRunRecord) => !entry.endedAt);
+  const isActive =
+    params.isActive ??
+    ((entry: SubagentRunRecord) =>
+      !entry.endedAt ||
+      (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason));
   const recentCutoff = Date.now() - params.recentWindowMinutes * 60_000;
   const numericOrder = [
     ...deduped.filter((entry) => isActive(entry)),

--- a/src/auto-reply/reply/subagents-utils.ts
+++ b/src/auto-reply/reply/subagents-utils.ts
@@ -19,7 +19,7 @@ export function formatRunStatus(entry: SubagentRunRecord) {
   if (!entry.endedAt) {
     return "running";
   }
-  if (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) {
+  if (!entry.cleanupCompletedAt && !entry.suppressAnnounceReason) {
     return "completing";
   }
   const status = entry.outcome?.status ?? "done";
@@ -75,8 +75,7 @@ export function resolveSubagentTargetFromRuns(params: {
   const isActive =
     params.isActive ??
     ((entry: SubagentRunRecord) =>
-      !entry.endedAt ||
-      (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason));
+      !entry.endedAt || (!entry.cleanupCompletedAt && !entry.suppressAnnounceReason));
   const recentCutoff = Date.now() - params.recentWindowMinutes * 60_000;
   const numericOrder = [
     ...deduped.filter((entry) => isActive(entry)),


### PR DESCRIPTION
## Summary

- Problem: `subagents list` shows mode="run" orchestrators as "done" right after model turn ends, even when cleanup is still in progress — causing duplicate orchestrator spawns.
- Why it matters: depth-0 agents see "done" → spawn duplicate orchestrators → two orchestrators run same pipeline simultaneously.
- What changed: added `cleanupCompletedAt` + `suppressAnnounceReason` gate to all active-run predicates. Runs show "completing" until cleanup finalizes.
- What did NOT change (scope boundary): no spawn semantics, no lifecycle timing, no cleanup flow changes.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #39619
- Related #39658
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `isActiveSubagentRun` only checked `endedAt` and `pendingDescendantCount`, missing the cleanup-pending window where a run has ended but cleanup (announce/descendant settle) hasn't finalized.
- Missing detection / guardrail: no intermediate status between "running" and "done" for the cleanup phase.
- Prior context: original `isActiveSubagentRun` at `src/agents/subagent-control.ts`.
- Why this regressed now: always present since orchestrator depth-2 patterns were introduced.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/auto-reply/reply/reply-plumbing.test.ts`, `src/agents/subagent-registry-queries.test.ts`
- Scenario the test should lock in: `formatRunStatus` returns "completing" when `endedAt` set but `cleanupCompletedAt` absent (including during active cleanup with `cleanupHandled=true`); returns "done" when `suppressAnnounceReason` is set.
- Why this is the smallest reliable guardrail: directly tests the status resolution logic without needing full orchestrator setup.

## User-visible / Behavior Changes

- `subagents list` shows "completing" instead of "done" for runs with pending cleanup.
- Orchestrators with pending children stay in "active" section instead of "recent".
- Cleanup-pending runs count toward `maxChildrenPerAgent` spawn limit.
- Status command active count includes cleanup-pending runs and descendant-pending runs.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: spawn gating slightly more conservative (cleanup-pending runs count toward `maxChildrenPerAgent`).
  - Mitigation: cleanup completes in seconds; `ANNOUNCE_EXPIRY_MS` / `MAX_ANNOUNCE_RETRY_COUNT` prevent hangs. Suppressed runs (`steer-restart`, `killed`) are excluded. Orphan reconciliation handles legacy stuck state on restart.