### PR TITLE
fix(acp): resolve agent profile alias to harness ID and inherit profile workspace cwd

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1069,6 +1069,182 @@ describe("spawnAcpDirect", () => {
     expect(expectFailedSpawn(result, "error").error).toContain("set `acp.defaultAgent`");
   });
 
+  it("resolves agent profile alias to underlying ACP harness ID", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        allowedAgents: ["claude"],
+      },
+      agents: {
+        list: [
+          {
+            id: "analyst",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "claude" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Analyze data",
+        agentId: "analyst",
+      },
+      {
+        agentSessionKey: "agent:main:telegram:direct:123",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:123",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    // The session key should contain the resolved harness ID "claude", not the alias "analyst"
+    expect(result.childSessionKey).toMatch(/^agent:claude:acp:/);
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "claude", cwd: undefined }),
+    );
+  });
+
+  it("inherits profile workspace cwd when caller does not specify cwd", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        allowedAgents: ["claude"],
+      },
+      agents: {
+        list: [
+          {
+            id: "analyst",
+            workspace: "/workspace/analysis",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "claude", cwd: "/workspace/analysis" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Analyze data",
+        agentId: "analyst",
+      },
+      {
+        agentSessionKey: "agent:main:telegram:direct:123",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:123",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/workspace/analysis" }),
+    );
+  });
+
+  it("prefers explicit cwd over profile workspace when both are provided", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        allowedAgents: ["claude"],
+      },
+      agents: {
+        list: [
+          {
+            id: "analyst",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "claude", cwd: "/workspace/analysis" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Analyze data",
+        agentId: "analyst",
+        cwd: "/override/workspace",
+      },
+      {
+        agentSessionKey: "agent:main:telegram:direct:123",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:123",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/override/workspace" }),
+    );
+  });
+
+  it("inherits profile cwd from defaultAgent when agentId is omitted", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        defaultAgent: "codex",
+        allowedAgents: ["codex"],
+      },
+      agents: {
+        list: [
+          {
+            id: "codex",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "codex", cwd: "/workspace/default-agent" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/workspace/default-agent" }),
+    );
+  });
+
+  it("passes raw harness ID through when no matching agent profile exists", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+        agentId: "codex",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.childSessionKey).toMatch(/^agent:codex:acp:/);
+  });
+
   it("fails fast when Discord ACP thread spawn is disabled", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1230,6 +1230,44 @@ describe("spawnAcpDirect", () => {
     );
   });
 
