### PR TITLE
Persist fallback model overrides before retrying

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -44,11 +44,13 @@ import {
   buildEmbeddedRunExecutionParams,
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
+import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import { type BlockReplyPipeline } from "./block-reply-pipeline.js";
 import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.runtime.js";
 import type { TypingSignaler } from "./typing-mode.js";
+import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 
 export type RuntimeFallbackAttempt = {
   provider: string;
@@ -144,6 +146,42 @@ export async function runAgentTurnWithFallback(params: {
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
   );
+  // Persist the fallback candidate before the next attempt starts so any
+  // live-session reconciliation observes the selected model instead of the
+  // previous primary/default selection.
+  const persistFallbackCandidateSelection = async (provider: string, model: string) => {
+    if (
+      !params.sessionKey ||
+      !params.activeSessionStore ||
+      (provider === params.followupRun.run.provider && model === params.followupRun.run.model)
+    ) {
+      return;
+    }
+
+    const activeSessionEntry =
+      params.getActiveSessionEntry() ?? params.activeSessionStore[params.sessionKey];
+    if (!activeSessionEntry) {
+      return;
+    }
+
+    const scopedAuthProfile = resolveRunAuthProfile(params.followupRun.run, provider);
+    const { updated } = applyModelOverrideToSessionEntry({
+      entry: activeSessionEntry,
+      selection: { provider, model },
+      profileOverride: scopedAuthProfile.authProfileId,
+      profileOverrideSource: scopedAuthProfile.authProfileIdSource,
+    });
+    if (!updated) {
+      return;
+    }
+
+    params.activeSessionStore[params.sessionKey] = activeSessionEntry;
+    if (params.storePath) {
+      await updateSessionStore(params.storePath, (store) => {
+        store[params.sessionKey!] = activeSessionEntry;
+      });
+    }
+  };
 
   while (true) {
     try {
@@ -220,7 +258,7 @@ export async function runAgentTurnWithFallback(params: {
       const fallbackResult = await runWithModelFallback({
         ...resolveModelFallbackOptions(params.followupRun.run),
         runId,
-        run: (provider, model, runOptions) => {
+        run: async (provider, model, runOptions) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.
           params.opts?.onModelSelected?.({
@@ -228,6 +266,8 @@ export async function runAgentTurnWithFallback(params: {
             model,
             thinkLevel: params.followupRun.run.thinkLevel,
           });
+
+          await persistFallbackCandidateSelection(provider, model);
 
           if (isCliProvider(provider, params.followupRun.run.config)) {
             const startedAt = Date.now();

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -178,7 +178,7 @@ export async function runAgentTurnWithFallback(params: {
       return;
     }
 
-    const writeEntry = async (snapshot: SessionEntry) => {
+    const applySnapshot = (snapshot: SessionEntry) => {
       for (const key of Object.keys(activeSessionEntry)) {
         if (!(key in snapshot)) {
           delete activeSessionEntry[key as keyof SessionEntry];
@@ -186,6 +186,9 @@ export async function runAgentTurnWithFallback(params: {
       }
       Object.assign(activeSessionEntry, snapshot);
       params.activeSessionStore![params.sessionKey!] = activeSessionEntry;
+    };
+
+    const persistEntry = async () => {
       if (params.storePath) {
         await updateSessionStore(params.storePath, (store) => {
           store[params.sessionKey!] = activeSessionEntry;
@@ -193,10 +196,17 @@ export async function runAgentTurnWithFallback(params: {
       }
     };
 
-    await writeEntry(activeSessionEntry);
+    applySnapshot(activeSessionEntry);
+    try {
+      await persistEntry();
+    } catch (error) {
+      applySnapshot(previousEntry);
+      throw error;
+    }
 
     return async () => {
-      await writeEntry({ ...previousEntry });
+      applySnapshot({ ...previousEntry });
+      await persistEntry();
     };
   };
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -148,7 +148,8 @@ export async function runAgentTurnWithFallback(params: {
   );
   // Persist the fallback candidate before the next attempt starts so any
   // live-session reconciliation observes the selected model instead of the
-  // previous primary/default selection.
+  // previous primary/default selection. Skip only when this is the no-op
+  // primary attempt and there is nothing new to persist.
   const persistFallbackCandidateSelection = async (provider: string, model: string) => {
     if (
       !params.sessionKey ||
@@ -164,6 +165,8 @@ export async function runAgentTurnWithFallback(params: {
       return;
     }
 
+    const previousEntry = { ...activeSessionEntry };
+
     const scopedAuthProfile = resolveRunAuthProfile(params.followupRun.run, provider);
     const { updated } = applyModelOverrideToSessionEntry({
       entry: activeSessionEntry,
@@ -175,12 +178,26 @@ export async function runAgentTurnWithFallback(params: {
       return;
     }
 
-    params.activeSessionStore[params.sessionKey] = activeSessionEntry;
-    if (params.storePath) {
-      await updateSessionStore(params.storePath, (store) => {
-        store[params.sessionKey!] = activeSessionEntry;
-      });
-    }
+    const writeEntry = async (snapshot: SessionEntry) => {
+      for (const key of Object.keys(activeSessionEntry)) {
+        if (!(key in snapshot)) {
+          delete activeSessionEntry[key as keyof SessionEntry];
+        }
+      }
+      Object.assign(activeSessionEntry, snapshot);
+      params.activeSessionStore![params.sessionKey!] = activeSessionEntry;
+      if (params.storePath) {
+        await updateSessionStore(params.storePath, (store) => {
+          store[params.sessionKey!] = activeSessionEntry;
+        });
+      }
+    };
+
+    await writeEntry(activeSessionEntry);
+
+    return async () => {
+      await writeEntry({ ...previousEntry });
+    };
   };
 
   while (true) {
@@ -267,7 +284,17 @@ export async function runAgentTurnWithFallback(params: {
             thinkLevel: params.followupRun.run.thinkLevel,
           });
 
-          await persistFallbackCandidateSelection(provider, model);
+          let rollbackFallbackCandidateSelection: (() => Promise<void>) | undefined;
+          try {
+            rollbackFallbackCandidateSelection = await persistFallbackCandidateSelection(
+              provider,
+              model,
+            );
+          } catch (error) {
+            logVerbose(
+              `failed to persist fallback candidate selection (non-fatal): ${String(error)}`,
+            );
+          }
 
           if (isCliProvider(provider, params.followupRun.run.config)) {
             const startedAt = Date.now();
@@ -336,6 +363,15 @@ export async function runAgentTurnWithFallback(params: {
 
                 return result;
               } catch (err) {
+                if (rollbackFallbackCandidateSelection) {
+                  try {
+                    await rollbackFallbackCandidateSelection();
+                  } catch (rollbackError) {
+                    logVerbose(
+                      `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
+                    );
+                  }
+                }
                 emitAgentEvent({
                   runId,
                   stream: "lifecycle",
@@ -547,6 +583,17 @@ export async function runAgentTurnWithFallback(params: {
               );
               attemptCompactionCount = Math.max(attemptCompactionCount, resultCompactionCount);
               return result;
+            } catch (err) {
+              if (rollbackFallbackCandidateSelection) {
+                try {
+                  await rollbackFallbackCandidateSelection();
+                } catch (rollbackError) {
+                  logVerbose(
+                    `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
+                  );
+                }
+              }
+              throw err;
             } finally {
               autoCompactionCount += attemptCompactionCount;
             }

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as sessionsStore from "../../config/sessions.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
@@ -424,6 +425,207 @@ describe("runReplyAgent authProfileId fallback scoping", () => {
     expect(sessionEntry.modelOverride).toBe("claude-sonnet");
     expect(sessionEntry.authProfileOverride).toBe("anthropic:openclaw");
     expect(sessionEntry.authProfileOverrideSource).toBe("user");
+  });
+
+  it("continues the fallback attempt when persisting the candidate selection fails", async () => {
+    runWithModelFallbackMock.mockImplementationOnce(
+      async ({ run }: RunWithModelFallbackParams) => ({
+        result: await run("openai-codex", "gpt-5.4"),
+        provider: "openai-codex",
+        model: "gpt-5.4",
+      }),
+    );
+
+    runEmbeddedPiAgentMock.mockResolvedValue({ payloads: [{ text: "ok" }], meta: {} });
+
+    const updateSessionStoreSpy = vi
+      .spyOn(sessionsStore, "updateSessionStore")
+      .mockRejectedValueOnce(new Error("disk locked"));
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      OriginatingTo: "chat",
+      AccountId: "primary",
+      MessageSid: "msg",
+      Surface: "telegram",
+    } as unknown as TemplateContext;
+
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId: "main",
+        agentDir: "/tmp/agent",
+        sessionId: "session",
+        sessionKey: "main",
+        messageProvider: "telegram",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude-opus",
+        authProfileId: "anthropic:openclaw",
+        authProfileIdSource: "manual",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 5_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 1,
+      compactionCount: 0,
+      authProfileOverride: "anthropic:openclaw",
+      authProfileOverrideSource: "auto",
+    };
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath: "/tmp/failing-sessions.json",
+      defaultModel: "anthropic/claude-opus-4-5",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(updateSessionStoreSpy).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ text: "ok" });
+  });
+
+  it("rolls back the persisted fallback candidate when that candidate fails", async () => {
+    runWithModelFallbackMock.mockImplementationOnce(async ({ run }: RunWithModelFallbackParams) => {
+      await expect(run("openai-codex", "gpt-5.4")).rejects.toThrow("fallback failed");
+      throw new Error("fallback failed");
+    });
+
+    runEmbeddedPiAgentMock.mockRejectedValueOnce(new Error("fallback failed"));
+
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fallback-rollback-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 1,
+      compactionCount: 0,
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus",
+      authProfileOverride: "anthropic:openclaw",
+      authProfileOverrideSource: "manual",
+    };
+    await saveSessionStore(storePath, { [sessionKey]: { ...sessionEntry } });
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      OriginatingTo: "chat",
+      AccountId: "primary",
+      MessageSid: "msg",
+      Surface: "telegram",
+    } as unknown as TemplateContext;
+
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId: "main",
+        agentDir: "/tmp/agent",
+        sessionId: "session",
+        sessionKey,
+        messageProvider: "telegram",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude-opus",
+        authProfileId: "anthropic:openclaw",
+        authProfileIdSource: "manual",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 5_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    const sessionStore = { [sessionKey]: sessionEntry };
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-5",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toMatchObject({
+      text: expect.stringContaining("fallback failed"),
+    });
+    expect(sessionEntry.providerOverride).toBe("anthropic");
+    expect(sessionEntry.modelOverride).toBe("claude-opus");
+    expect(sessionEntry.authProfileOverride).toBe("anthropic:openclaw");
+    expect(sessionEntry.authProfileOverrideSource).toBe("manual");
+
+    const persistedStore = await loadSessionStore(storePath);
+    expect(persistedStore[sessionKey]?.providerOverride).toBe("anthropic");
+    expect(persistedStore[sessionKey]?.modelOverride).toBe("claude-opus");
+    expect(persistedStore[sessionKey]?.authProfileOverride).toBe("anthropic:openclaw");
+    expect(persistedStore[sessionKey]?.authProfileOverrideSource).toBe("manual");
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -276,6 +276,8 @@ describe("runReplyAgent authProfileId fallback scoping", () => {
       updatedAt: Date.now(),
       totalTokens: 1,
       compactionCount: 0,
+      authProfileOverride: "anthropic:openclaw",
+      authProfileOverrideSource: "auto",
     };
 
     await runReplyAgent({
@@ -313,6 +315,115 @@ describe("runReplyAgent authProfileId fallback scoping", () => {
     expect(call.provider).toBe("openai-codex");
     expect(call.authProfileId).toBeUndefined();
     expect(call.authProfileIdSource).toBeUndefined();
+    expect(sessionEntry.providerOverride).toBe("openai-codex");
+    expect(sessionEntry.modelOverride).toBe("gpt-5.2");
+    expect(sessionEntry.authProfileOverride).toBeUndefined();
+    expect(sessionEntry.authProfileOverrideSource).toBeUndefined();
+  });
+
+  it("persists same-provider fallback model while keeping the scoped auth profile", async () => {
+    runWithModelFallbackMock.mockImplementationOnce(
+      async ({ run }: RunWithModelFallbackParams) => ({
+        result: await run("anthropic", "claude-sonnet"),
+        provider: "anthropic",
+        model: "claude-sonnet",
+      }),
+    );
+
+    runEmbeddedPiAgentMock.mockResolvedValue({ payloads: [{ text: "ok" }], meta: {} });
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      OriginatingTo: "chat",
+      AccountId: "primary",
+      MessageSid: "msg",
+      Surface: "telegram",
+    } as unknown as TemplateContext;
+
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId: "main",
+        agentDir: "/tmp/agent",
+        sessionId: "session",
+        sessionKey: "main",
+        messageProvider: "telegram",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude-opus",
+        authProfileId: "anthropic:openclaw",
+        authProfileIdSource: "user",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 5_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 1,
+      compactionCount: 0,
+      authProfileOverride: "anthropic:openclaw",
+      authProfileOverrideSource: "user",
+    };
+
+    await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath: undefined,
+      defaultModel: "anthropic/claude-opus-4-5",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const call = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as {
+      authProfileId?: unknown;
+      authProfileIdSource?: unknown;
+      provider?: unknown;
+      model?: unknown;
+    };
+
+    expect(call.provider).toBe("anthropic");
+    expect(call.model).toBe("claude-sonnet");
+    expect(call.authProfileId).toBe("anthropic:openclaw");
+    expect(call.authProfileIdSource).toBe("user");
+    expect(sessionEntry.providerOverride).toBe("anthropic");
+    expect(sessionEntry.modelOverride).toBe("claude-sonnet");
+    expect(sessionEntry.authProfileOverride).toBe("anthropic:openclaw");
+    expect(sessionEntry.authProfileOverrideSource).toBe("user");
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -521,6 +521,10 @@ describe("runReplyAgent authProfileId fallback scoping", () => {
     expect(updateSessionStoreSpy).toHaveBeenCalledTimes(1);
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({ text: "ok" });
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.authProfileOverride).toBe("anthropic:openclaw");
+    expect(sessionEntry.authProfileOverrideSource).toBe("auto");
   });
 
   it("rolls back the persisted fallback candidate when that candidate fails", async () => {


### PR DESCRIPTION
## Summary
- persist the selected fallback provider/model in the active session before the next fallback attempt starts
- scope the persisted auth profile to the fallback provider so cross-provider failover clears stale profile overrides
- add regression coverage for both cross-provider and same-provider fallback persistence

## Problem
When a primary model fails over to a fallback model, the active session can still persist the original primary selection until after the run finishes. If any live-session reconciliation re-reads the stored session during the retry loop, it can treat the fallback candidate as a transient mismatch and switch the run back to the primary model before the fallback attempt actually begins.

## Reproduction
1. Start a session on a primary model with a configured fallback.
2. Trigger a failover condition on the primary model, such as a provider rate limit.
3. Observe that the fallback candidate is selected for the next attempt.
4. Before that retry executes, any live-session selection refresh that reads the persisted session still sees the primary model.

Expected:
The retry stays on the selected fallback model.

Actual:
The retry can snap back to the primary model because the session store has not yet recorded the fallback selection.

## Fix
Persist the selected fallback model override immediately when `runWithModelFallback()` chooses the next candidate, before the attempt starts. The persisted auth profile is also re-scoped to the fallback provider so same-provider failover preserves the profile while cross-provider failover drops stale profile overrides.

## Validation
- regression coverage for cross-provider fallback persistence in `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- regression coverage for same-provider fallback persistence in `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- `git diff --check`
- targeted module import of `src/auto-reply/reply/agent-runner-execution.ts`
- unable to run Vitest locally in this environment because the repo's `rolldown` native binding is blocked by macOS system policy
- unable to complete full `tsc --noEmit` locally because the repo exhausted the Node heap in this environment
