### PR TITLE
fix(build): fallback to copy on Windows when symlink fails with EPERM

### DIFF
--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -35,7 +35,17 @@ function ensureSymlink(targetValue, targetPath, type) {
 }
 
 function symlinkPath(sourcePath, targetPath, type) {
-  ensureSymlink(relativeSymlinkTarget(sourcePath, targetPath), targetPath, type);
+  try {
+    ensureSymlink(relativeSymlinkTarget(sourcePath, targetPath), targetPath, type);
+  } catch (error) {
+    // On Windows without Developer Mode, symlink creation can fail with EPERM or EACCES.
+    // Fall back to copying the file so the build completes successfully.
+    if (error?.code === "EPERM" || error?.code === "EACCES") {
+      fs.copyFileSync(sourcePath, targetPath);
+      return;
+    }
+    throw error;
+  }
 }
 
 function shouldWrapRuntimeJsFile(sourcePath) {


### PR DESCRIPTION
## Summary

On Windows without Developer Mode or symlink privileges, `pnpm build` fails during runtime post-build staging with:

```
EPERM: operation not permitted, symlink
```

This blocks Windows contributors from completing a full source build.

## Root cause

The `symlinkPath()` function calls `ensureSymlink()` which uses `fs.symlinkSync()`. On Windows, symlink creation requires elevated privileges. When those are not available (no Developer Mode, no admin), the call fails with `EPERM`.

## Fix

Wrap `symlinkPath()` in a try/catch that detects `EPERM`/`EACCES` errors and falls back to `fs.copyFileSync()`. This allows the build to complete successfully on Windows without requiring elevated privileges.

## Testing

- [x] Linux build still uses symlinks (no behavior change)
- [x] Windows without symlink privileges falls back to copy
- [x] All other error codes still throw (no silent failures)

Fixes #55454