### PR TITLE
fix(sessions_send): route agent-to-agent announce delivery to requester target

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -884,9 +884,112 @@ describe("sessions tools", () => {
     );
     expect(replySteps).toHaveLength(2);
     expect(sendParams).toMatchObject({
-      to: "group:target",
+      to: "group:req",
       channel: "discord",
       message: "announce now",
+    });
+  });
+
+  it("sessions_send announces back to the requester session target, not the target session target", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    let agentCallCount = 0;
+    let lastWaitedRunId: string | undefined;
+    const replyByRunId = new Map<string, string>();
+    const requesterKey = "agent:design-agent:webchat:group:self";
+    const targetKey = "agent:coding-agent:openclaw-tmcp-dingtalk:group:self";
+    let sendParams: { to?: string; channel?: string; message?: string } = {};
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        agentCallCount += 1;
+        const runId = `run-${agentCallCount}`;
+        const params = request.params as
+          | {
+              message?: string;
+              sessionKey?: string;
+              extraSystemPrompt?: string;
+            }
+          | undefined;
+        let reply = "initial";
+        if (params?.extraSystemPrompt?.includes("Agent-to-agent announce step")) {
+          reply = "announce back to requester";
+        }
+        replyByRunId.set(runId, reply);
+        return { runId, status: "accepted", acceptedAt: 3000 + agentCallCount };
+      }
+      if (request.method === "agent.wait") {
+        const runId = typeof request.params?.runId === "string" ? request.params.runId : undefined;
+        lastWaitedRunId = runId;
+        return { runId: runId ?? "run-1", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [
+            {
+              key: requesterKey,
+              deliveryContext: { channel: "webchat", to: "group:self" },
+            },
+            {
+              key: targetKey,
+              deliveryContext: { channel: "openclaw-tmcp-dingtalk", to: "group:self" },
+            },
+          ],
+        };
+      }
+      if (request.method === "send") {
+        sendParams = {
+          to: typeof request.params?.to === "string" ? request.params.to : undefined,
+          channel: typeof request.params?.channel === "string" ? request.params.channel : undefined,
+          message: typeof request.params?.message === "string" ? request.params.message : undefined,
+        };
+        return { messageId: "m-announce" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: requesterKey,
+      agentChannel: "webchat",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const waited = await tool.execute("call8", {
+      sessionKey: targetKey,
+      message: "doc update",
+      timeoutSeconds: 1,
+    });
+    expect(waited.details).toMatchObject({
+      status: "ok",
+      reply: "initial",
+    });
+    await vi.waitFor(
+      () => {
+        expect(calls.filter((call) => call.method === "send")).toHaveLength(1);
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+
+    expect(sendParams).toMatchObject({
+      to: "self",
+      channel: "webchat",
+      message: "announce back to requester",
     });
   });
 

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -11,6 +11,7 @@ import {
   buildAgentToAgentReplyContext,
   isAnnounceSkip,
   isReplySkip,
+  resolveAnnounceTargetFromKey,
 } from "./sessions-send-helpers.js";
 
 const log = createSubsystemLogger("agents/sessions-send");
@@ -61,11 +62,23 @@ export async function runSessionsSendA2AFlow(params: {
       return;
     }
 
-    const announceTarget = await resolveAnnounceTarget({
-      sessionKey: params.targetSessionKey,
-      displayKey: params.displayKey,
-    });
-    const targetChannel = announceTarget?.channel ?? "unknown";
+    const announceTarget = params.requesterSessionKey
+      ? await resolveAnnounceTarget({
+          sessionKey: params.requesterSessionKey,
+          displayKey: params.requesterSessionKey,
+        })
+      : await resolveAnnounceTarget({
+          sessionKey: params.targetSessionKey,
+          displayKey: params.displayKey,
+        });
+    const targetDisplayTarget =
+      resolveAnnounceTargetFromKey(params.displayKey) ??
+      resolveAnnounceTargetFromKey(params.targetSessionKey) ??
+      (await resolveAnnounceTarget({
+        sessionKey: params.targetSessionKey,
+        displayKey: params.displayKey,
+      }));
+    const targetDisplayChannel = targetDisplayTarget?.channel ?? "unknown";
 
     if (
       params.maxPingPongTurns > 0 &&
@@ -82,7 +95,7 @@ export async function runSessionsSendA2AFlow(params: {
           requesterSessionKey: params.requesterSessionKey,
           requesterChannel: params.requesterChannel,
           targetSessionKey: params.displayKey,
-          targetChannel,
+          targetChannel: targetDisplayChannel,
           currentRole,
           turn,
           maxTurns: params.maxPingPongTurns,
@@ -95,7 +108,9 @@ export async function runSessionsSendA2AFlow(params: {
           lane: AGENT_LANE_NESTED,
           sourceSessionKey: nextSessionKey,
           sourceChannel:
-            nextSessionKey === params.requesterSessionKey ? params.requesterChannel : targetChannel,
+            nextSessionKey === params.requesterSessionKey
+              ? params.requesterChannel
+              : targetDisplayChannel,
           sourceTool: "sessions_send",
         });
         if (!replyText || isReplySkip(replyText)) {
@@ -113,7 +128,7 @@ export async function runSessionsSendA2AFlow(params: {
       requesterSessionKey: params.requesterSessionKey,
       requesterChannel: params.requesterChannel,
       targetSessionKey: params.displayKey,
-      targetChannel,
+      targetChannel: targetDisplayChannel,
       originalMessage: params.message,
       roundOneReply: primaryReply,
       latestReply,


### PR DESCRIPTION

## Summary

Fix `sessions_send` agent-to-agent announce routing so the announce delivery target is resolved from the **requester session**, not the **target session**.

This prevents replies that were already consumed synchronously via `toolResult.reply` from being routed back into the wrong conversation flow during the follow-up announce step.

## Problem

In agent-to-agent `sessions_send` flows, the sequence is:

1. a requester agent sends a message to a target agent
2. the target agent produces its main reply
3. that reply is already returned synchronously to the requester via `reply`
4. OpenClaw then runs the agent-to-agent announce step

Before this change, the announce delivery target was resolved using the **target session key** instead of the **requester session key**.

In practice, this could cause the target agent's reply to be delivered relative to the wrong session context and later show up again in the sender-side flow as a follow-up inter-session message, even though that reply had already been received and processed by the requester.

## Root Cause

`runSessionsSendA2AFlow()` resolved `announceTarget` from:

- `targetSessionKey`
- `displayKey`

That was the wrong side of the exchange.

For agent-to-agent announce delivery, the final delivery target should be derived from the **requester session**, because the announce result is meant to go back to the requester-side conversation target.

## Fix

Change announce target resolution in `runSessionsSendA2AFlow()` to use:

- `requesterSessionKey`

The announce step itself still runs in the target agent session, but the final announce delivery is now routed back to the requester-side destination.

## Tests

Updated existing expectations and added regression coverage to verify that:

- `sessions_send` announce delivery goes to the **requester target**
- it does **not** route to the **target session target**

Local verification:

```bash
pnpm -C /Users/kite/project/openclaw test src/agents/openclaw-tools.sessions.test.ts
```

Result:

- `22 passed`

## Changed Files

- `src/agents/tools/sessions-send-tool.a2a.ts`
- `src/agents/openclaw-tools.sessions.test.ts`

## Notes

This patch fixes the routing bug that made the duplicate / reinjected behavior possible.

A follow-up hardening change could additionally ensure that inter-session announce traffic is never persisted as a normal user message in the requester flow, but that is intentionally kept out of scope for this PR.
```