### PR TITLE
read: guard binary office documents from raw text output

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -572,4 +572,33 @@ describe("createOpenClawCodingTools", () => {
     });
     expect(details?.truncation).not.toHaveProperty("content");
   });
+
+  it("replaces raw binary office reads with a structured fallback message", async () => {
+    const readResult: AgentToolResult<unknown> = {
+      content: [{ type: "text" as const, text: "PK\u0003\u0004raw-binary-garbage" }],
+    };
+    const baseRead: AgentTool = {
+      name: "read",
+      label: "read",
+      description: "test read",
+      parameters: Type.Object({
+        path: Type.String(),
+      }),
+      execute: vi.fn(async () => readResult),
+    };
+
+    const wrapped = createOpenClawReadTool(
+      baseRead as unknown as Parameters<typeof createOpenClawReadTool>[0],
+      {
+        readBufferForToolPath: async () => Buffer.from("fake-docx-buffer"),
+      },
+    );
+
+    const result = await wrapped.execute("read-docx-1", { path: "demo.docx" });
+    const text = extractToolText(result);
+
+    expect(text).toContain("This file appears to be a binary document (.docx");
+    expect(text).toContain("The read tool is not suitable");
+    expect(text).toContain("Use a document parser or conversion tool");
+  });
 });

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -50,6 +50,7 @@ const MAX_ADAPTIVE_READ_PAGES = 8;
 type OpenClawReadToolOptions = {
   modelContextWindowTokens?: number;
   imageSanitization?: ImageSanitizationLimits;
+  readBufferForToolPath?: (toolPath: string) => Promise<Buffer>;
 };
 
 type ReadTruncationDetails = {
@@ -289,6 +290,56 @@ function rewriteReadImageHeader(text: string, mimeType: string): string {
     return `Read image file [${mimeType}]`;
   }
   return text;
+}
+
+const BINARY_DOCUMENT_FALLBACK_BY_MIME: Record<string, string> = {
+  "application/pdf": ".pdf",
+  "application/msword": ".doc",
+  "application/vnd.ms-excel": ".xls",
+  "application/vnd.ms-powerpoint": ".ppt",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+};
+
+function buildBinaryDocumentReadFallback(filePath: string, mimeType: string): string {
+  const ext = BINARY_DOCUMENT_FALLBACK_BY_MIME[mimeType] ?? "binary document";
+  return [
+    `This file appears to be a binary document (${ext}, ${mimeType}).`,
+    "",
+    "The read tool is not suitable for extracting readable text from this format.",
+    "",
+    "Use a document parser or conversion tool to extract text before continuing.",
+    `File: ${filePath}`,
+  ].join("\n");
+}
+
+async function normalizeBinaryDocumentReadResult(
+  result: AgentToolResult<unknown>,
+  filePath: string,
+  options?: OpenClawReadToolOptions,
+): Promise<AgentToolResult<unknown>> {
+  const loadBuffer = options?.readBufferForToolPath;
+  if (!loadBuffer || !filePath || filePath === "<unknown>") {
+    return result;
+  }
+
+  const text = getToolResultText(result);
+  if (typeof text !== "string" || !text.trim()) {
+    return result;
+  }
+
+  try {
+    const buffer = await loadBuffer(filePath);
+    const mimeType = await detectMime({ buffer, filePath });
+    const normalizedMime = typeof mimeType === "string" ? mimeType.trim().toLowerCase() : undefined;
+    if (!normalizedMime || !(normalizedMime in BINARY_DOCUMENT_FALLBACK_BY_MIME)) {
+      return result;
+    }
+    return withToolResultText(result, buildBinaryDocumentReadFallback(filePath, normalizedMime));
+  } catch {
+    return result;
+  }
 }
 
 async function normalizeReadImageResult(
@@ -593,6 +644,8 @@ export function createSandboxedReadTool(params: SandboxToolParams) {
   return createOpenClawReadTool(base, {
     modelContextWindowTokens: params.modelContextWindowTokens,
     imageSanitization: params.imageSanitization,
+    readBufferForToolPath: (toolPath: string) =>
+      params.bridge.readFile({ filePath: toolPath, cwd: params.root }),
   });
 }
 
@@ -655,7 +708,12 @@ export function createOpenClawReadTool(
       });
       const filePath = typeof record?.path === "string" ? String(record.path) : "<unknown>";
       const strippedDetailsResult = stripReadTruncationContentDetails(result);
-      const normalizedResult = await normalizeReadImageResult(strippedDetailsResult, filePath);
+      const normalizedImageResult = await normalizeReadImageResult(strippedDetailsResult, filePath);
+      const normalizedResult = await normalizeBinaryDocumentReadResult(
+        normalizedImageResult,
+        filePath,
+        options,
+      );
       return sanitizeToolResultImages(
         normalizedResult,
         `read:${filePath}`,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { codingTools, createReadTool, readTool } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelCompatConfig } from "../config/types.models.js";
@@ -388,6 +390,12 @@ export function createOpenClawCodingTools(options?: {
       const wrapped = createOpenClawReadTool(freshReadTool, {
         modelContextWindowTokens: options?.modelContextWindowTokens,
         imageSanitization,
+        readBufferForToolPath: async (toolPath: string) => {
+          const resolved = path.isAbsolute(toolPath)
+            ? path.resolve(toolPath)
+            : path.resolve(workspaceRoot, toolPath);
+          return await fs.readFile(resolved);
+        },
       });
       return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
     }


### PR DESCRIPTION
## Summary

This is a small first step toward better native document handling in OpenClaw.

Today the `read` tool can end up returning raw binary-looking output for Office-style documents such as `.docx`, `.xlsx`, and `.pptx`, which wastes tokens and confuses the model. This PR adds a lightweight guard so these files return a structured fallback message instead of garbled binary text.

## What changed

- add binary document MIME detection in the OpenClaw `read` wrapper
- return a structured fallback message for `.pdf`, `.doc`, `.xls`, `.ppt`, `.docx`, `.xlsx`, and `.pptx`
- wire the MIME detection through both host and sandbox read paths
- add a regression test covering `.docx` fallback behavior

## Why

As the author of `aigroup-mdtoword-mcp`, I have run into this workflow repeatedly from the document-conversion side: agents often try `read()` first, get binary junk for Office documents, and burn tokens before switching strategies.

This change does not implement native DOCX parsing by itself, but it creates a safer default behavior and a cleaner foundation for future native document extraction.

## Related issue

- Closes #35406

## Testing

Ran locally after installing repo dependencies:

- `pnpm test -- src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts`
