### PR TITLE
fix(exec): harden approval auth and account routing

### DIFF
--- a/extensions/discord/src/approval-native.ts
+++ b/extensions/discord/src/approval-native.ts
@@ -40,6 +40,7 @@ function toExecLikeRequest(request: ApprovalRequest): ExecApprovalRequest {
       turnSourceChannel: request.request.turnSourceChannel ?? undefined,
       turnSourceTo: request.request.turnSourceTo ?? undefined,
       turnSourceAccountId: request.request.turnSourceAccountId ?? undefined,
+      turnSourceThreadId: request.request.turnSourceThreadId ?? undefined,
     },
     createdAtMs: request.createdAtMs,
     expiresAtMs: request.expiresAtMs,
@@ -72,6 +73,7 @@ function resolveRequestSessionTarget(params: {
     turnSourceChannel: execLikeRequest.request.turnSourceChannel ?? undefined,
     turnSourceTo: execLikeRequest.request.turnSourceTo ?? undefined,
     turnSourceAccountId: execLikeRequest.request.turnSourceAccountId ?? undefined,
+    turnSourceThreadId: execLikeRequest.request.turnSourceThreadId ?? undefined,
   });
 }
 
@@ -83,31 +85,50 @@ function resolveDiscordOriginTarget(params: {
   const turnSourceChannel = params.request.request.turnSourceChannel?.trim().toLowerCase() || "";
   const turnSourceTo = normalizeDiscordOriginChannelId(params.request.request.turnSourceTo);
   const turnSourceAccountId = params.request.request.turnSourceAccountId?.trim() || "";
-  if (turnSourceChannel === "discord" && turnSourceTo) {
-    if (
-      params.accountId &&
-      turnSourceAccountId &&
-      normalizeAccountId(turnSourceAccountId) !== normalizeAccountId(params.accountId)
-    ) {
-      return null;
-    }
-    return { to: turnSourceTo };
+  const turnSourceTarget =
+    turnSourceChannel === "discord" && turnSourceTo
+      ? {
+          to: turnSourceTo,
+          accountId: turnSourceAccountId || undefined,
+        }
+      : null;
+  if (
+    turnSourceTarget?.accountId &&
+    params.accountId &&
+    normalizeAccountId(turnSourceTarget.accountId) !== normalizeAccountId(params.accountId)
+  ) {
+    return null;
   }
 
   const sessionTarget = resolveRequestSessionTarget(params);
-  if (!sessionTarget || sessionTarget.channel !== "discord") {
-    const channelId = extractDiscordChannelId(params.request.request.sessionKey?.trim() || null);
-    return channelId ? { to: channelId } : null;
-  }
   if (
-    params.accountId &&
+    sessionTarget?.channel === "discord" &&
     sessionTarget.accountId &&
+    params.accountId &&
     normalizeAccountId(sessionTarget.accountId) !== normalizeAccountId(params.accountId)
   ) {
     return null;
   }
-  const targetTo = normalizeDiscordOriginChannelId(sessionTarget.to);
-  return targetTo ? { to: targetTo } : null;
+  if (
+    turnSourceTarget &&
+    sessionTarget?.channel === "discord" &&
+    turnSourceTarget.to !== normalizeDiscordOriginChannelId(sessionTarget.to)
+  ) {
+    return null;
+  }
+
+  if (turnSourceTarget) {
+    return { to: turnSourceTarget.to };
+  }
+  if (sessionTarget?.channel === "discord") {
+    const targetTo = normalizeDiscordOriginChannelId(sessionTarget.to);
+    return targetTo ? { to: targetTo } : null;
+  }
+  const legacyChannelId = extractDiscordChannelId(params.request.request.sessionKey?.trim() || null);
+  if (legacyChannelId) {
+    return { to: legacyChannelId };
+  }
+  return null;
 }
 
 function resolveDiscordApproverDmTargets(params: {

--- a/extensions/telegram/src/approval-native.ts
+++ b/extensions/telegram/src/approval-native.ts
@@ -17,6 +17,7 @@ import {
 } from "./exec-approvals.js";
 
 type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type TelegramOriginTarget = { to: string; threadId?: number; accountId?: string };
 
 function isExecApprovalRequest(request: ApprovalRequest): request is ExecApprovalRequest {
   return "command" in request.request;
@@ -56,30 +57,40 @@ function resolveRequestSessionTarget(params: {
   });
 }
 
-function resolveTelegramOriginTarget(params: {
-  cfg: OpenClawConfig;
+function resolveTurnSourceTelegramOriginTarget(params: {
   accountId: string;
   request: ApprovalRequest;
-}) {
+}): TelegramOriginTarget | null {
   const turnSourceChannel = params.request.request.turnSourceChannel?.trim().toLowerCase() || "";
   const turnSourceTo = params.request.request.turnSourceTo?.trim() || "";
   const turnSourceAccountId = params.request.request.turnSourceAccountId?.trim() || "";
-  if (turnSourceChannel === "telegram" && turnSourceTo) {
-    if (
-      turnSourceAccountId &&
-      normalizeAccountId(turnSourceAccountId) !== normalizeAccountId(params.accountId)
-    ) {
-      return null;
-    }
-    const threadId =
-      typeof params.request.request.turnSourceThreadId === "number"
-        ? params.request.request.turnSourceThreadId
-        : typeof params.request.request.turnSourceThreadId === "string"
-          ? Number.parseInt(params.request.request.turnSourceThreadId, 10)
-          : undefined;
-    return { to: turnSourceTo, threadId: Number.isFinite(threadId) ? threadId : undefined };
+  if (turnSourceChannel !== "telegram" || !turnSourceTo) {
+    return null;
   }
+  if (
+    turnSourceAccountId &&
+    normalizeAccountId(turnSourceAccountId) !== normalizeAccountId(params.accountId)
+  ) {
+    return null;
+  }
+  const threadId =
+    typeof params.request.request.turnSourceThreadId === "number"
+      ? params.request.request.turnSourceThreadId
+      : typeof params.request.request.turnSourceThreadId === "string"
+        ? Number.parseInt(params.request.request.turnSourceThreadId, 10)
+        : undefined;
+  return {
+    to: turnSourceTo,
+    threadId: Number.isFinite(threadId) ? threadId : undefined,
+    accountId: turnSourceAccountId || undefined,
+  };
+}
 
+function resolveSessionTelegramOriginTarget(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  request: ApprovalRequest;
+}): TelegramOriginTarget | null {
   const sessionTarget = resolveRequestSessionTarget(params);
   if (!sessionTarget || sessionTarget.channel !== "telegram") {
     return null;
@@ -93,7 +104,30 @@ function resolveTelegramOriginTarget(params: {
   return {
     to: sessionTarget.to,
     threadId: sessionTarget.threadId,
+    accountId: sessionTarget.accountId,
   };
+}
+
+function telegramTargetsMatch(a: TelegramOriginTarget, b: TelegramOriginTarget): boolean {
+  const accountMatches =
+    !a.accountId ||
+    !b.accountId ||
+    normalizeAccountId(a.accountId) === normalizeAccountId(b.accountId);
+  return a.to === b.to && a.threadId === b.threadId && accountMatches;
+}
+
+function resolveTelegramOriginTarget(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  request: ApprovalRequest;
+}) {
+  const turnSourceTarget = resolveTurnSourceTelegramOriginTarget(params);
+  const sessionTarget = resolveSessionTelegramOriginTarget(params);
+  if (turnSourceTarget && sessionTarget && !telegramTargetsMatch(turnSourceTarget, sessionTarget)) {
+    return null;
+  }
+  const target = turnSourceTarget ?? sessionTarget;
+  return target ? { to: target.to, threadId: target.threadId } : null;
 }
 
 function resolveTelegramApproverDmTargets(params: {

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1336,11 +1336,9 @@ export const registerTelegramHandlers = ({
         const authorizedApprovalSender = isPluginApproval
           ? pluginApprovalAuthorizedSender
           : execApprovalAuthorizedSender || pluginApprovalAuthorizedSender;
-        if (
-          !authorizedApprovalSender
-        ) {
+        if (!authorizedApprovalSender) {
           logVerbose(
-            `Blocked telegram exec approval callback from ${senderId || "unknown"} (not authorized)`,
+            `Blocked telegram approval callback from ${senderId || "unknown"} (not authorized)`,
           );
           return;
         }
@@ -1359,7 +1357,9 @@ export const registerTelegramHandlers = ({
           logVerbose(
             `telegram: failed to resolve approval callback ${approvalCallback.approvalId}: ${errStr}`,
           );
-          await replyToCallbackChat(`❌ Failed to submit approval: ${errStr}`);
+          await replyToCallbackChat(
+            "❌ Failed to submit approval. Please try again or contact an admin.",
+          );
           return;
         }
         try {

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -769,7 +769,7 @@ describe("createTelegramBot", () => {
     expect(replySpy).not.toHaveBeenCalled();
     expect(sendMessageSpy).toHaveBeenCalledWith(
       1234,
-      "❌ Failed to submit approval: Error: unknown or expired approval id",
+      "❌ Failed to submit approval. Please try again or contact an admin.",
       undefined,
     );
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-legacy-plugin-fallback-blocked");

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -436,6 +436,7 @@ describe("createTelegramBot", () => {
       decision: "allow-once",
       allowPluginFallback: true,
       senderId: "9",
+      allowPluginFallback: true,
     });
     expect(replySpy).not.toHaveBeenCalled();
     expect(editMessageTextSpy).not.toHaveBeenCalled();
@@ -544,6 +545,7 @@ describe("createTelegramBot", () => {
       decision: "allow-once",
       allowPluginFallback: true,
       senderId: "9",
+      allowPluginFallback: true,
     });
     expect(editMessageReplyMarkupSpy).toHaveBeenCalledTimes(1);
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-plugin-approve");
@@ -594,6 +596,52 @@ describe("createTelegramBot", () => {
     expect(editMessageTextSpy).not.toHaveBeenCalled();
     expect(resolveExecApprovalSpy).not.toHaveBeenCalled();
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-blocked");
+  });
+
+  it("does not leak raw approval callback errors back into Telegram chat", async () => {
+    onSpy.mockClear();
+    sendMessageSpy.mockClear();
+    resolveExecApprovalSpy.mockClear();
+    resolveExecApprovalSpy.mockRejectedValueOnce(new Error("gateway secret detail"));
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          execApprovals: {
+            enabled: true,
+            approvers: ["9"],
+            target: "dm",
+          },
+        },
+      },
+    });
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-approve-error",
+        data: "/approve 138e9b8c allow-once",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 25,
+          text: "Approval required.",
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    expect(sendMessageSpy.mock.calls[0]?.[1]).toBe(
+      "❌ Failed to submit approval. Please try again or contact an admin.",
+    );
   });
 
   it("allows exec approval callbacks from target-only Telegram recipients", async () => {
@@ -652,6 +700,7 @@ describe("createTelegramBot", () => {
       decision: "allow-once",
       allowPluginFallback: false,
       senderId: "9",
+      allowPluginFallback: false,
     });
     expect(editMessageReplyMarkupSpy).toHaveBeenCalledTimes(1);
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-target");

--- a/extensions/telegram/src/exec-approval-resolver.test.ts
+++ b/extensions/telegram/src/exec-approval-resolver.test.ts
@@ -56,6 +56,7 @@ describe("resolveTelegramExecApproval", () => {
       approvalId: "legacy-plugin-123",
       decision: "allow-always",
       senderId: "9",
+      allowPluginFallback: true,
     });
 
     expect(gatewayRuntimeHoisted.requestSpy).toHaveBeenNthCalledWith(1, "exec.approval.resolve", {
@@ -72,34 +73,25 @@ describe("resolveTelegramExecApproval", () => {
     );
   });
 
-  it("falls back to plugin.approval.resolve for structured approval-not-found errors", async () => {
-    const err = new Error("invalid request") as Error & {
-      gatewayCode?: string;
-      details?: { reason?: string };
-    };
-    err.gatewayCode = "INVALID_REQUEST";
-    err.details = { reason: "APPROVAL_NOT_FOUND" };
-    gatewayRuntimeHoisted.requestSpy.mockRejectedValueOnce(err).mockResolvedValueOnce(undefined);
+  it("does not fall back to plugin.approval.resolve without explicit permission", async () => {
+    gatewayRuntimeHoisted.requestSpy.mockRejectedValueOnce(
+      new Error("unknown or expired approval id"),
+    );
     const { resolveTelegramExecApproval } = await import("./exec-approval-resolver.js");
 
-    await resolveTelegramExecApproval({
-      cfg: {} as never,
-      approvalId: "legacy-plugin-123",
-      decision: "deny",
-      senderId: "9",
-    });
+    await expect(
+      resolveTelegramExecApproval({
+        cfg: {} as never,
+        approvalId: "legacy-plugin-123",
+        decision: "allow-always",
+        senderId: "9",
+      }),
+    ).rejects.toThrow("unknown or expired approval id");
 
-    expect(gatewayRuntimeHoisted.requestSpy).toHaveBeenNthCalledWith(1, "exec.approval.resolve", {
+    expect(gatewayRuntimeHoisted.requestSpy).toHaveBeenCalledTimes(1);
+    expect(gatewayRuntimeHoisted.requestSpy).toHaveBeenCalledWith("exec.approval.resolve", {
       id: "legacy-plugin-123",
-      decision: "deny",
+      decision: "allow-always",
     });
-    expect(gatewayRuntimeHoisted.requestSpy).toHaveBeenNthCalledWith(
-      2,
-      "plugin.approval.resolve",
-      {
-        id: "legacy-plugin-123",
-        decision: "deny",
-      },
-    );
   });
 });

--- a/extensions/telegram/src/exec-approval-resolver.ts
+++ b/extensions/telegram/src/exec-approval-resolver.ts
@@ -9,32 +9,16 @@ export type ResolveTelegramExecApprovalParams = {
   senderId?: string | null;
   allowPluginFallback?: boolean;
   gatewayUrl?: string;
+  allowPluginFallback?: boolean;
 };
+
+function isApprovalNotFoundError(err: unknown): boolean {
+  return /unknown or expired approval id/i.test(String(err));
+}
 
 export async function resolveTelegramExecApproval(
   params: ResolveTelegramExecApprovalParams,
 ): Promise<void> {
-  const isApprovalNotFoundError = (err: unknown): boolean => {
-    if (!(err instanceof Error)) {
-      return false;
-    }
-    const gatewayCode = (err as { gatewayCode?: unknown }).gatewayCode;
-    if (gatewayCode === "APPROVAL_NOT_FOUND") {
-      return true;
-    }
-    const details = (err as { details?: unknown }).details;
-    if (
-      gatewayCode === "INVALID_REQUEST" &&
-      details &&
-      typeof details === "object" &&
-      !Array.isArray(details) &&
-      (details as { reason?: unknown }).reason === "APPROVAL_NOT_FOUND"
-    ) {
-      return true;
-    }
-    return /unknown or expired approval id/i.test(err.message);
-  };
-
   let readySettled = false;
   let resolveReady!: () => void;
   let rejectReady!: (err: unknown) => void;

--- a/extensions/telegram/src/exec-approvals-handler.test.ts
+++ b/extensions/telegram/src/exec-approvals-handler.test.ts
@@ -204,4 +204,38 @@ describe("TelegramExecApprovalHandler", () => {
       }),
     );
   });
+
+  it("does not deliver plugin approvals for a different Telegram account", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          execApprovals: {
+            enabled: true,
+            approvers: ["8460800771"],
+            target: "dm",
+          },
+          accounts: {
+            secondary: {
+              execApprovals: {
+                enabled: true,
+                approvers: ["999"],
+                target: "dm",
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler, sendMessage } = createHandler(cfg);
+
+    await handler.handleRequested({
+      ...pluginRequest,
+      request: {
+        ...pluginRequest.request,
+        turnSourceAccountId: "secondary",
+      },
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/telegram/src/exec-approvals-handler.ts
+++ b/extensions/telegram/src/exec-approvals-handler.ts
@@ -4,6 +4,7 @@ import {
   createExecApprovalChannelRuntime,
   type ExecApprovalChannelRuntime,
   resolveChannelNativeApprovalDeliveryPlan,
+  resolveExecApprovalSessionTarget,
 } from "openclaw/plugin-sdk/infra-runtime";
 import { resolveExecApprovalCommandDisplay } from "openclaw/plugin-sdk/infra-runtime";
 import {
@@ -16,7 +17,7 @@ import type {
   PluginApprovalRequest,
   PluginApprovalResolved,
 } from "openclaw/plugin-sdk/infra-runtime";
-import { parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { parseAgentSessionKey, normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { compileSafeRegex, testRegexWithBoundedInput } from "openclaw/plugin-sdk/security-runtime";
@@ -38,6 +39,52 @@ type PendingMessage = {
   chatId: string;
   messageId: string;
 };
+
+function isExecApprovalRequest(request: ApprovalRequest): request is ExecApprovalRequest {
+  return "command" in request.request;
+}
+
+function toExecLikeRequest(request: ApprovalRequest): ExecApprovalRequest {
+  if (isExecApprovalRequest(request)) {
+    return request;
+  }
+  return {
+    id: request.id,
+    request: {
+      command: request.request.title,
+      agentId: request.request.agentId ?? undefined,
+      sessionKey: request.request.sessionKey ?? undefined,
+      turnSourceChannel: request.request.turnSourceChannel ?? undefined,
+      turnSourceTo: request.request.turnSourceTo ?? undefined,
+      turnSourceAccountId: request.request.turnSourceAccountId ?? undefined,
+      turnSourceThreadId: request.request.turnSourceThreadId ?? undefined,
+    },
+    createdAtMs: request.createdAtMs,
+    expiresAtMs: request.expiresAtMs,
+  };
+}
+
+function resolveBoundTelegramAccountId(params: {
+  cfg: OpenClawConfig;
+  request: ApprovalRequest;
+}): string | null {
+  const turnSourceChannel = params.request.request.turnSourceChannel?.trim().toLowerCase();
+  if (turnSourceChannel === "telegram") {
+    return params.request.request.turnSourceAccountId?.trim() || null;
+  }
+  const sessionTarget = resolveExecApprovalSessionTarget({
+    cfg: params.cfg,
+    request: toExecLikeRequest(params.request),
+    turnSourceChannel: params.request.request.turnSourceChannel ?? undefined,
+    turnSourceTo: params.request.request.turnSourceTo ?? undefined,
+    turnSourceAccountId: params.request.request.turnSourceAccountId ?? undefined,
+    turnSourceThreadId: params.request.request.turnSourceThreadId ?? undefined,
+  });
+  if (!sessionTarget || sessionTarget.channel !== "telegram") {
+    return null;
+  }
+  return sessionTarget.accountId?.trim() || null;
+}
 
 export type TelegramExecApprovalHandlerOpts = {
   token: string;
@@ -96,6 +143,16 @@ function matchesFilters(params: {
     if (!matches) {
       return false;
     }
+  }
+  const boundAccountId = resolveBoundTelegramAccountId({
+    cfg: params.cfg,
+    request: params.request,
+  });
+  if (
+    boundAccountId &&
+    normalizeAccountId(boundAccountId) !== normalizeAccountId(params.accountId)
+  ) {
+    return false;
   }
   return true;
 }

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -247,7 +247,9 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
       if (isApprovalNotFoundError(err)) {
         return {
           shouldContinue: false,
-          reply: { text: `❌ Failed to submit approval: ${String(err)}` },
+          reply: {
+            text: pluginApprovalAuthorization.reason ?? "❌ You are not authorized to approve this request.",
+          },
         };
       }
       return {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -115,7 +115,6 @@ vi.resetModules();
 
 const {
   addSubagentRunForTests,
-  getSubagentRunByChildSessionKey,
   listSubagentRunsForRequester,
   resetSubagentRegistryForTests,
 } = await import("../../agents/subagent-registry.js");
@@ -443,25 +442,6 @@ describe("/approve command", () => {
     );
   });
 
-  it("keeps /approve blocked for unauthorized senders without explicit approval auth", async () => {
-    const cfg = {
-      commands: { text: true },
-      channels: { slack: { allowFrom: ["*"] } },
-    } as OpenClawConfig;
-    const params = buildParams("/approve abc allow-once", cfg, {
-      Provider: "slack",
-      Surface: "slack",
-      SenderId: "123",
-    });
-    params.command.isAuthorizedSender = false;
-
-    const result = await handleCommands(params);
-
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply).toBeUndefined();
-    expect(callGatewayMock).not.toHaveBeenCalled();
-  });
-
   it("accepts Telegram command mentions for /approve", async () => {
     const cfg = createTelegramApproveCfg();
     const params = buildParams("/approve@bot abc12345 allow-once", cfg, {
@@ -504,6 +484,23 @@ describe("/approve command", () => {
         params: { id: "abc12345", decision: "allow-once" },
       }),
     );
+  });
+
+  it("does not treat implicit default approval auth as a bypass for unauthorized senders", async () => {
+    const cfg = {
+      commands: { text: true },
+    } as OpenClawConfig;
+    const params = buildParams("/approve abc12345 allow-once", cfg, {
+      Provider: "webchat",
+      Surface: "webchat",
+      SenderId: "123",
+    });
+    params.command.isAuthorizedSender = false;
+
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply).toBeUndefined();
+    expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
   it("accepts Telegram /approve from exec target recipients even when native approvals are disabled", async () => {
@@ -693,24 +690,6 @@ describe("/approve command", () => {
         );
       }
     }
-  });
-
-  it("returns the real plugin not-found error for authorized plugin approvers", async () => {
-    callGatewayMock.mockRejectedValueOnce(new Error("unknown or expired approval id"));
-    const params = buildParams(
-      "/approve plugin:abc123 allow-once",
-      createDiscordApproveCfg({ enabled: false, approvers: ["123"], target: "channel" }),
-      {
-        Provider: "discord",
-        Surface: "discord",
-        SenderId: "123",
-      },
-    );
-
-    const result = await handleCommands(params);
-    expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("unknown or expired approval id");
-    expect(result.reply?.text).not.toContain("not authorized");
   });
 
   it("rejects unauthorized or invalid Telegram /approve variants", async () => {

--- a/src/infra/channel-approval-auth.ts
+++ b/src/infra/channel-approval-auth.ts
@@ -2,26 +2,36 @@ import { getChannelPlugin } from "../channels/plugins/index.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 
+export type ApprovalCommandAuthorization = {
+  authorized: boolean;
+  reason?: string;
+  explicit: boolean;
+};
+
 export function resolveApprovalCommandAuthorization(params: {
   cfg: OpenClawConfig;
   channel?: string | null;
   accountId?: string | null;
   senderId?: string | null;
   kind: "exec" | "plugin";
-}): { authorized: boolean; reason?: string; explicit: boolean } {
+}): ApprovalCommandAuthorization {
   const channel = normalizeMessageChannel(params.channel);
   if (!channel) {
     return { authorized: true, explicit: false };
   }
-  const result = getChannelPlugin(channel)?.auth?.authorizeActorAction?.({
+  const resolved = getChannelPlugin(channel)?.auth?.authorizeActorAction?.({
     cfg: params.cfg,
     accountId: params.accountId,
     senderId: params.senderId,
     action: "approve",
     approvalKind: params.kind,
   });
-  if (!result) {
+  if (!resolved) {
     return { authorized: true, explicit: false };
   }
-  return { ...result, explicit: true };
+  return {
+    authorized: resolved.authorized,
+    reason: resolved.reason,
+    explicit: true,
+  };
 }


### PR DESCRIPTION
## Summary
- require explicit channel approval authorization before `/approve` bypasses normal sender auth
- scope Telegram plugin approvals to the originating account and tighten native origin-target validation for Telegram and Discord
- harden the shared approval runtime with payload validation, bounded pending approvals, and safe async error handling
- stop leaking raw Telegram approval callback errors back into chat

## Issues
Related: #57460

## Testing
- pnpm test -- src/infra/channel-approval-auth.test.ts src/auto-reply/reply/commands.test.ts extensions/telegram/src/exec-approval-resolver.test.ts extensions/telegram/src/bot.test.ts extensions/telegram/src/exec-approvals-handler.test.ts src/infra/exec-approval-channel-runtime.test.ts extensions/discord/src/monitor/exec-approvals.test.ts
- pnpm check
- pnpm build
