### PR TITLE
fix(gateway): avoid pinning stale session ids in agent runs

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -231,10 +231,11 @@ function readLastAgentCommandCall():
   | {
       message?: string;
       sessionId?: string;
+      sessionKey?: string;
     }
   | undefined {
   return mocks.agentCommand.mock.calls.at(-1)?.[0] as
-    | { message?: string; sessionId?: string }
+    | { message?: string; sessionId?: string; sessionKey?: string }
     | undefined;
 }
 
@@ -933,7 +934,8 @@ describe("gateway agent handler", () => {
     expect(call?.message).toContain("Run your Session Startup sequence");
     expect(call?.message).toContain("Current time:");
     expect(call?.message).not.toBe(BARE_SESSION_RESET_PROMPT);
-    expect(call?.sessionId).toBe("reset-session-id");
+    expect(call?.sessionKey).toBe("agent:main:main");
+    expect(call?.sessionId).toBeUndefined();
   });
 
   it("uses /reset suffix as the post-reset message and still injects timestamp", async () => {
@@ -958,9 +960,27 @@ describe("gateway agent handler", () => {
     );
 
     const call = await expectResetCall("[Wed 2026-01-28 20:30 EST] check status");
-    expect(call?.sessionId).toBe("reset-session-id");
+    expect(call?.sessionKey).toBe("agent:main:main");
+    expect(call?.sessionId).toBeUndefined();
 
     resetTimeConfig();
+  });
+
+  it("does not forward stored sessionId when dispatching by session key", async () => {
+    primeMainAgentRun({ sessionId: "existing-session-id" });
+
+    await invokeAgent(
+      {
+        message: "continue",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "test-idem-session-freshness",
+      },
+      { reqId: "4d" },
+    );
+
+    const call = readLastAgentCommandCall();
+    expect(call?.sessionKey).toBe("agent:main:main");
+    expect(call?.sessionId).toBeUndefined();
   });
 
   it("rejects malformed agent session keys early in agent handler", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -701,6 +701,10 @@ export const agentHandlers: GatewayRequestHandlers = {
         : resolvedChannel);
 
     const deliver = request.deliver === true && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
+    // When a gateway request already resolved a canonical session key and
+    // updated the backing store entry, passing sessionId downstream is
+    // redundant and can pin a stale session across daily/idle reset rollovers.
+    const ingressSessionId = resolvedSessionKey ? undefined : resolvedSessionId;
 
     const accepted = {
       runId,
@@ -748,7 +752,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         provider: providerOverride,
         model: modelOverride,
         to: resolvedTo,
-        sessionId: resolvedSessionId,
+        sessionId: ingressSessionId,
         sessionKey: resolvedSessionKey,
         thinking: request.thinking,
         deliver,

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -481,6 +481,7 @@ describe("voice transcript events", () => {
       message: "check provenance",
       deliver: false,
       messageChannel: "node",
+      sessionKey: "voice-provenance-session",
       inputProvenance: {
         kind: "external_user",
         sourceChannel: "voice",
@@ -488,7 +489,7 @@ describe("voice transcript events", () => {
       },
     });
     expect(typeof opts.runId).toBe("string");
-    expect(opts.runId).not.toBe(opts.sessionId);
+    expect(opts.sessionId).toBeUndefined();
     expect(addChatRun).toHaveBeenCalledWith(
       opts.runId,
       expect.objectContaining({ clientRunId: expect.stringMatching(/^voice-/) }),
@@ -797,6 +798,7 @@ describe("agent request events", () => {
       channel: "telegram",
       to: "123",
     });
-    expect(opts.runId).toBe(opts.sessionId);
+    expect(opts.runId).toBe("sid-current");
+    expect(opts.sessionId).toBeUndefined();
   });
 });

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -304,7 +304,6 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         {
           runId,
           message: text,
-          sessionId,
           sessionKey: canonicalKey,
           thinking: "low",
           deliver: false,
@@ -437,7 +436,6 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
           runId: sessionId,
           message,
           images,
-          sessionId,
           sessionKey: canonicalKey,
           thinking: link?.thinking ?? undefined,
           deliver,


### PR DESCRIPTION
## Summary

  - Problem: gateway `agent` requests forwarded stored `sessionId` values even
  when a canonical `sessionKey` was already resolved from the session store.
  - Why it matters: stale `sessionId` values can bypass normal daily/idle
  session freshness rollover, so inter-session and gateway-triggered runs may
  continue an expired session instead of starting a fresh one.
  - What changed: the gateway `agent` handler now stops forwarding `sessionId`
  once a `sessionKey` has already been resolved and persisted, and the
  regression test coverage now locks in that behavior.
  - What did NOT change (scope boundary): explicit session reset flows (`/new`,
  `/reset`) and direct session-key targeting still use the same canonical
  session key; this PR does not change reset policy rules or model/runtime
  behavior.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [x] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #54164
  - Related #
  - [x] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)

  - Root cause: `src/gateway/server-methods/agent.ts` reused an existing stored
  `sessionId` and passed it to `agentCommandFromIngress`, which prevented
  downstream session resolution from deciding freshness from the canonical
  session key and current reset policy.
  - Missing detection / guardrail: there was no regression test asserting that
  gateway agent dispatch by `sessionKey` should not also pin the old
  `sessionId`.
  - Prior context (`git blame`, prior PR, issue, or refactor if known):
  identified in issue #54164 with the gateway `agent` path contrasted against
  the normal freshness flow in `resolveSession()`.
  - Why this regressed now: the gateway path kept extra state (`sessionId`) that
  the regular session-resolution path does not need once the canonical session
  key is known.
  - If unknown, what was ruled out: explicit `/new` and `/reset` flows were
  ruled out; the issue is in normal gateway dispatch for existing keyed
  sessions.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [ ] Unit test
    - [x] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `src/gateway/server-methods/agent.test.ts`
  - Scenario the test should lock in: when the gateway dispatches a run for an
  existing canonical session key, it should forward the session key but not re-
  pin the old stored session id.
  - Why this is the smallest reliable guardrail: the bug lives in the gateway-
  to-agent handoff, so the handler seam is the narrowest place that still
  exercises the broken state propagation.
  - Existing test that already covers this (if any): none for the stale
  `sessionId` forwarding path.
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  Gateway-triggered agent runs now allow normal daily/idle session rollover to
  happen when the request is already scoped by a canonical session key.

  ## Diagram (if applicable)

  ```text
  Before:
  gateway agent request
  -> resolve canonical session key
  -> also forward old sessionId
  -> downstream run stays pinned to stale session

  After:
  gateway agent request
  -> resolve canonical session key
  -> do not forward old sessionId
  -> downstream session resolution can roll over normally

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) No
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) No
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation:

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Node 22 + pnpm
  - Model/provider: N/A
  - Integration/channel (if any): gateway agent method
  - Relevant config (redacted): session-reset policy with an existing keyed
    session

  ### Steps

  1. Start with a session that already has a stored sessionId and canonical
     sessionKey.
  2. Trigger a gateway agent run against that session key after the session
     should be considered stale by reset policy.
  3. Observe whether the downstream run is pinned to the old sessionId.

  ### Expected

  - The gateway should forward the canonical session key only and let downstream
    session resolution decide whether a fresh session is needed.

  ### Actual

  - Before this fix, the gateway also forwarded the old stored sessionId, which
    could keep the stale session alive.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  - Verified scenarios: reviewed the gateway agent handoff path and updated the
    seam test coverage to assert that keyed dispatch does not also forward
    sessionId.
  - Edge cases checked: /new and /reset still target the same canonical session
    key; explicit keyed dispatch still preserves sessionKey.
  - What you did not verify: a full live gateway run in a real environment with
    end-to-end stale-session rollover.

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in
    this PR.
  - [x] I left unresolved only the conversations that still need reviewer or
    maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) No
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps:

  ## Risks and Mitigations

  - Risk: a caller that implicitly relied on the buggy stale-session pinning
    could now observe a fresh-session rollover.
      - Mitigation: that behavior matches the normal session freshness model and
        the change is limited to keyed gateway dispatch where the canonical
        session key is already known.