### PR TITLE
fix(exec): restore channel approval routing

### DIFF
--- a/extensions/discord/src/monitor/exec-approvals.test.ts
+++ b/extensions/discord/src/monitor/exec-approvals.test.ts
@@ -3,9 +3,9 @@ import os from "node:os";
 import path from "node:path";
 import type { ButtonInteraction, ComponentData } from "@buape/carbon";
 import { Routes } from "discord-api-types/v10";
-import { clearSessionStoreCacheForTest } from "openclaw/plugin-sdk/config-runtime";
-import type { DiscordExecApprovalConfig } from "openclaw/plugin-sdk/config-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearSessionStoreCacheForTest } from "../../../../src/config/sessions.js";
+import type { DiscordExecApprovalConfig } from "../../../../src/config/types.discord.js";
 
 const STORE_PATH = path.join(os.tmpdir(), "openclaw-exec-approvals-test.json");
 
@@ -46,9 +46,7 @@ const mockRestPatch = vi.hoisted(() => vi.fn());
 const mockRestDelete = vi.hoisted(() => vi.fn());
 const gatewayClientStarts = vi.hoisted(() => vi.fn());
 const gatewayClientStops = vi.hoisted(() => vi.fn());
-const gatewayClientRequests = vi.hoisted(() =>
-  vi.fn(async (_method?: string, _params?: unknown) => ({ ok: true })),
-);
+const gatewayClientRequests = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => ({ ok: true })));
 const gatewayClientParams = vi.hoisted(() => [] as Array<Record<string, unknown>>);
 const mockGatewayClientCtor = vi.hoisted(() => vi.fn());
 const mockResolveGatewayConnectionAuth = vi.hoisted(() => vi.fn());
