### PR TITLE
fix(plugins): defer provider-setup import in sglang/vllm models to break circular jiti dependency

### DIFF
--- a/extensions/sglang/models.ts
+++ b/extensions/sglang/models.ts
@@ -1,5 +1,4 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { discoverOpenAICompatibleLocalModels } from "openclaw/plugin-sdk/provider-setup";
 import { SGLANG_DEFAULT_BASE_URL, SGLANG_PROVIDER_LABEL } from "./defaults.js";
 
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
@@ -9,6 +8,10 @@ export async function buildSglangProvider(params?: {
   baseUrl?: string;
   apiKey?: string;
 }): Promise<ProviderConfig> {
+  // Dynamic import avoids a circular load-time dependency:
+  // sglang/models.ts -> provider-setup -> sglang facade -> loadBundledPlugin(sglang/api.ts) -> sglang/models.ts
+  const { discoverOpenAICompatibleLocalModels } =
+    await import("openclaw/plugin-sdk/provider-setup");
   const baseUrl = (params?.baseUrl?.trim() || SGLANG_DEFAULT_BASE_URL).replace(/\/+$/, "");
   const models = await discoverOpenAICompatibleLocalModels({
     baseUrl,

--- a/extensions/vllm/models.ts
+++ b/extensions/vllm/models.ts
@@ -1,5 +1,4 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { discoverOpenAICompatibleLocalModels } from "openclaw/plugin-sdk/provider-setup";
 import { VLLM_DEFAULT_BASE_URL, VLLM_PROVIDER_LABEL } from "./defaults.js";
 
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
@@ -9,6 +8,10 @@ export async function buildVllmProvider(params?: {
   baseUrl?: string;
   apiKey?: string;
 }): Promise<ProviderConfig> {
+  // Dynamic import avoids a circular load-time dependency:
+  // vllm/models.ts -> provider-setup -> vllm facade -> loadBundledPlugin(vllm/api.ts) -> vllm/models.ts
+  const { discoverOpenAICompatibleLocalModels } =
+    await import("openclaw/plugin-sdk/provider-setup");
   const baseUrl = (params?.baseUrl?.trim() || VLLM_DEFAULT_BASE_URL).replace(/\/+$/, "");
   const models = await discoverOpenAICompatibleLocalModels({
     baseUrl,


### PR DESCRIPTION
## Summary

- **Problem:** `sglang` and `vllm` plugins crash at startup with `RangeError: Maximum call stack size exceeded`
- **Why it matters:** Every `openclaw` invocation logs plugin load failures for both providers, making them completely non-functional
- **What changed:** Converted the static `import { discoverOpenAICompatibleLocalModels } from "openclaw/plugin-sdk/provider-setup"` to a `await import(...)` inside the async function body in `extensions/sglang/models.ts` and `extensions/vllm/models.ts`
- **What did NOT change:** Runtime behavior, return types, or any other module

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** Commit `4ca07559ab` added `export { buildSglangProvider }` and `export { buildVllmProvider }` to `src/plugin-sdk/provider-setup.ts`, creating a circular dependency that crosses jiti instance boundaries. The cycle: plugin loader's jiti loads `sglang/api.ts` → `sglang/models.ts` (static import at eval time) → `provider-setup.ts` → `sglang.ts` facade → `loadBundledPluginPublicSurfaceModuleSync("sglang/api.ts")` → **new** independent jiti instance → `sglang/api.ts` → ∞. Because each `loadBundledPluginPublicSurfaceModuleSync` call creates an independent jiti instance with its own fresh module cache, jiti's built-in circular-dep guard (returning a partial module) never fires across the boundary.
- **Missing detection / guardrail:** No test exercises the full plugin load path for sglang/vllm through `loadBundledPluginPublicSurfaceModuleSync`
- **Prior context:** Introduced by `4ca07559ab` (`refactor: move provider seams behind plugin sdk surfaces`)
- **Why this regressed now:** The static import made `provider-setup.ts` a load-time dependency of `sglang/models.ts`, which only became circular after the facades were re-exported through that same module

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**
  - [ ] Unit test
  - [x] Seam / integration test
- **Scenario the test should lock in:** loading the sglang/vllm plugins via the full `loadBundledPlugin` path must not throw a stack overflow
- **If no new test is added, why not:** A reliable test would need to exercise the jiti cross-instance load path; adding that is out of scope for this targeted fix

## User-visible / Behavior Changes

None — sglang and vllm providers load and function correctly instead of failing on every startup.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Run any `openclaw` command (e.g. `openclaw channels status`)
2. Observe `[plugins] sglang failed to load ... RangeError: Maximum call stack size exceeded` in logs

### Expected

No plugin load errors for sglang/vllm.

### Actual (before fix)

```
[plugins] sglang failed to load from .../extensions/sglang/index.ts: RangeError: Maximum call stack size exceeded
[plugins] vllm failed to load from .../extensions/vllm/index.ts: RangeError: Maximum call stack size exceeded
```

## Evidence

- [x] Trace/log snippets — no sglang/vllm errors after fix with jiti cache cleared
- Build passes clean with no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings (`pnpm build`)
- `pnpm check` passes

## Human Verification (required)

- Verified: `node dist/entry.js channels status` produces no sglang/vllm plugin load errors after fix
- Edge cases checked: jiti transform cache cleared to confirm regenerated cache uses dynamic import
- What was not verified: live model calls through sglang/vllm endpoints

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `await import()` is called on every `buildSglangProvider`/`buildVllmProvider` invocation
  - Mitigation: Node/jiti module caching makes repeated dynamic imports effectively free after the first call