### PR TITLE
fix(hooks): preserve provenance field in plugin hook event messages

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -15,6 +15,7 @@ import {
   ensureContextEnginesInitialized,
   resolveContextEngine,
 } from "../../context-engine/index.js";
+import { readMessagesFromSessionTranscript } from "../../hooks/session-transcript-messages.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -776,6 +777,7 @@ export async function compactEmbeddedPiSessionDirect(
           sessionAgentId,
           workspaceDir: effectiveWorkspace,
           messageProvider: resolvedMessageProvider,
+          sessionFile: params.sessionFile,
           metrics: beforeHookMetrics,
         });
         const { messageCountOriginal } = beforeHookMetrics;
@@ -999,9 +1001,11 @@ export async function compactEmbeddedPiSession(
         // can read the transcript themselves if they need exact counts.
         if (hookRunner?.hasHooks?.("before_compaction") && hookRunner.runBeforeCompaction) {
           try {
+            const transcriptMessages = await readMessagesFromSessionTranscript(params.sessionFile);
             await hookRunner.runBeforeCompaction(
               {
-                messageCount: -1,
+                messageCount: transcriptMessages?.length ?? -1,
+                messages: transcriptMessages ?? undefined,
                 sessionFile: params.sessionFile,
               },
               hookCtx,

--- a/src/agents/pi-embedded-runner/compaction-hooks.ts
+++ b/src/agents/pi-embedded-runner/compaction-hooks.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import { readMessagesFromSessionTranscript } from "../../hooks/session-transcript-messages.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { getActiveMemorySearchManager } from "../../plugins/memory-runtime.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
@@ -99,7 +100,12 @@ export async function runPostCompactionSideEffects(params: {
 export type CompactionHookRunner = {
   hasHooks?: (hookName?: string) => boolean;
   runBeforeCompaction?: (
-    metrics: { messageCount: number; tokenCount?: number; sessionFile?: string },
+    metrics: {
+      messageCount: number;
+      messages?: unknown[];
+      tokenCount?: number;
+      sessionFile?: string;
+    },
     context: {
       sessionId: string;
       agentId: string;
@@ -176,6 +182,7 @@ export async function runBeforeCompactionHooks(params: {
   sessionAgentId: string;
   workspaceDir: string;
   messageProvider?: string;
+  sessionFile?: string;
   metrics: ReturnType<typeof buildBeforeCompactionHookMetrics>;
 }) {
   const missingSessionKey = !params.sessionKey || !params.sessionKey.trim();
@@ -198,10 +205,13 @@ export async function runBeforeCompactionHooks(params: {
   }
   if (params.hookRunner?.hasHooks?.("before_compaction")) {
     try {
+      const transcriptMessages = await readMessagesFromSessionTranscript(params.sessionFile);
       await params.hookRunner.runBeforeCompaction?.(
         {
           messageCount: params.metrics.messageCountBefore,
+          messages: transcriptMessages ?? undefined,
           tokenCount: params.metrics.tokenCountBefore,
+          sessionFile: params.sessionFile,
         },
         {
           sessionId: params.sessionId,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -5,6 +5,7 @@ import {
   ensureContextEnginesInitialized,
   resolveContextEngine,
 } from "../../context-engine/index.js";
+import { readMessagesFromSessionTranscript } from "../../hooks/session-transcript-messages.js";
 import { computeBackoff, sleepWithAbort } from "../../infra/backoff.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
@@ -384,8 +385,13 @@ export async function runEmbeddedPiAgent(
             return;
           }
           try {
+            const transcriptMessages = await readMessagesFromSessionTranscript(params.sessionFile);
             await hookRunner.runBeforeCompaction(
-              { messageCount: -1, sessionFile: params.sessionFile },
+              {
+                messageCount: transcriptMessages?.length ?? -1,
+                messages: transcriptMessages ?? undefined,
+                sessionFile: params.sessionFile,
+              },
               hookCtx,
             );
           } catch (hookErr) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1751,6 +1751,9 @@ export async function runEmbeddedAttempt(
         if (hookRunner?.hasHooks("agent_end")) {
           // Read from transcript to preserve provenance and other extension
           // fields that the in-memory AgentMessage[] may not carry.
+          // Capture duration before the async read so it reflects actual run
+          // time, not run time + transcript I/O.
+          const agentEndDurationMs = Date.now() - promptStartedAt;
           const transcriptReadForHook = readMessagesFromSessionTranscript(params.sessionFile);
           void transcriptReadForHook
             .then((transcriptMessages) => transcriptMessages ?? messagesSnapshot)
@@ -1760,7 +1763,7 @@ export async function runEmbeddedAttempt(
                   messages: hookMessages,
                   success: !aborted && !promptError,
                   error: promptError ? describeUnknownError(promptError) : undefined,
-                  durationMs: Date.now() - promptStartedAt,
+                  durationMs: agentEndDurationMs,
                 },
                 {
                   runId: params.runId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -9,6 +9,7 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
+import { readMessagesFromSessionTranscript } from "../../../hooks/session-transcript-messages.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import {
   ensureGlobalUndiciEnvProxyDispatcher,
@@ -1748,24 +1749,30 @@ export async function runEmbeddedAttempt(
         // This is fire-and-forget, so we don't await
         // Run even on compaction timeout so plugins can log/cleanup
         if (hookRunner?.hasHooks("agent_end")) {
-          hookRunner
-            .runAgentEnd(
-              {
-                messages: messagesSnapshot,
-                success: !aborted && !promptError,
-                error: promptError ? describeUnknownError(promptError) : undefined,
-                durationMs: Date.now() - promptStartedAt,
-              },
-              {
-                runId: params.runId,
-                agentId: hookAgentId,
-                sessionKey: params.sessionKey,
-                sessionId: params.sessionId,
-                workspaceDir: params.workspaceDir,
-                messageProvider: params.messageProvider ?? undefined,
-                trigger: params.trigger,
-                channelId: params.messageChannel ?? params.messageProvider ?? undefined,
-              },
+          // Read from transcript to preserve provenance and other extension
+          // fields that the in-memory AgentMessage[] may not carry.
+          const transcriptReadForHook = readMessagesFromSessionTranscript(params.sessionFile);
+          void transcriptReadForHook
+            .then((transcriptMessages) => transcriptMessages ?? messagesSnapshot)
+            .then((hookMessages) =>
+              hookRunner.runAgentEnd(
+                {
+                  messages: hookMessages,
+                  success: !aborted && !promptError,
+                  error: promptError ? describeUnknownError(promptError) : undefined,
+                  durationMs: Date.now() - promptStartedAt,
+                },
+                {
+                  runId: params.runId,
+                  agentId: hookAgentId,
+                  sessionKey: params.sessionKey,
+                  sessionId: params.sessionId,
+                  workspaceDir: params.workspaceDir,
+                  messageProvider: params.messageProvider ?? undefined,
+                  trigger: params.trigger,
+                  channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+                },
+              ),
             )
             .catch((err) => {
               log.warn(`agent_end hook failed: ${err}`);

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -1,5 +1,6 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import { resolveStorePath, updateSessionStoreEntry } from "../config/sessions.js";
+import { readMessagesFromSessionTranscript } from "../hooks/session-transcript-messages.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
@@ -20,18 +21,22 @@ export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
   });
 
   // Run before_compaction plugin hook (fire-and-forget)
+  // Read from transcript to preserve provenance and other extension fields
+  // that the in-memory AgentMessage[] may not carry.
   const hookRunner = getGlobalHookRunner();
   if (hookRunner?.hasHooks("before_compaction")) {
-    void hookRunner
-      .runBeforeCompaction(
-        {
-          messageCount: ctx.params.session.messages?.length ?? 0,
-          messages: ctx.params.session.messages,
-          sessionFile: ctx.params.session.sessionFile,
-        },
-        {
-          sessionKey: ctx.params.sessionKey,
-        },
+    void readMessagesFromSessionTranscript(ctx.params.session.sessionFile)
+      .then((transcriptMessages) =>
+        hookRunner.runBeforeCompaction(
+          {
+            messageCount: transcriptMessages?.length ?? ctx.params.session.messages?.length ?? 0,
+            messages: transcriptMessages ?? ctx.params.session.messages,
+            sessionFile: ctx.params.session.sessionFile,
+          },
+          {
+            sessionKey: ctx.params.sessionKey,
+          },
+        ),
       )
       .catch((err) => {
         ctx.log.warn(`before_compaction hook failed: ${String(err)}`);

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs/promises";
 import { resetConfiguredBindingTargetInPlace } from "../../channels/plugins/binding-targets.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import { readMessagesFromSessionTranscript } from "../../hooks/session-transcript-messages.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { isAcpSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -86,23 +86,8 @@ export async function emitResetCommandHooks(params: {
     // Fire-and-forget: read old session messages and run hook
     void (async () => {
       try {
-        const messages: unknown[] = [];
-        if (sessionFile) {
-          const content = await fs.readFile(sessionFile, "utf-8");
-          for (const line of content.split("\n")) {
-            if (!line.trim()) {
-              continue;
-            }
-            try {
-              const entry = JSON.parse(line);
-              if (entry.type === "message" && entry.message) {
-                messages.push(entry.message);
-              }
-            } catch {
-              // skip malformed lines
-            }
-          }
-        } else {
+        const messages = (await readMessagesFromSessionTranscript(sessionFile)) ?? [];
+        if (!sessionFile) {
           logVerbose("before_reset: no session file available, firing hook with empty messages");
         }
         await hookRunner.runBeforeReset(

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -86,9 +86,14 @@ export async function emitResetCommandHooks(params: {
     // Fire-and-forget: read old session messages and run hook
     void (async () => {
       try {
-        const messages = (await readMessagesFromSessionTranscript(sessionFile)) ?? [];
+        const transcriptMessages = await readMessagesFromSessionTranscript(sessionFile);
+        const messages = transcriptMessages ?? [];
         if (!sessionFile) {
           logVerbose("before_reset: no session file available, firing hook with empty messages");
+        } else if (transcriptMessages === null) {
+          logVerbose(
+            `before_reset: could not read session file ${sessionFile}, firing hook with empty messages`,
+          );
         }
         await hookRunner.runBeforeReset(
           { sessionFile, messages, reason: params.action },

--- a/src/hooks/session-transcript-messages.test.ts
+++ b/src/hooks/session-transcript-messages.test.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readMessagesFromSessionTranscript } from "./session-transcript-messages.js";
+
+describe("readMessagesFromSessionTranscript", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "transcript-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null for undefined sessionFile", async () => {
+    expect(await readMessagesFromSessionTranscript(undefined)).toBeNull();
+  });
+
+  it("returns null for missing file", async () => {
+    expect(await readMessagesFromSessionTranscript("/nonexistent/file.jsonl")).toBeNull();
+  });
+
+  it("reads messages from JSONL transcript", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const lines = [
+      JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+      JSON.stringify({ type: "message", message: { role: "assistant", content: "hi" } }),
+    ];
+    await fs.writeFile(sessionFile, lines.join("\n") + "\n");
+
+    const messages = await readMessagesFromSessionTranscript(sessionFile);
+    expect(messages).toEqual([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ]);
+  });
+
+  it("preserves provenance field on messages", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const provenance = {
+      kind: "inter_session",
+      sourceSessionKey: "agent:other-agent:main",
+      sourceChannel: "discord",
+      sourceTool: "sessions_send",
+    };
+    const lines = [
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "from another agent", provenance },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "got it" },
+      }),
+    ];
+    await fs.writeFile(sessionFile, lines.join("\n") + "\n");
+
+    const messages = await readMessagesFromSessionTranscript(sessionFile);
+    expect(messages).toHaveLength(2);
+    expect(messages![0]).toEqual({
+      role: "user",
+      content: "from another agent",
+      provenance,
+    });
+    // Assistant message has no provenance — should pass through unchanged
+    expect(messages![1]).toEqual({ role: "assistant", content: "got it" });
+  });
+
+  it("skips malformed JSONL lines", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const lines = [
+      JSON.stringify({ type: "message", message: { role: "user", content: "valid" } }),
+      "not valid json {{{",
+      JSON.stringify({ type: "message", message: { role: "assistant", content: "also valid" } }),
+    ];
+    await fs.writeFile(sessionFile, lines.join("\n") + "\n");
+
+    const messages = await readMessagesFromSessionTranscript(sessionFile);
+    expect(messages).toEqual([
+      { role: "user", content: "valid" },
+      { role: "assistant", content: "also valid" },
+    ]);
+  });
+
+  it("skips non-message entries", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const lines = [
+      JSON.stringify({ type: "system", data: { config: true } }),
+      JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+      JSON.stringify({ type: "tool_call", data: { name: "bash" } }),
+    ];
+    await fs.writeFile(sessionFile, lines.join("\n") + "\n");
+
+    const messages = await readMessagesFromSessionTranscript(sessionFile);
+    expect(messages).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  it("skips empty lines", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const lines = [
+      JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+      "",
+      "  ",
+      JSON.stringify({ type: "message", message: { role: "assistant", content: "hi" } }),
+    ];
+    await fs.writeFile(sessionFile, lines.join("\n") + "\n");
+
+    const messages = await readMessagesFromSessionTranscript(sessionFile);
+    expect(messages).toHaveLength(2);
+  });
+
+  it("returns empty array for transcript with no messages", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    await fs.writeFile(sessionFile, JSON.stringify({ type: "system", data: {} }) + "\n");
+
+    const messages = await readMessagesFromSessionTranscript(sessionFile);
+    expect(messages).toEqual([]);
+  });
+
+  it("preserves all custom fields on messages", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const message = {
+      role: "user",
+      content: "test",
+      provenance: { kind: "inter_session", sourceSessionKey: "agent:x:main" },
+      customField: "preserved",
+      metadata: { sender_id: "12345" },
+    };
+    await fs.writeFile(sessionFile, JSON.stringify({ type: "message", message }) + "\n");
+
+    const messages = await readMessagesFromSessionTranscript(sessionFile);
+    expect(messages![0]).toEqual(message);
+  });
+});

--- a/src/hooks/session-transcript-messages.ts
+++ b/src/hooks/session-transcript-messages.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs/promises";
+
+/**
+ * Read messages from a session JSONL transcript file, preserving all fields
+ * including `provenance`. Returns `null` if the file is unavailable or
+ * unreadable so callers can fall back to an in-memory snapshot.
+ */
+export async function readMessagesFromSessionTranscript(
+  sessionFile: string | undefined,
+): Promise<unknown[] | null> {
+  if (!sessionFile) {
+    return null;
+  }
+  try {
+    const content = await fs.readFile(sessionFile, "utf-8");
+    const messages: unknown[] = [];
+    for (const line of content.split("\n")) {
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        const entry = JSON.parse(line);
+        if (entry.type === "message" && entry.message) {
+          messages.push(entry.message);
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+    return messages;
+  } catch {
+    return null;
+  }
+}

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -496,10 +496,7 @@ export async function resolveMediaBufferPath(
  * @param id     The media ID as returned by SavedMedia.id.
  * @param subdir The subdirectory the file was saved into (default "inbound").
  */
-export async function deleteMediaBuffer(
-  id: string,
-  subdir: "inbound" = "inbound",
-): Promise<void> {
+export async function deleteMediaBuffer(id: string, subdir: "inbound" = "inbound"): Promise<void> {
   const physicalPath = await resolveMediaBufferPath(id, subdir);
   await fs.unlink(physicalPath);
 }


### PR DESCRIPTION
## Summary

Plugin hook events (`agent_end`, `before_compaction`, `before_reset`) were stripping the `provenance` field from messages before passing them to plugins. The data exists in the session transcript `.jsonl` files but was lost because the in-memory `AgentMessage[]` from pi-agent-core doesn't carry the `provenance` extension field.

This caused plugins that need sender attribution (e.g. memory/analytics plugins) to misattribute all `role: "user"` messages to the session owner, even when the message was injected via `sessions_send` from another agent session.

## Changes

- **New shared utility** (`src/hooks/session-transcript-messages.ts`): Reads messages from session JSONL transcripts preserving all fields including `provenance`. Returns `null` when the file is unavailable so callers can fall back to the in-memory snapshot.
- **`agent_end` hook**: Now reads from the session transcript with fallback to in-memory snapshot.
- **`before_compaction` hook**: All 4 call sites (run.ts, compact.ts, compaction-hooks.ts, handlers.compaction.ts) now include messages read from the transcript. Previously, 2 of the 4 sites passed no messages at all.
- **`before_reset` hook**: Refactored to use the shared utility (was already reading JSONL inline — now DRY).
- **`CompactionHookRunner` type**: Added `messages?: unknown[]` to the metrics parameter.

## Root cause

1. `applyInputProvenanceToUserMessage()` adds provenance to messages during the persistence path (`transformMessageForPersistence`)
2. The enriched message is written to the session JSONL transcript
3. But the in-memory `AgentMessage[]` managed by pi-agent-core does NOT retain the `provenance` extension field
4. Hook events were sourcing messages from the in-memory array, so provenance was lost

## Test plan

- [x] 9 new tests for the shared utility (provenance preservation, malformed lines, missing files, custom fields, empty transcripts)
- [x] 42 existing hook tests pass unchanged
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] Pre-existing type error in `loader.ts` confirmed on `main` (unrelated)

## Related

- Closes #57796
- Fixes plastic-labs/openclaw-honcho#35 (attribution bug in Honcho plugin)
- Related to plastic-labs/openclaw-honcho#31 (group chat attribution)
- Adjacent to #36006 (preserves custom fields in JSONL transcripts)
- Adjacent to #47087 (attaches provenance to spawned subagent tasks)