### PR TITLE
Add QNAIGC provider plugin

### DIFF
--- a/extensions/qnaigc-api/README.md
+++ b/extensions/qnaigc-api/README.md
@@ -1,0 +1,24 @@
+# QNAIGC API (OpenClaw plugin)
+
+Provider plugin for QNAIGC models served through an Anthropic-compatible endpoint.
+
+## Enable
+
+Bundled plugins are disabled by default. Enable this one:
+
+```bash
+openclaw plugins enable qnaigc-api
+```
+
+Restart the Gateway after enabling.
+
+## Authenticate
+
+```bash
+openclaw models auth login --provider qnaigc-api --set-default
+```
+
+## Notes
+
+- Set `QNAIGC_API_KEY` before using the provider.
+- The provider uses `https://anthropic.qnaigc.com`.

--- a/extensions/qnaigc-api/index.ts
+++ b/extensions/qnaigc-api/index.ts
@@ -1,0 +1,210 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+const PROVIDER_ID = "qnaigc-api";
+const QNAIGC_BASE_URL = "https://anthropic.qnaigc.com";
+
+type QnaigcCatalogEntry = {
+  id: string;
+  name: string;
+  reasoning: boolean;
+  input: ReadonlyArray<ModelDefinitionConfig["input"][number]>;
+  contextWindow: number;
+  maxTokens: number;
+};
+
+const QNAIGC_MODELS = [
+  {
+    id: "minimax/minimax-m2.5",
+    name: "MiniMax M2.5 (QNAIGC)",
+    reasoning: false,
+    input: ["text"] as const,
+    contextWindow: 204800,
+    maxTokens: 128000,
+  },
+  {
+    id: "minimax/minimax-m2.1",
+    name: "MiniMax M2.1 (QNAIGC)",
+    reasoning: false,
+    input: ["text"] as const,
+    contextWindow: 204800,
+    maxTokens: 128000,
+  },
+  {
+    id: "minimax/minimax-m2.7",
+    name: "MiniMax M2.7 (QNAIGC)",
+    reasoning: false,
+    input: ["text"] as const,
+    contextWindow: 204800,
+    maxTokens: 128000,
+  },
+  {
+    id: "minimax/minimax-m2.5-highspeed",
+    name: "MiniMax M2.5 HighSpeed (QNAIGC)",
+    reasoning: false,
+    input: ["text"] as const,
+    contextWindow: 204800,
+    maxTokens: 128000,
+  },
+  {
+    id: "deepseek/deepseek-v3.2-251201",
+    name: "DeepSeek V3.2 251201 (QNAIGC)",
+    reasoning: false,
+    input: ["text"] as const,
+    contextWindow: 128000,
+    maxTokens: 32000,
+  },
+  {
+    id: "deepseek-r1-0528",
+    name: "DeepSeek R1 0528 (QNAIGC)",
+    reasoning: true,
+    input: ["text"] as const,
+    contextWindow: 128000,
+    maxTokens: 32000,
+  },
+  {
+    id: "moonshotai/kimi-k2.5",
+    name: "Moonshot AI Kimi K2.5 (QNAIGC)",
+    reasoning: true,
+    input: ["text"] as const,
+    contextWindow: 256000,
+    maxTokens: 256000,
+  },
+  {
+    id: "xiaomi/mimo-v2-flash",
+    name: "Xiaomi Mimo-V2-Flash (QNAIGC)",
+    reasoning: true,
+    input: ["text"] as const,
+    contextWindow: 256000,
+    maxTokens: 256000,
+  },
+  {
+    id: "doubao-seed-1.6",
+    name: "Doubao Seed 1.6 (QNAIGC)",
+    reasoning: false,
+    input: ["text"] as const,
+    contextWindow: 256000,
+    maxTokens: 32000,
+  },
+  {
+    id: "doubao-seed-2.0-mini",
+    name: "Doubao Seed 2.0 Mini (QNAIGC)",
+    reasoning: false,
+    input: ["text"] as const,
+    contextWindow: 256000,
+    maxTokens: 32000,
+  },
+  {
+    id: "doubao-seed-2.0-pro",
+    name: "Doubao Seed 2.0 Pro (QNAIGC)",
+    reasoning: false,
+    input: ["text"] as const,
+    contextWindow: 256000,
+    maxTokens: 128000,
+  },
+  {
+    id: "qwen3.5-397b-a17b",
+    name: "Qwen3.5 397B A17B (QNAIGC)",
+    reasoning: false,
+    input: ["text"] as const,
+    contextWindow: 256000,
+    maxTokens: 64000,
+  },
+  {
+    id: "z-ai/glm-5",
+    name: "Z-AI GLM-5 (QNAIGC)",
+    reasoning: false,
+    input: ["text"] as const,
+    contextWindow: 128000,
+    maxTokens: 32000,
+  },
+  {
+    id: "stepfun/step-3.5-flash",
+    name: "StepFun Step 3.5 Flash (QNAIGC)",
+    reasoning: false,
+    input: ["text"] as const,
+    contextWindow: 256000,
+    maxTokens: 32000,
+  },
+  {
+    id: "meituan/longcat-flash-lite",
+    name: "Meituan LongCat Flash Lite (QNAIGC)",
+    reasoning: false,
+    input: ["text"] as const,
+    contextWindow: 256000,
+    maxTokens: 320000,
+  },
+] as const satisfies readonly QnaigcCatalogEntry[];
+
+function buildQnaigcModelDefinition(entry: QnaigcCatalogEntry): ModelDefinitionConfig {
+  return {
+    id: entry.id,
+    name: entry.name,
+    reasoning: entry.reasoning,
+    input: [...entry.input],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: entry.contextWindow,
+    maxTokens: entry.maxTokens,
+  };
+}
+
+export default definePluginEntry({
+  id: PROVIDER_ID,
+  name: "QNAIGC API",
+  description: "QNAIGC models using an Anthropic-compatible endpoint",
+  register(api) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "QNAIGC",
+      docsPath: "/providers/qnaigc-api",
+      envVars: ["QNAIGC_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: PROVIDER_ID,
+          methodId: "api-key",
+          label: "QNAIGC API key",
+          hint: "API key from QNAIGC",
+          optionKey: "qnaigcApiKey",
+          flagName: "--qnaigc-api-key",
+          envVar: "QNAIGC_API_KEY",
+          promptMessage: "Enter your QNAIGC API key",
+          defaultModel: "deepseek/deepseek-v3.2-251201",
+        }),
+      ],
+      catalog: {
+        order: "simple",
+        run: async (ctx) => {
+          const { apiKey } = ctx.resolveProviderApiKey(PROVIDER_ID);
+          if (!apiKey) return null;
+
+          return {
+            provider: {
+              baseUrl: QNAIGC_BASE_URL,
+              apiKey,
+              api: "anthropic-messages",
+              models: QNAIGC_MODELS.map(buildQnaigcModelDefinition).map((model) => ({
+                ...model,
+                api: "anthropic-messages",
+                provider: PROVIDER_ID,
+                baseUrl: QNAIGC_BASE_URL,
+              })),
+            },
+          };
+        },
+      },
+      resolveDynamicModel: (ctx) => ({
+        id: ctx.modelId,
+        name: ctx.modelId,
+        provider: PROVIDER_ID,
+        api: "anthropic-messages",
+        baseUrl: QNAIGC_BASE_URL,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 32000,
+      }),
+    });
+  },
+});

