### PR TITLE
CLI: keep root help plugin descriptors non-activating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Live Activities: mark the `ActivityKit` import in `LiveActivityManager.swift` as `@preconcurrency` so Xcode 26.4 / Swift 6 builds stop failing on strict concurrency checks. (#57180) Thanks @ngutman.
 - Plugins/Matrix: mirror the Matrix crypto WASM runtime dependency into the root packaged install and enforce root/plugin dependency parity so bundled Matrix E2EE crypto resolves correctly in shipped builds. (#57163) Thanks @gumadeiras.
 - Plugins/CLI: add descriptor-backed lazy plugin CLI registration so Matrix can keep its CLI module lazy-loaded without dropping `openclaw matrix ...` from parse-time command registration. (#57165) Thanks @gumadeiras.
-- Plugins/CLI: keep root-help plugin descriptor loads non-activating while reusing loader-side plugin config validation and channel entry selection semantics. (#57294) thanks @gumadeiras.
+- Plugins/CLI: collect root-help plugin descriptors through a dedicated non-activating CLI metadata path so enabled plugins keep validated config semantics without triggering runtime-only plugin registration work. (#57294) thanks @gumadeiras.
 
 ## 2026.3.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Live Activities: mark the `ActivityKit` import in `LiveActivityManager.swift` as `@preconcurrency` so Xcode 26.4 / Swift 6 builds stop failing on strict concurrency checks. (#57180) Thanks @ngutman.
 - Plugins/Matrix: mirror the Matrix crypto WASM runtime dependency into the root packaged install and enforce root/plugin dependency parity so bundled Matrix E2EE crypto resolves correctly in shipped builds. (#57163) Thanks @gumadeiras.
 - Plugins/CLI: add descriptor-backed lazy plugin CLI registration so Matrix can keep its CLI module lazy-loaded without dropping `openclaw matrix ...` from parse-time command registration. (#57165) Thanks @gumadeiras.
+- Plugins/CLI: keep root-help plugin descriptor loads non-activating while reusing loader-side plugin config validation and channel entry selection semantics. (#57294) thanks @gumadeiras.
 
 ## 2026.3.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Live Activities: mark the `ActivityKit` import in `LiveActivityManager.swift` as `@preconcurrency` so Xcode 26.4 / Swift 6 builds stop failing on strict concurrency checks. (#57180) Thanks @ngutman.
 - Plugins/Matrix: mirror the Matrix crypto WASM runtime dependency into the root packaged install and enforce root/plugin dependency parity so bundled Matrix E2EE crypto resolves correctly in shipped builds. (#57163) Thanks @gumadeiras.
 - Plugins/CLI: add descriptor-backed lazy plugin CLI registration so Matrix can keep its CLI module lazy-loaded without dropping `openclaw matrix ...` from parse-time command registration. (#57165) Thanks @gumadeiras.
-- Plugins/CLI: collect root-help plugin descriptors through a dedicated non-activating CLI metadata path so enabled plugins keep validated config semantics without triggering runtime-only plugin registration work. (#57294) thanks @gumadeiras.
+- Plugins/CLI: collect root-help plugin descriptors through a dedicated non-activating CLI metadata path so enabled plugins keep validated config semantics without triggering runtime-only plugin registration work, while preserving runtime CLI command registration for legacy channel plugins that still wire commands from full registration. (#57294) thanks @gumadeiras.
 
 ## 2026.3.28
 

--- a/docs/internal/gumadeiras/2026-03-29-root-help-cli-descriptors.md
+++ b/docs/internal/gumadeiras/2026-03-29-root-help-cli-descriptors.md
@@ -1,0 +1,33 @@
+---
+title: "Root Help CLI Descriptor Loader Note"
+summary: "Move root-help descriptor capture onto shared loader semantics while keeping channel plugins non-activating."
+author: "Gustavo Madeira Santana"
+github_username: "gumadeiras"
+created: "2026-03-29"
+status: "implemented"
+---
+
+This note covers the follow-up on PR #57294 after review found that the first descriptor-capture approach rebuilt plugin discovery and import logic inside `src/plugins/cli.ts`.
+
+Decision:
+
+- Root help should be non-activating, not semantically different.
+- That means `openclaw --help` should keep loader semantics for enable-state, per-plugin config, config validation, and channel/plugin selection rules.
+- The loader gets a dedicated CLI-metadata snapshot mode instead of `src/plugins/cli.ts` importing plugin entries by itself.
+
+Implementation shape:
+
+- Add `captureCliMetadataOnly` to `loadOpenClawPlugins()`.
+- In that mode, enabled channel plugins load from their real entry file but receive `registrationMode: "setup-only"` so `registerFull(...)` work does not run.
+- Non-channel plugins keep the normal validated loader path, including `pluginConfig`.
+- `getPluginCliCommandDescriptors()` now asks the loader for a non-activating snapshot registry and reads `registry.cliRegistrars`.
+
+Why this replaced the earlier approach:
+
+- The manual import loop in `src/plugins/cli.ts` dropped `api.pluginConfig`, which broke config-dependent CLI plugins.
+- It also drifted away from loader behavior around channel setup entry selection and plugin registration rules.
+
+Regression coverage added:
+
+- A loader test that proves CLI metadata snapshot loads still receive validated `pluginConfig`.
+- A loader test that proves channel CLI metadata capture uses the real channel entry in `setup-only` mode instead of the package `setupEntry`.

--- a/docs/internal/gumadeiras/2026-03-29-root-help-cli-descriptors.md
+++ b/docs/internal/gumadeiras/2026-03-29-root-help-cli-descriptors.md
@@ -27,9 +27,10 @@ Implementation shape:
 - The collector awaits `register(api)` so async plugin registration contributes CLI metadata.
 - The collector only exposes `registerCli(...)` to plugin code; it does not activate services, tools, providers, or gateway handlers.
 - `getPluginCliCommandDescriptors()` and root-help rendering are now async and route through the dedicated collector.
-- `defineChannelPluginEntry(...)` gained an additive `registerCliMetadata(api)` seam so channel plugins can register root-help metadata without entering `registerFull(...)`.
+- `defineChannelPluginEntry(...)` gained an additive `registerCliMetadata(api)` seam so channel plugins can register root-help metadata without entering `registerFull(...)`, while full loads still collect the same CLI descriptors.
 - `extensions/matrix/index.ts` moved its CLI descriptor registration onto that seam.
 - `defineChannelPluginEntry(...)` now skips `setRuntime(...)` in `cli-metadata` mode so help rendering does not poison channel runtime stores with a fake runtime object.
+- `registerPluginCliCommands()` still uses the normal full plugin loader so legacy channel plugins that wired CLI commands inside `registerFull(...)` keep working until they adopt `registerCliMetadata(...)`.
 
 Why this replaced the earlier approach:
 

--- a/docs/internal/gumadeiras/2026-03-29-root-help-cli-descriptors.md
+++ b/docs/internal/gumadeiras/2026-03-29-root-help-cli-descriptors.md
@@ -1,33 +1,45 @@
 ---
 title: "Root Help CLI Descriptor Loader Note"
-summary: "Move root-help descriptor capture onto shared loader semantics while keeping channel plugins non-activating."
+summary: "Collect root-help plugin CLI descriptors through a dedicated non-activating loader path with validated config, awaited registration, and plugin-owned channel metadata."
 author: "Gustavo Madeira Santana"
 github_username: "gumadeiras"
 created: "2026-03-29"
 status: "implemented"
 ---
 
-This note covers the follow-up on PR #57294 after review found that the first descriptor-capture approach rebuilt plugin discovery and import logic inside `src/plugins/cli.ts`.
+This note covers the final implementation on PR #57294 after review found two remaining gaps in the earlier branch state:
+
+- root help still depended on an activating plugin loader path
+- async `register()` implementations were still ignored during descriptor capture
 
 Decision:
 
 - Root help should be non-activating, not semantically different.
-- That means `openclaw --help` should keep loader semantics for enable-state, per-plugin config, config validation, and channel/plugin selection rules.
-- The loader gets a dedicated CLI-metadata snapshot mode instead of `src/plugins/cli.ts` importing plugin entries by itself.
+- That means `openclaw --help` should keep loader semantics for enable-state, per-plugin config, duplicate precedence, config validation, and memory-slot gating.
+- Help should use a dedicated async CLI metadata collector instead of piggybacking on the general activating registry loader.
+- Channel plugins should keep ownership of their own root-help metadata wherever possible.
 
 Implementation shape:
 
-- Add `captureCliMetadataOnly` to `loadOpenClawPlugins()`.
-- In that mode, enabled channel plugins load from their real entry file but receive `registrationMode: "setup-only"` so `registerFull(...)` work does not run.
-- Non-channel plugins keep the normal validated loader path, including `pluginConfig`.
-- `getPluginCliCommandDescriptors()` now asks the loader for a non-activating snapshot registry and reads `registry.cliRegistrars`.
+- Add `loadOpenClawPluginCliRegistry()` in `src/plugins/loader.ts`.
+- The collector reuses plugin discovery, manifest loading, duplicate precedence, enable-state resolution, config validation, and memory-slot gating.
+- The collector always runs with `activate: false` and `cache: false`.
+- The collector awaits `register(api)` so async plugin registration contributes CLI metadata.
+- The collector only exposes `registerCli(...)` to plugin code; it does not activate services, tools, providers, or gateway handlers.
+- `getPluginCliCommandDescriptors()` and root-help rendering are now async and route through the dedicated collector.
+- `defineChannelPluginEntry(...)` gained an additive `registerCliMetadata(api)` seam so channel plugins can register root-help metadata without entering `registerFull(...)`.
+- `extensions/matrix/index.ts` moved its CLI descriptor registration onto that seam.
+- `defineChannelPluginEntry(...)` now skips `setRuntime(...)` in `cli-metadata` mode so help rendering does not poison channel runtime stores with a fake runtime object.
 
 Why this replaced the earlier approach:
 
-- The manual import loop in `src/plugins/cli.ts` dropped `api.pluginConfig`, which broke config-dependent CLI plugins.
-- It also drifted away from loader behavior around channel setup entry selection and plugin registration rules.
+- The original manual import loop in `src/plugins/cli.ts` dropped `api.pluginConfig`, which broke config-dependent CLI plugins.
+- The intermediate loader-flag approach still tied descriptor capture to the sync general loader path and left async `register()` unsupported.
+- The dedicated collector keeps the special behavior narrow and explicit instead of broadening the general loader contract further.
 
 Regression coverage added:
 
-- A loader test that proves CLI metadata snapshot loads still receive validated `pluginConfig`.
-- A loader test that proves channel CLI metadata capture uses the real channel entry in `setup-only` mode instead of the package `setupEntry`.
+- A loader test that proves CLI metadata loads still receive validated `pluginConfig`.
+- A loader test that proves channel CLI metadata capture uses the real channel entry, reports `registrationMode: "cli-metadata"`, and does not load `setupEntry`.
+- A loader test that proves async plugin `register()` contributes CLI descriptors during metadata collection.
+- A loader test that proves `cli-metadata` mode does not call `setRuntime(...)` for channel plugins.

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -214,7 +214,7 @@ dispatch.
       name: "Acme Chat",
       description: "Acme Chat channel plugin",
       plugin: acmeChatPlugin,
-      registerFull(api) {
+      registerCliMetadata(api) {
         api.registerCli(
           ({ program }) => {
             program
@@ -232,11 +232,16 @@ dispatch.
           },
         );
       },
+      registerFull(api) {
+        api.registerGatewayMethod(/* ... */);
+      },
     });
     ```
 
-    `defineChannelPluginEntry` handles the setup/full registration split
-    automatically. See
+    Put root-help CLI descriptors in `registerCliMetadata(...)` so OpenClaw can
+    show them without activating the full channel runtime. Keep
+    `registerFull(...)` for runtime-only work. `defineChannelPluginEntry`
+    handles the registration-mode split automatically. See
     [Entry Points](/plugins/sdk-entrypoints#definechannelpluginentry) for all
     options.
 

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -238,10 +238,11 @@ dispatch.
     });
     ```
 
-    Put root-help CLI descriptors in `registerCliMetadata(...)` so OpenClaw can
-    show them without activating the full channel runtime. Keep
-    `registerFull(...)` for runtime-only work. `defineChannelPluginEntry`
-    handles the registration-mode split automatically. See
+    Put channel-owned CLI descriptors in `registerCliMetadata(...)` so OpenClaw
+    can show them in root help without activating the full channel runtime,
+    while normal full loads still pick up the same descriptors for real command
+    registration. Keep `registerFull(...)` for runtime-only work.
+    `defineChannelPluginEntry` handles the registration-mode split automatically. See
     [Entry Points](/plugins/sdk-entrypoints#definechannelpluginentry) for all
     options.
 

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -4,7 +4,7 @@ sidebarTitle: "Entry Points"
 summary: "Reference for definePluginEntry, defineChannelPluginEntry, and defineSetupPluginEntry"
 read_when:
   - You need the exact type signature of definePluginEntry or defineChannelPluginEntry
-  - You want to understand registration mode (full vs setup)
+  - You want to understand registration mode (full vs setup vs CLI metadata)
   - You are looking up entry point options
 ---
 
@@ -61,7 +61,8 @@ export default definePluginEntry({
 **Import:** `openclaw/plugin-sdk/core`
 
 Wraps `definePluginEntry` with channel-specific wiring. Automatically calls
-`api.registerChannel({ plugin })` and gates `registerFull` on registration mode.
+`api.registerChannel({ plugin })`, exposes an optional root-help CLI metadata
+seam, and gates `registerFull` on registration mode.
 
 ```typescript
 import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
@@ -72,30 +73,37 @@ export default defineChannelPluginEntry({
   description: "Short summary",
   plugin: myChannelPlugin,
   setRuntime: setMyRuntime,
-  registerFull(api) {
+  registerCliMetadata(api) {
     api.registerCli(/* ... */);
+  },
+  registerFull(api) {
     api.registerGatewayMethod(/* ... */);
   },
 });
 ```
 
-| Field          | Type                                                             | Required | Default             |
-| -------------- | ---------------------------------------------------------------- | -------- | ------------------- |
-| `id`           | `string`                                                         | Yes      | —                   |
-| `name`         | `string`                                                         | Yes      | —                   |
-| `description`  | `string`                                                         | Yes      | —                   |
-| `plugin`       | `ChannelPlugin`                                                  | Yes      | —                   |
-| `configSchema` | `OpenClawPluginConfigSchema \| () => OpenClawPluginConfigSchema` | No       | Empty object schema |
-| `setRuntime`   | `(runtime: PluginRuntime) => void`                               | No       | —                   |
-| `registerFull` | `(api: OpenClawPluginApi) => void`                               | No       | —                   |
+| Field                 | Type                                                             | Required | Default             |
+| --------------------- | ---------------------------------------------------------------- | -------- | ------------------- |
+| `id`                  | `string`                                                         | Yes      | —                   |
+| `name`                | `string`                                                         | Yes      | —                   |
+| `description`         | `string`                                                         | Yes      | —                   |
+| `plugin`              | `ChannelPlugin`                                                  | Yes      | —                   |
+| `configSchema`        | `OpenClawPluginConfigSchema \| () => OpenClawPluginConfigSchema` | No       | Empty object schema |
+| `setRuntime`          | `(runtime: PluginRuntime) => void`                               | No       | —                   |
+| `registerCliMetadata` | `(api: OpenClawPluginApi) => void`                               | No       | —                   |
+| `registerFull`        | `(api: OpenClawPluginApi) => void`                               | No       | —                   |
 
 - `setRuntime` is called during registration so you can store the runtime reference
-  (typically via `createPluginRuntimeStore`).
+  (typically via `createPluginRuntimeStore`). It is skipped during CLI metadata
+  capture.
+- `registerCliMetadata` runs only when `api.registrationMode === "cli-metadata"`.
+  Use it for root-help CLI descriptors that should stay non-activating.
 - `registerFull` only runs when `api.registrationMode === "full"`. It is skipped
   during setup-only loading.
 - For plugin-owned root CLI commands, prefer `api.registerCli(..., { descriptors: [...] })`
   when you want the command to stay lazy-loaded without disappearing from the
-  root CLI parse tree.
+  root CLI parse tree. For channel plugins, prefer registering those descriptors
+  from `registerCliMetadata(...)` and keep `registerFull(...)` focused on runtime-only work.
 
 ## `defineSetupPluginEntry`
 
@@ -123,17 +131,22 @@ unconfigured, or when deferred loading is enabled. See
 | `"full"`          | Normal gateway startup            | Everything                    |
 | `"setup-only"`    | Disabled/unconfigured channel     | Channel registration only     |
 | `"setup-runtime"` | Setup flow with runtime available | Channel + lightweight runtime |
+| `"cli-metadata"`  | Root help / CLI metadata capture  | CLI descriptors only          |
 
 `defineChannelPluginEntry` handles this split automatically. If you use
 `definePluginEntry` directly for a channel, check mode yourself:
 
 ```typescript
 register(api) {
+  if (api.registrationMode === "cli-metadata") {
+    api.registerCli(/* ... */);
+    return;
+  }
+
   api.registerChannel({ plugin: myPlugin });
   if (api.registrationMode !== "full") return;
 
   // Heavy runtime-only registrations
-  api.registerCli(/* ... */);
   api.registerService(/* ... */);
 }
 ```

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -96,8 +96,11 @@ export default defineChannelPluginEntry({
 - `setRuntime` is called during registration so you can store the runtime reference
   (typically via `createPluginRuntimeStore`). It is skipped during CLI metadata
   capture.
-- `registerCliMetadata` runs only when `api.registrationMode === "cli-metadata"`.
-  Use it for root-help CLI descriptors that should stay non-activating.
+- `registerCliMetadata` runs during both `api.registrationMode === "cli-metadata"`
+  and `api.registrationMode === "full"`.
+  Use it as the canonical place for channel-owned CLI descriptors so root help
+  stays non-activating while normal CLI command registration remains compatible
+  with full plugin loads.
 - `registerFull` only runs when `api.registrationMode === "full"`. It is skipped
   during setup-only loading.
 - For plugin-owned root CLI commands, prefer `api.registerCli(..., { descriptors: [...] })`
@@ -138,9 +141,9 @@ unconfigured, or when deferred loading is enabled. See
 
 ```typescript
 register(api) {
-  if (api.registrationMode === "cli-metadata") {
+  if (api.registrationMode === "cli-metadata" || api.registrationMode === "full") {
     api.registerCli(/* ... */);
-    return;
+    if (api.registrationMode === "cli-metadata") return;
   }
 
   api.registerChannel({ plugin: myPlugin });

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -237,20 +237,20 @@ AI CLI backend such as `claude-cli` or `codex-cli`.
 
 ### API object fields
 
-| Field                    | Type                      | Description                                               |
-| ------------------------ | ------------------------- | --------------------------------------------------------- |
-| `api.id`                 | `string`                  | Plugin id                                                 |
-| `api.name`               | `string`                  | Display name                                              |
-| `api.version`            | `string?`                 | Plugin version (optional)                                 |
-| `api.description`        | `string?`                 | Plugin description (optional)                             |
-| `api.source`             | `string`                  | Plugin source path                                        |
-| `api.rootDir`            | `string?`                 | Plugin root directory (optional)                          |
-| `api.config`             | `OpenClawConfig`          | Current config snapshot                                   |
-| `api.pluginConfig`       | `Record<string, unknown>` | Plugin-specific config from `plugins.entries.<id>.config` |
-| `api.runtime`            | `PluginRuntime`           | [Runtime helpers](/plugins/sdk-runtime)                   |
-| `api.logger`             | `PluginLogger`            | Scoped logger (`debug`, `info`, `warn`, `error`)          |
-| `api.registrationMode`   | `PluginRegistrationMode`  | `"full"`, `"setup-only"`, or `"setup-runtime"`            |
-| `api.resolvePath(input)` | `(string) => string`      | Resolve path relative to plugin root                      |
+| Field                    | Type                      | Description                                                      |
+| ------------------------ | ------------------------- | ---------------------------------------------------------------- |
+| `api.id`                 | `string`                  | Plugin id                                                        |
+| `api.name`               | `string`                  | Display name                                                     |
+| `api.version`            | `string?`                 | Plugin version (optional)                                        |
+| `api.description`        | `string?`                 | Plugin description (optional)                                    |
+| `api.source`             | `string`                  | Plugin source path                                               |
+| `api.rootDir`            | `string?`                 | Plugin root directory (optional)                                 |
+| `api.config`             | `OpenClawConfig`          | Current config snapshot                                          |
+| `api.pluginConfig`       | `Record<string, unknown>` | Plugin-specific config from `plugins.entries.<id>.config`        |
+| `api.runtime`            | `PluginRuntime`           | [Runtime helpers](/plugins/sdk-runtime)                          |
+| `api.logger`             | `PluginLogger`            | Scoped logger (`debug`, `info`, `warn`, `error`)                 |
+| `api.registrationMode`   | `PluginRegistrationMode`  | `"full"`, `"setup-only"`, `"setup-runtime"`, or `"cli-metadata"` |
+| `api.resolvePath(input)` | `(string) => string`      | Resolve path relative to plugin root                             |
 
 ## Internal module convention
 

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -330,15 +330,15 @@ export function tryGetRuntime() {
 
 Beyond `api.runtime`, the API object also provides:
 
-| Field                    | Type                      | Description                                               |
-| ------------------------ | ------------------------- | --------------------------------------------------------- |
-| `api.id`                 | `string`                  | Plugin id                                                 |
-| `api.name`               | `string`                  | Plugin display name                                       |
-| `api.config`             | `OpenClawConfig`          | Current config snapshot                                   |
-| `api.pluginConfig`       | `Record<string, unknown>` | Plugin-specific config from `plugins.entries.<id>.config` |
-| `api.logger`             | `PluginLogger`            | Scoped logger (`debug`, `info`, `warn`, `error`)          |
-| `api.registrationMode`   | `PluginRegistrationMode`  | `"full"`, `"setup-only"`, or `"setup-runtime"`            |
-| `api.resolvePath(input)` | `(string) => string`      | Resolve a path relative to the plugin root                |
+| Field                    | Type                      | Description                                                      |
+| ------------------------ | ------------------------- | ---------------------------------------------------------------- |
+| `api.id`                 | `string`                  | Plugin id                                                        |
+| `api.name`               | `string`                  | Plugin display name                                              |
+| `api.config`             | `OpenClawConfig`          | Current config snapshot                                          |
+| `api.pluginConfig`       | `Record<string, unknown>` | Plugin-specific config from `plugins.entries.<id>.config`        |
+| `api.logger`             | `PluginLogger`            | Scoped logger (`debug`, `info`, `warn`, `error`)                 |
+| `api.registrationMode`   | `PluginRegistrationMode`  | `"full"`, `"setup-only"`, `"setup-runtime"`, or `"cli-metadata"` |
+| `api.resolvePath(input)` | `(string) => string`      | Resolve a path relative to the plugin root                       |
 
 ## Related
 

--- a/extensions/matrix/index.test.ts
+++ b/extensions/matrix/index.test.ts
@@ -48,4 +48,32 @@ describe("matrix plugin", () => {
     await result;
     expect(cliMocks.registerMatrixCli).toHaveBeenCalledWith({ program });
   });
+
+  it("keeps runtime bootstrap out of setup-only registration while exposing CLI metadata", () => {
+    const registerCli = vi.fn();
+    const registerGatewayMethod = vi.fn();
+    const api = createTestPluginApi({
+      id: "matrix",
+      name: "Matrix",
+      source: "test",
+      config: {},
+      runtime: {} as never,
+      registrationMode: "setup-only",
+      registerCli,
+      registerGatewayMethod,
+    });
+
+    matrixPlugin.register(api);
+
+    expect(registerCli).toHaveBeenCalledWith(expect.any(Function), {
+      descriptors: [
+        {
+          name: "matrix",
+          description: "Manage Matrix accounts, verification, devices, and profile state",
+          hasSubcommands: true,
+        },
+      ],
+    });
+    expect(registerGatewayMethod).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/matrix/index.test.ts
+++ b/extensions/matrix/index.test.ts
@@ -18,13 +18,16 @@ import matrixPlugin from "./index.js";
 describe("matrix plugin", () => {
   it("registers matrix CLI through a descriptor-backed lazy registrar", async () => {
     const registerCli = vi.fn();
+    const registerGatewayMethod = vi.fn();
     const api = createTestPluginApi({
       id: "matrix",
       name: "Matrix",
       source: "test",
       config: {},
       runtime: {} as never,
+      registrationMode: "cli-metadata",
       registerCli,
+      registerGatewayMethod,
     });
 
     matrixPlugin.register(api);
@@ -47,9 +50,10 @@ describe("matrix plugin", () => {
 
     await result;
     expect(cliMocks.registerMatrixCli).toHaveBeenCalledWith({ program });
+    expect(registerGatewayMethod).not.toHaveBeenCalled();
   });
 
-  it("keeps runtime bootstrap out of setup-only registration while exposing CLI metadata", () => {
+  it("keeps runtime bootstrap and CLI metadata out of setup-only registration", () => {
     const registerCli = vi.fn();
     const registerGatewayMethod = vi.fn();
     const api = createTestPluginApi({
@@ -65,15 +69,7 @@ describe("matrix plugin", () => {
 
     matrixPlugin.register(api);
 
-    expect(registerCli).toHaveBeenCalledWith(expect.any(Function), {
-      descriptors: [
-        {
-          name: "matrix",
-          description: "Manage Matrix accounts, verification, devices, and profile state",
-          hasSubcommands: true,
-        },
-      ],
-    });
+    expect(registerCli).not.toHaveBeenCalled();
     expect(registerGatewayMethod).not.toHaveBeenCalled();
   });
 });

--- a/extensions/matrix/index.ts
+++ b/extensions/matrix/index.ts
@@ -1,17 +1,44 @@
 import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { matrixPlugin } from "./src/channel.js";
 import { setMatrixRuntime } from "./src/runtime.js";
 
 export { matrixPlugin } from "./src/channel.js";
 export { setMatrixRuntime } from "./src/runtime.js";
 
-export default defineChannelPluginEntry({
+const matrixEntry = defineChannelPluginEntry({
   id: "matrix",
   name: "Matrix",
   description: "Matrix channel plugin (matrix-js-sdk)",
   plugin: matrixPlugin,
   setRuntime: setMatrixRuntime,
-  registerFull(api) {
+});
+
+export default {
+  ...matrixEntry,
+  register(api: OpenClawPluginApi) {
+    matrixEntry.register(api);
+    // Expose Matrix CLI metadata during descriptor capture without crossing
+    // into the full runtime bootstrap path.
+    api.registerCli(
+      async ({ program }) => {
+        const { registerMatrixCli } = await import("./src/cli.js");
+        registerMatrixCli({ program });
+      },
+      {
+        descriptors: [
+          {
+            name: "matrix",
+            description: "Manage Matrix accounts, verification, devices, and profile state",
+            hasSubcommands: true,
+          },
+        ],
+      },
+    );
+    if (api.registrationMode !== "full") {
+      return;
+    }
+
     void import("./src/plugin-entry.runtime.js")
       .then(({ ensureMatrixCryptoRuntime }) =>
         ensureMatrixCryptoRuntime({ log: api.logger.info }).catch((err: unknown) => {
@@ -38,21 +65,5 @@ export default defineChannelPluginEntry({
       const { handleVerificationStatus } = await import("./src/plugin-entry.runtime.js");
       await handleVerificationStatus(ctx);
     });
-
-    api.registerCli(
-      async ({ program }) => {
-        const { registerMatrixCli } = await import("./src/cli.js");
-        registerMatrixCli({ program });
-      },
-      {
-        descriptors: [
-          {
-            name: "matrix",
-            description: "Manage Matrix accounts, verification, devices, and profile state",
-            hasSubcommands: true,
-          },
-        ],
-      },
-    );
   },
-});
+};

--- a/extensions/matrix/index.ts
+++ b/extensions/matrix/index.ts
@@ -1,25 +1,17 @@
 import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { matrixPlugin } from "./src/channel.js";
 import { setMatrixRuntime } from "./src/runtime.js";
 
 export { matrixPlugin } from "./src/channel.js";
 export { setMatrixRuntime } from "./src/runtime.js";
 
-const matrixEntry = defineChannelPluginEntry({
+export default defineChannelPluginEntry({
   id: "matrix",
   name: "Matrix",
   description: "Matrix channel plugin (matrix-js-sdk)",
   plugin: matrixPlugin,
   setRuntime: setMatrixRuntime,
-});
-
-export default {
-  ...matrixEntry,
-  register(api: OpenClawPluginApi) {
-    matrixEntry.register(api);
-    // Expose Matrix CLI metadata during descriptor capture without crossing
-    // into the full runtime bootstrap path.
+  registerCliMetadata(api) {
     api.registerCli(
       async ({ program }) => {
         const { registerMatrixCli } = await import("./src/cli.js");
@@ -35,10 +27,8 @@ export default {
         ],
       },
     );
-    if (api.registrationMode !== "full") {
-      return;
-    }
-
+  },
+  registerFull(api) {
     void import("./src/plugin-entry.runtime.js")
       .then(({ ensureMatrixCryptoRuntime }) =>
         ensureMatrixCryptoRuntime({ log: api.logger.info }).catch((err: unknown) => {
@@ -66,4 +56,4 @@ export default {
       await handleVerificationStatus(ctx);
     });
   },
-};
+});

--- a/src/cli/program/root-help.test.ts
+++ b/src/cli/program/root-help.test.ts
@@ -23,7 +23,7 @@ vi.mock("./subcli-descriptors.js", () => ({
 }));
 
 vi.mock("../../plugins/cli.js", () => ({
-  getPluginCliCommandDescriptors: () => [
+  getPluginCliCommandDescriptors: async () => [
     {
       name: "matrix",
       description: "Matrix channel utilities",
@@ -35,8 +35,8 @@ vi.mock("../../plugins/cli.js", () => ({
 const { renderRootHelpText } = await import("./root-help.js");
 
 describe("root help", () => {
-  it("includes plugin CLI descriptors alongside core and sub-CLI commands", () => {
-    const text = renderRootHelpText();
+  it("includes plugin CLI descriptors alongside core and sub-CLI commands", async () => {
+    const text = await renderRootHelpText();
 
     expect(text).toContain("status");
     expect(text).toContain("config");

--- a/src/cli/program/root-help.ts
+++ b/src/cli/program/root-help.ts
@@ -5,7 +5,7 @@ import { getCoreCliCommandDescriptors } from "./core-command-descriptors.js";
 import { configureProgramHelp } from "./help.js";
 import { getSubCliEntries } from "./subcli-descriptors.js";
 
-function buildRootHelpProgram(): Command {
+async function buildRootHelpProgram(): Promise<Command> {
   const program = new Command();
   configureProgramHelp(program, {
     programVersion: VERSION,
@@ -26,7 +26,7 @@ function buildRootHelpProgram(): Command {
     program.command(command.name).description(command.description);
     existingCommands.add(command.name);
   }
-  for (const command of getPluginCliCommandDescriptors()) {
+  for (const command of await getPluginCliCommandDescriptors()) {
     if (existingCommands.has(command.name)) {
       continue;
     }
@@ -37,8 +37,8 @@ function buildRootHelpProgram(): Command {
   return program;
 }
 
-export function renderRootHelpText(): string {
-  const program = buildRootHelpProgram();
+export async function renderRootHelpText(): Promise<string> {
+  const program = await buildRootHelpProgram();
   let output = "";
   const originalWrite = process.stdout.write.bind(process.stdout);
   const captureWrite: typeof process.stdout.write = ((chunk: string | Uint8Array) => {
@@ -54,6 +54,6 @@ export function renderRootHelpText(): string {
   return output;
 }
 
-export function outputRootHelp(): void {
-  process.stdout.write(renderRootHelpText());
+export async function outputRootHelp(): Promise<void> {
+  process.stdout.write(await renderRootHelpText());
 }

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -160,7 +160,7 @@ export async function runCli(argv: string[] = process.argv) {
   try {
     if (shouldUseRootHelpFastPath(normalizedArgv)) {
       const { outputRootHelp } = await import("./program/root-help.js");
-      outputRootHelp();
+      await outputRootHelp();
       return;
     }
 

--- a/src/entry.test.ts
+++ b/src/entry.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import { tryHandleRootHelpFastPath } from "./entry.js";
 
 describe("entry root help fast path", () => {
-  it("renders root help without importing the full program", () => {
+  it("renders root help without importing the full program", async () => {
     const outputRootHelpMock = vi.fn();
 
     const handled = tryHandleRootHelpFastPath(["node", "openclaw", "--help"], {
       outputRootHelp: outputRootHelpMock,
       env: {},
     });
+    await Promise.resolve();
 
     expect(handled).toBe(true);
     expect(outputRootHelpMock).toHaveBeenCalledTimes(1);

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -159,7 +159,7 @@ if (
 export function tryHandleRootHelpFastPath(
   argv: string[],
   deps: {
-    outputRootHelp?: () => void;
+    outputRootHelp?: () => void | Promise<void>;
     onError?: (error: unknown) => void;
     env?: NodeJS.ProcessEnv;
   } = {},
@@ -180,16 +180,14 @@ export function tryHandleRootHelpFastPath(
       process.exitCode = 1;
     });
   if (deps.outputRootHelp) {
-    try {
-      deps.outputRootHelp();
-    } catch (error) {
-      handleError(error);
-    }
+    Promise.resolve()
+      .then(() => deps.outputRootHelp?.())
+      .catch(handleError);
     return true;
   }
   import("./cli/program/root-help.js")
     .then(({ outputRootHelp }) => {
-      outputRootHelp();
+      return outputRootHelp();
     })
     .catch(handleError);
   return true;

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -218,6 +218,7 @@ type DefineChannelPluginEntryOptions<TPlugin = ChannelPlugin> = {
   plugin: TPlugin;
   configSchema?: OpenClawPluginConfigSchema | (() => OpenClawPluginConfigSchema);
   setRuntime?: (runtime: PluginRuntime) => void;
+  registerCliMetadata?: (api: OpenClawPluginApi) => void;
   registerFull?: (api: OpenClawPluginApi) => void;
 };
 
@@ -281,6 +282,7 @@ export function defineChannelPluginEntry<TPlugin>({
   plugin,
   configSchema = emptyPluginConfigSchema,
   setRuntime,
+  registerCliMetadata,
   registerFull,
 }: DefineChannelPluginEntryOptions<TPlugin>): DefinedChannelPluginEntry<TPlugin> {
   const resolvedConfigSchema = typeof configSchema === "function" ? configSchema() : configSchema;
@@ -291,6 +293,10 @@ export function defineChannelPluginEntry<TPlugin>({
     configSchema: resolvedConfigSchema,
     register(api: OpenClawPluginApi) {
       setRuntime?.(api.runtime);
+      if (api.registrationMode === "cli-metadata") {
+        registerCliMetadata?.(api);
+        return;
+      }
       api.registerChannel({ plugin: plugin as ChannelPlugin });
       if (api.registrationMode !== "full") {
         return;

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -301,6 +301,7 @@ export function defineChannelPluginEntry<TPlugin>({
       if (api.registrationMode !== "full") {
         return;
       }
+      registerCliMetadata?.(api);
       registerFull?.(api);
     },
   };

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -292,11 +292,11 @@ export function defineChannelPluginEntry<TPlugin>({
     description,
     configSchema: resolvedConfigSchema,
     register(api: OpenClawPluginApi) {
-      setRuntime?.(api.runtime);
       if (api.registrationMode === "cli-metadata") {
         registerCliMetadata?.(api);
         return;
       }
+      setRuntime?.(api.runtime);
       api.registerChannel({ plugin: plugin as ChannelPlugin });
       if (api.registrationMode !== "full") {
         return;

--- a/src/plugins/captured-registration.ts
+++ b/src/plugins/captured-registration.ts
@@ -7,14 +7,23 @@ import type {
   ImageGenerationProviderPlugin,
   MediaUnderstandingProviderPlugin,
   OpenClawPluginApi,
+  OpenClawPluginCliCommandDescriptor,
+  OpenClawPluginCliRegistrar,
   ProviderPlugin,
   SpeechProviderPlugin,
   WebSearchProviderPlugin,
 } from "./types.js";
 
+type CapturedPluginCliRegistration = {
+  register: OpenClawPluginCliRegistrar;
+  commands: string[];
+  descriptors: OpenClawPluginCliCommandDescriptor[];
+};
+
 export type CapturedPluginRegistration = {
   api: OpenClawPluginApi;
   providers: ProviderPlugin[];
+  cliRegistrars: CapturedPluginCliRegistration[];
   cliBackends: CliBackendPlugin[];
   speechProviders: SpeechProviderPlugin[];
   mediaUnderstandingProviders: MediaUnderstandingProviderPlugin[];
@@ -23,8 +32,12 @@ export type CapturedPluginRegistration = {
   tools: AnyAgentTool[];
 };
 
-export function createCapturedPluginRegistration(): CapturedPluginRegistration {
+export function createCapturedPluginRegistration(params?: {
+  config?: OpenClawConfig;
+  registrationMode?: OpenClawPluginApi["registrationMode"];
+}): CapturedPluginRegistration {
   const providers: ProviderPlugin[] = [];
+  const cliRegistrars: CapturedPluginCliRegistration[] = [];
   const cliBackends: CliBackendPlugin[] = [];
   const speechProviders: SpeechProviderPlugin[] = [];
   const mediaUnderstandingProviders: MediaUnderstandingProviderPlugin[] = [];
@@ -40,6 +53,7 @@ export function createCapturedPluginRegistration(): CapturedPluginRegistration {
 
   return {
     providers,
+    cliRegistrars,
     cliBackends,
     speechProviders,
     mediaUnderstandingProviders,
@@ -50,12 +64,35 @@ export function createCapturedPluginRegistration(): CapturedPluginRegistration {
       id: "captured-plugin-registration",
       name: "Captured Plugin Registration",
       source: "captured-plugin-registration",
-      registrationMode: "full",
-      config: {} as OpenClawConfig,
+      registrationMode: params?.registrationMode ?? "full",
+      config: params?.config ?? ({} as OpenClawConfig),
       runtime: {} as PluginRuntime,
       logger: noopLogger,
       resolvePath: (input) => input,
       handlers: {
+        registerCli(registrar, opts) {
+          const descriptors = (opts?.descriptors ?? [])
+            .map((descriptor) => ({
+              name: descriptor.name.trim(),
+              description: descriptor.description.trim(),
+              hasSubcommands: descriptor.hasSubcommands,
+            }))
+            .filter((descriptor) => descriptor.name && descriptor.description);
+          const commands = [
+            ...(opts?.commands ?? []),
+            ...descriptors.map((descriptor) => descriptor.name),
+          ]
+            .map((command) => command.trim())
+            .filter(Boolean);
+          if (commands.length === 0) {
+            return;
+          }
+          cliRegistrars.push({
+            register: registrar,
+            commands,
+            descriptors,
+          });
+        },
         registerProvider(provider: ProviderPlugin) {
           providers.push(provider);
         },

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -6,12 +6,13 @@ const mocks = vi.hoisted(() => ({
   memoryRegister: vi.fn(),
   otherRegister: vi.fn(),
   memoryListAction: vi.fn(),
-  loadOpenClawPlugins: vi.fn(),
+  loadOpenClawPluginCliRegistry: vi.fn(),
   applyPluginAutoEnable: vi.fn(),
 }));
 
 vi.mock("./loader.js", () => ({
-  loadOpenClawPlugins: (...args: unknown[]) => mocks.loadOpenClawPlugins(...args),
+  loadOpenClawPluginCliRegistry: (...args: unknown[]) =>
+    mocks.loadOpenClawPluginCliRegistry(...args),
 }));
 
 vi.mock("../config/plugin-auto-enable.js", () => ({
@@ -63,7 +64,7 @@ function createCliRegistry(params?: {
 }
 
 function expectPluginLoaderConfig(config: OpenClawConfig) {
-  expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+  expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledWith(
     expect.objectContaining({
       config,
     }),
@@ -109,8 +110,8 @@ describe("registerPluginCliCommands", () => {
       program.command("other").description("Other commands");
     });
     mocks.memoryListAction.mockReset();
-    mocks.loadOpenClawPlugins.mockReset();
-    mocks.loadOpenClawPlugins.mockReturnValue(createCliRegistry());
+    mocks.loadOpenClawPluginCliRegistry.mockReset();
+    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue(createCliRegistry());
     mocks.applyPluginAutoEnable.mockReset();
     mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
   });
@@ -129,7 +130,7 @@ describe("registerPluginCliCommands", () => {
 
     await registerPluginCliCommands(createProgram(), {} as OpenClawConfig, env);
 
-    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledWith(
       expect.objectContaining({
         env,
       }),
@@ -150,10 +151,10 @@ describe("registerPluginCliCommands", () => {
     );
   });
 
-  it("loads root-help descriptors through the non-activating loader path", () => {
+  it("loads root-help descriptors through the dedicated non-activating CLI collector", async () => {
     const { rawConfig, autoEnabledConfig } = createAutoEnabledCliFixture();
     mocks.applyPluginAutoEnable.mockReturnValue({ config: autoEnabledConfig, changes: [] });
-    mocks.loadOpenClawPlugins.mockReturnValue({
+    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue({
       cliRegistrars: [
         {
           pluginId: "matrix",
@@ -184,19 +185,16 @@ describe("registerPluginCliCommands", () => {
       ],
     });
 
-    expect(getPluginCliCommandDescriptors(rawConfig)).toEqual([
+    await expect(getPluginCliCommandDescriptors(rawConfig)).resolves.toEqual([
       {
         name: "matrix",
         description: "Matrix channel utilities",
         hasSubcommands: true,
       },
     ]);
-    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledWith(
       expect.objectContaining({
         config: autoEnabledConfig,
-        activate: false,
-        cache: false,
-        captureCliMetadataOnly: true,
       }),
     );
   });
@@ -220,7 +218,7 @@ describe("registerPluginCliCommands", () => {
   });
 
   it("falls back to eager registration when descriptors do not cover every command root", async () => {
-    mocks.loadOpenClawPlugins.mockReturnValue(
+    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue(
       createCliRegistry({
         memoryCommands: ["memory", "memory-admin"],
         memoryDescriptors: [

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -1,6 +1,3 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
@@ -11,15 +8,6 @@ const mocks = vi.hoisted(() => ({
   memoryListAction: vi.fn(),
   loadOpenClawPlugins: vi.fn(),
   applyPluginAutoEnable: vi.fn(),
-  discoverOpenClawPlugins: vi.fn(),
-  loadPluginManifestRegistry: vi.fn(),
-  resolveEffectiveEnableState: vi.fn(),
-  resolveMemorySlotDecision: vi.fn(),
-  createJiti: vi.fn(),
-}));
-
-vi.mock("jiti", () => ({
-  createJiti: (...args: unknown[]) => mocks.createJiti(...args),
 }));
 
 vi.mock("./loader.js", () => ({
@@ -29,23 +17,6 @@ vi.mock("./loader.js", () => ({
 vi.mock("../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable: (...args: unknown[]) => mocks.applyPluginAutoEnable(...args),
 }));
-
-vi.mock("./discovery.js", () => ({
-  discoverOpenClawPlugins: (...args: unknown[]) => mocks.discoverOpenClawPlugins(...args),
-}));
-
-vi.mock("./manifest-registry.js", () => ({
-  loadPluginManifestRegistry: (...args: unknown[]) => mocks.loadPluginManifestRegistry(...args),
-}));
-
-vi.mock("./config-state.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./config-state.js")>();
-  return {
-    ...actual,
-    resolveEffectiveEnableState: (...args: unknown[]) => mocks.resolveEffectiveEnableState(...args),
-    resolveMemorySlotDecision: (...args: unknown[]) => mocks.resolveMemorySlotDecision(...args),
-  };
-});
 
 import { getPluginCliCommandDescriptors, registerPluginCliCommands } from "./cli.js";
 
@@ -142,22 +113,6 @@ describe("registerPluginCliCommands", () => {
     mocks.loadOpenClawPlugins.mockReturnValue(createCliRegistry());
     mocks.applyPluginAutoEnable.mockReset();
     mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
-    mocks.discoverOpenClawPlugins.mockReset();
-    mocks.discoverOpenClawPlugins.mockReturnValue({
-      candidates: [],
-      diagnostics: [],
-    });
-    mocks.loadPluginManifestRegistry.mockReset();
-    mocks.loadPluginManifestRegistry.mockReturnValue({
-      plugins: [],
-      diagnostics: [],
-    });
-    mocks.resolveEffectiveEnableState.mockReset();
-    mocks.resolveEffectiveEnableState.mockReturnValue({ enabled: true });
-    mocks.resolveMemorySlotDecision.mockReset();
-    mocks.resolveMemorySlotDecision.mockReturnValue({ enabled: true });
-    mocks.createJiti.mockReset();
-    mocks.createJiti.mockReturnValue(() => ({}));
   });
 
   it("skips plugin CLI registrars when commands already exist", async () => {
@@ -195,165 +150,55 @@ describe("registerPluginCliCommands", () => {
     );
   });
 
-  it("captures channel plugin descriptors without using the activating loader", () => {
-    const tempRoot = mkdtempSync(path.join(tmpdir(), "openclaw-cli-descriptors-"));
-    const pluginRoot = path.join(tempRoot, "matrix");
-    const source = path.join(pluginRoot, "index.ts");
-    mkdirSync(pluginRoot, { recursive: true });
-    writeFileSync(source, "export default {}");
-    mocks.discoverOpenClawPlugins.mockReturnValue({
-      candidates: [],
-      diagnostics: [],
-    });
-    mocks.loadPluginManifestRegistry.mockReturnValue({
-      plugins: [
+  it("loads root-help descriptors through the non-activating loader path", () => {
+    const { rawConfig, autoEnabledConfig } = createAutoEnabledCliFixture();
+    mocks.applyPluginAutoEnable.mockReturnValue({ config: autoEnabledConfig, changes: [] });
+    mocks.loadOpenClawPlugins.mockReturnValue({
+      cliRegistrars: [
         {
-          id: "matrix",
-          enabledByDefault: true,
-          format: "openclaw",
-          channels: ["matrix"],
-          providers: [],
-          cliBackends: [],
-          skills: [],
-          hooks: [],
-          origin: "bundled",
-          rootDir: pluginRoot,
-          source,
-          manifestPath: path.join(pluginRoot, "openclaw.plugin.json"),
+          pluginId: "matrix",
+          register: vi.fn(),
+          commands: ["matrix"],
+          descriptors: [
+            {
+              name: "matrix",
+              description: "Matrix channel utilities",
+              hasSubcommands: true,
+            },
+          ],
+          source: "bundled",
+        },
+        {
+          pluginId: "duplicate-matrix",
+          register: vi.fn(),
+          commands: ["matrix"],
+          descriptors: [
+            {
+              name: "matrix",
+              description: "Duplicate Matrix channel utilities",
+              hasSubcommands: true,
+            },
+          ],
+          source: "bundled",
         },
       ],
-      diagnostics: [],
     });
-    const registerFull = vi.fn();
-    mocks.createJiti.mockReturnValue(
-      () =>
-        ({
-          default: {
-            id: "matrix",
-            name: "Matrix",
-            description: "Matrix channel plugin",
-            channelPlugin: {},
-            register(api: {
-              registrationMode: "full" | "setup-only" | "setup-runtime";
-              registerChannel: (registration: unknown) => void;
-              registerCli: (
-                registrar: () => void,
-                opts: {
-                  descriptors: Array<{
-                    name: string;
-                    description: string;
-                    hasSubcommands: boolean;
-                  }>;
-                },
-              ) => void;
-            }) {
-              api.registerChannel({ plugin: {} });
-              api.registerCli(() => {}, {
-                descriptors: [
-                  {
-                    name: "matrix",
-                    description: "Matrix channel utilities",
-                    hasSubcommands: true,
-                  },
-                ],
-              });
-              if (api.registrationMode === "full") {
-                registerFull();
-              }
-            },
-          },
-        }) as never,
+
+    expect(getPluginCliCommandDescriptors(rawConfig)).toEqual([
+      {
+        name: "matrix",
+        description: "Matrix channel utilities",
+        hasSubcommands: true,
+      },
+    ]);
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: autoEnabledConfig,
+        activate: false,
+        cache: false,
+        captureCliMetadataOnly: true,
+      }),
     );
-
-    try {
-      expect(getPluginCliCommandDescriptors({} as OpenClawConfig)).toEqual([
-        {
-          name: "matrix",
-          description: "Matrix channel utilities",
-          hasSubcommands: true,
-        },
-      ]);
-      expect(registerFull).not.toHaveBeenCalled();
-      expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
-  });
-
-  it("keeps non-channel descriptor capture in full registration mode", () => {
-    const tempRoot = mkdtempSync(path.join(tmpdir(), "openclaw-cli-descriptors-"));
-    const pluginRoot = path.join(tempRoot, "memory-core");
-    const source = path.join(pluginRoot, "index.ts");
-    mkdirSync(pluginRoot, { recursive: true });
-    writeFileSync(source, "export default {}");
-    mocks.loadPluginManifestRegistry.mockReturnValue({
-      plugins: [
-        {
-          id: "memory-core",
-          enabledByDefault: true,
-          format: "openclaw",
-          kind: "memory",
-          channels: [],
-          providers: [],
-          cliBackends: [],
-          skills: [],
-          hooks: [],
-          origin: "bundled",
-          rootDir: pluginRoot,
-          source,
-          manifestPath: path.join(pluginRoot, "openclaw.plugin.json"),
-        },
-      ],
-      diagnostics: [],
-    });
-    const seenModes: string[] = [];
-    mocks.createJiti.mockReturnValue(
-      () =>
-        ({
-          default: {
-            id: "memory-core",
-            name: "Memory (Core)",
-            description: "Memory plugin",
-            register(api: {
-              registrationMode: string;
-              registerCli: (
-                registrar: () => void,
-                opts: {
-                  descriptors: Array<{
-                    name: string;
-                    description: string;
-                    hasSubcommands: boolean;
-                  }>;
-                },
-              ) => void;
-            }) {
-              seenModes.push(api.registrationMode);
-              api.registerCli(() => {}, {
-                descriptors: [
-                  {
-                    name: "memory",
-                    description: "Memory commands",
-                    hasSubcommands: true,
-                  },
-                ],
-              });
-            },
-          },
-        }) as never,
-    );
-
-    try {
-      expect(getPluginCliCommandDescriptors({} as OpenClawConfig)).toEqual([
-        {
-          name: "memory",
-          description: "Memory commands",
-          hasSubcommands: true,
-        },
-      ]);
-      expect(seenModes).toEqual(["full"]);
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
   });
 
   it("lazy-registers descriptor-backed plugin commands on first invocation", async () => {

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
@@ -8,6 +11,15 @@ const mocks = vi.hoisted(() => ({
   memoryListAction: vi.fn(),
   loadOpenClawPlugins: vi.fn(),
   applyPluginAutoEnable: vi.fn(),
+  discoverOpenClawPlugins: vi.fn(),
+  loadPluginManifestRegistry: vi.fn(),
+  resolveEffectiveEnableState: vi.fn(),
+  resolveMemorySlotDecision: vi.fn(),
+  createJiti: vi.fn(),
+}));
+
+vi.mock("jiti", () => ({
+  createJiti: (...args: unknown[]) => mocks.createJiti(...args),
 }));
 
 vi.mock("./loader.js", () => ({
@@ -18,7 +30,24 @@ vi.mock("../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable: (...args: unknown[]) => mocks.applyPluginAutoEnable(...args),
 }));
 
-import { registerPluginCliCommands } from "./cli.js";
+vi.mock("./discovery.js", () => ({
+  discoverOpenClawPlugins: (...args: unknown[]) => mocks.discoverOpenClawPlugins(...args),
+}));
+
+vi.mock("./manifest-registry.js", () => ({
+  loadPluginManifestRegistry: (...args: unknown[]) => mocks.loadPluginManifestRegistry(...args),
+}));
+
+vi.mock("./config-state.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./config-state.js")>();
+  return {
+    ...actual,
+    resolveEffectiveEnableState: (...args: unknown[]) => mocks.resolveEffectiveEnableState(...args),
+    resolveMemorySlotDecision: (...args: unknown[]) => mocks.resolveMemorySlotDecision(...args),
+  };
+});
+
+import { getPluginCliCommandDescriptors, registerPluginCliCommands } from "./cli.js";
 
 function createProgram(existingCommandName?: string) {
   const program = new Command();
@@ -113,6 +142,22 @@ describe("registerPluginCliCommands", () => {
     mocks.loadOpenClawPlugins.mockReturnValue(createCliRegistry());
     mocks.applyPluginAutoEnable.mockReset();
     mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
+    mocks.discoverOpenClawPlugins.mockReset();
+    mocks.discoverOpenClawPlugins.mockReturnValue({
+      candidates: [],
+      diagnostics: [],
+    });
+    mocks.loadPluginManifestRegistry.mockReset();
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
+    mocks.resolveEffectiveEnableState.mockReset();
+    mocks.resolveEffectiveEnableState.mockReturnValue({ enabled: true });
+    mocks.resolveMemorySlotDecision.mockReset();
+    mocks.resolveMemorySlotDecision.mockReturnValue({ enabled: true });
+    mocks.createJiti.mockReset();
+    mocks.createJiti.mockReturnValue(() => ({}));
   });
 
   it("skips plugin CLI registrars when commands already exist", async () => {
@@ -148,6 +193,167 @@ describe("registerPluginCliCommands", () => {
         config: autoEnabledConfig,
       }),
     );
+  });
+
+  it("captures channel plugin descriptors without using the activating loader", () => {
+    const tempRoot = mkdtempSync(path.join(tmpdir(), "openclaw-cli-descriptors-"));
+    const pluginRoot = path.join(tempRoot, "matrix");
+    const source = path.join(pluginRoot, "index.ts");
+    mkdirSync(pluginRoot, { recursive: true });
+    writeFileSync(source, "export default {}");
+    mocks.discoverOpenClawPlugins.mockReturnValue({
+      candidates: [],
+      diagnostics: [],
+    });
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "matrix",
+          enabledByDefault: true,
+          format: "openclaw",
+          channels: ["matrix"],
+          providers: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          origin: "bundled",
+          rootDir: pluginRoot,
+          source,
+          manifestPath: path.join(pluginRoot, "openclaw.plugin.json"),
+        },
+      ],
+      diagnostics: [],
+    });
+    const registerFull = vi.fn();
+    mocks.createJiti.mockReturnValue(
+      () =>
+        ({
+          default: {
+            id: "matrix",
+            name: "Matrix",
+            description: "Matrix channel plugin",
+            channelPlugin: {},
+            register(api: {
+              registrationMode: "full" | "setup-only" | "setup-runtime";
+              registerChannel: (registration: unknown) => void;
+              registerCli: (
+                registrar: () => void,
+                opts: {
+                  descriptors: Array<{
+                    name: string;
+                    description: string;
+                    hasSubcommands: boolean;
+                  }>;
+                },
+              ) => void;
+            }) {
+              api.registerChannel({ plugin: {} });
+              api.registerCli(() => {}, {
+                descriptors: [
+                  {
+                    name: "matrix",
+                    description: "Matrix channel utilities",
+                    hasSubcommands: true,
+                  },
+                ],
+              });
+              if (api.registrationMode === "full") {
+                registerFull();
+              }
+            },
+          },
+        }) as never,
+    );
+
+    try {
+      expect(getPluginCliCommandDescriptors({} as OpenClawConfig)).toEqual([
+        {
+          name: "matrix",
+          description: "Matrix channel utilities",
+          hasSubcommands: true,
+        },
+      ]);
+      expect(registerFull).not.toHaveBeenCalled();
+      expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps non-channel descriptor capture in full registration mode", () => {
+    const tempRoot = mkdtempSync(path.join(tmpdir(), "openclaw-cli-descriptors-"));
+    const pluginRoot = path.join(tempRoot, "memory-core");
+    const source = path.join(pluginRoot, "index.ts");
+    mkdirSync(pluginRoot, { recursive: true });
+    writeFileSync(source, "export default {}");
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "memory-core",
+          enabledByDefault: true,
+          format: "openclaw",
+          kind: "memory",
+          channels: [],
+          providers: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          origin: "bundled",
+          rootDir: pluginRoot,
+          source,
+          manifestPath: path.join(pluginRoot, "openclaw.plugin.json"),
+        },
+      ],
+      diagnostics: [],
+    });
+    const seenModes: string[] = [];
+    mocks.createJiti.mockReturnValue(
+      () =>
+        ({
+          default: {
+            id: "memory-core",
+            name: "Memory (Core)",
+            description: "Memory plugin",
+            register(api: {
+              registrationMode: string;
+              registerCli: (
+                registrar: () => void,
+                opts: {
+                  descriptors: Array<{
+                    name: string;
+                    description: string;
+                    hasSubcommands: boolean;
+                  }>;
+                },
+              ) => void;
+            }) {
+              seenModes.push(api.registrationMode);
+              api.registerCli(() => {}, {
+                descriptors: [
+                  {
+                    name: "memory",
+                    description: "Memory commands",
+                    hasSubcommands: true,
+                  },
+                ],
+              });
+            },
+          },
+        }) as never,
+    );
+
+    try {
+      expect(getPluginCliCommandDescriptors({} as OpenClawConfig)).toEqual([
+        {
+          name: "memory",
+          description: "Memory commands",
+          hasSubcommands: true,
+        },
+      ]);
+      expect(seenModes).toEqual(["full"]);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("lazy-registers descriptor-backed plugin commands on first invocation", async () => {

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -7,12 +7,14 @@ const mocks = vi.hoisted(() => ({
   otherRegister: vi.fn(),
   memoryListAction: vi.fn(),
   loadOpenClawPluginCliRegistry: vi.fn(),
+  loadOpenClawPlugins: vi.fn(),
   applyPluginAutoEnable: vi.fn(),
 }));
 
 vi.mock("./loader.js", () => ({
   loadOpenClawPluginCliRegistry: (...args: unknown[]) =>
     mocks.loadOpenClawPluginCliRegistry(...args),
+  loadOpenClawPlugins: (...args: unknown[]) => mocks.loadOpenClawPlugins(...args),
 }));
 
 vi.mock("../config/plugin-auto-enable.js", () => ({
@@ -64,7 +66,7 @@ function createCliRegistry(params?: {
 }
 
 function expectPluginLoaderConfig(config: OpenClawConfig) {
-  expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledWith(
+  expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
     expect.objectContaining({
       config,
     }),
@@ -112,6 +114,8 @@ describe("registerPluginCliCommands", () => {
     mocks.memoryListAction.mockReset();
     mocks.loadOpenClawPluginCliRegistry.mockReset();
     mocks.loadOpenClawPluginCliRegistry.mockResolvedValue(createCliRegistry());
+    mocks.loadOpenClawPlugins.mockReset();
+    mocks.loadOpenClawPlugins.mockReturnValue(createCliRegistry());
     mocks.applyPluginAutoEnable.mockReset();
     mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
   });
@@ -130,7 +134,7 @@ describe("registerPluginCliCommands", () => {
 
     await registerPluginCliCommands(createProgram(), {} as OpenClawConfig, env);
 
-    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledWith(
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
       expect.objectContaining({
         env,
       }),
@@ -199,6 +203,34 @@ describe("registerPluginCliCommands", () => {
     );
   });
 
+  it("keeps runtime CLI command registration on the full plugin loader for legacy channel plugins", async () => {
+    const { rawConfig, autoEnabledConfig } = createAutoEnabledCliFixture();
+    mocks.applyPluginAutoEnable.mockReturnValue({ config: autoEnabledConfig, changes: [] });
+    mocks.loadOpenClawPlugins.mockReturnValue(
+      createCliRegistry({
+        memoryCommands: ["legacy-channel"],
+        memoryDescriptors: [
+          {
+            name: "legacy-channel",
+            description: "Legacy channel commands",
+            hasSubcommands: true,
+          },
+        ],
+      }),
+    );
+
+    await registerPluginCliCommands(createProgram(), rawConfig, undefined, undefined, {
+      mode: "lazy",
+    });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: autoEnabledConfig,
+      }),
+    );
+    expect(mocks.loadOpenClawPluginCliRegistry).not.toHaveBeenCalled();
+  });
+
   it("lazy-registers descriptor-backed plugin commands on first invocation", async () => {
     const program = createProgram();
     program.exitOverride();
@@ -218,7 +250,7 @@ describe("registerPluginCliCommands", () => {
   });
 
   it("falls back to eager registration when descriptors do not cover every command root", async () => {
-    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue(
+    mocks.loadOpenClawPlugins.mockReturnValue(
       createCliRegistry({
         memoryCommands: ["memory", "memory-admin"],
         memoryDescriptors: [

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -6,7 +6,11 @@ import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { loadOpenClawPluginCliRegistry, type PluginLoadOptions } from "./loader.js";
+import {
+  loadOpenClawPluginCliRegistry,
+  loadOpenClawPlugins,
+  type PluginLoadOptions,
+} from "./loader.js";
 import type { OpenClawPluginCliCommandDescriptor } from "./types.js";
 import type { PluginLogger } from "./types.js";
 
@@ -30,11 +34,7 @@ function canRegisterPluginCliLazily(entry: {
   return entry.commands.every((command) => descriptorNames.has(command));
 }
 
-async function loadPluginCliRegistry(
-  cfg?: OpenClawConfig,
-  env?: NodeJS.ProcessEnv,
-  loaderOptions?: Pick<PluginLoadOptions, "pluginSdkResolution">,
-) {
+function resolvePluginCliLoadContext(cfg?: OpenClawConfig, env?: NodeJS.ProcessEnv) {
   const config = cfg ?? loadConfig();
   const resolvedConfig = applyPluginAutoEnable({ config, env: env ?? process.env }).config;
   const workspaceDir = resolveAgentWorkspaceDir(
@@ -51,11 +51,40 @@ async function loadPluginCliRegistry(
     config: resolvedConfig,
     workspaceDir,
     logger,
+  };
+}
+
+async function loadPluginCliMetadataRegistry(
+  cfg?: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+  loaderOptions?: Pick<PluginLoadOptions, "pluginSdkResolution">,
+) {
+  const context = resolvePluginCliLoadContext(cfg, env);
+  return {
+    ...context,
     registry: await loadOpenClawPluginCliRegistry({
-      config: resolvedConfig,
-      workspaceDir,
+      config: context.config,
+      workspaceDir: context.workspaceDir,
       env,
-      logger,
+      logger: context.logger,
+      ...loaderOptions,
+    }),
+  };
+}
+
+function loadPluginCliCommandRegistry(
+  cfg?: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+  loaderOptions?: Pick<PluginLoadOptions, "pluginSdkResolution">,
+) {
+  const context = resolvePluginCliLoadContext(cfg, env);
+  return {
+    ...context,
+    registry: loadOpenClawPlugins({
+      config: context.config,
+      workspaceDir: context.workspaceDir,
+      env,
+      logger: context.logger,
       ...loaderOptions,
     }),
   };
@@ -66,7 +95,7 @@ export async function getPluginCliCommandDescriptors(
   env?: NodeJS.ProcessEnv,
 ): Promise<OpenClawPluginCliCommandDescriptor[]> {
   try {
-    const { registry } = await loadPluginCliRegistry(cfg, env);
+    const { registry } = await loadPluginCliMetadataRegistry(cfg, env);
     const seen = new Set<string>();
     const descriptors: OpenClawPluginCliCommandDescriptor[] = [];
     for (const entry of registry.cliRegistrars) {
@@ -91,7 +120,7 @@ export async function registerPluginCliCommands(
   loaderOptions?: Pick<PluginLoadOptions, "pluginSdkResolution">,
   options?: RegisterPluginCliOptions,
 ) {
-  const { config, workspaceDir, logger, registry } = await loadPluginCliRegistry(
+  const { config, workspaceDir, logger, registry } = loadPluginCliCommandRegistry(
     cfg,
     env,
     loaderOptions,

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -1,30 +1,14 @@
-import fs from "node:fs";
 import type { Command } from "commander";
-import { createJiti } from "jiti";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { removeCommandByName } from "../cli/program/command-tree.js";
 import { registerLazyCommand } from "../cli/program/register-lazy-command.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
-import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { createCapturedPluginRegistration } from "./captured-registration.js";
-import {
-  normalizePluginsConfig,
-  resolveEffectiveEnableState,
-  resolveMemorySlotDecision,
-} from "./config-state.js";
-import { discoverOpenClawPlugins } from "./discovery.js";
 import { loadOpenClawPlugins, type PluginLoadOptions } from "./loader.js";
-import { loadPluginManifestRegistry } from "./manifest-registry.js";
-import {
-  buildPluginLoaderAliasMap,
-  buildPluginLoaderJitiOptions,
-  shouldPreferNativeJiti,
-} from "./sdk-alias.js";
 import type { OpenClawPluginCliCommandDescriptor } from "./types.js";
-import type { OpenClawPluginDefinition, OpenClawPluginModule, PluginLogger } from "./types.js";
+import type { PluginLogger } from "./types.js";
 
 const log = createSubsystemLogger("plugins");
 
@@ -34,39 +18,6 @@ type RegisterPluginCliOptions = {
   mode?: PluginCliRegistrationMode;
   primary?: string | null;
 };
-
-function resolvePluginModuleExport(moduleExport: unknown): {
-  definition?: OpenClawPluginDefinition;
-  register?: OpenClawPluginDefinition["register"];
-} {
-  const resolved =
-    moduleExport &&
-    typeof moduleExport === "object" &&
-    "default" in (moduleExport as Record<string, unknown>)
-      ? (moduleExport as { default: unknown }).default
-      : moduleExport;
-  if (typeof resolved === "function") {
-    return {
-      register: resolved as OpenClawPluginDefinition["register"],
-    };
-  }
-  if (resolved && typeof resolved === "object") {
-    const definition = resolved as OpenClawPluginDefinition;
-    return {
-      definition,
-      register: definition.register ?? definition.activate,
-    };
-  }
-  return {};
-}
-
-function isChannelPluginDefinition(definition: OpenClawPluginDefinition | undefined): boolean {
-  return Boolean(
-    definition &&
-    typeof definition === "object" &&
-    "channelPlugin" in (definition as Record<string, unknown>),
-  );
-}
 
 function canRegisterPluginCliLazily(entry: {
   commands: string[];
@@ -82,7 +33,10 @@ function canRegisterPluginCliLazily(entry: {
 function loadPluginCliRegistry(
   cfg?: OpenClawConfig,
   env?: NodeJS.ProcessEnv,
-  loaderOptions?: Pick<PluginLoadOptions, "pluginSdkResolution">,
+  loaderOptions?: Pick<
+    PluginLoadOptions,
+    "pluginSdkResolution" | "activate" | "cache" | "captureCliMetadataOnly"
+  >,
 ) {
   const config = cfg ?? loadConfig();
   const resolvedConfig = applyPluginAutoEnable({ config, env: env ?? process.env }).config;
@@ -110,125 +64,19 @@ function loadPluginCliRegistry(
   };
 }
 
-// Root help only needs parse-time CLI metadata. Capture `registerCli(...)`
-// against a throwaway API so plugin runtime activation does not leak into
-// `openclaw --help`.
-function getPluginCliCommandDescriptorsFromMetadata(
+export function getPluginCliCommandDescriptors(
   cfg?: OpenClawConfig,
   env?: NodeJS.ProcessEnv,
 ): OpenClawPluginCliCommandDescriptor[] {
-  const config = cfg ?? loadConfig();
-  const resolvedEnv = env ?? process.env;
-  const resolvedConfig = applyPluginAutoEnable({ config, env: resolvedEnv }).config;
-  const workspaceDir = resolveAgentWorkspaceDir(
-    resolvedConfig,
-    resolveDefaultAgentId(resolvedConfig),
-  );
-  const normalized = normalizePluginsConfig(resolvedConfig.plugins);
-  const discovery = discoverOpenClawPlugins({
-    workspaceDir,
-    extraPaths: normalized.loadPaths,
-    cache: false,
-    env: resolvedEnv,
-  });
-  const manifestRegistry = loadPluginManifestRegistry({
-    config: resolvedConfig,
-    workspaceDir,
-    cache: false,
-    env: resolvedEnv,
-    candidates: discovery.candidates,
-    diagnostics: discovery.diagnostics,
-  });
-  const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
-  const getJiti = (modulePath: string) => {
-    const tryNative = shouldPreferNativeJiti(modulePath);
-    const aliasMap = buildPluginLoaderAliasMap(
-      modulePath,
-      process.argv[1],
-      import.meta.url,
-      undefined,
-    );
-    const cacheKey = JSON.stringify({
-      tryNative,
-      aliasMap: Object.entries(aliasMap).toSorted(([left], [right]) => left.localeCompare(right)),
+  try {
+    const { registry } = loadPluginCliRegistry(cfg, env, {
+      activate: false,
+      cache: false,
+      captureCliMetadataOnly: true,
     });
-    const cached = jitiLoaders.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-    const loader = createJiti(import.meta.url, {
-      ...buildPluginLoaderJitiOptions(aliasMap),
-      tryNative,
-    });
-    jitiLoaders.set(cacheKey, loader);
-    return loader;
-  };
-
-  const descriptors: OpenClawPluginCliCommandDescriptor[] = [];
-  const seen = new Set<string>();
-  let selectedMemoryPluginId: string | null = null;
-
-  for (const manifest of manifestRegistry.plugins) {
-    const enableState = resolveEffectiveEnableState({
-      id: manifest.id,
-      origin: manifest.origin,
-      config: normalized,
-      rootConfig: resolvedConfig,
-      enabledByDefault: manifest.enabledByDefault,
-    });
-    if (!enableState.enabled || manifest.format === "bundle") {
-      continue;
-    }
-    const memoryDecision = resolveMemorySlotDecision({
-      id: manifest.id,
-      kind: manifest.kind,
-      slot: normalized.slots.memory,
-      selectedId: selectedMemoryPluginId,
-    });
-    if (!memoryDecision.enabled) {
-      continue;
-    }
-    if (memoryDecision.selected && manifest.kind === "memory") {
-      selectedMemoryPluginId = manifest.id;
-    }
-
-    const opened = openBoundaryFileSync({
-      absolutePath: manifest.source,
-      rootPath: manifest.rootDir,
-      boundaryLabel: "plugin root",
-      rejectHardlinks: manifest.origin !== "bundled",
-      skipLexicalRootCheck: true,
-    });
-    if (!opened.ok) {
-      continue;
-    }
-
-    const safeSource = opened.path;
-    fs.closeSync(opened.fd);
-
-    let mod: OpenClawPluginModule | null = null;
-    try {
-      mod = getJiti(safeSource)(safeSource) as OpenClawPluginModule;
-    } catch {
-      continue;
-    }
-
-    const { definition, register } = resolvePluginModuleExport(mod);
-    if (typeof register !== "function") {
-      continue;
-    }
-
-    const captured = createCapturedPluginRegistration({
-      config: resolvedConfig,
-      registrationMode: isChannelPluginDefinition(definition) ? "setup-only" : "full",
-    });
-    try {
-      void register(captured.api);
-    } catch {
-      continue;
-    }
-
-    for (const entry of captured.cliRegistrars) {
+    const seen = new Set<string>();
+    const descriptors: OpenClawPluginCliCommandDescriptor[] = [];
+    for (const entry of registry.cliRegistrars) {
       for (const descriptor of entry.descriptors) {
         if (seen.has(descriptor.name)) {
           continue;
@@ -237,17 +85,7 @@ function getPluginCliCommandDescriptorsFromMetadata(
         descriptors.push(descriptor);
       }
     }
-  }
-
-  return descriptors;
-}
-
-export function getPluginCliCommandDescriptors(
-  cfg?: OpenClawConfig,
-  env?: NodeJS.ProcessEnv,
-): OpenClawPluginCliCommandDescriptor[] {
-  try {
-    return getPluginCliCommandDescriptorsFromMetadata(cfg, env);
+    return descriptors;
   } catch {
     return [];
   }

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -6,7 +6,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { loadOpenClawPlugins, type PluginLoadOptions } from "./loader.js";
+import { loadOpenClawPluginCliRegistry, type PluginLoadOptions } from "./loader.js";
 import type { OpenClawPluginCliCommandDescriptor } from "./types.js";
 import type { PluginLogger } from "./types.js";
 
@@ -30,13 +30,10 @@ function canRegisterPluginCliLazily(entry: {
   return entry.commands.every((command) => descriptorNames.has(command));
 }
 
-function loadPluginCliRegistry(
+async function loadPluginCliRegistry(
   cfg?: OpenClawConfig,
   env?: NodeJS.ProcessEnv,
-  loaderOptions?: Pick<
-    PluginLoadOptions,
-    "pluginSdkResolution" | "activate" | "cache" | "captureCliMetadataOnly"
-  >,
+  loaderOptions?: Pick<PluginLoadOptions, "pluginSdkResolution">,
 ) {
   const config = cfg ?? loadConfig();
   const resolvedConfig = applyPluginAutoEnable({ config, env: env ?? process.env }).config;
@@ -54,7 +51,7 @@ function loadPluginCliRegistry(
     config: resolvedConfig,
     workspaceDir,
     logger,
-    registry: loadOpenClawPlugins({
+    registry: await loadOpenClawPluginCliRegistry({
       config: resolvedConfig,
       workspaceDir,
       env,
@@ -64,16 +61,12 @@ function loadPluginCliRegistry(
   };
 }
 
-export function getPluginCliCommandDescriptors(
+export async function getPluginCliCommandDescriptors(
   cfg?: OpenClawConfig,
   env?: NodeJS.ProcessEnv,
-): OpenClawPluginCliCommandDescriptor[] {
+): Promise<OpenClawPluginCliCommandDescriptor[]> {
   try {
-    const { registry } = loadPluginCliRegistry(cfg, env, {
-      activate: false,
-      cache: false,
-      captureCliMetadataOnly: true,
-    });
+    const { registry } = await loadPluginCliRegistry(cfg, env);
     const seen = new Set<string>();
     const descriptors: OpenClawPluginCliCommandDescriptor[] = [];
     for (const entry of registry.cliRegistrars) {
@@ -98,7 +91,11 @@ export async function registerPluginCliCommands(
   loaderOptions?: Pick<PluginLoadOptions, "pluginSdkResolution">,
   options?: RegisterPluginCliOptions,
 ) {
-  const { config, workspaceDir, logger, registry } = loadPluginCliRegistry(cfg, env, loaderOptions);
+  const { config, workspaceDir, logger, registry } = await loadPluginCliRegistry(
+    cfg,
+    env,
+    loaderOptions,
+  );
   const mode = options?.mode ?? "eager";
   const primary = options?.primary ?? null;
 

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -1,14 +1,30 @@
+import fs from "node:fs";
 import type { Command } from "commander";
+import { createJiti } from "jiti";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { removeCommandByName } from "../cli/program/command-tree.js";
 import { registerLazyCommand } from "../cli/program/register-lazy-command.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
+import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { createCapturedPluginRegistration } from "./captured-registration.js";
+import {
+  normalizePluginsConfig,
+  resolveEffectiveEnableState,
+  resolveMemorySlotDecision,
+} from "./config-state.js";
+import { discoverOpenClawPlugins } from "./discovery.js";
 import { loadOpenClawPlugins, type PluginLoadOptions } from "./loader.js";
+import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import {
+  buildPluginLoaderAliasMap,
+  buildPluginLoaderJitiOptions,
+  shouldPreferNativeJiti,
+} from "./sdk-alias.js";
 import type { OpenClawPluginCliCommandDescriptor } from "./types.js";
-import type { PluginLogger } from "./types.js";
+import type { OpenClawPluginDefinition, OpenClawPluginModule, PluginLogger } from "./types.js";
 
 const log = createSubsystemLogger("plugins");
 
@@ -18,6 +34,39 @@ type RegisterPluginCliOptions = {
   mode?: PluginCliRegistrationMode;
   primary?: string | null;
 };
+
+function resolvePluginModuleExport(moduleExport: unknown): {
+  definition?: OpenClawPluginDefinition;
+  register?: OpenClawPluginDefinition["register"];
+} {
+  const resolved =
+    moduleExport &&
+    typeof moduleExport === "object" &&
+    "default" in (moduleExport as Record<string, unknown>)
+      ? (moduleExport as { default: unknown }).default
+      : moduleExport;
+  if (typeof resolved === "function") {
+    return {
+      register: resolved as OpenClawPluginDefinition["register"],
+    };
+  }
+  if (resolved && typeof resolved === "object") {
+    const definition = resolved as OpenClawPluginDefinition;
+    return {
+      definition,
+      register: definition.register ?? definition.activate,
+    };
+  }
+  return {};
+}
+
+function isChannelPluginDefinition(definition: OpenClawPluginDefinition | undefined): boolean {
+  return Boolean(
+    definition &&
+    typeof definition === "object" &&
+    "channelPlugin" in (definition as Record<string, unknown>),
+  );
+}
 
 function canRegisterPluginCliLazily(entry: {
   commands: string[];
@@ -61,15 +110,125 @@ function loadPluginCliRegistry(
   };
 }
 
-export function getPluginCliCommandDescriptors(
+// Root help only needs parse-time CLI metadata. Capture `registerCli(...)`
+// against a throwaway API so plugin runtime activation does not leak into
+// `openclaw --help`.
+function getPluginCliCommandDescriptorsFromMetadata(
   cfg?: OpenClawConfig,
   env?: NodeJS.ProcessEnv,
 ): OpenClawPluginCliCommandDescriptor[] {
-  try {
-    const { registry } = loadPluginCliRegistry(cfg, env);
-    const seen = new Set<string>();
-    const descriptors: OpenClawPluginCliCommandDescriptor[] = [];
-    for (const entry of registry.cliRegistrars) {
+  const config = cfg ?? loadConfig();
+  const resolvedEnv = env ?? process.env;
+  const resolvedConfig = applyPluginAutoEnable({ config, env: resolvedEnv }).config;
+  const workspaceDir = resolveAgentWorkspaceDir(
+    resolvedConfig,
+    resolveDefaultAgentId(resolvedConfig),
+  );
+  const normalized = normalizePluginsConfig(resolvedConfig.plugins);
+  const discovery = discoverOpenClawPlugins({
+    workspaceDir,
+    extraPaths: normalized.loadPaths,
+    cache: false,
+    env: resolvedEnv,
+  });
+  const manifestRegistry = loadPluginManifestRegistry({
+    config: resolvedConfig,
+    workspaceDir,
+    cache: false,
+    env: resolvedEnv,
+    candidates: discovery.candidates,
+    diagnostics: discovery.diagnostics,
+  });
+  const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
+  const getJiti = (modulePath: string) => {
+    const tryNative = shouldPreferNativeJiti(modulePath);
+    const aliasMap = buildPluginLoaderAliasMap(
+      modulePath,
+      process.argv[1],
+      import.meta.url,
+      undefined,
+    );
+    const cacheKey = JSON.stringify({
+      tryNative,
+      aliasMap: Object.entries(aliasMap).toSorted(([left], [right]) => left.localeCompare(right)),
+    });
+    const cached = jitiLoaders.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const loader = createJiti(import.meta.url, {
+      ...buildPluginLoaderJitiOptions(aliasMap),
+      tryNative,
+    });
+    jitiLoaders.set(cacheKey, loader);
+    return loader;
+  };
+
+  const descriptors: OpenClawPluginCliCommandDescriptor[] = [];
+  const seen = new Set<string>();
+  let selectedMemoryPluginId: string | null = null;
+
+  for (const manifest of manifestRegistry.plugins) {
+    const enableState = resolveEffectiveEnableState({
+      id: manifest.id,
+      origin: manifest.origin,
+      config: normalized,
+      rootConfig: resolvedConfig,
+      enabledByDefault: manifest.enabledByDefault,
+    });
+    if (!enableState.enabled || manifest.format === "bundle") {
+      continue;
+    }
+    const memoryDecision = resolveMemorySlotDecision({
+      id: manifest.id,
+      kind: manifest.kind,
+      slot: normalized.slots.memory,
+      selectedId: selectedMemoryPluginId,
+    });
+    if (!memoryDecision.enabled) {
+      continue;
+    }
+    if (memoryDecision.selected && manifest.kind === "memory") {
+      selectedMemoryPluginId = manifest.id;
+    }
+
+    const opened = openBoundaryFileSync({
+      absolutePath: manifest.source,
+      rootPath: manifest.rootDir,
+      boundaryLabel: "plugin root",
+      rejectHardlinks: manifest.origin !== "bundled",
+      skipLexicalRootCheck: true,
+    });
+    if (!opened.ok) {
+      continue;
+    }
+
+    const safeSource = opened.path;
+    fs.closeSync(opened.fd);
+
+    let mod: OpenClawPluginModule | null = null;
+    try {
+      mod = getJiti(safeSource)(safeSource) as OpenClawPluginModule;
+    } catch {
+      continue;
+    }
+
+    const { definition, register } = resolvePluginModuleExport(mod);
+    if (typeof register !== "function") {
+      continue;
+    }
+
+    const captured = createCapturedPluginRegistration({
+      config: resolvedConfig,
+      registrationMode: isChannelPluginDefinition(definition) ? "setup-only" : "full",
+    });
+    try {
+      void register(captured.api);
+    } catch {
+      continue;
+    }
+
+    for (const entry of captured.cliRegistrars) {
       for (const descriptor of entry.descriptors) {
         if (seen.has(descriptor.name)) {
           continue;
@@ -78,7 +237,17 @@ export function getPluginCliCommandDescriptors(
         descriptors.push(descriptor);
       }
     }
-    return descriptors;
+  }
+
+  return descriptors;
+}
+
+export function getPluginCliCommandDescriptors(
+  cfg?: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+): OpenClawPluginCliCommandDescriptor[] {
+  try {
+    return getPluginCliCommandDescriptorsFromMetadata(cfg, env);
   } catch {
     return [];
   }

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2597,6 +2597,193 @@ module.exports = {
     expect(registry.channels).toHaveLength(expectedChannels);
   });
 
+  it("passes validated plugin config into non-activating CLI metadata loads", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "config-cli",
+      filename: "config-cli.cjs",
+      body: `module.exports = {
+  id: "config-cli",
+  register(api) {
+    if (!api.pluginConfig || api.pluginConfig.token !== "ok") {
+      throw new Error("missing plugin config");
+    }
+    api.registerCli(() => {}, {
+      descriptors: [
+        {
+          name: "cfg",
+          description: "Config-backed CLI command",
+          hasSubcommands: true,
+        },
+      ],
+    });
+  },
+};`,
+    });
+    fs.writeFileSync(
+      path.join(plugin.dir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "config-cli",
+          configSchema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              token: { type: "string" },
+            },
+            required: ["token"],
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      activate: false,
+      captureCliMetadataOnly: true,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["config-cli"],
+          entries: {
+            "config-cli": {
+              config: {
+                token: "ok",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain("cfg");
+    expect(registry.plugins.find((entry) => entry.id === "config-cli")?.status).toBe("loaded");
+  });
+
+  it("uses the real channel entry in setup-only mode for CLI metadata capture", () => {
+    useNoBundledPlugins();
+    const pluginDir = makeTempDir();
+    const fullMarker = path.join(pluginDir, "full-loaded.txt");
+    const setupMarker = path.join(pluginDir, "setup-loaded.txt");
+    const modeMarker = path.join(pluginDir, "registration-mode.txt");
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "@openclaw/cli-metadata-channel",
+          openclaw: {
+            extensions: ["./index.cjs"],
+            setupEntry: "./setup-entry.cjs",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "cli-metadata-channel",
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+          channels: ["cli-metadata-channel"],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "index.cjs"),
+      `require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
+module.exports = {
+  id: "cli-metadata-channel",
+  register(api) {
+    require("node:fs").writeFileSync(
+      ${JSON.stringify(modeMarker)},
+      String(api.registrationMode),
+      "utf-8",
+    );
+    api.registerChannel({
+      plugin: {
+        id: "cli-metadata-channel",
+        meta: {
+          id: "cli-metadata-channel",
+          label: "CLI Metadata Channel",
+          selectionLabel: "CLI Metadata Channel",
+          docsPath: "/channels/cli-metadata-channel",
+          blurb: "cli metadata channel",
+        },
+        capabilities: { chatTypes: ["direct"] },
+        config: {
+          listAccountIds: () => [],
+          resolveAccount: () => ({ accountId: "default" }),
+        },
+        outbound: { deliveryMode: "direct" },
+      },
+    });
+    api.registerCli(() => {}, {
+      descriptors: [
+        {
+          name: "cli-metadata-channel",
+          description: "Channel CLI metadata",
+          hasSubcommands: true,
+        },
+      ],
+    });
+  },
+};`,
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "setup-entry.cjs"),
+      `require("node:fs").writeFileSync(${JSON.stringify(setupMarker)}, "loaded", "utf-8");
+module.exports = {
+  plugin: {
+    id: "cli-metadata-channel",
+    meta: {
+      id: "cli-metadata-channel",
+      label: "CLI Metadata Channel",
+      selectionLabel: "CLI Metadata Channel",
+      docsPath: "/channels/cli-metadata-channel",
+      blurb: "setup entry",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => [],
+      resolveAccount: () => ({ accountId: "default" }),
+    },
+    outbound: { deliveryMode: "direct" },
+  },
+};`,
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      activate: false,
+      captureCliMetadataOnly: true,
+      config: {
+        plugins: {
+          load: { paths: [pluginDir] },
+          allow: ["cli-metadata-channel"],
+        },
+      },
+    });
+
+    expect(fs.existsSync(fullMarker)).toBe(true);
+    expect(fs.existsSync(setupMarker)).toBe(false);
+    expect(fs.readFileSync(modeMarker, "utf-8")).toBe("setup-only");
+    expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain(
+      "cli-metadata-channel",
+    );
+  });
+
   it("blocks before_prompt_build but preserves legacy model overrides when prompt injection is disabled", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2666,6 +2666,7 @@ module.exports = {
     const pluginDir = makeTempDir();
     const fullMarker = path.join(pluginDir, "full-loaded.txt");
     const modeMarker = path.join(pluginDir, "registration-mode.txt");
+    const runtimeMarker = path.join(pluginDir, "runtime-set.txt");
 
     fs.writeFileSync(
       path.join(pluginDir, "package.json"),
@@ -2701,6 +2702,9 @@ module.exports = {
     id: "cli-metadata-channel",
     name: "CLI Metadata Channel",
     description: "cli metadata channel",
+    setRuntime() {
+      require("node:fs").writeFileSync(${JSON.stringify(runtimeMarker)}, "loaded", "utf-8");
+    },
     plugin: {
       id: "cli-metadata-channel",
       meta: {
@@ -2756,6 +2760,7 @@ module.exports = {
     });
 
     expect(fs.existsSync(fullMarker)).toBe(true);
+    expect(fs.existsSync(runtimeMarker)).toBe(false);
     expect(fs.readFileSync(modeMarker, "utf-8")).toBe("cli-metadata");
     expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain(
       "cli-metadata-channel",

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2900,6 +2900,59 @@ module.exports = {
     ).toBe(false);
   });
 
+  it("applies memory slot gating to non-bundled CLI metadata loads", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "memory-external",
+      filename: "memory-external.cjs",
+      body: `module.exports = {
+  id: "memory-external",
+  kind: "memory",
+  register(api) {
+    api.registerCli(() => {}, {
+      descriptors: [
+        {
+          name: "memory-external",
+          description: "External memory CLI metadata",
+          hasSubcommands: true,
+        },
+      ],
+    });
+  },
+};`,
+    });
+    fs.writeFileSync(
+      path.join(plugin.dir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "memory-external",
+          kind: "memory",
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const registry = await loadOpenClawPluginCliRegistry({
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["memory-external"],
+          slots: { memory: "memory-other" },
+        },
+      },
+    });
+
+    expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).not.toContain(
+      "memory-external",
+    );
+    const memory = registry.plugins.find((entry) => entry.id === "memory-external");
+    expect(memory?.status).toBe("disabled");
+    expect(String(memory?.error ?? "")).toContain('memory slot set to "memory-other"');
+  });
+
   it("blocks before_prompt_build but preserves legacy model overrides when prompt injection is disabled", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -11,6 +11,7 @@ import { createHookRunner } from "./hooks.js";
 import {
   __testing,
   clearPluginLoaderCache,
+  loadOpenClawPluginCliRegistry,
   loadOpenClawPlugins,
   resolveRuntimePluginRegistry,
 } from "./loader.js";
@@ -2597,7 +2598,7 @@ module.exports = {
     expect(registry.channels).toHaveLength(expectedChannels);
   });
 
-  it("passes validated plugin config into non-activating CLI metadata loads", () => {
+  it("passes validated plugin config into non-activating CLI metadata loads", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({
       id: "config-cli",
@@ -2640,10 +2641,7 @@ module.exports = {
       "utf-8",
     );
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      activate: false,
-      captureCliMetadataOnly: true,
+    const registry = await loadOpenClawPluginCliRegistry({
       config: {
         plugins: {
           load: { paths: [plugin.file] },
@@ -2663,11 +2661,10 @@ module.exports = {
     expect(registry.plugins.find((entry) => entry.id === "config-cli")?.status).toBe("loaded");
   });
 
-  it("uses the real channel entry in setup-only mode for CLI metadata capture", () => {
+  it("uses the real channel entry in cli-metadata mode for CLI metadata capture", async () => {
     useNoBundledPlugins();
     const pluginDir = makeTempDir();
     const fullMarker = path.join(pluginDir, "full-loaded.txt");
-    const setupMarker = path.join(pluginDir, "setup-loaded.txt");
     const modeMarker = path.join(pluginDir, "registration-mode.txt");
 
     fs.writeFileSync(
@@ -2675,10 +2672,7 @@ module.exports = {
       JSON.stringify(
         {
           name: "@openclaw/cli-metadata-channel",
-          openclaw: {
-            extensions: ["./index.cjs"],
-            setupEntry: "./setup-entry.cjs",
-          },
+          openclaw: { extensions: ["./index.cjs"], setupEntry: "./setup-entry.cjs" },
         },
         null,
         2,
@@ -2700,74 +2694,59 @@ module.exports = {
     );
     fs.writeFileSync(
       path.join(pluginDir, "index.cjs"),
-      `require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
+      `const { defineChannelPluginEntry } = require("openclaw/plugin-sdk/core");
+require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
 module.exports = {
-  id: "cli-metadata-channel",
-  register(api) {
-    require("node:fs").writeFileSync(
-      ${JSON.stringify(modeMarker)},
-      String(api.registrationMode),
-      "utf-8",
-    );
-    api.registerChannel({
-      plugin: {
+  ...defineChannelPluginEntry({
+    id: "cli-metadata-channel",
+    name: "CLI Metadata Channel",
+    description: "cli metadata channel",
+    plugin: {
+      id: "cli-metadata-channel",
+      meta: {
         id: "cli-metadata-channel",
-        meta: {
-          id: "cli-metadata-channel",
-          label: "CLI Metadata Channel",
-          selectionLabel: "CLI Metadata Channel",
-          docsPath: "/channels/cli-metadata-channel",
-          blurb: "cli metadata channel",
-        },
-        capabilities: { chatTypes: ["direct"] },
-        config: {
-          listAccountIds: () => [],
-          resolveAccount: () => ({ accountId: "default" }),
-        },
-        outbound: { deliveryMode: "direct" },
+        label: "CLI Metadata Channel",
+        selectionLabel: "CLI Metadata Channel",
+        docsPath: "/channels/cli-metadata-channel",
+        blurb: "cli metadata channel",
       },
-    });
-    api.registerCli(() => {}, {
-      descriptors: [
-        {
-          name: "cli-metadata-channel",
-          description: "Channel CLI metadata",
-          hasSubcommands: true,
-        },
-      ],
-    });
-  },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({ accountId: "default" }),
+      },
+      outbound: { deliveryMode: "direct" },
+    },
+    registerCliMetadata(api) {
+      require("node:fs").writeFileSync(
+        ${JSON.stringify(modeMarker)},
+        String(api.registrationMode),
+        "utf-8",
+      );
+      api.registerCli(() => {}, {
+        descriptors: [
+          {
+            name: "cli-metadata-channel",
+            description: "Channel CLI metadata",
+            hasSubcommands: true,
+          },
+        ],
+      });
+    },
+    registerFull() {
+      throw new Error("full channel entry should not run during CLI metadata capture");
+    },
+  }),
 };`,
       "utf-8",
     );
     fs.writeFileSync(
       path.join(pluginDir, "setup-entry.cjs"),
-      `require("node:fs").writeFileSync(${JSON.stringify(setupMarker)}, "loaded", "utf-8");
-module.exports = {
-  plugin: {
-    id: "cli-metadata-channel",
-    meta: {
-      id: "cli-metadata-channel",
-      label: "CLI Metadata Channel",
-      selectionLabel: "CLI Metadata Channel",
-      docsPath: "/channels/cli-metadata-channel",
-      blurb: "setup entry",
-    },
-    capabilities: { chatTypes: ["direct"] },
-    config: {
-      listAccountIds: () => [],
-      resolveAccount: () => ({ accountId: "default" }),
-    },
-    outbound: { deliveryMode: "direct" },
-  },
-};`,
+      `throw new Error("setup entry should not load during CLI metadata capture");`,
       "utf-8",
     );
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      activate: false,
-      captureCliMetadataOnly: true,
+    const registry = await loadOpenClawPluginCliRegistry({
       config: {
         plugins: {
           load: { paths: [pluginDir] },
@@ -2777,11 +2756,47 @@ module.exports = {
     });
 
     expect(fs.existsSync(fullMarker)).toBe(true);
-    expect(fs.existsSync(setupMarker)).toBe(false);
-    expect(fs.readFileSync(modeMarker, "utf-8")).toBe("setup-only");
+    expect(fs.readFileSync(modeMarker, "utf-8")).toBe("cli-metadata");
     expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain(
       "cli-metadata-channel",
     );
+  });
+
+  it("awaits async plugin registration when collecting CLI metadata", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "async-cli",
+      filename: "async-cli.cjs",
+      body: `module.exports = {
+  id: "async-cli",
+  async register(api) {
+    await Promise.resolve();
+    api.registerCli(() => {}, {
+      descriptors: [
+        {
+          name: "async-cli",
+          description: "Async CLI metadata",
+          hasSubcommands: true,
+        },
+      ],
+    });
+  },
+};`,
+    });
+
+    const registry = await loadOpenClawPluginCliRegistry({
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["async-cli"],
+        },
+      },
+    });
+
+    expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain("async-cli");
+    expect(
+      registry.diagnostics.some((entry) => entry.message.includes("async registration is ignored")),
+    ).toBe(false);
   });
 
   it("blocks before_prompt_build but preserves legacy model overrides when prompt injection is disabled", async () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2767,6 +2767,102 @@ module.exports = {
     );
   });
 
+  it("collects channel CLI metadata during full plugin loads", () => {
+    useNoBundledPlugins();
+    const pluginDir = makeTempDir();
+    const modeMarker = path.join(pluginDir, "registration-mode.txt");
+    const fullMarker = path.join(pluginDir, "full-loaded.txt");
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "@openclaw/full-cli-metadata-channel",
+          openclaw: { extensions: ["./index.cjs"] },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "full-cli-metadata-channel",
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+          channels: ["full-cli-metadata-channel"],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "index.cjs"),
+      `const { defineChannelPluginEntry } = require("openclaw/plugin-sdk/core");
+module.exports = {
+  ...defineChannelPluginEntry({
+    id: "full-cli-metadata-channel",
+    name: "Full CLI Metadata Channel",
+    description: "full cli metadata channel",
+    plugin: {
+      id: "full-cli-metadata-channel",
+      meta: {
+        id: "full-cli-metadata-channel",
+        label: "Full CLI Metadata Channel",
+        selectionLabel: "Full CLI Metadata Channel",
+        docsPath: "/channels/full-cli-metadata-channel",
+        blurb: "full cli metadata channel",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({ accountId: "default" }),
+      },
+      outbound: { deliveryMode: "direct" },
+    },
+    registerCliMetadata(api) {
+      require("node:fs").writeFileSync(
+        ${JSON.stringify(modeMarker)},
+        String(api.registrationMode),
+        "utf-8",
+      );
+      api.registerCli(() => {}, {
+        descriptors: [
+          {
+            name: "full-cli-metadata-channel",
+            description: "Full-load channel CLI metadata",
+            hasSubcommands: true,
+          },
+        ],
+      });
+    },
+    registerFull() {
+      require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
+    },
+  }),
+};`,
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [pluginDir] },
+          allow: ["full-cli-metadata-channel"],
+        },
+      },
+    });
+
+    expect(fs.readFileSync(modeMarker, "utf-8")).toBe("full");
+    expect(fs.existsSync(fullMarker)).toBe(true);
+    expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain(
+      "full-cli-metadata-channel",
+    );
+  });
+
   it("awaits async plugin registration when collecting CLI metadata", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -88,6 +88,15 @@ export type PluginLoadOptions = {
    * via package metadata because their setup entry covers the pre-listen startup surface.
    */
   preferSetupRuntimeForChannelPlugins?: boolean;
+  /**
+   * Capture CLI descriptors without activating plugin runtime side effects.
+   *
+   * Enabled channel plugins still load from their real entry file so
+   * descriptor registration can follow the normal plugin entry contract, but
+   * they register in setup-only mode to keep `registerFull(...)` work out of
+   * parse-time help paths.
+   */
+  captureCliMetadataOnly?: boolean;
   activate?: boolean;
   throwOnLoadError?: boolean;
 };
@@ -202,6 +211,7 @@ function buildCacheKey(params: {
   onlyPluginIds?: string[];
   includeSetupOnlyChannelPlugins?: boolean;
   preferSetupRuntimeForChannelPlugins?: boolean;
+  captureCliMetadataOnly?: boolean;
   runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
   pluginSdkResolution?: PluginSdkResolutionPreference;
   coreGatewayMethodNames?: string[];
@@ -231,12 +241,13 @@ function buildCacheKey(params: {
   const setupOnlyKey = params.includeSetupOnlyChannelPlugins === true ? "setup-only" : "runtime";
   const startupChannelMode =
     params.preferSetupRuntimeForChannelPlugins === true ? "prefer-setup" : "full";
+  const cliMetadataMode = params.captureCliMetadataOnly === true ? "cli-metadata" : "default";
   const gatewayMethodsKey = JSON.stringify(params.coreGatewayMethodNames ?? []);
   return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
     ...params.plugins,
     installs,
     loadPaths,
-  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${params.runtimeSubagentMode ?? "default"}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}`;
+  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${cliMetadataMode}::${params.runtimeSubagentMode ?? "default"}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}`;
 }
 
 function normalizeScopedPluginIds(ids?: string[]): string[] | undefined {
@@ -269,7 +280,8 @@ function hasExplicitCompatibilityInputs(options: PluginLoadOptions): boolean {
     options.pluginSdkResolution !== undefined ||
     options.coreGatewayHandlers !== undefined ||
     options.includeSetupOnlyChannelPlugins === true ||
-    options.preferSetupRuntimeForChannelPlugins === true,
+    options.preferSetupRuntimeForChannelPlugins === true ||
+    options.captureCliMetadataOnly === true,
   );
 }
 
@@ -280,6 +292,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const onlyPluginIds = normalizeScopedPluginIds(options.onlyPluginIds);
   const includeSetupOnlyChannelPlugins = options.includeSetupOnlyChannelPlugins === true;
   const preferSetupRuntimeForChannelPlugins = options.preferSetupRuntimeForChannelPlugins === true;
+  const captureCliMetadataOnly = options.captureCliMetadataOnly === true;
   const coreGatewayMethodNames = Object.keys(options.coreGatewayHandlers ?? {}).toSorted();
   const cacheKey = buildCacheKey({
     workspaceDir: options.workspaceDir,
@@ -289,6 +302,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     onlyPluginIds,
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
+    captureCliMetadataOnly,
     runtimeSubagentMode: resolveRuntimeSubagentMode(options.runtimeOptions),
     pluginSdkResolution: options.pluginSdkResolution,
     coreGatewayMethodNames,
@@ -300,6 +314,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     onlyPluginIds,
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
+    captureCliMetadataOnly,
     shouldActivate: options.activate !== false,
     runtimeSubagentMode: resolveRuntimeSubagentMode(options.runtimeOptions),
     cacheKey,
@@ -793,6 +808,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     onlyPluginIds,
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
+    captureCliMetadataOnly,
     shouldActivate,
     cacheKey,
     runtimeSubagentMode,
@@ -1066,18 +1082,20 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     };
 
     const registrationMode = enableState.enabled
-      ? !validateOnly &&
-        shouldLoadChannelPluginInSetupRuntime({
-          manifestChannels: manifestRecord.channels,
-          setupSource: manifestRecord.setupSource,
-          startupDeferConfiguredChannelFullLoadUntilAfterListen:
-            manifestRecord.startupDeferConfiguredChannelFullLoadUntilAfterListen,
-          cfg,
-          env,
-          preferSetupRuntimeForChannelPlugins,
-        })
-        ? "setup-runtime"
-        : "full"
+      ? captureCliMetadataOnly && manifestRecord.channels.length > 0
+        ? "setup-only"
+        : !validateOnly &&
+            shouldLoadChannelPluginInSetupRuntime({
+              manifestChannels: manifestRecord.channels,
+              setupSource: manifestRecord.setupSource,
+              startupDeferConfiguredChannelFullLoadUntilAfterListen:
+                manifestRecord.startupDeferConfiguredChannelFullLoadUntilAfterListen,
+              cfg,
+              env,
+              preferSetupRuntimeForChannelPlugins,
+            })
+          ? "setup-runtime"
+          : "full"
       : includeSetupOnlyChannelPlugins && !validateOnly && manifestRecord.channels.length > 0
         ? "setup-only"
         : null;
@@ -1183,9 +1201,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
 
     const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
-    const loadSource =
-      (registrationMode === "setup-only" || registrationMode === "setup-runtime") &&
-      manifestRecord.setupSource
+    const loadSource = captureCliMetadataOnly
+      ? candidate.source
+      : (registrationMode === "setup-only" || registrationMode === "setup-runtime") &&
+          manifestRecord.setupSource
         ? manifestRecord.setupSource
         : candidate.source;
     const opened = openBoundaryFileSync({
@@ -1221,6 +1240,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
 
     if (
+      !captureCliMetadataOnly &&
       (registrationMode === "setup-only" || registrationMode === "setup-runtime") &&
       manifestRecord.setupSource
     ) {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -9,6 +9,7 @@ import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveUserPath } from "../utils.js";
+import { buildPluginApi } from "./api-builder.js";
 import { inspectBundleMcpRuntimeSupport } from "./bundle-mcp.js";
 import { clearPluginCommands } from "./command-registry-state.js";
 import {
@@ -88,15 +89,6 @@ export type PluginLoadOptions = {
    * via package metadata because their setup entry covers the pre-listen startup surface.
    */
   preferSetupRuntimeForChannelPlugins?: boolean;
-  /**
-   * Capture CLI descriptors without activating plugin runtime side effects.
-   *
-   * Enabled channel plugins still load from their real entry file so
-   * descriptor registration can follow the normal plugin entry contract, but
-   * they register in setup-only mode to keep `registerFull(...)` work out of
-   * parse-time help paths.
-   */
-  captureCliMetadataOnly?: boolean;
   activate?: boolean;
   throwOnLoadError?: boolean;
 };
@@ -153,6 +145,37 @@ export function clearPluginLoaderCache(): void {
 }
 
 const defaultLogger = () => createSubsystemLogger("plugins");
+
+function createPluginJitiLoader(options: Pick<PluginLoadOptions, "pluginSdkResolution">) {
+  const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
+  return (modulePath: string) => {
+    const tryNative = shouldPreferNativeJiti(modulePath);
+    const aliasMap = buildPluginLoaderAliasMap(
+      modulePath,
+      process.argv[1],
+      import.meta.url,
+      options.pluginSdkResolution,
+    );
+    const cacheKey = JSON.stringify({
+      tryNative,
+      aliasMap: Object.entries(aliasMap).toSorted(([left], [right]) => left.localeCompare(right)),
+    });
+    const cached = jitiLoaders.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const loader = createJiti(import.meta.url, {
+      ...buildPluginLoaderJitiOptions(aliasMap),
+      // Source .ts runtime shims import sibling ".js" specifiers that only exist
+      // after build. Disable native loading for source entries so Jiti rewrites
+      // those imports against the source graph, while keeping native dist/*.js
+      // loading for the canonical built module graph.
+      tryNative,
+    });
+    jitiLoaders.set(cacheKey, loader);
+    return loader;
+  };
+}
 
 export const __testing = {
   buildPluginLoaderJitiOptions,
@@ -211,7 +234,6 @@ function buildCacheKey(params: {
   onlyPluginIds?: string[];
   includeSetupOnlyChannelPlugins?: boolean;
   preferSetupRuntimeForChannelPlugins?: boolean;
-  captureCliMetadataOnly?: boolean;
   runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
   pluginSdkResolution?: PluginSdkResolutionPreference;
   coreGatewayMethodNames?: string[];
@@ -241,13 +263,12 @@ function buildCacheKey(params: {
   const setupOnlyKey = params.includeSetupOnlyChannelPlugins === true ? "setup-only" : "runtime";
   const startupChannelMode =
     params.preferSetupRuntimeForChannelPlugins === true ? "prefer-setup" : "full";
-  const cliMetadataMode = params.captureCliMetadataOnly === true ? "cli-metadata" : "default";
   const gatewayMethodsKey = JSON.stringify(params.coreGatewayMethodNames ?? []);
   return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
     ...params.plugins,
     installs,
     loadPaths,
-  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${cliMetadataMode}::${params.runtimeSubagentMode ?? "default"}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}`;
+  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${params.runtimeSubagentMode ?? "default"}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}`;
 }
 
 function normalizeScopedPluginIds(ids?: string[]): string[] | undefined {
@@ -280,8 +301,7 @@ function hasExplicitCompatibilityInputs(options: PluginLoadOptions): boolean {
     options.pluginSdkResolution !== undefined ||
     options.coreGatewayHandlers !== undefined ||
     options.includeSetupOnlyChannelPlugins === true ||
-    options.preferSetupRuntimeForChannelPlugins === true ||
-    options.captureCliMetadataOnly === true,
+    options.preferSetupRuntimeForChannelPlugins === true,
   );
 }
 
@@ -292,7 +312,6 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const onlyPluginIds = normalizeScopedPluginIds(options.onlyPluginIds);
   const includeSetupOnlyChannelPlugins = options.includeSetupOnlyChannelPlugins === true;
   const preferSetupRuntimeForChannelPlugins = options.preferSetupRuntimeForChannelPlugins === true;
-  const captureCliMetadataOnly = options.captureCliMetadataOnly === true;
   const coreGatewayMethodNames = Object.keys(options.coreGatewayHandlers ?? {}).toSorted();
   const cacheKey = buildCacheKey({
     workspaceDir: options.workspaceDir,
@@ -302,7 +321,6 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     onlyPluginIds,
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
-    captureCliMetadataOnly,
     runtimeSubagentMode: resolveRuntimeSubagentMode(options.runtimeOptions),
     pluginSdkResolution: options.pluginSdkResolution,
     coreGatewayMethodNames,
@@ -314,7 +332,6 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     onlyPluginIds,
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
-    captureCliMetadataOnly,
     shouldActivate: options.activate !== false,
     runtimeSubagentMode: resolveRuntimeSubagentMode(options.runtimeOptions),
     cacheKey,
@@ -808,7 +825,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     onlyPluginIds,
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
-    captureCliMetadataOnly,
     shouldActivate,
     cacheKey,
     runtimeSubagentMode,
@@ -842,36 +858,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   }
 
   // Lazy: avoid creating the Jiti loader when all plugins are disabled (common in unit tests).
-  const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
-  const getJiti = (modulePath: string) => {
-    const tryNative = shouldPreferNativeJiti(modulePath);
-    // Pass loader's moduleUrl so the openclaw root can always be resolved even when
-    // loading external plugins from outside the managed install directory.
-    const aliasMap = buildPluginLoaderAliasMap(
-      modulePath,
-      process.argv[1],
-      import.meta.url,
-      options.pluginSdkResolution,
-    );
-    const cacheKey = JSON.stringify({
-      tryNative,
-      aliasMap: Object.entries(aliasMap).toSorted(([left], [right]) => left.localeCompare(right)),
-    });
-    const cached = jitiLoaders.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-    const loader = createJiti(import.meta.url, {
-      ...buildPluginLoaderJitiOptions(aliasMap),
-      // Source .ts runtime shims import sibling ".js" specifiers that only exist
-      // after build. Disable native loading for source entries so Jiti rewrites
-      // those imports against the source graph, while keeping native dist/*.js
-      // loading for the canonical built module graph.
-      tryNative,
-    });
-    jitiLoaders.set(cacheKey, loader);
-    return loader;
-  };
+  const getJiti = createPluginJitiLoader(options);
 
   let createPluginRuntimeFactory: ((options?: CreatePluginRuntimeOptions) => PluginRuntime) | null =
     null;
@@ -1082,20 +1069,18 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     };
 
     const registrationMode = enableState.enabled
-      ? captureCliMetadataOnly && manifestRecord.channels.length > 0
-        ? "setup-only"
-        : !validateOnly &&
-            shouldLoadChannelPluginInSetupRuntime({
-              manifestChannels: manifestRecord.channels,
-              setupSource: manifestRecord.setupSource,
-              startupDeferConfiguredChannelFullLoadUntilAfterListen:
-                manifestRecord.startupDeferConfiguredChannelFullLoadUntilAfterListen,
-              cfg,
-              env,
-              preferSetupRuntimeForChannelPlugins,
-            })
-          ? "setup-runtime"
-          : "full"
+      ? !validateOnly &&
+        shouldLoadChannelPluginInSetupRuntime({
+          manifestChannels: manifestRecord.channels,
+          setupSource: manifestRecord.setupSource,
+          startupDeferConfiguredChannelFullLoadUntilAfterListen:
+            manifestRecord.startupDeferConfiguredChannelFullLoadUntilAfterListen,
+          cfg,
+          env,
+          preferSetupRuntimeForChannelPlugins,
+        })
+        ? "setup-runtime"
+        : "full"
       : includeSetupOnlyChannelPlugins && !validateOnly && manifestRecord.channels.length > 0
         ? "setup-only"
         : null;
@@ -1201,10 +1186,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
 
     const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
-    const loadSource = captureCliMetadataOnly
-      ? candidate.source
-      : (registrationMode === "setup-only" || registrationMode === "setup-runtime") &&
-          manifestRecord.setupSource
+    const loadSource =
+      (registrationMode === "setup-only" || registrationMode === "setup-runtime") &&
+      manifestRecord.setupSource
         ? manifestRecord.setupSource
         : candidate.source;
     const opened = openBoundaryFileSync({
@@ -1240,7 +1224,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
 
     if (
-      !captureCliMetadataOnly &&
       (registrationMode === "setup-only" || registrationMode === "setup-runtime") &&
       manifestRecord.setupSource
     ) {
@@ -1424,6 +1407,300 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   if (shouldActivate) {
     activatePluginRegistry(registry, cacheKey, runtimeSubagentMode);
   }
+  return registry;
+}
+
+export async function loadOpenClawPluginCliRegistry(
+  options: PluginLoadOptions = {},
+): Promise<PluginRegistry> {
+  const { env, cfg, normalized, onlyPluginIds, cacheKey } = resolvePluginLoadCacheContext({
+    ...options,
+    activate: false,
+    cache: false,
+  });
+  const logger = options.logger ?? defaultLogger();
+  const onlyPluginIdSet = onlyPluginIds ? new Set(onlyPluginIds) : null;
+  const getJiti = createPluginJitiLoader(options);
+  const { registry, registerCli } = createPluginRegistry({
+    logger,
+    runtime: {} as PluginRuntime,
+    coreGatewayHandlers: options.coreGatewayHandlers as Record<string, GatewayRequestHandler>,
+    suppressGlobalCommands: true,
+  });
+
+  const discovery = discoverOpenClawPlugins({
+    workspaceDir: options.workspaceDir,
+    extraPaths: normalized.loadPaths,
+    cache: false,
+    env,
+  });
+  const manifestRegistry = loadPluginManifestRegistry({
+    config: cfg,
+    workspaceDir: options.workspaceDir,
+    cache: false,
+    env,
+    candidates: discovery.candidates,
+    diagnostics: discovery.diagnostics,
+  });
+  pushDiagnostics(registry.diagnostics, manifestRegistry.diagnostics);
+  warnWhenAllowlistIsOpen({
+    logger,
+    pluginsEnabled: normalized.enabled,
+    allow: normalized.allow,
+    warningCacheKey: `${cacheKey}::cli-metadata`,
+    discoverablePlugins: manifestRegistry.plugins
+      .filter((plugin) => !onlyPluginIdSet || onlyPluginIdSet.has(plugin.id))
+      .map((plugin) => ({
+        id: plugin.id,
+        source: plugin.source,
+        origin: plugin.origin,
+      })),
+  });
+  const provenance = buildProvenanceIndex({
+    config: cfg,
+    normalizedLoadPaths: normalized.loadPaths,
+    env,
+  });
+  const manifestByRoot = new Map(
+    manifestRegistry.plugins.map((record) => [record.rootDir, record]),
+  );
+  const orderedCandidates = [...discovery.candidates].toSorted((left, right) => {
+    return compareDuplicateCandidateOrder({
+      left,
+      right,
+      manifestByRoot,
+      provenance,
+      env,
+    });
+  });
+
+  const seenIds = new Map<string, PluginRecord["origin"]>();
+  const memorySlot = normalized.slots.memory;
+  let selectedMemoryPluginId: string | null = null;
+
+  for (const candidate of orderedCandidates) {
+    const manifestRecord = manifestByRoot.get(candidate.rootDir);
+    if (!manifestRecord) {
+      continue;
+    }
+    const pluginId = manifestRecord.id;
+    if (onlyPluginIdSet && !onlyPluginIdSet.has(pluginId)) {
+      continue;
+    }
+    const existingOrigin = seenIds.get(pluginId);
+    if (existingOrigin) {
+      const record = createPluginRecord({
+        id: pluginId,
+        name: manifestRecord.name ?? pluginId,
+        description: manifestRecord.description,
+        version: manifestRecord.version,
+        format: manifestRecord.format,
+        bundleFormat: manifestRecord.bundleFormat,
+        bundleCapabilities: manifestRecord.bundleCapabilities,
+        source: candidate.source,
+        rootDir: candidate.rootDir,
+        origin: candidate.origin,
+        workspaceDir: candidate.workspaceDir,
+        enabled: false,
+        configSchema: Boolean(manifestRecord.configSchema),
+      });
+      record.status = "disabled";
+      record.error = `overridden by ${existingOrigin} plugin`;
+      registry.plugins.push(record);
+      continue;
+    }
+
+    const enableState = resolveEffectiveEnableState({
+      id: pluginId,
+      origin: candidate.origin,
+      config: normalized,
+      rootConfig: cfg,
+      enabledByDefault: manifestRecord.enabledByDefault,
+    });
+    const entry = normalized.entries[pluginId];
+    const record = createPluginRecord({
+      id: pluginId,
+      name: manifestRecord.name ?? pluginId,
+      description: manifestRecord.description,
+      version: manifestRecord.version,
+      format: manifestRecord.format,
+      bundleFormat: manifestRecord.bundleFormat,
+      bundleCapabilities: manifestRecord.bundleCapabilities,
+      source: candidate.source,
+      rootDir: candidate.rootDir,
+      origin: candidate.origin,
+      workspaceDir: candidate.workspaceDir,
+      enabled: enableState.enabled,
+      configSchema: Boolean(manifestRecord.configSchema),
+    });
+    record.kind = manifestRecord.kind;
+    record.configUiHints = manifestRecord.configUiHints;
+    record.configJsonSchema = manifestRecord.configSchema;
+    const pushPluginLoadError = (message: string) => {
+      record.status = "error";
+      record.error = message;
+      registry.plugins.push(record);
+      seenIds.set(pluginId, candidate.origin);
+      registry.diagnostics.push({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: record.error,
+      });
+    };
+
+    if (!enableState.enabled) {
+      record.status = "disabled";
+      record.error = enableState.reason;
+      registry.plugins.push(record);
+      seenIds.set(pluginId, candidate.origin);
+      continue;
+    }
+
+    if (record.format === "bundle") {
+      registry.plugins.push(record);
+      seenIds.set(pluginId, candidate.origin);
+      continue;
+    }
+
+    if (candidate.origin === "bundled" && manifestRecord.kind === "memory") {
+      const memoryDecision = resolveMemorySlotDecision({
+        id: record.id,
+        kind: "memory",
+        slot: memorySlot,
+        selectedId: selectedMemoryPluginId,
+      });
+      if (!memoryDecision.enabled) {
+        record.enabled = false;
+        record.status = "disabled";
+        record.error = memoryDecision.reason;
+        registry.plugins.push(record);
+        seenIds.set(pluginId, candidate.origin);
+        continue;
+      }
+      if (memoryDecision.selected) {
+        selectedMemoryPluginId = record.id;
+      }
+    }
+
+    if (!manifestRecord.configSchema) {
+      pushPluginLoadError("missing config schema");
+      continue;
+    }
+
+    const validatedConfig = validatePluginConfig({
+      schema: manifestRecord.configSchema,
+      cacheKey: manifestRecord.schemaCacheKey,
+      value: entry?.config,
+    });
+    if (!validatedConfig.ok) {
+      logger.error(`[plugins] ${record.id} invalid config: ${validatedConfig.errors?.join(", ")}`);
+      pushPluginLoadError(`invalid config: ${validatedConfig.errors?.join(", ")}`);
+      continue;
+    }
+
+    const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
+    const opened = openBoundaryFileSync({
+      absolutePath: candidate.source,
+      rootPath: pluginRoot,
+      boundaryLabel: "plugin root",
+      rejectHardlinks: candidate.origin !== "bundled",
+      skipLexicalRootCheck: true,
+    });
+    if (!opened.ok) {
+      pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+      continue;
+    }
+    const safeSource = opened.path;
+    fs.closeSync(opened.fd);
+
+    let mod: OpenClawPluginModule | null = null;
+    try {
+      mod = getJiti(safeSource)(safeSource) as OpenClawPluginModule;
+    } catch (err) {
+      recordPluginError({
+        logger,
+        registry,
+        record,
+        seenIds,
+        pluginId,
+        origin: candidate.origin,
+        error: err,
+        logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
+        diagnosticMessagePrefix: "failed to load plugin: ",
+      });
+      continue;
+    }
+
+    const resolved = resolvePluginModuleExport(mod);
+    const definition = resolved.definition;
+    const register = resolved.register;
+
+    if (definition?.id && definition.id !== record.id) {
+      pushPluginLoadError(
+        `plugin id mismatch (config uses "${record.id}", export uses "${definition.id}")`,
+      );
+      continue;
+    }
+
+    record.name = definition?.name ?? record.name;
+    record.description = definition?.description ?? record.description;
+    record.version = definition?.version ?? record.version;
+    const manifestKind = record.kind as string | undefined;
+    const exportKind = definition?.kind as string | undefined;
+    if (manifestKind && exportKind && exportKind !== manifestKind) {
+      registry.diagnostics.push({
+        level: "warn",
+        pluginId: record.id,
+        source: record.source,
+        message: `plugin kind mismatch (manifest uses "${manifestKind}", export uses "${exportKind}")`,
+      });
+    }
+    record.kind = definition?.kind ?? record.kind;
+
+    if (typeof register !== "function") {
+      logger.error(`[plugins] ${record.id} missing register/activate export`);
+      pushPluginLoadError("plugin export missing register/activate");
+      continue;
+    }
+
+    const api = buildPluginApi({
+      id: record.id,
+      name: record.name,
+      version: record.version,
+      description: record.description,
+      source: record.source,
+      rootDir: record.rootDir,
+      registrationMode: "cli-metadata",
+      config: cfg,
+      pluginConfig: validatedConfig.value,
+      runtime: {} as PluginRuntime,
+      logger,
+      resolvePath: (input) => resolveUserPath(input),
+      handlers: {
+        registerCli: (registrar, opts) => registerCli(record, registrar, opts),
+      },
+    });
+
+    try {
+      await register(api);
+      registry.plugins.push(record);
+      seenIds.set(pluginId, candidate.origin);
+    } catch (err) {
+      recordPluginError({
+        logger,
+        registry,
+        record,
+        seenIds,
+        pluginId,
+        origin: candidate.origin,
+        error: err,
+        logPrefix: `[plugins] ${record.id} failed during register from ${record.source}: `,
+        diagnosticMessagePrefix: "plugin failed during register: ",
+      });
+    }
+  }
+
   return registry;
 }
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1563,7 +1563,7 @@ export async function loadOpenClawPluginCliRegistry(
       continue;
     }
 
-    if (candidate.origin === "bundled" && manifestRecord.kind === "memory") {
+    if (manifestRecord.kind === "memory") {
       const memoryDecision = resolveMemorySlotDecision({
         id: record.id,
         kind: "memory",

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -988,7 +988,6 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
               registerWebSearchProvider: (provider) => registerWebSearchProvider(record, provider),
               registerGatewayMethod: (method, handler, opts) =>
                 registerGatewayMethod(record, method, handler, opts),
-              registerCli: (registrar, opts) => registerCli(record, registrar, opts),
               registerService: (service) => registerService(record, service),
               registerCliBackend: (backend) => registerCliBackend(record, backend),
               registerInteractiveHandler: (registration) => {
@@ -1097,6 +1096,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                 registerTypedHook(record, hookName, handler, opts, params.hookPolicy),
             }
           : {}),
+        // Allow setup-only/setup-runtime paths to surface parse-time CLI metadata
+        // without opting into the wider full-registration surface.
+        registerCli: (registrar, opts) => registerCli(record, registrar, opts),
         registerChannel: (registration) => registerChannel(record, registration, registrationMode),
       },
     });

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1674,7 +1674,7 @@ export type OpenClawPluginModule =
   | OpenClawPluginDefinition
   | ((api: OpenClawPluginApi) => void | Promise<void>);
 
-export type PluginRegistrationMode = "full" | "setup-only" | "setup-runtime";
+export type PluginRegistrationMode = "full" | "setup-only" | "setup-runtime" | "cli-metadata";
 
 /** Main registration API injected into native plugin entry files. */
 export type OpenClawPluginApi = {


### PR DESCRIPTION
## Summary

- Problem: `openclaw --help` started calling `getPluginCliCommandDescriptors()` through the normal plugin loader path, which could execute plugin full-registration work during root help.
- Why it matters: root help should stay parse-time and side-effect free; on current `main` Matrix could cross its runtime bootstrap path just to render help.
- What changed: root-help descriptor reads now capture `registerCli(...)` metadata through a throwaway plugin API instead of using the activating loader, and Matrix exposes its CLI descriptor before the full-runtime branch.
- What did NOT change (scope boundary): normal plugin CLI registration, lazy command installation, and plugin runtime activation for real command execution still use the existing loader path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #57165
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the descriptor-backed root-help path added in #57165 reused the normal plugin CLI registry load path, which loads plugin modules and runs `register(api)` in full registration mode.
- Missing detection / guardrail: there was no regression test proving that root-help descriptor reads avoid the activating loader and skip channel `registerFull` work.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #57165 added descriptor-backed lazy root command registration and wired `src/cli/program/root-help.ts` to `getPluginCliCommandDescriptors()`.
- Why this regressed now: root help moved from static core/sub-CLI descriptors to plugin-backed descriptors without a metadata-only capture path.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/cli.test.ts` and `extensions/matrix/index.test.ts`
- Scenario the test should lock in: descriptor capture for root help reads plugin CLI metadata without using `loadOpenClawPlugins()` and without running Matrix full registration.
- Why this is the smallest reliable guardrail: the regression happens before command execution, at the plugin descriptor capture seam.
- Existing test that already covers this (if any): `src/cli/program/root-help.test.ts` already covers command visibility, but not the non-activating behavior.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw --help` and other root-help descriptor reads no longer cross plugin full-registration/runtime bootstrap paths just to list plugin commands.

## Diagram (if applicable)

```text
Before:
[root help] -> [getPluginCliCommandDescriptors] -> [activating plugin loader] -> [plugin registerFull side effects]

After:
[root help] -> [descriptor capture API] -> [registerCli metadata only] -> [help text]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm dev tree
- Model/provider: N/A
- Integration/channel (if any): Matrix plugin entry
- Relevant config (redacted): default local dev config

### Steps

1. On `main`, follow root help into `src/cli/program/root-help.ts` and `src/plugins/cli.ts`.
2. Observe that `getPluginCliCommandDescriptors()` used the normal plugin loader path.
3. Run targeted regression tests after the fix.

### Expected

- Root help reads plugin CLI descriptors without activating plugin runtime state or channel `registerFull` work.

### Actual

- Verified by tests after the fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: traced the `main` code path, confirmed the Matrix `registerFull` hazard, implemented the metadata-only capture path, and reran targeted tests after rebasing onto latest `origin/main`.
- Edge cases checked: channel plugin descriptor capture uses setup-only registration to skip `registerFull`; non-channel plugins still capture descriptors in full registration mode.
- What you did **not** verify: I did not measure help-path performance deltas or run a live Matrix runtime smoke test.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: channel entries that only register CLI inside their full-runtime branch would stay invisible to metadata capture.
  - Mitigation: Matrix was updated in the same PR, and the capture-path tests lock in the intended contract.
