### PR TITLE
fix(tools): strip patternProperties for all non-Anthropic providers

### DIFF
--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -4,6 +4,47 @@ import { normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 
 describe("normalizeToolParameters", () => {
+  it("strips patternProperties for non-Anthropic providers by default (#57443)", () => {
+    const tool: AnyAgentTool = {
+      name: "exec",
+      label: "exec",
+      description: "run a command",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string" },
+          env: {
+            type: "object",
+            patternProperties: {
+              "^(.*)$": { type: "string" },
+            },
+          },
+        },
+        required: ["command"],
+      },
+      execute: vi.fn(),
+    };
+
+    // Non-Anthropic provider (e.g. BytePlus Ark) should strip patternProperties
+    const normalized = normalizeToolParameters(tool, {
+      modelProvider: "bytedance",
+    });
+    const env = (normalized.parameters as Record<string, unknown>).properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(env.env.patternProperties).toBeUndefined();
+    expect(env.env.type).toBe("object");
+
+    // Anthropic native API supports full JSON Schema — keep patternProperties
+    const anthropicNormalized = normalizeToolParameters(tool, {
+      modelProvider: "anthropic",
+    });
+    const anthropicEnv = (anthropicNormalized.parameters as Record<string, unknown>)
+      .properties as Record<string, Record<string, unknown>>;
+    expect(anthropicEnv.env.patternProperties).toBeDefined();
+  });
+
   it("strips compat-declared unsupported schema keywords without provider-specific branching", () => {
     const tool: AnyAgentTool = {
       name: "demo",

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -99,12 +99,20 @@ export function normalizeToolParameters(
   const isAnthropicProvider = options?.modelProvider?.toLowerCase().includes("anthropic");
   const unsupportedToolSchemaKeywords = resolveUnsupportedToolSchemaKeywords(options?.modelCompat);
 
+  // Keywords that are not part of the OpenAI tool-schema subset and are
+  // rejected by many OpenAI-compatible providers (BytePlus Ark, etc.).
+  // Anthropic's native API supports full JSON Schema, so it is excluded.
+  // (#57443)
+  const baseUnsupported = isAnthropicProvider
+    ? unsupportedToolSchemaKeywords
+    : new Set([...unsupportedToolSchemaKeywords, "patternProperties"]);
+
   function applyProviderCleaning(s: unknown): unknown {
     if (isGeminiProvider && !isAnthropicProvider) {
       return cleanSchemaForGemini(s);
     }
-    if (unsupportedToolSchemaKeywords.size > 0) {
-      return stripUnsupportedSchemaKeywords(s, unsupportedToolSchemaKeywords);
+    if (baseUnsupported.size > 0) {
+      return stripUnsupportedSchemaKeywords(s, baseUnsupported);
     }
     return s;
   }


### PR DESCRIPTION
## Summary

Fixes #57443

- `normalizeToolParameters()` only cleaned `patternProperties` for Google/Gemini providers via `cleanSchemaForGemini()`
- Many OpenAI-compatible providers (BytePlus Ark/doubao, etc.) also reject `patternProperties` with HTTP 400
- Now `patternProperties` is stripped by default for all non-Anthropic providers, since Anthropic's native API is the only one that fully supports JSON Schema draft 2020-12

## Changes

- `src/agents/pi-tools.schema.ts`: Build a `baseUnsupported` keyword set that includes `patternProperties` for all non-Anthropic providers, merged with any explicit `modelCompat.unsupportedToolSchemaKeywords`
- `src/agents/pi-tools.schema.test.ts`: Add test verifying patternProperties is stripped for non-Anthropic providers but preserved for Anthropic

## Test plan

- [x] 2 unit tests pass (`pi-tools.schema.test.ts`)
- [ ] Manual: configure BytePlus Ark provider, send a message that triggers exec tool, verify no HTTP 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)