### PR TITLE
fix(mcp): include full data in content field for channel tools

### DIFF
--- a/src/mcp/channel-shared.ts
+++ b/src/mcp/channel-shared.ts
@@ -137,6 +137,12 @@ export function resolveMessageId(entry: Record<string, unknown>): string | undef
   );
 }
 
+/**
+ * Build a `content` array for an MCP tool result.
+ * When `data` is provided the full payload is JSON-serialized into `content`
+ * so that standard MCP clients (Cursor, Claude.ai) receive actionable data.
+ * `count` is kept as a fallback for callers that don't pass `data`.
+ */
 export function summarizeResult(
   label: string,
   count: number,

--- a/src/mcp/channel-shared.ts
+++ b/src/mcp/channel-shared.ts
@@ -140,9 +140,11 @@ export function resolveMessageId(entry: Record<string, unknown>): string | undef
 export function summarizeResult(
   label: string,
   count: number,
+  data?: unknown,
 ): { content: Array<{ type: "text"; text: string }> } {
+  const text = data !== undefined ? JSON.stringify({ [label]: data }) : `${label}: ${count}`;
   return {
-    content: [{ type: "text", text: `${label}: ${count}` }],
+    content: [{ type: "text", text }],
   };
 }
 

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -34,7 +34,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     async (args) => {
       const conversations = await bridge.listConversations(args);
       return {
-        ...summarizeResult("conversations", conversations.length),
+        ...summarizeResult("conversations", conversations.length, conversations),
         structuredContent: { conversations },
       };
     },
@@ -53,7 +53,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
         };
       }
       return {
-        content: [{ type: "text", text: `conversation ${conversation.sessionKey}` }],
+        content: [{ type: "text", text: JSON.stringify({ conversation }) }],
         structuredContent: { conversation },
       };
     },
@@ -69,7 +69,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     async ({ session_key, limit }) => {
       const messages = await bridge.readMessages(session_key, limit ?? 20);
       return {
-        ...summarizeResult("messages", messages.length),
+        ...summarizeResult("messages", messages.length, messages),
         structuredContent: { messages },
       };
     },
@@ -94,7 +94,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       }
       const attachments = extractAttachmentsFromMessage(message);
       return {
-        ...summarizeResult("attachments", attachments.length),
+        ...summarizeResult("attachments", attachments.length, attachments),
         structuredContent: { attachments, message },
       };
     },
@@ -114,7 +114,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
         limit ?? 20,
       );
       return {
-        ...summarizeResult("events", events.length),
+        ...summarizeResult("events", events.length, events),
         structuredContent: { events, next_cursor: nextCursor },
       };
     },
@@ -134,7 +134,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
         timeout_ms ?? 30_000,
       );
       return {
-        content: [{ type: "text", text: event ? `event ${event.cursor}` : "timeout" }],
+        content: [{ type: "text", text: event ? JSON.stringify({ event }) : "timeout" }],
         structuredContent: { event },
       };
     },
@@ -150,7 +150,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     async ({ session_key, text }) => {
       const result = await bridge.sendMessage({ sessionKey: session_key, text });
       return {
-        content: [{ type: "text", text: "sent" }],
+        content: [{ type: "text", text: JSON.stringify({ result }) }],
         structuredContent: { result },
       };
     },
@@ -163,7 +163,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     async () => {
       const approvals = bridge.listPendingApprovals();
       return {
-        ...summarizeResult("approvals", approvals.length),
+        ...summarizeResult("approvals", approvals.length, approvals),
         structuredContent: { approvals },
       };
     },
@@ -180,7 +180,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     async ({ kind, id, decision }) => {
       const result = await bridge.respondToApproval({ kind, id, decision });
       return {
-        content: [{ type: "text", text: "approval resolved" }],
+        content: [{ type: "text", text: JSON.stringify({ result }) }],
         structuredContent: { result },
       };
     },

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -94,7 +94,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       }
       const attachments = extractAttachmentsFromMessage(message);
       return {
-        ...summarizeResult("attachments", attachments.length, attachments),
+        content: [{ type: "text", text: JSON.stringify({ attachments, message }) }],
         structuredContent: { attachments, message },
       };
     },
@@ -114,7 +114,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
         limit ?? 20,
       );
       return {
-        ...summarizeResult("events", events.length, events),
+        content: [{ type: "text", text: JSON.stringify({ events, next_cursor: nextCursor }) }],
         structuredContent: { events, next_cursor: nextCursor },
       };
     },


### PR DESCRIPTION
## Summary

- MCP channel tools (`conversations_list`, `messages_read`, `events_poll`, etc.) now include full JSON data in the `content` field, not just summary counts
- Standard MCP clients (Cursor, Claude.ai) only read `content`, so they were receiving useless strings like `"conversations: 1"` instead of actual data
- `structuredContent` is preserved for clients that support it

Closes #57461

## Test plan

- [ ] Verify `conversations_list` returns full conversation data in `content[0].text` as JSON
- [ ] Verify `messages_read`, `events_poll`, `attachments_fetch` similarly include data in `content`
- [ ] Verify `conversation_get`, `events_wait`, `messages_send`, `permissions_respond` include JSON data in `content`
- [ ] Verify `structuredContent` still present for backward compatibility
- [ ] Confirm Cursor/Claude.ai MCP integration can now see full tool result data

🤖 Generated with [Claude Code](https://claude.com/claude-code)