### PR TITLE
MS Teams: validate webhook auth before JSON parsing

### DIFF
--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import type { Request, Response } from "express";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
 import type { MSTeamsConversationStore } from "./conversation-store.js";
@@ -13,6 +14,11 @@ type FakeServer = EventEmitter & {
 
 const expressControl = vi.hoisted(() => ({
   mode: { value: "listening" as "listening" | "error" },
+  apps: [] as Array<{
+    use: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    listen: ReturnType<typeof vi.fn>;
+  }>,
 }));
 
 vi.mock("../runtime-api.js", () => ({
@@ -72,8 +78,14 @@ vi.mock("express", () => {
     }),
   });
 
+  const wrappedFactory = () => {
+    const app = factory();
+    expressControl.apps.push(app);
+    return app;
+  };
+
   return {
-    default: factory,
+    default: wrappedFactory,
     json,
   };
 });
@@ -88,6 +100,7 @@ const createMSTeamsAdapter = vi.hoisted(() =>
     process: vi.fn(async () => {}),
   })),
 );
+const jwtValidate = vi.hoisted(() => vi.fn().mockResolvedValue(true));
 const loadMSTeamsSdkWithAuth = vi.hoisted(() =>
   vi.fn(async () => ({
     sdk: {
@@ -117,7 +130,7 @@ vi.mock("./sdk.js", () => ({
     getAccessToken: vi.fn().mockResolvedValue("mock-token"),
   }),
   createBotFrameworkJwtValidator: vi.fn().mockResolvedValue({
-    validate: vi.fn().mockResolvedValue(true),
+    validate: jwtValidate,
   }),
 }));
 
@@ -178,6 +191,8 @@ describe("monitorMSTeamsProvider lifecycle", () => {
   afterEach(() => {
     vi.clearAllMocks();
     expressControl.mode.value = "listening";
+    expressControl.apps.length = 0;
+    jwtValidate.mockReset().mockResolvedValue(true);
   });
 
   it("stays active until aborted", async () => {
@@ -214,5 +229,50 @@ describe("monitorMSTeamsProvider lifecycle", () => {
         pollStore: createStores().pollStore,
       }),
     ).rejects.toThrow(/EADDRINUSE/);
+  });
+
+  it("runs JWT validation before JSON body parsing", async () => {
+    const abort = new AbortController();
+    const task = monitorMSTeamsProvider({
+      cfg: createConfig(0),
+      runtime: createRuntime(),
+      abortSignal: abort.signal,
+      conversationStore: createStores().conversationStore,
+      pollStore: createStores().pollStore,
+    });
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    const app = expressControl.apps.at(-1);
+    expect(app).toBeDefined();
+    expect(app!.use).toHaveBeenCalledTimes(4);
+
+    const jsonMiddleware = vi.mocked((await import("express")).json).mock.results[0]?.value;
+    expect(jsonMiddleware).toBeDefined();
+    expect(app!.use.mock.calls[1]?.[0]).not.toBe(jsonMiddleware);
+    expect(app!.use.mock.calls[2]?.[0]).toBe(jsonMiddleware);
+
+    const jwtMiddleware = app!.use.mock.calls[1]?.[0] as (
+      req: Request,
+      res: Response,
+      next: (err?: unknown) => void,
+    ) => void;
+    const next = vi.fn();
+    jwtMiddleware(
+      { headers: { authorization: "Bearer token" } } as Request,
+      {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn(),
+      } as unknown as Response,
+      next,
+    );
+
+    await vi.waitFor(() => {
+      expect(jwtValidate).toHaveBeenCalledWith("Bearer token");
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    abort.abort();
+    await task;
   });
 });

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -266,24 +266,16 @@ export async function monitorMSTeamsProvider(
     next();
   });
 
-  expressApp.use(express.json({ limit: MSTEAMS_WEBHOOK_MAX_BODY_BYTES }));
-  expressApp.use((err: unknown, _req: Request, res: Response, next: (err?: unknown) => void) => {
-    if (err && typeof err === "object" && "status" in err && err.status === 413) {
-      res.status(413).json({ error: "Payload too large" });
-      return;
-    }
-    next(err);
-  });
-
   // JWT validation — verify Bot Framework tokens using the Teams SDK's
   // JwtValidator (validates signature via JWKS, audience, issuer, expiration).
   const jwtValidator = await createBotFrameworkJwtValidator(creds);
   expressApp.use((req: Request, res: Response, next: (err?: unknown) => void) => {
     // Authorization header is guaranteed by the pre-parse auth gate above.
+    // `serviceUrl` is optional, so authenticate from headers alone before body
+    // I/O to avoid spending memory and CPU on unauthenticated requests.
     const authHeader = req.headers.authorization!;
-    const serviceUrl = (req.body as Record<string, unknown>)?.serviceUrl as string | undefined;
     jwtValidator
-      .validate(authHeader, serviceUrl)
+      .validate(authHeader)
       .then((valid) => {
         if (!valid) {
           log.debug?.("JWT validation failed");
@@ -296,6 +288,15 @@ export async function monitorMSTeamsProvider(
         log.debug?.(`JWT validation error: ${String(err)}`);
         res.status(401).json({ error: "Unauthorized" });
       });
+  });
+
+  expressApp.use(express.json({ limit: MSTEAMS_WEBHOOK_MAX_BODY_BYTES }));
+  expressApp.use((err: unknown, _req: Request, res: Response, next: (err?: unknown) => void) => {
+    if (err && typeof err === "object" && "status" in err && err.status === 413) {
+      res.status(413).json({ error: "Payload too large" });
+      return;
+    }
+    next(err);
   });
 
   // Set up the messages endpoint - use configured path and /api/messages as fallback


### PR DESCRIPTION
## Summary
- validate the Bot Framework bearer token before `express.json()` runs in the MS Teams webhook pipeline
- keep the existing JSON body limit and 413 handling after authentication
- add a lifecycle regression test that asserts JWT validation runs before body parsing

## Changes
- moved JWT validation ahead of JSON parsing in `extensions/msteams/src/monitor.ts`
- authenticate from the Authorization header alone instead of reading `serviceUrl` from the request body during pre-auth handling
- extended `extensions/msteams/src/monitor.lifecycle.test.ts` to verify the middleware ordering and pre-parse JWT call

## Validation
- Ran `pnpm test -- extensions/msteams/src/monitor.lifecycle.test.ts extensions/msteams/src/monitor.test.ts`
- Verified the JWT middleware now runs before the JSON parser is registered in the request chain
- Ran local agentic review with `claude -p "/review"` and removed the dead pre-auth `req.body` access it flagged

## Notes
- Residual risk or follow-up: this change is intentionally narrow and does not add new rate limiting or in-flight limiting to the Teams webhook path