### PR TITLE
fix(memory): rebind qmd collections on pattern drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Docs: https://docs.openclaw.ai
 - Agents/MCP: reuse bundled MCP runtimes across turns in the same session, while recreating them when MCP config changes and disposing stale runtimes cleanly on session rollover. (#55090) Thanks @allan0509.
 - Memory/QMD: honor `memory.qmd.update.embedInterval` even when regular QMD update cadence is disabled or slower by arming a dedicated embed-cadence maintenance timer, while avoiding redundant timers when regular updates are already frequent enough. (#37326) Thanks @barronlroth.
 - Memory/QMD: add `memory.qmd.searchTool` as an exact mcporter tool override, so custom QMD MCP tools such as `hybrid_search` can be used without weakening the validated `searchMode` config surface. (#27801) Thanks @keramblock.
+- Memory/QMD: rebind collections when QMD reports a changed pattern but omits path metadata, so config pattern changes stop being silently ignored on restart. (#49897) Thanks @Madruru.
 - Agents/memory flush: keep daily memory flush files append-only during embedded attempts so compaction writes do not overwrite earlier notes. (#53725) Thanks @HPluseven.
 - Web UI/markdown: stop bare auto-links from swallowing adjacent CJK text while preserving valid mixed-script path and query characters in rendered links. (#48410) Thanks @jnuyao.
 - BlueBubbles/iMessage: coalesce URL-only inbound messages with their link-preview balloon again so sharing a bare link no longer drops the URL from agent context. Thanks @vincentkoc.

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -610,6 +610,55 @@ describe("QmdMemoryManager", () => {
     expect(addCalls).toHaveLength(0);
   });
 
+  it("rebinds collection when qmd text output exposes a changed pattern without a path", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          ["workspace-main (qmd://workspace-main/)", "  Pattern:  *.txt", "  Files:    17"].join(
+            "\n",
+          ),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "full" });
+    await manager.close();
+
+    const commands = spawnMock.mock.calls.map((call: unknown[]) => call[1] as string[]);
+    const removeCalls = commands.filter(
+      (args) => args[0] === "collection" && args[1] === "remove" && args[2] === "workspace-main",
+    );
+    expect(removeCalls).toHaveLength(1);
+
+    const addCall = commands.find((args) => {
+      if (args[0] !== "collection" || args[1] !== "add") {
+        return false;
+      }
+      const nameIdx = args.indexOf("--name");
+      return nameIdx >= 0 && args[nameIdx + 1] === "workspace-main";
+    });
+    expect(addCall).toBeDefined();
+    expect(addCall?.[2]).toBe(workspaceDir);
+    expect(addCall).toContain("**/*.md");
+  });
+
   it("migrates unscoped legacy collections before adding scoped names", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -734,16 +734,17 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private shouldRebindCollection(collection: ManagedCollection, listed: ListedCollection): boolean {
+    if (typeof listed.pattern === "string" && listed.pattern !== collection.pattern) {
+      return true;
+    }
     if (!listed.path) {
       // Older qmd versions may only return names from `collection list --json`.
-      // Do not perform destructive rebinds when metadata is incomplete: remove+add
-      // can permanently drop collections if add fails (for example on timeout).
+      // If the pattern is also missing, do not perform destructive rebinds when
+      // metadata is incomplete: remove+add can permanently drop collections if
+      // add fails (for example on timeout).
       return false;
     }
     if (!this.pathsMatch(listed.path, collection.path)) {
-      return true;
-    }
-    if (typeof listed.pattern === "string" && listed.pattern !== collection.pattern) {
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary

- Problem: `shouldRebindCollection()` returned early when QMD collection metadata omitted `path`, so pattern changes in `memory.qmd.paths[].pattern` were silently ignored on restart.
- Why it matters: operators could change config, restart successfully, and still keep the stale old collection pattern with no visible correction.
- What changed: check pattern drift before the missing-path guard, and keep the old non-destructive behavior only for truly metadata-incomplete name-only rows.
- What did NOT change (scope boundary): collection creation semantics, path-based rebind logic when path metadata exists, and the current non-destructive handling for collection-name-only list output.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49897
- Related #49994
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the missing-path guard in `shouldRebindCollection()` ran before the pattern comparison.
- Missing detection / guardrail: there was no regression test covering text-mode `collection list` output with pattern metadata but no path metadata.
- Prior context (`git blame`, prior PR, issue, or refactor if known): closed `#49994` had the right basic diagnosis but was left behind as the code moved.
- Why this regressed now: current QMD outputs still omit path in some list modes, so the short-circuit remains live on current `main`.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/memory/qmd-manager.test.ts`
- Scenario the test should lock in: when QMD list output exposes a changed pattern but omits path metadata, OpenClaw removes and re-adds the collection with the configured pattern.
- Why this is the smallest reliable guardrail: the bug is entirely inside collection-list parsing plus rebind decision logic.
- Existing test that already covers this (if any): the nearby name-only list test still covers the non-destructive path for truly metadata-incomplete rows.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- QMD collection pattern changes in config now take effect on restart even when QMD list output omits path metadata.

## Diagram (if applicable)

```text
Before:
config pattern changes -> restart -> listed.path missing -> rebind skipped -> stale pattern stays live

After:
config pattern changes -> restart -> listed.pattern differs -> collection rebind -> new pattern takes effect
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `memory.backend=qmd`, custom `memory.qmd.paths[].pattern`

### Steps

1. Start with a QMD collection created from one pattern.
2. Change `memory.qmd.paths[].pattern`.
3. Restart OpenClaw.

### Expected

- OpenClaw detects the pattern drift and rebinds the collection.

### Actual

- Before this change, `listed.path` missing caused an early return and the stale pattern survived indefinitely.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test -- extensions/memory-core/src/memory/qmd-manager.test.ts`
- Edge cases checked:
  - name-only list output still avoids destructive rebinds
  - text-mode list output with pattern but no path now rebinds correctly
- What you did **not** verify:
  - a live external QMD process with manual restart/rebind observation

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk:
  - Missing-path list output could now trigger more rebinds when pattern metadata disagrees.
- Mitigation:
  - limit the new behavior to explicit pattern drift only; keep name-only metadata on the old non-destructive path.
