### PR TITLE
fix(telegram): fall back to HTML chunking for oversized IR chunks

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { markdownToTelegramHtml, splitTelegramHtmlChunks } from "./format.js";
+import {
+  markdownToTelegramHtml,
+  markdownToTelegramHtmlChunks,
+  splitTelegramHtmlChunks,
+} from "./format.js";
 
 describe("markdownToTelegramHtml", () => {
   it("handles core markdown-to-telegram conversions", () => {
@@ -133,5 +137,20 @@ describe("markdownToTelegramHtml", () => {
 
   it("fails loudly when tag overhead leaves no room for text", () => {
     expect(() => splitTelegramHtmlChunks("<b><i><u>x</u></i></b>", 10)).toThrow(/tag overhead/i);
+  });
+
+  it("splits markdown whose HTML expansion exceeds the limit", () => {
+    // Build markdown with heavy formatting that expands significantly in HTML.
+    // Each **bold** becomes <b>bold</b> (7 extra chars), tables and code blocks
+    // add further overhead. This simulates the real-world case where IR-level
+    // chunking fits within the text limit but the rendered HTML overflows.
+    const rows = Array.from({ length: 80 }, (_, i) => `| **item${i}** | ${"x".repeat(40)} |`);
+    const markdown = `| Col A | Col B |\n|-------|-------|\n${rows.join("\n")}`;
+    const limit = 4000;
+    const chunks = markdownToTelegramHtmlChunks(markdown, limit);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(limit);
+    }
   });
 });

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -441,15 +441,26 @@ function renderTelegramChunksWithinHtmlLimit(
   ir: MarkdownIR,
   limit: number,
 ): TelegramFormattedChunk[] {
-  return renderMarkdownIRChunksWithinLimit({
+  const chunks = renderMarkdownIRChunksWithinLimit({
     ir,
     limit,
     renderChunk: renderTelegramChunkHtml,
     measureRendered: (html) => html.length,
-  }).map(({ source, rendered }) => ({
-    html: rendered,
-    text: source.text,
-  }));
+  });
+  const result: TelegramFormattedChunk[] = [];
+  for (const { source, rendered } of chunks) {
+    if (rendered.length <= limit) {
+      result.push({ html: rendered, text: source.text });
+    } else {
+      // IR-level splitting couldn't reduce below the limit (e.g. heavy markdown
+      // expanding significantly in HTML). Fall back to raw HTML splitting which
+      // can break mid-text to guarantee every chunk fits.
+      for (const htmlChunk of splitTelegramHtmlChunks(rendered, limit)) {
+        result.push({ html: htmlChunk, text: htmlChunk });
+      }
+    }
+  }
+  return result;
 }
 
 export function markdownToTelegramChunks(

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -51,6 +51,7 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
   /User .* not in room/i,
+  /message is too long/i,
 ];
 
 function createEmptyRecoverySummary(): RecoverySummary {

--- a/src/infra/outbound/delivery-queue.policy.test.ts
+++ b/src/infra/outbound/delivery-queue.policy.test.ts
@@ -17,6 +17,7 @@ describe("delivery-queue policy", () => {
       "chat_id is empty",
       "Outbound not configured for channel: demo-channel",
       "MatrixError: [403] User @bot:matrix.example.com not in room !mixedCase:matrix.example.com",
+      "Call to 'sendMessage' failed! (400: Bad Request: message is too long)",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);
     });


### PR DESCRIPTION
## Summary

- When markdown with heavy formatting (tables, bold, code blocks) is converted to Telegram HTML, the rendered output can exceed the 4096-char API limit even though the text-based IR chunks fit within it
- The IR-level splitter's worst-case path previously returned oversized HTML as-is, causing repeated `"message is too long"` delivery failures
- Added a safety net in `renderTelegramChunksWithinHtmlLimit`: any chunk whose HTML exceeds the limit is re-split via `splitTelegramHtmlChunks`
- Also marked `"message is too long"` as a permanent delivery error in `delivery-queue-recovery.ts` to prevent useless retries

## Test plan

- [x] Added test case: markdown table with heavy bold formatting that expands beyond limit → verifies all output chunks fit within limit
- [x] Added `"message is too long"` to permanent error test cases
- [x] All existing tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)