### PR TITLE
gateway: use identity.name in agent summaries when name is unset

### DIFF
--- a/src/gateway/agent-list.test.ts
+++ b/src/gateway/agent-list.test.ts
@@ -35,4 +35,17 @@ describe("listGatewayAgentsBasic", () => {
 
     expect(result.agents).toEqual([{ id: "main", name: "Ops" }]);
   });
+
+  it("leaves the name unset when neither agents.list[].name nor identity.name is present", () => {
+    const cfg: OpenClawConfig = {
+      session: { mainKey: "main" },
+      agents: {
+        list: [{ id: "main", default: true, identity: {} }],
+      },
+    };
+
+    const result = listGatewayAgentsBasic(cfg);
+
+    expect(result.agents).toEqual([{ id: "main", name: undefined }]);
+  });
 });

--- a/src/gateway/agent-list.test.ts
+++ b/src/gateway/agent-list.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { listGatewayAgentsBasic } from "./agent-list.js";
+
+describe("listGatewayAgentsBasic", () => {
+  it("falls back to identity.name when the configured agent name is missing", () => {
+    const cfg: OpenClawConfig = {
+      session: { mainKey: "main" },
+      agents: {
+        list: [{ id: "main", default: true, identity: { name: "小金" } }],
+      },
+    };
+
+    const result = listGatewayAgentsBasic(cfg);
+
+    expect(result.agents).toEqual([{ id: "main", name: "小金" }]);
+  });
+
+  it("prefers the explicit configured name over identity.name", () => {
+    const cfg: OpenClawConfig = {
+      session: { mainKey: "main" },
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            name: "Ops",
+            identity: { name: "开发助手" },
+          },
+        ],
+      },
+    };
+
+    const result = listGatewayAgentsBasic(cfg);
+
+    expect(result.agents).toEqual([{ id: "main", name: "Ops" }]);
+  });
+});

--- a/src/gateway/agent-list.ts
+++ b/src/gateway/agent-list.ts
@@ -62,8 +62,11 @@ export function listGatewayAgentsBasic(cfg: OpenClawConfig): {
     if (!entry?.id) {
       continue;
     }
+    const configuredName =
+      typeof entry.name === "string" && entry.name.trim() ? entry.name.trim() : undefined;
+    const identityName = entry.identity?.name?.trim() || undefined;
     configuredById.set(normalizeAgentId(entry.id), {
-      name: normalizeOptionalString(entry.name),
+      name: configuredName ?? identityName,
     });
   }
   const explicitIds = new Set(

--- a/src/gateway/agent-list.ts
+++ b/src/gateway/agent-list.ts
@@ -5,7 +5,6 @@ import { resolveStateDir } from "../config/paths.js";
 import type { SessionScope } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, normalizeMainKey } from "../routing/session-key.js";
-import { normalizeOptionalString } from "../shared/string-coerce.js";
 
 export type GatewayAgentListRow = {
   id: string;

--- a/src/gateway/agent-list.ts
+++ b/src/gateway/agent-list.ts
@@ -5,7 +5,6 @@ import { resolveStateDir } from "../config/paths.js";
 import type { SessionScope } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, normalizeMainKey } from "../routing/session-key.js";
-import { normalizeOptionalString } from "../shared/string-coerce.js";
 
 type GatewayAgentListRow = {
   id: string;

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -677,6 +677,23 @@ describe("gateway session utils", () => {
     );
   });
 
