### PR TITLE
fix(msteams): delete FileConsentCard after user accepts, declines, or upload expires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: invalidate cached assembled context views when source history shrinks or assembly fails, preventing stale pre-reset history from being reused. Fixes #77968. (#78163) Thanks @brokemac79 and @ChrisBot2026.
 - Plugin SDK: add a generic `api.runtime.llm.complete` host completion helper with runtime-derived caller attribution, config-gated model/agent overrides, session-bound context-engine access, request-scoped config, audit metadata, and normalized usage attribution. (#64294) Thanks @DaevMithran.
 - Control UI/exec approvals: highlight parsed shell command fragments that may deserve extra review in approval prompts. (#77153) Thanks @jesse-merhi.
+- MS Teams: clean up stale FileConsentCard prompts after file upload accept, decline, expiry, mismatch, or upload failure paths while preserving successful FileInfoCard replacement. (#57364) Thanks @HangGlidersRule.
 
 ### Breaking
 

--- a/extensions/msteams/src/file-consent-invoke.ts
+++ b/extensions/msteams/src/file-consent-invoke.ts
@@ -45,6 +45,24 @@ async function handleMSTeamsFileConsentInvoke(
         consentCardActivityId?: string;
       }
     | undefined = inMemoryFile ?? fsFile;
+  const replyToActivityId = typeof activity.replyToId === "string" ? activity.replyToId : undefined;
+
+  async function tryDeleteConsentCard(reason: string, activityId?: string): Promise<void> {
+    if (!activityId) {
+      return;
+    }
+    try {
+      await context.deleteActivity(activityId);
+      log.debug?.("deleted file consent card", { activityId, reason });
+    } catch (err) {
+      log.debug?.("failed to delete file consent card", {
+        activityId,
+        reason,
+        error: formatUnknownError(err),
+      });
+    }
+  }
+
   if (pendingFile) {
     const pendingConversationId = normalizeMSTeamsConversationId(pendingFile.conversationId);
     const invokeConversationId = normalizeMSTeamsConversationId(activity.conversation?.id ?? "");
@@ -57,6 +75,7 @@ async function handleMSTeamsFileConsentInvoke(
       if (consentResponse.action === "accept") {
         await context.sendActivity(expiredUploadMessage);
       }
+      await tryDeleteConsentCard("conversation-mismatch", replyToActivityId);
       return true;
     }
   }
@@ -102,7 +121,13 @@ async function handleMSTeamsFileConsentInvoke(
               type: "message",
               attachments: [fileInfoCard],
             });
+            await tryDeleteConsentCard(
+              "upload-success-update-failed",
+              pendingFile.consentCardActivityId,
+            );
           }
+        } else {
+          await tryDeleteConsentCard("upload-success", replyToActivityId);
         }
 
         log.info("file upload complete", {
@@ -112,6 +137,10 @@ async function handleMSTeamsFileConsentInvoke(
         });
       } catch (err) {
         log.error("file upload failed", { uploadId, error: formatUnknownError(err) });
+        await tryDeleteConsentCard(
+          "upload-failed",
+          pendingFile.consentCardActivityId ?? replyToActivityId,
+        );
         await context.sendActivity("File upload failed. Please try again.");
       } finally {
         removePendingUpload(uploadId);
@@ -119,10 +148,15 @@ async function handleMSTeamsFileConsentInvoke(
       }
     } else {
       log.debug?.("pending file not found for consent", { uploadId });
+      await tryDeleteConsentCard("expired-pending-not-found", replyToActivityId);
       await context.sendActivity(expiredUploadMessage);
     }
   } else {
     log.debug?.("user declined file consent", { uploadId });
+    await tryDeleteConsentCard(
+      "user-declined",
+      pendingFile?.consentCardActivityId ?? replyToActivityId,
+    );
     removePendingUpload(uploadId);
     await removePendingUploadFs(uploadId);
   }

