### PR TITLE
fix(diffs): harden viewer proxy access

### DIFF
--- a/extensions/diffs/index.ts
+++ b/extensions/diffs/index.ts
@@ -38,6 +38,8 @@ export default definePluginEntry({
         store,
         logger: api.logger,
         allowRemoteViewer: security.allowRemoteViewer,
+        trustedProxies: api.config.gateway?.trustedProxies,
+        allowRealIpFallback: api.config.gateway?.allowRealIpFallback === true,
       }),
     });
     api.on("before_prompt_build", async () => ({

--- a/extensions/diffs/runtime-api.ts
+++ b/extensions/diffs/runtime-api.ts
@@ -1,0 +1,1 @@
+export { resolveRequestClientIp } from "openclaw/plugin-sdk/webhook-ingress";

--- a/extensions/diffs/src/http.ts
+++ b/extensions/diffs/src/http.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { PluginLogger } from "../api.js";
+import { resolveRequestClientIp } from "../runtime-api.js";
 import type { DiffArtifactStore } from "./store.js";
 import { DIFF_ARTIFACT_ID_PATTERN, DIFF_ARTIFACT_TOKEN_PATTERN } from "./types.js";
 import { VIEWER_ASSET_PREFIX, getServedViewerAsset } from "./viewer-assets.js";
@@ -25,6 +26,8 @@ export function createDiffsHttpHandler(params: {
   store: DiffArtifactStore;
   logger?: PluginLogger;
   allowRemoteViewer?: boolean;
+  trustedProxies?: readonly string[];
+  allowRealIpFallback?: boolean;
 }) {
   const viewerFailureLimiter = new ViewerFailureLimiter();
 
@@ -42,7 +45,10 @@ export function createDiffsHttpHandler(params: {
       return false;
     }
 
-    const access = resolveViewerAccess(req);
+    const access = resolveViewerAccess(req, {
+      trustedProxies: params.trustedProxies,
+      allowRealIpFallback: params.allowRealIpFallback,
+    });
     if (!access.localRequest && params.allowRemoteViewer !== true) {
       respondText(res, 404, "Diff not found");
       return true;
@@ -186,12 +192,30 @@ function hasProxyForwardingHints(req: IncomingMessage): boolean {
   );
 }
 
-function resolveViewerAccess(req: IncomingMessage): {
+function resolveViewerAccess(
+  req: IncomingMessage,
+  params: {
+    trustedProxies?: readonly string[];
+    allowRealIpFallback?: boolean;
+  },
+): {
   remoteKey: string;
   localRequest: boolean;
 } {
-  const remoteKey = normalizeRemoteClientKey(req.socket?.remoteAddress);
-  const localRequest = isLoopbackClientIp(remoteKey) && !hasProxyForwardingHints(req);
+  const proxyHintsPresent = hasProxyForwardingHints(req);
+  const clientIp =
+    proxyHintsPresent || (params.trustedProxies?.length ?? 0) > 0
+      ? // Reuse gateway proxy trust rules and fail closed when a trusted proxy hop
+        // does not provide usable client-origin headers.
+        resolveRequestClientIp(
+          req,
+          params.trustedProxies ? [...params.trustedProxies] : undefined,
+          params.allowRealIpFallback === true,
+        )
+      : req.socket?.remoteAddress;
+  const remoteKey = normalizeRemoteClientKey(clientIp ?? req.socket?.remoteAddress);
+  const localRequest =
+    !proxyHintsPresent && typeof clientIp === "string" && isLoopbackClientIp(clientIp);
   return { remoteKey, localRequest };
 }
 

--- a/extensions/diffs/src/http.ts
+++ b/extensions/diffs/src/http.ts
@@ -215,7 +215,7 @@ function resolveViewerAccess(
       : req.socket?.remoteAddress;
   const remoteKey = normalizeRemoteClientKey(clientIp ?? req.socket?.remoteAddress);
   const localRequest =
-    !proxyHintsPresent && typeof clientIp === "string" && isLoopbackClientIp(clientIp);
+    !proxyHintsPresent && typeof clientIp === "string" && isLoopbackClientIp(remoteKey);
   return { remoteKey, localRequest };
 }
 

--- a/extensions/diffs/src/store.test.ts
+++ b/extensions/diffs/src/store.test.ts
@@ -315,6 +315,12 @@ describe("createDiffsHttpHandler", () => {
       expectedStatusCode: 200,
     },
     {
+      name: "allows ipv4-mapped ipv6 loopback viewer access by default",
+      request: ipv4MappedLoopbackReq,
+      allowRemoteViewer: false,
+      expectedStatusCode: 200,
+    },
+    {
       name: "blocks non-loopback viewer access by default",
       request: remoteReq,
       allowRemoteViewer: false,
@@ -429,5 +435,17 @@ function remoteReq(input: {
     ...input,
     headers: input.headers ?? {},
     socket: { remoteAddress: "203.0.113.10" },
+  } as unknown as IncomingMessage;
+}
+
+function ipv4MappedLoopbackReq(input: {
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+}): IncomingMessage {
+  return {
+    ...input,
+    headers: input.headers ?? {},
+    socket: { remoteAddress: "::ffff:127.0.0.1" },
   } as unknown as IncomingMessage;
 }

--- a/extensions/diffs/src/store.test.ts
+++ b/extensions/diffs/src/store.test.ts
@@ -309,6 +309,12 @@ describe("createDiffsHttpHandler", () => {
 
   it.each([
     {
+      name: "allows direct loopback viewer access by default",
+      request: localReq,
+      allowRemoteViewer: false,
+      expectedStatusCode: 200,
+    },
+    {
       name: "blocks non-loopback viewer access by default",
       request: remoteReq,
       allowRemoteViewer: false,
@@ -322,6 +328,13 @@ describe("createDiffsHttpHandler", () => {
       expectedStatusCode: 404,
     },
     {
+      name: "blocks trusted-proxy loopback requests without client-origin headers by default",
+      request: localReq,
+      trustedProxies: ["127.0.0.1"],
+      allowRemoteViewer: false,
+      expectedStatusCode: 404,
+    },
+    {
       name: "allows remote access when allowRemoteViewer is enabled",
       request: remoteReq,
       allowRemoteViewer: true,
@@ -331,29 +344,33 @@ describe("createDiffsHttpHandler", () => {
       name: "allows proxied loopback requests when allowRemoteViewer is enabled",
       request: localReq,
       headers: { "x-forwarded-for": "203.0.113.10" },
+      trustedProxies: ["127.0.0.1"],
       allowRemoteViewer: true,
       expectedStatusCode: 200,
     },
-  ])("$name", async ({ request, headers, allowRemoteViewer, expectedStatusCode }) => {
-    const artifact = await createViewerArtifact(store);
+  ])(
+    "$name",
+    async ({ request, headers, trustedProxies, allowRemoteViewer, expectedStatusCode }) => {
+      const artifact = await createViewerArtifact(store);
 
-    const handler = createDiffsHttpHandler({ store, allowRemoteViewer });
-    const res = createMockServerResponse();
-    const handled = await handler(
-      request({
-        method: "GET",
-        url: artifact.viewerPath,
-        headers,
-      }),
-      res,
-    );
+      const handler = createDiffsHttpHandler({ store, allowRemoteViewer, trustedProxies });
+      const res = createMockServerResponse();
+      const handled = await handler(
+        request({
+          method: "GET",
+          url: artifact.viewerPath,
+          headers,
+        }),
+        res,
+      );
 
-    expect(handled).toBe(true);
-    expect(res.statusCode).toBe(expectedStatusCode);
-    if (expectedStatusCode === 200) {
-      expect(res.body).toBe("<html>viewer</html>");
-    }
-  });
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(expectedStatusCode);
+      if (expectedStatusCode === 200) {
+        expect(res.body).toBe("<html>viewer</html>");
+      }
+    },
+  );
 
   it("rate-limits repeated remote misses", async () => {
     const handler = createDiffsHttpHandler({ store, allowRemoteViewer: true });


### PR DESCRIPTION
## Summary

- Fix the diffs viewer local-only gate so trusted loopback proxies cannot bypass `allowRemoteViewer=false` when client-origin headers are missing.
- Reuse the shared gateway client-IP resolver instead of the diffs plugin's weaker socket-plus-header heuristic.
- Track the security report from https://github.com/NVIDIA-dev/openclaw-tracking/issues/138.

## Changes

- Add `extensions/diffs/runtime-api.ts` to expose the shared request client-IP resolver through a local extension barrel.
- Pass `gateway.trustedProxies` and `gateway.allowRealIpFallback` into the diffs HTTP handler from `extensions/diffs/index.ts`.
- Update `extensions/diffs/src/http.ts` to classify viewer requests with the shared resolver and fail closed for ambiguous proxy provenance.
- Extend `extensions/diffs/src/store.test.ts` with coverage for direct loopback access, forwarded loopback requests, and trusted-proxy loopback requests that omit client-origin headers.

## Validation

- `corepack pnpm test -- extensions/diffs/src/store.test.ts`
- `PATH=/tmp/codex-bin:$PATH pnpm check`
- `PATH=/tmp/codex-bin:$PATH pnpm build`

## Notes

- Related tracking issue: https://github.com/NVIDIA-dev/openclaw-tracking/issues/138
- This container had `corepack pnpm` available but no `pnpm` binary on `PATH`, so the verification commands used a temporary PATH shim without changing the repo.