+  test("listAgentsForGateway falls back to identity.name when name is unset", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: {
+        list: [{ id: "main", default: true, identity: { name: "开发助手" } }],
+      },
+    } as OpenClawConfig;
+
+    const result = listAgentsForGateway(cfg);
+
+    expect(result.agents[0]).toMatchObject({
+      id: "main",
+      name: "开发助手",
+      identity: { name: "开发助手" },
+    });
+  });
+
   test("listAgentsForGateway keeps explicit agents.list scope over disk-only agents (scope boundary)", async () => {
     await withStateDirEnv("openclaw-agent-list-scope-", async ({ stateDir }) => {
       fs.mkdirSync(path.join(stateDir, "agents", "main"), { recursive: true });

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -694,6 +694,23 @@ describe("gateway session utils", () => {
     });
   });
 
+  test("listAgentsForGateway leaves name unset when both configured and identity names are absent", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: {
+        list: [{ id: "main", default: true, identity: {} }],
+      },
+    } as OpenClawConfig;
+
+    const result = listAgentsForGateway(cfg);
+
+    expect(result.agents[0]).toMatchObject({
+      id: "main",
+      name: undefined,
+      identity: {},
+    });
+  });
+
   test("listAgentsForGateway keeps explicit agents.list scope over disk-only agents (scope boundary)", async () => {
     await withStateDirEnv("openclaw-agent-list-scope-", async ({ stateDir }) => {
       fs.mkdirSync(path.join(stateDir, "agents", "main"), { recursive: true });

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1041,6 +1041,23 @@ describe("gateway session utils", () => {
     );
   });
 
+  test("listAgentsForGateway falls back to identity.name when name is unset", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: {
+        list: [{ id: "main", default: true, identity: { name: "开发助手" } }],
+      },
+    } as OpenClawConfig;
+
+    const result = listAgentsForGateway(cfg);
+
+    expect(result.agents[0]).toMatchObject({
+      id: "main",
+      name: "开发助手",
+      identity: { name: "开发助手" },
+    });
+  });
+
   test("listAgentsForGateway keeps explicit agents.list scope over disk-only agents (scope boundary)", async () => {
     await withStateDirEnv("openclaw-agent-list-scope-", async ({ stateDir }) => {
       fs.mkdirSync(path.join(stateDir, "agents", "main"), { recursive: true });

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1058,6 +1058,23 @@ describe("gateway session utils", () => {
     });
   });
 
+  test("listAgentsForGateway leaves name unset when both configured and identity names are absent", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: {
+        list: [{ id: "main", default: true, identity: {} }],
+      },
+    } as OpenClawConfig;
+
+    const result = listAgentsForGateway(cfg);
+
+    expect(result.agents[0]).toMatchObject({
+      id: "main",
+      name: undefined,
+      identity: {},
+    });
+  });
+
   test("listAgentsForGateway keeps explicit agents.list scope over disk-only agents (scope boundary)", async () => {
     await withStateDirEnv("openclaw-agent-list-scope-", async ({ stateDir }) => {
       fs.mkdirSync(path.join(stateDir, "agents", "main"), { recursive: true });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -751,6 +751,8 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
     if (!entry?.id) {
       continue;
     }
+    const configuredName =
+      typeof entry.name === "string" && entry.name.trim() ? entry.name.trim() : undefined;
     const identity = entry.identity
       ? {
           name: normalizeOptionalString(entry.identity.name),
@@ -765,7 +767,7 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
         }
       : undefined;
     configuredById.set(normalizeAgentId(entry.id), {
-      name: normalizeOptionalString(entry.name),
+      name: configuredName ?? identity?.name,
       identity,
     });
   }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -978,6 +978,8 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
     if (!entry?.id) {
       continue;
     }
+    const configuredName =
+      typeof entry.name === "string" && entry.name.trim() ? entry.name.trim() : undefined;
     const identity = entry.identity
       ? {
           name: normalizeOptionalString(entry.identity.name),
@@ -992,7 +994,7 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
         }
       : undefined;
     configuredById.set(normalizeAgentId(entry.id), {
-      name: normalizeOptionalString(entry.name),
+      name: configuredName ?? identity?.name,
       identity,
     });
   }


### PR DESCRIPTION
## Summary
- fall back to `identity.name` when `agents.list[].name` is unset in gateway agent summaries
- keep explicit configured `name` values authoritative when both fields are present
- add regression coverage for both the basic agent list and the richer gateway summary path

Fixes #57822

## Testing
- `corepack pnpm test src/gateway/agent-list.test.ts src/gateway/session-utils.test.ts`

Result on 2026-05-12 after rebasing onto `origin/main` `5abb4b18c8`:

```text
Test Files  2 passed (2)
Tests       89 passed (89)
```

## Real behavior proof

**Behavior or issue addressed:** Gateway agent summaries should display `agents.list[].identity.name` when the legacy top-level `agents.list[].name` is absent, while preserving explicit top-level `name` precedence.

**Real environment tested:** Local Linux checkout of OpenClaw on branch head `009acaff81`, Node/tsx runtime from the repository dependency set, after rebasing onto `origin/main` `5abb4b18c8`.

**Exact steps or command run after this patch:** Ran a Node/tsx terminal probe that imported `listGatewayAgentsBasic` from `src/gateway/agent-list.ts` and `listAgentsForGateway` from `src/gateway/session-utils.ts`, then passed a config containing one identity-only agent, one explicit-name agent, and one unnamed agent.

**Evidence after fix:** Terminal output from the probe:

```json
{
  "basic": [
    { "id": "main", "hasName": true, "name": "Identity Name" },
    { "id": "explicit", "hasName": true, "name": "Explicit Name" },
    { "id": "missing", "hasName": true, "name": null }
  ],
  "full": [
    { "id": "main", "hasName": true, "name": "Identity Name" },
    { "id": "explicit", "hasName": true, "name": "Explicit Name" },
    { "id": "missing", "hasName": true, "name": null }
  ]
}
```

**Observed result after fix:** Both exported gateway summary paths returned `Identity Name` for the identity-only agent, kept `Explicit Name` for the explicit-name agent, and left the unnamed agent without a display name.

**What was not tested:** No browser UI screenshot was captured; this proof exercises the exported gateway summary functions directly.
