### PR TITLE
fix(agents): forward resolved model to agent gateway call in sessions_spawn

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -275,6 +275,61 @@ describe("openclaw-tools: subagents (sessions_spawn model + thinking)", () => {
     expect(calls.some((call) => call.method === "agent")).toBe(false);
   });
 
+  it("sessions_spawn forwards resolved model to the agent gateway call", async () => {
+    const calls: GatewayCall[] = [];
+    mockPatchAndSingleAgentRun({ calls, runId: "run-model-forward" });
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "discord:group:req",
+      agentChannel: "discord",
+    });
+
+    const result = await tool.execute("call-model-forward", {
+      task: "do thing",
+      model: "claude-haiku-4-5",
+    });
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      modelApplied: true,
+    });
+
+    const agentCall = calls.find((call) => call.method === "agent");
+    expect(agentCall).toBeDefined();
+    expect(agentCall?.params).toMatchObject({
+      model: "claude-haiku-4-5",
+    });
+  });
+
+  it("sessions_spawn forwards config-resolved model to the agent gateway call", async () => {
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        list: [{ id: "research", model: { primary: "opencode/claude" } }],
+      },
+    });
+    const calls: GatewayCall[] = [];
+    mockPatchAndSingleAgentRun({ calls, runId: "run-config-model-forward" });
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:research:main",
+      agentChannel: "discord",
+    });
+
+    const result = await tool.execute("call-config-model-forward", {
+      task: "do thing",
+    });
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      modelApplied: true,
+    });
+
+    const agentCall = calls.find((call) => call.method === "agent");
+    expect(agentCall).toBeDefined();
+    expect(agentCall?.params).toMatchObject({
+      model: "opencode/claude",
+    });
+  });
+
   it("sessions_spawn supports legacy timeoutSeconds alias", async () => {
     let spawnedTimeout: number | undefined;
 

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -710,6 +710,7 @@ export async function spawnSubagentDirect(
         lane: AGENT_LANE_SUBAGENT,
         extraSystemPrompt: childSystemPrompt,
         thinking: thinkingOverride,
+        model: resolvedModel || undefined,
         timeout: runTimeoutSeconds,
         label: label || undefined,
         ...publicSpawnedMetadata,


### PR DESCRIPTION
## Summary

Fixes #57428

`sessions_spawn` with `runtime="subagent"` resolves the target agent's `model.primary` config correctly via `resolveSubagentSpawnModelSelection` and patches it onto the child session, but **never passes it in the actual `agent` gateway call**. This causes spawned subagents to use the global default model instead of the configured per-agent model.

## Changes

### `src/agents/subagent-spawn.ts`
- Added `model: resolvedModel || undefined` to the `callSubagentGateway({ method: "agent", params: {...} })` call so the resolved model is forwarded to the gateway when spawning the subagent.

### `src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts`
- Added test: **"sessions_spawn forwards resolved model to the agent gateway call"** — verifies that an explicit `model` override is forwarded in the `agent` call params (not just `sessions.patch`).
- Added test: **"sessions_spawn forwards config-resolved model to the agent gateway call"** — verifies that a config-resolved `model.primary` from the target agent is forwarded in the `agent` call params.

## Root Cause

In `spawnSubagentDirect`, the resolved model was:
1. ✅ Computed correctly at line 483 via `resolveSubagentSpawnModelSelection`
2. ✅ Patched onto the child session via `sessions.patch`
3. ✅ Persisted via `persistInitialChildSessionRuntimeModel`
4. ❌ **Not passed** in the `callSubagentGateway({ method: "agent" })` params

The gateway `agent` method uses its own model resolution when no model is provided in the call, falling back to the global default rather than respecting the session-patched value.

## Testing

- All 11 tests pass (9 existing + 2 new):
  ```
  ✓ sessions_spawn applies a model to the child session
  ✓ sessions_spawn forwards thinking overrides to the agent run
  ✓ sessions_spawn rejects invalid thinking levels
  ✓ sessions_spawn applies default subagent model from defaults config
  ✓ sessions_spawn falls back to runtime default model when no model config is set
  ✓ sessions_spawn prefers per-agent subagent model over defaults
  ✓ sessions_spawn prefers target agent primary model over global default
  ✓ sessions_spawn fails when model patch is rejected
  ✓ sessions_spawn forwards resolved model to the agent gateway call (NEW)
  ✓ sessions_spawn forwards config-resolved model to the agent gateway call (NEW)
  ✓ sessions_spawn supports legacy timeoutSeconds alias
  ```