### PR TITLE
fix(agents): accept canonical edits[] in wrapped edit tool

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
@@ -137,4 +137,25 @@ describe("createOpenClawCodingTools", () => {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("still rejects malformed legacy single-edit input missing newText", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-edit-invalid-"));
+    try {
+      const filePath = path.join(tmpDir, "legacy-invalid.js");
+      await fs.writeFile(filePath, "const value = 'old';\n", "utf8");
+
+      const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
+      const { editTool } = expectReadWriteEditTools(tools);
+
+      await expect(
+        editTool.execute("tool-legacy-edit-invalid", {
+          path: "legacy-invalid.js",
+          oldText: "old",
+        }),
+      ).rejects.toThrow(/newText|oldText/i);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
@@ -116,4 +116,25 @@ describe("createOpenClawCodingTools", () => {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("accepts canonical edits arrays through the wrapped edit tool path", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-canonical-edit-"));
+    try {
+      const filePath = path.join(tmpDir, "canonical-edit.js");
+      await fs.writeFile(filePath, "const value = 'old';\n", "utf8");
+
+      const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
+      const { editTool } = expectReadWriteEditTools(tools);
+
+      await editTool.execute("tool-canonical-edit", {
+        path: "canonical-edit.js",
+        edits: [{ oldText: "old", newText: "new" }],
+      });
+
+      const edited = await fs.readFile(filePath, "utf8");
+      expect(edited).toBe("const value = 'new';\n");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
@@ -158,4 +158,26 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
+
+  it("still rejects blank legacy oldText values", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-edit-blank-"));
+    try {
+      const filePath = path.join(tmpDir, "legacy-blank.js");
+      await fs.writeFile(filePath, "const value = 'old';\n", "utf8");
+
+      const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
+      const { editTool } = expectReadWriteEditTools(tools);
+
+      await expect(
+        editTool.execute("tool-legacy-edit-blank", {
+          path: "legacy-blank.js",
+          oldText: "   ",
+          newText: "new",
+        }),
+      ).rejects.toThrow(/oldText|edits/i);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
@@ -138,6 +138,26 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
+  it("rejects malformed canonical edits[] entries missing newText", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-canonical-edit-invalid-"));
+    try {
+      const filePath = path.join(tmpDir, "canonical-invalid.js");
+      await fs.writeFile(filePath, "const value = 'old';\n", "utf8");
+
+      const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
+      const { editTool } = expectReadWriteEditTools(tools);
+
+      await expect(
+        editTool.execute("tool-canonical-edit-invalid", {
+          path: "canonical-invalid.js",
+          edits: [{ oldText: "old" }],
+        }),
+      ).rejects.toThrow(/edits|oldText|newText/i);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("accepts legacy old/newText when edits[] is present but empty", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-edit-empty-edits-"));
     try {

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
@@ -138,6 +138,29 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
+  it("accepts legacy old/newText when edits[] is present but empty", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-edit-empty-edits-"));
+    try {
+      const filePath = path.join(tmpDir, "legacy-empty-edits.js");
+      await fs.writeFile(filePath, "const value = 'old';\n", "utf8");
+
+      const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
+      const { editTool } = expectReadWriteEditTools(tools);
+
+      const result = await editTool.execute("tool-legacy-edit-empty-edits", {
+        path: "legacy-empty-edits.js",
+        oldText: "const value = 'old';\n",
+        newText: "const value = 'new';\n",
+        edits: [],
+      });
+
+      expect(result.content[0].text).toMatch(/Edited|Successfully replaced/i);
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("const value = 'new';\n");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("still rejects malformed legacy single-edit input missing newText", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-edit-invalid-"));
     try {
@@ -158,26 +181,5 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
-
-  it("still rejects blank legacy oldText values", async () => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-edit-blank-"));
-    try {
-      const filePath = path.join(tmpDir, "legacy-blank.js");
-      await fs.writeFile(filePath, "const value = 'old';\n", "utf8");
-
-      const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
-      const { editTool } = expectReadWriteEditTools(tools);
-
-      await expect(
-        editTool.execute("tool-legacy-edit-blank", {
-          path: "legacy-blank.js",
-          oldText: "   ",
-          newText: "new",
-        }),
-      ).rejects.toThrow(/oldText|edits/i);
-    } finally {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    }
-  });
 
 });

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
@@ -174,7 +174,10 @@ describe("createOpenClawCodingTools", () => {
         edits: [],
       });
 
-      expect(result.content[0].text).toMatch(/Edited|Successfully replaced/i);
+      const textParts = result.content
+        .filter((part): part is Extract<(typeof result.content)[number], { type: "text" }> => part.type === "text")
+        .map((part) => part.text);
+      expect(textParts.join("\n")).toMatch(/Edited|Successfully replaced/i);
       await expect(fs.readFile(filePath, "utf8")).resolves.toBe("const value = 'new';\n");
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });

--- a/src/agents/pi-tools.host-edit.ts
+++ b/src/agents/pi-tools.host-edit.ts
@@ -36,13 +36,28 @@ function readStringParam(record: Record<string, unknown> | undefined, ...keys: s
   return undefined;
 }
 
+function readCanonicalEditPair(record: Record<string, unknown> | undefined) {
+  const firstEdit = Array.isArray(record?.edits) ? record.edits[0] : undefined;
+  if (!firstEdit || typeof firstEdit !== "object") {
+    return {};
+  }
+  const editRecord = firstEdit as Record<string, unknown>;
+  return {
+    oldText: readStringParam(editRecord, "oldText", "old_string", "old_text", "oldString"),
+    newText: readStringParam(editRecord, "newText", "new_string", "new_text", "newString"),
+  };
+}
+
 function readEditToolParams(params: unknown): EditToolParams {
   const record =
     params && typeof params === "object" ? (params as Record<string, unknown>) : undefined;
+  const canonical = readCanonicalEditPair(record);
   return {
-    pathParam: readStringParam(record, "path", "file_path", "file"),
-    oldText: readStringParam(record, "oldText", "old_string", "old_text", "oldString"),
-    newText: readStringParam(record, "newText", "new_string", "new_text", "newString"),
+    pathParam: readStringParam(record, "path", "file_path", "file", "filePath"),
+    oldText:
+      readStringParam(record, "oldText", "old_string", "old_text", "oldString") ?? canonical.oldText,
+    newText:
+      readStringParam(record, "newText", "new_string", "new_text", "newString") ?? canonical.newText,
   };
 }
 

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -25,7 +25,22 @@ export const CLAUDE_PARAM_GROUPS = {
       keys: ["edits", "oldText", "old_string", "old_text", "oldString"],
       label: "edits or oldText/newText aliases",
       validate: (record: Record<string, unknown>) => {
-        if (Array.isArray(record.edits) && record.edits.length > 0) {
+        const hasCanonicalEdit = Array.isArray(record.edits)
+          ? record.edits.some((entry) => {
+              if (!entry || typeof entry !== "object") {
+                return false;
+              }
+              const edit = entry as Record<string, unknown>;
+              const oldText = edit.oldText;
+              const newText = edit.newText;
+              return (
+                typeof oldText === "string" &&
+                oldText.trim().length > 0 &&
+                typeof newText === "string"
+              );
+            })
+          : false;
+        if (hasCanonicalEdit) {
           return true;
         }
         const readNonEmptyString = (...keys: string[]) =>

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -220,7 +220,10 @@ export function assertRequiredParams(
 
   const missingLabels: string[] = [];
   for (const group of groups) {
-    if (group.validate?.(record)) {
+    if (group.validate !== undefined) {
+      if (!group.validate(record)) {
+        missingLabels.push(group.label ?? group.keys.join(" or "));
+      }
       continue;
     }
     const satisfied = group.keys.some((key) => {

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -4,6 +4,7 @@ export type RequiredParamGroup = {
   keys: readonly string[];
   allowEmpty?: boolean;
   label?: string;
+  validate?: (record: Record<string, unknown>) => boolean;
 };
 
 const RETRY_GUIDANCE_SUFFIX = " Supply correct parameters before retrying.";
@@ -21,13 +22,24 @@ export const CLAUDE_PARAM_GROUPS = {
   edit: [
     { keys: ["path", "file_path", "filePath", "file"], label: "path alias" },
     {
-      keys: ["oldText", "old_string", "old_text", "oldString"],
-      label: "oldText alias",
-    },
-    {
-      keys: ["newText", "new_string", "new_text", "newString"],
-      label: "newText alias",
-      allowEmpty: true,
+      keys: ["edits", "oldText", "old_string", "old_text", "oldString"],
+      label: "edits or oldText/newText aliases",
+      validate: (record: Record<string, unknown>) => {
+        if (Array.isArray(record.edits)) {
+          return record.edits.length > 0;
+        }
+        const hasOldText =
+          typeof record.oldText === "string" ||
+          typeof record.old_string === "string" ||
+          typeof record.old_text === "string" ||
+          typeof record.oldString === "string";
+        const hasNewText =
+          typeof record.newText === "string" ||
+          typeof record.new_string === "string" ||
+          typeof record.new_text === "string" ||
+          typeof record.newString === "string";
+        return hasOldText && hasNewText;
+      },
     },
   ],
 } as const;
@@ -145,6 +157,25 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
   normalizeTextLikeParam(normalized, "content");
   normalizeTextLikeParam(normalized, "oldText");
   normalizeTextLikeParam(normalized, "newText");
+  if (Array.isArray(normalized.edits)) {
+    normalized.edits = normalized.edits.map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return entry;
+      }
+      const normalizedEntry = { ...(entry as Record<string, unknown>) };
+      normalizeClaudeParamAliases(normalizedEntry);
+      normalizeTextLikeParam(normalizedEntry, "oldText");
+      normalizeTextLikeParam(normalizedEntry, "newText");
+      return normalizedEntry;
+    });
+  }
+  if (
+    !("edits" in normalized) &&
+    typeof normalized.oldText === "string" &&
+    typeof normalized.newText === "string"
+  ) {
+    normalized.edits = [{ oldText: normalized.oldText, newText: normalized.newText }];
+  }
   return normalized;
 }
 
@@ -189,6 +220,9 @@ export function assertRequiredParams(
 
   const missingLabels: string[] = [];
   for (const group of groups) {
+    if (group.validate?.(record)) {
+      continue;
+    }
     const satisfied = group.keys.some((key) => {
       if (!(key in record)) {
         return false;

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -28,16 +28,13 @@ export const CLAUDE_PARAM_GROUPS = {
         if (Array.isArray(record.edits)) {
           return record.edits.length > 0;
         }
-        const hasOldText =
-          typeof record.oldText === "string" ||
-          typeof record.old_string === "string" ||
-          typeof record.old_text === "string" ||
-          typeof record.oldString === "string";
-        const hasNewText =
-          typeof record.newText === "string" ||
-          typeof record.new_string === "string" ||
-          typeof record.new_text === "string" ||
-          typeof record.newString === "string";
+        const readNonEmptyString = (...keys: string[]) =>
+          keys.some((key) => {
+            const value = record[key];
+            return typeof value === "string" && value.trim().length > 0;
+          });
+        const hasOldText = readNonEmptyString("oldText", "old_string", "old_text", "oldString");
+        const hasNewText = readNonEmptyString("newText", "new_string", "new_text", "newString");
         return hasOldText && hasNewText;
       },
     },

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -25,8 +25,8 @@ export const CLAUDE_PARAM_GROUPS = {
       keys: ["edits", "oldText", "old_string", "old_text", "oldString"],
       label: "edits or oldText/newText aliases",
       validate: (record: Record<string, unknown>) => {
-        if (Array.isArray(record.edits)) {
-          return record.edits.length > 0;
+        if (Array.isArray(record.edits) && record.edits.length > 0) {
+          return true;
         }
         const readNonEmptyString = (...keys: string[]) =>
           keys.some((key) => {
@@ -167,7 +167,8 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
     });
   }
   if (
-    !("edits" in normalized) &&
+    ((!("edits" in normalized) ||
+      (Array.isArray(normalized.edits) && normalized.edits.length === 0))) &&
     typeof normalized.oldText === "string" &&
     typeof normalized.newText === "string"
   ) {

--- a/src/agents/pi-tools.read.host-edit-recovery.test.ts
+++ b/src/agents/pi-tools.read.host-edit-recovery.test.ts
@@ -213,4 +213,39 @@ describe("edit tool recovery hardening", () => {
       text: `Successfully replaced text in ${filePath}.`,
     });
   });
+
+  it("recovers success for canonical edits[] after a post-write throw", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-recovery-"));
+    const filePath = path.join(tmpDir, "demo.txt");
+    await fs.writeFile(filePath, 'const value = "foo";\r\n', "utf-8");
+
+    const tool = createRecoveredEditTool({
+      root: tmpDir,
+      readFile: (absolutePath) => fs.readFile(absolutePath, "utf-8"),
+      execute: async () => {
+        await fs.writeFile(filePath, 'const value = "foobar";\r\n', "utf-8");
+        throw new Error("Simulated post-write failure (e.g. generateDiffString)");
+      },
+    });
+    const result = await tool.execute(
+      "call-1",
+      {
+        path: filePath,
+        edits: [
+          {
+            oldText: 'const value = "foo";\n',
+            newText: 'const value = "foobar";\n',
+          },
+        ],
+      },
+      undefined,
+    );
+
+    expect(result).toMatchObject({ isError: false });
+    expect(result.content[0]).toMatchObject({
+      type: "text",
+      text: `Successfully replaced text in ${filePath}.`,
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary
- accept canonical `{ path, edits: [...] }` input through the wrapped OpenClaw edit tool path
- preserve legacy single-edit compatibility for `{ path, oldText, newText }` and Claude-style aliases
- add an end-to-end wrapped-tool test covering canonical `edits[]`

## Problem
OpenClaw’s edit wrapper layer normalized legacy single-edit inputs, but required-param validation still rejected canonical upstream edit payloads before execution. That meant callers using the canonical `edits[]` shape could fail with:

- `Missing required parameters: oldText alias, newText alias`

## Fix
- keep the existing normalization path that rewrites legacy single-edit input into `edits[]`
- broaden edit required-param validation so it accepts either:
  - a non-empty canonical `edits[]` array, or
  - a legacy single-edit `oldText/newText` pair via supported aliases
- add a wrapped-tool execution test via `createOpenClawCodingTools()` proving canonical `edits[]` succeeds end-to-end

## Testing
Ran locally before opening the PR:
- `pnpm test -- src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts src/agents/pi-tools.workspace-paths.test.ts`

This is a small compatibility follow-up to the edit-tool regression discovered while doing recent local OpenClaw work.
