### PR TITLE
fix(msteams): extract emoji unicode from Teams CDN img tags instead of treating as image attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- MS Teams: render Teams CDN emoji image tags as their Unicode alt text instead of reporting emoji sprites as image attachments to the agent. (#57366) Thanks @HangGlidersRule.
 - Cron/agents: recognize same-target `edit`↔`write` recovery in `isSameToolMutationAction`, so a successful `write` to a path clears an earlier failed `edit` on the same path. Stops cron from reporting fatal failures when an agent self-heals across `edit` and `write`, while preserving same-tool fingerprint matching, blocking different-target writes, and excluding tools (including `apply_patch`) whose real call args do not produce a stable `path` fingerprint segment. Fixes #79024. Thanks @RenzoMXD.
 - Gateway/Tailscale: add opt-in `gateway.tailscale.preserveFunnel` so when `tailscale.mode = "serve"` and an externally configured Tailscale Funnel route already covers the gateway port, OpenClaw skips re-applying `tailscale serve` on startup and skips the `resetOnExit` teardown for that run, keeping operator-managed Funnel exposure alive across gateway restarts. Fixes #57241. Thanks @RenzoMXD.
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.

--- a/extensions/msteams/src/attachments/html.test.ts
+++ b/extensions/msteams/src/attachments/html.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMSTeamsAttachmentPlaceholder,
+  extractTeamsEmojiText,
+} from "./html.js";
+import type { MSTeamsAttachmentLike } from "./types.js";
+
+function htmlAttachment(html: string): MSTeamsAttachmentLike {
+  return {
+    contentType: "text/html",
+    content: html,
+  };
+}
+
+describe("extractTeamsEmojiText", () => {
+  it("extracts emoji from Teams CDN img tags", () => {
+    const result = extractTeamsEmojiText([
+      htmlAttachment(
+        '<img src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/wave/default/30_f.png" alt="👋">',
+      ),
+    ]);
+    expect(result).toBe("👋");
+  });
+
+  it("extracts multiple emoji from a single attachment", () => {
+    const result = extractTeamsEmojiText([
+      htmlAttachment(
+        '<img src="https://statics.teams.cdn.office.net/emoji/v1/thumbsup.png" alt="👍">' +
+          '<img src="https://statics.teams.cdn.office.net/emoji/v1/fire.png" alt="🔥">',
+      ),
+    ]);
+    expect(result).toBe("👍🔥");
+  });
+
+  it("returns null for non-emoji images", () => {
+    const result = extractTeamsEmojiText([
+      htmlAttachment(
+        '<img src="https://graph.microsoft.com/v1.0/users/photo" alt="profile photo">',
+      ),
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for mixed emoji and non-emoji", () => {
+    const result = extractTeamsEmojiText([
+      htmlAttachment(
+        '<img src="https://statics.teams.cdn.office.net/emoji/v1/wave.png" alt="👋">' +
+          '<img src="https://example.com/screenshot.png" alt="screenshot">',
+      ),
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty attachments", () => {
+    expect(extractTeamsEmojiText([])).toBeNull();
+    expect(extractTeamsEmojiText(undefined)).toBeNull();
+  });
+
+  it("returns null when CDN hostname appears in query param but host is different", () => {
+    const result = extractTeamsEmojiText([
+      htmlAttachment(
+        '<img src="https://evil.example.com/redirect?ref=statics.teams.cdn.office.net/emoji.png" alt="👋">',
+      ),
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when non-HTML attachments are present alongside emoji", () => {
+    const result = extractTeamsEmojiText([
+      htmlAttachment(
+        '<img src="https://statics.teams.cdn.office.net/emoji/v1/wave.png" alt="👋">',
+      ),
+      // Non-HTML attachment (e.g. a real image file)
+      { contentType: "image/jpeg", content: null } as unknown as MSTeamsAttachmentLike,
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for img tag with alt but no src", () => {
+    const result = extractTeamsEmojiText([
+      htmlAttachment('<img alt="sneaky text">'),
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for img tag with non-CDN src", () => {
+    const result = extractTeamsEmojiText([
+      htmlAttachment(
+        '<img src="https://example.com/image.png" alt="not emoji">',
+      ),
+    ]);
+    expect(result).toBeNull();
+  });
+});
+
+describe("buildMSTeamsAttachmentPlaceholder with emoji", () => {
+  it("returns emoji text instead of <media:image> for emoji attachments", () => {
+    const result = buildMSTeamsAttachmentPlaceholder([
+      htmlAttachment(
+        '<img src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/wave/default/30_f.png" alt="👋">',
+      ),
+    ]);
+    expect(result).toBe("👋");
+    expect(result).not.toContain("media:image");
+  });
+});

--- a/extensions/msteams/src/attachments/html.ts
+++ b/extensions/msteams/src/attachments/html.ts
@@ -103,6 +103,69 @@ export function summarizeMSTeamsHtmlAttachments(
   };
 }
 
+const TEAMS_EMOJI_CDN_HOST = "statics.teams.cdn.office.net";
+
+function isTeamsEmojiCdnUrl(src: string): boolean {
+  const host = safeHostForUrl(src);
+  return host === TEAMS_EMOJI_CDN_HOST;
+}
+
+const IMG_TAG_RE = /<img\s+([^>]*)>/gi;
+const SRC_ATTR_RE = /\bsrc=["']([^"']+)["']/i;
+const ALT_ATTR_RE = /\balt=["']([^"']+)["']/i;
+
+/**
+ * Extract emoji unicode characters from Teams HTML attachments that contain
+ * only emoji CDN image references. Returns the emoji text if all img tags
+ * in the attachment are from the Teams emoji CDN, or null otherwise.
+ *
+ * Bails out immediately if any non-HTML attachment exists in the list (e.g.
+ * a real image/jpeg file), since that means this is not a pure-emoji message.
+ *
+ * Uses a single-pass regex to evaluate each <img> tag's src and alt atomically,
+ * preventing divergence between separate src/alt loops.
+ */
+export function extractTeamsEmojiText(
+  attachments: MSTeamsAttachmentLike[] | undefined,
+): string | null {
+  const list = Array.isArray(attachments) ? attachments : [];
+  if (list.length === 0) {
+    return null;
+  }
+
+  const emojiChars: string[] = [];
+
+  for (const att of list) {
+    const html = extractHtmlFromAttachment(att);
+    if (!html) {
+      // A non-HTML attachment means this is not a pure emoji message.
+      return null;
+    }
+
+    IMG_TAG_RE.lastIndex = 0;
+    let tagMatch: RegExpExecArray | null = IMG_TAG_RE.exec(html);
+    while (tagMatch) {
+      const attrs = tagMatch[1] ?? "";
+      const srcMatch = SRC_ATTR_RE.exec(attrs);
+      const altMatch = ALT_ATTR_RE.exec(attrs);
+      const src = srcMatch?.[1]?.trim();
+
+      if (!src || !isTeamsEmojiCdnUrl(src)) {
+        return null;
+      }
+
+      const alt = altMatch?.[1]?.trim();
+      if (alt) {
+        emojiChars.push(alt);
+      }
+
+      tagMatch = IMG_TAG_RE.exec(html);
+    }
+  }
+
+  return emojiChars.length > 0 ? emojiChars.join("") : null;
+}
+
 export function buildMSTeamsAttachmentPlaceholder(
   attachments: MSTeamsAttachmentLike[] | undefined,
   limits?: { maxInlineBytes?: number; maxInlineTotalBytes?: number },
@@ -111,6 +174,13 @@ export function buildMSTeamsAttachmentPlaceholder(
   if (list.length === 0) {
     return "";
   }
+
+  // Teams emoji sprites should read as text, not as user-sent images.
+  const emojiText = extractTeamsEmojiText(list);
+  if (emojiText) {
+    return emojiText;
+  }
+
   const imageCount = list.filter(isLikelyImageAttachment).length;
   const inlineCount = extractInlineImageCandidates(list, limits).length;
   const totalImages = imageCount + inlineCount;


### PR DESCRIPTION
## Problem

When a Teams user sends an emoji (e.g. 👋), the Teams client wraps it as an HTML `<img>` tag pointing to `statics.teams.cdn.office.net` with the unicode character in the `alt` attribute:

```html
<img src="https://statics.teams.cdn.office.net/.../wave/default/30_f.png" alt="👋">
```

The gateway downloads these ~1KB sprite images as media attachments, and `buildMSTeamsAttachmentPlaceholder()` reports them as `<media:image> (2 images)` to the LLM. This causes the model to hallucinate about screenshots or image attachments the user never sent.

## Solution

- Added `extractTeamsEmojiText()` — detects when all `<img>` tags in HTML attachments are from the Teams emoji CDN (`statics.teams.cdn.office.net`) and extracts the unicode characters from their `alt` attributes
- Updated `buildMSTeamsAttachmentPlaceholder()` to call `extractTeamsEmojiText()` first — if the attachments are pure emoji, returns the unicode text (e.g. `👋`) instead of `<media:image>`
- Mixed content (emoji + real images) correctly falls through to the existing image/document placeholder logic

## Testing

Added tests covering:
- Single emoji extraction
- Multiple emoji in one attachment
- Non-emoji images (returns null, falls through)
- Mixed emoji + real images (returns null, falls through)
- Empty/undefined attachments

## AI Disclosure

This PR was developed with AI assistance (Clawdbot on OpenClaw). The bug was identified during real-world testing — an LLM told a user "I can see you sent two screenshots" when the user had only typed 👋.