### PR TITLE
fix(gateway): restore default operator scopes for pure HTTP token auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/delivery recovery: treat Synapse `User not in room` replay failures as permanent during startup recovery so poisoned queued messages move to `failed/` instead of crash-looping Matrix after restart. (#57426) thanks @dlardo.
 - Plugins/facades: guard bundled plugin facade loads with a cache-first sentinel so circular re-entry stops crashing `xai`, `sglang`, and `vllm` during gateway plugin startup. (#57508) Thanks @openperf.
 - Agents/MCP: dispose bundled MCP runtimes after one-shot `openclaw agent --local` runs finish, while preserving bundled MCP state across in-run retries so local JSON runs exit cleanly without restarting stateful MCP tools mid-run.
+- Gateway/OpenAI HTTP: restore default operator scopes for bearer-authenticated requests that omit `x-openclaw-scopes`, so headless `/v1/chat/completions` and session-history callers work again after the recent method-scope hardening. (#57596) Thanks @openperf.
 
 ## 2026.3.28
 

--- a/src/gateway/http-auth-helpers.test.ts
+++ b/src/gateway/http-auth-helpers.test.ts
@@ -1,7 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { authorizeGatewayBearerRequestOrReply } from "./http-auth-helpers.js";
+import {
+  authorizeGatewayBearerRequestOrReply,
+  resolveGatewayRequestedOperatorScopes,
+} from "./http-auth-helpers.js";
+import { CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
 
 vi.mock("./auth.js", () => ({
   authorizeHttpGatewayConnect: vi.fn(),
@@ -13,11 +17,12 @@ vi.mock("./http-common.js", () => ({
 
 vi.mock("./http-utils.js", () => ({
   getBearerToken: vi.fn(),
+  getHeader: vi.fn(),
 }));
 
 const { authorizeHttpGatewayConnect } = await import("./auth.js");
 const { sendGatewayAuthFailure } = await import("./http-common.js");
-const { getBearerToken } = await import("./http-utils.js");
+const { getBearerToken, getHeader } = await import("./http-utils.js");
 
 describe("authorizeGatewayBearerRequestOrReply", () => {
   const bearerAuth = {
@@ -68,5 +73,62 @@ describe("authorizeGatewayBearerRequestOrReply", () => {
       }),
     );
     expect(vi.mocked(sendGatewayAuthFailure)).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveGatewayRequestedOperatorScopes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns CLI_DEFAULT_OPERATOR_SCOPES when header is absent", () => {
+    vi.mocked(getHeader).mockReturnValue(undefined);
+    const req = {} as IncomingMessage;
+    const scopes = resolveGatewayRequestedOperatorScopes(req);
+    expect(scopes).toEqual(CLI_DEFAULT_OPERATOR_SCOPES);
+    // Returned array must be a copy, not the original constant.
+    expect(scopes).not.toBe(CLI_DEFAULT_OPERATOR_SCOPES);
+  });
+
+  it("returns empty array when header is present but empty", () => {
+    vi.mocked(getHeader).mockReturnValue("");
+    const req = {} as IncomingMessage;
+    const scopes = resolveGatewayRequestedOperatorScopes(req);
+    expect(scopes).toEqual([]);
+  });
+
+  it("returns empty array when header is present but only whitespace", () => {
+    vi.mocked(getHeader).mockReturnValue("   ");
+    const req = {} as IncomingMessage;
+    const scopes = resolveGatewayRequestedOperatorScopes(req);
+    expect(scopes).toEqual([]);
+  });
+
+  it("parses comma-separated scopes from header", () => {
+    vi.mocked(getHeader).mockReturnValue("operator.write,operator.read");
+    const req = {} as IncomingMessage;
+    const scopes = resolveGatewayRequestedOperatorScopes(req);
+    expect(scopes).toEqual(["operator.write", "operator.read"]);
+  });
+
+  it("trims whitespace around individual scopes", () => {
+    vi.mocked(getHeader).mockReturnValue("  operator.write , operator.read  ");
+    const req = {} as IncomingMessage;
+    const scopes = resolveGatewayRequestedOperatorScopes(req);
+    expect(scopes).toEqual(["operator.write", "operator.read"]);
+  });
+
+  it("filters out empty segments from trailing commas", () => {
+    vi.mocked(getHeader).mockReturnValue("operator.write,,operator.read,");
+    const req = {} as IncomingMessage;
+    const scopes = resolveGatewayRequestedOperatorScopes(req);
+    expect(scopes).toEqual(["operator.write", "operator.read"]);
+  });
+
+  it("returns single scope when only one is declared", () => {
+    vi.mocked(getHeader).mockReturnValue("operator.approvals");
+    const req = {} as IncomingMessage;
+    const scopes = resolveGatewayRequestedOperatorScopes(req);
+    expect(scopes).toEqual(["operator.approvals"]);
   });
 });

--- a/src/gateway/http-auth-helpers.ts
+++ b/src/gateway/http-auth-helpers.ts
@@ -3,6 +3,7 @@ import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import { authorizeHttpGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
 import { sendGatewayAuthFailure } from "./http-common.js";
 import { getBearerToken, getHeader } from "./http-utils.js";
+import { CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
 
 const OPERATOR_SCOPES_HEADER = "x-openclaw-scopes";
 
@@ -32,7 +33,20 @@ export async function authorizeGatewayBearerRequestOrReply(params: {
 
 export function resolveGatewayRequestedOperatorScopes(req: IncomingMessage): string[] {
   const raw = getHeader(req, OPERATOR_SCOPES_HEADER)?.trim();
+  if (raw === undefined || raw === null) {
+    // No x-openclaw-scopes header present at all: the caller is a plain
+    // Bearer-token HTTP client (curl, OpenAI SDK, etc.) that has already
+    // passed gateway token authentication.  Grant the same default operator
+    // scopes that the CLI and other first-party callers receive so that
+    // authenticated HTTP requests are not denied by the method-scope gate.
+    //
+    // When the header IS present (even if empty), honour the declared value
+    // so that callers can voluntarily restrict their own privilege set and
+    // the CVE-2026-32919 / CVE-2026-28473 security boundary is preserved.
+    return [...CLI_DEFAULT_OPERATOR_SCOPES];
+  }
   if (!raw) {
+    // Header present but empty string → caller explicitly declared no scopes.
     return [];
   }
   return raw

--- a/src/gateway/http-auth-helpers.ts
+++ b/src/gateway/http-auth-helpers.ts
@@ -33,7 +33,7 @@ export async function authorizeGatewayBearerRequestOrReply(params: {
 
 export function resolveGatewayRequestedOperatorScopes(req: IncomingMessage): string[] {
   const raw = getHeader(req, OPERATOR_SCOPES_HEADER)?.trim();
-  if (raw === undefined || raw === null) {
+  if (raw === undefined) {
     // No x-openclaw-scopes header present at all: the caller is a plain
     // Bearer-token HTTP client (curl, OpenAI SDK, etc.) that has already
     // passed gateway token authentication.  Grant the same default operator

--- a/src/gateway/server.openai-compatible-http-write-scope-bypass.poc.test.ts
+++ b/src/gateway/server.openai-compatible-http-write-scope-bypass.poc.test.ts
@@ -51,7 +51,12 @@ describe("gateway OpenAI-compatible HTTP write-scope bypass PoC", () => {
       expect(body.error?.message).toBe("missing scope: operator.write");
       expect(agentCommand).toHaveBeenCalledTimes(0);
 
+      // Requests without x-openclaw-scopes header now receive default
+      // CLI_DEFAULT_OPERATOR_SCOPES (which include operator.write), so they
+      // are authorised.  The explicit-header test above still proves that a
+      // caller who *declares* only operator.approvals is correctly rejected.
       agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
       const missingHeaderRes = await fetch(`http://127.0.0.1:${started.port}/v1/chat/completions`, {
         method: "POST",
         headers: {
@@ -64,13 +69,14 @@ describe("gateway OpenAI-compatible HTTP write-scope bypass PoC", () => {
         }),
       });
 
-      expect(missingHeaderRes.status).toBe(403);
+      expect(missingHeaderRes.status).toBe(200);
       const missingHeaderBody = (await missingHeaderRes.json()) as {
-        error?: { type?: string; message?: string };
+        object?: string;
+        choices?: Array<{ message?: { content?: string } }>;
       };
-      expect(missingHeaderBody.error?.type).toBe("forbidden");
-      expect(missingHeaderBody.error?.message).toBe("missing scope: operator.write");
-      expect(agentCommand).toHaveBeenCalledTimes(0);
+      expect(missingHeaderBody.object).toBe("chat.completion");
+      expect(missingHeaderBody.choices?.[0]?.message?.content).toBe("hello");
+      expect(agentCommand).toHaveBeenCalledTimes(1);
     } finally {
       started.ws.close();
       await started.server.close();

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -422,20 +422,17 @@ describe("session history HTTP endpoints", () => {
         },
       });
 
+      // Requests without x-openclaw-scopes header now receive default
+      // CLI_DEFAULT_OPERATOR_SCOPES (which include operator.read), so they
+      // are authorised.  The explicit-header test above still proves that a
+      // caller who *declares* only operator.approvals is correctly rejected.
       const httpHistoryWithoutScopes = await fetch(
         `http://127.0.0.1:${harness.port}/sessions/${encodeURIComponent("agent:main:main")}/history?limit=1`,
         {
           headers: AUTH_HEADER,
         },
       );
-      expect(httpHistoryWithoutScopes.status).toBe(403);
-      await expect(httpHistoryWithoutScopes.json()).resolves.toMatchObject({
-        ok: false,
-        error: {
-          type: "forbidden",
-          message: "missing scope: operator.read",
-        },
-      });
+      expect(httpHistoryWithoutScopes.status).toBe(200);
     } finally {
       ws.close();
       await harness.close();


### PR DESCRIPTION

### Summary

- **Problem**: All HTTP API integrations (like `/v1/chat/completions`) using pure Bearer Token authentication are broken in v3.28+, returning `{"ok":false,"error":{"type":"forbidden","message":"missing scope: operator.write"}}`. This affects `curl`, OpenAI SDKs, and other headless callers. The issue is located in `src/gateway/http-auth-helpers.ts` where `resolveGatewayRequestedOperatorScopes()` returns an empty array when the `x-openclaw-scopes` header is missing.
- **Root Cause**: The CVE-2026-32919 / CVE-2026-28473 security patches introduced strict method-scope gating (`requiredOperatorMethod`) for HTTP endpoints. However, the scope resolution logic assumed that a missing `x-openclaw-scopes` header meant "no scopes requested" (returning `[]`). Pure HTTP Bearer Token callers do not send this header, so despite passing Gateway Token authentication, they were stripped of all operator privileges and subsequently blocked by the method-scope gate.
- **Fix**: Updated `resolveGatewayRequestedOperatorScopes()` to return `CLI_DEFAULT_OPERATOR_SCOPES` when the `x-openclaw-scopes` header is completely absent. If the header is present but empty, it still returns `[]` to honor explicit scope restrictions. This restores the intended behavior where authenticated HTTP clients receive default operator privileges, while preserving the security boundary for callers that explicitly declare restricted scopes.
- **What changed**:
  - `src/gateway/http-auth-helpers.ts`: Modified `resolveGatewayRequestedOperatorScopes` to return default scopes when the header is undefined/null.
  - `src/gateway/http-auth-helpers.test.ts`: Added comprehensive unit tests for `resolveGatewayRequestedOperatorScopes`.
  - `src/gateway/server.openai-compatible-http-write-scope-bypass.poc.test.ts`: Updated the missing-header test expectation from 403 to 200.
  - `src/gateway/sessions-history-http.test.ts`: Updated the missing-header test expectation from 403 to 200.
- **What did NOT change (scope boundary)**: The WebSocket connection auth logic (`message-handler.ts`) and device pairing scope bindings remain completely untouched. The CVE security patch logic that prevents `operator.approvals` from bypassing `operator.write` remains fully intact when scopes are explicitly declared.

### Reproduction

1. Start the OpenClaw gateway with token auth enabled.
2. Send a pure HTTP request without the `x-openclaw-scopes` header:
   ```bash
   curl http://127.0.0.1:8080/v1/chat/completions \
     -H "Authorization: Bearer <TOKEN>" \
     -H "Content-Type: application/json" \
     -d '{"model": "openclaw", "messages": [{"role": "user", "content": "hi"}]}'
   ```
3. Before fix: Returns 403 Forbidden (`missing scope: operator.write`).
4. After fix: Returns 200 OK.

### Risk / Mitigation

- **Risk**: The fix might inadvertently grant excessive permissions to HTTP callers that were intentionally restricted.
- **Mitigation**: The fix explicitly checks for `undefined` or `null` header values. If a caller sends an empty header (`x-openclaw-scopes: `), it still resolves to an empty array `[]`, honoring the explicit restriction. Comprehensive unit tests have been added to `http-auth-helpers.test.ts` to verify this exact parsing behavior, and existing PoC tests were updated to ensure the CVE bypass protection remains active for explicitly declared scopes.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway

### Linked Issue/PR

Fixes #57550

