### PR TITLE
feat(cli): add agent-id and session-key to system event wake

### DIFF
--- a/src/cli/system-cli.test.ts
+++ b/src/cli/system-cli.test.ts
@@ -61,6 +61,46 @@ describe("system-cli", () => {
     expect(runtimeLogs).toEqual([JSON.stringify({ id: "wake-1" }, null, 2)]);
   });
 
+  it("passes --agent-id to gateway params", async () => {
+    await runCli(["system", "event", "--text", "hello", "--agent-id", "my-agent"]);
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "wake",
+      expect.objectContaining({ text: "hello", agentId: "my-agent" }),
+      { mode: "next-heartbeat", text: "hello", agentId: "my-agent" },
+      { expectFinal: false },
+    );
+  });
+
+  it("passes --session-key to gateway params", async () => {
+    await runCli([
+      "system",
+      "event",
+      "--text",
+      "hello",
+      "--agent-id",
+      "coding",
+      "--session-key",
+      "agent:coding:discord:direct:123",
+    ]);
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "wake",
+      expect.objectContaining({
+        text: "hello",
+        agentId: "coding",
+        sessionKey: "agent:coding:discord:direct:123",
+      }),
+      {
+        mode: "next-heartbeat",
+        text: "hello",
+        agentId: "coding",
+        sessionKey: "agent:coding:discord:direct:123",
+      },
+      { expectFinal: false },
+    );
+  });
+
   it("handles invalid wake mode as runtime error", async () => {
     await runCli(["system", "event", "--text", "hello", "--mode", "later"]);
 

--- a/src/cli/system-cli.ts
+++ b/src/cli/system-cli.ts
@@ -6,7 +6,13 @@ import { theme } from "../terminal/theme.js";
 import type { GatewayRpcOpts } from "./gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "./gateway-rpc.js";
 
-type SystemEventOpts = GatewayRpcOpts & { text?: string; mode?: string; json?: boolean };
+type SystemEventOpts = GatewayRpcOpts & {
+  text?: string;
+  mode?: string;
+  agentId?: string;
+  sessionKey?: string;
+  json?: boolean;
+};
 type SystemGatewayOpts = GatewayRpcOpts & { json?: boolean };
 
 const normalizeWakeMode = (raw: unknown) => {
@@ -54,6 +60,8 @@ export function registerSystemCli(program: Command) {
       .description("Enqueue a system event and optionally trigger a heartbeat")
       .requiredOption("--text <text>", "System event text")
       .option("--mode <mode>", "Wake mode (now|next-heartbeat)", "next-heartbeat")
+      .option("--agent-id <agentId>", "Target agent id")
+      .option("--session-key <sessionKey>", "Target session key")
       .option("--json", "Output JSON", false),
   ).action(async (opts: SystemEventOpts) => {
     await runSystemGatewayCommand(
@@ -64,7 +72,16 @@ export function registerSystemCli(program: Command) {
           throw new Error("--text is required");
         }
         const mode = normalizeWakeMode(opts.mode);
-        return await callGatewayFromCli("wake", opts, { mode, text }, { expectFinal: false });
+        const agentId =
+          typeof opts.agentId === "string" ? opts.agentId.trim() || undefined : undefined;
+        const sessionKey =
+          typeof opts.sessionKey === "string" ? opts.sessionKey.trim() || undefined : undefined;
+        return await callGatewayFromCli(
+          "wake",
+          opts,
+          { mode, text, ...(agentId ? { agentId } : {}), ...(sessionKey ? { sessionKey } : {}) },
+          { expectFinal: false },
+        );
       },
       "ok",
     );

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -54,7 +54,7 @@ export class CronService {
     return this.state.store?.jobs.find((job) => job.id === id);
   }
 
-  wake(opts: { mode: "now" | "next-heartbeat"; text: string }) {
+  wake(opts: { mode: "now" | "next-heartbeat"; text: string; agentId?: string; sessionKey?: string }) {
     return ops.wakeNow(this.state, opts);
   }
 }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -594,7 +594,7 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
 
 export function wakeNow(
   state: CronServiceState,
-  opts: { mode: "now" | "next-heartbeat"; text: string },
+  opts: { mode: "now" | "next-heartbeat"; text: string; agentId?: string; sessionKey?: string },
 ) {
   return wake(state, opts);
 }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1234,15 +1234,22 @@ function emitJobFinished(
 
 export function wake(
   state: CronServiceState,
-  opts: { mode: "now" | "next-heartbeat"; text: string },
+  opts: { mode: "now" | "next-heartbeat"; text: string; agentId?: string; sessionKey?: string },
 ) {
   const text = opts.text.trim();
   if (!text) {
     return { ok: false } as const;
   }
-  state.deps.enqueueSystemEvent(text);
+  state.deps.enqueueSystemEvent(text, {
+    ...(opts.agentId ? { agentId: opts.agentId } : {}),
+    ...(opts.sessionKey ? { sessionKey: opts.sessionKey } : {}),
+  });
   if (opts.mode === "now") {
-    state.deps.requestHeartbeatNow({ reason: "wake" });
+    state.deps.requestHeartbeatNow({
+      reason: "wake",
+      agentId: opts.agentId,
+      sessionKey: opts.sessionKey,
+    });
   }
   return { ok: true } as const;
 }

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -134,6 +134,8 @@ export const WakeParamsSchema = Type.Object(
   {
     mode: Type.Union([Type.Literal("now"), Type.Literal("next-heartbeat")]),
     text: NonEmptyString,
+    agentId: Type.Optional(NonEmptyString),
+    sessionKey: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -37,8 +37,15 @@ export const cronHandlers: GatewayRequestHandlers = {
     const p = params as {
       mode: "now" | "next-heartbeat";
       text: string;
+      agentId?: string;
+      sessionKey?: string;
     };
-    const result = context.cron.wake({ mode: p.mode, text: p.text });
+    const result = context.cron.wake({
+      mode: p.mode,
+      text: p.text,
+      agentId: p.agentId,
+      sessionKey: p.sessionKey,
+    });
     respond(true, result, undefined);
   },
   "cron.list": async ({ params, respond, context }) => {


### PR DESCRIPTION
## Summary

Adds `--agent-id <agentId>` and `--session-key <sessionKey>` to `openclaw system event`, threading both through the wake request validation and cron wake handling so a system event can target a specific agent and session.

## Why

On multi-agent setups, `openclaw system event` always targets the default agent's main session. This makes it impossible to:
- Wake a specific non-default agent (e.g. `coding` instead of `main`)
- Target a specific conversation session (e.g. a Discord DM session instead of the heartbeat session)

With both params, commands like:

```bash
# Target an agent (uses its main/heartbeat session)
openclaw system event --text "Task done" --agent-id coding --mode now

# Target a specific conversation session
openclaw system event --text "Task done" \
  --agent-id coding \
  --session-key "agent:coding:discord:direct:123456" \
  --mode now
```

route the event and heartbeat wake to the correct agent and session.

## Changes

- **CLI**: add `--agent-id <agentId>` and `--session-key <sessionKey>` options with whitespace normalization
- **Schema**: `WakeParamsSchema` gains optional `agentId` (NonEmptyString) and `sessionKey` (String)
- **Cron handler**: extracts both from validated params and forwards to `cron.wake()`
- **Timer**: passes `agentId`/`sessionKey` to both `enqueueSystemEvent` and `requestHeartbeatNow`
- **Tests**: coverage for both `--agent-id` and `--session-key` forwarding

## How it works

- `agentId` determines which agent handles the event (workspace, model, heartbeat config)
- `sessionKey` determines which conversation session the event lands in
- Both are optional and work independently:
  - `--agent-id` alone → agent's default main session
  - `--session-key` alone → agent inferred from the key prefix
  - Both → explicit targeting

## Testing

- `pnpm vitest run src/cli/system-cli.test.ts`
- `pnpm vitest run src/cron/`
- Manual end-to-end on a local multi-agent install: confirmed events route to the correct agent DM session with full conversation context
