### PR TITLE
fix: handle openrouter compatibility aliases

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -589,6 +589,49 @@ describe("model-selection", () => {
   });
 
   describe("resolveConfiguredModelRef", () => {
+    it("resolves openrouter:auto to canonical openrouter/auto", () => {
+      const cfg: Partial<OpenClawConfig> = {
+        agents: {
+          defaults: {
+            model: { primary: "openrouter:auto" },
+          },
+        },
+      };
+
+      const result = resolveConfiguredModelRef({
+        cfg: cfg as OpenClawConfig,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-6",
+      });
+
+      expect(result).toEqual({ provider: "openrouter", model: "openrouter/auto" });
+    });
+
+    it("resolves openrouter:free to the first configured concrete free OpenRouter model", () => {
+      const cfg: Partial<OpenClawConfig> = {
+        agents: {
+          defaults: {
+            model: { primary: "openrouter:free" },
+            models: {
+              "openrouter/meta-llama/llama-3.3-70b-instruct:free": {},
+              "openrouter/openai/gpt-oss-20b:free": {},
+            },
+          },
+        },
+      };
+
+      const result = resolveConfiguredModelRef({
+        cfg: cfg as OpenClawConfig,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-6",
+      });
+
+      expect(result).toEqual({
+        provider: "openrouter",
+        model: "meta-llama/llama-3.3-70b-instruct:free",
+      });
+    });
+
     it("should fall back to anthropic and warn if provider is missing for non-alias", () => {
       setLoggerOverride({ level: "silent", consoleLevel: "warn" });
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -333,6 +333,38 @@ export function resolveModelRefFromString(params: {
   return { ref: parsed };
 }
 
+function resolveOpenRouterCompatAlias(params: {
+  raw: string;
+  cfg: OpenClawConfig;
+  allowPluginNormalization?: boolean;
+}): ModelRef | null {
+  const normalized = params.raw.trim().toLowerCase();
+  if (normalized === "openrouter:auto") {
+    return normalizeModelRef("openrouter", "auto", {
+      allowPluginNormalization: params.allowPluginNormalization,
+    });
+  }
+  if (normalized !== "openrouter:free") {
+    return null;
+  }
+
+  const configuredModels = params.cfg.agents?.defaults?.models ?? {};
+  for (const keyRaw of Object.keys(configuredModels)) {
+    const key = String(keyRaw ?? "").trim();
+    if (!key.startsWith("openrouter/")) {
+      continue;
+    }
+    const parsed = parseModelRef(key, DEFAULT_PROVIDER, {
+      allowPluginNormalization: params.allowPluginNormalization,
+    });
+    if (parsed?.provider === "openrouter" && parsed.model.endsWith(":free")) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
 export function resolveConfiguredModelRef(params: {
   cfg: OpenClawConfig;
   defaultProvider: string;
@@ -352,6 +384,15 @@ export function resolveConfiguredModelRef(params: {
       const aliasMatch = aliasIndex.byAlias.get(aliasKey);
       if (aliasMatch) {
         return aliasMatch.ref;
+      }
+
+      const openRouterCompat = resolveOpenRouterCompatAlias({
+        raw: trimmed,
+        cfg: params.cfg,
+        allowPluginNormalization: params.allowPluginNormalization,
+      });
+      if (openRouterCompat) {
+        return openRouterCompat;
       }
 
       // Default to anthropic if no provider is specified, but warn as this is deprecated.


### PR DESCRIPTION
## Summary

Handle the two providerless OpenRouter compatibility shorthands before the legacy anthropic fallback kicks in.

## Changes

- resolve `openrouter:auto` directly to canonical `openrouter/auto`
- resolve `openrouter:free` to the first configured concrete `openrouter/...:free` model
- add regression tests for both compatibility aliases

## Testing

- Added targeted regression tests in `src/agents/model-selection.test.ts`
- Local vitest execution on this host did not complete cleanly in time, so CI should be treated as the source of truth for the full suite

Fixes #57066
