### PR TITLE
Tests: harden Windows temp sqlite cleanup + reduce hook/test timeouts

### DIFF
--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -26,6 +26,7 @@ import {
   parseAgentSessionKey,
   toAgentStoreSessionKey,
 } from "../routing/session-key.js";
+import { removeTempDir } from "../test-helpers/temp-dir.js";
 import { captureEnv } from "../test-utils/env.js";
 import { getDeterministicFreePortBlock } from "../test-utils/ports.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -340,12 +341,7 @@ async function cleanupGatewayTestHome(options: { restoreEnv: boolean }) {
     gatewayEnvSnapshot = undefined;
   }
   if (options.restoreEnv && tempHome) {
-    await fs.rm(tempHome, {
-      recursive: true,
-      force: true,
-      maxRetries: 20,
-      retryDelay: 25,
-    });
+    await removeTempDir(tempHome);
     tempHome = undefined;
   }
   tempConfigRoot = undefined;
@@ -361,16 +357,16 @@ export function installGatewayTestHooks(options?: { scope?: "test" | "suite" }) 
     beforeAll(async () => {
       await setupGatewayTestHome();
       await resetGatewayTestState({ uniqueConfigRoot: false });
-    });
+    }, 60_000);
     beforeEach(async () => {
       await resetGatewayTestState({ uniqueConfigRoot: false });
     }, 60_000);
     afterEach(async () => {
       await cleanupGatewayTestHome({ restoreEnv: false });
-    });
+    }, 60_000);
     afterAll(async () => {
       await cleanupGatewayTestHome({ restoreEnv: true });
-    });
+    }, 60_000);
     return;
   }
 
