### PR TITLE
feat(slack): add per-channel replyToMode config override (rebased #51848)

### DIFF
--- a/extensions/slack/src/monitor/channel-config.test.ts
+++ b/extensions/slack/src/monitor/channel-config.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { resolveSlackChannelConfig } from "./channel-config.js";
+
+describe("resolveSlackChannelConfig", () => {
+  it("returns per-channel replyToMode when configured", () => {
+    const result = resolveSlackChannelConfig({
+      channelId: "C0ABC12345",
+      channels: {
+        C0ABC12345: { allow: true, replyToMode: "all" },
+      },
+      defaultRequireMention: false,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.replyToMode).toBe("all");
+  });
+
+  it("falls back to wildcard replyToMode when channel has no override", () => {
+    const result = resolveSlackChannelConfig({
+      channelId: "C0ABC12345",
+      channels: {
+        "*": { allow: true, replyToMode: "first" },
+      },
+      defaultRequireMention: false,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.replyToMode).toBe("first");
+  });
+
+  it("prefers exact channel replyToMode over wildcard", () => {
+    const result = resolveSlackChannelConfig({
+      channelId: "C0ABC12345",
+      channels: {
+        C0ABC12345: { allow: true, replyToMode: "off" },
+        "*": { allow: true, replyToMode: "all" },
+      },
+      defaultRequireMention: false,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.replyToMode).toBe("off");
+  });
+
+  it("falls back to wildcard replyToMode when exact channel entry omits it", () => {
+    const result = resolveSlackChannelConfig({
+      channelId: "C0ABC12345",
+      channels: {
+        C0ABC12345: { allow: true },
+        "*": { allow: true, replyToMode: "first" },
+      },
+      defaultRequireMention: false,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.replyToMode).toBe("first");
+  });
+
+  it("returns undefined replyToMode when not configured", () => {
+    const result = resolveSlackChannelConfig({
+      channelId: "C0ABC12345",
+      channels: {
+        C0ABC12345: { allow: true },
+      },
+      defaultRequireMention: false,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.replyToMode).toBeUndefined();
+  });
+});

--- a/extensions/slack/src/monitor/channel-config.ts
+++ b/extensions/slack/src/monitor/channel-config.ts
@@ -4,7 +4,7 @@ import {
   resolveChannelEntryMatchWithFallback,
   type ChannelMatchSource,
 } from "openclaw/plugin-sdk/channel-targets";
-import type { SlackReactionNotificationMode } from "openclaw/plugin-sdk/config-runtime";
+import type { ReplyToMode, SlackReactionNotificationMode } from "openclaw/plugin-sdk/config-runtime";
 import type { SlackMessageEvent } from "../types.js";
 import { allowListMatches, normalizeAllowListLower, normalizeSlackSlug } from "./allow-list.js";
 
@@ -15,6 +15,7 @@ export type SlackChannelConfigResolved = {
   users?: Array<string | number>;
   skills?: string[];
   systemPrompt?: string;
+  replyToMode?: ReplyToMode;
   matchKey?: string;
   matchSource?: ChannelMatchSource;
 };
@@ -27,6 +28,7 @@ export type SlackChannelConfigEntry = {
   users?: Array<string | number>;
   skills?: string[];
   systemPrompt?: string;
+  replyToMode?: ReplyToMode;
 };
 
 export type SlackChannelConfigEntries = Record<string, SlackChannelConfigEntry>;
@@ -145,6 +147,7 @@ export function resolveSlackChannelConfig(params: {
   const users = firstDefined(resolved.users, fallback?.users);
   const skills = firstDefined(resolved.skills, fallback?.skills);
   const systemPrompt = firstDefined(resolved.systemPrompt, fallback?.systemPrompt);
+  const replyToMode = firstDefined(resolved.replyToMode, fallback?.replyToMode);
   const result: SlackChannelConfigResolved = {
     allowed,
     requireMention,
@@ -152,6 +155,7 @@ export function resolveSlackChannelConfig(params: {
     users,
     skills,
     systemPrompt,
+    replyToMode,
   };
   return applyChannelMatchMeta(result, match);
 }

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -275,7 +275,8 @@ function resolveSlackRoutingContext(params: {
   });
 
   const chatType = isDirectMessage ? "direct" : isGroupDm ? "group" : "channel";
-  const replyToMode = resolveSlackReplyToMode(account, chatType);
+  const accountReplyToMode = resolveSlackReplyToMode(account, chatType);
+  const replyToMode = channelConfig?.replyToMode ?? accountReplyToMode;
   const threadContext = resolveSlackThreadContext({ message, replyToMode });
   const threadTs = threadContext.incomingThreadTs;
   const isThreadReply = threadContext.isThreadReply;
@@ -735,6 +736,7 @@ export async function prepareSlackMessage(params: {
     OriginatingChannel: "slack" as const,
     OriginatingTo: slackTo,
     NativeChannelId: message.channel,
+    ReplyToMode: replyToMode,
   }) satisfies FinalizedMsgContext;
   const pinnedMainDmOwner = isDirectMessage
     ? resolvePinnedMainDmOwnerFromAllowlist({

--- a/extensions/slack/src/threading-tool-context.test.ts
+++ b/extensions/slack/src/threading-tool-context.test.ts
@@ -136,6 +136,34 @@ describe("buildSlackThreadingToolContext", () => {
     expect(result.replyToMode).toBe("first");
   });
 
+  it("uses pre-resolved ReplyToMode from context over account config", () => {
+    const cfg = {
+      channels: {
+        slack: { replyToMode: "off" },
+      },
+    } as OpenClawConfig;
+    const result = buildSlackThreadingToolContext({
+      cfg,
+      accountId: null,
+      context: { ChatType: "channel", ReplyToMode: "all" },
+    });
+    expect(result.replyToMode).toBe("all");
+  });
+
+  it("falls back to account config when ReplyToMode is not in context", () => {
+    const cfg = {
+      channels: {
+        slack: { replyToMode: "first" },
+      },
+    } as OpenClawConfig;
+    const result = buildSlackThreadingToolContext({
+      cfg,
+      accountId: null,
+      context: { ChatType: "channel" },
+    });
+    expect(result.replyToMode).toBe("first");
+  });
+
   it("defaults to off when no replyToMode is configured", () => {
     const result = buildSlackThreadingToolContext({
       cfg: emptyCfg,

--- a/extensions/slack/src/threading-tool-context.ts
+++ b/extensions/slack/src/threading-tool-context.ts
@@ -15,7 +15,9 @@ export function buildSlackThreadingToolContext(params: {
     cfg: params.cfg,
     accountId: params.accountId,
   });
-  const configuredReplyToMode = resolveSlackReplyToMode(account, params.context.ChatType);
+  // Prefer pre-resolved replyToMode (includes per-channel overrides) over re-resolving from account.
+  const configuredReplyToMode =
+    params.context.ReplyToMode ?? resolveSlackReplyToMode(account, params.context.ChatType);
   const hasExplicitThreadTarget = params.context.MessageThreadId != null;
   const effectiveReplyToMode = hasExplicitThreadTarget ? "all" : configuredReplyToMode;
   const threadId = params.context.MessageThreadId ?? params.context.ReplyToId;

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -69,6 +69,7 @@ export function buildThreadingToolContext(params: {
         ThreadLabel: sessionCtx.ThreadLabel,
         MessageThreadId: sessionCtx.MessageThreadId,
         NativeChannelId: sessionCtx.NativeChannelId,
+        ReplyToMode: sessionCtx.ReplyToMode,
       },
       hasRepliedRef,
     }) ?? {};

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -154,12 +154,15 @@ export async function runReplyAgent(params: {
     originatingChannel: sessionCtx.OriginatingChannel,
     provider: sessionCtx.Surface ?? sessionCtx.Provider,
   }) as OriginatingChannelType | undefined;
-  const replyToMode = resolveReplyToMode(
-    followupRun.run.config,
-    replyToChannel,
-    sessionCtx.AccountId,
-    sessionCtx.ChatType,
-  );
+  // Prefer pre-resolved replyToMode (includes per-channel overrides) over re-resolving from account config.
+  const replyToMode =
+    sessionCtx.ReplyToMode ??
+    resolveReplyToMode(
+      followupRun.run.config,
+      replyToChannel,
+      sessionCtx.AccountId,
+      sessionCtx.ChatType,
+    );
   const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
   const cfg = followupRun.run.config;
   const normalizeReplyMediaPaths = createReplyMediaPathNormalizer({

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -1,4 +1,5 @@
 import type { ChannelId } from "../channels/plugins/types.js";
+import type { ReplyToMode } from "../config/types.base.js";
 import type {
   MediaUnderstandingDecision,
   MediaUnderstandingOutput,
@@ -149,6 +150,8 @@ export type MsgContext = {
   MessageThreadId?: string | number;
   /** Platform-native channel/conversation id (e.g. Slack DM channel "D…" id). */
   NativeChannelId?: string;
+  /** Pre-resolved replyToMode including per-channel overrides. */
+  ReplyToMode?: ReplyToMode;
   /** Telegram forum supergroup marker. */
   IsForum?: boolean;
   /** Warning: DM has topics enabled but this message is not in a topic. */

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -3,6 +3,7 @@ import type { TSchema } from "@sinclair/typebox";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { ReplyToMode } from "../../config/types.base.js";
 import type { PollInput } from "../../polls.js";
 import type { GatewayClientMode, GatewayClientName } from "../../utils/message-channel.js";
 import type { ChatType } from "../chat-type.js";
@@ -375,6 +376,8 @@ export type ChannelThreadingContext = {
   MessageThreadId?: string | number;
   /** Platform-native channel/conversation id (e.g. Slack DM channel "D…" id). */
   NativeChannelId?: string;
+  /** Pre-resolved replyToMode (e.g. per-channel override); avoids re-resolving from account config. */
+  ReplyToMode?: ReplyToMode;
 };
 
 export type ChannelThreadingToolContext = {

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -45,6 +45,8 @@ export type SlackChannelConfig = {
   skills?: string[];
   /** Optional system prompt for this channel. */
   systemPrompt?: string;
+  /** Per-channel reply threading override (overrides account-level replyToMode). */
+  replyToMode?: ReplyToMode;
 };
 
 export type SlackReactionNotificationMode = "off" | "own" | "all" | "allowlist";

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -840,6 +840,7 @@ export const SlackChannelSchema = z
     users: z.array(z.union([z.string(), z.number()])).optional(),
     skills: z.array(z.string()).optional(),
     systemPrompt: z.string().optional(),
+    replyToMode: ReplyToModeSchema.optional(),
   })
   .strict();
 


### PR DESCRIPTION
Rebased port of #51848 onto current main.

**Problem:** No way to configure reply threading behavior per Slack channel — only account-level `replyToMode` existed.

**Fix:** Added optional `replyToMode` to per-channel Slack config entries. Per-channel value takes highest priority, falling through to account-level settings when not set. Also fixed propagation to threading tool context during agent execution.

Example:
```json
{
  "channels": {
    "slack": {
      "replyToMode": "off",
      "channels": {
        "#support": { "allow": true, "replyToMode": "all" },
        "#general": { "allow": true }
      }
    }
  }
}
```

Original author: @wonderchook
Related #51836