### PR TITLE
feat: configurable sessionTarget on hook dispatches

### DIFF
--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -19565,6 +19565,27 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   description:
                     "Target agent ID for mapping execution when action routing should not use defaults. Use dedicated automation agents to isolate webhook behavior from interactive operator sessions.",
                 },
+                sessionTarget: {
+                  anyOf: [
+                    {
+                      type: "string",
+                      const: "isolated",
+                    },
+                    {
+                      type: "string",
+                      const: "main",
+                    },
+                    {
+                      type: "string",
+                      const: "current",
+                    },
+                    {
+                      type: "string",
+                      pattern: "^session:[^\\s]+$",
+                    },
+                  ],
+                  description: 'Session target: "isolated" | "main" | "current" | "session:<id>"',
+                },
                 sessionKey: {
                   type: "string",
                   title: "Hook Mapping Session Key",

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -1,3 +1,5 @@
+import type { CronSessionTarget } from "../cron/types.js";
+
 export type HookMappingMatch = {
   path?: string;
   source?: string;
@@ -16,6 +18,8 @@ export type HookMappingConfig = {
   name?: string;
   /** Route this hook to a specific agent (unknown ids fall back to the default agent). */
   agentId?: string;
+  /** Session target for the hook dispatch ("isolated" | "main" | "current" | "session:<id>"). Defaults to "isolated". */
+  sessionTarget?: CronSessionTarget;
   sessionKey?: string;
   messageTemplate?: string;
   textTemplate?: string;

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -44,6 +44,15 @@ export const HookMappingSchema = z
     wakeMode: z.union([z.literal("now"), z.literal("next-heartbeat")]).optional(),
     name: z.string().optional(),
     agentId: z.string().optional(),
+    sessionTarget: z
+      .union([
+        z.literal("isolated"),
+        z.literal("main"),
+        z.literal("current"),
+        z.string().regex(/^session:[^\s]+$/),
+      ])
+      .describe('Session target: "isolated" | "main" | "current" | "session:<id>"')
+      .optional(),
     sessionKey: z.string().optional().register(sensitive),
     messageTemplate: z.string().optional(),
     textTemplate: z.string().optional(),

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { CONFIG_PATH, type HookMappingConfig, type HooksConfig } from "../config/config.js";
+import type { CronSessionTarget } from "../cron/types.js";
 import { importFileModule, resolveFunctionModuleExport } from "../hooks/module-loader.js";
 import type { HookMessageChannel } from "./hooks.js";
 
@@ -12,6 +13,7 @@ export type HookMappingResolved = {
   wakeMode?: "now" | "next-heartbeat";
   name?: string;
   agentId?: string;
+  sessionTarget?: CronSessionTarget;
   sessionKey?: string;
   messageTemplate?: string;
   textTemplate?: string;
@@ -49,6 +51,7 @@ export type HookAction =
       name?: string;
       agentId?: string;
       wakeMode: "now" | "next-heartbeat";
+      sessionTarget?: CronSessionTarget;
       sessionKey?: string;
       deliver?: boolean;
       allowUnsafeExternalContent?: boolean;
@@ -89,6 +92,7 @@ type HookTransformResult = Partial<{
   agentId: string;
   wakeMode: "now" | "next-heartbeat";
   name: string;
+  sessionTarget: CronSessionTarget;
   sessionKey: string;
   deliver: boolean;
   allowUnsafeExternalContent: boolean;
@@ -182,6 +186,20 @@ export async function applyHookMappings(
   return null;
 }
 
+/** Validate and normalize sessionTarget — drop invalid values to undefined (defaults to "isolated"). */
+function validateSessionTarget(
+  value: CronSessionTarget | undefined,
+): CronSessionTarget | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const v = typeof value === "string" ? value.trim() : "";
+  if (v === "isolated" || v === "main" || v === "current" || /^session:[^\s]+$/.test(v)) {
+    return v as CronSessionTarget;
+  }
+  return undefined;
+}
+
 function normalizeHookMapping(
   mapping: HookMappingConfig,
   index: number,
@@ -207,6 +225,7 @@ function normalizeHookMapping(
     wakeMode,
     name: mapping.name,
     agentId: mapping.agentId?.trim() || undefined,
+    sessionTarget: validateSessionTarget(mapping.sessionTarget),
     sessionKey: mapping.sessionKey,
     messageTemplate: mapping.messageTemplate,
     textTemplate: mapping.textTemplate,
@@ -260,6 +279,7 @@ function buildActionFromMapping(
       name: renderOptional(mapping.name, ctx),
       agentId: mapping.agentId,
       wakeMode: mapping.wakeMode ?? "now",
+      sessionTarget: mapping.sessionTarget,
       sessionKey: renderOptional(mapping.sessionKey, ctx),
       deliver: mapping.deliver,
       allowUnsafeExternalContent: mapping.allowUnsafeExternalContent,
@@ -298,6 +318,7 @@ function mergeAction(
     wakeMode,
     name: override.name ?? baseAgent?.name,
     agentId: override.agentId ?? baseAgent?.agentId,
+    sessionTarget: validateSessionTarget(override.sessionTarget) ?? baseAgent?.sessionTarget,
     sessionKey: override.sessionKey ?? baseAgent?.sessionKey,
     deliver: typeof override.deliver === "boolean" ? override.deliver : baseAgent?.deliver,
     allowUnsafeExternalContent:

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -8,6 +8,7 @@ import {
   extractHookToken,
   isHookAgentAllowed,
   normalizeHookDispatchSessionKey,
+  resolveHookRuntimeSessionKey,
   resolveHookSessionKey,
   resolveHookTargetAgentId,
   normalizeAgentPayload,
@@ -313,6 +314,81 @@ describe("gateway hooks helpers", () => {
         targetAgentId: "hooks",
       }),
     ).toBe("agent:hooks:slack:channel:c123");
+  });
+
+  test("resolveHookRuntimeSessionKey agent-scopes plain session keys", () => {
+    expect(
+      resolveHookRuntimeSessionKey({
+        sessionKey: "foo",
+        targetAgentId: "dev",
+      }),
+    ).toBe("agent:dev:foo");
+  });
+
+  test("resolveHookRuntimeSessionKey preserves already agent-scoped keys", () => {
+    expect(
+      resolveHookRuntimeSessionKey({
+        sessionKey: "agent:dev:bar",
+        targetAgentId: "dev",
+      }),
+    ).toBe("agent:dev:bar");
+  });
+
+  test("resolveHookRuntimeSessionKey rebinds cross-agent keys and scopes", () => {
+    expect(
+      resolveHookRuntimeSessionKey({
+        sessionKey: "agent:main:slack:channel:c123",
+        targetAgentId: "hooks",
+      }),
+    ).toBe("agent:hooks:slack:channel:c123");
+  });
+
+  test("resolveHookRuntimeSessionKey scopes main alias to agent", () => {
+    expect(
+      resolveHookRuntimeSessionKey({
+        sessionKey: "main",
+        targetAgentId: "dev",
+      }),
+    ).toBe("agent:dev:main");
+  });
+
+  test("resolveHookRuntimeSessionKey falls back to defaultAgentId when targetAgentId is omitted", () => {
+    expect(
+      resolveHookRuntimeSessionKey({
+        sessionKey: "foo",
+        targetAgentId: undefined,
+        defaultAgentId: "main",
+      }),
+    ).toBe("agent:main:foo");
+  });
+
+  test("resolveHookRuntimeSessionKey returns unscoped key when both agentIds are omitted", () => {
+    expect(
+      resolveHookRuntimeSessionKey({
+        sessionKey: "foo",
+        targetAgentId: undefined,
+      }),
+    ).toBe("foo");
+  });
+
+  test("resolveHookRuntimeSessionKey canonicalizes main alias when cfg.session.mainKey differs", () => {
+    expect(
+      resolveHookRuntimeSessionKey({
+        sessionKey: "main",
+        targetAgentId: "dev",
+        cfg: { session: { mainKey: "primary" } },
+      }),
+    ).toBe("agent:dev:primary");
+  });
+
+  test("resolveHookRuntimeSessionKey canonicalizes agent:id:main to configured mainKey", () => {
+    expect(
+      resolveHookRuntimeSessionKey({
+        sessionKey: "agent:dev:main",
+        targetAgentId: "dev",
+        cfg: { session: { mainKey: "work" } },
+      }),
+    ).toBe("agent:dev:work");
   });
 
   test("resolveHooksConfig validates defaultSessionKey and generated fallback against prefixes", () => {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -4,8 +4,14 @@ import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js";
+import type { CronSessionTarget } from "../cron/types.js";
 import { readJsonBodyWithLimit, requestBodyErrorToText } from "../infra/http-body.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import {
+  normalizeAgentId,
+  parseAgentSessionKey,
+  toAgentStoreSessionKey,
+} from "../routing/session-key.js";
 import type { HookExternalContentSource } from "../security/external-content.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { type HookMappingResolved, resolveHookMappings } from "./hooks-mapping.js";
@@ -205,6 +211,7 @@ export type HookAgentPayload = {
   agentId?: string;
   idempotencyKey?: string;
   wakeMode: "now" | "next-heartbeat";
+  sessionTarget?: CronSessionTarget;
   sessionKey?: string;
   deliver: boolean;
   channel: HookMessageChannel;
@@ -352,6 +359,45 @@ export function normalizeHookDispatchSessionKey(params: {
   return `agent:${targetAgentId}:${parsed.rest}`;
 }
 
+/**
+ * Resolve the full runtime session key that will actually be used by
+ * runCronIsolatedAgentTurn. This applies both the agent-scoping normalization
+ * (toAgentStoreSessionKey) and the dispatch-level rebinding, matching the key
+ * that the cron runner will ultimately use. Use this for prefix policy checks
+ * so that policy is enforced against the actual runtime key, not a
+ * pre-normalization intermediate.
+ */
+export function resolveHookRuntimeSessionKey(params: {
+  sessionKey: string;
+  targetAgentId: string | undefined;
+  defaultAgentId?: string | undefined;
+  cfg?: { session?: { mainKey?: string } };
+}): string {
+  // First apply the dispatch-level normalization (agent rebinding).
+  const dispatched = normalizeHookDispatchSessionKey(params);
+  // When targetAgentId is omitted, the cron runner falls back to the default
+  // agent (resolveDefaultAgentId). Use the same fallback for policy checks so
+  // the prefix is validated against the actual runtime key.
+  const effectiveAgentId = params.targetAgentId ?? params.defaultAgentId;
+  if (!effectiveAgentId) {
+    return dispatched;
+  }
+  // Apply the same agent-store scoping that resolveCronAgentSessionKey uses.
+  // This ensures plain keys like "foo" become "agent:<id>:foo" and already-scoped
+  // keys are preserved, matching the runtime behavior.
+  const storeKey = toAgentStoreSessionKey({
+    agentId: effectiveAgentId,
+    requestKey: dispatched,
+  });
+  // Canonicalize main-key aliases (e.g. "agent:<id>:main" → "agent:<id>:primary"
+  // when session.mainKey="primary") so policy checks match the final runtime key.
+  return canonicalizeMainSessionAlias({
+    cfg: params.cfg,
+    agentId: effectiveAgentId,
+    sessionKey: storeKey,
+  });
+}
+
 export function normalizeAgentPayload(payload: Record<string, unknown>):
   | {
       ok: true;
@@ -383,6 +429,15 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
   if (modelRaw !== undefined && !model) {
     return { ok: false, error: "model required" };
   }
+  const sessionTargetRaw = payload.sessionTarget;
+  let sessionTarget: CronSessionTarget | undefined;
+  if (typeof sessionTargetRaw === "string" && sessionTargetRaw.trim()) {
+    const v = sessionTargetRaw.trim();
+    if (v === "isolated" || v === "main" || v === "current" || /^session:[^\s]+$/.test(v)) {
+      sessionTarget = v as CronSessionTarget;
+    }
+    // Invalid values are silently ignored → defaults to "isolated" at dispatch
+  }
   const deliver = resolveHookDeliver(payload.deliver);
   const thinkingRaw = payload.thinking;
   const thinking =
@@ -400,6 +455,7 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
       agentId,
       idempotencyKey,
       wakeMode,
+      sessionTarget,
       sessionKey,
       deliver,
       channel,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -13,6 +13,7 @@ import { CANVAS_WS_PATH, handleA2uiHttpRequest } from "../canvas-host/a2ui.js";
 import type { CanvasHostHandler } from "../canvas-host/server.js";
 import { listBundledChannelPlugins } from "../channels/plugins/bundled.js";
 import { loadConfig } from "../config/config.js";
+import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveHookExternalContentSource as resolveHookExternalContentSourceFromSession } from "../security/external-content.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
@@ -51,6 +52,7 @@ import {
   normalizeWakePayload,
   readJsonBody,
   normalizeHookDispatchSessionKey,
+  resolveHookRuntimeSessionKey,
   resolveHookSessionKey,
   resolveHookTargetAgentId,
   resolveHookChannel,
@@ -551,16 +553,68 @@ export function createHooksRequestHandler(
         sendJson(res, 400, { ok: false, error: getHookAgentPolicyError() });
         return true;
       }
-      const sessionKey = resolveHookSessionKey({
-        hooksConfig,
-        source: "request",
-        sessionKey: normalized.value.sessionKey,
-      });
-      if (!sessionKey.ok) {
-        sendJson(res, 400, { ok: false, error: sessionKey.error });
-        return true;
+      // Normalize "current" to "isolated" before policy checks — hooks have no active
+      // conversation context, so "current" is equivalent to "isolated".
+      const requestSessionTarget =
+        normalized.value.sessionTarget === "current" ? "isolated" : normalized.value.sessionTarget;
+      // sessionTarget values other than "isolated" override the policy-checked sessionKey
+      // in dispatchAgentHook. Enforce session policy for all non-isolated targets from requests.
+      if (requestSessionTarget && requestSessionTarget !== "isolated") {
+        if (!hooksConfig.sessionPolicy.allowRequestSessionKey) {
+          sendJson(res, 400, {
+            ok: false,
+            error: 'sessionTarget other than "isolated" requires hooks.allowRequestSessionKey=true',
+          });
+          return true;
+        }
+      }
+      const effectiveIsolated = !requestSessionTarget || requestSessionTarget === "isolated";
+      // Only validate request sessionKey when the target is "isolated" — for non-isolated
+      // targets (main, session:<id>) dispatch overrides the session key, so the request
+      // sessionKey is irrelevant and should not cause spurious 400 rejections.
+      let resolvedSessionKeyValue = "";
+      if (effectiveIsolated) {
+        const sessionKey = resolveHookSessionKey({
+          hooksConfig,
+          source: "request",
+          sessionKey: normalized.value.sessionKey,
+        });
+        if (!sessionKey.ok) {
+          sendJson(res, 400, { ok: false, error: sessionKey.error });
+          return true;
+        }
+        resolvedSessionKeyValue = sessionKey.value;
       }
       const targetAgentId = resolveHookTargetAgentId(hooksConfig, normalized.value.agentId);
+      // For "session:<id>" and "main", validate the resolved session key against prefix policy.
+      // Done after agent resolution so the check covers the agent-normalized key.
+      if (requestSessionTarget?.startsWith("session:")) {
+        const extractedId = requestSessionTarget.slice("session:".length);
+        const runtimeKey = resolveHookRuntimeSessionKey({
+          sessionKey: extractedId,
+          targetAgentId,
+          defaultAgentId: hooksConfig.agentPolicy.defaultAgentId,
+          cfg: loadConfig(),
+        });
+        const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
+        if (allowedPrefixes && !isSessionKeyAllowedByPrefix(runtimeKey, allowedPrefixes)) {
+          sendJson(res, 400, { ok: false, error: getHookSessionKeyPrefixError(allowedPrefixes) });
+          return true;
+        }
+      } else if (requestSessionTarget === "main") {
+        const mainKey = resolveMainSessionKeyFromConfig();
+        const runtimeKey = resolveHookRuntimeSessionKey({
+          sessionKey: mainKey,
+          targetAgentId,
+          defaultAgentId: hooksConfig.agentPolicy.defaultAgentId,
+          cfg: loadConfig(),
+        });
+        const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
+        if (allowedPrefixes && !isSessionKeyAllowedByPrefix(runtimeKey, allowedPrefixes)) {
+          sendJson(res, 400, { ok: false, error: getHookSessionKeyPrefixError(allowedPrefixes) });
+          return true;
+        }
+      }
       const replayKey = buildHookReplayCacheKey({
         pathKey: "agent",
         token,
@@ -572,6 +626,7 @@ export function createHooksRequestHandler(
           message: normalized.value.message,
           name: normalized.value.name,
           wakeMode: normalized.value.wakeMode,
+          sessionTarget: normalized.value.sessionTarget ?? "isolated",
           deliver: normalized.value.deliver,
           channel: normalized.value.channel,
           to: normalized.value.to ?? null,
@@ -585,17 +640,21 @@ export function createHooksRequestHandler(
         sendJson(res, 200, { ok: true, runId: cachedRunId });
         return true;
       }
+      // For isolated targets, validate the normalized dispatch session key against prefix policy.
+      // Non-isolated targets have already been validated above against the actual runtime key.
       const normalizedDispatchSessionKey = normalizeHookDispatchSessionKey({
-        sessionKey: sessionKey.value,
+        sessionKey: resolvedSessionKeyValue,
         targetAgentId,
       });
-      const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
-      if (
-        allowedPrefixes &&
-        !isSessionKeyAllowedByPrefix(normalizedDispatchSessionKey, allowedPrefixes)
-      ) {
-        sendJson(res, 400, { ok: false, error: getHookSessionKeyPrefixError(allowedPrefixes) });
-        return true;
+      if (effectiveIsolated) {
+        const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
+        if (
+          allowedPrefixes &&
+          !isSessionKeyAllowedByPrefix(normalizedDispatchSessionKey, allowedPrefixes)
+        ) {
+          sendJson(res, 400, { ok: false, error: getHookSessionKeyPrefixError(allowedPrefixes) });
+          return true;
+        }
       }
       const runId = dispatchAgentHook({
         ...normalized.value,
@@ -658,6 +717,38 @@ export function createHooksRequestHandler(
             sessionKey: sessionKey.value,
             targetAgentId,
           });
+          // Validate session:<id> and "main" targets against allowedSessionKeyPrefixes.
+          // Normalize through agent rebinding first so the check covers the final key.
+          const mappingSessionTarget = mapped.action.sessionTarget;
+          if (mappingSessionTarget?.startsWith("session:")) {
+            const extractedId = mappingSessionTarget.slice("session:".length);
+            const runtimeKey = resolveHookRuntimeSessionKey({
+              sessionKey: extractedId,
+              targetAgentId,
+            });
+            const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
+            if (allowedPrefixes && !isSessionKeyAllowedByPrefix(runtimeKey, allowedPrefixes)) {
+              sendJson(res, 400, {
+                ok: false,
+                error: getHookSessionKeyPrefixError(allowedPrefixes),
+              });
+              return true;
+            }
+          } else if (mappingSessionTarget === "main") {
+            const mainKey = resolveMainSessionKeyFromConfig();
+            const runtimeKey = resolveHookRuntimeSessionKey({
+              sessionKey: mainKey,
+              targetAgentId,
+            });
+            const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
+            if (allowedPrefixes && !isSessionKeyAllowedByPrefix(runtimeKey, allowedPrefixes)) {
+              sendJson(res, 400, {
+                ok: false,
+                error: getHookSessionKeyPrefixError(allowedPrefixes),
+              });
+              return true;
+            }
+          }
           const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
           if (
             allowedPrefixes &&
@@ -677,6 +768,7 @@ export function createHooksRequestHandler(
               message: mapped.action.message,
               name: mapped.action.name ?? "Hook",
               wakeMode: mapped.action.wakeMode,
+              sessionTarget: mapped.action.sessionTarget ?? "isolated",
               deliver: resolveHookDeliver(mapped.action.deliver),
               channel,
               to: mapped.action.to ?? null,
@@ -696,6 +788,7 @@ export function createHooksRequestHandler(
             idempotencyKey,
             agentId: targetAgentId,
             wakeMode: mapped.action.wakeMode,
+            sessionTarget: mapped.action.sessionTarget,
             sessionKey: normalizedDispatchSessionKey,
             deliver: resolveHookDeliver(mapped.action.deliver),
             channel,

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -7,7 +7,13 @@ import type { CronJob } from "../../cron/types.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
-import { type HookAgentDispatchPayload, type HooksConfigResolved } from "../hooks.js";
+import {
+  isSessionKeyAllowedByPrefix,
+  normalizeHookDispatchSessionKey,
+  resolveHookRuntimeSessionKey,
+  type HookAgentDispatchPayload,
+  type HooksConfigResolved,
+} from "../hooks.js";
 import { createHooksRequestHandler, type HookClientIpConfig } from "../server-http.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
@@ -38,8 +44,59 @@ export function createGatewayHooksRequestHandler(params: {
   };
 
   const dispatchAgentHook = (value: HookAgentDispatchPayload) => {
-    const sessionKey = value.sessionKey;
     const mainSessionKey = resolveMainSessionKeyFromConfig();
+    const rawTarget = value.sessionTarget ?? "isolated";
+
+    // "current" has no meaning for hooks (no active conversation context) —
+    // falls back to default session resolution (mapping sessionKey if configured, otherwise fresh UUID).
+    const resolvedTarget = rawTarget === "current" ? "isolated" : rawTarget;
+    if (rawTarget === "current") {
+      logHooks.info(
+        `hook "${value.name}": sessionTarget "current" has no effect in hook context — using default session resolution`,
+      );
+    }
+
+    // Defense-in-depth: validate "session:<id>" and "main" targets against prefix policy.
+    // Primary enforcement is in server-http.ts, but guard here in case dispatchAgentHook
+    // is reached from a future code path that skips the HTTP-layer checks.
+    // Note: allowRequestSessionKey is intentionally NOT checked here — this function
+    // handles both request-sourced and mapping-sourced dispatches, and mappings are
+    // trusted operator config that should not be gated by request policy.
+    // On policy rejection, downgrade to "isolated" (fresh session) and log a warning.
+    let policyTarget = resolvedTarget;
+    if (resolvedTarget.startsWith("session:") || resolvedTarget === "main") {
+      const hooksConfig = getHooksConfig();
+      if (hooksConfig) {
+        const keyToCheck = resolveHookRuntimeSessionKey({
+          sessionKey:
+            resolvedTarget === "main" ? mainSessionKey : resolvedTarget.slice("session:".length),
+          targetAgentId: value.agentId,
+          defaultAgentId: hooksConfig.agentPolicy.defaultAgentId,
+          cfg: loadConfig(),
+        });
+        const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
+        if (allowedPrefixes && !isSessionKeyAllowedByPrefix(keyToCheck, allowedPrefixes)) {
+          logHooks.warn(
+            `hook "${value.name}": sessionTarget "${resolvedTarget}" rejected by prefix policy; falling back to isolated`,
+          );
+          policyTarget = "isolated";
+        }
+      }
+    }
+
+    // Resolve sessionKey based on sessionTarget:
+    // "main" → use canonical main session key (runs in main session via cron runner)
+    // "session:<id>" → use the explicit session id
+    // "isolated" / default → use mapping sessionKey or generate unique key
+    const sessionKey = normalizeHookDispatchSessionKey({
+      sessionKey:
+        policyTarget === "main"
+          ? mainSessionKey
+          : policyTarget.startsWith("session:")
+            ? policyTarget.slice("session:".length)
+            : value.sessionKey,
+      targetAgentId: value.agentId,
+    });
     const jobId = randomUUID();
     const now = Date.now();
     const delivery = value.deliver
@@ -57,7 +114,7 @@ export function createGatewayHooksRequestHandler(params: {
       createdAtMs: now,
       updatedAtMs: now,
       schedule: { kind: "at", at: new Date(now).toISOString() },
-      sessionTarget: "isolated",
+      sessionTarget: policyTarget,
       wakeMode: value.wakeMode,
       payload: {
         kind: "agentTurn",


### PR DESCRIPTION
## Motivation

Webhook hooks currently hardcode `sessionTarget: "isolated"`, so every invocation spawns a fresh session. This makes it impossible to deliver webhook messages into an agent's existing session — e.g., routing GitHub PR events into a dev agent's ongoing conversation, or building stateful workflows where multiple webhooks contribute to the same context.

Closes #42621

## Changes

Adds a `sessionTarget` field to hook mapping config with four modes:
- `"isolated"` (default) — fresh session per invocation (current behavior, no breaking change)
- `"main"` — delivers into the agent's canonical main session
- `"session:<id>"` — targets a specific named session (validated against `allowedSessionKeyPrefixes`)
- `"current"` — normalized to `"isolated"` in hook context (no active conversation)

### Implementation details

- **Config & schema:** `sessionTarget` added to `HookMappingConfig` with strict Zod union validation (rejects bare `session:` and whitespace-only suffixes)
- **Session policy enforcement:** `session:<id>` targets validated against `allowedSessionKeyPrefixes` after agent rebinding normalization, on both request and mapping paths. `"main"` gated by `allowRequestSessionKey` on the request path. Defense-in-depth check in `dispatchAgentHook` for prefix policy.
- **Dispatch:** threaded through `normalizeHookMapping`, `mergeAction`, `HookTransformResult`, and gateway dispatch to cron job creation

### Security considerations

- Non-isolated targets from external requests require `allowRequestSessionKey: true`
- `session:<id>` prefix validation runs on the agent-normalized key (post-rebinding), preventing namespace bypass via keys like `session:agent:hooks:foo`
- Mapping-sourced targets are trusted operator config — `allowRequestSessionKey` is intentionally not enforced for mappings

## Test plan

- [x] Existing hook tests pass (no behavioral change for default `"isolated"`)
- [ ] Manual test: hook with `sessionTarget: "main"` dispatches into main session
- [ ] Manual test: hook with `sessionTarget: "session:abc"` reuses named session
- [ ] Verify invalid `sessionTarget` values rejected by Zod schema