### PR TITLE
fix: inter-session messages must not overwrite established external lastRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - Security/dependency audit: bump Hono to `4.12.12` and `@hono/node-server` to `1.19.13` in production resolution paths.
 - Slack/partial streaming: keep the final fallback reply path active when preview finalization fails so stale preview text cannot suppress the actual final answer. (#62859) Thanks @gumadeiras.
 - Plugins/contracts: keep test-only helpers out of production contract barrels, load shared contract harnesses through bundled test surfaces, and harden guardrails so indirect re-exports and canonical `*.test.ts` files stay blocked. (#63311) Thanks @altaywtf.
+- Sessions/routing: preserve established external routes on inter-session announce traffic so `sessions_send` follow-ups do not steal delivery from Telegram, Discord, or other external channels. (#58013) thanks @duqaXxX.
 
 ## 2026.4.8
 

--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -1,6 +1,83 @@
 import { describe, expect, it } from "vitest";
 import { resolveLastChannelRaw, resolveLastToRaw } from "./session-delivery.js";
 
+describe("inter-session lastRoute preservation (fixes #54441)", () => {
+  it("inter-session message does NOT overwrite established Discord lastChannel", () => {
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: "webchat",
+        persistedLastChannel: "discord",
+        sessionKey: "agent:samantha:main",
+        isInterSession: true,
+      }),
+    ).toBe("discord");
+  });
+
+  it("inter-session message does NOT overwrite established Telegram lastChannel", () => {
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: "webchat",
+        persistedLastChannel: "telegram",
+        sessionKey: "agent:main:telegram:direct:123456",
+        isInterSession: true,
+      }),
+    ).toBe("telegram");
+  });
+
+  it("inter-session message does NOT overwrite established external lastTo", () => {
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: "webchat",
+        originatingToRaw: "session:somekey",
+        toRaw: "session:somekey",
+        persistedLastTo: "channel:1234567890",
+        persistedLastChannel: "discord",
+        sessionKey: "agent:samantha:main",
+        isInterSession: true,
+      }),
+    ).toBe("channel:1234567890");
+  });
+
+  it("regular Discord user message DOES update lastChannel normally", () => {
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: "discord",
+        persistedLastChannel: "discord",
+        sessionKey: "agent:main:discord:channel:123",
+        isInterSession: false,
+      }),
+    ).toBe("discord");
+  });
+
+  it("inter-session on a NEW session (no persisted external route) may set webchat", () => {
+    // When there is no established external route, inter-session should not
+    // forcefully block the update — the session has no external route to protect.
+    const result = resolveLastChannelRaw({
+      originatingChannelRaw: "webchat",
+      persistedLastChannel: undefined,
+      sessionKey: "agent:samantha:main",
+      isInterSession: true,
+    });
+    // No external route existed — falls through to normal resolution (webchat or undefined)
+    // The important thing is it does NOT throw and returns a defined or undefined value.
+    expect(result === "webchat" || result === undefined).toBe(true);
+  });
+
+  it("inter-session on session with no persisted lastTo does not crash", () => {
+    const result = resolveLastToRaw({
+      originatingChannelRaw: "webchat",
+      originatingToRaw: "session:somekey",
+      toRaw: "session:somekey",
+      persistedLastTo: undefined,
+      persistedLastChannel: undefined,
+      sessionKey: "agent:samantha:main",
+      isInterSession: true,
+    });
+    // No external route — falls through to normal resolution
+    expect(result === "session:somekey" || result === undefined).toBe(true);
+  });
+});
+
 describe("session delivery direct-session routing overrides", () => {
   it.each([
     "agent:main:direct:user-1",

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -97,6 +97,7 @@ export function resolveLastChannelRaw(params: {
   originatingChannelRaw?: string;
   persistedLastChannel?: string;
   sessionKey?: string;
+  isInterSession?: boolean;
 }): string | undefined {
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
   // WebChat should own reply routing for direct-session UI turns, but only when
@@ -109,6 +110,14 @@ export function resolveLastChannelRaw(params: {
   const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
   const hasEstablishedExternalRoute =
     isExternalRoutingChannel(persistedChannel) || isExternalRoutingChannel(sessionKeyChannelHint);
+  // Inter-session messages (sessions_send) always arrive with channel=webchat,
+  // but must never overwrite an already-established external delivery route.
+  // Without this guard, a sessions_send call resets lastChannel to webchat,
+  // causing subsequent Discord (or other external) deliveries to be lost.
+  // See: https://github.com/openclaw/openclaw/issues/54441
+  if (params.isInterSession && hasEstablishedExternalRoute) {
+    return persistedChannel || sessionKeyChannelHint;
+  }
   if (
     originatingChannel === INTERNAL_MESSAGE_CHANNEL &&
     !hasEstablishedExternalRoute &&
@@ -136,12 +145,20 @@ export function resolveLastToRaw(params: {
   persistedLastTo?: string;
   persistedLastChannel?: string;
   sessionKey?: string;
+  isInterSession?: boolean;
 }): string | undefined {
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
   const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
   const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
   const hasEstablishedExternalRouteForTo =
     isExternalRoutingChannel(persistedChannel) || isExternalRoutingChannel(sessionKeyChannelHint);
+  // Inter-session messages must not replace a persisted external `to` with
+  // webchat-scoped identifiers (e.g. session keys). Preserve the established
+  // external destination so deliveries continue routing to the correct channel.
+  // See: https://github.com/openclaw/openclaw/issues/54441
+  if (params.isInterSession && hasEstablishedExternalRouteForTo && params.persistedLastTo) {
+    return params.persistedLastTo;
+  }
   if (
     originatingChannel === INTERNAL_MESSAGE_CHANNEL &&
     !hasEstablishedExternalRouteForTo &&

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -38,6 +38,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { isInterSessionInputProvenance } from "../../sessions/input-provenance.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
@@ -476,10 +477,12 @@ export async function initSessionState(params: {
   const baseEntry = !isNewSession && freshEntry ? entry : undefined;
   // Track the originating channel/to for announce routing (subagent announce-back).
   const originatingChannelRaw = ctx.OriginatingChannel as string | undefined;
+  const isInterSession = isInterSessionInputProvenance(ctx.InputProvenance);
   const lastChannelRaw = resolveLastChannelRaw({
     originatingChannelRaw,
     persistedLastChannel: baseEntry?.lastChannel,
     sessionKey,
+    isInterSession,
   });
   const lastToRaw = resolveLastToRaw({
     originatingChannelRaw,
@@ -488,6 +491,7 @@ export async function initSessionState(params: {
     persistedLastTo: baseEntry?.lastTo,
     persistedLastChannel: baseEntry?.lastChannel,
     sessionKey,
+    isInterSession,
   });
   const lastAccountIdRaw = resolveSessionDefaultAccountId({
     cfg,


### PR DESCRIPTION
## Problem

Fixes #54441

Inter-session messages (`sessions_send`) always arrive with `channel=webchat`. When `resolveLastChannelRaw` / `resolveLastToRaw` processed these turns they could overwrite a previously-established external `lastChannel`/`lastTo` (e.g. `discord`, `telegram`) with webchat routing identifiers, breaking delivery on all subsequent turns of that session.

**Root cause:** both resolver functions had no visibility into whether the current turn originated from `sessions_send` (inter-session) vs a real user message. The existing guard only protected against the webchat-with-established-external-route case for *direct-session* keys (fix #47745), but not for the general inter-session case.

## Fix

- **`session-delivery.ts`** — add `isInterSession?: boolean` to both `resolveLastChannelRaw` and `resolveLastToRaw`. When `true` **and** an external route is already persisted, return the persisted route unchanged. The fast-path sits above all other logic and adds zero overhead for non-inter-session turns.
- **`session.ts`** — import `isInterSessionInputProvenance` from `src/sessions/input-provenance.ts` and pass `isInterSession: isInterSessionInputProvenance(ctx.InputProvenance)` to both resolvers at the existing call site (~line 440).

Behaviour for sessions with **no** external route established is fully preserved — inter-session can still set the initial route on brand-new sessions.

## Files changed

| File | Change |
|---|---|
| `src/auto-reply/reply/session-delivery.ts` | Add `isInterSession` param + guard to both resolvers |
| `src/auto-reply/reply/session.ts` | Import `isInterSessionInputProvenance`, pass flag at call sites |
| `src/auto-reply/reply/session-delivery.test.ts` | 6 new test cases covering the fix and edge cases |

## Tests

All 18 tests in `session-delivery.test.ts` pass (12 pre-existing + 6 new):

- inter-session message does NOT overwrite established Discord `lastChannel`
- inter-session message does NOT overwrite established Telegram `lastChannel`
- inter-session message does NOT overwrite established external `lastTo`
- regular Discord user message DOES update `lastChannel` normally
- inter-session on a NEW session (no persisted external route) — falls through to normal resolution
- inter-session with no `persistedLastTo` — no crash, falls through