### PR TITLE
Fix/#57256 status mem0 false negative

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -22,6 +22,7 @@ import {
 } from "./memory-embedding-providers.js";
 import {
   buildMemoryPromptSection,
+  clearMemoryPluginState,
   getMemoryRuntime,
   registerMemoryFlushPlanResolver,
   registerMemoryPromptSection,
@@ -3637,6 +3638,49 @@ describe("resolveRuntimePluginRegistry", () => {
     setActivePluginRegistry(registry, cacheKey);
 
     expect(resolveRuntimePluginRegistry(loadOptions)).toBe(registry);
+  });
+
+  it("restores memory runtime side effects when reusing the active registry", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "runtime-memory",
+      filename: "runtime-memory.cjs",
+      body: `module.exports = {
+  id: "runtime-memory",
+  kind: "memory",
+  register(api) {
+    api.registerMemoryRuntime({
+      async getMemorySearchManager() {
+        return { manager: null };
+      },
+      resolveMemoryBackendConfig() {
+        return { backend: "builtin" };
+      },
+    });
+  },
+};`,
+    });
+    const loadOptions = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["runtime-memory"],
+          slots: {
+            memory: "runtime-memory",
+          },
+        },
+      },
+    };
+
+    const registry = loadOpenClawPlugins(loadOptions);
+    expect(getMemoryRuntime()).toBeDefined();
+
+    clearMemoryPluginState();
+    expect(getMemoryRuntime()).toBeUndefined();
+
+    expect(resolveRuntimePluginRegistry(loadOptions)).toBe(registry);
+    expect(getMemoryRuntime()).toBeDefined();
   });
 
   it("falls back to the current active runtime when no explicit load context is provided", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -180,6 +180,27 @@ function getCachedPluginRegistry(cacheKey: string): CachedPluginState | undefine
   return cached;
 }
 
