### PR TITLE
fix(agents): classify Anthropic "unexpected error" api_error as transient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Docs: https://docs.openclaw.ai
 - Harden async approval followup delivery in webchat-only sessions (#57359) Thanks @joshavant.
 - Status: fix cache hit rate exceeding 100% by deriving denominator from prompt-side token fields instead of potentially undersized totalTokens. Fixes #26643.
 - Config/update: stop `openclaw doctor` write-backs from persisting plugin-injected channel defaults, so `openclaw update` no longer seeds config keys that later break service refresh validation. (#56834) Thanks @openperf.
+- Agents/Anthropic failover: treat Anthropic `api_error` payloads with `An unexpected error occurred while processing the response` as transient so retry/fallback can engage instead of surfacing a terminal failure. (#57441) Thanks @zijiess and @vincentkoc.
 
 ## 2026.3.28
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -916,6 +916,12 @@ describe("classifyFailoverReason", () => {
         '{"type":"error","error":{"type":"api_error","message":"Service temporarily unavailable"}}',
       ),
     ).toBe("timeout");
+    // Anthropic "unexpected error" variant (#57010)
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"api_error","message":"An unexpected error occurred while processing the response"}}',
+      ),
+    ).toBe("timeout");
   });
   it("does not classify non-transient api_error payloads as timeout", () => {
     // Context overflow - not transient

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -859,7 +859,7 @@ export function isBillingAssistantError(msg: AssistantMessage | undefined): bool
 // Non-transient api_error payloads (context overflow, validation/schema errors)
 // must NOT be classified as timeout.
 const API_ERROR_TRANSIENT_SIGNALS_RE =
-  /internal server error|overload|temporarily unavailable|service unavailable|unknown error|server error|bad gateway|gateway timeout|upstream error|backend error|try again later|temporarily.+unable/i;
+  /internal server error|overload|temporarily unavailable|service unavailable|unknown error|server error|bad gateway|gateway timeout|upstream error|backend error|try again later|temporarily.+unable|unexpected error/i;
 
 function isJsonApiInternalServerError(raw: string): boolean {
   if (!raw) {


### PR DESCRIPTION
## Problem

Anthropic sometimes returns `api_error` payloads with message `"An unexpected error occurred while processing the response"` during mid-stream failures. This is not matched by `API_ERROR_TRANSIENT_SIGNALS_RE`, so the error surfaces as terminal instead of triggering retry/fallback.

During Anthropic's March 2026 instability (5+ outages), this caused repeated session truncations mid-generation. Agent sessions attempting tool calls were interrupted with no retry.

## Root Cause

`API_ERROR_TRANSIENT_SIGNALS_RE` in `src/agents/pi-embedded-helpers/errors.ts` does not include `"unexpected error"`:

```
/internal server error|overload|temporarily unavailable|...|temporarily.+unable/i
```

The string `"An unexpected error occurred while processing the response"` does not match any of these patterns.

## Fix

Add `unexpected error` to the transient signal regex. This follows the same pattern as prior fixes:
- #23193 — added "Internal server error"
- #34535 — added overloaded_error 529

Includes test case for the new pattern.

## Longer-term suggestion

Each new Anthropic error variant requires a regex update. An inverted approach — treat all `api_error` payloads as transient **unless** they match known permanent patterns (auth, billing, context overflow, schema validation) — would be more resilient. Happy to follow up with a separate PR if there's interest.

Closes #57010