### PR TITLE
test(android): harden SMS capability coverage

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
@@ -1,10 +1,21 @@
 package ai.openclaw.app.node
 
+import ai.openclaw.app.LocationMode
+import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.VoiceWakeMode
+import ai.openclaw.app.protocol.OpenClawCapability
+import ai.openclaw.app.protocol.OpenClawSmsCommand
 import ai.openclaw.app.gateway.GatewayEndpoint
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
+@RunWith(RobolectricTestRunner::class)
 class ConnectionManagerTest {
   @Test
   fun resolveTlsParamsForEndpoint_prefersStoredPinOverAdvertisedFingerprint() {
@@ -72,5 +83,88 @@ class ConnectionManagerTest {
       )
     assertNull(on?.expectedFingerprint)
     assertEquals(false, on?.allowTOFU)
+  }
+
+  @Test
+  fun buildNodeConnectOptions_advertisesRequestableSmsSearchWithoutSmsCapability() {
+    val options =
+      newManager(
+        sendSmsAvailable = false,
+        readSmsAvailable = false,
+        smsSearchPossible = true,
+      ).buildNodeConnectOptions()
+
+    assertTrue(options.commands.contains(OpenClawSmsCommand.Search.rawValue))
+    assertFalse(options.commands.contains(OpenClawSmsCommand.Send.rawValue))
+    assertFalse(options.caps.contains(OpenClawCapability.Sms.rawValue))
+  }
+
+  @Test
+  fun buildNodeConnectOptions_doesNotAdvertiseSmsWhenSearchIsImpossible() {
+    val options =
+      newManager(
+        sendSmsAvailable = false,
+        readSmsAvailable = false,
+        smsSearchPossible = false,
+      ).buildNodeConnectOptions()
+
+    assertFalse(options.commands.contains(OpenClawSmsCommand.Search.rawValue))
+    assertFalse(options.commands.contains(OpenClawSmsCommand.Send.rawValue))
+    assertFalse(options.caps.contains(OpenClawCapability.Sms.rawValue))
+  }
+
+  @Test
+  fun buildNodeConnectOptions_advertisesSmsCapabilityWhenReadSmsIsAvailable() {
+    val options =
+      newManager(
+        sendSmsAvailable = false,
+        readSmsAvailable = true,
+        smsSearchPossible = true,
+      ).buildNodeConnectOptions()
+
+    assertTrue(options.commands.contains(OpenClawSmsCommand.Search.rawValue))
+    assertTrue(options.caps.contains(OpenClawCapability.Sms.rawValue))
+  }
+
+  @Test
+  fun buildNodeConnectOptions_advertisesSmsSendWithoutSearchWhenOnlySendIsAvailable() {
+    val options =
+      newManager(
+        sendSmsAvailable = true,
+        readSmsAvailable = false,
+        smsSearchPossible = false,
+      ).buildNodeConnectOptions()
+
+    assertTrue(options.commands.contains(OpenClawSmsCommand.Send.rawValue))
+    assertFalse(options.commands.contains(OpenClawSmsCommand.Search.rawValue))
+    assertTrue(options.caps.contains(OpenClawCapability.Sms.rawValue))
+  }
+
+  private fun newManager(
+    sendSmsAvailable: Boolean = false,
+    readSmsAvailable: Boolean = false,
+    smsSearchPossible: Boolean = false,
+  ): ConnectionManager {
+    val context = RuntimeEnvironment.getApplication()
+    val prefs =
+      SecurePrefs(
+        context,
+        securePrefsOverride = context.getSharedPreferences("connection-manager-test", android.content.Context.MODE_PRIVATE),
+      )
+
+    return ConnectionManager(
+      prefs = prefs,
+      cameraEnabled = { false },
+      locationMode = { LocationMode.Off },
+      voiceWakeMode = { VoiceWakeMode.Off },
+      motionActivityAvailable = { false },
+      motionPedometerAvailable = { false },
+      sendSmsAvailable = { sendSmsAvailable },
+      readSmsAvailable = { readSmsAvailable },
+      smsSearchPossible = { smsSearchPossible },
+      callLogAvailable = { false },
+      hasRecordAudioPermission = { false },
+      manualTls = { false },
+    )
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceHandlerTest.kt
@@ -150,6 +150,30 @@ class DeviceHandlerTest {
   }
 
   @Test
+  fun smsTopLevelStatusTreatsDisabledSmsAsDenied() {
+    assertTrue(
+      !DeviceHandler.hasAnySmsCapability(
+        smsEnabled = false,
+        telephonyAvailable = true,
+        smsSendGranted = true,
+        smsReadGranted = true,
+      ),
+    )
+  }
+
+  @Test
+  fun smsTopLevelStatusTreatsMissingTelephonyAsDenied() {
+    assertTrue(
+      !DeviceHandler.hasAnySmsCapability(
+        smsEnabled = true,
+        telephonyAvailable = false,
+        smsSendGranted = true,
+        smsReadGranted = true,
+      ),
+    )
+  }
+
+  @Test
   fun smsTopLevelPromptableStaysTrueUntilBothSmsPermissionsAreGranted() {
     assertTrue(
       DeviceHandler.isSmsPromptable(
@@ -165,6 +189,26 @@ class DeviceHandlerTest {
         telephonyAvailable = true,
         smsSendGranted = true,
         smsReadGranted = true,
+      ),
+    )
+  }
+
+  @Test
+  fun smsTopLevelPromptableIsFalseWhenSmsCannotExist() {
+    assertTrue(
+      !DeviceHandler.isSmsPromptable(
+        smsEnabled = false,
+        telephonyAvailable = true,
+        smsSendGranted = false,
+        smsReadGranted = false,
+      ),
+    )
+    assertTrue(
+      !DeviceHandler.isSmsPromptable(
+        smsEnabled = true,
+        telephonyAvailable = false,
+        smsSendGranted = false,
+        smsReadGranted = false,
       ),
     )
   }


### PR DESCRIPTION
## Summary
- add node connection coverage for SMS command/cap advertisement splits
- lock down device permission semantics for disabled SMS and missing telephony
- target the Android SMS regression surface from recent landing work

## Testing
- apps/android/gradlew --no-daemon :app:testThirdPartyDebugUnitTest --tests 'ai.openclaw.app.node.ConnectionManagerTest' --tests 'ai.openclaw.app.node.DeviceHandlerTest' --tests 'ai.openclaw.app.node.InvokeCommandRegistryTest' --tests 'ai.openclaw.app.node.InvokeDispatcherTest'