### PR TITLE
fix(gateway): bind OpenResponses HTTP ingress as non-owner

### DIFF
--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -700,6 +700,40 @@ describe("OpenResponses HTTP API (e2e)", () => {
     }
   });
 
+  it("treats HTTP callers as non-owner regardless of requested scopes", async () => {
+    const port = enabledPort;
+
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
+
+    const writeScopeResponse = await postResponses(port, {
+      model: "openclaw",
+      input: "hi",
+    });
+    expect(writeScopeResponse.status).toBe(200);
+    const writeScopeOpts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
+      | { senderIsOwner?: boolean }
+      | undefined;
+    expect(writeScopeOpts?.senderIsOwner).toBe(false);
+    await ensureResponseConsumed(writeScopeResponse);
+
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
+
+    const adminScopeResponse = await postResponses(
+      port,
+      { model: "openclaw", input: "hi" },
+      { "x-openclaw-scopes": "operator.admin, operator.write" },
+    );
+    expect(adminScopeResponse.status).toBe(200);
+    const adminScopeOpts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
+      | { senderIsOwner?: boolean }
+      | undefined;
+    // Requested HTTP scopes do not prove owner identity for owner-only tools.
+    expect(adminScopeOpts?.senderIsOwner).toBe(false);
+    await ensureResponseConsumed(adminScopeResponse);
+  });
+
   it("preserves assistant text alongside non-stream function_call output", async () => {
     const port = enabledPort;
     agentCommand.mockClear();

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -732,6 +732,28 @@ describe("OpenResponses HTTP API (e2e)", () => {
     // Requested HTTP scopes do not prove owner identity for owner-only tools.
     expect(adminScopeOpts?.senderIsOwner).toBe(false);
     await ensureResponseConsumed(adminScopeResponse);
+
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) =>
+      buildAssistantDeltaResult({
+        opts,
+        emit: emitAgentEvent,
+        deltas: ["he", "llo"],
+        text: "hello",
+      })) as never);
+
+    const streamingResponse = await postResponses(
+      port,
+      { stream: true, model: "openclaw", input: "hi" },
+      { "x-openclaw-scopes": "operator.admin, operator.write" },
+    );
+    expect(streamingResponse.status).toBe(200);
+    const streamingOpts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
+      | { senderIsOwner?: boolean }
+      | undefined;
+    expect(streamingOpts?.senderIsOwner).toBe(false);
+    const streamingEvents = parseSseEvents(await streamingResponse.text());
+    expect(streamingEvents.some((event) => event.event === "response.completed")).toBe(true);
   });
 
   it("preserves assistant text alongside non-stream function_call output", async () => {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -424,6 +424,7 @@ async function runResponsesAgentCommand(params: {
   sessionKey: string;
   runId: string;
   messageChannel: string;
+  senderIsOwner: boolean;
   deps: ReturnType<typeof createDefaultDeps>;
 }) {
   return agentCommandFromIngress(
@@ -439,8 +440,7 @@ async function runResponsesAgentCommand(params: {
       deliver: false,
       messageChannel: params.messageChannel,
       bestEffortDeliver: false,
-      // HTTP API callers are authenticated operator clients for this gateway context.
-      senderIsOwner: true,
+      senderIsOwner: params.senderIsOwner,
       allowModelOverride: true,
     },
     defaultRuntime,
@@ -704,6 +704,7 @@ export async function handleOpenResponsesHttpRequest(
         sessionKey,
         runId: responseId,
         messageChannel,
+        senderIsOwner: false,
         deps,
       });
 
@@ -956,6 +957,7 @@ export async function handleOpenResponsesHttpRequest(
         sessionKey,
         runId: responseId,
         messageChannel,
+        senderIsOwner: false,
         deps,
       });
 


### PR DESCRIPTION
## Summary
- bind OpenResponses HTTP ingress to non-owner agent execution
- keep owner-only tools unavailable to external API callers even when scopes are requested

## Changes
- thread an explicit `senderIsOwner` flag through the OpenResponses ingress helper
- set `senderIsOwner: false` for both streaming and non-streaming `/v1/responses` execution paths
- add a regression test that verifies requested HTTP scopes do not upgrade owner status

## Validation
- ran `pnpm test -- src/gateway/openresponses-http.test.ts -t "treats HTTP callers as non-owner regardless of requested scopes"`
- ran `pnpm exec oxlint src/gateway/openresponses-http.ts src/gateway/openresponses-http.test.ts`
- ran local agentic review with `claude -p "/review"` and addressed follow-up by keeping HTTP ingress hard-bound to non-owner

## Notes
- residual risk or follow-up: OpenAI-compatible HTTP ingress still needs separate handling in its own tracked work