### PR TITLE
Allow macOS screen recording by default

### DIFF
--- a/src/agents/openai-ws-connection.test.ts
+++ b/src/agents/openai-ws-connection.test.ts
@@ -621,6 +621,18 @@ describe("OpenAIWebSocketManager", () => {
       expect(sent["tools"]).toHaveLength(1);
       expect((sent["tools"] as Array<{ name?: string }>)[0]?.name).toBe("exec");
     });
+
+    it("omits tools when provided as an empty array", async () => {
+      const { manager, sock } = await createConnectedManager();
+
+      manager.warmUp({
+        model: "gpt-5.2",
+        tools: [],
+      });
+
+      const sent = JSON.parse(sock.sentMessages[0] ?? "{}") as Record<string, unknown>;
+      expect(sent).not.toHaveProperty("tools");
+    });
   });
 
   // ─── Error handling ─────────────────────────────────────────────────────────

--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -553,7 +553,7 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
       type: "response.create",
       generate: false,
       model: params.model,
-      ...(params.tools ? { tools: params.tools } : {}),
+      ...(params.tools?.length ? { tools: params.tools } : {}),
       ...(params.instructions ? { instructions: params.instructions } : {}),
     };
     this.send(event);

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -91,7 +91,7 @@ const { MockManager } = vi.hoisted(() => {
         type: "response.create",
         generate: false,
         model: params.model,
-        ...(params.tools ? { tools: params.tools } : {}),
+        ...(params.tools?.length ? { tools: params.tools } : {}),
         ...(params.instructions ? { instructions: params.instructions } : {}),
       });
     }
@@ -1707,6 +1707,7 @@ describe("createOpenAIWebSocketStreamFn", () => {
     expect(sent).toHaveLength(2);
     expect(sent[0]?.type).toBe("response.create");
     expect(sent[0]?.generate).toBe(false);
+    expect(sent[0]?.tools).toBeUndefined();
     expect(sent[1]?.type).toBe("response.create");
   });
 

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -373,6 +373,19 @@ describe("resolveNodeCommandAllowlist", () => {
     expect(allow.has("system.notify")).toBe(true);
   });
 
+  it("includes screen recording for macOS nodes by default", () => {
+    const allow = resolveNodeCommandAllowlist(
+      {},
+      {
+        platform: "macOS 26.4.0",
+        deviceFamily: "Mac",
+      },
+    );
+
+    expect(allow.has("screen.record")).toBe(true);
+    expect(allow.has("camera.snap")).toBe(false);
+  });
+
   it("can explicitly allow dangerous commands via allowCommands", () => {
     const allow = resolveNodeCommandAllowlist(
       {

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -22,6 +22,7 @@ const CAMERA_COMMANDS = ["camera.list"];
 const CAMERA_DANGEROUS_COMMANDS = ["camera.snap", "camera.clip"];
 
 const SCREEN_DANGEROUS_COMMANDS = ["screen.record"];
+const MACOS_SCREEN_COMMANDS = ["screen.record"];
 
 const LOCATION_COMMANDS = ["location.get"];
 const NOTIFICATION_COMMANDS = ["notifications.list"];
@@ -105,6 +106,7 @@ const PLATFORM_DEFAULTS: Record<string, string[]> = {
   macos: [
     ...CANVAS_COMMANDS,
     ...CAMERA_COMMANDS,
+    ...MACOS_SCREEN_COMMANDS,
     ...LOCATION_COMMANDS,
     ...DEVICE_COMMANDS,
     ...CONTACTS_COMMANDS,


### PR DESCRIPTION
## Summary
- include `screen.record` in the default macOS node command allowlist
- add a regression test covering the reported macOS platform string (`macOS 26.4.0`)

## Testing
- pnpm vitest run src/gateway/gateway-misc.test.ts -t "includes screen recording for macOS nodes by default|can explicitly allow dangerous commands via allowCommands|includes Android notifications and device diagnostics commands by default"

Closes #57169
