### PR TITLE
fix: apply schema cleaning for Ark/Volcengine/BytePlus providers

### DIFF
--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -86,6 +86,8 @@ export function normalizeToolParameters(
 
   // Provider quirks:
   // - Gemini rejects several JSON Schema keywords, so we scrub those.
+  // - Ark/Volcengine/BytePlus reject `patternProperties` and similar keywords
+  //   (same subset as Gemini), so we apply the same cleaning. (#57443)
   // - OpenAI rejects function tool schemas unless the *top-level* is `type: "object"`.
   //   (TypeBox root unions compile to `{ anyOf: [...] }` without `type`).
   // - Anthropic expects full JSON Schema draft 2020-12 compliance.
@@ -97,10 +99,13 @@ export function normalizeToolParameters(
     options?.modelProvider?.toLowerCase().includes("google") ||
     options?.modelProvider?.toLowerCase().includes("gemini");
   const isAnthropicProvider = options?.modelProvider?.toLowerCase().includes("anthropic");
+  const isArkProvider = /(volcengine(-plan)?|byteplus(-plan)?|ark)\/?/.test(
+    options?.modelProvider?.toLowerCase() ?? "",
+  );
   const unsupportedToolSchemaKeywords = resolveUnsupportedToolSchemaKeywords(options?.modelCompat);
 
   function applyProviderCleaning(s: unknown): unknown {
-    if (isGeminiProvider && !isAnthropicProvider) {
+    if ((isGeminiProvider || isArkProvider) && !isAnthropicProvider) {
       return cleanSchemaForGemini(s);
     }
     if (unsupportedToolSchemaKeywords.size > 0) {

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -99,7 +99,7 @@ export function normalizeToolParameters(
     options?.modelProvider?.toLowerCase().includes("google") ||
     options?.modelProvider?.toLowerCase().includes("gemini");
   const isAnthropicProvider = options?.modelProvider?.toLowerCase().includes("anthropic");
-  const isArkProvider = /(volcengine(-plan)?|byteplus(-plan)?|ark)\/?/.test(
+  const isArkProvider = /^(volcengine(-plan)?|byteplus(-plan)?|ark)(\/.*)?$/.test(
     options?.modelProvider?.toLowerCase() ?? "",
   );
   const unsupportedToolSchemaKeywords = resolveUnsupportedToolSchemaKeywords(options?.modelCompat);


### PR DESCRIPTION
## Problem

Ark API (used by Volcengine/BytePlus/Ark providers) rejects the `patternProperties` JSON Schema keyword with HTTP 400:

```
HTTP 400: Invalid decoding guidance syntax: Keyword 'patternProperties' is not supported
for type 'object' at path '$.properties.env'
```

This affects any tool that uses `patternProperties` in its schema (e.g., `exec` tool's `env` parameter).

## Root Cause

`applyProviderCleaning()` in `pi-tools.schema.ts` only calls `cleanSchemaForGemini()` for Google/Gemini providers. Ark-family providers have the same restriction but are not covered.

## Fix

Add `isArkProvider` detection matching `volcengine`, `volcengine-plan`, `byteplus`, `byteplus-plan`, and `ark` provider IDs. Apply the same `cleanSchemaForGemini()` cleaning to these providers.

The regex also handles the `ark/model-name` format with an optional trailing slash.

## Changes

- `src/agents/pi-tools.schema.ts`: Add `isArkProvider` variable and extend the condition in `applyProviderCleaning()` from `isGeminiProvider` to `(isGeminiProvider || isArkProvider)`.

## Testing

1. Configure a Volcengine/Ark provider with a doubao model
2. Send a message that triggers `exec` tool usage
3. Before fix: HTTP 400 with `patternProperties` error
4. After fix: Tool schema cleaned, API call succeeds

Fixes #57443