### PR TITLE
fix(discord): proxy Carbon REST and webhook fetch paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Slack/app manifest: add the missing `groups:read` scope to the onboarding and example Slack app manifest so apps copied from the OpenClaw templates can resolve private group conversations reliably.
 - Mobile pairing/Android: stop generating Tailscale and public mobile setup codes that point at unusable cleartext remote gateways, keep private LAN pairing allowed, and make Android reject insecure remote endpoints with clearer guidance while mixed bootstrap approvals honor operator scopes correctly. (#60128) Thanks @obviyus.
 - Telegram/media: add `channels.telegram.network.dangerouslyAllowPrivateNetwork` for trusted fake-IP or transparent-proxy environments where Telegram media downloads resolve `api.telegram.org` to private/internal/special-use addresses.
+- Discord/proxy: keep Carbon REST, monitor startup, and webhook sends on the configured Discord proxy while falling back cleanly when the proxy URL is invalid, so Discord replies and deploys do not hard-fail on malformed proxy config. (#57465) Thanks @geekhuashan.
 
 ## 2026.4.2
 

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -9,6 +9,15 @@ let setDiscordRuntime: typeof import("./runtime.js").setDiscordRuntime;
 const probeDiscordMock = vi.hoisted(() => vi.fn());
 const monitorDiscordProviderMock = vi.hoisted(() => vi.fn());
 const auditDiscordChannelPermissionsMock = vi.hoisted(() => vi.fn());
+const sleepWithAbortMock = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  return {
+    ...actual,
+    sleepWithAbort: sleepWithAbortMock,
+  };
+});
 
 vi.mock("./probe.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./probe.js")>();
@@ -45,14 +54,14 @@ function createCfg(): OpenClawConfig {
   } as OpenClawConfig;
 }
 
