### PR TITLE
media: add native docx text extraction for input_file

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-d.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-d.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import JSZip from "jszip";
 import { describe, expect, it } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import { createOpenClawCodingTools } from "./pi-tools.js";
@@ -12,6 +13,16 @@ const tinyPngBuffer = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2f7z8AAAAASUVORK5CYII=",
   "base64",
 );
+
+async function makeDocx(documentXml: string): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>',
+  );
+  zip.file("word/document.xml", documentXml);
+  return await zip.generateAsync({ type: "nodebuffer" });
+}
 
 describe("createOpenClawCodingTools", () => {
   it("returns image-aware read metadata for images and text-only blocks for text files", async () => {
@@ -56,6 +67,33 @@ describe("createOpenClawCodingTools", () => {
       expect(textBlocks?.length ?? 0).toBeGreaterThan(0);
       const combinedText = textBlocks?.map((block) => block.text ?? "").join("\n");
       expect(combinedText).toContain(contents);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+  it("extracts native text when reading docx files", async () => {
+    const readTool = defaultTools.find((tool) => tool.name === "read");
+    expect(readTool).toBeDefined();
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-docx-"));
+    try {
+      const docxPath = path.join(tmpDir, "sample.docx");
+      const buffer = await makeDocx(
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello DOCX</w:t></w:r></w:p><w:tbl><w:tr><w:tc><w:p><w:r><w:t>Revenue</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>42</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>',
+      );
+      await fs.writeFile(docxPath, buffer);
+
+      const result = await readTool?.execute("tool-docx-1", {
+        path: docxPath,
+      });
+
+      const textBlocks = result?.content?.filter((block) => block.type === "text") as
+        | Array<{ text?: string }>
+        | undefined;
+      const combinedText = textBlocks?.map((block) => block.text ?? "").join("\n") ?? "";
+      expect(combinedText).toContain("Hello DOCX");
+      expect(combinedText).toContain("Revenue\t42");
+      expect(result?.content?.some((block) => block.type === "image")).toBe(false);
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-d.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-d.test.ts
@@ -98,6 +98,35 @@ describe("createOpenClawCodingTools", () => {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("caps docx read output to the adaptive byte budget", async () => {
+    const constrainedTools = createOpenClawCodingTools({ modelContextWindowTokens: 1 });
+    const readTool = constrainedTools.find((tool) => tool.name === "read");
+    expect(readTool).toBeDefined();
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-docx-cap-"));
+    try {
+      const docxPath = path.join(tmpDir, "sample.docx");
+      const repeatedText = "DOCX-LINE-12345 ".repeat(4_000);
+      const buffer = await makeDocx(
+        `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>${repeatedText}</w:t></w:r></w:p></w:body></w:document>`,
+      );
+      await fs.writeFile(docxPath, buffer);
+
+      const result = await readTool?.execute("tool-docx-cap", {
+        path: docxPath,
+      });
+
+      const textBlocks = result?.content?.filter((block) => block.type === "text") as
+        | Array<{ text?: string }>
+        | undefined;
+      const combinedText = textBlocks?.map((block) => block.text ?? "").join("\n") ?? "";
+      expect(Buffer.byteLength(combinedText, "utf-8")).toBeLessThanOrEqual(50 * 1024);
+      expect(combinedText).toContain("[Read output capped at 50KB for this call.]");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
   it("filters tools by sandbox policy", () => {
     const sandboxDir = path.join(os.tmpdir(), "openclaw-sandbox");
     const sandbox = createPiToolsSandboxContext({

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -359,11 +359,19 @@ async function normalizeReadDocumentResult(params: {
   readBufferForToolPath?: OpenClawReadToolOptions["readBufferForToolPath"];
   signal?: AbortSignal;
 }): Promise<AgentToolResult<unknown>> {
-  if (!params.readBufferForToolPath) {
+  if (!params.readBufferForToolPath || path.extname(params.filePath).toLowerCase() !== ".docx") {
     return params.result;
   }
 
-  const buffer = await params.readBufferForToolPath(params.filePath, params.signal);
+  let buffer: Buffer;
+  try {
+    buffer = await params.readBufferForToolPath(params.filePath, params.signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      return params.result;
+    }
+    throw error;
+  }
   const mimeType = await detectMime({ buffer, filePath: params.filePath });
   if (mimeType !== "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
     return params.result;

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -10,6 +10,7 @@ import {
   writeFileWithinRoot,
 } from "../infra/fs-safe.js";
 import { trySafeFileURLToPath } from "../infra/local-file-access.js";
+import { extractDocxText } from "../media/docx-extract.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
@@ -50,6 +51,7 @@ const MAX_ADAPTIVE_READ_PAGES = 8;
 type OpenClawReadToolOptions = {
   modelContextWindowTokens?: number;
   imageSanitization?: ImageSanitizationLimits;
+  readBufferForToolPath?: (toolPath: string, signal?: AbortSignal) => Promise<Buffer>;
 };
 
 type ReadTruncationDetails = {
@@ -351,6 +353,30 @@ async function normalizeReadImageResult(
   return { ...result, content: nextContent };
 }
 
+async function normalizeReadDocumentResult(params: {
+  result: AgentToolResult<unknown>;
+  filePath: string;
+  readBufferForToolPath?: OpenClawReadToolOptions["readBufferForToolPath"];
+  signal?: AbortSignal;
+}): Promise<AgentToolResult<unknown>> {
+  if (!params.readBufferForToolPath) {
+    return params.result;
+  }
+
+  const buffer = await params.readBufferForToolPath(params.filePath, params.signal);
+  const mimeType = await detectMime({ buffer, filePath: params.filePath });
+  if (mimeType !== "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
+    return params.result;
+  }
+
+  const text = await extractDocxText({ buffer });
+  if (!text.trim()) {
+    return params.result;
+  }
+
+  return withToolResultText(params.result, text);
+}
+
 export function wrapToolWorkspaceRootGuard(tool: AnyAgentTool, root: string): AnyAgentTool {
   return wrapToolWorkspaceRootGuardWithOptions(tool, root);
 }
@@ -593,6 +619,8 @@ export function createSandboxedReadTool(params: SandboxToolParams) {
   return createOpenClawReadTool(base, {
     modelContextWindowTokens: params.modelContextWindowTokens,
     imageSanitization: params.imageSanitization,
+    readBufferForToolPath: (toolPath, signal) =>
+      params.bridge.readFile({ filePath: toolPath, cwd: params.root, signal }),
   });
 }
 
@@ -655,7 +683,13 @@ export function createOpenClawReadTool(
       });
       const filePath = typeof record?.path === "string" ? String(record.path) : "<unknown>";
       const strippedDetailsResult = stripReadTruncationContentDetails(result);
-      const normalizedResult = await normalizeReadImageResult(strippedDetailsResult, filePath);
+      const normalizedDocumentResult = await normalizeReadDocumentResult({
+        result: strippedDetailsResult,
+        filePath,
+        readBufferForToolPath: options?.readBufferForToolPath,
+        signal,
+      });
+      const normalizedResult = await normalizeReadImageResult(normalizedDocumentResult, filePath);
       return sanitizeToolResultImages(
         normalizedResult,
         `read:${filePath}`,

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -10,7 +10,7 @@ import {
   writeFileWithinRoot,
 } from "../infra/fs-safe.js";
 import { trySafeFileURLToPath } from "../infra/local-file-access.js";
-import { extractDocxText } from "../media/docx-extract.js";
+import { DEFAULT_DOCX_XML_MAX_BYTES, extractDocxText } from "../media/docx-extract.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
@@ -47,6 +47,7 @@ const MAX_ADAPTIVE_READ_MAX_BYTES = 512 * 1024;
 const ADAPTIVE_READ_CONTEXT_SHARE = 0.2;
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 const MAX_ADAPTIVE_READ_PAGES = 8;
+const MAX_READ_DOCX_XML_BYTES = 2 * 1024 * 1024;
 
 type OpenClawReadToolOptions = {
   modelContextWindowTokens?: number;
@@ -90,6 +91,44 @@ function formatBytes(bytes: number): string {
     return `${Math.round(bytes / 1024)}KB`;
   }
   return `${bytes}B`;
+}
+
+function truncateTextToUtf8Bytes(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, "utf-8") <= maxBytes) {
+    return text;
+  }
+
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(text.slice(0, mid), "utf-8") <= maxBytes) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return text.slice(0, low);
+}
+
+function capReadTextToMaxBytes(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, "utf-8") <= maxBytes) {
+    return text;
+  }
+
+  const notice = `\n\n[Read output capped at ${formatBytes(maxBytes)} for this call.]`;
+  const noticeBytes = Buffer.byteLength(notice, "utf-8");
+  if (noticeBytes >= maxBytes) {
+    return truncateTextToUtf8Bytes(notice, maxBytes);
+  }
+
+  const availableTextBytes = maxBytes - noticeBytes;
+  const truncatedText = truncateTextToUtf8Bytes(text, availableTextBytes).trimEnd();
+  return `${truncatedText}${notice}`;
+}
+
+function resolveReadDocxXmlMaxBytes(maxBytes: number): number {
+  return clamp(maxBytes * 4, DEFAULT_DOCX_XML_MAX_BYTES, MAX_READ_DOCX_XML_BYTES);
 }
 
 function getToolResultText(result: AgentToolResult<unknown>): string | undefined {
@@ -356,6 +395,7 @@ async function normalizeReadImageResult(
 async function normalizeReadDocumentResult(params: {
   result: AgentToolResult<unknown>;
   filePath: string;
+  maxBytes: number;
   readBufferForToolPath?: OpenClawReadToolOptions["readBufferForToolPath"];
   signal?: AbortSignal;
 }): Promise<AgentToolResult<unknown>> {
@@ -377,7 +417,13 @@ async function normalizeReadDocumentResult(params: {
     return params.result;
   }
 
-  const text = await extractDocxText({ buffer });
+  const text = capReadTextToMaxBytes(
+    await extractDocxText({
+      buffer,
+      maxXmlBytes: resolveReadDocxXmlMaxBytes(params.maxBytes),
+    }),
+    params.maxBytes,
+  );
   if (!text.trim()) {
     return params.result;
   }
@@ -694,6 +740,7 @@ export function createOpenClawReadTool(
       const normalizedDocumentResult = await normalizeReadDocumentResult({
         result: strippedDetailsResult,
         filePath,
+        maxBytes: resolveAdaptiveReadMaxBytes(options),
         readBufferForToolPath: options?.readBufferForToolPath,
         signal,
       });

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import { codingTools, createReadTool, readTool } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelCompatConfig } from "../config/types.models.js";
@@ -37,6 +38,7 @@ import {
   createSandboxedWriteTool,
   normalizeToolParams,
   patchToolSchemaForClaudeCompatibility,
+  resolveToolPathAgainstWorkspaceRoot,
   wrapToolMemoryFlushAppendOnlyWrite,
   wrapToolWorkspaceRootGuard,
   wrapToolWorkspaceRootGuardWithOptions,
@@ -388,6 +390,13 @@ export function createOpenClawCodingTools(options?: {
       const wrapped = createOpenClawReadTool(freshReadTool, {
         modelContextWindowTokens: options?.modelContextWindowTokens,
         imageSanitization,
+        readBufferForToolPath: (toolPath) =>
+          fs.readFile(
+            resolveToolPathAgainstWorkspaceRoot({
+              filePath: toolPath,
+              root: workspaceRoot,
+            }),
+          ),
       });
       return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
     }

--- a/src/media/docx-extract.test.ts
+++ b/src/media/docx-extract.test.ts
@@ -28,4 +28,12 @@ describe("extractDocxText", () => {
 
     await expect(extractDocxText({ buffer })).resolves.toBe("Revenue & Margin\t42");
   });
+
+  it("decodes numeric XML character references", async () => {
+    const buffer = await makeDocx(
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Price&#160;is&#x2019;good</w:t></w:r></w:p></w:body></w:document>',
+    );
+
+    await expect(extractDocxText({ buffer })).resolves.toBe("Price is’good");
+  });
 });

--- a/src/media/docx-extract.test.ts
+++ b/src/media/docx-extract.test.ts
@@ -1,0 +1,31 @@
+import JSZip from "jszip";
+import { describe, expect, it } from "vitest";
+import { extractDocxText } from "./docx-extract.js";
+
+async function makeDocx(documentXml: string): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>',
+  );
+  zip.file("word/document.xml", documentXml);
+  return await zip.generateAsync({ type: "nodebuffer" });
+}
+
+describe("extractDocxText", () => {
+  it("extracts paragraph text from a docx buffer", async () => {
+    const buffer = await makeDocx(
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello</w:t></w:r></w:p><w:p><w:r><w:t>World</w:t></w:r></w:p></w:body></w:document>',
+    );
+
+    await expect(extractDocxText({ buffer })).resolves.toBe("Hello\n\nWorld");
+  });
+
+  it("extracts simple table text and decodes XML entities", async () => {
+    const buffer = await makeDocx(
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>Revenue &amp; Margin</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>42</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>',
+    );
+
+    await expect(extractDocxText({ buffer })).resolves.toBe("Revenue & Margin\t42");
+  });
+});

--- a/src/media/docx-extract.test.ts
+++ b/src/media/docx-extract.test.ts
@@ -36,4 +36,26 @@ describe("extractDocxText", () => {
 
     await expect(extractDocxText({ buffer })).resolves.toBe("Price is’good");
   });
+
+  it("preserves literal angle-bracket text encoded inside runs", async () => {
+    const buffer = await makeDocx(
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>&lt;div&gt;Hello&lt;/div&gt;</w:t></w:r></w:p></w:body></w:document>',
+    );
+
+    await expect(extractDocxText({ buffer })).resolves.toBe("<div>Hello</div>");
+  });
+
+  it("returns an empty string for malformed docx payloads", async () => {
+    await expect(extractDocxText({ buffer: Buffer.from("not-a-zip") })).resolves.toBe("");
+  });
+
+  it("returns an empty string when document.xml exceeds the configured byte budget", async () => {
+    const documentXml =
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>' +
+      "A".repeat(128) +
+      "</w:t></w:r></w:p></w:body></w:document>";
+    const buffer = await makeDocx(documentXml);
+
+    await expect(extractDocxText({ buffer, maxXmlBytes: 32 })).resolves.toBe("");
+  });
 });

--- a/src/media/docx-extract.ts
+++ b/src/media/docx-extract.ts
@@ -10,7 +10,16 @@ function decodeXmlEntities(value: string): string {
 }
 
 function normalizeDocxWhitespace(value: string): string {
-  return value.replace(/\r/g, "").replace(/[ \t]+/g, " ").replace(/\n{3,}/g, "\n\n").trim();
+  return value
+    .replace(/\r/g, "")
+    .replace(/[ ]+\t/g, "\t")
+    .replace(/\t[ ]+/g, "\t")
+    .replace(/[ ]+\n/g, "\n")
+    .replace(/\n[ ]+/g, "\n")
+    .replace(/ {2,}/g, " ")
+    .replace(/\n\n(?=\t|\n)/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }
 
 function extractDocxTextFromXml(xml: string): string {

--- a/src/media/docx-extract.ts
+++ b/src/media/docx-extract.ts
@@ -1,0 +1,40 @@
+import JSZip from "jszip";
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function normalizeDocxWhitespace(value: string): string {
+  return value.replace(/\r/g, "").replace(/[ \t]+/g, " ").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function extractDocxTextFromXml(xml: string): string {
+  const withStructuralBreaks = xml
+    .replace(/<w:tab\b[^>]*\/>/g, "\t")
+    .replace(/<w:br\b[^>]*\/>/g, "\n")
+    .replace(/<\/w:p>/g, "\n\n")
+    .replace(/<\/w:tr>/g, "\n")
+    .replace(/<\/w:tc>/g, "\t");
+
+  const text = withStructuralBreaks
+    .replace(/<w:t\b[^>]*>([\s\S]*?)<\/w:t>/g, (_match, textContent: string) =>
+      decodeXmlEntities(textContent),
+    )
+    .replace(/<[^>]+>/g, "");
+
+  return normalizeDocxWhitespace(text);
+}
+
+export async function extractDocxText(params: { buffer: Buffer }): Promise<string> {
+  const zip = await JSZip.loadAsync(params.buffer);
+  const documentXml = await zip.file("word/document.xml")?.async("string");
+  if (!documentXml) {
+    return "";
+  }
+  return extractDocxTextFromXml(documentXml);
+}

--- a/src/media/docx-extract.ts
+++ b/src/media/docx-extract.ts
@@ -2,6 +2,12 @@ import JSZip from "jszip";
 
 function decodeXmlEntities(value: string): string {
   return value
+    .replace(/&#x([0-9a-f]+);/gi, (_match, hex: string) =>
+      String.fromCodePoint(Number.parseInt(hex, 16)),
+    )
+    .replace(/&#([0-9]+);/g, (_match, decimal: string) =>
+      String.fromCodePoint(Number.parseInt(decimal, 10)),
+    )
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
@@ -12,6 +18,7 @@ function decodeXmlEntities(value: string): string {
 function normalizeDocxWhitespace(value: string): string {
   return value
     .replace(/\r/g, "")
+    .replace(/\u00a0/g, " ")
     .replace(/[ ]+\t/g, "\t")
     .replace(/\t[ ]+/g, "\t")
     .replace(/[ ]+\n/g, "\n")

--- a/src/media/docx-extract.ts
+++ b/src/media/docx-extract.ts
@@ -1,5 +1,8 @@
 import JSZip from "jszip";
 
+const DOCX_TEXT_PLACEHOLDER_PREFIX = "__openclaw_docx_text_";
+export const DEFAULT_DOCX_XML_MAX_BYTES = 256 * 1024;
+
 function decodeXmlEntities(value: string): string {
   return value
     .replace(/&#x([0-9a-f]+);/gi, (_match, hex: string) =>
@@ -37,20 +40,46 @@ function extractDocxTextFromXml(xml: string): string {
     .replace(/<\/w:tr>/g, "\n")
     .replace(/<\/w:tc>/g, "\t");
 
-  const text = withStructuralBreaks
-    .replace(/<w:t\b[^>]*>([\s\S]*?)<\/w:t>/g, (_match, textContent: string) =>
-      decodeXmlEntities(textContent),
-    )
-    .replace(/<[^>]+>/g, "");
+  const textNodes: string[] = [];
+  const withTextPlaceholders = withStructuralBreaks.replace(
+    /<w:t\b[^>]*>([\s\S]*?)<\/w:t>/g,
+    (_match, textContent: string) => {
+      const index = textNodes.push(textContent) - 1;
+      return `${DOCX_TEXT_PLACEHOLDER_PREFIX}${index}__`;
+    },
+  );
+
+  const text = withTextPlaceholders
+    .replace(/<[^>]+>/g, "")
+    .replace(new RegExp(`${DOCX_TEXT_PLACEHOLDER_PREFIX}(\\d+)__`, "g"), (_match, index) =>
+      decodeXmlEntities(textNodes[Number(index)] ?? ""),
+    );
 
   return normalizeDocxWhitespace(text);
 }
 
-export async function extractDocxText(params: { buffer: Buffer }): Promise<string> {
-  const zip = await JSZip.loadAsync(params.buffer);
-  const documentXml = await zip.file("word/document.xml")?.async("string");
-  if (!documentXml) {
+export async function extractDocxText(params: {
+  buffer: Buffer;
+  maxXmlBytes?: number;
+}): Promise<string> {
+  try {
+    const zip = await JSZip.loadAsync(params.buffer);
+    const documentXmlFile = zip.file("word/document.xml");
+    if (!documentXmlFile) {
+      return "";
+    }
+    const documentXmlBytes = await documentXmlFile.async("uint8array");
+    if (
+      typeof params.maxXmlBytes === "number" &&
+      Number.isFinite(params.maxXmlBytes) &&
+      params.maxXmlBytes > 0 &&
+      documentXmlBytes.byteLength > params.maxXmlBytes
+    ) {
+      return "";
+    }
+    const documentXml = new TextDecoder().decode(documentXmlBytes);
+    return extractDocxTextFromXml(documentXml);
+  } catch {
     return "";
   }
-  return extractDocxTextFromXml(documentXml);
 }

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -23,10 +23,15 @@ async function waitForMicrotaskTurn(): Promise<void> {
 let fetchWithGuard: typeof import("./input-files.js").fetchWithGuard;
 let extractImageContentFromSource: typeof import("./input-files.js").extractImageContentFromSource;
 let extractFileContentFromSource: typeof import("./input-files.js").extractFileContentFromSource;
+let DEFAULT_INPUT_FILE_MIMES: typeof import("./input-files.js").DEFAULT_INPUT_FILE_MIMES;
 
 beforeAll(async () => {
-  ({ fetchWithGuard, extractImageContentFromSource, extractFileContentFromSource } =
-    await import("./input-files.js"));
+  ({
+    fetchWithGuard,
+    extractImageContentFromSource,
+    extractFileContentFromSource,
+    DEFAULT_INPUT_FILE_MIMES,
+  } = await import("./input-files.js"));
 });
 
 beforeEach(() => {
@@ -358,6 +363,12 @@ describe("input image base64 validation", () => {
 });
 
 describe("input file docx extraction", () => {
+  it("includes docx in the default input_file MIME allowlist", () => {
+    expect(DEFAULT_INPUT_FILE_MIMES).toContain(
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    );
+  });
+
   it("extracts text from docx base64 input_file sources", async () => {
     const { default: JSZip } = await import("jszip");
     const zip = new JSZip();

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -356,3 +356,44 @@ describe("input image base64 validation", () => {
     });
   });
 });
+
+describe("input file docx extraction", () => {
+  it("extracts text from docx base64 input_file sources", async () => {
+    const { default: JSZip } = await import("jszip");
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>',
+    );
+    zip.file(
+      "word/document.xml",
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello DOCX</w:t></w:r></w:p></w:body></w:document>',
+    );
+    const docxBuffer = await zip.generateAsync({ type: "nodebuffer" });
+
+    const result = await extractFileContentFromSource({
+      source: {
+        type: "base64",
+        data: docxBuffer.toString("base64"),
+        mediaType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        filename: "demo.docx",
+      },
+      limits: {
+        allowUrl: false,
+        allowedMimes: new Set([
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ]),
+        maxBytes: 1024 * 1024,
+        maxChars: 1000,
+        maxRedirects: 0,
+        timeoutMs: 1,
+        pdf: { maxPages: 1, maxPixels: 1, minTextChars: 1 },
+      },
+    });
+
+    expect(result).toEqual({
+      filename: "demo.docx",
+      text: "Hello DOCX",
+    });
+  });
+});

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -2,6 +2,7 @@ import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { logWarn } from "../logger.js";
 import { canonicalizeBase64, estimateBase64DecodedBytes } from "./base64.js";
+import { extractDocxText } from "./docx-extract.js";
 import { convertHeicToJpeg } from "./image-ops.js";
 import { detectMime } from "./mime.js";
 import { extractPdfContent, type PdfExtractedImage } from "./pdf-extract.js";
@@ -388,6 +389,11 @@ export async function extractFileContentFromSource(params: {
       text,
       images: extracted.images.length > 0 ? extracted.images : undefined,
     };
+  }
+
+  if (mimeType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
+    const text = clampText(await extractDocxText({ buffer }), limits.maxChars);
+    return { filename, text };
   }
 
   const text = clampText(decodeTextContent(buffer, charset), limits.maxChars);

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -103,6 +103,7 @@ export const DEFAULT_INPUT_FILE_MIMES = [
   "text/csv",
   "application/json",
   "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 ];
 export const DEFAULT_INPUT_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
 export const DEFAULT_INPUT_FILE_MAX_BYTES = 5 * 1024 * 1024;

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -2,7 +2,7 @@ import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { logWarn } from "../logger.js";
 import { canonicalizeBase64, estimateBase64DecodedBytes } from "./base64.js";
-import { extractDocxText } from "./docx-extract.js";
+import { DEFAULT_DOCX_XML_MAX_BYTES, extractDocxText } from "./docx-extract.js";
 import { convertHeicToJpeg } from "./image-ops.js";
 import { detectMime } from "./mime.js";
 import { extractPdfContent, type PdfExtractedImage } from "./pdf-extract.js";
@@ -113,6 +113,7 @@ export const DEFAULT_INPUT_TIMEOUT_MS = 10_000;
 export const DEFAULT_INPUT_PDF_MAX_PAGES = 4;
 export const DEFAULT_INPUT_PDF_MAX_PIXELS = 4_000_000;
 export const DEFAULT_INPUT_PDF_MIN_TEXT_CHARS = 200;
+const MAX_INPUT_DOCX_XML_BYTES = 2 * 1024 * 1024;
 const NORMALIZED_INPUT_IMAGE_MIME = "image/jpeg";
 const HEIC_INPUT_IMAGE_MIMES = new Set(["image/heic", "image/heif"]);
 
@@ -229,6 +230,10 @@ function clampText(text: string, maxChars: number): string {
     return text;
   }
   return text.slice(0, maxChars);
+}
+
+function resolveInputDocxXmlMaxBytes(maxBytes: number): number {
+  return Math.max(DEFAULT_DOCX_XML_MAX_BYTES, Math.min(maxBytes * 4, MAX_INPUT_DOCX_XML_BYTES));
 }
 
 async function normalizeInputImage(params: {
@@ -393,7 +398,13 @@ export async function extractFileContentFromSource(params: {
   }
 
   if (mimeType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
-    const text = clampText(await extractDocxText({ buffer }), limits.maxChars);
+    const text = clampText(
+      await extractDocxText({
+        buffer,
+        maxXmlBytes: resolveInputDocxXmlMaxBytes(limits.maxBytes),
+      }),
+      limits.maxChars,
+    );
     return { filename, text };
   }
 


### PR DESCRIPTION
## Summary

This PR adds a first native `.docx` text extraction path to OpenClaw.

OpenClaw already has native PDF extraction for `input_file`, but `.docx` files still fall back to generic binary/text handling. This PR adds a lightweight native `.docx -> text` extractor and wires it into two existing entry points:

- `input_file`
- `read`

## What changed

- add `src/media/docx-extract.ts`
- extract paragraph text from `word/document.xml`
- preserve simple structure with paragraph breaks and basic table cell separators
- decode common XML entities
- route `.docx` `input_file` payloads through native extraction
- route `.docx` `read` calls through native extraction instead of generic binary/text fallback
- add regression tests for paragraph extraction, table extraction, `input_file` integration, and `read` integration

## Why

As the author of `aigroup-mdtoword-mcp`, I have repeatedly seen agents and workflows struggle with `.docx` as a first-class document type.

This PR is intentionally narrow:
- it focuses on native text extraction only
- it does not attempt style/layout fidelity
- it does not yet cover `.xlsx` or `.pptx`

The goal is to improve OpenClaw's native document handling incrementally, starting with the most common editable office document format.

## Scope

Current support in this PR:
- `.docx` text extraction
- paragraph breaks
- simple table text flattening
- XML entity decoding
- `input_file` support
- `read` support

Not included yet:
- advanced OOXML structures
- comments / footnotes / headers / footers
- tracked changes
- style-aware export or layout preservation
- markdown -> docx generation

## Testing

Ran locally after installing repo dependencies:

- `pnpm test -- src/media/docx-extract.test.ts`
- `pnpm test -- src/media/input-files.fetch-guard.test.ts`
- `pnpm test -- src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-d.test.ts`
