### PR TITLE
feat(acp): add DM conversation handoff with bind:here and revertable bindings

### DIFF
--- a/extensions/telegram/src/thread-bindings.test.ts
+++ b/extensions/telegram/src/thread-bindings.test.ts
@@ -322,4 +322,84 @@ describe("telegram thread bindings", () => {
     };
     expect(persisted.bindings?.[0]?.idleTimeoutMs).toBe(90_000);
   });
+
+  it("restores previous binding when unbinding by session key", async () => {
+    createTelegramThreadBindingManager({
+      accountId: "default",
+      persist: false,
+      enableSweeper: false,
+    });
+
+    const dmConversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "12345678",
+    };
+
+    // Bind DM to main agent session
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:main:telegram:direct:12345678",
+      targetKind: "session",
+      conversation: dmConversation,
+      placement: "current",
+    });
+
+    // Specialist takes over (rebind)
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:coder:acp:uuid-1",
+      targetKind: "session",
+      conversation: dmConversation,
+      placement: "current",
+    });
+
+    // Verify specialist is active
+    const active = getSessionBindingService().resolveByConversation(dmConversation);
+    expect(active?.targetSessionKey).toBe("agent:coder:acp:uuid-1");
+
+    // Unbind specialist (session end)
+    await getSessionBindingService().unbind({
+      targetSessionKey: "agent:coder:acp:uuid-1",
+      reason: "manual-close",
+    });
+
+    // Verify DM reverted to main agent
+    const restored = getSessionBindingService().resolveByConversation(dmConversation);
+    expect(restored?.targetSessionKey).toBe("agent:main:telegram:direct:12345678");
+  });
+
+  it("restores previous binding when unbinding by conversation", async () => {
+    createTelegramThreadBindingManager({
+      accountId: "default",
+      persist: false,
+      enableSweeper: false,
+    });
+
+    const dmConversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "87654321",
+    };
+
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:main:session:1",
+      targetKind: "session",
+      conversation: dmConversation,
+      placement: "current",
+    });
+
+    const bound = await getSessionBindingService().bind({
+      targetSessionKey: "agent:analyst:acp:uuid-2",
+      targetKind: "session",
+      conversation: dmConversation,
+      placement: "current",
+    });
+
+    await getSessionBindingService().unbind({
+      bindingId: bound.bindingId,
+      reason: "manual-close",
+    });
+
+    const restored = getSessionBindingService().resolveByConversation(dmConversation);
+    expect(restored?.targetSessionKey).toBe("agent:main:session:1");
+  });
 });

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -204,6 +204,15 @@ function fromSessionBindingInput(params: {
     metadata: {
       ...existing?.metadata,
       ...metadata,
+      ...(existing && existing.targetSessionKey !== params.input.targetSessionKey
+        ? {
+            previousBinding: {
+              targetSessionKey: existing.targetSessionKey,
+              targetKind: existing.targetKind,
+              metadata: existing.metadata,
+            },
+          }
+        : {}),
     },
   };
 
@@ -220,6 +229,34 @@ function fromSessionBindingInput(params: {
   }
 
   return record;
+}
+
+function maybeRestorePreviousThreadBinding(params: {
+  accountId: string;
+  key: string;
+  removed: TelegramThreadBindingRecord;
+}): void {
+  const prev = params.removed.metadata?.previousBinding as
+    | { targetSessionKey: string; targetKind: string; metadata?: Record<string, unknown> }
+    | undefined;
+  if (!prev?.targetSessionKey) {
+    return;
+  }
+  const now = Date.now();
+  const restored: TelegramThreadBindingRecord = {
+    accountId: params.accountId,
+    conversationId: params.removed.conversationId,
+    targetKind: prev.targetKind === "subagent" ? "subagent" : "acp",
+    targetSessionKey: prev.targetSessionKey,
+    boundAt: now,
+    lastActivityAt: now,
+    metadata: {
+      ...prev.metadata,
+      lastActivityAt: now,
+      restoredFrom: params.removed.targetSessionKey,
+    },
+  };
+  getThreadBindingsState().bindingsByAccountConversation.set(params.key, restored);
 }
 
 function resolveBindingsPath(accountId: string, env: NodeJS.ProcessEnv = process.env): string {
@@ -503,6 +540,7 @@ export function createTelegramThreadBindingManager(
         return null;
       }
       getThreadBindingsState().bindingsByAccountConversation.delete(key);
+      maybeRestorePreviousThreadBinding({ accountId, key, removed });
       persistBindingsSafely({
         accountId,
         persist: manager.shouldPersistMutations(),
@@ -526,6 +564,7 @@ export function createTelegramThreadBindingManager(
           conversationId: entry.conversationId,
         });
         getThreadBindingsState().bindingsByAccountConversation.delete(key);
+        maybeRestorePreviousThreadBinding({ accountId, key, removed: entry });
         removed.push(entry);
       }
       if (removed.length > 0) {

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -231,14 +231,26 @@ function fromSessionBindingInput(params: {
   return record;
 }
 
+/**
+ * Restores the previous binding into the in-memory map after an unbind.
+ * Caller is responsible for calling persistBindingsSafely() afterward.
+ */
 function maybeRestorePreviousThreadBinding(params: {
   accountId: string;
   key: string;
   removed: TelegramThreadBindingRecord;
 }): void {
-  const prev = params.removed.metadata?.previousBinding as
-    | { targetSessionKey: string; targetKind: string; metadata?: Record<string, unknown> }
-    | undefined;
+  const raw = params.removed.metadata?.previousBinding;
+  const prev =
+    raw != null &&
+    typeof raw === "object" &&
+    typeof (raw as Record<string, unknown>).targetSessionKey === "string"
+      ? (raw as {
+          targetSessionKey: string;
+          targetKind: string;
+          metadata?: Record<string, unknown>;
+        })
+      : undefined;
   if (!prev?.targetSessionKey) {
     return;
   }
@@ -246,7 +258,7 @@ function maybeRestorePreviousThreadBinding(params: {
   const restored: TelegramThreadBindingRecord = {
     accountId: params.accountId,
     conversationId: params.removed.conversationId,
-    targetKind: prev.targetKind === "subagent" ? "subagent" : "acp",
+    targetKind: toTelegramTargetKind(prev.targetKind === "subagent" ? "subagent" : "session"),
     targetSessionKey: prev.targetSessionKey,
     boundAt: now,
     lastActivityAt: now,

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -210,6 +210,8 @@ function fromSessionBindingInput(params: {
               targetSessionKey: existing.targetSessionKey,
               targetKind: existing.targetKind,
               metadata: existing.metadata,
+              idleTimeoutMs: existing.idleTimeoutMs,
+              maxAgeMs: existing.maxAgeMs,
             },
           }
         : {}),
@@ -249,6 +251,8 @@ function maybeRestorePreviousThreadBinding(params: {
           targetSessionKey: string;
           targetKind: string;
           metadata?: Record<string, unknown>;
+          idleTimeoutMs?: number;
+          maxAgeMs?: number;
         })
       : undefined;
   if (!prev?.targetSessionKey) {
@@ -262,6 +266,8 @@ function maybeRestorePreviousThreadBinding(params: {
     targetSessionKey: prev.targetSessionKey,
     boundAt: now,
     lastActivityAt: now,
+    ...(typeof prev.idleTimeoutMs === "number" ? { idleTimeoutMs: prev.idleTimeoutMs } : {}),
+    ...(typeof prev.maxAgeMs === "number" ? { maxAgeMs: prev.maxAgeMs } : {}),
     metadata: {
       ...prev.metadata,
       lastActivityAt: now,

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1069,6 +1069,182 @@ describe("spawnAcpDirect", () => {
     expect(expectFailedSpawn(result, "error").error).toContain("set `acp.defaultAgent`");
   });
 
+  it("resolves agent profile alias to underlying ACP harness ID", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        allowedAgents: ["claude"],
+      },
+      agents: {
+        list: [
+          {
+            id: "analyst",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "claude" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Analyze data",
+        agentId: "analyst",
+      },
+      {
+        agentSessionKey: "agent:main:telegram:direct:123",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:123",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    // The session key should contain the resolved harness ID "claude", not the alias "analyst"
+    expect(result.childSessionKey).toMatch(/^agent:claude:acp:/);
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "claude", cwd: undefined }),
+    );
+  });
+
+  it("inherits profile workspace cwd when caller does not specify cwd", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        allowedAgents: ["claude"],
+      },
+      agents: {
+        list: [
+          {
+            id: "analyst",
+            workspace: "/workspace/analysis",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "claude", cwd: "/workspace/analysis" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Analyze data",
+        agentId: "analyst",
+      },
+      {
+        agentSessionKey: "agent:main:telegram:direct:123",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:123",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/workspace/analysis" }),
+    );
+  });
+
+  it("prefers explicit cwd over profile workspace when both are provided", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        allowedAgents: ["claude"],
+      },
+      agents: {
+        list: [
+          {
+            id: "analyst",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "claude", cwd: "/workspace/analysis" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Analyze data",
+        agentId: "analyst",
+        cwd: "/override/workspace",
+      },
+      {
+        agentSessionKey: "agent:main:telegram:direct:123",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:123",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/override/workspace" }),
+    );
+  });
+
+  it("inherits profile cwd from defaultAgent when agentId is omitted", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        defaultAgent: "codex",
+        allowedAgents: ["codex"],
+      },
+      agents: {
+        list: [
+          {
+            id: "codex",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "codex", cwd: "/workspace/default-agent" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/workspace/default-agent" }),
+    );
+  });
+
+  it("passes raw harness ID through when no matching agent profile exists", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+        agentId: "codex",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.childSessionKey).toMatch(/^agent:codex:acp:/);
+  });
+
   it("fails fast when Discord ACP thread spawn is disabled", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1230,6 +1230,44 @@ describe("spawnAcpDirect", () => {
     );
   });
 
+  it("resolves defaultAgent alias to harness ID when agentId is omitted", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        defaultAgent: "analyst",
+        allowedAgents: ["claude"],
+      },
+      agents: {
+        list: [
+          {
+            id: "analyst",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "claude", cwd: "/workspace/analysis" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.childSessionKey).toMatch(/^agent:claude:acp:/);
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "claude", cwd: "/workspace/analysis" }),
+    );
+  });
+
   it("passes raw harness ID through when no matching agent profile exists", async () => {
     const result = await spawnAcpDirect(
       {

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1283,6 +1283,82 @@ describe("spawnAcpDirect", () => {
     expect(result.childSessionKey).toMatch(/^agent:codex:acp:/);
   });
 
+  it("resolves telegram channel-prefixed target for DM thread binding", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      channels: {
+        ...hoisted.state.cfg.channels,
+        telegram: {
+          threadBindings: {
+            enabled: true,
+            spawnAcpSessions: true,
+          },
+        },
+      },
+    });
+    registerSessionBindingAdapter({
+      channel: "telegram",
+      accountId: "default",
+      capabilities: {
+        bindSupported: true,
+        unbindSupported: true,
+        placements: ["current"] satisfies SessionBindingPlacement[],
+      },
+      bind: async (input) => await hoisted.sessionBindingBindMock(input),
+      listBySession: (targetSessionKey) =>
+        hoisted.sessionBindingListBySessionMock(targetSessionKey),
+      resolveByConversation: (ref) => hoisted.sessionBindingResolveByConversationMock(ref),
+      unbind: async (input) => await hoisted.sessionBindingUnbindMock(input),
+    });
+    hoisted.sessionBindingBindMock.mockImplementationOnce(
+      async (input: {
+        targetSessionKey: string;
+        conversation: { accountId: string; conversationId: string };
+        metadata?: Record<string, unknown>;
+      }) =>
+        createSessionBinding({
+          targetSessionKey: input.targetSessionKey,
+          conversation: {
+            channel: "telegram",
+            accountId: input.conversation.accountId,
+            conversationId: input.conversation.conversationId,
+          },
+          metadata: {
+            boundBy:
+              typeof input.metadata?.boundBy === "string" ? input.metadata.boundBy : "system",
+            agentId: "codex",
+          },
+        }),
+    );
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Analyze data",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:telegram:direct:12345678",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:12345678",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: "current",
+        conversation: expect.objectContaining({
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "12345678",
+        }),
+      }),
+    );
+  });
+
   it("fails fast when Discord ACP thread spawn is disabled", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -389,11 +389,16 @@ function resolveTargetAcpAgentId(params: {
     const defaultProfile = listAgentEntries(params.cfg).find(
       (a) => normalizeAgentId(a.id) === configuredDefault,
     );
+    let defaultAgentId = configuredDefault;
     const defaultProfileCwd =
       defaultProfile?.runtime?.type === "acp"
         ? defaultProfile.runtime.acp?.cwd || defaultProfile.workspace
         : defaultProfile?.workspace;
-    return { ok: true, agentId: configuredDefault, profileCwd: defaultProfileCwd };
+    if (defaultProfile?.runtime?.type === "acp" && defaultProfile.runtime.acp?.agent) {
+      defaultAgentId =
+        normalizeOptionalAgentId(defaultProfile.runtime.acp.agent) || configuredDefault;
+    }
+    return { ok: true, agentId: defaultAgentId, profileCwd: defaultProfileCwd };
   }
 
   return {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -57,7 +57,7 @@ import {
   resolveAcpSpawnStreamLogPath,
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
-import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
+import { listAgentEntries, resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { resolveSpawnedWorkspaceInheritance } from "./spawned-context.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
@@ -364,15 +364,36 @@ function hasSessionLocalHeartbeatRelayRoute(params: {
 function resolveTargetAcpAgentId(params: {
   requestedAgentId?: string;
   cfg: OpenClawConfig;
-}): { ok: true; agentId: string } | { ok: false; error: string } {
+}): { ok: true; agentId: string; profileCwd?: string } | { ok: false; error: string } {
   const requested = normalizeOptionalAgentId(params.requestedAgentId);
   if (requested) {
-    return { ok: true, agentId: requested };
+    // Check if the requested ID is an agent profile alias that maps to
+    // a different underlying ACP harness ID (e.g. "analyst" → "claude").
+    const profile = listAgentEntries(params.cfg).find((a) => normalizeAgentId(a.id) === requested);
+
+    let targetAgentId = requested;
+    let profileCwd: string | undefined;
+
+    if (profile?.runtime?.type === "acp" && profile.runtime.acp?.agent) {
+      targetAgentId = normalizeOptionalAgentId(profile.runtime.acp.agent) || requested;
+      profileCwd = profile.runtime.acp.cwd || profile.workspace;
+    } else if (profile?.workspace) {
+      profileCwd = profile.workspace;
+    }
+
+    return { ok: true, agentId: targetAgentId, profileCwd };
   }
 
   const configuredDefault = normalizeOptionalAgentId(params.cfg.acp?.defaultAgent);
   if (configuredDefault) {
-    return { ok: true, agentId: configuredDefault };
+    const defaultProfile = listAgentEntries(params.cfg).find(
+      (a) => normalizeAgentId(a.id) === configuredDefault,
+    );
+    const defaultProfileCwd =
+      defaultProfile?.runtime?.type === "acp"
+        ? defaultProfile.runtime.acp?.cwd || defaultProfile.workspace
+        : defaultProfile?.workspace;
+    return { ok: true, agentId: configuredDefault, profileCwd: defaultProfileCwd };
   }
 
   return {
@@ -1001,7 +1022,7 @@ export async function spawnAcpDirect(
     config: cfg,
     targetAgentId,
     requesterSessionKey: ctx.agentSessionKey,
-    explicitWorkspaceDir: params.cwd,
+    explicitWorkspaceDir: params.cwd || targetAgentResult.profileCwd,
   });
   let runtimeCwd: string | undefined;
   try {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -565,7 +565,7 @@ function resolveConversationIdForThreadBinding(params: {
   // Strip channel prefix from numeric DM targets (e.g. "telegram:12345678" → "12345678")
   if (channel && target.toLowerCase().startsWith(`${channel}:`)) {
     const stripped = target.slice(channel.length + 1).trim();
-    if (stripped && /^\d{6,}$/.test(stripped)) {
+    if (stripped && /^\d+$/.test(stripped)) {
       return stripped;
     }
   }

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -549,6 +549,27 @@ function resolveConversationIdForThreadBinding(params: {
   if (genericConversationId) {
     return genericConversationId;
   }
+
+  const channel = params.channel?.trim().toLowerCase();
+  const target = params.to?.trim() || "";
+  if (channel === "line") {
+    const prefixed = target.match(/^line:(?:(?:user|group|room):)?([UCR][a-f0-9]{32})$/i)?.[1];
+    if (prefixed) {
+      return prefixed;
+    }
+    if (/^[UCR][a-f0-9]{32}$/i.test(target)) {
+      return target;
+    }
+  }
+
+  // Generic: strip channel prefix from target (e.g. "telegram:12345" → "12345")
+  if (channel && target.toLowerCase().startsWith(`${channel}:`)) {
+    const stripped = target.slice(channel.length + 1).trim();
+    if (stripped && /^\d{6,}$/.test(stripped)) {
+      return stripped;
+    }
+  }
+
   return undefined;
 }
 

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -562,7 +562,7 @@ function resolveConversationIdForThreadBinding(params: {
     }
   }
 
-  // Generic: strip channel prefix from target (e.g. "telegram:12345" → "12345")
+  // Strip channel prefix from numeric DM targets (e.g. "telegram:12345678" → "12345678")
   if (channel && target.toLowerCase().startsWith(`${channel}:`)) {
     const stripped = target.slice(channel.length + 1).trim();
     if (stripped && /^\d{6,}$/.test(stripped)) {

--- a/src/infra/outbound/current-conversation-bindings.test.ts
+++ b/src/infra/outbound/current-conversation-bindings.test.ts
@@ -279,4 +279,36 @@ describe("generic current-conversation bindings", () => {
       targetSessionKey: "agent:main:session:1",
     });
   });
+
+  it("restores previous binding when specialist expires via TTL", async () => {
+    const conversation = {
+      channel: "slack",
+      accountId: "default",
+      conversationId: "dm:U555",
+    };
+
+    await bindGenericCurrentConversation({
+      targetSessionKey: "agent:main:session:1",
+      targetKind: "session",
+      conversation,
+    });
+
+    await bindGenericCurrentConversation({
+      targetSessionKey: "agent:coder:acp:2",
+      targetKind: "session",
+      conversation,
+      ttlMs: 1,
+    });
+
+    // Wait for TTL to expire
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Resolve triggers pruneExpiredBinding which should restore main
+    const restored = resolveGenericCurrentConversationBinding(conversation);
+    expect(restored).toMatchObject({
+      targetSessionKey: "agent:main:session:1",
+      targetKind: "session",
+    });
+    expect(restored?.metadata?.restoredFrom).toBe("agent:coder:acp:2");
+  });
 });

--- a/src/infra/outbound/current-conversation-bindings.test.ts
+++ b/src/infra/outbound/current-conversation-bindings.test.ts
@@ -311,4 +311,40 @@ describe("generic current-conversation bindings", () => {
     });
     expect(restored?.metadata?.restoredFrom).toBe("agent:coder:acp:2");
   });
+
+  it("does not delete restored binding when late bindingId unbind races with TTL expiry", async () => {
+    const conversation = {
+      channel: "slack",
+      accountId: "default",
+      conversationId: "dm:U444",
+    };
+
+    await bindGenericCurrentConversation({
+      targetSessionKey: "agent:main:session:1",
+      targetKind: "session",
+      conversation,
+    });
+
+    const specialist = await bindGenericCurrentConversation({
+      targetSessionKey: "agent:coder:acp:2",
+      targetKind: "session",
+      conversation,
+      ttlMs: 1,
+    });
+
+    // Wait for TTL to expire
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Late unbind by stale bindingId — should not destroy the restored main binding
+    await unbindGenericCurrentConversationBindings({
+      bindingId: specialist!.bindingId,
+      reason: "session-end",
+    });
+
+    const afterUnbind = resolveGenericCurrentConversationBinding(conversation);
+    expect(afterUnbind).toMatchObject({
+      targetSessionKey: "agent:main:session:1",
+      targetKind: "session",
+    });
+  });
 });

--- a/src/infra/outbound/current-conversation-bindings.test.ts
+++ b/src/infra/outbound/current-conversation-bindings.test.ts
@@ -149,4 +149,134 @@ describe("generic current-conversation bindings", () => {
       }),
     ).toBeNull();
   });
+
+  it("saves previousBinding in metadata when rebinding to a different session", async () => {
+    const conversation = {
+      channel: "slack",
+      accountId: "default",
+      conversationId: "dm:U999",
+    };
+
+    await bindGenericCurrentConversation({
+      targetSessionKey: "agent:main:session:1",
+      targetKind: "session",
+      conversation,
+    });
+
+    await bindGenericCurrentConversation({
+      targetSessionKey: "agent:coder:acp:2",
+      targetKind: "session",
+      conversation,
+    });
+
+    const binding = resolveGenericCurrentConversationBinding(conversation);
+    expect(binding).toMatchObject({
+      targetSessionKey: "agent:coder:acp:2",
+    });
+    expect(binding?.metadata?.previousBinding).toMatchObject({
+      targetSessionKey: "agent:main:session:1",
+      targetKind: "session",
+    });
+  });
+
+  it("does not save previousBinding when rebinding to the same session", async () => {
+    const conversation = {
+      channel: "slack",
+      accountId: "default",
+      conversationId: "dm:U888",
+    };
+
+    await bindGenericCurrentConversation({
+      targetSessionKey: "agent:main:session:1",
+      targetKind: "session",
+      conversation,
+    });
+
+    await bindGenericCurrentConversation({
+      targetSessionKey: "agent:main:session:1",
+      targetKind: "session",
+      conversation,
+      metadata: { label: "refreshed" },
+    });
+
+    const binding = resolveGenericCurrentConversationBinding(conversation);
+    expect(binding?.targetSessionKey).toBe("agent:main:session:1");
+    expect(binding?.metadata?.previousBinding).toBeUndefined();
+  });
+
+  it("restores previous binding on unbind", async () => {
+    const conversation = {
+      channel: "slack",
+      accountId: "default",
+      conversationId: "dm:U777",
+    };
+
+    await bindGenericCurrentConversation({
+      targetSessionKey: "agent:main:session:1",
+      targetKind: "session",
+      conversation,
+    });
+
+    await bindGenericCurrentConversation({
+      targetSessionKey: "agent:coder:acp:2",
+      targetKind: "session",
+      conversation,
+    });
+
+    await unbindGenericCurrentConversationBindings({
+      targetSessionKey: "agent:coder:acp:2",
+      reason: "session-end",
+    });
+
+    const restored = resolveGenericCurrentConversationBinding(conversation);
+    expect(restored).toMatchObject({
+      targetSessionKey: "agent:main:session:1",
+      targetKind: "session",
+    });
+    expect(restored?.metadata?.restoredFrom).toBe("agent:coder:acp:2");
+  });
+
+  it("restores stacked bindings in correct order", async () => {
+    const conversation = {
+      channel: "slack",
+      accountId: "default",
+      conversationId: "dm:U666",
+    };
+
+    await bindGenericCurrentConversation({
+      targetSessionKey: "agent:main:session:1",
+      targetKind: "session",
+      conversation,
+    });
+
+    await bindGenericCurrentConversation({
+      targetSessionKey: "agent:coder:acp:2",
+      targetKind: "session",
+      conversation,
+    });
+
+    await bindGenericCurrentConversation({
+      targetSessionKey: "agent:analyst:acp:3",
+      targetKind: "session",
+      conversation,
+    });
+
+    // Unbind analyst → should revert to coder
+    await unbindGenericCurrentConversationBindings({
+      targetSessionKey: "agent:analyst:acp:3",
+      reason: "session-end",
+    });
+    expect(resolveGenericCurrentConversationBinding(conversation)).toMatchObject({
+      targetSessionKey: "agent:coder:acp:2",
+    });
+
+    // Unbind coder → should revert to main
+    await unbindGenericCurrentConversationBindings({
+      targetSessionKey: "agent:coder:acp:2",
+      reason: "session-end",
+    });
+    expect(resolveGenericCurrentConversationBinding(conversation)).toMatchObject({
+      targetSessionKey: "agent:main:session:1",
+    });
+  });
 });

--- a/src/infra/outbound/current-conversation-bindings.ts
+++ b/src/infra/outbound/current-conversation-bindings.ts
@@ -283,11 +283,21 @@ export async function unbindGenericCurrentConversationBindings(
   const normalizedTargetSessionKey = input.targetSessionKey?.trim();
   if (normalizedBindingId?.startsWith(CURRENT_BINDINGS_ID_PREFIX)) {
     const key = normalizedBindingId.slice(CURRENT_BINDINGS_ID_PREFIX.length);
+    // Snapshot the raw entry before pruning — pruneExpiredBinding may expire the
+    // binding and restore a previous one in place, so the post-prune map entry
+    // can differ from the original specialist binding we intend to remove.
+    const raw = bindingsByConversationKey.get(key);
     const record = pruneExpiredBinding(key);
     if (record) {
-      bindingsByConversationKey.delete(key);
-      maybeRestorePreviousBinding(key, record);
-      removed.push(record);
+      // If pruneExpiredBinding already expired+restored, the live map entry is
+      // now the restored binding. Only delete+restore when the entry still
+      // belongs to the original specialist (i.e. was not already expired).
+      const alreadyExpired = raw != null && isBindingExpired(raw);
+      if (!alreadyExpired) {
+        bindingsByConversationKey.delete(key);
+        maybeRestorePreviousBinding(key, record);
+      }
+      removed.push(alreadyExpired ? raw : record);
       await enqueuePersist();
     }
     return removed;
@@ -296,13 +306,24 @@ export async function unbindGenericCurrentConversationBindings(
     return removed;
   }
   for (const key of bindingsByConversationKey.keys()) {
+    const raw = bindingsByConversationKey.get(key);
     const record = pruneExpiredBinding(key);
-    if (!record || record.targetSessionKey !== normalizedTargetSessionKey) {
+    if (!record) {
       continue;
     }
-    bindingsByConversationKey.delete(key);
-    maybeRestorePreviousBinding(key, record);
-    removed.push(record);
+    // After pruning, the map entry may be a restored binding with a different
+    // targetSessionKey. Match against the pre-prune snapshot to decide whether
+    // this key's original binding targeted the session being unbound.
+    const target = raw ?? record;
+    if (target.targetSessionKey !== normalizedTargetSessionKey) {
+      continue;
+    }
+    const alreadyExpired = raw != null && isBindingExpired(raw);
+    if (!alreadyExpired) {
+      bindingsByConversationKey.delete(key);
+      maybeRestorePreviousBinding(key, record);
+    }
+    removed.push(alreadyExpired ? raw : record);
   }
   if (removed.length > 0) {
     await enqueuePersist();

--- a/src/infra/outbound/current-conversation-bindings.ts
+++ b/src/infra/outbound/current-conversation-bindings.ts
@@ -183,6 +183,15 @@ export async function bindGenericCurrentConversation(
       ...existing?.metadata,
       ...input.metadata,
       lastActivityAt: now,
+      ...(existing && existing.targetSessionKey !== targetSessionKey
+        ? {
+            previousBinding: {
+              targetSessionKey: existing.targetSessionKey,
+              targetKind: existing.targetKind,
+              metadata: existing.metadata,
+            },
+          }
+        : {}),
     },
   };
   bindingsByConversationKey.set(key, record);
@@ -230,6 +239,29 @@ export function touchGenericCurrentConversationBinding(bindingId: string, at = D
   });
 }
 
+function maybeRestorePreviousBinding(key: string, removed: SessionBindingRecord): void {
+  const prev = removed.metadata?.previousBinding as
+    | { targetSessionKey: string; targetKind: string; metadata?: Record<string, unknown> }
+    | undefined;
+  if (!prev?.targetSessionKey) {
+    return;
+  }
+  const now = Date.now();
+  bindingsByConversationKey.set(key, {
+    bindingId: removed.bindingId,
+    targetSessionKey: prev.targetSessionKey,
+    targetKind: (prev.targetKind as SessionBindingRecord["targetKind"]) ?? "session",
+    conversation: removed.conversation,
+    status: "active",
+    boundAt: now,
+    metadata: {
+      ...prev.metadata,
+      lastActivityAt: now,
+      restoredFrom: removed.targetSessionKey,
+    },
+  });
+}
+
 export async function unbindGenericCurrentConversationBindings(
   input: SessionBindingUnbindInput,
 ): Promise<SessionBindingRecord[]> {
@@ -242,6 +274,7 @@ export async function unbindGenericCurrentConversationBindings(
     const record = pruneExpiredBinding(key);
     if (record) {
       bindingsByConversationKey.delete(key);
+      maybeRestorePreviousBinding(key, record);
       removed.push(record);
       await enqueuePersist();
     }
@@ -256,6 +289,7 @@ export async function unbindGenericCurrentConversationBindings(
       continue;
     }
     bindingsByConversationKey.delete(key);
+    maybeRestorePreviousBinding(key, record);
     removed.push(record);
   }
   if (removed.length > 0) {

--- a/src/infra/outbound/current-conversation-bindings.ts
+++ b/src/infra/outbound/current-conversation-bindings.ts
@@ -114,8 +114,9 @@ function pruneExpiredBinding(key: string): SessionBindingRecord | null {
     return record;
   }
   bindingsByConversationKey.delete(key);
+  maybeRestorePreviousBinding(key, record);
   void enqueuePersist();
-  return null;
+  return bindingsByConversationKey.get(key) ?? null;
 }
 
 function resolveChannelSupportsCurrentConversationBinding(channel: string): boolean {
@@ -240,17 +241,25 @@ export function touchGenericCurrentConversationBinding(bindingId: string, at = D
 }
 
 function maybeRestorePreviousBinding(key: string, removed: SessionBindingRecord): void {
-  const prev = removed.metadata?.previousBinding as
-    | { targetSessionKey: string; targetKind: string; metadata?: Record<string, unknown> }
-    | undefined;
+  const raw = removed.metadata?.previousBinding;
+  const prev =
+    raw != null &&
+    typeof raw === "object" &&
+    typeof (raw as Record<string, unknown>).targetSessionKey === "string"
+      ? (raw as {
+          targetSessionKey: string;
+          targetKind: string;
+          metadata?: Record<string, unknown>;
+        })
+      : undefined;
   if (!prev?.targetSessionKey) {
     return;
   }
   const now = Date.now();
   bindingsByConversationKey.set(key, {
-    bindingId: removed.bindingId,
+    bindingId: buildBindingId(removed.conversation),
     targetSessionKey: prev.targetSessionKey,
-    targetKind: (prev.targetKind as SessionBindingRecord["targetKind"]) ?? "session",
+    targetKind: prev.targetKind === "subagent" ? "subagent" : "session",
     conversation: removed.conversation,
     status: "active",
     boundAt: now,

--- a/src/infra/outbound/current-conversation-bindings.ts
+++ b/src/infra/outbound/current-conversation-bindings.ts
@@ -190,6 +190,7 @@ export async function bindGenericCurrentConversation(
               targetSessionKey: existing.targetSessionKey,
               targetKind: existing.targetKind,
               metadata: existing.metadata,
+              expiresAt: existing.expiresAt,
             },
           }
         : {}),
@@ -250,6 +251,7 @@ function maybeRestorePreviousBinding(key: string, removed: SessionBindingRecord)
           targetSessionKey: string;
           targetKind: string;
           metadata?: Record<string, unknown>;
+          expiresAt?: number;
         })
       : undefined;
   if (!prev?.targetSessionKey) {
@@ -263,6 +265,7 @@ function maybeRestorePreviousBinding(key: string, removed: SessionBindingRecord)
     conversation: removed.conversation,
     status: "active",
     boundAt: now,
+    ...(typeof prev.expiresAt === "number" ? { expiresAt: prev.expiresAt } : {}),
     metadata: {
       ...prev.metadata,
       lastActivityAt: now,


### PR DESCRIPTION
## Summary

`--bind here` doesn't work in Telegram DM conversations — `resolveConversationIdForThreadBinding` can't extract conversation IDs from channel-prefixed targets like `telegram:12345`. When a specialist agent unbinds, the DM binding is silently lost instead of reverting to the main agent. Additionally, the binding restore path has safety gaps: unvalidated metadata from disk, stale bindingId reuse, inconsistent targetKind mapping, and silent binding loss on TTL expiry.

## Bug

- `resolveConversationIdForThreadBinding` has no handler for channel-prefixed DM targets (`telegram:12345`)
- No mechanism to save/restore previous binding when a specialist takes over a DM conversation
- `maybeRestorePreviousBinding` trusts deserialized `previousBinding` metadata with an unsafe `as` cast — corrupted JSON from disk passes silently
- Restored binding reuses the removed specialist's `bindingId` — late cleanup calls can accidentally kill the restored main binding
- Telegram restore hardcodes `targetKind` fallback to `"acp"` instead of using `toTelegramTargetKind` converter; generic side uses an unchecked `as` cast
- `pruneExpiredBinding` silently deletes expired bindings without restoring the previous binding (Telegram sweeper already handles this correctly)

## Fix

- Added channel-prefix stripping for numeric DM targets (`telegram:12345` → `12345`)
- Save `previousBinding` in metadata on rebind, auto-restore on unbind/close
- Runtime shape guard on deserialized `previousBinding` instead of `as` cast
- Fresh `bindingId` via `buildBindingId()` on restore instead of reusing removed binding's ID
- `targetKind` aligned through existing `toTelegramTargetKind` / validated union
- `pruneExpiredBinding` now calls `maybeRestorePreviousBinding` and returns the restored record
- Added JSDoc on Telegram restore function documenting caller persistence responsibility

Backward compatible — no changes to session binding service interface, persistence format, or plugin SDK contracts.

Depends on #57732, related #57448.

## Validation

- `pnpm test -- src/agents/acp-spawn.test.ts` — 37/37 pass (1 new)
- `pnpm test -- extensions/telegram/src/thread-bindings.test.ts` — 9/9 pass (2 new)
- `pnpm test -- src/infra/outbound/current-conversation-bindings.test.ts` — 8/8 pass (4 new)
- `pnpm check` — clean
- Live Telegram DM walkthrough: main agent (analyst) → spawn claude specialist → specialist handles messages → `/acp close` → main agent restored with original session key
- Not verified: persistence round-trip across gateway restart, concurrent specialist spawn race

## Notes

- ACP sessions cannot spawn other ACP sessions (no spawn tool), so handoff depth is bounded at 1 in practice
- Subagent depth is capped at 5 by config
- AI-assisted (Claude Opus 4.6), fully tested