### PR TITLE
fix(memory): export archived qmd session transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Docs: https://docs.openclaw.ai
 - Agents/MCP: reuse bundled MCP runtimes across turns in the same session, while recreating them when MCP config changes and disposing stale runtimes cleanly on session rollover. (#55090) Thanks @allan0509.
 - Memory/QMD: honor `memory.qmd.update.embedInterval` even when regular QMD update cadence is disabled or slower by arming a dedicated embed-cadence maintenance timer, while avoiding redundant timers when regular updates are already frequent enough. (#37326) Thanks @barronlroth.
 - Memory/QMD: add `memory.qmd.searchTool` as an exact mcporter tool override, so custom QMD MCP tools such as `hybrid_search` can be used without weakening the validated `searchMode` config surface. (#27801) Thanks @keramblock.
+- Memory/QMD: keep reset and deleted session transcripts in QMD session export so daily session resets do not silently drop most historical recall from `memory_search`. (#30220) Thanks @pushkarsingh32.
 - Agents/memory flush: keep daily memory flush files append-only during embedded attempts so compaction writes do not overwrite earlier notes. (#53725) Thanks @HPluseven.
 - Web UI/markdown: stop bare auto-links from swallowing adjacent CJK text while preserving valid mixed-script path and query characters in rendered links. (#48410) Thanks @jnuyao.
 - BlueBubbles/iMessage: coalesce URL-only inbound messages with their link-preview balloon again so sharing a bare link no longer drops the URL from agent context. Thanks @vincentkoc.

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -4,25 +4,25 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildSessionEntry, listSessionFilesForAgent } from "./session-files.js";
 
-describe("buildSessionEntry", () => {
-  let tmpDir: string;
-  let originalStateDir: string | undefined;
+let tmpDir: string;
+let originalStateDir: string | undefined;
 
-  beforeEach(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "session-entry-test-"));
-    originalStateDir = process.env.OPENCLAW_STATE_DIR;
-    process.env.OPENCLAW_STATE_DIR = tmpDir;
-  });
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "session-entry-test-"));
+  originalStateDir = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = tmpDir;
+});
 
