### PR TITLE
fix(telegram): avoid startup hangs in source mode

### DIFF
--- a/extensions/telegram/src/account-inspect.ts
+++ b/extensions/telegram/src/account-inspect.ts
@@ -1,8 +1,10 @@
 import { resolveAccountWithDefaultFallback } from "openclaw/plugin-sdk/account-core";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { coerceSecretRef } from "openclaw/plugin-sdk/config-runtime";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/core";
-import { resolveDefaultSecretProviderAlias } from "openclaw/plugin-sdk/provider-auth";
+import {
+  coerceSecretRef,
+  resolveDefaultSecretProviderAlias,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-auth";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import {
   hasConfiguredSecretInput,

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -1,13 +1,16 @@
 import type { Chat, Message, MessageOrigin, User } from "@grammyjs/types";
-import { formatLocationText, type NormalizedLocation } from "openclaw/plugin-sdk/channel-inbound";
-import { resolveTelegramPreviewStreamMode } from "openclaw/plugin-sdk/config-runtime";
 import type {
   TelegramDirectConfig,
   TelegramGroupConfig,
   TelegramTopicConfig,
-} from "openclaw/plugin-sdk/config-runtime";
-import { readChannelAllowFromStore } from "openclaw/plugin-sdk/conversation-runtime";
-import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
+  NormalizedLocation,
+} from "openclaw/plugin-sdk/telegram-core";
+import {
+  formatLocationText,
+  normalizeAccountId,
+  readChannelAllowFromStore,
+  resolveTelegramPreviewStreamMode,
+} from "openclaw/plugin-sdk/telegram-core";
 import { firstDefined, normalizeAllowFrom, type NormalizedAllowFrom } from "../bot-access.js";
 import { normalizeTelegramReplyToMessageId } from "../outbound-params.js";
 import type { TelegramGetChat, TelegramStreamMode } from "./types.js";

--- a/extensions/telegram/src/channel.runtime.ts
+++ b/extensions/telegram/src/channel.runtime.ts
@@ -1,0 +1,5 @@
+export { auditTelegramGroupMembership, collectTelegramUnmentionedGroupIds } from "./audit.js";
+export { monitorTelegramProvider } from "./monitor.js";
+export { sendTelegramPayloadMessages } from "./outbound-adapter.js";
+export { probeTelegram } from "./probe.js";
+export { sendTypingTelegram } from "./send.js";

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -2,12 +2,16 @@ import {
   buildDmGroupAccountAllowlistAdapter,
   createNestedAllowlistOverrideResolver,
 } from "openclaw/plugin-sdk/allowlist-config-edit";
