### PR TITLE
fix(feishu): add compatibility fields for official @larksuite/openclaw-lark plugin

### DIFF
--- a/src/canvas-host/a2ui.ts
+++ b/src/canvas-host/a2ui.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { setDefaultSecurityHeaders } from "../gateway/http-common.js";
 import { detectMime } from "../media/mime.js";
 import { resolveFileWithinRoot } from "./file-resolver.js";
 
@@ -154,6 +155,8 @@ export async function handleA2uiHttpRequest(
   if (!basePath) {
     return false;
   }
+
+  setDefaultSecurityHeaders(res);
 
   if (req.method !== "GET" && req.method !== "HEAD") {
     res.statusCode = 405;

--- a/src/canvas-host/server.test.ts
+++ b/src/canvas-host/server.test.ts
@@ -142,6 +142,9 @@ describe("canvas host", () => {
     try {
       const { res, html } = await fetchCanvasHtml(server.port);
       expect(res.status).toBe(200);
+      expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+      expect(res.headers.get("permissions-policy")).toContain("camera=()");
       expect(html).toContain("Interactive test page");
       expect(html).toContain("openclawSendUserAction");
       expect(html).toContain(CANVAS_WS_PATH);
@@ -364,6 +367,9 @@ describe("canvas host", () => {
       const res = await realFetch(`http://127.0.0.1:${server.port}/__openclaw__/a2ui/`);
       const html = await res.text();
       expect(res.status).toBe(200);
+      expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+      expect(res.headers.get("permissions-policy")).toContain("camera=()");
       expect(html).toContain("openclaw-a2ui-host");
       expect(html).toContain("openclawCanvasA2UIAction");
 
@@ -372,6 +378,8 @@ describe("canvas host", () => {
       );
       const js = await bundleRes.text();
       expect(bundleRes.status).toBe(200);
+      expect(bundleRes.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(bundleRes.headers.get("referrer-policy")).toBe("no-referrer");
       expect(js).toContain("openclawA2UI");
       const traversalRes = await realFetch(
         `http://127.0.0.1:${server.port}${A2UI_PATH}/%2e%2e%2fpackage.json`,

--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -12,6 +12,7 @@ import {
 import chokidar from "chokidar";
 import { type WebSocket, WebSocketServer } from "ws";
 import { resolveStateDir } from "../config/paths.js";
+import { setDefaultSecurityHeaders } from "../gateway/http-common.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { detectMime } from "../media/mime.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -339,6 +340,7 @@ export async function createCanvasHostHandler(
     try {
       const url = new URL(urlRaw, "http://localhost");
       if (url.pathname === CANVAS_WS_PATH) {
+        setDefaultSecurityHeaders(res);
         res.statusCode = liveReload ? 426 : 404;
         res.setHeader("Content-Type", "text/plain; charset=utf-8");
         res.end(liveReload ? "upgrade required" : "not found");
@@ -354,11 +356,14 @@ export async function createCanvasHostHandler(
       }
 
       if (req.method !== "GET" && req.method !== "HEAD") {
+        setDefaultSecurityHeaders(res);
         res.statusCode = 405;
         res.setHeader("Content-Type", "text/plain; charset=utf-8");
         res.end("Method Not Allowed");
         return true;
       }
+
+      setDefaultSecurityHeaders(res);
 
       const opened = await resolveFileWithinRoot(rootReal, urlPath);
       if (!opened) {


### PR DESCRIPTION
## Summary

Fixes #57173

This PR adds compatibility fields to the bundled `feishu` plugin schema to support configuration options documented in the official `@larksuite/openclaw-lark` plugin.

## Problem

OpenClaw core uses a bundled feishu plugin schema that lacks fields supported by the official plugin, causing validation errors when users follow the official documentation:

```
channels.feishu: invalid config: must NOT have additional properties
```

## Changes

### New Schema Fields

Added the following fields to `FeishuSharedConfigShape` for compatibility with `@larksuite/openclaw-lark`:

| Field | Type | Description |
|-------|------|-------------|
| `footer` | `FeishuFooterSchema` | Card footer display config (status, elapsed, tokens, cache, context, model) |
| `replyMode` | `ReplyModeSchema` | Reply mode: `"auto" \| "static" \| "streaming"` or per-context object |
| `threadSession` | `boolean` | Enable thread-level session isolation |
| `dedup` | `DedupSchema` | Message deduplication config (ttlMs, maxEntries) |
| `uat` | `UATConfigSchema` | User Access Token config (enabled, allowedScopes, blockedScopes) |

### Forward Compatibility

Changed `.strict()` to `.passthrough()` on both schemas:
- `FeishuConfigSchema`
- `FeishuAccountConfigSchema`

This allows the bundled plugin to accept additional fields that may be added to the official plugin in the future, preventing similar breakage.

## Testing

- [x] Schema compiles without TypeScript errors
- [x] New fields are optional and backward compatible
- [x] Existing configurations continue to work

## Related

- Closes #57173
- Official plugin: `@larksuite/openclaw-lark`
- [Official Feishu Plugin Docs](https://bytedance.larkoffice.com/docx/MFK7dDFLFoVlOGxWCv5cTXKmnMh)