### PR TITLE
fix(telegram): add api.telegram.org to SSRF allowedHostnames to fix media download regression

### DIFF
--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -163,6 +163,7 @@ async function expectTransientGetFileRetrySuccess() {
       ssrfPolicy: {
         allowRfc2544BenchmarkRange: true,
         hostnameAllowlist: ["api.telegram.org"],
+        allowedHostnames: ["api.telegram.org"],
       },
     }),
   );
@@ -538,7 +539,7 @@ describe("resolveMedia original filename preservation", () => {
       expect.objectContaining({
         ssrfPolicy: {
           hostnameAllowlist: ["api.telegram.org", "192.168.1.50"],
-          allowedHostnames: ["192.168.1.50"],
+          allowedHostnames: ["api.telegram.org", "192.168.1.50"],
           allowRfc2544BenchmarkRange: true,
         },
       }),

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -20,25 +20,19 @@ const GrammyErrorCtor: typeof GrammyError | undefined =
 
 function buildTelegramMediaSsrfPolicy(apiRoot?: string) {
   const hostnames = ["api.telegram.org"];
-  let allowedHostnames: string[] | undefined;
+  const allowedHostnames = ["api.telegram.org"];
   if (apiRoot) {
     try {
       const customHost = new URL(apiRoot).hostname;
       if (customHost && !hostnames.includes(customHost)) {
         hostnames.push(customHost);
-        // A configured custom Bot API host is an explicit operator override and
-        // may legitimately live on a private network (for example, self-hosted
-        // Bot API or an internal reverse proxy). Keep that host reachable while
-        // still enforcing resolved-IP checks for the default public host.
-        allowedHostnames = [customHost];
+        allowedHostnames.push(customHost);
       }
     } catch {
       // invalid URL; fall through to default
     }
   }
   return {
-    // Restrict media downloads to the configured Telegram API hosts while still
-    // enforcing SSRF checks on the resolved and redirected targets.
     hostnameAllowlist: hostnames,
     ...(allowedHostnames ? { allowedHostnames } : {}),
     allowRfc2544BenchmarkRange: true,


### PR DESCRIPTION
﻿## Problem

After upgrading OpenClaw to 2026.3.28, Telegram image/media messages fail with:

```
MediaFetchError: Failed to fetch media from https://api.telegram.org/file/bot.../photos/file_X.jpg: Blocked: resolves to private/internal/special-use IP address
```

Text messages still work normally. Rolling back to 2026.3.24 restores media downloads.

## Root Cause

`buildTelegramMediaSsrfPolicy` in `extensions/telegram/src/bot/delivery.resolve-media.ts` sets `hostnameAllowlist: ["api.telegram.org"]` (restricting which hosts can be fetched) but does **not** include `api.telegram.org` in `allowedHostnames` for the default case.

Without `allowedHostnames`, the SSRF guard still performs DNS resolution IP checks on `api.telegram.org`. If any resolved IP falls into a "private/internal/special-use" range (e.g. Telegram CDN edge IPs that overlap with RFC2544 or other special-use blocks), the download is blocked.

The existing test file (`fetch.network-policy.test.ts`) explicitly passes `allowedHostnames: ["api.telegram.org"]` in its SSRF policy, which masked the production mismatch.

## Fix

Always include `api.telegram.org` in `allowedHostnames` so the SSRF guard skips DNS-resolved IP checks for this trusted public API endpoint. The `hostnameAllowlist` still restricts downloads to only the configured Telegram API hosts.

For custom `apiRoot` configurations, the custom host is now also added to `allowedHostnames` alongside `api.telegram.org`.

## Test Plan

- [x] Updated `delivery.resolve-media-retry.test.ts` assertions to match the new default SSRF policy (`allowedHostnames` always includes `api.telegram.org`)
- [x] Updated custom `apiRoot` test to verify both hosts appear in `allowedHostnames`
- [x] Verified existing `fetch.network-policy.test.ts` tests already use the corrected policy shape

Closes #57412
