### PR TITLE
fix(sessions): let a2a policy gate cross-agent sends independently of visibility

### DIFF
--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -157,6 +157,46 @@ describe("createSessionVisibilityGuard", () => {
     });
   });
 
+  it("allows cross-agent send with tree visibility when a2a policy permits (#57447)", async () => {
+    const guard = await createSessionVisibilityGuard({
+      action: "send",
+      requesterSessionKey: "agent:main:main",
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({
+        tools: {
+          agentToAgent: {
+            enabled: true,
+            allow: ["main", "ops"],
+          },
+        },
+      } as unknown as OpenClawConfig),
+    });
+
+    expect(guard.check("agent:ops:main")).toEqual({ allowed: true });
+  });
+
+  it("blocks cross-agent history with tree visibility even when a2a policy permits", async () => {
+    const guard = await createSessionVisibilityGuard({
+      action: "history",
+      requesterSessionKey: "agent:main:main",
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({
+        tools: {
+          agentToAgent: {
+            enabled: true,
+            allow: ["main", "ops"],
+          },
+        },
+      } as unknown as OpenClawConfig),
+    });
+
+    expect(guard.check("agent:ops:main")).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error: expect.stringContaining("visibility"),
+    });
+  });
+
   it("enforces self visibility for same-agent sessions", async () => {
     const guard = await createSessionVisibilityGuard({
       action: "history",

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -166,9 +166,7 @@ function crossVisibilityMessage(action: SessionAccessAction): string {
   if (action === "history") {
     return "Session history visibility is restricted. Set tools.sessions.visibility=all to allow cross-agent access.";
   }
-  if (action === "send") {
-    return "Session send visibility is restricted. Set tools.sessions.visibility=all to allow cross-agent access.";
-  }
+  // "send" is gated by a2a policy, not visibility — see createSessionVisibilityGuard.
   if (action === "status") {
     return "Session status visibility is restricted. Set tools.sessions.visibility=all to allow cross-agent access.";
   }

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -201,7 +201,10 @@ export async function createSessionVisibilityGuard(params: {
     const targetAgentId = resolveAgentIdFromSessionKey(targetSessionKey);
     const isCrossAgent = targetAgentId !== requesterAgentId;
     if (isCrossAgent) {
-      if (params.visibility !== "all") {
+      // For "send", a2a policy is the authorization gate — sending does not
+      // require visibility into the target session's history.  Visibility
+      // only governs read operations (list, history, status).  (#57447)
+      if (params.action !== "send" && params.visibility !== "all") {
         return {
           allowed: false,
           status: "forbidden",


### PR DESCRIPTION
## Summary

Fixes #57447

- `createSessionVisibilityGuard()` blocked all cross-agent access when `visibility !== "all"`, including `sessions_send`, even when `agentToAgent` policy explicitly allowed it
- This forced an all-or-nothing choice: `visibility=all` exposes all sessions, `visibility=tree` blocks legitimate cross-agent messaging
- One-line fix: skip the visibility gate for `"send"` action on cross-agent targets, letting a2a policy be the sole authorization gate

## Rationale

| Action | Gate | Rationale |
|--------|------|-----------|
| list | visibility | controls what you can **see** |
| history | visibility | controls what you can **read** |
| status | visibility | controls what you can **inspect** |
| send | a2a policy | controls what you can **message** — sending does not require seeing |

## Changes

- `src/agents/tools/sessions-access.ts`: Add `params.action !== "send"` to the cross-agent visibility check
- `src/agents/tools/sessions-access.test.ts`: Add 2 tests — send allowed with tree+a2a, history still blocked with tree+a2a

## Test plan

- [x] 14 unit tests pass (`sessions-access.test.ts`)
- [ ] Manual: configure `visibility=tree` + `agentToAgent.enabled=true`, verify cross-agent `sessions_send` works while `sessions_history` remains blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)