### PR TITLE
Diffs: return schema-shaped plugin config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/OpenAI HTTP: restore default operator scopes for bearer-authenticated requests that omit `x-openclaw-scopes`, so headless `/v1/chat/completions` and session-history callers work again after the recent method-scope hardening. (#57596) Thanks @openperf.
 - Gateway/attachments: offload large inbound images without leaking `media://` markers into text-only runs, preserve mixed attachment order for model input/transcripts, and fail closed when model image capability cannot be resolved. (#55513) Thanks @Syysean.
 - Agents/subagents: fix interim subagent runtime display so `/subagents list` and `/subagents info` stop inflating short runtimes and show second-level durations correctly. (#57739) Thanks @samzong.
+- Diffs/config: preserve schema-shaped plugin config parsing from `diffsPluginConfigSchema.safeParse()`, so direct callers keep `defaults` and `security` sections instead of receiving flattened tool defaults. (#57904) Thanks @gumadeiras.
 
 ## 2026.3.28
 

--- a/extensions/diffs/openclaw.plugin.json
+++ b/extensions/diffs/openclaw.plugin.json
@@ -133,14 +133,12 @@
           "fileScale": {
             "type": "number",
             "minimum": 1,
-            "maximum": 4,
-            "default": 2
+            "maximum": 4
           },
           "fileMaxWidth": {
             "type": "number",
             "minimum": 640,
-            "maximum": 2400,
-            "default": 960
+            "maximum": 2400
           },
           "imageFormat": {
             "type": "string",

--- a/extensions/diffs/src/browser.test.ts
+++ b/extensions/diffs/src/browser.test.ts
@@ -261,6 +261,9 @@ describe("diffs plugin registration", () => {
           diffIndicators: "classic",
           lineSpacing: 2,
         },
+        security: {
+          allowRemoteViewer: true,
+        },
       },
       runtime: {} as never,
       registerTool(tool: Parameters<OpenClawPluginApi["registerTool"]>[0]) {
@@ -311,6 +314,21 @@ describe("diffs plugin registration", () => {
         agentAccountId: "default",
       },
     );
+
+    const proxiedRes = createMockServerResponse();
+    const proxiedHandled = await registeredHttpRouteHandler?.(
+      localReq({
+        method: "GET",
+        url: viewerPath,
+        headers: {
+          "x-forwarded-for": "203.0.113.10",
+        },
+      }),
+      proxiedRes,
+    );
+
+    expect(proxiedHandled).toBe(true);
+    expect(proxiedRes.statusCode).toBe(200);
   });
 });
 

--- a/extensions/diffs/src/config.test.ts
+++ b/extensions/diffs/src/config.test.ts
@@ -5,6 +5,7 @@ import {
   ResolvedThemes,
   ResolvingThemes,
 } from "@pierre/diffs";
+import AjvPkg from "ajv";
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_DIFFS_PLUGIN_SECURITY,
@@ -164,6 +165,41 @@ describe("resolveDiffsPluginDefaults", () => {
       fileMaxWidth: 1024,
     });
   });
