### PR TITLE
telegram: improve polling outage detection and recovery after network loss

### DIFF
--- a/extensions/telegram/index.ts
+++ b/extensions/telegram/index.ts
@@ -5,6 +5,7 @@ import { setTelegramRuntime } from "./src/runtime.js";
 
 export { telegramPlugin } from "./src/channel.js";
 export { setTelegramRuntime } from "./src/runtime.js";
+export { resetTelegramThreadBindingsForTests } from "./src/thread-bindings.js";
 
 export default defineChannelPluginEntry({
   id: "telegram",

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -302,6 +302,7 @@ vi.mock("./webhook.js", () => ({
 
 vi.mock("./fetch.js", () => ({
   resolveTelegramTransport: resolveTelegramTransportSpy,
+  resolveTelegramApiBase: (apiRoot?: string) => apiRoot ?? "https://api.telegram.org",
 }));
 
 vi.mock("./update-offset-store.js", () => ({
@@ -657,8 +658,12 @@ describe("monitorTelegramProvider (grammY)", () => {
 
     expect(stop).toHaveBeenCalledTimes(1);
     expect(computeBackoff).not.toHaveBeenCalled();
-    expect(sleepWithAbort).not.toHaveBeenCalled();
     expect(runSpy).toHaveBeenCalledTimes(1);
+    for (const call of sleepWithAbort.mock.calls as unknown as Array<[number, AbortSignal]>) {
+      expect(call[0]).toBe(30000);
+      expect(call[1]).toBeInstanceOf(AbortSignal);
+      expect(call[1].aborted).toBe(true);
+    }
   });
 
   it("passes configured webhookHost to webhook listener", async () => {

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -9,7 +9,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { TelegramExecApprovalHandler } from "./exec-approvals-handler.js";
-import { resolveTelegramTransport } from "./fetch.js";
+import { resolveTelegramApiBase, resolveTelegramTransport } from "./fetch.js";
 import {
   isRecoverableTelegramNetworkError,
   isTelegramPollingNetworkError,
@@ -202,6 +202,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       log,
       telegramTransport,
       createTelegramTransport: createTelegramTransportForPolling,
+      apiBase: resolveTelegramApiBase(account.config.apiRoot?.trim() || undefined),
     });
     await pollingSession.runUntilAbort();
   } finally {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const runMock = vi.hoisted(() => vi.fn());
 const createTelegramBotMock = vi.hoisted(() => vi.fn());
@@ -13,6 +13,14 @@ vi.mock("@grammyjs/runner", () => ({
 vi.mock("./bot.js", () => ({
   createTelegramBot: createTelegramBotMock,
 }));
+
+vi.mock("./fetch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./fetch.js")>();
+  return {
+    ...actual,
+    resolveTelegramApiBase: vi.fn((apiRoot?: string) => apiRoot ?? "https://api.telegram.org"),
+  };
+});
 
 vi.mock("./network-errors.js", () => ({
   isRecoverableTelegramNetworkError: isRecoverableTelegramNetworkErrorMock,
@@ -142,7 +150,12 @@ describe("TelegramPollingSession", () => {
     isRecoverableTelegramNetworkErrorMock.mockReset().mockReturnValue(true);
     computeBackoffMock.mockReset().mockReturnValue(0);
     sleepWithAbortMock.mockReset().mockResolvedValue(undefined);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
     ({ TelegramPollingSession } = await import("./polling-session.js"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("uses backoff helpers for recoverable polling retries", async () => {
@@ -199,7 +212,7 @@ describe("TelegramPollingSession", () => {
 
     expect(runMock).toHaveBeenCalledTimes(2);
     expect(computeBackoffMock).toHaveBeenCalledTimes(1);
-    expect(sleepWithAbortMock).toHaveBeenCalledTimes(1);
+    expect(sleepWithAbortMock.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 
   it("forces a restart when polling stalls without getUpdates activity", async () => {
@@ -269,8 +282,8 @@ describe("TelegramPollingSession", () => {
       expect(runMock).toHaveBeenCalledTimes(2);
       expect(firstRunnerStop).toHaveBeenCalledTimes(1);
       expect(botStop).toHaveBeenCalled();
-      expect(log).toHaveBeenCalledWith(expect.stringContaining("Polling stall detected"));
       expect(log).toHaveBeenCalledWith(expect.stringContaining("polling stall detected"));
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("forcing restart"));
     } finally {
       watchdogHarness.restore();
     }

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -7,7 +7,7 @@ import {
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
-import { type TelegramTransport } from "./fetch.js";
+import { resolveTelegramApiBase, type TelegramTransport } from "./fetch.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { TelegramPollingTransportState } from "./polling-transport-state.js";
 
@@ -21,6 +21,10 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;
+const SUPERVISOR_UPDATES_STALE_THRESHOLD_MS = 90_000;
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const HEARTBEAT_TIMEOUT_MS = 10_000;
+const HEARTBEAT_FAIL_THRESHOLD = 3;
 
 const waitForGracefulStop = async (stop: () => Promise<void>) => {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -56,6 +60,8 @@ type TelegramPollingSessionOpts = {
   telegramTransport?: TelegramTransport;
   /** Rebuild Telegram transport after stall/network recovery when marked dirty. */
   createTelegramTransport?: () => TelegramTransport;
+  /** Pre-resolved API base for lightweight heartbeat probes. */
+  apiBase?: string;
 };
 
 export class TelegramPollingSession {
@@ -91,24 +97,117 @@ export class TelegramPollingSession {
   }
 
   async runUntilAbort(): Promise<void> {
-    while (!this.opts.abortSignal?.aborted) {
-      const bot = await this.#createPollingBot();
-      if (!bot) {
-        continue;
-      }
+    // The heartbeat supervisor lives across polling cycles.
+    // It controls whether polling is allowed to run.
+    let heartbeatSuspended = false;
+    let heartbeatConsecutiveFailures = 0;
+    let currentCycleAbort: AbortController | undefined;
+    let heartbeatRecoveryWake = new AbortController();
+    const heartbeatStop = new AbortController();
+    const heartbeatAborted = () => this.opts.abortSignal?.aborted || heartbeatStop.signal.aborted;
 
-      const cleanupState = await this.#ensureWebhookCleanup(bot);
-      if (cleanupState === "retry") {
-        continue;
-      }
-      if (cleanupState === "exit") {
-        return;
-      }
+    // Start the heartbeat loop — it runs for the entire session lifetime.
+    const heartbeatLoop = (async () => {
+      while (!heartbeatAborted()) {
+        await sleepWithAbort(HEARTBEAT_INTERVAL_MS, heartbeatStop.signal).catch(() => {});
+        if (heartbeatAborted()) return;
 
-      const state = await this.#runPollingCycle(bot);
-      if (state === "exit") {
-        return;
+        const heartbeat = await this.#probeHeartbeatOnce({
+          stopSignal: heartbeatStop.signal,
+          rebuildTransportIfDirty: heartbeatSuspended,
+        });
+        if (heartbeat === "ok") {
+          if (heartbeatConsecutiveFailures > 0) {
+            this.opts.log(
+              `[telegram] Heartbeat recovered after ${heartbeatConsecutiveFailures} failure(s).`,
+            );
+          }
+          heartbeatConsecutiveFailures = 0;
+          if (heartbeatSuspended) {
+            heartbeatSuspended = false;
+            heartbeatRecoveryWake.abort();
+            heartbeatRecoveryWake = new AbortController();
+          }
+          continue;
+        }
+
+        if (heartbeat === "fatal-api-failure") {
+          this.opts.log(
+            `[telegram] Heartbeat probe hit a fatal API error; releasing heartbeat suspension so the normal fatal path can surface the error.`,
+          );
+          heartbeatConsecutiveFailures = 0;
+          if (heartbeatSuspended) {
+            heartbeatSuspended = false;
+            heartbeatRecoveryWake.abort();
+            heartbeatRecoveryWake = new AbortController();
+          }
+          continue;
+        }
+
+        heartbeatConsecutiveFailures += 1;
+        if (heartbeatSuspended) {
+          this.#transportState.markDirty();
+        }
+        if (heartbeatConsecutiveFailures < HEARTBEAT_FAIL_THRESHOLD) {
+          this.opts.log(
+            `[telegram][diag] Heartbeat failed (${heartbeatConsecutiveFailures}/${HEARTBEAT_FAIL_THRESHOLD}).`,
+          );
+          continue;
+        }
+
+        if (!heartbeatSuspended) {
+          this.opts.log(
+            `[telegram] Heartbeat failed ${heartbeatConsecutiveFailures} consecutive times; stopping polling and waiting for recovery.`,
+          );
+          heartbeatSuspended = true;
+          this.#transportState.markDirty();
+        }
+        // Always abort the current polling cycle if one is running.
+        currentCycleAbort?.abort();
       }
+    })();
+
+    try {
+      while (!this.opts.abortSignal?.aborted) {
+        // If heartbeat has suspended polling, wait for recovery.
+        while (heartbeatSuspended && !this.opts.abortSignal?.aborted) {
+          const abortController = new AbortController();
+          const onSessionAbort = () => abortController.abort();
+          const onRecovery = () => abortController.abort();
+          this.opts.abortSignal?.addEventListener("abort", onSessionAbort, { once: true });
+          heartbeatRecoveryWake.signal.addEventListener("abort", onRecovery, { once: true });
+          await sleepWithAbort(HEARTBEAT_INTERVAL_MS, abortController.signal).catch(() => {});
+          this.opts.abortSignal?.removeEventListener("abort", onSessionAbort);
+          heartbeatRecoveryWake.signal.removeEventListener("abort", onRecovery);
+        }
+        if (this.opts.abortSignal?.aborted) return;
+
+        const bot = await this.#createPollingBot();
+        if (!bot) continue;
+
+        const cleanupState = await this.#ensureWebhookCleanup(bot);
+        if (cleanupState === "retry") continue;
+        if (cleanupState === "exit") return;
+
+        // Re-check suspension after async setup to avoid a race window.
+        if (heartbeatSuspended || this.opts.abortSignal?.aborted) {
+          continue;
+        }
+
+        // Give the current cycle an abort controller so the heartbeat can stop it.
+        const cycleAbort = new AbortController();
+        currentCycleAbort = cycleAbort;
+
+        const state = await this.#runPollingCycle(bot, cycleAbort.signal);
+        currentCycleAbort = undefined;
+
+        if (state === "exit") return;
+        // "continue" — loop back, will check heartbeatSuspended before starting next cycle.
+      }
+    } finally {
+      // Session ending or fatal error — stop heartbeat loop so runUntilAbort can exit.
+      heartbeatStop.abort();
+      await heartbeatLoop.catch(() => {});
     }
   }
 
@@ -200,7 +299,10 @@ export class TelegramPollingSession {
     }
   }
 
-  async #runPollingCycle(bot: TelegramBot): Promise<"continue" | "exit"> {
+  async #runPollingCycle(
+    bot: TelegramBot,
+    cycleSignal?: AbortSignal,
+  ): Promise<"continue" | "exit"> {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
@@ -215,7 +317,6 @@ export class TelegramPollingSession {
     let lastGetUpdatesError: string | null = null;
     let lastGetUpdatesOffset: number | null = null;
     let inFlightGetUpdates = 0;
-    let stopSequenceLogged = false;
     let stallDiagLoggedAt = 0;
 
     bot.api.config.use(async (prev, method, payload, signal) => {
@@ -289,6 +390,7 @@ export class TelegramPollingSession {
     }
     let stopPromise: Promise<void> | undefined;
     let stalledRestart = false;
+    let heartbeatAbortedCycle = false;
     let forceCycleTimer: ReturnType<typeof setTimeout> | undefined;
     let forceCycleResolve: (() => void) | undefined;
     const forceCyclePromise = new Promise<void>((resolve) => {
@@ -334,6 +436,37 @@ export class TelegramPollingSession {
           ? lastApiActivityAt
           : Math.max(lastApiActivityAt, latestInFlightApiStartedAt);
       const apiElapsed = now - apiLivenessAt;
+      const updatesElapsed = now - (lastGetUpdatesFinishedAt ?? lastGetUpdatesAt);
+      const updatesStale =
+        updatesElapsed > SUPERVISOR_UPDATES_STALE_THRESHOLD_MS &&
+        inFlightGetUpdates === 0 &&
+        apiElapsed > SUPERVISOR_UPDATES_STALE_THRESHOLD_MS;
+
+      if (updatesStale && runner.isRunning()) {
+        if (stallDiagLoggedAt && now - stallDiagLoggedAt < POLL_STALL_THRESHOLD_MS / 2) {
+          return;
+        }
+        stallDiagLoggedAt = now;
+        this.#transportState.markDirty();
+        stalledRestart = true;
+        this.opts.log(
+          `[telegram] Polling freshness check failed (no successful getUpdates for ${formatDurationPrecise(updatesElapsed)} with no in-flight request); forcing restart. [diag inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}]`,
+        );
+        void stopRunner();
+        void stopBot();
+        if (!forceCycleTimer) {
+          forceCycleTimer = setTimeout(() => {
+            if (this.opts.abortSignal?.aborted) {
+              return;
+            }
+            this.opts.log(
+              `[telegram] Polling runner stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)}; forcing restart cycle.`,
+            );
+            forceCycleResolve?.();
+          }, POLL_STOP_GRACE_MS);
+        }
+        return;
+      }
 
       // Treat recent non-getUpdates success and recent non-getUpdates start as
       // the same liveness signal. Slow delivery should suppress the watchdog,
@@ -373,16 +506,32 @@ export class TelegramPollingSession {
     }, POLL_WATCHDOG_INTERVAL_MS);
 
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+
+    // If the outer heartbeat supervisor aborts this cycle, treat it like a stall.
+    const onCycleAbort = () => {
+      heartbeatAbortedCycle = true;
+      void stopRunner();
+      void stopBot();
+      forceCycleResolve?.();
+    };
+    if (cycleSignal?.aborted) {
+      onCycleAbort();
+    } else {
+      cycleSignal?.addEventListener("abort", onCycleAbort, { once: true });
+    }
+
     try {
       await Promise.race([runner.task(), forceCyclePromise]);
       if (this.opts.abortSignal?.aborted) {
         return "exit";
       }
-      const reason = stalledRestart
-        ? "polling stall detected"
-        : this.#forceRestarted
-          ? "unhandled network error"
-          : "runner stopped (maxRetryTime exceeded or graceful stop)";
+      const reason = heartbeatAbortedCycle
+        ? "heartbeat abort"
+        : stalledRestart
+          ? "polling stall detected"
+          : this.#forceRestarted
+            ? "unhandled network error"
+            : "runner stopped (maxRetryTime exceeded or graceful stop)";
       this.#forceRestarted = false;
       this.opts.log(
         `[telegram][diag] polling cycle finished reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}`,
@@ -417,6 +566,7 @@ export class TelegramPollingSession {
       );
       return shouldRestart ? "continue" : "exit";
     } finally {
+      cycleSignal?.removeEventListener("abort", onCycleAbort);
       clearInterval(watchdog);
       if (forceCycleTimer) {
         clearTimeout(forceCycleTimer);
@@ -429,6 +579,51 @@ export class TelegramPollingSession {
       if (this.#activeFetchAbort === fetchAbortController) {
         this.#activeFetchAbort = undefined;
       }
+    }
+  }
+
+  /**
+   * Lightweight heartbeat probe using the same transport as polling
+   * (respects forceIpv4, DNS tuning, proxy, sticky fallback, etc.).
+   * Returns true on success, false on failure.
+   */
+  async #probeHeartbeatOnce(params?: {
+    stopSignal?: AbortSignal;
+    rebuildTransportIfDirty?: boolean;
+  }): Promise<"ok" | "network-failure" | "fatal-api-failure"> {
+    const apiBase = this.opts.apiBase ?? resolveTelegramApiBase(undefined);
+    const url = `${apiBase}/bot${this.opts.token}/getMe`;
+    const transport = params?.rebuildTransportIfDirty
+      ? this.#transportState.acquireForHeartbeatProbe()
+      : this.#transportState.currentTransport();
+    const fetchImpl = transport?.fetch ?? this.opts.proxyFetch ?? globalThis.fetch;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), HEARTBEAT_TIMEOUT_MS);
+    timeout.unref?.();
+    const onSessionAbort = () => controller.abort();
+    const onStopAbort = () => controller.abort();
+    this.opts.abortSignal?.addEventListener("abort", onSessionAbort, { once: true });
+    params?.stopSignal?.addEventListener("abort", onStopAbort, { once: true });
+    try {
+      const response = await fetchImpl(url, {
+        method: "POST",
+        signal: controller.signal,
+      });
+      const status = response.status;
+      await response.body?.cancel().catch(() => {});
+      if (response.ok) {
+        return "ok";
+      }
+      if (status >= 400 && status < 500) {
+        return "fatal-api-failure";
+      }
+      return "network-failure";
+    } catch {
+      return "network-failure";
+    } finally {
+      clearTimeout(timeout);
+      this.opts.abortSignal?.removeEventListener("abort", onSessionAbort);
+      params?.stopSignal?.removeEventListener("abort", onStopAbort);
     }
   }
 }

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -607,6 +607,8 @@ export class TelegramPollingSession {
     try {
       const response = await fetchImpl(url, {
         method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
         signal: controller.signal,
       });
       const status = response.status;

--- a/extensions/telegram/src/polling-transport-state.ts
+++ b/extensions/telegram/src/polling-transport-state.ts
@@ -18,6 +18,29 @@ export class TelegramPollingTransportState {
     this.#transportDirty = true;
   }
 
+  /** Returns the current transport without rebuilding (read-only access for heartbeat). */
+  currentTransport(): TelegramTransport | undefined {
+    return this.#telegramTransport;
+  }
+
+  /**
+   * Returns a transport for heartbeat probing.
+   * If transport was marked dirty, rebuild now so recovery probes are not stuck
+   * on a stale sticky-fallback transport while polling is suspended.
+   */
+  acquireForHeartbeatProbe(): TelegramTransport | undefined {
+    const shouldCreateTransport = this.#transportDirty || !this.#telegramTransport;
+    const nextTransport = shouldCreateTransport
+      ? (this.opts.createTelegramTransport?.() ?? this.#telegramTransport)
+      : this.#telegramTransport;
+    if (this.#transportDirty && nextTransport) {
+      this.opts.log("[telegram][diag] rebuilding transport for heartbeat probe");
+    }
+    this.#telegramTransport = nextTransport;
+    this.#transportDirty = false;
+    return nextTransport;
+  }
+
   acquireForNextCycle(): TelegramTransport | undefined {
     const shouldCreateTransport = this.#transportDirty || !this.#telegramTransport;
     const nextTransport = shouldCreateTransport


### PR DESCRIPTION
## Background

In real-world network interruption tests, the current Telegram polling recovery path is not sensitive enough to connection loss.

After repeated observation on a local OpenClaw deployment, we saw cases where Telegram connectivity had already been broken for a long time, but the process did not emit a meaningful error log until much later. In some runs, the gap was well over 15 minutes before a clear failure signal appeared in the logs.

This PR adjusts Telegram polling supervision to make outage detection and recovery more responsive under real network interruptions.

## What changed

### 1. Heartbeat supervisor (outer loop)

A heartbeat supervisor runs at the `runUntilAbort()` level — above individual polling cycles — so it persists across cycle restarts and controls the polling lifecycle:

- Periodically probes Telegram with `getMe` requests through the same transport as `getUpdates` (respects `forceIpv4`, DNS tuning, proxy config, sticky IPv4 fallback).
- API base is resolved once from the account's `apiRoot` config and passed via `opts.apiBase`, so deployments using a custom Telegram Bot API server are correctly handled.
- Tracks consecutive heartbeat failures.
- After reaching the failure threshold (3 consecutive failures):
  - aborts the current polling cycle via a cycle-scoped `AbortController`
  - marks transport dirty for rebuild on next cycle
  - enters a quiet wait state and keeps probing without restart loops
- Once heartbeat recovers, releases the gate so the main loop starts a new polling cycle.

Implementation details that matter operationally:
- Heartbeat uses the polling transport's fetch (`TelegramPollingTransportState.currentTransport()`), so it follows the same network path as polling.
- Heartbeat response bodies are explicitly canceled so sockets are returned to the connection pool.
- The outer heartbeat loop has its own stop controller so fatal errors can still propagate cleanly; `runUntilAbort()` does not hang in `finally`.

### 2. `getUpdates` freshness check (inside watchdog)

Adds a secondary staleness signal inside the existing watchdog interval:

- If `getUpdates` has not completed for longer than the stale threshold and no `getUpdates` is currently in-flight and no other API calls have been active recently (`apiElapsed` guard), the watchdog triggers a restart.
- The `apiElapsed` guard avoids false-positive restarts when the connection is demonstrably alive (for example, `sendMessage` is succeeding).

## Behavior summary

- Normal operation: heartbeat succeeds, polling cycles run normally, supervisor stays idle.
- Network outage detected by heartbeat: consecutive failures accumulate -> current cycle aborted -> supervisor waits quietly for recovery -> on recovery, a fresh cycle starts.
- Stale `getUpdates` detected by watchdog: no successful `getUpdates` + no in-flight request + no other API liveness -> watchdog forces restart.

## Testing

Validated with local outage/recovery experiments:
- earlier detection of broken Telegram connectivity via heartbeat
- correct stop behavior after repeated heartbeat failures
- quiet wait without repeated restart loops
- successful restart after heartbeat recovery
- no false-positive restarts when non-`getUpdates` API traffic is active
