### PR TITLE
feat(agent): support openclaw agent --cwd

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -537,6 +537,7 @@ public struct AgentParams: Codable, Sendable {
     public let besteffortdeliver: Bool?
     public let lane: String?
     public let extrasystemprompt: String?
+    public let workspacedir: String?
     public let internalevents: [[String: AnyCodable]]?
     public let inputprovenance: [String: AnyCodable]?
     public let idempotencykey: String
@@ -566,6 +567,7 @@ public struct AgentParams: Codable, Sendable {
         besteffortdeliver: Bool?,
         lane: String?,
         extrasystemprompt: String?,
+        workspacedir: String?,
         internalevents: [[String: AnyCodable]]?,
         inputprovenance: [String: AnyCodable]?,
         idempotencykey: String,
@@ -594,6 +596,7 @@ public struct AgentParams: Codable, Sendable {
         self.besteffortdeliver = besteffortdeliver
         self.lane = lane
         self.extrasystemprompt = extrasystemprompt
+        self.workspacedir = workspacedir
         self.internalevents = internalevents
         self.inputprovenance = inputprovenance
         self.idempotencykey = idempotencykey
@@ -624,6 +627,7 @@ public struct AgentParams: Codable, Sendable {
         case besteffortdeliver = "bestEffortDeliver"
         case lane
         case extrasystemprompt = "extraSystemPrompt"
+        case workspacedir = "workspaceDir"
         case internalevents = "internalEvents"
         case inputprovenance = "inputProvenance"
         case idempotencykey = "idempotencyKey"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -537,6 +537,7 @@ public struct AgentParams: Codable, Sendable {
     public let besteffortdeliver: Bool?
     public let lane: String?
     public let extrasystemprompt: String?
+    public let workspacedir: String?
     public let internalevents: [[String: AnyCodable]]?
     public let inputprovenance: [String: AnyCodable]?
     public let idempotencykey: String
@@ -566,6 +567,7 @@ public struct AgentParams: Codable, Sendable {
         besteffortdeliver: Bool?,
         lane: String?,
         extrasystemprompt: String?,
+        workspacedir: String?,
         internalevents: [[String: AnyCodable]]?,
         inputprovenance: [String: AnyCodable]?,
         idempotencykey: String,
@@ -594,6 +596,7 @@ public struct AgentParams: Codable, Sendable {
         self.besteffortdeliver = besteffortdeliver
         self.lane = lane
         self.extrasystemprompt = extrasystemprompt
+        self.workspacedir = workspacedir
         self.internalevents = internalevents
         self.inputprovenance = inputprovenance
         self.idempotencykey = idempotencykey
@@ -624,6 +627,7 @@ public struct AgentParams: Codable, Sendable {
         case besteffortdeliver = "bestEffortDeliver"
         case lane
         case extrasystemprompt = "extraSystemPrompt"
+        case workspacedir = "workspaceDir"
         case internalevents = "internalEvents"
         case inputprovenance = "inputProvenance"
         case idempotencykey = "idempotencyKey"

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -36,6 +36,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     .option("--reply-to <target>", "Delivery target override (separate from session routing)")
     .option("--reply-channel <channel>", "Delivery channel override (separate from routing)")
     .option("--reply-account <id>", "Delivery account id override")
+    .option("--cwd <dir>", "Workspace directory override for this agent run")
     .option(
       "--local",
       "Run the embedded agent locally (requires model provider API keys in your shell)",
@@ -62,6 +63,10 @@ ${formatHelpExamples([
   [
     'openclaw agent --to +15555550123 --message "Trace logs" --verbose on --json',
     "Enable verbose logging and JSON output.",
+  ],
+  [
+    'openclaw agent --agent ops --cwd ~/src/project --message "Review this repo"',
+    "Run the turn against a specific workspace.",
   ],
   ['openclaw agent --to +15555550123 --message "Summon reply" --deliver', "Deliver reply."],
   [

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveUserPath } from "../utils.js";
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn(),
@@ -107,7 +108,7 @@ describe("agentCliCommand", () => {
     });
   });
 
-  it("forwards --cwd to gateway workspaceDir", async () => {
+  it("normalizes --cwd before forwarding to gateway workspaceDir", async () => {
     await withTempStore(async () => {
       mockGatewaySuccessReply();
 
@@ -116,7 +117,27 @@ describe("agentCliCommand", () => {
       const request = vi.mocked(callGateway).mock.calls[0]?.[0] as {
         params?: { workspaceDir?: string };
       };
-      expect(request.params?.workspaceDir).toBe("~/src/project");
+      expect(request.params?.workspaceDir).toBe(resolveUserPath("~/src/project"));
+    });
+  });
+
+  it("resolves relative --cwd against the invoking CLI cwd before gateway forwarding", async () => {
+    await withTempStore(async ({ dir }) => {
+      mockGatewaySuccessReply();
+      const originalCwd = process.cwd();
+      let expectedWorkspaceDir = "";
+      process.chdir(dir);
+      try {
+        expectedWorkspaceDir = resolveUserPath(".");
+        await agentCliCommand({ message: "hi", to: "+1555", cwd: "." }, runtime);
+      } finally {
+        process.chdir(originalCwd);
+      }
+
+      const request = vi.mocked(callGateway).mock.calls[0]?.[0] as {
+        params?: { workspaceDir?: string };
+      };
+      expect(request.params?.workspaceDir).toBe(expectedWorkspaceDir);
     });
   });
 
@@ -152,7 +173,7 @@ describe("agentCliCommand", () => {
     });
   });
 
-  it("forwards --cwd to embedded workspaceDir when --local is set", async () => {
+  it("normalizes --cwd for embedded workspaceDir when --local is set", async () => {
     await withTempStore(async () => {
       mockLocalAgentReply();
 
@@ -167,7 +188,7 @@ describe("agentCliCommand", () => {
       );
 
       const localCall = vi.mocked(agentCommand).mock.calls[0]?.[0] as { workspaceDir?: string };
-      expect(localCall.workspaceDir).toBe("~/src/project");
+      expect(localCall.workspaceDir).toBe(resolveUserPath("~/src/project"));
     });
   });
 });

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -107,6 +107,19 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it("forwards --cwd to gateway workspaceDir", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555", cwd: "~/src/project" }, runtime);
+
+      const request = vi.mocked(callGateway).mock.calls[0]?.[0] as {
+        params?: { workspaceDir?: string };
+      };
+      expect(request.params?.workspaceDir).toBe("~/src/project");
+    });
+  });
+
   it("falls back to embedded agent when gateway fails", async () => {
     await withTempStore(async () => {
       vi.mocked(callGateway).mockRejectedValue(new Error("gateway not connected"));
@@ -136,6 +149,25 @@ describe("agentCliCommand", () => {
       expect(callGateway).not.toHaveBeenCalled();
       expect(agentCommand).toHaveBeenCalledTimes(1);
       expect(runtime.log).toHaveBeenCalledWith("local");
+    });
+  });
+
+  it("forwards --cwd to embedded workspaceDir when --local is set", async () => {
+    await withTempStore(async () => {
+      mockLocalAgentReply();
+
+      await agentCliCommand(
+        {
+          message: "hi",
+          to: "+1555",
+          cwd: "~/src/project",
+          local: true,
+        },
+        runtime,
+      );
+
+      const localCall = vi.mocked(agentCommand).mock.calls[0]?.[0] as { workspaceDir?: string };
+      expect(localCall.workspaceDir).toBe("~/src/project");
     });
   });
 });

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -7,6 +7,7 @@ import { loadConfig } from "../config/config.js";
 import { callGateway, randomIdempotencyKey } from "../gateway/call.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { resolveUserPath } from "../utils.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -66,6 +67,14 @@ function parseTimeoutSeconds(opts: { cfg: ReturnType<typeof loadConfig>; timeout
   return raw;
 }
 
+function normalizeCliWorkspaceDir(raw?: string): string | undefined {
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
+  if (!trimmed) {
+    return undefined;
+  }
+  return resolveUserPath(trimmed);
+}
+
 function formatPayloadForLog(payload: {
   text?: string;
   mediaUrls?: string[];
@@ -121,6 +130,7 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
 
   const channel = normalizeMessageChannel(opts.channel);
   const idempotencyKey = opts.runId?.trim() || randomIdempotencyKey();
+  const workspaceDir = normalizeCliWorkspaceDir(opts.cwd);
 
   const response = await withProgress(
     {
@@ -147,7 +157,7 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
           timeout: timeoutSeconds,
           lane: opts.lane,
           extraSystemPrompt: opts.extraSystemPrompt,
-          workspaceDir: opts.cwd,
+          workspaceDir,
           idempotencyKey,
         },
         expectFinal: true,
@@ -181,11 +191,12 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
 }
 
 export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, deps?: CliDeps) {
+  const workspaceDir = normalizeCliWorkspaceDir(opts.cwd);
   const localOpts = {
     ...opts,
     agentId: opts.agent,
     replyAccountId: opts.replyAccount,
-    workspaceDir: opts.cwd,
+    workspaceDir,
   };
   if (opts.local === true) {
     return await agentCommand(localOpts, runtime, deps);

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -51,6 +51,7 @@ export type AgentCliOpts = {
   lane?: string;
   runId?: string;
   extraSystemPrompt?: string;
+  cwd?: string;
   local?: boolean;
 };
 
@@ -146,6 +147,7 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
           timeout: timeoutSeconds,
           lane: opts.lane,
           extraSystemPrompt: opts.extraSystemPrompt,
+          workspaceDir: opts.cwd,
           idempotencyKey,
         },
         expectFinal: true,
@@ -183,6 +185,7 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
     ...opts,
     agentId: opts.agent,
     replyAccountId: opts.replyAccount,
+    workspaceDir: opts.cwd,
   };
   if (opts.local === true) {
     return await agentCommand(localOpts, runtime, deps);

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -96,6 +96,7 @@ export const AgentParamsSchema = Type.Object(
     bestEffortDeliver: Type.Optional(Type.Boolean()),
     lane: Type.Optional(Type.String()),
     extraSystemPrompt: Type.Optional(Type.String()),
+    workspaceDir: Type.Optional(Type.String()),
     internalEvents: Type.Optional(Type.Array(AgentInternalEventSchema)),
     inputProvenance: Type.Optional(InputProvenanceSchema),
     idempotencyKey: NonEmptyString,

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -768,7 +768,7 @@ describe("gateway agent handler", () => {
     );
   });
 
-  it("rejects workspaceDir override for non-CLI callers", async () => {
+  it("rejects workspaceDir override for untrusted callers", async () => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();
     const respond = vi.fn();
@@ -788,12 +788,14 @@ describe("gateway agent handler", () => {
       false,
       undefined,
       expect.objectContaining({
-        message: expect.stringContaining("workspaceDir override is restricted to CLI agent runs"),
+        message: expect.stringContaining(
+          "workspaceDir override requires trusted owner authorization",
+        ),
       }),
     );
   });
 
-  it("forwards workspaceDir override for CLI callers only", async () => {
+  it("forwards workspaceDir override for trusted owner-authorized callers", async () => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();
 
@@ -808,6 +810,7 @@ describe("gateway agent handler", () => {
         reqId: "workspace-cli-forwarded-1",
         client: {
           connect: {
+            scopes: ["operator.admin"],
             client: { id: "cli", mode: "cli" },
           },
         } as AgentHandlerArgs["client"],

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -768,7 +768,7 @@ describe("gateway agent handler", () => {
     );
   });
 
-  it("rejects public spawned-run metadata fields", async () => {
+  it("rejects workspaceDir override for non-CLI callers", async () => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();
     const respond = vi.fn();
@@ -777,7 +777,6 @@ describe("gateway agent handler", () => {
       {
         message: "spawned run",
         sessionKey: "agent:main:main",
-        spawnedBy: "agent:main:subagent:parent",
         workspaceDir: "/tmp/injected",
         idempotencyKey: "workspace-rejected",
       } as AgentParams,
@@ -789,9 +788,35 @@ describe("gateway agent handler", () => {
       false,
       undefined,
       expect.objectContaining({
-        message: expect.stringContaining("invalid agent params"),
+        message: expect.stringContaining("workspaceDir override is restricted to CLI agent runs"),
       }),
     );
+  });
+
+  it("forwards workspaceDir override for CLI callers only", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+
+    await invokeAgent(
+      {
+        message: "cli workspace run",
+        sessionKey: "agent:main:main",
+        workspaceDir: "/tmp/cli-workspace",
+        idempotencyKey: "workspace-cli-forwarded",
+      } as AgentParams,
+      {
+        reqId: "workspace-cli-forwarded-1",
+        client: {
+          connect: {
+            client: { id: "cli", mode: "cli" },
+          },
+        } as AgentHandlerArgs["client"],
+      },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const cliCall = mocks.agentCommand.mock.calls.at(-1)?.[0] as { workspaceDir?: string };
+    expect(cliCall.workspaceDir).toBe("/tmp/cli-workspace");
   });
 
   it("only forwards workspaceDir for spawned sessions with stored workspace inheritance", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -42,7 +42,12 @@ import { resolveAssistantIdentity } from "../assistant-identity.js";
 import { parseMessageWithAttachments } from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
-import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
+import {
+  GATEWAY_CLIENT_CAPS,
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+  hasGatewayClientCap,
+} from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -86,6 +91,23 @@ function resolveAllowModelOverrideFromClient(
 
 function resolveCanResetSessionFromClient(client: GatewayRequestHandlerOptions["client"]): boolean {
   return resolveSenderIsOwnerFromClient(client);
+}
+
+function resolveCliWorkspaceOverrideFromClient(
+  client: GatewayRequestHandlerOptions["client"],
+  workspaceDir?: string,
+): string | undefined {
+  const trimmed = typeof workspaceDir === "string" ? workspaceDir.trim() : "";
+  if (!trimmed) {
+    return undefined;
+  }
+  const info = client?.connect?.client;
+  const isCliCaller =
+    info?.id === GATEWAY_CLIENT_NAMES.CLI && info?.mode === GATEWAY_CLIENT_MODES.CLI;
+  if (!isCliCaller) {
+    throw new Error("invalid agent params: workspaceDir override is restricted to CLI agent runs");
+  }
+  return trimmed;
 }
 
 async function runSessionResetFromAgent(params: {
@@ -298,6 +320,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       groupSpace?: string;
       lane?: string;
       extraSystemPrompt?: string;
+      workspaceDir?: string;
       internalEvents?: AgentInternalEvent[];
       idempotencyKey: string;
       timeout?: number;
@@ -322,6 +345,13 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
     const providerOverride = allowModelOverride ? request.provider : undefined;
     const modelOverride = allowModelOverride ? request.model : undefined;
+    let cliWorkspaceOverride: string | undefined;
+    try {
+      cliWorkspaceOverride = resolveCliWorkspaceOverrideFromClient(client, request.workspaceDir);
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
+      return;
+    }
     const cfg = loadConfig();
     const idem = request.idempotencyKey;
     const normalizedSpawned = normalizeSpawnedRunMetadata({
@@ -797,11 +827,14 @@ export const agentHandlers: GatewayRequestHandlers = {
         extraSystemPrompt: request.extraSystemPrompt,
         internalEvents: request.internalEvents,
         inputProvenance,
-        // Internal-only: allow workspace override for spawned subagent runs.
-        workspaceDir: resolveIngressWorkspaceOverrideForSpawnedRun({
-          spawnedBy: spawnedByValue,
-          workspaceDir: sessionEntry?.spawnedWorkspaceDir,
-        }),
+        // Internal-only: allow workspace override only for trusted CLI runs,
+        // otherwise keep the existing spawned-session inheritance path.
+        workspaceDir:
+          cliWorkspaceOverride ??
+          resolveIngressWorkspaceOverrideForSpawnedRun({
+            spawnedBy: spawnedByValue,
+            workspaceDir: sessionEntry?.spawnedWorkspaceDir,
+          }),
         senderIsOwner,
         allowModelOverride,
       },

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -42,12 +42,7 @@ import { resolveAssistantIdentity } from "../assistant-identity.js";
 import { parseMessageWithAttachments } from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
-import {
-  GATEWAY_CLIENT_CAPS,
-  GATEWAY_CLIENT_MODES,
-  GATEWAY_CLIENT_NAMES,
-  hasGatewayClientCap,
-} from "../protocol/client-info.js";
+import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -93,7 +88,7 @@ function resolveCanResetSessionFromClient(client: GatewayRequestHandlerOptions["
   return resolveSenderIsOwnerFromClient(client);
 }
 
-function resolveCliWorkspaceOverrideFromClient(
+function resolveTrustedWorkspaceOverrideFromClient(
   client: GatewayRequestHandlerOptions["client"],
   workspaceDir?: string,
 ): string | undefined {
@@ -101,11 +96,10 @@ function resolveCliWorkspaceOverrideFromClient(
   if (!trimmed) {
     return undefined;
   }
-  const info = client?.connect?.client;
-  const isCliCaller =
-    info?.id === GATEWAY_CLIENT_NAMES.CLI && info?.mode === GATEWAY_CLIENT_MODES.CLI;
-  if (!isCliCaller) {
-    throw new Error("invalid agent params: workspaceDir override is restricted to CLI agent runs");
+  if (!resolveSenderIsOwnerFromClient(client)) {
+    throw new Error(
+      "invalid agent params: workspaceDir override requires trusted owner authorization",
+    );
   }
   return trimmed;
 }
@@ -345,9 +339,12 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
     const providerOverride = allowModelOverride ? request.provider : undefined;
     const modelOverride = allowModelOverride ? request.model : undefined;
-    let cliWorkspaceOverride: string | undefined;
+    let trustedWorkspaceOverride: string | undefined;
     try {
-      cliWorkspaceOverride = resolveCliWorkspaceOverrideFromClient(client, request.workspaceDir);
+      trustedWorkspaceOverride = resolveTrustedWorkspaceOverrideFromClient(
+        client,
+        request.workspaceDir,
+      );
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
       return;
@@ -827,10 +824,11 @@ export const agentHandlers: GatewayRequestHandlers = {
         extraSystemPrompt: request.extraSystemPrompt,
         internalEvents: request.internalEvents,
         inputProvenance,
-        // Internal-only: allow workspace override only for trusted CLI runs,
-        // otherwise keep the existing spawned-session inheritance path.
+        // Internal-only: allow explicit workspace override only for trusted
+        // owner-authorized callers; otherwise keep the existing spawned-session
+        // inheritance path.
         workspaceDir:
-          cliWorkspaceOverride ??
+          trustedWorkspaceOverride ??
           resolveIngressWorkspaceOverrideForSpawnedRun({
             spawnedBy: spawnedByValue,
             workspaceDir: sessionEntry?.spawnedWorkspaceDir,


### PR DESCRIPTION
## Summary
- add a real `openclaw agent --cwd <path>` CLI option and route it into the existing `workspaceDir` plumbing
- forward the override through both embedded and gateway agent paths
- gate gateway `workspaceDir` overrides to CLI-originated agent RPC calls only, while preserving existing spawned-session inheritance
- add regression coverage for CLI forwarding and gateway handler authorization behavior

## Testing
- pnpm exec vitest run src/commands/agent-via-gateway.test.ts src/commands/agent.test.ts src/gateway/server-methods/agent.test.ts
- git commit hook also ran: pnpm check:no-conflict-markers && pnpm check:host-env-policy:swift && pnpm tsgo && pnpm lint && pnpm lint:webhook:no-low-level-body-read && pnpm lint:auth:no-pairing-store-group && pnpm lint:auth:pairing-account-scope
