### PR TITLE
fix: auto-enable minimax plugin for API key auth route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Tasks/gateway: keep the task registry maintenance sweep from stalling the gateway event loop under synchronous SQLite pressure, so upgraded gateways stop hanging about a minute after startup. (#58670) Thanks @openperf
 - Channels/WhatsApp: pass inbound message timestamp to model context so the AI can see when WhatsApp messages were sent. (#58590) Thanks @Maninae
 - Web UI/OpenResponses: preserve rewritten stream snapshots in webchat and keep OpenResponses final streamed text aligned when models rewind earlier output. (#58641) Thanks @neeravmakwana
+- MiniMax/plugins: auto-enable the bundled MiniMax plugin for API-key auth/config so MiniMax image generation and other plugin-owned capabilities load without manual plugin allowlisting. (#57127) Thanks @tars90percent.
 
 ## 2026.3.31
 

--- a/extensions/minimax/openclaw.plugin.json
+++ b/extensions/minimax/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "enabledByDefault": true,
   "legacyPluginIds": ["minimax-portal-auth"],
   "providers": ["minimax", "minimax-portal"],
-  "autoEnableWhenConfiguredProviders": ["minimax-portal"],
+  "autoEnableWhenConfiguredProviders": ["minimax", "minimax-portal"],
   "providerAuthEnvVars": {
     "minimax": ["MINIMAX_API_KEY"],
     "minimax-portal": ["MINIMAX_OAUTH_TOKEN", "MINIMAX_API_KEY"]

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -522,6 +522,24 @@ describe("applyPluginAutoEnable", () => {
     expect(result.config.plugins?.entries?.["minimax-portal-auth"]).toBeUndefined();
   });
 
+  it("auto-enables minimax when minimax API key auth is configured", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        auth: {
+          profiles: {
+            "minimax:default": {
+              provider: "minimax",
+              mode: "api_key",
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(result.config.plugins?.entries?.minimax?.enabled).toBe(true);
+  });
+
   it("does not auto-enable unrelated provider plugins just because auth profiles exist", () => {
     const result = applyPluginAutoEnable({
       config: {


### PR DESCRIPTION
fix: auto-enable minimax plugin for API key auth route

The minimax plugin auto-enables for OAuth users (minimax-portal provider) but not for API key users (minimax provider). This is because the plugin manifest's autoEnableWhenConfiguredProviders only listed `minimax-portal`.

Changes:
  - extensions/minimax/openclaw.plugin.json: add "minimax" to autoEnableWhenConfiguredProviders
  - src/config/plugin-auto-enable.test.ts: add test covering the API key auth path