### PR TITLE
fix: restore deterministic CI failures on main

### DIFF
--- a/extensions/browser/src/browser/navigation-guard.test.ts
+++ b/extensions/browser/src/browser/navigation-guard.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SsrFBlockedError, type LookupFn } from "../infra/net/ssrf.js";
 import {
   assertBrowserNavigationAllowed,
@@ -13,7 +13,22 @@ function createLookupFn(address: string): LookupFn {
   return vi.fn(async () => [{ address, family }]) as unknown as LookupFn;
 }
 
+const PROXY_ENV_KEYS = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+] as const;
+
 describe("browser navigation guard", () => {
+  beforeEach(() => {
+    for (const key of PROXY_ENV_KEYS) {
+      vi.stubEnv(key, "");
+    }
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
   });

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -98,7 +98,7 @@ const whatsappChunkConfig: OpenClawConfig = {
   channels: { whatsapp: { textChunkLimit: 4000 } },
 };
 
-const expectedResolvedTmpRoot = path.resolve(resolvePreferredOpenClawTmpDir());
+const expectedPreferredTmpRoot = resolvePreferredOpenClawTmpDir();
 
 type DeliverOutboundArgs = Parameters<DeliverModule["deliverOutboundPayloads"]>[0];
 type DeliverOutboundPayload = DeliverOutboundArgs["payloads"][number];
@@ -491,7 +491,7 @@ describe("deliverOutboundPayloads", () => {
       "123",
       "hi",
       expect.objectContaining({
-        mediaLocalRoots: expect.arrayContaining([expectedResolvedTmpRoot]),
+        mediaLocalRoots: expect.arrayContaining([expectedPreferredTmpRoot]),
       }),
     );
   });
@@ -511,7 +511,7 @@ describe("deliverOutboundPayloads", () => {
       "+1555",
       "hi",
       expect.objectContaining({
-        mediaLocalRoots: expect.arrayContaining([expectedResolvedTmpRoot]),
+        mediaLocalRoots: expect.arrayContaining([expectedPreferredTmpRoot]),
       }),
     );
   });
@@ -574,7 +574,7 @@ describe("deliverOutboundPayloads", () => {
       "+1555",
       "hi",
       expect.objectContaining({
-        mediaLocalRoots: expect.arrayContaining([expectedResolvedTmpRoot]),
+        mediaLocalRoots: expect.arrayContaining([expectedPreferredTmpRoot]),
       }),
     );
   });
@@ -594,7 +594,7 @@ describe("deliverOutboundPayloads", () => {
       "imessage:+15551234567",
       "hi",
       expect.objectContaining({
-        mediaLocalRoots: expect.arrayContaining([expectedResolvedTmpRoot]),
+        mediaLocalRoots: expect.arrayContaining([expectedPreferredTmpRoot]),
       }),
     );
   });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1425,7 +1425,7 @@ export async function loadOpenClawPluginCliRegistry(
     logger,
     runtime: {} as PluginRuntime,
     coreGatewayHandlers: options.coreGatewayHandlers as Record<string, GatewayRequestHandler>,
-    suppressGlobalCommands: true,
+    activateGlobalSideEffects: false,
   });
 
   const discovery = discoverOpenClawPlugins({


### PR DESCRIPTION
## Summary
- align outbound media tmp-root assertions with configuration-derived paths
- restore the renamed plugin registry side-effect option in the CLI loader
- isolate browser navigation guard tests from inherited host proxy env

## Validation
- pnpm build
- pnpm test -- src/infra/outbound/deliver.test.ts src/media/local-roots.test.ts src/plugins/loader.test.ts
- pnpm test -- extensions/browser/src/browser/navigation-guard.test.ts
- pnpm test:contracts && pnpm protocol:check