### PR TITLE
fix(agents): fallback retry image safety and partial execution detection

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -787,6 +787,9 @@ async function agentCommandInternal(
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
             sessionHasHistory: !isNewSession || (await sessionFileHasContent(sessionFile)),
+            primaryProvider: provider,
+            previousFailureReason: runOptions?.previousFailureReason,
+            previousPartialExecution: runOptions?.previousPartialExecution,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -266,4 +266,12 @@ describe("buildPartialExecutionSystemContext", () => {
     });
     expect(ctx).toBeUndefined();
   });
+
+  it("returns undefined when all tool names sanitize to empty", () => {
+    const ctx = buildPartialExecutionSystemContext({
+      toolNames: ["!!!", "<<<>>>"],
+      didSendViaMessagingTool: false,
+    });
+    expect(ctx).toBeUndefined();
+  });
 });

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -2,7 +2,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { resolveFallbackRetryPrompt, sessionFileHasContent } from "./attempt-execution.js";
+import {
+  buildPartialExecutionSystemContext,
+  resolveFallbackRetryPrompt,
+  resolveRetryImages,
+  sessionFileHasContent,
+} from "./attempt-execution.js";
+import type { ImageContent } from "./types.js";
 
 describe("resolveFallbackRetryPrompt", () => {
   const originalBody = "Summarize the quarterly earnings report and highlight key trends.";
@@ -155,5 +161,109 @@ describe("sessionFileHasContent", () => {
     const link = path.join(tmpDir, "link.jsonl");
     await fs.symlink(realFile, link);
     expect(await sessionFileHasContent(link)).toBe(false);
+  });
+});
+
+describe("resolveRetryImages", () => {
+  const fakeImages: ImageContent[] = [{ type: "image", mimeType: "image/png", data: "abc" }];
+
+  it("returns images on first attempt (not a retry)", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: false,
+        previousFailureReason: undefined,
+        primaryProvider: "anthropic",
+        currentProvider: "anthropic",
+      }),
+    ).toEqual(fakeImages);
+  });
+
+  it("strips images on format error retry (same provider)", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: "format",
+        primaryProvider: "anthropic",
+        currentProvider: "anthropic",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves images on rate_limit retry (same provider)", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: "rate_limit",
+        primaryProvider: "anthropic",
+        currentProvider: "anthropic",
+      }),
+    ).toEqual(fakeImages);
+  });
+
+  it("strips images on cross-provider retry", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: "rate_limit",
+        primaryProvider: "anthropic",
+        currentProvider: "openai",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves images when primaryProvider is undefined (no cross-provider detection)", () => {
+    expect(
+      resolveRetryImages({
+        images: fakeImages,
+        isFallbackRetry: true,
+        previousFailureReason: "rate_limit",
+        primaryProvider: undefined,
+        currentProvider: "openai",
+      }),
+    ).toEqual(fakeImages);
+  });
+
+  it("returns undefined when images are undefined regardless of retry state", () => {
+    expect(
+      resolveRetryImages({
+        images: undefined,
+        isFallbackRetry: false,
+        previousFailureReason: undefined,
+        primaryProvider: "anthropic",
+        currentProvider: "anthropic",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("buildPartialExecutionSystemContext", () => {
+  it("returns context string listing tool names", () => {
+    const ctx = buildPartialExecutionSystemContext({
+      toolNames: ["bash", "web_search"],
+      didSendViaMessagingTool: false,
+    });
+    expect(ctx).toContain("bash");
+    expect(ctx).toContain("web_search");
+    expect(ctx).toContain("already executed");
+  });
+
+  it("includes messaging warning when didSendViaMessagingTool is true", () => {
+    const ctx = buildPartialExecutionSystemContext({
+      toolNames: ["send_message"],
+      didSendViaMessagingTool: true,
+    });
+    expect(ctx).toMatch(/messag/i);
+  });
+
+  it("returns undefined when toolNames is empty", () => {
+    const ctx = buildPartialExecutionSystemContext({
+      toolNames: [],
+      didSendViaMessagingTool: false,
+    });
+    expect(ctx).toBeUndefined();
   });
 });

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -552,6 +552,7 @@ export function runAgentAttempt(params: {
     inputProvenance: params.opts.inputProvenance,
     streamParams: params.opts.streamParams,
     agentDir: params.agentDir,
+    suppressPromptImageDetection: isCrossProviderRetry,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
     cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,
     onAgentEvent: params.onAgentEvent,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -343,10 +343,11 @@ export function resolveRetryImages(params: {
 export function buildPartialExecutionSystemContext(
   partialExecution: PartialExecution,
 ): string | undefined {
-  if (partialExecution.toolNames.length === 0) {
+  const safeNames = FailoverError.sanitizeToolNames(partialExecution.toolNames);
+  if (safeNames.length === 0) {
     return undefined;
   }
-  const toolList = partialExecution.toolNames.join(", ");
+  const toolList = safeNames.join(", ");
   const messagingWarning = partialExecution.didSendViaMessagingTool
     ? " At least one of these tools sent a user-visible message — do not resend it."
     : "";

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -381,12 +381,40 @@ export function runAgentAttempt(params: {
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
   sessionHasHistory?: boolean;
+  primaryProvider?: string;
+  previousFailureReason?: FailoverReason;
+  previousPartialExecution?: PartialExecution;
 }) {
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
     isFallbackRetry: params.isFallbackRetry,
     sessionHasHistory: params.sessionHasHistory,
   });
+  const isCrossProviderRetry =
+    params.isFallbackRetry &&
+    !!params.primaryProvider &&
+    params.primaryProvider !== params.providerOverride;
+
+  // Build partial execution warning for same-provider retries only.
+  // Cross-provider retries skip this to avoid leaking tool names (CWE-200).
+  const partialExecContext =
+    !isCrossProviderRetry && params.previousPartialExecution
+      ? buildPartialExecutionSystemContext(params.previousPartialExecution)
+      : undefined;
+
+  const effectiveExtraSystemPrompt = partialExecContext
+    ? [params.opts.extraSystemPrompt, partialExecContext].filter(Boolean).join("\n\n")
+    : params.opts.extraSystemPrompt;
+
+  // Resolve images with failure-mode awareness instead of unconditional stripping.
+  const retryImages = resolveRetryImages({
+    images: params.opts.images,
+    isFallbackRetry: params.isFallbackRetry,
+    previousFailureReason: params.previousFailureReason,
+    primaryProvider: params.primaryProvider,
+    currentProvider: params.providerOverride,
+  });
+
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,
   );
@@ -412,15 +440,15 @@ export function runAgentAttempt(params: {
         thinkLevel: params.resolvedThinkLevel,
         timeoutMs: params.timeoutMs,
         runId: params.runId,
-        extraSystemPrompt: params.opts.extraSystemPrompt,
+        extraSystemPrompt: effectiveExtraSystemPrompt,
         cliSessionId: nextCliSessionId,
         cliSessionBinding:
           nextCliSessionId === cliSessionBinding?.sessionId ? cliSessionBinding : undefined,
         authProfileId,
         bootstrapPromptWarningSignaturesSeen,
         bootstrapPromptWarningSignature,
-        images: params.isFallbackRetry ? undefined : params.opts.images,
-        imageOrder: params.isFallbackRetry ? undefined : params.opts.imageOrder,
+        images: retryImages,
+        imageOrder: retryImages ? params.opts.imageOrder : undefined,
         streamParams: params.opts.streamParams,
       });
     return runCliWithSession(cliSessionBinding?.sessionId).catch(async (err) => {
@@ -507,8 +535,8 @@ export function runAgentAttempt(params: {
     config: params.cfg,
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
-    images: params.isFallbackRetry ? undefined : params.opts.images,
-    imageOrder: params.isFallbackRetry ? undefined : params.opts.imageOrder,
+    images: retryImages,
+    imageOrder: retryImages ? params.opts.imageOrder : undefined,
     clientTools: params.opts.clientTools,
     provider: params.providerOverride,
     model: params.modelOverride,
@@ -520,7 +548,7 @@ export function runAgentAttempt(params: {
     runId: params.runId,
     lane: params.opts.lane,
     abortSignal: params.opts.abortSignal,
-    extraSystemPrompt: params.opts.extraSystemPrompt,
+    extraSystemPrompt: effectiveExtraSystemPrompt,
     inputProvenance: params.opts.inputProvenance,
     streamParams: params.opts.streamParams,
     agentDir: params.agentDir,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -20,13 +20,15 @@ import { resolveBootstrapWarningSignaturesSeen } from "../bootstrap-budget.js";
 import { runCliAgent } from "../cli-runner.js";
 import { clearCliSession, getCliSessionBinding, setCliSessionBinding } from "../cli-session.js";
 import { FailoverError } from "../failover-error.js";
+import type { PartialExecution } from "../failover-error.js";
 import { formatAgentInternalEventsForPrompt } from "../internal-events.js";
 import { isCliProvider } from "../model-selection.js";
+import type { FailoverReason } from "../pi-embedded-helpers.js";
 import { prepareSessionManagerForRun } from "../pi-embedded-runner/session-manager-init.js";
 import { runEmbeddedPiAgent } from "../pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "../skills.js";
 import { resolveAgentRunContext } from "./run-context.js";
-import type { AgentCommandOpts } from "./types.js";
+import type { AgentCommandOpts, ImageContent } from "./types.js";
 
 const log = createSubsystemLogger("agents/agent-command");
 
@@ -299,6 +301,56 @@ export async function persistAcpTurnTranscript(params: {
 
   emitSessionTranscriptUpdate(sessionFile);
   return sessionEntry;
+}
+
+/**
+ * Resolve which images to forward on a fallback retry.
+ *
+ * - First attempt (not a retry): always forward images.
+ * - Same-provider retry with format error: strip (model can't handle them).
+ * - Cross-provider retry: strip (privacy — don't leak to a different provider).
+ * - Same-provider retry for non-format reasons (rate_limit, timeout, etc.): preserve.
+ */
+export function resolveRetryImages(params: {
+  images: ImageContent[] | undefined;
+  isFallbackRetry: boolean;
+  previousFailureReason: FailoverReason | undefined;
+  primaryProvider: string | undefined;
+  currentProvider: string;
+}): ImageContent[] | undefined {
+  if (!params.isFallbackRetry || !params.images) {
+    return params.images;
+  }
+  // Format error: model can't handle the images
+  if (params.previousFailureReason === "format") {
+    return undefined;
+  }
+  // Cross-provider: don't leak images to a different provider
+  if (params.primaryProvider && params.primaryProvider !== params.currentProvider) {
+    return undefined;
+  }
+  return params.images;
+}
+
+/**
+ * Build a system context block warning the fallback model about tools that
+ * already executed in a prior attempt. This prevents replaying non-idempotent
+ * operations (sending messages, shell commands, API calls).
+ *
+ * Only used on same-provider retries. Cross-provider retries skip this to
+ * avoid leaking tool names to a different provider (CWE-200).
+ */
+export function buildPartialExecutionSystemContext(
+  partialExecution: PartialExecution,
+): string | undefined {
+  if (partialExecution.toolNames.length === 0) {
+    return undefined;
+  }
+  const toolList = partialExecution.toolNames.join(", ");
+  const messagingWarning = partialExecution.didSendViaMessagingTool
+    ? " At least one of these tools sent a user-visible message — do not resend it."
+    : "";
+  return `[System: The previous model attempt already executed these tools before failing: ${toolList}.${messagingWarning} Do not repeat actions that already completed successfully.]`;
 }
 
 export function runAgentAttempt(params: {

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  FailoverError,
   coerceToFailoverError,
   describeFailoverError,
   isTimeoutError,
@@ -507,5 +508,64 @@ describe("failover-error", () => {
     const described = describeFailoverError(123);
     expect(described.message).toBe("123");
     expect(described.reason).toBeUndefined();
+  });
+
+  it("carries partialExecution when provided", () => {
+    const err = new FailoverError("timeout", {
+      reason: "timeout",
+      partialExecution: {
+        toolNames: ["bash", "web_search"],
+        didSendViaMessagingTool: true,
+      },
+    });
+    expect(err.partialExecution).toEqual({
+      toolNames: ["bash", "web_search"],
+      didSendViaMessagingTool: true,
+    });
+  });
+
+  it("partialExecution is undefined when not provided", () => {
+    const err = new FailoverError("timeout", { reason: "timeout" });
+    expect(err.partialExecution).toBeUndefined();
+  });
+
+  it("sanitizeToolNames caps at 20 entries and sanitizes characters", () => {
+    const raw = Array.from({ length: 25 }, (_, i) => `tool_${i}`);
+    raw.push("mal!cious<script>");
+    const sanitized = FailoverError.sanitizeToolNames(raw);
+    expect(sanitized.length).toBeLessThanOrEqual(20);
+    expect(sanitized.every((n) => /^[a-zA-Z0-9_-]+$/.test(n))).toBe(true);
+  });
+
+  it("sanitizeToolNames truncates individual names to 100 chars", () => {
+    const long = "a".repeat(150);
+    const sanitized = FailoverError.sanitizeToolNames([long]);
+    expect(sanitized[0].length).toBeLessThanOrEqual(100);
+  });
+
+  it("sanitizeToolNames filters empty strings after sanitization", () => {
+    const sanitized = FailoverError.sanitizeToolNames(["!!!", "", "valid_tool"]);
+    expect(sanitized).toEqual(["valid_tool"]);
+  });
+
+  it("describeFailoverError includes partialExecution when present", () => {
+    const err = new FailoverError("timeout", {
+      reason: "timeout",
+      partialExecution: {
+        toolNames: ["bash"],
+        didSendViaMessagingTool: false,
+      },
+    });
+    const described = describeFailoverError(err);
+    expect(described.partialExecution).toEqual({
+      toolNames: ["bash"],
+      didSendViaMessagingTool: false,
+    });
+  });
+
+  it("describeFailoverError omits partialExecution when absent", () => {
+    const err = new FailoverError("rate limit", { reason: "rate_limit" });
+    const described = describeFailoverError(err);
+    expect(described.partialExecution).toBeUndefined();
   });
 });

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -8,6 +8,11 @@ import {
 
 const ABORT_TIMEOUT_RE = /request was aborted|request aborted/i;
 
+export type PartialExecution = {
+  toolNames: string[];
+  didSendViaMessagingTool: boolean;
+};
+
 export class FailoverError extends Error {
   readonly reason: FailoverReason;
   readonly provider?: string;
@@ -15,6 +20,7 @@ export class FailoverError extends Error {
   readonly profileId?: string;
   readonly status?: number;
   readonly code?: string;
+  readonly partialExecution?: PartialExecution;
 
   constructor(
     message: string,
@@ -26,6 +32,7 @@ export class FailoverError extends Error {
       status?: number;
       code?: string;
       cause?: unknown;
+      partialExecution?: PartialExecution;
     },
   ) {
     super(message, { cause: params.cause });
@@ -36,6 +43,15 @@ export class FailoverError extends Error {
     this.profileId = params.profileId;
     this.status = params.status;
     this.code = params.code;
+    this.partialExecution = params.partialExecution;
+  }
+
+  /** Sanitize tool names from model output before embedding in system prompts. */
+  static sanitizeToolNames(names: string[]): string[] {
+    return names
+      .map((n) => n.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 100))
+      .filter(Boolean)
+      .slice(0, 20);
   }
 }
 
@@ -280,6 +296,7 @@ export function describeFailoverError(err: unknown): {
   reason?: FailoverReason;
   status?: number;
   code?: string;
+  partialExecution?: PartialExecution;
 } {
   if (isFailoverError(err)) {
     return {
@@ -287,6 +304,7 @@ export function describeFailoverError(err: unknown): {
       reason: err.reason,
       status: err.status,
       code: err.code,
+      partialExecution: err.partialExecution,
     };
   }
   const message = getErrorMessage(err) || String(err);

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1631,7 +1631,7 @@ describe("runWithModelFallback", () => {
           throw new FailoverError("rate_limit", {
             reason: "rate_limit",
             partialExecution: {
-              toolNames: ["web_search"],
+              toolNames: ["bash", "web_search"],
               didSendViaMessagingTool: true,
             },
           });
@@ -1639,6 +1639,7 @@ describe("runWithModelFallback", () => {
         return "ok";
       },
     });
+    // bash appears in both attempts; Set dedup should keep it only once
     expect(captured[2]?.previousPartialExecution).toEqual({
       toolNames: ["bash", "web_search"],
       didSendViaMessagingTool: true,

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -8,8 +8,13 @@ import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import { FailoverError } from "./failover-error.js";
 import { isAnthropicBillingError } from "./live-auth-keys.js";
-import { runWithImageModelFallback, runWithModelFallback } from "./model-fallback.js";
+import {
+  type ModelFallbackRunOptions,
+  runWithImageModelFallback,
+  runWithModelFallback,
+} from "./model-fallback.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
 const makeCfg = makeModelFallbackCfg;
@@ -303,7 +308,7 @@ describe("runWithModelFallback", () => {
     expect(result.model).toBe("gpt-4.1-mini");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4-5"],
-      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -341,7 +346,7 @@ describe("runWithModelFallback", () => {
     expect(result.model).toBe("openrouter/deepseek-chat");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-haiku-3-5"],
-      ["openrouter", "openrouter/deepseek-chat"],
+      ["openrouter", "openrouter/deepseek-chat", { previousFailureReason: "rate_limit" }],
     ]);
   });
 
@@ -372,7 +377,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["openai", "gpt-4.1-mini"],
-      ["anthropic", "claude-haiku-3-5"],
+      ["anthropic", "claude-haiku-3-5", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -443,7 +448,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4"],
-      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -675,7 +680,7 @@ describe("runWithModelFallback", () => {
 
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4-5"],
-      ["anthropic", "claude-haiku-3-5"],
+      ["anthropic", "claude-haiku-3-5", { previousFailureReason: "auth" }],
     ]);
   });
 
@@ -871,7 +876,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-sonnet-4"],
-      ["openai", "gpt-4o"],
+      ["openai", "gpt-4o", { previousFailureReason: "rate_limit" }],
     ]);
   });
 
@@ -1138,7 +1143,9 @@ describe("runWithModelFallback", () => {
       expect(result.result).toBe("fallback success");
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-20250514");
-      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5"); // Fallback tried
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5", {
+        previousFailureReason: "rate_limit",
+      }); // Fallback tried
     });
 
     it("allows fallbacks with model version differences within same provider", async () => {
@@ -1167,7 +1174,9 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("groq success");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      });
     });
 
     it("still skips fallbacks when using different provider than config", async () => {
@@ -1198,7 +1207,9 @@ describe("runWithModelFallback", () => {
       expect(result.result).toBe("config primary worked");
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini"); // Original request
-      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-opus-4-6"); // Config primary as final fallback
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-opus-4-6", {
+        previousFailureReason: "auth",
+      }); // Config primary as final fallback
     });
 
     it("uses fallbacks when session model exactly matches config primary", async () => {
@@ -1227,7 +1238,9 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("fallback worked");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      });
     });
   });
 
@@ -1429,7 +1442,9 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
       }); // Rate limit allows attempt
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile"); // Cross-provider works
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      }); // Cross-provider works
     });
 
     it("limits cooldown probes to one per provider before moving to cross-provider fallback", async () => {
@@ -1469,7 +1484,9 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
       });
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        previousFailureReason: "rate_limit",
+      });
     });
 
     it("does not consume transient probe slot when first same-provider probe fails with model_not_found", async () => {
@@ -1509,8 +1526,151 @@ describe("runWithModelFallback", () => {
       });
       expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5", {
         allowTransientCooldownProbe: true,
+        previousFailureReason: "model_not_found",
       });
     });
