### PR TITLE
fix(matrix): restore E2EE for one-off CLI sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ Docs: https://docs.openclaw.ai
 - Diffs/config: preserve schema-shaped plugin config parsing from `diffsPluginConfigSchema.safeParse()`, so direct callers keep `defaults` and `security` sections instead of receiving flattened tool defaults. (#57904) Thanks @gumadeiras.
 - Diffs: fall back to plain text when `lang` hints are invalid during diff render and viewer hydration, so bad or stale language values no longer break the diff viewer. (#57902) Thanks @gumadeiras.
 - Doctor/plugins: skip false Matrix legacy-helper warnings when no migration plans exist, and keep bundled `enabledByDefault` plugins in the gateway startup set. (#57931) Thanks @dinakars777.
-- Matrix/CLI send: start one-off Matrix send clients before outbound delivery so `openclaw message send --channel matrix` restores E2EE in encrypted rooms instead of sending plain events. (#57936) Thanks @gumadeiras. Fixes #56569.
+- Matrix/CLI send: start one-off Matrix send clients before outbound delivery so `openclaw message send --channel matrix` restores E2EE in encrypted rooms instead of sending plain events. (#57936) Thanks @gumadeiras.
 
 ## 2026.3.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Docs: https://docs.openclaw.ai
 - Diffs/config: preserve schema-shaped plugin config parsing from `diffsPluginConfigSchema.safeParse()`, so direct callers keep `defaults` and `security` sections instead of receiving flattened tool defaults. (#57904) Thanks @gumadeiras.
 - Diffs: fall back to plain text when `lang` hints are invalid during diff render and viewer hydration, so bad or stale language values no longer break the diff viewer. (#57902) Thanks @gumadeiras.
 - Doctor/plugins: skip false Matrix legacy-helper warnings when no migration plans exist, and keep bundled `enabledByDefault` plugins in the gateway startup set. (#57931) Thanks @dinakars777.
+- Matrix/CLI send: start one-off Matrix send clients before outbound delivery so `openclaw message send --channel matrix` restores E2EE in encrypted rooms instead of sending plain events. (#57936) Thanks @gumadeiras. Fixes #56569.
 
 ## 2026.3.28
 

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -4,7 +4,11 @@ import type { CoreConfig } from "../types.js";
 import { buildPollStartContent, M_POLL_START } from "./poll-types.js";
 import { buildMatrixReactionContent } from "./reaction-common.js";
 import type { MatrixClient } from "./sdk.js";
-import { resolveMediaMaxBytes, withResolvedMatrixClient } from "./send/client.js";
+import {
+  resolveMediaMaxBytes,
+  withResolvedMatrixControlClient,
+  withResolvedMatrixSendClient,
+} from "./send/client.js";
 import {
   buildReplyRelation,
   buildTextContent,
@@ -133,7 +137,7 @@ export async function sendMessageMatrix(
   if (!trimmedMessage && !opts.mediaUrl) {
     throw new Error("Matrix send requires text or media");
   }
-  return await withResolvedMatrixClient(
+  return await withResolvedMatrixSendClient(
     {
       client: opts.client,
       cfg: opts.cfg,
@@ -249,7 +253,7 @@ export async function sendPollMatrix(
   if (!poll.options?.length) {
     throw new Error("Matrix poll requires options");
   }
-  return await withResolvedMatrixClient(
+  return await withResolvedMatrixSendClient(
     {
       client: opts.client,
       cfg: opts.cfg,
@@ -279,7 +283,7 @@ export async function sendTypingMatrix(
   timeoutMs?: number,
   client?: MatrixClient,
 ): Promise<void> {
-  await withResolvedMatrixClient(
+  await withResolvedMatrixControlClient(
     {
       client,
       timeoutMs,
@@ -300,7 +304,7 @@ export async function sendReadReceiptMatrix(
   if (!eventId?.trim()) {
     return;
   }
-  await withResolvedMatrixClient({ client }, async (resolved) => {
+  await withResolvedMatrixControlClient({ client }, async (resolved) => {
     const resolvedRoom = await resolveMatrixRoomId(resolved, roomId);
     await resolved.sendReadReceipt(resolvedRoom, eventId.trim());
   });
@@ -330,7 +334,7 @@ export async function sendSingleTextMessageMatrix(
       `Matrix single-message text exceeds limit (${convertedText.length} > ${singleEventLimit})`,
     );
   }
-  return await withResolvedMatrixClient(
+  return await withResolvedMatrixSendClient(
     {
       client: opts.client,
       cfg: opts.cfg,
@@ -363,7 +367,7 @@ export async function editMessageMatrix(
     accountId?: string;
   } = {},
 ): Promise<string> {
-  return await withResolvedMatrixClient(
+  return await withResolvedMatrixSendClient(
     {
       client: opts.client,
       cfg: opts.cfg,
@@ -416,7 +420,7 @@ export async function reactMatrixMessage(
   opts?: MatrixClient | MatrixClientResolveOpts,
 ): Promise<void> {
   const clientOpts = normalizeMatrixClientResolveOpts(opts);
-  await withResolvedMatrixClient(
+  await withResolvedMatrixSendClient(
     {
       client: clientOpts.client,
       cfg: clientOpts.cfg,

--- a/extensions/matrix/src/matrix/send/client.test.ts
+++ b/extensions/matrix/src/matrix/send/client.test.ts
@@ -34,12 +34,14 @@ vi.mock("../../runtime.js", () => ({
   getMatrixRuntime: () => getMatrixRuntimeMock(),
 }));
 
-let withResolvedMatrixClient: typeof import("./client.js").withResolvedMatrixClient;
+let withResolvedMatrixControlClient: typeof import("./client.js").withResolvedMatrixControlClient;
+let withResolvedMatrixSendClient: typeof import("./client.js").withResolvedMatrixSendClient;
 
-describe("withResolvedMatrixClient", () => {
+describe("matrix send client helpers", () => {
   beforeEach(async () => {
     vi.resetModules();
-    ({ withResolvedMatrixClient } = await import("./client.js"));
+    ({ withResolvedMatrixControlClient, withResolvedMatrixSendClient } =
+      await import("./client.js"));
     primeMatrixClientResolverMocks({
       resolved: {},
     });
@@ -52,7 +54,7 @@ describe("withResolvedMatrixClient", () => {
   it("stops one-off shared clients when no active monitor client is registered", async () => {
     vi.stubEnv("OPENCLAW_GATEWAY_PORT", "18799");
 
-    const result = await withResolvedMatrixClient({ accountId: "default" }, async () => "ok");
+    const result = await withResolvedMatrixSendClient({ accountId: "default" }, async () => "ok");
 
     await expectOneOffSharedMatrixClient({
       prepareForOneOffCalls: 0,
@@ -66,7 +68,7 @@ describe("withResolvedMatrixClient", () => {
     const activeClient = createMockMatrixClient();
     getActiveMatrixClientMock.mockReturnValue(activeClient);
 
-    const result = await withResolvedMatrixClient({ accountId: "default" }, async (client) => {
+    const result = await withResolvedMatrixSendClient({ accountId: "default" }, async (client) => {
       expect(client).toBe(activeClient);
       return "ok";
     });
@@ -85,7 +87,7 @@ describe("withResolvedMatrixClient", () => {
       accountId: "ops",
       resolved: {},
     });
-    await withResolvedMatrixClient({}, async () => {});
+    await withResolvedMatrixSendClient({}, async () => {});
 
     await expectOneOffSharedMatrixClient({
       accountId: "ops",
@@ -104,7 +106,7 @@ describe("withResolvedMatrixClient", () => {
       },
     };
 
-    await withResolvedMatrixClient({ cfg: explicitCfg, accountId: "ops" }, async () => {});
+    await withResolvedMatrixSendClient({ cfg: explicitCfg, accountId: "ops" }, async () => {});
 
     expectExplicitMatrixClientConfig({
       cfg: explicitCfg,
@@ -117,7 +119,7 @@ describe("withResolvedMatrixClient", () => {
     acquireSharedMatrixClientMock.mockResolvedValue(sharedClient);
 
     await expect(
-      withResolvedMatrixClient({ accountId: "default" }, async () => {
+      withResolvedMatrixSendClient({ accountId: "default" }, async () => {
         throw new Error("boom");
       }),
     ).rejects.toThrow("boom");
@@ -129,9 +131,42 @@ describe("withResolvedMatrixClient", () => {
     const sharedClient = createMockMatrixClient();
     acquireSharedMatrixClientMock.mockResolvedValue(sharedClient);
 
-    await withResolvedMatrixClient({ accountId: "default" }, async () => "ok");
+    await withResolvedMatrixSendClient({ accountId: "default" }, async () => "ok");
 
     expect(sharedClient.start).toHaveBeenCalledTimes(1);
     expect(sharedClient.prepareForOneOff).not.toHaveBeenCalled();
+  });
+
+  it("keeps one-off control clients lightweight when no active monitor client is registered", async () => {
+    const result = await withResolvedMatrixControlClient(
+      { accountId: "default" },
+      async () => "ok",
+    );
+
+    await expectOneOffSharedMatrixClient({
+      prepareForOneOffCalls: 0,
+      startCalls: 0,
+      releaseMode: "stop",
+    });
+    expect(result).toBe("ok");
+  });
+
+  it("reuses active monitor clients for control operations without restarting them", async () => {
+    const activeClient = createMockMatrixClient();
+    getActiveMatrixClientMock.mockReturnValue(activeClient);
+
+    const result = await withResolvedMatrixControlClient(
+      { accountId: "default" },
+      async (client) => {
+        expect(client).toBe(activeClient);
+        return "ok";
+      },
+    );
+
+    expect(result).toBe("ok");
+    expect(acquireSharedMatrixClientMock).not.toHaveBeenCalled();
+    expect(activeClient.start).not.toHaveBeenCalled();
+    expect(activeClient.stop).not.toHaveBeenCalled();
+    expect(activeClient.stopAndPersist).not.toHaveBeenCalled();
   });
 });

--- a/extensions/matrix/src/matrix/send/client.test.ts
+++ b/extensions/matrix/src/matrix/send/client.test.ts
@@ -54,7 +54,10 @@ describe("withResolvedMatrixClient", () => {
 
     const result = await withResolvedMatrixClient({ accountId: "default" }, async () => "ok");
 
-    await expectOneOffSharedMatrixClient();
+    await expectOneOffSharedMatrixClient({
+      prepareForOneOffCalls: 0,
+      startCalls: 1,
+    });
     expect(result).toBe("ok");
   });
 
@@ -83,6 +86,8 @@ describe("withResolvedMatrixClient", () => {
 
     await expectOneOffSharedMatrixClient({
       accountId: "ops",
+      prepareForOneOffCalls: 0,
+      startCalls: 1,
     });
   });
 
@@ -114,5 +119,15 @@ describe("withResolvedMatrixClient", () => {
     ).rejects.toThrow("boom");
 
     expect(releaseSharedClientInstanceMock).toHaveBeenCalledWith(sharedClient, "stop");
+  });
+
+  it("starts one-off clients before outbound sends so encrypted rooms can reuse live crypto state", async () => {
+    const sharedClient = createMockMatrixClient();
+    acquireSharedMatrixClientMock.mockResolvedValue(sharedClient);
+
+    await withResolvedMatrixClient({ accountId: "default" }, async () => "ok");
+
+    expect(sharedClient.start).toHaveBeenCalledTimes(1);
+    expect(sharedClient.prepareForOneOff).not.toHaveBeenCalled();
   });
 });

--- a/extensions/matrix/src/matrix/send/client.test.ts
+++ b/extensions/matrix/src/matrix/send/client.test.ts
@@ -57,6 +57,7 @@ describe("withResolvedMatrixClient", () => {
     await expectOneOffSharedMatrixClient({
       prepareForOneOffCalls: 0,
       startCalls: 1,
+      releaseMode: "persist",
     });
     expect(result).toBe("ok");
   });
@@ -72,7 +73,9 @@ describe("withResolvedMatrixClient", () => {
 
     expect(result).toBe("ok");
     expect(acquireSharedMatrixClientMock).not.toHaveBeenCalled();
+    expect(activeClient.start).toHaveBeenCalledTimes(1);
     expect(activeClient.stop).not.toHaveBeenCalled();
+    expect(activeClient.stopAndPersist).not.toHaveBeenCalled();
   });
 
   it("uses the effective account id when auth resolution is implicit", async () => {
@@ -88,6 +91,7 @@ describe("withResolvedMatrixClient", () => {
       accountId: "ops",
       prepareForOneOffCalls: 0,
       startCalls: 1,
+      releaseMode: "persist",
     });
   });
 
@@ -118,7 +122,7 @@ describe("withResolvedMatrixClient", () => {
       }),
     ).rejects.toThrow("boom");
 
-    expect(releaseSharedClientInstanceMock).toHaveBeenCalledWith(sharedClient, "stop");
+    expect(releaseSharedClientInstanceMock).toHaveBeenCalledWith(sharedClient, "persist");
   });
 
   it("starts one-off clients before outbound sends so encrypted rooms can reuse live crypto state", async () => {

--- a/extensions/matrix/src/matrix/send/client.ts
+++ b/extensions/matrix/src/matrix/send/client.ts
@@ -36,5 +36,8 @@ export async function withResolvedMatrixClient<T>(
       readiness: "started",
     },
     run,
+    // Started one-off send clients should flush sync/crypto state before CLI
+    // shutdown paths can tear down the process.
+    "persist",
   );
 }

--- a/extensions/matrix/src/matrix/send/client.ts
+++ b/extensions/matrix/src/matrix/send/client.ts
@@ -19,7 +19,7 @@ export function resolveMediaMaxBytes(
   return undefined;
 }
 
-export async function withResolvedMatrixClient<T>(
+export async function withResolvedMatrixSendClient<T>(
   opts: {
     client?: MatrixClient;
     cfg?: CoreConfig;
@@ -39,5 +39,23 @@ export async function withResolvedMatrixClient<T>(
     // Started one-off send clients should flush sync/crypto state before CLI
     // shutdown paths can tear down the process.
     "persist",
+  );
+}
+
+export async function withResolvedMatrixControlClient<T>(
+  opts: {
+    client?: MatrixClient;
+    cfg?: CoreConfig;
+    timeoutMs?: number;
+    accountId?: string | null;
+  },
+  run: (client: MatrixClient) => Promise<T>,
+): Promise<T> {
+  return await withResolvedRuntimeMatrixClient(
+    {
+      ...opts,
+      readiness: "none",
+    },
+    run,
   );
 }

--- a/extensions/matrix/src/matrix/send/client.ts
+++ b/extensions/matrix/src/matrix/send/client.ts
@@ -31,7 +31,9 @@ export async function withResolvedMatrixClient<T>(
   return await withResolvedRuntimeMatrixClient(
     {
       ...opts,
-      readiness: "prepared",
+      // One-off outbound sends still need a started client so room encryption
+      // state and live crypto sessions are available before sendMessage/sendEvent.
+      readiness: "started",
     },
     run,
   );


### PR DESCRIPTION
## Summary
- start one-off Matrix outbound clients before send operations so encrypted-room CLI sends regain the live crypto state they need
- lock the readiness contract with Matrix send-client regression coverage
- add an unreleased changelog note for the Matrix CLI E2EE fix

## Testing
- OPENCLAW_TEST_PROFILE=serial OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test -- extensions/matrix/src/matrix/send/client.test.ts extensions/matrix/src/matrix/send.test.ts
- OPENCLAW_TEST_PROFILE=serial OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test -- src/infra/outbound/message.channels.test.ts extensions/matrix/src/outbound.test.ts
- pnpm check
- pnpm build

Fixes #56569.
