### PR TITLE
fix: break circular import in vllm/sglang provider-setup facades

### DIFF
--- a/extensions/sglang/models.ts
+++ b/extensions/sglang/models.ts
@@ -1,5 +1,4 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { discoverOpenAICompatibleLocalModels } from "openclaw/plugin-sdk/provider-setup";
 import { SGLANG_DEFAULT_BASE_URL, SGLANG_PROVIDER_LABEL } from "./defaults.js";
 
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
@@ -9,6 +8,10 @@ export async function buildSglangProvider(params?: {
   baseUrl?: string;
   apiKey?: string;
 }): Promise<ProviderConfig> {
+  // Dynamic import to avoid circular dependency: provider-setup re-exports
+  // the sglang facade which eagerly loads this module at import time.
+  const { discoverOpenAICompatibleLocalModels } =
+    await import("openclaw/plugin-sdk/provider-setup");
   const baseUrl = (params?.baseUrl?.trim() || SGLANG_DEFAULT_BASE_URL).replace(/\/+$/, "");
   const models = await discoverOpenAICompatibleLocalModels({
     baseUrl,

--- a/extensions/vllm/models.ts
+++ b/extensions/vllm/models.ts
@@ -1,5 +1,4 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { discoverOpenAICompatibleLocalModels } from "openclaw/plugin-sdk/provider-setup";
 import { VLLM_DEFAULT_BASE_URL, VLLM_PROVIDER_LABEL } from "./defaults.js";
 
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
@@ -9,6 +8,10 @@ export async function buildVllmProvider(params?: {
   baseUrl?: string;
   apiKey?: string;
 }): Promise<ProviderConfig> {
+  // Dynamic import to avoid circular dependency: provider-setup re-exports
+  // the vllm facade which eagerly loads this module at import time.
+  const { discoverOpenAICompatibleLocalModels } =
+    await import("openclaw/plugin-sdk/provider-setup");
   const baseUrl = (params?.baseUrl?.trim() || VLLM_DEFAULT_BASE_URL).replace(/\/+$/, "");
   const models = await discoverOpenAICompatibleLocalModels({
     baseUrl,


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw onboard --install-daemon` hangs, then fails with `RangeError: Maximum call stack size exceeded` when loading the vllm plugin. Same issue affects sglang.
- **Why it matters:** Onboarding is completely blocked; all commands that load the plugin registry are affected.
- **What changed:** Converted static `import { discoverOpenAICompatibleLocalModels }` to dynamic `await import()` inside the async `buildVllmProvider()` / `buildSglangProvider()` functions in models.ts and models.ts.
- **What did NOT change (scope boundary):** No public API surface, SDK subpath exports, or provider-setup barrel changes. Only the import timing in two extension files.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** Circular import cycle: models.ts statically imports `openclaw/plugin-sdk/provider-setup` → which re-exports `buildVllmProvider` from `./vllm.js` (facade) → facade eagerly calls `loadFacadeModule()` at init → loads api.ts → re-exports from `./models.js` → back to step 1 → infinite loop.
- **Missing detection / guardrail:** No cycle detection for facade → extension → SDK subpath import chains.
- **Prior context:** Introduced in `4ca07559ab` (_refactor: move provider seams behind plugin sdk surfaces_), which simultaneously created models.ts with a static import of `provider-setup`, and changed provider-setup.ts to re-export `buildVllmProvider` from the vllm facade.
- **Why this regressed now:** The facade re-export + extension file extraction happened in the same commit, creating the cycle from day one.
- **If unknown, what was ruled out:** N/A — root cause is confirmed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Existing coverage already sufficient
- Target test or file: provider.contract.test.ts, provider-discovery.contract.test.ts
- Scenario the test should lock in: Plugin loads without stack overflow.
- Why this is the smallest reliable guardrail: The contract tests already exercise the plugin loader; the cycle prevented them from even starting.
- If no new test is added, why not: The existing contract tests cover this — they were failing due to the cycle and now pass.

## User-visible / Behavior Changes

None — restores expected behavior (plugins load without hanging).

## Diagram (if applicable)

```text
Before:
vllm/models.ts → provider-setup → vllm.ts (facade)
  → loadFacadeModule() → vllm/api.ts → vllm/models.ts → ∞

After:
vllm/models.ts (no static import of provider-setup)
  → buildVllmProvider() called → await import("provider-setup") → OK (no cycle)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24.14.1
- Model/provider: N/A
- Integration/channel: N/A

### Steps

1. `pnpm openclaw onboard --install-daemon`

### Expected

- Onboard wizard starts immediately.

### Actual

- Hangs for a long time, then: `[plugins] vllm failed to load from extensions/vllm/index.ts: RangeError: Maximum call stack size exceeded`

## Evidence

- [x] Failing test/log before + passing after
- Before: `RangeError: Maximum call stack size exceeded` on plugin load
- After: `pnpm openclaw onboard --install-daemon` starts the setup wizard immediately, vllm/sglang load successfully

## Human Verification (required)

- Verified scenarios: `openclaw onboard --install-daemon` starts without hang; jiti loading of index.ts and index.ts succeeds; `pnpm build` passes.
- Edge cases checked: Both vllm and sglang extensions load correctly.
- What you did **not** verify: Full `pnpm test` suite (pre-existing infra issues with test runner).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None — the change only affects import timing within two async functions that already `await` their results.