+
+  it("keeps loader-applied schema defaults from shadowing aliases and quality-derived defaults", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+    ) as { configSchema: Record<string, unknown> };
+    const Ajv = AjvPkg as unknown as new (opts?: object) => import("ajv").default;
+    const ajv = new Ajv({ allErrors: true, strict: false, useDefaults: true });
+    const validate = ajv.compile(manifest.configSchema);
+
+    const aliasOnly = {
+      defaults: {
+        format: "pdf",
+        imageQuality: "hq",
+      },
+    };
+    expect(validate(aliasOnly)).toBe(true);
+    expect(resolveDiffsPluginDefaults(aliasOnly)).toMatchObject({
+      fileFormat: "pdf",
+      fileQuality: "hq",
+      fileScale: 2.5,
+      fileMaxWidth: 1200,
+    });
+
+    const qualityOnly = {
+      defaults: {
+        fileQuality: "hq",
+      },
+    };
+    expect(validate(qualityOnly)).toBe(true);
+    expect(resolveDiffsPluginDefaults(qualityOnly)).toMatchObject({
+      fileQuality: "hq",
+      fileScale: 2.5,
+      fileMaxWidth: 1200,
+    });
+  });
 });
 
 describe("resolveDiffsPluginSecurity", () => {
@@ -210,6 +246,27 @@ describe("diffs plugin schema surfaces", () => {
         },
         security: {
           allowRemoteViewer: true,
+        },
+      },
+    });
+  });
+
+  it("canonicalizes alias-driven defaults for direct safeParse callers", () => {
+    expect(
+      diffsPluginConfigSchema.safeParse?.({
+        defaults: {
+          format: "pdf",
+          imageQuality: "hq",
+        },
+      }),
+    ).toMatchObject({
+      success: true,
+      data: {
+        defaults: {
+          fileFormat: "pdf",
+          fileQuality: "hq",
+          fileScale: 2.5,
+          fileMaxWidth: 1200,
         },
       },
     });

--- a/extensions/diffs/src/config.test.ts
+++ b/extensions/diffs/src/config.test.ts
@@ -179,6 +179,42 @@ describe("resolveDiffsPluginSecurity", () => {
 });
 
 describe("diffs plugin schema surfaces", () => {
+  it("preserves defaults and security for direct safeParse callers", () => {
+    expect(
+      diffsPluginConfigSchema.safeParse?.({
+        defaults: {
+          theme: "light",
+        },
+        security: {
+          allowRemoteViewer: true,
+        },
+      }),
+    ).toMatchObject({
+      success: true,
+      data: {
+        defaults: {
+          fontFamily: "Fira Code",
+          fontSize: 15,
+          lineSpacing: 1.6,
+          layout: "unified",
+          showLineNumbers: true,
+          diffIndicators: "bars",
+          wordWrap: true,
+          background: true,
+          theme: "light",
+          fileFormat: "png",
+          fileQuality: "standard",
+          fileScale: 2,
+          fileMaxWidth: 960,
+          mode: "both",
+        },
+        security: {
+          allowRemoteViewer: true,
+        },
+      },
+    });
+  });
+
   it("keeps the runtime json schema in sync with the manifest config schema", () => {
     const manifest = JSON.parse(
       fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),

--- a/extensions/diffs/src/config.ts
+++ b/extensions/diffs/src/config.ts
@@ -122,13 +122,8 @@ const DiffsPluginJsonSchemaSource = z.strictObject({
         .enum(DIFF_IMAGE_QUALITY_PRESETS)
         .default(DEFAULT_DIFFS_TOOL_DEFAULTS.fileQuality)
         .optional(),
-      fileScale: z.number().min(1).max(4).default(DEFAULT_DIFFS_TOOL_DEFAULTS.fileScale).optional(),
-      fileMaxWidth: z
-        .number()
-        .min(640)
-        .max(2400)
-        .default(DEFAULT_DIFFS_TOOL_DEFAULTS.fileMaxWidth)
-        .optional(),
+      fileScale: z.number().min(1).max(4).optional(),
+      fileMaxWidth: z.number().min(640).max(2400).optional(),
       imageFormat: z.enum(DIFF_OUTPUT_FORMATS).optional(),
       imageQuality: z.enum(DIFF_IMAGE_QUALITY_PRESETS).optional(),
       imageScale: z.number().min(1).max(4).optional(),
@@ -155,7 +150,10 @@ export const diffsPluginConfigSchema: OpenClawPluginConfigSchema = buildPluginCo
       }
       const result = DiffsPluginJsonSchemaSource.safeParse(value);
       if (result.success) {
-        return result;
+        return {
+          success: true,
+          data: buildDiffsPluginConfigShape(result.data as DiffsPluginConfig),
+        };
       }
       return {
         success: false,
@@ -173,6 +171,25 @@ export const diffsPluginConfigSchema: OpenClawPluginConfigSchema = buildPluginCo
   },
 );
 
+function resolveConfiguredValue<T>(options: {
+  primary: T | undefined;
+  aliases: Array<T | undefined>;
+  schemaDefault?: T;
+}): T | undefined {
+  const alias = options.aliases.find((value): value is T => value !== undefined);
+  if (alias !== undefined && options.primary === options.schemaDefault) {
+    return alias;
+  }
+  return options.primary ?? alias;
+}
+
+function buildDiffsPluginConfigShape(config: DiffsPluginConfig): DiffsPluginConfig {
+  return {
+    ...(config.defaults !== undefined ? { defaults: resolveDiffsPluginDefaults(config) } : {}),
+    ...(config.security !== undefined ? { security: resolveDiffsPluginSecurity(config) } : {}),
+  };
+}
+
 export function resolveDiffsPluginDefaults(config: unknown): DiffToolDefaults {
   if (!config || typeof config !== "object" || Array.isArray(config)) {
     return { ...DEFAULT_DIFFS_TOOL_DEFAULTS };
@@ -183,8 +200,27 @@ export function resolveDiffsPluginDefaults(config: unknown): DiffToolDefaults {
     return { ...DEFAULT_DIFFS_TOOL_DEFAULTS };
   }
 
-  const fileQuality = normalizeFileQuality(defaults.fileQuality ?? defaults.imageQuality);
+  const fileQuality = normalizeFileQuality(
+    resolveConfiguredValue({
+      primary: defaults.fileQuality,
+      aliases: [defaults.imageQuality],
+      schemaDefault: DEFAULT_DIFFS_TOOL_DEFAULTS.fileQuality,
+    }),
+  );
   const profile = DEFAULT_IMAGE_QUALITY_PROFILES[fileQuality];
+  const fileFormat = resolveConfiguredValue({
+    primary: defaults.fileFormat,
+    aliases: [defaults.imageFormat, defaults.format],
+    schemaDefault: DEFAULT_DIFFS_TOOL_DEFAULTS.fileFormat,
+  });
+  const fileScale = resolveConfiguredValue({
+    primary: defaults.fileScale,
+    aliases: [defaults.imageScale],
+  });
+  const fileMaxWidth = resolveConfiguredValue({
+    primary: defaults.fileMaxWidth,
+    aliases: [defaults.imageMaxWidth],
+  });
 
   return {
     fontFamily: normalizeFontFamily(defaults.fontFamily),
@@ -196,13 +232,10 @@ export function resolveDiffsPluginDefaults(config: unknown): DiffToolDefaults {
     wordWrap: defaults.wordWrap !== false,
     background: defaults.background !== false,
     theme: normalizeTheme(defaults.theme),
-    fileFormat: normalizeFileFormat(defaults.fileFormat ?? defaults.imageFormat ?? defaults.format),
+    fileFormat: normalizeFileFormat(fileFormat),
     fileQuality,
-    fileScale: normalizeFileScale(defaults.fileScale ?? defaults.imageScale, profile.scale),
-    fileMaxWidth: normalizeFileMaxWidth(
-      defaults.fileMaxWidth ?? defaults.imageMaxWidth,
-      profile.maxWidth,
-    ),
+    fileScale: normalizeFileScale(fileScale, profile.scale),
+    fileMaxWidth: normalizeFileMaxWidth(fileMaxWidth, profile.maxWidth),
     mode: normalizeMode(defaults.mode),
   };
 }

--- a/extensions/diffs/src/config.ts
+++ b/extensions/diffs/src/config.ts
@@ -153,16 +153,22 @@ export const diffsPluginConfigSchema: OpenClawPluginConfigSchema = buildPluginCo
       if (value === undefined) {
         return { success: true, data: undefined };
       }
-      try {
-        return { success: true, data: resolveDiffsPluginDefaults(value) };
-      } catch (error) {
-        return {
-          success: false,
-          error: {
-            issues: [{ path: [], message: error instanceof Error ? error.message : String(error) }],
-          },
-        };
+      const result = DiffsPluginJsonSchemaSource.safeParse(value);
+      if (result.success) {
+        return result;
       }
+      return {
+        success: false,
+        error: {
+          issues: result.error.issues.map((issue) => ({
+            path: issue.path.filter((segment): segment is string | number => {
+              const kind = typeof segment;
+              return kind === "string" || kind === "number";
+            }),
+            message: issue.message,
+          })),
+        },
+      };
     },
   },
 );


### PR DESCRIPTION
## Summary
- make `diffsPluginConfigSchema.safeParse()` return plugin-config-shaped data instead of flattened tool defaults
- preserve the plugin-config schema contract while keeping `resolveDiffsPluginDefaults` and `resolveDiffsPluginSecurity` as runtime helpers
- add direct schema and registration-path tests for `security.allowRemoteViewer`

## Verification
- pnpm test -- extensions/diffs/src/config.test.ts extensions/diffs/src/browser.test.ts
- pnpm check
- pnpm build
