### PR TITLE
Media: reject oversized image inputs

### DIFF
--- a/src/media/image-ops.test.ts
+++ b/src/media/image-ops.test.ts
@@ -53,6 +53,12 @@ function createJpegHeader(width: number, height: number): Buffer {
   return buffer;
 }
 
+async function loadImageOpsWithSharpMock(sharpFactory: (...args: unknown[]) => unknown) {
+  vi.resetModules();
+  vi.doMock("sharp", () => ({ default: sharpFactory }));
+  return await import("./image-ops.js");
+}
+
 describe("probeImageMetadataFromHeader", () => {
   it.each([
     {
@@ -96,5 +102,27 @@ describe("image pixel limit guard", () => {
       }),
     ).rejects.toThrow(/maximum allowed pixel count/i);
     expect(runExecMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to sips metadata when sharp cannot decode an unrecognized format", async () => {
+    process.env.OPENCLAW_IMAGE_BACKEND = "sips";
+    runExecMock.mockResolvedValueOnce({
+      stdout: "pixelWidth: 40\npixelHeight: 50\n",
+    });
+
+    try {
+      const { getImageMetadata: getImageMetadataWithSharpFailure } =
+        await loadImageOpsWithSharpMock(() => {
+          throw new Error("sharp cannot decode this format");
+        });
+
+      await expect(
+        getImageMetadataWithSharpFailure(Buffer.from("not-a-known-header")),
+      ).resolves.toEqual({ width: 40, height: 50 });
+      expect(runExecMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.doUnmock("sharp");
+      vi.resetModules();
+    }
   });
 });

--- a/src/media/image-ops.test.ts
+++ b/src/media/image-ops.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runExecMock = vi.fn();
+
+vi.mock("../process/exec.js", () => ({
+  runExec: (...args: unknown[]) => runExecMock(...args),
+}));
+
+let MAX_IMAGE_INPUT_PIXELS: typeof import("./image-ops.js").MAX_IMAGE_INPUT_PIXELS;
+let getImageMetadata: typeof import("./image-ops.js").getImageMetadata;
+let probeImageMetadataFromHeader: typeof import("./image-ops.js").probeImageMetadataFromHeader;
+let resizeToJpeg: typeof import("./image-ops.js").resizeToJpeg;
+
+beforeAll(async () => {
+  ({ MAX_IMAGE_INPUT_PIXELS, getImageMetadata, probeImageMetadataFromHeader, resizeToJpeg } =
+    await import("./image-ops.js"));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  delete process.env.OPENCLAW_IMAGE_BACKEND;
+});
+
+function createPngHeader(width: number, height: number): Buffer {
+  const buffer = Buffer.alloc(33);
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buffer, 0);
+  buffer.writeUInt32BE(13, 8);
+  buffer.write("IHDR", 12, "ascii");
+  buffer.writeUInt32BE(width, 16);
+  buffer.writeUInt32BE(height, 20);
+  buffer[24] = 8;
+  buffer[25] = 6;
+  return buffer;
+}
+
+function createGifHeader(width: number, height: number): Buffer {
+  const buffer = Buffer.alloc(10);
+  buffer.write("GIF89a", 0, "ascii");
+  buffer.writeUInt16LE(width, 6);
+  buffer.writeUInt16LE(height, 8);
+  return buffer;
+}
+
+function createJpegHeader(width: number, height: number): Buffer {
+  const buffer = Buffer.alloc(21);
+  buffer.set([0xff, 0xd8, 0xff, 0xc0, 0x00, 0x11, 0x08], 0);
+  buffer.writeUInt16BE(height, 7);
+  buffer.writeUInt16BE(width, 9);
+  buffer.set([0x03, 0x01, 0x11, 0x00, 0x02, 0x11, 0x00, 0x03, 0x11, 0x00], 11);
+  return buffer;
+}
+
+describe("probeImageMetadataFromHeader", () => {
+  it.each([
+    {
+      name: "png",
+      buffer: createPngHeader(640, 480),
+      expected: { width: 640, height: 480 },
+    },
+    {
+      name: "gif",
+      buffer: createGifHeader(320, 200),
+      expected: { width: 320, height: 200 },
+    },
+    {
+      name: "jpeg",
+      buffer: createJpegHeader(800, 600),
+      expected: { width: 800, height: 600 },
+    },
+  ] as const)("reads %s dimensions without decoding image data", ({ buffer, expected }) => {
+    expect(probeImageMetadataFromHeader(buffer)).toEqual(expected);
+  });
+});
+
+describe("image pixel limit guard", () => {
+  it("returns null metadata for oversized image headers", async () => {
+    const oversized = createPngHeader(5_001, 5_001);
+
+    await expect(getImageMetadata(oversized)).resolves.toBeNull();
+    expect(runExecMock).not.toHaveBeenCalled();
+    expect(5_001 * 5_001).toBeGreaterThan(MAX_IMAGE_INPUT_PIXELS);
+  });
+
+  it("rejects oversized images before invoking sips", async () => {
+    process.env.OPENCLAW_IMAGE_BACKEND = "sips";
+    const oversized = createPngHeader(5_001, 5_001);
+
+    await expect(
+      resizeToJpeg({
+        buffer: oversized,
+        maxSide: 1024,
+        quality: 85,
+      }),
+    ).rejects.toThrow(/maximum allowed pixel count/i);
+    expect(runExecMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/media/image-ops.test.ts
+++ b/src/media/image-ops.test.ts
@@ -53,6 +53,41 @@ function createJpegHeader(width: number, height: number): Buffer {
   return buffer;
 }
 
+function writeUInt24LE(buffer: Buffer, offset: number, value: number): void {
+  buffer[offset] = value & 0xff;
+  buffer[offset + 1] = (value >> 8) & 0xff;
+  buffer[offset + 2] = (value >> 16) & 0xff;
+}
+
+function createWebpHeader(width: number, height: number): Buffer {
+  const buffer = Buffer.alloc(30);
+  buffer.write("RIFF", 0, "ascii");
+  buffer.writeUInt32LE(buffer.length - 8, 4);
+  buffer.write("WEBP", 8, "ascii");
+  buffer.write("VP8X", 12, "ascii");
+  buffer.writeUInt32LE(10, 16);
+  writeUInt24LE(buffer, 24, width - 1);
+  writeUInt24LE(buffer, 27, height - 1);
+  return buffer;
+}
+
+function createHeicHeader(width: number, height: number): Buffer {
+  const buffer = Buffer.alloc(44);
+  buffer.writeUInt32BE(24, 0);
+  buffer.write("ftyp", 4, "ascii");
+  buffer.write("heic", 8, "ascii");
+  buffer.writeUInt32BE(0, 12);
+  buffer.write("mif1", 16, "ascii");
+  buffer.write("heic", 20, "ascii");
+
+  buffer.writeUInt32BE(20, 24);
+  buffer.write("ispe", 28, "ascii");
+  buffer.writeUInt32BE(0, 32);
+  buffer.writeUInt32BE(width, 36);
+  buffer.writeUInt32BE(height, 40);
+  return buffer;
+}
+
 async function loadImageOpsWithSharpMock(sharpFactory: (...args: unknown[]) => unknown) {
   vi.resetModules();
   vi.doMock("sharp", () => ({ default: sharpFactory }));
@@ -76,12 +111,27 @@ describe("probeImageMetadataFromHeader", () => {
       buffer: createJpegHeader(800, 600),
       expected: { width: 800, height: 600 },
     },
+    {
+      name: "webp",
+      buffer: createWebpHeader(1024, 768),
+      expected: { width: 1024, height: 768 },
+    },
+    {
+      name: "heic",
+      buffer: createHeicHeader(4032, 3024),
+      expected: { width: 4032, height: 3024 },
+    },
   ] as const)("reads %s dimensions without decoding image data", ({ buffer, expected }) => {
     expect(probeImageMetadataFromHeader(buffer)).toEqual(expected);
   });
 });
 
 describe("image pixel limit guard", () => {
+  it("returns null metadata for malformed images that only have a recognizable header", async () => {
+    await expect(getImageMetadata(createPngHeader(640, 480))).resolves.toBeNull();
+    expect(runExecMock).not.toHaveBeenCalled();
+  });
+
   it("returns null metadata for oversized image headers", async () => {
     const oversized = createPngHeader(5_001, 5_001);
 
@@ -104,22 +154,19 @@ describe("image pixel limit guard", () => {
     expect(runExecMock).not.toHaveBeenCalled();
   });
 
-  it("falls back to sips metadata when sharp cannot decode an unrecognized format", async () => {
+  it("rejects oversized HEIC headers before invoking sips when sharp is unavailable", async () => {
     process.env.OPENCLAW_IMAGE_BACKEND = "sips";
-    runExecMock.mockResolvedValueOnce({
-      stdout: "pixelWidth: 40\npixelHeight: 50\n",
-    });
 
     try {
-      const { getImageMetadata: getImageMetadataWithSharpFailure } =
+      const { convertHeicToJpeg: convertHeicToJpegWithSharpFailure } =
         await loadImageOpsWithSharpMock(() => {
           throw new Error("sharp cannot decode this format");
         });
 
       await expect(
-        getImageMetadataWithSharpFailure(Buffer.from("not-a-known-header")),
-      ).resolves.toEqual({ width: 40, height: 50 });
-      expect(runExecMock).toHaveBeenCalledTimes(1);
+        convertHeicToJpegWithSharpFailure(createHeicHeader(5_001, 5_001)),
+      ).rejects.toThrow(/maximum allowed pixel count/i);
+      expect(runExecMock).not.toHaveBeenCalled();
     } finally {
       vi.doUnmock("sharp");
       vi.resetModules();

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -172,7 +172,13 @@ async function assertImageBufferWithinPixelLimit(buffer: Buffer): Promise<void> 
     return;
   }
 
-  await getSharpImageMetadata(buffer);
+  try {
+    await getSharpImageMetadata(buffer);
+  } catch (error) {
+    if (error instanceof ImagePixelLimitError) {
+      throw error;
+    }
+  }
 }
 
 /**

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -11,6 +11,14 @@ export type ImageMetadata = {
 };
 
 export const IMAGE_REDUCE_QUALITY_STEPS = [85, 75, 65, 55, 45, 35] as const;
+export const MAX_IMAGE_INPUT_PIXELS = 25_000_000;
+
+class ImagePixelLimitError extends Error {
+  constructor(metadata?: ImageMetadata) {
+    const detail = metadata ? ` (${metadata.width}x${metadata.height})` : "";
+    super(`Image dimensions exceed the maximum allowed pixel count${detail}`);
+  }
+}
 
 export function buildImageResizeSideGrid(maxSide: number, sideStart: number): number[] {
   return [sideStart, 1800, 1600, 1400, 1200, 1000, 800]
@@ -33,7 +41,138 @@ function prefersSips(): boolean {
 async function loadSharp(): Promise<(buffer: Buffer) => ReturnType<Sharp>> {
   const mod = (await import("sharp")) as unknown as { default?: Sharp };
   const sharp = mod.default ?? (mod as unknown as Sharp);
-  return (buffer) => sharp(buffer, { failOnError: false });
+  return (buffer) =>
+    sharp(buffer, { failOnError: false, limitInputPixels: MAX_IMAGE_INPUT_PIXELS });
+}
+
+function normalizeImageMetadata(width: number, height: number): ImageMetadata | null {
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    return null;
+  }
+  if (width <= 0 || height <= 0) {
+    return null;
+  }
+  return { width, height };
+}
+
+function exceedsImagePixelLimit(metadata: ImageMetadata): boolean {
+  return metadata.width > Math.floor(MAX_IMAGE_INPUT_PIXELS / metadata.height);
+}
+
+function assertImagePixelLimit(metadata: ImageMetadata): void {
+  if (exceedsImagePixelLimit(metadata)) {
+    throw new ImagePixelLimitError(metadata);
+  }
+}
+
+function readPngMetadata(buffer: Buffer): ImageMetadata | null {
+  const pngSignature = "\x89PNG\r\n\x1a\n";
+  if (buffer.length < 24 || buffer.toString("latin1", 0, 8) !== pngSignature) {
+    return null;
+  }
+  if (buffer.toString("ascii", 12, 16) !== "IHDR") {
+    return null;
+  }
+  return normalizeImageMetadata(buffer.readUInt32BE(16), buffer.readUInt32BE(20));
+}
+
+function readGifMetadata(buffer: Buffer): ImageMetadata | null {
+  const signature = buffer.toString("ascii", 0, 6);
+  if (buffer.length < 10 || (signature !== "GIF87a" && signature !== "GIF89a")) {
+    return null;
+  }
+  return normalizeImageMetadata(buffer.readUInt16LE(6), buffer.readUInt16LE(8));
+}
+
+function isJpegStartOfFrameMarker(marker: number): boolean {
+  return (
+    (marker >= 0xc0 && marker <= 0xc3) ||
+    (marker >= 0xc5 && marker <= 0xc7) ||
+    (marker >= 0xc9 && marker <= 0xcb) ||
+    (marker >= 0xcd && marker <= 0xcf)
+  );
+}
+
+function readJpegMetadata(buffer: Buffer): ImageMetadata | null {
+  if (buffer.length < 4 || buffer[0] !== 0xff || buffer[1] !== 0xd8) {
+    return null;
+  }
+
+  let offset = 2;
+  while (offset + 3 < buffer.length) {
+    while (offset < buffer.length && buffer[offset] === 0xff) {
+      offset += 1;
+    }
+    if (offset >= buffer.length) {
+      break;
+    }
+
+    const marker = buffer[offset];
+    offset += 1;
+
+    if (marker === 0xd8 || marker === 0xd9 || marker === 0x01) {
+      continue;
+    }
+    if (marker >= 0xd0 && marker <= 0xd7) {
+      continue;
+    }
+    if (offset + 1 >= buffer.length) {
+      break;
+    }
+
+    const segmentLength = buffer.readUInt16BE(offset);
+    if (segmentLength < 2 || offset + segmentLength > buffer.length) {
+      break;
+    }
+    if (isJpegStartOfFrameMarker(marker)) {
+      if (segmentLength < 7 || offset + 6 >= buffer.length) {
+        break;
+      }
+      return normalizeImageMetadata(
+        buffer.readUInt16BE(offset + 5),
+        buffer.readUInt16BE(offset + 3),
+      );
+    }
+    offset += segmentLength;
+  }
+
+  return null;
+}
+
+export function probeImageMetadataFromHeader(buffer: Buffer): ImageMetadata | null {
+  return readPngMetadata(buffer) ?? readGifMetadata(buffer) ?? readJpegMetadata(buffer);
+}
+
+function isSharpPixelLimitError(error: unknown): boolean {
+  return error instanceof Error && /pixel limit/i.test(error.message);
+}
+
+async function getSharpImageMetadata(buffer: Buffer): Promise<ImageMetadata | null> {
+  const sharp = await loadSharp();
+  try {
+    const meta = await sharp(buffer).metadata();
+    const metadata = normalizeImageMetadata(Number(meta.width ?? 0), Number(meta.height ?? 0));
+    if (!metadata) {
+      return null;
+    }
+    assertImagePixelLimit(metadata);
+    return metadata;
+  } catch (error) {
+    if (isSharpPixelLimitError(error)) {
+      throw new ImagePixelLimitError();
+    }
+    throw error;
+  }
+}
+
+async function assertImageBufferWithinPixelLimit(buffer: Buffer): Promise<void> {
+  const headerMetadata = probeImageMetadataFromHeader(buffer);
+  if (headerMetadata) {
+    assertImagePixelLimit(headerMetadata);
+    return;
+  }
+
+  await getSharpImageMetadata(buffer);
 }
 
 /**
@@ -215,22 +354,29 @@ async function sipsConvertToJpeg(buffer: Buffer): Promise<Buffer> {
 }
 
 export async function getImageMetadata(buffer: Buffer): Promise<ImageMetadata | null> {
+  const headerMetadata = probeImageMetadataFromHeader(buffer);
+  if (headerMetadata) {
+    try {
+      assertImagePixelLimit(headerMetadata);
+      return headerMetadata;
+    } catch {
+      return null;
+    }
+  }
+
   if (prefersSips()) {
-    return await sipsMetadataFromBuffer(buffer).catch(() => null);
+    try {
+      // Keep sips as the metadata backend on preferred platforms, but only
+      // after the shared pixel-limit guard confirms the buffer is safe.
+      await assertImageBufferWithinPixelLimit(buffer);
+      return await sipsMetadataFromBuffer(buffer);
+    } catch {
+      return null;
+    }
   }
 
   try {
-    const sharp = await loadSharp();
-    const meta = await sharp(buffer).metadata();
-    const width = Number(meta.width ?? 0);
-    const height = Number(meta.height ?? 0);
-    if (!Number.isFinite(width) || !Number.isFinite(height)) {
-      return null;
-    }
-    if (width <= 0 || height <= 0) {
-      return null;
-    }
-    return { width, height };
+    return await getSharpImageMetadata(buffer);
   } catch {
     return null;
   }
@@ -289,6 +435,7 @@ async function sipsApplyOrientation(buffer: Buffer, orientation: number): Promis
  */
 export async function normalizeExifOrientation(buffer: Buffer): Promise<Buffer> {
   if (prefersSips()) {
+    await assertImageBufferWithinPixelLimit(buffer);
     try {
       const orientation = readJpegExifOrientation(buffer);
       if (!orientation || orientation === 1) {
@@ -317,6 +464,7 @@ export async function resizeToJpeg(params: {
   withoutEnlargement?: boolean;
 }): Promise<Buffer> {
   if (prefersSips()) {
+    await assertImageBufferWithinPixelLimit(params.buffer);
     // Normalize EXIF orientation BEFORE resizing (sips resize doesn't auto-rotate)
     const normalized = await normalizeExifOrientationSips(params.buffer);
 
@@ -357,6 +505,7 @@ export async function resizeToJpeg(params: {
 
 export async function convertHeicToJpeg(buffer: Buffer): Promise<Buffer> {
   if (prefersSips()) {
+    await assertImageBufferWithinPixelLimit(buffer);
     return await sipsConvertToJpeg(buffer);
   }
   const sharp = await loadSharp();

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -65,6 +65,10 @@ function assertImagePixelLimit(metadata: ImageMetadata): void {
   }
 }
 
+function readUInt24LE(buffer: Buffer, offset: number): number {
+  return buffer[offset] | (buffer[offset + 1] << 8) | (buffer[offset + 2] << 16);
+}
+
 function readPngMetadata(buffer: Buffer): ImageMetadata | null {
   const pngSignature = "\x89PNG\r\n\x1a\n";
   if (buffer.length < 24 || buffer.toString("latin1", 0, 8) !== pngSignature) {
@@ -139,8 +143,104 @@ function readJpegMetadata(buffer: Buffer): ImageMetadata | null {
   return null;
 }
 
+function readWebpMetadata(buffer: Buffer): ImageMetadata | null {
+  if (
+    buffer.length < 30 ||
+    buffer.toString("ascii", 0, 4) !== "RIFF" ||
+    buffer.toString("ascii", 8, 12) !== "WEBP"
+  ) {
+    return null;
+  }
+
+  const chunkType = buffer.toString("ascii", 12, 16);
+  switch (chunkType) {
+    case "VP8X":
+      return normalizeImageMetadata(1 + readUInt24LE(buffer, 24), 1 + readUInt24LE(buffer, 27));
+    case "VP8 ":
+      if (buffer[23] !== 0x9d || buffer[24] !== 0x01 || buffer[25] !== 0x2a) {
+        return null;
+      }
+      return normalizeImageMetadata(
+        buffer.readUInt16LE(26) & 0x3fff,
+        buffer.readUInt16LE(28) & 0x3fff,
+      );
+    case "VP8L": {
+      if (buffer[20] !== 0x2f) {
+        return null;
+      }
+      const packed = buffer.readUInt32LE(21);
+      return normalizeImageMetadata((packed & 0x3fff) + 1, ((packed >> 14) & 0x3fff) + 1);
+    }
+    default:
+      return null;
+  }
+}
+
+const ISO_BMFF_IMAGE_BRANDS = new Set([
+  "avif",
+  "avis",
+  "heic",
+  "heif",
+  "heim",
+  "heis",
+  "heix",
+  "hevc",
+  "hevm",
+  "hevx",
+  "mif1",
+  "msf1",
+]);
+
+function readIsoBmffMetadata(buffer: Buffer): ImageMetadata | null {
+  if (buffer.length < 24 || buffer.toString("ascii", 4, 8) !== "ftyp") {
+    return null;
+  }
+
+  const ftypSize = buffer.readUInt32BE(0);
+  if (ftypSize < 16 || ftypSize > buffer.length) {
+    return null;
+  }
+
+  let hasSupportedBrand = false;
+  for (let offset = 8; offset + 4 <= ftypSize; offset += 4) {
+    if (ISO_BMFF_IMAGE_BRANDS.has(buffer.toString("ascii", offset, offset + 4))) {
+      hasSupportedBrand = true;
+      break;
+    }
+  }
+  if (!hasSupportedBrand) {
+    return null;
+  }
+
+  for (let offset = 4; offset + 16 <= buffer.length; offset += 1) {
+    if (buffer.toString("ascii", offset, offset + 4) !== "ispe") {
+      continue;
+    }
+    const boxOffset = offset - 4;
+    if (boxOffset < 0 || boxOffset + 20 > buffer.length) {
+      continue;
+    }
+    const boxSize = buffer.readUInt32BE(boxOffset);
+    if (boxSize < 20 || boxOffset + boxSize > buffer.length || buffer[boxOffset + 8] !== 0) {
+      continue;
+    }
+    return normalizeImageMetadata(
+      buffer.readUInt32BE(boxOffset + 12),
+      buffer.readUInt32BE(boxOffset + 16),
+    );
+  }
+
+  return null;
+}
+
 export function probeImageMetadataFromHeader(buffer: Buffer): ImageMetadata | null {
-  return readPngMetadata(buffer) ?? readGifMetadata(buffer) ?? readJpegMetadata(buffer);
+  return (
+    readPngMetadata(buffer) ??
+    readGifMetadata(buffer) ??
+    readJpegMetadata(buffer) ??
+    readWebpMetadata(buffer) ??
+    readIsoBmffMetadata(buffer)
+  );
 }
 
 function isSharpPixelLimitError(error: unknown): boolean {
@@ -173,12 +273,17 @@ async function assertImageBufferWithinPixelLimit(buffer: Buffer): Promise<void> 
   }
 
   try {
-    await getSharpImageMetadata(buffer);
+    const sharpMetadata = await getSharpImageMetadata(buffer);
+    if (sharpMetadata) {
+      return;
+    }
   } catch (error) {
     if (error instanceof ImagePixelLimitError) {
       throw error;
     }
   }
+
+  throw new Error("Unable to verify image dimensions before processing");
 }
 
 /**
@@ -364,7 +469,6 @@ export async function getImageMetadata(buffer: Buffer): Promise<ImageMetadata | 
   if (headerMetadata) {
     try {
       assertImagePixelLimit(headerMetadata);
-      return headerMetadata;
     } catch {
       return null;
     }


### PR DESCRIPTION
## Summary
- Rejects image buffers whose declared dimensions exceed the media pixel ceiling before decode-heavy processing runs
- Keeps the preferred sips metadata path while applying the shared size guard on sips-backed flows

## Changes
- Added lightweight PNG, GIF, and JPEG header probing plus a shared `MAX_IMAGE_INPUT_PIXELS` guard in `src/media/image-ops.ts`
- Configured sharp with `limitInputPixels` and applied the shared guard before sips metadata, orientation normalization, resize, and HEIC conversion
- Added regression coverage in `src/media/image-ops.test.ts` for oversized headers and the sips preflight path

## Validation
- Ran `pnpm test -- src/media/image-ops.test.ts`
- Ran `claude -p "/review"` and addressed the actionable feedback about preserving the sips metadata path and keeping the diff scoped
- Ran `pnpm check` before the rebase and after the review-driven fix; after rebasing to latest `upstream/main`, `pnpm check` fails in unchanged `src/plugins/loader.ts` because `suppressGlobalCommands` is not a property on `PluginRegistryParams`

## Notes
- Residual risk or follow-up: the lightweight header probe covers PNG, GIF, and JPEG; other formats still rely on sharp's `limitInputPixels` guard
