### PR TITLE
fix(facade-runtime): add recursion guard to facade module loader to prevent infinite stack overflow

### DIFF
--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -168,7 +168,7 @@ export function createLazyFacadeArrayValue<T extends readonly unknown[]>(load: (
   return createLazyFacadeProxyValue({ load, target: [] });
 }
 
-export function loadBundledPluginPublicSurfaceModuleSync<T>(params: {
+export function loadBundledPluginPublicSurfaceModuleSync<T extends object>(params: {
   dirName: string;
   artifactBasename: string;
 }): T {
@@ -200,7 +200,23 @@ export function loadBundledPluginPublicSurfaceModuleSync<T>(params: {
   }
   fs.closeSync(opened.fd);
 
-  const loaded = getJiti(location.modulePath)(location.modulePath) as T;
-  loadedFacadeModules.set(location.modulePath, loaded);
-  return loaded;
+  // Place a sentinel object in the cache *before* the Jiti load begins.
+  // If a transitive dependency of the loaded module re-enters this function
+  // for the same modulePath (circular facade reference), it will receive the
+  // sentinel instead of recursing infinitely.  Once the real module finishes
+  // loading, Object.assign() back-fills the sentinel so any references
+  // captured during the circular load phase see the final exports.
+  const sentinel = {} as T;
+  loadedFacadeModules.set(location.modulePath, sentinel);
+
+  let loaded: T;
+  try {
+    loaded = getJiti(location.modulePath)(location.modulePath) as T;
+  } catch (err) {
+    loadedFacadeModules.delete(location.modulePath);
+    throw err;
+  }
+  Object.assign(sentinel, loaded);
+
+  return sentinel;
 }

--- a/src/test-utils/bundled-plugin-public-surface.ts
+++ b/src/test-utils/bundled-plugin-public-surface.ts
@@ -21,7 +21,7 @@ function findBundledPluginMetadata(pluginId: string): BundledPluginMetadata {
   return metadata;
 }
 
-export function loadBundledPluginPublicSurfaceSync<T>(params: {
+export function loadBundledPluginPublicSurfaceSync<T extends object>(params: {
   pluginId: string;
   artifactBasename: string;
 }): T {
@@ -32,7 +32,7 @@ export function loadBundledPluginPublicSurfaceSync<T>(params: {
   });
 }
 
-export function loadBundledPluginTestApiSync<T>(pluginId: string): T {
+export function loadBundledPluginTestApiSync<T extends object>(pluginId: string): T {
   return loadBundledPluginPublicSurfaceSync<T>({
     pluginId,
     artifactBasename: "test-api.js",


### PR DESCRIPTION
### Summary

- **Problem**: The `xai`, `sglang`, and `vllm` plugins crash on every load attempt with `RangeError: Maximum call stack size exceeded`. The gateway retries loading these plugins every ~8 minutes, each time hitting the same stack overflow. This occurs in `src/plugin-sdk/facade-runtime.ts` at `loadBundledPluginPublicSurfaceModuleSync()` (line 171-206).
- **Root Cause**: The facade lazy-loading pattern introduced in `8e0ab35b0e` handles function exports correctly (wrapped in closures, loaded on first call) but constant exports eagerly call `loadFacadeModule()` at module-evaluation time. When the constant initializer triggers `loadFacadeModule()` → Jiti sync load of `extensions/{xai,sglang,vllm}/api.ts`, any transitive dependency that imports back to `openclaw/plugin-sdk/{xai,sglang,vllm}` (even indirectly) re-enters `loadBundledPluginPublicSurfaceModuleSync()`. The `loadedFacadeModules` cache is only set **after** the Jiti load returns (line 204), so the re-entrant call finds no cache entry and recurses until stack overflow.
- **Fix**: Set a sentinel object in the `loadedFacadeModules` cache **before** the Jiti load begins. Re-entrant calls receive the sentinel instead of recursing. Once the real module finishes loading, the sentinel is populated via `Object.assign()` so any references obtained during the circular load phase see the real exports. This safely breaks the infinite recursion without changing the eager evaluation semantics of constant exports. The generic constraint `<T>` was also tightened to `<T extends object>` to ensure `Object.assign()` is type-safe.
- **What changed**: 
  - `src/plugin-sdk/facade-runtime.ts`: Added sentinel object logic in `loadBundledPluginPublicSurfaceModuleSync` and tightened generic constraint to `<T extends object>`.
  - `src/test-utils/bundled-plugin-public-surface.ts`: Propagated the `<T extends object>` constraint to `loadBundledPluginPublicSurfaceSync` and `loadBundledPluginTestApiSync`.
- **What did NOT change (scope boundary)**: No changes to actual plugin implementations (`xai`, `sglang`, `vllm`) or their dependency graphs. No changes to the Jiti loader configuration, the `resolveFacadeModuleLocation` function, or the `openBoundaryFileSync` security boundary. The fix is purely at the infrastructure level (facade loader) to gracefully handle circular facade references during module evaluation.

### Reproduction

1. Run `pnpm build` on any commit after `8e0ab35b0e`.
2. Start the gateway: `node dist/index.js gateway --port 18789`.
3. Observe stderr — xai, sglang, and vllm fail in a retry loop with `RangeError: Maximum call stack size exceeded`.

### Risk / Mitigation

- **Risk**: The sentinel object is temporarily empty during the synchronous Jiti load. If a circular dependency attempts to *read* a property from the facade module *during* the load phase (rather than just capturing a reference to the module object itself), it would get `undefined`.
- **Mitigation**: This risk is mitigated because the circular dependencies in these plugins only capture references to the facade module or its exports during evaluation; they do not execute logic that reads the constants until after the module graph is fully loaded. Furthermore, `Object.assign()` ensures that all captured references to the sentinel object are populated with the actual exports immediately after the Jiti load completes. Local testing confirms all three plugins load successfully.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Plugin SDK (`src/plugin-sdk`)

### Linked Issue/PR

Fixes #57394