+  it("resolves defaultAgent alias to harness ID when agentId is omitted", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        defaultAgent: "analyst",
+        allowedAgents: ["claude"],
+      },
+      agents: {
+        list: [
+          {
+            id: "analyst",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "claude", cwd: "/workspace/analysis" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.childSessionKey).toMatch(/^agent:claude:acp:/);
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "claude", cwd: "/workspace/analysis" }),
+    );
+  });
+
   it("passes raw harness ID through when no matching agent profile exists", async () => {
     const result = await spawnAcpDirect(
       {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -389,11 +389,16 @@ function resolveTargetAcpAgentId(params: {
     const defaultProfile = listAgentEntries(params.cfg).find(
       (a) => normalizeAgentId(a.id) === configuredDefault,
     );
+    let defaultAgentId = configuredDefault;
     const defaultProfileCwd =
       defaultProfile?.runtime?.type === "acp"
         ? defaultProfile.runtime.acp?.cwd || defaultProfile.workspace
         : defaultProfile?.workspace;
-    return { ok: true, agentId: configuredDefault, profileCwd: defaultProfileCwd };
+    if (defaultProfile?.runtime?.type === "acp" && defaultProfile.runtime.acp?.agent) {
+      defaultAgentId =
+        normalizeOptionalAgentId(defaultProfile.runtime.acp.agent) || configuredDefault;
+    }
+    return { ok: true, agentId: defaultAgentId, profileCwd: defaultProfileCwd };
   }
 
   return {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -57,7 +57,7 @@ import {
   resolveAcpSpawnStreamLogPath,
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
-import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
+import { listAgentEntries, resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { resolveSpawnedWorkspaceInheritance } from "./spawned-context.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
@@ -364,15 +364,36 @@ function hasSessionLocalHeartbeatRelayRoute(params: {
 function resolveTargetAcpAgentId(params: {
   requestedAgentId?: string;
   cfg: OpenClawConfig;
-}): { ok: true; agentId: string } | { ok: false; error: string } {
+}): { ok: true; agentId: string; profileCwd?: string } | { ok: false; error: string } {
   const requested = normalizeOptionalAgentId(params.requestedAgentId);
   if (requested) {
-    return { ok: true, agentId: requested };
+    // Check if the requested ID is an agent profile alias that maps to
+    // a different underlying ACP harness ID (e.g. "analyst" → "claude").
+    const profile = listAgentEntries(params.cfg).find((a) => normalizeAgentId(a.id) === requested);
+
+    let targetAgentId = requested;
+    let profileCwd: string | undefined;
+
+    if (profile?.runtime?.type === "acp" && profile.runtime.acp?.agent) {
+      targetAgentId = normalizeOptionalAgentId(profile.runtime.acp.agent) || requested;
+      profileCwd = profile.runtime.acp.cwd || profile.workspace;
+    } else if (profile?.workspace) {
+      profileCwd = profile.workspace;
+    }
+
+    return { ok: true, agentId: targetAgentId, profileCwd };
   }
 
   const configuredDefault = normalizeOptionalAgentId(params.cfg.acp?.defaultAgent);
   if (configuredDefault) {
-    return { ok: true, agentId: configuredDefault };
+    const defaultProfile = listAgentEntries(params.cfg).find(
+      (a) => normalizeAgentId(a.id) === configuredDefault,
+    );
+    const defaultProfileCwd =
+      defaultProfile?.runtime?.type === "acp"
+        ? defaultProfile.runtime.acp?.cwd || defaultProfile.workspace
+        : defaultProfile?.workspace;
+    return { ok: true, agentId: configuredDefault, profileCwd: defaultProfileCwd };
   }
 
   return {
@@ -1001,7 +1022,7 @@ export async function spawnAcpDirect(
     config: cfg,
     targetAgentId,
     requesterSessionKey: ctx.agentSessionKey,
-    explicitWorkspaceDir: params.cwd,
+    explicitWorkspaceDir: params.cwd || targetAgentResult.profileCwd,
   });
   let runtimeCwd: string | undefined;
   try {


### PR DESCRIPTION
## Summary

`resolveTargetAcpAgentId` passes the OpenClaw agent profile ID (e.g. `"analyst"`) directly to `acpx` instead of resolving `runtime.acp.agent` (e.g. `"claude"`). Any profile whose ID doesn't match a built-in harness name crashes with `acpx exited with code 1`. The profile's `cwd`/`workspace` is also lost.

## Bug

- `resolveTargetAcpAgentId` returns `requested` verbatim without looking up `agents.list[].runtime.acp.agent`
- `spawnAcpDirect` passes `params.cwd` only — never reads the profile's configured workspace

## Fix

- `resolveTargetAcpAgentId` now cross-references `agents.list` to map alias → `runtime.acp.agent` and carries `profileCwd`
- Same lookup applies to the `configuredDefault` fallback path
- `spawnAcpDirect` uses `params.cwd || targetAgentResult.profileCwd`

Backward compatible — raw harness IDs with no matching profile pass through unchanged.

Closes #48136, related #51909.

## Validation

- `pnpm test -- --run src/agents/acp-spawn.test.ts` — 35/35 pass (5 new)
- `pnpm build` — succeeds
- `tsc --noEmit` — clean on modified files
- Not verified: live `acpx` spawn, channel binding with aliased agent

## Notes

- No open PRs touch `src/agents/acp-spawn.ts` or address alias resolution
- AI-assisted (Claude Opus 4.6), fully tested