-import { buildPluginApprovalRequestMessage } from "openclaw/plugin-sdk/approval-runtime";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import { createAllowlistProviderRouteAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import { createChatChannelPlugin } from "openclaw/plugin-sdk/core";
 import { createChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
+import { buildPluginApprovalRequestMessage } from "openclaw/plugin-sdk/exec-approval-runtime";
+import {
+  createLazyRuntimeMethodBinder,
+  createLazyRuntimeModule,
+} from "openclaw/plugin-sdk/lazy-runtime";
 import {
   resolveOutboundSendDep,
   type OutboundSendDeps,
@@ -59,14 +63,10 @@ import {
   resolveTelegramGroupRequireMention,
   resolveTelegramGroupToolPolicy,
 } from "./group-policy.js";
-import * as monitorModule from "./monitor.js";
 import { looksLikeTelegramTargetId, normalizeTelegramMessagingTarget } from "./normalize.js";
-import { sendTelegramPayloadMessages } from "./outbound-adapter.js";
 import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
-import * as probeModule from "./probe.js";
 import type { TelegramProbe } from "./probe.js";
 import { getTelegramRuntime } from "./runtime.js";
-import { sendTypingTelegram } from "./send.js";
 import { telegramSetupAdapter } from "./setup-core.js";
 import { telegramSetupWizard } from "./setup-surface.js";
 import {
@@ -78,6 +78,22 @@ import {
 import { collectTelegramStatusIssues } from "./status-issues.js";
 import { parseTelegramTarget } from "./targets.js";
 
+type TelegramChannelRuntimeModule = typeof import("./channel.runtime.js");
+
+const loadTelegramChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));
+const bindTelegramChannelRuntime = createLazyRuntimeMethodBinder(loadTelegramChannelRuntime);
+const sendTelegramPayloadMessages = bindTelegramChannelRuntime(
+  (runtime) => runtime.sendTelegramPayloadMessages,
+);
+const sendTypingTelegram = bindTelegramChannelRuntime((runtime) => runtime.sendTypingTelegram);
+const probeTelegram = bindTelegramChannelRuntime((runtime) => runtime.probeTelegram);
+const monitorTelegramProvider = bindTelegramChannelRuntime(
+  (runtime) => runtime.monitorTelegramProvider,
+);
+const auditTelegramGroupMembership = bindTelegramChannelRuntime(
+  (runtime) => runtime.auditTelegramGroupMembership,
+);
+
 type TelegramSendFn = ReturnType<
   typeof getTelegramRuntime
 >["channel"]["telegram"]["sendMessageTelegram"];
@@ -85,10 +101,10 @@ type TelegramSendFn = ReturnType<
 type TelegramSendOptions = NonNullable<Parameters<TelegramSendFn>[2]>;
 
 type TelegramStatusRuntimeHelpers = {
-  probeTelegram?: typeof probeModule.probeTelegram;
-  collectTelegramUnmentionedGroupIds?: typeof auditModule.collectTelegramUnmentionedGroupIds;
-  auditTelegramGroupMembership?: typeof auditModule.auditTelegramGroupMembership;
-  monitorTelegramProvider?: typeof monitorModule.monitorTelegramProvider;
+  probeTelegram?: TelegramChannelRuntimeModule["probeTelegram"];
+  collectTelegramUnmentionedGroupIds?: TelegramChannelRuntimeModule["collectTelegramUnmentionedGroupIds"];
+  auditTelegramGroupMembership?: TelegramChannelRuntimeModule["auditTelegramGroupMembership"];
+  monitorTelegramProvider?: TelegramChannelRuntimeModule["monitorTelegramProvider"];
 };
 
 function getTelegramStatusRuntimeHelpers(): TelegramStatusRuntimeHelpers {
@@ -103,7 +119,7 @@ function getTelegramStatusRuntimeHelpers(): TelegramStatusRuntimeHelpers {
 }
 
 function resolveTelegramProbe() {
-  return getTelegramStatusRuntimeHelpers().probeTelegram ?? probeModule.probeTelegram;
+  return getTelegramStatusRuntimeHelpers().probeTelegram ?? probeTelegram;
 }
 
 function resolveTelegramAuditCollector() {
@@ -115,16 +131,12 @@ function resolveTelegramAuditCollector() {
 
 function resolveTelegramAuditMembership() {
   return (
-    getTelegramStatusRuntimeHelpers().auditTelegramGroupMembership ??
-    auditModule.auditTelegramGroupMembership
+    getTelegramStatusRuntimeHelpers().auditTelegramGroupMembership ?? auditTelegramGroupMembership
   );
 }
 
 function resolveTelegramMonitor() {
-  return (
-    getTelegramStatusRuntimeHelpers().monitorTelegramProvider ??
-    monitorModule.monitorTelegramProvider
-  );
+  return getTelegramStatusRuntimeHelpers().monitorTelegramProvider ?? monitorTelegramProvider;
 }
 
 function buildTelegramSendOptions(params: {

--- a/extensions/telegram/src/exec-approval-forwarding.ts
+++ b/extensions/telegram/src/exec-approval-forwarding.ts
@@ -1,9 +1,9 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import {
   buildExecApprovalPendingReplyPayload,
   resolveExecApprovalCommandDisplay,
   type ExecApprovalRequest,
-} from "openclaw/plugin-sdk/approval-runtime";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+} from "openclaw/plugin-sdk/exec-approval-runtime";
 import { normalizeMessageChannel } from "openclaw/plugin-sdk/routing";
 import { buildTelegramExecApprovalButtons } from "./approval-buttons.js";
 import { isTelegramExecApprovalClientEnabled } from "./exec-approvals.js";

--- a/extensions/telegram/src/exec-approvals.ts
+++ b/extensions/telegram/src/exec-approvals.ts
@@ -1,6 +1,6 @@
-import { getExecApprovalReplyMetadata } from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { TelegramExecApprovalConfig } from "openclaw/plugin-sdk/config-runtime";
+import { getExecApprovalReplyMetadata } from "openclaw/plugin-sdk/exec-approval-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { resolveTelegramAccount } from "./accounts.js";

--- a/extensions/telegram/test-api.ts
+++ b/extensions/telegram/test-api.ts
@@ -1,4 +1,18 @@
-export { buildTelegramMessageContextForTest } from "./src/bot-message-context.test-harness.js";
+export async function buildTelegramMessageContextForTest(
+  ...args: Parameters<
+    typeof import("./src/bot-message-context.test-harness.js").buildTelegramMessageContextForTest
+  >
+): Promise<
+  Awaited<
+    ReturnType<
+      typeof import("./src/bot-message-context.test-harness.js").buildTelegramMessageContextForTest
+    >
+  >
+> {
+  const { buildTelegramMessageContextForTest: buildForTest } =
+    await import("./src/bot-message-context.test-harness.js");
+  return await buildForTest(...args);
+}
 export { handleTelegramAction } from "./src/action-runtime.js";
 export { telegramMessageActionRuntime } from "./src/channel-actions.js";
 export { telegramPlugin } from "./src/channel.js";

--- a/package.json
+++ b/package.json
@@ -92,6 +92,10 @@
       "types": "./dist/plugin-sdk/approval-runtime.d.ts",
       "default": "./dist/plugin-sdk/approval-runtime.js"
     },
+    "./plugin-sdk/exec-approval-runtime": {
+      "types": "./dist/plugin-sdk/exec-approval-runtime.d.ts",
+      "default": "./dist/plugin-sdk/exec-approval-runtime.js"
+    },
     "./plugin-sdk/config-runtime": {
       "types": "./dist/plugin-sdk/config-runtime.d.ts",
       "default": "./dist/plugin-sdk/config-runtime.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -13,6 +13,7 @@
   "channel-setup",
   "setup-tools",
   "approval-runtime",
+  "exec-approval-runtime",
   "config-runtime",
   "reply-runtime",
   "reply-payload",

--- a/src/channels/chat-meta.ts
+++ b/src/channels/chat-meta.ts
@@ -64,7 +64,7 @@ function toChatChannelMeta(params: {
 function buildChatChannelMetaById(): Record<ChatChannelId, ChatChannelMeta> {
   const entries = new Map<ChatChannelId, ChatChannelMeta>();
 
-  for (const entry of listBundledPluginMetadata()) {
+  for (const entry of listBundledPluginMetadata({ includeChannelConfigs: false })) {
     const channel =
       entry.packageManifest && "channel" in entry.packageManifest
         ? entry.packageManifest.channel

--- a/src/config/bundled-channel-config-runtime.test.ts
+++ b/src/config/bundled-channel-config-runtime.test.ts
@@ -4,6 +4,7 @@ describe("bundled channel config runtime", () => {
   afterEach(() => {
     vi.resetModules();
     vi.doUnmock("../channels/plugins/bundled.js");
+    vi.doUnmock("../plugins/bundled-plugin-metadata.js");
   });
 
   it("tolerates an unavailable bundled channel list during import", async () => {
@@ -32,5 +33,40 @@ describe("bundled channel config runtime", () => {
 
     expect(configSchemaMap.has("msteams")).toBe(true);
     expect(configSchemaMap.has("whatsapp")).toBe(true);
+  });
+
+  it("does not memoize partial config schema metadata before bundled plugins are readable", async () => {
+    vi.resetModules();
+
+    let pluginsReady = false;
+    vi.doMock("../channels/plugins/bundled.js", () => ({
+      listBundledChannelPlugins: () =>
+        pluginsReady
+          ? [{ id: "telegram", configSchema: { schema: { type: "object", properties: {} } } }]
+          : undefined,
+    }));
+    vi.doMock("../plugins/bundled-plugin-metadata.js", () => ({
+      listBundledPluginMetadata: () =>
+        pluginsReady
+          ? [
+              {
+                manifest: {
+                  id: "telegram",
+                  channelConfigs: {
+                    telegram: { schema: { type: "object", properties: {} } },
+                  },
+                },
+              },
+            ]
+          : [],
+    }));
+
+    const runtime = await import("./bundled-channel-config-runtime.js");
+
+    expect(runtime.getBundledChannelConfigSchemaMap().has("telegram")).toBe(false);
+
+    pluginsReady = true;
+
+    expect(runtime.getBundledChannelConfigSchemaMap().has("telegram")).toBe(true);
   });
 });

--- a/src/config/bundled-channel-config-runtime.ts
+++ b/src/config/bundled-channel-config-runtime.ts
@@ -106,8 +106,16 @@ export function getBundledChannelRuntimeMap(): BundledChannelRuntimeMap {
 }
 
 export function getBundledChannelConfigSchemaMap(): BundledChannelConfigSchemaMap {
-  if (!cachedBundledChannelConfigSchemaMap) {
-    cachedBundledChannelConfigSchemaMap = buildBundledChannelConfigSchemaMap();
+  const plugins = readBundledChannelPlugins();
+  if (plugins && cachedBundledChannelConfigSchemaMap) {
+    return cachedBundledChannelConfigSchemaMap;
   }
-  return cachedBundledChannelConfigSchemaMap;
+
+  const configSchemaMap = buildBundledChannelConfigSchemaMap();
+  // Channel config metadata can be partial while bundled plugin imports are still
+  // stabilizing. Only memoize after the bundled channel list is actually readable.
+  if (plugins) {
+    cachedBundledChannelConfigSchemaMap = configSchemaMap;
+  }
+  return configSchemaMap;
 }

--- a/src/config/bundled-channel-config-runtime.ts
+++ b/src/config/bundled-channel-config-runtime.ts
@@ -14,33 +14,16 @@ type BundledChannelPluginShape = {
   id: string;
   configSchema?: ChannelConfigSchema;
 };
-type BundledChannelMaps = {
-  runtimeMap: Map<string, ChannelConfigRuntimeSchema>;
-  configSchemaMap: Map<string, ChannelConfigSchema>;
-};
 
 const staticBundledChannelSchemas = new Map<string, ChannelConfigSchema>([
   ["msteams", buildChannelConfigSchema(MSTeamsConfigSchema)],
   ["whatsapp", buildChannelConfigSchema(WhatsAppConfigSchema)],
 ]);
-let cachedBundledChannelMaps: BundledChannelMaps | undefined;
+let cachedBundledChannelRuntimeMap: Map<string, ChannelConfigRuntimeSchema> | undefined;
+let cachedBundledChannelConfigSchemaMap: Map<string, ChannelConfigSchema> | undefined;
 
-function buildBundledChannelMaps(
-  plugins: readonly BundledChannelPluginShape[],
-): BundledChannelMaps {
-  const runtimeMap = new Map<string, ChannelConfigRuntimeSchema>();
+function buildBundledChannelConfigSchemaMap(): Map<string, ChannelConfigSchema> {
   const configSchemaMap = new Map<string, ChannelConfigSchema>();
-
-  for (const plugin of plugins) {
-    const channelSchema = plugin.configSchema;
-    if (!channelSchema) {
-      continue;
-    }
-    configSchemaMap.set(plugin.id, channelSchema);
-    if (channelSchema.runtime) {
-      runtimeMap.set(plugin.id, channelSchema.runtime);
-    }
-  }
 
   for (const entry of listBundledPluginMetadata({ includeChannelConfigs: true })) {
     const channelConfigs = entry.manifest.channelConfigs;
@@ -62,12 +45,33 @@ function buildBundledChannelMaps(
     if (!configSchemaMap.has(channelId)) {
       configSchemaMap.set(channelId, channelSchema);
     }
+  }
+
+  return configSchemaMap;
+}
+
+function buildBundledChannelRuntimeMap(
+  plugins: readonly BundledChannelPluginShape[],
+): Map<string, ChannelConfigRuntimeSchema> {
+  const runtimeMap = new Map<string, ChannelConfigRuntimeSchema>();
+
+  for (const plugin of plugins) {
+    const channelSchema = plugin.configSchema;
+    if (!channelSchema) {
+      continue;
+    }
+    if (channelSchema.runtime) {
+      runtimeMap.set(plugin.id, channelSchema.runtime);
+    }
+  }
+
+  for (const [channelId, channelSchema] of staticBundledChannelSchemas) {
     if (channelSchema.runtime && !runtimeMap.has(channelId)) {
       runtimeMap.set(channelId, channelSchema.runtime);
     }
   }
 
-  return { runtimeMap, configSchemaMap };
+  return runtimeMap;
 }
 
 function readBundledChannelPlugins(): readonly BundledChannelPluginShape[] | undefined {
@@ -87,25 +91,23 @@ function readBundledChannelPlugins(): readonly BundledChannelPluginShape[] | und
   }
 }
 
-function getBundledChannelMaps(): BundledChannelMaps {
-  const plugins = readBundledChannelPlugins();
-  if (plugins && cachedBundledChannelMaps) {
-    return cachedBundledChannelMaps;
-  }
-
-  const maps = buildBundledChannelMaps(plugins ?? []);
-  // Tests and some import cycles can temporarily expose an incomplete bundled list.
-  // Only cache once the exported plugin array is actually available.
-  if (plugins) {
-    cachedBundledChannelMaps = maps;
-  }
-  return maps;
-}
-
 export function getBundledChannelRuntimeMap(): BundledChannelRuntimeMap {
-  return getBundledChannelMaps().runtimeMap;
+  const plugins = readBundledChannelPlugins();
+  if (plugins && cachedBundledChannelRuntimeMap) {
+    return cachedBundledChannelRuntimeMap;
+  }
+
+  const runtimeMap = buildBundledChannelRuntimeMap(plugins ?? []);
+  // Only cache once the bundled channel list is actually available.
+  if (plugins) {
+    cachedBundledChannelRuntimeMap = runtimeMap;
+  }
+  return runtimeMap;
 }
 
 export function getBundledChannelConfigSchemaMap(): BundledChannelConfigSchemaMap {
-  return getBundledChannelMaps().configSchemaMap;
+  if (!cachedBundledChannelConfigSchemaMap) {
+    cachedBundledChannelConfigSchemaMap = buildBundledChannelConfigSchemaMap();
+  }
+  return cachedBundledChannelConfigSchemaMap;
 }

--- a/src/config/slack-http-config.test.ts
+++ b/src/config/slack-http-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { validateConfigObject } from "./config.js";
+import { validateConfigObject } from "./validation.js";
 
 describe("Slack HTTP mode config", () => {
   it("accepts HTTP mode when signing secret is configured", () => {

--- a/src/config/zod-schema.signal-groups.test.ts
+++ b/src/config/zod-schema.signal-groups.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { validateConfigObject } from "./config.js";
+import { validateConfigObject } from "./validation.js";
 
 describe("signal groups schema", () => {
   it("accepts top-level Signal groups overrides", () => {

--- a/src/infra/matrix-account-selection.test.ts
+++ b/src/infra/matrix-account-selection.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   findMatrixAccountEntry,
+  getMatrixScopedEnvVarNames,
   resolveConfiguredMatrixAccountIds,
   resolveMatrixDefaultOrOnlyAccountId,
   requiresExplicitMatrixDefaultAccount,
-} from "../../extensions/matrix/src/account-selection.ts";
-import { getMatrixScopedEnvVarNames } from "../../extensions/matrix/src/env-vars.ts";
+} from "../../extensions/matrix/api.ts";
 import type { OpenClawConfig } from "../config/config.js";
 
 describe("matrix account selection", () => {

--- a/src/infra/matrix-account-selection.test.ts
+++ b/src/infra/matrix-account-selection.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { OpenClawConfig } from "../config/config.js";
 import {
   findMatrixAccountEntry,
-  getMatrixScopedEnvVarNames,
-  requiresExplicitMatrixDefaultAccount,
   resolveConfiguredMatrixAccountIds,
   resolveMatrixDefaultOrOnlyAccountId,
-} from "../plugin-sdk/matrix.js";
+  requiresExplicitMatrixDefaultAccount,
+} from "../../extensions/matrix/src/account-selection.ts";
+import { getMatrixScopedEnvVarNames } from "../../extensions/matrix/src/env-vars.ts";
+import type { OpenClawConfig } from "../config/config.js";
 
 describe("matrix account selection", () => {
   it("resolves configured account ids from non-canonical account keys", () => {

--- a/src/plugin-sdk/exec-approval-runtime.ts
+++ b/src/plugin-sdk/exec-approval-runtime.ts
@@ -1,0 +1,10 @@
+// Narrow exec-approval helpers for channel plugins that only need reply metadata
+// and payload formatting, without loading the broader approval runtime surface.
+
+export type { ExecApprovalRequest } from "../infra/exec-approvals.js";
+export {
+  buildExecApprovalPendingReplyPayload,
+  getExecApprovalReplyMetadata,
+} from "../infra/exec-approval-reply.js";
+export { resolveExecApprovalCommandDisplay } from "../infra/exec-approval-command-display.js";
+export { buildPluginApprovalRequestMessage } from "../infra/plugin-approvals.js";

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -7,7 +7,10 @@ import { loadBundledPluginPublicSurfaceModuleSync } from "./facade-runtime.js";
 
 const tempDirs: string[] = [];
 const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
-const FACADE_RUNTIME_MODULE_PATH = fileURLToPath(new URL("./facade-runtime.ts", import.meta.url));
+const FACADE_RUNTIME_MODULE_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  `facade-runtime${path.extname(fileURLToPath(import.meta.url))}`,
+);
 
 function createBundledPluginDir(prefix: string, marker: string): string {
   const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -1,11 +1,13 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadBundledPluginPublicSurfaceModuleSync } from "./facade-runtime.js";
 
 const tempDirs: string[] = [];
 const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+const FACADE_RUNTIME_MODULE_PATH = fileURLToPath(new URL("./facade-runtime.ts", import.meta.url));
 
 function createBundledPluginDir(prefix: string, marker: string): string {
   const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -14,6 +16,23 @@ function createBundledPluginDir(prefix: string, marker: string): string {
   fs.writeFileSync(
     path.join(rootDir, "demo", "api.js"),
     `export const marker = ${JSON.stringify(marker)};\n`,
+    "utf8",
+  );
+  return rootDir;
+}
+
+function createReentrantBundledPluginDir(prefix: string): string {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(rootDir);
+  fs.mkdirSync(path.join(rootDir, "demo"), { recursive: true });
+  fs.writeFileSync(
+    path.join(rootDir, "demo", "api.js"),
+    [
+      `import { loadBundledPluginPublicSurfaceModuleSync } from ${JSON.stringify(FACADE_RUNTIME_MODULE_PATH)};`,
+      `export const recurse = loadBundledPluginPublicSurfaceModuleSync({ dirName: "demo", artifactBasename: "api.js" });`,
+      `export const marker = "reentrant-ok";`,
+      "",
+    ].join("\n"),
     "utf8",
   );
   return rootDir;
@@ -49,5 +68,21 @@ describe("plugin-sdk facade runtime", () => {
       artifactBasename: "api.js",
     });
     expect(fromB.marker).toBe("override-b");
+  });
+
+  it("returns a placeholder during reentrant facade loads instead of recursing forever", () => {
+    const override = createReentrantBundledPluginDir("openclaw-facade-runtime-reentrant-");
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = override;
+
+    const loaded = loadBundledPluginPublicSurfaceModuleSync<{
+      marker: string;
+      recurse: { marker: string };
+    }>({
+      dirName: "demo",
+      artifactBasename: "api.js",
+    });
+
+    expect(loaded.marker).toBe("reentrant-ok");
+    expect(loaded.recurse.marker).toBe("reentrant-ok");
   });
 });

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -21,6 +21,7 @@ const CURRENT_MODULE_PATH = fileURLToPath(import.meta.url);
 const PUBLIC_SURFACE_SOURCE_EXTENSIONS = [".ts", ".mts", ".js", ".mjs", ".cts", ".cjs"] as const;
 const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
 const loadedFacadeModules = new Map<string, unknown>();
+const inProgressFacadeModules = new Map<string, unknown>();
 
 function resolveSourceFirstPublicSurfacePath(params: {
   bundledPluginsDir?: string;
@@ -182,6 +183,10 @@ export function loadBundledPluginPublicSurfaceModuleSync<T>(params: {
   if (cached) {
     return cached as T;
   }
+  const inProgress = inProgressFacadeModules.get(location.modulePath);
+  if (inProgress) {
+    return inProgress as T;
+  }
 
   const opened = openBoundaryFileSync({
     absolutePath: location.modulePath,
@@ -200,7 +205,21 @@ export function loadBundledPluginPublicSurfaceModuleSync<T>(params: {
   }
   fs.closeSync(opened.fd);
 
-  const loaded = getJiti(location.modulePath)(location.modulePath) as T;
-  loadedFacadeModules.set(location.modulePath, loaded);
-  return loaded;
+  const reentrantPlaceholder = createLazyFacadeObjectValue(() => {
+    const resolved = loadedFacadeModules.get(location.modulePath);
+    if (!resolved) {
+      throw new Error(
+        `Bundled plugin public surface ${params.dirName}/${params.artifactBasename} was accessed before initialization completed`,
+      );
+    }
+    return resolved as object;
+  });
+  inProgressFacadeModules.set(location.modulePath, reentrantPlaceholder);
+  try {
+    const loaded = getJiti(location.modulePath)(location.modulePath) as T;
+    loadedFacadeModules.set(location.modulePath, loaded);
+    return loaded;
+  } finally {
+    inProgressFacadeModules.delete(location.modulePath);
+  }
 }

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -205,18 +205,19 @@ export function loadBundledPluginPublicSurfaceModuleSync<T>(params: {
   }
   fs.closeSync(opened.fd);
 
-  const reentrantPlaceholder = createLazyFacadeObjectValue(() => {
-    const resolved = loadedFacadeModules.get(location.modulePath);
-    if (!resolved) {
-      throw new Error(
-        `Bundled plugin public surface ${params.dirName}/${params.artifactBasename} was accessed before initialization completed`,
-      );
-    }
-    return resolved as object;
-  });
+  const reentrantPlaceholder: Record<PropertyKey, unknown> = {};
   inProgressFacadeModules.set(location.modulePath, reentrantPlaceholder);
   try {
     const loaded = getJiti(location.modulePath)(location.modulePath) as T;
+    if (loaded && typeof loaded === "object") {
+      Object.defineProperties(
+        reentrantPlaceholder,
+        Object.getOwnPropertyDescriptors(loaded as object),
+      );
+      Object.setPrototypeOf(reentrantPlaceholder, Object.getPrototypeOf(loaded as object));
+      loadedFacadeModules.set(location.modulePath, reentrantPlaceholder);
+      return reentrantPlaceholder as T;
+    }
     loadedFacadeModules.set(location.modulePath, loaded);
     return loaded;
   } finally {

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -205,6 +205,8 @@ export function loadBundledPluginPublicSurfaceModuleSync<T>(params: {
   }
   fs.closeSync(opened.fd);
 
+  // Reentrant callers may capture this placeholder during synchronous loading,
+  // but they must not read its properties until the outer load completes.
   const reentrantPlaceholder: Record<PropertyKey, unknown> = {};
   inProgressFacadeModules.set(location.modulePath, reentrantPlaceholder);
   try {

--- a/src/plugin-sdk/telegram-core.ts
+++ b/src/plugin-sdk/telegram-core.ts
@@ -10,7 +10,10 @@ export type { OpenClawPluginApi } from "../plugins/types.js";
 export type {
   TelegramAccountConfig,
   TelegramActionConfig,
+  TelegramDirectConfig,
+  TelegramGroupConfig,
   TelegramNetworkConfig,
+  TelegramTopicConfig,
 } from "../config/types.js";
 export type {
   ChannelConfiguredBindingProvider,
@@ -52,3 +55,7 @@ export {
 export { TelegramConfigSchema } from "../config/zod-schema.providers-core.js";
 export { resolvePollMaxSelections } from "../polls.js";
 export { buildTokenChannelStatusSummary } from "./status-helpers.js";
+export { readChannelAllowFromStore } from "../pairing/pairing-store.js";
+export { resolveTelegramPreviewStreamMode } from "../config/discord-preview-streaming.js";
+export type { NormalizedLocation } from "../channels/location.js";
+export { formatLocationText } from "../channels/location.js";

--- a/src/plugins/contracts/discovery.contract.test.ts
+++ b/src/plugins/contracts/discovery.contract.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import type { ModelDefinitionConfig } from "../../config/types.models.js";
 import {
-  loadBundledPluginPublicSurfaceSync,
+  loadBundledPluginPublicSurface,
   resolveRelativeBundledPluginPublicModuleId,
 } from "../../test-utils/bundled-plugin-public-surface.js";
 import { registerProviders, requireProvider } from "./testkit.js";
@@ -217,25 +217,25 @@ describe("provider discovery contract", () => {
       { default: modelStudioPlugin },
       { default: cloudflareAiGatewayPlugin },
     ] = await Promise.all([
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "github-copilot", artifactBasename: "index.js" }),
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "ollama", artifactBasename: "index.js" }),
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "vllm", artifactBasename: "index.js" }),
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "sglang", artifactBasename: "index.js" }),
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "minimax", artifactBasename: "index.js" }),
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "modelstudio", artifactBasename: "index.js" }),
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "cloudflare-ai-gateway", artifactBasename: "index.js" }),
     ]);

--- a/src/plugins/contracts/telegram-loader.contract.test.ts
+++ b/src/plugins/contracts/telegram-loader.contract.test.ts
@@ -1,0 +1,27 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+describe("telegram bundled plugin loader", () => {
+  it("loads the telegram channel plugin entry without recursive facade overflow", () => {
+    const childCode = [
+      'const path = require("node:path");',
+      'const { createJiti } = require("jiti");',
+      'const jiti = createJiti(path.join(process.cwd(), "debug-probe.cjs"));',
+      'const { loadBundledPluginPublicSurfaceSync } = jiti("./src/test-utils/bundled-plugin-public-surface.ts");',
+      'const mod = loadBundledPluginPublicSurfaceSync({ pluginId: "telegram", artifactBasename: "index.js" });',
+      'console.log(mod?.default?.id ?? "missing-id");',
+    ].join("\n");
+
+    const result = spawnSync(process.execPath, ["-e", childCode], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      timeout: 20_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("Maximum call stack size exceeded");
+    expect(result.stdout.trim()).toBe("telegram");
+  });
+});

--- a/src/test-utils/bundled-plugin-public-surface.ts
+++ b/src/test-utils/bundled-plugin-public-surface.ts
@@ -1,5 +1,6 @@
+import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { loadBundledPluginPublicSurfaceModuleSync } from "../plugin-sdk/facade-runtime.js";
 import {
   findBundledPluginMetadataById,
@@ -12,6 +13,7 @@ const OPENCLAW_PACKAGE_ROOT =
     modulePath: fileURLToPath(import.meta.url),
     moduleUrl: import.meta.url,
   }) ?? fileURLToPath(new URL("../..", import.meta.url));
+const SOURCE_FIRST_EXTENSIONS = [".ts", ".mts", ".js", ".mjs", ".cts", ".cjs"] as const;
 
 function findBundledPluginMetadata(pluginId: string): BundledPluginMetadata {
   const metadata = findBundledPluginMetadataById(pluginId);
@@ -19,6 +21,25 @@ function findBundledPluginMetadata(pluginId: string): BundledPluginMetadata {
     throw new Error(`Unknown bundled plugin id: ${pluginId}`);
   }
   return metadata;
+}
+
+function resolveBundledPluginPublicSurfaceTargetPath(params: {
+  pluginId: string;
+  artifactBasename: string;
+}): string {
+  const metadata = findBundledPluginMetadata(params.pluginId);
+  const targetPath = path.resolve(
+    OPENCLAW_PACKAGE_ROOT,
+    "extensions",
+    metadata.dirName,
+    params.artifactBasename,
+  );
+  const targetRoot = targetPath.replace(/\.[cm]?[jt]s$/u, "");
+  return (
+    SOURCE_FIRST_EXTENSIONS.map((ext) => `${targetRoot}${ext}`).find((candidate) =>
+      fs.existsSync(candidate),
+    ) ?? targetPath
+  );
 }
 
 export function loadBundledPluginPublicSurfaceSync<T>(params: {
@@ -30,6 +51,14 @@ export function loadBundledPluginPublicSurfaceSync<T>(params: {
     dirName: metadata.dirName,
     artifactBasename: params.artifactBasename,
   });
+}
+
+export async function loadBundledPluginPublicSurface<T>(params: {
+  pluginId: string;
+  artifactBasename: string;
+}): Promise<T> {
+  const modulePath = resolveBundledPluginPublicSurfaceTargetPath(params);
+  return (await import(pathToFileURL(modulePath).href)) as T;
 }
 
 export function loadBundledPluginTestApiSync<T>(pluginId: string): T {
@@ -44,16 +73,10 @@ export function resolveRelativeBundledPluginPublicModuleId(params: {
   pluginId: string;
   artifactBasename: string;
 }): string {
-  const metadata = findBundledPluginMetadata(params.pluginId);
   const fromFilePath = fileURLToPath(params.fromModuleUrl);
-  const targetPath = path.resolve(
-    OPENCLAW_PACKAGE_ROOT,
-    "extensions",
-    metadata.dirName,
-    params.artifactBasename,
-  );
+  const resolvedTargetPath = resolveBundledPluginPublicSurfaceTargetPath(params);
   const relativePath = path
-    .relative(path.dirname(fromFilePath), targetPath)
+    .relative(path.dirname(fromFilePath), resolvedTargetPath)
     .replaceAll(path.sep, "/");
   return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
 }

--- a/test/helpers/channels/inbound-contract.ts
+++ b/test/helpers/channels/inbound-contract.ts
@@ -33,23 +33,8 @@ const { createInboundSlackTestContext, prepareSlackMessage } = loadBundledPlugin
     opts: { source: string };
   }) => Promise<SlackPrepareResult>;
 }>("slack");
-const { telegramHarnessModuleId, signalApiModuleId, whatsAppTestApiModuleId } = vi.hoisted(() => ({
-  telegramHarnessModuleId: resolveRelativeBundledPluginPublicModuleId({
-    fromModuleUrl: import.meta.url,
-    pluginId: "telegram",
-    artifactBasename: "src/bot-message-context.test-harness.js",
-  }),
-  signalApiModuleId: resolveRelativeBundledPluginPublicModuleId({
-    fromModuleUrl: import.meta.url,
-    pluginId: "signal",
-    artifactBasename: "api.js",
-  }),
-  whatsAppTestApiModuleId: resolveRelativeBundledPluginPublicModuleId({
-    fromModuleUrl: import.meta.url,
-    pluginId: "whatsapp",
-    artifactBasename: "test-api.js",
-  }),
-}));
+const telegramHarnessModuleId =
+  "../../../extensions/telegram/src/bot-message-context.test-harness.js";
 
 async function buildTelegramMessageContextForTest(params: {
   cfg: OpenClawConfig;

--- a/test/helpers/channels/inbound-contract.ts
+++ b/test/helpers/channels/inbound-contract.ts
@@ -4,10 +4,7 @@ import { inboundCtxCapture } from "../../../src/channels/plugins/contracts/inbou
 import { expectChannelInboundContextContract } from "../../../src/channels/plugins/contracts/suites.js";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import type { ResolvedSlackAccount } from "../../../src/plugin-sdk/slack.js";
-import {
-  loadBundledPluginTestApiSync,
-  resolveRelativeBundledPluginPublicModuleId,
-} from "../../../src/test-utils/bundled-plugin-public-surface.js";
+import { loadBundledPluginTestApiSync } from "../../../src/test-utils/bundled-plugin-public-surface.js";
 import { withTempHome } from "../temp-home.js";
 
 type SlackMessageEvent = {
@@ -108,7 +105,7 @@ vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
   };
 });
 
-vi.mock(signalApiModuleId, () => ({
+vi.mock("../../../extensions/signal/api.js", () => ({
   sendMessageSignal: vi.fn(),
   sendTypingSignal: vi.fn(async () => true),
   sendReadReceiptSignal: vi.fn(async () => true),
@@ -119,7 +116,7 @@ vi.mock("../../../src/pairing/pairing-store.js", () => ({
   upsertChannelPairingRequest: vi.fn(),
 }));
 
-vi.mock(whatsAppTestApiModuleId, async (importOriginal) => {
+vi.mock("../../../extensions/whatsapp/test-api.js", async (importOriginal) => {
   const actual = await importOriginal<object>();
   return {
     ...actual,

--- a/test/helpers/channels/outbound-payload-contract.ts
+++ b/test/helpers/channels/outbound-payload-contract.ts
@@ -12,10 +12,7 @@ import {
   sendPayloadWithChunkedTextAndMedia as sendZaloPayloadWithChunkedTextAndMedia,
 } from "../../../src/plugin-sdk/zalo.js";
 import { sendPayloadWithChunkedTextAndMedia as sendZalouserPayloadWithChunkedTextAndMedia } from "../../../src/plugin-sdk/zalouser.js";
-import {
-  loadBundledPluginTestApiSync,
-  resolveRelativeBundledPluginPublicModuleId,
-} from "../../../src/test-utils/bundled-plugin-public-surface.js";
+import { loadBundledPluginTestApiSync } from "../../../src/test-utils/bundled-plugin-public-surface.js";
 
 type ChannelSendResponse = { ok?: boolean; messageId?: string };
 type SendMessageZalo = (
@@ -44,20 +41,7 @@ const { sendMessageZalouser, parseZalouserOutboundTarget } = loadBundledPluginTe
   parseZalouserOutboundTarget: ParseZalouserOutboundTarget;
 }>("zalouser");
 
-const { zaloTestApiModuleId, zalouserTestApiModuleId } = vi.hoisted(() => ({
-  zaloTestApiModuleId: resolveRelativeBundledPluginPublicModuleId({
-    fromModuleUrl: import.meta.url,
-    pluginId: "zalo",
-    artifactBasename: "test-api.js",
-  }),
-  zalouserTestApiModuleId: resolveRelativeBundledPluginPublicModuleId({
-    fromModuleUrl: import.meta.url,
-    pluginId: "zalouser",
-    artifactBasename: "test-api.js",
-  }),
-}));
-
-vi.mock(zaloTestApiModuleId, async (importOriginal) => {
+vi.mock("../../../extensions/zalo/test-api.js", async (importOriginal) => {
   const actual = await importOriginal<object>();
   return {
     ...actual,
@@ -65,7 +49,7 @@ vi.mock(zaloTestApiModuleId, async (importOriginal) => {
   };
 });
 
-vi.mock(zalouserTestApiModuleId, async (importOriginal) => {
+vi.mock("../../../extensions/zalouser/test-api.js", async (importOriginal) => {
   const actual = await importOriginal<object>();
   return {
     ...actual,

--- a/test/helpers/plugins/bluebubbles-monitor.ts
+++ b/test/helpers/plugins/bluebubbles-monitor.ts
@@ -1,27 +1,16 @@
 import type { HistoryEntry, PluginRuntime } from "openclaw/plugin-sdk/bluebubbles";
 import { vi } from "vitest";
-import { loadBundledPluginPublicSurfaceSync } from "../../../src/test-utils/bundled-plugin-public-surface.js";
+import {
+  _resetBlueBubblesShortIdState,
+  clearBlueBubblesWebhookSecurityStateForTest,
+} from "../../../extensions/bluebubbles/src/monitor.ts";
+import { setBlueBubblesRuntime } from "../../../extensions/bluebubbles/src/runtime.ts";
 import { createPluginRuntimeMock } from "./plugin-runtime-mock.js";
 
 type BlueBubblesHistoryFetchResult = {
   entries: HistoryEntry[];
   resolved: boolean;
 };
-
-const { _resetBlueBubblesShortIdState, clearBlueBubblesWebhookSecurityStateForTest } =
-  loadBundledPluginPublicSurfaceSync<{
-    _resetBlueBubblesShortIdState: () => void;
-    clearBlueBubblesWebhookSecurityStateForTest: () => void;
-  }>({
-    pluginId: "bluebubbles",
-    artifactBasename: "src/monitor.js",
-  });
-const { setBlueBubblesRuntime } = loadBundledPluginPublicSurfaceSync<{
-  setBlueBubblesRuntime: (runtime: PluginRuntime) => void;
-}>({
-  pluginId: "bluebubbles",
-  artifactBasename: "src/runtime.js",
-});
 
 export type DispatchReplyParams = Parameters<
   PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"]

--- a/test/helpers/plugins/discord-provider.test-support.ts
+++ b/test/helpers/plugins/discord-provider.test-support.ts
@@ -2,7 +2,6 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { Mock } from "vitest";
 import { expect, vi } from "vitest";
 import type { OpenClawConfig } from "../../../src/plugin-sdk/discord.js";
-import { resolveRelativeBundledPluginPublicModuleId } from "../../../src/test-utils/bundled-plugin-public-surface.js";
 
 export type NativeCommandSpecMock = {
   name: string;
@@ -146,11 +145,7 @@ const providerMonitorTestMocks: ProviderMonitorTestMocks = vi.hoisted(() => {
 });
 
 function buildDiscordSourceModuleId(artifactBasename: string): string {
-  return resolveRelativeBundledPluginPublicModuleId({
-    fromModuleUrl: import.meta.url,
-    pluginId: "discord",
-    artifactBasename: `src/${artifactBasename}`,
-  });
+  return `../../../extensions/discord/src/${artifactBasename}`;
 }
 
 const {

--- a/test/helpers/plugins/jiti-runtime-api.ts
+++ b/test/helpers/plugins/jiti-runtime-api.ts
@@ -132,7 +132,7 @@ function collectPluginSdkAliases(params: {
   const realSpecifiers = new Set<string>();
   const stubSpecifiers = new Set<string>();
   const visitedFiles = new Set<string>();
-  const stubPath = path.join(params.root, "test", "helpers", "extensions", "plugin-sdk-stub.cjs");
+  const stubPath = path.join(params.root, "test", "helpers", "plugins", "plugin-sdk-stub.cjs");
   const explicitRealSpecifiers = new Set(params.realPluginSdkSpecifiers ?? []);
 
   function visitModule(filePath: string, rootModule: boolean): void {

--- a/test/helpers/plugins/provider-discovery-contract.ts
+++ b/test/helpers/plugins/provider-discovery-contract.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "../../../src/config/config.js";
 import type { ModelDefinitionConfig } from "../../../src/config/types.models.js";
 import { registerProviders, requireProvider } from "../../../src/plugins/contracts/testkit.js";
 import {
-  loadBundledPluginPublicSurfaceSync,
+  loadBundledPluginPublicSurface,
   resolveRelativeBundledPluginPublicModuleId,
 } from "../../../src/test-utils/bundled-plugin-public-surface.js";
 
@@ -186,25 +186,25 @@ function installDiscoveryHooks(state: DiscoveryState) {
       { default: modelStudioPlugin },
       { default: cloudflareAiGatewayPlugin },
     ] = await Promise.all([
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "github-copilot", artifactBasename: "index.js" }),
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "ollama", artifactBasename: "index.js" }),
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "vllm", artifactBasename: "index.js" }),
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "sglang", artifactBasename: "index.js" }),
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "minimax", artifactBasename: "index.js" }),
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "modelstudio", artifactBasename: "index.js" }),
-      loadBundledPluginPublicSurfaceSync<{
+      loadBundledPluginPublicSurface<{
         default: Parameters<typeof registerProviders>[0];
       }>({ pluginId: "cloudflare-ai-gateway", artifactBasename: "index.js" }),
     ]);

--- a/test/helpers/plugins/zalo-lifecycle.ts
+++ b/test/helpers/plugins/zalo-lifecycle.ts
@@ -3,10 +3,7 @@ import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/zalo";
 import { expect, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../../../src/plugins/registry.js";
 import { setActivePluginRegistry } from "../../../src/plugins/runtime.js";
-import {
-  loadBundledPluginPublicSurfaceSync,
-  resolveRelativeBundledPluginPublicModuleId,
-} from "../../../src/test-utils/bundled-plugin-public-surface.js";
+import { loadBundledPluginPublicSurfaceSync } from "../../../src/test-utils/bundled-plugin-public-surface.js";
 import { withServer } from "../http-test-server.js";
 import { createPluginRuntimeMock } from "./plugin-runtime-mock.js";
 import { createRuntimeEnv } from "./runtime-env.js";
@@ -45,17 +42,6 @@ const { normalizeSecretInputString } = loadBundledPluginPublicSurfaceSync<{
   artifactBasename: "src/secret-input.js",
 });
 
-const zaloApiModuleId = resolveRelativeBundledPluginPublicModuleId({
-  fromModuleUrl: import.meta.url,
-  pluginId: "zalo",
-  artifactBasename: "src/api.js",
-});
-const zaloRuntimeModuleId = resolveRelativeBundledPluginPublicModuleId({
-  fromModuleUrl: import.meta.url,
-  pluginId: "zalo",
-  artifactBasename: "src/runtime.js",
-});
-
 const lifecycleMocks = vi.hoisted(() => ({
   setWebhookMock: vi.fn(async () => ({ ok: true, result: { url: "" } })),
   deleteWebhookMock: vi.fn(async () => ({ ok: true, result: { url: "" } })),
@@ -79,7 +65,7 @@ export const sendMessageMock = lifecycleMocks.sendMessageMock;
 export const sendPhotoMock = lifecycleMocks.sendPhotoMock;
 export const getZaloRuntimeMock = lifecycleMocks.getZaloRuntimeMock;
 
-vi.mock(zaloApiModuleId, async (importOriginal) => {
+vi.mock("../../../extensions/zalo/src/api.ts", async (importOriginal) => {
   const actual = await importOriginal<object>();
   return {
     ...actual,
@@ -93,7 +79,7 @@ vi.mock(zaloApiModuleId, async (importOriginal) => {
   };
 });
 
-vi.mock(zaloRuntimeModuleId, () => ({
+vi.mock("../../../extensions/zalo/src/runtime.ts", () => ({
   getZaloRuntime: lifecycleMocks.getZaloRuntimeMock,
 }));
 


### PR DESCRIPTION
## Summary
- add a generic reentrant facade placeholder so same-surface recursive loads do not overflow the stack
- slim Telegram startup imports by moving heavy channel runtime operations behind a lazy runtime module and replacing broad approval/runtime barrels with narrower seams
- avoid pulling channel config schemas while deriving chat metadata, and add a bundled Telegram loader regression test that asserts the channel entry loads without a stack overflow

## Testing
- pnpm exec vitest run src/plugin-sdk/facade-runtime.test.ts src/plugins/contracts/telegram-loader.contract.test.ts src/plugin-sdk/subpaths.test.ts src/plugin-sdk/package-contract-guardrails.test.ts
- pnpm build

Closes #57130