### PR TITLE
Fix OpenAI websocket transport provider normalization

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.websocket.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.websocket.test.ts
@@ -20,6 +20,15 @@ describe("openai websocket transport selection", () => {
     ).toBe(true);
   });
 
+  it("normalizes provider and modelApi before matching", () => {
+    expect(
+      shouldUseOpenAIWebSocketTransport({
+        provider: "  OpenAI  ",
+        modelApi: " OpenAI-Responses ",
+      }),
+    ).toBe(true);
+  });
+
   it("rejects mismatched OpenAI websocket transport pairs", () => {
     expect(
       shouldUseOpenAIWebSocketTransport({

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -2000,6 +2000,34 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     expect(resolved).toBe(currentStreamFn);
   });
 
+  it("does not enable websocket transport for non-openai providers even when flag is set", () => {
+    const currentStreamFn = vi.fn();
+
+    const resolved = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: currentStreamFn as never,
+      shouldUseWebSocketTransport: true,
+      wsApiKey: "sk-***",
+      sessionId: "session-1",
+      model: { provider: "xai" } as never,
+    });
+
+    expect(resolved).toBe(currentStreamFn);
+  });
+
+  it("uses websocket transport for normalized openai provider values", () => {
+    const currentStreamFn = vi.fn();
+
+    const resolved = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: currentStreamFn as never,
+      shouldUseWebSocketTransport: true,
+      wsApiKey: "sk-***",
+      sessionId: "session-1",
+      model: { provider: "  OpenAI  " } as never,
+    });
+
+    expect(resolved).not.toBe(currentStreamFn);
+  });
+
   it("prefers a provider-owned stream override when present", () => {
     const currentStreamFn = vi.fn();
     const providerStreamFn = vi.fn();

--- a/src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../../config/config.js";
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
+import { normalizeProviderId } from "../../provider-id.js";
 
 export const ATTEMPT_CACHE_TTL_CUSTOM_TYPE = "openclaw.cache-ttl";
 
@@ -35,9 +36,12 @@ export function shouldUseOpenAIWebSocketTransport(params: {
   provider: string;
   modelApi?: string | null;
 }): boolean {
+  const provider = normalizeProviderId(params.provider);
+  const modelApi = params.modelApi?.trim().toLowerCase();
+
   return (
-    (params.modelApi === "openai-responses" && params.provider === "openai") ||
-    (params.modelApi === "openai-codex-responses" && params.provider === "openai-codex")
+    (modelApi === "openai-responses" && provider === "openai") ||
+    (modelApi === "openai-codex-responses" && provider === "openai-codex")
   );
 }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -76,6 +76,7 @@ import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settin
 import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
+import { normalizeProviderId } from "../../provider-id.js";
 import { registerProviderStreamForModel } from "../../provider-stream.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
@@ -153,6 +154,7 @@ import {
   stripSessionsYieldArtifacts,
   waitForSessionsYieldAbortSettle,
 } from "./attempt.sessions-yield.js";
+import { wrapStreamFnHandleSensitiveStopReason } from "./attempt.stop-reason-recovery.js";
 import {
   appendAttemptCacheTtlIfNeeded,
   composeSystemPromptWithHookContext,
@@ -164,7 +166,6 @@ import {
   wrapStreamFnDecodeXaiToolCallArguments,
   wrapStreamFnRepairMalformedToolCallArguments,
 } from "./attempt.tool-call-argument-repair.js";
-import { wrapStreamFnHandleSensitiveStopReason } from "./attempt.stop-reason-recovery.js";
 import {
   wrapStreamFnSanitizeMalformedToolCalls,
   wrapStreamFnTrimToolCallNames,
@@ -230,7 +231,11 @@ export function resolveEmbeddedAgentStreamFn(params: {
   }
 
   const currentStreamFn = params.currentStreamFn ?? streamSimple;
-  if (params.shouldUseWebSocketTransport) {
+  const normalizedModelProvider = normalizeProviderId(params.model.provider);
+  const shouldUseOpenAIWebSocketTransport =
+    params.shouldUseWebSocketTransport &&
+    (normalizedModelProvider === "openai" || normalizedModelProvider === "openai-codex");
+  if (shouldUseOpenAIWebSocketTransport) {
     return params.wsApiKey
       ? createOpenAIWebSocketStreamFn(params.wsApiKey, params.sessionId, {
           signal: params.signal,


### PR DESCRIPTION
## Summary
- normalize provider ids before deciding whether the embedded runner should use OpenAI websocket transport
- normalize the websocket helper\'s modelApi/provider matching so whitespace and casing do not silently disable the transport
- add regression coverage for normalized provider values and non-OpenAI providers

## Security
- reviewed the staged patch and confirmed it only touches the four runner/test files in this change
- scanned the staged diff for common secret patterns and found no .env content, API keys, tokens, or private-key material

## Verification
- 
> openclaw@2026.3.28 check:no-conflict-markers /Users/leo/openclaw
> node scripts/check-no-conflict-markers.mjs
- 
> openclaw@2026.3.28 check:host-env-policy:swift /Users/leo/openclaw
> node scripts/generate-host-env-security-policy-swift.mjs --check

OK apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
- attempted targeted vitest runs for the affected files, but the runner did not produce completion output in this local environment