### PR TITLE
fix(msteams): preserve outbound activity types

### DIFF
--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -139,8 +139,11 @@ function createSendContext(params: {
         return { id: "unknown" };
       }
 
+      const activityType =
+        typeof msg.type === "string" && msg.type.trim().length > 0 ? msg.type : "message";
+
       return await apiClient.conversations.activities(params.conversationId).create({
-        type: "message",
+        type: activityType,
         ...msg,
         from: params.bot?.id
           ? { id: params.bot.id, name: params.bot.name ?? "", role: "bot" }
@@ -149,7 +152,7 @@ function createSendContext(params: {
           id: params.conversationId,
           conversationType: params.conversationType ?? "personal",
         },
-        ...(params.replyToActivityId && !msg.replyToId
+        ...(activityType === "message" && params.replyToActivityId && !msg.replyToId
           ? { replyToId: params.replyToActivityId }
           : {}),
       } as Parameters<


### PR DESCRIPTION
## Summary

- Problem: The Microsoft Teams SDK adapter forces every outbound activity sent via sendActivity() to `type: "message"`, even when the original outbound activity is a different Bot Framework activity type.
- Why it matters: This can interfere with Teams activity lifecycle behavior such as typing indicators and other non-message activity handling, and may contribute to stream-like partial visibility or lifecycle inconsistencies reported by users.
- What changed: Preserve the outbound activity's original `type` when present, defaulting to `message` only when no valid type is supplied; only attach `replyToId` automatically for actual message activities.
- What did NOT change (scope boundary): This PR does not redesign the broader blockStreaming pipeline or claim to fully solve every Teams duplicate/final-delivery symptom.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The Teams SDK adapter hard-codes outbound activity type to `message` inside `createSendContext().sendActivity()`.
- Missing detection / guardrail: No adapter-level test appears to assert preservation of non-message outbound activity types.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: Unknown.
- If unknown, what was ruled out: The issue is not explained solely by user config because the current source code unconditionally forces `type: "message"` in the adapter path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/msteams/src/sdk.test.ts` or equivalent adapter-focused test file.
- Scenario the test should lock in: When `sendActivity()` is called with a non-message activity such as `{ type: "typing" }`, the created Teams activity should preserve `type: "typing"` instead of coercing it to `message`.
- Why this is the smallest reliable guardrail: The bug originates inside a single adapter helper and can be validated without a full live Teams environment.
- Existing test that already covers this (if any): Unknown.
- If no new test is added, why not: NOT_ENOUGH_INFO

## User-visible / Behavior Changes

- Microsoft Teams outbound non-message activity types are preserved instead of being coerced to `message`.
- This may improve typing indicator behavior and other Teams activity-lifecycle handling.

## Diagram (if applicable)

```text
Before:
[adapter gets typing activity] -> [forces type=message] -> [Teams receives wrong activity kind]

After:
[adapter gets typing activity] -> [preserves type=typing] -> [Teams receives intended activity kind]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3 (arm64)
- Runtime/container: local Homebrew/npm-style installation
- Model/provider: openai-codex/gpt-5.4
- Integration/channel (if any): Microsoft Teams
- Relevant config (redacted): Teams configured; `blockStreaming: true` observed during investigation

### Steps

1. Configure Microsoft Teams and run OpenClaw.
2. Trigger an outbound non-message activity path in the Teams adapter (for example a typing activity).
3. Observe that current code coerces the outbound activity to `message` before sending.

### Expected

- The outbound activity type should be preserved.

### Actual

- The adapter forces outbound activity type to `message`.

## Evidence

- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Confirmed the current upstream source contains the forced `type: "message"` logic in `extensions/msteams/src/sdk.ts`; confirmed a local hotfix can preserve the original activity type without breaking module import.
- Edge cases checked: `replyToId` should only be auto-attached for message activities.
- What you did **not** verify: Full live Teams end-to-end validation against every stop/typing/duplicate symptom.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Some Teams flows may rely unintentionally on message coercion.
  - Mitigation: Add focused adapter tests for message and non-message activity types.