--- a/extensions/msteams/src/monitor-handler.file-consent.test.ts
+++ b/extensions/msteams/src/monitor-handler.file-consent.test.ts
@@ -66,13 +66,16 @@ function createInvokeContext(params: {
   conversationId: string;
   uploadId: string;
   action: "accept" | "decline";
+  replyToId?: string;
 }): {
   context: MSTeamsTurnContext;
   sendActivity: ReturnType<typeof vi.fn>;
   updateActivity: ReturnType<typeof vi.fn>;
+  deleteActivity: ReturnType<typeof vi.fn>;
 } {
   const sendActivity = vi.fn(async () => ({ id: "activity-id" }));
   const updateActivity = vi.fn(async () => ({ id: "activity-id" }));
+  const deleteActivity = vi.fn(async () => {});
   const uploadInfo =
     params.action === "accept"
       ? {
@@ -89,6 +92,7 @@ function createInvokeContext(params: {
         type: "invoke",
         name: "fileConsent/invoke",
         conversation: { id: params.conversationId },
+        replyToId: params.replyToId,
         value: {
           type: "fileUpload",
           action: params.action,
@@ -99,9 +103,11 @@ function createInvokeContext(params: {
       sendActivity,
       sendActivities: async () => [],
       updateActivity,
+      deleteActivity,
     } as unknown as MSTeamsTurnContext,
     sendActivity,
     updateActivity,
+    deleteActivity,
   };
 }
 
@@ -110,6 +116,7 @@ function createConsentInvokeHarness(params: {
   invokeConversationId: string;
   action: "accept" | "decline";
   consentCardActivityId?: string;
+  replyToId?: string;
 }) {
   const uploadId = storePendingUpload({
     buffer: Buffer.from("TOP_SECRET_VICTIM_FILE\n"),
@@ -118,12 +125,13 @@ function createConsentInvokeHarness(params: {
     conversationId: params.pendingConversationId ?? "19:victim@thread.v2",
     consentCardActivityId: params.consentCardActivityId,
   });
-  const { context, sendActivity, updateActivity } = createInvokeContext({
+  const { context, sendActivity, updateActivity, deleteActivity } = createInvokeContext({
     conversationId: params.invokeConversationId,
     uploadId,
     action: params.action,
+    replyToId: params.replyToId,
   });
-  return { uploadId, context, sendActivity, updateActivity };
+  return { uploadId, context, sendActivity, updateActivity, deleteActivity };
 }
 
 function requirePendingUpload(uploadId: string) {
@@ -236,8 +244,21 @@ describe("msteams file consent invoke authz", () => {
     expect(updateActivity).not.toHaveBeenCalled();
   });
 
+  it("deletes the replied-to consent card after successful upload when no stored card id exists", async () => {
+    const { context, deleteActivity } = createConsentInvokeHarness({
+      invokeConversationId: "19:victim@thread.v2;messageid=abc123",
+      action: "accept",
+      replyToId: "reply-to-consent-card",
+    });
+
+    await respondToMSTeamsFileConsentInvoke(context, log);
+
+    expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledTimes(1);
+    expect(deleteActivity).toHaveBeenCalledWith("reply-to-consent-card");
+  });
+
   it("still completes upload if updateActivity throws", async () => {
-    const { uploadId, context, updateActivity } = createConsentInvokeHarness({
+    const { uploadId, context, updateActivity, deleteActivity } = createConsentInvokeHarness({
       invokeConversationId: "19:victim@thread.v2;messageid=abc123",
       action: "accept",
       consentCardActivityId: "consent-card-activity-id-fail",
@@ -250,12 +271,28 @@ describe("msteams file consent invoke authz", () => {
     expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledTimes(1);
     expect(getPendingUpload(uploadId)).toBeUndefined();
     expect(updateActivity).toHaveBeenCalledTimes(1);
+    expect(deleteActivity).toHaveBeenCalledWith("consent-card-activity-id-fail");
+  });
+
+  it("deletes the consent card when upload fails", async () => {
+    fileConsentMockState.uploadToConsentUrl.mockRejectedValueOnce(new Error("upload failed"));
+    const { context, sendActivity, deleteActivity } = createConsentInvokeHarness({
+      invokeConversationId: "19:victim@thread.v2;messageid=abc123",
+      action: "accept",
+      consentCardActivityId: "consent-card-upload-failed",
+    });
+
+    await respondToMSTeamsFileConsentInvoke(context, log);
+
+    expect(deleteActivity).toHaveBeenCalledWith("consent-card-upload-failed");
+    expect(sendActivity).toHaveBeenCalledWith("File upload failed. Please try again.");
   });
 
   it("rejects cross-conversation accept invoke and keeps pending upload", async () => {
-    const { uploadId, context, sendActivity } = createConsentInvokeHarness({
+    const { uploadId, context, sendActivity, deleteActivity } = createConsentInvokeHarness({
       invokeConversationId: "19:attacker@thread.v2",
       action: "accept",
+      replyToId: "mismatched-consent-card",
     });
 
     await respondToMSTeamsFileConsentInvoke(context, log);
@@ -272,6 +309,7 @@ describe("msteams file consent invoke authz", () => {
     );
 
     expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
+    expect(deleteActivity).toHaveBeenCalledWith("mismatched-consent-card");
     expect(requirePendingUpload(uploadId)).toMatchObject({
       conversationId: "19:victim@thread.v2",
       filename: "secret.txt",
@@ -280,9 +318,10 @@ describe("msteams file consent invoke authz", () => {
   });
 
   it("ignores cross-conversation decline invoke and keeps pending upload", async () => {
-    const { uploadId, context, sendActivity } = createConsentInvokeHarness({
+    const { uploadId, context, sendActivity, deleteActivity } = createConsentInvokeHarness({
       invokeConversationId: "19:attacker@thread.v2",
       action: "decline",
+      replyToId: "mismatched-decline-consent-card",
     });
 
     await respondToMSTeamsFileConsentInvoke(context, log);
@@ -295,12 +334,56 @@ describe("msteams file consent invoke authz", () => {
     );
 
     expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
+    expect(deleteActivity).toHaveBeenCalledWith("mismatched-decline-consent-card");
     expect(requirePendingUpload(uploadId)).toMatchObject({
       conversationId: "19:victim@thread.v2",
       filename: "secret.txt",
       contentType: "text/plain",
     });
     expect(sendActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes the consent card when the pending upload has expired", async () => {
+    const { context, sendActivity, deleteActivity } = createInvokeContext({
+      conversationId: "19:victim@thread.v2;messageid=abc123",
+      uploadId: "missing-upload-id",
+      action: "accept",
+      replyToId: "expired-consent-card",
+    });
+
+    await respondToMSTeamsFileConsentInvoke(context, log);
+
+    expect(deleteActivity).toHaveBeenCalledWith("expired-consent-card");
+    expect(sendActivity).toHaveBeenCalledWith(
+      "The file upload request has expired. Please try sending the file again.",
+    );
+  });
+
+  it("deletes the consent card when the user declines", async () => {
+    const { context, deleteActivity } = createConsentInvokeHarness({
+      invokeConversationId: "19:victim@thread.v2;messageid=abc123",
+      action: "decline",
+      consentCardActivityId: "declined-consent-card",
+    });
+
+    await respondToMSTeamsFileConsentInvoke(context, log);
+
+    expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
+    expect(deleteActivity).toHaveBeenCalledWith("declined-consent-card");
+  });
+
+  it("continues when consent card deletion fails", async () => {
+    const { uploadId, context, deleteActivity } = createConsentInvokeHarness({
+      invokeConversationId: "19:victim@thread.v2;messageid=abc123",
+      action: "decline",
+      consentCardActivityId: "delete-fails-consent-card",
+    });
+    deleteActivity.mockRejectedValueOnce(new Error("delete failed"));
+
+    await respondToMSTeamsFileConsentInvoke(context, log);
+
+    expect(deleteActivity).toHaveBeenCalledWith("delete-fails-consent-card");
+    expect(getPendingUpload(uploadId)).toBeUndefined();
   });
 });
 
@@ -349,6 +432,7 @@ describe("msteams file consent invoke FS fallback", () => {
 
     const sendActivity = vi.fn(async () => ({ id: "activity-id" }));
     const updateActivity = vi.fn(async () => ({ id: "activity-id" }));
+    const deleteActivity = vi.fn(async () => {});
     const context = {
       activity: {
         type: "invoke",
@@ -370,6 +454,7 @@ describe("msteams file consent invoke FS fallback", () => {
       sendActivity,
       sendActivities: async () => [],
       updateActivity,
+      deleteActivity,
     } as unknown as MSTeamsTurnContext;
 
     await respondToMSTeamsFileConsentInvoke(context, log);
@@ -399,6 +484,7 @@ describe("msteams file consent invoke FS fallback", () => {
 
     const sendActivity = vi.fn(async () => ({ id: "activity-id" }));
     const updateActivity = vi.fn(async () => ({ id: "activity-id" }));
+    const deleteActivity = vi.fn(async () => {});
     const context = {
       activity: {
         type: "invoke",
@@ -413,6 +499,7 @@ describe("msteams file consent invoke FS fallback", () => {
       sendActivity,
       sendActivities: async () => [],
       updateActivity,
+      deleteActivity,
     } as unknown as MSTeamsTurnContext;
 
     await respondToMSTeamsFileConsentInvoke(context, log);


### PR DESCRIPTION
## Problem

The `FileConsentCard` (Allow/Decline prompt for file uploads) remains in the Teams chat after the user acts on it, cluttering the conversation with stale interactive cards. Users see orphaned Allow/Decline buttons even after files have been successfully uploaded or the upload has expired.

## Solution

Call `context.deleteActivity(activity.replyToId)` to remove the original consent card after processing. The invoke activity from Bot Framework includes the consent card's activity ID in `replyToId`.

Deletion is applied on all four code paths in `handleFileConsentInvoke`:

| Path | Before | After |
|------|--------|-------|
| User accepts, upload succeeds | Consent card remains | Deleted, only FileInfoCard shown |
| User declines | Consent card remains | Deleted |
| Pending upload expired (not found) | Consent card remains, expired message sent | Deleted, expired message sent |
| Conversation mismatch (security) | Consent card remains | Deleted |

Implemented as a best-effort `tryDeleteConsentCard()` helper — if deletion fails (e.g. permissions, timing), the upload flow continues normally with a debug log.

Per [Microsoft docs](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4):
> *Optionally, remove the original consent card if you do not want the user to accept further uploads of the same file.*

## Testing

- Added 4 new tests covering consent card deletion on all paths
- Updated existing test harness to include `deleteActivity` mock and `replyToId` field
- Verified in production Teams environment (NemoClaw deployment)

## AI Disclosure

This PR was developed with AI assistance (Clawdbot on OpenClaw). The bug was identified during real-world testing of file uploads in a Teams bot deployment.