### PR TITLE
fix(exec): ignore malformed drive-less windows exec paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Android/assistant: keep queued App Actions prompts pending when auto-send enqueue is rejected, so transient chat-health drops do not silently lose the assistant request. Thanks @obviyus.
 - Zalo/webhook: scope replay-dedupe cache key to path and account using `JSON.stringify` so multi-account deployments do not silently drop events due to cross-account cache poisoning. (#59387) Thanks @pgondhi987.
 - Plugins/Google: separate OAuth CSRF state from PKCE code verifier during Gemini browser sign-in so state validation and token exchange use independent values. (#59116) Thanks @eleqtrizit.
+- Exec/Windows: reject malformed drive-less rooted executable paths like `:\Users\...` so approval and allowlist candidate resolution no longer treat them as cwd-relative commands. (#58040) Thanks @SnowSky1.
 
 ## 2026.4.2-beta.1
 

--- a/src/infra/exec-command-resolution.test.ts
+++ b/src/infra/exec-command-resolution.test.ts
@@ -9,6 +9,7 @@ import {
   parseExecArgvToken,
   resolveCommandResolution,
   resolveCommandResolutionFromArgv,
+  resolveAllowlistCandidatePath,
   resolveExecutionTargetCandidatePath,
   resolvePolicyTargetCandidatePath,
 } from "./exec-approvals.js";
@@ -428,5 +429,21 @@ describe("exec-command-resolution", () => {
       expect(long.flag).toBe("--output");
       expect(long.inlineValue).toBe("blocked.txt");
     }
+  });
+
+  it("does not synthesize cwd-joined allowlist candidates from drive-less windows roots", () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    expect(
+      resolveAllowlistCandidatePath(
+        {
+          rawExecutable: String.raw`:\Users\demo\AI\system\openclaw`,
+          executableName: "openclaw",
+        },
+        String.raw`C:\Users\demo\AI\system\openclaw`,
+      ),
+    ).toBeUndefined();
   });
 });

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -45,6 +45,10 @@ function parseFirstToken(command: string): string | null {
   return match ? match[0] : null;
 }
 
+function isDriveLessWindowsRootedPath(value: string): boolean {
+  return process.platform === "win32" && /^:[\\/]/.test(value);
+}
+
 function tryResolveRealpath(filePath: string | undefined): string | undefined {
   if (!filePath) {
     return undefined;
@@ -176,6 +180,9 @@ function resolveExecutableCandidatePathFromResolution(
     return undefined;
   }
   const expanded = raw.startsWith("~") ? expandHomePrefix(raw) : raw;
+  if (isDriveLessWindowsRootedPath(expanded)) {
+    return undefined;
+  }
   if (!expanded.includes("/") && !expanded.includes("\\")) {
     return undefined;
   }

--- a/src/infra/executable-path.test.ts
+++ b/src/infra/executable-path.test.ts
@@ -74,4 +74,16 @@ describe("executable path helpers", () => {
     );
     expect(resolveExecutablePath("~/missing-tool", { env: { HOME: homeDir } })).toBeUndefined();
   });
+
+  it("does not treat drive-less rooted windows paths as cwd-relative executables", () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    expect(
+      resolveExecutablePath(String.raw`:\Users\demo\AI\system\openclaw\git.exe`, {
+        cwd: String.raw`C:\Users\demo\AI\system\openclaw`,
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/src/infra/executable-path.ts
+++ b/src/infra/executable-path.ts
@@ -2,6 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { expandHomePrefix } from "./home-dir.js";
 
+function isDriveLessWindowsRootedPath(value: string): boolean {
+  return process.platform === "win32" && /^:[\\/]/.test(value);
+}
+
 function resolveWindowsExecutableExtensions(
   executable: string,
   env: NodeJS.ProcessEnv | undefined,
@@ -86,6 +90,9 @@ export function resolveExecutablePath(
   const expanded = rawExecutable.startsWith("~")
     ? expandHomePrefix(rawExecutable, { env: options?.env })
     : rawExecutable;
+  if (isDriveLessWindowsRootedPath(expanded)) {
+    return undefined;
+  }
   if (expanded.includes("/") || expanded.includes("\\")) {
     if (path.isAbsolute(expanded)) {
       return isExecutableFile(expanded) ? expanded : undefined;


### PR DESCRIPTION
## Summary

- Problem: when a malformed Windows executable token like `:\Users\...` reaches exec resolution, OpenClaw currently treats it as cwd-relative and synthesizes even more broken candidate paths such as `C:\workspace\:\Users\...`.
- Why it matters: this amplifies the original corruption by polluting approval/audit paths and allowlist metadata with invalid Windows paths.
- What changed: reject drive-less rooted Windows tokens before relative-path resolution in both executable lookup and allowlist/audit candidate-path fallback helpers.
- What did NOT change (scope boundary): this PR does not claim to identify the original source of the missing drive letter; it only stops malformed `:\...` tokens from being expanded into worse derived paths.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Security / approvals / allowlists

## Linked Issue/PR

- Related #57358

## User-visible / Behavior Changes

Malformed drive-less Windows exec tokens are no longer treated as cwd-relative paths during resolution, so OpenClaw will stop generating duplicated invalid audit/allowlist paths from inputs like `:\Users\...`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: local workspace
- Integration/channel (if any): gateway exec path resolution

### Steps

1. Resolve an executable token that is already malformed as `:\Users\demo\AI\system\openclaw`.
2. Compute the allowlist/audit candidate path with cwd `C:\Users\demo\AI\system\openclaw`.

### Expected

- OpenClaw should not synthesize a cwd-joined path like `C:\Users\demo\AI\system\openclaw\:\Users\demo\AI\system\openclaw`.

### Actual

- Covered by the new regression tests.

## Evidence

- [x] Failing test/log before + passing after

Targeted local verification:
- `pnpm test -- src/infra/executable-path.test.ts src/infra/exec-command-resolution.test.ts`
- `pnpm exec oxfmt --check src/infra/executable-path.ts src/infra/exec-command-resolution.ts src/infra/executable-path.test.ts src/infra/exec-command-resolution.test.ts`

## Human Verification (required)

What I personally verified:
- Reproduced the pre-fix behavior where `path.resolve("C:\\Users\\demo\\AI\\system\\openclaw", ":\\Users\\demo\\AI\\system\\openclaw")` produced the duplicated malformed Windows path pattern reported in #57358.
- Verified the new regression tests prevent that expansion in both executable lookup and allowlist-candidate fallback logic.

What I did **not** verify:
- The original upstream source that first strips the drive letter from the command token.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `src/infra/executable-path.ts`, `src/infra/exec-command-resolution.ts`

## Risks and Mitigations

- Risk: an intentionally relative path beginning with `:\` would now be ignored instead of being resolved against cwd.
  - Mitigation: on Windows this token shape is already invalid as an absolute path and is the exact malformed pattern reported in #57358.

AI-assisted: yes. I verified the change locally and understand the narrowed scope.
