### PR TITLE
fix(zai): support glm-5.1 and glm-5.* semver-style model ids

### DIFF
--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -39,7 +39,7 @@ openclaw onboard --auth-choice zai-cn
 
 ## Notes
 
-- GLM models are available as `zai/<model>` (example: `zai/glm-5`).
+- GLM models are available as `zai/<model>` (examples: `zai/glm-5`, `zai/glm-5.1`, `zai/glm-5-turbo`).
 - `tool_stream` is enabled by default for Z.AI tool-call streaming. Set
   `agents.defaults.models["zai/<model>"].params.tool_stream` to `false` to disable it.
 - See [/providers/glm](/providers/glm) for the model family overview.

--- a/docs/zh-CN/providers/zai.md
+++ b/docs/zh-CN/providers/zai.md
@@ -46,7 +46,7 @@ openclaw onboard --auth-choice zai-cn
 
 ## 说明
 
-- GLM 模型可用作 `zai/<model>`（例如：`zai/glm-5`）。
+- GLM 模型可用作 `zai/<model>`（例如：`zai/glm-5`、`zai/glm-5.1`、`zai/glm-5-turbo`）。
 - `tool_stream` 默认启用，用于 Z.AI 工具调用流式传输。若要禁用，请设置
   `agents.defaults.models["zai/<model>"].params.tool_stream` 为 `false`。
 - 关于模型家族概览，请参阅 [/providers/glm](/providers/glm)。

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -31,12 +31,21 @@ const GLM5_MODEL_ID = "glm-5";
 const GLM5_TEMPLATE_MODEL_ID = "glm-4.7";
 const PROFILE_ID = "zai:default";
 
+/** GLM-5 base id, hyphen variants (e.g. glm-5-turbo), and semver-style minors (e.g. glm-5.1). */
+function isGlm5FamilyModelId(modelIdLower: string): boolean {
+  return (
+    modelIdLower === GLM5_MODEL_ID ||
+    modelIdLower.startsWith(`${GLM5_MODEL_ID}-`) ||
+    modelIdLower.startsWith(`${GLM5_MODEL_ID}.`)
+  );
+}
+
 function resolveGlm5ForwardCompatModel(
   ctx: ProviderResolveDynamicModelContext,
 ): ProviderRuntimeModel | undefined {
   const trimmedModelId = ctx.modelId.trim();
   const lower = trimmedModelId.toLowerCase();
-  if (lower !== GLM5_MODEL_ID && !lower.startsWith(`${GLM5_MODEL_ID}-`)) {
+  if (!isGlm5FamilyModelId(lower)) {
     return undefined;
   }
 

--- a/extensions/zai/model-definitions.test.ts
+++ b/extensions/zai/model-definitions.test.ts
@@ -50,4 +50,16 @@ describe("zai model definitions", () => {
       cost: { input: 1.2, output: 4, cacheRead: 0.24, cacheWrite: 0 },
     });
   });
+
+  it("includes glm-5.1 with glm-5-class limits", () => {
+    expect(buildZaiModelDefinition({ id: "glm-5.1" })).toMatchObject({
+      id: "glm-5.1",
+      name: "GLM-5.1",
+      reasoning: true,
+      input: ["text"],
+      contextWindow: 202800,
+      maxTokens: 131100,
+      cost: ZAI_DEFAULT_COST,
+    });
+  });
 });

--- a/extensions/zai/model-definitions.ts
+++ b/extensions/zai/model-definitions.ts
@@ -40,6 +40,15 @@ const ZAI_MODEL_CATALOG = {
     maxTokens: 131100,
     cost: { input: 1.2, output: 4, cacheRead: 0.24, cacheWrite: 0 },
   },
