### PR TITLE
fix: register exit handler for gateway lock cleanup on early crash (closes #57032)

### DIFF
--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -204,10 +204,24 @@ export async function acquireGatewayLock(
         payload.startTime = startTime;
       }
       await handle.writeFile(JSON.stringify(payload), "utf8");
+
+      // Clean up lock file on early exit (before signal handlers are registered).
+      // Without this, a crash between lock acquisition and registerCleanupHandlers()
+      // leaves a stale lock file that delays the next gateway start by up to 30s.
+      const exitHandler = () => {
+        try {
+          fsSync.unlinkSync(lockPath);
+        } catch {
+          // best-effort — file may already be removed
+        }
+      };
+      process.on("exit", exitHandler);
+
       return {
         lockPath,
         configPath,
         release: async () => {
+          process.removeListener("exit", exitHandler);
           await handle.close().catch(() => undefined);
           await fs.rm(lockPath, { force: true });
         },


### PR DESCRIPTION
## Summary

Register a `process.on('exit')` handler immediately after gateway lock acquisition, before the lock result is returned.

## The issue

If the gateway crashes between lock acquisition (line 196) and signal handler registration (which happens later in the startup sequence), the lock file persists with a valid PID. The next gateway instance detects the lock, reads the PID, and waits up to 30 seconds for staleness before it can start.

## The fix

A synchronous `exit` handler that `unlinkSync`s the lock file. The `exit` event fires on both clean exit and after unhandled exceptions, covering the early-crash window. The handler is removed in `release()` so it doesn't interfere with normal lock lifecycle.

This mirrors the pattern used in `session-write-lock.ts` (`registerCleanupHandlers`).

Closes #57032.
