### PR TITLE
feat(tasks): add status health and maintenance command

### DIFF
--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -8,6 +8,7 @@ const sessionsCommand = vi.fn();
 const sessionsCleanupCommand = vi.fn();
 const tasksListCommand = vi.fn();
 const tasksAuditCommand = vi.fn();
+const tasksMaintenanceCommand = vi.fn();
 const tasksShowCommand = vi.fn();
 const tasksNotifyCommand = vi.fn();
 const tasksCancelCommand = vi.fn();
@@ -34,6 +35,7 @@ vi.mock("../../commands/sessions-cleanup.js", () => ({
 vi.mock("../../commands/tasks.js", () => ({
   tasksListCommand,
   tasksAuditCommand,
+  tasksMaintenanceCommand,
   tasksShowCommand,
   tasksNotifyCommand,
   tasksCancelCommand,
@@ -70,6 +72,7 @@ describe("registerStatusHealthSessionsCommands", () => {
     sessionsCleanupCommand.mockResolvedValue(undefined);
     tasksListCommand.mockResolvedValue(undefined);
     tasksAuditCommand.mockResolvedValue(undefined);
+    tasksMaintenanceCommand.mockResolvedValue(undefined);
     tasksShowCommand.mockResolvedValue(undefined);
     tasksNotifyCommand.mockResolvedValue(undefined);
     tasksCancelCommand.mockResolvedValue(undefined);
@@ -240,6 +243,18 @@ describe("registerStatusHealthSessionsCommands", () => {
       expect.objectContaining({
         lookup: "run-123",
         json: true,
+      }),
+      runtime,
+    );
+  });
+
+  it("runs tasks maintenance subcommand with apply forwarding", async () => {
+    await runCli(["tasks", "--json", "maintenance", "--apply"]);
+
+    expect(tasksMaintenanceCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: true,
+        apply: true,
       }),
       runtime,
     );

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -7,6 +7,7 @@ import {
   tasksAuditCommand,
   tasksCancelCommand,
   tasksListCommand,
+  tasksMaintenanceCommand,
   tasksNotifyCommand,
   tasksShowCommand,
 } from "../../commands/tasks.js";
@@ -299,6 +300,24 @@ export function registerStatusHealthSessionsCommands(program: Command) {
               | "inconsistent_timestamps"
               | undefined,
             limit: parsePositiveIntOrUndefined(opts.limit),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  tasksCmd
+    .command("maintenance")
+    .description("Preview or apply task ledger maintenance")
+    .option("--json", "Output as JSON", false)
+    .option("--apply", "Apply reconciliation, cleanup stamping, and pruning", false)
+    .action(async (opts, command) => {
+      const parentOpts = command.parent?.opts() as { json?: boolean } | undefined;
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await tasksMaintenanceCommand(
+          {
+            json: Boolean(opts.json || parentOpts?.json),
+            apply: Boolean(opts.apply),
           },
           defaultRuntime,
         );

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -394,11 +394,13 @@ export async function statusCommand(
           summary.tasks.failures > 0
             ? warn(`${summary.tasks.failures} issue${summary.tasks.failures === 1 ? "" : "s"}`)
             : muted("no issues"),
-          summary.taskAudit.total > 0
+          summary.taskAudit.errors > 0
             ? warn(
                 `audit ${summary.taskAudit.errors} error${summary.taskAudit.errors === 1 ? "" : "s"} · ${summary.taskAudit.warnings} warn`,
               )
-            : muted("audit clean"),
+            : summary.taskAudit.warnings > 0
+              ? muted(`audit ${summary.taskAudit.warnings} warn`)
+              : muted("audit clean"),
           `${summary.tasks.total} tracked`,
         ].join(" · ")
       : muted("none");

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -394,6 +394,11 @@ export async function statusCommand(
           summary.tasks.failures > 0
             ? warn(`${summary.tasks.failures} issue${summary.tasks.failures === 1 ? "" : "s"}`)
             : muted("no issues"),
+          summary.taskAudit.total > 0
+            ? warn(
+                `audit ${summary.taskAudit.errors} error${summary.taskAudit.errors === 1 ? "" : "s"} · ${summary.taskAudit.warnings} warn`,
+              )
+            : muted("audit clean"),
           `${summary.tasks.total} tracked`,
         ].join(" · ")
       : muted("none");

--- a/src/commands/status.scan.json-core.ts
+++ b/src/commands/status.scan.json-core.ts
@@ -3,6 +3,7 @@ import type { UpdateCheckResult } from "../infra/update-check.js";
 import { loggingState } from "../logging/state.js";
 import { runExec } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { createEmptyTaskAuditSummary } from "../tasks/task-registry.audit.js";
 import { createEmptyTaskRegistrySummary } from "../tasks/task-registry.summary.js";
 import type { getAgentLocalStatuses as getAgentLocalStatusesFn } from "./status.agent-local.js";
 import type { StatusScanResult } from "./status.scan.js";
@@ -74,6 +75,7 @@ function buildColdStartStatusSummary(): Awaited<ReturnType<typeof getStatusSumma
     channelSummary: [],
     queuedSystemEvents: [],
     tasks: createEmptyTaskRegistrySummary(),
+    taskAudit: createEmptyTaskAuditSummary(),
     sessions: {
       paths: [],
       count: 0,

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -17,6 +17,7 @@ import {
 import { runExec } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
+import { createEmptyTaskAuditSummary } from "../tasks/task-registry.audit.js";
 import { createEmptyTaskRegistrySummary } from "../tasks/task-registry.summary.js";
 import type { buildChannelsTable as buildChannelsTableFn } from "./status-all/channels.js";
 import type { getAgentLocalStatuses as getAgentLocalStatusesFn } from "./status.agent-local.js";
@@ -174,6 +175,7 @@ function buildColdStartStatusSummary(): Awaited<ReturnType<typeof getStatusSumma
     channelSummary: [],
     queuedSystemEvents: [],
     tasks: createEmptyTaskRegistrySummary(),
+    taskAudit: createEmptyTaskAuditSummary(),
     sessions: {
       paths: [],
       count: 0,

--- a/src/commands/status.summary.redaction.test.ts
+++ b/src/commands/status.summary.redaction.test.ts
@@ -50,6 +50,19 @@ describe("redactSensitiveStatusSummary", () => {
           cron: 1,
         },
       },
+      taskAudit: {
+        total: 1,
+        warnings: 1,
+        errors: 0,
+        byCode: {
+          stale_queued: 0,
+          stale_running: 0,
+          lost: 0,
+          delivery_failed: 1,
+          missing_cleanup: 0,
+          inconsistent_timestamps: 0,
+        },
+      },
       sessions: {
         paths: ["/tmp/openclaw/sessions.json"],
         count: 1,
@@ -76,5 +89,6 @@ describe("redactSensitiveStatusSummary", () => {
     expect(redacted.heartbeat).toEqual(input.heartbeat);
     expect(redacted.channelSummary).toEqual(input.channelSummary);
     expect(redacted.tasks).toEqual(input.tasks);
+    expect(redacted.taskAudit).toEqual(input.taskAudit);
   });
 });

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -81,6 +81,19 @@ vi.mock("../tasks/task-registry.maintenance.js", () => ({
       cron: 0,
     },
   })),
+  getInspectableTaskAuditSummary: vi.fn(() => ({
+    total: 1,
+    warnings: 1,
+    errors: 0,
+    byCode: {
+      stale_queued: 0,
+      stale_running: 0,
+      lost: 0,
+      delivery_failed: 1,
+      missing_cleanup: 0,
+      inconsistent_timestamps: 0,
+    },
+  })),
 }));
 
 vi.mock("../routing/session-key.js", () => ({
@@ -121,6 +134,7 @@ describe("getStatusSummary", () => {
     expect(summary.heartbeat.defaultAgentId).toBe("main");
     expect(summary.channelSummary).toEqual(["ok"]);
     expect(summary.tasks.active).toBe(0);
+    expect(summary.taskAudit.warnings).toBe(1);
   });
 
   it("skips channel summary imports when no channels are configured", async () => {

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -144,7 +144,9 @@ export async function getStatusSummary(
     : [];
   const mainSessionKey = resolveMainSessionKey(cfg);
   const queuedSystemEvents = peekSystemEvents(mainSessionKey);
-  const tasks = (await loadTaskRegistryMaintenanceModule()).getInspectableTaskRegistrySummary();
+  const taskMaintenanceModule = await loadTaskRegistryMaintenanceModule();
+  const tasks = taskMaintenanceModule.getInspectableTaskRegistrySummary();
+  const taskAudit = taskMaintenanceModule.getInspectableTaskAuditSummary();
 
   const resolved = resolveConfiguredStatusModelRef({
     cfg,
@@ -273,6 +275,7 @@ export async function getStatusSummary(
     channelSummary,
     queuedSystemEvents,
     tasks,
+    taskAudit,
     sessions: {
       paths: Array.from(paths),
       count: totalSessions,

--- a/src/commands/status.types.ts
+++ b/src/commands/status.types.ts
@@ -1,4 +1,5 @@
 import type { ChannelId } from "../channels/plugins/types.js";
+import type { TaskAuditSummary } from "../tasks/task-registry.audit.js";
 import type { TaskRegistrySummary } from "../tasks/task-registry.types.js";
 
 export type SessionStatus = {
@@ -50,6 +51,7 @@ export type StatusSummary = {
   channelSummary: string[];
   queuedSystemEvents: string[];
   tasks: TaskRegistrySummary;
+  taskAudit: TaskAuditSummary;
   sessions: {
     paths: string[];
     count: number;

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -324,4 +324,72 @@ describe("tasks commands", () => {
     );
     expect(runtimeLogs[2]).toContain("Dry run only.");
   });
+
+  it("shows before and after audit health when applying maintenance", async () => {
+    runTaskRegistryMaintenanceMock.mockReturnValue({
+      reconciled: 2,
+      cleanupStamped: 1,
+      pruned: 3,
+    });
+    getInspectableTaskRegistrySummaryMock.mockReturnValue({
+      total: 4,
+      active: 2,
+      terminal: 2,
+      failures: 1,
+      byStatus: {
+        queued: 1,
+        running: 1,
+        succeeded: 1,
+        failed: 0,
+        timed_out: 0,
+        cancelled: 0,
+        lost: 1,
+      },
+      byRuntime: {
+        subagent: 1,
+        acp: 1,
+        cli: 0,
+        cron: 2,
+      },
+    });
+    getInspectableTaskAuditSummaryMock
+      .mockReturnValueOnce({
+        total: 3,
+        warnings: 2,
+        errors: 1,
+        byCode: {
+          stale_queued: 0,
+          stale_running: 1,
+          lost: 1,
+          delivery_failed: 0,
+          missing_cleanup: 1,
+          inconsistent_timestamps: 0,
+        },
+      })
+      .mockReturnValueOnce({
+        total: 1,
+        warnings: 1,
+        errors: 0,
+        byCode: {
+          stale_queued: 0,
+          stale_running: 0,
+          lost: 1,
+          delivery_failed: 0,
+          missing_cleanup: 0,
+          inconsistent_timestamps: 0,
+        },
+      });
+
+    await tasksMaintenanceCommand({ apply: true }, runtime);
+
+    expect(previewTaskRegistryMaintenanceMock).not.toHaveBeenCalled();
+    expect(runTaskRegistryMaintenanceMock).toHaveBeenCalled();
+    expect(runtimeLogs[0]).toContain(
+      "Task maintenance (applied): 2 reconcile · 1 cleanup stamp · 3 prune",
+    );
+    expect(runtimeLogs[1]).toContain(
+      "Task health after apply: 1 queued · 1 running · 0 audit errors · 1 audit warnings",
+    );
+    expect(runtimeLogs[2]).toContain("Task health before apply: 1 audit errors · 2 audit warnings");
+  });
 });

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -5,6 +5,10 @@ const reconcileInspectableTasksMock = vi.fn();
 const reconcileTaskLookupTokenMock = vi.fn();
 const listTaskAuditFindingsMock = vi.fn();
 const summarizeTaskAuditFindingsMock = vi.fn();
+const previewTaskRegistryMaintenanceMock = vi.fn();
+const runTaskRegistryMaintenanceMock = vi.fn();
+const getInspectableTaskRegistrySummaryMock = vi.fn();
+const getInspectableTaskAuditSummaryMock = vi.fn();
 const updateTaskNotifyPolicyByIdMock = vi.fn();
 const cancelTaskByIdMock = vi.fn();
 const getTaskByIdMock = vi.fn();
@@ -18,6 +22,16 @@ vi.mock("../tasks/task-registry.reconcile.js", () => ({
 vi.mock("../tasks/task-registry.audit.js", () => ({
   listTaskAuditFindings: (...args: unknown[]) => listTaskAuditFindingsMock(...args),
   summarizeTaskAuditFindings: (...args: unknown[]) => summarizeTaskAuditFindingsMock(...args),
+}));
+
+vi.mock("../tasks/task-registry.maintenance.js", () => ({
+  previewTaskRegistryMaintenance: (...args: unknown[]) =>
+    previewTaskRegistryMaintenanceMock(...args),
+  runTaskRegistryMaintenance: (...args: unknown[]) => runTaskRegistryMaintenanceMock(...args),
+  getInspectableTaskRegistrySummary: (...args: unknown[]) =>
+    getInspectableTaskRegistrySummaryMock(...args),
+  getInspectableTaskAuditSummary: (...args: unknown[]) =>
+    getInspectableTaskAuditSummaryMock(...args),
 }));
 
 vi.mock("../tasks/task-registry.js", () => ({
@@ -42,6 +56,7 @@ let tasksShowCommand: typeof import("./tasks.js").tasksShowCommand;
 let tasksNotifyCommand: typeof import("./tasks.js").tasksNotifyCommand;
 let tasksCancelCommand: typeof import("./tasks.js").tasksCancelCommand;
 let tasksAuditCommand: typeof import("./tasks.js").tasksAuditCommand;
+let tasksMaintenanceCommand: typeof import("./tasks.js").tasksMaintenanceCommand;
 
 const taskFixture = {
   taskId: "task-12345678",
@@ -73,6 +88,7 @@ beforeAll(async () => {
     tasksNotifyCommand,
     tasksCancelCommand,
     tasksAuditCommand,
+    tasksMaintenanceCommand,
   } = await import("./tasks.js"));
 });
 
@@ -84,6 +100,50 @@ describe("tasks commands", () => {
     reconcileTaskLookupTokenMock.mockReturnValue(undefined);
     listTaskAuditFindingsMock.mockReturnValue([]);
     summarizeTaskAuditFindingsMock.mockReturnValue({
+      total: 0,
+      warnings: 0,
+      errors: 0,
+      byCode: {
+        stale_queued: 0,
+        stale_running: 0,
+        lost: 0,
+        delivery_failed: 0,
+        missing_cleanup: 0,
+        inconsistent_timestamps: 0,
+      },
+    });
+    previewTaskRegistryMaintenanceMock.mockReturnValue({
+      reconciled: 0,
+      cleanupStamped: 0,
+      pruned: 0,
+    });
+    runTaskRegistryMaintenanceMock.mockReturnValue({
+      reconciled: 0,
+      cleanupStamped: 0,
+      pruned: 0,
+    });
+    getInspectableTaskRegistrySummaryMock.mockReturnValue({
+      total: 0,
+      active: 0,
+      terminal: 0,
+      failures: 0,
+      byStatus: {
+        queued: 0,
+        running: 0,
+        succeeded: 0,
+        failed: 0,
+        timed_out: 0,
+        cancelled: 0,
+        lost: 0,
+      },
+      byRuntime: {
+        subagent: 0,
+        acp: 0,
+        cli: 0,
+        cron: 0,
+      },
+    });
+    getInspectableTaskAuditSummaryMock.mockReturnValue({
       total: 0,
       warnings: 0,
       errors: 0,
@@ -209,5 +269,59 @@ describe("tasks commands", () => {
     expect(runtimeLogs.join("\n")).toContain("stale_running");
     expect(runtimeLogs.join("\n")).toContain("running task appears stuck");
     expect(runtimeLogs.join("\n")).not.toContain("delivery_failed");
+  });
+
+  it("previews task maintenance without applying changes", async () => {
+    previewTaskRegistryMaintenanceMock.mockReturnValue({
+      reconciled: 2,
+      cleanupStamped: 1,
+      pruned: 3,
+    });
+    getInspectableTaskRegistrySummaryMock.mockReturnValue({
+      total: 5,
+      active: 2,
+      terminal: 3,
+      failures: 1,
+      byStatus: {
+        queued: 1,
+        running: 1,
+        succeeded: 1,
+        failed: 1,
+        timed_out: 0,
+        cancelled: 0,
+        lost: 1,
+      },
+      byRuntime: {
+        subagent: 1,
+        acp: 1,
+        cli: 1,
+        cron: 2,
+      },
+    });
+    getInspectableTaskAuditSummaryMock.mockReturnValue({
+      total: 2,
+      warnings: 1,
+      errors: 1,
+      byCode: {
+        stale_queued: 0,
+        stale_running: 1,
+        lost: 1,
+        delivery_failed: 0,
+        missing_cleanup: 0,
+        inconsistent_timestamps: 0,
+      },
+    });
+
+    await tasksMaintenanceCommand({}, runtime);
+
+    expect(previewTaskRegistryMaintenanceMock).toHaveBeenCalled();
+    expect(runTaskRegistryMaintenanceMock).not.toHaveBeenCalled();
+    expect(runtimeLogs[0]).toContain(
+      "Task maintenance (preview): 2 reconcile · 1 cleanup stamp · 3 prune",
+    );
+    expect(runtimeLogs[1]).toContain(
+      "Task health: 1 queued · 1 running · 1 audit errors · 1 audit warnings",
+    );
+    expect(runtimeLogs[2]).toContain("Dry run only.");
   });
 });

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -10,6 +10,12 @@ import {
 } from "../tasks/task-registry.audit.js";
 import { cancelTaskById, getTaskById, updateTaskNotifyPolicyById } from "../tasks/task-registry.js";
 import {
+  getInspectableTaskAuditSummary,
+  getInspectableTaskRegistrySummary,
+  previewTaskRegistryMaintenance,
+  runTaskRegistryMaintenance,
+} from "../tasks/task-registry.maintenance.js";
+import {
   reconcileInspectableTasks,
   reconcileTaskLookupToken,
 } from "../tasks/task-registry.reconcile.js";
@@ -374,5 +380,44 @@ export async function tasksAuditCommand(
   const rich = isRich();
   for (const line of formatAuditRows(displayed, rich)) {
     runtime.log(line);
+  }
+}
+
+export async function tasksMaintenanceCommand(
+  opts: { json?: boolean; apply?: boolean },
+  runtime: RuntimeEnv,
+) {
+  const maintenance = opts.apply ? runTaskRegistryMaintenance() : previewTaskRegistryMaintenance();
+  const summary = getInspectableTaskRegistrySummary();
+  const audit = getInspectableTaskAuditSummary();
+
+  if (opts.json) {
+    runtime.log(
+      JSON.stringify(
+        {
+          mode: opts.apply ? "apply" : "preview",
+          maintenance,
+          tasks: summary,
+          audit,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  runtime.log(
+    info(
+      `Task maintenance (${opts.apply ? "applied" : "preview"}): ${maintenance.reconciled} reconcile · ${maintenance.cleanupStamped} cleanup stamp · ${maintenance.pruned} prune`,
+    ),
+  );
+  runtime.log(
+    info(
+      `Task health: ${summary.byStatus.queued} queued · ${summary.byStatus.running} running · ${audit.errors} audit errors · ${audit.warnings} audit warnings`,
+    ),
+  );
+  if (!opts.apply) {
+    runtime.log("Dry run only. Re-run with `openclaw tasks maintenance --apply` to write changes.");
   }
 }

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -387,9 +387,10 @@ export async function tasksMaintenanceCommand(
   opts: { json?: boolean; apply?: boolean },
   runtime: RuntimeEnv,
 ) {
+  const auditBefore = getInspectableTaskAuditSummary();
   const maintenance = opts.apply ? runTaskRegistryMaintenance() : previewTaskRegistryMaintenance();
   const summary = getInspectableTaskRegistrySummary();
-  const audit = getInspectableTaskAuditSummary();
+  const auditAfter = opts.apply ? getInspectableTaskAuditSummary() : auditBefore;
 
   if (opts.json) {
     runtime.log(
@@ -398,7 +399,8 @@ export async function tasksMaintenanceCommand(
           mode: opts.apply ? "apply" : "preview",
           maintenance,
           tasks: summary,
-          audit,
+          auditBefore,
+          auditAfter,
         },
         null,
         2,
@@ -414,9 +416,16 @@ export async function tasksMaintenanceCommand(
   );
   runtime.log(
     info(
-      `Task health: ${summary.byStatus.queued} queued · ${summary.byStatus.running} running · ${audit.errors} audit errors · ${audit.warnings} audit warnings`,
+      `${opts.apply ? "Task health after apply" : "Task health"}: ${summary.byStatus.queued} queued · ${summary.byStatus.running} running · ${auditAfter.errors} audit errors · ${auditAfter.warnings} audit warnings`,
     ),
   );
+  if (opts.apply) {
+    runtime.log(
+      info(
+        `Task health before apply: ${auditBefore.errors} audit errors · ${auditBefore.warnings} audit warnings`,
+      ),
+    );
+  }
   if (!opts.apply) {
     runtime.log("Dry run only. Re-run with `openclaw tasks maintenance --apply` to write changes.");
   }

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -35,7 +35,7 @@ export type TaskAuditOptions = {
 const DEFAULT_STALE_QUEUED_MS = 10 * 60_000;
 const DEFAULT_STALE_RUNNING_MS = 30 * 60_000;
 
-function createEmptyTaskAuditSummary(): TaskAuditSummary {
+export function createEmptyTaskAuditSummary(): TaskAuditSummary {
   return {
     total: 0,
     warnings: 0,

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -1,6 +1,8 @@
 import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
+import { listTaskAuditFindings, summarizeTaskAuditFindings } from "./task-registry.audit.js";
+import type { TaskAuditSummary } from "./task-registry.audit.js";
 import {
   deleteTaskRecordById,
   ensureTaskRegistryReady,
@@ -18,6 +20,12 @@ const TASK_RETENTION_MS = 7 * 24 * 60 * 60_000;
 const TASK_SWEEP_INTERVAL_MS = 60_000;
 
 let sweeper: NodeJS.Timeout | null = null;
+
+export type TaskRegistryMaintenanceSummary = {
+  reconciled: number;
+  cleanupStamped: number;
+  pruned: number;
+};
 
 function findSessionEntryByKey(store: Record<string, unknown>, sessionKey: string): unknown {
   const direct = store[sessionKey];
@@ -90,6 +98,15 @@ function shouldPruneTerminalTask(task: TaskRecord, now: number): boolean {
   return now - terminalAt >= TASK_RETENTION_MS;
 }
 
+function shouldStampCleanupAfter(task: TaskRecord): boolean {
+  return isTerminalTask(task) && typeof task.cleanupAfter !== "number";
+}
+
+function resolveCleanupAfter(task: TaskRecord): number {
+  const terminalAt = task.endedAt ?? task.lastEventAt ?? task.createdAt;
+  return terminalAt + TASK_RETENTION_MS;
+}
+
 function markTaskLost(task: TaskRecord, now: number): TaskRecord {
   const updated =
     updateTaskRecordById(task.taskId, {
@@ -129,16 +146,44 @@ export function getInspectableTaskRegistrySummary(): TaskRegistrySummary {
   return summarizeTaskRecords(reconcileInspectableTasks());
 }
 
+export function getInspectableTaskAuditSummary(): TaskAuditSummary {
+  const tasks = reconcileInspectableTasks();
+  return summarizeTaskAuditFindings(listTaskAuditFindings({ tasks }));
+}
+
 export function reconcileTaskLookupToken(token: string): TaskRecord | undefined {
   ensureTaskRegistryReady();
   const task = resolveTaskForLookupToken(token);
   return task ? reconcileTaskRecordForOperatorInspection(task) : undefined;
 }
 
-export function sweepTaskRegistry(): { reconciled: number; pruned: number } {
+export function previewTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary {
   ensureTaskRegistryReady();
   const now = Date.now();
   let reconciled = 0;
+  let cleanupStamped = 0;
+  let pruned = 0;
+  for (const task of listTaskRecords()) {
+    if (shouldMarkLost(task, now)) {
+      reconciled += 1;
+      continue;
+    }
+    if (shouldPruneTerminalTask(task, now)) {
+      pruned += 1;
+      continue;
+    }
+    if (shouldStampCleanupAfter(task)) {
+      cleanupStamped += 1;
+    }
+  }
+  return { reconciled, cleanupStamped, pruned };
+}
+
+export function runTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary {
+  ensureTaskRegistryReady();
+  const now = Date.now();
+  let reconciled = 0;
+  let cleanupStamped = 0;
   let pruned = 0;
   for (const task of listTaskRecords()) {
     if (shouldMarkLost(task, now)) {
@@ -150,9 +195,22 @@ export function sweepTaskRegistry(): { reconciled: number; pruned: number } {
     }
     if (shouldPruneTerminalTask(task, now) && deleteTaskRecordById(task.taskId)) {
       pruned += 1;
+      continue;
+    }
+    if (
+      shouldStampCleanupAfter(task) &&
+      updateTaskRecordById(task.taskId, {
+        cleanupAfter: resolveCleanupAfter(task),
+      })
+    ) {
+      cleanupStamped += 1;
     }
   }
-  return { reconciled, pruned };
+  return { reconciled, cleanupStamped, pruned };
+}
+
+export function sweepTaskRegistry(): TaskRegistryMaintenanceSummary {
+  return runTaskRegistryMaintenance();
 }
 
 export function startTaskRegistryMaintenance() {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -21,7 +21,14 @@ import {
   updateTaskRecordById,
   updateTaskStateByRunId,
 } from "./task-registry.js";
-import { reconcileInspectableTasks, sweepTaskRegistry } from "./task-registry.maintenance.js";
+import {
+  getInspectableTaskAuditSummary,
+  previewTaskRegistryMaintenance,
+  reconcileInspectableTasks,
+  runTaskRegistryMaintenance,
+  sweepTaskRegistry,
+} from "./task-registry.maintenance.js";
+import { configureTaskRegistryRuntime } from "./task-registry.store.js";
 
 const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
 const hoisted = vi.hoisted(() => {
@@ -832,9 +839,101 @@ describe("task-registry", () => {
 
       expect(sweepTaskRegistry()).toEqual({
         reconciled: 0,
+        cleanupStamped: 0,
         pruned: 1,
       });
       expect(listTaskRecords()).toEqual([]);
+    });
+  });
+
+  it("previews and repairs missing cleanup timestamps during maintenance", async () => {
+    await withTempDir({ prefix: "openclaw-task-registry-" }, async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const now = Date.now();
+      configureTaskRegistryRuntime({
+        store: {
+          loadSnapshot: () =>
+            new Map([
+              [
+                "task-missing-cleanup",
+                {
+                  taskId: "task-missing-cleanup",
+                  runtime: "cron",
+                  requesterSessionKey: "",
+                  runId: "run-maintenance-cleanup",
+                  task: "Finished cron",
+                  status: "failed",
+                  deliveryStatus: "not_applicable",
+                  notifyPolicy: "silent",
+                  createdAt: now - 120_000,
+                  endedAt: now - 60_000,
+                  lastEventAt: now - 60_000,
+                },
+              ],
+            ]),
+          saveSnapshot: () => {},
+        },
+      });
+
+      expect(previewTaskRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        cleanupStamped: 1,
+        pruned: 0,
+      });
+
+      expect(runTaskRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        cleanupStamped: 1,
+        pruned: 0,
+      });
+      expect(getTaskById("task-missing-cleanup")?.cleanupAfter).toBeGreaterThan(200);
+    });
+  });
+
+  it("summarizes inspectable task audit findings", async () => {
+    await withTempDir({ prefix: "openclaw-task-registry-" }, async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const now = Date.now();
+      configureTaskRegistryRuntime({
+        store: {
+          loadSnapshot: () =>
+            new Map([
+              [
+                "task-audit-summary",
+                {
+                  taskId: "task-audit-summary",
+                  runtime: "acp",
+                  requesterSessionKey: "agent:main:main",
+                  runId: "run-audit-summary",
+                  task: "Hung task",
+                  status: "running",
+                  deliveryStatus: "pending",
+                  notifyPolicy: "done_only",
+                  createdAt: now - 50 * 60_000,
+                  startedAt: now - 40 * 60_000,
+                  lastEventAt: now - 40 * 60_000,
+                },
+              ],
+            ]),
+          saveSnapshot: () => {},
+        },
+      });
+
+      expect(getInspectableTaskAuditSummary()).toEqual({
+        total: 1,
+        warnings: 0,
+        errors: 1,
+        byCode: {
+          stale_queued: 0,
+          stale_running: 1,
+          lost: 0,
+          delivery_failed: 0,
+          missing_cleanup: 0,
+          inconsistent_timestamps: 0,
+        },
+      });
     });
   });
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -887,7 +887,7 @@ describe("task-registry", () => {
         cleanupStamped: 1,
         pruned: 0,
       });
-      expect(getTaskById("task-missing-cleanup")?.cleanupAfter).toBeGreaterThan(200);
+      expect(getTaskById("task-missing-cleanup")?.cleanupAfter).toBeGreaterThan(now);
     });
   });
 


### PR DESCRIPTION
## Summary

- Problem: the new SQLite-backed task ledger can be audited, but operators still have to remember a separate command and there is no shared repair path for obviously broken rows.
- Why it matters: task health stays out of the main status surface, and cleanup drift on restored terminal rows remains visible but not fixable from the CLI.
- What changed: added task audit health to `openclaw status`, added `openclaw tasks maintenance` with preview/apply modes, and taught maintenance to stamp missing cleanup retention on terminal rows before pruning.
- What did NOT change (scope boundary): no new task metadata model, no executor/retry semantics, no Redis/Temporal work.

## Change Type (select all)

- [x] Feature
- [x] Refactor required for the fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage
- [x] UI / DX

## Linked Issue/PR

- Closes #
- Related #57361
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Prior context (`git blame`, prior PR, issue, or refactor if known): follow-up to the SQLite task ledger and audit work in #57361.
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `src/commands/status.summary.test.ts`, `src/commands/tasks.test.ts`, `src/cli/program/register.status-health-sessions.test.ts`, `src/tasks/task-registry.test.ts`
- Scenario the test should lock in: status includes task audit health, the new maintenance command is wired correctly, and maintenance can preview/apply cleanup stamping for legacy terminal rows.
- Why this is the smallest reliable guardrail: these flows are pure command/registry seams without needing broader end-to-end coverage.
- Existing test that already covers this (if any): existing task registry tests already covered reconcile/prune behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw status` now surfaces task audit health counts alongside task-run counts.
- `openclaw tasks maintenance` previews or applies task-ledger reconciliation, cleanup stamping, and pruning.

## Diagram (if applicable)

```text
Before:
[operator] -> [openclaw status] -> [task counts only]
[operator] -> [openclaw tasks audit] -> [health details]

After:
[operator] -> [openclaw status] -> [task counts + audit health]
[operator] -> [openclaw tasks maintenance] -> [preview/apply repair + prune summary]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: added one local maintenance CLI command over the existing task ledger only; behavior is explicit and gated by `--apply`, with preview as the default.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local state dir

### Steps

1. Create task rows with stale/lost/missing-cleanup conditions.
2. Run `openclaw status` and `openclaw tasks maintenance`.
3. Re-run maintenance with `--apply`.

### Expected

- Status surfaces task audit health.
- Maintenance previews changes by default, then applies reconciliation/cleanup/pruning with `--apply`.

### Actual

- Matches expected in scoped tests.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: scoped status summary, maintenance command wiring, maintenance preview/apply behavior, task audit summary surfacing.
- Edge cases checked: restored terminal rows missing `cleanupAfter`, empty audit summaries, JSON scan fallback shape.
- What you did **not** verify: full `pnpm test` suite; interactive manual CLI session against a live task db.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: maintenance could over-report or over-apply task cleanup in edge cases.
  - Mitigation: preview is the default, apply path is separately tested, and the write scope stays limited to task-ledger reconciliation/cleanup fields.
- Risk: `pnpm check` is currently red on latest `main` due to an unrelated existing type error in `src/agents/skills.test-helpers.ts`.
  - Mitigation: scoped task/status tests, plus `pnpm build`, are green for this PR.

## AI Assistance

- AI-assisted: yes
- Testing: scoped tests + `pnpm build`; `pnpm check` blocked by unrelated existing `main` failure noted above.
- `codex review --base origin/main`: attempted, but it failed with a local transport error to `127.0.0.1`, so there was no usable review output.
