### PR TITLE
fix(delivery): treat Matrix "User not in room" as permanent delivery error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Docs: https://docs.openclaw.ai
 - Config/update: stop `openclaw doctor` write-backs from persisting plugin-injected channel defaults, so `openclaw update` no longer seeds config keys that later break service refresh validation. (#56834) Thanks @openperf.
 - Agents/Anthropic failover: treat Anthropic `api_error` payloads with `An unexpected error occurred while processing the response` as transient so retry/fallback can engage instead of surfacing a terminal failure. (#57441) Thanks @zijiess and @vincentkoc.
 - Agents/compaction: keep late compaction-retry rejections handled after the aggregate timeout path wins without swallowing real pre-timeout wait failures, so timed-out retries no longer surface an unhandled rejection on later unsubscribe. (#57451) Thanks @mpz4life and @vincentkoc.
+- Matrix/delivery recovery: treat Synapse `User not in room` replay failures as permanent during startup recovery so poisoned queued messages move to `failed/` instead of crash-looping Matrix after restart. (#57426) thanks @dlardo.
 
 ## 2026.3.28
 

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -50,6 +50,7 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  /User .* not in room/i,
 ];
 
 function createEmptyRecoverySummary(): RecoverySummary {

--- a/src/infra/outbound/delivery-queue.policy.test.ts
+++ b/src/infra/outbound/delivery-queue.policy.test.ts
@@ -16,6 +16,7 @@ describe("delivery-queue policy", () => {
       "Forbidden: bot was kicked from the group chat",
       "chat_id is empty",
       "Outbound not configured for channel: demo-channel",
+      "MatrixError: [403] User @bot:matrix.example.com not in room !mixedCase:matrix.example.com",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);
     });

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -116,6 +116,28 @@ describe("delivery-queue recovery", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("permanent error"));
   });
 
+  it("treats Matrix 'User not in room' as a permanent error", async () => {
+    const id = await enqueueDelivery(
+      { channel: "matrix", to: "!lowercased:matrix.example.com", payloads: [{ text: "hi" }] },
+      tmpDir(),
+    );
+    const deliver = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          "MatrixError: [403] User @bot:matrix.example.com not in room !lowercased:matrix.example.com",
+        ),
+      );
+    const log = createRecoveryLog();
+    const { result } = await runRecovery({ deliver, log });
+
+    expect(result.failed).toBe(1);
+    expect(result.recovered).toBe(0);
+    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+    expect(fs.existsSync(path.join(tmpDir(), "delivery-queue", "failed", `${id}.json`))).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("permanent error"));
+  });
+
   it("passes skipQueue: true to prevent re-enqueueing during recovery", async () => {
     await enqueueDelivery(
       { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },


### PR DESCRIPTION
## Summary

When delivery-recovery retries a queued message with a **lowercased Matrix room ID** (from case-normalized session keys), Synapse returns a 403 "User not in room" error. Previously this error was not recognized as permanent, so:

1. The entry retried up to 5 times across restarts
2. Each retry propagated the 403 error, which **crashed the Matrix sync loop**
3. The gateway stayed running but Matrix was completely dead
4. The poisoned entry persisted, causing the **same crash on every restart**

## Fix

Add `User .* not in room` to `PERMANENT_ERROR_PATTERNS` in delivery-queue-recovery. This causes delivery-recovery to immediately move the poisoned entry to `failed/` instead of retrying, preventing the sync loop crash.

## What this does NOT fix

The root cause — session key normalization lowercasing Matrix room IDs — remains. That requires a broader strategy touching the session store stack (as noted by @vincentkoc in #57337). This PR prevents the catastrophic crash-loop symptom while that work is scoped.

## Changes

- **`src/infra/outbound/delivery-queue-recovery.ts`**: Add `User .* not in room` to permanent error patterns
- **`src/infra/outbound/delivery-queue.recovery.test.ts`**: Add test for Matrix 403 permanent error handling

## Testing

All 12 delivery-queue recovery tests pass (11 existing + 1 new).

Fixes the crash-loop symptom of #57321
Supersedes #57337