### PR TITLE
fix(cron): deliver full announce output instead of last chunk only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Live Activities: mark the `ActivityKit` import in `LiveActivityManager.swift` as `@preconcurrency` so Xcode 26.4 / Swift 6 builds stop failing on strict concurrency checks. (#57180) Thanks @ngutman.
 - Plugins/Matrix: mirror the Matrix crypto WASM runtime dependency into the root packaged install and enforce root/plugin dependency parity so bundled Matrix E2EE crypto resolves correctly in shipped builds. (#57163) Thanks @gumadeiras.
 - Plugins/CLI: add descriptor-backed lazy plugin CLI registration so Matrix can keep its CLI module lazy-loaded without dropping `openclaw matrix ...` from parse-time command registration. (#57165) Thanks @gumadeiras.
+- Cron/announce: preserve all deliverable text payloads for announce mode instead of collapsing to the last chunk, so multi-line cron reports deliver in full to Telegram forum topics. (#13812)
 
 ## 2026.3.28
 

--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -281,13 +281,23 @@ describe("runCronIsolatedAgentTurn", () => {
 
   it("delivers explicit targets with final-payload text", async () => {
     await withTelegramAnnounceFixture(async ({ home, storePath, deps }) => {
-      await assertExplicitTelegramTargetDelivery({
+      mockAgentPayloads([{ text: "Working on it..." }, { text: "Final weather summary" }]);
+      const res = await runExplicitTelegramAnnounceTurn({
         home,
         storePath,
         deps,
-        payloads: [{ text: "Working on it..." }, { text: "Final weather summary" }],
-        expectedText: "Final weather summary",
       });
+
+      expectDeliveredOk(res);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).toHaveBeenCalledTimes(2);
+      const sendMessageTelegramCalls = vi.mocked(
+        deps.sendMessageTelegram as (...args: unknown[]) => unknown,
+      ).mock.calls;
+      expect(sendMessageTelegramCalls).toEqual([
+        ["123", "Working on it...", expect.objectContaining({ cfg: expect.any(Object) })],
+        ["123", "Final weather summary", expect.objectContaining({ cfg: expect.any(Object) })],
+      ]);
     });
   });
 

--- a/src/cron/isolated-agent.telegram-topic-announce-regression.test.ts
+++ b/src/cron/isolated-agent.telegram-topic-announce-regression.test.ts
@@ -1,0 +1,63 @@
+import "./isolated-agent.mocks.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
+import {
+  createCliDeps,
+  mockAgentPayloads,
+  runTelegramAnnounceTurn,
+} from "./isolated-agent.delivery.test-helpers.js";
+import { resolveCronPayloadOutcome } from "./isolated-agent/helpers.js";
+import { withTempCronHome, writeSessionStore } from "./isolated-agent.test-harness.js";
+import { setupIsolatedAgentTurnMocks } from "./isolated-agent.test-setup.js";
+
+describe("Telegram topic announce regression", () => {
+  beforeEach(() => {
+    setupIsolatedAgentTurnMocks();
+  });
+
+  it("preserves the full successful delivery payload sequence", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "part 1" },
+        { text: "part 2" },
+        { text: "ignored error", isError: true },
+        { text: "part 3" },
+      ],
+    });
+
+    expect(result.summary).toBe("part 3");
+    expect(result.outputText).toBe("part 3");
+    expect(result.deliveryPayloads).toEqual([
+      { text: "part 1" },
+      { text: "part 2" },
+      { text: "part 3" },
+    ]);
+  });
+
+  it("delivers every text payload chunk to Telegram forum topics", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "chunk 1" }, { text: "chunk 2" }, { text: "chunk 3" }]);
+
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123:topic:42" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      const sendMessageTelegramCalls = vi.mocked(
+        deps.sendMessageTelegram as (...args: unknown[]) => unknown,
+      ).mock.calls;
+      expect(sendMessageTelegramCalls).toEqual([
+        ["123", "chunk 1", expect.objectContaining({ messageThreadId: 42 })],
+        ["123", "chunk 2", expect.objectContaining({ messageThreadId: 42 })],
+        ["123", "chunk 3", expect.objectContaining({ messageThreadId: 42 })],
+      ]);
+    });
+  });
+});

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -71,26 +71,37 @@ export function pickLastNonEmptyTextFromPayloads(
   return undefined;
 }
 
