### PR TITLE
fix(cache): compact newest tool results first to preserve prompt cache prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/runtime: reuse compatible active registries for `web_search` and `web_fetch` provider snapshot resolution so repeated runtime reads do not re-import the same bundled plugin set on each agent message. Related #48380.
 - Infra/tailscale: ignore `OPENCLAW_TEST_TAILSCALE_BINARY` outside explicit test environments and block it from workspace `.env`, so test-only binary overrides cannot be injected through trusted repository state. (#58468) Thanks @eleqtrizit.
 - Plugins/OpenAI: enable reference-image edits for `gpt-image-1` by routing edit calls to `/images/edits` with multipart image uploads, and update image-generation capability/docs metadata accordingly. Thanks @steipete.
+- Cache/context guard: compact newest tool results first so the cached prompt prefix stays byte-identical and avoids full re-tokenization every turn past the 75% context threshold. (#58036) Thanks @bcherny.
 - Agents/tools: include value-shape hints in missing-parameter tool errors so dropped, empty-string, and wrong-type write payloads are easier to diagnose from logs. (#55317) Thanks @priyansh19.
 - Android/assistant: keep queued App Actions prompts pending when auto-send enqueue is rejected, so transient chat-health drops do not silently lose the assistant request. Thanks @obviyus.
 - Plugins/startup: migrate legacy `tools.web.search.<provider>` config before strict startup validation, and record plugin failure phase/timestamp so degraded plugin startup is easier to diagnose from logs and `plugins list`.

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -106,7 +106,7 @@ function expectCompactedToolResultsWithoutContextNotice(
 }
 
 describe("installToolResultContextGuard", () => {
-  it("compacts oldest-first when total context overflows, even if each result fits individually", async () => {
+  it("compacts newest-first when total context overflows, even if each result fits individually", async () => {
     const agent = makeGuardableAgent();
     const contextForNextCall = makeTwoToolResultOverflowContext();
     const transformed = await applyGuardToContext(agent, contextForNextCall);
@@ -115,7 +115,7 @@ describe("installToolResultContextGuard", () => {
     expectCompactedToolResultsWithoutContextNotice(contextForNextCall, 1, 2);
   });
 
-  it("keeps compacting oldest-first until context is back under budget", async () => {
+  it("keeps compacting newest-first until context is back under budget", async () => {
     const agent = makeGuardableAgent();
 
     installToolResultContextGuard({
@@ -141,7 +141,7 @@ describe("installToolResultContextGuard", () => {
     expect(third).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
   });
 
-  it("survives repeated large tool results by compacting older outputs before later turns", async () => {
+  it("survives repeated large tool results by compacting the newest output each turn", async () => {
     const agent = makeGuardableAgent();
 
     installToolResultContextGuard({
@@ -159,8 +159,10 @@ describe("installToolResultContextGuard", () => {
       .filter((msg) => msg.role === "toolResult")
       .map((msg) => getToolResultText(msg as AgentMessage));
 
-    expect(toolResultTexts[0]).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
-    expect(toolResultTexts[3]?.length).toBe(95_000);
+    // Newest-first compaction: oldest results stay intact to preserve the
+    // cached prefix; the newest overflowing result is compacted.
+    expect(toolResultTexts[0]?.length).toBe(95_000);
+    expect(toolResultTexts[3]).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
     expect(toolResultTexts.join("\n")).not.toContain(CONTEXT_LIMIT_TRUNCATION_NOTICE);
   });
 
@@ -181,7 +183,7 @@ describe("installToolResultContextGuard", () => {
     expect(newResultText).toContain(CONTEXT_LIMIT_TRUNCATION_NOTICE);
   });
 
-  it("keeps compacting oldest-first until overflow clears, including the newest tool result when needed", async () => {
+  it("keeps compacting newest-first until overflow clears, reaching older tool results when needed", async () => {
     const agent = makeGuardableAgent();
 
     installToolResultContextGuard({

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -108,7 +108,9 @@ function compactExistingToolResultsInPlace(params: {
   }
 
   let reduced = 0;
-  for (let i = 0; i < messages.length; i++) {
+  // Compact newest-first so the cached prefix stays intact: rewriting messages[k]
+  // for small k invalidates the provider prompt cache from that point onward.
+  for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (!isToolResultMessage(msg)) {
       continue;
@@ -179,7 +181,8 @@ function enforceToolResultContextBudgetInPlace(params: {
     return;
   }
 
-  // Compact oldest tool outputs first until the context is back under budget.
+  // Compact newest tool outputs first to preserve the cached prefix; stop once
+  // the context is back under budget.
   compactExistingToolResultsInPlace({
     messages,
     charsNeeded: currentChars - contextBudgetChars,


### PR DESCRIPTION
## Problem

`compactExistingToolResultsInPlace` (src/agents/pi-embedded-runner/tool-result-context-guard.ts:111) iterated front-to-back. When context exceeded 75%, it replaced the **oldest** tool results with `[compacted: ...]` placeholders first. This rewrote `messages[k]` for small k, invalidating the provider prompt cache from that point onward on every turn past the threshold.

## Fix

Reverse the loop to compact **newest-first**: `for (let i = messages.length - 1; i >= 0; i--)`. The cached prefix stays byte-identical; only the tail diverges.

## Tradeoff

The model loses recent tool output instead of old. Acceptable because:
- This guard only fires as an emergency measure past 75% context
- Cache-bust cost (full re-tokenization every turn) outweighs the model-quality hit
- If compaction isn't enough, the 90% preemptive-overflow cascade still triggers full session compaction

## Verification

- 11/11 tests pass in `tool-result-context-guard.test.ts`
- No downstream dependency on compaction order: sole caller `enforceToolResultContextBudgetInPlace` only reads the return value (a sum) and the in-place mutations
- Early-exit (`reduced >= charsNeeded`) is direction-agnostic — the accumulator is a simple sum
- `applyMessageMutationInPlace` + cache invalidation are per-message, no ordering assumption

## Notes

- Test assertions updated to reflect newest-first ordering (the "survives repeated large tool results" test previously asserted oldest compacted / newest intact; now inverted)
- Pre-commit hook currently fails on `origin/main` due to unrelated `getEditorKeybindings` import breakage introduced in c6d8318d07 — this change does not touch those files


🤖 Generated with [Claude Code](https://claude.ai/code)