-function resolveAccount(cfg: OpenClawConfig): ResolvedDiscordAccount {
-  return discordPlugin.config.resolveAccount(cfg, "default") as ResolvedDiscordAccount;
+function resolveAccount(cfg: OpenClawConfig, accountId = "default"): ResolvedDiscordAccount {
+  return discordPlugin.config.resolveAccount(cfg, accountId) as ResolvedDiscordAccount;
 }
 
-function startDiscordAccount(cfg: OpenClawConfig) {
+function startDiscordAccount(cfg: OpenClawConfig, accountId = "default") {
   return discordPlugin.gateway!.startAccount!(
     createStartAccountContext({
-      account: resolveAccount(cfg),
+      account: resolveAccount(cfg, accountId),
       cfg,
     }),
   );
@@ -73,6 +82,8 @@ afterEach(() => {
   probeDiscordMock.mockReset();
   monitorDiscordProviderMock.mockReset();
   auditDiscordChannelPermissionsMock.mockReset();
+  sleepWithAbortMock.mockReset();
+  sleepWithAbortMock.mockResolvedValue(undefined);
 });
 
 beforeEach(async () => {
@@ -184,8 +195,45 @@ describe("discordPlugin outbound", () => {
         accountId: "default",
       }),
     );
+    expect(sleepWithAbortMock).not.toHaveBeenCalled();
     expect(runtimeProbeDiscord).not.toHaveBeenCalled();
     expect(runtimeMonitorDiscordProvider).not.toHaveBeenCalled();
+  });
+
+  it("stagger starts later accounts in multi-bot setups", async () => {
+    probeDiscordMock.mockResolvedValue({
+      ok: true,
+      bot: { username: "Cherry" },
+      application: {
+        intents: {
+          messageContent: "limited",
+          guildMembers: "disabled",
+          presence: "disabled",
+        },
+      },
+      elapsedMs: 1,
+    });
+    monitorDiscordProviderMock.mockResolvedValue(undefined);
+
+    const cfg = {
+      channels: {
+        discord: {
+          accounts: {
+            // "alpha" sorts before "zeta" so alpha is index 0, zeta is index 1
+            alpha: { token: "Bot alpha-token", enabled: true },
+            zeta: { token: "Bot zeta-token", enabled: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    // First account (index 0) — no delay
+    await startDiscordAccount(cfg, "alpha");
+    expect(sleepWithAbortMock).not.toHaveBeenCalled();
+
+    // Second account (index 1) — 10s delay
+    await startDiscordAccount(cfg, "zeta");
+    expect(sleepWithAbortMock).toHaveBeenCalledWith(10_000, expect.any(Object));
   });
 });
 

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -18,6 +18,7 @@ import {
   resolveOutboundSendDep,
 } from "openclaw/plugin-sdk/outbound-runtime";
 import { normalizeMessageChannel } from "openclaw/plugin-sdk/routing";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
@@ -86,6 +87,19 @@ async function loadDiscordProbeRuntime() {
 
 const meta = getChatChannelMeta("discord");
 const REQUIRED_DISCORD_PERMISSIONS = ["ViewChannel", "SendMessages"] as const;
+const DISCORD_ACCOUNT_STARTUP_STAGGER_MS = 10_000;
+
+function resolveDiscordStartupDelayMs(cfg: OpenClawConfig, accountId: string): number {
+  const startupAccountIds = listDiscordAccountIds(cfg).filter((candidateId) => {
+    const candidate = resolveDiscordAccount({ cfg, accountId: candidateId });
+    return (
+      candidate.enabled &&
+      (resolveConfiguredFromCredentialStatuses(candidate) ?? Boolean(candidate.token.trim()))
+    );
+  });
+  const startupIndex = startupAccountIds.findIndex((candidateId) => candidateId === accountId);
+  return startupIndex <= 0 ? 0 : startupIndex * DISCORD_ACCOUNT_STARTUP_STAGGER_MS;
+}
 
 const resolveDiscordDmPolicy = createScopedDmSecurityResolver<ResolvedDiscordAccount>({
   channelKey: "discord",
@@ -561,6 +575,17 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
       gateway: {
         startAccount: async (ctx) => {
           const account = ctx.account;
+          const startupDelayMs = resolveDiscordStartupDelayMs(ctx.cfg, account.accountId);
+          if (startupDelayMs > 0) {
+            ctx.log?.info(
+              `[${account.accountId}] delaying provider startup ${Math.round(startupDelayMs / 1000)}s to reduce Discord startup rate limits`,
+            );
+            try {
+              await sleepWithAbort(startupDelayMs, ctx.abortSignal);
+            } catch {
+              return;
+            }
+          }
           const token = account.token.trim();
           let discordBotLabel = "";
           try {

--- a/extensions/discord/src/client.proxy.test.ts
+++ b/extensions/discord/src/client.proxy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import { createDiscordRestClient } from "./client.js";
+
+describe("createDiscordRestClient proxy support", () => {
+  it("injects a custom fetch into RequestClient when a Discord proxy is configured", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://proxy.test:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({}, cfg);
+    const requestClient = rest as unknown as {
+      customFetch?: typeof fetch;
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(requestClient.options?.fetch).toEqual(expect.any(Function));
+    expect(requestClient.customFetch).toBe(requestClient.options?.fetch);
+  });
+
+  it("does not inject fetch when no proxy is configured", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({}, cfg);
+    const requestClient = rest as unknown as {
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(requestClient.options?.fetch).toBeUndefined();
+  });
+});

--- a/extensions/discord/src/client.proxy.test.ts
+++ b/extensions/discord/src/client.proxy.test.ts
@@ -1,6 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import { createDiscordRestClient } from "./client.js";
+
+const makeProxyFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  makeProxyFetchMock.mockImplementation((proxyUrl: string) => {
+    if (proxyUrl === "bad-proxy") {
+      throw new Error("bad proxy");
+    }
+    return actual.makeProxyFetch(proxyUrl);
+  });
+  return {
+    ...actual,
+    makeProxyFetch: makeProxyFetchMock,
+  };
+});
 
 describe("createDiscordRestClient proxy support", () => {
   it("injects a custom fetch into RequestClient when a Discord proxy is configured", () => {
@@ -37,6 +53,25 @@ describe("createDiscordRestClient proxy support", () => {
       options?: { fetch?: typeof fetch };
     };
 
+    expect(requestClient.options?.fetch).toBeUndefined();
+  });
+
+  it("falls back to direct fetch when the Discord proxy URL is invalid", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "bad-proxy",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({}, cfg);
+    const requestClient = rest as unknown as {
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("bad-proxy");
     expect(requestClient.options?.fetch).toBeUndefined();
   });
 });

--- a/extensions/discord/src/client.ts
+++ b/extensions/discord/src/client.ts
@@ -1,5 +1,6 @@
 import { RequestClient } from "@buape/carbon";
 import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
+import { makeProxyFetch } from "openclaw/plugin-sdk/infra-runtime";
 import type { RetryConfig, RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import {
@@ -29,8 +30,53 @@ function resolveToken(params: { accountId: string; fallbackToken?: string }) {
   return fallback;
 }
 
-function resolveRest(token: string, rest?: RequestClient) {
-  return rest ?? new RequestClient(token);
+function resolveDiscordProxyUrl(
+  account: Pick<ResolvedDiscordAccount, "config">,
+  cfg?: ReturnType<typeof loadConfig>,
+): string | undefined {
+  const accountProxy = account.config.proxy?.trim();
+  if (accountProxy) {
+    return accountProxy;
+  }
+  const channelProxy = cfg?.channels?.discord?.proxy;
+  if (typeof channelProxy !== "string") {
+    return undefined;
+  }
+  const trimmed = channelProxy.trim();
+  return trimmed || undefined;
+}
+
+export function resolveDiscordProxyFetchForAccount(
+  account: Pick<ResolvedDiscordAccount, "config">,
+  cfg?: ReturnType<typeof loadConfig>,
+): typeof fetch | undefined {
+  const proxy = resolveDiscordProxyUrl(account, cfg);
+  return proxy ? makeProxyFetch(proxy) : undefined;
+}
+
+export function resolveDiscordProxyFetch(
+  opts: Pick<DiscordClientOpts, "cfg" | "accountId">,
+  cfg?: ReturnType<typeof loadConfig>,
+): typeof fetch | undefined {
+  const resolvedCfg = opts.cfg ?? cfg ?? loadConfig();
+  const account = resolveAccountWithoutToken({
+    cfg: resolvedCfg,
+    accountId: opts.accountId,
+  });
+  return resolveDiscordProxyFetchForAccount(account, resolvedCfg);
+}
+
+function resolveRest(
+  token: string,
+  account: ResolvedDiscordAccount,
+  cfg: ReturnType<typeof loadConfig>,
+  rest?: RequestClient,
+) {
+  if (rest) {
+    return rest;
+  }
+  const proxyFetch = resolveDiscordProxyFetchForAccount(account, cfg);
+  return new RequestClient(token, proxyFetch ? { fetch: proxyFetch } : undefined);
 }
 
 function resolveAccountWithoutToken(params: {
@@ -66,7 +112,7 @@ export function createDiscordRestClient(
       accountId: account.accountId,
       fallbackToken: account.token,
     });
-  const rest = resolveRest(token, opts.rest);
+  const rest = resolveRest(token, account, resolvedCfg, opts.rest);
   return { token, rest, account };
 }
 

--- a/extensions/discord/src/client.ts
+++ b/extensions/discord/src/client.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import { makeProxyFetch } from "openclaw/plugin-sdk/infra-runtime";
 import type { RetryConfig, RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import { danger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
   mergeDiscordAccountConfig,
   resolveDiscordAccount,
@@ -46,24 +47,41 @@ function resolveDiscordProxyUrl(
   return trimmed || undefined;
 }
 
+function resolveDiscordProxyFetchByUrl(
+  proxyUrl: string | undefined,
+  runtime?: Pick<RuntimeEnv, "error">,
+): typeof fetch | undefined {
+  const proxy = proxyUrl?.trim();
+  if (!proxy) {
+    return undefined;
+  }
+  try {
+    return makeProxyFetch(proxy);
+  } catch (err) {
+    runtime?.error?.(danger(`discord: invalid rest proxy: ${String(err)}`));
+    return undefined;
+  }
+}
+
 export function resolveDiscordProxyFetchForAccount(
   account: Pick<ResolvedDiscordAccount, "config">,
   cfg?: ReturnType<typeof loadConfig>,
+  runtime?: Pick<RuntimeEnv, "error">,
 ): typeof fetch | undefined {
-  const proxy = resolveDiscordProxyUrl(account, cfg);
-  return proxy ? makeProxyFetch(proxy) : undefined;
+  return resolveDiscordProxyFetchByUrl(resolveDiscordProxyUrl(account, cfg), runtime);
 }
 
 export function resolveDiscordProxyFetch(
   opts: Pick<DiscordClientOpts, "cfg" | "accountId">,
   cfg?: ReturnType<typeof loadConfig>,
+  runtime?: Pick<RuntimeEnv, "error">,
 ): typeof fetch | undefined {
   const resolvedCfg = opts.cfg ?? cfg ?? loadConfig();
   const account = resolveAccountWithoutToken({
     cfg: resolvedCfg,
     accountId: opts.accountId,
   });
-  return resolveDiscordProxyFetchForAccount(account, resolvedCfg);
+  return resolveDiscordProxyFetchForAccount(account, resolvedCfg, runtime);
 }
 
 function resolveRest(

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -70,6 +70,7 @@ export function createDiscordMonitorClient(params: {
   accountId: string;
   applicationId: string;
   token: string;
+  proxyFetch?: typeof fetch;
   commands: BaseCommand[];
   components: BaseMessageInteractiveComponent[];
   modals: Modal[];
@@ -115,6 +116,7 @@ export function createDiscordMonitorClient(params: {
       token: params.token,
       autoDeploy: false,
       eventQueue: eventQueueOpts,
+      ...(params.proxyFetch ? { requestOptions: { fetch: params.proxyFetch } } : {}),
     },
     {
       commands: params.commands,

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -593,7 +593,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   const discordAccountThreadBindings =
     cfg.channels?.discord?.accounts?.[account.accountId]?.threadBindings;
   const discordRestFetch = resolveDiscordRestFetch(rawDiscordCfg.proxy, runtime);
-  const discordProxyFetch = resolveDiscordProxyFetchForAccount(account, cfg);
+  const discordProxyFetch = resolveDiscordProxyFetchForAccount(account, cfg, runtime);
   const dmConfig = rawDiscordCfg.dm;
   let guildEntries = rawDiscordCfg.guilds;
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -42,6 +42,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { summarizeStringEntries } from "openclaw/plugin-sdk/text-runtime";
 import { resolveDiscordAccount } from "../accounts.js";
 import { isDiscordExecApprovalClientEnabled } from "../exec-approvals.js";
+import { resolveDiscordProxyFetchForAccount } from "../client.js";
 import { fetchDiscordApplicationId } from "../probe.js";
 import { normalizeDiscordToken } from "../token.js";
 import { createDiscordVoiceCommand } from "../voice/command.js";
@@ -592,6 +593,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   const discordAccountThreadBindings =
     cfg.channels?.discord?.accounts?.[account.accountId]?.threadBindings;
   const discordRestFetch = resolveDiscordRestFetch(rawDiscordCfg.proxy, runtime);
+  const discordProxyFetch = resolveDiscordProxyFetchForAccount(account, cfg);
   const dmConfig = rawDiscordCfg.dm;
   let guildEntries = rawDiscordCfg.guilds;
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
@@ -903,6 +905,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       accountId: account.accountId,
       applicationId,
       token,
+      proxyFetch: discordProxyFetch,
       commands,
       components,
       modals,

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -16,6 +16,7 @@ import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-runtime";
 import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { resolveDiscordAccount } from "./accounts.js";
+import { resolveDiscordProxyFetch } from "./client.js";
 import { rewriteDiscordKnownMentions } from "./mentions.js";
 import {
   buildDiscordMessagePayload,
@@ -369,8 +370,9 @@ export async function sendWebhookMessageDiscord(
   });
   const replyTo = typeof opts.replyTo === "string" ? opts.replyTo.trim() : "";
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
+  const fetchImpl = resolveDiscordProxyFetch({ cfg: opts.cfg, accountId: opts.accountId });
 
-  const response = await fetch(
+  const response = await (fetchImpl ?? fetch)(
     resolveWebhookExecutionUrl({
       webhookId,
       webhookToken,

--- a/extensions/discord/src/send.webhook.proxy.test.ts
+++ b/extensions/discord/src/send.webhook.proxy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import { sendWebhookMessageDiscord } from "./send.outbound.js";
+
+const makeProxyFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  return {
+    ...actual,
+    makeProxyFetch: makeProxyFetchMock,
+  };
+});
+
+describe("sendWebhookMessageDiscord proxy support", () => {
+  it("uses proxy fetch when a Discord proxy is configured", async () => {
+    const proxiedFetch = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-1" }), { status: 200 }));
+    makeProxyFetchMock.mockReturnValue(proxiedFetch);
+
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://proxy.test:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    await sendWebhookMessageDiscord("hello", {
+      cfg,
+      accountId: "default",
+      webhookId: "123",
+      webhookToken: "abc",
+      wait: true,
+    });
+
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(proxiedFetch).toHaveBeenCalledOnce();
+  });
+
+  it("uses global fetch when no proxy is configured", async () => {
+    makeProxyFetchMock.mockReturnValue(undefined);
+    const globalFetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-2" }), { status: 200 }));
+
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    await sendWebhookMessageDiscord("hello", {
+      cfg,
+      accountId: "default",
+      webhookId: "123",
+      webhookToken: "abc",
+      wait: true,
+    });
+
+    expect(globalFetchMock).toHaveBeenCalledOnce();
+    globalFetchMock.mockRestore();
+  });
+});

--- a/extensions/discord/src/send.webhook.proxy.test.ts
+++ b/extensions/discord/src/send.webhook.proxy.test.ts
@@ -13,6 +13,36 @@ vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
 });
 
 describe("sendWebhookMessageDiscord proxy support", () => {
+  it("falls back to global fetch when the Discord proxy URL is invalid", async () => {
+    makeProxyFetchMock.mockImplementation(() => {
+      throw new Error("bad proxy");
+    });
+    const globalFetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-0" }), { status: 200 }));
+
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "bad-proxy",
+        },
+      },
+    } as OpenClawConfig;
+
+    await sendWebhookMessageDiscord("hello", {
+      cfg,
+      accountId: "default",
+      webhookId: "123",
+      webhookToken: "abc",
+      wait: true,
+    });
+
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("bad-proxy");
+    expect(globalFetchMock).toHaveBeenCalledOnce();
+    globalFetchMock.mockRestore();
+  });
+
   it("uses proxy fetch when a Discord proxy is configured", async () => {
     const proxiedFetch = vi
       .fn()


### PR DESCRIPTION
## Summary

- Problem: Discord gateway login already honored the configured proxy, but multiple REST paths still used the default fetch path and intermittently failed behind censored networks or unstable HTTP proxies.
- Why it matters: sending replies, fetching bot identity, native command deployment, and webhook delivery could all fail even when WebSocket login was healthy.
- What changed: inject the configured Discord proxy fetch into Carbon `RequestClient`, pass the same fetch into the monitor `Client` request options, and use the proxy fetch for webhook sends.
- What did NOT change (scope boundary): no retry policy changes, no queue/concurrency changes, and no Discord DNS/proxy node tuning.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the Discord channel had split proxy behavior. Gateway WebSocket traffic already used the configured proxy agent, but Carbon REST and webhook sends still defaulted to unproxied/global fetch paths.
- Missing detection / guardrail: there was no targeted test asserting that proxy-configured Discord accounts injected a custom fetch into Carbon REST paths or webhook sends.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: the issue shows up clearly in censored or partially proxied environments where WebSocket and REST behavior diverge.
- If unknown, what was ruled out: verified that the old packaged runtime constructed `new RequestClient(token)` without proxy fetch injection and that monitor startup paths did not pass `requestOptions.fetch`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/discord/src/client.proxy.test.ts`
  - `extensions/discord/src/monitor/provider.test.ts`
  - `extensions/discord/src/send.webhook.proxy.test.ts`
- Scenario the test should lock in: when a Discord proxy is configured, REST clients, monitor startup clients, and webhook sends all use a custom proxy fetch rather than the default fetch path.
- Why this is the smallest reliable guardrail: the bug is specifically about constructor wiring and outbound fetch selection, which can be asserted directly without a live Discord environment.
- Existing test that already covers this (if any): none for these proxy gaps.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Discord REST operations now honor the same configured proxy as Discord gateway login.
- Webhook sends now also honor the configured Discord proxy.

## Diagram (if applicable)

```text
Before:
[Discord proxy configured] -> [gateway login proxied]
                          -> [REST / webhook paths use default fetch] -> [intermittent fetch failed]

After:
[Discord proxy configured] -> [gateway login proxied]
                          -> [REST / monitor / webhook paths use proxy fetch] -> [consistent network path]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 25.x, local OpenClaw gateway
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): `channels.discord.proxy=http://127.0.0.1:8888`

### Steps

1. Configure a Discord proxy in OpenClaw.
2. Start the Discord provider in an environment where direct Discord REST access is unreliable or blocked.
3. Trigger native command deploy, bot identity lookup, or outbound webhook/reply send.

### Expected

- All Discord outbound HTTP paths use the configured proxy.

### Actual

- Before this patch, gateway login used the proxy but Carbon REST and webhook sends could still fail with `fetch failed`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: inspected the packaged runtime before/after, reproduced that old runtime missed proxy injection on REST paths, ran targeted Discord tests, deployed patched runtime locally, and confirmed post-restart logs showed proxy-enabled REST startup without new Discord `fetch failed` entries in the immediate verification window.
- Edge cases checked: account-level proxy override, channel-level fallback proxy, webhook sends with thread ids.
- What you did **not** verify: full repository-wide `pnpm check` is currently red due unrelated pre-existing TypeScript errors outside this change.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: environments that rely on intentionally distinct proxy behavior between Discord gateway and REST paths will now get unified behavior.
  - Mitigation: the proxy source remains the existing Discord account/channel proxy config; this only makes previously unproxied Discord HTTP paths honor that config consistently.
