### PR TITLE
fix: allow absolute paths for OPENCLAW_CONFIG_PATH and OPENCLAW_STATE_DIR in workspace .env

### DIFF
--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -125,7 +125,9 @@ describe("loadDotEnv", () => {
         expect(process.env.SAFE_KEY).toBe("from-cwd");
         expect(process.env.BAR).toBe("from-global");
         expect(process.env.NODE_OPTIONS).toBeUndefined();
+        // Relative OPENCLAW_STATE_DIR is blocked (security: cannot redirect state dir via CWD .env)
         expect(process.env.OPENCLAW_STATE_DIR).toBe(stateDir);
+        // Relative OPENCLAW_CONFIG_PATH is blocked (security: cannot redirect config via CWD .env)
         expect(process.env.OPENCLAW_CONFIG_PATH).toBeUndefined();
         expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
         expect(process.env.HTTP_PROXY).toBeUndefined();
@@ -133,7 +135,7 @@ describe("loadDotEnv", () => {
     });
   });
 
-  it("blocks OPENCLAW_STATE_DIR from workspace .env even when unset in process env", async () => {
+  it("blocks relative OPENCLAW_STATE_DIR and OPENCLAW_CONFIG_PATH from workspace .env even when unset in process env", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir }) => {
         await writeEnvFile(
@@ -148,6 +150,31 @@ describe("loadDotEnv", () => {
 
         expect(process.env.OPENCLAW_STATE_DIR).toBeUndefined();
         expect(process.env.OPENCLAW_CONFIG_PATH).toBeUndefined();
+      });
+    });
+  });
+
+  it("allows absolute OPENCLAW_CONFIG_PATH and OPENCLAW_STATE_DIR from workspace .env", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ cwdDir, base }) => {
+        const absoluteStateDir = path.join(base, "my-custom-state");
+        const absoluteConfigPath = path.join(base, "my-config", "openclaw.runtime.json5");
+        await writeEnvFile(
+          path.join(cwdDir, ".env"),
+          [
+            `OPENCLAW_STATE_DIR=${absoluteStateDir}`,
+            `OPENCLAW_CONFIG_PATH=${absoluteConfigPath}`,
+          ].join("\n"),
+        );
+
+        delete process.env.OPENCLAW_STATE_DIR;
+        delete process.env.OPENCLAW_CONFIG_PATH;
+
+        loadWorkspaceDotEnvFile(path.join(cwdDir, ".env"), { quiet: true });
+
+        // Absolute paths are allowed: users legitimately configure these in project-local .env
+        expect(process.env.OPENCLAW_STATE_DIR).toBe(absoluteStateDir);
+        expect(process.env.OPENCLAW_CONFIG_PATH).toBe(absoluteConfigPath);
       });
     });
   });
@@ -217,7 +244,7 @@ describe("loadDotEnv", () => {
 });
 
 describe("loadCliDotEnv", () => {
-  it("blocks OPENCLAW_STATE_DIR from workspace .env even when unset in process env", async () => {
+  it("blocks relative OPENCLAW_STATE_DIR from workspace .env even when unset in process env", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir }) => {
         await writeEnvFile(path.join(cwdDir, ".env"), "OPENCLAW_STATE_DIR=./evil-state\n");
@@ -260,10 +287,32 @@ describe("loadCliDotEnv", () => {
 
         expect(process.env.SAFE_KEY).toBe("from-cwd");
         expect(process.env.BAR).toBe("from-global");
+        // Relative OPENCLAW_STATE_DIR blocked (prevents redirecting global .env loading)
         expect(process.env.OPENCLAW_STATE_DIR).toBe(stateDir);
+        // Relative OPENCLAW_CONFIG_PATH blocked
         expect(process.env.OPENCLAW_CONFIG_PATH).toBeUndefined();
         expect(process.env.NODE_OPTIONS).toBeUndefined();
         expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
+      });
+    });
+  });
+
+  it("allows absolute OPENCLAW_CONFIG_PATH from workspace .env", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ cwdDir, base }) => {
+        const absoluteConfigPath = path.join(base, "config", "openclaw.runtime.json5");
+        await writeEnvFile(
+          path.join(cwdDir, ".env"),
+          `OPENCLAW_CONFIG_PATH=${absoluteConfigPath}\n`,
+        );
+
+        delete process.env.OPENCLAW_CONFIG_PATH;
+        vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
+
+        loadCliDotEnv({ quiet: true });
+
+        // Absolute OPENCLAW_CONFIG_PATH from project .env should be respected
+        expect(process.env.OPENCLAW_CONFIG_PATH).toBe(absoluteConfigPath);
       });
     });
   });

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -15,12 +15,21 @@ const BLOCKED_WORKSPACE_DOTENV_KEYS = new Set([
   "NODE_TLS_REJECT_UNAUTHORIZED",
   "NO_PROXY",
   "OPENCLAW_AGENT_DIR",
-  "OPENCLAW_CONFIG_PATH",
   "OPENCLAW_HOME",
   "OPENCLAW_OAUTH_DIR",
   "OPENCLAW_PROFILE",
-  "OPENCLAW_STATE_DIR",
   "PI_CODING_AGENT_DIR",
+]);
+
+/**
+ * Keys that control path resolution and are allowed from a workspace .env only
+ * when the value is an absolute path. Relative paths are blocked to prevent a
+ * malicious workspace from redirecting config/state loading to an attacker-
+ * controlled location (e.g. `OPENCLAW_CONFIG_PATH=./evil-config.json`).
+ */
+const ABSOLUTE_PATH_ONLY_WORKSPACE_DOTENV_KEYS = new Set([
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_STATE_DIR",
 ]);
 
 const BLOCKED_WORKSPACE_DOTENV_SUFFIXES = ["_BASE_URL"];
