### PR TITLE
Hide brew-only skill installs in Linux containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 - Release/beta smoke: resolve the dispatched Telegram beta E2E run from `gh run list` when `gh workflow run` returns no run URL, so the maintainer helper does not fail immediately after dispatch. Thanks @vincentkoc.
 - Media/images: keep HEIC/HEIF attachments fail-closed when optional Sharp conversion is unavailable instead of sending originals that still need conversion. Thanks @vincentkoc.
 - Google Meet: fork the caller's current agent transcript into agent-mode meeting consultant sessions, so Meet replies inherit the context from the tool call that joined the meeting.
+- Skills/onboarding: hide brew-only skill dependency installs inside Linux containers without Homebrew, using the shared container detector so Docker, Podman, containerd, and Kubernetes paths avoid the broken Homebrew prompt. (#57553) Thanks @txhno.
 - Telegram/streaming: sanitize tool-progress draft preview backticks before shared compaction, so long backtick-heavy progress text still renders inside the safe code-formatted preview instead of collapsing to an ellipsis.
 - UI/chat: remove the unsupported `line-clamp` declaration from the chat queue text rule to eliminate Firefox console noise without changing visible truncation behavior. Thanks @ZanderH-code.
 - Agents/Pi: suppress persistence for synthetic mid-turn overflow continuation prompts, so transcript-retry recovery does not write the "continue from transcript" prompt as a new user turn. Thanks @vincentkoc.

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../config/config.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   buildWorkspaceSkillStatus: vi.fn(),
   installSkill: vi.fn(),
   detectBinary: vi.fn(),
+  isContainerEnvironment: vi.fn(),
   resolveNodeManagerOptions: vi.fn(() => [
     { value: "npm", label: "npm" },
     { value: "pnpm", label: "pnpm" },
@@ -20,6 +21,9 @@ vi.mock("../agents/skills-status.js", () => ({
 }));
 vi.mock("../agents/skills-install.js", () => ({
   installSkill: mocks.installSkill,
+}));
+vi.mock("../gateway/net.js", () => ({
+  isContainerEnvironment: mocks.isContainerEnvironment,
 }));
 vi.mock("./onboard-helpers.js", () => ({
   detectBinary: mocks.detectBinary,
@@ -134,6 +138,32 @@ const runtime: RuntimeEnv = {
 };
 
 describe("setupSkills", () => {
+  afterEach(() => {
+    mocks.isContainerEnvironment.mockReturnValue(false);
+  });
+
+  it.skipIf(process.platform !== "linux")(
+    "hides brew-only installs in Linux containers when brew is missing",
+    async () => {
+      mockMissingBrewStatus([
+        createBundledSkill({
+          name: "video-frames",
+          description: "ffmpeg",
+          bins: ["ffmpeg"],
+          installLabel: "Install ffmpeg (brew)",
+        }),
+      ]);
+      mocks.isContainerEnvironment.mockReturnValue(true);
+
+      const { prompter, notes } = createPrompter({});
+      await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+      expect(prompter.multiselect).not.toHaveBeenCalled();
+      expect(notes.find((n) => n.title === "Container skill installs")).toBeDefined();
+      expect(notes.find((n) => n.title === "Homebrew recommended")).toBeUndefined();
+    },
+  );
+
   it("does not recommend Homebrew when user skips installing brew-backed deps", async () => {
     if (process.platform === "win32") {
       return;
@@ -155,6 +185,7 @@ describe("setupSkills", () => {
       }),
     ]);
 
+    mocks.isContainerEnvironment.mockReturnValue(false);
     const { prompter, notes } = createPrompter({ multiselect: ["__skip__"] });
     await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
 
@@ -180,6 +211,7 @@ describe("setupSkills", () => {
       }),
     ]);
 
+    mocks.isContainerEnvironment.mockReturnValue(false);
     const { prompter, notes } = createPrompter({ multiselect: ["video-frames"] });
     await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
 

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -2,6 +2,7 @@ import { installSkill } from "../agents/skills-install.js";
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isContainerEnvironment } from "../gateway/net.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
@@ -81,10 +82,35 @@ export async function setupSkills(
     return cfg;
   }
 
-  const installable = missing.filter(
-    (skill) => skill.install.length > 0 && skill.missing.bins.length > 0,
-  );
+  const brewAvailable = await detectBinary("brew");
+  const inLinuxContainer = process.platform === "linux" && isContainerEnvironment();
+  const installable = missing.filter((skill) => {
+    if (skill.install.length === 0 || skill.missing.bins.length === 0) {
+      return false;
+    }
+    if (!inLinuxContainer || brewAvailable) {
+      return true;
+    }
+    return !skill.install.every((option) => option.kind === "brew");
+  });
   let next: OpenClawConfig = cfg;
+  if (inLinuxContainer && !brewAvailable) {
+    const hiddenBrewOnly = missing.filter(
+      (skill) =>
+        skill.install.length > 0 &&
+        skill.missing.bins.length > 0 &&
+        skill.install.every((option) => option.kind === "brew"),
+    );
+    if (hiddenBrewOnly.length > 0) {
+      await prompter.note(
+        [
+          "Brew-only skill installs are hidden in Linux containers because the official image does not ship Homebrew.",
+          "Use a custom image with Homebrew preinstalled or install those dependencies manually.",
+        ].join("\n"),
+        "Container skill installs",
+      );
+    }
+  }
   if (installable.length > 0) {
     const toInstall = await prompter.multiselect({
       message: "Install missing skill dependencies",
@@ -111,7 +137,7 @@ export async function setupSkills(
     const needsBrewPrompt =
       process.platform !== "win32" &&
       selectedSkills.some((skill) => skill.install.some((option) => option.kind === "brew")) &&
-      !(await detectBinary("brew"));
+      !brewAvailable;
 
     if (needsBrewPrompt) {
       await prompter.note(


### PR DESCRIPTION
Summary:
- hide brew-only skill installs during onboarding when running in a Linux container without Homebrew
- show a container-specific note instead of steering users into a broken install path
- keep the existing Homebrew prompt for non-container environments

Testing:
- corepack pnpm exec vitest run src/commands/onboard-skills.test.ts
