### PR TITLE
Fix Windows test hangs: settle child wait on exit + force gateway close

### DIFF
--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -46,4 +46,61 @@ describe("createGatewayCloseHandler", () => {
 
     expect(lifecycleUnsub).toHaveBeenCalledTimes(1);
   });
+
+  it("forces websocket and http shutdown to settle when close callbacks hang", async () => {
+    vi.useFakeTimers();
+    const terminate = vi.fn();
+    const close = createGatewayCloseHandler({
+      bonjourStop: null,
+      tailscaleCleanup: null,
+      canvasHost: null,
+      canvasHostServer: null,
+      stopChannel: vi.fn(async () => undefined),
+      pluginServices: null,
+      cron: { stop: vi.fn() },
+      heartbeatRunner: { stop: vi.fn() } as never,
+      updateCheckStop: null,
+      nodePresenceTimers: new Map(),
+      broadcast: vi.fn(),
+      tickInterval: setInterval(() => undefined, 60_000),
+      healthInterval: setInterval(() => undefined, 60_000),
+      dedupeCleanup: setInterval(() => undefined, 60_000),
+      mediaCleanup: null,
+      agentUnsub: null,
+      heartbeatUnsub: null,
+      transcriptUnsub: null,
+      lifecycleUnsub: null,
+      chatRunState: { clear: vi.fn() },
+      clients: new Set([
+        {
+          socket: {
+            close: vi.fn(),
+            terminate,
+          },
+        },
+      ]),
+      configReloader: { stop: vi.fn(async () => undefined) },
+      wss: {
+        clients: new Set([{ terminate }]),
+        close: vi.fn(),
+      } as never,
+      httpServer: {
+        close: vi.fn(),
+        closeIdleConnections: vi.fn(),
+        closeAllConnections: vi.fn(),
+      } as never,
+    });
+
+    const closePromise = close({ reason: "test shutdown" });
+    const settled = vi.fn();
+    void closePromise.then(() => settled());
+
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(4_000);
+    await closePromise;
+
+    expect(terminate).toHaveBeenCalled();
+  });
 });

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -6,6 +6,102 @@ import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 
+const FORCE_WS_CLOSE_GRACE_MS = 2_000;
+const FORCE_HTTP_CLOSE_GRACE_MS = 2_000;
+
+type GatewaySocket = {
+  close: (code: number, reason: string) => void;
+  terminate?: () => void;
+};
+
+async function closeWebSocketServer(
+  wss: WebSocketServer,
+  clients: Iterable<{ socket: GatewaySocket }>,
+): Promise<void> {
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      resolve();
+    };
+    const timeout = setTimeout(() => {
+      for (const client of clients) {
+        try {
+          client.socket.terminate?.();
+        } catch {
+          /* ignore */
+        }
+      }
+      for (const client of wss.clients) {
+        try {
+          client.terminate();
+        } catch {
+          /* ignore */
+        }
+      }
+      finish();
+    }, FORCE_WS_CLOSE_GRACE_MS);
+    timeout.unref?.();
+    try {
+      wss.close(() => finish());
+    } catch {
+      finish();
+    }
+  });
+}
+
+async function closeHttpServer(server: HttpServer): Promise<void> {
+  const httpServer = server as HttpServer & {
+    closeIdleConnections?: () => void;
+    closeAllConnections?: () => void;
+  };
+  if (typeof httpServer.closeIdleConnections === "function") {
+    httpServer.closeIdleConnections();
+  }
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    };
+    const timeout = setTimeout(() => {
+      try {
+        httpServer.closeAllConnections?.();
+      } catch {
+        /* ignore */
+      }
+      try {
+        httpServer.closeIdleConnections?.();
+      } catch {
+        /* ignore */
+      }
+      finish();
+    }, FORCE_HTTP_CLOSE_GRACE_MS);
+    timeout.unref?.();
+    try {
+      httpServer.close((err) => finish(err ?? null));
+    } catch (error) {
+      finish(error as Error);
+    }
+  });
+}
+
 export function createGatewayCloseHandler(params: {
   bonjourStop: (() => Promise<void>) | null;
   tailscaleCleanup: (() => Promise<void>) | null;
@@ -28,7 +124,7 @@ export function createGatewayCloseHandler(params: {
   transcriptUnsub: (() => void) | null;
   lifecycleUnsub: (() => void) | null;
   chatRunState: { clear: () => void };
-  clients: Set<{ socket: { close: (code: number, reason: string) => void } }>;
+  clients: Set<{ socket: GatewaySocket }>;
   configReloader: { stop: () => Promise<void> };
   wss: WebSocketServer;
   httpServer: HttpServer;
@@ -123,7 +219,8 @@ export function createGatewayCloseHandler(params: {
         }
       }
       params.chatRunState.clear();
-      for (const c of params.clients) {
+      const clients = [...params.clients];
+      for (const c of clients) {
         try {
           c.socket.close(1012, "service restart");
         } catch {
@@ -132,21 +229,13 @@ export function createGatewayCloseHandler(params: {
       }
       params.clients.clear();
       await params.configReloader.stop().catch(() => {});
-      await new Promise<void>((resolve) => params.wss.close(() => resolve()));
+      await closeWebSocketServer(params.wss, clients);
       const servers =
         params.httpServers && params.httpServers.length > 0
           ? params.httpServers
           : [params.httpServer];
       for (const server of servers) {
-        const httpServer = server as HttpServer & {
-          closeIdleConnections?: () => void;
-        };
-        if (typeof httpServer.closeIdleConnections === "function") {
-          httpServer.closeIdleConnections();
-        }
-        await new Promise<void>((resolve, reject) =>
-          httpServer.close((err) => (err ? reject(err) : resolve())),
-        );
+        await closeHttpServer(server);
       }
     } finally {
       try {

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -19,6 +19,8 @@ import {
 import { drainSystemEvents, peekSystemEvents } from "../infra/system-events.js";
 import { rawDataToString } from "../infra/ws.js";
 import { resetLogger, setLoggerOverride } from "../logging.js";
+import { resetGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
 import { clearGatewaySubagentRuntime } from "../plugins/runtime/index.js";
 import {
   DEFAULT_AGENT_ID,
@@ -282,6 +284,8 @@ async function resetGatewayTestState(options: { uniqueConfigRoot: boolean }) {
   );
   setTestConfigRoot(tempConfigRoot);
   resetConfigRuntimeState();
+  resetPluginRuntimeStateForTest();
+  resetGlobalHookRunner();
   resetTestPluginRegistry();
   clearGatewaySubagentRuntime();
   sessionStoreSaveDelayMs.value = 0;
@@ -333,6 +337,9 @@ async function resetGatewayTestState(options: { uniqueConfigRoot: boolean }) {
 
 async function cleanupGatewayTestHome(options: { restoreEnv: boolean }) {
   vi.useRealTimers();
+  resetGlobalHookRunner();
+  resetPluginRuntimeStateForTest();
+  resetTestPluginRegistry();
   clearGatewaySubagentRuntime();
   resetLogger();
   if (options.restoreEnv) {

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -30,7 +30,10 @@ function createStubChild(pid = 1234) {
   const emitClose = (code: number | null, signal: NodeJS.Signals | null = null) => {
     child.emit("close", code, signal);
   };
-  return { child, killMock, emitClose };
+  const emitExit = (code: number | null, signal: NodeJS.Signals | null = null) => {
+    child.emit("exit", code, signal);
+  };
+  return { child, killMock, emitClose, emitExit };
 }
 
 async function createAdapterHarness(params?: {
@@ -151,6 +154,31 @@ describe("createChildAdapter", () => {
     await vi.advanceTimersByTimeAsync(4_001);
     await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: "SIGKILL" });
     expect(killMock).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("settles wait on exit when close never arrives after SIGKILL", async () => {
+    vi.useFakeTimers();
+    const { adapter, emitExit } = await (async () => {
+      const stub = createStubChild(1357);
+      spawnWithFallbackMock.mockResolvedValue({
+        child: stub.child,
+        usedFallback: false,
+      });
+      const adapter = await createChildAdapter({
+        argv: ["node", "-e", "setTimeout(() => {}, 1000)"],
+        stdinMode: "pipe-open",
+      });
+      return { ...stub, adapter };
+    })();
+
+    const waitPromise = adapter.wait();
+    adapter.kill();
+    emitExit(null, "SIGKILL");
+
+    await expect(waitPromise).resolves.toEqual({ code: null, signal: "SIGKILL" });
+
+    await vi.advanceTimersByTimeAsync(4_001);
+    await expect(adapter.wait()).resolves.toEqual({ code: null, signal: "SIGKILL" });
   });
 
   it("disables detached mode in service-managed runtime", async () => {

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -114,13 +114,13 @@ export async function createChildAdapter(params: {
     });
   };
 
-  let waitResult: { code: number | null; signal: NodeJS.Signals | null } | null = null;
+  type WaitResult = { code: number | null; signal: NodeJS.Signals | null };
+
+  let waitResult: WaitResult | null = null;
   let waitError: unknown;
-  let resolveWait:
-    | ((value: { code: number | null; signal: NodeJS.Signals | null }) => void)
-    | null = null;
+  let resolveWait: ((value: WaitResult) => void) | null = null;
   let rejectWait: ((reason?: unknown) => void) | null = null;
-  let waitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }> | null = null;
+  let waitPromise: Promise<WaitResult> | null = null;
   let forceKillWaitFallbackTimer: NodeJS.Timeout | null = null;
 
   const clearForceKillWaitFallback = () => {
@@ -131,7 +131,7 @@ export async function createChildAdapter(params: {
     forceKillWaitFallbackTimer = null;
   };
 
-  const settleWait = (value: { code: number | null; signal: NodeJS.Signals | null }) => {
+  const settleWait = (value: WaitResult) => {
     if (waitResult || waitError !== undefined) {
       return;
     }
@@ -171,6 +171,11 @@ export async function createChildAdapter(params: {
   child.once("error", (error) => {
     rejectPendingWait(error);
   });
+  // On Windows a force-killed child can emit `exit` without ever reaching
+  // `close` if stdio handles stay stuck. Settle on the first terminal signal.
+  child.once("exit", (code, signal) => {
+    settleWait({ code, signal });
+  });
   child.once("close", (code, signal) => {
     settleWait({ code, signal });
   });
@@ -183,25 +188,23 @@ export async function createChildAdapter(params: {
       throw waitError;
     }
     if (!waitPromise) {
-      waitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-        (resolve, reject) => {
-          resolveWait = resolve;
-          rejectWait = reject;
-          if (waitResult) {
-            const settled = waitResult;
-            resolveWait = null;
-            rejectWait = null;
-            resolve(settled);
-            return;
-          }
-          if (waitError !== undefined) {
-            const error = waitError;
-            resolveWait = null;
-            rejectWait = null;
-            reject(error);
-          }
-        },
-      );
+      waitPromise = new Promise<WaitResult>((resolve, reject) => {
+        resolveWait = resolve;
+        rejectWait = reject;
+        if (waitResult) {
+          const settled = waitResult;
+          resolveWait = null;
+          rejectWait = null;
+          resolve(settled);
+          return;
+        }
+        if (waitError !== undefined) {
+          const error = waitError;
+          resolveWait = null;
+          rejectWait = null;
+          reject(error);
+        }
+      });
     }
     return waitPromise;
   };


### PR DESCRIPTION
Windows CI has been failing with timeouts/hangs in:
- supervisor tests (run.wait() not settling on Windows when close doesn't fire)
- gateway test hooks (installGatewayTestHooks timing out), invoked by mcp/channel-server.test

This PR addresses the underlying teardown issues without skipping tests:

- child adapter: settle wait on `exit` event (Windows can emit exit without close when stdio never closes after SIGKILL)
  - adds unit coverage for exit-without-close

- gateway close handler: force websocket/http shutdown to settle even if close callbacks hang
  - terminate stuck websocket clients after a grace period
  - force-close http connections after a grace period

- gateway test helpers: reset plugin runtime/global hook runner state during reset+cleanup to avoid cross-test leakage.

Local QA (linux):
- pnpm check
- vitest unit: supervisor + child adapter + mcp/channel-server
- vitest gateway: server-close.test.ts

Goal: reduce Windows-only hangs and unblock PRs like #57356.
