### PR TITLE
Preserve session model overrides on generic persistence

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -90,6 +90,7 @@ type PersistSessionEntryParams = {
   sessionKey: string;
   storePath: string;
   entry: SessionEntry;
+  clearMissingOverrideFields?: boolean;
 };
 
 type OverrideFieldClearedByDelete =
@@ -121,6 +122,7 @@ async function persistSessionEntry(params: PersistSessionEntryParams): Promise<v
   await persistSessionEntryBase({
     ...params,
     clearedFields: OVERRIDE_FIELDS_CLEARED_BY_DELETE,
+    clearMissingFields: params.clearMissingOverrideFields === true,
   });
 }
 
@@ -611,6 +613,7 @@ async function agentCommandInternal(
               sessionKey,
               storePath,
               entry,
+              clearMissingOverrideFields: true,
             });
           }
         }

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { resolveFallbackRetryPrompt, sessionFileHasContent } from "./attempt-execution.js";
+import {
+  persistSessionEntry,
+  resolveFallbackRetryPrompt,
+  sessionFileHasContent,
+} from "./attempt-execution.js";
 
 describe("resolveFallbackRetryPrompt", () => {
   const originalBody = "Summarize the quarterly earnings report and highlight key trends.";
@@ -155,5 +159,87 @@ describe("sessionFileHasContent", () => {
     const link = path.join(tmpDir, "link.jsonl");
     await fs.symlink(realFile, link);
     expect(await sessionFileHasContent(link)).toBe(false);
+  });
+});
+
+describe("persistSessionEntry", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oc-persist-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("preserves omitted cleared fields by default", async () => {
+    const storePath = path.join(tmpDir, "sessions.json");
+    const sessionKey = "agent:main:main";
+    const initialEntry = {
+      sessionId: "sess-1",
+      updatedAt: 1,
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-6",
+    };
+    await fs.writeFile(storePath, JSON.stringify({ [sessionKey]: initialEntry }), "utf-8");
+
+    const sessionStore = { [sessionKey]: { ...initialEntry } };
+    await persistSessionEntry({
+      sessionStore,
+      sessionKey,
+      storePath,
+      entry: {
+        sessionId: "sess-1",
+        updatedAt: 2,
+        thinkingLevel: "adaptive",
+      },
+      clearedFields: ["providerOverride", "modelOverride"],
+    });
+
+    expect(sessionStore[sessionKey]?.providerOverride).toBe("anthropic");
+    expect(sessionStore[sessionKey]?.modelOverride).toBe("claude-opus-4-6");
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      { providerOverride?: string; modelOverride?: string }
+    >;
+    expect(persisted[sessionKey]?.providerOverride).toBe("anthropic");
+    expect(persisted[sessionKey]?.modelOverride).toBe("claude-opus-4-6");
+  });
+
+  it("clears omitted fields only when explicitly requested", async () => {
+    const storePath = path.join(tmpDir, "sessions.json");
+    const sessionKey = "agent:main:main";
+    const initialEntry = {
+      sessionId: "sess-2",
+      updatedAt: 1,
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-6",
+    };
+    await fs.writeFile(storePath, JSON.stringify({ [sessionKey]: initialEntry }), "utf-8");
+
+    const sessionStore = { [sessionKey]: { ...initialEntry } };
+    await persistSessionEntry({
+      sessionStore,
+      sessionKey,
+      storePath,
+      entry: {
+        sessionId: "sess-2",
+        updatedAt: 2,
+      },
+      clearedFields: ["providerOverride", "modelOverride"],
+      clearMissingFields: true,
+    });
+
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      { providerOverride?: string; modelOverride?: string }
+    >;
+    expect(persisted[sessionKey]?.providerOverride).toBeUndefined();
+    expect(persisted[sessionKey]?.modelOverride).toBeUndefined();
   });
 });

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -97,14 +97,17 @@ export type PersistSessionEntryParams = {
   storePath: string;
   entry: SessionEntry;
   clearedFields?: string[];
+  clearMissingFields?: boolean;
 };
 
 export async function persistSessionEntry(params: PersistSessionEntryParams): Promise<void> {
   const persisted = await updateSessionStore(params.storePath, (store) => {
     const merged = mergeSessionEntry(store[params.sessionKey], params.entry);
-    for (const field of params.clearedFields ?? []) {
-      if (!Object.hasOwn(params.entry, field)) {
-        Reflect.deleteProperty(merged, field);
+    if (params.clearMissingFields === true) {
+      for (const field of params.clearedFields ?? []) {
+        if (!Object.hasOwn(params.entry, field)) {
+          Reflect.deleteProperty(merged, field);
+        }
       }
     }
     store[params.sessionKey] = merged;
@@ -395,6 +398,8 @@ export function runAgentAttempt(params: {
             sessionKey: params.sessionKey,
             storePath: params.storePath,
             entry: updatedEntry,
+            clearedFields: params.providerOverride === "claude-cli" ? ["claudeCliSessionId"] : [],
+            clearMissingFields: params.providerOverride === "claude-cli",
           });
 
           params.sessionEntry = updatedEntry;


### PR DESCRIPTION
## Summary
Generic session persistence was clearing omitted override fields by default. That can drop a previously selected `/model` session override when a later non-model session write merges a partial entry.

## Repro
1. Set a per-session model with `/model`.
2. Persist a later session update that does not touch model/provider override fields.
3. The merged session entry can lose `providerOverride` and `modelOverride` because omitted fields are treated as deletions.

## Fix
- Make `persistSessionEntry()` preserve omitted fields by default.
- Only clear missing override fields on explicit reset paths.
- Keep Claude CLI expiry cleanup on the explicit-clear path.

## Tests
- Added regression coverage for preserving omitted cleared fields by default.
- Added regression coverage for explicit field clearing when requested.
- Re-ran focused agent + CLI provider tests.

## Validation
```bash
corepack pnpm exec vitest run --config vitest.config.ts \
  src/agents/command/attempt-execution.test.ts \
  src/commands/agent.test.ts \
  src/commands/agent.cli-provider.test.ts
```
