### PR TITLE
fix(telegram): export thread binding reset from test api

### DIFF
--- a/extensions/telegram/test-api.ts
+++ b/extensions/telegram/test-api.ts
@@ -8,3 +8,4 @@ export { makeProxyFetch } from "./src/proxy.js";
 export { telegramOutbound } from "./src/outbound-adapter.js";
 export { setTelegramRuntime } from "./src/runtime.js";
 export { sendMessageTelegram, sendPollTelegram, type TelegramApiOverride } from "./src/send.js";
+export { resetTelegramThreadBindingsForTests } from "./src/thread-bindings.js";


### PR DESCRIPTION
## Summary

- Problem: `checks-fast-extensions` fails because `test/helpers/channels/registry-backed-contract.ts` loads `resetTelegramThreadBindingsForTests` from Telegram's bundled `test-api`, but `extensions/telegram/test-api.ts` does not export it.
- Why it matters: The shared registry-backed contract suite crashes with `TypeError: resetTelegramThreadBindingsForTests is not a function`, which keeps the extensions lane red on `main` and on unrelated PRs.
- What changed: Re-exported `resetTelegramThreadBindingsForTests` from `extensions/telegram/test-api.ts`.
- What did NOT change (scope boundary): No production Telegram runtime behavior, thread binding logic, or CI orchestration changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #57373
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The Telegram bundled test API stopped short of re-exporting `resetTelegramThreadBindingsForTests`, while the shared registry-backed contract helper expects to load that seam from the plugin's `test-api` surface.
- Missing detection / guardrail: There is no dedicated guardrail for bundled `test-api` exports; the first detection was the failing shared registry-backed contract coverage in CI.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: The contract helper now relies on the Telegram test API exposing the same reset seam that Telegram's local tests already use.
- If unknown, what was ruled out: The reset function itself still exists in `extensions/telegram/src/thread-bindings.ts`; the break was in the test API export surface, not the binding implementation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `test/helpers/channels/registry-backed-contract.ts` via `extensions/matrix/src/registry-backed.contract.test.ts` and `extensions/telegram/src/registry-backed.contract.test.ts`
- Scenario the test should lock in: The shared registry-backed contract helper can load and call Telegram's thread-binding reset seam through the bundled `test-api` surface.
- Why this is the smallest reliable guardrail: The failure happens at the bundled plugin public test surface boundary, so the shared contract suite is the closest existing seam.
- Existing test that already covers this (if any): `extensions/matrix/src/registry-backed.contract.test.ts` and `extensions/telegram/src/registry-backed.contract.test.ts`
- If no new test is added, why not: Existing failing coverage already exercises this exact seam; the fix is to restore the missing export rather than add duplicate coverage.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node `v24.14.0`, Bun `1.3.11`
- Model/provider: N/A
- Integration/channel (if any): Telegram bundled test API / shared registry-backed contract helper
- Relevant config (redacted): N/A

### Steps

1. Load Telegram's bundled test API through `test/helpers/channels/registry-backed-contract.ts`.
2. Call `resetTelegramThreadBindingsForTests()` from that loaded surface.
3. Run the shared registry-backed contract tests in CI.

### Expected

- The Telegram test API exposes `resetTelegramThreadBindingsForTests` as a callable function.
- The shared contract helper can reset Telegram thread bindings before each case.

### Actual

- The Telegram test API omitted the export.
- `checks-fast-extensions` failed with `TypeError: resetTelegramThreadBindingsForTests is not a function`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Confirmed the failing CI log points at `test/helpers/channels/registry-backed-contract.ts:129`; directly imported `extensions/telegram/test-api.ts` after the patch and verified `resetTelegramThreadBindingsForTests` is exported as a function.
- Edge cases checked: Confirmed the underlying reset function still exists in `extensions/telegram/src/thread-bindings.ts`, so the missing export is the only broken seam touched here.
- What you did **not** verify: I did not get a full local rerun of the extensions wrapper lane to complete in the isolated temp clone before timeout.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: The change adds a test-only export to the Telegram bundled test API surface.
  - Mitigation: The export already exists in `extensions/telegram/src/thread-bindings.ts`; this patch only restores the missing pass-through on the test-only surface.
