### PR TITLE
CLI: reset remote URL after trust decline

### DIFF
--- a/src/commands/onboard-remote.test.ts
+++ b/src/commands/onboard-remote.test.ts
@@ -138,7 +138,7 @@ describe("promptRemoteGatewayConfig", () => {
     const manualUrl = "wss://manual.example.com:18789";
     const text: WizardPrompter["text"] = vi.fn(async (params) => {
       if (params.message === "Gateway WebSocket URL") {
-        expect(params.initialValue).toBe("wss://evil.example:443");
+        expect(params.initialValue).toBe("ws://127.0.0.1:18789");
         return manualUrl;
       }
       return "";

--- a/src/commands/onboard-remote.ts
+++ b/src/commands/onboard-remote.ts
@@ -132,6 +132,9 @@ export async function promptRemoteGatewayConfig(
             ].join("\n"),
             "Direct remote",
           );
+        } else {
+          // Clear the discovered endpoint so the manual prompt falls back to a safe default.
+          suggestedUrl = DEFAULT_GATEWAY_URL;
         }
       } else {
         suggestedUrl = DEFAULT_GATEWAY_URL;


### PR DESCRIPTION
## Summary
- reset the remote onboarding URL prompt to the loopback default after a discovered endpoint is declined
- keep the trusted direct-connection path and SSH tunnel path unchanged

## Changes
- add a trust-decline fallback to `DEFAULT_GATEWAY_URL` in `promptRemoteGatewayConfig`
- update the onboarding regression to assert the safe default after declining a discovered endpoint

## Validation
- ran `pnpm test -- src/commands/onboard-remote.test.ts`
- ran `pnpm check`
- ran `claude -p "/review"` with no actionable feedback

## Notes
- validation is mock-based for the onboarding flow; no live Bonjour E2E run locally