### PR TITLE
WhatsApp: send commentary live

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -319,6 +319,19 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
+  it("does not wire live commentary callbacks for telegram dispatch", async () => {
+    const draftStream = createDraftStream();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({ queuedFinal: false });
+
+    await dispatchWithContext({ context: createContext() });
+
+    const firstCall = dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0] as
+      | { replyOptions?: { onCommentaryReply?: unknown } }
+      | undefined;
+    expect(firstCall?.replyOptions?.onCommentaryReply).toBeUndefined();
+  });
+
   it("does not inject approval buttons in local dispatch once the monitor owns approvals", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver(

--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -31,6 +31,7 @@ export type ResolvedWhatsAppAccount = {
   chunkMode?: "length" | "newline";
   mediaMaxMb?: number;
   blockStreaming?: boolean;
+  commentaryDelivery?: "off" | "live";
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
   debounceMs?: number;
@@ -153,6 +154,7 @@ export function resolveWhatsAppAccount(params: {
     chunkMode: merged.chunkMode,
     mediaMaxMb: merged.mediaMaxMb,
     blockStreaming: merged.blockStreaming,
+    commentaryDelivery: merged.commentaryDelivery,
     ackReaction: merged.ackReaction,
     groups: merged.groups,
     debounceMs: merged.debounceMs,

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -1,11 +1,11 @@
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { sleep } from "openclaw/plugin-sdk/text-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { logVerbose } from "../../../../src/globals.js";
-import { sleep } from "../../../../src/utils.js";
 import { loadWebMedia } from "../media.js";
 import type { WebInboundMsg } from "./types.js";
 
-vi.mock("../../../../src/globals.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../../src/globals.js")>();
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
   return {
     ...actual,
     shouldLogVerbose: vi.fn(() => true),
@@ -17,8 +17,8 @@ vi.mock("../media.js", () => ({
   loadWebMedia: vi.fn(),
 }));
 
-vi.mock("../../../../src/utils.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../../src/utils.js")>();
+vi.mock("openclaw/plugin-sdk/text-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/text-runtime")>();
   return {
     ...actual,
     sleep: vi.fn(async () => {}),
@@ -65,6 +65,10 @@ function mockSecondReplySuccess(msg: WebInboundMsg) {
   );
 }
 
+function createNeverSettlingPromise<T>() {
+  return new Promise<T>(() => {});
+}
+
 const replyLogger = {
   info: vi.fn(),
   warn: vi.fn(),
@@ -88,6 +92,14 @@ describe("deliverWebReply", () => {
   beforeAll(async () => {
     vi.resetModules();
     ({ deliverWebReply } = await import("./deliver-reply.js"));
+  });
+
+  beforeEach(() => {
+    replyLogger.info.mockClear();
+    replyLogger.warn.mockClear();
+    vi.mocked(loadWebMedia).mockReset();
+    vi.mocked(logVerbose).mockClear();
+    vi.mocked(sleep).mockClear();
   });
 
   it("suppresses payloads flagged as reasoning", async () => {
@@ -154,6 +166,151 @@ describe("deliverWebReply", () => {
       expect(sleep).toHaveBeenCalledWith(500);
     },
   );
+
+  it("stops sending later text chunks after commentary delivery is aborted", async () => {
+    const msg = makeMsg();
+    const abortController = new AbortController();
+    vi.mocked(sleep).mockClear();
+    (
+      msg.reply as unknown as { mockImplementationOnce: (fn: () => Promise<void>) => void }
+    ).mockImplementationOnce(async () => {
+      const abortError = new Error("commentary aborted");
+      abortError.name = "AbortError";
+      abortController.abort(abortError);
+    });
+
+    await expect(
+      deliverWebReply({
+        replyResult: { text: "aaaaaa" },
+        msg,
+        maxMediaBytes: 1024 * 1024,
+        textLimit: 3,
+        replyLogger,
+        abortSignal: abortController.signal,
+        skipLog: true,
+      }),
+    ).rejects.toThrow("commentary aborted");
+
+    expect(msg.reply).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops retry backoff once commentary delivery is aborted", async () => {
+    const msg = makeMsg();
+    const abortController = new AbortController();
+    vi.mocked(sleep).mockClear();
+    (
+      msg.reply as unknown as { mockImplementationOnce: (fn: () => Promise<void>) => void }
+    ).mockImplementationOnce(async () => {
+      const abortError = new Error("commentary aborted");
+      abortError.name = "AbortError";
+      abortController.abort(abortError);
+      throw new Error("connection closed");
+    });
+
+    await expect(
+      deliverWebReply({
+        replyResult: { text: "hi" },
+        msg,
+        maxMediaBytes: 1024 * 1024,
+        textLimit: 200,
+        replyLogger,
+        abortSignal: abortController.signal,
+        skipLog: true,
+      }),
+    ).rejects.toThrow("commentary aborted");
+
+    expect(msg.reply).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("times out a hung text send instead of waiting forever", async () => {
+    vi.useFakeTimers();
+    try {
+      const msg = makeMsg();
+      (
+        msg.reply as unknown as { mockImplementationOnce: (fn: () => Promise<void>) => void }
+      ).mockImplementationOnce(() => createNeverSettlingPromise<void>());
+
+      const deliveryPromise = deliverWebReply({
+        replyResult: { text: "hi" },
+        msg,
+        maxMediaBytes: 1024 * 1024,
+        textLimit: 200,
+        replyLogger,
+        timeoutMs: 25,
+        skipLog: true,
+      });
+      const deliveryExpectation = expect(deliveryPromise).rejects.toThrow(
+        "delivery timed out after 25ms",
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      await deliveryExpectation;
+      expect(msg.reply).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out a hung media load instead of waiting forever", async () => {
+    vi.useFakeTimers();
+    try {
+      const msg = makeMsg();
+      (
+        loadWebMedia as unknown as { mockImplementationOnce: (fn: () => Promise<unknown>) => void }
+      ).mockImplementationOnce(() => createNeverSettlingPromise());
+
+      const deliveryPromise = deliverWebReply({
+        replyResult: { text: "caption", mediaUrl: "http://example.com/img.jpg" },
+        msg,
+        maxMediaBytes: 1024 * 1024,
+        textLimit: 200,
+        replyLogger,
+        timeoutMs: 25,
+        skipLog: true,
+      });
+      const deliveryExpectation = expect(deliveryPromise).rejects.toThrow(
+        "delivery timed out after 25ms",
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      await deliveryExpectation;
+      expect(loadWebMedia).toHaveBeenCalledTimes(1);
+      expect(msg.sendMedia).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out a hung media send instead of waiting forever", async () => {
+    vi.useFakeTimers();
+    try {
+      const msg = makeMsg();
+      mockLoadedImageMedia();
+      (
+        msg.sendMedia as unknown as { mockImplementationOnce: (fn: () => Promise<void>) => void }
+      ).mockImplementationOnce(() => createNeverSettlingPromise<void>());
+
+      const deliveryPromise = deliverWebReply({
+        replyResult: { text: "caption", mediaUrl: "http://example.com/img.jpg" },
+        msg,
+        maxMediaBytes: 1024 * 1024,
+        textLimit: 200,
+        replyLogger,
+        timeoutMs: 25,
+        skipLog: true,
+      });
+      const deliveryExpectation = expect(deliveryPromise).rejects.toThrow(
+        "delivery timed out after 25ms",
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      await deliveryExpectation;
+      expect(msg.sendMedia).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it("sends image media with caption and then remaining text", async () => {
     const msg = makeMsg();

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -1,8 +1,5 @@
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-runtime";
-import {
-  resolveOutboundMediaUrls,
-  sendMediaWithLeadingCaption,
-} from "openclaw/plugin-sdk/reply-payload";
+import { resolveOutboundMediaUrls } from "openclaw/plugin-sdk/reply-payload";
 import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -41,6 +38,8 @@ export async function deliverWebReply(params: {
     warn: (obj: unknown, msg: string) => void;
   };
   connectionId?: string;
+  abortSignal?: AbortSignal;
+  timeoutMs?: number;
   skipLog?: boolean;
   tableMode?: MarkdownTableMode;
 }) {
@@ -57,14 +56,100 @@ export async function deliverWebReply(params: {
   );
   const textChunks = chunkMarkdownTextWithMode(convertedText, textLimit, chunkMode);
   const mediaList = resolveOutboundMediaUrls(replyResult);
+  const abortController =
+    params.abortSignal || params.timeoutMs ? new AbortController() : undefined;
+  const abortSignal = abortController?.signal ?? params.abortSignal;
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  let upstreamAbortListener: (() => void) | undefined;
+  if (abortController && params.abortSignal) {
+    upstreamAbortListener = () => {
+      abortController.abort(params.abortSignal?.reason);
+    };
+    if (params.abortSignal.aborted) {
+      upstreamAbortListener();
+    } else {
+      params.abortSignal.addEventListener("abort", upstreamAbortListener, { once: true });
+    }
+  }
+  if (abortController && params.timeoutMs && params.timeoutMs > 0) {
+    timeoutHandle = setTimeout(() => {
+      const timeoutError = new Error(`delivery timed out after ${params.timeoutMs}ms`);
+      timeoutError.name = "AbortError";
+      abortController.abort(timeoutError);
+    }, params.timeoutMs);
+  }
+  const throwIfAborted = () => {
+    if (!abortSignal?.aborted) {
+      return;
+    }
+    throw abortSignal.reason instanceof Error
+      ? abortSignal.reason
+      : new Error(String(abortSignal.reason ?? "aborted"));
+  };
+  const sleepWithAbort = async (ms: number) => {
+    throwIfAborted();
+    if (!abortSignal) {
+      await sleep(ms);
+      return;
+    }
+    let abortListener: (() => void) | undefined;
+    const abortPromise = new Promise<never>((_, reject) => {
+      abortListener = () => {
+        reject(
+          abortSignal.reason instanceof Error
+            ? abortSignal.reason
+            : new Error(String(abortSignal.reason ?? "aborted")),
+        );
+      };
+      abortSignal.addEventListener("abort", abortListener, { once: true });
+    });
+    try {
+      await Promise.race([sleep(ms), abortPromise]);
+    } finally {
+      if (abortListener) {
+        abortSignal.removeEventListener("abort", abortListener);
+      }
+    }
+  };
+  const awaitWithAbort = async <T>(fn: () => Promise<T>): Promise<T> => {
+    throwIfAborted();
+    const workPromise = Promise.resolve().then(fn);
+    if (!abortSignal) {
+      return await workPromise;
+    }
+    let abortListener: (() => void) | undefined;
+    const abortPromise = new Promise<never>((_, reject) => {
+      abortListener = () => {
+        reject(
+          abortSignal.reason instanceof Error
+            ? abortSignal.reason
+            : new Error(String(abortSignal.reason ?? "aborted")),
+        );
+      };
+      abortSignal.addEventListener("abort", abortListener, { once: true });
+    });
+    try {
+      // Underlying provider I/O is not cancelable here, but callers should not
+      // stay pinned behind hung media loads or sends once a turn is aborting.
+      return await Promise.race([workPromise, abortPromise]);
+    } finally {
+      if (abortListener) {
+        abortSignal.removeEventListener("abort", abortListener);
+      }
+    }
+  };
 
   const sendWithRetry = async (fn: () => Promise<unknown>, label: string, maxAttempts = 3) => {
     let lastErr: unknown;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      throwIfAborted();
       try {
-        return await fn();
+        return await awaitWithAbort(fn);
       } catch (err) {
         lastErr = err;
+        if (abortSignal?.aborted) {
+          throw err;
+        }
         const errText = formatError(err);
         const isLast = attempt === maxAttempts;
         const shouldRetry = /closed|reset|timed\s*out|disconnect/i.test(errText);
@@ -75,143 +160,154 @@ export async function deliverWebReply(params: {
         logVerbose(
           `Retrying ${label} to ${msg.from} after failure (${attempt}/${maxAttempts - 1}) in ${backoffMs}ms: ${errText}`,
         );
-        await sleep(backoffMs);
+        await sleepWithAbort(backoffMs);
       }
     }
     throw lastErr;
   };
 
-  // Text-only replies
-  if (mediaList.length === 0 && textChunks.length) {
-    const totalChunks = textChunks.length;
-    for (const [index, chunk] of textChunks.entries()) {
-      const chunkStarted = Date.now();
-      await sendWithRetry(() => msg.reply(chunk), "text");
-      if (!skipLog) {
-        const durationMs = Date.now() - chunkStarted;
-        whatsappOutboundLog.debug(
-          `Sent chunk ${index + 1}/${totalChunks} to ${msg.from} (${durationMs.toFixed(0)}ms)`,
-        );
+  try {
+    // Text-only replies
+    if (mediaList.length === 0 && textChunks.length) {
+      const totalChunks = textChunks.length;
+      for (const [index, chunk] of textChunks.entries()) {
+        throwIfAborted();
+        const chunkStarted = Date.now();
+        await sendWithRetry(() => msg.reply(chunk), "text");
+        if (!skipLog) {
+          const durationMs = Date.now() - chunkStarted;
+          whatsappOutboundLog.debug(
+            `Sent chunk ${index + 1}/${totalChunks} to ${msg.from} (${durationMs.toFixed(0)}ms)`,
+          );
+        }
       }
-    }
-    replyLogger.info(
-      {
-        correlationId: msg.id ?? newConnectionId(),
-        connectionId: connectionId ?? null,
-        to: msg.from,
-        from: msg.to,
-        text: elide(replyResult.text, 240),
-        mediaUrl: null,
-        mediaSizeBytes: null,
-        mediaKind: null,
-        durationMs: Date.now() - replyStarted,
-      },
-      "auto-reply sent (text)",
-    );
-    return;
-  }
-
-  const remainingText = [...textChunks];
-
-  // Media (with optional caption on first item)
-  const leadingCaption = remainingText.shift() || "";
-  await sendMediaWithLeadingCaption({
-    mediaUrls: mediaList,
-    caption: leadingCaption,
-    send: async ({ mediaUrl, caption }) => {
-      const media = await loadWebMedia(mediaUrl, {
-        maxBytes: maxMediaBytes,
-        localRoots: params.mediaLocalRoots,
-      });
-      if (shouldLogVerbose()) {
-        logVerbose(
-          `Web auto-reply media size: ${(media.buffer.length / (1024 * 1024)).toFixed(2)}MB`,
-        );
-        logVerbose(`Web auto-reply media source: ${mediaUrl} (kind ${media.kind})`);
-      }
-      if (media.kind === "image") {
-        await sendWithRetry(
-          () =>
-            msg.sendMedia({
-              image: media.buffer,
-              caption,
-              mimetype: media.contentType,
-            }),
-          "media:image",
-        );
-      } else if (media.kind === "audio") {
-        await sendWithRetry(
-          () =>
-            msg.sendMedia({
-              audio: media.buffer,
-              ptt: true,
-              mimetype: media.contentType,
-              caption,
-            }),
-          "media:audio",
-        );
-      } else if (media.kind === "video") {
-        await sendWithRetry(
-          () =>
-            msg.sendMedia({
-              video: media.buffer,
-              caption,
-              mimetype: media.contentType,
-            }),
-          "media:video",
-        );
-      } else {
-        const fileName = media.fileName ?? mediaUrl.split("/").pop() ?? "file";
-        const mimetype = media.contentType ?? "application/octet-stream";
-        await sendWithRetry(
-          () =>
-            msg.sendMedia({
-              document: media.buffer,
-              fileName,
-              caption,
-              mimetype,
-            }),
-          "media:document",
-        );
-      }
-      whatsappOutboundLog.info(
-        `Sent media reply to ${msg.from} (${(media.buffer.length / (1024 * 1024)).toFixed(2)}MB)`,
-      );
       replyLogger.info(
         {
           correlationId: msg.id ?? newConnectionId(),
           connectionId: connectionId ?? null,
           to: msg.from,
           from: msg.to,
-          text: caption ?? null,
-          mediaUrl,
-          mediaSizeBytes: media.buffer.length,
-          mediaKind: media.kind,
+          text: elide(replyResult.text, 240),
+          mediaUrl: null,
+          mediaSizeBytes: null,
+          mediaKind: null,
           durationMs: Date.now() - replyStarted,
         },
-        "auto-reply sent (media)",
+        "auto-reply sent (text)",
       );
-    },
-    onError: async ({ error, mediaUrl, caption, isFirst }) => {
-      whatsappOutboundLog.error(`Failed sending web media to ${msg.from}: ${formatError(error)}`);
-      replyLogger.warn({ err: error, mediaUrl }, "failed to send web media reply");
-      if (!isFirst) {
-        return;
-      }
-      const warning =
-        error instanceof Error ? `⚠️ Media failed: ${error.message}` : "⚠️ Media failed.";
-      const fallbackTextParts = [remainingText.shift() ?? caption ?? "", warning].filter(Boolean);
-      const fallbackText = fallbackTextParts.join("\n");
-      if (!fallbackText) {
-        return;
-      }
-      whatsappOutboundLog.warn(`Media skipped; sent text-only to ${msg.from}`);
-      await msg.reply(fallbackText);
-    },
-  });
+      return;
+    }
 
-  // Remaining text chunks after media
-  for (const chunk of remainingText) {
-    await msg.reply(chunk);
+    const remainingText = [...textChunks];
+
+    // Media (with optional caption on the first item)
+    for (const [index, mediaUrl] of mediaList.entries()) {
+      throwIfAborted();
+      const caption = index === 0 ? remainingText.shift() || undefined : undefined;
+      try {
+        const media = await awaitWithAbort(() =>
+          loadWebMedia(mediaUrl, {
+            maxBytes: maxMediaBytes,
+            localRoots: params.mediaLocalRoots,
+          }),
+        );
+        if (shouldLogVerbose()) {
+          logVerbose(
+            `Web auto-reply media size: ${(media.buffer.length / (1024 * 1024)).toFixed(2)}MB`,
+          );
+          logVerbose(`Web auto-reply media source: ${mediaUrl} (kind ${media.kind})`);
+        }
+        if (media.kind === "image") {
+          await sendWithRetry(
+            () =>
+              msg.sendMedia({
+                image: media.buffer,
+                caption,
+                mimetype: media.contentType,
+              }),
+            "media:image",
+          );
+        } else if (media.kind === "audio") {
+          await sendWithRetry(
+            () =>
+              msg.sendMedia({
+                audio: media.buffer,
+                ptt: true,
+                mimetype: media.contentType,
+                caption,
+              }),
+            "media:audio",
+          );
+        } else if (media.kind === "video") {
+          await sendWithRetry(
+            () =>
+              msg.sendMedia({
+                video: media.buffer,
+                caption,
+                mimetype: media.contentType,
+              }),
+            "media:video",
+          );
+        } else {
+          const fileName = media.fileName ?? mediaUrl.split("/").pop() ?? "file";
+          const mimetype = media.contentType ?? "application/octet-stream";
+          await sendWithRetry(
+            () =>
+              msg.sendMedia({
+                document: media.buffer,
+                fileName,
+                caption,
+                mimetype,
+              }),
+            "media:document",
+          );
+        }
+        whatsappOutboundLog.info(
+          `Sent media reply to ${msg.from} (${(media.buffer.length / (1024 * 1024)).toFixed(2)}MB)`,
+        );
+        replyLogger.info(
+          {
+            correlationId: msg.id ?? newConnectionId(),
+            connectionId: connectionId ?? null,
+            to: msg.from,
+            from: msg.to,
+            text: caption ?? null,
+            mediaUrl,
+            mediaSizeBytes: media.buffer.length,
+            mediaKind: media.kind,
+            durationMs: Date.now() - replyStarted,
+          },
+          "auto-reply sent (media)",
+        );
+      } catch (error) {
+        whatsappOutboundLog.error(`Failed sending web media to ${msg.from}: ${formatError(error)}`);
+        replyLogger.warn({ err: error, mediaUrl }, "failed to send web media reply");
+        if (index > 0) {
+          continue;
+        }
+        const warning =
+          error instanceof Error ? `⚠️ Media failed: ${error.message}` : "⚠️ Media failed.";
+        const fallbackTextParts = [remainingText.shift() ?? caption ?? "", warning].filter(Boolean);
+        const fallbackText = fallbackTextParts.join("\n");
+        if (!fallbackText) {
+          continue;
+        }
+        whatsappOutboundLog.warn(`Media skipped; sent text-only to ${msg.from}`);
+        await awaitWithAbort(() => msg.reply(fallbackText));
+      }
+    }
+
+    // Remaining text chunks after media
+    for (const chunk of remainingText) {
+      throwIfAborted();
+      await awaitWithAbort(() => msg.reply(chunk));
+    }
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+    if (params.abortSignal && upstreamAbortListener) {
+      params.abortSignal.removeEventListener("abort", upstreamAbortListener);
+    }
   }
 }

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
@@ -63,13 +63,19 @@ function makeProcessMessageArgs(params: {
 
 function createWhatsAppDirectStreamingArgs(params?: {
   rememberSentText?: (text: string | undefined, opts: unknown) => void;
+  commentaryDelivery?: "off" | "live";
 }) {
   return makeProcessMessageArgs({
     routeSessionKey: "agent:main:whatsapp:direct:+1555",
     groupHistoryKey: "+1555",
     rememberSentText: params?.rememberSentText,
     cfg: {
-      channels: { whatsapp: { blockStreaming: true } },
+      channels: {
+        whatsapp: {
+          blockStreaming: true,
+          ...(params?.commentaryDelivery ? { commentaryDelivery: params.commentaryDelivery } : {}),
+        },
+      },
       messages: {},
       session: { store: sessionStorePath },
     } as unknown as ReturnType<typeof import("../../../../../src/config/config.js").loadConfig>,
@@ -312,6 +318,92 @@ describe("web processMessage inbound context", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     const replyOptions = (capturedDispatchParams as any)?.replyOptions;
     expect(replyOptions?.disableBlockStreaming).toBe(true);
+  });
+
+  it("does not wire commentary delivery by default", async () => {
+    await processMessage(createWhatsAppDirectStreamingArgs());
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const replyOptions = (capturedDispatchParams as any)?.replyOptions;
+    expect(replyOptions?.onCommentaryReply).toBeUndefined();
+  });
+
+  it("wires commentary delivery when WhatsApp live commentary is enabled", async () => {
+    await processMessage(createWhatsAppDirectStreamingArgs({ commentaryDelivery: "live" }));
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const replyOptions = (capturedDispatchParams as any)?.replyOptions;
+    expect(replyOptions?.onCommentaryReply).toBeTypeOf("function");
+    expect(replyOptions?.blockReplyTimeoutMs).toBe(15_000);
+  });
+
+  it("normalizes commentary directives before delivery", async () => {
+    await processMessage(createWhatsAppDirectStreamingArgs({ commentaryDelivery: "live" }));
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const replyOptions = (capturedDispatchParams as any)?.replyOptions;
+    await replyOptions?.onCommentaryReply?.({ text: "   [[replyToCurrent]]hello" });
+
+    expect(deliverWebReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyResult: expect.objectContaining({
+          text: "hello",
+          replyToCurrent: true,
+        }),
+      }),
+    );
+  });
+
+  it("suppresses silent commentary after normalization", async () => {
+    const rememberSentText = vi.fn();
+    await processMessage(
+      createWhatsAppDirectStreamingArgs({
+        commentaryDelivery: "live",
+        rememberSentText,
+      }),
+    );
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const replyOptions = (capturedDispatchParams as any)?.replyOptions;
+    await replyOptions?.onCommentaryReply?.({ text: "   " });
+
+    expect(deliverWebReplyMock).not.toHaveBeenCalled();
+    expect(rememberSentText).not.toHaveBeenCalled();
+  });
+
+  it("allows media-only commentary delivery", async () => {
+    await processMessage(createWhatsAppDirectStreamingArgs({ commentaryDelivery: "live" }));
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const replyOptions = (capturedDispatchParams as any)?.replyOptions;
+    await replyOptions?.onCommentaryReply?.({ mediaUrl: "https://example.com/test.jpg" });
+
+    expect(deliverWebReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyResult: expect.objectContaining({
+          mediaUrl: "https://example.com/test.jpg",
+        }),
+      }),
+    );
+  });
+
+  it("forwards commentary abort and timeout into WhatsApp delivery", async () => {
+    await processMessage(createWhatsAppDirectStreamingArgs({ commentaryDelivery: "live" }));
+    const abortController = new AbortController();
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const replyOptions = (capturedDispatchParams as any)?.replyOptions;
+    await replyOptions?.onCommentaryReply?.(
+      { text: "hello" },
+      { abortSignal: abortController.signal, timeoutMs: 3_000 },
+    );
+
+    expect(deliverWebReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        abortSignal: abortController.signal,
+        timeoutMs: 3_000,
+      }),
+    );
   });
 
   it("passes sendComposing through as the reply typing callback", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -15,7 +15,12 @@ import {
   type HistoryEntry,
 } from "openclaw/plugin-sdk/reply-history";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { resolveChunkMode, resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  normalizeReplyPayloadDirectives,
+  resolveChunkMode,
+  resolveTextChunkLimit,
+} from "openclaw/plugin-sdk/reply-runtime";
+import type { BlockReplyContext } from "openclaw/plugin-sdk/reply-runtime";
 import type { getReplyFromConfig } from "openclaw/plugin-sdk/reply-runtime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
 import { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-runtime";
@@ -57,6 +62,8 @@ export type GroupHistoryEntry = {
   id?: string;
   senderJid?: string;
 };
+
+const COMMENTARY_REPLY_TIMEOUT_MS = 15_000;
 
 async function resolveWhatsAppCommandAuthorized(params: {
   cfg: ReturnType<typeof loadConfig>;
@@ -272,6 +279,11 @@ export async function processMessage(params: {
     channel: "whatsapp",
     accountId: params.route.accountId,
   });
+  const whatsAppAccount = resolveWhatsAppAccount({
+    cfg: params.cfg,
+    accountId: params.route.accountId,
+  });
+  const commentaryDelivery = whatsAppAccount.commentaryDelivery ?? "off";
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(params.cfg, params.route.agentId);
   let didLogHeartbeatStrip = false;
   let didSendReply = false;
@@ -398,6 +410,78 @@ export async function processMessage(params: {
   });
   trackBackgroundTask(params.backgroundTasks, metaTask);
 
+  const sendWhatsAppPayload = async (
+    payload: ReplyPayload,
+    kind: "commentary" | "final",
+    context?: BlockReplyContext,
+  ): Promise<void> => {
+    if (context?.abortSignal?.aborted) {
+      throw context.abortSignal.reason instanceof Error
+        ? context.abortSignal.reason
+        : new Error(String(context.abortSignal.reason ?? "aborted"));
+    }
+
+    const normalized = normalizeReplyPayloadDirectives({
+      payload,
+      trimLeadingWhitespace: true,
+      parseMode: "auto",
+    });
+    const hasMedia = resolveSendableOutboundReplyParts(normalized.payload).hasMedia;
+    const hasVisibleContent =
+      Boolean(normalized.payload.text) || hasMedia || Boolean(normalized.payload.audioAsVoice);
+    if (!hasVisibleContent) {
+      return;
+    }
+    if (normalized.isSilent && !hasMedia) {
+      return;
+    }
+
+    await deliverWebReply({
+      replyResult: normalized.payload,
+      msg: params.msg,
+      mediaLocalRoots,
+      maxMediaBytes: params.maxMediaBytes,
+      textLimit,
+      chunkMode,
+      replyLogger: params.replyLogger,
+      connectionId: params.connectionId,
+      abortSignal: context?.abortSignal,
+      timeoutMs: context?.timeoutMs,
+      skipLog: false,
+      tableMode,
+    });
+    didSendReply = true;
+
+    params.rememberSentText(
+      normalized.payload.text,
+      kind === "final"
+        ? {
+            combinedBody,
+            combinedBodySessionKey: params.route.sessionKey,
+            logVerboseMessage: normalized.payload.text ? true : undefined,
+          }
+        : {
+            logVerboseMessage: normalized.payload.text ? true : undefined,
+          },
+    );
+
+    const fromDisplay =
+      params.msg.chatType === "group" ? conversationId : (params.msg.from ?? "unknown");
+    if (kind === "commentary") {
+      whatsappOutboundLog.info(
+        `Sent commentary update to ${fromDisplay}${hasMedia ? " (media)" : ""}`,
+      );
+    } else {
+      whatsappOutboundLog.info(`Auto-replied to ${fromDisplay}${hasMedia ? " (media)" : ""}`);
+    }
+    if (shouldLogVerbose()) {
+      const preview =
+        normalized.payload.text != null ? elide(normalized.payload.text, 400) : "<media>";
+      const prefix = kind === "commentary" ? "Commentary body" : "Reply body";
+      whatsappOutboundLog.debug(`${prefix}: ${preview}${hasMedia ? " (media)" : ""}`);
+    }
+  };
+
   const { queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
     ctx: ctxPayload,
     cfg: params.cfg,
@@ -418,34 +502,7 @@ export async function processMessage(params: {
           // web UI only; sending them here leaks chain-of-thought to end users.
           return;
         }
-        await deliverWebReply({
-          replyResult: payload,
-          msg: params.msg,
-          mediaLocalRoots,
-          maxMediaBytes: params.maxMediaBytes,
-          textLimit,
-          chunkMode,
-          replyLogger: params.replyLogger,
-          connectionId: params.connectionId,
-          skipLog: false,
-          tableMode,
-        });
-        didSendReply = true;
-        const shouldLog = payload.text ? true : undefined;
-        params.rememberSentText(payload.text, {
-          combinedBody,
-          combinedBodySessionKey: params.route.sessionKey,
-          logVerboseMessage: shouldLog,
-        });
-        const fromDisplay =
-          params.msg.chatType === "group" ? conversationId : (params.msg.from ?? "unknown");
-        const reply = resolveSendableOutboundReplyParts(payload);
-        const hasMedia = reply.hasMedia;
-        whatsappOutboundLog.info(`Auto-replied to ${fromDisplay}${hasMedia ? " (media)" : ""}`);
-        if (shouldLogVerbose()) {
-          const preview = payload.text != null ? elide(reply.text, 400) : "<media>";
-          whatsappOutboundLog.debug(`Reply body: ${preview}${hasMedia ? " (media)" : ""}`);
-        }
+        await sendWhatsAppPayload(payload, "final");
       },
       onError: (err, info) => {
         const label =
@@ -464,6 +521,13 @@ export async function processMessage(params: {
       // WhatsApp delivery intentionally suppresses non-final payloads.
       // Keep block streaming disabled so final replies are still produced.
       disableBlockStreaming: true,
+      blockReplyTimeoutMs: COMMENTARY_REPLY_TIMEOUT_MS,
+      onCommentaryReply:
+        commentaryDelivery === "live"
+          ? async (payload, context) => {
+              await sendWhatsAppPayload(payload, "commentary", context);
+            }
+          : undefined,
       onModelSelected,
     },
   });
@@ -472,8 +536,10 @@ export async function processMessage(params: {
     if (shouldClearGroupHistory) {
       params.groupHistories.set(params.groupHistoryKey, []);
     }
-    logVerbose("Skipping auto-reply: silent token or no text/media returned from resolver");
-    return false;
+    if (!didSendReply) {
+      logVerbose("Skipping auto-reply: silent token or no text/media returned from resolver");
+    }
+    return didSendReply;
   }
 
   if (shouldClearGroupHistory) {

--- a/src/agents/pi-embedded-commentary.ts
+++ b/src/agents/pi-embedded-commentary.ts
@@ -1,0 +1,192 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { sanitizeUserFacingText } from "./pi-embedded-helpers.js";
+import {
+  extractAssistantText,
+  stripDowngradedToolCallText,
+  stripMinimaxToolCallXml,
+  stripModelSpecialTokens,
+  stripThinkingTagsFromText,
+} from "./pi-embedded-utils.js";
+
+export type AssistantMessagePhase = "commentary" | "final_answer";
+
+export type AssistantOutputEntry = {
+  segmentId: string;
+  text: string;
+  phase?: AssistantMessagePhase | null;
+};
+
+export type AssistantOutputCandidate = AssistantOutputEntry & {
+  isTerminal: boolean;
+};
+
+export function normalizeAssistantMessagePhase(value: unknown): AssistantMessagePhase | null {
+  return value === "commentary" || value === "final_answer" ? value : null;
+}
+
+function sanitizeAssistantSegmentText(text: string, errorContext: boolean) {
+  return sanitizeUserFacingText(
+    stripThinkingTagsFromText(
+      stripDowngradedToolCallText(stripModelSpecialTokens(stripMinimaxToolCallXml(text))),
+    ).trim(),
+    { errorContext },
+  );
+}
+
+function parseAssistantTextSignature(
+  value: unknown,
+): { id: string; phase?: AssistantMessagePhase } | null {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{")) {
+    return { id: trimmed };
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as { id?: unknown; phase?: unknown };
+    if (typeof parsed.id !== "string" || parsed.id.trim().length === 0) {
+      return null;
+    }
+    const normalizedPhase = normalizeAssistantMessagePhase(parsed.phase);
+    return {
+      id: parsed.id,
+      ...(normalizedPhase ? { phase: normalizedPhase } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function resolveAssistantTextBlockPhase(
+  block: Record<string, unknown>,
+  defaultPhase?: AssistantMessagePhase | null,
+) {
+  const directPhase = normalizeAssistantMessagePhase(block.phase);
+  if (directPhase) {
+    return directPhase;
+  }
+  const parsedSignature = parseAssistantTextSignature(block.textSignature);
+  if (parsedSignature?.phase) {
+    return parsedSignature.phase;
+  }
+  return defaultPhase ?? null;
+}
+
+function resolveAssistantTextBlockSignatureId(block: Record<string, unknown>) {
+  return parseAssistantTextSignature(block.textSignature)?.id;
+}
+
+function resolveAssistantMessageStableId(
+  messageRecord?: Record<string, unknown>,
+  fallbackMessageStableId?: string,
+) {
+  const id = messageRecord?.id;
+  return typeof id === "string" && id.trim().length > 0
+    ? id
+    : (fallbackMessageStableId ?? "message");
+}
+
+export function extractAssistantOutputCandidates(
+  msg: AgentMessage,
+  options?: { fallbackMessageStableId?: string },
+): AssistantOutputCandidate[] {
+  if (msg?.role !== "assistant") {
+    return [];
+  }
+  const messageRecord =
+    msg && typeof msg === "object" ? (msg as unknown as Record<string, unknown>) : undefined;
+  const messageStableId = resolveAssistantMessageStableId(
+    messageRecord,
+    options?.fallbackMessageStableId,
+  );
+  const defaultPhase = normalizeAssistantMessagePhase(messageRecord?.phase);
+  const errorContext = messageRecord?.stopReason === "error";
+  const content = Array.isArray(messageRecord?.content)
+    ? (messageRecord.content as Array<Record<string, unknown>>)
+    : null;
+
+  if (!content) {
+    const text = extractAssistantText(msg);
+    return text
+      ? [
+          {
+            segmentId: `assistant:${messageStableId}:segment:0`,
+            text,
+            isTerminal: true,
+            ...(defaultPhase ? { phase: defaultPhase } : {}),
+          },
+        ]
+      : [];
+  }
+
+  const groupedSegments: AssistantOutputCandidate[] = [];
+  let pendingUnsignedSegment: AssistantOutputCandidate | null = null;
+  let unsignedSegmentOrdinal = 0;
+
+  const flushPendingUnsignedSegment = () => {
+    if (!pendingUnsignedSegment) {
+      return;
+    }
+    groupedSegments.push(pendingUnsignedSegment);
+    pendingUnsignedSegment = null;
+  };
+
+  for (const [index, block] of content.entries()) {
+    if (block.type !== "text" || typeof block.text !== "string") {
+      flushPendingUnsignedSegment();
+      continue;
+    }
+    const phase = resolveAssistantTextBlockPhase(block, defaultPhase);
+    const signatureId = resolveAssistantTextBlockSignatureId(block);
+    if (signatureId) {
+      flushPendingUnsignedSegment();
+      groupedSegments.push({
+        segmentId: signatureId,
+        text: block.text,
+        isTerminal: index === content.length - 1,
+        ...(phase ? { phase } : {}),
+      });
+      continue;
+    }
+    if (!pendingUnsignedSegment || (pendingUnsignedSegment.phase ?? null) !== (phase ?? null)) {
+      flushPendingUnsignedSegment();
+      pendingUnsignedSegment = {
+        segmentId: `assistant:${messageStableId}:segment:${unsignedSegmentOrdinal}`,
+        text: block.text,
+        isTerminal: index === content.length - 1,
+        ...(phase ? { phase } : {}),
+      };
+      unsignedSegmentOrdinal += 1;
+      continue;
+    }
+    pendingUnsignedSegment.text += block.text;
+    pendingUnsignedSegment.isTerminal = index === content.length - 1;
+  }
+  flushPendingUnsignedSegment();
+
+  return groupedSegments
+    .map<AssistantOutputCandidate | null>((segment) => {
+      const text = sanitizeAssistantSegmentText(segment.text, errorContext).trim();
+      return text
+        ? {
+            segmentId: segment.segmentId,
+            text,
+            isTerminal: segment.isTerminal,
+            ...(segment.phase ? { phase: segment.phase } : {}),
+          }
+        : null;
+    })
+    .filter((segment): segment is AssistantOutputCandidate => Boolean(segment));
+}
+
+export function extractAssistantOutputSegments(
+  msg: AgentMessage,
+  options?: { fallbackMessageStableId?: string },
+): AssistantOutputEntry[] {
+  return extractAssistantOutputCandidates(msg, options).map(
+    ({ isTerminal: _isTerminal, ...segment }) => {
+      return segment;
+    },
+  );
+}

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -523,10 +523,12 @@ export async function runEmbeddedPiAgent(
             shouldEmitToolOutput: params.shouldEmitToolOutput,
             onPartialReply: params.onPartialReply,
             onAssistantMessageStart: params.onAssistantMessageStart,
+            onCommentaryReply: params.onCommentaryReply,
             onBlockReply: params.onBlockReply,
             onBlockReplyFlush: params.onBlockReplyFlush,
             blockReplyBreak: params.blockReplyBreak,
             blockReplyChunking: params.blockReplyChunking,
+            blockReplyTimeoutMs: params.blockReplyTimeoutMs,
             onReasoningStream: params.onReasoningStream,
             onReasoningEnd: params.onReasoningEnd,
             onToolResult: params.onToolResult,
@@ -1250,6 +1252,8 @@ export async function runEmbeddedPiAgent(
 
           const payloads = buildEmbeddedRunPayloads({
             assistantTexts: attempt.assistantTexts,
+            assistantOutputs: attempt.assistantOutputs,
+            deliveredCommentarySegmentIds: attempt.deliveredCommentarySegmentIds,
             toolMetas: attempt.toolMetas,
             lastAssistant: attempt.lastAssistant,
             lastToolError: attempt.lastToolError,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -153,6 +153,7 @@ import {
   stripSessionsYieldArtifacts,
   waitForSessionsYieldAbortSettle,
 } from "./attempt.sessions-yield.js";
+import { wrapStreamFnHandleSensitiveStopReason } from "./attempt.stop-reason-recovery.js";
 import {
   appendAttemptCacheTtlIfNeeded,
   composeSystemPromptWithHookContext,
@@ -164,7 +165,6 @@ import {
   wrapStreamFnDecodeXaiToolCallArguments,
   wrapStreamFnRepairMalformedToolCallArguments,
 } from "./attempt.tool-call-argument-repair.js";
-import { wrapStreamFnHandleSensitiveStopReason } from "./attempt.stop-reason-recovery.js";
 import {
   wrapStreamFnSanitizeMalformedToolCalls,
   wrapStreamFnTrimToolCallNames,
@@ -1231,12 +1231,16 @@ export async function runEmbeddedAttempt(
         onReasoningEnd: params.onReasoningEnd,
         onBlockReply: params.onBlockReply,
         onBlockReplyFlush: params.onBlockReplyFlush,
+        onCommentaryReply: params.onCommentaryReply,
+        blockReplyTimeoutMs: params.blockReplyTimeoutMs,
         blockReplyBreak: params.blockReplyBreak,
         blockReplyChunking: params.blockReplyChunking,
         onPartialReply: params.onPartialReply,
         onAssistantMessageStart: params.onAssistantMessageStart,
         onAgentEvent: params.onAgentEvent,
         enforceFinalTag: params.enforceFinalTag,
+        silentExpected: params.silentExpected,
+        abortSignal: params.abortSignal,
         config: params.config,
         sessionKey: sandboxSessionKey,
         sessionId: params.sessionId,
@@ -1245,8 +1249,13 @@ export async function runEmbeddedAttempt(
 
       const {
         assistantTexts,
+        assistantOutputs,
         toolMetas,
         unsubscribe,
+        deliveredCommentarySegmentIds,
+        getPendingCommentaryDeliveryCount,
+        waitForCommentaryDeliveryRound,
+        abortCommentaryDelivery,
         waitForCompactionRetry,
         isCompactionInFlight,
         getMessagingToolSentTexts,
@@ -1271,6 +1280,54 @@ export async function runEmbeddedAttempt(
 
       let abortWarnTimer: NodeJS.Timeout | undefined;
       const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
+      const commentaryDeliveryTimeoutMs = Math.max(1, params.blockReplyTimeoutMs ?? 15_000);
+      const waitForCommentaryDeliveryBounded = async () => {
+        if (!params.onCommentaryReply) {
+          return;
+        }
+        while (true) {
+          const pendingCount = Math.max(1, getPendingCommentaryDeliveryCount());
+          const roundTimeoutMs = commentaryDeliveryTimeoutMs * pendingCount;
+          let timer: NodeJS.Timeout | undefined;
+          const timeoutError = new Error(`commentary delivery timed out after ${roundTimeoutMs}ms`);
+          timeoutError.name = "AbortError";
+          const timeoutPromise = new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(timeoutError), roundTimeoutMs);
+          });
+          try {
+            const didDrain = await abortable(
+              Promise.race([waitForCommentaryDeliveryRound(), timeoutPromise]),
+            );
+            if (didDrain) {
+              return;
+            }
+            continue;
+          } catch (err) {
+            abortCommentaryDelivery(err);
+            if (err === timeoutError) {
+              if (!isProbeSession) {
+                log.warn(
+                  `commentary delivery wait timed out: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${roundTimeoutMs} pendingCount=${pendingCount}`,
+                );
+              }
+              return;
+            }
+            if (isRunnerAbortError(err)) {
+              if (!isProbeSession) {
+                log.debug(
+                  `commentary delivery wait aborted: runId=${params.runId} sessionId=${params.sessionId}`,
+                );
+              }
+              return;
+            }
+            throw err;
+          } finally {
+            if (timer) {
+              clearTimeout(timer);
+            }
+          }
+        }
+      };
       const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
       let abortTimer: NodeJS.Timeout | undefined;
       let compactionGraceUsed = false;
@@ -1664,6 +1721,7 @@ export async function runEmbeddedAttempt(
         }
         messagesSnapshot = snapshotSelection.messagesSnapshot;
         sessionIdUsed = snapshotSelection.sessionIdUsed;
+        await waitForCommentaryDeliveryBounded();
 
         if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
           try {
@@ -1827,6 +1885,8 @@ export async function runEmbeddedAttempt(
         systemPromptReport,
         messagesSnapshot,
         assistantTexts,
+        assistantOutputs,
+        deliveredCommentarySegmentIds: deliveredCommentarySegmentIds(),
         toolMetas: toolMetasNormalized,
         lastAssistant,
         lastToolError: getLastToolError?.(),

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -1,6 +1,6 @@
 import type { ImageContent } from "@mariozechner/pi-ai";
 import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
-import type { ReplyPayload } from "../../../auto-reply/types.js";
+import type { BlockReplyContext, ReplyPayload } from "../../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import type { enqueueCommand } from "../../../process/command-queue.js";
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
@@ -106,10 +106,12 @@ export type RunEmbeddedPiAgentParams = {
   shouldEmitToolOutput?: () => boolean;
   onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
+  onCommentaryReply?: (payload: ReplyPayload, context?: BlockReplyContext) => void | Promise<void>;
   onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
   onBlockReplyFlush?: () => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;
+  blockReplyTimeoutMs?: number;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onReasoningEnd?: () => void | Promise<void>;
   onToolResult?: (payload: ReplyPayload) => void | Promise<void>;
@@ -121,6 +123,7 @@ export type RunEmbeddedPiAgentParams = {
   streamParams?: AgentStreamParams;
   ownerNumbers?: string[];
   enforceFinalTag?: boolean;
+  silentExpected?: boolean;
   /**
    * Allow a single run attempt even when all auth profiles are in cooldown,
    * but only for inferred transient cooldowns like `rate_limit` or `overloaded`.

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -91,6 +91,44 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("strips commentary that was actually delivered live", () => {
+    const payloads = buildPayloads({
+      assistantOutputs: [
+        { segmentId: "c1", text: "Checking the repo state now.", phase: "commentary" },
+        { segmentId: "f1", text: "Lint passed cleanly.", phase: "final_answer" },
+      ],
+      deliveredCommentarySegmentIds: ["c1"],
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Lint passed cleanly.");
+  });
+
+  it("keeps commentary in the final reply when it was not sent live", () => {
+    const payloads = buildPayloads({
+      assistantOutputs: [
+        { segmentId: "c1", text: "Checking the repo state now.", phase: "commentary" },
+        { segmentId: "f1", text: "Lint passed cleanly.", phase: "final_answer" },
+      ],
+    });
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads.map((payload) => payload.text)).toEqual([
+      "Checking the repo state now.",
+      "Lint passed cleanly.",
+    ]);
+  });
+
+  it("does not fall back to assistantTexts when delivered commentary strips all assistant outputs", () => {
+    expectNoPayloads({
+      assistantOutputs: [
+        { segmentId: "c1", text: "Checking the repo state now.", phase: "commentary" },
+      ],
+      deliveredCommentarySegmentIds: ["c1"],
+      assistantTexts: ["Lint passed cleanly."],
+    });
+  });
+
   it("suppresses JSON NO_REPLY assistant payloads", () => {
     expectNoPayloads({
       assistantTexts: ['{"action":"NO_REPLY"}'],

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -5,6 +5,7 @@ import type { ReasoningLevel, VerboseLevel } from "../../../auto-reply/thinking.
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { formatToolAggregate } from "../../../auto-reply/tool-meta.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import type { AssistantOutputEntry } from "../../pi-embedded-commentary.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
   formatAssistantErrorText,
@@ -90,6 +91,8 @@ function resolveToolErrorWarningPolicy(params: {
 
 export function buildEmbeddedRunPayloads(params: {
   assistantTexts: string[];
+  assistantOutputs?: AssistantOutputEntry[];
+  deliveredCommentarySegmentIds?: string[];
   toolMetas: ToolMetaEntry[];
   lastAssistant: AssistantMessage | undefined;
   lastToolError?: LastToolError;
@@ -250,14 +253,27 @@ export function buildEmbeddedRunPayloads(params: {
     }
     return isRawApiErrorPayload(trimmed);
   };
+  const deliveredCommentarySegmentIds = new Set(params.deliveredCommentarySegmentIds ?? []);
+  const resolvedAssistantTexts = (() => {
+    if (params.assistantOutputs) {
+      const filteredAssistantOutputs = params.assistantOutputs
+        .filter((segment) => {
+          return !(
+            segment.phase === "commentary" && deliveredCommentarySegmentIds.has(segment.segmentId)
+          );
+        })
+        .map((segment) => segment.text);
+      return filteredAssistantOutputs;
+    }
+    return params.assistantTexts.length
+      ? params.assistantTexts
+      : fallbackAnswerText
+        ? [fallbackAnswerText]
+        : [];
+  })();
   const answerTexts = suppressAssistantArtifacts
     ? []
-    : (params.assistantTexts.length
-        ? params.assistantTexts
-        : fallbackAnswerText
-          ? [fallbackAnswerText]
-          : []
-      ).filter((text) => !shouldSuppressRawErrorText(text));
+    : resolvedAssistantTexts.filter((text) => !shouldSuppressRawErrorText(text));
 
   let hasUserFacingAssistantReply = false;
   for (const text of answerTexts) {

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -5,6 +5,7 @@ import type { ThinkLevel } from "../../../auto-reply/thinking.js";
 import type { SessionSystemPromptReport } from "../../../config/sessions/types.js";
 import type { ContextEngine } from "../../../context-engine/types.js";
 import type { PluginHookBeforeAgentStartResult } from "../../../plugins/types.js";
+import type { AssistantOutputEntry } from "../../pi-embedded-commentary.js";
 import type { MessagingToolSend } from "../../pi-embedded-messaging.js";
 import type { NormalizedUsage } from "../../usage.js";
 import type { RunEmbeddedPiAgentParams } from "./params.js";
@@ -44,6 +45,8 @@ export type EmbeddedRunAttemptResult = {
   systemPromptReport?: SessionSystemPromptReport;
   messagesSnapshot: AgentMessage[];
   assistantTexts: string[];
+  assistantOutputs?: AssistantOutputEntry[];
+  deliveredCommentarySegmentIds?: string[];
   toolMetas: Array<{ toolName: string; meta?: string }>;
   lastAssistant: AssistantMessage | undefined;
   lastToolError?: {

--- a/src/agents/pi-embedded-subscribe.commentary.test.ts
+++ b/src/agents/pi-embedded-subscribe.commentary.test.ts
@@ -1,0 +1,429 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSubscribedSessionHarness } from "./pi-embedded-subscribe.e2e-harness.js";
+
+function buildAssistantMessage(params: {
+  id?: string;
+  stopReason?: string;
+  content: Array<Record<string, unknown>>;
+}) {
+  return {
+    role: "assistant",
+    ...(params.id ? { id: params.id } : {}),
+    ...(params.stopReason ? { stopReason: params.stopReason } : {}),
+    content: params.content,
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("subscribeEmbeddedPiSession commentary delivery", () => {
+  it("does no live commentary work when the callback is unset", async () => {
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+    });
+
+    emit({
+      type: "message_end",
+      message: buildAssistantMessage({
+        id: "assistant-1",
+        stopReason: "toolUse",
+        content: [
+          {
+            type: "text",
+            text: "Checking the repo state now.",
+            textSignature: JSON.stringify({ id: "sig-1", phase: "commentary" }),
+          },
+          {
+            type: "toolCall",
+            toolCallId: "call-1",
+            toolName: "exec",
+            args: "{}",
+          },
+        ],
+      }),
+    });
+
+    await subscription.waitForCommentaryDelivery();
+
+    expect(subscription.assistantOutputs).toEqual([
+      {
+        segmentId: "sig-1",
+        text: "Checking the repo state now.",
+        phase: "commentary",
+      },
+    ]);
+    expect(subscription.deliveredCommentarySegmentIds()).toEqual([]);
+    expect(subscription.getPendingCommentaryDeliveryCount()).toBe(0);
+  });
+
+  it("emits live commentary once after the segment stops being terminal", async () => {
+    const onCommentaryReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onCommentaryReply,
+    });
+
+    emit({
+      type: "message_start",
+      message: buildAssistantMessage({
+        id: "assistant-1",
+        content: [],
+      }),
+    });
+    emit({
+      type: "message_update",
+      message: buildAssistantMessage({
+        id: "assistant-1",
+        content: [
+          {
+            type: "text",
+            text: "Step 2/3: running lint.",
+            textSignature: JSON.stringify({ id: "sig-stream", phase: "commentary" }),
+          },
+        ],
+      }),
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "Step 2/3: running lint.",
+      },
+    });
+
+    await subscription.waitForCommentaryDelivery();
+    expect(onCommentaryReply).not.toHaveBeenCalled();
+
+    emit({
+      type: "message_update",
+      message: buildAssistantMessage({
+        id: "assistant-1",
+        content: [
+          {
+            type: "text",
+            text: "Step 2/3: running lint.",
+            textSignature: JSON.stringify({ id: "sig-stream", phase: "commentary" }),
+          },
+          {
+            type: "toolCall",
+            toolCallId: "call-1",
+            toolName: "exec",
+            args: "{}",
+          },
+        ],
+      }),
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "",
+      },
+    });
+
+    await subscription.waitForCommentaryDelivery();
+    expect(onCommentaryReply).toHaveBeenCalledTimes(1);
+    expect(onCommentaryReply).toHaveBeenCalledWith(
+      { text: "Step 2/3: running lint." },
+      expect.objectContaining({ timeoutMs: undefined }),
+    );
+  });
+
+  it("delivers undelivered commentary on message_end and preserves final outputs", async () => {
+    const onCommentaryReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onCommentaryReply,
+    });
+
+    emit({
+      type: "message_end",
+      message: buildAssistantMessage({
+        id: "assistant-1",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "Checking the repo state now.",
+            textSignature: JSON.stringify({ id: "sig-1", phase: "commentary" }),
+          },
+          {
+            type: "text",
+            text: " Final answer.",
+            textSignature: JSON.stringify({ id: "sig-2", phase: "final_answer" }),
+          },
+        ],
+      }),
+    });
+
+    await subscription.waitForCommentaryDelivery();
+
+    expect(onCommentaryReply).toHaveBeenCalledTimes(1);
+    expect(subscription.assistantOutputs).toEqual([
+      {
+        segmentId: "sig-1",
+        text: "Checking the repo state now.",
+        phase: "commentary",
+      },
+      {
+        segmentId: "sig-2",
+        text: "Final answer.",
+        phase: "final_answer",
+      },
+    ]);
+    expect(subscription.deliveredCommentarySegmentIds()).toEqual(["sig-1"]);
+  });
+
+  it("keeps repeated identical unsigned commentary distinct across assistant turns", async () => {
+    const onCommentaryReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onCommentaryReply,
+    });
+
+    const firstMessage = buildAssistantMessage({
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "text",
+          text: "Still working...",
+          phase: "commentary",
+        },
+        {
+          type: "toolCall",
+          toolCallId: "call-1",
+          toolName: "exec",
+          args: "{}",
+        },
+      ],
+    });
+    const secondMessage = buildAssistantMessage({
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "text",
+          text: "Still working...",
+          phase: "commentary",
+        },
+        {
+          type: "toolCall",
+          toolCallId: "call-2",
+          toolName: "exec",
+          args: "{}",
+        },
+      ],
+    });
+
+    emit({ type: "message_start", message: firstMessage });
+    emit({ type: "message_end", message: firstMessage });
+    emit({ type: "message_start", message: secondMessage });
+    emit({ type: "message_end", message: secondMessage });
+
+    await subscription.waitForCommentaryDelivery();
+
+    expect(subscription.assistantOutputs).toHaveLength(2);
+    expect(subscription.assistantOutputs[0]?.text).toBe("Still working...");
+    expect(subscription.assistantOutputs[1]?.text).toBe("Still working...");
+    expect(subscription.assistantOutputs[0]?.segmentId).not.toBe(
+      subscription.assistantOutputs[1]?.segmentId,
+    );
+    expect(onCommentaryReply).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps unsigned fallback ids stable across late updates after message_end", async () => {
+    const onCommentaryReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onCommentaryReply,
+    });
+
+    const assistantMessage = buildAssistantMessage({
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "text",
+          text: "Still working...",
+          phase: "commentary",
+        },
+        {
+          type: "toolCall",
+          toolCallId: "call-1",
+          toolName: "exec",
+          args: "{}",
+        },
+      ],
+    });
+
+    emit({ type: "message_start", message: assistantMessage });
+    emit({ type: "message_end", message: assistantMessage });
+    emit({
+      type: "message_update",
+      message: assistantMessage,
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "",
+      },
+    });
+
+    await subscription.waitForCommentaryDelivery();
+
+    expect(onCommentaryReply).toHaveBeenCalledTimes(1);
+    expect(subscription.assistantOutputs).toEqual([
+      {
+        segmentId: "assistant:stream-0:segment:0",
+        text: "Still working...",
+        phase: "commentary",
+      },
+    ]);
+    expect(subscription.deliveredCommentarySegmentIds()).toEqual(["assistant:stream-0:segment:0"]);
+  });
+
+  it("waits for commentary queued after the wait has already started", async () => {
+    const firstDelivery = createDeferred<void>();
+    const secondDelivery = createDeferred<void>();
+    const onCommentaryReply = vi
+      .fn()
+      .mockImplementationOnce(() => firstDelivery.promise)
+      .mockImplementationOnce(() => secondDelivery.promise);
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onCommentaryReply,
+    });
+
+    const firstMessage = buildAssistantMessage({
+      id: "assistant-1",
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "text",
+          text: "First step.",
+          textSignature: JSON.stringify({ id: "sig-1", phase: "commentary" }),
+        },
+        {
+          type: "toolCall",
+          toolCallId: "call-1",
+          toolName: "exec",
+          args: "{}",
+        },
+      ],
+    });
+    const secondMessage = buildAssistantMessage({
+      id: "assistant-2",
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "text",
+          text: "Second step.",
+          textSignature: JSON.stringify({ id: "sig-2", phase: "commentary" }),
+        },
+        {
+          type: "toolCall",
+          toolCallId: "call-2",
+          toolName: "exec",
+          args: "{}",
+        },
+      ],
+    });
+
+    emit({ type: "message_start", message: firstMessage });
+    emit({ type: "message_end", message: firstMessage });
+
+    let waitResolved = false;
+    const waitPromise = subscription.waitForCommentaryDelivery().then(() => {
+      waitResolved = true;
+    });
+
+    emit({ type: "message_start", message: secondMessage });
+    emit({ type: "message_end", message: secondMessage });
+
+    firstDelivery.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(waitResolved).toBe(false);
+
+    secondDelivery.resolve();
+    await waitPromise;
+
+    expect(onCommentaryReply).toHaveBeenCalledTimes(2);
+    expect(subscription.deliveredCommentarySegmentIds()).toEqual(["sig-1", "sig-2"]);
+  });
+
+  it("aborts stale commentary work on compaction retry and keeps delivered ids for replay suppression", async () => {
+    const firstDelivery = createDeferred<void>();
+    const onCommentaryReply = vi
+      .fn()
+      .mockImplementationOnce((_payload, context?: { abortSignal?: AbortSignal }) => {
+        context?.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            firstDelivery.reject(context.abortSignal?.reason ?? new Error("aborted"));
+          },
+          { once: true },
+        );
+        return firstDelivery.promise;
+      })
+      .mockResolvedValueOnce(undefined);
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onCommentaryReply,
+    });
+
+    emit({
+      type: "message_update",
+      message: buildAssistantMessage({
+        id: "assistant-1",
+        content: [
+          {
+            type: "text",
+            text: "Step 2/3: running lint.",
+            textSignature: JSON.stringify({ id: "sig-stream", phase: "commentary" }),
+          },
+          {
+            type: "toolCall",
+            toolCallId: "call-1",
+            toolName: "exec",
+            args: "{}",
+          },
+        ],
+      }),
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "",
+      },
+    });
+
+    await Promise.resolve();
+    emit({ type: "auto_compaction_end", willRetry: true });
+    emit({
+      type: "message_update",
+      message: buildAssistantMessage({
+        id: "assistant-1",
+        content: [
+          {
+            type: "text",
+            text: "Step 2/3: running lint.",
+            textSignature: JSON.stringify({ id: "sig-stream", phase: "commentary" }),
+          },
+          {
+            type: "toolCall",
+            toolCallId: "call-2",
+            toolName: "exec",
+            args: "{}",
+          },
+        ],
+      }),
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "",
+      },
+    });
+
+    await subscription.waitForCommentaryDelivery();
+
+    expect(onCommentaryReply).toHaveBeenCalledTimes(2);
+    expect(subscription.deliveredCommentarySegmentIds()).toEqual(["sig-stream"]);
+  });
+});

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -1,9 +1,10 @@
 import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
+import { extractAssistantOutputCandidates } from "./pi-embedded-commentary.js";
 import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
@@ -53,6 +54,16 @@ function emitReasoningEnd(ctx: EmbeddedPiSubscribeContext) {
   }
   ctx.state.reasoningStreamOpen = false;
   void ctx.params.onReasoningEnd?.();
+}
+
+function extractAssistantOutputsForMessage(ctx: EmbeddedPiSubscribeContext, msg: AgentMessage) {
+  const messageRecord =
+    msg && typeof msg === "object" ? (msg as unknown as Record<string, unknown>) : undefined;
+  const fallbackMessageStableId =
+    typeof messageRecord?.id === "string" && messageRecord.id.trim().length > 0
+      ? undefined
+      : ctx.resolveCurrentAssistantFallbackMessageId();
+  return extractAssistantOutputCandidates(msg, { fallbackMessageStableId });
 }
 
 export function resolveSilentReplyFallbackText(params: {
@@ -296,6 +307,10 @@ export function handleMessageUpdate(
     ctx.state.lastStreamedAssistant = next;
     ctx.state.lastStreamedAssistantCleaned = cleanedText;
 
+    if (ctx.params.silentExpected) {
+      shouldEmit = false;
+    }
+
     if (shouldEmit) {
       const data = buildAssistantStreamData({
         text: cleanedText,
@@ -318,12 +333,34 @@ export function handleMessageUpdate(
     }
   }
 
-  if (ctx.params.onBlockReply && ctx.blockChunking && ctx.state.blockReplyBreak === "text_end") {
+  if (
+    !ctx.params.silentExpected &&
+    ctx.params.onBlockReply &&
+    ctx.blockChunking &&
+    ctx.state.blockReplyBreak === "text_end"
+  ) {
     ctx.blockChunker?.drain({ force: false, emit: ctx.emitBlockChunk });
   }
 
-  if (evtType === "text_end" && ctx.state.blockReplyBreak === "text_end") {
+  if (
+    !ctx.params.silentExpected &&
+    evtType === "text_end" &&
+    ctx.state.blockReplyBreak === "text_end"
+  ) {
     ctx.flushBlockReplyBuffer();
+  }
+
+  for (const segment of extractAssistantOutputsForMessage(ctx, msg)) {
+    if (
+      segment.phase !== "commentary" ||
+      segment.isTerminal ||
+      ctx.state.seenLiveCommentarySegmentIds.has(segment.segmentId)
+    ) {
+      continue;
+    }
+    ctx.state.seenLiveCommentarySegmentIds.add(segment.segmentId);
+    const { isTerminal: _isTerminal, ...commentarySegment } = segment;
+    ctx.queueCommentaryDelivery(commentarySegment);
   }
 }
 
@@ -379,7 +416,11 @@ export function handleMessageEnd(
     }
   }
 
-  if (!ctx.state.emittedAssistantUpdate && (cleanedText || hasMedia)) {
+  if (
+    !ctx.params.silentExpected &&
+    !ctx.state.emittedAssistantUpdate &&
+    (cleanedText || hasMedia)
+  ) {
     const data = buildAssistantStreamData({
       text: cleanedText,
       delta: cleanedText,
@@ -397,9 +438,16 @@ export function handleMessageEnd(
     ctx.state.emittedAssistantUpdate = true;
   }
 
+  const silentExpectedWithoutSentinel =
+    ctx.params.silentExpected && !isSilentReplyText(trimmedText, SILENT_REPLY_TOKEN);
+  const finalAssistantText = silentExpectedWithoutSentinel ? "" : text;
   const addedDuringMessage = ctx.state.assistantTexts.length > ctx.state.assistantTextBaseline;
   const chunkerHasBuffered = ctx.blockChunker?.hasBuffered() ?? false;
-  ctx.finalizeAssistantTexts({ text, addedDuringMessage, chunkerHasBuffered });
+  ctx.finalizeAssistantTexts({
+    text: finalAssistantText,
+    addedDuringMessage,
+    chunkerHasBuffered,
+  });
 
   const onBlockReply = ctx.params.onBlockReply;
   const emitBlockReplySafely = (payload: Parameters<NonNullable<typeof onBlockReply>>[0]) => {
@@ -413,6 +461,7 @@ export function handleMessageEnd(
       });
   };
   const shouldEmitReasoning = Boolean(
+    !ctx.params.silentExpected &&
     ctx.state.includeReasoning &&
     formattedReasoning &&
     onBlockReply &&
@@ -460,6 +509,7 @@ export function handleMessageEnd(
   };
 
   if (
+    !ctx.params.silentExpected &&
     (ctx.state.blockReplyBreak === "message_end" ||
       (ctx.blockChunker ? ctx.blockChunker.hasBuffered() : ctx.state.blockBuffer.length > 0)) &&
     text &&
@@ -490,12 +540,30 @@ export function handleMessageEnd(
   if (!shouldEmitReasoningBeforeAnswer) {
     maybeEmitReasoning();
   }
-  if (ctx.state.streamReasoning && rawThinking) {
+  if (!ctx.params.silentExpected && ctx.state.streamReasoning && rawThinking) {
     ctx.emitReasoningStream(rawThinking);
   }
 
-  if (ctx.state.blockReplyBreak === "text_end" && onBlockReply) {
+  if (!ctx.params.silentExpected && ctx.state.blockReplyBreak === "text_end" && onBlockReply) {
     emitSplitResultAsBlockReply(ctx.consumeReplyDirectives("", { final: true }));
+  }
+
+  for (const segment of extractAssistantOutputsForMessage(ctx, assistantMessage)) {
+    const { isTerminal: _isTerminal, ...finalizedSegment } = segment;
+    if (
+      !ctx.state.assistantOutputs.some(
+        (existingSegment) => existingSegment.segmentId === finalizedSegment.segmentId,
+      )
+    ) {
+      ctx.state.assistantOutputs.push(finalizedSegment);
+    }
+    if (
+      finalizedSegment.phase === "commentary" &&
+      !ctx.state.deliveredCommentarySegmentIds.has(finalizedSegment.segmentId) &&
+      !ctx.state.pendingCommentarySegmentIds.has(finalizedSegment.segmentId)
+    ) {
+      ctx.queueCommentaryDelivery(finalizedSegment);
+    }
   }
 
   ctx.state.deltaBuffer = "";

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -4,6 +4,7 @@ import type { ReasoningLevel } from "../auto-reply/thinking.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
+import type { AssistantOutputEntry } from "./pi-embedded-commentary.js";
 import type { MessagingToolSend } from "./pi-embedded-messaging.js";
 import type { BlockReplyPayload } from "./pi-embedded-payloads.js";
 import type {
@@ -61,6 +62,15 @@ export type EmbeddedPiSubscribeState = {
   assistantTextBaseline: number;
   suppressBlockChunks: boolean;
   lastReasoningSent?: string;
+  assistantOutputs: AssistantOutputEntry[];
+  seenLiveCommentarySegmentIds: Set<string>;
+  pendingCommentarySegmentIds: Set<string>;
+  deliveredCommentarySegmentIds: Set<string>;
+  commentaryGeneration: number;
+  commentaryQueueVersion: number;
+  commentaryAbortControllers: Set<AbortController>;
+  currentAssistantFallbackMessageId?: string;
+  nextAssistantFallbackMessageId: number;
 
   compactionInFlight: boolean;
   pendingCompactionRetry: number;
@@ -128,6 +138,11 @@ export type EmbeddedPiSubscribeContext = {
   getUsageTotals: () => NormalizedUsage | undefined;
   getCompactionCount: () => number;
   emitBlockReply: (payload: BlockReplyPayload) => void;
+  resolveCurrentAssistantFallbackMessageId: () => string;
+  queueCommentaryDelivery: (segment: AssistantOutputEntry) => void;
+  waitForCommentaryDeliveryRound: () => Promise<boolean>;
+  waitForCommentaryDelivery: () => Promise<void>;
+  abortCommentaryDelivery: (reason?: unknown) => void;
 };
 
 /**

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -1,12 +1,14 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streaming-directives.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
 import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-spans.js";
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
+import type { AssistantOutputEntry } from "./pi-embedded-commentary.js";
 import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
@@ -66,6 +68,15 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     assistantTextBaseline: 0,
     suppressBlockChunks: false, // Avoid late chunk inserts after final text merge.
     lastReasoningSent: undefined,
+    assistantOutputs: [],
+    seenLiveCommentarySegmentIds: new Set(),
+    pendingCommentarySegmentIds: new Set(),
+    deliveredCommentarySegmentIds: new Set(),
+    commentaryGeneration: 0,
+    commentaryQueueVersion: 0,
+    commentaryAbortControllers: new Set(),
+    currentAssistantFallbackMessageId: undefined,
+    nextAssistantFallbackMessageId: 0,
     compactionInFlight: false,
     pendingCompactionRetry: 0,
     compactionRetryResolve: undefined,
@@ -105,6 +116,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const pendingMessagingTargets = state.pendingMessagingTargets;
   const replyDirectiveAccumulator = createStreamingDirectiveAccumulator();
   const partialReplyDirectiveAccumulator = createStreamingDirectiveAccumulator();
+  const shouldAllowSilentTurnText = (text: string | undefined) =>
+    Boolean(text && isSilentReplyText(text, SILENT_REPLY_TOKEN));
   const emitBlockReplySafely = (
     payload: Parameters<NonNullable<SubscribeEmbeddedPiSessionParams["onBlockReply"]>>[0],
   ) => {
@@ -146,6 +159,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.lastAssistantTextNormalized = undefined;
     state.lastAssistantTextTrimmed = undefined;
     state.assistantTextBaseline = nextAssistantTextBaseline;
+    state.currentAssistantFallbackMessageId = undefined;
   };
 
   const rememberAssistantText = (text: string) => {
@@ -172,6 +186,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
 
   const pushAssistantText = (text: string) => {
     if (!text) {
+      return;
+    }
+    if (params.silentExpected && !shouldAllowSilentTurnText(text)) {
       return;
     }
     if (shouldSkipAssistantText(text)) {
@@ -313,6 +330,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const incrementCompactionCount = () => {
     compactionCount += 1;
   };
+  let commentaryDeliveryQueue = Promise.resolve();
 
   const blockChunking = params.blockReplyChunking;
   const blockChunker = blockChunking ? new EmbeddedBlockChunker(blockChunking) : null;
@@ -487,7 +505,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   };
 
   const emitBlockChunk = (text: string) => {
-    if (state.suppressBlockChunks) {
+    if (state.suppressBlockChunks || params.silentExpected) {
       return;
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
@@ -513,8 +531,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     }
 
     state.lastBlockReplyText = chunk;
-    assistantTexts.push(chunk);
-    rememberAssistantText(chunk);
+    pushAssistantText(chunk);
     if (!params.onBlockReply) {
       return;
     }
@@ -565,6 +582,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   };
 
   const emitReasoningStream = (text: string) => {
+    if (params.silentExpected) {
+      return;
+    }
     if (!state.streamReasoning || !params.onReasoningStream) {
       return;
     }
@@ -596,8 +616,109 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     });
   };
 
+  const resolveCurrentAssistantFallbackMessageId = () => {
+    if (!state.currentAssistantFallbackMessageId) {
+      state.currentAssistantFallbackMessageId = `stream-${state.nextAssistantFallbackMessageId}`;
+      state.nextAssistantFallbackMessageId += 1;
+    }
+    return state.currentAssistantFallbackMessageId;
+  };
+
+  const createCommentaryAbortError = (message: string, reason?: unknown): Error => {
+    if (reason instanceof Error) {
+      reason.name = "AbortError";
+      return reason;
+    }
+    const error = new Error(message);
+    error.name = "AbortError";
+    return error;
+  };
+
+  const abortCommentaryDelivery = (reason?: unknown) => {
+    state.commentaryGeneration += 1;
+    state.commentaryQueueVersion += 1;
+    for (const controller of state.commentaryAbortControllers) {
+      controller.abort(createCommentaryAbortError("Commentary delivery aborted", reason));
+    }
+    state.commentaryAbortControllers.clear();
+    state.pendingCommentarySegmentIds.clear();
+    commentaryDeliveryQueue = Promise.resolve();
+  };
+
+  const queueCommentaryDelivery = (segment: AssistantOutputEntry) => {
+    if (!params.onCommentaryReply) {
+      return;
+    }
+    if (
+      state.pendingCommentarySegmentIds.has(segment.segmentId) ||
+      state.deliveredCommentarySegmentIds.has(segment.segmentId)
+    ) {
+      return;
+    }
+    const generation = state.commentaryGeneration;
+    const abortController = new AbortController();
+    if (params.abortSignal) {
+      const upstreamAbort = () => {
+        abortController.abort(params.abortSignal?.reason);
+      };
+      if (params.abortSignal.aborted) {
+        upstreamAbort();
+      } else {
+        params.abortSignal.addEventListener("abort", upstreamAbort, { once: true });
+      }
+    }
+    state.pendingCommentarySegmentIds.add(segment.segmentId);
+    state.commentaryAbortControllers.add(abortController);
+    state.commentaryQueueVersion += 1;
+    commentaryDeliveryQueue = commentaryDeliveryQueue
+      .then(async () => {
+        if (generation !== state.commentaryGeneration || abortController.signal.aborted) {
+          return;
+        }
+        await params.onCommentaryReply?.(
+          { text: segment.text },
+          {
+            abortSignal: abortController.signal,
+            timeoutMs: params.blockReplyTimeoutMs,
+          },
+        );
+        if (generation !== state.commentaryGeneration || abortController.signal.aborted) {
+          return;
+        }
+        state.deliveredCommentarySegmentIds.add(segment.segmentId);
+      })
+      .catch((err) => {
+        if (abortController.signal.aborted || generation !== state.commentaryGeneration) {
+          return;
+        }
+        log.warn(`commentary reply callback failed: ${String(err)}`);
+      })
+      .finally(() => {
+        state.commentaryAbortControllers.delete(abortController);
+        if (generation === state.commentaryGeneration) {
+          state.pendingCommentarySegmentIds.delete(segment.segmentId);
+        }
+      });
+  };
+
+  const waitForCommentaryDeliveryRound = async () => {
+    const queueVersion = state.commentaryQueueVersion;
+    const queue = commentaryDeliveryQueue;
+    await queue;
+    return (
+      queueVersion === state.commentaryQueueVersion && state.pendingCommentarySegmentIds.size === 0
+    );
+  };
+
+  const waitForCommentaryDelivery = async () => {
+    while (!(await waitForCommentaryDeliveryRound())) {
+      // Wait until no newer commentary work lands while draining the queue.
+    }
+  };
+
   const resetForCompactionRetry = () => {
     assistantTexts.length = 0;
+    state.assistantOutputs.length = 0;
     toolMetas.length = 0;
     toolMetaById.clear();
     toolSummaryById.clear();
@@ -613,6 +734,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.pendingToolMediaUrls = [];
     state.pendingToolAudioAsVoice = false;
     state.deterministicApprovalPromptSent = false;
+    abortCommentaryDelivery(createCommentaryAbortError("Commentary delivery aborted on retry"));
+    state.seenLiveCommentarySegmentIds.clear();
     resetAssistantMessageState(0);
   };
 
@@ -653,6 +776,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     incrementCompactionCount,
     getUsageTotals,
     getCompactionCount: () => compactionCount,
+    resolveCurrentAssistantFallbackMessageId,
+    queueCommentaryDelivery,
+    waitForCommentaryDeliveryRound,
+    waitForCommentaryDelivery,
+    abortCommentaryDelivery,
   };
 
   const sessionUnsubscribe = params.session.subscribe(createEmbeddedPiSessionEventHandler(ctx));
@@ -687,11 +815,15 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
         log.warn(`unsubscribe: compaction abort failed runId=${params.runId} err=${String(err)}`);
       }
     }
+    abortCommentaryDelivery(
+      createCommentaryAbortError("Commentary delivery aborted on unsubscribe"),
+    );
     sessionUnsubscribe();
   };
 
   return {
     assistantTexts,
+    assistantOutputs: state.assistantOutputs,
     toolMetas,
     unsubscribe,
     isCompacting: () => state.compactionInFlight || state.pendingCompactionRetry > 0,
@@ -708,6 +840,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     getLastToolError: () => (state.lastToolError ? { ...state.lastToolError } : undefined),
     getUsageTotals,
     getCompactionCount: () => compactionCount,
+    deliveredCommentarySegmentIds: () => Array.from(state.deliveredCommentarySegmentIds),
+    getPendingCommentaryDeliveryCount: () => state.pendingCommentarySegmentIds.size,
+    waitForCommentaryDeliveryRound,
+    waitForCommentaryDelivery,
+    abortCommentaryDelivery,
     waitForCompactionRetry: () => {
       // Reject after unsubscribe so callers treat it as cancellation, not success
       if (state.unsubscribed) {

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -1,5 +1,6 @@
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type { ReasoningLevel, VerboseLevel } from "../auto-reply/thinking.js";
+import type { BlockReplyContext } from "../auto-reply/types.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookRunner } from "../plugins/hooks.js";
@@ -24,12 +25,16 @@ export type SubscribeEmbeddedPiSessionParams = {
   onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
   /** Flush pending block replies (e.g., before tool execution to preserve message boundaries). */
   onBlockReplyFlush?: () => void | Promise<void>;
+  onCommentaryReply?: (payload: ReplyPayload, context?: BlockReplyContext) => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;
   onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void | Promise<void>;
   enforceFinalTag?: boolean;
+  silentExpected?: boolean;
+  blockReplyTimeoutMs?: number;
+  abortSignal?: AbortSignal;
   config?: OpenClawConfig;
   sessionKey?: string;
   /** Ephemeral session UUID — regenerated on /new and /reset. */

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -430,6 +430,7 @@ export async function runAgentTurnWithFallback(params: {
                   await params.typingSignals.signalMessageStart();
                   await params.opts?.onAssistantMessageStart?.();
                 },
+                onCommentaryReply: params.opts?.onCommentaryReply,
                 onReasoningStream:
                   params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
                     ? async (payload) => {
@@ -504,6 +505,7 @@ export async function runAgentTurnWithFallback(params: {
                         await blockReplyPipeline.flush({ force: true });
                       }
                     : undefined,
+                blockReplyTimeoutMs: params.opts?.blockReplyTimeoutMs,
                 shouldEmitToolResult: params.shouldEmitToolResult,
                 shouldEmitToolOutput: params.shouldEmitToolOutput,
                 bootstrapPromptWarningSignaturesSeen,

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -10,6 +10,13 @@ import type { TypingSignaler } from "./typing-mode.js";
 
 export type ReplyDirectiveParseMode = "always" | "auto" | "never";
 
+function normalizeDirectiveAliases(text: string): string {
+  return text
+    .replaceAll("[[replyToCurrent]]", "[[reply_to_current]]")
+    .replace(/\[\[\s*replyTo\s*:/g, "[[reply_to:")
+    .replaceAll("[[audioAsVoice]]", "[[audio_as_voice]]");
+}
+
 export function normalizeReplyPayloadDirectives(params: {
   payload: ReplyPayload;
   currentMessageId?: string;
@@ -19,7 +26,8 @@ export function normalizeReplyPayloadDirectives(params: {
 }): { payload: ReplyPayload; isSilent: boolean } {
   const parseMode = params.parseMode ?? "always";
   const silentToken = params.silentToken ?? SILENT_REPLY_TOKEN;
-  const sourceText = params.payload.text ?? "";
+  const rawSourceText = normalizeDirectiveAliases(params.payload.text ?? "");
+  const sourceText = params.trimLeadingWhitespace ? rawSourceText.trimStart() : rawSourceText;
 
   const shouldParse =
     parseMode === "always" ||

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -51,6 +51,7 @@ export type GetReplyOptions = {
   onReasoningEnd?: () => Promise<void> | void;
   /** Called when a new assistant message starts (e.g., after tool call or thinking block). */
   onAssistantMessageStart?: () => Promise<void> | void;
+  onCommentaryReply?: (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> | void;
   onBlockReply?: (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> | void;
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when a tool phase starts/updates, before summary payloads are emitted. */

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -13663,6 +13663,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         blockStreaming: {
           type: "boolean",
         },
+        commentaryDelivery: {
+          type: "string",
+          enum: ["off", "live"],
+        },
         blockStreamingCoalesce: {
           type: "object",
           properties: {
@@ -13907,6 +13911,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               blockStreaming: {
                 type: "boolean",
+              },
+              commentaryDelivery: {
+                type: "string",
+                enum: ["off", "live"],
               },
               blockStreamingCoalesce: {
                 type: "object",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1452,4 +1452,6 @@ export const FIELD_HELP: Record<string, string> = {
     "Override default timing. Keys: debounceMs (700), stallSoftMs (25000), stallHardMs (60000), doneHoldMs (1500), errorHoldMs (2500).",
   "messages.inbound.debounceMs":
     "Debounce window (ms) for batching rapid inbound messages from the same sender (0 to disable).",
+  "channels.whatsapp.commentaryDelivery":
+    'WhatsApp live assistant commentary delivery. Use "live" to send interim `commentary` messages during the run; "off" keeps final-only delivery.',
 };

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -734,6 +734,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.mattermost": "Mattermost",
   "channels.modelByChannel": "Channel Model Overrides",
   "channels.matrix.allowBots": "Matrix Allow Bot Messages",
+  "channels.whatsapp.commentaryDelivery": "WhatsApp Live Commentary Delivery",
   "channels.mattermost.botToken": "Mattermost Bot Token",
   "channels.mattermost.baseUrl": "Mattermost Base URL",
   "channels.mattermost.configWrites": "Mattermost Config Writes",

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -72,6 +72,8 @@ type WhatsAppSharedConfig = {
   mediaMaxMb?: number;
   /** Disable block streaming for this account. */
   blockStreaming?: boolean;
+  /** WhatsApp live assistant commentary delivery mode. */
+  commentaryDelivery?: "off" | "live";
   /** Merge streamed block replies before sending. */
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
   groups?: Record<string, WhatsAppGroupConfig>;

--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -60,6 +60,26 @@ describe("config validation allowed-values metadata", () => {
     }
   });
 
+  it("includes WhatsApp commentary delivery enum values", () => {
+    const result = validateConfigObjectRaw({
+      channels: {
+        whatsapp: {
+          commentaryDelivery: "maybe",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = result.issues.find(
+        (entry) => entry.path === "channels.whatsapp.commentaryDelivery",
+      );
+      expect(issue).toBeDefined();
+      expect(issue?.allowedValues).toEqual(["off", "live"]);
+      expect(issue?.allowedValuesHiddenCount).toBe(0);
+    }
+  });
+
   it("skips allowed-values hints for unions with open-ended branches", () => {
     const result = validateConfigObjectRaw({
       cron: { sessionRetention: true },

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -54,6 +54,7 @@ const WhatsAppSharedSchema = z.object({
   textChunkLimit: z.number().int().positive().optional(),
   chunkMode: z.enum(["length", "newline"]).optional(),
   blockStreaming: z.boolean().optional(),
+  commentaryDelivery: z.enum(["off", "live"]).optional(),
   blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
   groups: WhatsAppGroupsSchema,
   ackReaction: WhatsAppAckReactionSchema,

--- a/src/plugin-sdk/reply-runtime.ts
+++ b/src/plugin-sdk/reply-runtime.ts
@@ -46,7 +46,8 @@ export type {
   ReplyDispatcherWithTypingOptions,
 } from "../auto-reply/reply/reply-dispatcher.js";
 export { createReplyReferencePlanner } from "../auto-reply/reply/reply-reference.js";
-export type { GetReplyOptions, ReplyPayload } from "../auto-reply/types.js";
+export type { BlockReplyContext, GetReplyOptions, ReplyPayload } from "../auto-reply/types.js";
+export { normalizeReplyPayloadDirectives } from "../auto-reply/reply/reply-delivery.js";
 export type { FinalizedMsgContext, MsgContext } from "../auto-reply/templating.js";
 export {
   resolveAutoTopicLabelConfig,

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -18060,6 +18060,10 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               blockStreaming: {
                 type: "boolean",
               },
+              commentaryDelivery: {
+                type: "string",
+                enum: ["off", "live"],
+              },
               blockStreamingCoalesce: {
                 type: "object",
                 properties: {
@@ -18304,6 +18308,10 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     },
                     blockStreaming: {
                       type: "boolean",
+                    },
+                    commentaryDelivery: {
+                      type: "string",
+                      enum: ["off", "live"],
                     },
                     blockStreamingCoalesce: {
                       type: "object",


### PR DESCRIPTION
## Summary

- Problem: WhatsApp currently accumulates assistant `commentary` and returns it together with the final answer, which makes live progress updates unusable in chat.
- Why it matters: users who opt into live commentary want incremental WhatsApp updates during the run, without changing behavior for every other channel.
- What changed: added opt-in `channels.whatsapp.commentaryDelivery: "off" | "live"`, threaded a channel-agnostic `onCommentaryReply` seam through the embedded runner, and delivered finalized commentary segments live through the existing WhatsApp send path.
- What did NOT change (scope boundary): no cross-channel rollout, no generic commentary dispatcher kind, and no change to default WhatsApp behavior when the new config is unset or `off`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #43731
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Prior context (`git blame`, prior PR, issue, or refactor if known): clean replacement for #43731 after the earlier branch became too stale relative to current review expectations.
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-subscribe.commentary.test.ts`, `src/agents/pi-embedded-runner/run/payloads.test.ts`, `extensions/whatsapp/src/auto-reply/deliver-reply.test.ts`, `extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts`, `extensions/telegram/src/bot-message-dispatch.test.ts`
- Scenario the test should lock in: live commentary emits once for finalized commentary segments, delivered commentary is filtered out of the final payload, WhatsApp send normalization/suppression behaves correctly, and non-WhatsApp channels remain unwired.
- Why this is the smallest reliable guardrail: the feature spans subscribe lifecycle, final payload assembly, and WhatsApp delivery, so narrow seam coverage at those boundaries catches the real failure modes without requiring full end-to-end infrastructure.
- Existing test that already covers this (if any): the Telegram boundary check covers the non-rollout scope.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- WhatsApp keeps its existing default behavior when `channels.whatsapp.commentaryDelivery` is unset or `off`.
- With `channels.whatsapp.commentaryDelivery: "live"`, assistant `commentary` is delivered to WhatsApp in real time as separate messages.
- The final WhatsApp reply still arrives separately.
- Commentary already delivered live is removed from the terminal payload so it does not get repeated with the final answer.

## Diagram (if applicable)

```text
Before:
[user message] -> [assistant commentary accumulates internally] -> [final WhatsApp reply includes commentary + final answer]

After:
[user message] -> [commentary segment finalizes] -> [live WhatsApp commentary message]
[user message] -> [assistant final answer] -> [final WhatsApp reply only]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: repo-run OpenClaw gateway
- Model/provider: Pi embedded runner with WhatsApp channel enabled
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): `channels.whatsapp.commentaryDelivery = "live"`

### Steps

1. Configure WhatsApp with `channels.whatsapp.commentaryDelivery = "live"`.
2. Send a prompt that causes the assistant to emit `commentary` before the final answer.
3. Observe the WhatsApp thread while the run is still in progress.

### Expected

- Commentary messages appear live during the run.
- The final reply is delivered separately.
- Previously delivered commentary is not repeated in the final reply.

### Actual

- Matches expected behavior in manual WhatsApp verification.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: user manually verified live commentary on WhatsApp; I verified the stable repo-run gateway starts cleanly with the feature branch, and I ran targeted commentary/WhatsApp/Telegram regressions locally.
- Edge cases checked: default-off behavior remains unchanged, silent commentary with no visible content is suppressed, media-only commentary remains deliverable, and delivered commentary is filtered out of the final payload.
- What you did **not** verify: other channels beyond the Telegram regression boundary test, and current `main` startup behavior unrelated to this feature.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (Yes)
- Migration needed? (No)
- If yes, exact upgrade steps: set `channels.whatsapp.commentaryDelivery = "live"` to opt in.

## Risks and Mitigations

- Risk: duplicate or missing commentary delivery if commentary segment bookkeeping drifts.
  - Mitigation: commentary ownership stays inside `subscribeEmbeddedPiSession()` with stable segment IDs and targeted seam coverage.
- Risk: directive or silent-message handling diverges from normal WhatsApp replies.
  - Mitigation: commentary send reuses the existing WhatsApp normalization path and dedicated delivery tests.
