### PR TITLE
CLI: keep sessions --json stdout parseable

### DIFF
--- a/src/cli/route.test.ts
+++ b/src/cli/route.test.ts
@@ -103,6 +103,32 @@ describe("tryRouteCli", () => {
     expect(loggingState.forceConsoleToStderr).toBe(false);
   });
 
+  it("keeps routed sessions --json diagnostics off stdout for the full command run", async () => {
+    findRoutedCommandMock.mockReturnValue({
+      loadPlugins: false,
+      run: vi.fn(async () => {
+        expect(loggingState.forceConsoleToStderr).toBe(true);
+        return true;
+      }),
+    });
+
+    await expect(tryRouteCli(["node", "openclaw", "sessions", "--json"])).resolves.toBe(true);
+    expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+
+  it("leaves routed sessions diagnostics on their normal streams without --json", async () => {
+    findRoutedCommandMock.mockReturnValue({
+      loadPlugins: false,
+      run: vi.fn(async () => {
+        expect(loggingState.forceConsoleToStderr).toBe(false);
+        return true;
+      }),
+    });
+
+    await expect(tryRouteCli(["node", "openclaw", "sessions"])).resolves.toBe(true);
+    expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+
   it("does not route logs to stderr during plugin loading without --json", async () => {
     findRoutedCommandMock.mockReturnValue({
       loadPlugins: true,

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -63,6 +63,14 @@ export async function tryRouteCli(argv: string[]): Promise<boolean> {
   if (!route) {
     return false;
   }
-  await prepareRoutedCommand({ argv, commandPath: path, loadPlugins: route.loadPlugins });
-  return route.run(argv);
+  const prevForceConsoleToStderr = loggingState.forceConsoleToStderr;
+  if (hasFlag(argv, "--json")) {
+    loggingState.forceConsoleToStderr = true;
+  }
+  try {
+    await prepareRoutedCommand({ argv, commandPath: path, loadPlugins: route.loadPlugins });
+    return route.run(argv);
+  } finally {
+    loggingState.forceConsoleToStderr = prevForceConsoleToStderr;
+  }
 }

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -6,6 +6,7 @@ const loadDotEnvMock = vi.hoisted(() => vi.fn());
 const normalizeEnvMock = vi.hoisted(() => vi.fn());
 const ensurePathMock = vi.hoisted(() => vi.fn());
 const assertRuntimeMock = vi.hoisted(() => vi.fn());
+const enableConsoleCaptureMock = vi.hoisted(() => vi.fn());
 const closeActiveMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {}));
 const hasMemoryRuntimeMock = vi.hoisted(() => vi.fn(() => false));
 const ensureTaskRegistryReadyMock = vi.hoisted(() => vi.fn());
@@ -41,6 +42,10 @@ vi.mock("../infra/path-env.js", () => ({
 
 vi.mock("../infra/runtime-guard.js", () => ({
   assertSupportedRuntime: assertRuntimeMock,
+}));
+
+vi.mock("../logging.js", () => ({
+  enableConsoleCapture: enableConsoleCaptureMock,
 }));
 
 vi.mock("../plugins/memory-runtime.js", () => ({
@@ -84,6 +89,9 @@ describe("runCli exit behavior", () => {
     await runCli(["node", "openclaw", "status"]);
 
     expect(maybeRunCliInContainerMock).toHaveBeenCalledWith(["node", "openclaw", "status"]);
+    expect(enableConsoleCaptureMock.mock.invocationCallOrder[0]).toBeLessThan(
+      tryRouteCliMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
     expect(tryRouteCliMock).toHaveBeenCalledWith(["node", "openclaw", "status"]);
     expect(closeActiveMemorySearchManagersMock).not.toHaveBeenCalled();
     expect(ensureTaskRegistryReadyMock).not.toHaveBeenCalled();

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -164,12 +164,13 @@ export async function runCli(argv: string[] = process.argv) {
       return;
     }
 
+    // Routed commands can still trigger config/plugin diagnostics. Capture
+    // console output before the fast path so JSON stdout routing works there too.
+    enableConsoleCapture();
+
     if (await tryRouteCli(normalizedArgv)) {
       return;
     }
-
-    // Capture all console output into structured logs while keeping stdout/stderr behavior.
-    enableConsoleCapture();
 
     const { buildProgram } = await import("./program.js");
     const program = buildProgram();


### PR DESCRIPTION
Problem: openclaw sessions --json can print plugin diagnostics to stdout after the JSON payload, breaking JSON.parse().\n\nFix: when routing commands, if argv includes --json, temporarily set loggingState.forceConsoleToStderr=true for the duration of the routed command and restore afterwards. Also enable console capture before the fast routed path in runCli().\n\nTests: added unit coverage for the json flag routing + ordering in run-main.\n\nNote: local pnpm test in this environment is unreliable (vitest SIGTERM infra failures); CI should validate.