### PR TITLE
fix: remove duplicate utilities + sweep orphaned toolStartData entries

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -34,8 +34,44 @@ type ToolStartRecord = {
 /** Track tool execution start data for after_tool_call hook. */
 const toolStartData = new Map<string, ToolStartRecord>();
 
+/**
+ * Track last activity timestamp per run. Used to sweep orphaned toolStartData
+ * entries when a run has been idle (no tool-start or tool-end) for longer than
+ * TOOL_START_DATA_RUN_IDLE_MS. This protects long-running tool calls: entries
+ * are only swept when the entire run is idle, not per-entry age.
+ */
+const lastRunActivity = new Map<string, number>();
+const TOOL_START_DATA_RUN_IDLE_MS = 5 * 60 * 1000; // 5 minutes
+
 function buildToolStartKey(runId: string, toolCallId: string): string {
   return `${runId}:${toolCallId}`;
+}
+
+/**
+ * Sweep orphaned toolStartData entries for runs that have been idle longer
+ * than TOOL_START_DATA_RUN_IDLE_MS. A run is considered idle when no
+ * tool-start or tool-end event has been processed for it within the window.
+ */
+function sweepOrphanedToolStartData(): void {
+  if (lastRunActivity.size === 0) {
+    return;
+  }
+  const now = Date.now();
+  const idleRunIds: string[] = [];
+  for (const [runId, lastActive] of lastRunActivity) {
+    if (now - lastActive >= TOOL_START_DATA_RUN_IDLE_MS) {
+      idleRunIds.push(runId);
+    }
+  }
+  for (const runId of idleRunIds) {
+    const prefix = `${runId}:`;
+    for (const key of toolStartData.keys()) {
+      if (key.startsWith(prefix)) {
+        toolStartData.delete(key);
+      }
+    }
+    lastRunActivity.delete(runId);
+  }
 }
 
 function isCronAddAction(args: unknown): boolean {
@@ -343,7 +379,9 @@ export async function handleToolExecutionStart(
   const runId = ctx.params.runId;
 
   // Track start time and args for after_tool_call hook
+  sweepOrphanedToolStartData();
   toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: Date.now(), args });
+  lastRunActivity.set(runId, Date.now());
 
   if (toolName === "read") {
     const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
@@ -469,6 +507,11 @@ export async function handleToolExecutionEnd(
   const toolStartKey = buildToolStartKey(runId, toolCallId);
   const startData = toolStartData.get(toolStartKey);
   toolStartData.delete(toolStartKey);
+  lastRunActivity.set(runId, Date.now());
+  // Clean up lastRunActivity when this run has no remaining entries in toolStartData.
+  if (!Array.from(toolStartData.keys()).some((key) => key.startsWith(`${runId}:`))) {
+    lastRunActivity.delete(runId);
+  }
   const callSummary = ctx.state.toolMetaById.get(toolCallId);
   const meta = callSummary?.meta;
   ctx.state.toolMetas.push({ toolName, meta });

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -12,6 +12,7 @@ import {
 import { trySafeFileURLToPath } from "../infra/local-file-access.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
+import { clamp } from "../utils.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
 import { toRelativeWorkspacePath } from "./path-policy.js";
 import { wrapEditToolWithRecovery } from "./pi-tools.host-edit.js";
@@ -60,10 +61,6 @@ type ReadTruncationDetails = {
 
 const READ_CONTINUATION_NOTICE_RE =
   /\n\n\[(?:Showing lines [^\]]*?Use offset=\d+ to continue\.|\d+ more lines in file\. Use offset=\d+ to continue\.)\]\s*$/;
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
 
 function resolveAdaptiveReadMaxBytes(options?: OpenClawReadToolOptions): number {
   const contextWindowTokens = options?.modelContextWindowTokens;

--- a/src/commands/doctor-legacy-config.ts
+++ b/src/commands/doctor-legacy-config.ts
@@ -14,6 +14,7 @@ import { migrateLegacyWebSearchConfig } from "../config/legacy-web-search.js";
 import { LEGACY_TALK_PROVIDER_ID, normalizeTalkSection } from "../config/talk.js";
 import { DEFAULT_GOOGLE_API_BASE_URL } from "../infra/google-api-base-url.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+import { isRecord } from "../utils.js";
 
 export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
   config: OpenClawConfig;
@@ -23,9 +24,6 @@ export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
   const NANO_BANANA_SKILL_KEY = "nano-banana-pro";
   const NANO_BANANA_MODEL = "google/gemini-3-pro-image-preview";
   let next: OpenClawConfig = cfg;
-
-  const isRecord = (value: unknown): value is Record<string, unknown> =>
-    Boolean(value) && typeof value === "object" && !Array.isArray(value);
 
   const normalizeDmAliases = (params: {
     provider: "slack" | "discord";


### PR DESCRIPTION
## Summary

Consolidates duplicate utility removal and a memory leak fix:

- **Remove duplicate `clamp`** in `pi-tools.read.ts`: Replace local implementation with import from `../utils.js`
- **Remove duplicate `isRecord`** in `doctor-legacy-config.ts`: Replace local arrow function with import from `../utils.js`
- **Sweep orphaned `toolStartData` entries**: Add per-run activity tracking via `lastRunActivity` Map. Orphaned entries are swept when the entire run has been idle for 5+ minutes, protecting long-running tool calls from premature cleanup. Activity is updated at both tool-start and tool-end, and `lastRunActivity` is cleaned up when a run has no remaining entries.

## Test plan

- [ ] Verify `clamp` import works correctly in adaptive read sizing
- [ ] Verify `isRecord` import works in legacy config normalization
- [ ] Verify tool start/end tracking still provides correct `durationMs` in `after_tool_call` hook
- [ ] Verify orphaned entries from crashed/abandoned runs are cleaned up after 5 minutes of run inactivity
- [ ] Verify long-running tool calls (>5 min) are not swept while the run is still active

Consolidates: #56972, #57015
