### PR TITLE
fix(agents): prevent unhandled rejection when compaction retry times out [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Docs: https://docs.openclaw.ai
 - Status: fix cache hit rate exceeding 100% by deriving denominator from prompt-side token fields instead of potentially undersized totalTokens. Fixes #26643.
 - Config/update: stop `openclaw doctor` write-backs from persisting plugin-injected channel defaults, so `openclaw update` no longer seeds config keys that later break service refresh validation. (#56834) Thanks @openperf.
 - Agents/Anthropic failover: treat Anthropic `api_error` payloads with `An unexpected error occurred while processing the response` as transient so retry/fallback can engage instead of surfacing a terminal failure. (#57441) Thanks @zijiess and @vincentkoc.
+- Agents/compaction: keep late compaction-retry rejections handled after the aggregate timeout path wins without swallowing real pre-timeout wait failures, so timed-out retries no longer surface an unhandled rejection on later unsubscribe. (#57451) Thanks @mpz4life and @vincentkoc.
 
 ## 2026.3.28
 

--- a/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.test.ts
@@ -116,6 +116,46 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
     });
   });
 
+  it("propagates immediate waitForCompactionRetry failures", async () => {
+    await withFakeTimers(async () => {
+      const waitError = new Error("compaction wait failed");
+      const waitForCompactionRetry = vi.fn(async () => {
+        throw waitError;
+      });
+      const params = buildAggregateTimeoutParams({ waitForCompactionRetry });
+
+      await expect(waitForCompactionRetryWithAggregateTimeout(params)).rejects.toThrow(
+        "compaction wait failed",
+      );
+
+      expectClearedTimeoutState(params.onTimeout, false);
+    });
+  });
+
+  it("handles waitForCompactionRetry rejection after timeout wins", async () => {
+    await withFakeTimers(async () => {
+      let rejectWait: ((error: Error) => void) | undefined;
+      const waitForCompactionRetry = vi.fn(
+        async () =>
+          await new Promise<void>((_resolve, reject) => {
+            rejectWait = reject;
+          }),
+      );
+      const params = buildAggregateTimeoutParams({ waitForCompactionRetry });
+
+      const resultPromise = waitForCompactionRetryWithAggregateTimeout(params);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await resultPromise;
+
+      rejectWait?.(new Error("cancelled after timeout"));
+      await Promise.resolve();
+
+      expect(result.timedOut).toBe(true);
+      expectClearedTimeoutState(params.onTimeout, true);
+    });
+  });
+
   it("propagates abort errors from abortable and clears timer", async () => {
     await withFakeTimers(async () => {
       const abortError = new Error("aborted");

--- a/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.ts
@@ -13,7 +13,10 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
   const timeoutMs = Number.isFinite(timeoutMsRaw) ? Math.max(1, Math.floor(timeoutMsRaw)) : 1;
 
   let timedOut = false;
-  const waitPromise = params.waitForCompactionRetry().then(() => "done" as const);
+  const waitPromise = params
+    .waitForCompactionRetry()
+    .then(() => "done" as const)
+    .catch(() => "cancelled" as const);
 
   while (true) {
     let timer: ReturnType<typeof setTimeout> | undefined;
@@ -27,7 +30,7 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
         ]),
       );
 
-      if (result === "done") {
+      if (result === "done" || result === "cancelled") {
         break;
       }
 

--- a/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.ts
@@ -13,10 +13,12 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
   const timeoutMs = Number.isFinite(timeoutMsRaw) ? Math.max(1, Math.floor(timeoutMsRaw)) : 1;
 
   let timedOut = false;
-  const waitPromise = params
-    .waitForCompactionRetry()
-    .then(() => "done" as const)
-    .catch(() => "cancelled" as const);
+  // Reflect the retry promise so late rejections after a timeout stay handled
+  // without masking failures that settle before the timeout path wins.
+  const waitPromise = params.waitForCompactionRetry().then(
+    () => ({ kind: "done" as const }),
+    (error: unknown) => ({ kind: "rejected" as const, error }),
+  );
 
   while (true) {
     let timer: ReturnType<typeof setTimeout> | undefined;
@@ -30,8 +32,11 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
         ]),
       );
 
-      if (result === "done" || result === "cancelled") {
-        break;
+      if (result !== "timeout") {
+        if (result.kind === "done") {
+          break;
+        }
+        throw result.error;
       }
 
       // Keep extending the timeout window while compaction is actively running.


### PR DESCRIPTION
## Summary

- **Problem**: `Promise.race()` returns the first resolved/rejected promise, but other promises continue executing. When timeout triggers first, `waitPromise` continues waiting for compaction completion, becoming a leaked pending promise. Later when `unsubscribe()` calls `reject()`, this leaked promise produces Unhandled Promise Rejection, causing Node.js process crash.
- **Why it matters**: This is a critical stability issue - the Node.js process can crash unexpectedly during session compaction when timing out.
- **What changed**: Added `.catch(() => "cancelled" as const)` handler to the `waitPromise` chain to swallow rejections when the race times out first. Also updated the condition to break the loop on both "done" and "cancelled" results.
- **What did NOT change (scope boundary)**: No changes to the compaction logic itself, timeout handling, or abort behavior - only the promise rejection handling.

## Change Type

- [x] Bug fix

## Scope

- [x] Skills / tool execution

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- **Root cause**: `Promise.race()` does not cancel other promises - they continue to execute. When the timeout won the race, the underlying `waitForCompactionRetry()` promise was still pending. When `unsubscribe()` later rejected it, there was no error handler, causing an unhandled rejection.
- **Missing detection / guardrail**: The original code assumed that once `Promise.race()` resolved, the losing promise would be "forgotten", but JavaScript promises don't work that way.

## Regression Test Plan

- **Coverage level that should have caught this**: Unit test
- **Target test or file**: `compaction-retry-aggregate-timeout.test.ts`
- **Existing test that already covers this (if any)**: The existing tests pass, confirming the fix doesn't break existing behavior.

## User-visible / Behavior Changes

None - this is an internal stability fix.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Linux
- Runtime: Node.js 22+

### Steps

1. Run `pnpm test -- src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.test.ts`
2. All 5 tests pass

### Expected

- Tests pass without unhandled rejections

### Actual

- All tests pass

## Evidence

Test results:
```
Test Files  1 passed (1)
Tests  5 passed (5)
```

## Human Verification

- **Verified scenarios**:
  - Unit tests in `compaction-retry-aggregate-timeout.test.ts` pass
  - Integration tests in `pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts` pass (8 tests)
- **Edge cases checked**:
  - Promise resolves normally ("done" path)
  - Promise rejects after timeout ("cancelled" path)
- **What you did NOT verify**:
  - Full E2E compaction flow with actual model calls

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

None - this is a minimal, targeted fix that only adds error handling to an existing promise chain.

---

**AI-Assisted PR**: This PR was created with AI assistance (Codex/Claude).
- Testing degree: `fully tested`
- Understanding: I understand that the fix prevents unhandled promise rejections by attaching a catch handler to the promise that might be abandoned by Promise.race().