### PR TITLE
fix(auth-profiles): reconcile provider keys from config on reload

### DIFF
--- a/src/agents/auth-profiles.reconcile-config-provider-keys.test.ts
+++ b/src/agents/auth-profiles.reconcile-config-provider-keys.test.ts
@@ -1,0 +1,233 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import type { AuthProfileStore } from "./auth-profiles/types.js";
+
+const mocks = vi.hoisted(() => ({
+  syncExternalCliCredentials: vi.fn((_: AuthProfileStore) => false),
+}));
+
+vi.mock("./auth-profiles/external-cli-sync.js", () => ({
+  syncExternalCliCredentials: mocks.syncExternalCliCredentials,
+}));
+
+let reconcileConfigProviderKeys: typeof import("./auth-profiles.js").reconcileConfigProviderKeys;
+let clearRuntimeAuthProfileStoreSnapshots: typeof import("./auth-profiles.js").clearRuntimeAuthProfileStoreSnapshots;
+
+async function loadFreshModule() {
+  vi.resetModules();
+  ({ reconcileConfigProviderKeys, clearRuntimeAuthProfileStoreSnapshots } =
+    await import("./auth-profiles.js"));
+}
+
+function makeTempAgentDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeAuthStore(agentDir: string, store: AuthProfileStore): void {
+  const authPath = path.join(agentDir, "auth-profiles.json");
+  fs.writeFileSync(authPath, `${JSON.stringify(store, null, 2)}\n`, "utf8");
+}
+
+function readAuthStore(agentDir: string): AuthProfileStore {
+  const authPath = path.join(agentDir, "auth-profiles.json");
+  return JSON.parse(fs.readFileSync(authPath, "utf8")) as AuthProfileStore;
+}
+
+function buildStore(profiles: AuthProfileStore["profiles"]): AuthProfileStore {
+  return { version: AUTH_STORE_VERSION, profiles };
+}
+
+describe("reconcileConfigProviderKeys", () => {
+  let agentDir: string;
+
+  beforeEach(async () => {
+    await loadFreshModule();
+    agentDir = makeTempAgentDir("openclaw-reconcile-");
+  });
+
+  afterEach(() => {
+    clearRuntimeAuthProfileStoreSnapshots();
+    vi.clearAllMocks();
+    fs.rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it("updates stale api_key profile when config apiKey differs", () => {
+    const store = buildStore({
+      "anthropic:default": {
+        type: "api_key",
+        provider: "anthropic",
+        key: "sk-old-key",
+      },
+    });
+    writeAuthStore(agentDir, store);
+
+    const result = reconcileConfigProviderKeys({
+      configProviders: { anthropic: { apiKey: "sk-new-key" } },
+      authStores: [{ agentDir, store }],
+    });
+
+    expect(result).toBe(true);
+    const saved = readAuthStore(agentDir);
+    expect(saved.profiles["anthropic:default"]).toMatchObject({
+      type: "api_key",
+      provider: "anthropic",
+      key: "sk-new-key",
+    });
+  });
+
+  it("does not update when config apiKey matches profile key", () => {
+    const store = buildStore({
+      "openai:default": {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-same-key",
+      },
+    });
+    writeAuthStore(agentDir, store);
+    const mtimeBefore = fs.statSync(path.join(agentDir, "auth-profiles.json")).mtimeMs;
+
+    const result = reconcileConfigProviderKeys({
+      configProviders: { openai: { apiKey: "sk-same-key" } },
+      authStores: [{ agentDir, store }],
+    });
+
+    expect(result).toBe(false);
+    const mtimeAfter = fs.statSync(path.join(agentDir, "auth-profiles.json")).mtimeMs;
+    expect(mtimeAfter).toBe(mtimeBefore);
+  });
+
+  it("skips profiles backed by keyRef", () => {
+    const store = buildStore({
+      "anthropic:default": {
+        type: "api_key",
+        provider: "anthropic",
+        key: "resolved-value",
+        keyRef: { source: "env", provider: "default", id: "ANTHROPIC_API_KEY" },
+      },
+    });
+    writeAuthStore(agentDir, store);
+
+    const result = reconcileConfigProviderKeys({
+      configProviders: { anthropic: { apiKey: "different-value" } },
+      authStores: [{ agentDir, store }],
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("skips non-api_key profile types", () => {
+    const store = buildStore({
+      "github-copilot:default": {
+        type: "oauth",
+        provider: "github-copilot",
+        access: "gho_test",
+        refresh: "ghr_test",
+        expires: Date.now() + 3600_000,
+      },
+    });
+    writeAuthStore(agentDir, store);
+
+    const result = reconcileConfigProviderKeys({
+      configProviders: { "github-copilot": { apiKey: "some-key" } },
+      authStores: [{ agentDir, store }],
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("skips providers with no apiKey in config", () => {
+    const store = buildStore({
+      "ollama:default": {
+        type: "api_key",
+        provider: "ollama",
+        key: "old-key",
+      },
+    });
+    writeAuthStore(agentDir, store);
+
+    const result = reconcileConfigProviderKeys({
+      configProviders: { ollama: {} },
+      authStores: [{ agentDir, store }],
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("reconciles across multiple agent dirs", () => {
+    const agentDir2 = makeTempAgentDir("openclaw-reconcile-2-");
+    try {
+      const store1 = buildStore({
+        "anthropic:default": { type: "api_key", provider: "anthropic", key: "old-1" },
+      });
+      const store2 = buildStore({
+        "anthropic:default": { type: "api_key", provider: "anthropic", key: "old-2" },
+      });
+      writeAuthStore(agentDir, store1);
+      writeAuthStore(agentDir2, store2);
+
+      const result = reconcileConfigProviderKeys({
+        configProviders: { anthropic: { apiKey: "new-key" } },
+        authStores: [
+          { agentDir, store: store1 },
+          { agentDir: agentDir2, store: store2 },
+        ],
+      });
+
+      expect(result).toBe(true);
+      expect(readAuthStore(agentDir).profiles["anthropic:default"]).toMatchObject({
+        key: "new-key",
+      });
+      expect(readAuthStore(agentDir2).profiles["anthropic:default"]).toMatchObject({
+        key: "new-key",
+      });
+    } finally {
+      fs.rmSync(agentDir2, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves usageStats and order when reconciling", () => {
+    const store = buildStore({
+      "anthropic:default": { type: "api_key", provider: "anthropic", key: "old-key" },
+    });
+    store.usageStats = {
+      "anthropic:default": { lastUsed: 1000, errorCount: 2 },
+    };
+    store.order = { anthropic: ["anthropic:default"] };
+    writeAuthStore(agentDir, store);
+
+    reconcileConfigProviderKeys({
+      configProviders: { anthropic: { apiKey: "new-key" } },
+      authStores: [{ agentDir, store }],
+    });
+
+    const saved = readAuthStore(agentDir);
+    expect(saved.profiles["anthropic:default"]).toMatchObject({ key: "new-key" });
+    expect(saved.usageStats?.["anthropic:default"]).toMatchObject({
+      lastUsed: 1000,
+      errorCount: 2,
+    });
+    expect(saved.order?.anthropic).toEqual(["anthropic:default"]);
+  });
+
+  it("returns false for empty configProviders", () => {
+    const store = buildStore({
+      "openai:default": { type: "api_key", provider: "openai", key: "key" },
+    });
+    const result = reconcileConfigProviderKeys({
+      configProviders: {},
+      authStores: [{ agentDir, store }],
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns false for empty authStores", () => {
+    const result = reconcileConfigProviderKeys({
+      configProviders: { anthropic: { apiKey: "key" } },
+      authStores: [],
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -26,6 +26,7 @@ export {
   ensureAuthProfileStore,
   loadAuthProfileStoreForSecretsRuntime,
   loadAuthProfileStoreForRuntime,
+  reconcileConfigProviderKeys,
   replaceRuntimeAuthProfileStoreSnapshots,
   loadAuthProfileStore,
   saveAuthProfileStore,

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -595,3 +595,69 @@ export function saveAuthProfileStore(store: AuthProfileStore, agentDir?: string)
     runtimeAuthStoreSnapshots.set(runtimeKey, cloneAuthProfileStore(payload));
   }
 }
+
+/**
+ * Reconcile provider API keys from a resolved config snapshot into per-agent
+ * auth-profiles.json files on disk.
+ *
+ * When `openclaw.json` `models.providers.<name>.apiKey` changes, the per-agent
+ * `auth-profiles.json` files retain the old key. This function compares each
+ * config provider's resolved apiKey against the matching `<provider>:default`
+ * profile and updates the on-disk store when they diverge.
+ *
+ * Only plain-text `api_key` profiles without a `keyRef` are eligible — profiles
+ * backed by secret refs are resolved at runtime and don't need reconciliation.
+ *
+ * Returns `true` if any auth-profiles.json file was updated.
+ */
+export function reconcileConfigProviderKeys(params: {
+  configProviders: Record<string, { apiKey?: unknown }>;
+  authStores: Array<{ agentDir: string; store: AuthProfileStore }>;
+}): boolean {
+  const { configProviders, authStores } = params;
+  const providerEntries = Object.entries(configProviders);
+  if (providerEntries.length === 0 || authStores.length === 0) {
+    return false;
+  }
+
+  let anyUpdated = false;
+  for (const { agentDir, store } of authStores) {
+    let storeMutated = false;
+    for (const [providerKey, providerConfig] of providerEntries) {
+      // Only reconcile plain-text apiKey values. Secret refs (objects) are
+      // resolved at runtime and don't need disk reconciliation.
+      if (typeof providerConfig.apiKey !== "string") {
+        continue;
+      }
+      const configApiKey = providerConfig.apiKey.trim();
+      if (!configApiKey) {
+        continue;
+      }
+      const profileId = `${providerKey}:default`;
+      const profile = store.profiles[profileId];
+      if (!profile || profile.type !== "api_key") {
+        continue;
+      }
+      const apiKeyProfile = profile;
+      // Skip profiles backed by secret refs — resolved at runtime.
+      if (apiKeyProfile.keyRef) {
+        continue;
+      }
+      if (apiKeyProfile.key === configApiKey) {
+        continue;
+      }
+      log.info("reconciled stale provider key from config", {
+        provider: providerKey,
+        profileId,
+        agentDir,
+      });
+      apiKeyProfile.key = configApiKey;
+      storeMutated = true;
+    }
+    if (storeMutated) {
+      saveAuthProfileStore(store, agentDir);
+      anyUpdated = true;
+    }
+  }
+  return anyUpdated;
+}

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -197,6 +197,10 @@ export async function ensureOpenClawModelsJson(
   }
 }
 
+export function clearModelsJsonReadyCache(): void {
+  MODELS_JSON_READY_CACHE.clear();
+}
+
 export function resetModelsJsonReadyCacheForTest(): void {
   MODELS_JSON_READY_CACHE.clear();
 }

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -9,8 +9,10 @@ import type { AuthProfileStore } from "../agents/auth-profiles.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   loadAuthProfileStoreForSecretsRuntime,
+  reconcileConfigProviderKeys,
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "../agents/auth-profiles.js";
+import { clearModelsJsonReadyCache } from "../agents/models-config.js";
 import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshotRefreshHandler,
@@ -250,6 +252,20 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
     } satisfies SecretsRuntimeRefreshContext);
   setRuntimeConfigSnapshot(next.config, next.sourceConfig);
   replaceRuntimeAuthProfileStoreSnapshots(next.authStores);
+
+  // Reconcile provider API keys from config into per-agent auth-profiles on
+  // disk so that restarted gateways and new sessions pick up the current key.
+  const configProviders = next.config.models?.providers;
+  if (configProviders) {
+    const reconciled = reconcileConfigProviderKeys({
+      configProviders,
+      authStores: next.authStores,
+    });
+    if (reconciled) {
+      clearModelsJsonReadyCache();
+    }
+  }
+
   activeSnapshot = next;
   activeRefreshContext = cloneRefreshContext(refreshContext);
   setRuntimeConfigSnapshotRefreshHandler({


### PR DESCRIPTION
## Summary

When a provider API key is changed in `openclaw.json` under `models.providers.<name>.apiKey`, the per-agent `auth-profiles.json` files retain the stale key. The agent continues using the old key indefinitely — surviving hot reloads and full gateway stop/start cycles.

This PR adds a reconciliation step that compares resolved config provider keys against the matching `<provider>:default` auth-profile entries and updates them on disk when they diverge.

**Changes:**

- **`src/agents/auth-profiles/store.ts`** — New `reconcileConfigProviderKeys()` function that iterates config providers, compares their `apiKey` to the auth-profile's `key`, and persists updates via `saveAuthProfileStore()`
- **`src/secrets/runtime.ts`** — Calls reconciliation from `activateSecretsRuntimeSnapshot()` so both initial load and hot reload propagate key changes
- **`src/agents/models-config.ts`** — New `clearModelsJsonReadyCache()` export, called after reconciliation so `models.json` regenerates with updated auth-profiles
- **`src/agents/auth-profiles.ts`** — Re-exports the new function

**Scope guards:**

- Only plain-text `api_key` profiles without a `keyRef` are eligible — profiles backed by secret refs are resolved at runtime
- Non-string `apiKey` values (SecretRef objects) are skipped
- OAuth and token profile types are not affected
- Usage stats, cooldown state, and profile order are preserved

## Test plan

- [x] 9 unit tests covering: key update, no-op match, keyRef skip, OAuth skip, empty config skip, multi-agent reconciliation, metadata preservation
- [x] All 24 existing auth-profiles test files pass (1 pre-existing unrelated failure in `state-observation.test.ts`)
- [x] TypeScript compiles with no errors in modified files
- [ ] Manual verification: change API key in `openclaw.json` → restart gateway → confirm `auth-profiles.json` updated

## Linked issues

- Closes #40363
- Related #30667, #55648, #47684