### PR TITLE
fix(gateway): harden HTTP server with connection timeout limits

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -784,6 +784,16 @@ export function createGatewayHttpServer(opts: {
         void handleRequest(req, res);
       });
 
+  // Harden against Slowloris and slow-read DoS attacks by enforcing timeouts
+  // on header reception, full request delivery, and idle keep-alive connections.
+  // Node.js defaults are very permissive (headersTimeout: 60s, requestTimeout: 0,
+  // keepAliveTimeout: 5s) which allows resource exhaustion with minimal effort.
+  httpServer.headersTimeout = 30_000; // 30s to receive complete headers
+  httpServer.requestTimeout = 120_000; // 2min for the full request (body included)
+  httpServer.keepAliveTimeout = 30_000; // 30s idle before closing keep-alive sockets
+  // Cap max headers per request to limit header-bomb memory pressure.
+  httpServer.maxHeadersCount = 100;
+
   async function handleRequest(req: IncomingMessage, res: ServerResponse) {
     setDefaultSecurityHeaders(res, {
       strictTransportSecurity: strictTransportSecurityHeader,


### PR DESCRIPTION
## Problem

The gateway HTTP server relies on Node.js defaults for connection timeouts, which are quite permissive: `headersTimeout` defaults to 60s, `requestTimeout` to 0 (unlimited), and `keepAliveTimeout` to 5s. This leaves the server vulnerable to Slowloris-style resource exhaustion attacks where an attacker holds many connections open by sending data very slowly.

## Fix

Set explicit timeout values on the HTTP server instance immediately after creation:

- **`headersTimeout`**: 30s (down from 60s default) — time allowed to receive complete request headers
- **`requestTimeout`**: 120s (from unlimited) — time allowed for the full request including body
- **`keepAliveTimeout`**: 30s (up from 5s default) — idle time before closing keep-alive sockets; slightly higher than default to avoid churning connections from active clients
- **`maxHeadersCount`**: 100 (down from 2000 default) — limits per-request header count to reduce header-bomb memory pressure

These values are generous enough to accommodate legitimate use cases (large file uploads, SSE streams) while providing practical protection against connection exhaustion.

## Testing

Verified the change compiles cleanly and passes lint. The timeout properties are standard Node.js `http.Server` attributes that take effect immediately on assignment.