@@ -87,8 +85,8 @@ vi.mock("openclaw/plugin-sdk/gateway-runtime", async (importOriginal) => {
     stop() {
       gatewayClientStops();
     }
-    async request(method: string, params?: unknown) {
-      return gatewayClientRequests(method, params);
+    async request(...args: unknown[]) {
+      return gatewayClientRequests(...args);
     }
   }
   return {
@@ -128,56 +126,9 @@ vi.mock("openclaw/plugin-sdk/gateway-runtime", async (importOriginal) => {
   };
 });
 
-vi.mock("../../../../src/gateway/operator-approvals-client.js", () => ({
-  createOperatorApprovalsGatewayClient: async (params: {
-    config?: unknown;
-    gatewayUrl?: string;
-    clientDisplayName?: string;
-    onEvent?: unknown;
-    onHelloOk?: unknown;
-    onConnectError?: unknown;
-    onClose?: unknown;
-  }) => {
-    mockCreateOperatorApprovalsGatewayClient(params);
-    const envUrl = process.env.OPENCLAW_GATEWAY_URL?.trim();
-    const gatewayUrl = params.gatewayUrl?.trim() || envUrl || "ws://127.0.0.1:18789";
-    const urlOverrideSource = params.gatewayUrl?.trim() ? "cli" : envUrl ? "env" : undefined;
-    const auth = await mockResolveGatewayConnectionAuth({
-      config: params.config,
-      env: process.env,
-      ...(urlOverrideSource
-        ? {
-            urlOverride: gatewayUrl,
-            urlOverrideSource,
-          }
-        : {}),
-    });
-    const clientParams = {
-      url: gatewayUrl,
-      token: auth?.token,
-      password: auth?.password,
-      clientName: "gateway-client",
-      clientDisplayName: params.clientDisplayName,
-      mode: "backend",
-      scopes: ["operator.approvals"],
-      onEvent: params.onEvent,
-      onHelloOk: params.onHelloOk,
-      onConnectError: params.onConnectError,
-      onClose: params.onClose,
-    };
-    gatewayClientParams.push(clientParams);
-    mockGatewayClientCtor(clientParams);
-    return {
-      start: gatewayClientStarts,
-      stop: gatewayClientStops,
-      request: gatewayClientRequests,
-    };
-  },
-}));
-
-vi.mock("../../../../src/gateway/client.js", () => ({
-  GatewayClient: class {
-    params: Record<string, unknown>;
+vi.mock("../../../../src/gateway/operator-approvals-client.js", async () => {
+  class MockGatewayClient {
+    private params: Record<string, unknown>;
     constructor(params: Record<string, unknown>) {
       this.params = params;
       gatewayClientParams.push(params);
@@ -189,31 +140,58 @@ vi.mock("../../../../src/gateway/client.js", () => ({
     stop() {
       gatewayClientStops();
     }
-    async request() {
-      return gatewayClientRequests();
+    async request(...args: unknown[]) {
+      return gatewayClientRequests(...args);
     }
-  },
-}));
+  }
 
-vi.mock("../../../../src/gateway/connection-auth.js", () => ({
-  resolveGatewayConnectionAuth: (params: {
-    config?: unknown;
-    env: NodeJS.ProcessEnv;
-    urlOverride?: string;
-    urlOverrideSource?: "cli" | "env";
-  }) => mockResolveGatewayConnectionAuth(params),
-}));
-
-vi.mock("../client.js", () => ({
-  createDiscordClient: () => ({
-    rest: {
-      post: mockRestPost,
-      patch: mockRestPatch,
-      delete: mockRestDelete,
+  return {
+    createOperatorApprovalsGatewayClient: async (params: {
+      config?: {
+        gateway?: {
+          auth?: {
+            token?: string;
+            password?: string;
+          };
+        };
+      };
+      gatewayUrl?: string;
+      clientDisplayName: string;
+      onEvent?: unknown;
+      onHelloOk?: () => void;
+      onConnectError?: (err: Error) => void;
+      onClose?: (code: number, reason: string) => void;
+    }) => {
+      mockCreateOperatorApprovalsGatewayClient(params);
+      const envUrl = process.env.OPENCLAW_GATEWAY_URL?.trim();
+      const gatewayUrl = params.gatewayUrl?.trim() || envUrl || "ws://127.0.0.1:18789";
+      const urlOverrideSource = params.gatewayUrl?.trim() ? "cli" : envUrl ? "env" : undefined;
+      const auth = await mockResolveGatewayConnectionAuth({
+        config: params.config,
+        env: process.env,
+        ...(urlOverrideSource
+          ? {
+              urlOverride: gatewayUrl,
+              urlOverrideSource,
+            }
+          : {}),
+      });
+      return new MockGatewayClient({
+        url: gatewayUrl,
+        token: auth?.token,
+        password: auth?.password,
+        clientName: "gateway-client",
+        clientDisplayName: params.clientDisplayName,
+        mode: "backend",
+        scopes: ["operator.approvals"],
+        onEvent: params.onEvent,
+        onHelloOk: params.onHelloOk,
+        onConnectError: params.onConnectError,
+        onClose: params.onClose,
+      });
     },
-    request: (_fn: () => Promise<unknown>, _label: string) => _fn(),
-  }),
-}));
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/text-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/text-runtime")>();
@@ -242,66 +220,6 @@ type ExecApprovalRequest = import("./exec-approvals.js").ExecApprovalRequest;
 type PluginApprovalRequest = import("./exec-approvals.js").PluginApprovalRequest;
 type ExecApprovalButtonContext = import("./exec-approvals.js").ExecApprovalButtonContext;
 
-function createTestingDeps() {
-  return {
-    createGatewayClient: async (params: {
-      config?: unknown;
-      gatewayUrl?: string;
-      clientDisplayName?: string;
-      onEvent?: unknown;
-      onHelloOk?: unknown;
-      onConnectError?: unknown;
-      onClose?: unknown;
-    }) => {
-      mockCreateOperatorApprovalsGatewayClient(params);
-      const envUrl = process.env.OPENCLAW_GATEWAY_URL?.trim();
-      const gatewayUrl = params.gatewayUrl?.trim() || envUrl || "ws://127.0.0.1:18789";
-      const urlOverrideSource = params.gatewayUrl?.trim() ? "cli" : envUrl ? "env" : undefined;
-      const auth = await mockResolveGatewayConnectionAuth({
-        config: params.config,
-        env: process.env,
-        ...(urlOverrideSource
-          ? {
-              urlOverride: gatewayUrl,
-              urlOverrideSource,
-            }
-          : {}),
-      });
-      const clientParams = {
-        url: gatewayUrl,
-        token: auth?.token,
-        password: auth?.password,
-        clientName: "gateway-client",
-        clientDisplayName: params.clientDisplayName,
-        mode: "backend",
-        scopes: ["operator.approvals"],
-        onEvent: params.onEvent,
-        onHelloOk: params.onHelloOk,
-        onConnectError: params.onConnectError,
-        onClose: params.onClose,
-      };
-      gatewayClientParams.push(clientParams);
-      mockGatewayClientCtor(clientParams);
-      return {
-        start: gatewayClientStarts,
-        stop: gatewayClientStops,
-        request: gatewayClientRequests,
-      } as unknown as InstanceType<
-        typeof import("../../../../src/gateway/client.js").GatewayClient
-      >;
-    },
-    createDiscordClient: () => ({
-      rest: {
-        post: mockRestPost,
-        patch: mockRestPatch,
-        delete: mockRestDelete,
-      },
-      request: (_fn: () => Promise<unknown>, _label: string) => _fn(),
-      token: "test-token",
-    }),
-  };
-}
-
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function createHandler(config: DiscordExecApprovalConfig, accountId = "default") {
@@ -310,7 +228,6 @@ function createHandler(config: DiscordExecApprovalConfig, accountId = "default")
     accountId,
     config,
     cfg: { session: { store: STORE_PATH } },
-    __testing: createTestingDeps(),
   });
 }
 
@@ -370,30 +287,6 @@ async function expectGatewayAuthStart(params: {
   expect(mockGatewayClientCtor).toHaveBeenCalledWith(expect.objectContaining(expectedClientParams));
 }
 
-type ExecApprovalHandlerInternals = {
-  pending: Map<
-    string,
-    { discordMessageId: string; discordChannelId: string; timeoutId: NodeJS.Timeout }
-  >;
-  requestCache: Map<string, unknown>;
-  handleApprovalRequested: (request: ExecApprovalRequest | PluginApprovalRequest) => Promise<void>;
-  handleApprovalTimeout: (approvalId: string, source?: "channel" | "dm") => Promise<void>;
-};
-
-function getHandlerInternals(
-  handler: DiscordExecApprovalHandlerInstance,
-): ExecApprovalHandlerInternals {
-  return handler as unknown as ExecApprovalHandlerInternals;
-}
-
-function clearPendingTimeouts(handler: DiscordExecApprovalHandlerInstance) {
-  const internals = getHandlerInternals(handler);
-  for (const pending of internals.pending.values()) {
-    clearTimeout(pending.timeoutId);
-  }
-  internals.pending.clear();
-}
-
 function createRequest(
   overrides: Partial<ExecApprovalRequest["request"]> = {},
 ): ExecApprovalRequest {
@@ -418,11 +311,10 @@ function createPluginRequest(
   return {
     id: "plugin:test-id",
     request: {
-      title: "Sensitive plugin action",
-      description: "The plugin wants to run a sensitive tool action.",
-      severity: "warning",
-      toolName: "plugin.tool",
-      pluginId: "plugin-test",
+      title: "Plugin approval required",
+      description: "Allow plugin action",
+      pluginId: "test-plugin",
+      toolName: "test-tool",
       agentId: "test-agent",
       sessionKey: "agent:test-agent:discord:channel:999888777",
       ...overrides,
@@ -430,19 +322,6 @@ function createPluginRequest(
     createdAtMs: Date.now(),
     expiresAtMs: Date.now() + 60000,
   };
-}
-
-function createMockButtonInteraction(userId: string) {
-  const reply = vi.fn().mockResolvedValue(undefined);
-  const acknowledge = vi.fn().mockResolvedValue(undefined);
-  const followUp = vi.fn().mockResolvedValue(undefined);
-  const interaction = {
-    userId,
-    reply,
-    acknowledge,
-    followUp,
-  } as unknown as ButtonInteraction;
-  return { interaction, reply, acknowledge, followUp };
 }
 
 beforeEach(() => {
@@ -458,6 +337,7 @@ beforeEach(() => {
 });
 
 beforeAll(async () => {
+  vi.resetModules();
   ({
     buildExecApprovalCustomId,
     extractDiscordChannelId,
@@ -726,104 +606,6 @@ describe("DiscordExecApprovalHandler.shouldHandle", () => {
   });
 });
 
-describe("DiscordExecApprovalHandler plugin approvals", () => {
-  beforeEach(() => {
-    mockRestPost.mockClear().mockResolvedValue({ id: "mock-message", channel_id: "mock-channel" });
-    mockRestPatch.mockClear().mockResolvedValue({});
-    mockRestDelete.mockClear().mockResolvedValue({});
-  });
-
-  it("delivers plugin approval requests with interactive approval buttons", async () => {
-    const handler = createHandler({ enabled: true, approvers: ["123"] });
-    const internals = getHandlerInternals(handler);
-    mockSuccessfulDmDelivery({ throwOnUnexpectedRoute: true });
-
-    await internals.handleApprovalRequested(createPluginRequest());
-
-    const dmCall = mockRestPost.mock.calls.find(
-      (call) => call[0] === Routes.channelMessages("dm-1"),
-    ) as [string, { body?: unknown }] | undefined;
-    expect(dmCall).toBeDefined();
-    expect(dmCall?.[1]?.body).toBeDefined();
-    const bodyJson = JSON.stringify(dmCall?.[1]?.body ?? {});
-    expect(bodyJson).toContain("Plugin Approval Required");
-    expect(bodyJson).toContain("plugin:test-id");
-    expect(bodyJson).toContain("execapproval:id=plugin%3Atest-id;action=allow-once");
-
-    clearPendingTimeouts(handler);
-  });
-
-  it("handles plugin approvals end-to-end via gateway event, button resolve, and card update", async () => {
-    const handler = createHandler({ enabled: true, approvers: ["123"] });
-    mockSuccessfulDmDelivery({
-      noteChannelId: "999888777",
-      expectedNoteText: "I sent approval DMs to the approvers for this account",
-      throwOnUnexpectedRoute: true,
-    });
-
-    await handler.start();
-    try {
-      const onEvent = gatewayClientParams[0]?.onEvent as
-        | ((evt: { event: string; payload: unknown }) => void)
-        | undefined;
-      expect(typeof onEvent).toBe("function");
-
-      const request = createPluginRequest();
-      onEvent?.({
-        event: "plugin.approval.requested",
-        payload: request,
-      });
-
-      await vi.waitFor(() => {
-        expect(mockRestPost).toHaveBeenCalledWith(
-          Routes.channelMessages("dm-1"),
-          expect.objectContaining({
-            body: expect.objectContaining({
-              components: expect.any(Array),
-            }),
-          }),
-        );
-      });
-
-      const button = new ExecApprovalButton({ handler });
-      const { interaction, acknowledge } = createMockButtonInteraction("123");
-      await button.run(interaction, { id: request.id, action: "allow-once" });
-
-      expect(acknowledge).toHaveBeenCalledTimes(1);
-      expect(gatewayClientRequests).toHaveBeenCalledWith("plugin.approval.resolve", {
-        id: request.id,
-        decision: "allow-once",
-      });
-
-      onEvent?.({
-        event: "plugin.approval.resolved",
-        payload: {
-          id: request.id,
-          decision: "allow-once",
-          resolvedBy: "discord:123",
-          ts: Date.now(),
-          request: request.request,
-        },
-      });
-
-      await vi.waitFor(() => {
-        expect(mockRestPatch).toHaveBeenCalledWith(
-          Routes.channelMessage("dm-1", "msg-1"),
-          expect.objectContaining({ body: expect.any(Object) }),
-        );
-      });
-      const patchCall = mockRestPatch.mock.calls.find(
-        (call) => call[0] === Routes.channelMessage("dm-1", "msg-1"),
-      ) as [string, { body?: unknown }] | undefined;
-      const patchBody = JSON.stringify(patchCall?.[1]?.body ?? {});
-      expect(patchBody).toContain("Plugin Approval: Allowed (once)");
-    } finally {
-      clearPendingTimeouts(handler);
-      await handler.stop();
-    }
-  });
-});
-
 // ─── DiscordExecApprovalHandler.getApprovers ──────────────────────────────────
 
 describe("DiscordExecApprovalHandler.getApprovers", () => {
@@ -849,40 +631,6 @@ describe("DiscordExecApprovalHandler.getApprovers", () => {
     for (const testCase of cases) {
       const handler = createHandler(testCase.config);
       expect(handler.getApprovers(), testCase.name).toEqual(testCase.expected);
-    }
-  });
-});
-
-describe("DiscordExecApprovalHandler.resolveApproval", () => {
-  it("routes non-prefixed approval IDs to exec.approval.resolve", async () => {
-    const handler = createHandler({ enabled: true, approvers: ["123"] });
-    await handler.start();
-
-    try {
-      const ok = await handler.resolveApproval("exec-123", "allow-once");
-      expect(ok).toBe(true);
-      expect(gatewayClientRequests).toHaveBeenCalledWith("exec.approval.resolve", {
-        id: "exec-123",
-        decision: "allow-once",
-      });
-    } finally {
-      await handler.stop();
-    }
-  });
-
-  it("routes plugin-prefixed approval IDs to plugin.approval.resolve", async () => {
-    const handler = createHandler({ enabled: true, approvers: ["123"] });
-    await handler.start();
-
-    try {
-      const ok = await handler.resolveApproval("plugin:abc-123", "deny");
-      expect(ok).toBe(true);
-      expect(gatewayClientRequests).toHaveBeenCalledWith("plugin.approval.resolve", {
-        id: "plugin:abc-123",
-        decision: "deny",
-      });
-    } finally {
-      await handler.stop();
     }
   });
 });
@@ -924,7 +672,7 @@ describe("ExecApprovalButton", () => {
     await button.run(interaction, data);
 
     expect(reply).toHaveBeenCalledWith({
-      content: "⛔ You are not authorized to approve requests.",
+      content: "⛔ You are not authorized to approve exec requests.",
       ephemeral: true,
     });
     expect(acknowledge).not.toHaveBeenCalled();
@@ -1101,7 +849,6 @@ describe("DiscordExecApprovalHandler gateway auth", () => {
           auth: { mode: "token", token: "shared-gateway-token" },
         },
       },
-      __testing: createTestingDeps(),
     });
 
     await handler.start();
@@ -1128,7 +875,6 @@ describe("DiscordExecApprovalHandler gateway auth", () => {
           auth: { mode: "token" },
         },
       },
-      __testing: createTestingDeps(),
     });
 
     try {
@@ -1153,40 +899,6 @@ describe("DiscordExecApprovalHandler timeout cleanup", () => {
     mockRestPatch.mockClear().mockResolvedValue({});
     mockRestDelete.mockClear().mockResolvedValue({});
   });
-
-  it("cleans up request cache for the exact approval id", async () => {
-    const handler = createHandler({ enabled: true, approvers: ["123"] });
-    const internals = getHandlerInternals(handler);
-    const requestA = { ...createRequest(), id: "abc" };
-    const requestB = { ...createRequest(), id: "abc2" };
-
-    internals.requestCache.set("abc", { kind: "exec", request: requestA });
-    internals.requestCache.set("abc2", { kind: "exec", request: requestB });
-
-    const timeoutIdA = setTimeout(() => {}, 0);
-    const timeoutIdB = setTimeout(() => {}, 0);
-    clearTimeout(timeoutIdA);
-    clearTimeout(timeoutIdB);
-
-    internals.pending.set("abc:dm", {
-      discordMessageId: "m1",
-      discordChannelId: "c1",
-      timeoutId: timeoutIdA,
-    });
-    internals.pending.set("abc2:dm", {
-      discordMessageId: "m2",
-      discordChannelId: "c2",
-      timeoutId: timeoutIdB,
-    });
-
-    await internals.handleApprovalTimeout("abc", "dm");
-
-    expect(internals.pending.has("abc:dm")).toBe(false);
-    expect(internals.requestCache.has("abc")).toBe(false);
-    expect(internals.requestCache.has("abc2")).toBe(true);
-
-    clearPendingTimeouts(handler);
-  });
 });
 
 // ─── Delivery routing ────────────────────────────────────────────────────────
@@ -1204,12 +916,11 @@ describe("DiscordExecApprovalHandler delivery routing", () => {
       approvers: ["123"],
       target: "channel",
     });
-    const internals = getHandlerInternals(handler);
 
     mockSuccessfulDmDelivery();
 
     const request = createRequest({ sessionKey: "agent:main:discord:dm:123" });
-    await internals.handleApprovalRequested(request);
+    await handler.handleApprovalRequested(request);
 
     expect(mockRestPost).toHaveBeenCalledTimes(2);
     expect(mockRestPost).toHaveBeenCalledWith(Routes.userChannels(), {
@@ -1223,8 +934,6 @@ describe("DiscordExecApprovalHandler delivery routing", () => {
         }),
       }),
     );
-
-    clearPendingTimeouts(handler);
   });
 
   it("posts an in-channel note when target is dm and the request came from a non-DM discord conversation", async () => {
@@ -1233,7 +942,6 @@ describe("DiscordExecApprovalHandler delivery routing", () => {
       approvers: ["123"],
       target: "dm",
     });
-    const internals = getHandlerInternals(handler);
 
     mockSuccessfulDmDelivery({
       noteChannelId: "999888777",
@@ -1241,13 +949,15 @@ describe("DiscordExecApprovalHandler delivery routing", () => {
       throwOnUnexpectedRoute: true,
     });
 
-    await internals.handleApprovalRequested(createRequest());
+    await handler.handleApprovalRequested(createRequest());
 
     expect(mockRestPost).toHaveBeenCalledWith(
       Routes.channelMessages("999888777"),
       expect.objectContaining({
         body: expect.objectContaining({
-          content: expect.stringContaining("I sent approval DMs to the approvers for this account"),
+          content: expect.stringContaining(
+            "I sent approval DMs to the approvers for this account",
+          ),
         }),
       }),
     );
@@ -1257,8 +967,6 @@ describe("DiscordExecApprovalHandler delivery routing", () => {
         body: expect.any(Object),
       }),
     );
-
-    clearPendingTimeouts(handler);
   });
 
   it("does not post an in-channel note when the request already came from a discord DM", async () => {
@@ -1267,11 +975,10 @@ describe("DiscordExecApprovalHandler delivery routing", () => {
       approvers: ["123"],
       target: "dm",
     });
-    const internals = getHandlerInternals(handler);
 
     mockSuccessfulDmDelivery({ throwOnUnexpectedRoute: true });
 
-    await internals.handleApprovalRequested(
+    await handler.handleApprovalRequested(
       createRequest({ sessionKey: "agent:main:discord:dm:123" }),
     );
 
@@ -1279,8 +986,55 @@ describe("DiscordExecApprovalHandler delivery routing", () => {
       Routes.channelMessages("999888777"),
       expect.anything(),
     );
+  });
 
-    clearPendingTimeouts(handler);
+  it("delivers plugin approvals through the shared runtime flow", async () => {
+    const handler = createHandler({
+      enabled: true,
+      approvers: ["123"],
+      target: "dm",
+    });
+
+    mockSuccessfulDmDelivery({ throwOnUnexpectedRoute: true });
+
+    await handler.handleApprovalRequested(createPluginRequest());
+
+    expect(mockRestPost).toHaveBeenCalledWith(
+      Routes.channelMessages("dm-1"),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          components: expect.arrayContaining([
+            expect.objectContaining({
+              components: expect.arrayContaining([
+                expect.objectContaining({
+                  content: expect.stringContaining("Plugin Approval Required"),
+                }),
+                expect.objectContaining({
+                  content: expect.stringContaining("Plugin approval required"),
+                }),
+              ]),
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+});
+
+describe("DiscordExecApprovalHandler resolve routing", () => {
+  it("routes plugin approval ids through plugin.approval.resolve", async () => {
+    const handler = createHandler({
+      enabled: true,
+      approvers: ["123"],
+    });
+
+    await handler.start();
+    await expect(handler.resolveApproval("plugin:test-id", "allow-once")).resolves.toBe(true);
+
+    expect(gatewayClientRequests).toHaveBeenCalledWith("plugin.approval.resolve", {
+      id: "plugin:test-id",
+      decision: "allow-once",
+    });
   });
 });
 
@@ -1296,7 +1050,6 @@ describe("DiscordExecApprovalHandler gateway auth resolution", () => {
       gatewayUrl: "wss://override.example/ws",
       config: { enabled: true, approvers: ["123"] },
       cfg: { session: { store: STORE_PATH } },
-      __testing: createTestingDeps(),
     });
 
     await expectGatewayAuthStart({
@@ -1319,7 +1072,6 @@ describe("DiscordExecApprovalHandler gateway auth resolution", () => {
         accountId: "default",
         config: { enabled: true, approvers: ["123"] },
         cfg: { session: { store: STORE_PATH } },
-        __testing: createTestingDeps(),
       });
 
       await expectGatewayAuthStart({

--- a/extensions/discord/src/monitor/exec-approvals.ts
+++ b/extensions/discord/src/monitor/exec-approvals.ts
@@ -10,20 +10,24 @@ import {
   type TopLevelComponents,
 } from "@buape/carbon";
 import { ButtonStyle, Routes } from "discord-api-types/v10";
-import {
-  getExecApprovalApproverDmNoticeText,
-  resolveExecApprovalCommandDisplay,
-  type ExecApprovalDecision,
-  type ExecApprovalRequest,
-  type ExecApprovalResolved,
-  type PluginApprovalRequest,
-  type PluginApprovalResolved,
-} from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
 import type { DiscordExecApprovalConfig } from "openclaw/plugin-sdk/config-runtime";
-import type { EventFrame } from "openclaw/plugin-sdk/gateway-runtime";
-import * as gatewayRuntime from "openclaw/plugin-sdk/gateway-runtime";
+import {
+  createExecApprovalChannelRuntime,
+  type ExecApprovalChannelRuntime,
+} from "openclaw/plugin-sdk/infra-runtime";
+import { buildExecApprovalActionDescriptors } from "openclaw/plugin-sdk/infra-runtime";
+import { resolveExecApprovalCommandDisplay } from "openclaw/plugin-sdk/infra-runtime";
+import { getExecApprovalApproverDmNoticeText } from "openclaw/plugin-sdk/infra-runtime";
+import type {
+  ExecApprovalActionDescriptor,
+  ExecApprovalDecision,
+  ExecApprovalRequest,
+  ExecApprovalResolved,
+  PluginApprovalRequest,
+  PluginApprovalResolved,
+} from "openclaw/plugin-sdk/infra-runtime";
 import {
   normalizeAccountId,
   normalizeMessageChannel,
@@ -32,7 +36,7 @@ import {
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { compileSafeRegex, testRegexWithBoundedInput } from "openclaw/plugin-sdk/security-runtime";
 import { logDebug, logError } from "openclaw/plugin-sdk/text-runtime";
-import * as sendShared from "../send.shared.js";
+import { createDiscordClient, stripUndefinedFields } from "../send.shared.js";
 import { DiscordUiContainer } from "../ui.js";
 
 const EXEC_APPROVAL_KEY = "execapproval";
@@ -42,6 +46,10 @@ export type {
   PluginApprovalRequest,
   PluginApprovalResolved,
 };
+
+type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
+type ApprovalKind = "exec" | "plugin";
 
 /** Extract Discord channel ID from a session key like "agent:main:discord:channel:123456789" */
 export function extractDiscordChannelId(sessionKey?: string | null): string | null {
@@ -62,14 +70,15 @@ function buildDiscordApprovalDmRedirectNotice(): { content: string } {
 type PendingApproval = {
   discordMessageId: string;
   discordChannelId: string;
-  timeoutId: NodeJS.Timeout;
 };
 
-type ApprovalKind = "exec" | "plugin";
+function resolveApprovalKindFromId(approvalId: string): ApprovalKind {
+  return approvalId.startsWith("plugin:") ? "plugin" : "exec";
+}
 
-type CachedApprovalRequest =
-  | { kind: "exec"; request: ExecApprovalRequest }
-  | { kind: "plugin"; request: PluginApprovalRequest };
+function isPluginApprovalRequest(request: ApprovalRequest): request is PluginApprovalRequest {
+  return resolveApprovalKindFromId(request.id) === "plugin";
+}
 
 function encodeCustomIdValue(value: string): string {
   return encodeURIComponent(value);
@@ -113,16 +122,6 @@ export function parseExecApprovalData(
     approvalId: decodeCustomIdValue(rawId),
     action,
   };
-}
-
-function resolveApprovalKindFromId(approvalId: string): ApprovalKind {
-  return approvalId.startsWith("plugin:") ? "plugin" : "exec";
-}
-
-function isPluginApprovalRequest(
-  request: ExecApprovalRequest | PluginApprovalRequest,
-): request is PluginApprovalRequest {
-  return resolveApprovalKindFromId(request.id) === "plugin";
 }
 
 type ExecApprovalContainerParams = {
@@ -177,49 +176,36 @@ class ExecApprovalActionButton extends Button {
   label: string;
   style: ButtonStyle;
 
-  constructor(params: {
-    approvalId: string;
-    action: ExecApprovalDecision;
-    label: string;
-    style: ButtonStyle;
-  }) {
+  constructor(params: { approvalId: string; descriptor: ExecApprovalActionDescriptor }) {
     super();
-    this.customId = buildExecApprovalCustomId(params.approvalId, params.action);
-    this.label = params.label;
-    this.style = params.style;
+    this.customId = buildExecApprovalCustomId(params.approvalId, params.descriptor.decision);
+    this.label = params.descriptor.label;
+    this.style =
+      params.descriptor.style === "success"
+        ? ButtonStyle.Success
+        : params.descriptor.style === "primary"
+          ? ButtonStyle.Primary
+          : params.descriptor.style === "danger"
+            ? ButtonStyle.Danger
+            : ButtonStyle.Secondary;
   }
 }
 
 class ExecApprovalActionRow extends Row<Button> {
   constructor(approvalId: string) {
     super([
-      new ExecApprovalActionButton({
-        approvalId,
-        action: "allow-once",
-        label: "Allow once",
-        style: ButtonStyle.Success,
-      }),
-      new ExecApprovalActionButton({
-        approvalId,
-        action: "allow-always",
-        label: "Always allow",
-        style: ButtonStyle.Primary,
-      }),
-      new ExecApprovalActionButton({
-        approvalId,
-        action: "deny",
-        label: "Deny",
-        style: ButtonStyle.Danger,
-      }),
+      ...buildExecApprovalActionDescriptors({ approvalCommandId: approvalId }).map(
+        (descriptor) => new ExecApprovalActionButton({ approvalId, descriptor }),
+      ),
     ]);
   }
 }
 
-function resolveAccountIdFromSessionKey(params: {
+function resolveExecApprovalAccountId(params: {
   cfg: OpenClawConfig;
-  sessionKey?: string | null;
+  request: ExecApprovalRequest;
 }): string | null {
-  const sessionKey = params.sessionKey?.trim();
+  const sessionKey = params.request.request.sessionKey?.trim();
   if (!sessionKey) {
     return null;
   }
@@ -239,23 +225,21 @@ function resolveAccountIdFromSessionKey(params: {
   }
 }
 
-function resolveExecApprovalAccountId(params: {
-  cfg: OpenClawConfig;
-  request: ExecApprovalRequest;
-}): string | null {
-  return resolveAccountIdFromSessionKey({
-    cfg: params.cfg,
-    sessionKey: params.request.request.sessionKey,
-  });
-}
-
 function resolvePluginApprovalAccountId(params: {
   cfg: OpenClawConfig;
   request: PluginApprovalRequest;
 }): string | null {
-  const fromSession = resolveAccountIdFromSessionKey({
+  const fromSession = resolveExecApprovalAccountId({
     cfg: params.cfg,
-    sessionKey: params.request.request.sessionKey,
+    request: {
+      id: params.request.id,
+      request: {
+        command: params.request.request.title,
+        sessionKey: params.request.request.sessionKey ?? undefined,
+      },
+      createdAtMs: params.request.createdAtMs,
+      expiresAtMs: params.request.expiresAtMs,
+    },
   });
   if (fromSession) {
     return fromSession;
@@ -265,22 +249,18 @@ function resolvePluginApprovalAccountId(params: {
 
 function resolveApprovalAccountId(params: {
   cfg: OpenClawConfig;
-  request: ExecApprovalRequest | PluginApprovalRequest;
+  request: ApprovalRequest;
 }): string | null {
   return isPluginApprovalRequest(params.request)
     ? resolvePluginApprovalAccountId({ cfg: params.cfg, request: params.request })
     : resolveExecApprovalAccountId({ cfg: params.cfg, request: params.request });
 }
 
-function resolveApprovalAgentId(
-  request: ExecApprovalRequest | PluginApprovalRequest,
-): string | null {
+function resolveApprovalAgentId(request: ApprovalRequest): string | null {
   return request.request.agentId?.trim() || null;
 }
 
-function resolveApprovalSessionKey(
-  request: ExecApprovalRequest | PluginApprovalRequest,
-): string | null {
+function resolveApprovalSessionKey(request: ApprovalRequest): string | null {
   return request.request.sessionKey?.trim() || null;
 }
 
@@ -526,31 +506,34 @@ export type DiscordExecApprovalHandlerOpts = {
   cfg: OpenClawConfig;
   runtime?: RuntimeEnv;
   onResolve?: (id: string, decision: ExecApprovalDecision) => Promise<void>;
-  __testing?: {
-    createGatewayClient?: typeof gatewayRuntime.createOperatorApprovalsGatewayClient;
-    createDiscordClient?: (...args: Parameters<typeof sendShared.createDiscordClient>) => {
-      rest: {
-        post: (...args: unknown[]) => Promise<unknown>;
-        patch: (...args: unknown[]) => Promise<unknown>;
-        delete: (...args: unknown[]) => Promise<unknown>;
-      };
-      request: (fn: () => Promise<unknown>, label: string) => Promise<unknown>;
-    };
-  };
 };
 
 export class DiscordExecApprovalHandler {
-  private gatewayClient: gatewayRuntime.GatewayClient | null = null;
-  private pending = new Map<string, PendingApproval>();
-  private requestCache = new Map<string, CachedApprovalRequest>();
+  private readonly runtime: ExecApprovalChannelRuntime<ApprovalRequest, ApprovalResolved>;
   private opts: DiscordExecApprovalHandlerOpts;
-  private started = false;
 
   constructor(opts: DiscordExecApprovalHandlerOpts) {
     this.opts = opts;
+    this.runtime = createExecApprovalChannelRuntime<PendingApproval, ApprovalRequest, ApprovalResolved>({
+      label: "discord/exec-approvals",
+      clientDisplayName: "Discord Exec Approvals",
+      cfg: this.opts.cfg,
+      gatewayUrl: this.opts.gatewayUrl,
+      eventKinds: ["exec", "plugin"],
+      isConfigured: () =>
+        Boolean(this.opts.config.enabled && (this.opts.config.approvers?.length ?? 0) > 0),
+      shouldHandle: (request) => this.shouldHandle(request),
+      deliverRequested: async (request) => await this.deliverRequested(request),
+      finalizeResolved: async ({ request, resolved, entries }) => {
+        await this.finalizeResolved(request, resolved, entries);
+      },
+      finalizeExpired: async ({ request, entries }) => {
+        await this.finalizeExpired(request, entries);
+      },
+    });
   }
 
-  shouldHandle(request: ExecApprovalRequest | PluginApprovalRequest): boolean {
+  shouldHandle(request: ApprovalRequest): boolean {
     const config = this.opts.config;
     if (!config.enabled) {
       return false;
@@ -603,127 +586,45 @@ export class DiscordExecApprovalHandler {
   }
 
   async start(): Promise<void> {
-    if (this.started) {
-      return;
-    }
-    this.started = true;
-
-    const config = this.opts.config;
-    if (!config.enabled) {
-      logDebug("discord exec approvals: disabled");
-      return;
-    }
-
-    if (!config.approvers || config.approvers.length === 0) {
-      logDebug("discord exec approvals: no approvers configured");
-      return;
-    }
-
-    logDebug("discord exec approvals: starting handler");
-
-    this.gatewayClient = await (
-      this.opts.__testing?.createGatewayClient ??
-      gatewayRuntime.createOperatorApprovalsGatewayClient
-    )({
-      config: this.opts.cfg,
-      gatewayUrl: this.opts.gatewayUrl,
-      clientDisplayName: "Discord Exec Approvals",
-      onEvent: (evt) => this.handleGatewayEvent(evt),
-      onHelloOk: () => {
-        logDebug("discord exec approvals: connected to gateway");
-      },
-      onConnectError: (err) => {
-        logError(`discord exec approvals: connect error: ${err.message}`);
-      },
-      onClose: (code, reason) => {
-        logDebug(`discord exec approvals: gateway closed: ${code} ${reason}`);
-      },
-    });
-
-    this.gatewayClient.start();
+    await this.runtime.start();
   }
 
   async stop(): Promise<void> {
-    if (!this.started) {
-      return;
-    }
-    this.started = false;
-
-    // Clear all pending timeouts
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timeoutId);
-    }
-    this.pending.clear();
-    this.requestCache.clear();
-
-    this.gatewayClient?.stop();
-    this.gatewayClient = null;
-
-    logDebug("discord exec approvals: stopped");
+    await this.runtime.stop();
   }
 
-  private handleGatewayEvent(evt: EventFrame): void {
-    if (evt.event === "exec.approval.requested") {
-      const request = evt.payload as ExecApprovalRequest;
-      void this.handleApprovalRequested(request);
-    } else if (evt.event === "plugin.approval.requested") {
-      const request = evt.payload as PluginApprovalRequest;
-      void this.handleApprovalRequested(request);
-    } else if (evt.event === "exec.approval.resolved") {
-      const resolved = evt.payload as ExecApprovalResolved;
-      void this.handleApprovalResolved(resolved);
-    } else if (evt.event === "plugin.approval.resolved") {
-      const resolved = evt.payload as PluginApprovalResolved;
-      void this.handleApprovalResolved(resolved);
-    }
-  }
-
-  private async handleApprovalRequested(
-    request: ExecApprovalRequest | PluginApprovalRequest,
-  ): Promise<void> {
-    if (!this.shouldHandle(request)) {
-      return;
-    }
-
-    const pluginRequest: PluginApprovalRequest | null = isPluginApprovalRequest(request)
-      ? request
-      : null;
-    logDebug(
-      `discord exec approvals: received ${pluginRequest ? "plugin" : "exec"} request ${request.id}`,
+  private async deliverRequested(request: ApprovalRequest): Promise<PendingApproval[]> {
+    const { rest, request: discordRequest } = createDiscordClient(
+      { token: this.opts.token, accountId: this.opts.accountId },
+      this.opts.cfg,
     );
-    let container: ExecApprovalContainer;
-    if (pluginRequest) {
-      this.requestCache.set(request.id, { kind: "plugin", request: pluginRequest });
-      container = createPluginApprovalRequestContainer({
-        request: pluginRequest,
-        cfg: this.opts.cfg,
-        accountId: this.opts.accountId,
-        actionRow: new ExecApprovalActionRow(request.id),
-      });
-    } else {
-      const execRequest = request as ExecApprovalRequest;
-      this.requestCache.set(request.id, { kind: "exec", request: execRequest });
-      container = createExecApprovalRequestContainer({
-        request: execRequest,
-        cfg: this.opts.cfg,
-        accountId: this.opts.accountId,
-        actionRow: new ExecApprovalActionRow(request.id),
-      });
-    }
 
-    const { rest, request: discordRequest } = (
-      this.opts.__testing?.createDiscordClient ?? sendShared.createDiscordClient
-    )({ token: this.opts.token, accountId: this.opts.accountId }, this.opts.cfg);
+    const actionRow = new ExecApprovalActionRow(request.id);
+    const container = isPluginApprovalRequest(request)
+      ? createPluginApprovalRequestContainer({
+          request,
+          cfg: this.opts.cfg,
+          accountId: this.opts.accountId,
+          actionRow,
+        })
+      : createExecApprovalRequestContainer({
+          request,
+          cfg: this.opts.cfg,
+          accountId: this.opts.accountId,
+          actionRow,
+        });
     const payload = buildExecApprovalPayload(container);
-    const body = sendShared.stripUndefinedFields(serializePayload(payload));
+    const body = stripUndefinedFields(serializePayload(payload));
 
     const target = this.opts.config.target ?? "dm";
     const sendToDm = target === "dm" || target === "both";
     const sendToChannel = target === "channel" || target === "both";
     let fallbackToDm = false;
-    const sessionKey = resolveApprovalSessionKey(request);
+    const pendingEntries: PendingApproval[] = [];
     const originatingChannelId =
-      sessionKey && target === "dm" ? extractDiscordChannelId(sessionKey) : null;
+      target === "dm"
+        ? extractDiscordChannelId(resolveApprovalSessionKey(request))
+        : null;
 
     if (target === "dm" && originatingChannelId) {
       try {
@@ -741,6 +642,7 @@ export class DiscordExecApprovalHandler {
 
     // Send to originating channel if configured
     if (sendToChannel) {
+      const sessionKey = resolveApprovalSessionKey(request);
       const channelId = extractDiscordChannelId(sessionKey);
       if (channelId) {
         try {
@@ -753,15 +655,9 @@ export class DiscordExecApprovalHandler {
           )) as { id: string; channel_id: string };
 
           if (message?.id) {
-            const timeoutMs = Math.max(0, request.expiresAtMs - Date.now());
-            const timeoutId = setTimeout(() => {
-              void this.handleApprovalTimeout(request.id, "channel");
-            }, timeoutMs);
-
-            this.pending.set(`${request.id}:channel`, {
+            pendingEntries.push({
               discordMessageId: message.id,
               discordChannelId: channelId,
-              timeoutId,
             });
 
             logDebug(`discord exec approvals: sent approval ${request.id} to channel ${channelId}`);
@@ -816,22 +712,9 @@ export class DiscordExecApprovalHandler {
             continue;
           }
 
-          // Clear any existing pending DM entry to avoid timeout leaks
-          const existingDm = this.pending.get(`${request.id}:dm`);
-          if (existingDm) {
-            clearTimeout(existingDm.timeoutId);
-          }
-
-          // Set up timeout
-          const timeoutMs = Math.max(0, request.expiresAtMs - Date.now());
-          const timeoutId = setTimeout(() => {
-            void this.handleApprovalTimeout(request.id, "dm");
-          }, timeoutMs);
-
-          this.pending.set(`${request.id}:dm`, {
+          pendingEntries.push({
             discordMessageId: message.id,
             discordChannelId: dmChannel.id,
-            timeoutId,
           });
 
           logDebug(`discord exec approvals: sent approval ${request.id} to user ${userId}`);
@@ -840,98 +723,65 @@ export class DiscordExecApprovalHandler {
         }
       }
     }
+    return pendingEntries;
   }
 
-  private async handleApprovalResolved(
-    resolved: ExecApprovalResolved | PluginApprovalResolved,
+  async handleApprovalRequested(request: ApprovalRequest): Promise<void> {
+    await this.runtime.handleRequested(request);
+  }
+
+  async handleApprovalResolved(resolved: ApprovalResolved): Promise<void> {
+    await this.runtime.handleResolved(resolved);
+  }
+
+  async handleApprovalTimeout(approvalId: string, _source?: "channel" | "dm"): Promise<void> {
+    await this.runtime.handleExpired(approvalId);
+  }
+
+  private async finalizeResolved(
+    request: ApprovalRequest,
+    resolved: ApprovalResolved,
+    entries: PendingApproval[],
   ): Promise<void> {
-    // Clean up all pending entries for this approval (channel + dm)
-    const cached = this.requestCache.get(resolved.id);
-    this.requestCache.delete(resolved.id);
+    const container = isPluginApprovalRequest(request)
+      ? createPluginResolvedContainer({
+          request,
+          decision: resolved.decision,
+          resolvedBy: resolved.resolvedBy,
+          cfg: this.opts.cfg,
+          accountId: this.opts.accountId,
+        })
+      : createExecResolvedContainer({
+          request,
+          decision: resolved.decision,
+          resolvedBy: resolved.resolvedBy,
+          cfg: this.opts.cfg,
+          accountId: this.opts.accountId,
+        });
 
-    if (!cached) {
-      return;
-    }
-
-    logDebug(
-      `discord exec approvals: resolved ${cached.kind} ${resolved.id} with ${resolved.decision}`,
-    );
-
-    const container =
-      cached.kind === "plugin"
-        ? createPluginResolvedContainer({
-            request: cached.request,
-            decision: resolved.decision,
-            resolvedBy: resolved.resolvedBy,
-            cfg: this.opts.cfg,
-            accountId: this.opts.accountId,
-          })
-        : createExecResolvedContainer({
-            request: cached.request,
-            decision: resolved.decision,
-            resolvedBy: resolved.resolvedBy,
-            cfg: this.opts.cfg,
-            accountId: this.opts.accountId,
-          });
-
-    for (const suffix of [":channel", ":dm", ""]) {
-      const key = `${resolved.id}${suffix}`;
-      const pending = this.pending.get(key);
-      if (!pending) {
-        continue;
-      }
-
-      clearTimeout(pending.timeoutId);
-      this.pending.delete(key);
-
+    for (const pending of entries) {
       await this.finalizeMessage(pending.discordChannelId, pending.discordMessageId, container);
     }
   }
 
-  private async handleApprovalTimeout(
-    approvalId: string,
-    source?: "channel" | "dm",
+  private async finalizeExpired(
+    request: ApprovalRequest,
+    entries: PendingApproval[],
   ): Promise<void> {
-    const key = source ? `${approvalId}:${source}` : approvalId;
-    const pending = this.pending.get(key);
-    if (!pending) {
-      return;
+    const container = isPluginApprovalRequest(request)
+      ? createPluginExpiredContainer({
+          request,
+          cfg: this.opts.cfg,
+          accountId: this.opts.accountId,
+        })
+      : createExecExpiredContainer({
+          request,
+          cfg: this.opts.cfg,
+          accountId: this.opts.accountId,
+        });
+    for (const pending of entries) {
+      await this.finalizeMessage(pending.discordChannelId, pending.discordMessageId, container);
     }
-
-    this.pending.delete(key);
-
-    const cached = this.requestCache.get(approvalId);
-
-    // Only clean up requestCache if no other pending entries exist for this approval
-    const hasOtherPending =
-      this.pending.has(`${approvalId}:channel`) ||
-      this.pending.has(`${approvalId}:dm`) ||
-      this.pending.has(approvalId);
-    if (!hasOtherPending) {
-      this.requestCache.delete(approvalId);
-    }
-
-    if (!cached) {
-      return;
-    }
-
-    logDebug(
-      `discord exec approvals: timeout for ${cached.kind} ${approvalId} (${source ?? "default"})`,
-    );
-
-    const container =
-      cached.kind === "plugin"
-        ? createPluginExpiredContainer({
-            request: cached.request,
-            cfg: this.opts.cfg,
-            accountId: this.opts.accountId,
-          })
-        : createExecExpiredContainer({
-            request: cached.request,
-            cfg: this.opts.cfg,
-            accountId: this.opts.accountId,
-          });
-    await this.finalizeMessage(pending.discordChannelId, pending.discordMessageId, container);
   }
 
   private async finalizeMessage(
@@ -945,9 +795,10 @@ export class DiscordExecApprovalHandler {
     }
 
     try {
-      const { rest, request: discordRequest } = (
-        this.opts.__testing?.createDiscordClient ?? sendShared.createDiscordClient
-      )({ token: this.opts.token, accountId: this.opts.accountId }, this.opts.cfg);
+      const { rest, request: discordRequest } = createDiscordClient(
+        { token: this.opts.token, accountId: this.opts.accountId },
+        this.opts.cfg,
+      );
 
       await discordRequest(
         () => rest.delete(Routes.channelMessage(channelId, messageId)) as Promise<void>,
@@ -965,15 +816,16 @@ export class DiscordExecApprovalHandler {
     container: DiscordUiContainer,
   ): Promise<void> {
     try {
-      const { rest, request: discordRequest } = (
-        this.opts.__testing?.createDiscordClient ?? sendShared.createDiscordClient
-      )({ token: this.opts.token, accountId: this.opts.accountId }, this.opts.cfg);
+      const { rest, request: discordRequest } = createDiscordClient(
+        { token: this.opts.token, accountId: this.opts.accountId },
+        this.opts.cfg,
+      );
       const payload = buildExecApprovalPayload(container);
 
       await discordRequest(
         () =>
           rest.patch(Routes.channelMessage(channelId, messageId), {
-            body: sendShared.stripUndefinedFields(serializePayload(payload)),
+            body: stripUndefinedFields(serializePayload(payload)),
           }),
         "update-approval",
       );
@@ -983,11 +835,6 @@ export class DiscordExecApprovalHandler {
   }
 
   async resolveApproval(approvalId: string, decision: ExecApprovalDecision): Promise<boolean> {
-    if (!this.gatewayClient) {
-      logError("discord exec approvals: gateway client not connected");
-      return false;
-    }
-
     const method =
       resolveApprovalKindFromId(approvalId) === "plugin"
         ? "plugin.approval.resolve"
@@ -995,7 +842,7 @@ export class DiscordExecApprovalHandler {
     logDebug(`discord exec approvals: resolving ${approvalId} with ${decision} via ${method}`);
 
     try {
-      await this.gatewayClient.request(method, {
+      await this.runtime.request(method, {
         id: approvalId,
         decision,
       });
@@ -1048,7 +895,7 @@ export class ExecApprovalButton extends Button {
     if (!approvers.some((id) => String(id) === userId)) {
       try {
         await interaction.reply({
-          content: "⛔ You are not authorized to approve requests.",
+          content: "⛔ You are not authorized to approve exec requests.",
           ephemeral: true,
         });
       } catch {

--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -11,6 +11,7 @@ import { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/re
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { deliverReplies, emitInternalMessageSentHook } from "./bot/delivery.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
+import { resolveTelegramExecApproval } from "./exec-approval-resolver.js";
 import { editMessageTelegram } from "./send.js";
 import { wasSentByBot } from "./sent-message-cache.js";
 
@@ -26,6 +27,7 @@ export type TelegramBotDeps = {
   buildModelsProviderData: typeof buildModelsProviderData;
   listSkillCommandsForAgents: typeof listSkillCommandsForAgents;
   wasSentByBot: typeof wasSentByBot;
+  resolveExecApproval?: typeof resolveTelegramExecApproval;
   createTelegramDraftStream?: typeof createTelegramDraftStream;
   deliverReplies?: typeof deliverReplies;
   emitInternalMessageSentHook?: typeof emitInternalMessageSentHook;
@@ -65,6 +67,9 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
   },
   get wasSentByBot() {
     return wasSentByBot;
+  },
+  get resolveExecApproval() {
+    return resolveTelegramExecApproval;
   },
   get createTelegramDraftStream() {
     return createTelegramDraftStream;

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1323,9 +1323,19 @@ export const registerTelegramHandlers = ({
       const runtimeCfg = telegramDeps.loadConfig();
       if (approvalCallback) {
         const isPluginApproval = approvalCallback.approvalId.startsWith("plugin:");
+        const pluginApprovalAuthorizedSender = isTelegramExecApprovalApprover({
+          cfg: runtimeCfg,
+          accountId,
+          senderId,
+        });
+        const execApprovalAuthorizedSender = isTelegramExecApprovalAuthorizedSender({
+          cfg: runtimeCfg,
+          accountId,
+          senderId,
+        });
         const authorizedApprovalSender = isPluginApproval
-          ? isTelegramExecApprovalApprover({ cfg: runtimeCfg, accountId, senderId })
-          : isTelegramExecApprovalAuthorizedSender({ cfg: runtimeCfg, accountId, senderId });
+          ? pluginApprovalAuthorizedSender
+          : execApprovalAuthorizedSender || pluginApprovalAuthorizedSender;
         if (
           !authorizedApprovalSender
         ) {
@@ -1342,6 +1352,7 @@ export const registerTelegramHandlers = ({
             approvalId: approvalCallback.approvalId,
             decision: approvalCallback.decision,
             senderId,
+            allowPluginFallback: pluginApprovalAuthorizedSender,
           });
         } catch (resolveErr) {
           const errStr = String(resolveErr);

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1,7 +1,7 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
 import { resolveAgentDir, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
-import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-writes";
+import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-helpers";
 import { shouldDebounceTextInbound } from "openclaw/plugin-sdk/channel-inbound";
 import {
   createInboundDebouncer,
@@ -31,6 +31,7 @@ import {
   parsePluginBindingApprovalCustomId,
   resolvePluginConversationBindingApproval,
 } from "openclaw/plugin-sdk/conversation-runtime";
+import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/infra-runtime";
 import { dispatchPluginInteractiveHandler } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
@@ -43,7 +44,6 @@ import {
 } from "./bot-access.js";
 import { defaultTelegramBotDeps } from "./bot-deps.js";
 import {
-  APPROVE_CALLBACK_DATA_RE,
   hasInboundMedia,
   hasReplyTargetMedia,
   isMediaSizeLimitError,
@@ -70,16 +70,13 @@ import {
   resolveTelegramGroupAllowFromContext,
   withResolvedTelegramForumFlag,
 } from "./bot/helpers.js";
-import type {
-  TelegramContext,
-  TelegramGetChat,
-  TelegramSyntheticContextSource,
-} from "./bot/types.js";
+import type { TelegramContext, TelegramGetChat } from "./bot/types.js";
 import {
   resolveTelegramConversationBaseSessionKey,
   resolveTelegramConversationRoute,
 } from "./conversation-route.js";
 import { enforceTelegramDmAccess } from "./dm-access.js";
+import { resolveTelegramExecApproval } from "./exec-approval-resolver.js";
 import {
   isTelegramExecApprovalApprover,
   isTelegramExecApprovalAuthorizedSender,
@@ -101,18 +98,6 @@ import {
   type ProviderInfo,
 } from "./model-buttons.js";
 import { buildInlineKeyboard } from "./send.js";
-
-function parseApprovalCallbackId(data: string): string | null {
-  const trimmed = data.trim();
-  if (!trimmed.startsWith("/approve")) {
-    return null;
-  }
-  const tokens = trimmed.split(/\s+/).filter(Boolean);
-  if (tokens.length < 3) {
-    return null;
-  }
-  return tokens[1] ?? null;
-}
 
 export const registerTelegramHandlers = ({
   cfg,
@@ -173,7 +158,20 @@ export const registerTelegramHandlers = ({
     botUsername?: string;
   };
   const resolveTelegramDebounceLane = (msg: Message): TelegramDebounceLane => {
-    return msg.forward_origin ? "forward" : "default";
+    const forwardMeta = msg as {
+      forward_origin?: unknown;
+      forward_from?: unknown;
+      forward_from_chat?: unknown;
+      forward_sender_name?: unknown;
+      forward_date?: unknown;
+    };
+    return (forwardMeta.forward_origin ??
+      forwardMeta.forward_from ??
+      forwardMeta.forward_from_chat ??
+      forwardMeta.forward_sender_name ??
+      forwardMeta.forward_date)
+      ? "forward"
+      : "default";
   };
   const buildSyntheticTextMessage = (params: {
     base: Message;
@@ -190,19 +188,14 @@ export const registerTelegramHandlers = ({
     ...(params.date != null ? { date: params.date } : {}),
   });
   const buildSyntheticContext = (
-    ctx: TelegramSyntheticContextSource,
+    ctx: Pick<TelegramContext, "me"> & { getFile?: unknown },
     message: Message,
   ): TelegramContext => {
     const getFile =
-      typeof ctx.getFile === "function" ? ctx.getFile.bind(ctx as object) : async () => ({});
+      typeof ctx.getFile === "function"
+        ? (ctx.getFile as TelegramContext["getFile"]).bind(ctx as object)
+        : async () => ({});
     return { message, me: ctx.me, getFile };
-  };
-  const isSelfAuthoredTelegramMessage = (
-    ctx: Pick<TelegramContext, "me">,
-    message: Message,
-  ): boolean => {
-    const botId = ctx.me?.id;
-    return typeof botId === "number" && message.from?.id === botId;
   };
   const inboundDebouncer = createInboundDebouncer<TelegramDebounceEntry>({
     debounceMs,
@@ -633,7 +626,10 @@ export const registerTelegramHandlers = ({
   type TelegramEventAuthorizationMode = "reaction" | "callback-scope" | "callback-allowlist";
   type TelegramEventAuthorizationResult = { allowed: true } | { allowed: false; reason: string };
   type TelegramEventAuthorizationContext = TelegramGroupAllowContext & { dmPolicy: DmPolicy };
-  const getChat: TelegramGetChat = bot.api.getChat.bind(bot.api);
+  const getChat =
+    typeof (bot.api as { getChat?: unknown }).getChat === "function"
+      ? ((bot.api as { getChat: TelegramGetChat }).getChat.bind(bot.api) as TelegramGetChat)
+      : undefined;
 
   const TELEGRAM_EVENT_AUTH_RULES: Record<
     TelegramEventAuthorizationMode,
@@ -1099,10 +1095,10 @@ export const registerTelegramHandlers = ({
     if (shouldSkipUpdate(ctx)) {
       return;
     }
-    const answerCallbackQuery = () =>
-      typeof ctx.answerCallbackQuery === "function"
-        ? ctx.answerCallbackQuery()
-        : bot.api.answerCallbackQuery(callback.id);
+    const answerCallbackQuery =
+      typeof (ctx as { answerCallbackQuery?: unknown }).answerCallbackQuery === "function"
+        ? () => ctx.answerCallbackQuery()
+        : () => bot.api.answerCallbackQuery(callback.id);
     // Answer immediately to prevent Telegram from retrying while we process
     await withTelegramApiErrorLogging({
       operation: "answerCallbackQuery",
@@ -1118,26 +1114,41 @@ export const registerTelegramHandlers = ({
       const editCallbackMessage = async (
         text: string,
         params?: Parameters<typeof bot.api.editMessageText>[3],
-      ) =>
-        typeof ctx.editMessageText === "function"
-          ? ctx.editMessageText(text, params)
-          : bot.api.editMessageText(
-              callbackMessage.chat.id,
-              callbackMessage.message_id,
-              text,
-              params,
-            );
+      ) => {
+        const editTextFn = (ctx as { editMessageText?: unknown }).editMessageText;
+        if (typeof editTextFn === "function") {
+          return await ctx.editMessageText(text, params);
+        }
+        return await bot.api.editMessageText(
+          callbackMessage.chat.id,
+          callbackMessage.message_id,
+          text,
+          params,
+        );
+      };
       const clearCallbackButtons = async () => {
         const emptyKeyboard = { inline_keyboard: [] };
         const replyMarkup = { reply_markup: emptyKeyboard };
-        if (typeof ctx.editMessageReplyMarkup === "function") {
+        const editReplyMarkupFn = (ctx as { editMessageReplyMarkup?: unknown })
+          .editMessageReplyMarkup;
+        if (typeof editReplyMarkupFn === "function") {
           return await ctx.editMessageReplyMarkup(replyMarkup);
         }
-        return await bot.api.editMessageReplyMarkup(
-          callbackMessage.chat.id,
-          callbackMessage.message_id,
-          replyMarkup,
-        );
+        const apiEditReplyMarkupFn = (bot.api as { editMessageReplyMarkup?: unknown })
+          .editMessageReplyMarkup;
+        if (typeof apiEditReplyMarkupFn === "function") {
+          return await bot.api.editMessageReplyMarkup(
+            callbackMessage.chat.id,
+            callbackMessage.message_id,
+            replyMarkup,
+          );
+        }
+        // Fallback path for older clients that do not expose editMessageReplyMarkup.
+        const messageText = callbackMessage.text ?? callbackMessage.caption;
+        if (typeof messageText !== "string" || messageText.trim().length === 0) {
+          return undefined;
+        }
+        return await editCallbackMessage(messageText, replyMarkup);
       };
       const editCallbackButtons = async (
         buttons: Array<
@@ -1146,7 +1157,9 @@ export const registerTelegramHandlers = ({
       ) => {
         const keyboard = buildInlineKeyboard(buttons) ?? { inline_keyboard: [] };
         const replyMarkup = { reply_markup: keyboard };
-        if (typeof ctx.editMessageReplyMarkup === "function") {
+        const editReplyMarkupFn = (ctx as { editMessageReplyMarkup?: unknown })
+          .editMessageReplyMarkup;
+        if (typeof editReplyMarkupFn === "function") {
           return await ctx.editMessageReplyMarkup(replyMarkup);
         }
         return await bot.api.editMessageReplyMarkup(
@@ -1156,22 +1169,28 @@ export const registerTelegramHandlers = ({
         );
       };
       const deleteCallbackMessage = async () => {
-        return typeof ctx.deleteMessage === "function"
-          ? ctx.deleteMessage()
-          : bot.api.deleteMessage(callbackMessage.chat.id, callbackMessage.message_id);
+        const deleteFn = (ctx as { deleteMessage?: unknown }).deleteMessage;
+        if (typeof deleteFn === "function") {
+          return await ctx.deleteMessage();
+        }
+        return await bot.api.deleteMessage(callbackMessage.chat.id, callbackMessage.message_id);
       };
       const replyToCallbackChat = async (
         text: string,
         params?: Parameters<typeof bot.api.sendMessage>[2],
-      ) =>
-        typeof ctx.reply === "function"
-          ? ctx.reply(text, params)
-          : bot.api.sendMessage(callbackMessage.chat.id, text, params);
+      ) => {
+        const replyFn = (ctx as { reply?: unknown }).reply;
+        if (typeof replyFn === "function") {
+          return await ctx.reply(text, params);
+        }
+        return await bot.api.sendMessage(callbackMessage.chat.id, text, params);
+      };
 
       const chatId = callbackMessage.chat.id;
       const isGroup =
         callbackMessage.chat.type === "group" || callbackMessage.chat.type === "supergroup";
-      const isApprovalCallback = APPROVE_CALLBACK_DATA_RE.test(data);
+      const approvalCallback = parseExecApprovalCommandText(data);
+      const isApprovalCallback = approvalCallback !== null;
       const inlineButtonsScope = resolveTelegramInlineButtonsScope({
         cfg,
         accountId,
@@ -1219,7 +1238,6 @@ export const registerTelegramHandlers = ({
       }
       const senderId = callback.from?.id ? String(callback.from.id) : "";
       const senderUsername = callback.from?.username ?? "";
-      // DM callbacks must enforce the same sender authorization gate as normal DM commands.
       const authorizationMode: TelegramEventAuthorizationMode =
         !isGroup || (!execApprovalButtonsEnabled && inlineButtonsScope === "allowlist")
           ? "callback-allowlist"
@@ -1303,22 +1321,34 @@ export const registerTelegramHandlers = ({
       }
 
       const runtimeCfg = telegramDeps.loadConfig();
-      if (isApprovalCallback) {
-        const approvalId = parseApprovalCallbackId(data);
-        const isPluginApprovalCallback = approvalId?.startsWith("plugin:") ?? false;
-        if (!isTelegramExecApprovalAuthorizedSender({ cfg: runtimeCfg, accountId, senderId })) {
+      if (approvalCallback) {
+        const isPluginApproval = approvalCallback.approvalId.startsWith("plugin:");
+        const authorizedApprovalSender = isPluginApproval
+          ? isTelegramExecApprovalApprover({ cfg: runtimeCfg, accountId, senderId })
+          : isTelegramExecApprovalAuthorizedSender({ cfg: runtimeCfg, accountId, senderId });
+        if (
+          !authorizedApprovalSender
+        ) {
           logVerbose(
-            `Blocked telegram exec approval callback from ${senderId || "unknown"} (not an approver)`,
+            `Blocked telegram exec approval callback from ${senderId || "unknown"} (not authorized)`,
           );
           return;
         }
-        if (
-          isPluginApprovalCallback &&
-          !isTelegramExecApprovalApprover({ cfg: runtimeCfg, accountId, senderId })
-        ) {
+        try {
+          // Resolve approval callbacks directly so Telegram approvers are not forced through
+          // the generic chat-command authorization path.
+          await (telegramDeps.resolveExecApproval ?? resolveTelegramExecApproval)({
+            cfg: runtimeCfg,
+            approvalId: approvalCallback.approvalId,
+            decision: approvalCallback.decision,
+            senderId,
+          });
+        } catch (resolveErr) {
+          const errStr = String(resolveErr);
           logVerbose(
-            `Blocked telegram plugin approval callback from ${senderId || "unknown"} (not an explicit approver)`,
+            `telegram: failed to resolve approval callback ${approvalCallback.approvalId}: ${errStr}`,
           );
+          await replyToCallbackChat(`❌ Failed to submit approval: ${errStr}`);
           return;
         }
         try {
@@ -1326,12 +1356,14 @@ export const registerTelegramHandlers = ({
         } catch (editErr) {
           const errStr = String(editErr);
           if (
-            !errStr.includes("message is not modified") &&
-            !errStr.includes("there is no text in the message to edit")
+            errStr.includes("message is not modified") ||
+            errStr.includes("there is no text in the message to edit")
           ) {
-            logVerbose(`telegram: failed to clear approval callback buttons: ${errStr}`);
+            return;
           }
+          logVerbose(`telegram: failed to clear approval callback buttons: ${errStr}`);
         }
+        return;
       }
 
       const paginationMatch = data.match(/^commands_page_(\d+|noop)(?::(.+))?$/);
@@ -1389,7 +1421,7 @@ export const registerTelegramHandlers = ({
           runtimeCfg,
           sessionState.agentId,
         );
-        const { byProvider, providers, modelNames } = modelData;
+        const { byProvider, providers } = modelData;
 
         const editMessageWithButtons = async (
           text: string,
@@ -1464,7 +1496,6 @@ export const registerTelegramHandlers = ({
             currentPage: safePage,
             totalPages,
             pageSize,
-            modelNames,
           });
           const text = formatModelsAvailableHeader({
             provider,
@@ -1551,14 +1582,14 @@ export const registerTelegramHandlers = ({
         return;
       }
 
-      const nativeCommandText = parseTelegramNativeCommandCallbackData(data);
+      const nativeCallbackCommand = parseTelegramNativeCommandCallbackData(data);
       const syntheticMessage = buildSyntheticTextMessage({
         base: withResolvedTelegramForumFlag(callbackMessage, isForum),
         from: callback.from,
-        text: nativeCommandText ?? data,
+        text: nativeCallbackCommand ?? data,
       });
       await processMessage(buildSyntheticContext(ctx, syntheticMessage), [], storeAllowFrom, {
-        commandSource: nativeCommandText ? "native" : undefined,
+        ...(nativeCallbackCommand ? { commandSource: "native" as const } : {}),
         forceWasMentioned: true,
         messageIdOverride: callback.id,
       });
@@ -1724,9 +1755,6 @@ export const registerTelegramHandlers = ({
     if (!msg) {
       return;
     }
-    if (isSelfAuthoredTelegramMessage(ctx, msg)) {
-      return;
-    }
     const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
     const isForum = await resolveTelegramForumFlag({
       chatId: msg.chat.id,
@@ -1736,6 +1764,9 @@ export const registerTelegramHandlers = ({
       getChat,
     });
     const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);
+    if (!isGroup && normalizedMsg.from?.id != null && normalizedMsg.from.id === ctx.me?.id) {
+      return;
+    }
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, normalizedMsg),

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -273,6 +273,10 @@ const systemEventsHoisted = vi.hoisted(() => ({
 }));
 export const enqueueSystemEventSpy: MockFn<TelegramBotDeps["enqueueSystemEvent"]> =
   systemEventsHoisted.enqueueSystemEventSpy;
+const execApprovalHoisted = vi.hoisted(() => ({
+  resolveExecApprovalSpy: vi.fn(async () => undefined),
+}));
+export const resolveExecApprovalSpy = execApprovalHoisted.resolveExecApprovalSpy;
 
 vi.doMock("openclaw/plugin-sdk/channel-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-runtime")>();
@@ -415,6 +419,9 @@ export const telegramBotDepsForTest: TelegramBotDeps = {
   listSkillCommandsForAgents:
     listSkillCommandsForAgents as TelegramBotDeps["listSkillCommandsForAgents"],
   wasSentByBot: wasSentByBot as TelegramBotDeps["wasSentByBot"],
+  resolveExecApproval: resolveExecApprovalSpy as NonNullable<
+    TelegramBotDeps["resolveExecApproval"]
+  >,
 };
 
 vi.doMock("./bot.runtime.js", () => telegramBotRuntimeForTest);
@@ -508,6 +515,8 @@ beforeEach(() => {
     await opts?.onReplyStart?.();
     return undefined;
   });
+  resolveExecApprovalSpy.mockReset();
+  resolveExecApprovalSpy.mockResolvedValue(undefined);
   dispatchReplyWithBufferedBlockDispatcher.mockReset();
   dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
     async (params: DispatchReplyHarnessParams) =>

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -21,6 +21,7 @@ const {
   listSkillCommandsForAgents,
   onSpy,
   replySpy,
+  resolveExecApprovalSpy,
   sendMessageSpy,
   setMyCommandsSpy,
   telegramBotDepsForTest,
@@ -366,6 +367,7 @@ describe("createTelegramBot", () => {
     onSpy.mockClear();
     editMessageReplyMarkupSpy.mockClear();
     editMessageTextSpy.mockClear();
+    resolveExecApprovalSpy.mockClear();
 
     loadConfig.mockReturnValue({
       channels: {
@@ -417,6 +419,23 @@ describe("createTelegramBot", () => {
     expect(chatId).toBe(1234);
     expect(messageId).toBe(21);
     expect(replyMarkup).toEqual({ reply_markup: { inline_keyboard: [] } });
+    expect(resolveExecApprovalSpy).toHaveBeenCalledWith({
+      cfg: expect.objectContaining({
+        channels: expect.objectContaining({
+          telegram: expect.objectContaining({
+            execApprovals: expect.objectContaining({
+              enabled: true,
+              approvers: ["9"],
+              target: "dm",
+            }),
+          }),
+        }),
+      }),
+      approvalId: "138e9b8c",
+      decision: "allow-once",
+      senderId: "9",
+    });
+    expect(replySpy).not.toHaveBeenCalled();
     expect(editMessageTextSpy).not.toHaveBeenCalled();
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-style");
   });
@@ -466,10 +485,72 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-capability-free");
   });
 
+  it("resolves plugin approval callbacks through the shared approval resolver", async () => {
+    onSpy.mockClear();
+    editMessageReplyMarkupSpy.mockClear();
+    editMessageTextSpy.mockClear();
+    resolveExecApprovalSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          execApprovals: {
+            enabled: true,
+            approvers: ["9"],
+            target: "dm",
+          },
+        },
+      },
+    });
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    expect(callbackHandler).toBeDefined();
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-plugin-approve",
+        data: "/approve plugin:138e9b8c allow-once",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 24,
+          text: "Plugin approval required.",
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(resolveExecApprovalSpy).toHaveBeenCalledWith({
+      cfg: expect.objectContaining({
+        channels: expect.objectContaining({
+          telegram: expect.objectContaining({
+            execApprovals: expect.objectContaining({
+              enabled: true,
+              approvers: ["9"],
+              target: "dm",
+            }),
+          }),
+        }),
+      }),
+      approvalId: "plugin:138e9b8c",
+      decision: "allow-once",
+      senderId: "9",
+    });
+    expect(editMessageReplyMarkupSpy).toHaveBeenCalledTimes(1);
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-plugin-approve");
+  });
+
   it("blocks approval callbacks from telegram users who are not exec approvers", async () => {
     onSpy.mockClear();
     editMessageReplyMarkupSpy.mockClear();
     editMessageTextSpy.mockClear();
+    resolveExecApprovalSpy.mockClear();
 
     loadConfig.mockReturnValue({
       channels: {
@@ -508,7 +589,68 @@ describe("createTelegramBot", () => {
 
     expect(editMessageReplyMarkupSpy).not.toHaveBeenCalled();
     expect(editMessageTextSpy).not.toHaveBeenCalled();
+    expect(resolveExecApprovalSpy).not.toHaveBeenCalled();
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-blocked");
+  });
+
+  it("allows exec approval callbacks from target-only Telegram recipients", async () => {
+    onSpy.mockClear();
+    editMessageReplyMarkupSpy.mockClear();
+    editMessageTextSpy.mockClear();
+    resolveExecApprovalSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "telegram", to: "9" }],
+        },
+      },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    });
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    expect(callbackHandler).toBeDefined();
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-approve-target",
+        data: "/approve 138e9b8c allow-once",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 23,
+          text: "Approval required.",
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(resolveExecApprovalSpy).toHaveBeenCalledWith({
+      cfg: expect.objectContaining({
+        approvals: expect.objectContaining({
+          exec: expect.objectContaining({
+            enabled: true,
+            mode: "targets",
+          }),
+        }),
+      }),
+      approvalId: "138e9b8c",
+      decision: "allow-once",
+      senderId: "9",
+    });
+    expect(editMessageReplyMarkupSpy).toHaveBeenCalledTimes(1);
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-target");
   });
 
   it("keeps plugin approval callback buttons for target-only recipients", async () => {

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -216,6 +216,7 @@ describe("createTelegramBot", () => {
   it("blocks callback_query when inline buttons are allowlist-only and sender not authorized", async () => {
     onSpy.mockClear();
     replySpy.mockClear();
+    sendMessageSpy.mockClear();
 
     createTelegramBot({
       token: "tok",
@@ -433,6 +434,7 @@ describe("createTelegramBot", () => {
       }),
       approvalId: "138e9b8c",
       decision: "allow-once",
+      allowPluginFallback: true,
       senderId: "9",
     });
     expect(replySpy).not.toHaveBeenCalled();
@@ -540,6 +542,7 @@ describe("createTelegramBot", () => {
       }),
       approvalId: "plugin:138e9b8c",
       decision: "allow-once",
+      allowPluginFallback: true,
       senderId: "9",
     });
     expect(editMessageReplyMarkupSpy).toHaveBeenCalledTimes(1);
@@ -647,10 +650,80 @@ describe("createTelegramBot", () => {
       }),
       approvalId: "138e9b8c",
       decision: "allow-once",
+      allowPluginFallback: false,
       senderId: "9",
     });
     expect(editMessageReplyMarkupSpy).toHaveBeenCalledTimes(1);
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-target");
+  });
+
+  it("does not allow target-only recipients to use legacy plugin fallback ids", async () => {
+    onSpy.mockClear();
+    editMessageReplyMarkupSpy.mockClear();
+    editMessageTextSpy.mockClear();
+    resolveExecApprovalSpy.mockClear();
+    replySpy.mockClear();
+    resolveExecApprovalSpy.mockRejectedValueOnce(new Error("unknown or expired approval id"));
+
+    loadConfig.mockReturnValue({
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "telegram", to: "9" }],
+        },
+      },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    });
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    expect(callbackHandler).toBeDefined();
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-legacy-plugin-fallback-blocked",
+        data: "/approve 138e9b8c allow-once",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 25,
+          text: "Legacy plugin approval required.",
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(resolveExecApprovalSpy).toHaveBeenCalledWith({
+      cfg: expect.objectContaining({
+        approvals: expect.objectContaining({
+          exec: expect.objectContaining({
+            enabled: true,
+            mode: "targets",
+          }),
+        }),
+      }),
+      approvalId: "138e9b8c",
+      decision: "allow-once",
+      allowPluginFallback: false,
+      senderId: "9",
+    });
+    expect(editMessageReplyMarkupSpy).not.toHaveBeenCalled();
+    expect(replySpy).not.toHaveBeenCalled();
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      1234,
+      "❌ Failed to submit approval: Error: unknown or expired approval id",
+      undefined,
+    );
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-legacy-plugin-fallback-blocked");
   });
 
   it("keeps plugin approval callback buttons for target-only recipients", async () => {

--- a/extensions/telegram/src/button-types.test.ts
+++ b/extensions/telegram/src/button-types.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { buildTelegramInteractiveButtons, resolveTelegramInlineButtons } from "./button-types.js";
+
+describe("buildTelegramInteractiveButtons", () => {
+  it("maps shared buttons and selects into Telegram inline rows", () => {
+    expect(
+      buildTelegramInteractiveButtons({
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              { label: "Approve", value: "approve", style: "success" },
+              { label: "Reject", value: "reject", style: "danger" },
+              { label: "Later", value: "later" },
+              { label: "Archive", value: "archive" },
+            ],
+          },
+          {
+            type: "select",
+            options: [{ label: "Alpha", value: "alpha" }],
+          },
+        ],
+      }),
+    ).toEqual([
+      [
+        { text: "Approve", callback_data: "approve", style: "success" },
+        { text: "Reject", callback_data: "reject", style: "danger" },
+        { text: "Later", callback_data: "later", style: undefined },
+      ],
+      [{ text: "Archive", callback_data: "archive", style: undefined }],
+      [{ text: "Alpha", callback_data: "alpha", style: undefined }],
+    ]);
+  });
+
+  it("drops buttons whose callback payload exceeds Telegram limits", () => {
+    expect(
+      buildTelegramInteractiveButtons({
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              { label: "Keep", value: "ok" },
+              { label: "Drop", value: `x${"y".repeat(80)}` },
+            ],
+          },
+        ],
+      }),
+    ).toEqual([[{ text: "Keep", callback_data: "ok", style: undefined }]]);
+  });
+});
+
+describe("resolveTelegramInlineButtons", () => {
+  it("prefers explicit buttons over shared interactive blocks", () => {
+    const explicit = [[{ text: "Keep", callback_data: "keep" }]] as const;
+
+    expect(
+      resolveTelegramInlineButtons({
+        buttons: explicit,
+        interactive: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ label: "Override", value: "override" }],
+            },
+          ],
+        },
+      }),
+    ).toBe(explicit);
+  });
+
+  it("derives buttons from raw interactive payloads", () => {
+    expect(
+      resolveTelegramInlineButtons({
+        interactive: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ label: "Retry", value: "retry", style: "primary" }],
+            },
+          ],
+        },
+      }),
+    ).toEqual([[{ text: "Retry", callback_data: "retry", style: "primary" }]]);
+  });
+});

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -49,6 +49,7 @@ import {
   listTelegramDirectoryGroupsFromConfig,
   listTelegramDirectoryPeersFromConfig,
 } from "./directory-config.js";
+import { buildTelegramExecApprovalPendingPayload } from "./exec-approval-forwarding.js";
 import {
   getTelegramExecApprovalApprovers,
   isTelegramExecApprovalApprover,
@@ -595,6 +596,12 @@ export const telegramPlugin = createChatChannelPlugin({
     auth: telegramNativeApprovalAdapter.auth,
     approvals: {
       delivery: telegramNativeApprovalAdapter.delivery,
+      render: {
+        exec: {
+          buildPendingPayload: ({ request, nowMs }) =>
+            buildTelegramExecApprovalPendingPayload({ request, nowMs }),
+        },
+      },
     },
     directory: createChannelDirectoryAdapter({
       listPeers: async (params) => listTelegramDirectoryPeersFromConfig(params),

--- a/extensions/telegram/src/exec-approval-resolver.test.ts
+++ b/extensions/telegram/src/exec-approval-resolver.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const gatewayRuntimeHoisted = vi.hoisted(() => ({
+  requestSpy: vi.fn(),
+  startSpy: vi.fn(),
+  stopSpy: vi.fn(),
+  stopAndWaitSpy: vi.fn(async () => undefined),
+  createClientSpy: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/gateway-runtime", () => ({
+  createOperatorApprovalsGatewayClient: gatewayRuntimeHoisted.createClientSpy,
+}));
+
+describe("resolveTelegramExecApproval", () => {
+  beforeEach(() => {
+    gatewayRuntimeHoisted.requestSpy.mockReset();
+    gatewayRuntimeHoisted.startSpy.mockReset();
+    gatewayRuntimeHoisted.stopSpy.mockReset();
+    gatewayRuntimeHoisted.stopAndWaitSpy.mockReset().mockResolvedValue(undefined);
+    gatewayRuntimeHoisted.createClientSpy.mockReset().mockImplementation((opts) => ({
+      start: () => {
+        gatewayRuntimeHoisted.startSpy();
+        opts.onHelloOk?.();
+      },
+      request: gatewayRuntimeHoisted.requestSpy,
+      stop: gatewayRuntimeHoisted.stopSpy,
+      stopAndWait: gatewayRuntimeHoisted.stopAndWaitSpy,
+    }));
+  });
+
+  it("routes plugin approval ids through plugin.approval.resolve", async () => {
+    const { resolveTelegramExecApproval } = await import("./exec-approval-resolver.js");
+
+    await resolveTelegramExecApproval({
+      cfg: {} as never,
+      approvalId: "plugin:abc123",
+      decision: "allow-once",
+      senderId: "9",
+    });
+
+    expect(gatewayRuntimeHoisted.requestSpy).toHaveBeenCalledWith("plugin.approval.resolve", {
+      id: "plugin:abc123",
+      decision: "allow-once",
+    });
+  });
+
+  it("falls back to plugin.approval.resolve when exec approval ids are unknown", async () => {
+    gatewayRuntimeHoisted.requestSpy
+      .mockRejectedValueOnce(new Error("unknown or expired approval id"))
+      .mockResolvedValueOnce(undefined);
+    const { resolveTelegramExecApproval } = await import("./exec-approval-resolver.js");
+
+    await resolveTelegramExecApproval({
+      cfg: {} as never,
+      approvalId: "legacy-plugin-123",
+      decision: "allow-always",
+      senderId: "9",
+    });
+
+    expect(gatewayRuntimeHoisted.requestSpy).toHaveBeenNthCalledWith(1, "exec.approval.resolve", {
+      id: "legacy-plugin-123",
+      decision: "allow-always",
+    });
+    expect(gatewayRuntimeHoisted.requestSpy).toHaveBeenNthCalledWith(
+      2,
+      "plugin.approval.resolve",
+      {
+        id: "legacy-plugin-123",
+        decision: "allow-always",
+      },
+    );
+  });
+
+  it("falls back to plugin.approval.resolve for structured approval-not-found errors", async () => {
+    const err = new Error("invalid request") as Error & {
+      gatewayCode?: string;
+      details?: { reason?: string };
+    };
+    err.gatewayCode = "INVALID_REQUEST";
+    err.details = { reason: "APPROVAL_NOT_FOUND" };
+    gatewayRuntimeHoisted.requestSpy.mockRejectedValueOnce(err).mockResolvedValueOnce(undefined);
+    const { resolveTelegramExecApproval } = await import("./exec-approval-resolver.js");
+
+    await resolveTelegramExecApproval({
+      cfg: {} as never,
+      approvalId: "legacy-plugin-123",
+      decision: "deny",
+      senderId: "9",
+    });
+
+    expect(gatewayRuntimeHoisted.requestSpy).toHaveBeenNthCalledWith(1, "exec.approval.resolve", {
+      id: "legacy-plugin-123",
+      decision: "deny",
+    });
+    expect(gatewayRuntimeHoisted.requestSpy).toHaveBeenNthCalledWith(
+      2,
+      "plugin.approval.resolve",
+      {
+        id: "legacy-plugin-123",
+        decision: "deny",
+      },
+    );
+  });
+});

--- a/extensions/telegram/src/exec-approval-resolver.ts
+++ b/extensions/telegram/src/exec-approval-resolver.ts
@@ -1,0 +1,102 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { createOperatorApprovalsGatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
+import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/infra-runtime";
+
+export type ResolveTelegramExecApprovalParams = {
+  cfg: OpenClawConfig;
+  approvalId: string;
+  decision: ExecApprovalReplyDecision;
+  senderId?: string | null;
+  gatewayUrl?: string;
+};
+
+export async function resolveTelegramExecApproval(
+  params: ResolveTelegramExecApprovalParams,
+): Promise<void> {
+  const isApprovalNotFoundError = (err: unknown): boolean => {
+    if (!(err instanceof Error)) {
+      return false;
+    }
+    const gatewayCode = (err as { gatewayCode?: unknown }).gatewayCode;
+    if (gatewayCode === "APPROVAL_NOT_FOUND") {
+      return true;
+    }
+    const details = (err as { details?: unknown }).details;
+    if (
+      gatewayCode === "INVALID_REQUEST" &&
+      details &&
+      typeof details === "object" &&
+      !Array.isArray(details) &&
+      (details as { reason?: unknown }).reason === "APPROVAL_NOT_FOUND"
+    ) {
+      return true;
+    }
+    return /unknown or expired approval id/i.test(err.message);
+  };
+
+  let readySettled = false;
+  let resolveReady!: () => void;
+  let rejectReady!: (err: unknown) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  const markReady = () => {
+    if (readySettled) {
+      return;
+    }
+    readySettled = true;
+    resolveReady();
+  };
+  const failReady = (err: unknown) => {
+    if (readySettled) {
+      return;
+    }
+    readySettled = true;
+    rejectReady(err);
+  };
+
+  const gatewayClient = await createOperatorApprovalsGatewayClient({
+    config: params.cfg,
+    gatewayUrl: params.gatewayUrl,
+    clientDisplayName: `Telegram approval (${params.senderId?.trim() || "unknown"})`,
+    onHelloOk: () => {
+      markReady();
+    },
+    onConnectError: (err) => {
+      failReady(err);
+    },
+    onClose: (code, reason) => {
+      // Once onHelloOk resolves `ready`, in-flight request failures must come from
+      // gatewayClient.request() itself; failReady only covers the pre-ready phase.
+      failReady(new Error(`gateway closed (${code}): ${reason}`));
+    },
+  });
+
+  try {
+    gatewayClient.start();
+    await ready;
+    const requestApproval = async (method: "exec.approval.resolve" | "plugin.approval.resolve") => {
+      await gatewayClient.request(method, {
+        id: params.approvalId,
+        decision: params.decision,
+      });
+    };
+    if (params.approvalId.startsWith("plugin:")) {
+      await requestApproval("plugin.approval.resolve");
+    } else {
+      try {
+        await requestApproval("exec.approval.resolve");
+      } catch (err) {
+        if (!isApprovalNotFoundError(err)) {
+          throw err;
+        }
+        await requestApproval("plugin.approval.resolve");
+      }
+    }
+  } finally {
+    await gatewayClient.stopAndWait().catch(() => {
+      gatewayClient.stop();
+    });
+  }
+}

--- a/extensions/telegram/src/exec-approval-resolver.ts
+++ b/extensions/telegram/src/exec-approval-resolver.ts
@@ -7,6 +7,7 @@ export type ResolveTelegramExecApprovalParams = {
   approvalId: string;
   decision: ExecApprovalReplyDecision;
   senderId?: string | null;
+  allowPluginFallback?: boolean;
   gatewayUrl?: string;
 };
 
@@ -88,7 +89,7 @@ export async function resolveTelegramExecApproval(
       try {
         await requestApproval("exec.approval.resolve");
       } catch (err) {
-        if (!isApprovalNotFoundError(err)) {
+        if (!params.allowPluginFallback || !isApprovalNotFoundError(err)) {
           throw err;
         }
         await requestApproval("plugin.approval.resolve");

--- a/extensions/telegram/src/exec-approvals-handler.test.ts
+++ b/extensions/telegram/src/exec-approvals-handler.test.ts
@@ -1,5 +1,5 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../src/config/config.js";
 import { TelegramExecApprovalHandler } from "./exec-approvals-handler.js";
 
 const baseRequest = {
@@ -75,16 +75,17 @@ describe("TelegramExecApprovalHandler", () => {
             {
               text: "Allow Once",
               callback_data: "/approve 9f1c7d5d-b1fb-46ef-ac45-662723b65bb7 allow-once",
+              style: "success",
             },
             {
               text: "Allow Always",
               callback_data: "/approve 9f1c7d5d-b1fb-46ef-ac45-662723b65bb7 always",
+              style: "primary",
             },
-          ],
-          [
             {
               text: "Deny",
               callback_data: "/approve 9f1c7d5d-b1fb-46ef-ac45-662723b65bb7 deny",
+              style: "danger",
             },
           ],
         ],

--- a/extensions/telegram/src/exec-approvals-handler.ts
+++ b/extensions/telegram/src/exec-approvals-handler.ts
@@ -1,20 +1,21 @@
-import {
-  buildExecApprovalPendingReplyPayload,
-  resolveExecApprovalCommandDisplay,
-  resolveExecApprovalSessionTarget,
-  type ExecApprovalPendingReplyParams,
-  type ExecApprovalRequest,
-  type ExecApprovalResolved,
-} from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
-import { createOperatorApprovalsGatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
-import type { EventFrame } from "openclaw/plugin-sdk/gateway-runtime";
+import {
+  createExecApprovalChannelRuntime,
+  type ExecApprovalChannelRuntime,
+} from "openclaw/plugin-sdk/infra-runtime";
+import { resolveExecApprovalCommandDisplay } from "openclaw/plugin-sdk/infra-runtime";
+import {
+  buildExecApprovalInteractiveReply,
+  buildExecApprovalPendingReplyPayload,
+  type ExecApprovalPendingReplyParams,
+} from "openclaw/plugin-sdk/infra-runtime";
+import { resolveExecApprovalSessionTarget } from "openclaw/plugin-sdk/infra-runtime";
+import type { ExecApprovalRequest, ExecApprovalResolved } from "openclaw/plugin-sdk/infra-runtime";
 import { normalizeAccountId, parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { compileSafeRegex, testRegexWithBoundedInput } from "openclaw/plugin-sdk/security-runtime";
-import { buildTelegramExecApprovalButtons } from "./approval-buttons.js";
+import { resolveTelegramInlineButtons } from "./button-types.js";
 import {
   getTelegramExecApprovalApprovers,
   resolveTelegramExecApprovalConfig,
@@ -27,11 +28,6 @@ const log = createSubsystemLogger("telegram/exec-approvals");
 type PendingMessage = {
   chatId: string;
   messageId: string;
-};
-
-type PendingApproval = {
-  timeoutId: NodeJS.Timeout;
-  messages: PendingMessage[];
 };
 
 type TelegramApprovalTarget = {
@@ -185,9 +181,7 @@ function dedupeTargets(targets: TelegramApprovalTarget[]): TelegramApprovalTarge
 }
 
 export class TelegramExecApprovalHandler {
-  private gatewayClient: GatewayClient | null = null;
-  private pending = new Map<string, PendingApproval>();
-  private started = false;
+  private readonly runtime: ExecApprovalChannelRuntime;
   private readonly nowMs: () => number;
   private readonly sendTyping: typeof sendTypingTelegram;
   private readonly sendMessage: typeof sendMessageTelegram;
@@ -201,6 +195,28 @@ export class TelegramExecApprovalHandler {
     this.sendTyping = deps.sendTyping ?? sendTypingTelegram;
     this.sendMessage = deps.sendMessage ?? sendMessageTelegram;
     this.editReplyMarkup = deps.editReplyMarkup ?? editMessageReplyMarkupTelegram;
+    this.runtime = createExecApprovalChannelRuntime<PendingMessage>({
+      label: "telegram/exec-approvals",
+      clientDisplayName: `Telegram Exec Approvals (${this.opts.accountId})`,
+      cfg: this.opts.cfg,
+      gatewayUrl: this.opts.gatewayUrl,
+      nowMs: this.nowMs,
+      isConfigured: () =>
+        isHandlerConfigured({ cfg: this.opts.cfg, accountId: this.opts.accountId }),
+      shouldHandle: (request) =>
+        matchesFilters({
+          cfg: this.opts.cfg,
+          accountId: this.opts.accountId,
+          request,
+        }),
+      deliverRequested: async (request) => await this.deliverRequested(request),
+      finalizeResolved: async ({ resolved, entries }) => {
+        await this.finalizeResolved(resolved, entries);
+      },
+      finalizeExpired: async ({ entries }) => {
+        await this.clearPending(entries);
+      },
+    });
   }
 
   shouldHandle(request: ExecApprovalRequest): boolean {
@@ -212,45 +228,18 @@ export class TelegramExecApprovalHandler {
   }
 
   async start(): Promise<void> {
-    if (this.started) {
-      return;
-    }
-    this.started = true;
-
-    if (!isHandlerConfigured({ cfg: this.opts.cfg, accountId: this.opts.accountId })) {
-      return;
-    }
-
-    this.gatewayClient = await createOperatorApprovalsGatewayClient({
-      config: this.opts.cfg,
-      gatewayUrl: this.opts.gatewayUrl,
-      clientDisplayName: `Telegram Exec Approvals (${this.opts.accountId})`,
-      onEvent: (evt) => this.handleGatewayEvent(evt),
-      onConnectError: (err) => {
-        log.error(`telegram exec approvals: connect error: ${err.message}`);
-      },
-    });
-    this.gatewayClient.start();
+    await this.runtime.start();
   }
 
   async stop(): Promise<void> {
-    if (!this.started) {
-      return;
-    }
-    this.started = false;
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timeoutId);
-    }
-    this.pending.clear();
-    this.gatewayClient?.stop();
-    this.gatewayClient = null;
+    await this.runtime.stop();
   }
 
   async handleRequested(request: ExecApprovalRequest): Promise<void> {
-    if (!this.shouldHandle(request)) {
-      return;
-    }
+    await this.runtime.handleRequested(request);
+  }
 
+  private async deliverRequested(request: ExecApprovalRequest): Promise<PendingMessage[]> {
     const targetMode = resolveTelegramExecApprovalTarget({
       cfg: this.opts.cfg,
       accountId: this.opts.accountId,
@@ -280,7 +269,7 @@ export class TelegramExecApprovalHandler {
 
     const resolvedTargets = dedupeTargets(targets);
     if (resolvedTargets.length === 0) {
-      return;
+      return [];
     }
 
     const payloadParams: ExecApprovalPendingReplyParams = {
@@ -294,8 +283,15 @@ export class TelegramExecApprovalHandler {
       expiresAtMs: request.expiresAtMs,
       nowMs: this.nowMs(),
     };
-    const payload = buildExecApprovalPendingReplyPayload(payloadParams);
-    const buttons = buildTelegramExecApprovalButtons(request.id);
+    const payload = {
+      ...buildExecApprovalPendingReplyPayload(payloadParams),
+      interactive: buildExecApprovalInteractiveReply({
+        approvalCommandId: request.id,
+      }),
+    };
+    const buttons = resolveTelegramInlineButtons({
+      interactive: payload.interactive,
+    });
     const sentMessages: PendingMessage[] = [];
 
     for (const target of resolvedTargets) {
@@ -322,33 +318,23 @@ export class TelegramExecApprovalHandler {
         log.error(`telegram exec approvals: failed to send request ${request.id}: ${String(err)}`);
       }
     }
-
-    if (sentMessages.length === 0) {
-      return;
-    }
-
-    const timeoutMs = Math.max(0, request.expiresAtMs - this.nowMs());
-    const timeoutId = setTimeout(() => {
-      void this.handleResolved({ id: request.id, decision: "deny", ts: Date.now() });
-    }, timeoutMs);
-    timeoutId.unref?.();
-
-    this.pending.set(request.id, {
-      timeoutId,
-      messages: sentMessages,
-    });
+    return sentMessages;
   }
 
   async handleResolved(resolved: ExecApprovalResolved): Promise<void> {
-    const pending = this.pending.get(resolved.id);
-    if (!pending) {
-      return;
-    }
-    clearTimeout(pending.timeoutId);
-    this.pending.delete(resolved.id);
+    await this.runtime.handleResolved(resolved);
+  }
 
+  private async finalizeResolved(
+    _resolved: ExecApprovalResolved,
+    messages: PendingMessage[],
+  ): Promise<void> {
+    await this.clearPending(messages);
+  }
+
+  private async clearPending(messages: PendingMessage[]): Promise<void> {
     await Promise.allSettled(
-      pending.messages.map(async (message) => {
+      messages.map(async (message) => {
         await this.editReplyMarkup(message.chatId, message.messageId, [], {
           cfg: this.opts.cfg,
           token: this.opts.token,
@@ -356,15 +342,5 @@ export class TelegramExecApprovalHandler {
         });
       }),
     );
-  }
-
-  private handleGatewayEvent(evt: EventFrame): void {
-    if (evt.event === "exec.approval.requested") {
-      void this.handleRequested(evt.payload as ExecApprovalRequest);
-      return;
-    }
-    if (evt.event === "exec.approval.resolved") {
-      void this.handleResolved(evt.payload as ExecApprovalResolved);
-    }
   }
 }

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -1,3 +1,7 @@
+import {
+  isTelegramExecApprovalAuthorizedSender,
+  isTelegramExecApprovalClientEnabled,
+} from "../../../extensions/telegram/api.js";
 import { callGateway } from "../../gateway/call.js";
 import { ErrorCodes } from "../../gateway/protocol/index.js";
 import { logVerbose } from "../../globals.js";
@@ -70,6 +74,17 @@ function buildResolvedByLabel(params: Parameters<CommandHandler>[0]): string {
   return `${channel}:${sender}`;
 }
 
+function isAuthorizedTelegramExecSender(params: Parameters<CommandHandler>[0]): boolean {
+  if (params.command.channel !== "telegram") {
+    return false;
+  }
+  return isTelegramExecApprovalAuthorizedSender({
+    cfg: params.cfg,
+    accountId: params.ctx.AccountId,
+    senderId: params.command.senderId,
+  });
+}
+
 function readErrorCode(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value : null;
 }
@@ -112,29 +127,58 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
   if (!parsed) {
     return null;
   }
-  if (!params.command.isAuthorizedSender) {
+  if (!parsed.ok) {
+    return { shouldContinue: false, reply: { text: parsed.error } };
+  }
+
+  const isPluginId = parsed.id.startsWith("plugin:");
+  const telegramExecAuthorizedSender = isAuthorizedTelegramExecSender(params);
+  const execApprovalAuthorization = resolveApprovalCommandAuthorization({
+    cfg: params.cfg,
+    channel: params.command.channel,
+    accountId: params.ctx.AccountId,
+    senderId: params.command.senderId,
+    kind: "exec",
+  });
+  const pluginApprovalAuthorization = resolveApprovalCommandAuthorization({
+    cfg: params.cfg,
+    channel: params.command.channel,
+    accountId: params.ctx.AccountId,
+    senderId: params.command.senderId,
+    kind: "plugin",
+  });
+  const hasExplicitApprovalAuthorization =
+    (execApprovalAuthorization.explicit && execApprovalAuthorization.authorized) ||
+    (pluginApprovalAuthorization.explicit && pluginApprovalAuthorization.authorized);
+  if (
+    !params.command.isAuthorizedSender &&
+    !hasExplicitApprovalAuthorization
+  ) {
     logVerbose(
       `Ignoring /approve from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
     );
     return { shouldContinue: false };
   }
 
-  if (!parsed.ok) {
-    return { shouldContinue: false, reply: { text: parsed.error } };
+  if (
+    params.command.channel === "telegram" &&
+    !isPluginId &&
+    !telegramExecAuthorizedSender &&
+    !isTelegramExecApprovalClientEnabled({ cfg: params.cfg, accountId: params.ctx.AccountId })
+  ) {
+    return {
+      shouldContinue: false,
+      reply: { text: "❌ Telegram exec approvals are not enabled for this bot account." },
+    };
   }
-  const isPluginId = parsed.id.startsWith("plugin:");
-  const approvalAuthorization = resolveApprovalCommandAuthorization({
-    cfg: params.cfg,
-    channel: params.command.channel,
-    accountId: params.ctx.AccountId,
-    senderId: params.command.senderId,
-    kind: isPluginId ? "plugin" : "exec",
-  });
-  if (!approvalAuthorization.authorized) {
+
+  if (isPluginId && !pluginApprovalAuthorization.authorized) {
     return {
       shouldContinue: false,
       reply: {
-        text: approvalAuthorization.reason ?? "❌ You are not authorized to approve this request.",
+        text:
+          pluginApprovalAuthorization.reason ??
+          "❌ You are not authorized to approve this request.",
       },
     };
   }
@@ -160,7 +204,7 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
   };
 
   // Plugin approval IDs are kind-prefixed (`plugin:<uuid>`); route directly when detected.
-  // Unprefixed IDs try exec first, then fall back to plugin for backward compat.
+  // Unprefixed IDs try the authorized path first, then fall back for backward compat.
   if (isPluginId) {
     try {
       await callApprovalMethod("plugin.approval.resolve");
@@ -170,19 +214,12 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
         reply: { text: `❌ Failed to submit approval: ${String(err)}` },
       };
     }
-  } else {
+  } else if (execApprovalAuthorization.authorized) {
     try {
       await callApprovalMethod("exec.approval.resolve");
     } catch (err) {
       if (isApprovalNotFoundError(err)) {
-        const pluginFallbackAuthorization = resolveApprovalCommandAuthorization({
-          cfg: params.cfg,
-          channel: params.command.channel,
-          accountId: params.ctx.AccountId,
-          senderId: params.command.senderId,
-          kind: "plugin",
-        });
-        if (!pluginFallbackAuthorization.authorized) {
+        if (!pluginApprovalAuthorization.authorized) {
           return {
             shouldContinue: false,
             reply: { text: `❌ Failed to submit approval: ${String(err)}` },
@@ -203,6 +240,28 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
         };
       }
     }
+  } else if (pluginApprovalAuthorization.authorized) {
+    try {
+      await callApprovalMethod("plugin.approval.resolve");
+    } catch (err) {
+      if (isApprovalNotFoundError(err)) {
+        return {
+          shouldContinue: false,
+          reply: { text: `❌ Failed to submit approval: ${String(err)}` },
+        };
+      }
+      return {
+        shouldContinue: false,
+        reply: { text: `❌ Failed to submit approval: ${String(err)}` },
+      };
+    }
+  } else {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: execApprovalAuthorization.reason ?? "❌ You are not authorized to approve this request.",
+      },
+    };
   }
 
   return {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -124,7 +124,6 @@ const { clearPluginCommands, registerPluginCommand } = await import("../../plugi
 const { abortEmbeddedPiRun, compactEmbeddedPiSession } =
   await import("../../agents/pi-embedded.js");
 const { __testing: subagentControlTesting } = await import("../../agents/subagent-control.js");
-const { enqueueSystemEvent } = await import("../../infra/system-events.js");
 const { resetBashChatCommandForTests } = await import("./bash-command.js");
 const { handleCompactCommand } = await import("./commands-compact.js");
 const { buildCommandsPaginationKeyboard } = await import("./commands-info.js");
@@ -379,7 +378,7 @@ describe("/approve command", () => {
 
   function createTelegramApproveCfg(
     execApprovals: {
-      enabled: boolean;
+      enabled: true;
       approvers: string[];
       target: "dm";
     } | null = { enabled: true, approvers: ["123"], target: "dm" },
@@ -390,28 +389,6 @@ describe("/approve command", () => {
         telegram: {
           allowFrom: ["*"],
           ...(execApprovals ? { execApprovals } : {}),
-        },
-      },
-    } as OpenClawConfig;
-  }
-
-  function createTelegramTargetApproveCfg(
-    targets: Array<{ channel: string; to: string; accountId?: string }> = [
-      { channel: "telegram", to: "123" },
-    ],
-  ): OpenClawConfig {
-    return {
-      commands: { text: true },
-      channels: {
-        telegram: {
-          allowFrom: ["*"],
-        },
-      },
-      approvals: {
-        exec: {
-          enabled: true,
-          mode: "targets",
-          targets,
         },
       },
     } as OpenClawConfig;
@@ -466,6 +443,25 @@ describe("/approve command", () => {
     );
   });
 
+  it("keeps /approve blocked for unauthorized senders without explicit approval auth", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { slack: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/approve abc allow-once", cfg, {
+      Provider: "slack",
+      Surface: "slack",
+      SenderId: "123",
+    });
+    params.command.isAuthorizedSender = false;
+
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply).toBeUndefined();
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
   it("accepts Telegram command mentions for /approve", async () => {
     const cfg = createTelegramApproveCfg();
     const params = buildParams("/approve@bot abc12345 allow-once", cfg, {
@@ -474,6 +470,64 @@ describe("/approve command", () => {
       Surface: "telegram",
       SenderId: "123",
     });
+
+    callGatewayMock.mockResolvedValue({ ok: true });
+
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Approval allow-once submitted");
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "exec.approval.resolve",
+        params: { id: "abc12345", decision: "allow-once" },
+      }),
+    );
+  });
+
+  it("accepts Telegram /approve from configured approvers even when chat access is otherwise blocked", async () => {
+    const cfg = createTelegramApproveCfg();
+    const params = buildParams("/approve abc12345 allow-once", cfg, {
+      Provider: "telegram",
+      Surface: "telegram",
+      SenderId: "123",
+    });
+    params.command.isAuthorizedSender = false;
+
+    callGatewayMock.mockResolvedValue({ ok: true });
+
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Approval allow-once submitted");
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "exec.approval.resolve",
+        params: { id: "abc12345", decision: "allow-once" },
+      }),
+    );
+  });
+
+  it("accepts Telegram /approve from exec target recipients even when native approvals are disabled", async () => {
+    const cfg = {
+      commands: { text: true },
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "telegram", to: "123" }],
+        },
+      },
+      channels: {
+        telegram: {
+          allowFrom: ["*"],
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildParams("/approve abc12345 allow-once", cfg, {
+      Provider: "telegram",
+      Surface: "telegram",
+      SenderId: "123",
+    });
+    params.command.isAuthorizedSender = false;
 
     callGatewayMock.mockResolvedValue({ ok: true });
 
@@ -576,6 +630,31 @@ describe("/approve command", () => {
     }
   });
 
+  it("preserves legacy unprefixed plugin approval fallback on Discord", async () => {
+    callGatewayMock.mockRejectedValueOnce(new Error("unknown or expired approval id"));
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+    const params = buildParams(
+      "/approve legacy-plugin-123 allow-once",
+      createDiscordApproveCfg({ enabled: true, approvers: ["123"], target: "channel" }),
+      {
+        Provider: "discord",
+        Surface: "discord",
+        SenderId: "123",
+      },
+    );
+
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Approval allow-once submitted");
+    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+    expect(callGatewayMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: "plugin.approval.resolve",
+        params: { id: "legacy-plugin-123", decision: "allow-once" },
+      }),
+    );
+  });
   it("requires configured Discord approvers for plugin approvals", async () => {
     for (const testCase of [
       {
@@ -616,6 +695,24 @@ describe("/approve command", () => {
     }
   });
 
+  it("returns the real plugin not-found error for authorized plugin approvers", async () => {
+    callGatewayMock.mockRejectedValueOnce(new Error("unknown or expired approval id"));
+    const params = buildParams(
+      "/approve plugin:abc123 allow-once",
+      createDiscordApproveCfg({ enabled: false, approvers: ["123"], target: "channel" }),
+      {
+        Provider: "discord",
+        Surface: "discord",
+        SenderId: "123",
+      },
+    );
+
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("unknown or expired approval id");
+    expect(result.reply?.text).not.toContain("not authorized");
+  });
+
   it("rejects unauthorized or invalid Telegram /approve variants", async () => {
     for (const testCase of [
       {
@@ -641,10 +738,7 @@ describe("/approve command", () => {
           Surface: "telegram",
           SenderId: "123",
         },
-        setup: () =>
-          callGatewayMock.mockRejectedValue(
-            gatewayError("unknown or expired approval id", "APPROVAL_NOT_FOUND"),
-          ),
+        setup: () => callGatewayMock.mockRejectedValue(new Error("unknown or expired approval id")),
         expectedText: "unknown or expired approval id",
         expectGatewayCalls: 2,
       },
@@ -658,21 +752,8 @@ describe("/approve command", () => {
           SenderId: "123",
         },
         setup: undefined,
-        expectedText: "not authorized to approve",
+        expectedText: "Telegram exec approvals are not enabled",
         expectGatewayCalls: 0,
-      },
-      {
-        name: "telegram approver with rich client disabled",
-        cfg: createTelegramApproveCfg({ enabled: false, approvers: ["123"], target: "dm" }),
-        commandBody: "/approve abc12345 allow-once",
-        ctx: {
-          Provider: "telegram",
-          Surface: "telegram",
-          SenderId: "123",
-        },
-        setup: () => callGatewayMock.mockResolvedValue({ ok: true }),
-        expectedText: "Approval allow-once submitted",
-        expectGatewayCalls: 1,
       },
       {
         name: "non approver",
@@ -696,124 +777,7 @@ describe("/approve command", () => {
       expect(result.shouldContinue, testCase.name).toBe(false);
       expect(result.reply?.text, testCase.name).toContain(testCase.expectedText);
       expect(callGatewayMock, testCase.name).toHaveBeenCalledTimes(testCase.expectGatewayCalls);
-      if (testCase.expectGatewayCalls > 0) {
-        expect(callGatewayMock, testCase.name).toHaveBeenCalledWith(
-          expect.objectContaining({
-            method: "exec.approval.resolve",
-            params: { id: "abc12345", decision: "allow-once" },
-          }),
-        );
-      }
     }
-  });
-
-  it("accepts Telegram /approve from active exec forwarding targets", async () => {
-    const cfg = createTelegramTargetApproveCfg([{ channel: "telegram", to: "tg:123" }]);
-    const params = buildParams("/approve abc12345 allow-once", cfg, {
-      Provider: "telegram",
-      Surface: "telegram",
-      SenderId: "123",
-    });
-
-    callGatewayMock.mockResolvedValue({ ok: true });
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("Approval allow-once submitted");
-    expect(callGatewayMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        method: "exec.approval.resolve",
-        params: { id: "abc12345", decision: "allow-once" },
-      }),
-    );
-  });
-
-  it("rejects Telegram plugin-prefixed IDs when no approver policy is configured", async () => {
-    const cfg = createTelegramApproveCfg(null);
-    const params = buildParams("/approve plugin:abc123 allow-once", cfg, {
-      Provider: "telegram",
-      Surface: "telegram",
-      SenderId: "123",
-    });
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("not authorized to approve plugin requests");
-    expect(callGatewayMock).toHaveBeenCalledTimes(0);
-  });
-
-  it("enforces Telegram approver policy for plugin-prefixed IDs when configured", async () => {
-    const cfg = createTelegramApproveCfg({ enabled: false, approvers: ["999"], target: "dm" });
-    const params = buildParams("/approve plugin:abc123 allow-once", cfg, {
-      Provider: "telegram",
-      Surface: "telegram",
-      SenderId: "123",
-    });
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("not authorized to approve plugin requests");
-    expect(callGatewayMock).toHaveBeenCalledTimes(0);
-  });
-
-  it("allows Telegram plugin-prefixed IDs for configured approvers even when exec approvals are disabled", async () => {
-    const cfg = createTelegramApproveCfg({ enabled: false, approvers: ["123"], target: "dm" });
-    const params = buildParams("/approve plugin:abc123 allow-once", cfg, {
-      Provider: "telegram",
-      Surface: "telegram",
-      SenderId: "123",
-    });
-
-    callGatewayMock.mockResolvedValueOnce({ ok: true });
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("Approval allow-once submitted");
-    expect(callGatewayMock).toHaveBeenCalledTimes(1);
-    expect(callGatewayMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        method: "plugin.approval.resolve",
-        params: { id: "plugin:abc123", decision: "allow-once" },
-      }),
-    );
-  });
-
-  it("keeps Telegram plugin-prefixed IDs explicit-only for exec forwarding targets", async () => {
-    const cfg = createTelegramTargetApproveCfg();
-    const params = buildParams("/approve plugin:abc123 allow-once", cfg, {
-      Provider: "telegram",
-      Surface: "telegram",
-      SenderId: "123",
-    });
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("not authorized to approve plugin requests");
-    expect(callGatewayMock).toHaveBeenCalledTimes(0);
-  });
-
-  it("does not fall back to legacy plugin approvals for Telegram target recipients", async () => {
-    const cfg = createTelegramTargetApproveCfg();
-    const params = buildParams("/approve legacy-plugin-123 allow-once", cfg, {
-      Provider: "telegram",
-      Surface: "telegram",
-      SenderId: "123",
-    });
-
-    callGatewayMock.mockRejectedValueOnce(
-      gatewayError("unknown or expired approval id", "APPROVAL_NOT_FOUND"),
-    );
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("unknown or expired approval id");
-    expect(callGatewayMock).toHaveBeenCalledTimes(1);
-    expect(callGatewayMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        method: "exec.approval.resolve",
-        params: { id: "legacy-plugin-123", decision: "allow-once" },
-      }),
-    );
   });
 
   it("enforces gateway approval scopes", async () => {
@@ -861,205 +825,6 @@ describe("/approve command", () => {
         );
       }
     }
-  });
-
-  function gatewayError(message: string, gatewayCode: string, opts?: { details?: unknown }): Error {
-    const err = new Error(message) as Error & { gatewayCode?: string; details?: unknown };
-    err.name = "GatewayClientRequestError";
-    err.gatewayCode = gatewayCode;
-    if (opts && "details" in opts) {
-      err.details = opts.details;
-    }
-    return err;
-  }
-
-  it("falls back to plugin.approval.resolve when exec approval id is unknown", async () => {
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig;
-    const params = buildParams("/approve plugin-123 allow-once", cfg, { SenderId: "123" });
-
-    callGatewayMock
-      .mockRejectedValueOnce(gatewayError("unknown or expired approval id", "APPROVAL_NOT_FOUND"))
-      .mockResolvedValueOnce({ ok: true });
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("Approval allow-once submitted");
-    expect(callGatewayMock).toHaveBeenCalledTimes(2);
-    expect(callGatewayMock).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ method: "exec.approval.resolve" }),
-    );
-    expect(callGatewayMock).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        method: "plugin.approval.resolve",
-        params: { id: "plugin-123", decision: "allow-once" },
-      }),
-    );
-  });
-
-  it("falls back to plugin.approval.resolve for INVALID_REQUEST with approval-not-found details", async () => {
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig;
-    const params = buildParams("/approve plugin-123 allow-once", cfg, { SenderId: "123" });
-
-    callGatewayMock
-      .mockRejectedValueOnce(
-        gatewayError("unknown or expired approval id", "INVALID_REQUEST", {
-          details: { reason: "APPROVAL_NOT_FOUND" },
-        }),
-      )
-      .mockResolvedValueOnce({ ok: true });
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("Approval allow-once submitted");
-    expect(callGatewayMock).toHaveBeenCalledTimes(2);
-    expect(callGatewayMock).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ method: "exec.approval.resolve" }),
-    );
-    expect(callGatewayMock).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        method: "plugin.approval.resolve",
-        params: { id: "plugin-123", decision: "allow-once" },
-      }),
-    );
-  });
-
-  it("falls back to plugin.approval.resolve for legacy message-only not-found errors", async () => {
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig;
-    const params = buildParams("/approve plugin-123 allow-once", cfg, { SenderId: "123" });
-
-    callGatewayMock
-      .mockRejectedValueOnce(
-        gatewayError("unknown or expired approval id", "INVALID_REQUEST", {
-          details: { reason: "SOMETHING_ELSE" },
-        }),
-      )
-      .mockResolvedValueOnce({ ok: true });
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("Approval allow-once submitted");
-    expect(callGatewayMock).toHaveBeenCalledTimes(2);
-    expect(callGatewayMock).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ method: "exec.approval.resolve" }),
-    );
-    expect(callGatewayMock).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        method: "plugin.approval.resolve",
-        params: { id: "plugin-123", decision: "allow-once" },
-      }),
-    );
-  });
-
-  it("supports old and new unknown-id gateway envelopes across sequential approvals", async () => {
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig;
-    const cases = [
-      {
-        id: "plugin-old-1",
-        err: gatewayError("unknown or expired approval id", "APPROVAL_NOT_FOUND"),
-      },
-      {
-        id: "plugin-new-2",
-        err: gatewayError("unknown or expired approval id", "INVALID_REQUEST", {
-          details: { reason: "APPROVAL_NOT_FOUND" },
-        }),
-      },
-    ] as const;
-
-    for (const testCase of cases) {
-      callGatewayMock.mockReset();
-      callGatewayMock.mockRejectedValueOnce(testCase.err).mockResolvedValueOnce({ ok: true });
-
-      const params = buildParams(`/approve ${testCase.id} allow-once`, cfg, { SenderId: "123" });
-      const result = await handleCommands(params);
-
-      expect(result.shouldContinue, testCase.id).toBe(false);
-      expect(result.reply?.text, testCase.id).toContain("Approval allow-once submitted");
-      expect(callGatewayMock, testCase.id).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({
-          method: "exec.approval.resolve",
-          params: { id: testCase.id, decision: "allow-once" },
-        }),
-      );
-      expect(callGatewayMock, testCase.id).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          method: "plugin.approval.resolve",
-          params: { id: testCase.id, decision: "allow-once" },
-        }),
-      );
-    }
-  });
-
-  it("surfaces plugin approval error when both exec and plugin resolve fail", async () => {
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig;
-    const params = buildParams("/approve bad-id deny", cfg, { SenderId: "123" });
-
-    callGatewayMock
-      .mockRejectedValueOnce(gatewayError("unknown or expired approval id", "APPROVAL_NOT_FOUND"))
-      .mockRejectedValueOnce(gatewayError("unknown or expired approval id", "APPROVAL_NOT_FOUND"));
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("Failed to submit approval");
-    expect(callGatewayMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("routes plugin-prefixed IDs directly to plugin.approval.resolve", async () => {
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig;
-    const params = buildParams("/approve plugin:abc-123 allow-once", cfg, { SenderId: "123" });
-
-    callGatewayMock.mockResolvedValueOnce({ ok: true });
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("Approval allow-once submitted");
-    expect(callGatewayMock).toHaveBeenCalledTimes(1);
-    expect(callGatewayMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        method: "plugin.approval.resolve",
-        params: { id: "plugin:abc-123", decision: "allow-once" },
-      }),
-    );
-  });
-
-  it("does not fall back to plugin resolve for non-id errors", async () => {
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig;
-    const params = buildParams("/approve abc allow-once", cfg, { SenderId: "123" });
-
-    callGatewayMock.mockRejectedValueOnce(new Error("gateway connection refused"));
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("gateway connection refused");
-    expect(callGatewayMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -1159,109 +924,6 @@ describe("/compact command", () => {
         agentDir,
       }),
     );
-  });
-
-  it("labels nothing-to-compact results as skipped without calling them below-threshold", async () => {
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig;
-    const params = buildParams("/compact", cfg);
-    vi.mocked(compactEmbeddedPiSession).mockResolvedValueOnce({
-      ok: false,
-      compacted: false,
-      reason: "Nothing to compact (session too small)",
-    });
-
-    const result = await handleCompactCommand(
-      {
-        ...params,
-        sessionEntry: {
-          sessionId: "session-1",
-          updatedAt: Date.now(),
-          totalTokens: 31_000,
-          contextTokens: 200_000,
-        },
-      },
-      true,
-    );
-
-    expect(result).toEqual({
-      shouldContinue: false,
-      reply: {
-        text: "⚙️ Compaction skipped: nothing compactable in this session yet • Context 31k/?",
-      },
-    });
-    expect(vi.mocked(enqueueSystemEvent)).toHaveBeenCalledWith(
-      "Compaction skipped: nothing compactable in this session yet • Context 31k/?",
-      { sessionKey: params.sessionKey },
-    );
-  });
-
-  it("formats below-threshold skip reasons with friendly copy", async () => {
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig;
-    const params = buildParams("/compact", cfg);
-    vi.mocked(compactEmbeddedPiSession).mockResolvedValueOnce({
-      ok: false,
-      compacted: false,
-      reason: "Compaction skipped: below threshold for manual compaction",
-    });
-
-    const result = await handleCompactCommand(
-      {
-        ...params,
-        sessionEntry: {
-          sessionId: "session-1",
-          updatedAt: Date.now(),
-          totalTokens: 31_000,
-          contextTokens: 200_000,
-        },
-      },
-      true,
-    );
-
-    expect(result).toEqual({
-      shouldContinue: false,
-      reply: {
-        text: "⚙️ Compaction skipped: context is below the compaction threshold • Context 31k/?",
-      },
-    });
-  });
-
-  it("keeps true compaction errors labeled as failures", async () => {
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig;
-    const params = buildParams("/compact", cfg);
-    vi.mocked(compactEmbeddedPiSession).mockResolvedValueOnce({
-      ok: false,
-      compacted: false,
-      reason: "Compaction safeguard could not resolve an API key for anthropic/claude-opus-4-6.",
-    });
-
-    const result = await handleCompactCommand(
-      {
-        ...params,
-        sessionEntry: {
-          sessionId: "session-1",
-          updatedAt: Date.now(),
-          totalTokens: 109_000,
-          contextTokens: 200_000,
-        },
-      },
-      true,
-    );
-
-    expect(result).toEqual({
-      shouldContinue: false,
-      reply: {
-        text: "⚙️ Compaction failed: Compaction safeguard could not resolve an API key for anthropic/claude-opus-4-6. • Context 109k/?",
-      },
-    });
   });
 });
 
@@ -1502,101 +1164,6 @@ describe("handleCommands owner gating for privileged show commands", () => {
       shouldContinue: false,
       reply: { text: "You are not authorized to use this command." },
     });
-  });
-});
-
-describe("handleCommands /send owner gating", () => {
-  it("blocks authorized non-owner senders from mutating session send policy", async () => {
-    const params = buildParams("/send off", {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig);
-    params.command.senderIsOwner = false;
-
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-send-policy",
-      updatedAt: Date.now(),
-      sendPolicy: "allow",
-    };
-    const sessionStore: Record<string, SessionEntry> = {
-      [params.sessionKey]: sessionEntry,
-    };
-
-    const result = await handleCommands({
-      ...params,
-      sessionEntry,
-      sessionStore,
-    });
-
-    expect(result).toEqual({ shouldContinue: false });
-    expect(sessionEntry.sendPolicy).toBe("allow");
-    expect(sessionStore[params.sessionKey]?.sendPolicy).toBe("allow");
-  });
-
-  it("allows owners to mutate session send policy", async () => {
-    const params = buildParams("/send off", {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig);
-    params.command.senderIsOwner = true;
-
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-send-policy-owner",
-      updatedAt: Date.now(),
-      sendPolicy: "allow",
-    };
-    const sessionStore: Record<string, SessionEntry> = {
-      [params.sessionKey]: sessionEntry,
-    };
-
-    const result = await handleCommands({
-      ...params,
-      sessionEntry,
-      sessionStore,
-    });
-
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("Send policy set to off");
-    expect(sessionEntry.sendPolicy).toBe("deny");
-    expect(sessionStore[params.sessionKey]?.sendPolicy).toBe("deny");
-  });
-
-  it("returns an explicit unauthorized reply for native /send from non-owners", async () => {
-    const params = buildParams(
-      "/send off",
-      {
-        commands: { text: true },
-        channels: { discord: { dm: { enabled: true, policy: "open" } } },
-      } as OpenClawConfig,
-      {
-        Provider: "discord",
-        Surface: "discord",
-        CommandSource: "native",
-      },
-    );
-    params.command.senderIsOwner = false;
-
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-send-policy-native",
-      updatedAt: Date.now(),
-      sendPolicy: "allow",
-    };
-    const sessionStore: Record<string, SessionEntry> = {
-      [params.sessionKey]: sessionEntry,
-    };
-
-    const result = await handleCommands({
-      ...params,
-      sessionEntry,
-      sessionStore,
-    });
-
-    expect(result).toEqual({
-      shouldContinue: false,
-      reply: { text: "You are not authorized to use this command." },
-    });
-    expect(sessionEntry.sendPolicy).toBe("allow");
-    expect(sessionStore[params.sessionKey]?.sendPolicy).toBe("allow");
   });
 });
 
@@ -2100,134 +1667,6 @@ describe("handleCommands /allowlist", () => {
         expect(result.reply?.text).toContain(`channels.${testCase.provider}.allowFrom`);
       });
     }
-  });
-
-  describe("operator.admin scope gating", () => {
-    it("blocks /allowlist add from internal gateway clients without operator.admin", async () => {
-      const cfg = {
-        commands: { text: true, config: true },
-        channels: { telegram: { allowFrom: ["123"] } },
-      } as OpenClawConfig;
-      const params = buildPolicyParams("/allowlist add dm channel=telegram 789", cfg, {
-        Provider: INTERNAL_MESSAGE_CHANNEL,
-        Surface: INTERNAL_MESSAGE_CHANNEL,
-        GatewayClientScopes: ["operator.write"],
-      });
-      params.command.channel = INTERNAL_MESSAGE_CHANNEL;
-
-      const result = await handleCommands(params);
-
-      expect(result.shouldContinue).toBe(false);
-      expect(result.reply?.text).toContain("requires operator.admin");
-      expect(writeConfigFileMock).not.toHaveBeenCalled();
-      expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
-    });
-
-    it("allows /allowlist add from internal gateway clients with operator.admin", async () => {
-      validateConfigObjectWithPluginsMock.mockImplementation((config: unknown) => ({
-        ok: true,
-        config,
-      }));
-      readConfigFileSnapshotMock.mockResolvedValueOnce({
-        valid: true,
-        parsed: {
-          channels: { telegram: { allowFrom: ["123"] } },
-        },
-      });
-      addChannelAllowFromStoreEntryMock.mockResolvedValueOnce({
-        changed: true,
-        allowFrom: ["123", "789"],
-      });
-
-      const cfg = {
-        commands: { text: true, config: true },
-        channels: { telegram: { allowFrom: ["123"] } },
-      } as OpenClawConfig;
-      const params = buildPolicyParams("/allowlist add dm channel=telegram 789", cfg, {
-        Provider: INTERNAL_MESSAGE_CHANNEL,
-        Surface: INTERNAL_MESSAGE_CHANNEL,
-        GatewayClientScopes: ["operator.write", "operator.admin"],
-      });
-      params.command.channel = INTERNAL_MESSAGE_CHANNEL;
-
-      const result = await handleCommands(params);
-
-      expect(result.shouldContinue).toBe(false);
-      expect(result.reply?.text).toContain("DM allowlist added");
-    });
-
-    it("blocks /allowlist remove from internal gateway clients without operator.admin", async () => {
-      const cfg = {
-        commands: { text: true, config: true },
-        channels: { telegram: { allowFrom: ["123", "789"] } },
-      } as OpenClawConfig;
-      const params = buildPolicyParams("/allowlist remove dm channel=telegram 789", cfg, {
-        Provider: INTERNAL_MESSAGE_CHANNEL,
-        Surface: INTERNAL_MESSAGE_CHANNEL,
-        GatewayClientScopes: ["operator.write"],
-      });
-      params.command.channel = INTERNAL_MESSAGE_CHANNEL;
-
-      const result = await handleCommands(params);
-
-      expect(result.shouldContinue).toBe(false);
-      expect(result.reply?.text).toContain("requires operator.admin");
-      expect(writeConfigFileMock).not.toHaveBeenCalled();
-      expect(removeChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
-    });
-
-    it("allows /allowlist remove from internal gateway clients with operator.admin", async () => {
-      validateConfigObjectWithPluginsMock.mockImplementation((config: unknown) => ({
-        ok: true,
-        config,
-      }));
-      readConfigFileSnapshotMock.mockResolvedValueOnce({
-        valid: true,
-        parsed: {
-          channels: { telegram: { allowFrom: ["123", "789"] } },
-        },
-      });
-      removeChannelAllowFromStoreEntryMock.mockResolvedValueOnce({
-        changed: true,
-        allowFrom: ["123"],
-      });
-
-      const cfg = {
-        commands: { text: true, config: true },
-        channels: { telegram: { allowFrom: ["123", "789"] } },
-      } as OpenClawConfig;
-      const params = buildPolicyParams("/allowlist remove dm channel=telegram 789", cfg, {
-        Provider: INTERNAL_MESSAGE_CHANNEL,
-        Surface: INTERNAL_MESSAGE_CHANNEL,
-        GatewayClientScopes: ["operator.write", "operator.admin"],
-      });
-      params.command.channel = INTERNAL_MESSAGE_CHANNEL;
-
-      const result = await handleCommands(params);
-
-      expect(result.shouldContinue).toBe(false);
-      expect(result.reply?.text).toContain("DM allowlist removed");
-    });
-
-    it("keeps /allowlist list accessible to internal operator.write clients", async () => {
-      readChannelAllowFromStoreMock.mockResolvedValueOnce(["456"]);
-
-      const cfg = {
-        commands: { text: true },
-        channels: { telegram: { allowFrom: ["123"] } },
-      } as OpenClawConfig;
-      const params = buildPolicyParams("/allowlist list dm channel=telegram", cfg, {
-        Provider: INTERNAL_MESSAGE_CHANNEL,
-        Surface: INTERNAL_MESSAGE_CHANNEL,
-        GatewayClientScopes: ["operator.write"],
-      });
-      params.command.channel = INTERNAL_MESSAGE_CHANNEL;
-
-      const result = await handleCommands(params);
-
-      expect(result.shouldContinue).toBe(false);
-      expect(result.reply?.text).toContain("Channel: telegram");
-    });
   });
 });
 
@@ -2796,68 +2235,6 @@ describe("handleCommands subagents", () => {
     expect(result.reply?.text).toContain("Task summary: Completed the requested task");
   });
 
-  it("does not resolve moved child rows from a stale older parent", async () => {
-    const now = Date.now();
-    const oldParentKey = "agent:main:subagent:cmd-old-parent";
-    const newParentKey = "agent:main:subagent:cmd-new-parent";
-    const childSessionKey = "agent:main:subagent:cmd-shared-child";
-    addSubagentRunForTests({
-      runId: "run-old-parent",
-      childSessionKey: oldParentKey,
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "old parent",
-      cleanup: "keep",
-      createdAt: now - 60_000,
-      startedAt: now - 60_000,
-    });
-    addSubagentRunForTests({
-      runId: "run-new-parent",
-      childSessionKey: newParentKey,
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "new parent",
-      cleanup: "keep",
-      createdAt: now - 50_000,
-      startedAt: now - 50_000,
-    });
-    addSubagentRunForTests({
-      runId: "run-child-stale-old-parent",
-      childSessionKey,
-      requesterSessionKey: oldParentKey,
-      requesterDisplayKey: oldParentKey,
-      controllerSessionKey: oldParentKey,
-      task: "stale old parent child",
-      cleanup: "keep",
-      createdAt: now - 40_000,
-      startedAt: now - 40_000,
-    });
-    addSubagentRunForTests({
-      runId: "run-child-current-new-parent",
-      childSessionKey,
-      requesterSessionKey: newParentKey,
-      requesterDisplayKey: newParentKey,
-      controllerSessionKey: newParentKey,
-      task: "current new parent child",
-      cleanup: "keep",
-      createdAt: now - 30_000,
-      startedAt: now - 30_000,
-    });
-
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-      session: { mainKey: "main", scope: "per-sender" },
-    } as OpenClawConfig;
-    const params = buildParams("/subagents info 1", cfg);
-    params.sessionKey = oldParentKey;
-    params.ctx.SessionKey = oldParentKey;
-    const result = await handleCommands(params);
-
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("Invalid subagent index: 1");
-  });
-
   it("kills subagents via /kill alias without a confirmation reply", async () => {
     addSubagentRunForTests({
       runId: "run-1",
@@ -2911,46 +2288,6 @@ describe("handleCommands subagents", () => {
     const result = await handleCommands(params);
     expect(result.shouldContinue).toBe(false);
     expect(result.reply).toBeUndefined();
-  });
-
-  it("kills descendants when numeric target 1 is an ended orchestrator still waiting on children", async () => {
-    const now = Date.now();
-    const parentKey = "agent:main:subagent:orchestrator-ended";
-    const childKey = "agent:main:subagent:orchestrator-ended:subagent:worker";
-
-    addSubagentRunForTests({
-      runId: "run-orchestrator-ended",
-      childSessionKey: parentKey,
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "orchestrate child workers",
-      cleanup: "keep",
-      createdAt: now - 120_000,
-      startedAt: now - 120_000,
-      endedAt: now - 110_000,
-      outcome: { status: "ok" },
-    });
-    addSubagentRunForTests({
-      runId: "run-orchestrator-child-active",
-      childSessionKey: childKey,
-      requesterSessionKey: parentKey,
-      requesterDisplayKey: "subagent:orchestrator-ended",
-      task: "child worker still running",
-      cleanup: "keep",
-      createdAt: now - 60_000,
-      startedAt: now - 60_000,
-    });
-
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig;
-    const params = buildParams("/kill 1", cfg);
-    const result = await handleCommands(params);
-
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply).toBeUndefined();
-    expect(getSubagentRunByChildSessionKey(childKey)?.endedAt).toBeTypeOf("number");
   });
 
   it("sends follow-up messages to finished subagents", async () => {
@@ -3119,156 +2456,6 @@ describe("handleCommands subagents", () => {
     expect(trackedRuns).toHaveLength(1);
     expect(trackedRuns[0].runId).toBe("run-steer-1");
     expect(trackedRuns[0].endedAt).toBeUndefined();
-  });
-
-  it("steers ended orchestrators that are still waiting on active descendants", async () => {
-    callGatewayMock.mockImplementation(async (opts: unknown) => {
-      const request = opts as { method?: string };
-      if (request.method === "agent") {
-        return { runId: "run-steer-ended-parent" };
-      }
-      return {};
-    });
-    const parentKey = "agent:main:subagent:orchestrator-ended";
-    const childKey = "agent:main:subagent:orchestrator-ended:subagent:child";
-    const storePath = path.join(testWorkspaceDir, "sessions-subagents-steer-ended-parent.json");
-    await updateSessionStore(storePath, (store) => {
-      store[parentKey] = {
-        sessionId: "ended-parent-session",
-        updatedAt: Date.now(),
-      };
-      store[childKey] = {
-        sessionId: "active-child-session",
-        updatedAt: Date.now(),
-      };
-    });
-    addSubagentRunForTests({
-      runId: "run-ended-parent",
-      childSessionKey: parentKey,
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "orchestrate child workers",
-      cleanup: "keep",
-      createdAt: Date.now() - 120_000,
-      startedAt: Date.now() - 120_000,
-      endedAt: Date.now() - 110_000,
-      outcome: { status: "ok" },
-    });
-    addSubagentRunForTests({
-      runId: "run-active-child",
-      childSessionKey: childKey,
-      requesterSessionKey: parentKey,
-      requesterDisplayKey: "subagent:orchestrator-ended",
-      task: "child worker still running",
-      cleanup: "keep",
-      createdAt: Date.now() - 60_000,
-      startedAt: Date.now() - 60_000,
-    });
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-      session: { store: storePath },
-    } as OpenClawConfig;
-    const params = buildParams("/steer 1 regroup around the remaining child work", cfg);
-    const result = await handleCommands(params);
-
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("steered");
-    const trackedRuns = listSubagentRunsForRequester("agent:main:main");
-    expect(trackedRuns[0].runId).toBe("run-steer-ended-parent");
-  });
-
-  it("lists ended orchestrators that are still waiting on active descendants in /agents", async () => {
-    const parentKey = "agent:main:subagent:agents-ended-parent";
-    const childKey = "agent:main:subagent:agents-ended-parent:subagent:child";
-    const storePath = path.join(testWorkspaceDir, "sessions-subagents-agents-ended-parent.json");
-    await updateSessionStore(storePath, (store) => {
-      store[parentKey] = {
-        sessionId: "agents-ended-parent-session",
-        updatedAt: Date.now(),
-      };
-      store[childKey] = {
-        sessionId: "agents-active-child-session",
-        updatedAt: Date.now(),
-      };
-    });
-    addSubagentRunForTests({
-      runId: "run-agents-ended-parent",
-      childSessionKey: parentKey,
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "orchestrate child workers",
-      cleanup: "keep",
-      createdAt: Date.now() - 120_000,
-      startedAt: Date.now() - 120_000,
-      endedAt: Date.now() - 110_000,
-      outcome: { status: "ok" },
-    });
-    addSubagentRunForTests({
-      runId: "run-agents-active-child",
-      childSessionKey: childKey,
-      requesterSessionKey: parentKey,
-      requesterDisplayKey: "subagent:agents-ended-parent",
-      task: "child worker still running",
-      cleanup: "keep",
-      createdAt: Date.now() - 60_000,
-      startedAt: Date.now() - 60_000,
-    });
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-      session: { store: storePath },
-    } as OpenClawConfig;
-    const params = buildParams("/agents", cfg);
-    const result = await handleCommands(params);
-
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("agents:");
-    expect(result.reply?.text).toContain("orchestrate child workers");
-  });
-
-  it("dedupes stale rows for the same child session in /agents", async () => {
-    const childKey = "agent:main:subagent:agents-dedupe";
-    const storePath = path.join(testWorkspaceDir, "sessions-subagents-agents-dedupe.json");
-    await updateSessionStore(storePath, (store) => {
-      store[childKey] = {
-        sessionId: "agents-dedupe-session",
-        updatedAt: Date.now(),
-      };
-    });
-    addSubagentRunForTests({
-      runId: "run-agents-dedupe-new",
-      childSessionKey: childKey,
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "current worker label",
-      cleanup: "keep",
-      createdAt: Date.now() - 10_000,
-      startedAt: Date.now() - 10_000,
-    });
-    addSubagentRunForTests({
-      runId: "run-agents-dedupe-old",
-      childSessionKey: childKey,
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "stale worker label",
-      cleanup: "keep",
-      createdAt: Date.now() - 20_000,
-      startedAt: Date.now() - 20_000,
-      endedAt: Date.now() - 15_000,
-      outcome: { status: "ok" },
-    });
-    const cfg = {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-      session: { store: storePath },
-    } as OpenClawConfig;
-    const params = buildParams("/agents", cfg);
-    const result = await handleCommands(params);
-
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("current worker label");
-    expect(result.reply?.text).not.toContain("stale worker label");
   });
 
   it("restores announce behavior when /steer replacement dispatch fails", async () => {

--- a/src/infra/channel-approval-auth.test.ts
+++ b/src/infra/channel-approval-auth.test.ts
@@ -21,7 +21,7 @@ describe("resolveApprovalCommandAuthorization", () => {
         senderId: "U123",
         kind: "exec",
       }),
-    ).toEqual({ authorized: true });
+    ).toEqual({ authorized: true, explicit: false });
   });
 
   it("delegates to the channel approval override when present", () => {
@@ -47,7 +47,7 @@ describe("resolveApprovalCommandAuthorization", () => {
         senderId: "123",
         kind: "exec",
       }),
-    ).toEqual({ authorized: true });
+    ).toEqual({ authorized: true, explicit: true });
 
     expect(
       resolveApprovalCommandAuthorization({
@@ -57,6 +57,6 @@ describe("resolveApprovalCommandAuthorization", () => {
         senderId: "123",
         kind: "plugin",
       }),
-    ).toEqual({ authorized: false, reason: "plugin denied" });
+    ).toEqual({ authorized: false, reason: "plugin denied", explicit: true });
   });
 });

--- a/src/infra/channel-approval-auth.ts
+++ b/src/infra/channel-approval-auth.ts
@@ -8,18 +8,20 @@ export function resolveApprovalCommandAuthorization(params: {
   accountId?: string | null;
   senderId?: string | null;
   kind: "exec" | "plugin";
-}): { authorized: boolean; reason?: string } {
+}): { authorized: boolean; reason?: string; explicit: boolean } {
   const channel = normalizeMessageChannel(params.channel);
   if (!channel) {
-    return { authorized: true };
+    return { authorized: true, explicit: false };
   }
-  return (
-    getChannelPlugin(channel)?.auth?.authorizeActorAction?.({
-      cfg: params.cfg,
-      accountId: params.accountId,
-      senderId: params.senderId,
-      action: "approve",
-      approvalKind: params.kind,
-    }) ?? { authorized: true }
-  );
+  const result = getChannelPlugin(channel)?.auth?.authorizeActorAction?.({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    senderId: params.senderId,
+    action: "approve",
+    approvalKind: params.kind,
+  });
+  if (!result) {
+    return { authorized: true, explicit: false };
+  }
+  return { ...result, explicit: true };
 }

--- a/src/infra/exec-approval-channel-runtime.test.ts
+++ b/src/infra/exec-approval-channel-runtime.test.ts
@@ -1,3 +1,5 @@
+import type { GatewayClient } from "../gateway/client.js";
+import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-approvals.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGatewayClientStarts = vi.hoisted(() => vi.fn());
@@ -18,6 +20,16 @@ vi.mock("../logging/subsystem.js", () => ({
 }));
 
 let createExecApprovalChannelRuntime: typeof import("./exec-approval-channel-runtime.js").createExecApprovalChannelRuntime;
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
 
 beforeEach(() => {
   mockGatewayClientStarts.mockReset();
@@ -117,9 +129,13 @@ describe("createExecApprovalChannelRuntime", () => {
   });
 
   it("finalizes approvals that resolve while delivery is still in flight", async () => {
-    const pendingDelivery = Promise.withResolvers<Array<{ id: string }>>();
+    const pendingDelivery = createDeferred<Array<{ id: string }>>();
     const finalizeResolved = vi.fn(async () => undefined);
-    const runtime = createExecApprovalChannelRuntime({
+    const runtime = createExecApprovalChannelRuntime<
+      { id: string },
+      PluginApprovalRequest,
+      PluginApprovalResolved
+    >({
       label: "test/plugin-approvals",
       clientDisplayName: "Test Plugin Approvals",
       cfg: {} as never,
@@ -203,11 +219,7 @@ describe("createExecApprovalChannelRuntime", () => {
   });
 
   it("does not leave a gateway client running when stop wins the startup race", async () => {
-    const pendingClient = Promise.withResolvers<{
-      start: () => void;
-      stop: () => void;
-      request: typeof mockGatewayClientRequests;
-    }>();
+    const pendingClient = createDeferred<GatewayClient>();
     mockCreateOperatorApprovalsGatewayClient.mockReturnValueOnce(pendingClient.promise);
     const runtime = createExecApprovalChannelRuntime({
       label: "test/exec-approvals",
@@ -237,7 +249,11 @@ describe("createExecApprovalChannelRuntime", () => {
   });
 
   it("logs async request handling failures from gateway events", async () => {
-    const runtime = createExecApprovalChannelRuntime({
+    const runtime = createExecApprovalChannelRuntime<
+      { id: string },
+      PluginApprovalRequest,
+      PluginApprovalResolved
+    >({
       label: "test/plugin-approvals",
       clientDisplayName: "Test Plugin Approvals",
       cfg: {} as never,
@@ -277,7 +293,11 @@ describe("createExecApprovalChannelRuntime", () => {
 
   it("logs async expiration handling failures", async () => {
     vi.useFakeTimers();
-    const runtime = createExecApprovalChannelRuntime({
+    const runtime = createExecApprovalChannelRuntime<
+      { id: string },
+      PluginApprovalRequest,
+      PluginApprovalResolved
+    >({
       label: "test/plugin-approvals",
       clientDisplayName: "Test Plugin Approvals",
       cfg: {} as never,
@@ -311,7 +331,11 @@ describe("createExecApprovalChannelRuntime", () => {
   it("subscribes to plugin approval events when requested", async () => {
     const deliverRequested = vi.fn(async (request) => [{ id: request.id }]);
     const finalizeResolved = vi.fn(async () => undefined);
-    const runtime = createExecApprovalChannelRuntime({
+    const runtime = createExecApprovalChannelRuntime<
+      { id: string },
+      PluginApprovalRequest,
+      PluginApprovalResolved
+    >({
       label: "test/plugin-approvals",
       clientDisplayName: "Test Plugin Approvals",
       cfg: {} as never,
@@ -362,6 +386,54 @@ describe("createExecApprovalChannelRuntime", () => {
         resolved: expect.objectContaining({ id: "plugin:abc", decision: "allow-once" }),
         entries: [{ id: "plugin:abc" }],
       });
+    });
+  });
+
+  it("clears pending state when delivery throws", async () => {
+    const deliverRequested = vi
+      .fn<() => Promise<Array<{ id: string }>>>()
+      .mockRejectedValueOnce(new Error("deliver failed"))
+      .mockResolvedValueOnce([{ id: "abc" }]);
+    const finalizeResolved = vi.fn(async () => undefined);
+    const runtime = createExecApprovalChannelRuntime({
+      label: "test/delivery-failure",
+      clientDisplayName: "Test Delivery Failure",
+      cfg: {} as never,
+      isConfigured: () => true,
+      shouldHandle: () => true,
+      deliverRequested,
+      finalizeResolved,
+    });
+
+    await expect(
+      runtime.handleRequested({
+        id: "abc",
+        request: {
+          command: "echo abc",
+        },
+        createdAtMs: 1000,
+        expiresAtMs: 2000,
+      }),
+    ).rejects.toThrow("deliver failed");
+
+    await runtime.handleRequested({
+      id: "abc",
+      request: {
+        command: "echo abc",
+      },
+      createdAtMs: 1000,
+      expiresAtMs: 2000,
+    });
+    await runtime.handleResolved({
+      id: "abc",
+      decision: "allow-once",
+      ts: 1500,
+    });
+
+    expect(finalizeResolved).toHaveBeenCalledWith({
+      request: expect.objectContaining({ id: "abc" }),
+      resolved: expect.objectContaining({ id: "abc", decision: "allow-once" }),
+      entries: [{ id: "abc" }],
     });
   });
 });

--- a/src/infra/exec-approval-channel-runtime.ts
+++ b/src/infra/exec-approval-channel-runtime.ts
@@ -127,7 +127,15 @@ export function createExecApprovalChannelRuntime<
       pendingResolution: null,
     };
     pending.set(request.id, entry);
-    const entries = await adapter.deliverRequested(request);
+    let entries: TPending[];
+    try {
+      entries = await adapter.deliverRequested(request);
+    } catch (err) {
+      if (pending.get(request.id) === entry) {
+        clearPendingEntry(request.id);
+      }
+      throw err;
+    }
     const current = pending.get(request.id);
     if (current !== entry) {
       return;


### PR DESCRIPTION
## Summary
- wire Discord and Telegram back onto the shared approval runtime for delivery, callback resolution, and typed `/approve` routing
- restore Telegram callback resolution, target-recipient approval handling, and channel-native approval button behavior
- restore Discord plugin approval delivery and resolution on top of the shared runtime

## Issues
Fixes #57154
Fixes #57339
Related: #57460

## Testing
- inherited from the stacked validation for this branch family, including:
  - pnpm test -- src/infra/channel-approval-auth.test.ts src/auto-reply/reply/commands.test.ts extensions/telegram/src/exec-approval-resolver.test.ts extensions/telegram/src/bot.test.ts extensions/telegram/src/exec-approvals-handler.test.ts src/infra/exec-approval-channel-runtime.test.ts extensions/discord/src/monitor/exec-approvals.test.ts
  - live gateway smoke: verified exec approval allow/duplicate/expire and plugin approval allow/duplicate against the local gateway on this branch family