+  /** Minor release; align with glm-5 until Z.AI publishes distinct pricing. */
+  "glm-5.1": {
+    name: "GLM-5.1",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 202800,
+    maxTokens: 131100,
+    cost: ZAI_DEFAULT_COST,
+  },
   "glm-4.7": {
     name: "GLM-4.7",
     reasoning: true,

--- a/extensions/zai/onboard.test.ts
+++ b/extensions/zai/onboard.test.ts
@@ -12,6 +12,7 @@ describe("zai onboard", () => {
     });
     const ids = cfg.models?.providers?.zai?.models?.map((m) => m.id);
     expect(ids).toContain("glm-5");
+    expect(ids).toContain("glm-5.1");
     expect(ids).toContain("glm-5-turbo");
     expect(ids).toContain("glm-4.7");
     expect(ids).toContain("glm-4.7-flash");

--- a/extensions/zai/onboard.ts
+++ b/extensions/zai/onboard.ts
@@ -12,6 +12,7 @@ export const ZAI_DEFAULT_MODEL_REF = `zai/${ZAI_DEFAULT_MODEL_ID}`;
 
 const ZAI_DEFAULT_MODELS = [
   buildZaiModelDefinition({ id: "glm-5" }),
+  buildZaiModelDefinition({ id: "glm-5.1" }),
   buildZaiModelDefinition({ id: "glm-5-turbo" }),
   buildZaiModelDefinition({ id: "glm-4.7" }),
   buildZaiModelDefinition({ id: "glm-4.7-flash" }),


### PR DESCRIPTION
## Summary

- **Problem:** Z.AI model ids like `glm-5.1` use a dot minor (`glm-5.*`), but GLM-5 family detection only treated `glm-5` and `glm-5-*` (hyphen) as GLM-5, so `zai/glm-5.1` was not handled consistently with the rest of the GLM-5 path.
- **Why it matters:** Users configuring `glm-5.1` would get incorrect or incomplete behavior vs `glm-5` / `glm-5-flash` style ids.
- **What changed:** Extend forward-compat so ids **starting with `glm-5.`** (e.g. `glm-5.1`) are in the GLM-5 family; register **`glm-5.1`** in the Z.AI catalog and default onboard model list; update English and zh-CN provider docs; add/adjust unit tests.
- **What did NOT change:** No change to non-GLM-5 models, gateway orchestration, auth, or unrelated providers; pricing/limits for `glm-5.1` stay aligned with `glm-5` until Z.AI publishes distinct numbers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** Model-id family matching was too narrow: dot-separated GLM-5 minors (`glm-5.1`) were not included alongside `glm-5` and `glm-5-*`.
- **Missing detection / guardrail:** No unit coverage (or insufficient pattern coverage) for `glm-5.*`-style ids in the Z.AI extension’s family helper.
- **Prior context:** N/A (not traced via blame in this PR).
- **Why this regressed now:** N/A — behavior was wrong as soon as `glm-5.1`-style ids appeared in configs; not necessarily a new upstream regression.
- **If unknown, what was ruled out:** N/A

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `extensions/zai/model-definitions.test.ts`, `extensions/zai/onboard.test.ts`
- **Scenario the test should lock in:** `glm-5.1` (and the `glm-5.*` pattern) is recognized as GLM-5 family and appears in catalog / default onboard list as intended.
- **Why this is the smallest reliable guardrail:** Pure string/pattern + static catalog/onboard assertions; no live API needed.
- **Existing test that already covers this (if any):** Extended/added in this PR.
- **If no new test is added, why not:** N/A — tests added/updated.

## User-visible / Behavior Changes

- **`glm-5.1` is treated as GLM-5 family** (same class of handling as other GLM-5 ids the extension already supports).
- **`glm-5.1` appears in the Z.AI model catalog and default onboard list** (defaults aligned with `glm-5` until distinct pricing is published).
- **Docs** mention the dot-minor id form where relevant.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node (repo default)
- Model/provider: Z.AI (`glm-5.1` id form)
- Integration/channel (if any): N/A
- Relevant config (redacted): any config using model id `glm-5.1` / `zai/glm-5.1` as applicable in OpenClaw

### Steps

1. `pnpm install`
2. `pnpm exec vitest run extensions/zai/model-definitions.test.ts extensions/zai/onboard.test.ts`
3. (Optional) Configure a Z.AI model id using `glm-5.1` and confirm it follows the GLM-5 path in-app.

### Expected

- Tests pass; `glm-5.1` is recognized and listed consistently with the change.

### Actual

- Targeted vitest run: **2 files, 7 tests passed** (local).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:** Ran targeted unit tests above; reviewed that family matching includes `glm-5.*` and that catalog/onboard include `glm-5.1`.
- **Edge cases checked:** Dot minor (`5.1`) vs hyphen suffix (`glm-5-flash`) — both paths covered by intent; exact assertions live in tests.
- **What you did not verify:** Full `pnpm test` / CI matrix for entire monorepo; live API calls to Z.AI with a real key.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

*(Check these after bots comment.)*

## Compatibility / Migration

- **Backward compatible?** **Yes** (additive recognition + catalog/onboard entry; existing `glm-5` configs unchanged).
- **Config/env changes?** **No** required.
- **Migration needed?** **No**
- **If yes, exact upgrade steps:** N/A

## Risks and Mitigations

- **Risk:** Catalog pricing/limits for `glm-5.1` are **copied from `glm-5`** and may drift from Z.AI’s published numbers later.
  - **Mitigation:** Document alignment; follow up when Z.AI publishes distinct pricing and adjust catalog fields.
