### PR TITLE
fix: use JSON5 fallback for plugin manifest parsing (#57734) [AI-assisted]

### DIFF
--- a/src/plugins/bundle-manifest.test.ts
+++ b/src/plugins/bundle-manifest.test.ts
@@ -331,4 +331,69 @@ describe("bundle manifest parsing", () => {
 
     expect(detectBundleManifestFormat(rootDir)).toBeNull();
   });
+
+  it("tolerates trailing commas in bundle manifest (JSON5 fallback)", () => {
+    const rootDir = makeTempDir();
+    mkdirSafe(path.join(rootDir, ".codex-plugin"));
+    mkdirSafe(path.join(rootDir, "skills"));
+    // Write raw JSON5 content with trailing commas
+    fs.writeFileSync(
+      path.join(rootDir, CODEX_BUNDLE_MANIFEST_RELATIVE_PATH),
+      `{
+  "name": "Trailing Comma Plugin",
+  "description": "Test trailing commas",
+  "skills": "skills",
+}`,
+      "utf-8",
+    );
+    const result = loadBundleManifest({ rootDir, bundleFormat: "codex" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.name).toBe("Trailing Comma Plugin");
+    }
+  });
+
+  it("tolerates comments in bundle manifest (JSON5 fallback)", () => {
+    const rootDir = makeTempDir();
+    mkdirSafe(path.join(rootDir, ".codex-plugin"));
+    mkdirSafe(path.join(rootDir, "skills"));
+    // Write raw JSON5 content with comments
+    fs.writeFileSync(
+      path.join(rootDir, CODEX_BUNDLE_MANIFEST_RELATIVE_PATH),
+      `{
+  // Plugin name
+  "name": "Comment Plugin",
+  /* Description */
+  "description": "Test comments in manifest",
+  "skills": "skills"
+}`,
+      "utf-8",
+    );
+    const result = loadBundleManifest({ rootDir, bundleFormat: "codex" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.name).toBe("Comment Plugin");
+    }
+  });
+
+  it("tolerates unquoted keys in bundle manifest (JSON5 fallback)", () => {
+    const rootDir = makeTempDir();
+    mkdirSafe(path.join(rootDir, ".codex-plugin"));
+    mkdirSafe(path.join(rootDir, "skills"));
+    // Write raw JSON5 content with unquoted keys
+    fs.writeFileSync(
+      path.join(rootDir, CODEX_BUNDLE_MANIFEST_RELATIVE_PATH),
+      `{
+  name: "Unquoted Keys Plugin",
+  description: "Test unquoted property names",
+  skills: "skills"
+}`,
+      "utf-8",
+    );
+    const result = loadBundleManifest({ rootDir, bundleFormat: "codex" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.name).toBe("Unquoted Keys Plugin");
+    }
+  });
 });