--- a/extensions/qnaigc-api/index.ts
+++ b/extensions/qnaigc-api/index.ts
@@ -69,7 +69,7 @@ const QNAIGC_MODELS = [
     reasoning: true,
     input: ["text"] as const,
     contextWindow: 256000,
-    maxTokens: 256000,
+    maxTokens: 32000,
   },
   {
     id: "xiaomi/mimo-v2-flash",
@@ -77,7 +77,7 @@ const QNAIGC_MODELS = [
     reasoning: true,
     input: ["text"] as const,
     contextWindow: 256000,
-    maxTokens: 256000,
+    maxTokens: 32000,
   },
   {
     id: "doubao-seed-1.6",
@@ -133,7 +133,7 @@ const QNAIGC_MODELS = [
     reasoning: false,
     input: ["text"] as const,
     contextWindow: 256000,
-    maxTokens: 320000,
+    maxTokens: 32000,
   },
 ] as const satisfies readonly QnaigcCatalogEntry[];
 

--- a/extensions/qnaigc-api/openclaw.plugin.json
+++ b/extensions/qnaigc-api/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "qnaigc-api",
-  "enabledByDefault": true,
+  "enabledByDefault": false,
   "providers": ["qnaigc-api"],
   "providerAuthEnvVars": {
     "qnaigc-api": ["QNAIGC_API_KEY"]

--- a/extensions/qnaigc-api/openclaw.plugin.json
+++ b/extensions/qnaigc-api/openclaw.plugin.json
@@ -1,0 +1,25 @@
+{
+  "id": "qnaigc-api",
+  "enabledByDefault": true,
+  "providers": ["qnaigc-api"],
+  "providerAuthEnvVars": {
+    "qnaigc-api": ["QNAIGC_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "qnaigc-api",
+      "method": "api-key",
+      "choiceId": "qnaigc-api-key",
+      "choiceLabel": "QNAIGC API key",
+      "groupId": "qnaigc-api",
+      "groupLabel": "QNAIGC",
+      "cliFlag": "--qnaigc-api-key",
+      "cliOption": "--qnaigc-api-key <key>",
+      "cliDescription": "QNAIGC API key (or set QNAIGC_API_KEY)"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false
+  }
+}

--- a/extensions/qnaigc-api/package.json
+++ b/extensions/qnaigc-api/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/qnaigc-api-provider",
+  "version": "2026.3.30",
+  "private": true,
+  "description": "OpenClaw QNAIGC provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/qnaigc-api/provider.contract.test.ts
+++ b/extensions/qnaigc-api/provider.contract.test.ts
@@ -1,0 +1,3 @@
+import { describeProviderContracts } from "../../test/helpers/plugins/provider-contract.js";
+
+describeProviderContracts("qnaigc-api");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,6 +560,8 @@ importers:
 
   extensions/qianfan: {}
 
+  extensions/qnaigc-api: {}
+
   extensions/sglang: {}
 
   extensions/signal: {}


### PR DESCRIPTION
## Summary
- Add the bundled QNAIGC provider plugin for the Anthropic-compatible endpoint.
- Register QNAIGC auth, catalog models, and plugin metadata.

## Test plan
- `pnpm check` (passed via commit hook)
- `pnpm test -- extensions/qnaigc-api/provider.contract.test.ts` (repo-wide contracts config does not include `extensions/**`)

## Notes
- AI-assisted change
- Branch is up to date with `origin/bundled-qnaigc-api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)