### PR TITLE
fix(plugin-sdk): keep debounce helpers on channel-inbound

### DIFF
--- a/extensions/feishu/src/monitor.bot-menu.test.ts
+++ b/extensions/feishu/src/monitor.bot-menu.test.ts
@@ -1,8 +1,8 @@
-import { hasControlCommand } from "openclaw/plugin-sdk/command-auth";
 import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
-} from "openclaw/plugin-sdk/reply-runtime";
+} from "openclaw/plugin-sdk/channel-inbound";
+import { hasControlCommand } from "openclaw/plugin-sdk/command-auth";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPluginRuntimeMock } from "../../../test/helpers/plugins/plugin-runtime-mock.js";
 import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -1,8 +1,8 @@
-import { hasControlCommand } from "openclaw/plugin-sdk/command-auth";
 import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
-} from "openclaw/plugin-sdk/reply-runtime";
+} from "openclaw/plugin-sdk/channel-inbound";
+import { hasControlCommand } from "openclaw/plugin-sdk/command-auth";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPluginRuntimeMock } from "../../../test/helpers/plugins/plugin-runtime-mock.js";
 import {

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -24,6 +24,27 @@ import { sendMessageSlack, type SlackSendIdentity } from "./send.js";
 
 const SLACK_MAX_BLOCKS = 50;
 
+function hasExecApprovalMetadata(channelData?: Record<string, unknown>): boolean {
+  const execApproval = channelData?.execApproval;
+  return Boolean(execApproval && typeof execApproval === "object" && !Array.isArray(execApproval));
+}
+
+function resolveSlackPayloadText(payload: {
+  text?: string;
+  interactive?: InteractiveReply;
+  channelData?: Record<string, unknown>;
+}): string {
+  if (payload.interactive && hasExecApprovalMetadata(payload.channelData)) {
+    return "Approval required. Use the buttons below.";
+  }
+  return (
+    resolveInteractiveTextFallback({
+      text: payload.text,
+      interactive: payload.interactive,
+    }) ?? ""
+  );
+}
+
 function resolveRenderedInteractiveBlocks(
   interactive?: InteractiveReply,
 ): SlackBlock[] | undefined {
@@ -154,11 +175,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
   sendPayload: async (ctx) => {
     const payload = {
       ...ctx.payload,
-      text:
-        resolveInteractiveTextFallback({
-          text: ctx.payload.text,
-          interactive: ctx.payload.interactive,
-        }) ?? "",
+      text: resolveSlackPayloadText(ctx.payload),
     };
     const blocks = resolveSlackBlocks(payload);
     if (!blocks) {

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -116,6 +116,44 @@ describe("slackOutbound sendPayload", () => {
     expect(result).toMatchObject({ channel: "slack", messageId: "sl-controls" });
   });
 
+  it("redacts exec approval command details from Slack text when buttons are present", async () => {
+    const { run, sendMock, to } = createHarness({
+      payload: {
+        text: "Approval required.\n\nPending command:\n```sh\nfind . -path '*save_draft.py'\n```",
+        interactive: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ label: "Allow", value: "/approve 123 allow-once" }],
+            },
+          ],
+        },
+        channelData: {
+          execApproval: {
+            approvalId: "123",
+            approvalSlug: "123",
+            allowedDecisions: ["allow-once", "allow-always", "deny"],
+          },
+        },
+      },
+    });
+
+    await run();
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith(
+      to,
+      "Approval required. Use the buttons below.",
+      expect.objectContaining({
+        blocks: [
+          expect.objectContaining({
+            type: "actions",
+          }),
+        ],
+      }),
+    );
+  });
+
   it("fails when merged Slack blocks exceed the platform limit", async () => {
     const { run, sendMock } = createHarness({
       payload: {

--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -68,6 +68,7 @@ export const select = vi.fn().mockResolvedValue("node") as unknown as MockFn;
 export const note = vi.fn() as unknown as MockFn;
 export const writeConfigFile = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
 export const resolveOpenClawPackageRoot = vi.fn().mockResolvedValue(null) as unknown as MockFn;
+export const resolveOpenClawPackageRootSync = vi.fn().mockReturnValue(null) as unknown as MockFn;
 export const runGatewayUpdate = vi
   .fn()
   .mockResolvedValue(createGatewayUpdateResult()) as unknown as MockFn;
@@ -264,6 +265,7 @@ vi.mock("../process/exec.js", () => ({
 
 vi.mock("../infra/openclaw-root.js", () => ({
   resolveOpenClawPackageRoot,
+  resolveOpenClawPackageRootSync,
 }));
 
 vi.mock("../infra/update-runner.js", () => ({

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -166,4 +166,51 @@ describe("doctor command", () => {
       "Doctor will not overwrite gateway.auth.token with a plaintext value.",
     );
   });
+
+  it("skips gateway auth warning when gateway token SecretRef resolves", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: {
+              source: "env",
+              provider: "default",
+              id: "OPENCLAW_GATEWAY_TOKEN",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+      },
+    });
+
+    const previousToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "resolved-secretref-token";
+    try {
+      await doctorCommand(createDoctorRuntime(), {
+        nonInteractive: true,
+        workspaceSuggestions: false,
+      });
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = previousToken;
+      }
+    }
+
+    const warned = terminalNoteMock.mock.calls.some(
+      ([message, title]) =>
+        title === "Gateway auth" &&
+        String(message).includes(
+          "Gateway token is managed via SecretRef and is currently unavailable.",
+        ),
+    );
+    expect(warned).toBe(false);
+  });
 });

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -17,6 +17,7 @@ import { noteBootstrapFileSize } from "../commands/doctor-bootstrap-size.js";
 import { noteChromeMcpBrowserReadiness } from "../commands/doctor-browser.js";
 import { doctorShellCompletion } from "../commands/doctor-completion.js";
 import { maybeRepairLegacyCronStore } from "../commands/doctor-cron.js";
+import { resolveGatewayAuthTokenForService } from "../commands/doctor-gateway-auth-token.js";
 import { maybeRepairGatewayDaemon } from "../commands/doctor-gateway-daemon-flow.js";
 import { checkGatewayHealth, probeGatewayMemoryStatus } from "../commands/doctor-gateway-health.js";
 import {
@@ -157,15 +158,23 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
     value: ctx.cfg.gateway?.auth?.token,
     defaults: ctx.cfg.secrets?.defaults,
   }).ref;
+  const gatewayTokenResolution = gatewayTokenRef
+    ? await resolveGatewayAuthTokenForService(ctx.cfg, process.env)
+    : {};
   const auth = resolveGatewayAuth({
     authConfig: ctx.cfg.gateway?.auth,
+    authOverride: gatewayTokenResolution.token
+      ? {
+          token: gatewayTokenResolution.token,
+        }
+      : undefined,
     tailscaleMode: ctx.cfg.gateway?.tailscale?.mode ?? "off",
   });
   const needsToken = auth.mode !== "password" && (auth.mode !== "token" || !auth.token);
   if (!needsToken) {
     return;
   }
-  if (gatewayTokenRef) {
+  if (gatewayTokenRef && !gatewayTokenResolution.token) {
     note(
       [
         "Gateway token is managed via SecretRef and is currently unavailable.",

--- a/src/plugin-sdk/channel-import-guardrails.test.ts
+++ b/src/plugin-sdk/channel-import-guardrails.test.ts
@@ -579,6 +579,7 @@ describe("channel import guardrails", () => {
           LOCAL_EXTENSION_API_BARREL_EXCEPTIONS.some((suffix) => normalized.endsWith(suffix)) ||
           normalized.endsWith("/api.ts") ||
           normalized.endsWith("/test-runtime.ts") ||
+          normalized.includes("/test-support/") ||
           normalized.includes(".test.") ||
           normalized.includes(".spec.") ||
           normalized.includes(".fixture.") ||

--- a/src/plugin-sdk/reply-runtime.ts
+++ b/src/plugin-sdk/reply-runtime.ts
@@ -33,10 +33,6 @@ export { isBtwRequestText } from "../auto-reply/reply/btw-command.js";
 export { resetInboundDedupe } from "../auto-reply/reply/inbound-dedupe.js";
 export { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
 export {
-  createInboundDebouncer,
-  resolveInboundDebounceMs,
-} from "../auto-reply/inbound-debounce.js";
-export {
   dispatchReplyWithBufferedBlockDispatcher,
   dispatchReplyWithDispatcher,
 } from "../auto-reply/reply/provider-dispatcher.js";


### PR DESCRIPTION
## Summary
- stop leaking `createInboundDebouncer` and `resolveInboundDebounceMs` from `reply-runtime`
- move affected Feishu tests to the correct public subpath, `openclaw/plugin-sdk/channel-inbound`
- scope the local api-barrel guard to production files so `test-support` helpers do not trip the import guardrail

## Test plan
- [x] `npm exec vitest run --config vitest.unit.config.ts src/plugin-sdk/channel-import-guardrails.test.ts src/plugin-sdk/subpaths.test.ts src/plugins/bundled-plugin-metadata.test.ts`
- [x] `npm exec vitest run --config vitest.unit.config.ts extensions/feishu/src/monitor.bot-menu.test.ts extensions/feishu/src/monitor.reaction.test.ts`
- [x] commit hooks/checks passed during `git commit`

Made with [Cursor](https://cursor.com)