--- a/src/plugins/bundle-manifest.ts
+++ b/src/plugins/bundle-manifest.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { matchBoundaryFileOpenFailure, openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { isRecord } from "../utils.js";
+import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { DEFAULT_PLUGIN_ENTRY_CANDIDATES, PLUGIN_MANIFEST_FILENAME } from "./manifest.js";
 import type { PluginBundleFormat } from "./types.js";
 
@@ -117,7 +118,7 @@ function loadBundleManifestFile(params: {
     });
   }
   try {
-    const raw = JSON.parse(fs.readFileSync(opened.fd, "utf-8")) as unknown;
+    const raw = parseJsonWithJson5Fallback(fs.readFileSync(opened.fd, "utf-8"));
     if (!isRecord(raw)) {
       return { ok: false, error: "plugin manifest must be an object", manifestPath };
     }

--- a/src/plugins/manifest.test.ts
+++ b/src/plugins/manifest.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadPluginManifest, PLUGIN_MANIFEST_FILENAME } from "./manifest.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir() {
+  return makeTrackedTempDir("openclaw-manifest", tempDirs);
+}
+
+function writeManifestRaw(rootDir: string, content: string) {
+  fs.writeFileSync(path.join(rootDir, PLUGIN_MANIFEST_FILENAME), content, "utf-8");
+}
+
+function writeManifestJson(rootDir: string, manifest: Record<string, unknown>) {
+  writeManifestRaw(rootDir, JSON.stringify(manifest, null, 2));
+}
+
+afterEach(() => {
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+describe("loadPluginManifest", () => {
+  it("loads a well-formed JSON manifest", () => {
+    const rootDir = makeTempDir();
+    writeManifestJson(rootDir, {
+      id: "test-plugin",
+      configSchema: { type: "object" },
+    });
+    const result = loadPluginManifest(rootDir, false);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.id).toBe("test-plugin");
+    }
+  });
+
+  it("tolerates trailing commas in the manifest (JSON5 fallback)", () => {
+    const rootDir = makeTempDir();
+    writeManifestRaw(
+      rootDir,
+      `{
+  "id": "trailing-comma-plugin",
+  "configSchema": { "type": "object", },
+}`,
+    );
+    const result = loadPluginManifest(rootDir, false);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.id).toBe("trailing-comma-plugin");
+    }
+  });
+
+  it("tolerates single-line comments in the manifest (JSON5 fallback)", () => {
+    const rootDir = makeTempDir();
+    writeManifestRaw(
+      rootDir,
+      `{
+  // This is a comment
+  "id": "comment-plugin",
+  "configSchema": { "type": "object" }
+}`,
+    );
+    const result = loadPluginManifest(rootDir, false);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.id).toBe("comment-plugin");
+    }
+  });
+
+  it("tolerates multi-line comments in the manifest (JSON5 fallback)", () => {
+    const rootDir = makeTempDir();
+    writeManifestRaw(
+      rootDir,
+      `{
+  /* Multi-line
+     comment */
+  "id": "multiline-comment-plugin",
+  "configSchema": { "type": "object" }
+}`,
+    );
+    const result = loadPluginManifest(rootDir, false);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.id).toBe("multiline-comment-plugin");
+    }
+  });
+
+  it("tolerates unquoted property names in the manifest (JSON5 fallback)", () => {
+    const rootDir = makeTempDir();
+    writeManifestRaw(
+      rootDir,
+      `{
+  id: "unquoted-keys-plugin",
+  configSchema: { type: "object" }
+}`,
+    );
+    const result = loadPluginManifest(rootDir, false);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.id).toBe("unquoted-keys-plugin");
+    }
+  });
+
+  it("returns an error when the manifest is not found", () => {
+    const rootDir = makeTempDir();
+    const result = loadPluginManifest(rootDir, false);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("plugin manifest not found");
+    }
+  });
+
+  it("returns an error when the manifest has completely invalid syntax", () => {
+    const rootDir = makeTempDir();
+    writeManifestRaw(rootDir, "<<<not json at all>>>");
+    const result = loadPluginManifest(rootDir, false);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("failed to parse plugin manifest");
+    }
+  });
+
+  it("returns an error when the manifest is not an object", () => {
+    const rootDir = makeTempDir();
+    writeManifestRaw(rootDir, '"just a string"');
+    const result = loadPluginManifest(rootDir, false);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("plugin manifest must be an object");
+    }
+  });
+
+  it("returns an error when the manifest is missing id", () => {
+    const rootDir = makeTempDir();
+    writeManifestJson(rootDir, { configSchema: { type: "object" } });
+    const result = loadPluginManifest(rootDir, false);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("plugin manifest requires id");
+    }
+  });
+
+  it("returns an error when the manifest is missing configSchema", () => {
+    const rootDir = makeTempDir();
+    writeManifestJson(rootDir, { id: "no-schema-plugin" });
+    const result = loadPluginManifest(rootDir, false);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("plugin manifest requires configSchema");
+    }
+  });
+});

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { matchBoundaryFileOpenFailure, openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { isRecord } from "../utils.js";
+import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import type { PluginConfigUiHint, PluginKind } from "./types.js";
 
 export const PLUGIN_MANIFEST_FILENAME = "openclaw.plugin.json";
@@ -270,7 +271,7 @@ export function loadPluginManifest(
   }
   let raw: unknown;
   try {
-    raw = JSON.parse(fs.readFileSync(opened.fd, "utf-8")) as unknown;
+    raw = parseJsonWithJson5Fallback(fs.readFileSync(opened.fd, "utf-8"));
   } catch (err) {
     return {
       ok: false,


### PR DESCRIPTION
fix: use JSON5 fallback for plugin manifest parsing (#57734) [AI-assisted]

Plugin installation fails with 'Config validation failed' when a third-party plugin's openclaw.plugin.json contains JSON5 syntax (trailing commas, comments, unquoted keys). Replace strict JSON.parse() with parseJsonWithJson5Fallback() in manifest.ts and bundle-manifest.ts to tolerate non-standard JSON in plugin manifests.

## Summary

- **Problem:** `manifest.ts` and `bundle-manifest.ts` use strict `JSON.parse()` to read plugin manifest files (`openclaw.plugin.json`). When a third-party plugin ships a manifest with JSON5 syntax (trailing commas, comments, unquoted property names), parsing fails with `SyntaxError: Expected double-quoted property name in JSON at position 8912 (line 219 column 5)`, which propagates through `manifest-registry.ts` → `validation.ts` → `io.ts` and surfaces as `Config validation failed`.
- **Why it matters:** Users cannot install any third-party plugin whose manifest contains even trivially non-standard JSON, making the plugin ecosystem less robust and the error message misleading (points to config validation rather than manifest parsing).
- **What changed:** Replaced `JSON.parse()` with the existing project utility `parseJsonWithJson5Fallback()` (from `src/utils/parse-json-compat.ts`) in both `manifest.ts` and `bundle-manifest.ts`. This function first attempts standard `JSON.parse()` and, on failure, falls back to `JSON5.parse()`, tolerating trailing commas, comments, and unquoted keys.
- **What did NOT change (scope boundary):** Config file writing (`io.ts` / `JSON.stringify`) is untouched — OpenClaw's own config output remains strict JSON. Only the *reading* of third-party plugin manifest files is relaxed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57734
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** `manifest.ts:263` and `bundle-manifest.ts:120` use strict `JSON.parse()` to parse plugin manifest files. The JSON spec does not allow trailing commas, comments, or unquoted keys, but many real-world tool ecosystems (VS Code extensions, TypeScript configs, etc.) commonly emit JSON5-compatible files. When `@vectorize-io/hindsight-openclaw` shipped an `openclaw.plugin.json` with such syntax, `JSON.parse()` threw a `SyntaxError` at line 219.
- **Missing detection / guardrail:** No test existed that exercised manifest parsing with non-standard JSON input. The project already had `parseJsonWithJson5Fallback()` for config reading (`src/utils/parse-json-compat.ts`) but it was not applied to plugin manifest loading.
- **Prior context:** The `parseJsonWithJson5Fallback` utility was introduced for `config/io.ts` to handle user-edited config files; plugin manifests were overlooked because they were assumed to always be machine-generated strict JSON.
- **Why this regressed now:** Not a regression — this is a latent bug exposed when the first third-party plugin (`@vectorize-io/hindsight-openclaw`) published a manifest with trailing commas.
- **If unknown, what was ruled out:** Config writing (`JSON.stringify` in `io.ts:2185`) was confirmed to always produce valid JSON — the issue is exclusively on the *read* path for plugin manifests.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/plugins/manifest.test.ts` (new), `src/plugins/bundle-manifest.test.ts` (extended)
- **Scenario the test should lock in:** `loadPluginManifest` and `loadBundleManifest` succeed when the manifest file contains trailing commas, single-line/block comments, or unquoted property names.
- **Why this is the smallest reliable guardrail:** Unit tests directly exercise the JSON parsing boundary in the two affected functions without requiring a full plugin installation flow.
- **Existing test that already covers this:** None previously — `bundle-manifest.test.ts` existed but only tested strict JSON inputs.

## User-visible / Behavior Changes

- Plugin installation now succeeds for plugins whose `openclaw.plugin.json` manifest contains JSON5-compatible syntax (trailing commas, comments, unquoted keys).
- No change to config file output format (remains strict JSON).
- No change to error messages for genuinely malformed manifests (both `JSON.parse` and `JSON5.parse` must fail for an error to surface).

## Diagram (if applicable)

```text
Before:
[plugin install] -> manifest.ts JSON.parse() -> SyntaxError -> manifest-registry diagnostic
  -> validation.ts config issue -> io.ts "Config validation failed" ✗

After:
[plugin install] -> manifest.ts parseJsonWithJson5Fallback()
  -> JSON.parse() fails -> JSON5.parse() succeeds -> manifest loaded ✓