@@ -381,7 +377,7 @@ export function installGatewayTestHooks(options?: { scope?: "test" | "suite" }) 
 
   afterEach(async () => {
     await cleanupGatewayTestHome({ restoreEnv: true });
-  });
+  }, 60_000);
 }
 
 export async function getFreePort(): Promise<number> {

--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -39,7 +39,7 @@ describe("process supervisor", () => {
     expect(exit.stdout).toBe("ok");
   });
 
-  it("enforces no-output timeout for silent processes", async () => {
+  it("enforces no-output timeout for silent processes", { timeout: 15_000 }, async () => {
     const supervisor = createProcessSupervisor();
     const run = await spawnChild(supervisor, {
       sessionId: "s1",
@@ -54,44 +54,52 @@ describe("process supervisor", () => {
     expect(exit.timedOut).toBe(true);
   });
 
-  it("cancels prior scoped run when replaceExistingScope is enabled", async () => {
-    const supervisor = createProcessSupervisor();
-    const first = await spawnChild(supervisor, {
-      sessionId: "s1",
-      scopeKey: "scope:a",
-      argv: [process.execPath, "-e", "setTimeout(() => {}, 80)"],
-      timeoutMs: 1_000,
-      stdinMode: "pipe-open",
-    });
+  it(
+    "cancels prior scoped run when replaceExistingScope is enabled",
+    { timeout: 15_000 },
+    async () => {
+      const supervisor = createProcessSupervisor();
+      const first = await spawnChild(supervisor, {
+        sessionId: "s1",
+        scopeKey: "scope:a",
+        argv: [process.execPath, "-e", "setTimeout(() => {}, 80)"],
+        timeoutMs: 1_000,
+        stdinMode: "pipe-open",
+      });
 
-    const second = await spawnChild(supervisor, {
-      sessionId: "s1",
-      scopeKey: "scope:a",
-      replaceExistingScope: true,
-      argv: createWriteStdoutArgv("new"),
-      timeoutMs: 1_000,
-      stdinMode: "pipe-closed",
-    });
+      const second = await spawnChild(supervisor, {
+        sessionId: "s1",
+        scopeKey: "scope:a",
+        replaceExistingScope: true,
+        argv: createWriteStdoutArgv("new"),
+        timeoutMs: 1_000,
+        stdinMode: "pipe-closed",
+      });
 
-    const firstExit = await first.wait();
-    const secondExit = await second.wait();
-    expect(firstExit.reason === "manual-cancel" || firstExit.reason === "signal").toBe(true);
-    expect(secondExit.reason).toBe("exit");
-    expect(secondExit.stdout).toBe("new");
-  });
+      const firstExit = await first.wait();
+      const secondExit = await second.wait();
+      expect(firstExit.reason === "manual-cancel" || firstExit.reason === "signal").toBe(true);
+      expect(secondExit.reason).toBe("exit");
+      expect(secondExit.stdout).toBe("new");
+    },
+  );
 
-  it("applies overall timeout even for near-immediate timer firing", async () => {
-    const supervisor = createProcessSupervisor();
-    const run = await spawnChild(supervisor, {
-      sessionId: "s-timeout",
-      argv: createSilentIdleArgv(),
-      timeoutMs: 1,
-      stdinMode: "pipe-closed",
-    });
-    const exit = await run.wait();
-    expect(exit.reason).toBe("overall-timeout");
-    expect(exit.timedOut).toBe(true);
-  });
+  it(
+    "applies overall timeout even for near-immediate timer firing",
+    { timeout: 15_000 },
+    async () => {
+      const supervisor = createProcessSupervisor();
+      const run = await spawnChild(supervisor, {
+        sessionId: "s-timeout",
+        argv: createSilentIdleArgv(),
+        timeoutMs: 1,
+        stdinMode: "pipe-closed",
+      });
+      const exit = await run.wait();
+      expect(exit.reason).toBe("overall-timeout");
+      expect(exit.timedOut).toBe(true);
+    },
+  );
 
   it("can stream output without retaining it in RunExit payload", async () => {
     const supervisor = createProcessSupervisor();

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -340,13 +340,24 @@ function ensureTaskRegistryPermissions(pathname: string) {
   }
 }
 
+function closeDatabase(store: TaskRegistryDatabase) {
+  try {
+    // Flush WAL sidecars before closing so Windows temp-dir cleanup can unlink
+    // runs.sqlite{-wal,-shm} without transient EBUSY/EPERM failures.
+    store.db.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+  } catch {
+    // Ignore checkpoint failures during teardown; close still releases handles.
+  }
+  store.db.close();
+}
+
 function openTaskRegistryDatabase(): TaskRegistryDatabase {
   const pathname = resolveTaskRegistrySqlitePath(process.env);
   if (cachedDatabase && cachedDatabase.path === pathname) {
     return cachedDatabase;
   }
   if (cachedDatabase) {
-    cachedDatabase.db.close();
+    closeDatabase(cachedDatabase);
     cachedDatabase = null;
   }
   ensureTaskRegistryPermissions(pathname);
@@ -430,6 +441,6 @@ export function closeTaskRegistrySqliteStore() {
   if (!cachedDatabase) {
     return;
   }
-  cachedDatabase.db.close();
+  closeDatabase(cachedDatabase);
   cachedDatabase = null;
 }

--- a/src/test-helpers/temp-dir.ts
+++ b/src/test-helpers/temp-dir.ts
@@ -2,6 +2,25 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+function getTempDirCleanupOptions(): Parameters<typeof fs.rm>[1] {
+  if (process.platform === "win32") {
+    return {
+      recursive: true,
+      force: true,
+      maxRetries: 20,
+      retryDelay: 50,
+    };
+  }
+  return {
+    recursive: true,
+    force: true,
+  };
+}
+
+export async function removeTempDir(dir: string): Promise<void> {
+  await fs.rm(dir, getTempDirCleanupOptions());
+}
+
 export async function withTempDir<T>(
   options: {
     prefix: string;
@@ -18,6 +37,6 @@ export async function withTempDir<T>(
   try {
     return await run(dir);
   } finally {
-    await fs.rm(base, { recursive: true, force: true });
+    await removeTempDir(base);
   }
 }


### PR DESCRIPTION
Context: PR #57356 is blocked on Windows-only flakes (EBUSY unlink on temp sqlite files + timeouts in gateway hooks / supervisor tests). This PR aims to make teardown and timeouts more Windows-friendly without skipping tests.

Changes:
- Add removeTempDir() helper with Windows-specific fs.rm retry options.
- Use removeTempDir() for gateway test home cleanup.
- Add explicit 60s hook timeouts around gateway test hooks.
- Ensure task-registry sqlite store checkpoints WAL and closes the DB before teardown.
- Tighten supervisor test timeouts so CI doesn't sit for 120s per hung test.

Local QA (linux): pnpm check + targeted vitest files passed (artifact logs available).
