### PR TITLE
fix(outbound): bootstrap missing requested channel in outbound resolution

### DIFF
--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -244,11 +244,7 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     mocks.getActivePluginRegistry.mockReturnValue({
       channels: [{ plugin: { id: "discord" } }],
     } as unknown as ReturnType<typeof mocks.getActivePluginRegistry>);
-    mocks.getChannelPlugin
-      .mockReturnValueOnce(undefined)
-      .mockReturnValue(plugin)
-      .mockReturnValue(plugin)
-      .mockReturnValue(plugin);
+    mocks.getChannelPlugin.mockReturnValueOnce(undefined).mockReturnValue(plugin);
     mocks.listGroups.mockResolvedValue([]);
     mocks.listGroupsLive.mockResolvedValue([entry]);
 

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -277,6 +277,7 @@ describe("resolveMessagingTarget (directory fallback)", () => {
       channels: [{ plugin: { id: "discord" } }],
     } as unknown as ReturnType<typeof mocks.getActivePluginRegistry>);
 
+    // First call simulates a missing plugin, forcing the bootstrap path to run.
     mocks.getChannelPlugin.mockReturnValueOnce(undefined).mockReturnValue(plugin);
 
     const entry: ChannelDirectoryEntry = { kind: "group", id: "123456789", name: "support" };
