### PR TITLE
WhatsApp: add group and direct system prompt support

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -36505,6 +36505,36 @@
       "hasChildren": false
     },
     {
+      "path": "channels.whatsapp.accounts.*.direct",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.whatsapp.accounts.*.direct.*",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.whatsapp.accounts.*.direct.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.whatsapp.accounts.*.dmHistoryLimit",
       "kind": "channel",
       "type": "integer",
@@ -36631,6 +36661,16 @@
       "path": "channels.whatsapp.accounts.*.groups.*.requireMention",
       "kind": "channel",
       "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.whatsapp.accounts.*.groups.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -37196,6 +37236,36 @@
       "hasChildren": false
     },
     {
+      "path": "channels.whatsapp.direct",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.whatsapp.direct.*",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.whatsapp.direct.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.whatsapp.dmHistoryLimit",
       "kind": "channel",
       "type": "integer",
@@ -37328,6 +37398,16 @@
       "path": "channels.whatsapp.groups.*.requireMention",
       "kind": "channel",
       "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.whatsapp.groups.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5645}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5653}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3294,6 +3294,9 @@
 {"recordType":"path","path":"channels.whatsapp.accounts.*.configWrites","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.debounceMs","kind":"channel","type":"integer","required":true,"defaultValue":0,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.defaultTo","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.direct","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.direct.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.direct.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -3306,6 +3309,7 @@
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.tools.allow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3359,6 +3363,9 @@
 {"recordType":"path","path":"channels.whatsapp.debounceMs","kind":"channel","type":"integer","required":true,"defaultValue":0,"deprecated":false,"sensitive":false,"tags":["channels","network","performance"],"label":"WhatsApp Message Debounce (ms)","help":"Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable).","hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.defaultAccount","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.defaultTo","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.direct","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.whatsapp.direct.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.whatsapp.direct.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"WhatsApp DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.whatsapp.allowFrom=[\"*\"].","hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -3371,6 +3378,7 @@
 {"recordType":"path","path":"channels.whatsapp.groups","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.groups.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.groups.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*.tools.allow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -378,6 +378,10 @@ The agent system prompt includes a group intro on the first turn of a new group 
 - List chats: `imsg chats --limit 20`.
 - Group replies always go back to the same `chat_id`.
 
+## WhatsApp system prompts
+
+See [WhatsApp](/channels/whatsapp#system-prompts) for the canonical WhatsApp system prompt rules, including group and direct prompt resolution, wildcard behavior, and account override semantics.
+
 ## WhatsApp specifics
 
 See [Group messages](/channels/group-messages) for WhatsApp-only behavior (history injection, mention handling details).

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -438,6 +438,73 @@ Behavior notes:
   </Accordion>
 </AccordionGroup>
 
+## System prompts
+
+WhatsApp supports Telegram-style system prompts for groups and direct chats via the `groups` and `direct` maps.
+
+Resolution hierarchy for group messages:
+
+1. **Group-specific system prompt** (`channels.whatsapp.groups["<groupId>"].systemPrompt` or `channels.whatsapp.accounts.<id>.groups["<groupId>"].systemPrompt`): the specific group entry is used if it defines a `systemPrompt`.
+2. **Group wildcard system prompt** (`channels.whatsapp.groups["*"].systemPrompt` or `channels.whatsapp.accounts.<id>.groups["*"].systemPrompt`): used when the specific group entry does not define a `systemPrompt`.
+
+Resolution hierarchy for direct messages:
+
+1. **Direct-specific system prompt** (`channels.whatsapp.direct["<peerId>"].systemPrompt` or `channels.whatsapp.accounts.<id>.direct["<peerId>"].systemPrompt`): the specific direct-chat entry is used if it defines a `systemPrompt`.
+2. **Direct wildcard system prompt** (`channels.whatsapp.direct["*"].systemPrompt` or `channels.whatsapp.accounts.<id>.direct["*"].systemPrompt`): used when the specific direct-chat entry does not define a `systemPrompt`.
+
+Map override semantics:
+
+- Account `groups` fully override root `groups`; they do not merge.
+- Account `direct` fully override root `direct`; they do not merge.
+- Existing `dms` remains the lightweight per-DM history override bucket (`dms.<id>.historyLimit`); prompt overrides live under `direct`.
+
+Important behavior:
+
+- `channels.whatsapp.groups` is both a per-group config map and the chat-level group allowlist. At either the root or account scope, `groups["*"]` means "all groups are admitted" for that scope.
+- Only add a wildcard group `systemPrompt` when you already want that scope to admit all groups. If you still want only a fixed set of group IDs to be eligible, do not use `groups["*"]` for the prompt default. Instead, repeat the prompt on each explicitly allowlisted group entry.
+- Group admission and sender authorization are separate checks. `groups["*"]` widens the set of groups that can reach group handling, but it does not by itself authorize every sender in those groups. Sender access is still controlled separately by `channels.whatsapp.groupPolicy` and `channels.whatsapp.groupAllowFrom`.
+- `channels.whatsapp.direct` does not have the same side effect for DMs. `direct["*"]` only provides a default direct-chat config after a DM is already admitted by `dmPolicy` plus `allowFrom` or pairing-store rules.
+
+Example:
+
+```json5
+{
+  channels: {
+    whatsapp: {
+      groups: {
+        // Use only if all groups should be admitted at the root scope.
+        // Applies to all accounts that do not define their own groups map.
+        "*": { systemPrompt: "Default prompt for all groups." },
+      },
+      direct: {
+        // Applies to all accounts that do not define their own direct map.
+        "*": { systemPrompt: "Default prompt for all direct chats." },
+      },
+      accounts: {
+        work: {
+          groups: {
+            // This account defines its own groups, so root groups are fully
+            // replaced. To keep a wildcard, define "*" explicitly here too.
+            "120363406415684625@g.us": {
+              requireMention: false,
+              systemPrompt: "Focus on project management.",
+            },
+            // Use only if all groups should be admitted in this account.
+            "*": { systemPrompt: "Default prompt for work groups." },
+          },
+          direct: {
+            // This account defines its own direct map, so root direct entries are
+            // fully replaced. To keep a wildcard, define "*" explicitly here too.
+            "+15551234567": { systemPrompt: "Prompt for a specific work direct chat." },
+            "*": { systemPrompt: "Default prompt for work direct chats." },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
 ## Configuration reference pointers
 
 Primary reference:
@@ -451,6 +518,7 @@ High-signal WhatsApp fields:
 - multi-account: `accounts.<id>.enabled`, `accounts.<id>.authDir`, account-level overrides
 - operations: `configWrites`, `debounceMs`, `web.enabled`, `web.heartbeatSeconds`, `web.reconnect.*`
 - session behavior: `session.dmScope`, `historyLimit`, `dmHistoryLimit`, `dms.<id>.historyLimit`
+- prompts: `groups.<id>.systemPrompt`, `groups["*"].systemPrompt`, `direct.<id>.systemPrompt`, `direct["*"].systemPrompt`
 
 ## Related
 

--- a/extensions/whatsapp/src/accounts.test.ts
+++ b/extensions/whatsapp/src/accounts.test.ts
@@ -71,4 +71,59 @@ describe("resolveWhatsAppAuthDir", () => {
     expect(resolved.messagePrefix).toBe("[root]");
     expect(resolved.debounceMs).toBe(250);
   });
+
+  it("account groups override root groups (no deep merge)", () => {
+    // An account setting groups: {} or a subset must fully override root.groups
+    // so that routing/gating and prompt surfaces see a consistent picture.
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            groups: {
+              "*": { systemPrompt: "Root wildcard prompt" },
+              "120363406415684625@g.us": { requireMention: true },
+            },
+            accounts: {
+              work: {
+                groups: {
+                  "120363406415684625@g.us": { requireMention: false },
+                },
+              },
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    // Account groups replace root groups entirely — root "*" must not bleed in.
+    expect(resolved.groups?.["*"]).toBeUndefined();
+    expect(resolved.groups?.["120363406415684625@g.us"]).toEqual({ requireMention: false });
+  });
+
+  it("account direct config overrides root direct config (no deep merge)", () => {
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            direct: {
+              "*": { systemPrompt: "Root direct wildcard" },
+              "+15551234567": { systemPrompt: "Root direct prompt" },
+            },
+            accounts: {
+              work: {
+                direct: {
+                  "+15551234567": { systemPrompt: "Account direct prompt" },
+                },
+              },
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    expect(resolved.direct?.["*"]).toBeUndefined();
+    expect(resolved.direct?.["+15551234567"]).toEqual({ systemPrompt: "Account direct prompt" });
+  });
 });

--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -33,6 +33,7 @@ export type ResolvedWhatsAppAccount = {
   blockStreaming?: boolean;
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
+  direct?: WhatsAppAccountConfig["direct"];
   debounceMs?: number;
 };
 
@@ -155,6 +156,7 @@ export function resolveWhatsAppAccount(params: {
     blockStreaming: merged.blockStreaming,
     ackReaction: merged.ackReaction,
     groups: merged.groups,
+    direct: merged.direct,
     debounceMs: merged.debounceMs,
   };
 }

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
@@ -242,6 +242,72 @@ describe("web processMessage inbound context", () => {
     expect(getDispatcherResponsePrefix()).toBeUndefined();
   });
 
+  it("injects WhatsApp group prompts into GroupSystemPrompt for group chats", async () => {
+    await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:group:123",
+        groupHistoryKey: "123@g.us",
+        cfg: {
+          channels: {
+            whatsapp: {
+              groups: {
+                "123@g.us": { systemPrompt: "Specific group prompt" },
+              },
+            },
+          },
+          messages: {},
+          session: { store: sessionStorePath },
+        } as unknown as ReturnType<typeof import("../../../../../src/config/config.js").loadConfig>,
+        msg: {
+          id: "msg-group-prompt-1",
+          from: "123@g.us",
+          to: "+15550001111",
+          chatType: "group",
+          body: "hi",
+          senderE164: "+15550002222",
+          groupSubject: "Test Group",
+          groupParticipants: [],
+        },
+      }),
+    );
+
+    expect(capturedCtx).toBeTruthy();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect((capturedCtx as any).GroupSystemPrompt).toBe("Specific group prompt");
+  });
+
+  it("injects WhatsApp direct prompts into GroupSystemPrompt for direct chats", async () => {
+    await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:direct:+1555",
+        groupHistoryKey: "+1555",
+        cfg: {
+          channels: {
+            whatsapp: {
+              direct: {
+                "+1555": { systemPrompt: "Specific direct prompt" },
+              },
+            },
+          },
+          messages: {},
+          session: { store: sessionStorePath },
+        } as unknown as ReturnType<typeof import("../../../../../src/config/config.js").loadConfig>,
+        msg: {
+          id: "msg-direct-prompt-1",
+          from: "+1555",
+          to: "+2000",
+          chatType: "direct",
+          body: "hi",
+          senderE164: "+1555",
+        },
+      }),
+    );
+
+    expect(capturedCtx).toBeTruthy();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect((capturedCtx as any).GroupSystemPrompt).toBe("Specific direct prompt");
+  });
+
   it("clears pending group history when the dispatcher does not queue a final reply", async () => {
     capturedCtx = undefined;
     const groupHistories = new Map<string, Array<{ sender: string; body: string }>>([

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -32,6 +32,10 @@ import {
   resolveDmGroupAccessWithCommandGate,
 } from "openclaw/plugin-sdk/security-runtime";
 import { jidToE164, normalizeE164 } from "openclaw/plugin-sdk/text-runtime";
+import {
+  resolveWhatsAppDirectSystemPrompt,
+  resolveWhatsAppGroupSystemPrompt,
+} from "openclaw/plugin-sdk/whatsapp-shared";
 import { resolveWhatsAppAccount } from "../../accounts.js";
 import {
   getPrimaryIdentityId,
@@ -61,6 +65,7 @@ export type GroupHistoryEntry = {
 async function resolveWhatsAppCommandAuthorized(params: {
   cfg: ReturnType<typeof loadConfig>;
   msg: WebInboundMsg;
+  account: ReturnType<typeof resolveWhatsAppAccount>;
 }): Promise<boolean> {
   const useAccessGroups = params.cfg.commands?.useAccessGroups !== false;
   if (!useAccessGroups) {
@@ -77,7 +82,7 @@ async function resolveWhatsAppCommandAuthorized(params: {
     return false;
   }
 
-  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.msg.accountId });
+  const account = params.account;
   const dmPolicy = account.dmPolicy ?? "pairing";
   const groupPolicy = account.groupPolicy ?? "allowlist";
   const configuredAllowFrom = account.allowFrom ?? [];
@@ -121,11 +126,11 @@ async function resolveWhatsAppCommandAuthorized(params: {
 function resolvePinnedMainDmRecipient(params: {
   cfg: ReturnType<typeof loadConfig>;
   msg: WebInboundMsg;
+  account: ReturnType<typeof resolveWhatsAppAccount>;
 }): string | null {
-  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.msg.accountId });
   return resolvePinnedMainDmOwnerFromAllowlist({
     dmScope: params.cfg.session?.dmScope,
-    allowFrom: account.allowFrom,
+    allowFrom: params.account.allowFrom,
     normalizeEntry: (entry) => normalizeE164(entry),
   });
 }
@@ -275,8 +280,9 @@ export async function processMessage(params: {
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(params.cfg, params.route.agentId);
   let didLogHeartbeatStrip = false;
   let didSendReply = false;
+  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.msg.accountId });
   const commandAuthorized = shouldComputeCommandAuthorized(params.msg.body, params.cfg)
-    ? await resolveWhatsAppCommandAuthorized({ cfg: params.cfg, msg: params.msg })
+    ? await resolveWhatsAppCommandAuthorized({ cfg: params.cfg, msg: params.msg, account })
     : undefined;
   const configuredResponsePrefix = params.cfg.messages?.responsePrefix;
   const { onModelSelected, ...replyPipeline } = createChannelReplyPipeline({
@@ -305,6 +311,17 @@ export async function processMessage(params: {
           }),
         )
       : undefined;
+  // Resolve combined conversation system prompt using the group or direct surface.
+  const conversationSystemPrompt =
+    params.msg.chatType === "group"
+      ? resolveWhatsAppGroupSystemPrompt({
+          accountConfig: account,
+          groupId: conversationId,
+        })
+      : resolveWhatsAppDirectSystemPrompt({
+          accountConfig: account,
+          peerId: dmRouteTarget ?? params.msg.from,
+        });
 
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
@@ -336,6 +353,7 @@ export async function processMessage(params: {
     SenderE164: sender.e164 ?? undefined,
     CommandAuthorized: commandAuthorized,
     WasMentioned: params.msg.wasMentioned,
+    GroupSystemPrompt: conversationSystemPrompt,
     ...(params.msg.location ? toLocationContext(params.msg.location) : {}),
     Provider: "whatsapp",
     Surface: "whatsapp",
@@ -349,6 +367,7 @@ export async function processMessage(params: {
   const pinnedMainDmRecipient = resolvePinnedMainDmRecipient({
     cfg: params.cfg,
     msg: params.msg,
+    account,
   });
   const shouldUpdateMainLastRoute =
     !pinnedMainDmRecipient || pinnedMainDmRecipient === dmRouteTarget;

--- a/src/channels/plugins/whatsapp-shared.test.ts
+++ b/src/channels/plugins/whatsapp-shared.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveWhatsAppDirectSystemPrompt,
+  resolveWhatsAppGroupSystemPrompt,
+} from "./whatsapp-shared.js";
+
+describe("resolveWhatsAppGroupSystemPrompt", () => {
+  it("returns undefined when no systemPrompt is configured", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {},
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns group-level systemPrompt when only group systemPrompt is set", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        groups: { "123@g.us": { systemPrompt: "You are helping with group discussions." } },
+      },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe("You are helping with group discussions.");
+  });
+
+  it("trims whitespace from systemPrompts", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        groups: { "123@g.us": { systemPrompt: "  Keep it brief  " } },
+      },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe("Keep it brief");
+  });
+
+  it("ignores empty systemPrompts after trimming", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        groups: { "123@g.us": { systemPrompt: "   " } }, // Only whitespace
+      },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when groupId is not provided", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        groups: { "123@g.us": { systemPrompt: "Group specific prompt" } },
+      },
+      groupId: undefined,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when group doesn't exist and there is no wildcard", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        groups: { "123@g.us": { systemPrompt: "Group specific prompt" } },
+      },
+      groupId: "999@g.us", // Non-existent group
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("handles pre-resolved account configs with group entries", () => {
+    const workResult = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        groups: { "456@g.us": { systemPrompt: "Work group" } },
+      },
+      groupId: "456@g.us",
+    });
+    expect(workResult).toBe("Work group");
+  });
+
+  it("falls back to wildcard '*' group when specific group is not configured", () => {
+    const accountConfig = {
+      groups: {
+        "*": { systemPrompt: "Default group prompt" },
+        "123@g.us": { systemPrompt: "Specific group prompt" },
+      },
+    };
+
+    // Specific group config takes precedence
+    expect(resolveWhatsAppGroupSystemPrompt({ accountConfig, groupId: "123@g.us" })).toBe(
+      "Specific group prompt",
+    );
+
+    // Unknown group falls back to "*"
+    expect(resolveWhatsAppGroupSystemPrompt({ accountConfig, groupId: "999@g.us" })).toBe(
+      "Default group prompt",
+    );
+  });
+
+  it("falls back to wildcard '*' in account-level groups", () => {
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        accountConfig: {
+          groups: { "*": { systemPrompt: "Default work group prompt" } },
+        },
+        groupId: "456@g.us",
+      }),
+    ).toBe("Default work group prompt");
+  });
+
+  it("uses wildcard systemPrompt when specific group entry has no systemPrompt", () => {
+    // Should still get wildcard's systemPrompt even though group entry exists
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        accountConfig: {
+          groups: {
+            "*": { systemPrompt: "Default group prompt" },
+            "123@g.us": {}, // Group entry exists but only sets non-prompt fields (e.g. requireMention)
+          },
+        },
+        groupId: "123@g.us",
+      }),
+    ).toBe("Default group prompt");
+  });
+});
+
+describe("resolveWhatsAppDirectSystemPrompt", () => {
+  it("returns undefined when no direct prompt is configured", () => {
+    const result = resolveWhatsAppDirectSystemPrompt({
+      accountConfig: {},
+      peerId: "+15551234567",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns direct-level systemPrompt when only direct systemPrompt is set", () => {
+    const result = resolveWhatsAppDirectSystemPrompt({
+      accountConfig: {
+        direct: { "+15551234567": { systemPrompt: "This is a VIP DM." } },
+      },
+      peerId: "+15551234567",
+    });
+
+    expect(result).toBe("This is a VIP DM.");
+  });
+
+  it("falls back to wildcard '*' direct config when specific peer is not configured", () => {
+    expect(
+      resolveWhatsAppDirectSystemPrompt({
+        accountConfig: {
+          direct: { "*": { systemPrompt: "Default work DM prompt" } },
+        },
+        peerId: "+15551234567",
+      }),
+    ).toBe("Default work DM prompt");
+  });
+
+  it("trims whitespace from direct systemPrompts", () => {
+    const result = resolveWhatsAppDirectSystemPrompt({
+      accountConfig: {
+        direct: { "+15551234567": { systemPrompt: "  Keep it brief  " } },
+      },
+      peerId: "+15551234567",
+    });
+
+    expect(result).toBe("Keep it brief");
+  });
+
+  it("ignores empty direct systemPrompts after trimming", () => {
+    const result = resolveWhatsAppDirectSystemPrompt({
+      accountConfig: {
+        direct: { "+15551234567": { systemPrompt: "   " } },
+      },
+      peerId: "+15551234567",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when peerId is not provided", () => {
+    const result = resolveWhatsAppDirectSystemPrompt({
+      accountConfig: {
+        direct: { "+15551234567": { systemPrompt: "Direct specific prompt" } },
+      },
+      peerId: undefined,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when direct chat doesn't exist and there is no wildcard", () => {
+    const result = resolveWhatsAppDirectSystemPrompt({
+      accountConfig: {
+        direct: { "+15550001111": { systemPrompt: "Known direct prompt" } },
+      },
+      peerId: "+15559999999",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("handles pre-resolved account configs with direct entries", () => {
+    const personalResult = resolveWhatsAppDirectSystemPrompt({
+      accountConfig: {
+        direct: { "+15551234567": { systemPrompt: "Family direct chat" } },
+      },
+      peerId: "+15551234567",
+    });
+    expect(personalResult).toBe("Family direct chat");
+
+    const workResult = resolveWhatsAppDirectSystemPrompt({
+      accountConfig: {
+        direct: { "+15557654321": { systemPrompt: "Work direct chat" } },
+      },
+      peerId: "+15557654321",
+    });
+    expect(workResult).toBe("Work direct chat");
+  });
+
+  it("uses wildcard systemPrompt when specific direct entry has no systemPrompt", () => {
+    expect(
+      resolveWhatsAppDirectSystemPrompt({
+        accountConfig: {
+          direct: {
+            "*": { systemPrompt: "Default direct prompt" },
+            "+15551234567": {},
+          },
+        },
+        peerId: "+15551234567",
+      }),
+    ).toBe("Default direct prompt");
+  });
+});

--- a/src/channels/plugins/whatsapp-shared.ts
+++ b/src/channels/plugins/whatsapp-shared.ts
@@ -7,6 +7,94 @@ import type { ChannelOutboundAdapter } from "./types.js";
 export const WHATSAPP_GROUP_INTRO_HINT =
   "WhatsApp IDs: SenderId is the participant JID (group participant id).";
 
+export type WhatsAppGroupSystemPromptParams = {
+  /** Pre-resolved merged account config (groups only). Mirrors Telegram's groupConfig param style. */
+  accountConfig?: {
+    groups?: Record<string, { systemPrompt?: string }>;
+  } | null;
+  groupId?: string | null;
+};
+
+export type WhatsAppDirectSystemPromptParams = {
+  /** Pre-resolved merged account config (direct only). */
+  accountConfig?: {
+    direct?: Record<string, { systemPrompt?: string }>;
+  } | null;
+  peerId?: string | null;
+};
+
+/**
+ * Resolves and combines WhatsApp system prompts from a pre-resolved account config slice.
+ * Follows the same pattern as Telegram's resolveTelegramGroupPromptSettings: the caller
+ * resolves the account config first, then passes the relevant slice here.
+ *
+ * Resolution hierarchy for group messages:
+ *
+ * 1. Group system prompt (groups["<groupId>"].systemPrompt or
+ *    groups["*"].systemPrompt):
+ *    - The specific group entry is used if it defines a systemPrompt.
+ *    - Falls back to groups["*"].systemPrompt for groups with no specific entry.
+ *    - resolveWhatsAppAccount uses the same override semantics as the shared
+ *      resolveChannelGroups helper: account groups replace root groups entirely
+ *      (no deep merge). The resolved account config therefore already contains
+ *      root groups (including "*") whenever the account defines no groups of its
+ *      own, mirroring Telegram's resolveTelegramGroupPromptSettings pattern.
+ *
+ * 2. Final prompt delivered to the agent for group messages:
+ *    groupSystemPrompt
+ */
+export function resolveWhatsAppGroupSystemPrompt(
+  params: WhatsAppGroupSystemPromptParams,
+): string | undefined {
+  // Get group-level systemPrompt if groupId is provided.
+  // Resolve per-field: use the specific group's systemPrompt if set, otherwise
+  // fall back to the wildcard "*" entry so default prompts still apply even when
+  // the specific group entry only defines non-prompt settings (e.g. requireMention).
+  let groupSystemPrompt: string | undefined;
+  if (params.groupId) {
+    const groups = params.accountConfig?.groups;
+    // Resolution order: specific group entry → wildcard "*" entry.
+    // Root groups naturally reach here when the account defines no groups of its
+    // own (resolveWhatsAppAccount uses override-not-merge semantics, same as
+    // resolveChannelGroups: accountGroups ?? rootGroups).
+    groupSystemPrompt =
+      groups?.[params.groupId]?.systemPrompt?.trim() ||
+      groups?.["*"]?.systemPrompt?.trim() ||
+      undefined;
+  }
+  return groupSystemPrompt;
+}
+
+/**
+ * Resolves and combines WhatsApp system prompts for direct chats from a pre-resolved
+ * account config slice.
+ *
+ * Resolution hierarchy for direct messages:
+ *
+ * 1. Direct-chat system prompt (direct["<peerId>"].systemPrompt or
+ *    direct["*"].systemPrompt):
+ *    - The specific DM entry is used if it defines a systemPrompt.
+ *    - Falls back to direct["*"].systemPrompt for direct chats with no specific entry.
+ *    - resolveWhatsAppAccount applies the same override semantics here as for groups:
+ *      account direct config replaces root direct config entirely (no deep merge).
+ *
+ * 2. Final prompt delivered to the agent for direct messages:
+ *    dmSystemPrompt
+ */
+export function resolveWhatsAppDirectSystemPrompt(
+  params: WhatsAppDirectSystemPromptParams,
+): string | undefined {
+  let directSystemPrompt: string | undefined;
+  if (params.peerId) {
+    const direct = params.accountConfig?.direct;
+    directSystemPrompt =
+      direct?.[params.peerId]?.systemPrompt?.trim() ||
+      direct?.["*"]?.systemPrompt?.trim() ||
+      undefined;
+  }
+  return directSystemPrompt;
+}
+
 export function resolveWhatsAppGroupIntroHint(): string {
   return WHATSAPP_GROUP_INTRO_HINT;
 }

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -21,6 +21,13 @@ export type WhatsAppGroupConfig = {
   requireMention?: boolean;
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
+  /** Optional system prompt for this group. */
+  systemPrompt?: string;
+};
+
+export type WhatsAppDirectConfig = {
+  /** Optional system prompt for this direct chat. */
+  systemPrompt?: string;
 };
 
 export type WhatsAppAckReactionConfig = {
@@ -62,7 +69,7 @@ type WhatsAppSharedConfig = {
   historyLimit?: number;
   /** Max DM turns to keep as history context. */
   dmHistoryLimit?: number;
-  /** Per-DM config overrides keyed by user ID. */
+  /** Per-DM history overrides keyed by user ID. */
   dms?: Record<string, DmConfig>;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
@@ -75,6 +82,8 @@ type WhatsAppSharedConfig = {
   /** Merge streamed block replies before sending. */
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
   groups?: Record<string, WhatsAppGroupConfig>;
+  /** Per-direct-chat prompt overrides keyed by user ID or `*` wildcard. */
+  direct?: Record<string, WhatsAppDirectConfig>;
   /** Acknowledgment reaction sent immediately upon message receipt. */
   ackReaction?: WhatsAppAckReactionConfig;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */

--- a/src/config/zod-schema.providers-whatsapp.test.ts
+++ b/src/config/zod-schema.providers-whatsapp.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { WhatsAppConfigSchema, WhatsAppAccountSchema } from "./zod-schema.providers-whatsapp.js";
+
+describe("WhatsApp prompt config Zod validation", () => {
+  it("validates group-level systemPrompt", () => {
+    const config = {
+      groups: {
+        "123@g.us": {
+          systemPrompt: "This is a work group",
+        },
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.groups?.["123@g.us"]?.systemPrompt).toBe("This is a work group");
+    }
+  });
+
+  it("validates direct-level systemPrompt", () => {
+    const config = {
+      direct: {
+        "+15551234567": {
+          systemPrompt: "This is a VIP direct chat",
+        },
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.direct?.["+15551234567"]?.systemPrompt).toBe("This is a VIP direct chat");
+    }
+  });
+
+  it("validates combined group and direct prompt surfaces", () => {
+    const config = {
+      groups: {
+        "*": {
+          systemPrompt: "Default group prompt",
+        },
+      },
+      direct: {
+        "+15551234567": {
+          systemPrompt: "Direct VIP",
+        },
+      },
+      accounts: {
+        work: {
+          groups: {
+            "456@g.us": {
+              systemPrompt: "Project team",
+            },
+          },
+          direct: {
+            "*": {
+              systemPrompt: "Work direct default",
+            },
+          },
+        },
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.groups?.["*"]?.systemPrompt).toBe("Default group prompt");
+      expect(result.data.direct?.["+15551234567"]?.systemPrompt).toBe("Direct VIP");
+      expect(result.data.accounts?.work?.groups?.["456@g.us"]?.systemPrompt).toBe("Project team");
+      expect(result.data.accounts?.work?.direct?.["*"]?.systemPrompt).toBe("Work direct default");
+    }
+  });
+
+  it("validates WhatsAppAccountSchema directly", () => {
+    const accountConfig = {
+      name: "Personal Account",
+      groups: {
+        "family@g.us": {
+          systemPrompt: "Keep responses family-friendly",
+        },
+      },
+      direct: {
+        "+15557654321": {
+          systemPrompt: "Keep responses concise",
+        },
+      },
+    };
+
+    const result = WhatsAppAccountSchema.safeParse(accountConfig);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.groups?.["family@g.us"]?.systemPrompt).toBe(
+        "Keep responses family-friendly",
+      );
+      expect(result.data.direct?.["+15557654321"]?.systemPrompt).toBe("Keep responses concise");
+    }
+  });
+});

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -19,11 +19,21 @@ const WhatsAppGroupEntrySchema = z
     requireMention: z.boolean().optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
+    systemPrompt: z.string().optional(),
   })
   .strict()
   .optional();
 
 const WhatsAppGroupsSchema = z.record(z.string(), WhatsAppGroupEntrySchema).optional();
+
+const WhatsAppDirectEntrySchema = z
+  .object({
+    systemPrompt: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
+const WhatsAppDirectSchema = z.record(z.string(), WhatsAppDirectEntrySchema).optional();
 
 const WhatsAppAckReactionSchema = z
   .object({
@@ -56,6 +66,7 @@ const WhatsAppSharedSchema = z.object({
   blockStreaming: z.boolean().optional(),
   blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
   groups: WhatsAppGroupsSchema,
+  direct: WhatsAppDirectSchema,
   ackReaction: WhatsAppAckReactionSchema,
   debounceMs: z.number().int().nonnegative().optional().default(0),
   heartbeat: ChannelHeartbeatVisibilitySchema,

--- a/src/plugin-sdk/whatsapp-shared.ts
+++ b/src/plugin-sdk/whatsapp-shared.ts
@@ -2,8 +2,14 @@ export type { ChannelMessageActionName } from "../channels/plugins/types.js";
 export type { DmPolicy, GroupPolicy, WhatsAppAccountConfig } from "../config/types.js";
 export {
   createWhatsAppOutboundBase,
+  resolveWhatsAppDirectSystemPrompt,
   resolveWhatsAppGroupIntroHint,
+  resolveWhatsAppGroupSystemPrompt,
   resolveWhatsAppMentionStripRegexes,
+} from "../channels/plugins/whatsapp-shared.js";
+export type {
+  WhatsAppDirectSystemPromptParams,
+  WhatsAppGroupSystemPromptParams,
 } from "../channels/plugins/whatsapp-shared.js";
 export {
   looksLikeWhatsAppTargetId,


### PR DESCRIPTION
## Summary

Developed with github co-pilot.

WhatsApp supports Telegram-style system prompts for groups and direct chats via the `groups` and `direct` maps.

Resolution hierarchy for group messages:

1. **Group-specific system prompt** (`channels.whatsapp.groups["<groupId>"].systemPrompt` or `channels.whatsapp.accounts.<id>.groups["<groupId>"].systemPrompt`): the specific group entry is used if it defines a `systemPrompt`.
2. **Group wildcard system prompt** (`channels.whatsapp.groups["*"].systemPrompt` or `channels.whatsapp.accounts.<id>.groups["*"].systemPrompt`): used when the specific group entry does not define a `systemPrompt`.

Resolution hierarchy for direct messages:

1. **Direct-specific system prompt** (`channels.whatsapp.direct["<peerId>"].systemPrompt` or `channels.whatsapp.accounts.<id>.direct["<peerId>"].systemPrompt`): the specific direct-chat entry is used if it defines a `systemPrompt`.
2. **Direct wildcard system prompt** (`channels.whatsapp.direct["*"].systemPrompt` or `channels.whatsapp.accounts.<id>.direct["*"].systemPrompt`): used when the specific direct-chat entry does not define a `systemPrompt`.

Map override semantics:

- Account `groups` fully override root `groups`; they do not merge.
- Account `direct` fully override root `direct`; they do not merge.
- Existing `dms` remains the lightweight per-DM history override bucket (`dms.<id>.historyLimit`); prompt overrides live under `direct`.

Important behavior:

- `channels.whatsapp.groups` is both a per-group config map and the chat-level group allowlist. At either the root or account scope, `groups["*"]` means "all groups are admitted" for that scope.
- Only add a wildcard group `systemPrompt` when you already want that scope to admit all groups. If you still want only a fixed set of group IDs to be eligible, do not use `groups["*"]` for the prompt default. Instead, repeat the prompt on each explicitly allowlisted group entry.
- Group admission and sender authorization are separate checks. `groups["*"]` widens the set of groups that can reach group handling, but it does not by itself authorize every sender in those groups. Sender access is still controlled separately by `channels.whatsapp.groupPolicy` and `channels.whatsapp.groupAllowFrom`.
- `channels.whatsapp.direct` does not have the same side effect for DMs. `direct["*"]` only provides a default direct-chat config after a DM is already admitted by `dmPolicy` plus `allowFrom` or pairing-store rules.

Example:

```json5
{
  channels: {
    whatsapp: {
      groups: {
        // Use only if all groups should be admitted at the root scope.
        // Applies to all accounts that do not define their own groups map.
        "*": { systemPrompt: "Default prompt for all groups." },
      },
      direct: {
        // Applies to all accounts that do not define their own direct map.
        "*": { systemPrompt: "Default prompt for all direct chats." },
      },
      accounts: {
        work: {
          groups: {
            // This account defines its own groups, so root groups are fully
            // replaced. To keep a wildcard, define "*" explicitly here too.
            "120363406415684625@g.us": {
              requireMention: false,
              systemPrompt: "Focus on project management.",
            },
            // Use only if all groups should be admitted in this account.
            "*": { systemPrompt: "Default prompt for work groups." },
          },
          direct: {
            // This account defines its own direct map, so root direct entries are
            // fully replaced. To keep a wildcard, define "*" explicitly here too.
            "+15551234567": { systemPrompt: "Prompt for a specific work direct chat." },
            "*": { systemPrompt: "Default prompt for work direct chats." },
          },
        },
      },
    },
  },
}
```

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
Addresses [#7011](https://github.com/openclaw/openclaw/issues/7011) (WhatsApp group prompt enhancement)

- Related #
I'm submitting this PR as a more focused PR instead of my previous PR [#40250](https://github.com/openclaw/openclaw/pull/40250)(WhatsApp: Add account/group systemPrompt hierarchy & fix group policy gating) which I'll subsequently close.

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

Use this:

- Added WhatsApp system prompt support for both group chats and direct chats via the `groups` and `direct` config maps.
- Added support for per-chat and wildcard prompts:
  - `channels.whatsapp.groups.<groupId>.systemPrompt`
  - `channels.whatsapp.groups["*"].systemPrompt`
  - `channels.whatsapp.direct.<peerId>.systemPrompt`
  - `channels.whatsapp.direct["*"].systemPrompt`
- Added account-scoped overrides for the same surfaces under `channels.whatsapp.accounts.<id>.groups` and `channels.whatsapp.accounts.<id>.direct`.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local gateway via `pnpm openclaw --dev gateway run --bind loopback --port 19001 --force`
- Model/provider: `google/gemini-3.1-pro-preview`
- Integration/channel: WhatsApp group chat
- Relevant config detailed in tests below

### Steps

### Expected

### Actual

## Evidence

## Human Verification (required)

### Screenshot

<img width="1294" height="151" alt="Screenshot 2026-03-30 at 18 06 57" src="https://github.com/user-attachments/assets/46159df2-3815-4d07-a2a0-fe0a47364f41" />

### Steps
1. Prepare configuration for test
2. Restart gateway (dev)
3. Send Hello or \new to group
4. Check response correctly combines instructions from system prompts

### Configuration
The following configuration was used for manual testing

```
  "channels": {
    "whatsapp": {
      "enabled": true,
      "groupPolicy": "allowlist",
      "groups": {
        "*": { "systemPrompt": "Add GROUP-ROOT-WILDCARD at the end of every response." }
      },
      "direct": {
        "*": { "systemPrompt": "Add DIRECT-ROOT-WILDCARD at the end of every direct response." }
      },
      "accounts": {
        "test": {
          "allowFrom": [
            "+972545751506",
            "+97289402586"
          ],
          "groupPolicy": "allowlist",
          "groups": {
            "120363406415684625@g.us": {
              "requireMention": false,
              "systemPrompt": "Add GROUP-SPECIFIC before the end of every group response."
            },
            "*": { "systemPrompt": "Add GROUP-ACCOUNT-WILDCARD at the middle of every response." }
          },
          "direct": {
            "+97289402586": {
              "systemPrompt": "Add DIRECT-SPECIFIC before the end of every response to +97289402586."
            },
            "*": {
              "systemPrompt": "Add DIRECT-ACCOUNT-WILDCARD at the middle of every direct response."
            }
          },
          "name": "Test Account"
        }
      }
    }
  },
```

### Verified scenarios:

1. Account specific direct mapped prompt: DIRECT_SPECIFIC text received in reply.
2. Account wildcard direct prompt: Remove the directly mapped prompt configuration.  DIRECT-ACCOUNT-WILDCARD received in reply.
3. Root wildcard direct prompt: Remove the entire direct map from account. DIRECT-ROOT-WILDCARD received in reply.
4. Account specific group mapped prompt: GROUP_SPECIFIC text received in reply.
5. Account wildcard group prompt: Remove the specific group  prompt configuration.  GROUP-ACCOUNT-WILDCARD received in reply.
6. Root wildcard group prompt: Remove the entire group map from account. GROUP-ROOT-WILDCARD received in reply.

### What you did **not** verify:

1. Did not test group maps at the root level (beyond wildcard).
2. All scenarios required gateway restart when configuration is changed. 

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`No`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

None
