### PR TITLE
fix: resolveLiveSessionModelSelection falls back to model/modelProvider fields

### DIFF
--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -48,8 +48,14 @@ export function resolveLiveSessionModelSelection(params: {
     agentId,
   });
   const entry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
-  const provider = entry?.providerOverride?.trim() || defaultModelRef.provider;
-  const model = entry?.modelOverride?.trim() || defaultModelRef.model;
+  const provider =
+    entry?.providerOverride?.trim() ||
+    entry?.modelProvider?.trim() ||
+    defaultModelRef.provider;
+  const model =
+    entry?.modelOverride?.trim() ||
+    entry?.model?.trim() ||
+    defaultModelRef.model;
   const authProfileId = entry?.authProfileOverride?.trim() || undefined;
   return {
     provider,


### PR DESCRIPTION
## Summary

Fixes #57191

When cron dispatch writes a model override to the session entry, it uses `model`/`modelProvider` fields (via `applyRuntimeModel`). However `resolveLiveSessionModelSelection` only reads `modelOverride`/`providerOverride`, causing it to always fall back to `resolveDefaultModelForAgent()`. When the agent default model differs from the cron payload model, this triggers `LiveSessionModelSwitchError` in a loop until retry limit.

## Changes

`src/agents/live-model-switch.ts` — `resolveLiveSessionModelSelection()`:
- Now checks `entry.model` / `entry.modelProvider` as intermediate fallback before resorting to `resolveDefaultModelForAgent()`

## Test

Verified locally: cron job with `payload.model: "minimax-portal/MiniMax-M2.7"` on an agent configured with `model.primary: "zai/glm-5-turbo"` now runs successfully instead of hitting `LiveSessionModelSwitchError` loop.