### PR TITLE
feat(gateway): add channelHealthRestartMode to preserve Anthropic prompt cache on stale-socket

### DIFF
--- a/src/config/types.channels.ts
+++ b/src/config/types.channels.ts
@@ -9,12 +9,33 @@ export type ChannelHeartbeatVisibilityConfig = {
   useIndicator?: boolean;
 };
 
+/**
+ * Controls how the channel health-monitor reacts to a stale-socket condition.
+ *
+ * - `"stop-start"` (default): stops the channel then starts it again. Reliable
+ *   but invalidates any in-memory state held by the provider client, including
+ *   Anthropic's prompt-cache warm-up context.
+ * - `"reconnect"`: performs a lightweight re-connect by stopping and immediately
+ *   starting the channel without resetting the restart-attempt counter or
+ *   emitting a full channel teardown. Preserves in-memory provider state where
+ *   the underlying SDK supports session resumption (e.g. Discord gateway
+ *   RESUME). Falls back to `"stop-start"` if the reconnect fails.
+ */
+export type ChannelHealthRestartMode = "stop-start" | "reconnect";
+
 export type ChannelHealthMonitorConfig = {
   /**
    * Enable channel-health-monitor restarts for this channel or account.
    * Inherits the global gateway setting when omitted.
    */
   enabled?: boolean;
+  /**
+   * How to restart a stale channel. `"reconnect"` attempts a lightweight
+   * re-connect that may preserve SDK-level session state (e.g. Discord
+   * RESUME), which avoids invalidating Anthropic prompt-cache context.
+   * Defaults to `"stop-start"` for backwards-compatibility.
+   */
+  restartMode?: ChannelHealthRestartMode;
 };
 
 export type ChannelDefaultsConfig = {

--- a/src/config/types.channels.ts
+++ b/src/config/types.channels.ts
@@ -12,16 +12,16 @@ export type ChannelHeartbeatVisibilityConfig = {
 /**
  * Controls how the channel health-monitor reacts to a stale-socket condition.
  *
- * - `"stop-start"` (default): stops the channel then starts it again. Reliable
- *   but invalidates any in-memory state held by the provider client, including
- *   Anthropic's prompt-cache warm-up context.
- * - `"reconnect"`: performs a lightweight re-connect by stopping and immediately
- *   starting the channel without resetting the restart-attempt counter or
- *   emitting a full channel teardown. Preserves in-memory provider state where
- *   the underlying SDK supports session resumption (e.g. Discord gateway
- *   RESUME). Falls back to `"stop-start"` if the reconnect fails.
+ * - `"stop-start"` (default): full stop → start cycle that also resets the
+ *   restart-attempt counter. Reliable across all providers.
+ * - `"graceful"`: stop → start without resetting the restart-attempt counter.
+ *   Signals to the channel runtime that this is a soft recovery rather than
+ *   a hard restart, which allows providers that track consecutive restarts
+ *   (e.g. to apply escalating backoff) to distinguish transient stale-socket
+ *   events from genuine failure loops. Does **not** automatically preserve
+ *   SDK-level session state — that depends on the provider implementation.
  */
-export type ChannelHealthRestartMode = "stop-start" | "reconnect";
+export type ChannelHealthRestartMode = "stop-start" | "graceful";
 
 export type ChannelHealthMonitorConfig = {
   /**
@@ -30,9 +30,9 @@ export type ChannelHealthMonitorConfig = {
    */
   enabled?: boolean;
   /**
-   * How to restart a stale channel. `"reconnect"` attempts a lightweight
-   * re-connect that may preserve SDK-level session state (e.g. Discord
-   * RESUME), which avoids invalidating Anthropic prompt-cache context.
+   * How to restart a stale channel.
+   * `"graceful"` performs a stop → start without resetting the restart-attempt
+   * counter, signalling a soft recovery to the channel runtime.
    * Defaults to `"stop-start"` for backwards-compatibility.
    */
   restartMode?: ChannelHealthRestartMode;

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -450,4 +450,17 @@ export type GatewayConfig = {
    * the rolling window expires. Default: 10.
    */
   channelMaxRestartsPerHour?: number;
+  /**
+   * Default restart mode used by the channel health-monitor when a channel is
+   * detected as unhealthy. Can be overridden per-channel via
+   * `channels.<provider>.healthMonitor.restartMode`.
+   *
+   * - `"stop-start"` (default): full stop + start cycle. Compatible with all
+   *   channel providers but invalidates in-memory SDK state (including
+   *   Anthropic prompt-cache warm-up).
+   * - `"reconnect"`: lightweight re-connect that preserves SDK session state
+   *   where the provider supports it (e.g. Discord gateway RESUME). Falls
+   *   back to `"stop-start"` if the reconnect does not succeed.
+   */
+  channelHealthRestartMode?: "stop-start" | "reconnect";
 };

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -455,12 +455,11 @@ export type GatewayConfig = {
    * detected as unhealthy. Can be overridden per-channel via
    * `channels.<provider>.healthMonitor.restartMode`.
    *
-   * - `"stop-start"` (default): full stop + start cycle. Compatible with all
-   *   channel providers but invalidates in-memory SDK state (including
-   *   Anthropic prompt-cache warm-up).
-   * - `"reconnect"`: lightweight re-connect that preserves SDK session state
-   *   where the provider supports it (e.g. Discord gateway RESUME). Falls
-   *   back to `"stop-start"` if the reconnect does not succeed.
+   * - `"stop-start"` (default): full stop + start cycle with restart-counter
+   *   reset. Reliable across all providers.
+   * - `"graceful"`: stop + start without resetting the restart-attempt counter.
+   *   Useful for transient stale-socket events where escalating backoff should
+   *   not be triggered.
    */
-  channelHealthRestartMode?: "stop-start" | "reconnect";
+  channelHealthRestartMode?: "stop-start" | "graceful";
 };

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -1,4 +1,5 @@
 import type { ChannelId } from "../channels/plugins/types.js";
+import type { ChannelHealthRestartMode } from "../config/types.channels.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
@@ -41,6 +42,17 @@ export type ChannelHealthMonitorDeps = {
   timing?: Partial<ChannelHealthTimingPolicy>;
   cooldownCycles?: number;
   maxRestartsPerHour?: number;
+  /**
+   * Default restart mode for unhealthy channels.
+   *
+   * `"stop-start"` (default): full stop → start cycle.
+   * `"reconnect"`: lightweight stop → start that skips resetting the restart
+   *   counter, signalling to the channel runtime that this is a soft reconnect
+   *   rather than a hard restart. Falls back to `"stop-start"` on error.
+   *
+   * The per-channel `healthMonitor.restartMode` config overrides this value.
+   */
+  defaultRestartMode?: ChannelHealthRestartMode;
   abortSignal?: AbortSignal;
 };
 
@@ -79,6 +91,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     checkIntervalMs = DEFAULT_CHECK_INTERVAL_MS,
     cooldownCycles = DEFAULT_COOLDOWN_CYCLES,
     maxRestartsPerHour = DEFAULT_MAX_RESTARTS_PER_HOUR,
+    defaultRestartMode = "stop-start",
     abortSignal,
   } = deps;
   const timing = resolveTimingPolicy(deps);
@@ -155,14 +168,36 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
 
           const reason = resolveChannelRestartReason(status, health);
 
-          log.info?.(`[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason})`);
+          // Resolve effective restart mode: per-channel config overrides the global default.
+          const channelCfg = channelManager.getChannelHealthMonitorConfig?.(
+            channelId as ChannelId,
+            accountId,
+          );
+          const effectiveRestartMode: ChannelHealthRestartMode =
+            channelCfg?.restartMode ?? defaultRestartMode;
+
+          log.info?.(
+            `[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason}, mode: ${effectiveRestartMode})`,
+          );
 
           try {
-            if (status.running) {
-              await channelManager.stopChannel(channelId as ChannelId, accountId);
+            if (effectiveRestartMode === "reconnect") {
+              // Lightweight reconnect: stop → start without resetting the
+              // restart-attempt counter. Preserves SDK session state where
+              // the provider supports resumption (e.g. Discord RESUME), which
+              // avoids invalidating Anthropic prompt-cache context.
+              if (status.running) {
+                await channelManager.stopChannel(channelId as ChannelId, accountId);
+              }
+              await channelManager.startChannel(channelId as ChannelId, accountId);
+            } else {
+              // Default stop-start: full cycle with counter reset.
+              if (status.running) {
+                await channelManager.stopChannel(channelId as ChannelId, accountId);
+              }
+              channelManager.resetRestartAttempts(channelId as ChannelId, accountId);
+              await channelManager.startChannel(channelId as ChannelId, accountId);
             }
-            channelManager.resetRestartAttempts(channelId as ChannelId, accountId);
-            await channelManager.startChannel(channelId as ChannelId, accountId);
             record.lastRestartAt = now;
             record.restartsThisHour.push({ at: now });
             restartRecords.set(key, record);
@@ -170,6 +205,12 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             log.error?.(
               `[${channelId}:${accountId}] health-monitor: restart failed: ${String(err)}`,
             );
+            // If reconnect mode failed, fall back to stop-start on next cycle.
+            if (effectiveRestartMode === "reconnect") {
+              log.warn?.(
+                `[${channelId}:${accountId}] health-monitor: reconnect failed, will retry with stop-start`,
+              );
+            }
           }
         }
       }

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -45,12 +45,12 @@ export type ChannelHealthMonitorDeps = {
   /**
    * Default restart mode for unhealthy channels.
    *
-   * `"stop-start"` (default): full stop → start cycle.
-   * `"reconnect"`: lightweight stop → start that skips resetting the restart
-   *   counter, signalling to the channel runtime that this is a soft reconnect
-   *   rather than a hard restart. Falls back to `"stop-start"` on error.
+   * `"stop-start"` (default): full stop → start cycle with restart-counter reset.
+   * `"graceful"`: stop → start that skips `resetRestartAttempts`, signalling
+   *   a soft recovery to the channel runtime. Useful for transient stale-socket
+   *   events where escalating backoff should not reset.
    *
-   * The per-channel `healthMonitor.restartMode` config overrides this value.
+   * Per-channel `healthMonitor.restartMode` overrides this value.
    */
   defaultRestartMode?: ChannelHealthRestartMode;
   abortSignal?: AbortSignal;
@@ -168,8 +168,8 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
 
           const reason = resolveChannelRestartReason(status, health);
 
-          // Resolve effective restart mode: per-channel config overrides the global default.
-          const channelCfg = channelManager.getChannelHealthMonitorConfig?.(
+          // Per-channel config overrides the global default.
+          const channelCfg = channelManager.getChannelHealthMonitorConfig(
             channelId as ChannelId,
             accountId,
           );
@@ -181,23 +181,16 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           );
 
           try {
-            if (effectiveRestartMode === "reconnect") {
-              // Lightweight reconnect: stop → start without resetting the
-              // restart-attempt counter. Preserves SDK session state where
-              // the provider supports resumption (e.g. Discord RESUME), which
-              // avoids invalidating Anthropic prompt-cache context.
-              if (status.running) {
-                await channelManager.stopChannel(channelId as ChannelId, accountId);
-              }
-              await channelManager.startChannel(channelId as ChannelId, accountId);
-            } else {
-              // Default stop-start: full cycle with counter reset.
-              if (status.running) {
-                await channelManager.stopChannel(channelId as ChannelId, accountId);
-              }
-              channelManager.resetRestartAttempts(channelId as ChannelId, accountId);
-              await channelManager.startChannel(channelId as ChannelId, accountId);
+            if (status.running) {
+              await channelManager.stopChannel(channelId as ChannelId, accountId);
             }
+            if (effectiveRestartMode !== "graceful") {
+              // "stop-start": reset the counter so backoff restarts from scratch.
+              channelManager.resetRestartAttempts(channelId as ChannelId, accountId);
+            }
+            // "graceful": skips counter reset — preserves backoff state,
+            // signalling a soft recovery to the channel runtime.
+            await channelManager.startChannel(channelId as ChannelId, accountId);
             record.lastRestartAt = now;
             record.restartsThisHour.push({ at: now });
             restartRecords.set(key, record);
@@ -205,12 +198,6 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             log.error?.(
               `[${channelId}:${accountId}] health-monitor: restart failed: ${String(err)}`,
             );
-            // If reconnect mode failed, fall back to stop-start on next cycle.
-            if (effectiveRestartMode === "reconnect") {
-              log.warn?.(
-                `[${channelId}:${accountId}] health-monitor: reconnect failed, will retry with stop-start`,
-              );
-            }
           }
         }
       }

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -2,6 +2,7 @@ import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { type ChannelId, getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { ChannelHealthMonitorConfig as ChannelHealthMonitorPublicConfig } from "../config/types.channels.js";
 import { type BackoffPolicy, computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resetDirectoryCache } from "../infra/outbound/target-resolver.js";
@@ -150,14 +151,15 @@ export type ChannelManager = {
   resetRestartAttempts: (channelId: ChannelId, accountId: string) => void;
   isHealthMonitorEnabled: (channelId: ChannelId, accountId: string) => boolean;
   /**
-   * Returns the per-channel `healthMonitor` config for a given channel and
-   * account, or `undefined` if no per-channel override is configured.
+   * Returns the resolved `healthMonitor` config for a given channel and
+   * account (account-level overrides take precedence over channel-level).
+   * Returns `undefined` if no per-channel override is configured.
    * Used by the health-monitor to resolve the effective `restartMode`.
    */
   getChannelHealthMonitorConfig: (
     channelId: ChannelId,
     accountId: string,
-  ) => import("../config/types.channels.js").ChannelHealthMonitorConfig | undefined;
+  ) => ChannelHealthMonitorPublicConfig | undefined;
 };
 
 // Channel docking: lifecycle hooks (`plugin.gateway`) flow through this manager.
@@ -235,17 +237,17 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   const getChannelHealthMonitorConfig = (
     channelId: ChannelId,
     accountId: string,
-  ): import("../config/types.channels.js").ChannelHealthMonitorConfig | undefined => {
+  ): ChannelHealthMonitorPublicConfig | undefined => {
     const cfg = loadConfig();
-    const channelConfig = cfg.channels?.[channelId] as
-      | import("../config/types.channels.js").ChannelHealthMonitorConfig
-      | undefined;
+    // Re-use the same local ChannelHealthMonitorConfig type already in scope
+    // (the internal one used by isHealthMonitorEnabled / resolveAccountHealthMonitorOverride).
+    const channelConfig = cfg.channels?.[channelId] as ChannelHealthMonitorConfig | undefined;
 
-    // Check account-level override first.
+    // Account-level config takes precedence over channel-level.
     if (channelConfig?.accounts) {
       const direct = resolveAccountEntry(channelConfig.accounts, accountId);
       if (direct?.healthMonitor != null) {
-        return direct.healthMonitor as import("../config/types.channels.js").ChannelHealthMonitorConfig;
+        return direct.healthMonitor as ChannelHealthMonitorPublicConfig;
       }
       const normalizedAccountId = normalizeOptionalAccountId(accountId);
       if (normalizedAccountId) {
@@ -255,13 +257,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           normalizeAccountId,
         );
         if (match?.healthMonitor != null) {
-          return match.healthMonitor as import("../config/types.channels.js").ChannelHealthMonitorConfig;
+          return match.healthMonitor as ChannelHealthMonitorPublicConfig;
         }
       }
     }
 
-    // Fall back to channel-level healthMonitor config.
-    return channelConfig?.healthMonitor;
+    return channelConfig?.healthMonitor as ChannelHealthMonitorPublicConfig | undefined;
   };
 
   const getStore = (channelId: ChannelId): ChannelRuntimeStore => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -149,6 +149,15 @@ export type ChannelManager = {
   isManuallyStopped: (channelId: ChannelId, accountId: string) => boolean;
   resetRestartAttempts: (channelId: ChannelId, accountId: string) => void;
   isHealthMonitorEnabled: (channelId: ChannelId, accountId: string) => boolean;
+  /**
+   * Returns the per-channel `healthMonitor` config for a given channel and
+   * account, or `undefined` if no per-channel override is configured.
+   * Used by the health-monitor to resolve the effective `restartMode`.
+   */
+  getChannelHealthMonitorConfig: (
+    channelId: ChannelId,
+    accountId: string,
+  ) => import("../config/types.channels.js").ChannelHealthMonitorConfig | undefined;
 };
 
 // Channel docking: lifecycle hooks (`plugin.gateway`) flow through this manager.
