### PR TITLE
fix(telegram): skip reply media download when replied-to message is from bot

### DIFF
--- a/extensions/telegram/src/bot-handlers.buffers.ts
+++ b/extensions/telegram/src/bot-handlers.buffers.ts
@@ -142,6 +142,10 @@ export function createTelegramInboundBufferRuntime(params: {
     if (!replyMessage || !hasInboundMedia(replyMessage)) {
       return [];
     }
+    // Do not re-ingest media from messages sent by this bot
+    if (ctx.me != null && replyMessage.from?.id === ctx.me.id) {
+      return [];
+    }
     const replyFileId = resolveInboundMediaFileId(replyMessage);
     if (!replyFileId) {
       return [];

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -484,6 +484,10 @@ export const registerTelegramHandlers = ({
     if (!replyMessage || !hasInboundMedia(replyMessage)) {
       return [];
     }
+    // Do not re-ingest media from messages sent by this bot
+    if (isSelfAuthoredTelegramMessage(ctx, replyMessage)) {
+      return [];
+    }
     const replyFileId = resolveInboundMediaFileId(replyMessage);
     if (!replyFileId) {
       return [];


### PR DESCRIPTION
Fixes #57278

When a user replies to a bot-sent photo, `resolveReplyMediaForMessage` downloaded the bot-sent image and injected it as inbound user media, causing the agent to react to images it previously generated.

`isSelfAuthoredTelegramMessage` already existed and was correctly used at the top-level inbound handler but was absent from `resolveReplyMediaForMessage` in both files.

## Changes

**`bot-handlers.runtime.ts`** — uses the already-in-scope `isSelfAuthoredTelegramMessage` helper:
```typescript
// Do not re-ingest media from messages sent by this bot
if (isSelfAuthoredTelegramMessage(ctx, replyMessage)) {
  return [];
}
```

**`bot-handlers.buffers.ts`** — uses an inline equivalent (helper not in scope):
```typescript
// Do not re-ingest media from messages sent by this bot
if (ctx.me != null && replyMessage.from?.id === ctx.me.id) {
  return [];
}
```

Both guards are placed immediately after the `hasInboundMedia` check, before any file download is attempted.