-  afterEach(async () => {
-    if (originalStateDir === undefined) {
-      delete process.env.OPENCLAW_STATE_DIR;
-    } else {
-      process.env.OPENCLAW_STATE_DIR = originalStateDir;
-    }
-    await fs.rm(tmpDir, { recursive: true, force: true });
-  });
+afterEach(async () => {
+  if (originalStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = originalStateDir;
+  }
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
 
+describe("listSessionFilesForAgent", () => {
   it("includes reset and deleted transcripts in session file listing", async () => {
     const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
     await fs.mkdir(path.join(sessionsDir, "archive"), { recursive: true });
@@ -48,7 +48,9 @@ describe("buildSessionEntry", () => {
       included.toSorted(),
     );
   });
+});
 
+describe("buildSessionEntry", () => {
   it("returns lineMap tracking original JSONL line numbers", async () => {
     // Simulate a real session JSONL file with metadata records interspersed
     // Lines 1-3: non-message metadata records

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -2,17 +2,51 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildSessionEntry } from "./session-files.js";
+import { buildSessionEntry, listSessionFilesForAgent } from "./session-files.js";
 
 describe("buildSessionEntry", () => {
   let tmpDir: string;
+  let originalStateDir: string | undefined;
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "session-entry-test-"));
+    originalStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = tmpDir;
   });
 
   afterEach(async () => {
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
     await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("includes reset and deleted transcripts in session file listing", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    await fs.mkdir(path.join(sessionsDir, "archive"), { recursive: true });
+
+    const included = [
+      "active.jsonl",
+      "active.jsonl.reset.2026-02-16T22-26-33.000Z",
+      "active.jsonl.deleted.2026-02-16T22-27-33.000Z",
+    ];
+    const excluded = ["active.jsonl.bak.2026-02-16T22-28-33.000Z", "sessions.json", "notes.md"];
+
+    for (const fileName of [...included, ...excluded]) {
+      await fs.writeFile(path.join(sessionsDir, fileName), "");
+    }
+    await fs.writeFile(
+      path.join(sessionsDir, "archive", "nested.jsonl.deleted.2026-02-16T22-29-33.000Z"),
+      "",
+    );
+
+    const files = await listSessionFilesForAgent("main");
+
+    expect(files.map((filePath) => path.basename(filePath)).toSorted()).toEqual(
+      included.toSorted(),
+    );
   });
 
   it("returns lineMap tracking original JSONL line numbers", async () => {

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isUsageCountedSessionTranscriptFileName } from "../../../../src/config/sessions/artifacts.js";
 import { resolveSessionTranscriptsDirForAgent } from "../../../../src/config/sessions/paths.js";
 import { redactSensitiveText } from "../../../../src/logging/redact.js";
 import { createSubsystemLogger } from "../../../../src/logging/subsystem.js";
@@ -25,7 +26,7 @@ export async function listSessionFilesForAgent(agentId: string): Promise<string[
     return entries
       .filter((entry) => entry.isFile())
       .map((entry) => entry.name)
-      .filter((name) => name.endsWith(".jsonl"))
+      .filter((name) => isUsageCountedSessionTranscriptFileName(name))
       .map((name) => path.join(dir, name));
   } catch {
     return [];


### PR DESCRIPTION
## Summary

- Problem: QMD session export only listed `*.jsonl` transcripts, so reset and deleted transcripts dropped out of QMD recall immediately after session resets.
- Why it matters: on setups with daily resets, most historical session memory became silently unsearchable even though the transcript files still existed on disk.
- What changed: `listSessionFilesForAgent()` now uses the existing usage-counted transcript helper, so live plus `.jsonl.reset.*` and `.jsonl.deleted.*` files are exported while backups and unrelated files stay excluded.
- What did NOT change (scope boundary): this does not change session retention policy, nested archive traversal, or QMD indexing behavior beyond which transcript files are surfaced to export.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30220
- Related #30273
- Related #43947
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `packages/memory-host-sdk/src/host/session-files.ts` filtered strictly on `name.endsWith(".jsonl")`, which excluded the `.jsonl.reset.*` and `.jsonl.deleted.*` transcript shapes produced by session reset/delete flows.
- Missing detection / guardrail: there was no direct regression test for `listSessionFilesForAgent()` covering archived transcript variants.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #30273 and #43947 both diagnosed the same stale suffix-only filter on the older path.
- Why this regressed now: current `main` still carried the narrow filename filter after the memory host refactor.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `packages/memory-host-sdk/src/host/session-files.test.ts`
- Scenario the test should lock in: list live, reset, and deleted transcripts from the agent sessions root while excluding backups and non-transcript files.
- Why this is the smallest reliable guardrail: the bug is purely in filename selection before QMD export, so a filesystem-level unit test on `listSessionFilesForAgent()` is enough.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- QMD session-backed `memory_search` can now recall reset and deleted transcript history again instead of only active session files.

## Diagram (if applicable)

```text
Before:
[session reset] -> [file renamed to .jsonl.reset.*] -> [QMD export ignores it] -> [memory_search loses old session]

After:
[session reset] -> [file renamed to .jsonl.reset.*] -> [QMD export keeps it] -> [memory_search can still recall it]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `memory.backend=qmd`, `memory.qmd.sessions.enabled=true`

### Steps

1. Put active, `.jsonl.reset.*`, and `.jsonl.deleted.*` transcript files in the agent sessions root.
2. Call `listSessionFilesForAgent()` through the QMD session export path.
3. Verify archived reset/deleted transcripts are still listed.

### Expected

- Live, reset, and deleted transcript files remain in the QMD export source set.

### Actual

- Before this fix, only bare `*.jsonl` transcripts were included.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test -- packages/memory-host-sdk/src/host/session-files.test.ts`; `pnpm build`
- Edge cases checked: `.jsonl.reset.*` and `.jsonl.deleted.*` are included; `.jsonl.bak.*`, `sessions.json`, non-JSONL files, and nested files remain excluded.
- What you did **not** verify: live end-to-end QMD export on a daily-reset deployment.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: including additional archived transcripts can increase QMD session-export volume for agents with long reset history.
  - Mitigation: the change reuses the existing usage-counted transcript helper, so it still excludes backups and unrelated artifacts while aligning export scope with current retention-managed transcript history.
