### PR TITLE
fix: defensive prune before reading cron run log (closes #57017)

### DIFF
--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -356,8 +356,15 @@ export async function readCronRunLogEntriesPage(
   opts?: ReadCronRunLogPageOptions,
 ): Promise<CronRunLogPageResult> {
   await drainPendingWrite(filePath);
+  // Defensive prune before reading — if prior prunes failed (disk pressure),
+  // this prevents reading an unbounded file into memory.
+  const resolved = path.resolve(filePath);
+  await pruneIfNeeded(resolved, {
+    maxBytes: DEFAULT_CRON_RUN_LOG_MAX_BYTES,
+    keepLines: DEFAULT_CRON_RUN_LOG_KEEP_LINES,
+  }).catch(() => undefined);
   const limit = Math.max(1, Math.min(200, Math.floor(opts?.limit ?? 50)));
-  const raw = await fs.readFile(path.resolve(filePath), "utf-8").catch(() => "");
+  const raw = await fs.readFile(resolved, "utf-8").catch(() => "");
   const statuses = normalizeRunStatuses(opts);
   const deliveryStatuses = normalizeDeliveryStatuses(opts);
   const query = opts?.query?.trim().toLowerCase() ?? "";


### PR DESCRIPTION
## Summary

Add a defensive `pruneIfNeeded` call before `fs.readFile` in `readCronRunLogEntriesPage`.

## The issue

The cron run log is pruned after writes (in `appendCronRunLogEntry`), but if pruning fails silently (disk pressure, permissions), the JSONL file grows unbounded. A subsequent read via `readCronRunLogEntriesPage` loads the entire file into memory, risking OOM.

## The fix

Call `pruneIfNeeded` at the start of the read path (before `fs.readFile`), using the same `DEFAULT_CRON_RUN_LOG_MAX_BYTES` and `DEFAULT_CRON_RUN_LOG_KEEP_LINES` constants. `pruneIfNeeded` is efficient — it `stat`s first and returns immediately if the file is within bounds. The `.catch(() => undefined)` ensures a failed prune doesn't block the read.

This is defense-in-depth: writes prune after append, reads prune before load. Either path keeps the file bounded.

Closes #57017.