+  });
+
+  it("passes previousFailureReason from failed attempt to next run call", async () => {
+    const captured: (ModelFallbackRunOptions | undefined)[] = [];
+    let callIndex = 0;
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/sonnet-4.6",
+            fallbacks: ["openai/gpt-5.4"],
+          },
+        },
+      },
+    });
+    await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "sonnet-4.6",
+      run: async (_p, _m, options) => {
+        captured.push(options ? { ...options } : undefined);
+        if (callIndex++ === 0) {
+          throw new FailoverError("rate limit", { reason: "rate_limit" });
+        }
+        return "ok";
+      },
+    });
+    expect(captured[0]?.previousFailureReason).toBeUndefined();
+    expect(captured[1]?.previousFailureReason).toBe("rate_limit");
+  });
+
+  it("passes previousPartialExecution from failed attempt to next run call", async () => {
+    const captured: (ModelFallbackRunOptions | undefined)[] = [];
+    let callIndex = 0;
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/sonnet-4.6",
+            fallbacks: ["openai/gpt-5.4"],
+          },
+        },
+      },
+    });
+    await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "sonnet-4.6",
+      run: async (_p, _m, options) => {
+        captured.push(options ? { ...options } : undefined);
+        if (callIndex++ === 0) {
+          throw new FailoverError("timeout", {
+            reason: "timeout",
+            partialExecution: {
+              toolNames: ["bash"],
+              didSendViaMessagingTool: true,
+            },
+          });
+        }
+        return "ok";
+      },
+    });
+    expect(captured[0]?.previousPartialExecution).toBeUndefined();
+    expect(captured[1]?.previousPartialExecution).toEqual({
+      toolNames: ["bash"],
+      didSendViaMessagingTool: true,
+    });
+  });
+
+  it("merges previousPartialExecution across multiple failed attempts", async () => {
+    const captured: (ModelFallbackRunOptions | undefined)[] = [];
+    let callIndex = 0;
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/sonnet-4.6",
+            fallbacks: ["openai/gpt-5.4", "google/gemini-2.5-pro"],
+          },
+        },
+      },
+    });
+    await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "sonnet-4.6",
+      run: async (_p, _m, options) => {
+        captured.push(options ? { ...options } : undefined);
+        callIndex++;
+        if (callIndex === 1) {
+          throw new FailoverError("timeout", {
+            reason: "timeout",
+            partialExecution: {
+              toolNames: ["bash"],
+              didSendViaMessagingTool: false,
+            },
+          });
+        }
+        if (callIndex === 2) {
+          throw new FailoverError("rate_limit", {
+            reason: "rate_limit",
+            partialExecution: {
+              toolNames: ["web_search"],
+              didSendViaMessagingTool: true,
+            },
+          });
+        }
+        return "ok";
+      },
+    });
+    expect(captured[2]?.previousPartialExecution).toEqual({
+      toolNames: ["bash", "web_search"],
+      didSendViaMessagingTool: true,
+    });
+  });
+
+  it("omits previousPartialExecution when no attempt had partial execution", async () => {
+    const captured: (ModelFallbackRunOptions | undefined)[] = [];
+    let callIndex = 0;
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/sonnet-4.6",
+            fallbacks: ["openai/gpt-5.4"],
+          },
+        },
+      },
+    });
+    await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "sonnet-4.6",
+      run: async (_p, _m, options) => {
+        captured.push(options ? { ...options } : undefined);
+        if (callIndex++ === 0) {
+          throw new FailoverError("rate limit", { reason: "rate_limit" });
+        }
+        return "ok";
+      },
+    });
+    expect(captured[1]?.previousPartialExecution).toBeUndefined();
   });
 });
 

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -819,8 +819,10 @@ export async function runWithModelFallback<T>(params: {
         mergedPartialExecution = mergedPartialExecution
           ? {
               toolNames: [
-                ...mergedPartialExecution.toolNames,
-                ...described.partialExecution.toolNames,
+                ...new Set([
+                  ...mergedPartialExecution.toolNames,
+                  ...described.partialExecution.toolNames,
+                ]),
               ],
               didSendViaMessagingTool:
                 mergedPartialExecution.didSendViaMessagingTool ||

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -15,6 +15,7 @@ import {
 } from "./auth-profiles.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import {
+  type PartialExecution,
   coerceToFailoverError,
   describeFailoverError,
   isFailoverError,
@@ -68,6 +69,8 @@ export function isFallbackSummaryError(err: unknown): err is FallbackSummaryErro
 
 export type ModelFallbackRunOptions = {
   allowTransientCooldownProbe?: boolean;
+  previousFailureReason?: FailoverReason;
+  previousPartialExecution?: PartialExecution;
 };
 
 type ModelFallbackRunFn<T> = (
@@ -606,6 +609,8 @@ export async function runWithModelFallback<T>(params: {
     : null;
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
+  let lastFailureReason: FailoverReason | undefined;
+  let mergedPartialExecution: PartialExecution | undefined;
   const cooldownProbeUsedProviders = new Set<string>();
 
   const hasFallbackCandidates = candidates.length > 1;
@@ -728,6 +733,15 @@ export async function runWithModelFallback<T>(params: {
       }
     }
 
+    // Thread accumulated failure context into runOptions for the next attempt.
+    if (lastFailureReason) {
+      runOptions = {
+        ...runOptions,
+        previousFailureReason: lastFailureReason,
+        ...(mergedPartialExecution ? { previousPartialExecution: mergedPartialExecution } : {}),
+      };
+    }
+
     const attemptRun = await runFallbackAttempt({
       run: params.run,
       ...candidate,
@@ -799,6 +813,21 @@ export async function runWithModelFallback<T>(params: {
         status: described.status,
         code: described.code,
       });
+      // Accumulate failure context for the next candidate's run callback.
+      lastFailureReason = described.reason ?? "unknown";
+      if (described.partialExecution) {
+        mergedPartialExecution = mergedPartialExecution
+          ? {
+              toolNames: [
+                ...mergedPartialExecution.toolNames,
+                ...described.partialExecution.toolNames,
+              ],
+              didSendViaMessagingTool:
+                mergedPartialExecution.didSendViaMessagingTool ||
+                described.partialExecution.didSendViaMessagingTool,
+            }
+          : described.partialExecution;
+      }
       logModelFallbackDecision({
         decision: "candidate_failed",
         runId: params.runId,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -507,6 +507,7 @@ export async function runEmbeddedPiAgent(
             prompt,
             images: params.images,
             imageOrder: params.imageOrder,
+            suppressPromptImageDetection: params.suppressPromptImageDetection,
             clientTools: params.clientTools,
             disableTools: params.disableTools,
             provider,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1472,21 +1472,25 @@ export async function runEmbeddedAttempt(
 
           // Detect and load images referenced in the prompt for vision-capable models.
           // Images are prompt-local only (pi-like behavior).
-          const imageResult = await detectAndLoadPromptImages({
-            prompt: effectivePrompt,
-            workspaceDir: effectiveWorkspace,
-            model: params.model,
-            existingImages: params.images,
-            imageOrder: params.imageOrder,
-            maxBytes: MAX_IMAGE_BYTES,
-            maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
-            workspaceOnly: effectiveFsWorkspaceOnly,
-            // Enforce sandbox path restrictions when sandbox is enabled
-            sandbox:
-              sandbox?.enabled && sandbox?.fsBridge
-                ? { root: sandbox.workspaceDir, bridge: sandbox.fsBridge }
-                : undefined,
-          });
+          // On cross-provider fallback retries, skip detection entirely to prevent local images
+          // referenced in the prompt from being loaded and sent to a different provider.
+          const imageResult = params.suppressPromptImageDetection
+            ? { images: params.images ?? [], detectedRefs: [], loadedCount: 0, skippedCount: 0 }
+            : await detectAndLoadPromptImages({
+                prompt: effectivePrompt,
+                workspaceDir: effectiveWorkspace,
+                model: params.model,
+                existingImages: params.images,
+                imageOrder: params.imageOrder,
+                maxBytes: MAX_IMAGE_BYTES,
+                maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
+                workspaceOnly: effectiveFsWorkspaceOnly,
+                // Enforce sandbox path restrictions when sandbox is enabled
+                sandbox:
+                  sandbox?.enabled && sandbox?.fsBridge
+                    ? { root: sandbox.workspaceDir, bridge: sandbox.fsBridge }
+                    : undefined,
+              });
 
           cacheTrace?.recordStage("prompt:images", {
             prompt: effectivePrompt,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -135,6 +135,12 @@ export type RunEmbeddedPiAgentParams = {
    */
   allowTransientCooldownProbe?: boolean;
   /**
+   * When true, skip prompt-based image detection (detectAndLoadPromptImages).
+   * Used on cross-provider fallback retries to prevent local images referenced
+   * in the prompt from being loaded and sent to a different provider.
+   */
+  suppressPromptImageDetection?: boolean;
+  /**
    * Dispose bundled MCP runtimes when the overall run ends instead of preserving
    * the session-scoped cache. Intended for one-shot local CLI runs that must
    * exit promptly after emitting the final JSON result.


### PR DESCRIPTION
## Summary

- **Failure-mode-aware image handling:** Replace unconditional image stripping on fallback retry with `resolveRetryImages` — only strip on `format` errors (model can't handle images) or cross-provider retries (privacy boundary)
- **Cross-provider image privacy:** Strip user-supplied images when fallback targets a different provider, preventing unintended third-party disclosure
- **Prompt-detected image bypass fix:** Add `suppressPromptImageDetection` to the embedded runner so `detectAndLoadPromptImages` is skipped on cross-provider retries — closes the gap where prompt-referenced local images bypassed the image strip
- **Partial tool execution detection:** Thread `previousFailureReason` and `previousPartialExecution` through `ModelFallbackRunOptions` so the retry callback knows what the prior attempt did; warn fallback models about already-executed tools to prevent replaying non-idempotent operations

Builds on #55632 (prompt preservation for new sessions). Supersedes #44188. Closes #43481, #43492.

## Design boundary

All changes stay at the `runAgentAttempt` / `runWithModelFallback` boundary. The pi-runner internals are not modified beyond accepting the `suppressPromptImageDetection` flag. This is intentional — the runner's internal loops (profile rotation, cooldown skips) are treated as opaque. See #44188 for the full design discussion.

## Changes

### `failover-error.ts`
- New `PartialExecution` type with `toolNames` and `didSendViaMessagingTool`
- `FailoverError` carries optional `partialExecution` field
- `sanitizeToolNames` static method (caps at 20 entries, strips non-alphanumeric, truncates to 100 chars)
- `describeFailoverError` returns `partialExecution` when present

### `model-fallback.ts`
- `ModelFallbackRunOptions` extended with `previousFailureReason` and `previousPartialExecution`
- Fallback loop accumulates failure reason and merges partial execution across attempts (union tool names, OR messaging flag)
- Threaded into `runOptions` for next candidate

### `attempt-execution.ts`
- `resolveRetryImages`: failure-mode-aware image handling (format → strip, cross-provider → strip, same-provider non-format → preserve)
- `buildPartialExecutionSystemContext`: system prompt warning about already-executed tools (same-provider only, CWE-200)
- `runAgentAttempt` extended with `primaryProvider`, `previousFailureReason`, `previousPartialExecution`
- Both CLI and embedded paths use `resolveRetryImages` and `effectiveExtraSystemPrompt`

### Embedded runner (`params.ts`, `run.ts`, `attempt.ts`)
- New `suppressPromptImageDetection` param gates `detectAndLoadPromptImages`

### `agent-command.ts`
- Passes `primaryProvider`, `previousFailureReason`, `previousPartialExecution` from fallback `runOptions` into `runAgentAttempt`

## Test plan

- [x] `resolveRetryImages` — 6 tests: first attempt, format error, rate_limit, cross-provider, undefined provider, undefined images
- [x] `buildPartialExecutionSystemContext` — 3 tests: tool listing, messaging warning, empty tools
- [x] `FailoverError.sanitizeToolNames` — 3 tests: cap at 20, truncate to 100, filter empty
- [x] `FailoverError.partialExecution` — 2 tests: carries when provided, undefined when absent
- [x] `describeFailoverError` — 2 tests: includes/omits partialExecution
- [x] `runWithModelFallback` — 4 tests: threads previousFailureReason, threads previousPartialExecution, merges across attempts, omits when absent
- [x] `pnpm check` — clean (0 warnings, 0 errors)
- [x] `pnpm build` — clean (no type errors, no INEFFECTIVE_DYNAMIC_IMPORT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)