### PR TITLE
fix(telegram): enable answer streaming when reasoning is on/hidden

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -465,7 +465,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("keeps block streaming enabled when session reasoning level is on", async () => {
+  it("initializes answer stream even when session reasoning level is on", async () => {
     loadSessionStore.mockReturnValue({
       s1: { reasoningLevel: "on" },
     });
@@ -482,7 +482,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       }),
     });
 
-    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+    expect(createTelegramDraftStream).toHaveBeenCalledTimes(1);
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
         replyOptions: expect.objectContaining({

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -203,9 +203,9 @@ export const dispatchTelegramMessage = async ({
   const forceBlockStreamingForReasoning = resolvedReasoningLevel === "on";
   const streamReasoningDraft = resolvedReasoningLevel === "stream";
   const previewStreamingEnabled = streamMode !== "off";
-  const canStreamAnswerDraft =
-    previewStreamingEnabled && !accountBlockStreamingEnabled && !forceBlockStreamingForReasoning;
-  const canStreamReasoningDraft = canStreamAnswerDraft || streamReasoningDraft;
+  const canStreamAnswerDraft = previewStreamingEnabled && !accountBlockStreamingEnabled;
+  const canStreamReasoningDraft =
+    (canStreamAnswerDraft && !forceBlockStreamingForReasoning) || streamReasoningDraft;
   const draftReplyToMessageId =
     replyToMode !== "off" && typeof msg.message_id === "number" ? msg.message_id : undefined;
   const draftMinInitialChars = DRAFT_MIN_INITIAL_CHARS;


### PR DESCRIPTION

## Summary
- Problem: Telegram answer streaming was entirely suppressed whenever "hidden reasoning" was active (reasoning: "on").
- Why it matters: Restores streaming parity with the Web UI (Fixes #41045).
- What changed: Decoupled the `canStreamAnswerDraft` gate from `forceBlockStreamingForReasoning` in `bot-message-dispatch.ts`.
- Boundary: Reasoning segments are still correctly hidden/suppressed as per user config.
## Change Type
- [x] Bug fix
## Linked Issue
- Fixes #41045
- [x] This PR fixes a bug or regression
## Root Cause
Conservative drafting gate logic in `bot-message-dispatch.ts` was erroneously tied to reasoning visibility instead of just the reasoning stream itself.
## Regression Test Plan
- Unit test in `extensions/telegram/src/bot-message-dispatch.test.ts`. Asserts `createTelegramDraftStream` initializes when `reasoningLevel: "on"`.
## Repro + Verification
### Environment
- OS: Linux (WSL2/Ubuntu)
- Model: `google/gemini-3.1-pro-preview` (active reasoning)
- Channel: Telegram DM
### Repro Config (`~/.openclaw/openclaw.json`)
```json
{
  "channels": {
    "telegram": {
      "enabled": true,
      "botToken": "<REDACTED>",
      "streaming": "partial",
      "blockStreaming": false
    }
  }
```
---

## I actually wrote this bit

I did manually test and quizzed Gemini and reviewed myself as well as discussing implications with IDE integrated Gemini and got it to scan historical commits and it did not identify any potential conflicts with previous changes. I now see streaming telegram messages which is nice :)