### PR TITLE
fix(mattermost): record pending history for non-allowlisted group senders

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1102,6 +1102,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     });
     const commandAuthorized = commandGate.commandAuthorized;
 
+    let senderBlockedByGroupAllowlist = false;
     if (accessDecision.decision !== "allow") {
       if (kind === "direct") {
         if (accessDecision.reasonCode === DM_GROUP_ACCESS_REASON.DM_POLICY_DISABLED) {
@@ -1144,16 +1145,17 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         return;
       }
       if (accessDecision.reasonCode === DM_GROUP_ACCESS_REASON.GROUP_POLICY_NOT_ALLOWLISTED) {
-        logVerboseMessage(`mattermost: drop group sender=${senderId} (not in groupAllowFrom)`);
+        logVerboseMessage(`mattermost: group sender=${senderId} not in groupAllowFrom (history-only)`);
+        senderBlockedByGroupAllowlist = true;
+      } else {
+        logVerboseMessage(
+          `mattermost: drop group message (groupPolicy=${groupPolicy} reason=${accessDecision.reason})`,
+        );
         return;
       }
-      logVerboseMessage(
-        `mattermost: drop group message (groupPolicy=${groupPolicy} reason=${accessDecision.reason})`,
-      );
-      return;
     }
 
-    if (kind !== "direct" && commandGate.shouldBlock) {
+    if (kind !== "direct" && commandGate.shouldBlock && !senderBlockedByGroupAllowlist) {
       logInboundDrop({
         log: logVerboseMessage,
         channel: "mattermost",
@@ -1259,6 +1261,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         `mattermost: drop group message (missing mention channel=${channelId} sender=${senderId} requireMention=${shouldRequireMention} bypass=${shouldBypassMention} canDetectMention=${canDetectMention})`,
       );
       recordPendingHistory();
+      return;
+    }
+    if (senderBlockedByGroupAllowlist) {
+      recordPendingHistory();
+      logVerboseMessage(`mattermost: recorded history for blocked sender=${senderId}, not responding`);
       return;
     }
     const mediaList = await resolveMattermostMedia(post.file_ids);


### PR DESCRIPTION
## Summary

- **Problem:** When `groupPolicy: "allowlist"`, messages from non-allowlisted senders are dropped at the access-check stage before `recordPendingHistoryEntryIfEnabled()` is called. The bot loses all conversation context from those users.
- **Why it matters:** Bots cannot summarize group conversations or answer questions about what non-allowlisted users said, even when an allowlisted user explicitly asks.
- **What changed:** Non-allowlisted messages now continue through the history-recording path (via a flag), then return without generating a response.
- **What did NOT change (scope boundary):** Access control behavior is unchanged — non-allowlisted users still cannot trigger bot responses. Only pending history recording is affected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57607
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** The `GROUP_POLICY_NOT_ALLOWLISTED` branch in the access-check block returns immediately, bypassing `recordPendingHistory()`. The mention-gating path correctly calls `recordPendingHistory()` before returning, but the allowlist path does not.
- **Missing detection / guardrail:** No test verifies that pending history is recorded for dropped-but-visible group messages.
- **Prior context:** The access check and history recording were likely written at different times. The mention-gating path was added later with the correct pattern.
- **Why this regressed now:** This is not a regression — it has always been this way. The behavior becomes noticeable when users rely on `groupPolicy: "allowlist"` for access control while expecting the bot to maintain full group context.
- **If unknown, what was ruled out:** N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `monitor.channel-kind.test.ts` or `monitor.authz.test.ts`
- **Scenario the test should lock in:** When a non-allowlisted sender posts in a group with `groupPolicy: "allowlist"`, the message should be recorded to `channelHistories` but no response should be generated.
- **Why this is the smallest reliable guardrail:** A unit test on the monitor's message handling path can directly verify the history map is populated.
- **Existing test that already covers this:** None found.
- **If no new test is added, why not:** The existing test infrastructure for the monitor is complex. Adding a proper test requires familiarity with the test helpers and mocking patterns used in the project. Happy to add one with maintainer guidance.

## User-visible / Behavior Changes

- Bots using `groupPolicy: "allowlist"` can now see messages from all group participants in their conversation context.
- Non-allowlisted users still cannot trigger bot responses (no change).
- When an allowlisted user @mentions the bot, the bot now has full group conversation context for better responses.

## Diagram (if applicable)

```text
Before:
[non-allowlisted sender posts] -> [access check: NOT_ALLOWLISTED] -> [return] (no history recorded)
[allowlisted user asks "summarize"] -> [bot has no context] -> [cannot summarize]

After:
[non-allowlisted sender posts] -> [access check: set flag] -> [recordPendingHistory()] -> [return] (no response)
[allowlisted user asks "summarize"] -> [bot has full context] -> [accurate summary]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — messages were already received via WebSocket; this only affects whether they are stored in the in-memory pending history buffer.

## Repro + Verification

### Environment

- OS: macOS 15.4 (Apple Silicon)
- Runtime/container: Node.js 25.8.1
- Model/provider: openai/gpt-5.4
- Integration/channel: Mattermost
- Relevant config (redacted):
  ```json
  {
    "channels": {
      "mattermost": {
        "chatmode": "oncall",
        "groupPolicy": "allowlist",
        "groupAllowFrom": ["<user-id>"],
        "historyLimit": 50
      }
    }
  }
  ```

### Steps

1. Configure Mattermost with `groupPolicy: "allowlist"` and one user in `groupAllowFrom`.
2. Have a non-allowlisted user send messages in the group.
3. Have the allowlisted user @mention the bot asking to summarize or reference those messages.

### Expected

Bot responds with context from all group messages, including non-allowlisted users.

### Actual

Before fix: Bot has no context of non-allowlisted user messages.
After fix: Bot correctly includes non-allowlisted messages in its context.

## Evidence

- [x] Trace/log snippets

Before: `mattermost: drop group sender=<id> (not in groupAllowFrom)` — no history recorded.
After: `mattermost: group sender=<id> not in groupAllowFrom (history-only)` followed by `mattermost: recorded history for blocked sender=<id>, not responding`.

## Human Verification (required)

- **Verified scenarios:** Tested with two Mattermost bot accounts, one allowlisted user, and multiple non-allowlisted users in a shared group channel. Confirmed bot can see and summarize non-allowlisted messages after patch.
- **Edge cases checked:** Verified non-allowlisted users still cannot trigger responses via @mention. Verified DM policy is unaffected. Verified other group policy modes (disabled, open) are unaffected.
- **What you did not verify:** Other channel plugins (Telegram, Signal, etc.) — this change only touches the Mattermost monitor.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** Increased memory usage from storing more history entries for high-traffic channels.
  - **Mitigation:** Bounded by the existing `historyLimit` setting (default 50). No unbounded growth.
- **Risk:** Non-allowlisted message content stored in memory could be seen by the bot in its responses.
  - **Mitigation:** This is the intended behavior — the bot already receives these messages via WebSocket. The change only affects whether they are available as context for future responses.