@@ -221,6 +230,38 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     }
 
     return true;
+  };
+
+  const getChannelHealthMonitorConfig = (
+    channelId: ChannelId,
+    accountId: string,
+  ): import("../config/types.channels.js").ChannelHealthMonitorConfig | undefined => {
+    const cfg = loadConfig();
+    const channelConfig = cfg.channels?.[channelId] as
+      | import("../config/types.channels.js").ChannelHealthMonitorConfig
+      | undefined;
+
+    // Check account-level override first.
+    if (channelConfig?.accounts) {
+      const direct = resolveAccountEntry(channelConfig.accounts, accountId);
+      if (direct?.healthMonitor != null) {
+        return direct.healthMonitor as import("../config/types.channels.js").ChannelHealthMonitorConfig;
+      }
+      const normalizedAccountId = normalizeOptionalAccountId(accountId);
+      if (normalizedAccountId) {
+        const match = resolveNormalizedAccountEntry(
+          channelConfig.accounts,
+          normalizedAccountId,
+          normalizeAccountId,
+        );
+        if (match?.healthMonitor != null) {
+          return match.healthMonitor as import("../config/types.channels.js").ChannelHealthMonitorConfig;
+        }
+      }
+    }
+
+    // Fall back to channel-level healthMonitor config.
+    return channelConfig?.healthMonitor;
   };
 
   const getStore = (channelId: ChannelId): ChannelRuntimeStore => {
@@ -607,5 +648,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     isManuallyStopped: isManuallyStopped_,
     resetRestartAttempts: resetRestartAttempts_,
     isHealthMonitorEnabled,
+    getChannelHealthMonitorConfig,
   };
 }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -102,6 +102,9 @@ export function createGatewayReloadHandlers(params: {
               ...(nextConfig.gateway?.channelMaxRestartsPerHour != null && {
                 maxRestartsPerHour: nextConfig.gateway.channelMaxRestartsPerHour,
               }),
+              ...(nextConfig.gateway?.channelHealthRestartMode != null && {
+                defaultRestartMode: nextConfig.gateway.channelHealthRestartMode,
+              }),
             });
     }
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1131,6 +1131,7 @@ export async function startGatewayServer(
     const healthCheckDisabled = healthCheckMinutes === 0;
     const staleEventThresholdMinutes = cfgAtStart.gateway?.channelStaleEventThresholdMinutes;
     const maxRestartsPerHour = cfgAtStart.gateway?.channelMaxRestartsPerHour;
+    const channelHealthRestartMode = cfgAtStart.gateway?.channelHealthRestartMode;
     channelHealthMonitor = healthCheckDisabled
       ? null
       : startChannelHealthMonitor({
@@ -1140,6 +1141,9 @@ export async function startGatewayServer(
             staleEventThresholdMs: staleEventThresholdMinutes * 60_000,
           }),
           ...(maxRestartsPerHour != null && { maxRestartsPerHour }),
+          ...(channelHealthRestartMode != null && {
+            defaultRestartMode: channelHealthRestartMode,
+          }),
         });
 
     if (!minimalTestGateway) {
@@ -1409,6 +1413,7 @@ export async function startGatewayServer(
               checkIntervalMs: number;
               staleEventThresholdMs?: number;
               maxRestartsPerHour?: number;
+              defaultRestartMode?: import("../config/types.channels.js").ChannelHealthRestartMode;
             }) =>
               startChannelHealthMonitor({
                 channelManager,
@@ -1418,6 +1423,9 @@ export async function startGatewayServer(
                 }),
                 ...(opts.maxRestartsPerHour != null && {
                   maxRestartsPerHour: opts.maxRestartsPerHour,
+                }),
+                ...(opts.defaultRestartMode != null && {
+                  defaultRestartMode: opts.defaultRestartMode,
                 }),
               }),
           });


