### PR TITLE
CI: fix discord media-runtime mock + telegram auto-thread test

### DIFF
--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -5,14 +5,11 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const fetchRemoteMedia = vi.fn();
 const saveMediaBuffer = vi.fn();
 
-vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
-  fetchRemoteMedia: (...args: unknown[]) => fetchRemoteMedia(...args),
-}));
-
 vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>();
   return {
     ...actual,
+    fetchRemoteMedia: (...args: unknown[]) => fetchRemoteMedia(...args),
     saveMediaBuffer: (...args: unknown[]) => saveMediaBuffer(...args),
   };
 });

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -35,10 +35,20 @@ function resolveTelegramAutoThreadIdForTest(params: {
     return undefined;
   }
   const normalizeChatId = (raw: string) => {
-    const trimmed = raw
-      .trim()
-      .replace(/^telegram:/i, "")
-      .replace(/^tg:/i, "");
+    let trimmed = raw.trim();
+    let strippedTelegramPrefix = false;
+    while (true) {
+      if (/^(telegram|tg):/i.test(trimmed)) {
+        strippedTelegramPrefix = true;
+        trimmed = trimmed.replace(/^(telegram|tg):/i, "").trim();
+        continue;
+      }
+      if (strippedTelegramPrefix && /^group:/i.test(trimmed)) {
+        trimmed = trimmed.replace(/^group:/i, "").trim();
+        continue;
+      }
+      break;
+    }
     const groupTopic = /^group:([^:]+):topic:\d+$/i.exec(trimmed);
     if (groupTopic) {
       return groupTopic[1].toLowerCase();


### PR DESCRIPTION
CI is currently red on main and blocks merging PR #57356.\n\nFixes included:\n- extensions/discord: media-runtime mock now preserves actual exports and overrides fetchRemoteMedia/saveMediaBuffer (previous mock only replaced fetchRemoteMedia; saveMediaBuffer stayed real, and the mock sometimes didn't intercept).\n- message-action-params threading test: normalize Telegram target prefixes so telegram:group:-100123:topic:77 matches tg:group:-100123.\n\nLocal note: vitest runs hang in this environment (Node 25), so targeted tests were executed with timeout and did not complete; rely on CI (Node 24) for authoritative pass/fail.\n