### PR TITLE
fix(acp): persist spawn labels in target session store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACP: persist `/acp spawn --label` updates in the spawned ACP session store so cross-agent labels resolve for follow-up commands. (#57597) Thanks @guanyu-zhang.
 - Channels/secrets: resolve SecretRef-backed channel credentials through external plugin secret contracts after the plugin split, covering runtime startup, target discovery, webhook auth, disabled-account enumeration, and late-bound web_search config. (#76449) Thanks @joshavant.
 - Docker/Gateway: pass Docker setup `.env` values into gateway and CLI containers and preserve exec SecretRef `passEnv` keys in managed service plans, so 1Password Connect-backed Discord tokens keep resolving after doctor or plugin repair. Thanks @vincentkoc.
 - Control UI/WebChat: explain compaction boundaries in chat history and link directly to session checkpoint controls so pre-compaction turns no longer look silently lost after refresh. Fixes #76415. Thanks @BunsDev.

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -18,6 +18,7 @@ const hoisted = vi.hoisted(() => {
   const upsertAcpSessionMetaMock = vi.fn();
   const resolveSessionStorePathForAcpMock = vi.fn();
   const loadSessionStoreMock = vi.fn();
+  const updateSessionStoreMock = vi.fn();
   const sessionBindingCapabilitiesMock = vi.fn();
   const sessionBindingBindMock = vi.fn();
   const sessionBindingListBySessionMock = vi.fn();
@@ -41,6 +42,7 @@ const hoisted = vi.hoisted(() => {
     upsertAcpSessionMetaMock,
     resolveSessionStorePathForAcpMock,
     loadSessionStoreMock,
+    updateSessionStoreMock,
     sessionBindingCapabilitiesMock,
     sessionBindingBindMock,
     sessionBindingListBySessionMock,
@@ -104,6 +106,7 @@ vi.mock("../../config/sessions.js", async () => {
   return {
     ...actual,
     loadSessionStore: (...args: unknown[]) => hoisted.loadSessionStoreMock(...args),
+    updateSessionStore: (...args: unknown[]) => hoisted.updateSessionStoreMock(...args),
   };
 });
 
@@ -866,6 +869,9 @@ describe("/acp command", () => {
       storePath: "/tmp/sessions-acp.json",
     });
     hoisted.loadSessionStoreMock.mockReset().mockReturnValue({});
+    hoisted.updateSessionStoreMock.mockReset().mockImplementation(async (_storePath, update) => {
+      return update({});
+    });
     hoisted.sessionBindingCapabilitiesMock
       .mockReset()
       .mockReturnValue(createSessionBindingCapabilities());
@@ -1145,6 +1151,54 @@ describe("/acp command", () => {
         method: "sessions.patch",
       }),
     );
+  });
+
+  it("persists ACP spawn labels to the spawned session store instead of the requester store", async () => {
+    const commandParams = createConversationParams(
+      "/acp spawn codex --bind here --label codex-a2ui",
+      {
+        channel: "telegram",
+        originatingTo: "telegram:-1003841603622",
+        threadId: "777",
+      },
+    );
+    commandParams.storePath = "/tmp/requester-sessions.json";
+    commandParams.sessionStore = {
+      "agent:main:telegram:group:-1003841603622:topic:777": {
+        sessionId: "requester-session",
+        updatedAt: Date.now(),
+      },
+    };
+    hoisted.resolveSessionStorePathForAcpMock.mockReturnValue({
+      cfg: baseCfg,
+      storePath: "/tmp/codex-sessions.json",
+    });
+
+    const result = await handleAcpCommand(commandParams, true);
+
+    expect(result?.reply?.text).toContain("Bound this conversation to");
+    const spawnedSessionKey = (
+      hoisted.ensureSessionMock.mock.calls[0]?.[0] as { sessionKey?: string } | undefined
+    )?.sessionKey;
+    expect(spawnedSessionKey).toMatch(/^agent:codex:acp:/);
+    expect(hoisted.updateSessionStoreMock).toHaveBeenCalledWith(
+      "/tmp/codex-sessions.json",
+      expect.any(Function),
+    );
+    expect(hoisted.updateSessionStoreMock).not.toHaveBeenCalledWith(
+      "/tmp/requester-sessions.json",
+      expect.any(Function),
+    );
+    const updateFn = hoisted.updateSessionStoreMock.mock.calls[0]?.[1] as
+      | ((store: Record<string, { label?: string; updatedAt: number }>) => unknown)
+      | undefined;
+    const updated = updateFn?.({
+      [spawnedSessionKey ?? "missing"]: {
+        updatedAt: 1,
+      },
+    }) as { label?: string; updatedAt?: number } | undefined;
+    expect(updated?.label).toBe("codex-a2ui");
+    expect(updated?.updatedAt).toBeTypeOf("number");
   });
 
   it("accepts unicode dash option prefixes in /acp spawn args", async () => {

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1155,7 +1155,7 @@ describe("/acp command", () => {
 
   it("persists ACP spawn labels to the spawned session store instead of the requester store", async () => {
     const commandParams = createConversationParams(
-      "/acp spawn codex --bind here --label codex-a2ui",
+      "/acp spawn codex --bind here --label spawned-label",
       {
         channel: "telegram",
         originatingTo: "telegram:-1003841603622",
@@ -1192,12 +1192,14 @@ describe("/acp command", () => {
     const updateFn = hoisted.updateSessionStoreMock.mock.calls[0]?.[1] as
       | ((store: Record<string, { label?: string; updatedAt: number }>) => unknown)
       | undefined;
-    const updated = updateFn?.({
+    const store: Record<string, { label?: string; updatedAt: number }> = {
       [spawnedSessionKey ?? "missing"]: {
         updatedAt: 1,
       },
-    }) as { label?: string; updatedAt?: number } | undefined;
-    expect(updated?.label).toBe("codex-a2ui");
+    };
+    updateFn?.(store);
+    const updated = store[spawnedSessionKey ?? "missing"];
+    expect(updated?.label).toBe("spawned-label");
     expect(updated?.updatedAt).toBeTypeOf("number");
   });
 

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -15,6 +15,7 @@ import {
   resolveAcpSessionCwd,
   resolveAcpThreadSessionDetailLines,
 } from "../../../acp/runtime/session-identifiers.js";
+import { resolveSessionStorePathForAcp } from "../../../acp/runtime/session-meta.js";
 import { resolveAcpSpawnRuntimePolicyError } from "../../../agents/acp-spawn.js";
 import { getChannelPlugin, normalizeChannelId } from "../../../channels/plugins/index.js";
 import {
@@ -456,7 +457,12 @@ async function persistSpawnedSessionLabel(params: {
   }
 
   const now = Date.now();
-  if (params.commandParams.sessionStore) {
+  const { storePath } = resolveSessionStorePathForAcp({
+    cfg: params.commandParams.cfg,
+    sessionKey: params.sessionKey,
+  });
+
+  if (params.commandParams.sessionStore && params.commandParams.storePath === storePath) {
     const existing = params.commandParams.sessionStore[params.sessionKey];
     if (existing) {
       params.commandParams.sessionStore[params.sessionKey] = {
@@ -466,10 +472,7 @@ async function persistSpawnedSessionLabel(params: {
       };
     }
   }
-  if (!params.commandParams.storePath) {
-    return;
-  }
-  await updateSessionStore(params.commandParams.storePath, (store) => {
+  await updateSessionStore(storePath, (store) => {
     const existing = store[params.sessionKey];
     if (!existing) {
       return;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `/acp spawn ... --label <name>` persisted the spawned ACP session metadata into the target agent store, but tried to persist the label into the requester store.
- Why it matters: Cross-agent ACP spawns (for example from a Telegram topic into a `codex` ACP session) silently lost the requested label, so follow-up commands like `/focus <label>` and `/acp status <label>` could not resolve the spawned session by label.
- What changed: `persistSpawnedSessionLabel(...)` now resolves the target session store from the spawned ACP `sessionKey` before writing the label, and only mutates the in-memory requester store when both stores are actually the same.
- What did NOT change (scope boundary): ACP spawn routing, binding behavior, and runtime option handling are unchanged.
- AI-assisted: Yes. This PR was prepared with Codex.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

ACP sessions spawned with `/acp spawn ... --label <name>` now retain the requested label even when the spawned session is written to a different agent session store than the requester. Label-based follow-up commands such as `/focus <label>` and `/acp status <label>` now work in those cross-agent ACP flows.

## Security Impact (required)

- New permissions/capabilities? (Yes/No) No
- Secrets/tokens handling changed? (Yes/No) No
- New/changed network calls? (Yes/No) No
- Command/tool execution surface changed? (Yes/No) No
- Data access scope changed? (Yes/No) No
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local source install + local dev checkout
- Model/provider: ACPX (`codex` / `gemini` harnesses)
- Integration/channel (if any): Telegram ACP topic binding
- Relevant config (redacted): `acp.enabled=true`, `acp.backend=acpx`, `acp.allowedAgents=["codex","gemini"]`

### Steps

1. From a Telegram topic with ACP commands enabled, run `/acp spawn codex --bind here --label codex-a2ui --cwd /path/to/worktree`.
2. Observe that the spawned ACP session is created in the `codex` session store.
3. Try to resolve the session by label, for example with `/focus codex-a2ui` or `/acp status codex-a2ui`.

### Expected

- The spawned ACP session entry in the target agent store includes `label: "codex-a2ui"`.
- Label-based session resolution works for follow-up commands.

### Actual (before fix)

- The spawned ACP session entry in the target agent store had `label: null`.
- The label was written against the requester store instead, so label-based resolution failed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets: local reproduction showed the spawned ACP session persisted in the target store with `label: null` before the fix; after patching the persistence path, the same session entry carried the requested label.
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: traced the spawn path, confirmed the label write used the requester `storePath`, reproduced the bug locally with a Telegram-bound ACP `codex` session, then verified the patched code writes to the target session store resolved from the spawned `sessionKey`.
- Edge cases checked: confirmed the in-memory requester store is only mutated when it matches the resolved target store, so same-store spawns still behave normally.
- What you did **not** verify: kept verification minimal per request. This checkout's current `origin/main` also has unrelated missing-dependency/typecheck failures (`@modelcontextprotocol/sdk`, `matrix-js-sdk`, and related surfaces), so `pnpm build` and the focused `pnpm vitest run src/auto-reply/reply/commands-acp.test.ts` run did not complete cleanly in this environment.

## Compatibility / Migration

- Backward compatible? (Yes/No) Yes
- Config/env changes? (Yes/No) No
- Migration needed? (Yes/No) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit
- Files/config to restore: `src/auto-reply/reply/commands-acp/lifecycle.ts`, `src/auto-reply/reply/commands-acp.test.ts`
- Known bad symptoms reviewers should watch for: labels still missing on cross-agent ACP spawns, or label writes regressing for same-store spawns

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: The fix touches session-store selection during spawn label persistence, so a bad store-path resolution could break label writes for a subset of ACP spawn flows.
  - Mitigation: Added a regression test that specifically covers a requester-store/target-store mismatch and asserts the label is written to the spawned session store, not the requester store.
