### PR TITLE
fix(cron): default announce delivery to channel=last

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -281,13 +281,14 @@ describe("normalizeCronJobCreate", () => {
     expect(delivery.to).toBe("https://example.invalid/cron");
   });
 
-  it("defaults isolated agentTurn delivery to announce", () => {
+  it("defaults isolated agentTurn delivery to announce with channel=last", () => {
     const normalized = normalizeIsolatedAgentTurnCreateJob({
       name: "default-announce",
     });
 
     const delivery = normalized.delivery as Record<string, unknown>;
     expect(delivery.mode).toBe("announce");
+    expect(delivery.channel).toBe("last");
   });
 
   it("migrates legacy delivery fields to delivery", () => {

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -519,7 +519,7 @@ export function normalizeCronJobInput(
       isIsolatedAgentTurn &&
       payloadKind === "agentTurn"
     ) {
-      next.delivery = { mode: "announce" };
+      next.delivery = { mode: "announce", channel: "last" };
     }
   }
 


### PR DESCRIPTION
## Summary

When an isolated agentTurn cron job has no explicit `delivery` field, it defaults to `{ mode: 'announce' }` but without a `channel`.

On multi-channel deployments (e.g., WhatsApp + Telegram), this causes a runtime error:
`Channel is required when multiple channels configured: telegram, whatsapp`

## Fix

Set the default channel to `'last'` (last-active channel) in the announce delivery default, so:
- Single-channel configs continue to work unchanged
- Multi-channel configs resolve to the last-used channel at delivery time

## Changes

- `src/cron/normalize.ts`: Default delivery changed from `{ mode: 'announce' }` to `{ mode: 'announce', channel: 'last' }`
- `src/cron/normalize.test.ts`: Updated test to assert `channel === 'last'`

## Testing

All 30 tests in `normalize.test.ts` pass.

## Related

Fixes openclaw/openclaw#53379
