### PR TITLE
fix(doctor/plugins): skip unused Matrix inspector loads and honor enabledByDefault startup plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: fix interim subagent runtime display so `/subagents list` and `/subagents info` stop inflating short runtimes and show second-level durations correctly. (#57739) Thanks @samzong.
 - Diffs/config: preserve schema-shaped plugin config parsing from `diffsPluginConfigSchema.safeParse()`, so direct callers keep `defaults` and `security` sections instead of receiving flattened tool defaults. (#57904) Thanks @gumadeiras.
 - Diffs: fall back to plain text when `lang` hints are invalid during diff render and viewer hydration, so bad or stale language values no longer break the diff viewer. (#57902) Thanks @gumadeiras.
+- Doctor/plugins: skip false Matrix legacy-helper warnings when no migration plans exist, and keep bundled `enabledByDefault` plugins in the gateway startup set. (#57931) Thanks @dinakars777.
 
 ## 2026.3.28
 

--- a/src/infra/matrix-legacy-crypto.test.ts
+++ b/src/infra/matrix-legacy-crypto.test.ts
@@ -176,6 +176,33 @@ describe("matrix legacy encrypted-state migration", () => {
     );
   });
 
+  it("skips inspector loading when no legacy Matrix plans exist", async () => {
+    await withTempHome(
+      async () => {
+        const matrixHelperModule = await import("./matrix-plugin-helper.js");
+        const loadInspectorSpy = vi.spyOn(matrixHelperModule, "loadMatrixLegacyCryptoInspector");
+
+        const result = await autoPrepareLegacyMatrixCrypto({
+          cfg: createDefaultMatrixConfig(),
+          env: process.env,
+        });
+
+        expect(result).toEqual({
+          migrated: false,
+          changes: [],
+          warnings: [],
+        });
+        expect(result.warnings).not.toContain(MATRIX_LEGACY_CRYPTO_INSPECTOR_UNAVAILABLE_MESSAGE);
+        expect(loadInspectorSpy).not.toHaveBeenCalled();
+      },
+      {
+        env: {
+          OPENCLAW_BUNDLED_PLUGINS_DIR: (home) => path.join(home, "empty-bundled"),
+        },
+      },
+    );
+  });
+
   it("warns when legacy local-only room keys cannot be recovered automatically", async () => {
     await withTempHome(async (home) => {
       const { cfg, rootDir } = writeDefaultLegacyCryptoFixture(home);

--- a/src/infra/matrix-legacy-crypto.ts
+++ b/src/infra/matrix-legacy-crypto.ts
@@ -328,10 +328,23 @@ export async function autoPrepareLegacyMatrixCrypto(params: {
     : detectLegacyMatrixCrypto({ cfg: params.cfg, env });
   const warnings = [...detection.warnings];
   const changes: string[] = [];
-  let inspectLegacyStore = params.deps?.inspectLegacyStore;
   const writeJsonFileAtomically =
     params.deps?.writeJsonFileAtomically ?? writeJsonFileAtomicallyImpl;
-  if (!inspectLegacyStore && detection.plans.length > 0) {
+  if (detection.plans.length === 0) {
+    if (warnings.length > 0) {
+      params.log?.warn?.(
+        `matrix: legacy encrypted-state warnings:\n${warnings.map((entry) => `- ${entry}`).join("\n")}`,
+      );
+    }
+    return {
+      migrated: false,
+      changes,
+      warnings,
+    };
+  }
+
+  let inspectLegacyStore = params.deps?.inspectLegacyStore;
+  if (!inspectLegacyStore) {
     try {
       inspectLegacyStore = await loadMatrixLegacyCryptoInspector({
         cfg: params.cfg,
@@ -354,6 +367,13 @@ export async function autoPrepareLegacyMatrixCrypto(params: {
       };
     }
   }
+  if (!inspectLegacyStore) {
+    return {
+      migrated: false,
+      changes,
+      warnings,
+    };
+  }
 
   for (const plan of detection.plans) {
     const existingState = loadLegacyCryptoMigrationState(plan.statePath);
@@ -370,8 +390,7 @@ export async function autoPrepareLegacyMatrixCrypto(params: {
 
     let summary: MatrixLegacyCryptoSummary;
     try {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      summary = await inspectLegacyStore!({
+      summary = await inspectLegacyStore({
         cryptoRootDir: plan.legacyCryptoPath,
         userId: plan.userId,
         deviceId: plan.deviceId,

--- a/src/infra/matrix-legacy-crypto.ts
+++ b/src/infra/matrix-legacy-crypto.ts
@@ -331,7 +331,7 @@ export async function autoPrepareLegacyMatrixCrypto(params: {
   let inspectLegacyStore = params.deps?.inspectLegacyStore;
   const writeJsonFileAtomically =
     params.deps?.writeJsonFileAtomically ?? writeJsonFileAtomicallyImpl;
-  if (!inspectLegacyStore) {
+  if (!inspectLegacyStore && detection.plans.length > 0) {
     try {
       inspectLegacyStore = await loadMatrixLegacyCryptoInspector({
         cfg: params.cfg,
@@ -370,7 +370,8 @@ export async function autoPrepareLegacyMatrixCrypto(params: {
 
     let summary: MatrixLegacyCryptoSummary;
     try {
-      summary = await inspectLegacyStore({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      summary = await inspectLegacyStore!({
         cryptoRootDir: plan.legacyCryptoPath,
         userId: plan.userId,
         deviceId: plan.deviceId,

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -138,19 +138,25 @@ describe("resolveGatewayStartupPluginIds", () => {
         enabledPluginIds: ["demo-bundled-sidecar"],
         modelId: "demo-cli/demo-model",
       }),
-      ["demo-channel", "demo-provider-plugin", "demo-bundled-sidecar", "demo-global-sidecar"],
+      [
+        "demo-channel",
+        "demo-default-on-sidecar",
+        "demo-provider-plugin",
+        "demo-bundled-sidecar",
+        "demo-global-sidecar",
+      ],
     ],
     [
-      "does not pull default-on bundled non-channel plugins into startup",
+      "includes bundled plugins with enabledByDefault: true",
       {} as OpenClawConfig,
-      ["demo-channel", "demo-global-sidecar"],
+      ["demo-channel", "demo-default-on-sidecar", "demo-global-sidecar"],
     ],
     [
       "auto-loads bundled plugins referenced by configured provider ids",
       createStartupConfig({
         providerIds: ["demo-provider"],
       }),
-      ["demo-channel", "demo-provider-plugin", "demo-global-sidecar"],
+      ["demo-channel", "demo-default-on-sidecar", "demo-provider-plugin", "demo-global-sidecar"],
     ],
   ] as const)("%s", (_name, config, expected) => {
     expectStartupPluginIdsCase({ config, expected });

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -337,7 +337,8 @@ export function resolveGatewayStartupPluginIds(params: {
       return (
         pluginsConfig.allow.includes(plugin.id) ||
         pluginsConfig.entries[plugin.id]?.enabled === true ||
-        pluginsConfig.slots.memory === plugin.id
+        pluginsConfig.slots.memory === plugin.id ||
+        plugin.enabledByDefault === true
       );
     })
     .map((plugin) => plugin.id);


### PR DESCRIPTION
## Summary

This PR fixes two small startup-time issues:

- `openclaw doctor --fix` no longer tries to load the Matrix legacy crypto inspector when there are no legacy Matrix migration plans.
- Gateway startup now keeps bundled plugins with `enabledByDefault: true` in the startup plugin set.

## Root Cause

### Matrix doctor false warning

`autoPrepareLegacyMatrixCrypto()` tried to load the Matrix legacy crypto inspector before checking whether there were any legacy crypto plans to process. On installs that never configured Matrix, that helper was not present, so doctor emitted a spurious warning.

### Bundled `enabledByDefault` startup mismatch

`resolveGatewayStartupPluginIds()` already used `resolveEffectiveEnableState()` to treat bundled `enabledByDefault` plugins as enabled, but a later bundled-only filter still dropped them from the startup list.

## Fix

- Return early from `autoPrepareLegacyMatrixCrypto()` when there are no migration plans, so no Matrix helper load is attempted.
- Keep the Matrix path covered with a regression test for the zero-plan/helper-missing case.
- Include bundled `enabledByDefault` plugins in the final gateway startup filter.

## Testing

- `pnpm test -- src/infra/matrix-legacy-crypto.test.ts src/plugins/channel-plugin-ids.test.ts`

Fixes #53156
