### PR TITLE
fix: pass parent delivery context to ACP stream relay for correct thread routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeats/sessions: remove stale accumulated isolated heartbeat session keys when the next tick converges them back to the canonical sibling, so repaired sessions stop showing orphaned `:heartbeat:heartbeat` variants in session listings. (#59606) Thanks @rogerdigital.
 - Cron/Telegram: collapse isolated announce delivery to the final assistant-visible text only for Telegram targets, while preserving existing multi-message direct delivery semantics for other channels. (#63228) Thanks @welfo-beo.
 - Gateway/thread routing: preserve Slack, Telegram, and Mattermost thread-child delivery targets so bound subagent completion messages land in the originating thread instead of top-level channels. (#54840) Thanks @yzzymt.
+- ACP/stream relay: pass parent delivery context to ACP stream relay system events so `streamTo="parent"` updates route to the correct thread or topic instead of falling back to the main DM. (#57056) Thanks @pingren.
 
 ## 2026.4.9
 

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -77,11 +77,18 @@ describe("startAcpSpawnParentStreamRelay", () => {
   });
 
   it("relays assistant progress and completion to the parent session", () => {
+    const deliveryContext = {
+      channel: "telegram",
+      to: "-1001234567890",
+      accountId: "default",
+      threadId: 1122,
+    };
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-1",
       parentSessionKey: "agent:main:main",
       childSessionKey: "agent:codex:acp:child-1",
       agentId: "codex",
+      deliveryContext,
       streamFlushMs: 10,
       noOutputNoticeMs: 120_000,
     });
@@ -114,6 +121,14 @@ describe("startAcpSpawnParentStreamRelay", () => {
         (call) => (call[1] as { trusted?: boolean } | undefined)?.trusted === false,
       ),
     ).toBe(true);
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        deliveryContext,
+        trusted: false,
+      }),
+    );
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith(
       expect.objectContaining({
         reason: "acp:spawn:stream",

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -8,6 +8,7 @@ import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { recordTaskRunProgressByRunId } from "../tasks/task-executor.js";
+import { type DeliveryContext } from "../utils/delivery-context.js";
 
 const DEFAULT_STREAM_FLUSH_MS = 2_500;
 const DEFAULT_NO_OUTPUT_NOTICE_MS = 60_000;
@@ -73,6 +74,7 @@ export function startAcpSpawnParentStreamRelay(params: {
   childSessionKey: string;
   agentId: string;
   logPath?: string;
+  deliveryContext?: DeliveryContext;
   surfaceUpdates?: boolean;
   streamFlushMs?: number;
   noOutputNoticeMs?: number;
@@ -196,6 +198,7 @@ export function startAcpSpawnParentStreamRelay(params: {
     enqueueSystemEvent(cleaned, {
       sessionKey: parentSessionKey,
       contextKey,
+      deliveryContext: params.deliveryContext,
       trusted: false,
     });
     wake();

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1271,6 +1271,11 @@ describe("spawnAcpDirect", () => {
         parentSessionKey: "agent:main:subagent:parent",
         agentId: "codex",
         logPath: "/tmp/sess-main.acp-stream.jsonl",
+        deliveryContext: {
+          channel: "discord",
+          to: "channel:parent-channel",
+          accountId: "default",
+        },
         emitStartNotice: false,
       }),
     );

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -44,6 +44,7 @@ import {
   isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
 } from "../routing/session-key.js";
 import {
   normalizeOptionalLowercaseString,
@@ -1108,6 +1109,19 @@ export async function spawnAcpDirect(
           childSessionKey: sessionKey,
         })
       : undefined;
+  // Resolve parent session delivery context so system events route to the
+  // correct thread/topic instead of falling back to the main DM.
+  const parentDeliveryCtx =
+    effectiveStreamToParent && parentSessionKey
+      ? deliveryContextFromSession(
+          loadSessionStore(
+            resolveStorePath(cfg.session?.store, {
+              agentId: resolveAgentIdFromSessionKey(parentSessionKey),
+            }),
+          )[parentSessionKey],
+        )
+      : undefined;
+
   let parentRelay: AcpSpawnParentRelayHandle | undefined;
   if (effectiveStreamToParent && parentSessionKey) {
     // Register relay before dispatch so fast lifecycle failures are not missed.
@@ -1117,6 +1131,7 @@ export async function spawnAcpDirect(
       childSessionKey: sessionKey,
       agentId: targetAgentId,
       logPath: streamLogPath,
+      deliveryContext: parentDeliveryCtx,
       emitStartNotice: false,
     });
   }
@@ -1166,6 +1181,7 @@ export async function spawnAcpDirect(
         childSessionKey: sessionKey,
         agentId: targetAgentId,
         logPath: streamLogPath,
+        deliveryContext: parentDeliveryCtx,
         emitStartNotice: false,
       });
     }


### PR DESCRIPTION
## Problem

When an agent spawns ACP sessions with `streamTo="parent"` from a **Telegram forum topic** (or Discord thread), the relay's system events — progress updates, stall warnings, and completion notices — all route to the **main DM** instead of the originating topic/thread.

This means the user sees ACP progress in the wrong conversation, and the agent's judge/report reply also lands in the wrong place.

### Reproduction

1. Open a Telegram DM with forum topics enabled
2. In a topic, ask your agent to spawn an ACP session with `streamTo="parent"`
3. Observe: all `System:` events (progress, "run completed") arrive in the main DM, not the topic

### Expected

System events should route back to the same topic/thread that initiated the spawn.

## Root Cause

`startAcpSpawnParentStreamRelay` calls `enqueueSystemEvent` without a `deliveryContext`. When the heartbeat runner processes queued system events:

1. `resolveSystemEventDeliveryContext()` returns no thread routing info
2. `resolveSessionDeliveryTarget` in heartbeat mode only uses `turnSourceThreadId` — it does **not** fall back to `lastThreadId`
3. Without `turnSourceThreadId`, `threadId` resolves to `undefined` → delivery falls back to main DM

## Fix

1. **`acp-spawn-parent-stream.ts`**: Accept optional `deliveryContext` param, pass to every `enqueueSystemEvent` call
2. **`acp-spawn.ts`**: Resolve parent session delivery context from session store at relay creation time, pass to relay

Graceful fallback: if parent session has no delivery context, behavior is identical to before.

## Changes

- `src/agents/acp-spawn-parent-stream.ts` (+7): Add optional `deliveryContext` param, pass to `enqueueSystemEvent`
- `src/agents/acp-spawn.ts` (+16): Resolve parent delivery context from session store, pass to both relay creation points