### PR TITLE
fix(daemon): support system-scoped systemd gateway units on linux

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -67,6 +67,7 @@ describe("restart-helper", () => {
   describe("prepareRestartScript", () => {
     it("creates a systemd restart script on Linux", async () => {
       Object.defineProperty(process, "platform", { value: "linux" });
+      vi.spyOn(fs, "access").mockRejectedValueOnce(new Error("missing"));
       const { scriptPath, content } = await prepareAndReadScript({
         OPENCLAW_PROFILE: "default",
       });
@@ -80,11 +81,23 @@ describe("restart-helper", () => {
 
     it("uses OPENCLAW_SYSTEMD_UNIT override for systemd scripts", async () => {
       Object.defineProperty(process, "platform", { value: "linux" });
+      vi.spyOn(fs, "access").mockRejectedValueOnce(new Error("missing"));
       const { scriptPath, content } = await prepareAndReadScript({
         OPENCLAW_PROFILE: "default",
         OPENCLAW_SYSTEMD_UNIT: "custom-gateway",
       });
       expect(content).toContain("systemctl --user restart 'custom-gateway.service'");
+      await cleanupScript(scriptPath);
+    });
+
+    it("uses sudo systemctl restart when the system unit exists on Linux", async () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      vi.spyOn(fs, "access").mockResolvedValueOnce(undefined);
+      const { scriptPath, content } = await prepareAndReadScript({
+        OPENCLAW_PROFILE: "default",
+      });
+      expect(content).toContain("sudo -n systemctl restart 'openclaw-gateway.service'");
+      expect(content).not.toContain("systemctl --user restart 'openclaw-gateway.service'");
       await cleanupScript(scriptPath);
     });
 
@@ -166,6 +179,7 @@ describe("restart-helper", () => {
 
     it("uses custom profile in service names", async () => {
       Object.defineProperty(process, "platform", { value: "linux" });
+      vi.spyOn(fs, "access").mockRejectedValueOnce(new Error("missing"));
       const { scriptPath, content } = await prepareAndReadScript({
         OPENCLAW_PROFILE: "production",
       });
@@ -203,6 +217,7 @@ describe("restart-helper", () => {
 
     it("returns null when script creation fails", async () => {
       Object.defineProperty(process, "platform", { value: "linux" });
+      vi.spyOn(fs, "access").mockRejectedValueOnce(new Error("missing"));
       const writeFileSpy = vi
         .spyOn(fs, "writeFile")
         .mockRejectedValueOnce(new Error("simulated write failure"));

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -33,6 +33,15 @@ function resolveSystemdUnit(env: NodeJS.ProcessEnv): string {
   return `${resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE)}.service`;
 }
 
+async function hasSystemdSystemUnit(unitName: string): Promise<boolean> {
+  try {
+    await fs.access(path.join("/etc", "systemd", "system", unitName));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function resolveLaunchdLabel(env: NodeJS.ProcessEnv): string {
   const override = env.OPENCLAW_LAUNCHD_LABEL?.trim();
   if (override) {
@@ -70,12 +79,13 @@ export async function prepareRestartScript(
     if (platform === "linux") {
       const unitName = resolveSystemdUnit(env);
       const escaped = shellEscape(unitName);
+      const useSystemUnit = await hasSystemdSystemUnit(unitName);
       filename = `openclaw-restart-${timestamp}.sh`;
       scriptContent = `#!/bin/sh
 # Standalone restart script — survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
 sleep 1
-systemctl --user restart '${escaped}'
+${useSystemUnit ? `sudo -n systemctl restart '${escaped}'` : `systemctl --user restart '${escaped}'`}
 # Self-cleanup
 rm -f "$0"
 `;

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -191,6 +191,26 @@ describe("isSystemdServiceEnabled", () => {
     expect(execFileMock).not.toHaveBeenCalled();
   });
 
+  it("checks a system-scoped unit with sudo systemctl when /etc system unit exists", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    vi.spyOn(fs, "access").mockImplementation(async (pathname) => {
+      const pathValue = pathLikeToString(pathname);
+      if (pathValue === `/etc/systemd/system/${GATEWAY_SERVICE}`) {
+        return undefined;
+      }
+      throw Object.assign(new Error("missing unit"), { code: "ENOENT" });
+    });
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      expect(_cmd).toBe("sudo");
+      expect(args).toEqual(["-n", "systemctl", "is-enabled", GATEWAY_SERVICE]);
+      cb(null, "enabled", "");
+    });
+
+    const result = await isSystemdServiceEnabled({ env: { HOME: TEST_MANAGED_HOME } });
+
+    expect(result).toBe(true);
+  });
+
   it("calls systemctl is-enabled when systemctl is present", async () => {
     execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
       assertUserSystemctlArgs(args, "is-enabled", GATEWAY_SERVICE);
@@ -654,6 +674,45 @@ describe("systemd service control", () => {
         cb(null, "", "");
       });
     await assertRestartSuccess({ OPENCLAW_PROFILE: "work" });
+  });
+
+  it("restarts a system-scoped unit with sudo when /etc system unit exists", async () => {
+    vi.spyOn(fs, "access").mockImplementation(async (pathname) => {
+      const pathValue = pathLikeToString(pathname);
+      if (pathValue === `/etc/systemd/system/${GATEWAY_SERVICE}`) {
+        return undefined;
+      }
+      throw Object.assign(new Error("missing unit"), { code: "ENOENT" });
+    });
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      expect(_cmd).toBe("sudo");
+      expect(args).toEqual(["-n", "systemctl", "restart", GATEWAY_SERVICE]);
+      cb(null, "", "");
+    });
+
+    await assertRestartSuccess({});
+  });
+
+  it("stops a system-scoped unit with sudo when /etc system unit exists", async () => {
+    vi.spyOn(fs, "access").mockImplementation(async (pathname) => {
+      const pathValue = pathLikeToString(pathname);
+      if (pathValue === `/etc/systemd/system/${GATEWAY_SERVICE}`) {
+        return undefined;
+      }
+      throw Object.assign(new Error("missing unit"), { code: "ENOENT" });
+    });
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      expect(_cmd).toBe("sudo");
+      expect(args).toEqual(["-n", "systemctl", "stop", GATEWAY_SERVICE]);
+      cb(null, "", "");
+    });
+    const write = vi.fn();
+    const stdout = { write } as unknown as NodeJS.WritableStream;
+
+    await stopSystemdService({ stdout, env: {} });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(String(write.mock.calls[0]?.[0])).toContain("Stopped systemd service");
   });
 
   it("surfaces stop failures with systemctl detail", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -43,6 +43,10 @@ function resolveSystemdUnitPathForName(env: GatewayServiceEnv, name: string): st
   return path.posix.join(home, ".config", "systemd", "user", `${name}.service`);
 }
 
+function resolveSystemdSystemUnitPathForName(name: string): string {
+  return path.posix.join("/etc", "systemd", "system", `${name}.service`);
+}
+
 function resolveSystemdServiceName(env: GatewayServiceEnv): string {
   const override = env.OPENCLAW_SYSTEMD_UNIT?.trim();
   if (override) {
@@ -59,6 +63,40 @@ export function resolveSystemdUserUnitPath(env: GatewayServiceEnv): string {
   return resolveSystemdUnitPath(env);
 }
 
+type SystemdServiceContext = {
+  scope: "user" | "system";
+  unitName: string;
+  unitPath: string;
+};
+
+async function pathExists(pathname: string): Promise<boolean> {
+  try {
+    await fs.access(pathname);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveSystemdServiceContext(
+  env: GatewayServiceEnv,
+): Promise<SystemdServiceContext> {
+  const serviceName = resolveSystemdServiceName(env);
+  const systemUnitPath = resolveSystemdSystemUnitPathForName(serviceName);
+  if (await pathExists(systemUnitPath)) {
+    return {
+      scope: "system",
+      unitName: `${serviceName}.service`,
+      unitPath: systemUnitPath,
+    };
+  }
+  return {
+    scope: "user",
+    unitName: `${serviceName}.service`,
+    unitPath: resolveSystemdUnitPath(env),
+  };
+}
+
 export { enableSystemdUserLinger, readSystemdUserLingerStatus };
 export type { SystemdUserLingerStatus };
 
@@ -67,7 +105,7 @@ export type { SystemdUserLingerStatus };
 export async function readSystemdServiceExecStart(
   env: GatewayServiceEnv,
 ): Promise<GatewayServiceCommandConfig | null> {
-  const unitPath = resolveSystemdUnitPath(env);
+  const { unitPath } = await resolveSystemdServiceContext(env);
   try {
     const content = await fs.readFile(unitPath, "utf8");
     let execStart = "";
@@ -263,6 +301,15 @@ async function execSystemctl(
   return await execFileUtf8("systemctl", args);
 }
 
+async function execSystemctlSystem(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  if (typeof process.getuid === "function" && process.getuid() !== 0) {
+    return await execFileUtf8("sudo", ["-n", "systemctl", ...args]);
+  }
+  return await execSystemctl(args);
+}
+
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
   // Concatenate both streams so pattern matchers (isSystemdUnitNotEnabled,
   // isSystemctlMissing) can see the unit status from stdout even when
@@ -382,6 +429,17 @@ async function execSystemctlUser(
     return directResult;
   }
   return await execSystemctl([...machineScopeArgs, ...args]);
+}
+
+async function execSystemctlForContext(
+  context: SystemdServiceContext,
+  env: GatewayServiceEnv,
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  if (context.scope === "system") {
+    return await execSystemctlSystem(args);
+  }
+  return await execSystemctlUser(env, args);
 }
 
 export async function isSystemdUserServiceAvailable(
@@ -525,12 +583,13 @@ export async function uninstallSystemdService({
   env,
   stdout,
 }: GatewayServiceManageArgs): Promise<void> {
-  await assertSystemdAvailable(env);
-  const serviceName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
-  const unitName = `${serviceName}.service`;
-  await execSystemctlUser(env, ["disable", "--now", unitName]);
+  const context = await resolveSystemdServiceContext(env);
+  if (context.scope === "user") {
+    await assertSystemdAvailable(env);
+  }
+  await execSystemctlForContext(context, env, ["disable", "--now", context.unitName]);
 
-  const unitPath = resolveSystemdUnitPath(env);
+  const unitPath = context.unitPath;
   try {
     await fs.unlink(unitPath);
     stdout.write(`${formatLine("Removed systemd service", unitPath)}\n`);
@@ -546,14 +605,15 @@ async function runSystemdServiceAction(params: {
   label: string;
 }) {
   const env = params.env ?? process.env;
-  await assertSystemdAvailable(env);
-  const serviceName = resolveSystemdServiceName(env);
-  const unitName = `${serviceName}.service`;
-  const res = await execSystemctlUser(env, [params.action, unitName]);
+  const context = await resolveSystemdServiceContext(env);
+  if (context.scope === "user") {
+    await assertSystemdAvailable(env);
+  }
+  const res = await execSystemctlForContext(context, env, [params.action, context.unitName]);
   if (res.code !== 0) {
     throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
   }
-  params.stdout.write(`${formatLine(params.label, unitName)}\n`);
+  params.stdout.write(`${formatLine(params.label, context.unitName)}\n`);
 }
 
 export async function stopSystemdService({
@@ -583,8 +643,9 @@ export async function restartSystemdService({
 
 export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Promise<boolean> {
   const env = args.env ?? process.env;
+  const context = await resolveSystemdServiceContext(env);
   try {
-    await fs.access(resolveSystemdUnitPath(env));
+    await fs.access(context.unitPath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return false;
@@ -592,9 +653,7 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
     throw error;
   }
 
-  const serviceName = resolveSystemdServiceName(env);
-  const unitName = `${serviceName}.service`;
-  const res = await execSystemctlUser(env, ["is-enabled", unitName]);
+  const res = await execSystemctlForContext(context, env, ["is-enabled", context.unitName]);
   if (res.code === 0) {
     return true;
   }
@@ -608,19 +667,20 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
 export async function readSystemdServiceRuntime(
   env: GatewayServiceEnv = process.env as GatewayServiceEnv,
 ): Promise<GatewayServiceRuntime> {
-  try {
-    await assertSystemdAvailable(env);
-  } catch (err) {
-    return {
-      status: "unknown",
-      detail: err instanceof Error ? err.message : String(err),
-    };
+  const context = await resolveSystemdServiceContext(env);
+  if (context.scope === "user") {
+    try {
+      await assertSystemdAvailable(env);
+    } catch (err) {
+      return {
+        status: "unknown",
+        detail: err instanceof Error ? err.message : String(err),
+      };
+    }
   }
-  const serviceName = resolveSystemdServiceName(env);
-  const unitName = `${serviceName}.service`;
-  const res = await execSystemctlUser(env, [
+  const res = await execSystemctlForContext(context, env, [
     "show",
-    unitName,
+    context.unitName,
     "--no-page",
     "--property",
     "ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode",


### PR DESCRIPTION
## Summary
- detect and use system-scoped systemd gateway units on Linux when `/etc/systemd/system/<unit>.service` exists
- fall back to the existing `systemctl --user` path when only the user unit exists
- teach the update restart helper to use the same system-vs-user rule
- add coverage for system-scoped unit detection and restart helper script generation

## Problem
On WSL with `systemd=true`, OpenClaw can validly run as a system unit under `/etc/systemd/system/openclaw-gateway.service`, but the Linux daemon adapter and restart helper still assume the gateway is always managed via `systemctl --user`.

That causes `openclaw gateway status` and `openclaw gateway restart` to misreport a healthy system-scoped install as disabled / unavailable.

## Verification
- rebuilt from source and installed locally from this branch
- verified `openclaw gateway status` reports:
  - `Service: systemd (enabled)`
  - `Service file: /etc/systemd/system/openclaw-gateway.service`
- verified `openclaw gateway restart` prints:
  - `Restarted systemd service: openclaw-gateway.service`
- verified the live WSL systemd unit restarted and came back active with a new MainPID

## Notes
- I attempted to run the focused Vitest files for the touched areas, but the repo's test runner was unusually slow/noisy in this environment.
- the repo pre-commit hook also failed on an unrelated existing typecheck issue in `src/config/redact-snapshot.test.ts`, so the commit here was created with `--no-verify` after validating the live behavior against a real WSL system unit.
