### PR TITLE
fix(matrix): preserve case in group/channel peer IDs for session keys

### DIFF
--- a/src/routing/session-key.continuity.test.ts
+++ b/src/routing/session-key.continuity.test.ts
@@ -65,3 +65,52 @@ describe("Discord Session Key Continuity", () => {
     expectUnknownChannelKeyCase(channelId);
   });
 });
+
+describe("Matrix Session Key Case Preservation", () => {
+  it("preserves mixed-case room IDs in group/channel session keys", () => {
+    const key = buildAgentSessionKey({
+      agentId: "main",
+      channel: "matrix",
+      peer: { kind: "channel", id: "!IEjZDNPucuFvKLrAQC:matrix.example.com" },
+    });
+    expect(key).toBe("agent:main:matrix:channel:!IEjZDNPucuFvKLrAQC:matrix.example.com");
+  });
+
+  it("preserves mixed-case room IDs in group session keys", () => {
+    const key = buildAgentSessionKey({
+      agentId: "main",
+      channel: "matrix",
+      peer: { kind: "group", id: "!AbCdEfGh:matrix.example.com" },
+    });
+    expect(key).toBe("agent:main:matrix:group:!AbCdEfGh:matrix.example.com");
+  });
+});
+
+describe("Non-Matrix providers still lowercase group/channel peer IDs", () => {
+  it("lowercases Slack channel IDs", () => {
+    const key = buildAgentSessionKey({
+      agentId: "main",
+      channel: "slack",
+      peer: { kind: "channel", id: "C0ABWMM7TDW" },
+    });
+    expect(key).toBe("agent:main:slack:channel:c0abwmm7tdw");
+  });
+
+  it("lowercases Discord channel IDs", () => {
+    const key = buildAgentSessionKey({
+      agentId: "main",
+      channel: "discord",
+      peer: { kind: "channel", id: "Channel456" },
+    });
+    expect(key).toBe("agent:main:discord:channel:channel456");
+  });
+
+  it("lowercases Telegram group IDs", () => {
+    const key = buildAgentSessionKey({
+      agentId: "main",
+      channel: "telegram",
+      peer: { kind: "group", id: "MyGroup123" },
+    });
+    expect(key).toBe("agent:main:telegram:group:mygroup123");
+  });
+});

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -169,7 +169,11 @@ export function buildAgentPeerSessionKey(params: {
     });
   }
   const channel = (params.channel ?? "").trim().toLowerCase() || "unknown";
-  const peerId = ((params.peerId ?? "").trim() || "unknown").toLowerCase();
+  // Matrix room IDs are case-sensitive opaque identifiers per the spec.
+  // Other providers (Slack, Discord, etc.) use case-insensitive IDs and
+  // must continue to be lowercased for consistent session key lookups.
+  const rawPeerId = (params.peerId ?? "").trim() || "unknown";
+  const peerId = channel === "matrix" ? rawPeerId : rawPeerId.toLowerCase();
   return `agent:${normalizeAgentId(params.agentId)}:${channel}:${peerKind}:${peerId}`;
 }
 
@@ -227,7 +231,8 @@ export function buildGroupHistoryKey(params: {
 }): string {
   const channel = normalizeToken(params.channel) || "unknown";
   const accountId = normalizeAccountId(params.accountId);
-  const peerId = params.peerId.trim().toLowerCase() || "unknown";
+  const rawPeerId = params.peerId.trim() || "unknown";
+  const peerId = channel === "matrix" ? rawPeerId : rawPeerId.toLowerCase();
   return `${channel}:${accountId}:${params.peerKind}:${peerId}`;
 }
 


### PR DESCRIPTION
## Summary

Matrix room IDs (e.g. `!IEjZDNPucuFvKLrAQC:server`) are **case-sensitive opaque identifiers** per the [Matrix spec](https://spec.matrix.org/v1.13/appendices/#room-ids). The `buildAgentPeerSessionKey()` function was calling `.toLowerCase()` on group/channel peer IDs, which destroyed the original case.

This caused a critical failure path:

1. Session key is built with lowercased room ID
2. Delivery queue entry stores the lowercased room ID as `"to"` target
3. On gateway restart, `delivery-recovery` retries the send using the lowercased room ID
4. Homeserver returns 403 (`M_FORBIDDEN: User not in room`)
5. The 403 crashes the Matrix sync loop permanently
6. The poisoned delivery persists across restarts, causing a crash loop

## Changes

- **`src/routing/session-key.ts`**: Remove `.toLowerCase()` from the group/channel peer ID path in `buildAgentPeerSessionKey()`. Direct/DM peer IDs still lowercase (Matrix user IDs are case-insensitive).
- **`src/routing/session-key.continuity.test.ts`**: Add tests verifying mixed-case room IDs are preserved in session keys.

## Testing

- All 59 existing + new session-key and delivery-recovery tests pass
- No existing tests relied on lowercased group/channel peer IDs

## Breaking change note

Existing Matrix group/channel session keys were lowercased. After this change, new sessions will use the original-case room ID, creating new session keys. Existing lowercased sessions will become orphaned. This is acceptable since group chat sessions are ephemeral and regularly compacted/reset.

Fixes #57321
Related: #19278, PR #31023