### PR TITLE
fix(minimax): drop thinking blocks from context to prevent content leakage

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -657,6 +657,8 @@ export async function compactEmbeddedPiSessionDirect(
         modelApi: model.api,
         provider,
         modelId,
+        config: params.config,
+        workspaceDir: params.workspaceDir,
       });
       const sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
         agentId: sessionAgentId,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -658,7 +658,7 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         config: params.config,
-        workspaceDir: params.workspaceDir,
+        workspaceDir: effectiveWorkspace,
       });
       const sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
         agentId: sessionAgentId,

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -592,6 +592,7 @@ export async function sanitizeSessionHistory(params: {
       modelApi: params.modelApi,
       provider: params.provider,
       modelId: params.modelId,
+      config: params.config,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
   const canonicalizedAssistantHistory = canonicalizeAssistantHistoryMessages({

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -581,6 +581,8 @@ export async function sanitizeSessionHistory(params: {
   provider?: string;
   allowedToolNames?: Iterable<string>;
   config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
   sessionManager: SessionManager;
   sessionId: string;
   policy?: TranscriptPolicy;
@@ -593,6 +595,8 @@ export async function sanitizeSessionHistory(params: {
       provider: params.provider,
       modelId: params.modelId,
       config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
   const canonicalizedAssistantHistory = canonicalizeAssistantHistoryMessages({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -712,6 +712,8 @@ export async function runEmbeddedAttempt(
         modelApi: params.model?.api,
         provider: params.provider,
         modelId: params.modelId,
+        config: params.config,
+        workspaceDir: params.workspaceDir,
       });
 
       await prewarmSessionFile(params.sessionFile);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -713,7 +713,7 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         config: params.config,
-        workspaceDir: params.workspaceDir,
+        workspaceDir: effectiveWorkspace,
       });
 
       await prewarmSessionFile(params.sessionFile);

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -241,6 +241,29 @@ describe("resolveProviderCapabilities", () => {
     ).toBe(true);
   });
 
+  it("drops thinking blocks for MiniMax models via static fallback", () => {
+    // Plugin mock returns undefined for minimax — relies on PLUGIN_CAPABILITIES_FALLBACKS.
+    // This ensures the fix works even when plugin context (config/workspaceDir) is absent.
+    expect(
+      shouldDropThinkingBlocksForModel({
+        provider: "minimax",
+        modelId: "MiniMax-M2.7",
+      }),
+    ).toBe(true);
+    expect(
+      shouldDropThinkingBlocksForModel({
+        provider: "minimax-portal",
+        modelId: "MiniMax-M2.7",
+      }),
+    ).toBe(true);
+    expect(
+      shouldDropThinkingBlocksForModel({
+        provider: "minimax",
+        modelId: "MiniMax-M2.5",
+      }),
+    ).toBe(true);
+  });
+
   it("forwards config and workspace context to plugin capability lookup", () => {
     const config = { plugins: { enabled: true } };
     const env = { OPENCLAW_HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv;

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -53,6 +53,12 @@ const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities
       "mistralai",
     ],
   },
+  minimax: {
+    dropThinkingBlockModelHints: ["minimax"],
+  },
+  "minimax-portal": {
+    dropThinkingBlockModelHints: ["minimax"],
+  },
   moonshot: {
     openAiPayloadNormalizationMode: "moonshot-thinking",
   },

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -1,3 +1,4 @@
+import type { OpenClawConfig } from "../config/config.js";
 import { normalizeProviderId } from "./model-selection.js";
 import { isGoogleModelApi } from "./pi-embedded-helpers/google.js";
 import {
@@ -61,6 +62,9 @@ export function resolveTranscriptPolicy(params: {
   modelApi?: string | null;
   provider?: string | null;
   modelId?: string | null;
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
 }): TranscriptPolicy {
   const provider = normalizeProviderId(params.provider ?? "");
   const modelId = params.modelId ?? "";
@@ -77,6 +81,9 @@ export function resolveTranscriptPolicy(params: {
     shouldSanitizeGeminiThoughtSignaturesForModel({
       provider,
       modelId,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
     });
   const requiresOpenAiCompatibleToolIdSanitization =
     params.modelApi === "openai-completions" ||
@@ -88,7 +95,13 @@ export function resolveTranscriptPolicy(params: {
   // Anthropic Claude endpoints can reject replayed `thinking` blocks unless the
   // original signatures are preserved byte-for-byte. Drop them at send-time to
   // keep persisted sessions usable across follow-up turns.
-  const dropThinkingBlocks = shouldDropThinkingBlocksForModel({ provider, modelId });
+  const dropThinkingBlocks = shouldDropThinkingBlocksForModel({
+    provider,
+    modelId,
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
 
   const needsNonImageSanitize =
     isGoogle || isAnthropic || isMistral || shouldSanitizeGeminiThoughtSignaturesForProvider;


### PR DESCRIPTION
## Summary

- **Problem:** MiniMax-M2.7 (and M2.5) sessions eventually start echoing the model's internal thinking verbatim into text responses. Once it starts, it cascades — each leaked thinking block in context reinforces the next turn.
- **Why it matters:** The `dropThinkingBlockModelHints` check in `shouldDropThinkingBlocksForModel` returns false for `minimax`/`minimax-portal` because neither provider has an entry in `PLUGIN_CAPABILITIES_FALLBACKS`. Thinking blocks accumulate in session history and get replayed on subsequent API calls, triggering the leakage loop.
- **What changed:**
  1. Added `minimax` and `minimax-portal` to `PLUGIN_CAPABILITIES_FALLBACKS` in `provider-capabilities.ts` — same pattern as `anthropic`/`mistral`. This is the direct fix.
  2. Fixed `resolveTranscriptPolicy` to accept and forward `config`/`workspaceDir`/`env` to the capability lookup. Without these, the plugin registry is never consulted and plugin-registered capabilities (e.g. `capabilities` in `registerProvider()`) silently have no effect for any plugin provider, not just MiniMax. Updated the three call sites in `attempt.ts`, `compact.ts`, and `google.ts`.
- **What did NOT change:** No behavioral change for providers not affected by this bug. `resolveTranscriptPolicy` params are additive/optional — all existing callers still work as-is.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #57788
- Related #47913, #54206
- Related #48221
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Two separate issues compounding. First, `minimax`/`minimax-portal` were never added to `PLUGIN_CAPABILITIES_FALLBACKS`, so `dropThinkingBlockModelHints` is always `[]` for these providers. Second, even though the minimax extension declares `capabilities: { dropThinkingBlockModelHints: ["minimax"] }` via `registerProvider()`, the call site in `transcript-policy.ts` calls `shouldDropThinkingBlocksForModel` without `config`/`workspaceDir`/`env`, so `resolveProviderCapabilitiesWithPlugin` returns nothing and plugin-registered capabilities are never applied.
- Missing detection / guardrail: No test covering `shouldDropThinkingBlocksForModel` for plugin-based providers (minimax, etc.) under the static fallback path.
- Prior context: The minimax extension has had the `registerProvider` capabilities declaration for some time, but it was never effective due to the missing call-site context.
- Why this regressed now: Wasn't a regression per se — the fix was just never landed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/provider-capabilities.test.ts`
- Scenario the test should lock in: `shouldDropThinkingBlocksForModel` returns `true` for `minimax`/`minimax-portal` even when the plugin mock returns `undefined` (i.e., the static fallback path works correctly).
- Why this is the smallest reliable guardrail: Directly exercises the fallback lookup without requiring a full plugin runtime.

## User-visible / Behavior Changes

MiniMax-M2.7 sessions stop leaking thinking block content into text responses.

## Diagram (if applicable)

```text
Before:
shouldDropThinkingBlocksForModel({ provider: "minimax", modelId }) 
  -> PLUGIN_CAPABILITIES_FALLBACKS["minimax"] = undefined
  -> pluginCapabilities = undefined (no config/workspaceDir passed)
  -> dropThinkingBlockModelHints = []
  -> returns false -> thinking blocks replay in context -> leakage

After:
shouldDropThinkingBlocksForModel({ provider: "minimax", modelId })
  -> PLUGIN_CAPABILITIES_FALLBACKS["minimax"] = { dropThinkingBlockModelHints: ["minimax"] }
  -> returns true -> thinking blocks stripped before API call -> no leakage
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Runtime/container: Docker (openclaw gateway container)
- Model/provider: minimax/MiniMax-M2.7 via anthropic-messages API
- Integration/channel: Telegram

### Steps

1. Start a long-lived agent session using MiniMax-M2.7 with `reasoning: true`
2. Send a series of short conversational messages (~10–20 turns)
3. Observe text response content

### Expected

- All responses contain only the intended text output in the target language

### Actual (before fix)

- After several turns, responses begin with English phrases echoing thinking content (e.g. starting with phrases describing the user's message), and this pattern repeats for all subsequent turns

## Evidence

- [x] Failing test/log before + passing after (new test in `provider-capabilities.test.ts` was failing before this fix, passes after)

## Human Verification (required)

- Verified scenarios: Applied equivalent fix to the compiled bundle in a running container and confirmed leakage stopped after restart. Subsequent turns all produced clean output in the expected language.
- Edge cases checked: `minimax-portal` (OAuth path), `MiniMax-M2.5` (non-reasoning model), no-config call site.
- What you did **not** verify: Live end-to-end with this exact source build (verified against patched bundle only).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Stripping thinking blocks from a provider that legitimately needs them replayed.
  - Mitigation: `dropThinkingBlockModelHints` matches on model ID substring (`"minimax"`), so it only affects MiniMax models. Other providers on the same host are unaffected.