### PR TITLE
fix(subagents): correct duration display showing 5-6x inflated runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ Docs: https://docs.openclaw.ai
 - Agents/MCP: dispose bundled MCP runtimes after one-shot `openclaw agent --local` runs finish, while preserving bundled MCP state across in-run retries so local JSON runs exit cleanly without restarting stateful MCP tools mid-run.
 - Gateway/OpenAI HTTP: restore default operator scopes for bearer-authenticated requests that omit `x-openclaw-scopes`, so headless `/v1/chat/completions` and session-history callers work again after the recent method-scope hardening. (#57596) Thanks @openperf.
 - Gateway/attachments: offload large inbound images without leaking `media://` markers into text-only runs, preserve mixed attachment order for model input/transcripts, and fail closed when model image capability cannot be resolved. (#55513) Thanks @Syysean.
-- Agents/subagents: fix active subagent runtime display so `/subagents list` and `/subagents info` stop inflating short runtimes and show second-level durations correctly. (#57739) Thanks @samzong.
+- Agents/subagents: fix interim subagent runtime display so `/subagents list` and `/subagents info` stop inflating short runtimes and show second-level durations correctly. (#57739) Thanks @samzong.
 
 ## 2026.3.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Docs: https://docs.openclaw.ai
 - Agents/MCP: dispose bundled MCP runtimes after one-shot `openclaw agent --local` runs finish, while preserving bundled MCP state across in-run retries so local JSON runs exit cleanly without restarting stateful MCP tools mid-run.
 - Gateway/OpenAI HTTP: restore default operator scopes for bearer-authenticated requests that omit `x-openclaw-scopes`, so headless `/v1/chat/completions` and session-history callers work again after the recent method-scope hardening. (#57596) Thanks @openperf.
 - Gateway/attachments: offload large inbound images without leaking `media://` markers into text-only runs, preserve mixed attachment order for model input/transcripts, and fail closed when model image capability cannot be resolved. (#55513) Thanks @Syysean.
+- Agents/subagents: fix active subagent runtime display so `/subagents list` and `/subagents info` stop inflating short runtimes and show second-level durations correctly. (#57739) Thanks @samzong.
 
 ## 2026.3.28
 

--- a/src/agents/subagent-control.ts
+++ b/src/agents/subagent-control.ts
@@ -345,7 +345,7 @@ export function buildSubagentList(params: {
           }),
       ),
     );
-    const runtime = formatDurationCompact(runtimeMs);
+    const runtime = formatDurationCompact(runtimeMs) ?? "n/a";
     const label = truncateLine(resolveSubagentLabel(entry), 48);
     const task = truncateLine(entry.task.trim(), params.taskMaxChars ?? 72);
     const line = `${index}. ${label} (${resolveModelDisplay(sessionEntry, entry.model)}, ${runtime}${usageText ? `, ${usageText}` : ""}) ${status}${task.toLowerCase() !== label.toLowerCase() ? ` - ${task}` : ""}`;

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -148,7 +148,7 @@ export function formatSubagentListLine(params: {
   const usageText = formatTokenUsageDisplay(params.sessionEntry);
   const label = truncateLine(formatRunLabel(params.entry, { maxLength: 48 }), 48);
   const task = formatTaskPreview(params.entry.task);
-  const runtime = formatDurationCompact(params.runtimeMs);
+  const runtime = formatDurationCompact(params.runtimeMs) ?? "n/a";
   const status = resolveDisplayStatus(params.entry, {
     pendingDescendants: params.pendingDescendants,
   });

--- a/src/shared/subagents-format.test.ts
+++ b/src/shared/subagents-format.test.ts
@@ -9,9 +9,10 @@ import {
 } from "./subagents-format.js";
 
 describe("shared/subagents-format", () => {
-  it("formats compact durations across minute, hour, and day buckets", () => {
-    expect(formatDurationCompact()).toBe("n/a");
-    expect(formatDurationCompact(30_000)).toBe("1m");
+  it("re-exports the canonical formatter with second-level precision", () => {
+    expect(formatDurationCompact()).toBeUndefined();
+    expect(formatDurationCompact(30_000)).toBe("30s");
+    expect(formatDurationCompact(90_000)).toBe("1m30s");
     expect(formatDurationCompact(60 * 60_000)).toBe("1h");
     expect(formatDurationCompact(61 * 60_000)).toBe("1h1m");
     expect(formatDurationCompact(24 * 60 * 60_000)).toBe("1d");

--- a/src/shared/subagents-format.ts
+++ b/src/shared/subagents-format.ts
@@ -1,20 +1,4 @@
-export function formatDurationCompact(valueMs?: number) {
-  if (!valueMs || !Number.isFinite(valueMs) || valueMs <= 0) {
-    return "n/a";
-  }
-  const minutes = Math.max(1, Math.round(valueMs / 60_000));
-  if (minutes < 60) {
-    return `${minutes}m`;
-  }
-  const hours = Math.floor(minutes / 60);
-  const minutesRemainder = minutes % 60;
-  if (hours < 24) {
-    return minutesRemainder > 0 ? `${hours}h${minutesRemainder}m` : `${hours}h`;
-  }
-  const days = Math.floor(hours / 24);
-  const hoursRemainder = hours % 24;
-  return hoursRemainder > 0 ? `${days}d${hoursRemainder}h` : `${days}d`;
-}
+export { formatDurationCompact } from "../infra/format-time/format-duration.ts";
 
 export function formatTokenShort(value?: number) {
   if (!value || !Number.isFinite(value) || value <= 0) {


### PR DESCRIPTION
## Summary

- Problem: Subagent interim status shows runtime inflated ~5-6x (e.g. 30s displayed as "1m")
- Why it matters: Users cannot trust `/subagents list` runtime during active runs
- What changed: Replaced buggy duplicate `formatDurationCompact` in `src/shared/subagents-format.ts` with a re-export of the canonical implementation from `src/infra/format-time/format-duration.ts`; added `?? "n/a"` fallback at two call sites
- What did NOT change (scope boundary): The canonical formatter, final completion stats, or any other display path

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #45009
- Related #45700 (prior PR by @jackjin1997 — same root cause analysis, closed by author to free PR queue)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: A duplicate `formatDurationCompact` in `src/shared/subagents-format.ts` divides ms by 60,000 (jumping to minutes) instead of 1,000 (seconds). `Math.max(1, Math.round(ms / 60_000))` rounds anything under 60s up to "1m".
- Missing detection / guardrail: The duplicate was never tested against short durations (<60s); existing test cases only covered minute+ ranges.
- Prior context: The canonical implementation in `src/infra/format-time/format-duration.ts` already handles second-level granularity correctly with full test coverage.
- Why this regressed now: The duplicate likely predates the canonical formatter; never caught because final completion stats use a different code path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/shared/subagents-format.test.ts`
- Scenario the test should lock in: `formatDurationCompact(30_000)` returns `"30s"` (not `"1m"`), and `formatDurationCompact(90_000)` returns `"1m30s"`
- Why this is the smallest reliable guardrail: Directly tests the re-exported formatter at the module boundary where callers import it
- Existing test that already covers this (if any): `src/infra/format-time/format-time.test.ts` covers the canonical implementation

## User-visible / Behavior Changes

- `/subagents list` and `/subagents info` now show seconds-level granularity (e.g. `45s` instead of `1m`)
- Short-running subagents no longer show inflated runtimes

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / Bun

### Steps

1. Spawn a subagent with a short task (~30s)
2. Run `/subagents list` during execution
3. Observe runtime display

### Expected

- Runtime shows `30s`

### Actual

- Runtime shows `1m` (before fix)

## Evidence

- [x] Failing test/log before + passing after
  - Before: `formatDurationCompact(30_000)` → `"1m"`
  - After: `formatDurationCompact(30_000)` → `"30s"`

## Human Verification (required)

- Verified scenarios: `subagents-format.test.ts` (5/5), `subagent-control.test.ts` + `reply-plumbing.test.ts` + `format-time.test.ts` (104/104 all passed)
- Edge cases checked: `undefined` input, sub-second input, boundary values (59s, 60s, 3599s, 3600s)
- What you did **not** verify: Live subagent run with real model (test-only verification)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None. The canonical formatter is already used by other callers (`bash-tools.process.ts`, `sandbox-display.ts`, `usage-render-*.ts`); this change aligns the remaining three callers to the same implementation.

---

Credit: Root cause originally identified by @jackjin1997 in #45009 comments and #45700. This PR corrects the test expectations that were missed in the prior attempt.