### PR TITLE
Security: block exec approval shell carrier targets

### DIFF
--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -134,7 +134,7 @@ describe("resolveAllowAlwaysPatterns", () => {
       env,
       safeBins,
     });
-    expect(persisted).not.toContain(touch);
+    expect(persisted).toEqual([]);
 
     const second = evaluateShellAllowlist({
       command: expandedCommand,
@@ -706,7 +706,7 @@ $0 \\"$1\\"" touch {marker}`,
       return;
     }
     const dir = makeTempDir();
-    makeExecutable(dir, "env");
+    const envPath = makeExecutable(dir, "env");
     const env = makePathEnv(dir);
     const safeBins = resolveSafeBins(undefined);
 
@@ -720,7 +720,7 @@ $0 \\"$1\\"" touch {marker}`,
 
     const second = evaluateShellAllowlist({
       command: `sh -lc '$0 "$@"' env BASH_ENV=/tmp/payload.sh bash -lc 'id > /tmp/pwned'`,
-      allowlist: persisted.map((pattern) => ({ pattern })),
+      allowlist: [{ pattern: envPath }],
       safeBins,
       cwd: dir,
       env,
@@ -734,7 +734,7 @@ $0 \\"$1\\"" touch {marker}`,
       return;
     }
     const dir = makeTempDir();
-    makeExecutable(dir, "bash");
+    const bashPath = makeExecutable(dir, "bash");
     const env = makePathEnv(dir);
     const safeBins = resolveSafeBins(undefined);
 
@@ -748,7 +748,7 @@ $0 \\"$1\\"" touch {marker}`,
 
     const second = evaluateShellAllowlist({
       command: `sh -lc '$0 "$@"' bash -lc 'id > /tmp/pwned'`,
-      allowlist: persisted.map((pattern) => ({ pattern })),
+      allowlist: [{ pattern: bashPath }],
       safeBins,
       cwd: dir,
       env,
@@ -762,7 +762,7 @@ $0 \\"$1\\"" touch {marker}`,
       return;
     }
     const dir = makeTempDir();
-    makeExecutable(dir, "xargs");
+    const xargsPath = makeExecutable(dir, "xargs");
     const env = makePathEnv(dir);
     const safeBins = resolveSafeBins(undefined);
 
@@ -776,7 +776,7 @@ $0 \\"$1\\"" touch {marker}`,
 
     const second = evaluateShellAllowlist({
       command: `sh -lc '$0 "$@"' xargs sh -lc 'id > /tmp/pwned'`,
-      allowlist: persisted.map((pattern) => ({ pattern })),
+      allowlist: [{ pattern: xargsPath }],
       safeBins,
       cwd: dir,
       env,

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -120,38 +120,31 @@ describe("resolveAllowAlwaysPatterns", () => {
     expect(second.allowlistSatisfied).toBe(true);
   }
 
-  function expectPositionalArgvCarrierResult(params: {
-    command: string;
-    expectPersisted: boolean;
-  }) {
+  function expectPositionalArgvCarrierRejected(command: string) {
     const dir = makeTempDir();
     const touch = makeExecutable(dir, "touch");
     const env = { PATH: `${dir}${path.delimiter}${process.env.PATH ?? ""}` };
     const safeBins = resolveSafeBins(undefined);
     const marker = path.join(dir, "marker");
-    const command = params.command.replaceAll("{marker}", marker);
+    const expandedCommand = command.replaceAll("{marker}", marker);
 
     const { persisted } = resolvePersistedPatterns({
-      command,
+      command: expandedCommand,
       dir,
       env,
       safeBins,
     });
-    if (params.expectPersisted) {
-      expect(persisted).toEqual([touch]);
-    } else {
-      expect(persisted).not.toContain(touch);
-    }
+    expect(persisted).not.toContain(touch);
 
     const second = evaluateShellAllowlist({
-      command,
+      command: expandedCommand,
       allowlist: [{ pattern: touch }],
       safeBins,
       cwd: dir,
       env,
       platform: process.platform,
     });
-    expect(second.allowlistSatisfied).toBe(params.expectPersisted);
+    expect(second.allowlistSatisfied).toBe(false);
   }
 
   it("returns direct executable paths for non-shell segments", () => {
@@ -290,63 +283,34 @@ describe("resolveAllowAlwaysPatterns", () => {
     });
   });
 
-  it("persists carried executables for shell-wrapper positional argv carriers", () => {
+  it("rejects shell-wrapper positional argv carriers", () => {
     if (process.platform === "win32") {
       return;
     }
-    const dir = makeTempDir();
-    const touch = makeExecutable(dir, "touch");
-    const env = { PATH: `${dir}${path.delimiter}${process.env.PATH ?? ""}` };
-    const safeBins = resolveSafeBins(undefined);
-
-    const { persisted } = resolvePersistedPatterns({
-      command: `sh -lc '$0 "$1"' touch ${path.join(dir, "marker")}`,
-      dir,
-      env,
-      safeBins,
-    });
-    expect(persisted).toEqual([touch]);
-
-    const second = evaluateShellAllowlist({
-      command: `sh -lc '$0 "$1"' touch ${path.join(dir, "second-marker")}`,
-      allowlist: [{ pattern: touch }],
-      safeBins,
-      cwd: dir,
-      env,
-      platform: process.platform,
-    });
-    expect(second.allowlistSatisfied).toBe(true);
+    expectPositionalArgvCarrierRejected(`sh -lc '$0 "$1"' touch {marker}`);
   });
 
-  it("persists carried executables for exec -- positional argv carriers", () => {
+  it("rejects exec positional argv carriers", () => {
     if (process.platform === "win32") {
       return;
     }
-    expectPositionalArgvCarrierResult({
-      command: `sh -lc 'exec -- "$0" "$1"' touch {marker}`,
-      expectPersisted: true,
-    });
+    expectPositionalArgvCarrierRejected(`sh -lc 'exec -- "$0" "$1"' touch {marker}`);
   });
 
   it("rejects positional argv carriers when $0 is single-quoted", () => {
     if (process.platform === "win32") {
       return;
     }
-    expectPositionalArgvCarrierResult({
-      command: `sh -lc "'$0' "$1"" touch {marker}`,
-      expectPersisted: false,
-    });
+    expectPositionalArgvCarrierRejected(`sh -lc "'$0' "$1"" touch {marker}`);
   });
 
   it("rejects positional argv carriers when exec is separated from $0 by a newline", () => {
     if (process.platform === "win32") {
       return;
     }
-    expectPositionalArgvCarrierResult({
-      command: `sh -lc "exec
+    expectPositionalArgvCarrierRejected(`sh -lc "exec
 $0 \\"$1\\"" touch {marker}`,
-      expectPersisted: false,
-    });
+    );
   });
 
   it("rejects positional argv carriers when inline command contains extra shell operations", () => {
@@ -784,6 +748,34 @@ $0 \\"$1\\"" touch {marker}`,
 
     const second = evaluateShellAllowlist({
       command: `sh -lc '$0 "$@"' bash -lc 'id > /tmp/pwned'`,
+      allowlist: persisted.map((pattern) => ({ pattern })),
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(false);
+  });
+
+  it("rejects positional carrier when carried executable is an unknown dispatch carrier", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    makeExecutable(dir, "xargs");
+    const env = makePathEnv(dir);
+    const safeBins = resolveSafeBins(undefined);
+
+    const { persisted } = resolvePersistedPatterns({
+      command: `sh -lc '$0 "$@"' xargs echo SAFE`,
+      dir,
+      env,
+      safeBins,
+    });
+    expect(persisted).toEqual([]);
+
+    const second = evaluateShellAllowlist({
+      command: `sh -lc '$0 "$@"' xargs sh -lc 'id > /tmp/pwned'`,
       allowlist: persisted.map((pattern) => ({ pattern })),
       safeBins,
       cwd: dir,

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { isDispatchWrapperExecutable } from "./dispatch-wrapper-resolution.js";
 import {
   analyzeShellCommand,
   isWindowsPlatform,
@@ -26,11 +25,9 @@ import { isTrustedSafeBinPath } from "./exec-safe-bin-trust.js";
 import {
   extractShellWrapperInlineCommand,
   isShellWrapperExecutable,
-  normalizeExecutableToken,
 } from "./exec-wrapper-resolution.js";
 import { resolveExecWrapperTrustPlan } from "./exec-wrapper-trust-plan.js";
 import { expandHomePrefix } from "./home-dir.js";
-import { POSIX_INLINE_COMMAND_FLAGS, resolveInlineCommandMatch } from "./shell-inline-command.js";
 
 function hasShellLineContinuation(command: string): boolean {
   return /\\(?:\r\n|\n|\r)/.test(command);
@@ -235,18 +232,6 @@ function evaluateSegments(
         : executableResolution;
     const executableMatch = matchAllowlist(params.allowlist, candidateResolution);
     const inlineCommand = extractShellWrapperInlineCommand(allowlistSegment.argv);
-    const shellPositionalArgvCandidatePath = resolveShellWrapperPositionalArgvCandidatePath({
-      segment: allowlistSegment,
-      cwd: params.cwd,
-      env: params.env,
-    });
-    const shellPositionalArgvMatch = shellPositionalArgvCandidatePath
-      ? matchAllowlist(params.allowlist, {
-          rawExecutable: shellPositionalArgvCandidatePath,
-          resolvedPath: shellPositionalArgvCandidatePath,
-          executableName: path.basename(shellPositionalArgvCandidatePath),
-        })
-      : null;
     const shellScriptCandidatePath =
       inlineCommand === null
         ? resolveShellWrapperScriptCandidatePath({
@@ -261,7 +246,7 @@ function evaluateSegments(
           executableName: path.basename(shellScriptCandidatePath),
         })
       : null;
-    const match = executableMatch ?? shellPositionalArgvMatch ?? shellScriptMatch;
+    const match = executableMatch ?? shellScriptMatch;
     if (match) {
       matches.push(match);
     }
@@ -428,71 +413,6 @@ function resolveShellWrapperScriptCandidatePath(params: {
   return path.resolve(base, expanded);
 }
 
-function resolveShellWrapperPositionalArgvCandidatePath(params: {
-  segment: ExecCommandSegment;
-  cwd?: string;
-  env?: NodeJS.ProcessEnv;
-}): string | undefined {
-  if (!isShellWrapperSegment(params.segment)) {
-    return undefined;
-  }
-
-  const argv = params.segment.argv;
-  if (!Array.isArray(argv) || argv.length < 4) {
-    return undefined;
-  }
-
-  const wrapper = normalizeExecutableToken(argv[0] ?? "");
-  if (!["ash", "bash", "dash", "fish", "ksh", "sh", "zsh"].includes(wrapper)) {
-    return undefined;
-  }
-
-  const inlineMatch = resolveInlineCommandMatch(argv, POSIX_INLINE_COMMAND_FLAGS, {
-    allowCombinedC: true,
-  });
-  if (inlineMatch.valueTokenIndex === null || !inlineMatch.command) {
-    return undefined;
-  }
-  if (!isDirectShellPositionalCarrierInvocation(inlineMatch.command)) {
-    return undefined;
-  }
-
-  const carriedExecutable = argv
-    .slice(inlineMatch.valueTokenIndex + 1)
-    .map((token) => token.trim())
-    .find((token) => token.length > 0);
-  if (!carriedExecutable) {
-    return undefined;
-  }
-
-  // Reject wrapper targets carried through `$0 "$@"` because their trailing argv can
-  // widen execution semantics beyond the original approved command.
-  const carriedName = normalizeExecutableToken(carriedExecutable);
-  if (isDispatchWrapperExecutable(carriedName) || isShellWrapperExecutable(carriedName)) {
-    return undefined;
-  }
-
-  const resolution = resolveCommandResolutionFromArgv([carriedExecutable], params.cwd, params.env);
-  return resolveExecutionTargetCandidatePath(resolution, params.cwd);
-}
-
-function isDirectShellPositionalCarrierInvocation(command: string): boolean {
-  const trimmed = command.trim();
-  if (trimmed.length === 0) {
-    return false;
-  }
-
-  // Keep carrier matching strict: only allow direct `$0` execution with positional arguments.
-  // This prevents payloads like `echo blocked; $0 "$1"` from satisfying allowlist checks.
-  const shellWhitespace = String.raw`[^\S\r\n]+`;
-  const positionalZero = String.raw`(?:\$(?:0|\{0\})|"\$(?:0|\{0\})")`;
-  const positionalArg = String.raw`(?:\$(?:[@*]|[1-9]|\{[@*1-9]\})|"\$(?:[@*]|[1-9]|\{[@*1-9]\})")`;
-  return new RegExp(
-    `^(?:exec${shellWhitespace}(?:--${shellWhitespace})?)?${positionalZero}(?:${shellWhitespace}${positionalArg})*$`,
-    "u",
-  ).test(trimmed);
-}
-
 function collectAllowAlwaysPatterns(params: {
   segment: ExecCommandSegment;
   cwd?: string;
@@ -527,18 +447,6 @@ function collectAllowAlwaysPatterns(params: {
   }
   if (!trustPlan.shellWrapperExecutable) {
     params.out.add(candidatePath);
-    return;
-  }
-  const positionalArgvPath = resolveShellWrapperPositionalArgvCandidatePath({
-    segment,
-    cwd: params.cwd,
-    env: params.env,
-  });
-  if (positionalArgvPath) {
-    if (isInterpreterLikeAllowlistPattern(positionalArgvPath)) {
-      return;
-    }
-    params.out.add(positionalArgvPath);
     return;
   }
   const inlineCommand =


### PR DESCRIPTION
## Summary

- Problem: exec approval allowlist handling treated shell positional carrier forms like `sh -lc '$0 "$@"' ...` as if the carried executable were the approved target.
- Why it matters: that special-case path failed closed only for a small set of known wrappers, so unrecognized dispatch-capable carriers could widen execution semantics after approval.
- What changed: removed shell positional-carrier target matching from exec allowlist evaluation and `allow-always` persistence, and added regression coverage that rejects both known and previously unrecognized carriers such as `xargs`.
- What did NOT change (scope boundary): this PR does not expand wrapper-family detection, add a new carrier allowlist abstraction, or change general shell-script path matching.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related https://github.com/NVIDIA-dev/openclaw-tracking/issues/130
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `exec-approvals-allowlist.ts` had a positional-carrier special case that extracted a carried executable from shell `$0` invocation patterns and treated it as the approval target.
- Missing detection / guardrail: the carrier path rejected only known shell/dispatch wrappers instead of failing closed for the entire carrier form.
- Prior context (`git blame`, prior PR, issue, or refactor if known): local code history in this checkout only showed the carrier-resolution path already present; I did not trace the original introducing PR.
- Why this regressed now: the logic depended on a deny-known-wrappers model, so newly encountered or previously unmodeled dispatch carriers remained eligible for allowlist binding.
- If unknown, what was ruled out: not caused by shell-script path persistence, direct executable matching, or safe-bin handling.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/exec-approvals-allow-always.test.ts`
- Scenario the test should lock in: shell positional carrier forms must not satisfy allowlist persistence or approval matching, including unrecognized carriers like `xargs`.
- Why this is the smallest reliable guardrail: the bug lives in pure approval-analysis logic and does not require a live gateway or external integration.
- Existing test that already covers this (if any): existing carrier tests covered known shell and dispatch wrappers only.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `allow-always` no longer persists carried executables from shell positional carrier forms such as `sh -lc '$0 "$1"' ...` or `sh -lc 'exec -- "$0" "$1"' ...`.
- Exec allowlist evaluation no longer treats shell positional-carrier targets as independently allowlisted executables.

## Diagram (if applicable)

```text
Before:
[shell positional carrier] -> [extract carried executable] -> [allowlist/persist carried path] -> [carrier reinterprets argv]

After:
[shell positional carrier] -> [no carrier target extraction] -> [requires normal approval path] -> [no carrier-based allowlist bypass]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this narrows the exec approval surface by removing a permissive carrier-special-case. Risk is reduced compatibility for users relying on positional shell carriers; mitigation is that direct executable approvals and shell-script path matching continue to work, and the change fails closed instead of trying to classify more wrappers.

## Repro + Verification

### Environment

- OS: Ubuntu container
- Runtime/container: Node.js 22.x
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default repo test harness; no special channel config

### Steps

1. Persist or evaluate an exec approval for a shell positional carrier form such as `sh -lc '$0 "$@"' xargs echo SAFE`.
2. Reuse the approved pattern with a widened carrier invocation such as `sh -lc '$0 "$@"' xargs sh -lc 'id > /tmp/pwned'`.
3. Confirm the carried executable is no longer persisted or treated as an allowlist match.

### Expected

- Positional shell carriers do not produce persisted allowlist patterns or satisfy allowlist matching through the carried executable.

### Actual

- After this patch, carrier-based approval matching is removed and the bypass path no longer succeeds.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran the targeted exec-approval test files and confirmed carrier forms are rejected, including the new `xargs` regression path.
- Edge cases checked: known dispatch wrapper carriers, shell-wrapper carriers, direct `$0 "$1"`, and `exec -- "$0" "$1"` carrier forms.
- What you did **not** verify: full repo `pnpm check`/full-suite CI from this PR branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: users relying on positional shell carrier approval persistence may need one-time reapproval through a direct executable path.
  - Mitigation: the change is intentionally fail-closed and keeps direct executable and shell-script path approval behavior intact.
- Risk: maintainers may prefer preserving some carrier targets via a positive allowlist instead of removing the feature entirely.
  - Mitigation: this patch isolates the security fix cleanly, and a later follow-up can reintroduce a positive safe-carrier allowlist if the product decision is to preserve that workflow.