@@ -291,7 +292,11 @@ describe("resolveMessagingTarget (directory fallback)", () => {
 
     expect(display).toBe("support");
     expect(mocks.listGroups).toHaveBeenCalledTimes(1);
-    expect(mocks.getChannelPlugin).toHaveBeenCalled();
+    expect(mocks.getChannelPlugin.mock.results[0]?.value).toBeUndefined();
+    expect(mocks.getChannelPlugin.mock.calls.some((call) => call[0] === "telegram")).toBe(true);
+    expect(mocks.getChannelPlugin.mock.results.some((result) => result.value === plugin)).toBe(
+      true,
+    );
   });
 
   it("defers target display formatting to the plugin when available", () => {

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   resolveTarget: vi.fn(),
   getChannelPlugin: vi.fn(),
   getActivePluginChannelRegistryVersion: vi.fn(() => 1),
+  getActivePluginRegistry: vi.fn(() => ({ channels: [] })),
+  getActivePluginRegistryKey: vi.fn(() => "target-resolver-test"),
 }));
 
 beforeEach(async () => {
@@ -26,13 +28,19 @@ beforeEach(async () => {
   mocks.resolveTarget.mockReset();
   mocks.getChannelPlugin.mockReset();
   mocks.getActivePluginChannelRegistryVersion.mockReset();
+  mocks.getActivePluginRegistry.mockReset();
+  mocks.getActivePluginRegistryKey.mockReset();
   mocks.getActivePluginChannelRegistryVersion.mockReturnValue(1);
+  mocks.getActivePluginRegistry.mockReturnValue({ channels: [] });
+  mocks.getActivePluginRegistryKey.mockReturnValue("target-resolver-test");
   vi.doMock("../../channels/plugins/index.js", () => ({
     getChannelPlugin: (...args: unknown[]) => mocks.getChannelPlugin(...args),
     normalizeChannelId: (value: string) => value,
   }));
   vi.doMock("../../plugins/runtime.js", () => ({
     getActivePluginChannelRegistryVersion: () => mocks.getActivePluginChannelRegistryVersion(),
+    getActivePluginRegistry: () => mocks.getActivePluginRegistry(),
+    getActivePluginRegistryKey: () => mocks.getActivePluginRegistryKey(),
   }));
   ({ resetDirectoryCache, resolveMessagingTarget, formatTargetDisplay } =
     await import("./target-resolver.js"));
@@ -215,6 +223,45 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     if (result.ok) {
       expect(result.target.to).toBe("channel:C123ABC");
       expect(result.target.display).toBeUndefined();
+    }
+  });
+
+  it("bootstraps the requested channel when the active registry is non-empty but missing it", async () => {
+    const entry: ChannelDirectoryEntry = { kind: "group", id: "123456789", name: "support" };
+    const plugin = {
+      directory: {
+        listPeers: mocks.listPeers,
+        listPeersLive: mocks.listPeersLive,
+        listGroups: mocks.listGroups,
+        listGroupsLive: mocks.listGroupsLive,
+      },
+      messaging: {
+        targetResolver: {
+          resolveTarget: mocks.resolveTarget,
+        },
+      },
+    };
+    mocks.getActivePluginRegistry.mockReturnValue({
+      channels: [{ plugin: { id: "discord" } }],
+    } as unknown as ReturnType<typeof mocks.getActivePluginRegistry>);
+    mocks.getChannelPlugin
+      .mockReturnValueOnce(undefined)
+      .mockReturnValue(plugin)
+      .mockReturnValue(plugin)
+      .mockReturnValue(plugin);
+    mocks.listGroups.mockResolvedValue([]);
+    mocks.listGroupsLive.mockResolvedValue([entry]);
+
+    const result = await resolveMessagingTarget({
+      cfg,
+      channel: "telegram",
+      input: "support",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.target.source).toBe("directory");
+      expect(result.target.to).toBe("123456789");
     }
   });
 

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -6,6 +6,7 @@ type TargetResolverModule = typeof import("./target-resolver.js");
 let resetDirectoryCache: TargetResolverModule["resetDirectoryCache"];
 let resolveMessagingTarget: TargetResolverModule["resolveMessagingTarget"];
 let formatTargetDisplay: TargetResolverModule["formatTargetDisplay"];
+let lookupDirectoryDisplay: TargetResolverModule["lookupDirectoryDisplay"];
 
 const mocks = vi.hoisted(() => ({
   listPeers: vi.fn(),
@@ -44,6 +45,7 @@ beforeEach(async () => {
   }));
   ({ resetDirectoryCache, resolveMessagingTarget, formatTargetDisplay } =
     await import("./target-resolver.js"));
+  ({ lookupDirectoryDisplay } = await import("./target-resolver.js"));
 });
 
 describe("resolveMessagingTarget (directory fallback)", () => {
@@ -259,6 +261,37 @@ describe("resolveMessagingTarget (directory fallback)", () => {
       expect(result.target.source).toBe("directory");
       expect(result.target.to).toBe("123456789");
     }
+  });
+
+  it("bootstraps the requested channel for lookupDirectoryDisplay when the active registry is non-empty but missing it", async () => {
+    const plugin = {
+      directory: {
+        listPeers: mocks.listPeers,
+        listPeersLive: mocks.listPeersLive,
+        listGroups: mocks.listGroups,
+        listGroupsLive: mocks.listGroupsLive,
+      },
+    };
+
+    mocks.getActivePluginRegistry.mockReturnValue({
+      channels: [{ plugin: { id: "discord" } }],
+    } as unknown as ReturnType<typeof mocks.getActivePluginRegistry>);
+
+    mocks.getChannelPlugin.mockReturnValueOnce(undefined).mockReturnValue(plugin);
+
+    const entry: ChannelDirectoryEntry = { kind: "group", id: "123456789", name: "support" };
+    mocks.listGroups.mockResolvedValue([entry]);
+    mocks.listPeers.mockResolvedValue([]);
+
+    const display = await lookupDirectoryDisplay({
+      cfg,
+      channel: "telegram",
+      targetId: "123456789",
+    });
+
+    expect(display).toBe("support");
+    expect(mocks.listGroups).toHaveBeenCalledTimes(1);
+    expect(mocks.getChannelPlugin).toHaveBeenCalled();
   });
 
   it("defers target display formatting to the plugin when available", () => {

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -392,13 +392,15 @@ export async function resolveMessagingTarget(params: {
     return { ok: false, error: new Error("Target is required") };
   }
   // Ensure the requested channel plugin is bootstrapped before any
-  // getChannelPlugin calls in this resolution path.  When the active plugin
-  // registry is non-empty but missing the requested channel,
-  // resolveOutboundChannelPlugin triggers the same bootstrap path used by the
-  // outbound send flow, preventing "Unknown channel" / "Unknown target" errors.
+  // provider-specific normalization or getChannelPlugin calls in this
+  // resolution path. When the active plugin registry is non-empty but missing
+  // the requested channel, resolveOutboundChannelPlugin triggers the same
+  // bootstrap path used by the outbound send flow, preventing "Unknown
+  // channel" / "Unknown target" errors.
   // See: https://github.com/openclaw/openclaw/issues/55338
-  resolveOutboundChannelPlugin({ channel: params.channel, cfg: params.cfg });
-  const plugin = getChannelPlugin(params.channel);
+  const plugin =
+    resolveOutboundChannelPlugin({ channel: params.channel, cfg: params.cfg }) ??
+    getChannelPlugin(params.channel);
   const providerLabel = plugin?.meta?.label ?? params.channel;
   const hint = plugin?.messaging?.targetResolver?.hint;
   const kind = detectTargetKind(params.channel, raw, params.preferredKind);
@@ -520,10 +522,10 @@ export async function lookupDirectoryDisplay(params: {
   accountId?: string | null;
   runtime?: RuntimeEnv;
 }): Promise<string | undefined> {
-  const normalized = normalizeTargetForProvider(params.channel, params.targetId) ?? params.targetId;
-
   // Ensure the channel plugin is available before directory lookups.
   resolveOutboundChannelPlugin({ channel: params.channel, cfg: params.cfg });
+
+  const normalized = normalizeTargetForProvider(params.channel, params.targetId) ?? params.targetId;
 
   // Targets can resolve to either peers (DMs) or groups. Try both.
   const [groups, users] = await Promise.all([

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -69,7 +69,12 @@ async function maybeResolvePluginTarget(
   if (!raw) {
     return undefined;
   }
-  const plugin = getChannelPlugin(params.channel);
+  // Use the same plugin resolution source as resolveMessagingTarget.
+  // This ensures we run through the outbound bootstrap path (when needed)
+  // before consulting plugin-provided target resolver hooks.
+  const plugin =
+    resolveOutboundChannelPlugin({ channel: params.channel, cfg: params.cfg }) ??
+    getChannelPlugin(params.channel);
   const resolver = plugin?.messaging?.targetResolver;
   if (!resolver?.resolveTarget) {
     return undefined;
@@ -185,7 +190,8 @@ export function formatTargetDisplay(params: {
 }
 
 function detectTargetKind(
-  channel: ChannelId,
+  _channel: ChannelId,
+  plugin: ReturnType<typeof getChannelPlugin> | undefined,
   raw: string,
   preferred?: TargetResolveKind,
 ): TargetResolveKind {
@@ -196,7 +202,7 @@ function detectTargetKind(
   if (!trimmed) {
     return "group";
   }
-  const inferredChatType = getChannelPlugin(channel)?.messaging?.inferTargetChatType?.({ to: raw });
+  const inferredChatType = plugin?.messaging?.inferTargetChatType?.({ to: raw });
   if (inferredChatType === "direct") {
     return "user";
   }
@@ -403,7 +409,7 @@ export async function resolveMessagingTarget(params: {
     getChannelPlugin(params.channel);
   const providerLabel = plugin?.meta?.label ?? params.channel;
   const hint = plugin?.messaging?.targetResolver?.hint;
-  const kind = detectTargetKind(params.channel, raw, params.preferredKind);
+  const kind = detectTargetKind(params.channel, plugin, raw, params.preferredKind);
   const normalized = normalizeTargetForProvider(params.channel, raw) ?? raw;
   const looksLikeTargetId = (): boolean => {
     const trimmed = raw.trim();

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
+import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { buildDirectoryCacheKey, DirectoryCache } from "./directory-cache.js";
 import { ambiguousTargetError, unknownTargetError } from "./target-errors.js";
 import {
@@ -390,6 +391,13 @@ export async function resolveMessagingTarget(params: {
   if (!raw) {
     return { ok: false, error: new Error("Target is required") };
   }
+  // Ensure the requested channel plugin is bootstrapped before any
+  // getChannelPlugin calls in this resolution path.  When the active plugin
+  // registry is non-empty but missing the requested channel,
+  // resolveOutboundChannelPlugin triggers the same bootstrap path used by the
+  // outbound send flow, preventing "Unknown channel" / "Unknown target" errors.
+  // See: https://github.com/openclaw/openclaw/issues/55338
+  resolveOutboundChannelPlugin({ channel: params.channel, cfg: params.cfg });
   const plugin = getChannelPlugin(params.channel);
   const providerLabel = plugin?.meta?.label ?? params.channel;
   const hint = plugin?.messaging?.targetResolver?.hint;
@@ -513,6 +521,9 @@ export async function lookupDirectoryDisplay(params: {
   runtime?: RuntimeEnv;
 }): Promise<string | undefined> {
   const normalized = normalizeTargetForProvider(params.channel, params.targetId) ?? params.targetId;
+
+  // Ensure the channel plugin is available before directory lookups.
+  resolveOutboundChannelPlugin({ channel: params.channel, cfg: params.cfg });
 
   // Targets can resolve to either peers (DMs) or groups. Try both.
   const [groups, users] = await Promise.all([


### PR DESCRIPTION
Carries over the changes from #55397 and additionally addresses the remaining review threads (bootstrap before provider normalization; use resolveOutboundChannelPlugin return value; simplify test mock chain).

Context: I don't have push access to the original PR head branch (reed1898:fix/issue-55338), so I'm opening this follow-up PR from my fork so maintainers can merge/cherry-pick.

Fixes: #55338