+function isDeliverablePayload(payload: DeliveryPayload) {
+  const hasInteractive = (payload?.interactive?.blocks?.length ?? 0) > 0;
+  const hasChannelData = Object.keys(payload?.channelData ?? {}).length > 0;
+  return hasOutboundReplyContent(payload, { trimText: true }) || hasInteractive || hasChannelData;
+}
+
 export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
-  const isDeliverable = (p: DeliveryPayload) => {
-    const hasInteractive = (p?.interactive?.blocks?.length ?? 0) > 0;
-    const hasChannelData = Object.keys(p?.channelData ?? {}).length > 0;
-    return hasOutboundReplyContent(p, { trimText: true }) || hasInteractive || hasChannelData;
-  };
   for (let i = payloads.length - 1; i >= 0; i--) {
     if (payloads[i]?.isError) {
       continue;
     }
-    if (isDeliverable(payloads[i])) {
+    if (isDeliverablePayload(payloads[i])) {
       return payloads[i];
     }
   }
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (isDeliverable(payloads[i])) {
+    if (isDeliverablePayload(payloads[i])) {
       return payloads[i];
     }
   }
   return undefined;
+}
+
+export function pickDeliverablePayloads(payloads: DeliveryPayload[]) {
+  const successfulPayloads = payloads.filter(
+    (payload) => payload?.isError !== true && isDeliverablePayload(payload),
+  );
+  if (successfulPayloads.length > 0) {
+    return successfulPayloads;
+  }
+  return payloads.filter(isDeliverablePayload);
 }
 
 /**
@@ -114,13 +125,15 @@ export function resolveCronPayloadOutcome(params: {
   const summary = pickSummaryFromPayloads(params.payloads) ?? pickSummaryFromOutput(firstText);
   const outputText = pickLastNonEmptyTextFromPayloads(params.payloads);
   const synthesizedText = outputText?.trim() || summary?.trim() || undefined;
-  const deliveryPayload = pickLastDeliverablePayload(params.payloads);
+  const pickedDeliveryPayloads = pickDeliverablePayloads(params.payloads);
+  const deliveryPayload = pickedDeliveryPayloads[pickedDeliveryPayloads.length - 1];
   const deliveryPayloads =
-    deliveryPayload !== undefined
-      ? [deliveryPayload]
+    pickedDeliveryPayloads.length > 0
+      ? pickedDeliveryPayloads
       : synthesizedText
         ? [{ text: synthesizedText }]
         : [];
+  // Only the last delivered payload controls downstream finalize-text safeguards.
   const deliveryPayloadHasStructuredContent =
     deliveryPayload?.mediaUrl !== undefined ||
     (deliveryPayload?.mediaUrls?.length ?? 0) > 0 ||


### PR DESCRIPTION
## Summary

- `resolveCronPayloadOutcome()` collapsed announce delivery to the last deliverable payload
- Replace `pickLastDeliverablePayload()` with `pickDeliverablePayloads()` that preserves all successful text payloads
- Multi-line cron reports now deliver in full to Telegram forum topics

## Root Cause

`pickLastDeliverablePayload()` in `src/cron/isolated-agent/helpers.ts` returned only one payload. When a cron job produced multiple text chunks, only the last survived. Telegram forum topics exposed this directly because they use the direct-delivery path.

## Change Type

- [x] Bug fix

## Testing

73 test suites, 551 tests pass in `src/cron/`. New regression test:
- Multi-payload announce with mixed success/error payloads
- Verifies all successful text chunks are delivered, errors filtered

Fixes #13812