### PR TITLE
perf: hot-path optimizations (regex hoist, cache reuse, credential stripping)

### DIFF
--- a/src/agents/anthropic-payload-log.ts
+++ b/src/agents/anthropic-payload-log.ts
@@ -7,7 +7,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveUserPath } from "../utils.js";
 import { parseBooleanValue } from "../utils/boolean.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
-import { redactImageDataForDiagnostics } from "./payload-redaction.js";
+import { sanitizeDiagnosticPayload } from "./payload-redaction.js";
 import { getQueuedFileWriter, type QueuedFileWriter } from "./queued-file-writer.js";
 
 type PayloadLogStage = "request" | "usage";
@@ -137,7 +137,7 @@ export function createAnthropicPayloadLogger(params: {
         return streamFn(model, context, options);
       }
       const nextOnPayload = (payload: unknown) => {
-        const redactedPayload = redactImageDataForDiagnostics(payload);
+        const redactedPayload = sanitizeDiagnosticPayload(payload);
         record({
           ...base,
           ts: new Date().toISOString(),

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -38,6 +38,14 @@ const FILE_URL_REGEX_SOURCE = "file://[^\\s<>\"'`\\]]+\\.(?:" + IMAGE_EXTENSION_
 const PATH_REGEX_SOURCE =
   "(?:^|\\s|[\"'`(])((\\.\\.?/|[~/])[^\\s\"'`()\\[\\]]*\\.(?:" + IMAGE_EXTENSION_PATTERN + "))";
 
+// Pre-compiled regex patterns for detectImageReferences.
+// g-flag patterns have lastIndex reset at the top of each call.
+const MEDIA_ATTACHED_PATTERN = /\[media attached(?:\s+\d+\/\d+)?:\s*([^\]]+)\]/gi;
+const MEDIA_ATTACHED_PATH_PATTERN = new RegExp(MEDIA_ATTACHED_PATH_REGEX_SOURCE, "i");
+const MESSAGE_IMAGE_PATTERN = new RegExp(MESSAGE_IMAGE_REGEX_SOURCE, "gi");
+const FILE_URL_PATTERN = new RegExp(FILE_URL_REGEX_SOURCE, "gi");
+const PATH_PATTERN = new RegExp(PATH_REGEX_SOURCE, "gi");
+
 /**
  * Result of detecting an image reference in text.
  */
@@ -118,16 +126,17 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     refs.push({ raw: trimmed, type: "path", resolved });
   };
 
+  // Reset lastIndex on g-flag patterns to ensure clean state across calls.
+  MEDIA_ATTACHED_PATTERN.lastIndex = 0;
+  MESSAGE_IMAGE_PATTERN.lastIndex = 0;
+  FILE_URL_PATTERN.lastIndex = 0;
+  PATH_PATTERN.lastIndex = 0;
+
   // Pattern for [media attached: path (type) | url] or [media attached N/M: path (type) | url] format
   // Each bracket = ONE file. The | separates path from URL, not multiple files.
   // Multi-file format uses separate brackets on separate lines.
-  const mediaAttachedPattern = /\[media attached(?:\s+\d+\/\d+)?:\s*([^\]]+)\]/gi;
-  const mediaAttachedPathPattern = new RegExp(MEDIA_ATTACHED_PATH_REGEX_SOURCE, "i");
-  const messageImagePattern = new RegExp(MESSAGE_IMAGE_REGEX_SOURCE, "gi");
-  const fileUrlPattern = new RegExp(FILE_URL_REGEX_SOURCE, "gi");
-  const pathPattern = new RegExp(PATH_REGEX_SOURCE, "gi");
   let match: RegExpExecArray | null;
-  while ((match = mediaAttachedPattern.exec(prompt)) !== null) {
+  while ((match = MEDIA_ATTACHED_PATTERN.exec(prompt)) !== null) {
     const content = match[1];
 
     // Skip "[media attached: N files]" header lines
@@ -139,14 +148,14 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     // Format is: path (type) | url  OR  just: path (type)
     // Path may contain spaces (e.g., "ChatGPT Image Apr 21.png")
     // Use non-greedy .+? to stop at first image extension
-    const pathMatch = content.match(mediaAttachedPathPattern);
+    const pathMatch = content.match(MEDIA_ATTACHED_PATH_PATTERN);
     if (pathMatch?.[1]) {
       addPathRef(pathMatch[1].trim());
     }
   }
 
   // Pattern for [Image: source: /path/...] format from messaging systems
-  while ((match = messageImagePattern.exec(prompt)) !== null) {
+  while ((match = MESSAGE_IMAGE_PATTERN.exec(prompt)) !== null) {
     const raw = match[1]?.trim();
     if (raw) {
       addPathRef(raw);
@@ -156,7 +165,7 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
   // Remote HTTP(S) URLs are intentionally ignored. Native image injection is local-only.
 
   // Pattern for file:// URLs - treat as paths since loadWebMedia handles them
-  while ((match = fileUrlPattern.exec(prompt)) !== null) {
+  while ((match = FILE_URL_PATTERN.exec(prompt)) !== null) {
     const raw = match[0];
     const dedupeKey = normalizeRefForDedupe(raw);
     if (seen.has(dedupeKey)) {
@@ -178,7 +187,7 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
   // - ./relative/path.ext
   // - ../parent/path.ext
   // - ~/home/path.ext
-  while ((match = pathPattern.exec(prompt)) !== null) {
+  while ((match = PATH_PATTERN.exec(prompt)) !== null) {
     // Use capture group 1 (the path without delimiter prefix); skip if undefined
     if (match[1]) {
       addPathRef(match[1]);

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -13,6 +13,9 @@ import {
   isRawApiErrorPayload,
   normalizeTextForComparison,
 } from "../../pi-embedded-helpers.js";
+
+/** Pre-normalized billing error text for deduplication comparisons. */
+const NORMALIZED_BILLING_ERROR_TEXT = normalizeTextForComparison(BILLING_ERROR_USER_MESSAGE);
 import type { ToolResultFormat } from "../../pi-embedded-subscribe.js";
 import {
   extractAssistantText,
@@ -156,7 +159,7 @@ export function buildEmbeddedRunPayloads(params: {
     ? normalizeTextForComparison(rawErrorMessage)
     : null;
   const normalizedErrorText = errorText ? normalizeTextForComparison(errorText) : null;
-  const normalizedGenericBillingErrorText = normalizeTextForComparison(BILLING_ERROR_USER_MESSAGE);
+  const normalizedGenericBillingErrorText = NORMALIZED_BILLING_ERROR_TEXT;
   const genericErrorText = "The AI service returned an error. Please try again.";
   if (errorText) {
     replyItems.push({ text: errorText, isError: true });

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -161,7 +161,7 @@ function enforceToolResultContextBudgetInPlace(params: {
   messages: AgentMessage[];
   contextBudgetChars: number;
   maxSingleToolResultChars: number;
-}): void {
+}): MessageCharEstimateCache {
   const { messages, contextBudgetChars, maxSingleToolResultChars } = params;
   const estimateCache = createMessageCharEstimateCache();
 
@@ -176,7 +176,7 @@ function enforceToolResultContextBudgetInPlace(params: {
 
   let currentChars = estimateContextChars(messages, estimateCache);
   if (currentChars <= contextBudgetChars) {
-    return;
+    return estimateCache;
   }
 
   // Compact oldest tool outputs first until the context is back under budget.
@@ -185,6 +185,8 @@ function enforceToolResultContextBudgetInPlace(params: {
     charsNeeded: currentChars - contextBudgetChars,
     cache: estimateCache,
   });
+
+  return estimateCache;
 }
 
 export function installToolResultContextGuard(params: {
@@ -218,7 +220,7 @@ export function installToolResultContextGuard(params: {
       : messages;
 
     const contextMessages = Array.isArray(transformed) ? transformed : messages;
-    enforceToolResultContextBudgetInPlace({
+    const enforcementCache = enforceToolResultContextBudgetInPlace({
       messages: contextMessages,
       contextBudgetChars,
       maxSingleToolResultChars,
@@ -228,10 +230,7 @@ export function installToolResultContextGuard(params: {
     // If it does, non-tool-result content dominates and only full LLM-based session
     // compaction can reduce context size. Throwing a context overflow error triggers
     // the existing overflow recovery cascade in run.ts.
-    const postEnforcementChars = estimateContextChars(
-      contextMessages,
-      createMessageCharEstimateCache(),
-    );
+    const postEnforcementChars = estimateContextChars(contextMessages, enforcementCache);
     if (postEnforcementChars > preemptiveOverflowChars) {
       throw new Error(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
     }


### PR DESCRIPTION
## Summary

Consolidates 4 hot-path performance improvements and a credential-stripping fix into a single PR:

- **Regex hoist in `detectImageReferences`**: Move 5 regex patterns from per-call instantiation to module-level constants with `lastIndex = 0` resets for g-flag patterns
- **Billing error const hoist**: Pre-compute `normalizeTextForComparison(BILLING_ERROR_USER_MESSAGE)` at module level instead of every `buildEmbeddedRunPayloads` call
- **Cache reuse in context guard**: Return the `MessageCharEstimateCache` from `enforceToolResultContextBudgetInPlace` and reuse it for the post-enforcement `estimateContextChars` call, avoiding a second full cache build
- **Credential stripping in payload logger**: Switch from `redactImageDataForDiagnostics` to `sanitizeDiagnosticPayload` which strips both credential fields and image data

## Test plan

- [ ] Verify `detectImageReferences` still detects all image reference patterns (file paths, file:// URLs, media attached, message image)
- [ ] Verify billing error suppression still works in `buildEmbeddedRunPayloads`
- [ ] Verify tool-result context guard truncation and overflow detection
- [ ] Verify payload logger redacts credentials in logged payloads

Consolidates: #56999, #57001, #57002, #56278