@@ -29,18 +38,28 @@ function shouldBlockRuntimeDotEnvKey(key: string): boolean {
   return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
 }
 
-function shouldBlockWorkspaceDotEnvKey(key: string): boolean {
+function shouldBlockWorkspaceDotEnvEntry(key: string, value: string): boolean {
   const upper = key.toUpperCase();
-  return (
-    shouldBlockRuntimeDotEnvKey(upper) ||
-    BLOCKED_WORKSPACE_DOTENV_KEYS.has(upper) ||
-    BLOCKED_WORKSPACE_DOTENV_SUFFIXES.some((suffix) => upper.endsWith(suffix))
-  );
+  if (shouldBlockRuntimeDotEnvKey(upper)) {
+    return true;
+  }
+  if (BLOCKED_WORKSPACE_DOTENV_KEYS.has(upper)) {
+    return true;
+  }
+  if (BLOCKED_WORKSPACE_DOTENV_SUFFIXES.some((suffix) => upper.endsWith(suffix))) {
+    return true;
+  }
+  // Allow path-override keys only when the value is an absolute path.
+  // Relative paths could redirect config loading to a malicious workspace file.
+  if (ABSOLUTE_PATH_ONLY_WORKSPACE_DOTENV_KEYS.has(upper)) {
+    return !path.isAbsolute(value.trim());
+  }
+  return false;
 }
 
 function loadDotEnvFile(params: {
   filePath: string;
-  shouldBlockKey: (key: string) => boolean;
+  shouldBlockEntry: (key: string, value: string) => boolean;
   quiet?: boolean;
 }) {
   let content: string;
@@ -68,7 +87,7 @@ function loadDotEnvFile(params: {
   }
   for (const [rawKey, value] of Object.entries(parsed)) {
     const key = normalizeEnvVarKey(rawKey, { portable: true });
-    if (!key || params.shouldBlockKey(key)) {
+    if (!key || params.shouldBlockEntry(key, value)) {
       continue;
     }
     if (process.env[key] !== undefined) {
@@ -81,7 +100,7 @@ function loadDotEnvFile(params: {
 export function loadRuntimeDotEnvFile(filePath: string, opts?: { quiet?: boolean }) {
   loadDotEnvFile({
     filePath,
-    shouldBlockKey: shouldBlockRuntimeDotEnvKey,
+    shouldBlockEntry: (key) => shouldBlockRuntimeDotEnvKey(key),
     quiet: opts?.quiet ?? true,
   });
 }
@@ -89,7 +108,7 @@ export function loadRuntimeDotEnvFile(filePath: string, opts?: { quiet?: boolean
 export function loadWorkspaceDotEnvFile(filePath: string, opts?: { quiet?: boolean }) {
   loadDotEnvFile({
     filePath,
-    shouldBlockKey: shouldBlockWorkspaceDotEnvKey,
+    shouldBlockEntry: shouldBlockWorkspaceDotEnvEntry,
     quiet: opts?.quiet ?? true,
   });
 }


### PR DESCRIPTION
## Summary

Fixes a regression introduced in 2026.3.28 where `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` were blocked from being loaded from a project-local `.env` file, even when set to absolute paths.

## Root Cause

PR #54631 added both keys to `BLOCKED_WORKSPACE_DOTENV_KEYS` to prevent malicious workspace files from redirecting config/state loading (e.g. `OPENCLAW_CONFIG_PATH=./evil-config.json`). However, this was overly broad and also blocked the legitimate user case of configuring these paths to absolute locations in a project `.env`.

## Fix

The security concern is specifically about **relative paths**, not absolute paths. Absolute paths are safe because they are explicitly configured by the user.

This PR introduces `ABSOLUTE_PATH_ONLY_WORKSPACE_DOTENV_KEYS` — a set of keys that are allowed from workspace `.env` only when the value is an absolute path. Relative path values for these keys remain blocked.

## Changes

- `src/infra/dotenv.ts`: Replace broad block on `OPENCLAW_CONFIG_PATH` / `OPENCLAW_STATE_DIR` with a value-aware check (`path.isAbsolute`) that only blocks relative paths
- `src/infra/dotenv.test.ts`: Add tests for both allowed (absolute path) and blocked (relative path) cases

## Testing

All existing tests pass. New tests added and verified:
- Allows absolute `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` from workspace `.env`
- Blocks relative `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` from CWD `.env`
- Blocks relative path values even when env vars are unset

Fixes #57408