### PR TITLE
fix: restore token mode for Anthropic auth

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -112,15 +112,19 @@ function resolveAnthropicDefaultAuthMode(cfg: OpenClawConfig): AnthropicAuthDefa
     if (entry.mode === "api_key") {
       return "api_key";
     }
-    if (entry.mode === "oauth" || entry.mode === "token") {
+    if (entry.mode === "oauth") {
       return "oauth";
+    }
+    // token mode should route as api_key, not oauth (regression fix for #57956)
+    if (entry.mode === "token") {
+      return "api_key";
     }
   }
 
-  const hasApiKey = anthropicProfiles.some(([, profile]) => profile?.mode === "api_key");
-  const hasOauth = anthropicProfiles.some(
-    ([, profile]) => profile?.mode === "oauth" || profile?.mode === "token",
+  const hasApiKey = anthropicProfiles.some(
+    ([, profile]) => profile?.mode === "api_key" || profile?.mode === "token",
   );
+  const hasOauth = anthropicProfiles.some(([, profile]) => profile?.mode === "oauth");
   if (hasApiKey && !hasOauth) {
     return "api_key";
   }


### PR DESCRIPTION
## Summary

Restore the v2026.3.24 behavior where type: "token" auth profiles are preserved as a distinct mode and routed as API key (x-api-key header) rather than being classified as OAuth (Authorization: Bearer header).

## Changes

- Modified the credential classification logic in `resolveAnthropicDefaultAuthMode()` to preserve "token" mode as distinct from "oauth"
- Token mode profiles now route as API key instead of OAuth

## Testing

Verified that type: "token" profiles now correctly route as API key.

Fixes openclaw/openclaw#57956