### PR TITLE
Infra: unwrap additional macOS dispatch wrappers

### DIFF
--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -386,10 +386,16 @@ type DispatchWrapperSpec = {
   name: string;
   unwrap?: (argv: string[]) => string[] | null;
   transparentUsage?: boolean | ((argv: string[]) => boolean);
+  supportedPlatforms?: readonly NodeJS.Platform[];
 };
 
 const DISPATCH_WRAPPER_SPECS: readonly DispatchWrapperSpec[] = [
-  { name: "caffeinate", unwrap: unwrapCaffeinateInvocation, transparentUsage: true },
+  {
+    name: "caffeinate",
+    unwrap: unwrapCaffeinateInvocation,
+    transparentUsage: true,
+    supportedPlatforms: ["darwin"],
+  },
   { name: "chrt" },
   { name: "doas" },
   {
@@ -400,7 +406,12 @@ const DISPATCH_WRAPPER_SPECS: readonly DispatchWrapperSpec[] = [
   { name: "ionice" },
   { name: "nice", unwrap: unwrapNiceInvocation, transparentUsage: true },
   { name: "nohup", unwrap: unwrapNohupInvocation, transparentUsage: true },
-  { name: "sandbox-exec", unwrap: unwrapSandboxExecInvocation, transparentUsage: true },
+  {
+    name: "sandbox-exec",
+    unwrap: unwrapSandboxExecInvocation,
+    transparentUsage: true,
+    supportedPlatforms: ["darwin"],
+  },
   { name: "script", unwrap: unwrapScriptInvocation, transparentUsage: true },
   { name: "setsid" },
   { name: "stdbuf", unwrap: unwrapStdbufInvocation, transparentUsage: true },
@@ -443,8 +454,16 @@ function unwrapDispatchWrapper(
     : blockDispatchWrapper(wrapper);
 }
 
+function isDispatchWrapperSupported(
+  spec: DispatchWrapperSpec | undefined,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return !spec?.supportedPlatforms || spec.supportedPlatforms.includes(platform);
+}
+
 export function isDispatchWrapperExecutable(token: string): boolean {
-  return DISPATCH_WRAPPER_SPEC_BY_NAME.has(normalizeExecutableToken(token));
+  const spec = DISPATCH_WRAPPER_SPEC_BY_NAME.get(normalizeExecutableToken(token));
+  return spec !== undefined && isDispatchWrapperSupported(spec);
 }
 
 export function unwrapKnownDispatchWrapperInvocation(argv: string[]): DispatchWrapperUnwrapResult {
@@ -454,7 +473,7 @@ export function unwrapKnownDispatchWrapperInvocation(argv: string[]): DispatchWr
   }
   const wrapper = normalizeExecutableToken(token0);
   const spec = DISPATCH_WRAPPER_SPEC_BY_NAME.get(wrapper);
-  if (!spec) {
+  if (!spec || !isDispatchWrapperSupported(spec)) {
     return { kind: "not-wrapper" };
   }
   return spec.unwrap

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -231,14 +231,14 @@ function unwrapCaffeinateInvocation(argv: string[]): string[] | null {
   return scanWrapperInvocation(argv, {
     separators: new Set(["--"]),
     onToken: (token, lower) => {
-      if (!lower.startsWith("-") || lower === "-") {
+      if (!token.startsWith("-") || token === "-") {
         return "stop";
       }
-      if (lower.startsWith("--")) {
+      if (token.startsWith("--")) {
         return "invalid";
       }
-      for (let idx = 1; idx < lower.length; idx += 1) {
-        const flag = lower[idx];
+      for (let idx = 1; idx < token.length; idx += 1) {
+        const flag = token[idx];
         if (!flag) {
           break;
         }
@@ -268,7 +268,8 @@ function unwrapNohupInvocation(argv: string[]): string[] | null {
 }
 
 function unwrapSandboxExecInvocation(argv: string[]): string[] | null {
-  return scanWrapperInvocation(argv, {
+  let sawProfileSource = false;
+  const unwrapped = scanWrapperInvocation(argv, {
     separators: new Set(["--"]),
     onToken: (token, lower) => {
       if (!token.startsWith("-") || token === "-") {
@@ -279,15 +280,22 @@ function unwrapSandboxExecInvocation(argv: string[]): string[] | null {
       }
       for (const flag of SANDBOX_EXEC_OPTIONS_WITH_VALUE) {
         if (token === flag) {
+          if (flag !== "-D") {
+            sawProfileSource = true;
+          }
           return "consume-next";
         }
         if (token.startsWith(flag)) {
+          if (flag !== "-D") {
+            sawProfileSource = true;
+          }
           return "continue";
         }
       }
       return "invalid";
     },
   });
+  return sawProfileSource ? unwrapped : null;
 }
 
 function unwrapStdbufInvocation(argv: string[]): string[] | null {

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -25,7 +25,10 @@ const ENV_INLINE_VALUE_PREFIXES = [
   "--block-signal=",
 ] as const;
 const ENV_FLAG_OPTIONS = new Set(["-i", "--ignore-environment", "-0", "--null"]);
+const CAFFEINATE_FLAG_OPTIONS = new Set(["d", "i", "m", "s", "u"]);
+const CAFFEINATE_OPTIONS_WITH_VALUE = new Set(["t", "w"]);
 const NICE_OPTIONS_WITH_VALUE = new Set(["-n", "--adjustment", "--priority"]);
+const SANDBOX_EXEC_OPTIONS_WITH_VALUE = ["-D", "-f", "-n", "-p"] as const;
 const STDBUF_OPTIONS_WITH_VALUE = new Set(["-i", "--input", "-o", "--output", "-e", "--error"]);
 const TIME_FLAG_OPTIONS = new Set([
   "-a",
@@ -224,6 +227,34 @@ function unwrapNiceInvocation(argv: string[]): string[] | null {
   });
 }
 
+function unwrapCaffeinateInvocation(argv: string[]): string[] | null {
+  return scanWrapperInvocation(argv, {
+    separators: new Set(["--"]),
+    onToken: (token, lower) => {
+      if (!lower.startsWith("-") || lower === "-") {
+        return "stop";
+      }
+      if (lower.startsWith("--")) {
+        return "invalid";
+      }
+      for (let idx = 1; idx < lower.length; idx += 1) {
+        const flag = lower[idx];
+        if (!flag) {
+          break;
+        }
+        if (CAFFEINATE_FLAG_OPTIONS.has(flag)) {
+          continue;
+        }
+        if (CAFFEINATE_OPTIONS_WITH_VALUE.has(flag)) {
+          return idx === lower.length - 1 ? "consume-next" : "continue";
+        }
+        return "invalid";
+      }
+      return "continue";
+    },
+  });
+}
+
 function unwrapNohupInvocation(argv: string[]): string[] | null {
   return scanWrapperInvocation(argv, {
     separators: new Set(["--"]),
@@ -232,6 +263,29 @@ function unwrapNohupInvocation(argv: string[]): string[] | null {
         return "stop";
       }
       return lower === "--help" || lower === "--version" ? "continue" : "invalid";
+    },
+  });
+}
+
+function unwrapSandboxExecInvocation(argv: string[]): string[] | null {
+  return scanWrapperInvocation(argv, {
+    separators: new Set(["--"]),
+    onToken: (token, lower) => {
+      if (!token.startsWith("-") || token === "-") {
+        return "stop";
+      }
+      if (lower.startsWith("--")) {
+        return "invalid";
+      }
+      for (const flag of SANDBOX_EXEC_OPTIONS_WITH_VALUE) {
+        if (token === flag) {
+          return "consume-next";
+        }
+        if (token.startsWith(flag)) {
+          return "continue";
+        }
+      }
+      return "invalid";
     },
   });
 }
@@ -327,6 +381,7 @@ type DispatchWrapperSpec = {
 };
 
 const DISPATCH_WRAPPER_SPECS: readonly DispatchWrapperSpec[] = [
+  { name: "caffeinate", unwrap: unwrapCaffeinateInvocation, transparentUsage: true },
   { name: "chrt" },
   { name: "doas" },
   {
@@ -337,6 +392,7 @@ const DISPATCH_WRAPPER_SPECS: readonly DispatchWrapperSpec[] = [
   { name: "ionice" },
   { name: "nice", unwrap: unwrapNiceInvocation, transparentUsage: true },
   { name: "nohup", unwrap: unwrapNohupInvocation, transparentUsage: true },
+  { name: "sandbox-exec", unwrap: unwrapSandboxExecInvocation, transparentUsage: true },
   { name: "script", unwrap: unwrapScriptInvocation, transparentUsage: true },
   { name: "setsid" },
   { name: "stdbuf", unwrap: unwrapStdbufInvocation, transparentUsage: true },

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -482,7 +482,7 @@ $0 \\"$1\\"" touch {marker}`,
   });
 
   it("unwraps caffeinate wrappers and persists the inner executable instead", () => {
-    if (process.platform === "win32") {
+    if (process.platform !== "darwin") {
       return;
     }
     const dir = makeTempDir();
@@ -510,7 +510,7 @@ $0 \\"$1\\"" touch {marker}`,
   });
 
   it("unwraps sandbox-exec wrappers and persists the inner executable instead", () => {
-    if (process.platform === "win32") {
+    if (process.platform !== "darwin") {
       return;
     }
     const dir = makeTempDir();
@@ -679,7 +679,7 @@ $0 \\"$1\\"" touch {marker}`,
   });
 
   it("prevents allow-always bypass for caffeinate wrapper chains", () => {
-    if (process.platform === "win32") {
+    if (process.platform !== "darwin") {
       return;
     }
     const dir = makeTempDir();
@@ -696,7 +696,7 @@ $0 \\"$1\\"" touch {marker}`,
   });
 
   it("prevents allow-always bypass for sandbox-exec wrapper chains", () => {
-    if (process.platform === "win32") {
+    if (process.platform !== "darwin") {
       return;
     }
     const dir = makeTempDir();

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -481,6 +481,62 @@ $0 \\"$1\\"" touch {marker}`,
     expect(patterns).not.toContain("/usr/bin/nice");
   });
 
+  it("unwraps caffeinate wrappers and persists the inner executable instead", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const whoami = makeExecutable(dir, "whoami");
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "/usr/bin/caffeinate -disu -t 60 /bin/zsh -lc whoami",
+          argv: ["/usr/bin/caffeinate", "-disu", "-t", "60", "/bin/zsh", "-lc", "whoami"],
+          resolution: makeMockCommandResolution({
+            execution: makeMockExecutableResolution({
+              rawExecutable: "/usr/bin/caffeinate",
+              resolvedPath: "/usr/bin/caffeinate",
+              executableName: "caffeinate",
+            }),
+          }),
+        },
+      ],
+      cwd: dir,
+      env: makePathEnv(dir),
+      platform: process.platform,
+    });
+    expect(patterns).toEqual([whoami]);
+    expect(patterns).not.toContain("/usr/bin/caffeinate");
+  });
+
+  it("unwraps sandbox-exec wrappers and persists the inner executable instead", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const whoami = makeExecutable(dir, "whoami");
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "/usr/bin/sandbox-exec -p '(deny default)' /bin/zsh -lc whoami",
+          argv: ["/usr/bin/sandbox-exec", "-p", "(deny default)", "/bin/zsh", "-lc", "whoami"],
+          resolution: makeMockCommandResolution({
+            execution: makeMockExecutableResolution({
+              rawExecutable: "/usr/bin/sandbox-exec",
+              resolvedPath: "/usr/bin/sandbox-exec",
+              executableName: "sandbox-exec",
+            }),
+          }),
+        },
+      ],
+      cwd: dir,
+      env: makePathEnv(dir),
+      platform: process.platform,
+    });
+    expect(patterns).toEqual([whoami]);
+    expect(patterns).not.toContain("/usr/bin/sandbox-exec");
+  });
+
   it("unwraps time wrappers and persists the inner executable instead", () => {
     if (process.platform === "win32") {
       return;
@@ -617,6 +673,41 @@ $0 \\"$1\\"" touch {marker}`,
       dir,
       firstCommand: "/usr/bin/nice /bin/zsh -lc 'echo warmup-ok'",
       secondCommand: "/usr/bin/nice /bin/zsh -lc 'id > marker'",
+      env,
+      persistedPattern: echo,
+    });
+  });
+
+  it("prevents allow-always bypass for caffeinate wrapper chains", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const echo = makeExecutable(dir, "echo");
+    makeExecutable(dir, "id");
+    const env = makePathEnv(dir);
+    expectAllowAlwaysBypassBlocked({
+      dir,
+      firstCommand: "/usr/bin/caffeinate -disu -t 60 /bin/zsh -lc 'echo warmup-ok'",
+      secondCommand: "/usr/bin/caffeinate -w 42 /bin/zsh -lc 'id > marker'",
+      env,
+      persistedPattern: echo,
+    });
+  });
+
+  it("prevents allow-always bypass for sandbox-exec wrapper chains", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const echo = makeExecutable(dir, "echo");
+    makeExecutable(dir, "id");
+    const env = makePathEnv(dir);
+    expectAllowAlwaysBypassBlocked({
+      dir,
+      firstCommand: "/usr/bin/sandbox-exec -p '(deny default)' /bin/zsh -lc 'echo warmup-ok'",
+      secondCommand:
+        "/usr/bin/sandbox-exec -DHOME=/tmp/openclaw -p '(allow default)' /bin/zsh -lc 'id > marker'",
       env,
       persistedPattern: echo,
     });

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -17,6 +17,10 @@ function supportsScriptPositionalCommandForTests(): boolean {
   return process.platform === "darwin" || process.platform === "freebsd";
 }
 
+function supportsDarwinNativeDispatchWrappersForTests(): boolean {
+  return process.platform === "darwin";
+}
+
 function expectTransparentDispatchWrapperCase(params: {
   argv: string[];
   wrapper: string;
@@ -61,8 +65,12 @@ describe("normalizeExecutableToken", () => {
 
 describe("wrapper classification", () => {
   test.each([
-    { token: "caffeinate", dispatch: true, shell: false },
-    { token: "sandbox-exec", dispatch: true, shell: false },
+    { token: "caffeinate", dispatch: supportsDarwinNativeDispatchWrappersForTests(), shell: false },
+    {
+      token: "sandbox-exec",
+      dispatch: supportsDarwinNativeDispatchWrappersForTests(),
+      shell: false,
+    },
     { token: "sudo", dispatch: true, shell: false },
     { token: "script", dispatch: true, shell: false },
     { token: "time", dispatch: true, shell: false },
@@ -134,11 +142,15 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
   test.each([
     {
       argv: ["caffeinate", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] },
+      expected: supportsDarwinNativeDispatchWrappersForTests()
+        ? { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] }
+        : { kind: "not-wrapper" },
     },
     {
       argv: ["caffeinate", "-disu", "-t", "60", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] },
+      expected: supportsDarwinNativeDispatchWrappersForTests()
+        ? { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] }
+        : { kind: "not-wrapper" },
     },
     {
       argv: ["env", "--", "bash", "-lc", "echo hi"],
@@ -163,7 +175,9 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
         "-lc",
         "echo hi",
       ],
-      expected: { kind: "unwrapped", wrapper: "sandbox-exec", argv: ["bash", "-lc", "echo hi"] },
+      expected: supportsDarwinNativeDispatchWrappersForTests()
+        ? { kind: "unwrapped", wrapper: "sandbox-exec", argv: ["bash", "-lc", "echo hi"] }
+        : { kind: "not-wrapper" },
     },
     {
       argv: ["script", "-q", "/dev/null", "bash", "-lc", "echo hi"],
@@ -189,11 +203,15 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
     },
     {
       argv: ["caffeinate", "-t"],
-      expected: { kind: "blocked", wrapper: "caffeinate" },
+      expected: supportsDarwinNativeDispatchWrappersForTests()
+        ? { kind: "blocked", wrapper: "caffeinate" }
+        : { kind: "not-wrapper" },
     },
     {
       argv: ["caffeinate", "-D", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "caffeinate" },
+      expected: supportsDarwinNativeDispatchWrappersForTests()
+        ? { kind: "blocked", wrapper: "caffeinate" }
+        : { kind: "not-wrapper" },
     },
     {
       argv: ["script", "-q", "/dev/null"],
@@ -201,19 +219,27 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
     },
     {
       argv: ["sandbox-exec", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "sandbox-exec" },
+      expected: supportsDarwinNativeDispatchWrappersForTests()
+        ? { kind: "blocked", wrapper: "sandbox-exec" }
+        : { kind: "not-wrapper" },
     },
     {
       argv: ["sandbox-exec", "-DHOME=/tmp/openclaw", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "sandbox-exec" },
+      expected: supportsDarwinNativeDispatchWrappersForTests()
+        ? { kind: "blocked", wrapper: "sandbox-exec" }
+        : { kind: "not-wrapper" },
     },
     {
       argv: ["sandbox-exec", "-p"],
-      expected: { kind: "blocked", wrapper: "sandbox-exec" },
+      expected: supportsDarwinNativeDispatchWrappersForTests()
+        ? { kind: "blocked", wrapper: "sandbox-exec" }
+        : { kind: "not-wrapper" },
     },
     {
       argv: ["sandbox-exec", "-x", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "sandbox-exec" },
+      expected: supportsDarwinNativeDispatchWrappersForTests()
+        ? { kind: "blocked", wrapper: "sandbox-exec" }
+        : { kind: "not-wrapper" },
     },
     {
       argv: ["sudo", "bash", "-lc", "echo hi"],
@@ -297,6 +323,19 @@ describe("resolveDispatchWrapperTrustPlan", () => {
       effectiveArgv: ["bash", "-lc", "echo hi"],
     },
   ])("keeps transparent wrapper handling in sync for %s", ({ argv, wrapper, effectiveArgv }) => {
+    if (
+      (wrapper === "caffeinate" || wrapper === "sandbox-exec") &&
+      !supportsDarwinNativeDispatchWrappersForTests()
+    ) {
+      expect(isDispatchWrapperExecutable(wrapper)).toBe(false);
+      expect(unwrapKnownDispatchWrapperInvocation(argv)).toEqual({ kind: "not-wrapper" });
+      expect(resolveDispatchWrapperTrustPlan(argv)).toEqual({
+        argv,
+        wrappers: [],
+        policyBlocked: false,
+      });
+      return;
+    }
     expectTransparentDispatchWrapperCase({ argv, wrapper, effectiveArgv });
   });
 

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -61,6 +61,8 @@ describe("normalizeExecutableToken", () => {
 
 describe("wrapper classification", () => {
   test.each([
+    { token: "caffeinate", dispatch: true, shell: false },
+    { token: "sandbox-exec", dispatch: true, shell: false },
     { token: "sudo", dispatch: true, shell: false },
     { token: "script", dispatch: true, shell: false },
     { token: "time", dispatch: true, shell: false },
@@ -131,6 +133,14 @@ describe("unwrapEnvInvocation", () => {
 describe("unwrapKnownDispatchWrapperInvocation", () => {
   test.each([
     {
+      argv: ["caffeinate", "bash", "-lc", "echo hi"],
+      expected: { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] },
+    },
+    {
+      argv: ["caffeinate", "-disu", "-t", "60", "bash", "-lc", "echo hi"],
+      expected: { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] },
+    },
+    {
       argv: ["env", "--", "bash", "-lc", "echo hi"],
       expected: { kind: "unwrapped", wrapper: "env", argv: ["bash", "-lc", "echo hi"] },
     },
@@ -141,6 +151,19 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
     {
       argv: ["nohup", "--", "bash", "-lc", "echo hi"],
       expected: { kind: "unwrapped", wrapper: "nohup", argv: ["bash", "-lc", "echo hi"] },
+    },
+    {
+      argv: [
+        "sandbox-exec",
+        "-D",
+        "HOME=/tmp/openclaw",
+        "-p",
+        "(deny default)",
+        "bash",
+        "-lc",
+        "echo hi",
+      ],
+      expected: { kind: "unwrapped", wrapper: "sandbox-exec", argv: ["bash", "-lc", "echo hi"] },
     },
     {
       argv: ["script", "-q", "/dev/null", "bash", "-lc", "echo hi"],
@@ -165,8 +188,20 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
       expected: { kind: "unwrapped", wrapper: "timeout", argv: ["bash", "-lc", "echo hi"] },
     },
     {
+      argv: ["caffeinate", "-t"],
+      expected: { kind: "blocked", wrapper: "caffeinate" },
+    },
+    {
       argv: ["script", "-q", "/dev/null"],
       expected: { kind: "blocked", wrapper: "script" },
+    },
+    {
+      argv: ["sandbox-exec", "-p"],
+      expected: { kind: "blocked", wrapper: "sandbox-exec" },
+    },
+    {
+      argv: ["sandbox-exec", "-x", "bash", "-lc", "echo hi"],
+      expected: { kind: "blocked", wrapper: "sandbox-exec" },
     },
     {
       argv: ["sudo", "bash", "-lc", "echo hi"],
@@ -202,6 +237,16 @@ describe("resolveDispatchWrapperTrustPlan", () => {
 
   test.each([
     {
+      argv: ["caffeinate", "bash", "-lc", "echo hi"],
+      wrapper: "caffeinate",
+      effectiveArgv: ["bash", "-lc", "echo hi"],
+    },
+    {
+      argv: ["caffeinate", "-disu", "-w", "123", "bash", "-lc", "echo hi"],
+      wrapper: "caffeinate",
+      effectiveArgv: ["bash", "-lc", "echo hi"],
+    },
+    {
       argv: ["nice", "-n", "5", "bash", "-lc", "echo hi"],
       wrapper: "nice",
       effectiveArgv: ["bash", "-lc", "echo hi"],
@@ -209,6 +254,19 @@ describe("resolveDispatchWrapperTrustPlan", () => {
     {
       argv: ["nohup", "--", "bash", "-lc", "echo hi"],
       wrapper: "nohup",
+      effectiveArgv: ["bash", "-lc", "echo hi"],
+    },
+    {
+      argv: [
+        "sandbox-exec",
+        "-DHOME=/tmp/openclaw",
+        "-p",
+        "(deny default)",
+        "bash",
+        "-lc",
+        "echo hi",
+      ],
+      wrapper: "sandbox-exec",
       effectiveArgv: ["bash", "-lc", "echo hi"],
     },
     {

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -192,8 +192,20 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
       expected: { kind: "blocked", wrapper: "caffeinate" },
     },
     {
+      argv: ["caffeinate", "-D", "bash", "-lc", "echo hi"],
+      expected: { kind: "blocked", wrapper: "caffeinate" },
+    },
+    {
       argv: ["script", "-q", "/dev/null"],
       expected: { kind: "blocked", wrapper: "script" },
+    },
+    {
+      argv: ["sandbox-exec", "bash", "-lc", "echo hi"],
+      expected: { kind: "blocked", wrapper: "sandbox-exec" },
+    },
+    {
+      argv: ["sandbox-exec", "-DHOME=/tmp/openclaw", "bash", "-lc", "echo hi"],
+      expected: { kind: "blocked", wrapper: "sandbox-exec" },
     },
     {
       argv: ["sandbox-exec", "-p"],

--- a/src/infra/exec-wrapper-trust-plan.test.ts
+++ b/src/infra/exec-wrapper-trust-plan.test.ts
@@ -5,7 +5,7 @@ describe("resolveExecWrapperTrustPlan", () => {
   test.each([
     {
       name: "unwraps caffeinate wrappers before evaluating nested shell payloads",
-      enabled: process.platform !== "win32",
+      enabled: process.platform === "darwin",
       argv: ["/usr/bin/caffeinate", "-disu", "-t", "60", "sh", "-lc", "echo hi"],
       expected: {
         argv: ["sh", "-lc", "echo hi"],
@@ -31,7 +31,7 @@ describe("resolveExecWrapperTrustPlan", () => {
     },
     {
       name: "unwraps sandbox-exec wrappers before evaluating nested shell payloads",
-      enabled: process.platform !== "win32",
+      enabled: process.platform === "darwin",
       argv: ["/usr/bin/sandbox-exec", "-p", "(deny default)", "sh", "-lc", "echo hi"],
       expected: {
         argv: ["sh", "-lc", "echo hi"],

--- a/src/infra/exec-wrapper-trust-plan.test.ts
+++ b/src/infra/exec-wrapper-trust-plan.test.ts
@@ -4,6 +4,19 @@ import { resolveExecWrapperTrustPlan } from "./exec-wrapper-trust-plan.js";
 describe("resolveExecWrapperTrustPlan", () => {
   test.each([
     {
+      name: "unwraps caffeinate wrappers before evaluating nested shell payloads",
+      enabled: process.platform !== "win32",
+      argv: ["/usr/bin/caffeinate", "-disu", "-t", "60", "sh", "-lc", "echo hi"],
+      expected: {
+        argv: ["sh", "-lc", "echo hi"],
+        policyArgv: ["sh", "-lc", "echo hi"],
+        wrapperChain: ["caffeinate"],
+        policyBlocked: false,
+        shellWrapperExecutable: true,
+        shellInlineCommand: "echo hi",
+      },
+    },
+    {
       name: "unwraps dispatch wrappers and shell multiplexers into one trust plan",
       enabled: process.platform !== "win32",
       argv: ["/usr/bin/time", "-p", "busybox", "sh", "-lc", "echo hi"],
@@ -11,6 +24,19 @@ describe("resolveExecWrapperTrustPlan", () => {
         argv: ["sh", "-lc", "echo hi"],
         policyArgv: ["busybox", "sh", "-lc", "echo hi"],
         wrapperChain: ["time", "busybox"],
+        policyBlocked: false,
+        shellWrapperExecutable: true,
+        shellInlineCommand: "echo hi",
+      },
+    },
+    {
+      name: "unwraps sandbox-exec wrappers before evaluating nested shell payloads",
+      enabled: process.platform !== "win32",
+      argv: ["/usr/bin/sandbox-exec", "-p", "(deny default)", "sh", "-lc", "echo hi"],
+      expected: {
+        argv: ["sh", "-lc", "echo hi"],
+        policyArgv: ["sh", "-lc", "echo hi"],
+        wrapperChain: ["sandbox-exec"],
         policyBlocked: false,
         shellWrapperExecutable: true,
         shellInlineCommand: "echo hi",

--- a/src/infra/system-run-command.test.ts
+++ b/src/infra/system-run-command.test.ts
@@ -52,12 +52,12 @@ describe("system run command helpers", () => {
   test.each([
     {
       argv: ["/usr/bin/caffeinate", "-disu", "-t", "60", "/bin/bash", "-lc", "echo hi"],
-      expected: "echo hi",
+      expected: process.platform === "darwin" ? "echo hi" : null,
     },
     { argv: ["/usr/bin/nice", "/bin/bash", "-lc", "echo hi"], expected: "echo hi" },
     {
       argv: ["/usr/bin/sandbox-exec", "-p", "(deny default)", "zsh", "-lc", "echo hi"],
-      expected: "echo hi",
+      expected: process.platform === "darwin" ? "echo hi" : null,
     },
     {
       argv: ["/usr/bin/timeout", "--signal=TERM", "5", "zsh", "-lc", "echo hi"],

--- a/src/infra/system-run-command.test.ts
+++ b/src/infra/system-run-command.test.ts
@@ -50,7 +50,15 @@ describe("system run command helpers", () => {
   });
 
   test.each([
+    {
+      argv: ["/usr/bin/caffeinate", "-disu", "-t", "60", "/bin/bash", "-lc", "echo hi"],
+      expected: "echo hi",
+    },
     { argv: ["/usr/bin/nice", "/bin/bash", "-lc", "echo hi"], expected: "echo hi" },
+    {
+      argv: ["/usr/bin/sandbox-exec", "-p", "(deny default)", "zsh", "-lc", "echo hi"],
+      expected: "echo hi",
+    },
     {
       argv: ["/usr/bin/timeout", "--signal=TERM", "5", "zsh", "-lc", "echo hi"],
       expected: "echo hi",


### PR DESCRIPTION
## Summary
- unwraps `caffeinate` and `sandbox-exec` before approval trust decisions
- keeps allow-always persistence anchored to the inner command instead of the wrapper

## Changes
- added dispatch-wrapper parsers for `caffeinate` and `sandbox-exec`
- added regression coverage for wrapper resolution, trust planning, command display, and allow-always persistence

## Validation
- ran `pnpm test -- src/infra/exec-wrapper-resolution.test.ts src/infra/exec-wrapper-trust-plan.test.ts src/infra/system-run-command.test.ts src/infra/exec-approvals-allow-always.test.ts`
- ran `pnpm check`
- ran `pnpm build`
- ran local agentic review and tightened `sandbox-exec` flag parsing to stay case-sensitive

## Notes
- residual risk or follow-up: `sandbox-exec` is deprecated on macOS, but while it is present it now follows the same transparent-wrapper trust model as the other native carriers
