### PR TITLE
fix(image): resolve relative paths against workspaceDir

### DIFF
--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -933,6 +933,40 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("resolves relative image paths against workspaceDir", async () => {
+    await withTempWorkspacePng(async ({ workspaceDir, imagePath }) => {
+      const fetch = stubMinimaxOkFetch();
+      await withTempAgentDir(async (agentDir) => {
+        const cfg = createMinimaxImageConfig();
+        const tool = createRequiredImageTool({ config: cfg, agentDir, workspaceDir });
+
+        // Use a relative path that should resolve against workspaceDir
+        const relativePath = path.relative(workspaceDir, imagePath);
+        await expectImageToolExecOk(tool, relativePath);
+        expect(fetch).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  it("resolves deeply nested relative image paths against workspaceDir", async () => {
+    await withTempWorkspacePng(async ({ workspaceDir, imagePath }) => {
+      const fetch = stubMinimaxOkFetch();
+      await withTempAgentDir(async (agentDir) => {
+        const cfg = createMinimaxImageConfig();
+        const tool = createRequiredImageTool({ config: cfg, agentDir, workspaceDir });
+
+        // Create a subdirectory and move the image there
+        const subDir = path.join(workspaceDir, "nested", "media", "folder");
+        await fs.mkdir(subDir, { recursive: true });
+        const nestedImage = path.join(subDir, "photo.png");
+        await fs.copyFile(imagePath, nestedImage);
+
+        await expectImageToolExecOk(tool, "nested/media/folder/photo.png");
+        expect(fetch).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
   it("allows non-workspace local image paths when workspaceOnly is disabled", async () => {
     const fetch = stubMinimaxOkFetch();
     await withTempAgentDir(async (agentDir) => {

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getMediaUnderstandingProvider } from "../../media-understanding/provider-registry.js";
@@ -403,6 +404,10 @@ export function createImageTool(options?: {
           }
           if (imageRaw.startsWith("~")) {
             return resolveUserPath(imageRaw);
+          }
+          // Resolve relative paths against workspaceDir, matching read tool behavior
+          if (!path.isAbsolute(imageRaw) && options?.workspaceDir) {
+            return path.resolve(options.workspaceDir, imageRaw);
           }
           return imageRaw;
         })();


### PR DESCRIPTION
Fixes #57215

The image tool resolved relative paths against \`process.cwd()\` instead of \`workspaceDir\`, causing "not under an allowed directory" errors when agents used relative paths like \`inbox/receipt.pdf\`.

Match the read tool behavior: resolve relative paths against \`workspaceDir\` when available.

Changes:
- \`image-tool.ts\`: resolve relative paths against \`workspaceDir\` using \`path.resolve()\`
- Tests: verify relative and deeply nested relative paths resolve correctly