### PR TITLE
fix(replies): strip leaked tool_call XML

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -20,6 +20,14 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");
   });
 
+  it("strips leaked tool_call scaffolding", () => {
+    expect(
+      sanitizeUserFacingText(
+        'Here is my response <tool_call>{"name":"exec","arguments":{"command":"echo test"}}</tool_call>',
+      ),
+    ).toBe("Here is my response ");
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -40,6 +40,12 @@ describe("sanitizeUserFacingText", () => {
     ).toBe("    key: value");
   });
 
+  it("preserves indentation after stripping leading reasoning scaffolding", () => {
+    expect(sanitizeUserFacingText("<thinking>secret</thinking>\n    key: value")).toBe(
+      "    key: value",
+    );
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -28,6 +28,18 @@ describe("sanitizeUserFacingText", () => {
     ).toBe("Here is my response ");
   });
 
+  it("preserves leading indentation when no scaffolding is present", () => {
+    expect(sanitizeUserFacingText("    key: value")).toBe("    key: value");
+  });
+
+  it("preserves indentation after stripping leading tool_call scaffolding", () => {
+    expect(
+      sanitizeUserFacingText(
+        '<tool_call>{"name":"exec","arguments":{"command":"echo test"}}</tool_call>\n    key: value',
+      ),
+    ).toBe("    key: value");
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -8,6 +8,7 @@ import {
   parseApiErrorInfo,
   parseApiErrorPayload,
 } from "../../shared/assistant-error-format.js";
+import { stripAssistantInternalScaffolding } from "../../shared/text/assistant-visible-text.js";
 export {
   extractLeadingHttpStatus,
   formatRawAssistantErrorForUi,
@@ -957,7 +958,12 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
     return raw;
   }
   const errorContext = opts?.errorContext ?? false;
-  const stripped = stripInternalRuntimeContext(stripFinalTagsFromText(raw));
+  const stripped = stripAssistantInternalScaffolding(
+    stripInternalRuntimeContext(stripFinalTagsFromText(raw)),
+    {
+      trimStart: false,
+    },
+  );
   const trimmed = stripped.trim();
   if (!trimmed) {
     return "";

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -125,6 +125,14 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).not.toContain("NO_REPLY");
   });
 
+  it("strips leaked tool_call scaffolding from final replies", () => {
+    const result = normalizeReplyPayload({
+      text: 'Here is my response <tool_call>{"name":"exec","arguments":{"command":"echo test"}}</tool_call>',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("Here is my response ");
+  });
+
   it("keeps NO_REPLY when used as leading substantive text", () => {
     const result = normalizeReplyPayload({ text: "NO_REPLY -- nope" });
     expect(result).not.toBeNull();

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -133,6 +133,14 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).toBe("Here is my response ");
   });
 
+  it("strips self-closing tool_call scaffolding without truncating trailing reply text", () => {
+    const result = normalizeReplyPayload({
+      text: 'Here is my response <tool_call name="exec" /> after',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("Here is my response  after");
+  });
+
   it("keeps NO_REPLY when used as leading substantive text", () => {
     const result = normalizeReplyPayload({ text: "NO_REPLY -- nope" });
     expect(result).not.toBeNull();

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -83,6 +83,14 @@ describe("stripAssistantInternalScaffolding", () => {
       expected: "Before\n\nsecret\n\nAfter",
     },
     {
+      name: "strips leaked tool_call scaffolding",
+      input: [
+        "Here is my response",
+        '<tool_call>{"name":"exec","arguments":{"command":"echo test"}}</tool_call>',
+      ].join(" "),
+      expected: "Here is my response ",
+    },
+    {
       name: "keeps relevant-memories tags inside fenced code",
       input: createLiteralRelevantMemoriesCodeBlock(),
       expected: undefined,
@@ -90,6 +98,17 @@ describe("stripAssistantInternalScaffolding", () => {
     {
       name: "keeps literal relevant-memories prose",
       input: "Use `<relevant-memories>example</relevant-memories>` literally.",
+      expected: undefined,
+    },
+    {
+      name: "keeps tool_call tags inside fenced code",
+      input: [
+        "```xml",
+        '<tool_call>{"name":"exec","arguments":{"command":"echo test"}}</tool_call>',
+        "```",
+        "",
+        "Visible text",
+      ].join("\n"),
       expected: undefined,
     },
   ] as const)("$name", ({ input, expected }) => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -96,6 +96,11 @@ describe("stripAssistantInternalScaffolding", () => {
       expected: "Before ",
     },
     {
+      name: "strips self-closing tool_call tags without truncating trailing text",
+      input: ["Before", '<tool_call name="exec" />', "After"].join(" "),
+      expected: "Before  After",
+    },
+    {
       name: "keeps relevant-memories tags inside fenced code",
       input: createLiteralRelevantMemoriesCodeBlock(),
       expected: undefined,

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -91,6 +91,11 @@ describe("stripAssistantInternalScaffolding", () => {
       expected: "Here is my response ",
     },
     {
+      name: "hides unfinished tool_call blocks",
+      input: ["Before", "<tool_call>", "incomplete..."].join(" "),
+      expected: "Before ",
+    },
+    {
       name: "keeps relevant-memories tags inside fenced code",
       input: createLiteralRelevantMemoriesCodeBlock(),
       expected: undefined,

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -84,7 +84,11 @@ export function stripAssistantInternalScaffolding(
   text: string,
   options?: { trimStart?: boolean },
 ): string {
-  const withoutReasoning = stripReasoningTagsFromText(text, { mode: "preserve", trim: "start" });
+  const trimMode = options?.trimStart === false ? "none" : "start";
+  const withoutReasoning = stripReasoningTagsFromText(text, {
+    mode: "preserve",
+    trim: trimMode,
+  });
   const withoutToolCalls = stripToolCallTags(withoutReasoning);
   const cleaned = stripRelevantMemoriesTags(withoutToolCalls);
   return options?.trimStart === false ? cleaned : cleaned.trimStart();

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -80,8 +80,12 @@ function stripToolCallTags(text: string): string {
   return result;
 }
 
-export function stripAssistantInternalScaffolding(text: string): string {
+export function stripAssistantInternalScaffolding(
+  text: string,
+  options?: { trimStart?: boolean },
+): string {
   const withoutReasoning = stripReasoningTagsFromText(text, { mode: "preserve", trim: "start" });
   const withoutToolCalls = stripToolCallTags(withoutReasoning);
-  return stripRelevantMemoriesTags(withoutToolCalls).trimStart();
+  const cleaned = stripRelevantMemoriesTags(withoutToolCalls);
+  return options?.trimStart === false ? cleaned : cleaned.trimStart();
 }

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -3,6 +3,8 @@ import { stripReasoningTagsFromText } from "./reasoning-tags.js";
 
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
+const TOOL_CALL_TAG_RE = /<\s*(\/?)\s*tool_call\b[^<>]*>/gi;
+const TOOL_CALL_TAG_QUICK_RE = /<\s*\/?\s*tool_call\b/i;
 
 function stripRelevantMemoriesTags(text: string): string {
   if (!text || !MEMORY_TAG_QUICK_RE.test(text)) {
@@ -41,7 +43,45 @@ function stripRelevantMemoriesTags(text: string): string {
   return result;
 }
 
+function stripToolCallTags(text: string): string {
+  if (!text || !TOOL_CALL_TAG_QUICK_RE.test(text)) {
+    return text;
+  }
+  TOOL_CALL_TAG_RE.lastIndex = 0;
+
+  const codeRegions = findCodeRegions(text);
+  let result = "";
+  let lastIndex = 0;
+  let inToolCallBlock = false;
+
+  for (const match of text.matchAll(TOOL_CALL_TAG_RE)) {
+    const idx = match.index ?? 0;
+    if (isInsideCode(idx, codeRegions)) {
+      continue;
+    }
+
+    const isClose = match[1] === "/";
+    if (!inToolCallBlock) {
+      result += text.slice(lastIndex, idx);
+      if (!isClose) {
+        inToolCallBlock = true;
+      }
+    } else if (isClose) {
+      inToolCallBlock = false;
+    }
+
+    lastIndex = idx + match[0].length;
+  }
+
+  if (!inToolCallBlock) {
+    result += text.slice(lastIndex);
+  }
+
+  return result;
+}
+
 export function stripAssistantInternalScaffolding(text: string): string {
   const withoutReasoning = stripReasoningTagsFromText(text, { mode: "preserve", trim: "start" });
-  return stripRelevantMemoriesTags(withoutReasoning).trimStart();
+  const withoutToolCalls = stripToolCallTags(withoutReasoning);
+  return stripRelevantMemoriesTags(withoutToolCalls).trimStart();
 }

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -60,7 +60,7 @@ function stripToolCallTags(text: string): string {
       continue;
     }
 
-    const isClose = match[1] === "/";
+    const isClose = match[1] === "/" || /\/\s*>$/.test(match[0]);
     if (!inToolCallBlock) {
       result += text.slice(lastIndex, idx);
       if (!isClose) {


### PR DESCRIPTION
## Summary

- Problem: final user-facing replies could leak raw `<tool_call>...</tool_call>` XML.
- Why it matters: Discord users saw internal tool scaffolding instead of clean reply text.
- What changed: strip leaked `<tool_call>` scaffolding in the shared assistant-visible text helper and use that helper in final reply sanitization.
- What did NOT change (scope boundary): tool execution behavior is unchanged; fenced code examples with literal `<tool_call>` text are preserved.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57868
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: final text sanitization stripped some internal tags (`<final>`, reasoning/memory scaffolding) but not raw `<tool_call>...</tool_call>` blocks.
- Missing detection / guardrail: no focused regression covered leaked `tool_call` XML in final reply normalization.
- Prior context (`git blame`, prior PR, issue, or refactor if known): adjacent internal-scaffolding stripping already existed; this XML shape was missing.
- Why this regressed now: unknown.
- If unknown, what was ruled out: no active upstream PR overlaps this exact issue.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/shared/text/assistant-visible-text.test.ts`
  - `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
  - `src/auto-reply/reply/reply-utils.test.ts`
- Scenario the test should lock in: leaked `<tool_call>...</tool_call>` blocks are removed from final user-facing replies, but fenced code literals remain visible.
- Why this is the smallest reliable guardrail: the bug lives in shared text sanitization and final reply normalization.
- Existing test that already covers this (if any): adjacent tests already covered other internal scaffolding.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

User-facing replies no longer include leaked raw `<tool_call>...</tool_call>` scaffolding.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm checkout
- Model/provider: N/A
- Integration/channel (if any): Discord final reply delivery path
- Relevant config (redacted): N/A

### Steps

1. Produce a reply containing leaked `<tool_call>...</tool_call>` XML.
2. Run final reply normalization.
3. Inspect the user-facing text payload.

### Expected

- Human-readable reply remains.
- Raw `<tool_call>` block is removed.
- Fenced code containing literal `<tool_call>` text remains intact.

### Actual

- Matches expected with this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/shared/text/assistant-visible-text.test.ts`
  - `pnpm test -- src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
  - `pnpm test -- src/auto-reply/reply/reply-utils.test.ts`
  - `pnpm exec oxfmt --check src/shared/text/assistant-visible-text.ts src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-helpers/errors.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/auto-reply/reply/reply-utils.test.ts`
- Edge cases checked: fenced code literals are preserved.
- What you did **not** verify: full `pnpm check`. Current `origin/main` already has unrelated TypeScript failures in the skills area.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: over-stripping literal `<tool_call>` prose outside code blocks.
  - Mitigation: keep the stripping scoped to assistant-internal scaffolding and preserve fenced-code literals with regression coverage.