+function restoreCachedPluginState(cached: CachedPluginState): void {
+  restoreRegisteredMemoryEmbeddingProviders(cached.memoryEmbeddingProviders);
+  restoreMemoryPluginState({
+    promptBuilder: cached.memoryPromptBuilder,
+    flushPlanResolver: cached.memoryFlushPlanResolver,
+    runtime: cached.memoryRuntime,
+  });
+}
+
+function restoreActivePluginStateFromCache(): void {
+  const activeCacheKey = getActivePluginRegistryKey();
+  if (!activeCacheKey) {
+    return;
+  }
+  const cached = getCachedPluginRegistry(activeCacheKey);
+  if (!cached) {
+    return;
+  }
+  restoreCachedPluginState(cached);
+}
+
 function setCachedPluginRegistry(cacheKey: string, state: CachedPluginState): void {
   if (registryCache.has(cacheKey)) {
     registryCache.delete(cacheKey);
@@ -328,10 +349,15 @@ function getCompatibleActivePluginRegistry(
 export function resolveRuntimePluginRegistry(
   options?: PluginLoadOptions,
 ): PluginRegistry | undefined {
-  if (!options || !hasExplicitCompatibilityInputs(options)) {
-    return getCompatibleActivePluginRegistry();
+  const activeRegistry = getCompatibleActivePluginRegistry(options ?? {});
+  if (activeRegistry) {
+    restoreActivePluginStateFromCache();
+    return activeRegistry;
   }
-  return getCompatibleActivePluginRegistry(options) ?? loadOpenClawPlugins(options);
+  if (!options || !hasExplicitCompatibilityInputs(options)) {
+    return undefined;
+  }
+  return loadOpenClawPlugins(options);
 }
 
 function validatePluginConfig(params: {
@@ -804,12 +830,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   if (cacheEnabled) {
     const cached = getCachedPluginRegistry(cacheKey);
     if (cached) {
-      restoreRegisteredMemoryEmbeddingProviders(cached.memoryEmbeddingProviders);
-      restoreMemoryPluginState({
-        promptBuilder: cached.memoryPromptBuilder,
-        flushPlanResolver: cached.memoryFlushPlanResolver,
-        runtime: cached.memoryRuntime,
-      });
+      restoreCachedPluginState(cached);
       if (shouldActivate) {
         activatePluginRegistry(cached.registry, cacheKey, runtimeSubagentMode);
       }

--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -44,7 +44,8 @@ function createMemoryRuntimeFixture() {
 }
 
 function expectMemoryRuntimeLoaded(autoEnabledConfig: unknown) {
-  expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith({
+  expect(resolveRuntimePluginRegistryMock).toHaveBeenNthCalledWith(1);
+  expect(resolveRuntimePluginRegistryMock).toHaveBeenNthCalledWith(2, {
     config: autoEnabledConfig,
   });
 }
@@ -61,7 +62,10 @@ function setAutoEnabledMemoryRuntime() {
   const { rawConfig, autoEnabledConfig } = createMemoryAutoEnableFixture();
   const runtime = createMemoryRuntimeFixture();
   applyPluginAutoEnableMock.mockReturnValue({ config: autoEnabledConfig, changes: [] });
-  getMemoryRuntimeMock.mockReturnValueOnce(undefined).mockReturnValue(runtime);
+  getMemoryRuntimeMock
+    .mockReturnValueOnce(undefined)
+    .mockReturnValueOnce(undefined)
+    .mockReturnValue(runtime);
   return { rawConfig, autoEnabledConfig, runtime };
 }
 
@@ -161,5 +165,24 @@ describe("memory runtime auto-enable loading", () => {
     },
   ] as const)("$name", async ({ config, setup }) => {
     await expectCloseMemoryRuntimeCase({ config, setup });
+  });
+
+  it("reuses the already active plugin registry before bootstrapping a config-only reload", async () => {
+    const rawConfig = {
+      plugins: {},
+      channels: { memory: { enabled: true } },
+    };
+    const runtime = createMemoryRuntimeFixture();
+    getMemoryRuntimeMock.mockReturnValueOnce(undefined).mockReturnValueOnce(runtime);
+
+    await getActiveMemorySearchManager({
+      cfg: rawConfig as never,
+      agentId: "main",
+      purpose: "status",
+    });
+
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledTimes(1);
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith();
+    expect(applyPluginAutoEnableMock).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -8,6 +8,15 @@ function ensureMemoryRuntime(cfg?: OpenClawConfig) {
   if (current || !cfg) {
     return current;
   }
+  // In a live gateway process, the active registry may have been loaded with
+  // gateway-specific compatibility inputs (workspace, handlers, subagent mode).
+  // Reuse that registry before attempting a config-only reload, or status probes
+  // can miss the already-registered memory runtime and report a false negative.
+  resolveRuntimePluginRegistry();
+  const active = getMemoryRuntime();
+  if (active) {
+    return active;
+  }
   const resolvedConfig = applyPluginAutoEnable({ config: cfg, env: process.env }).config;
   resolveRuntimePluginRegistry({ config: resolvedConfig });
   return getMemoryRuntime();


### PR DESCRIPTION
  Fix/#57256 status mem0 false negative
## Summary                                                                                                                                                                      
                                                                                                                                                                                  
  Fixes a false negative in `openclaw status --deep` / `doctor.memory.status` where memory could be reported as unavailable even though the live gateway had already loaded and   
  was actively using the configured memory plugin.                                                                                                                                
                                                                                                                                                                                  
  ## Root cause                                                                                                                                                                   
                                                                                                                                                                                  
  The status probe path called `getActiveMemorySearchManager({ purpose: "status" })`, which fell back to `resolveRuntimePluginRegistry({ config })` whenever `getMemoryRuntime()` 
  was unset in that call path.                                                                                                                                                    
                                                                                                                                                                                  
  In a live gateway process, the active plugin registry is often loaded with gateway-specific compatibility inputs such as workspace scope, gateway handlers, and runtime options.
  ## Fix

  3. Only then fall back to the existing config-only auto-enable/bootstrap path

  This preserves the old fallback behavior while fixing the status probe path for live gateway processes.

  ## Tests

  Added coverage to verify that:
  - the active plugin registry is reused before bootstrapping a config-only reload
  - the existing auto-enable fallback path still works when no active runtime is available

  ```bash
  pnpm vitest run src/plugins/memory-runtime.test.ts src/gateway/server-methods/doctor.test.ts