### PR TITLE
fix(agents): preserve fallback candidates in live sessions

### DIFF
--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -139,6 +139,7 @@ async function resolveRuntimeModel(params: {
   model: Model<Api>;
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
+  authProfileIdCompactionCount?: number;
 }> {
   await ensureOpenClawModelsJson(params.cfg, params.agentDir);
   const authStorage = discoverAuthStorage(params.agentDir);
@@ -167,6 +168,7 @@ async function resolveRuntimeModel(params: {
     model,
     authProfileId,
     authProfileIdSource: params.sessionEntry?.authProfileOverrideSource,
+    authProfileIdCompactionCount: params.sessionEntry?.authProfileOverrideCompactionCount,
   };
 }
 

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -387,6 +387,9 @@ export function runAgentAttempt(params: {
     model: params.modelOverride,
     authProfileId,
     authProfileIdSource: authProfileId ? params.sessionEntry?.authProfileOverrideSource : undefined,
+    authProfileIdCompactionCount: authProfileId
+      ? params.sessionEntry?.authProfileOverrideCompactionCount
+      : undefined,
     thinkLevel: params.resolvedThinkLevel,
     verboseLevel: params.resolvedVerboseLevel,
     timeoutMs: params.timeoutMs,

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -5,7 +5,6 @@ const state = vi.hoisted(() => ({
   abortEmbeddedPiRunMock: vi.fn(),
   requestEmbeddedRunModelSwitchMock: vi.fn(),
   consumeEmbeddedRunModelSwitchMock: vi.fn(),
-  resolveDefaultModelForAgentMock: vi.fn(),
   loadSessionStoreMock: vi.fn(),
   resolveStorePathMock: vi.fn(),
 }));
@@ -19,11 +18,6 @@ vi.mock("./pi-embedded-runner/runs.js", () => ({
     state.requestEmbeddedRunModelSwitchMock(...args),
   consumeEmbeddedRunModelSwitch: (...args: unknown[]) =>
     state.consumeEmbeddedRunModelSwitchMock(...args),
-}));
-
-vi.mock("./model-selection.js", () => ({
-  resolveDefaultModelForAgent: (...args: unknown[]) =>
-    state.resolveDefaultModelForAgentMock(...args),
 }));
 
 vi.mock("../config/sessions.js", () => ({
@@ -44,9 +38,6 @@ describe("live model switch", () => {
     state.abortEmbeddedPiRunMock.mockReset().mockReturnValue(false);
     state.requestEmbeddedRunModelSwitchMock.mockReset();
     state.consumeEmbeddedRunModelSwitchMock.mockReset();
-    state.resolveDefaultModelForAgentMock
-      .mockReset()
-      .mockReturnValue({ provider: "anthropic", model: "claude-opus-4-6" });
     state.loadSessionStoreMock.mockReset().mockReturnValue({});
     state.resolveStorePathMock.mockReset().mockReturnValue("/tmp/session-store.json");
   });
@@ -55,7 +46,7 @@ describe("live model switch", () => {
     vi.clearAllMocks();
   });
 
-  it("resolves persisted session overrides ahead of agent defaults", async () => {
+  it("resolves persisted session overrides ahead of the current selection", async () => {
     state.loadSessionStoreMock.mockReturnValue({
       main: {
         providerOverride: "openai",
@@ -81,9 +72,27 @@ describe("live model switch", () => {
       authProfileId: "profile-gpt",
       authProfileIdSource: "user",
     });
-    expect(state.resolveDefaultModelForAgentMock).toHaveBeenCalledWith({
-      cfg: { session: { store: "/tmp/custom-store.json" } },
+    expect(state.resolveStorePathMock).toHaveBeenCalledWith("/tmp/custom-store.json", {
       agentId: "reply",
+    });
+  });
+
+  it("falls back to the current attempt when the session has no explicit override", async () => {
+    const { resolveLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      resolveLiveSessionModelSelection({
+        cfg: { session: { store: "/tmp/custom-store.json" } },
+        sessionKey: "main",
+        agentId: "reply",
+        defaultProvider: "groq",
+        defaultModel: "llama-4",
+      }),
+    ).toEqual({
+      provider: "groq",
+      model: "llama-4",
+      authProfileId: undefined,
+      authProfileIdSource: undefined,
     });
     expect(state.resolveStorePathMock).toHaveBeenCalledWith("/tmp/custom-store.json", {
       agentId: "reply",

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -162,4 +162,64 @@ describe("live model switch", () => {
       ),
     ).toBe(false);
   });
+
+  it("treats a missing persisted auth profile as unchanged when the current selection is auto", async () => {
+    const { hasDifferentLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "openai",
+          model: "gpt-5.4",
+          authProfileId: "openai:default",
+          authProfileIdSource: "auto",
+        },
+        {
+          provider: "openai",
+          model: "gpt-5.4",
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("treats a persisted auto auth profile as unchanged when the current selection has not pinned one yet", async () => {
+    const { hasDifferentLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "openai",
+          model: "gpt-5.4",
+          authProfileIdSource: "auto",
+        },
+        {
+          provider: "openai",
+          model: "gpt-5.4",
+          authProfileId: "openai:default",
+          authProfileIdSource: "auto",
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("still detects real auto auth profile changes", async () => {
+    const { hasDifferentLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "openai",
+          model: "gpt-5.4",
+          authProfileId: "openai:default",
+          authProfileIdSource: "auto",
+        },
+        {
+          provider: "openai",
+          model: "gpt-5.4",
+          authProfileId: "openai:secondary",
+          authProfileIdSource: "auto",
+        },
+      ),
+    ).toBe(true);
+  });
 });

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -77,6 +77,31 @@ describe("live model switch", () => {
     });
   });
 
+  it("treats legacy manual auth profile overrides as user-selected", async () => {
+    state.loadSessionStoreMock.mockReturnValue({
+      main: {
+        authProfileOverride: "profile-gpt",
+      },
+    });
+
+    const { resolveLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      resolveLiveSessionModelSelection({
+        cfg: { session: { store: "/tmp/custom-store.json" } },
+        sessionKey: "main",
+        agentId: "reply",
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.4",
+      }),
+    ).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+      authProfileId: "profile-gpt",
+      authProfileIdSource: "user",
+    });
+  });
+
   it("falls back to the current attempt when the session has no explicit override", async () => {
     const { resolveLiveSessionModelSelection } = await loadModule();
 
@@ -221,5 +246,25 @@ describe("live model switch", () => {
         },
       ),
     ).toBe(true);
+  });
+
+  it("treats a missing current auth profile source as unchanged for legacy manual overrides", async () => {
+    const { hasDifferentLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "openai",
+          model: "gpt-5.4",
+          authProfileId: "profile-gpt",
+        },
+        {
+          provider: "openai",
+          model: "gpt-5.4",
+          authProfileId: "profile-gpt",
+          authProfileIdSource: "user",
+        },
+      ),
+    ).toBe(false);
   });
 });

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -151,6 +151,33 @@ describe("live model switch", () => {
     });
   });
 
+  it("keeps explicit user auth profile overrides even when stale compaction metadata remains", async () => {
+    state.loadSessionStoreMock.mockReturnValue({
+      main: {
+        authProfileOverride: "profile-gpt",
+        authProfileOverrideSource: "user",
+        authProfileOverrideCompactionCount: 2,
+      },
+    });
+
+    const { resolveLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      resolveLiveSessionModelSelection({
+        cfg: { session: { store: "/tmp/custom-store.json" } },
+        sessionKey: "main",
+        agentId: "reply",
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.4",
+      }),
+    ).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+      authProfileId: "profile-gpt",
+      authProfileIdSource: "user",
+    });
+  });
+
   it("queues a live switch only when an active run was aborted", async () => {
     state.abortEmbeddedPiRunMock.mockReturnValue(true);
 

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -99,6 +99,33 @@ describe("live model switch", () => {
     });
   });
 
+  it("ignores auto-selected auth profile overrides when resolving persisted selection", async () => {
+    state.loadSessionStoreMock.mockReturnValue({
+      main: {
+        authProfileOverride: "anthropic:default",
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 2,
+      },
+    });
+
+    const { resolveLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      resolveLiveSessionModelSelection({
+        cfg: { session: { store: "/tmp/custom-store.json" } },
+        sessionKey: "main",
+        agentId: "reply",
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.4",
+      }),
+    ).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+      authProfileId: undefined,
+      authProfileIdSource: undefined,
+    });
+  });
+
   it("queues a live switch only when an active run was aborted", async () => {
     state.abortEmbeddedPiRunMock.mockReturnValue(true);
 

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -254,6 +254,25 @@ describe("live model switch", () => {
     ).toBe(false);
   });
 
+  it("treats a missing persisted auth profile as unchanged for legacy auto overrides without source metadata", async () => {
+    const { hasDifferentLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "openai",
+          model: "gpt-5.4",
+          authProfileId: "openai:default",
+          authProfileIdCompactionCount: 2,
+        },
+        {
+          provider: "openai",
+          model: "gpt-5.4",
+        },
+      ),
+    ).toBe(false);
+  });
+
   it("still detects real auto auth profile changes", async () => {
     const { hasDifferentLiveSessionModelSelection } = await loadModule();
 

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -24,6 +24,34 @@ export class LiveSessionModelSwitchError extends Error {
   }
 }
 
+function resolvePersistedAuthProfileSelection(
+  entry: Pick<
+    SessionEntry,
+    "authProfileOverride" | "authProfileOverrideSource" | "authProfileOverrideCompactionCount"
+  >,
+): Pick<LiveSessionModelSelection, "authProfileId" | "authProfileIdSource"> {
+  const authProfileId = entry.authProfileOverride?.trim() || undefined;
+  if (!authProfileId) {
+    return {
+      authProfileId: undefined,
+      authProfileIdSource: undefined,
+    };
+  }
+  const authProfileIdSource =
+    entry.authProfileOverrideSource ??
+    (typeof entry.authProfileOverrideCompactionCount === "number" ? "auto" : "user");
+  if (authProfileIdSource !== "user") {
+    return {
+      authProfileId: undefined,
+      authProfileIdSource: undefined,
+    };
+  }
+  return {
+    authProfileId,
+    authProfileIdSource,
+  };
+}
+
 export function resolveLiveSessionModelSelection(params: {
   cfg?: { session?: { store?: string } } | undefined;
   sessionKey?: string;
@@ -43,12 +71,14 @@ export function resolveLiveSessionModelSelection(params: {
   const entry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
   const provider = entry?.providerOverride?.trim() || params.defaultProvider;
   const model = entry?.modelOverride?.trim() || params.defaultModel;
-  const authProfileId = entry?.authProfileOverride?.trim() || undefined;
+  const { authProfileId, authProfileIdSource } = entry
+    ? resolvePersistedAuthProfileSelection(entry)
+    : { authProfileId: undefined, authProfileIdSource: undefined };
   return {
     provider,
     model,
     authProfileId,
-    authProfileIdSource: authProfileId ? entry?.authProfileOverrideSource : undefined,
+    authProfileIdSource,
   };
 }
 

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -1,5 +1,4 @@
 import { loadSessionStore, resolveStorePath, type SessionEntry } from "../config/sessions.js";
-import { resolveDefaultModelForAgent } from "./model-selection.js";
 import {
   consumeEmbeddedRunModelSwitch,
   requestEmbeddedRunModelSwitch,
@@ -38,18 +37,12 @@ export function resolveLiveSessionModelSelection(params: {
     return null;
   }
   const agentId = params.agentId?.trim();
-  const defaultModelRef = agentId
-    ? resolveDefaultModelForAgent({
-        cfg,
-        agentId,
-      })
-    : { provider: params.defaultProvider, model: params.defaultModel };
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId,
   });
   const entry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
-  const provider = entry?.providerOverride?.trim() || defaultModelRef.provider;
-  const model = entry?.modelOverride?.trim() || defaultModelRef.model;
+  const provider = entry?.providerOverride?.trim() || params.defaultProvider;
+  const model = entry?.modelOverride?.trim() || params.defaultModel;
   const authProfileId = entry?.authProfileOverride?.trim() || undefined;
   return {
     provider,

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -41,13 +41,10 @@ function resolvePersistedAuthProfileSelection(
   >,
 ): Pick<LiveSessionModelSelection, "authProfileId" | "authProfileIdSource"> {
   const authProfileId = entry.authProfileOverride?.trim() || undefined;
-  const authProfileIdSource =
-    entry.authProfileOverrideSource === "auto"
-      ? "auto"
-      : normalizeSelectedAuthProfileSource(
-          authProfileId,
-          typeof entry.authProfileOverrideCompactionCount === "number" ? "auto" : "user",
-        );
+  const persistedSource =
+    entry.authProfileOverrideSource ??
+    (typeof entry.authProfileOverrideCompactionCount === "number" ? "auto" : "user");
+  const authProfileIdSource = normalizeSelectedAuthProfileSource(authProfileId, persistedSource);
   if (!authProfileId || authProfileIdSource !== "user") {
     return {
       authProfileId: undefined,

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -24,6 +24,16 @@ export class LiveSessionModelSwitchError extends Error {
   }
 }
 
+function normalizeSelectedAuthProfileSource(
+  authProfileId: string | undefined,
+  authProfileIdSource: string | undefined,
+): "auto" | "user" | undefined {
+  if (!authProfileId) {
+    return undefined;
+  }
+  return authProfileIdSource === "auto" ? "auto" : "user";
+}
+
 function resolvePersistedAuthProfileSelection(
   entry: Pick<
     SessionEntry,
@@ -31,16 +41,14 @@ function resolvePersistedAuthProfileSelection(
   >,
 ): Pick<LiveSessionModelSelection, "authProfileId" | "authProfileIdSource"> {
   const authProfileId = entry.authProfileOverride?.trim() || undefined;
-  if (!authProfileId) {
-    return {
-      authProfileId: undefined,
-      authProfileIdSource: undefined,
-    };
-  }
   const authProfileIdSource =
-    entry.authProfileOverrideSource ??
-    (typeof entry.authProfileOverrideCompactionCount === "number" ? "auto" : "user");
-  if (authProfileIdSource !== "user") {
+    entry.authProfileOverrideSource === "auto"
+      ? "auto"
+      : normalizeSelectedAuthProfileSource(
+          authProfileId,
+          typeof entry.authProfileOverrideCompactionCount === "number" ? "auto" : "user",
+        );
+  if (!authProfileId || authProfileIdSource !== "user") {
     return {
       authProfileId: undefined,
       authProfileIdSource: undefined,
@@ -118,8 +126,14 @@ export function hasDifferentLiveSessionModelSelection(
   }
   const currentAuthProfileId = current.authProfileId?.trim() || undefined;
   const nextAuthProfileId = next.authProfileId?.trim() || undefined;
-  const currentAuthProfileIdSource = currentAuthProfileId ? current.authProfileIdSource : undefined;
-  const nextAuthProfileIdSource = nextAuthProfileId ? next.authProfileIdSource : undefined;
+  const currentAuthProfileIdSource = normalizeSelectedAuthProfileSource(
+    currentAuthProfileId,
+    current.authProfileIdSource,
+  );
+  const nextAuthProfileIdSource = normalizeSelectedAuthProfileSource(
+    nextAuthProfileId,
+    next.authProfileIdSource,
+  );
   const authSelectionDiffers =
     currentAuthProfileId === nextAuthProfileId
       ? currentAuthProfileIdSource !== nextAuthProfileIdSource

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -116,11 +116,17 @@ export function hasDifferentLiveSessionModelSelection(
   if (!next) {
     return false;
   }
-  return (
-    current.provider !== next.provider ||
-    current.model !== next.model ||
-    (current.authProfileId?.trim() || undefined) !== next.authProfileId ||
-    (current.authProfileId?.trim() ? current.authProfileIdSource : undefined) !==
-      next.authProfileIdSource
-  );
+  const currentAuthProfileId = current.authProfileId?.trim() || undefined;
+  const nextAuthProfileId = next.authProfileId?.trim() || undefined;
+  const currentAuthProfileIdSource = currentAuthProfileId ? current.authProfileIdSource : undefined;
+  const nextAuthProfileIdSource = nextAuthProfileId ? next.authProfileIdSource : undefined;
+  const authSelectionDiffers =
+    currentAuthProfileId === nextAuthProfileId
+      ? currentAuthProfileIdSource !== nextAuthProfileIdSource
+      : currentAuthProfileId && !nextAuthProfileId
+        ? currentAuthProfileIdSource !== "auto"
+        : !currentAuthProfileId && nextAuthProfileId
+          ? nextAuthProfileIdSource !== "auto"
+          : true;
+  return current.provider !== next.provider || current.model !== next.model || authSelectionDiffers;
 }

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -27,11 +27,18 @@ export class LiveSessionModelSwitchError extends Error {
 function normalizeSelectedAuthProfileSource(
   authProfileId: string | undefined,
   authProfileIdSource: string | undefined,
+  authProfileIdCompactionCount?: number,
 ): "auto" | "user" | undefined {
   if (!authProfileId) {
     return undefined;
   }
-  return authProfileIdSource === "auto" ? "auto" : "user";
+  if (authProfileIdSource === "auto") {
+    return "auto";
+  }
+  if (authProfileIdSource === undefined && typeof authProfileIdCompactionCount === "number") {
+    return "auto";
+  }
+  return "user";
 }
 
 function resolvePersistedAuthProfileSelection(
@@ -44,7 +51,11 @@ function resolvePersistedAuthProfileSelection(
   const persistedSource =
     entry.authProfileOverrideSource ??
     (typeof entry.authProfileOverrideCompactionCount === "number" ? "auto" : "user");
-  const authProfileIdSource = normalizeSelectedAuthProfileSource(authProfileId, persistedSource);
+  const authProfileIdSource = normalizeSelectedAuthProfileSource(
+    authProfileId,
+    persistedSource,
+    entry.authProfileOverrideCompactionCount,
+  );
   if (!authProfileId || authProfileIdSource !== "user") {
     return {
       authProfileId: undefined,
@@ -115,6 +126,7 @@ export function hasDifferentLiveSessionModelSelection(
     model: string;
     authProfileId?: string;
     authProfileIdSource?: string;
+    authProfileIdCompactionCount?: number;
   },
   next: LiveSessionModelSelection | null | undefined,
 ): next is LiveSessionModelSelection {
@@ -126,6 +138,7 @@ export function hasDifferentLiveSessionModelSelection(
   const currentAuthProfileIdSource = normalizeSelectedAuthProfileSource(
     currentAuthProfileId,
     current.authProfileIdSource,
+    current.authProfileIdCompactionCount,
   );
   const nextAuthProfileIdSource = normalizeSelectedAuthProfileSource(
     nextAuthProfileId,

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -145,6 +145,14 @@ function makeConfig(): OpenClawConfig {
   } satisfies OpenClawConfig;
 }
 
+async function writeSessionStore(
+  storePath: string,
+  sessionKey: string,
+  entry: Record<string, unknown>,
+) {
+  await fs.writeFile(storePath, JSON.stringify({ [sessionKey]: entry }), "utf-8");
+}
+
 async function withAgentWorkspace<T>(
   fn: (ctx: { agentDir: string; workspaceDir: string }) => Promise<T>,
 ): Promise<T> {
@@ -205,6 +213,9 @@ async function runEmbeddedFallback(params: {
   abortSignal?: AbortSignal;
 }) {
   const cfg = makeConfig();
+  cfg.session = {
+    store: path.join(params.agentDir, "sessions.json"),
+  };
   return await runWithModelFallback({
     cfg,
     provider: "openai",
@@ -346,6 +357,32 @@ describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
       expect(result.attempts[0]?.reason).toBe("overloaded");
       expect(result.result.payloads?.[0]?.text ?? "").toContain("fallback ok");
       expectOpenAiThenGroqAttemptOrder();
+    });
+  });
+
+  it("ignores auto-selected persisted auth profiles when crossing providers during fallback", async () => {
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      await writeAuthStore(agentDir);
+      await writeSessionStore(path.join(agentDir, "sessions.json"), "main", {
+        sessionId: "session:run:overloaded-cross-provider:auto-auth",
+        authProfileOverride: "openai:p1",
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 1,
+      });
+      mockPrimaryOverloadedThenFallbackSuccess();
+
+      const result = await runEmbeddedFallback({
+        agentDir,
+        workspaceDir,
+        agentId: "main",
+        sessionKey: "main",
+        runId: "run:overloaded-cross-provider:auto-auth",
+      });
+
+      expect(result.provider).toBe("groq");
+      expect(result.model).toBe("mock-2");
+      expect(result.result.payloads?.[0]?.text ?? "").toContain("fallback ok");
+      expectOpenAiThenGroqAttemptOrder({ expectOpenAiAuthProfileId: "openai:p1" });
     });
   });
 

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -386,6 +386,31 @@ describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
     });
   });
 
+  it("tolerates legacy auto-selected auth profiles without source metadata during fallback", async () => {
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      await writeAuthStore(agentDir);
+      await writeSessionStore(path.join(agentDir, "sessions.json"), "main", {
+        sessionId: "session:run:overloaded-cross-provider:legacy-auto-auth",
+        authProfileOverride: "openai:p1",
+        authProfileOverrideCompactionCount: 1,
+      });
+      mockPrimaryOverloadedThenFallbackSuccess();
+
+      const result = await runEmbeddedFallback({
+        agentDir,
+        workspaceDir,
+        agentId: "main",
+        sessionKey: "main",
+        runId: "run:overloaded-cross-provider:legacy-auto-auth",
+      });
+
+      expect(result.provider).toBe("groq");
+      expect(result.model).toBe("mock-2");
+      expect(result.result.payloads?.[0]?.text ?? "").toContain("fallback ok");
+      expectOpenAiThenGroqAttemptOrder({ expectOpenAiAuthProfileId: "openai:p1" });
+    });
+  });
+
   it("surfaces a bounded overloaded summary when every fallback candidate is overloaded", async () => {
     await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
       await writeAuthStore(agentDir);

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -201,6 +201,7 @@ async function runEmbeddedFallback(params: {
   workspaceDir: string;
   sessionKey: string;
   runId: string;
+  agentId?: string;
   abortSignal?: AbortSignal;
 }) {
   const cfg = makeConfig();
@@ -214,6 +215,7 @@ async function runEmbeddedFallback(params: {
       runEmbeddedPiAgent({
         sessionId: `session:${params.runId}`,
         sessionKey: params.sessionKey,
+        agentId: params.agentId,
         sessionFile: path.join(params.workspaceDir, `${params.runId}.jsonl`),
         workspaceDir: params.workspaceDir,
         agentDir: params.agentDir,
@@ -323,6 +325,27 @@ describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
       expectOpenAiThenGroqAttemptOrder();
       expect(computeBackoffMock).toHaveBeenCalledTimes(1);
       expect(sleepWithAbortMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("falls back across providers for agent sessions without explicit model overrides", async () => {
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      await writeAuthStore(agentDir);
+      mockPrimaryOverloadedThenFallbackSuccess();
+
+      const result = await runEmbeddedFallback({
+        agentDir,
+        workspaceDir,
+        agentId: "main",
+        sessionKey: "main",
+        runId: "run:overloaded-cross-provider:agent-session",
+      });
+
+      expect(result.provider).toBe("groq");
+      expect(result.model).toBe("mock-2");
+      expect(result.attempts[0]?.reason).toBe("overloaded");
+      expect(result.result.payloads?.[0]?.text ?? "").toContain("fallback ok");
+      expectOpenAiThenGroqAttemptOrder();
     });
   });
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -233,6 +233,7 @@ export async function runEmbeddedPiAgent(
         model: modelId,
         authProfileId: preferredProfileId,
         authProfileIdSource: params.authProfileIdSource,
+        authProfileIdCompactionCount: params.authProfileIdCompactionCount,
       });
       const resolvePersistedLiveSelection = () =>
         resolveLiveSessionModelSelection({

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -82,6 +82,7 @@ export type RunEmbeddedPiAgentParams = {
   model?: string;
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
+  authProfileIdCompactionCount?: number;
   thinkLevel?: ThinkLevel;
   fastMode?: boolean;
   verboseLevel?: VerboseLevel;

--- a/src/auto-reply/reply/agent-runner-auth-profile.ts
+++ b/src/auto-reply/reply/agent-runner-auth-profile.ts
@@ -5,12 +5,18 @@ export function resolveProviderScopedAuthProfile(params: {
   primaryProvider: string;
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
-}): { authProfileId?: string; authProfileIdSource?: "auto" | "user" } {
+  authProfileIdCompactionCount?: number;
+}): {
+  authProfileId?: string;
+  authProfileIdSource?: "auto" | "user";
+  authProfileIdCompactionCount?: number;
+} {
   const authProfileId =
     params.provider === params.primaryProvider ? params.authProfileId : undefined;
   return {
     authProfileId,
     authProfileIdSource: authProfileId ? params.authProfileIdSource : undefined,
+    authProfileIdCompactionCount: authProfileId ? params.authProfileIdCompactionCount : undefined,
   };
 }
 
@@ -20,5 +26,6 @@ export function resolveRunAuthProfile(run: FollowupRun["run"], provider: string)
     primaryProvider: run.provider,
     authProfileId: run.authProfileId,
     authProfileIdSource: run.authProfileIdSource,
+    authProfileIdCompactionCount: run.authProfileIdCompactionCount,
   });
 }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -612,6 +612,7 @@ export async function runAgentTurnWithFallback(params: {
         params.followupRun.run.authProfileIdSource = err.authProfileId
           ? err.authProfileIdSource
           : undefined;
+        params.followupRun.run.authProfileIdCompactionCount = undefined;
         fallbackProvider = err.provider;
         fallbackModel = err.model;
         continue;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -518,6 +518,7 @@ export async function runPreparedReply(
     isNewSession,
   });
   const authProfileIdSource = sessionEntry?.authProfileOverrideSource;
+  const authProfileIdCompactionCount = sessionEntry?.authProfileOverrideCompactionCount;
   const followupRun = {
     prompt: queuedBody,
     messageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
@@ -558,6 +559,7 @@ export async function runPreparedReply(
       model,
       authProfileId,
       authProfileIdSource,
+      authProfileIdCompactionCount,
       thinkLevel: resolvedThinkLevel,
       fastMode: resolveFastModeState({
         cfg,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -65,6 +65,7 @@ export type FollowupRun = {
     model: string;
     authProfileId?: string;
     authProfileIdSource?: "auto" | "user";
+    authProfileIdCompactionCount?: number;
     thinkLevel?: ThinkLevel;
     verboseLevel?: VerboseLevel;
     reasoningLevel?: ReasoningLevel;


### PR DESCRIPTION
## Summary
- stop live-session model selection from snapping back to the agent default when there is no explicit session override
- preserve normal live `/model` behavior by still honoring stored session overrides from the session store
- add regression coverage for agent-session fallback so cross-provider retries keep running after a primary rate limit

## Root cause
`resolveLiveSessionModelSelection()` treated the agent default model as the persisted live-session selection whenever an `agentId` existed. During fallback, the embedded runner compared the current retry candidate against that agent default and threw `LiveSessionModelSwitchError`, which made internal fallback candidates look like user-requested live model switches.

## Fix
Use the current attempt's provider/model as the default live-session selection baseline. Only switch away when the session store has an explicit override.

## Validation
- `pnpm --dir /home/openclaw/openclaw exec vitest run src/agents/live-model-switch.test.ts`
- `pnpm --dir /home/openclaw/openclaw exec vitest run --config vitest.e2e.config.ts src/agents/model-fallback.run-embedded.e2e.test.ts`
- rebuilt local `dist/`, restarted the gateway, reverted the live config back to `anthropic/claude-sonnet-4-6`, and verified a direct agent turn fell back to `openai-codex/gpt-5.4`
- local command used for the live check:
  - `openclaw agent --agent main --message 'Reply with FALLBACK_FIX_OK and nothing else.' --json`
- observed result for run `a2ac9644-34bf-41db-9457-50261e59b067`:
  - Anthropic primary returned `429 rate_limit_error`
  - fallback then succeeded on `openai-codex/gpt-5.4`
  - no fresh `live session model switch detected before attempt` log entries were emitted for that run
