### PR TITLE
fix(gateway): treat OpenAI HTTP ingress as non-owner

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -146,6 +146,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
             message?: string;
             extraSystemPrompt?: string;
             images?: Array<{ type: string; data: string; mimeType: string }>;
+            senderIsOwner?: boolean;
           }
         | undefined;
     const getFirstAgentMessage = () => getFirstAgentCall()?.message ?? "";
@@ -169,6 +170,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         messages: [{ role: "user", content: message }],
       });
       expect(res.status).toBe(200);
+      expect(getFirstAgentCall()?.senderIsOwner).toBe(false);
       return (await res.json()) as Record<string, unknown>;
     };
 

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -117,8 +117,8 @@ function buildAgentCommandInput(params: {
     deliver: false as const,
     messageChannel: params.messageChannel,
     bestEffortDeliver: false as const,
-    // HTTP API callers are authenticated operator clients for this gateway context.
-    senderIsOwner: true as const,
+    // OpenAI-compatible HTTP ingress is external input and must not inherit owner-only tools.
+    senderIsOwner: false as const,
     allowModelOverride: true as const,
   };
 }


### PR DESCRIPTION
## Summary
- Treats OpenAI-compatible chat completions ingress as external non-owner input
- Keeps owner-only tools out of the HTTP chat-completions agent path

## Changes
- Sets `senderIsOwner` to `false` for `POST /v1/chat/completions` ingress
- Adds a regression assertion that the OpenAI HTTP handler dispatches agent runs with non-owner context

## Validation
- Ran `pnpm check` via the repo commit hook
- Attempted `pnpm test -- src/gateway/openai-http.test.ts`
- Attempted `OPENCLAW_TEST_PROFILE=serial OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test -- src/gateway/openai-http.test.ts`
- Ran local agentic review with `claude -p "/review"` and kept the patch scoped to this endpoint because `/v1/responses` is tracked separately

## Notes
- Residual risk or follow-up: the scoped OpenAI HTTP test hung in the local gateway worker harness under current environment load, so the regression assertion is covered in code but the targeted suite did not produce a clean local completion here
