### PR TITLE
Gateway: stop honoring HTTP scope headers

### DIFF
--- a/src/gateway/http-auth-helpers.test.ts
+++ b/src/gateway/http-auth-helpers.test.ts
@@ -1,11 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import {
-  authorizeGatewayBearerRequestOrReply,
-  resolveGatewayRequestedOperatorScopes,
-} from "./http-auth-helpers.js";
-import { CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
+import { authorizeGatewayBearerRequestOrReply } from "./http-auth-helpers.js";
 
 vi.mock("./auth.js", () => ({
   authorizeHttpGatewayConnect: vi.fn(),
@@ -17,12 +13,11 @@ vi.mock("./http-common.js", () => ({
 
 vi.mock("./http-utils.js", () => ({
   getBearerToken: vi.fn(),
-  getHeader: vi.fn(),
 }));
 
 const { authorizeHttpGatewayConnect } = await import("./auth.js");
 const { sendGatewayAuthFailure } = await import("./http-common.js");
-const { getBearerToken, getHeader } = await import("./http-utils.js");
+const { getBearerToken } = await import("./http-utils.js");
 
 describe("authorizeGatewayBearerRequestOrReply", () => {
   const bearerAuth = {
@@ -73,62 +68,5 @@ describe("authorizeGatewayBearerRequestOrReply", () => {
       }),
     );
     expect(vi.mocked(sendGatewayAuthFailure)).not.toHaveBeenCalled();
-  });
-});
-
-describe("resolveGatewayRequestedOperatorScopes", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("returns CLI_DEFAULT_OPERATOR_SCOPES when header is absent", () => {
-    vi.mocked(getHeader).mockReturnValue(undefined);
-    const req = {} as IncomingMessage;
-    const scopes = resolveGatewayRequestedOperatorScopes(req);
-    expect(scopes).toEqual(CLI_DEFAULT_OPERATOR_SCOPES);
-    // Returned array must be a copy, not the original constant.
-    expect(scopes).not.toBe(CLI_DEFAULT_OPERATOR_SCOPES);
-  });
-
-  it("returns empty array when header is present but empty", () => {
-    vi.mocked(getHeader).mockReturnValue("");
-    const req = {} as IncomingMessage;
-    const scopes = resolveGatewayRequestedOperatorScopes(req);
-    expect(scopes).toEqual([]);
-  });
-
-  it("returns empty array when header is present but only whitespace", () => {
-    vi.mocked(getHeader).mockReturnValue("   ");
-    const req = {} as IncomingMessage;
-    const scopes = resolveGatewayRequestedOperatorScopes(req);
-    expect(scopes).toEqual([]);
-  });
-
-  it("parses comma-separated scopes from header", () => {
-    vi.mocked(getHeader).mockReturnValue("operator.write,operator.read");
-    const req = {} as IncomingMessage;
-    const scopes = resolveGatewayRequestedOperatorScopes(req);
-    expect(scopes).toEqual(["operator.write", "operator.read"]);
-  });
-
-  it("trims whitespace around individual scopes", () => {
-    vi.mocked(getHeader).mockReturnValue("  operator.write , operator.read  ");
-    const req = {} as IncomingMessage;
-    const scopes = resolveGatewayRequestedOperatorScopes(req);
-    expect(scopes).toEqual(["operator.write", "operator.read"]);
-  });
-
-  it("filters out empty segments from trailing commas", () => {
-    vi.mocked(getHeader).mockReturnValue("operator.write,,operator.read,");
-    const req = {} as IncomingMessage;
-    const scopes = resolveGatewayRequestedOperatorScopes(req);
-    expect(scopes).toEqual(["operator.write", "operator.read"]);
-  });
-
-  it("returns single scope when only one is declared", () => {
-    vi.mocked(getHeader).mockReturnValue("operator.approvals");
-    const req = {} as IncomingMessage;
-    const scopes = resolveGatewayRequestedOperatorScopes(req);
-    expect(scopes).toEqual(["operator.approvals"]);
   });
 });

--- a/src/gateway/http-auth-helpers.ts
+++ b/src/gateway/http-auth-helpers.ts
@@ -2,10 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import { authorizeHttpGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
 import { sendGatewayAuthFailure } from "./http-common.js";
-import { getBearerToken, getHeader } from "./http-utils.js";
-import { CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
-
-const OPERATOR_SCOPES_HEADER = "x-openclaw-scopes";
+import { getBearerToken } from "./http-utils.js";
 
 export async function authorizeGatewayBearerRequestOrReply(params: {
   req: IncomingMessage;
@@ -29,28 +26,4 @@ export async function authorizeGatewayBearerRequestOrReply(params: {
     return false;
   }
   return true;
-}
-
-export function resolveGatewayRequestedOperatorScopes(req: IncomingMessage): string[] {
-  const raw = getHeader(req, OPERATOR_SCOPES_HEADER)?.trim();
-  if (raw === undefined) {
-    // No x-openclaw-scopes header present at all: the caller is a plain
-    // Bearer-token HTTP client (curl, OpenAI SDK, etc.) that has already
-    // passed gateway token authentication.  Grant the same default operator
-    // scopes that the CLI and other first-party callers receive so that
-    // authenticated HTTP requests are not denied by the method-scope gate.
-    //
-    // When the header IS present (even if empty), honour the declared value
-    // so that callers can voluntarily restrict their own privilege set and
-    // the CVE-2026-32919 / CVE-2026-28473 security boundary is preserved.
-    return [...CLI_DEFAULT_OPERATOR_SCOPES];
-  }
-  if (!raw) {
-    // Header present but empty string → caller explicitly declared no scopes.
-    return [];
-  }
-  return raw
-    .split(",")
-    .map((scope) => scope.trim())
-    .filter((scope) => scope.length > 0);
 }


### PR DESCRIPTION
## Summary
- stops treating `x-openclaw-scopes` as an authorization input on the HTTP gateway surface
- keeps HTTP bearer auth on the existing full-access operator boundary
- updates regression coverage for `/v1/*` and session history HTTP behavior while preserving WS scope checks

## Changes
- removed HTTP scope-header gating from shared POST endpoint handling, models, and session history
- dropped the now-unused compat-endpoint scope option wiring
- renamed and updated the gateway regression test to assert that HTTP ignores legacy scope headers

## Validation
- Ran `pnpm test -- src/gateway/http-endpoint-helpers.test.ts src/gateway/models-http.test.ts src/gateway/sessions-history-http.test.ts src/gateway/server.openai-compatible-http-scope-header-ignored.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts -t "continues once auth succeeds|ignores legacy x-openclaw-scopes header values|keeps WS scope checks but ignores legacy HTTP scope headers|chat completions no longer treat x-openclaw-scopes as a write gate|responses no longer treat x-openclaw-scopes as a write gate|handles request validation and routing|handles OpenResponses request parsing and validation"`
- Ran `pnpm check`
- Ran `pnpm build`
- Ran local agentic review with `claude -p "/review"` and addressed the actionable feedback

## Notes
- `src/gateway/openai-http.test.ts` and `src/gateway/openresponses-http.test.ts` still have existing `rejects when disabled (default + config)` timeout failures in this worktree when run directly; the scoped behavior above passed cleanly.