### PR TITLE
fix(image-tool): resolve relative paths against workspaceDir

### DIFF
--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -975,6 +975,26 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("resolves relative image paths against workspaceDir", async () => {
+    await withTempWorkspacePng(async ({ workspaceDir }) => {
+      // Place image in a subdirectory of the workspace
+      const subdir = path.join(workspaceDir, "inbox");
+      await fs.mkdir(subdir, { recursive: true });
+      const imagePath = path.join(subdir, "receipt.png");
+      await fs.writeFile(imagePath, Buffer.from(ONE_PIXEL_PNG_B64, "base64"));
+
+      const fetch = stubMinimaxOkFetch();
+      await withTempAgentDir(async (agentDir) => {
+        const cfg = createMinimaxImageConfig();
+        const tool = createRequiredImageTool({ config: cfg, agentDir, workspaceDir });
+
+        // Relative path should be resolved against workspaceDir
+        await expectImageToolExecOk(tool, "inbox/receipt.png");
+        expect(fetch).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
   it("sandboxes image paths like the read tool", async () => {
     await withTempSandboxState(async ({ agentDir, sandboxRoot }) => {
       await fs.writeFile(path.join(sandboxRoot, "img.png"), "fake", "utf8");

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -1,3 +1,4 @@
+import { resolve, isAbsolute } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getMediaUnderstandingProvider } from "../../media-understanding/provider-registry.js";
@@ -403,6 +404,19 @@ export function createImageTool(options?: {
           }
           if (imageRaw.startsWith("~")) {
             return resolveUserPath(imageRaw);
+          }
+          // Resolve relative paths against workspaceDir so agents can reference
+          // workspace-relative paths (e.g. "inbox/photo.png") without needing to
+          // know the absolute workspace location — matching the read tool behaviour.
+          if (
+            !isDataUrl &&
+            !isFileUrl &&
+            !isHttpUrl &&
+            !looksLikeWindowsDrivePath &&
+            !isAbsolute(imageRaw) &&
+            options?.workspaceDir
+          ) {
+            return resolve(options.workspaceDir, imageRaw);
           }
           return imageRaw;
         })();


### PR DESCRIPTION
## Summary

- Relative image paths (e.g. `inbox/receipt.png`) are now resolved against `workspaceDir` instead of `process.cwd()`
- Matches the existing behaviour of the `read` tool
- No change for absolute paths, `~`-prefixed paths, URLs, or data URIs

## Issue

Closes #57215

**Root cause:** In `createImageTool`, the `resolvedImage` computation returned relative paths unchanged. `loadWebMedia` then resolved them against `process.cwd()`, which is typically outside the workspace, causing the `localRoots` allowlist check to fail with `Local media path is not under an allowed directory`.

**Fix:** Added a guard in the `resolvedImage` closure: if the path is not a URL/data URI/absolute path and `workspaceDir` is set, `path.resolve(workspaceDir, imageRaw)` is used. This matches what the `read` tool already does via its explicit `root` parameter.

## Test plan

- [ ] New regression test: `resolves relative image paths against workspaceDir` — creates a file in `workspace/inbox/receipt.png`, calls the tool with `"inbox/receipt.png"`, verifies success
- [ ] Existing workspace/fsPolicy/sandbox tests continue to pass unchanged
- [ ] Absolute paths, `~` paths, and URLs are unaffected by the change

## Security impact

None — path resolution is constrained by the existing `localRoots` allowlist. The resolved absolute path must still pass the allowlist check; this change only affects how relative paths are converted to absolute before that check.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)