### PR TITLE
fix: primary probe should not consume transient probe slot for same-provider fallbacks

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1538,6 +1538,65 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(4, "openrouter", "openrouter/claude-opus-4.6");
     });
 
+    it("non-primary fallbacks still deduplicate among themselves on the same provider", async () => {
+      // After primary probe, two same-provider non-primary fallbacks:
+      // the first should probe, the second should be skipped.
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+      const now = Date.now();
+      const store: AuthProfileStore = {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "sub2api:default": { type: "api_key", provider: "sub2api", key: "test-key" },
+          "groq:default": { type: "api_key", provider: "groq", key: "test-key" },
+        },
+        usageStats: {
+          "sub2api:default": {
+            cooldownUntil: now + 60000,
+            failureCounts: { rate_limit: 1 },
+          },
+        },
+      };
+      saveAuthProfileStore(store, tmpDir);
+
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "sub2api/claude-opus-4-6",
+              fallbacks: [
+                "sub2api/claude-sonnet-4-6",
+                "sub2api/claude-haiku-3-5",
+                "groq/llama-3.3-70b-versatile",
+              ],
+            },
+          },
+        },
+      });
+
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("sub2api opus timeout")) // primary probe
+        .mockRejectedValueOnce(new Error("sub2api sonnet also down")) // first non-primary probe
+        // sub2api/haiku skipped (non-primary slot already consumed for sub2api)
+        .mockResolvedValueOnce("groq success");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "sub2api",
+        model: "claude-opus-4-6",
+        run,
+        agentDir: tmpDir,
+      });
+
+      expect(result.result).toBe("groq success");
+      // primary + sonnet (first non-primary probe) + groq; haiku skipped
+      expect(run).toHaveBeenCalledTimes(3);
+      expect(run).toHaveBeenNthCalledWith(2, "sub2api", "claude-sonnet-4-6", {
+        allowTransientCooldownProbe: true,
+      });
+      expect(run).toHaveBeenNthCalledWith(3, "groq", "llama-3.3-70b-versatile");
+    });
+
     it("does not consume transient probe slot when first same-provider probe fails with model_not_found", async () => {
       const { dir } = await makeAuthStoreWithCooldown("anthropic", "rate_limit");
       const cfg = makeCfg({

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1472,6 +1472,72 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
     });
 
+    it("primary probe does not consume transient probe slot for same-provider fallbacks", async () => {
+      // Scenario: sub2api/opus (primary) is in cooldown near expiry, probed but
+      // fails. sub2api/sonnet (fallback) should still get its own probe attempt
+      // rather than being skipped due to the primary's probe.
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+      const now = Date.now();
+      const store: AuthProfileStore = {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "sub2api:default": { type: "api_key", provider: "sub2api", key: "test-key" },
+          "zenmux:default": { type: "api_key", provider: "zenmux", key: "test-key" },
+          "openrouter:default": { type: "api_key", provider: "openrouter", key: "test-key" },
+        },
+        usageStats: {
+          "sub2api:default": {
+            // Near expiry so primary WILL be probed
+            cooldownUntil: now + 60000, // 1 min from now, within PROBE_MARGIN_MS
+            failureCounts: { rate_limit: 1 },
+          },
+          "zenmux:default": {
+            cooldownUntil: now + 300000,
+            failureCounts: { rate_limit: 2 },
+          },
+          // openrouter not in cooldown
+        },
+      };
+      saveAuthProfileStore(store, tmpDir);
+
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "sub2api/claude-opus-4-6",
+              fallbacks: [
+                "zenmux/claude-opus-4.6",
+                "zenmux/claude-sonnet-4.6",
+                "sub2api/claude-sonnet-4-6",
+                "openrouter/claude-opus-4.6",
+              ],
+            },
+          },
+        },
+      });
+
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("sub2api opus timeout")) // primary probe fails
+        .mockRejectedValueOnce(new Error("zenmux 402 quota")) // zenmux opus probe fails
+        // zenmux/sonnet skipped (same provider, probe already used)
+        .mockRejectedValueOnce(new Error("sub2api sonnet also down")) // sub2api/sonnet gets its own probe!
+        .mockResolvedValueOnce("openrouter success"); // cross-provider works
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "sub2api",
+        model: "claude-opus-4-6",
+        run,
+        agentDir: tmpDir,
+      });
+
+      expect(result.result).toBe("openrouter success");
+      // sub2api/opus (primary probe) + zenmux/opus (probe) + sub2api/sonnet (own probe) + openrouter
+      expect(run).toHaveBeenCalledTimes(4);
+      expect(run).toHaveBeenNthCalledWith(4, "openrouter", "openrouter/claude-opus-4.6");
+    });
+
     it("does not consume transient probe slot when first same-provider probe fails with model_not_found", async () => {
       const { dir } = await makeAuthStoreWithCooldown("anthropic", "rate_limit");
       const cfg = makeCfg({

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -684,6 +684,9 @@ export async function runWithModelFallback<T>(params: {
           // appears later in the fallback chain (e.g. same provider, different
           // model), that fallback candidate deserves its own probe attempt.
           const isTransientCooldownReason = shouldUseTransientCooldownProbeSlot(decision.reason);
+          // Primary probes must not consume a shared-provider slot — the
+          // primary is always probed near cooldown expiry as a recovery
+          // mechanism, and blocking same-provider fallbacks would stall the chain.
           if (
             isTransientCooldownReason &&
             !isPrimary &&
@@ -716,6 +719,7 @@ export async function runWithModelFallback<T>(params: {
           }
           runOptions = { allowTransientCooldownProbe: true };
           if (isTransientCooldownReason && !isPrimary) {
+            // Only non-primary probes mark the provider slot as consumed.
             transientProbeProviderForAttempt = candidate.provider;
           }
         }

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -676,8 +676,19 @@ export async function runWithModelFallback<T>(params: {
           // Probe at most once per provider per fallback run when all profiles
           // are cooldowned. Re-probing every same-provider candidate can stall
           // cross-provider fallback on providers with long internal retries.
+          //
+          // However, primary probe failures should NOT consume the transient
+          // probe slot. The primary is always probed (near cooldown expiry) as
+          // a recovery mechanism, and that attempt is fundamentally different
+          // from a fallback candidate probe. If the primary's provider also
+          // appears later in the fallback chain (e.g. same provider, different
+          // model), that fallback candidate deserves its own probe attempt.
           const isTransientCooldownReason = shouldUseTransientCooldownProbeSlot(decision.reason);
-          if (isTransientCooldownReason && cooldownProbeUsedProviders.has(candidate.provider)) {
+          if (
+            isTransientCooldownReason &&
+            !isPrimary &&
+            cooldownProbeUsedProviders.has(candidate.provider)
+          ) {
             const error = `Provider ${candidate.provider} is in cooldown (probe already attempted this run)`;
             attempts.push({
               provider: candidate.provider,
@@ -704,7 +715,7 @@ export async function runWithModelFallback<T>(params: {
             continue;
           }
           runOptions = { allowTransientCooldownProbe: true };
-          if (isTransientCooldownReason) {
+          if (isTransientCooldownReason && !isPrimary) {
             transientProbeProviderForAttempt = candidate.provider;
           }
         }


### PR DESCRIPTION
## Problem

When the primary model is in cooldown and gets probed (near expiry), the probe failure marks the provider in `cooldownProbeUsedProviders`. This blocks same-provider fallback candidates from getting their own probe attempt, causing the fallback chain to stall before reaching cross-provider alternatives.

### Real-world scenario

```
Fallback chain: sub2api/opus → zenmux/opus → zenmux/sonnet → sub2api/sonnet → openrouter/opus

1. sub2api/opus (primary) → timeout → probed → failed → sub2api marked in cooldownProbeUsedProviders
2. zenmux/opus → 402 quota_exceeded → probed → failed → zenmux marked
3. zenmux/sonnet → skipped (zenmux already probed) ← correct
4. sub2api/sonnet → skipped (sub2api already probed) ← BUG
5. openrouter/opus → attempted ← correct but user saw no response because chain errored out
```

In step 4, `sub2api/sonnet` is a different model that could be available (the primary `sub2api/opus` might have timed out due to a model-specific issue). But because the primary's probe consumed the transient probe slot for `sub2api`, this fallback candidate never gets attempted.

## Root Cause

In `runWithModelFallback`, the `cooldownProbeUsedProviders` set is populated after **any** probe attempt, including the primary's. Since the primary is always eligible for probing near cooldown expiry (by design), its probe attempt should not block fallback candidates on the same provider.

## Fix

- Primary probe attempts no longer add to `cooldownProbeUsedProviders`
- Non-primary fallback candidates on the same provider still get exactly one probe slot (unchanged behavior for fallback-to-fallback dedup)
- Added test covering the exact multi-provider scenario

## Test

New test: `primary probe does not consume transient probe slot for same-provider fallbacks`

All 63 existing tests pass.

Relates to #56053, #47576, #45774