### PR TITLE
fix(memory): preserve shared qmd collection names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,6 +316,7 @@ Docs: https://docs.openclaw.ai
 - Runtime/install: lower the supported Node 22 floor to `22.14+` while continuing to recommend Node 24, so npm installs and self-updates do not strand Node 22.14 users on older releases.
 - CLI/update: preflight the target npm package `engines.node` before `openclaw update` runs a global package install, so outdated Node runtimes fail with a clear upgrade message instead of attempting an unsupported latest release.
 - Tests/security audit: isolate audit-test home and personal skill resolution so local `~/.agents/skills` installs no longer make maintainer prep runs fail nondeterministically. (#54473) thanks @huntharo
+- Memory/QMD: preserve explicit custom collection names for shared paths outside the agent workspace so `memory_search` stops appending `-<agentId>` to externally managed QMD collections. (#52539) Thanks @lobsrice and @vincentkoc.
 
 ## 2026.3.24-beta.1
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1747,6 +1747,46 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("uses explicit external custom collection names verbatim at query time", async () => {
+    const sharedMirrorDir = path.join(tmpRoot, "shared-notion-mirror");
+    await fs.mkdir(sharedMirrorDir);
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: sharedMirrorDir, pattern: "**/*.md", name: "notion-mirror" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", "[]");
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager, resolved } = await createManager();
+
+    await manager.search("test", { sessionKey: "agent:main:slack:dm:u123" });
+    const maxResults = resolved.qmd?.limits.maxResults;
+    if (!maxResults) {
+      throw new Error("qmd maxResults missing");
+    }
+    const searchCalls = spawnMock.mock.calls
+      .map((call: unknown[]) => call[1] as string[])
+      .filter((args: string[]) => args[0] === "search");
+    expect(searchCalls).toEqual([
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "notion-mirror"],
+    ]);
+    await manager.close();
+  });
+
   it("runs qmd query per collection when query mode has multiple collection filters", async () => {
     cfg = {
       ...cfg,

--- a/packages/memory-host-sdk/src/host/backend-config.test.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.test.ts
@@ -111,6 +111,37 @@ describe("resolveMemoryBackendConfig", () => {
     expect(devNames.has("workspace-dev")).toBe(true);
   });
 
+  it("preserves explicit custom collection names for paths outside the workspace", () => {
+    const cfg = {
+      agents: {
+        defaults: { workspace: "/workspace/root" },
+        list: [
+          { id: "main", default: true, workspace: "/workspace/root" },
+          { id: "dev", workspace: "/workspace/dev" },
+        ],
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: true,
+          paths: [{ path: "/shared/notion-mirror", name: "notion-mirror", pattern: "**/*.md" }],
+        },
+      },
+    } as OpenClawConfig;
+    const mainResolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    const devResolved = resolveMemoryBackendConfig({ cfg, agentId: "dev" });
+    const mainNames = new Set(
+      (mainResolved.qmd?.collections ?? []).map((collection) => collection.name),
+    );
+    const devNames = new Set(
+      (devResolved.qmd?.collections ?? []).map((collection) => collection.name),
+    );
+    expect(mainNames.has("memory-dir-main")).toBe(true);
+    expect(devNames.has("memory-dir-dev")).toBe(true);
+    expect(mainNames.has("notion-mirror")).toBe(true);
+    expect(devNames.has("notion-mirror")).toBe(true);
+  });
+
   it("resolves qmd update timeout overrides", () => {
     const cfg = {
       agents: { defaults: { workspace: "/tmp/memory-test" } },
@@ -281,6 +312,25 @@ describe("memorySearch.extraPaths integration", () => {
       paths.filter((collectionPath) => collectionPath === resolveComparablePath("/shared/path")),
     ).toHaveLength(1);
     expect(paths).toContain(resolveComparablePath("/agent-only"));
+  });
+
+  it("keeps unnamed extra paths agent-scoped even when they resolve outside the workspace", () => {
+    const cfg = {
+      memory: { backend: "qmd" },
+      agents: {
+        defaults: {
+          workspace: "/workspace/root",
+          memorySearch: {
+            extraPaths: ["/shared/path"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const result = resolveMemoryBackendConfig({ cfg, agentId: "my-agent" });
+    const customCollections = (result.qmd?.collections ?? []).filter(
+      (collection) => collection.kind === "custom",
+    );
+    expect(customCollections.map((collection) => collection.name)).toContain("custom-1-my-agent");
   });
 
   it("matches per-agent memorySearch.extraPaths using normalized agent ids", () => {

--- a/packages/memory-host-sdk/src/host/backend-config.test.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveAgentWorkspaceDir } from "../../../../src/agents/agent-scope.js";
@@ -140,6 +142,35 @@ describe("resolveMemoryBackendConfig", () => {
     expect(devNames.has("memory-dir-dev")).toBe(true);
     expect(mainNames.has("notion-mirror")).toBe(true);
     expect(devNames.has("notion-mirror")).toBe(true);
+  });
+
+  it("keeps symlinked workspace paths agent-scoped when deciding custom collection names", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qmd-backend-config-"));
+    const workspaceDir = path.join(tmpRoot, "workspace");
+    const workspaceAliasDir = path.join(tmpRoot, "workspace-alias");
+    try {
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.symlink(workspaceDir, workspaceAliasDir);
+      const cfg = {
+        agents: {
+          defaults: { workspace: workspaceDir },
+          list: [{ id: "main", default: true, workspace: workspaceDir }],
+        },
+        memory: {
+          backend: "qmd",
+          qmd: {
+            includeDefaultMemory: false,
+            paths: [{ path: workspaceAliasDir, name: "workspace", pattern: "**/*.md" }],
+          },
+        },
+      } as OpenClawConfig;
+      const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+      const names = new Set((resolved.qmd?.collections ?? []).map((collection) => collection.name));
+      expect(names.has("workspace-main")).toBe(true);
+      expect(names.has("workspace")).toBe(false);
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 
   it("resolves qmd update timeout overrides", () => {

--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../../../../src/agents/agent-scope.js";
 import { parseDurationMs } from "../../../../src/cli/parse-duration.js";
@@ -115,8 +116,20 @@ function scopeCollectionBase(base: string, agentId: string): string {
   return `${base}-${sanitizeName(agentId)}`;
 }
 
+function canonicalizePathForContainment(rawPath: string): string {
+  const resolved = path.resolve(rawPath);
+  try {
+    return path.normalize(fs.realpathSync.native(resolved));
+  } catch {
+    return path.normalize(resolved);
+  }
+}
+
 function isPathInsideRoot(candidatePath: string, rootPath: string): boolean {
-  const relative = path.relative(path.resolve(rootPath), path.resolve(candidatePath));
+  const relative = path.relative(
+    canonicalizePathForContainment(rootPath),
+    canonicalizePathForContainment(candidatePath),
+  );
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 

--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -115,6 +115,11 @@ function scopeCollectionBase(base: string, agentId: string): string {
   return `${base}-${sanitizeName(agentId)}`;
 }
 
+function isPathInsideRoot(candidatePath: string, rootPath: string): boolean {
+  const relative = path.relative(path.resolve(rootPath), path.resolve(candidatePath));
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
 function ensureUniqueName(base: string, existing: Set<string>): string {
   let name = sanitizeName(base);
   if (!existing.has(name)) {
@@ -252,7 +257,11 @@ function resolveCustomPaths(
       return;
     }
     seenRoots.add(dedupeKey);
-    const baseName = scopeCollectionBase(entry.name?.trim() || `custom-${index + 1}`, agentId);
+    const explicitName = entry.name?.trim();
+    const baseName =
+      explicitName && !isPathInsideRoot(resolved, workspaceDir)
+        ? explicitName
+        : scopeCollectionBase(explicitName || `custom-${index + 1}`, agentId);
     const name = ensureUniqueName(baseName, existing);
     collections.push({
       name,


### PR DESCRIPTION
## Summary

- Problem: OpenClaw was suffixing explicit custom `memory.qmd.paths[*].name` collections with `-<agentId>`, so shared external QMD collections like `notion-mirror` were queried as `notion-mirror-main` and missed entirely.
- Why it matters: `memory_search` could not hit externally managed shared QMD collections even when users configured the correct collection name.
- What changed: preserve explicit custom collection names for paths outside the agent workspace, while keeping OpenClaw-owned default collections and unnamed extra paths agent-scoped.
- What did NOT change (scope boundary): workspace-local named paths, default memory collections, session collections, and unnamed `memorySearch.extraPaths` still keep current agent scoping.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52539
- Related #57560
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `packages/memory-host-sdk/src/host/backend-config.ts` ran custom `memory.qmd.paths[*].name` entries through the same `scopeCollectionBase(...)` path as OpenClaw-owned collections, so the configured external collection identity was rewritten before search execution.
- Missing detection / guardrail: resolver coverage verified agent scoping, but did not distinguish shared external custom collections from workspace-owned collections.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the current behavior lives in the post-refactor SDK host resolver path.
- Why this regressed now: shared external QMD collections became a real user path, but the config layer still assumed every custom collection should be isolated per agent.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `packages/memory-host-sdk/src/host/backend-config.test.ts`, `extensions/memory-core/src/memory/qmd-manager.test.ts`
- Scenario the test should lock in: explicit named custom paths outside the workspace keep their configured collection name verbatim and QMD search uses that exact name.
- Why this is the smallest reliable guardrail: the bug starts in config resolution but only matters once the manager issues search calls.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Explicit named `memory.qmd.paths[*]` entries that point outside the agent workspace now keep their configured collection name instead of gaining `-<agentId>`.
- Unnamed extra paths and OpenClaw-owned workspace/session collections keep current per-agent scoping.

## Diagram (if applicable)

```text
Before:
[external named collection notion-mirror] -> [resolver rewrites to notion-mirror-main] -> [QMD search misses collection]

After:
[external named collection notion-mirror] -> [resolver keeps notion-mirror] -> [QMD search hits shared collection]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: local repo dev runtime
- Model/provider: N/A
- Integration/channel (if any): QMD backend
- Relevant config (redacted): `memory.backend=qmd`, explicit `memory.qmd.paths[*].name`, path outside workspace

### Steps

1. Configure `memory.backend=qmd` with an explicit named custom path outside the agent workspace, for example `name: notion-mirror`.
2. Run `memory_search` from an agent using that QMD backend.
3. Inspect the resolved collection names / QMD CLI search calls.

### Expected

- OpenClaw searches `notion-mirror` exactly.

### Actual

- Before this fix, OpenClaw searched `notion-mirror-main` and missed the real shared collection.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: resolver preserves explicit names for external custom paths; unnamed extra paths remain agent-scoped; QMD manager search calls use `notion-mirror` verbatim.
- Edge cases checked: workspace-local named paths still scope; default memory collections still scope; unnamed extra paths outside workspace still scope.
- What you did **not** verify: live QMD daemon against a real external mirror collection.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: users relying on agent-suffixed names for explicitly named external collections could see collection selection change.
  - Mitigation: the change is narrowed to explicit names outside the workspace, which is the shared-collection case that was already broken; workspace-local named paths and unnamed paths keep prior behavior.
