### PR TITLE
fix(memory): expand tilde in extraMemoryPaths before path resolution

### DIFF
--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -39,6 +39,13 @@ describe("normalizeExtraMemoryPaths", () => {
     ]);
     expect(result).toEqual([path.resolve(workspaceDir, "notes"), absPath]);
   });
+
+  it("expands tilde prefix to home directory", () => {
+    const workspaceDir = path.join(os.tmpdir(), "memory-test-workspace");
+    const home = os.homedir();
+    const result = normalizeExtraMemoryPaths(workspaceDir, ["~/Documents/notes"]);
+    expect(result).toEqual([path.resolve(home, "Documents/notes")]);
+  });
 });
 
 describe("listMemoryFiles", () => {

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { expandHomePrefix } from "../../../../src/infra/home-dir.js";
 import { detectMime } from "../../../../src/media/mime.js";
 import { CHARS_PER_TOKEN_ESTIMATE, estimateStringChars } from "../../../../src/utils/cjk-chars.js";
 import { runTasksWithConcurrency } from "../../../../src/utils/run-with-concurrency.js";
@@ -66,6 +67,7 @@ export function normalizeExtraMemoryPaths(workspaceDir: string, extraPaths?: str
   const resolved = extraPaths
     .map((value) => value.trim())
     .filter(Boolean)
+    .map((value) => expandHomePrefix(value))
     .map((value) =>
       path.isAbsolute(value) ? path.resolve(value) : path.resolve(workspaceDir, value),
     );


### PR DESCRIPTION
lobster-biscuit

Closes #58026
Also fixes #58027 (same root cause)

## Problem

`normalizeExtraMemoryPaths()` does not expand `~/` before calling `path.isAbsolute()`. In Node.js, `path.isAbsolute("~/OneDrive/MyVault")` returns `false` because `~` is a shell expansion, not a filesystem absolute prefix. The path resolves to `<workspace>/~/OneDrive/MyVault` instead of `/home/user/OneDrive/MyVault`.

## Root cause

`packages/memory-host-sdk/src/host/internal.ts:70` — tilde paths are treated as relative and joined with `workspaceDir`.

## User impact

Any user with `memorySearch.extraPaths: ["~/MyVault"]` gets an empty or wrong memory index. The resolved path doesn't exist, so no files are found. Affects Obsidian vault users, OneDrive users, and anyone using `~/` in their config.

## Fix

Expand tilde via `expandHomePrefix()` (`src/infra/home-dir.ts:81`) before the `isAbsolute` check. This helper is already used in cron store path resolution and session store paths (G10: reuse existing helpers).

1 file, +2 lines (1 import + 1 map step).

## How to verify

1. Set `memorySearch.extraPaths: ["~/Documents/notes"]`
2. `openclaw memory index --force`
3. Before: resolves to `<workspace>/~/Documents/notes` (wrong). After: resolves to `/home/user/Documents/notes` (correct).

## Tests

`expandHomePrefix` is tested in `home-dir.test.ts`. The fix adds it as a preprocessing step before the existing `isAbsolute` logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)