### PR TITLE
fix(facade-runtime): add recursion guard to facade module loader to prevent infinite stack overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Anthropic failover: treat Anthropic `api_error` payloads with `An unexpected error occurred while processing the response` as transient so retry/fallback can engage instead of surfacing a terminal failure. (#57441) Thanks @zijiess and @vincentkoc.
 - Agents/compaction: keep late compaction-retry rejections handled after the aggregate timeout path wins without swallowing real pre-timeout wait failures, so timed-out retries no longer surface an unhandled rejection on later unsubscribe. (#57451) Thanks @mpz4life and @vincentkoc.
 - Matrix/delivery recovery: treat Synapse `User not in room` replay failures as permanent during startup recovery so poisoned queued messages move to `failed/` instead of crash-looping Matrix after restart. (#57426) thanks @dlardo.
+- Plugins/facades: guard bundled plugin facade loads with a cache-first sentinel so circular re-entry stops crashing `xai`, `sglang`, and `vllm` during gateway plugin startup. (#57508) Thanks @openperf.
 
 ## 2026.3.28
 

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -19,6 +19,18 @@ function createBundledPluginDir(prefix: string, marker: string): string {
   return rootDir;
 }
 
+function createThrowingPluginDir(prefix: string): string {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(rootDir);
+  fs.mkdirSync(path.join(rootDir, "bad"), { recursive: true });
+  fs.writeFileSync(
+    path.join(rootDir, "bad", "api.js"),
+    `throw new Error("plugin load failure");\n`,
+    "utf8",
+  );
+  return rootDir;
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   if (originalBundledPluginsDir === undefined) {
@@ -49,5 +61,41 @@ describe("plugin-sdk facade runtime", () => {
       artifactBasename: "api.js",
     });
     expect(fromB.marker).toBe("override-b");
+  });
+
+  it("returns the same object identity on repeated calls (sentinel consistency)", () => {
+    const dir = createBundledPluginDir("openclaw-facade-identity-", "identity-check");
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = dir;
+
+    const first = loadBundledPluginPublicSurfaceModuleSync<{ marker: string }>({
+      dirName: "demo",
+      artifactBasename: "api.js",
+    });
+    const second = loadBundledPluginPublicSurfaceModuleSync<{ marker: string }>({
+      dirName: "demo",
+      artifactBasename: "api.js",
+    });
+    expect(first).toBe(second);
+    expect(first.marker).toBe("identity-check");
+  });
+
+  it("clears the cache on load failure so retries re-execute", () => {
+    const dir = createThrowingPluginDir("openclaw-facade-throw-");
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = dir;
+
+    expect(() =>
+      loadBundledPluginPublicSurfaceModuleSync<{ marker: string }>({
+        dirName: "bad",
+        artifactBasename: "api.js",
+      }),
+    ).toThrow("plugin load failure");
+
+    // A second call must also throw (not return a stale empty sentinel).
+    expect(() =>
+      loadBundledPluginPublicSurfaceModuleSync<{ marker: string }>({
+        dirName: "bad",
+        artifactBasename: "api.js",
+      }),
+    ).toThrow("plugin load failure");
   });
 });

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -31,6 +31,36 @@ function createThrowingPluginDir(prefix: string): string {
   return rootDir;
 }
 
+function createCircularPluginDir(prefix: string): string {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(rootDir);
+  fs.mkdirSync(path.join(rootDir, "demo"), { recursive: true });
+  fs.writeFileSync(
+    path.join(rootDir, "facade.mjs"),
+    [
+      `import { loadBundledPluginPublicSurfaceModuleSync } from ${JSON.stringify(
+        new URL("./facade-runtime.js", import.meta.url).href,
+      )};`,
+      `export const marker = loadBundledPluginPublicSurfaceModuleSync({ dirName: "demo", artifactBasename: "api.js" }).marker;`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "demo", "helper.js"),
+    ['import { marker } from "../facade.mjs";', "export const circularMarker = marker;", ""].join(
+      "\n",
+    ),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "demo", "api.js"),
+    ['import "./helper.js";', 'export const marker = "circular-ok";', ""].join("\n"),
+    "utf8",
+  );
+  return rootDir;
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   if (originalBundledPluginsDir === undefined) {
@@ -77,6 +107,18 @@ describe("plugin-sdk facade runtime", () => {
     });
     expect(first).toBe(second);
     expect(first.marker).toBe("identity-check");
+  });
+
+  it("breaks circular facade re-entry during module evaluation", () => {
+    const dir = createCircularPluginDir("openclaw-facade-circular-");
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = dir;
+
+    const loaded = loadBundledPluginPublicSurfaceModuleSync<{ marker: string }>({
+      dirName: "demo",
+      artifactBasename: "api.js",
+    });
+
+    expect(loaded.marker).toBe("circular-ok");
   });
 
   it("clears the cache on load failure so retries re-execute", () => {

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -168,7 +168,7 @@ export function createLazyFacadeArrayValue<T extends readonly unknown[]>(load: (
   return createLazyFacadeProxyValue({ load, target: [] });
 }
 
-export function loadBundledPluginPublicSurfaceModuleSync<T>(params: {
+export function loadBundledPluginPublicSurfaceModuleSync<T extends object>(params: {
   dirName: string;
   artifactBasename: string;
 }): T {
@@ -200,7 +200,23 @@ export function loadBundledPluginPublicSurfaceModuleSync<T>(params: {
   }
   fs.closeSync(opened.fd);
 
-  const loaded = getJiti(location.modulePath)(location.modulePath) as T;
-  loadedFacadeModules.set(location.modulePath, loaded);
-  return loaded;
+  // Place a sentinel object in the cache *before* the Jiti load begins.
+  // If a transitive dependency of the loaded module re-enters this function
+  // for the same modulePath (circular facade reference), it will receive the
+  // sentinel instead of recursing infinitely.  Once the real module finishes
+  // loading, Object.assign() back-fills the sentinel so any references
+  // captured during the circular load phase see the final exports.
+  const sentinel = {} as T;
+  loadedFacadeModules.set(location.modulePath, sentinel);
+
+  let loaded: T;
+  try {
+    loaded = getJiti(location.modulePath)(location.modulePath) as T;
+    Object.assign(sentinel, loaded);
+  } catch (err) {
+    loadedFacadeModules.delete(location.modulePath);
+    throw err;
+  }
+
+  return sentinel;
 }

--- a/src/test-utils/bundled-plugin-public-surface.ts
+++ b/src/test-utils/bundled-plugin-public-surface.ts
@@ -21,7 +21,7 @@ function findBundledPluginMetadata(pluginId: string): BundledPluginMetadata {
   return metadata;
 }
 
-export function loadBundledPluginPublicSurfaceSync<T>(params: {
+export function loadBundledPluginPublicSurfaceSync<T extends object>(params: {
   pluginId: string;
   artifactBasename: string;
 }): T {
@@ -32,7 +32,7 @@ export function loadBundledPluginPublicSurfaceSync<T>(params: {
   });
 }
 
-export function loadBundledPluginTestApiSync<T>(pluginId: string): T {
+export function loadBundledPluginTestApiSync<T extends object>(pluginId: string): T {
   return loadBundledPluginPublicSurfaceSync<T>({
     pluginId,
     artifactBasename: "test-api.js",


### PR DESCRIPTION
### Summary

- **Problem**: The `xai`, `sglang`, and `vllm` plugins crash on every load attempt with `RangeError: Maximum call stack size exceeded`. The gateway retries loading these plugins every ~8 minutes, each time hitting the same stack overflow. This occurs in `src/plugin-sdk/facade-runtime.ts` at `loadBundledPluginPublicSurfaceModuleSync()` (line 171-206).
- **Root Cause**: The facade lazy-loading pattern introduced in `8e0ab35b0e` handles function exports correctly (wrapped in closures, loaded on first call) but constant exports eagerly call `loadFacadeModule()` at module-evaluation time. When the constant initializer triggers `loadFacadeModule()` → Jiti sync load of `extensions/{xai,sglang,vllm}/api.ts`, any transitive dependency that imports back to `openclaw/plugin-sdk/{xai,sglang,vllm}` (even indirectly) re-enters `loadBundledPluginPublicSurfaceModuleSync()`. The `loadedFacadeModules` cache is only set **after** the Jiti load returns (line 204), so the re-entrant call finds no cache entry and recurses until stack overflow.
- **Fix**: Set a sentinel object in the `loadedFacadeModules` cache **before** the Jiti load begins. Re-entrant calls receive the sentinel instead of recursing. Once the real module finishes loading, `Object.assign()` back-fills the sentinel so any references captured during the circular load phase see the final exports. Both the Jiti load and the `Object.assign()` back-fill are wrapped in `try/catch`: on failure the sentinel is removed from the cache so that subsequent retry attempts re-execute the load instead of silently returning an empty object. The function returns the sentinel (not the raw loaded module) to guarantee a single object identity for all callers, including those that captured a reference during the circular load phase.
- **What changed**:
  - `src/plugin-sdk/facade-runtime.ts`: Added sentinel object logic with try/catch guard (covering both Jiti load and Object.assign back-fill) in `loadBundledPluginPublicSurfaceModuleSync`, tightened generic constraint to `<T extends object>`.
  - `src/test-utils/bundled-plugin-public-surface.ts`: Propagated the `<T extends object>` constraint to `loadBundledPluginPublicSurfaceSync` and `loadBundledPluginTestApiSync`.
  - `src/plugin-sdk/facade-runtime.test.ts`: Added two test cases — sentinel object identity consistency on repeated calls, and cache cleanup on load failure ensuring retries re-execute.
- **What did NOT change (scope boundary)**: No changes to actual plugin implementations (`xai`, `sglang`, `vllm`) or their dependency graphs. No changes to the Jiti loader configuration, the `resolveFacadeModuleLocation` function, or the `openBoundaryFileSync` security boundary. The fix is purely at the infrastructure level (facade loader) to gracefully handle circular facade references during module evaluation.

### Reproduction

1. Upgrade to 2026.3.28 or later.
2. Enable any of the `xai`, `sglang`, or `vllm` LLM provider plugins.
3. Start the gateway — observe `RangeError: Maximum call stack size exceeded` in logs every ~8 minutes.

### Risk / Mitigation

- **Risk**: The sentinel object is temporarily empty during the Jiti load phase. If a circular caller reads a constant export from the sentinel before the load completes, it would get `undefined`.
- **Mitigation**: The circular dependencies in these plugins only capture references to the facade module or its exports during evaluation; they do not execute logic that reads the constants until after the module graph is fully loaded. The try/catch ensures that if the Jiti load fails for any reason, the sentinel is removed from the cache so subsequent retries re-execute the load cleanly. Returning the sentinel (instead of the raw loaded object) guarantees a single object identity for all callers.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Plugin SDK (`src/plugin-sdk`)

### Linked Issue/PR

Fixes #57394
