### PR TITLE
Diffs: fall back on invalid language hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Diffs: fall back to plain text when `lang` hints are invalid during diff render and viewer hydration, so bad or stale language values no longer break the diff viewer. (#57902) Thanks @gumadeiras.
 - Image generation/build: write stable runtime alias files into `dist/` and route provider-auth runtime lookups through those aliases so image-generation providers keep resolving auth/runtime modules after rebuilds instead of crashing on missing hashed chunk files.
 - Config/runtime: pin the first successful config load in memory for the running process and refresh that snapshot on successful writes/reloads, so hot paths stop reparsing `openclaw.json` between watcher-driven swaps.
 - Config/legacy cleanup: stop probing obsolete alternate legacy config names and service labels during local config/service detection, while keeping the active `~/.openclaw/openclaw.json` path canonical.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Diffs: fall back to plain text when `lang` hints are invalid during diff render and viewer hydration, so bad or stale language values no longer break the diff viewer. (#57902) Thanks @gumadeiras.
 - Image generation/build: write stable runtime alias files into `dist/` and route provider-auth runtime lookups through those aliases so image-generation providers keep resolving auth/runtime modules after rebuilds instead of crashing on missing hashed chunk files.
 - Config/runtime: pin the first successful config load in memory for the running process and refresh that snapshot on successful writes/reloads, so hot paths stop reparsing `openclaw.json` between watcher-driven swaps.
 - Config/legacy cleanup: stop probing obsolete alternate legacy config names and service labels during local config/service detection, while keeping the active `~/.openclaw/openclaw.json` path canonical.
@@ -110,6 +109,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/attachments: offload large inbound images without leaking `media://` markers into text-only runs, preserve mixed attachment order for model input/transcripts, and fail closed when model image capability cannot be resolved. (#55513) Thanks @Syysean.
 - Agents/subagents: fix interim subagent runtime display so `/subagents list` and `/subagents info` stop inflating short runtimes and show second-level durations correctly. (#57739) Thanks @samzong.
 - Diffs/config: preserve schema-shaped plugin config parsing from `diffsPluginConfigSchema.safeParse()`, so direct callers keep `defaults` and `security` sections instead of receiving flattened tool defaults. (#57904) Thanks @gumadeiras.
+- Diffs: fall back to plain text when `lang` hints are invalid during diff render and viewer hydration, so bad or stale language values no longer break the diff viewer. (#57902) Thanks @gumadeiras.
 
 ## 2026.3.28
 

--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -107,7 +107,7 @@ All fields are optional unless noted:
 - `after` (`string`): updated text. Required with `before` when `patch` is omitted.
 - `patch` (`string`): unified diff text. Mutually exclusive with `before` and `after`.
 - `path` (`string`): display filename for before and after mode.
-- `lang` (`string`): language override hint for before and after mode.
+- `lang` (`string`): language override hint for before and after mode. Unknown values fall back to plain text.
 - `title` (`string`): viewer title override.
 - `mode` (`"view" | "file" | "both"`): output mode. Defaults to plugin default `defaults.mode`.
   Deprecated alias: `"image"` behaves like `"file"` and is still accepted for backward compatibility.

--- a/extensions/diffs/src/config.test.ts
+++ b/extensions/diffs/src/config.test.ts
@@ -388,6 +388,34 @@ describe("renderDiffDocument", () => {
     ).toBe("/openclaw/plugins/diffs/assets/viewer.js");
   });
 
+  it("downgrades invalid language hints to plain text", async () => {
+    const rendered = await renderDiffDocument(
+      {
+        kind: "before_after",
+        before: "const value = 1;\n",
+        after: "const value = 2;\n",
+        lang: "not-a-real-language",
+      },
+      {
+        presentation: DEFAULT_DIFFS_TOOL_DEFAULTS,
+        image: resolveDiffImageRenderOptions({ defaults: DEFAULT_DIFFS_TOOL_DEFAULTS }),
+        expandUnchanged: false,
+      },
+    );
+
+    expect(rendered.title).toBe("Text diff");
+    expect(rendered.html).toContain("diff.txt");
+    expect(rendered.html).not.toContain("not-a-real-language");
+
+    const payloads = [...rendered.html.matchAll(/data-openclaw-diff-payload>(.*?)<\/script>/g)].map(
+      (match) => parseViewerPayloadJson(match[1] ?? ""),
+    );
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.langs).toEqual(["text"]);
+    expect(payloads[0]?.oldFile?.lang).toBeUndefined();
+    expect(payloads[0]?.newFile?.lang).toBeUndefined();
+  });
+
   it("renders multi-file patch input", async () => {
     const patch = [
       "diff --git a/a.ts b/a.ts",

--- a/extensions/diffs/src/config.test.ts
+++ b/extensions/diffs/src/config.test.ts
@@ -403,11 +403,13 @@ describe("renderDiffDocument", () => {
       },
     );
 
-    expect(rendered.title).toBe("Text diff");
-    expect(rendered.html).toContain("diff.txt");
-    expect(rendered.html).not.toContain("not-a-real-language");
+    const html = rendered.html ?? "";
 
-    const payloads = [...rendered.html.matchAll(/data-openclaw-diff-payload>(.*?)<\/script>/g)].map(
+    expect(rendered.title).toBe("Text diff");
+    expect(html).toContain("diff.txt");
+    expect(html).not.toContain("not-a-real-language");
+
+    const payloads = [...html.matchAll(/data-openclaw-diff-payload>(.*?)<\/script>/g)].map(
       (match) => parseViewerPayloadJson(match[1] ?? ""),
     );
     expect(payloads).toHaveLength(1);

--- a/extensions/diffs/src/language-hints.ts
+++ b/extensions/diffs/src/language-hints.ts
@@ -1,0 +1,39 @@
+import { resolveLanguage } from "@pierre/diffs";
+import type { SupportedLanguages } from "@pierre/diffs";
+
+const PASSTHROUGH_LANGUAGE_HINTS = new Set<SupportedLanguages>(["ansi", "text"]);
+
+export async function normalizeSupportedLanguageHint(
+  value?: string,
+): Promise<SupportedLanguages | undefined> {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  if (PASSTHROUGH_LANGUAGE_HINTS.has(normalized as SupportedLanguages)) {
+    return normalized as SupportedLanguages;
+  }
+  try {
+    await resolveLanguage(normalized as Exclude<SupportedLanguages, "text" | "ansi">);
+    return normalized as SupportedLanguages;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function filterSupportedLanguageHints(
+  values: Iterable<string>,
+): Promise<SupportedLanguages[]> {
+  const supported = new Set<SupportedLanguages>();
+  for (const value of values) {
+    const normalized = await normalizeSupportedLanguageHint(value);
+    if (!normalized) {
+      continue;
+    }
+    supported.add(normalized);
+  }
+  if (supported.size === 0) {
+    supported.add("text");
+  }
+  return [...supported];
+}

--- a/extensions/diffs/src/render.ts
+++ b/extensions/diffs/src/render.ts
@@ -1,5 +1,5 @@
 import type { FileContents, FileDiffMetadata, SupportedLanguages } from "@pierre/diffs";
-import { parsePatchFiles } from "@pierre/diffs";
+import { parsePatchFiles, resolveLanguage } from "@pierre/diffs";
 import { preloadFileDiff, preloadMultiFileDiff } from "@pierre/diffs/ssr";
 import { ensurePierreThemesRegistered } from "./pierre-themes.js";
 import type {
@@ -43,12 +43,16 @@ function buildDiffTitle(input: DiffInput): string {
   return "Patch diff";
 }
 
-function resolveBeforeAfterFileName(input: Extract<DiffInput, { kind: "before_after" }>): string {
+function resolveBeforeAfterFileName(params: {
+  input: Extract<DiffInput, { kind: "before_after" }>;
+  lang?: SupportedLanguages;
+}): string {
+  const { input, lang } = params;
   if (input.path?.trim()) {
     return input.path.trim();
   }
-  if (input.lang?.trim()) {
-    return `diff.${input.lang.trim().replace(/^\.+/, "")}`;
+  if (lang && lang !== "text") {
+    return `diff.${lang.replace(/^\.+/, "")}`;
   }
   return DEFAULT_FILE_NAME;
 }
@@ -174,9 +178,20 @@ function buildRenderVariants(params: { options: DiffRenderOptions; target: DiffR
   };
 }
 
-function normalizeSupportedLanguage(value?: string): SupportedLanguages | undefined {
+async function normalizeSupportedLanguage(value?: string): Promise<SupportedLanguages | undefined> {
   const normalized = value?.trim();
-  return normalized ? (normalized as SupportedLanguages) : undefined;
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized === "text" || normalized === "ansi") {
+    return normalized;
+  }
+  try {
+    await resolveLanguage(normalized as Exclude<SupportedLanguages, "text" | "ansi">);
+    return normalized as SupportedLanguages;
+  } catch {
+    return undefined;
+  }
 }
 
 function buildPayloadLanguages(payload: {
@@ -348,8 +363,8 @@ async function renderBeforeAfterDiff(
 ): Promise<{ viewerBodyHtml?: string; imageBodyHtml?: string; fileCount: number }> {
   ensurePierreThemesRegistered();
 
-  const fileName = resolveBeforeAfterFileName(input);
-  const lang = normalizeSupportedLanguage(input.lang);
+  const lang = await normalizeSupportedLanguage(input.lang);
+  const fileName = resolveBeforeAfterFileName({ input, lang });
   const oldFile: FileContents = {
     name: fileName,
     contents: input.before,

--- a/extensions/diffs/src/render.ts
+++ b/extensions/diffs/src/render.ts
@@ -1,6 +1,7 @@
 import type { FileContents, FileDiffMetadata, SupportedLanguages } from "@pierre/diffs";
-import { parsePatchFiles, resolveLanguage } from "@pierre/diffs";
+import { parsePatchFiles } from "@pierre/diffs";
 import { preloadFileDiff, preloadMultiFileDiff } from "@pierre/diffs/ssr";
+import { normalizeSupportedLanguageHint } from "./language-hints.js";
 import { ensurePierreThemesRegistered } from "./pierre-themes.js";
 import type {
   DiffInput,
@@ -178,22 +179,6 @@ function buildRenderVariants(params: { options: DiffRenderOptions; target: DiffR
   };
 }
 
-async function normalizeSupportedLanguage(value?: string): Promise<SupportedLanguages | undefined> {
-  const normalized = value?.trim();
-  if (!normalized) {
-    return undefined;
-  }
-  if (normalized === "text" || normalized === "ansi") {
-    return normalized;
-  }
-  try {
-    await resolveLanguage(normalized as Exclude<SupportedLanguages, "text" | "ansi">);
-    return normalized as SupportedLanguages;
-  } catch {
-    return undefined;
-  }
-}
-
 function buildPayloadLanguages(payload: {
   fileDiff?: FileDiffMetadata;
   oldFile?: FileContents;
@@ -363,7 +348,7 @@ async function renderBeforeAfterDiff(
 ): Promise<{ viewerBodyHtml?: string; imageBodyHtml?: string; fileCount: number }> {
   ensurePierreThemesRegistered();
 
-  const lang = await normalizeSupportedLanguage(input.lang);
+  const lang = await normalizeSupportedLanguageHint(input.lang);
   const fileName = resolveBeforeAfterFileName({ input, lang });
   const oldFile: FileContents = {
     name: fileName,

--- a/extensions/diffs/src/viewer-client.test.ts
+++ b/extensions/diffs/src/viewer-client.test.ts
@@ -10,14 +10,14 @@ describe("filterSupportedHydrationLanguages", () => {
   });
 
   it("drops invalid languages and falls back to text", async () => {
-    await expect(
-      filterSupportedHydrationLanguages(["not-a-real-language" as unknown as "text"]),
-    ).resolves.toEqual(["text"]);
+    await expect(filterSupportedHydrationLanguages(["not-a-real-language"])).resolves.toEqual([
+      "text",
+    ]);
   });
 
   it("keeps valid languages when invalid hints are mixed in", async () => {
     await expect(
-      filterSupportedHydrationLanguages(["typescript", "not-a-real-language" as unknown as "text"]),
+      filterSupportedHydrationLanguages(["typescript", "not-a-real-language"]),
     ).resolves.toEqual(["typescript"]);
   });
 });

--- a/extensions/diffs/src/viewer-client.test.ts
+++ b/extensions/diffs/src/viewer-client.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { filterSupportedHydrationLanguages } from "./viewer-client.js";
+
+describe("filterSupportedHydrationLanguages", () => {
+  it("keeps supported languages", async () => {
+    await expect(filterSupportedHydrationLanguages(["typescript", "text"])).resolves.toEqual([
+      "typescript",
+      "text",
+    ]);
+  });
+
+  it("drops invalid languages and falls back to text", async () => {
+    await expect(
+      filterSupportedHydrationLanguages(["not-a-real-language" as unknown as "text"]),
+    ).resolves.toEqual(["text"]);
+  });
+
+  it("keeps valid languages when invalid hints are mixed in", async () => {
+    await expect(
+      filterSupportedHydrationLanguages(["typescript", "not-a-real-language" as unknown as "text"]),
+    ).resolves.toEqual(["typescript"]);
+  });
+});

--- a/extensions/diffs/src/viewer-client.ts
+++ b/extensions/diffs/src/viewer-client.ts
@@ -30,7 +30,7 @@ const viewerState: ViewerState = {
 };
 
 export async function filterSupportedHydrationLanguages(
-  languages: Iterable<SupportedLanguages>,
+  languages: Iterable<string>,
 ): Promise<SupportedLanguages[]> {
   const supported = new Set<SupportedLanguages>();
   for (const language of languages) {

--- a/extensions/diffs/src/viewer-client.ts
+++ b/extensions/diffs/src/viewer-client.ts
@@ -1,10 +1,11 @@
-import { FileDiff, preloadHighlighter, resolveLanguage } from "@pierre/diffs";
+import { FileDiff, preloadHighlighter } from "@pierre/diffs";
 import type {
   FileContents,
   FileDiffMetadata,
   FileDiffOptions,
   SupportedLanguages,
 } from "@pierre/diffs";
+import { filterSupportedLanguageHints } from "./language-hints.js";
 import type { DiffViewerPayload, DiffLayout, DiffTheme } from "./types.js";
 import { parseViewerPayloadJson } from "./viewer-payload.js";
 
@@ -32,23 +33,7 @@ const viewerState: ViewerState = {
 export async function filterSupportedHydrationLanguages(
   languages: Iterable<string>,
 ): Promise<SupportedLanguages[]> {
-  const supported = new Set<SupportedLanguages>();
-  for (const language of languages) {
-    if (language === "text" || language === "ansi") {
-      supported.add(language);
-      continue;
-    }
-    try {
-      await resolveLanguage(language as Exclude<SupportedLanguages, "text" | "ansi">);
-      supported.add(language);
-    } catch {
-      // Ignore invalid persisted hints and let the viewer fall back to plain text.
-    }
-  }
-  if (supported.size === 0) {
-    supported.add("text");
-  }
-  return [...supported];
+  return filterSupportedLanguageHints(languages);
 }
 
 function parsePayload(element: HTMLScriptElement): DiffViewerPayload {

--- a/extensions/diffs/src/viewer-client.ts
+++ b/extensions/diffs/src/viewer-client.ts
@@ -1,4 +1,4 @@
-import { FileDiff, preloadHighlighter } from "@pierre/diffs";
+import { FileDiff, preloadHighlighter, resolveLanguage } from "@pierre/diffs";
 import type {
   FileContents,
   FileDiffMetadata,
@@ -28,6 +28,28 @@ const viewerState: ViewerState = {
   backgroundEnabled: true,
   wrapEnabled: true,
 };
+
+export async function filterSupportedHydrationLanguages(
+  languages: Iterable<SupportedLanguages>,
+): Promise<SupportedLanguages[]> {
+  const supported = new Set<SupportedLanguages>();
+  for (const language of languages) {
+    if (language === "text" || language === "ansi") {
+      supported.add(language);
+      continue;
+    }
+    try {
+      await resolveLanguage(language as Exclude<SupportedLanguages, "text" | "ansi">);
+      supported.add(language);
+    } catch {
+      // Ignore invalid persisted hints and let the viewer fall back to plain text.
+    }
+  }
+  if (supported.size === 0) {
+    supported.add("text");
+  }
+  return [...supported];
+}
 
 function parsePayload(element: HTMLScriptElement): DiffViewerPayload {
   const raw = element.textContent?.trim();
@@ -268,7 +290,7 @@ async function hydrateViewer(): Promise<void> {
 
   await preloadHighlighter({
     themes: ["pierre-light", "pierre-dark"],
-    langs: langs.size > 0 ? [...langs] : ["text"],
+    langs: await filterSupportedHydrationLanguages(langs),
   });
 
   syncDocumentTheme();
@@ -297,10 +319,12 @@ async function main(): Promise<void> {
   }
 }
 
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", () => {
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => {
+      void main();
+    });
+  } else {
     void main();
-  });
-} else {
-  void main();
+  }
 }


### PR DESCRIPTION
## Summary
- downgrade invalid `lang` hints to plain text instead of failing diff rendering
- filter persisted viewer payload languages before hydration preloads highlighting
- document the fallback and cover it with render + viewer-client tests

## Verification
- pnpm test -- extensions/diffs/src/config.test.ts extensions/diffs/src/tool.test.ts extensions/diffs/src/store.test.ts extensions/diffs/src/browser.test.ts extensions/diffs/src/viewer-client.test.ts
- pnpm check
- pnpm build
