### PR TITLE
fix(exec): prevent infinite /approve loop when exec returns approval-pending

### DIFF
--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -127,6 +127,44 @@ describe("emitExecSystemEvent", () => {
   });
 });
 
+describe("buildApprovalPendingMessage", () => {
+  let buildApprovalPendingMessage: typeof import("./bash-tools.exec-runtime.js").buildApprovalPendingMessage;
+
+  beforeEach(async () => {
+    ({ buildApprovalPendingMessage } = await import("./bash-tools.exec-runtime.js"));
+  });
+
+  it("includes explicit instruction not to execute /approve via exec", () => {
+    const message = buildApprovalPendingMessage({
+      approvalSlug: "abc123",
+      approvalId: "full-id-abc123",
+      command: "rm -rf /tmp/test",
+      cwd: "/home/user",
+      host: "gateway",
+    });
+
+    expect(message).toContain("/approve abc123 allow-once|allow-always|deny");
+    expect(message).toContain("Do NOT execute /approve via the exec tool");
+    expect(message).toContain("Show this /approve command to the user as a chat message");
+  });
+
+  it("includes the command block and host info", () => {
+    const message = buildApprovalPendingMessage({
+      approvalSlug: "xyz",
+      approvalId: "full-xyz",
+      command: "echo hello",
+      cwd: "/tmp",
+      host: "node",
+      nodeId: "node-1",
+    });
+
+    expect(message).toContain("echo hello");
+    expect(message).toContain("Host: node");
+    expect(message).toContain("Node: node-1");
+    expect(message).toContain("Approval required (id xyz, full full-xyz)");
+  });
+});
+
 describe("formatExecFailureReason", () => {
   it("formats timeout guidance with the configured timeout", () => {
     expect(

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -363,6 +363,9 @@ export function buildApprovalPendingMessage(params: {
   lines.push("Background mode requires pre-approved policy (allow-always or ask=off).");
   lines.push(`Reply with: /approve ${params.approvalSlug} allow-once|allow-always|deny`);
   lines.push("If the short code is ambiguous, use the full id in /approve.");
+  lines.push(
+    "IMPORTANT: Show this /approve command to the user as a chat message. Do NOT execute /approve via the exec tool.",
+  );
   return lines.join("\n");
 }
 

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -254,11 +254,15 @@ export function createExecTool(
       // Guard: /approve is a slash command for the chat input, not a shell command.
       // Executing it via exec triggers a new approval-pending, causing an infinite loop.
       // See: https://github.com/openclaw/openclaw/issues/57432
-      // Flags: m (multiline) anchors ^ per-line so multi-statement commands are caught;
-      //        i (case-insensitive) matches /APPROVE, /Approve, etc. as the slash-command
-      //        parser (commands-approve.ts) is case-insensitive.
+      //
+      // Only the first line is tested — the actual command the shell executes.
+      // Subsequent lines may be heredoc/stdin data containing "/approve" literals
+      // and must not trigger a false positive (see codex review feedback).
+      // Flag: i (case-insensitive) matches /APPROVE, /Approve, etc. aligned with
+      //       the slash-command parser in commands-approve.ts.
       // The optional @mention group covers `/approve@botname ...` foreign-mention syntax.
-      if (/^\s*\/approve(?:@[^\s]*)?(\s|$)/mi.test(params.command)) {
+      const firstLine = params.command.split("\n", 1)[0];
+      if (/^\s*\/approve(?:@[^\s]*)?(\s|$)/i.test(firstLine)) {
         throw new Error(
           "/approve is a chat slash command, not a shell command. " +
             "Show the /approve command to the user as a chat message instead of executing it via exec.",

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -62,24 +62,28 @@ const APPROVE_COMMAND_RE = /^\s*\/approve(?:@[^\s]*)?(\s|$)/i;
 
 /**
  * Split a single shell line into command segments separated by
- * `&&`, `||`, `;`, or `|`. This is a best-effort heuristic — it does
- * not handle quoted strings containing these operators, but that is
- * acceptable for a safety guard (false positives are safe, false
- * negatives are the risk).
+ * `&&`, `||`, `;`, `|`, or `&` (background operator). This is a best-effort
+ * heuristic — it does not handle quoted strings containing these operators,
+ * but that is acceptable for a safety guard (false positives are safe,
+ * false negatives are the risk).
  */
 function splitShellSegments(line: string): string[] {
-  return line.split(/\s*(?:&&|\|\||[;|])\s*/);
+  return line.split(/\s*(?:&&|\|\||[;&|])\s*/);
 }
 
 /**
  * Detect a heredoc opening on a line. Returns the delimiter word or null.
  * Supports: <<EOF  <<'EOF'  <<"EOF"  <<-EOF  <<-'EOF-1'  <<"EOF_2"
  * Uses [\w-]+ to cover delimiters with hyphens (e.g. END-OF-DATA).
- * Only matches `<<` that is preceded by start-of-string or whitespace
- * to avoid false positives on strings like `echo "<<EOF"`.
+ *
+ * To avoid false positives on quoted text like `echo " <<EOF"`, we first
+ * strip content inside single and double quotes before testing for `<<`.
  */
 function detectHeredocDelimiter(line: string): string | null {
-  const m = line.match(/(?:^|\s)<<-?\s*['"]?([\w-]+)['"]?/);
+  // Remove quoted strings so that `echo " <<EOF"` does not match,
+  // but preserve quotes that are part of heredoc syntax (e.g. <<'EOF').
+  const stripped = line.replace(/(?<!<<-?\s*)(['"])(?:(?!\1).)*\1/g, "");
+  const m = stripped.match(/(?:^|\s)<<-?\s*['"]?([\w-]+)['"]?/);
   return m ? m[1] : null;
 }
 
@@ -93,7 +97,7 @@ function detectHeredocDelimiter(line: string): string | null {
  * by LLM-generated commands.
  *
  * - Lines inside heredoc bodies are skipped (no false positives on data).
- * - Each executable line is split on shell separators (`&&`, `||`, `;`, `|`)
+ * - Each executable line is split on shell separators (`&&`, `||`, `;`, `|`, `&`)
  *   so that `/approve` after a separator is detected.
  */
 export function containsApproveCommand(command: string): boolean {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -52,13 +52,29 @@ export type {
   ExecToolDefaults,
   ExecToolDetails,
 } from "./bash-tools.exec-types.js";
-
 /**
  * The regex used to detect /approve slash commands.
  * Case-insensitive, supports optional @mention suffix.
- * Anchored to the start of a *segment* (after splitting on shell separators).
+ * Anchored to the start of a *segment* (after splitting on shell separators
+ * and stripping shell prefixes).
  */
-const APPROVE_COMMAND_RE = /^\s*\/approve(?:@[^\s]*)?(\s|$)/i;
+const APPROVE_COMMAND_RE = /^\s*\/approve(?:@[^\s]*)?(?:\s|$)/i;
+
+/**
+ * Strip known shell prefixes from a command segment so that constructs
+ * like `( /approve ...)`, `FOO=1 /approve ...`, or `then /approve ...`
+ * are normalised before the regex test.
+ */
+function stripShellPrefixes(segment: string): string {
+  let s = segment;
+  // Remove leading subshell parens: ( or ((
+  s = s.replace(/^\s*\(+\s*/, "");
+  // Remove env-var assignments: FOO=bar FOO="bar" etc.
+  s = s.replace(/^(\s*\w+=\S*\s*)+/, "");
+  // Remove shell keywords: then, do, else, elif, {, !
+  s = s.replace(/^\s*(?:then|do|else|elif|!|\{)\s+/, "");
+  return s;
+}
 
 /**
  * Split a single shell line into command segments separated by
@@ -76,15 +92,29 @@ function splitShellSegments(line: string): string[] {
  * Supports: <<EOF  <<'EOF'  <<"EOF"  <<-EOF  <<-'EOF-1'  <<"EOF_2"
  * Uses [\w-]+ to cover delimiters with hyphens (e.g. END-OF-DATA).
  *
- * To avoid false positives on quoted text like `echo " <<EOF"`, we first
- * strip content inside single and double quotes before testing for `<<`.
+ * To avoid false positives on quoted text like `echo " <<EOF"`, we verify
+ * that `<<` is not inside a quoted string by counting unmatched quotes
+ * before the match position. Comment lines (`# <<EOF`) are skipped entirely.
  */
 function detectHeredocDelimiter(line: string): string | null {
-  // Remove quoted strings so that `echo " <<EOF"` does not match,
-  // but preserve quotes that are part of heredoc syntax (e.g. <<'EOF').
-  const stripped = line.replace(/(?<!<<-?\s*)(['"])(?:(?!\1).)*\1/g, "");
-  const m = stripped.match(/(?:^|\s)<<-?\s*['"]?([\w-]+)['"]?/);
-  return m ? m[1] : null;
+  // Skip comment lines — `# <<EOF` is not a real heredoc opener.
+  if (/^\s*#/.test(line)) {
+    return null;
+  }
+  // Match the heredoc pattern, then verify `<<` is not inside a quoted string
+  // by counting unmatched quotes before the match position.
+  const m = line.match(/(?:^|\s)(<<-?\s*['"]?([\w-]+)['"]?)/);
+  if (!m) return null;
+  const matchIndex = (m.index ?? 0) + (/^\s/.test(m[0]) ? 1 : 0);
+  const before = line.substring(0, matchIndex);
+  let inSingle = false;
+  let inDouble = false;
+  for (const ch of before) {
+    if (ch === "'" && !inDouble) inSingle = !inSingle;
+    if (ch === '"' && !inSingle) inDouble = !inDouble;
+  }
+  if (inSingle || inDouble) return null;
+  return m[2];
 }
 
 /**
@@ -118,7 +148,7 @@ export function containsApproveCommand(command: string): boolean {
     }
     // Test every segment of the line (split on shell operators).
     for (const segment of splitShellSegments(line)) {
-      if (APPROVE_COMMAND_RE.test(segment)) {
+      if (APPROVE_COMMAND_RE.test(stripShellPrefixes(segment))) {
         return true;
       }
     }

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -255,14 +255,15 @@ export function createExecTool(
       // Executing it via exec triggers a new approval-pending, causing an infinite loop.
       // See: https://github.com/openclaw/openclaw/issues/57432
       //
-      // Only the first line is tested — the actual command the shell executes.
-      // Subsequent lines may be heredoc/stdin data containing "/approve" literals
-      // and must not trigger a false positive (see codex review feedback).
+      // We test the first non-empty line — the actual command the shell executes.
+      // Leading blank lines are skipped so "\n/approve ..." cannot bypass the guard.
+      // Subsequent non-empty lines may be heredoc/stdin data containing "/approve"
+      // literals and must not trigger a false positive (see codex review feedback).
       // Flag: i (case-insensitive) matches /APPROVE, /Approve, etc. aligned with
       //       the slash-command parser in commands-approve.ts.
       // The optional @mention group covers `/approve@botname ...` foreign-mention syntax.
-      const firstLine = params.command.split("\n", 1)[0];
-      if (/^\s*\/approve(?:@[^\s]*)?(\s|$)/i.test(firstLine)) {
+      const firstNonEmptyLine = params.command.split("\n").find((l) => l.trim() !== "") ?? "";
+      if (/^\s*\/approve(?:@[^\s]*)?(\s|$)/i.test(firstNonEmptyLine)) {
         throw new Error(
           "/approve is a chat slash command, not a shell command. " +
             "Show the /approve command to the user as a chat message instead of executing it via exec.",

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -53,6 +53,41 @@ export type {
   ExecToolDetails,
 } from "./bash-tools.exec-types.js";
 
+/**
+ * The regex used to detect /approve slash commands in executable lines.
+ * Case-insensitive, supports optional @mention suffix.
+ */
+const APPROVE_COMMAND_RE = /^\s*\/approve(?:@[^\s]*)?(\s|$)/i;
+
+/**
+ * Check whether any *executable* line in a shell command contains /approve.
+ * Heredoc / here-string bodies are skipped so that `/approve` literals
+ * inside data blocks do not trigger a false positive.
+ */
+export function containsApproveCommand(command: string): boolean {
+  const lines = command.split("\n");
+  let heredocDelimiter: string | null = null;
+  for (const line of lines) {
+    // If we are inside a heredoc body, check for the closing delimiter.
+    if (heredocDelimiter !== null) {
+      if (line.trim() === heredocDelimiter) {
+        heredocDelimiter = null;
+      }
+      continue; // skip data lines
+    }
+    // Detect heredoc start: <<[-]?['"\\]?DELIM['"\\]?
+    const heredocMatch = line.match(/<<-?\s*['"]?(\w+)['"]?/);
+    if (heredocMatch) {
+      heredocDelimiter = heredocMatch[1];
+    }
+    // Test the line (even if it also starts a heredoc, the command part is real).
+    if (APPROVE_COMMAND_RE.test(line)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function buildExecForegroundResult(params: {
   outcome: ExecProcessOutcome;
   cwd?: string;
@@ -255,15 +290,12 @@ export function createExecTool(
       // Executing it via exec triggers a new approval-pending, causing an infinite loop.
       // See: https://github.com/openclaw/openclaw/issues/57432
       //
-      // We test the first non-empty line — the actual command the shell executes.
-      // Leading blank lines are skipped so "\n/approve ..." cannot bypass the guard.
-      // Subsequent non-empty lines may be heredoc/stdin data containing "/approve"
-      // literals and must not trigger a false positive (see codex review feedback).
+      // All executable lines are checked. Heredoc/here-string bodies are skipped
+      // so that `/approve` literals inside data blocks do not false-positive.
       // Flag: i (case-insensitive) matches /APPROVE, /Approve, etc. aligned with
       //       the slash-command parser in commands-approve.ts.
       // The optional @mention group covers `/approve@botname ...` foreign-mention syntax.
-      const firstNonEmptyLine = params.command.split("\n").find((l) => l.trim() !== "") ?? "";
-      if (/^\s*\/approve(?:@[^\s]*)?(\s|$)/i.test(firstNonEmptyLine)) {
+      if (containsApproveCommand(params.command)) {
         throw new Error(
           "/approve is a chat slash command, not a shell command. " +
             "Show the /approve command to the user as a chat message instead of executing it via exec.",

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1,12 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
-import {
-  type ExecHost,
-  loadExecApprovals,
-  maxAsk,
-  minSecurity,
-} from "../infra/exec-approvals.js";
+import { type ExecHost, loadExecApprovals, maxAsk, minSecurity } from "../infra/exec-approvals.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import { sanitizeHostExecEnvWithDiagnostics } from "../infra/host-env-security.js";
 import {
@@ -254,6 +249,16 @@ export function createExecTool(
 
       if (!params.command) {
         throw new Error("Provide a command to start.");
+      }
+
+      // Guard: /approve is a slash command for the chat input, not a shell command.
+      // Executing it via exec triggers a new approval-pending, causing an infinite loop.
+      // See: https://github.com/openclaw/openclaw/issues/57432
+      if (/^\s*\/approve\b/.test(params.command)) {
+        throw new Error(
+          "/approve is a chat slash command, not a shell command. " +
+            "Show the /approve command to the user as a chat message instead of executing it via exec.",
+        );
       }
 
       const maxOutput = DEFAULT_MAX_OUTPUT;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -254,7 +254,11 @@ export function createExecTool(
       // Guard: /approve is a slash command for the chat input, not a shell command.
       // Executing it via exec triggers a new approval-pending, causing an infinite loop.
       // See: https://github.com/openclaw/openclaw/issues/57432
-      if (/^\s*\/approve\b/.test(params.command)) {
+      // Flags: m (multiline) anchors ^ per-line so multi-statement commands are caught;
+      //        i (case-insensitive) matches /APPROVE, /Approve, etc. as the slash-command
+      //        parser (commands-approve.ts) is case-insensitive.
+      // The optional @mention group covers `/approve@botname ...` foreign-mention syntax.
+      if (/^\s*\/approve(?:@[^\s]*)?(\s|$)/mi.test(params.command)) {
         throw new Error(
           "/approve is a chat slash command, not a shell command. " +
             "Show the /approve command to the user as a chat message instead of executing it via exec.",

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -53,60 +53,56 @@ export type {
   ExecToolDetails,
 } from "./bash-tools.exec-types.js";
 /**
- * The regex used to detect /approve slash commands.
+ * Matches the `/approve <hash> <mode>` pattern used by the approval system.
  * Case-insensitive, supports optional @mention suffix.
- * Anchored to the start of a *segment* (after splitting on shell separators
- * and stripping shell prefixes).
  */
-const APPROVE_COMMAND_RE = /^\s*\/approve(?:@[^\s]*)?(?:\s|$)/i;
+const APPROVE_FULL_RE =
+  /\/approve(?:@[^\s]*)?\s+[a-f0-9]+\s+allow-(?:once|always)/i;
 
 /**
- * Strip known shell prefixes from a command segment so that constructs
- * like `( /approve ...)`, `FOO=1 /approve ...`, or `then /approve ...`
- * are normalised before the regex test.
+ * Matches a bare `/approve` at end-of-line or end-of-string (no args),
+ * which would also trigger the approval loop.
  */
-function stripShellPrefixes(segment: string): string {
-  let s = segment;
-  // Remove leading subshell parens: ( or ((
-  s = s.replace(/^\s*\(+\s*/, "");
-  // Remove env-var assignments: FOO=bar FOO="bar" etc.
-  s = s.replace(/^(\s*\w+=\S*\s*)+/, "");
-  // Remove shell keywords: then, do, else, elif, {, !
-  s = s.replace(/^\s*(?:then|do|else|elif|!|\{)\s+/, "");
-  return s;
-}
+const APPROVE_BARE_RE = /\/approve(?:@[^\s]*)?\s*$/im;
 
 /**
- * Split a single shell line into command segments separated by
- * `&&`, `||`, `;`, `|`, or `&` (background operator). This is a best-effort
- * heuristic — it does not handle quoted strings containing these operators,
- * but that is acceptable for a safety guard (false positives are safe,
- * false negatives are the risk).
+ * Strip inline comments from a shell line, respecting single and double
+ * quotes. `echo ok # <<EOF` → `echo ok ` (the `# <<EOF` is a comment).
  */
-function splitShellSegments(line: string): string[] {
-  return line.split(/\s*(?:&&|\|\||[;&|])\s*/);
+function stripInlineComment(line: string): string {
+  let result = "";
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+    } else if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+    } else if (ch === "#" && !inSingle && !inDouble) {
+      return result;
+    }
+    result += ch;
+  }
+  return result;
 }
 
 /**
  * Detect a heredoc opening on a line. Returns the delimiter word or null.
- * Supports: <<EOF  <<'EOF'  <<"EOF"  <<-EOF  <<-'EOF-1'  <<"EOF_2"
- * Uses [\w-]+ to cover delimiters with hyphens (e.g. END-OF-DATA).
+ * Supports: `<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`, `<<-'EOF-1'`.
  *
- * To avoid false positives on quoted text like `echo " <<EOF"`, we verify
- * that `<<` is not inside a quoted string by counting unmatched quotes
- * before the match position. Comment lines (`# <<EOF`) are skipped entirely.
+ * To avoid false positives:
+ * - Inline comments are stripped first (`echo ok # <<EOF` → no heredoc).
+ * - `<<` inside quoted strings is ignored (`echo " <<EOF"` → no heredoc).
  */
 function detectHeredocDelimiter(line: string): string | null {
-  // Skip comment lines — `# <<EOF` is not a real heredoc opener.
-  if (/^\s*#/.test(line)) {
-    return null;
-  }
-  // Match the heredoc pattern, then verify `<<` is not inside a quoted string
-  // by counting unmatched quotes before the match position.
-  const m = line.match(/(?:^|\s)(<<-?\s*['"]?([\w-]+)['"]?)/);
+  // Strip inline comments so `echo ok # <<EOF` is not a heredoc.
+  const commentFree = stripInlineComment(line);
+  const m = commentFree.match(/(?:^|\s)(<<-?\s*['"]?([\w-]+)['"]?)/);
   if (!m) return null;
+  // Verify `<<` is not inside a quoted string.
   const matchIndex = (m.index ?? 0) + (/^\s/.test(m[0]) ? 1 : 0);
-  const before = line.substring(0, matchIndex);
+  const before = commentFree.substring(0, matchIndex);
   let inSingle = false;
   let inDouble = false;
   for (const ch of before) {
@@ -118,42 +114,53 @@ function detectHeredocDelimiter(line: string): string | null {
 }
 
 /**
- * Check whether any *executable* segment in a shell command contains /approve.
+ * Check whether a shell command contains an `/approve` invocation.
  *
  * This is a **best-effort defence layer** (layer 3 of 3). The primary fixes
  * are in the system prompt (layer 1) and the approval-pending tool output
- * (layer 2). A perfect check would require a full shell parser, which is
- * out of scope; this guard catches the realistic attack vectors produced
- * by LLM-generated commands.
+ * (layer 2).
  *
- * - Lines inside heredoc bodies are skipped (no false positives on data).
- * - Each executable line is split on shell separators (`&&`, `||`, `;`, `|`, `&`)
- *   so that `/approve` after a separator is detected.
+ * **Design rationale**: instead of trying to parse shell syntax (which is
+ * impossible to do perfectly with regex), this function:
+ *
+ * 1. Strips heredoc bodies — they are data, not executable commands.
+ * 2. Strips inline comments — they are not executed.
+ * 3. Matches the specific `/approve <hash> allow-once|allow-always` pattern
+ *    (or bare `/approve`) anywhere in the remaining text.
+ *
+ * This catches every realistic attack vector (direct call, after `&&`/`;`/`|`,
+ * inside subshells, after env assignments, inside `eval`/`bash -c`, etc.)
+ * without needing to split on shell operators or strip shell prefixes.
+ *
+ * The only false-positive risk is `/approve <hash> allow-once` appearing as
+ * a literal argument (e.g. `echo "/approve abc allow-always"`), but the
+ * approval hash is a random hex string that will never appear in normal
+ * echo/grep arguments.
  */
 export function containsApproveCommand(command: string): boolean {
   const lines = command.split("\n");
+  const executableLines: string[] = [];
   let heredocDelimiter: string | null = null;
+
   for (const line of lines) {
-    // If we are inside a heredoc body, check for the closing delimiter.
+    // If inside a heredoc body, skip until the closing delimiter.
     if (heredocDelimiter !== null) {
       if (line.trim() === heredocDelimiter) {
         heredocDelimiter = null;
       }
-      continue; // skip data lines
+      continue;
     }
     // Detect heredoc start on this line.
     const delim = detectHeredocDelimiter(line);
     if (delim) {
       heredocDelimiter = delim;
     }
-    // Test every segment of the line (split on shell operators).
-    for (const segment of splitShellSegments(line)) {
-      if (APPROVE_COMMAND_RE.test(stripShellPrefixes(segment))) {
-        return true;
-      }
-    }
+    // Strip inline comments and collect the executable portion.
+    executableLines.push(stripInlineComment(line));
   }
-  return false;
+
+  const executableText = executableLines.join("\n");
+  return APPROVE_FULL_RE.test(executableText) || APPROVE_BARE_RE.test(executableText);
 }
 
 function buildExecForegroundResult(params: {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -54,15 +54,47 @@ export type {
 } from "./bash-tools.exec-types.js";
 
 /**
- * The regex used to detect /approve slash commands in executable lines.
+ * The regex used to detect /approve slash commands.
  * Case-insensitive, supports optional @mention suffix.
+ * Anchored to the start of a *segment* (after splitting on shell separators).
  */
 const APPROVE_COMMAND_RE = /^\s*\/approve(?:@[^\s]*)?(\s|$)/i;
 
 /**
- * Check whether any *executable* line in a shell command contains /approve.
- * Heredoc / here-string bodies are skipped so that `/approve` literals
- * inside data blocks do not trigger a false positive.
+ * Split a single shell line into command segments separated by
+ * `&&`, `||`, `;`, or `|`. This is a best-effort heuristic — it does
+ * not handle quoted strings containing these operators, but that is
+ * acceptable for a safety guard (false positives are safe, false
+ * negatives are the risk).
+ */
+function splitShellSegments(line: string): string[] {
+  return line.split(/\s*(?:&&|\|\||[;|])\s*/);
+}
+
+/**
+ * Detect a heredoc opening on a line. Returns the delimiter word or null.
+ * Supports: <<EOF  <<'EOF'  <<"EOF"  <<-EOF  <<-'EOF-1'  <<"EOF_2"
+ * Uses [\w-]+ to cover delimiters with hyphens (e.g. END-OF-DATA).
+ * Only matches `<<` that is preceded by start-of-string or whitespace
+ * to avoid false positives on strings like `echo "<<EOF"`.
+ */
+function detectHeredocDelimiter(line: string): string | null {
+  const m = line.match(/(?:^|\s)<<-?\s*['"]?([\w-]+)['"]?/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Check whether any *executable* segment in a shell command contains /approve.
+ *
+ * This is a **best-effort defence layer** (layer 3 of 3). The primary fixes
+ * are in the system prompt (layer 1) and the approval-pending tool output
+ * (layer 2). A perfect check would require a full shell parser, which is
+ * out of scope; this guard catches the realistic attack vectors produced
+ * by LLM-generated commands.
+ *
+ * - Lines inside heredoc bodies are skipped (no false positives on data).
+ * - Each executable line is split on shell separators (`&&`, `||`, `;`, `|`)
+ *   so that `/approve` after a separator is detected.
  */
 export function containsApproveCommand(command: string): boolean {
   const lines = command.split("\n");
@@ -75,14 +107,16 @@ export function containsApproveCommand(command: string): boolean {
       }
       continue; // skip data lines
     }
-    // Detect heredoc start: <<[-]?['"\\]?DELIM['"\\]?
-    const heredocMatch = line.match(/<<-?\s*['"]?(\w+)['"]?/);
-    if (heredocMatch) {
-      heredocDelimiter = heredocMatch[1];
+    // Detect heredoc start on this line.
+    const delim = detectHeredocDelimiter(line);
+    if (delim) {
+      heredocDelimiter = delim;
     }
-    // Test the line (even if it also starts a heredoc, the command part is real).
-    if (APPROVE_COMMAND_RE.test(line)) {
-      return true;
+    // Test every segment of the line (split on shell operators).
+    for (const segment of splitShellSegments(line)) {
+      if (APPROVE_COMMAND_RE.test(segment)) {
+        return true;
+      }
     }
   }
   return false;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -53,17 +53,26 @@ export type {
   ExecToolDetails,
 } from "./bash-tools.exec-types.js";
 /**
- * Matches the `/approve <hash> <mode>` pattern used by the approval system.
+ * Matches the `/approve <id> <decision>` pattern used by the approval system.
  * Case-insensitive, supports optional @mention suffix.
+ *
+ * - `id` is either a short hex slug (`[a-f0-9]{1,}`) or a full UUID
+ *   (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`), so we match `[a-f0-9-]+`.
+ * - `decision` covers every alias accepted by the slash-command parser in
+ *   `commands-approve.ts`: allow-once, allow-always, deny, reject, block,
+ *   once, always, allow, allowonce, allowalways.
  */
 const APPROVE_FULL_RE =
-  /\/approve(?:@[^\s]*)?\s+[a-f0-9]+\s+allow-(?:once|always)/i;
+  /\/approve(?:@[^\s]*)?\s+[a-f0-9-]+\s+(?:allow-?(?:once|always)|allowonce|allowalways|deny|reject|block|once|always|allow)(?=[\s;)"'`}|&]|$)/i;
 
 /**
- * Matches a bare `/approve` at end-of-line or end-of-string (no args),
- * which would also trigger the approval loop.
+ * Matches a bare `/approve` at a command-start position (beginning of line
+ * or after a shell separator) with no arguments or only whitespace after it.
+ *
+ * The `(?:^|[;|&(])` anchor ensures we don't match `/approve` when it
+ * appears as an argument to another command (e.g. `echo /approve`).
  */
-const APPROVE_BARE_RE = /\/approve(?:@[^\s]*)?\s*$/im;
+const APPROVE_BARE_RE = /(?:^|[;|&(])\s*\/approve(?:@[^\s]*)?\s*$/im;
 
 /**
  * Strip inline comments from a shell line, respecting single and double
@@ -125,8 +134,9 @@ function detectHeredocDelimiter(line: string): string | null {
  *
  * 1. Strips heredoc bodies — they are data, not executable commands.
  * 2. Strips inline comments — they are not executed.
- * 3. Matches the specific `/approve <hash> allow-once|allow-always` pattern
- *    (or bare `/approve`) anywhere in the remaining text.
+ * 3. Matches the specific `/approve <id> <decision>` pattern (covering all
+ *    decision aliases from `commands-approve.ts` and UUID-format ids) or a
+ *    bare `/approve` at a command-start position in the remaining text.
  *
  * This catches every realistic attack vector (direct call, after `&&`/`;`/`|`,
  * inside subshells, after env assignments, inside `eval`/`bash -c`, etc.)

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -584,6 +584,19 @@ describe("exec /approve guard", () => {
     );
     expect(readTextContent(result.content)).toBeDefined();
   });
+
+  it("rejects /approve after & background operator on same line", async () => {
+    await expect(
+      executeExecCommand(execTool, "true & /approve abc123 allow-once"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("does not false-trigger heredoc on quoted <<EOF inside echo", async () => {
+    // echo " <<EOF" should NOT start a heredoc; the next line /approve must be caught.
+    await expect(
+      executeExecCommand(execTool, 'echo " <<EOF"\n/approve abc123 allow-always'),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
 });
 
 describe("exec exit codes", () => {

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -597,6 +597,31 @@ describe("exec /approve guard", () => {
       executeExecCommand(execTool, 'echo " <<EOF"\n/approve abc123 allow-always'),
     ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
+
+  it("rejects /approve inside subshell parens", async () => {
+    await expect(
+      executeExecCommand(execTool, "( /approve abc123 allow-once )"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve after shell keyword 'then'", async () => {
+    await expect(
+      executeExecCommand(execTool, "if true; then /approve abc123 allow-once; fi"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve with env-var prefix", async () => {
+    await expect(
+      executeExecCommand(execTool, "FOO=1 /approve abc123 allow-once"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("does not false-trigger heredoc on commented # <<EOF line", async () => {
+    // # <<EOF is a comment, not a heredoc; the next line /approve must be caught.
+    await expect(
+      executeExecCommand(execTool, "# <<EOF\n/approve abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
 });
 
 describe("exec exit codes", () => {

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -488,6 +488,26 @@ describe("exec tool backgrounding", () => {
   });
 });
 
+describe("exec /approve guard", () => {
+  it("rejects /approve commands to prevent infinite approval loop", async () => {
+    await expect(executeExecCommand(execTool, "/approve abc123 allow-always")).rejects.toThrow(
+      "/approve is a chat slash command, not a shell command",
+    );
+  });
+
+  it("rejects /approve with leading whitespace", async () => {
+    await expect(executeExecCommand(execTool, "  /approve xyz allow-once")).rejects.toThrow(
+      "/approve is a chat slash command, not a shell command",
+    );
+  });
+
+  it("does not reject commands that merely contain /approve in the middle", async () => {
+    // A legitimate command like `echo /approve` should not be blocked
+    const result = await executeExecCommand(execTool, shellEcho("/approve test"));
+    expect(readTextContent(result.content)).toBeDefined();
+  });
+});
+
 describe("exec exit codes", () => {
   useCapturedEnv([...SHELL_ENV_KEYS], applyDefaultShellEnv);
 

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -489,6 +489,8 @@ describe("exec tool backgrounding", () => {
 });
 
 describe("exec /approve guard", () => {
+  // === MUST BLOCK: direct /approve invocations ===
+
   it("rejects /approve commands to prevent infinite approval loop", async () => {
     await expect(executeExecCommand(execTool, "/approve abc123 allow-always")).rejects.toThrow(
       "/approve is a chat slash command, not a shell command",
@@ -496,59 +498,15 @@ describe("exec /approve guard", () => {
   });
 
   it("rejects /approve with leading whitespace", async () => {
-    await expect(executeExecCommand(execTool, "  /approve xyz allow-once")).rejects.toThrow(
+    await expect(executeExecCommand(execTool, "  /approve abc123 allow-once")).rejects.toThrow(
       "/approve is a chat slash command, not a shell command",
     );
   });
 
-  it("does not reject commands that merely contain /approve in the middle", async () => {
-    // A legitimate command like `echo /approve` should not be blocked
-    const result = await executeExecCommand(execTool, shellEcho("/approve test"));
-    expect(readTextContent(result.content)).toBeDefined();
-  });
-
-  it("does not reject /approve inside heredoc data", async () => {
-    const result = await executeExecCommand(
-      execTool,
-      "cat <<'EOF'\n/approve abc123 allow-always\nEOF",
+  it("rejects bare /approve with no arguments", async () => {
+    await expect(executeExecCommand(execTool, "/approve")).rejects.toThrow(
+      "/approve is a chat slash command, not a shell command",
     );
-    expect(readTextContent(result.content)).toBeDefined();
-  });
-
-  it("rejects /approve as the first line even in a multiline command", async () => {
-    await expect(
-      executeExecCommand(execTool, "/approve abc123 allow-always\necho done"),
-    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
-  });
-
-  it("rejects /approve on a later executable line after a comment", async () => {
-    await expect(
-      executeExecCommand(execTool, "# note\n/approve abc123 allow-always"),
-    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
-  });
-
-  it("rejects /approve on a later executable line after true", async () => {
-    await expect(
-      executeExecCommand(execTool, "true\n/approve abc123 allow-always"),
-    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
-  });
-
-  it("rejects /approve after && shell separator on same line", async () => {
-    await expect(
-      executeExecCommand(execTool, "true && /approve abc123 allow-once"),
-    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
-  });
-
-  it("rejects /approve after ; shell separator on same line", async () => {
-    await expect(
-      executeExecCommand(execTool, "echo ok; /approve abc123 allow-always"),
-    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
-  });
-
-  it("rejects /approve after || shell separator on same line", async () => {
-    await expect(
-      executeExecCommand(execTool, "false || /approve abc123 allow-always"),
-    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
 
   it("rejects case-insensitive variants like /APPROVE", async () => {
@@ -563,40 +521,65 @@ describe("exec /approve guard", () => {
     ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
 
+  // === MUST BLOCK: /approve on different lines ===
+
+  it("rejects /approve as the first line in a multiline command", async () => {
+    await expect(
+      executeExecCommand(execTool, "/approve abc123 allow-always\necho done"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
   it("rejects /approve preceded by leading blank lines", async () => {
     await expect(
       executeExecCommand(execTool, "\n\n/approve abc123 allow-always"),
     ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
 
-  it("does not reject /approve inside heredoc even with executable lines around it", async () => {
-    const result = await executeExecCommand(
-      execTool,
-      "echo start\ncat <<'DELIM'\n/approve abc123 allow-always\nDELIM\necho end",
-    );
-    expect(readTextContent(result.content)).toBeDefined();
+  it("rejects /approve after a comment line", async () => {
+    await expect(
+      executeExecCommand(execTool, "# note\n/approve abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
 
-  it("does not reject /approve inside heredoc with hyphenated delimiter", async () => {
-    const result = await executeExecCommand(
-      execTool,
-      "cat <<'END-DATA'\n/approve abc123 allow-always\nEND-DATA",
-    );
-    expect(readTextContent(result.content)).toBeDefined();
+  it("rejects /approve after an executable line", async () => {
+    await expect(
+      executeExecCommand(execTool, "true\n/approve abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
 
-  it("rejects /approve after & background operator on same line", async () => {
+  // === MUST BLOCK: /approve after shell operators ===
+
+  it("rejects /approve after && separator", async () => {
+    await expect(
+      executeExecCommand(execTool, "true && /approve abc123 allow-once"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve after ; separator", async () => {
+    await expect(
+      executeExecCommand(execTool, "echo ok; /approve abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve after || separator", async () => {
+    await expect(
+      executeExecCommand(execTool, "false || /approve abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve after | pipe", async () => {
+    await expect(
+      executeExecCommand(execTool, "echo x | /approve abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve after & background operator", async () => {
     await expect(
       executeExecCommand(execTool, "true & /approve abc123 allow-once"),
     ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
 
-  it("does not false-trigger heredoc on quoted <<EOF inside echo", async () => {
-    // echo " <<EOF" should NOT start a heredoc; the next line /approve must be caught.
-    await expect(
-      executeExecCommand(execTool, 'echo " <<EOF"\n/approve abc123 allow-always'),
-    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
-  });
+  // === MUST BLOCK: /approve with shell prefixes ===
 
   it("rejects /approve inside subshell parens", async () => {
     await expect(
@@ -616,11 +599,89 @@ describe("exec /approve guard", () => {
     ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
 
-  it("does not false-trigger heredoc on commented # <<EOF line", async () => {
-    // # <<EOF is a comment, not a heredoc; the next line /approve must be caught.
+  it("rejects /approve with quoted env-var prefix containing spaces", async () => {
+    await expect(
+      executeExecCommand(execTool, 'FOO="a b" /approve abc123 allow-once'),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  // === MUST BLOCK: /approve via indirect execution ===
+
+  it("rejects /approve inside eval", async () => {
+    await expect(
+      executeExecCommand(execTool, 'eval "/approve abc123 allow-always"'),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve inside bash -c", async () => {
+    await expect(
+      executeExecCommand(execTool, 'bash -c "/approve abc123 allow-always"'),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  // === MUST BLOCK: heredoc/comment edge cases ===
+
+  it("rejects /approve after inline comment with # <<EOF", async () => {
+    // `echo ok # <<EOF` is NOT a heredoc; the next line /approve must be caught.
+    await expect(
+      executeExecCommand(execTool, "echo ok # <<EOF\n/approve abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve after whole-line comment with # <<EOF", async () => {
     await expect(
       executeExecCommand(execTool, "# <<EOF\n/approve abc123 allow-always"),
     ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve after quoted <<EOF that is not a real heredoc", async () => {
+    await expect(
+      executeExecCommand(execTool, 'echo " <<EOF"\n/approve abc123 allow-always'),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  // === MUST ALLOW: legitimate commands ===
+
+  it("does not reject echo /approve (argument, not command)", async () => {
+    const result = await executeExecCommand(execTool, shellEcho("/approve test"));
+    expect(readTextContent(result.content)).toBeDefined();
+  });
+
+  it("does not reject /approve inside heredoc data", async () => {
+    const result = await executeExecCommand(
+      execTool,
+      "cat <<'EOF'\n/approve abc123 allow-always\nEOF",
+    );
+    expect(readTextContent(result.content)).toBeDefined();
+  });
+
+  it("does not reject /approve inside heredoc with surrounding commands", async () => {
+    const result = await executeExecCommand(
+      execTool,
+      "echo start\ncat <<'DELIM'\n/approve abc123 allow-always\nDELIM\necho end",
+    );
+    expect(readTextContent(result.content)).toBeDefined();
+  });
+
+  it("does not reject /approve inside heredoc with double-quoted delimiter", async () => {
+    const result = await executeExecCommand(
+      execTool,
+      'cat <<"EOF"\n/approve abc123 allow-always\nEOF',
+    );
+    expect(readTextContent(result.content)).toBeDefined();
+  });
+
+  it("does not reject /approve inside heredoc with hyphenated delimiter", async () => {
+    const result = await executeExecCommand(
+      execTool,
+      "cat <<'END-DATA'\n/approve abc123 allow-always\nEND-DATA",
+    );
+    expect(readTextContent(result.content)).toBeDefined();
+  });
+
+  it("does not reject normal commands", async () => {
+    const result = await executeExecCommand(execTool, "ls -la");
+    expect(readTextContent(result.content)).toBeDefined();
   });
 });
 

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -507,9 +507,18 @@ describe("exec /approve guard", () => {
     expect(readTextContent(result.content)).toBeDefined();
   });
 
-  it("rejects /approve on a non-first line of a multiline command", async () => {
+  it("does not reject /approve in heredoc or non-first-line data", async () => {
+    // /approve on a non-first line is heredoc/stdin data, not an executed command
+    const result = await executeExecCommand(
+      execTool,
+      "cat <<'EOF'\n/approve abc123 allow-always\nEOF",
+    );
+    expect(readTextContent(result.content)).toBeDefined();
+  });
+
+  it("rejects /approve as the first line even in a multiline command", async () => {
     await expect(
-      executeExecCommand(execTool, "ls\n/approve abc123 allow-always"),
+      executeExecCommand(execTool, "/approve abc123 allow-always\necho done"),
     ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
 

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -533,6 +533,12 @@ describe("exec /approve guard", () => {
       executeExecCommand(execTool, "/approve@mybot abc123 allow-always"),
     ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
+
+  it("rejects /approve preceded by leading blank lines", async () => {
+    await expect(
+      executeExecCommand(execTool, "\n\n/approve abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
 });
 
 describe("exec exit codes", () => {

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -506,6 +506,24 @@ describe("exec /approve guard", () => {
     const result = await executeExecCommand(execTool, shellEcho("/approve test"));
     expect(readTextContent(result.content)).toBeDefined();
   });
+
+  it("rejects /approve on a non-first line of a multiline command", async () => {
+    await expect(
+      executeExecCommand(execTool, "ls\n/approve abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects case-insensitive variants like /APPROVE", async () => {
+    await expect(
+      executeExecCommand(execTool, "/APPROVE abc123 allow-once"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve@botname foreign-mention syntax", async () => {
+    await expect(
+      executeExecCommand(execTool, "/approve@mybot abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
 });
 
 describe("exec exit codes", () => {

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -533,6 +533,24 @@ describe("exec /approve guard", () => {
     ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
 
+  it("rejects /approve after && shell separator on same line", async () => {
+    await expect(
+      executeExecCommand(execTool, "true && /approve abc123 allow-once"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve after ; shell separator on same line", async () => {
+    await expect(
+      executeExecCommand(execTool, "echo ok; /approve abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve after || shell separator on same line", async () => {
+    await expect(
+      executeExecCommand(execTool, "false || /approve abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
   it("rejects case-insensitive variants like /APPROVE", async () => {
     await expect(
       executeExecCommand(execTool, "/APPROVE abc123 allow-once"),
@@ -555,6 +573,14 @@ describe("exec /approve guard", () => {
     const result = await executeExecCommand(
       execTool,
       "echo start\ncat <<'DELIM'\n/approve abc123 allow-always\nDELIM\necho end",
+    );
+    expect(readTextContent(result.content)).toBeDefined();
+  });
+
+  it("does not reject /approve inside heredoc with hyphenated delimiter", async () => {
+    const result = await executeExecCommand(
+      execTool,
+      "cat <<'END-DATA'\n/approve abc123 allow-always\nEND-DATA",
     );
     expect(readTextContent(result.content)).toBeDefined();
   });

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -521,6 +521,51 @@ describe("exec /approve guard", () => {
     ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
 
+  it("rejects /approve with full UUID id", async () => {
+    await expect(
+      executeExecCommand(
+        execTool,
+        "/approve a1b2c3d4-e5f6-7890-abcd-ef1234567890 allow-once",
+      ),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve with deny decision", async () => {
+    await expect(
+      executeExecCommand(execTool, "/approve abc123 deny"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve with reject alias", async () => {
+    await expect(
+      executeExecCommand(execTool, "/approve abc123 reject"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve with block alias", async () => {
+    await expect(
+      executeExecCommand(execTool, "/approve abc123 block"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve with short alias 'once'", async () => {
+    await expect(
+      executeExecCommand(execTool, "/approve abc123 once"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve with short alias 'always'", async () => {
+    await expect(
+      executeExecCommand(execTool, "/approve abc123 always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve with allowonce alias", async () => {
+    await expect(
+      executeExecCommand(execTool, "/approve abc123 allowonce"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
   // === MUST BLOCK: /approve on different lines ===
 
   it("rejects /approve as the first line in a multiline command", async () => {
@@ -644,6 +689,24 @@ describe("exec /approve guard", () => {
 
   it("does not reject echo /approve (argument, not command)", async () => {
     const result = await executeExecCommand(execTool, shellEcho("/approve test"));
+    expect(readTextContent(result.content)).toBeDefined();
+  });
+
+  it("does not reject bare /approve as argument to echo", async () => {
+    const result = await executeExecCommand(execTool, "echo /approve");
+    expect(readTextContent(result.content)).toBeDefined();
+  });
+
+  it("does not reject /approve inside heredoc with tab-stripped delimiter", async () => {
+    const result = await executeExecCommand(
+      execTool,
+      "cat <<-EOF\n\t/approve abc123 allow-always\nEOF",
+    );
+    expect(readTextContent(result.content)).toBeDefined();
+  });
+
+  it("does not reject grep /approve in a file", async () => {
+    const result = await executeExecCommand(execTool, "grep /approve /dev/null");
     expect(readTextContent(result.content)).toBeDefined();
   });
 

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -507,8 +507,7 @@ describe("exec /approve guard", () => {
     expect(readTextContent(result.content)).toBeDefined();
   });
 
-  it("does not reject /approve in heredoc or non-first-line data", async () => {
-    // /approve on a non-first line is heredoc/stdin data, not an executed command
+  it("does not reject /approve inside heredoc data", async () => {
     const result = await executeExecCommand(
       execTool,
       "cat <<'EOF'\n/approve abc123 allow-always\nEOF",
@@ -519,6 +518,18 @@ describe("exec /approve guard", () => {
   it("rejects /approve as the first line even in a multiline command", async () => {
     await expect(
       executeExecCommand(execTool, "/approve abc123 allow-always\necho done"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve on a later executable line after a comment", async () => {
+    await expect(
+      executeExecCommand(execTool, "# note\n/approve abc123 allow-always"),
+    ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("rejects /approve on a later executable line after true", async () => {
+    await expect(
+      executeExecCommand(execTool, "true\n/approve abc123 allow-always"),
     ).rejects.toThrow("/approve is a chat slash command, not a shell command");
   });
 
@@ -538,6 +549,14 @@ describe("exec /approve guard", () => {
     await expect(
       executeExecCommand(execTool, "\n\n/approve abc123 allow-always"),
     ).rejects.toThrow("/approve is a chat slash command, not a shell command");
+  });
+
+  it("does not reject /approve inside heredoc even with executable lines around it", async () => {
+    const result = await executeExecCommand(
+      execTool,
+      "echo start\ncat <<'DELIM'\n/approve abc123 allow-always\nDELIM\necho end",
+    );
+    expect(readTextContent(result.content)).toBeDefined();
   });
 });
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -240,6 +240,18 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
+  it("instructs agent to show /approve to user and never execute via exec", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).toContain("NEVER execute /approve via the exec tool");
+    expect(prompt).toContain(
+      "/approve is a slash command handled by the chat input, not a shell command",
+    );
+    expect(prompt).toContain("show the concrete /approve command from tool output");
+  });
+
   it("lists available tools when provided", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -450,7 +450,7 @@ export function buildAgentSystemPrompt(params: {
     "Keep narration brief and value-dense; avoid repeating obvious steps.",
     "Use plain human language for narration unless in a technical context.",
     "When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.",
-    "When exec returns approval-pending, include the concrete /approve command from tool output (with allow-once|allow-always|deny) and do not ask for a different or rotated code.",
+    "When exec returns approval-pending, show the concrete /approve command from tool output (with allow-once|allow-always|deny) to the user as a chat message and do not ask for a different or rotated code. NEVER execute /approve via the exec tool — /approve is a slash command handled by the chat input, not a shell command.",
     "Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.",
     "When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run.",
     "",


### PR DESCRIPTION
### Summary

- **Problem**: When `exec` returns `approval-pending`, the agent interprets the `/approve` command as a shell command and re-executes it via the `exec` tool. Each re-execution triggers a new `approval-pending`, creating an infinite loop. Observed: 965 `/approve` exec calls over 58 minutes, consuming ~$5 in API budget, with the session file growing to 1.6 MB and all user messages silently dropped. (Issue #57432)

- **Root Cause**: Two conflicting instructions in `src/agents/system-prompt.ts` (lines 452–453):
  - Line 452: *"When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands."*
  - Line 453: *"When exec returns approval-pending, include the concrete /approve command from tool output…"*
  
  The word **"include"** is ambiguous. The model follows line 452's directive ("use the tool directly") and interprets "include" as "execute via exec tool" rather than "show to the user as a chat message." Additionally, there is **no guard** in the `exec` tool to reject `/approve` commands, and **no circuit breaker** to detect the same command being repeated hundreds of times.

- **Fix**: Three-layer defense to eliminate the loop:
  1. **System prompt clarification** (`system-prompt.ts:453`): Replaced ambiguous "include" with explicit "show … to the user as a chat message" and added `NEVER execute /approve via the exec tool — /approve is a slash command handled by the chat input, not a shell command.`
  2. **Approval-pending message reinforcement** (`bash-tools.exec-runtime.ts`): Appended `IMPORTANT: Show this /approve command to the user as a chat message. Do NOT execute /approve via the exec tool.` to the tool result text returned to the model.
  3. **Exec tool hard guard** (`bash-tools.exec.ts`): Added an early-exit check in `createExecTool`'s `execute` function — if the command matches `/^\s*\/approve\b/`, throw an immediate error explaining that `/approve` is a chat slash command. This is the definitive backstop: even if a model ignores prompt instructions, the loop cannot start.

  This layered approach avoids side effects: the regex only matches commands that **start with** `/approve` (with optional leading whitespace), so legitimate commands like `echo /approve` are unaffected. The prompt change is scoped to the single approval-pending instruction line and does not alter any other tool-use guidance.

- **What changed**:
  - `src/agents/system-prompt.ts` — Rewrote line 453 to disambiguate "include" → "show to user" and added explicit prohibition
  - `src/agents/bash-tools.exec-runtime.ts` — Added one line to `buildApprovalPendingMessage()` reinforcing the prohibition in tool output
  - `src/agents/bash-tools.exec.ts` — Added `/approve` command guard in `createExecTool()` execute function (early throw)
  - `src/agents/system-prompt.test.ts` — Added test verifying prompt contains the new prohibition language
  - `src/agents/bash-tools.exec-runtime.test.ts` — Added tests for `buildApprovalPendingMessage()` output
  - `src/agents/bash-tools.test.ts` — Added tests for exec `/approve` guard (rejection + non-false-positive)

- **What did NOT change (scope boundary)**:
  - No changes to the approval registration/decision flow (`bash-tools.exec-approval-request.ts`, `bash-tools.exec-approval-followup.ts`)
  - No changes to the embedded runner loop (`pi-embedded-runner/run.ts`, `pi-embedded-subscribe.ts`)
  - No changes to the `deterministicApprovalPromptSent` state machine
  - No changes to any other system prompt instructions (lines 452, 454, 455 untouched)
  - No changes to gateway allowlist processing or elevated exec logic

### Reproduction

1. Start OpenClaw with `google/gemini-3.1-flash-lite-preview` (or similar model)
2. Send a message that causes the agent to run an exec command requiring approval
3. Observe: agent receives `approval-pending` from exec, then calls `exec` again with `/approve <id> allow-always` as the shell command
4. This generates a new `approval-pending`, and the loop repeats indefinitely
5. After fix: step 3 now throws an immediate error, and the prompt instructs the model to show `/approve` to the user instead

### Risk / Mitigation

- **Risk**: A legitimate shell command starting with `/approve` would be blocked. In practice, no POSIX or common shell command starts with `/approve` — it is exclusively an OpenClaw slash command. The regex `^\s*\/approve\b` is intentionally narrow (start-of-string only) to avoid false positives on commands like `echo /approve`.
- **Mitigation**: Three test cases verify the guard: (1) `/approve` is rejected, (2) `/approve` with leading whitespace is rejected, (3) `echo /approve` is NOT rejected. The prompt and tool-output changes are additive and do not alter any existing behavior for non-approval flows.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Agent System Prompt
- [x] Exec Tool
- [x] Tests

### Linked Issue/PR

Fixes #57432