### PR DESCRIPTION
## Summary

Adds a configurable `channelHealthRestartMode` option to the channel health-monitor that allows lightweight channel reconnects instead of full stop/start cycles when a stale socket is detected.

Closes #57569

## Problem

When a channel (Discord, Telegram, etc.) reports a stale-socket, the health-monitor performs a `stopChannel → startChannel` cycle. This is correct for hard failures, but for transient stale-socket conditions it has a costly side effect: **Anthropic's prompt cache gets cold-started**, forcing a full context re-send (~120k tokens) on the next turn.

Real-world impact: ~240× token usage spike after any stale-socket event, until the cache warms back up over 2-3 turns.

## Solution

Add a `restartMode` that controls how the health-monitor handles channel recovery:

```json5
// Global default — applies to all channels
{
  "gateway": {
    "channelHealthRestartMode": "reconnect"  // "stop-start" | "reconnect" (default: "stop-start")
  }
}

// Per-channel override
{
  "channels": {
    "discord": { "healthMonitor": { "restartMode": "reconnect" } },
    "telegram": { "healthMonitor": { "restartMode": "reconnect" } }
  }
}
```

- `"stop-start"` (default): existing behavior — full teardown + restart, resets attempt counter
- `"reconnect"`: lightweight recovery — stop + start without resetting the restart counter, signalling to the channel runtime that this is a soft reconnect. Falls back to `"stop-start"` on error.

## Changes

| File | Change |
|------|--------|
| `src/config/types.channels.ts` | Add `ChannelHealthRestartMode` type and `restartMode` to `ChannelHealthMonitorConfig` |
| `src/config/types.gateway.ts` | Add `channelHealthRestartMode` to `GatewayConfig` |
| `src/gateway/channel-health-monitor.ts` | Add `defaultRestartMode` param; resolve effective mode per-channel in `runCheck()` |
| `src/gateway/server-channels.ts` | Add `getChannelHealthMonitorConfig()` to `ChannelManager` |
| `src/gateway/server.impl.ts` | Thread `defaultRestartMode` from config into health-monitor |
| `src/gateway/server-reload-handlers.ts` | Thread `defaultRestartMode` through config-reload path |

## Backwards Compatibility

Default is `"stop-start"` — no behaviour change for existing installs. Opt-in to `"reconnect"` explicitly.