### PR TITLE
fix: cron isolated sessions fail with LiveSessionModelSwitchError when payload.model differs from agent default

### DIFF
--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -128,24 +128,29 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     expect(cronSession.sessionEntry.model).toBe("claude-sonnet-4-6");
     expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
     expect(cronSession.sessionEntry.systemSent).toBe(true);
+    // providerOverride/modelOverride must also be set so live-model-switch
+    // detection sees the cron model and doesn't fall back to agent default.
+    expect(cronSession.sessionEntry.providerOverride).toBe("anthropic");
+    expect(cronSession.sessionEntry.modelOverride).toBe("claude-sonnet-4-6");
   });
 
   it("session entry already carries cron model at pre-run persist time (race condition)", async () => {
     // Capture a deep snapshot of the session entry at each persist call so we
     // can inspect what sessions_list would see mid-run — before the post-run
     // persist overwrites the entry with the actual model from agentMeta.
-    const persistedSnapshots: Array<{
+    type SnapshotEntry = {
       model?: string;
       modelProvider?: string;
+      providerOverride?: string;
+      modelOverride?: string;
       systemSent?: boolean;
-    }> = [];
+    };
+    const persistedSnapshots: Array<SnapshotEntry> = [];
     updateSessionStoreMock.mockImplementation(
       async (_path: string, cb: (s: Record<string, unknown>) => void) => {
         const store: Record<string, unknown> = {};
         cb(store);
-        const entry = Object.values(store)[0] as
-          | { model?: string; modelProvider?: string; systemSent?: boolean }
-          | undefined;
+        const entry = Object.values(store)[0] as SnapshotEntry | undefined;
         if (entry) {
           persistedSnapshots.push(JSON.parse(JSON.stringify(entry)));
         }
@@ -164,6 +169,10 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     expect(preRunSnapshot.model).toBe("claude-sonnet-4-6");
     expect(preRunSnapshot.modelProvider).toBe("anthropic");
     expect(preRunSnapshot.systemSent).toBe(true);
+    // providerOverride/modelOverride must appear before the run starts
+    // so concurrent live-model-switch checks don't trip on a false mismatch.
+    expect(preRunSnapshot.providerOverride).toBe("anthropic");
+    expect(preRunSnapshot.modelOverride).toBe("claude-sonnet-4-6");
   });
 
   it("returns error without persisting model when payload model is disallowed", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -406,6 +406,11 @@ export async function runCronIsolatedAgentTurn(params: {
   // must not prevent the actual agent run from executing.
   cronSession.sessionEntry.modelProvider = provider;
   cronSession.sessionEntry.model = model;
+  // Also set providerOverride/modelOverride so live-model-switch detection
+  // sees the cron job's intended model and doesn't fall back to the agent
+  // default (which would cause a false LiveSessionModelSwitchError).
+  cronSession.sessionEntry.providerOverride = provider;
+  cronSession.sessionEntry.modelOverride = model;
   cronSession.sessionEntry.systemSent = true;
   try {
     await persistSessionEntry();


### PR DESCRIPTION
## Problem

Cron isolated agent turns with `payload.model` set to a different model than the agent's default fail with `LiveSessionModelSwitchError`.

**Regression introduced in:** `7dd196ed74` "fix: apply live model switches during active retries" (2026-03-27)

**Doc-breaking:** `docs/automation/cron-vs-heartbeat.md` explicitly shows `--model` as supported for isolated cron.

## Root Cause

The cron runner (`src/cron/isolated-agent/run.ts`) sets `modelProvider`/`model` on the session entry. But the live-model-switch detection (`src/agents/live-model-switch.ts`) reads `providerOverride`/`modelOverride` instead. Since cron sessions don't set these override fields, the detection falls back to the agent's default model, finds a mismatch, and throws `LiveSessionModelSwitchError`.

## Fix

Set `providerOverride` and `modelOverride` on the session entry in the cron runner alongside `modelProvider`/`model`, so the switch detection correctly matches the cron model.

## Test

Existing `run.cron-model-override.test.ts` updated with new assertions. All 6 tests pass.
