### PR TITLE
test(ci): fix stale regression expectations

### DIFF
--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -676,7 +676,16 @@ describe("discord component interactions", () => {
       duplicate: false,
     });
 
-    const button = createDiscordComponentButton(createComponentContext());
+    const button = createDiscordComponentButton(
+      createComponentContext({
+        discordConfig: createDiscordConfig({
+          dm: {
+            groupEnabled: true,
+            groupChannels: ["group-dm-1"],
+          },
+        }),
+      }),
+    );
     const { interaction } = createComponentButtonInteraction({
       rawData: {
         channel_id: "group-dm-1",

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1742,7 +1742,7 @@ describe("QmdMemoryManager", () => {
       .filter((args: string[]) => args[0] === "search");
     expect(searchCalls).toEqual([
       ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "notes"],
     ]);
     await manager.close();
   });
@@ -1828,7 +1828,7 @@ describe("QmdMemoryManager", () => {
       .filter((args: string[]) => args[0] === "query");
     expect(queryCalls).toEqual([
       ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes"],
     ]);
     await manager.close();
   });
@@ -1880,7 +1880,7 @@ describe("QmdMemoryManager", () => {
     expect(searchAndQueryCalls).toEqual([
       ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
       ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes"],
     ]);
     await manager.close();
   });
@@ -2217,7 +2217,7 @@ describe("QmdMemoryManager", () => {
     await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
 
     expect(selectors).toEqual(["qmd.hybrid_search", "qmd.hybrid_search"]);
-    expect(collections).toEqual(["workspace-a-main", "workspace-b-main"]);
+    expect(collections).toEqual(["workspace-a", "workspace-b"]);
 
     await manager.close();
   });
@@ -3326,7 +3326,7 @@ describe("QmdMemoryManager", () => {
         );
         return child;
       }
-      if (args[0] === "search" && args.includes("notes-main")) {
+      if (args[0] === "search" && args.includes("notes")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(child, "stdout", "[]");
         return child;
@@ -3542,14 +3542,14 @@ describe("QmdMemoryManager", () => {
         );
         return child;
       }
-      if (args[0] === "search" && args.includes("notes-main")) {
+      if (args[0] === "search" && args.includes("notes")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(
           child,
           "stdout",
           JSON.stringify([
             {
-              file: "qmd://notes-main/guide.md",
+              file: "qmd://notes/guide.md",
               score: 0.7,
               snippet: "@@ -1,1\nnotes guide",
             },

--- a/test/scripts/test-planner.test.ts
+++ b/test/scripts/test-planner.test.ts
@@ -120,12 +120,33 @@ describe("test planner", () => {
   });
 
   it("scales down mid-tier local concurrency under saturated load", () => {
-    const artifacts = createExecutionArtifacts({
+    const env = {
       RUNNER_OS: "Linux",
       OPENCLAW_TEST_HOST_CPU_COUNT: "10",
       OPENCLAW_TEST_HOST_MEMORY_GIB: "64",
+    };
+    const baselineArtifacts = createExecutionArtifacts({
+      ...env,
+      OPENCLAW_TEST_LOAD_AWARE: "0",
     });
-    const plan = buildExecutionPlan(
+    const baselinePlan = buildExecutionPlan(
+      {
+        profile: null,
+        mode: "local",
+        surfaces: ["unit", "extensions"],
+        passthroughArgs: [],
+      },
+      {
+        env: {
+          ...env,
+          OPENCLAW_TEST_LOAD_AWARE: "0",
+        },
+        platform: "linux",
+        writeTempJsonArtifact: baselineArtifacts.writeTempJsonArtifact,
+      },
+    );
+    const saturatedArtifacts = createExecutionArtifacts(env);
+    const saturatedPlan = buildExecutionPlan(
       {
         profile: null,
         mode: "local",
@@ -140,19 +161,26 @@ describe("test planner", () => {
         },
         platform: "linux",
         loadAverage: [11.5, 11.5, 11.5],
-        writeTempJsonArtifact: artifacts.writeTempJsonArtifact,
+        writeTempJsonArtifact: saturatedArtifacts.writeTempJsonArtifact,
       },
     );
 
-    expect(plan.runtimeCapabilities.memoryBand).toBe("mid");
-    expect(plan.runtimeCapabilities.loadBand).toBe("saturated");
-    expect(plan.executionBudget.unitSharedWorkers).toBe(2);
-    expect(plan.executionBudget.unitIsolatedWorkers).toBe(1);
-    expect(plan.executionBudget.topLevelParallelLimitNoIsolate).toBe(4);
-    expect(plan.executionBudget.topLevelParallelLimitIsolated).toBe(1);
-    expect(plan.topLevelParallelLimit).toBe(4);
-    expect(plan.deferredRunConcurrency).toBe(1);
-    artifacts.cleanupTempArtifacts();
+    expect(saturatedPlan.runtimeCapabilities.memoryBand).toBe("mid");
+    expect(saturatedPlan.runtimeCapabilities.loadBand).toBe("saturated");
+    expect(saturatedPlan.executionBudget.unitSharedWorkers).toBe(2);
+    expect(saturatedPlan.executionBudget.unitSharedWorkers).toBeLessThan(
+      baselinePlan.executionBudget.unitSharedWorkers,
+    );
+    expect(saturatedPlan.executionBudget.unitIsolatedWorkers).toBe(1);
+    expect(saturatedPlan.executionBudget.topLevelParallelLimitNoIsolate).toBe(4);
+    expect(saturatedPlan.executionBudget.topLevelParallelLimitIsolated).toBe(1);
+    expect(saturatedPlan.topLevelParallelLimit).toBeLessThan(baselinePlan.topLevelParallelLimit);
+    expect(saturatedPlan.topLevelParallelLimit).toBeLessThanOrEqual(
+      saturatedPlan.executionBudget.topLevelParallelLimitNoIsolate,
+    );
+    expect(saturatedPlan.deferredRunConcurrency).toBe(1);
+    baselineArtifacts.cleanupTempArtifacts();
+    saturatedArtifacts.cleanupTempArtifacts();
   });
 
   it("coalesces saturated high-memory local unit bursts into fewer shared batches", () => {
@@ -161,8 +189,28 @@ describe("test planner", () => {
       OPENCLAW_TEST_HOST_CPU_COUNT: "16",
       OPENCLAW_TEST_HOST_MEMORY_GIB: "128",
     };
-    const artifacts = createExecutionArtifacts(env);
-    const plan = buildExecutionPlan(
+    const baselineArtifacts = createExecutionArtifacts({
+      ...env,
+      OPENCLAW_TEST_LOAD_AWARE: "0",
+    });
+    const baselinePlan = buildExecutionPlan(
+      {
+        profile: null,
+        mode: "local",
+        surfaces: ["unit"],
+        passthroughArgs: [],
+      },
+      {
+        env: {
+          ...env,
+          OPENCLAW_TEST_LOAD_AWARE: "0",
+        },
+        platform: "darwin",
+        writeTempJsonArtifact: baselineArtifacts.writeTempJsonArtifact,
+      },
+    );
+    const saturatedArtifacts = createExecutionArtifacts(env);
+    const saturatedPlan = buildExecutionPlan(
       {
         profile: null,
         mode: "local",
@@ -173,20 +221,30 @@ describe("test planner", () => {
         env,
         platform: "darwin",
         loadAverage: [18, 18, 18],
-        writeTempJsonArtifact: artifacts.writeTempJsonArtifact,
+        writeTempJsonArtifact: saturatedArtifacts.writeTempJsonArtifact,
       },
     );
 
-    const sharedUnitBatches = plan.selectedUnits.filter(
+    const baselineSharedUnitBatches = baselinePlan.selectedUnits.filter(
+      (unit) => unit.surface === "unit" && !unit.isolate && unit.id.startsWith("unit-fast"),
+    );
+    const saturatedSharedUnitBatches = saturatedPlan.selectedUnits.filter(
       (unit) => unit.surface === "unit" && !unit.isolate && unit.id.startsWith("unit-fast"),
     );
 
-    expect(plan.runtimeCapabilities.memoryBand).toBe("high");
-    expect(plan.runtimeCapabilities.loadBand).toBe("saturated");
-    expect(sharedUnitBatches).toHaveLength(3);
-    expect(plan.executionBudget.unitIsolatedWorkers).toBe(1);
-    expect(plan.executionBudget.unitFastBatchTargetMs).toBe(90_000);
-    artifacts.cleanupTempArtifacts();
+    expect(saturatedPlan.runtimeCapabilities.memoryBand).toBe("high");
+    expect(saturatedPlan.runtimeCapabilities.loadBand).toBe("saturated");
+    expect(saturatedPlan.executionBudget.unitIsolatedWorkers).toBe(1);
+    expect(saturatedPlan.executionBudget.unitIsolatedWorkers).toBeLessThan(
+      baselinePlan.executionBudget.unitIsolatedWorkers,
+    );
+    expect(saturatedPlan.executionBudget.unitFastBatchTargetMs).toBe(90_000);
+    expect(saturatedPlan.executionBudget.unitFastBatchTargetMs).toBeGreaterThan(
+      baselinePlan.executionBudget.unitFastBatchTargetMs,
+    );
+    expect(saturatedSharedUnitBatches.length).toBeLessThan(baselineSharedUnitBatches.length);
+    baselineArtifacts.cleanupTempArtifacts();
+    saturatedArtifacts.cleanupTempArtifacts();
   });
 
   it("keeps full local unit runs phased when isolated and heavy lanes are present", () => {
@@ -407,6 +465,7 @@ describe("test planner", () => {
       OPENCLAW_TEST_SHARDS: "4",
       OPENCLAW_TEST_SHARD_INDEX: "1",
       OPENCLAW_TEST_LOAD_AWARE: "0",
+      OPENCLAW_TEST_UNIT_FAST_BATCH_TARGET_MS: "1",
     };
     const artifacts = createExecutionArtifacts(env);
     const plan = buildExecutionPlan(


### PR DESCRIPTION
## Summary

- Problem: CI was red on stale regression tests in the planner, QMD memory manager, and Discord group-DM component coverage even though the current code paths were behaving as designed.
- Why it matters: these stale expectations blocked unrelated work on `main` and hid the next real failures behind duplicate red lanes.
- What changed: updated planner tests to compare saturated behavior against a controlled baseline, updated QMD tests to the current verbatim collection-name contract, and enabled/allowlisted group DMs in the Discord interaction test that expects group-DM routing.
- What did NOT change (scope boundary): no production code, runtime config, routing logic, or CI workflow behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: several tests encoded outdated assumptions about current behavior rather than asserting the current contract. Planner tests hard-coded batch counts tied to live manifests, QMD tests expected old `*-main` collection names for custom collections, and the Discord group-DM plugin test still used the default disabled group-DM config.
- Missing detection / guardrail: these tests were brittle against legitimate contract and fixture evolution.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the failing planner assertions came from recent planner scheduling work; the QMD and Discord failures reproduced directly from the failing commit CI on `main`.
- Why this regressed now: unrelated changes shifted manifests / expectations enough for the stale assertions to trip.
- If unknown, what was ruled out: production behavior was rechecked locally; the failures were reproducible as test-only drift.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/test-planner.test.ts`, `extensions/memory-core/src/memory/qmd-manager.test.ts`, `extensions/discord/src/monitor/monitor.test.ts`
- Scenario the test should lock in: planner saturation behavior relative to a baseline, QMD search/query collection scoping with current collection naming, and Discord plugin interaction routing for allowed group DMs.
- Why this is the smallest reliable guardrail: the failures were in the regression tests themselves, so tightening those assertions is the smallest fix.
- Existing test that already covers this (if any): `test/scripts/test-parallel.test.ts` still covers the wrapper surface.
- If no new test is added, why not: existing coverage was corrected rather than expanded.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 via repo test wrapper
- Model/provider: N/A
- Integration/channel (if any): Discord component tests, QMD memory tests
- Relevant config (redacted): default local test env plus per-test fixture env overrides

### Steps

1. Check failing CI on commit `e65c265e8972e48293e47183c4e3a9372aa98eb9`
2. Reproduce locally with targeted test files
3. Update stale assertions/fixtures and rerun the changed surfaces

### Expected

- Changed regression tests match the current contract and pass locally.

### Actual

- Verified with the grouped command below after the fixes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: planner wrapper tests, QMD manager test file, Discord monitor test file
- Edge cases checked: saturated planner behavior versus unsaturated baseline, forced single-file shard assignment, multi-collection QMD file-URI hits, group-DM plugin routing when group DMs are explicitly enabled
- What you did **not** verify: full GitHub Actions rerun, Windows execution

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: planner assertions could still drift if future tests rely on exact live manifest counts.
  - Mitigation: this PR switches the relevant expectations to baseline-vs-saturated comparisons and explicitly forces the shard-assignment case.
