### PR TITLE
fix(provider-capabilities): add minimax/minimax-portal to thinking block stripping

### DIFF
--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -31,6 +31,14 @@ const resolveProviderCapabilitiesWithPluginMock = vi.fn((params: { provider: str
       return {
         providerFamily: "openai",
       };
+    case "minimax":
+      return {
+        dropThinkingBlockModelHints: ["minimax"],
+      };
+    case "minimax-portal":
+      return {
+        dropThinkingBlockModelHints: ["minimax"],
+      };
     case "github-copilot":
       return {
         dropThinkingBlockModelHints: ["claude"],
@@ -239,6 +247,27 @@ describe("resolveProviderCapabilities", () => {
         modelId: "claude-3.7-sonnet",
       }),
     ).toBe(true);
+  });
+
+  it("strips thinking blocks for minimax and minimax-portal providers", () => {
+    expect(
+      shouldDropThinkingBlocksForModel({
+        provider: "minimax",
+        modelId: "MiniMax-M2.7",
+      }),
+    ).toBe(true);
+    expect(
+      shouldDropThinkingBlocksForModel({
+        provider: "minimax-portal",
+        modelId: "MiniMax-M2.7",
+      }),
+    ).toBe(true);
+    expect(
+      shouldDropThinkingBlocksForModel({
+        provider: "minimax",
+        modelId: "some-other-model",
+      }),
+    ).toBe(false);
   });
 
   it("forwards config and workspace context to plugin capability lookup", () => {

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -72,6 +72,12 @@ const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities
   openai: {
     providerFamily: "openai",
   },
+  minimax: {
+    dropThinkingBlockModelHints: ["minimax"],
+  },
+  "minimax-portal": {
+    dropThinkingBlockModelHints: ["minimax"],
+  },
 };
 
 const defaultResolveProviderCapabilitiesWithPlugin = resolveProviderCapabilitiesWithPluginRuntime;


### PR DESCRIPTION
## Summary

Fixes #57788

MiniMax models (e.g. `MiniMax-M2.7`) include thinking blocks in their responses. When these thinking blocks are not stripped before the API call, their content leaks verbatim into text responses — and once it starts, every subsequent turn leaks.

### Root cause

`minimax` and `minimax-portal` were missing from `PLUGIN_CAPABILITIES_FALLBACKS` in `src/agents/provider-capabilities.ts`, so `dropThinkingBlockModelHints` defaulted to `[]` for these providers. Thinking blocks were never stripped before context was sent back to the model.

Additionally, even though the minimax extension declares `capabilities.dropThinkingBlockModelHints` via `registerProvider()`, it has no effect because `shouldDropThinkingBlocksForModel` is called without `config`/`workspaceDir`/`env`, so the plugin registry lookup always returns `undefined`. This breaks plugin-registered capabilities for **all** plugin providers, not just MiniMax (flagged in #57788 but not addressed here — that is a separate fix).

### Changes

- **`src/agents/provider-capabilities.ts`**: Add `minimax` and `minimax-portal` entries to `PLUGIN_CAPABILITIES_FALLBACKS` with `dropThinkingBlockModelHints: ["minimax"]`, matching the existing pattern used by `anthropic`/`mistral`.
- **`src/agents/provider-capabilities.test.ts`**: Add mock entries and a test case verifying that thinking blocks are stripped for minimax/minimax-portal providers with minimax model IDs, and not stripped for non-matching model IDs.

### Test results

All 11 tests in `provider-capabilities.test.ts` pass (including the new one).

```
✓ src/agents/provider-capabilities.test.ts > resolveProviderCapabilities > strips thinking blocks for minimax and minimax-portal providers
✓ ... (10 more existing tests)
Test Files  1 passed (1)
Tests       11 passed (11)
```
