### PR TITLE
fix(heartbeat): strip HEARTBEAT_OK token from mid-text positions

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -657,6 +657,8 @@ export async function compactEmbeddedPiSessionDirect(
         modelApi: model.api,
         provider,
         modelId,
+        config: params.config,
+        workspaceDir: params.workspaceDir,
       });
       const sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
         agentId: sessionAgentId,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -658,7 +658,7 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         config: params.config,
-        workspaceDir: params.workspaceDir,
+        workspaceDir: effectiveWorkspace,
       });
       const sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
         agentId: sessionAgentId,

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -592,6 +592,7 @@ export async function sanitizeSessionHistory(params: {
       modelApi: params.modelApi,
       provider: params.provider,
       modelId: params.modelId,
+      config: params.config,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
   const canonicalizedAssistantHistory = canonicalizeAssistantHistoryMessages({

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -581,6 +581,8 @@ export async function sanitizeSessionHistory(params: {
   provider?: string;
   allowedToolNames?: Iterable<string>;
   config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
   sessionManager: SessionManager;
   sessionId: string;
   policy?: TranscriptPolicy;
@@ -593,6 +595,8 @@ export async function sanitizeSessionHistory(params: {
       provider: params.provider,
       modelId: params.modelId,
       config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
   const canonicalizedAssistantHistory = canonicalizeAssistantHistoryMessages({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -712,6 +712,8 @@ export async function runEmbeddedAttempt(
         modelApi: params.model?.api,
         provider: params.provider,
         modelId: params.modelId,
+        config: params.config,
+        workspaceDir: params.workspaceDir,
       });
 
       await prewarmSessionFile(params.sessionFile);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -713,7 +713,7 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         config: params.config,
-        workspaceDir: params.workspaceDir,
+        workspaceDir: effectiveWorkspace,
       });
 
       await prewarmSessionFile(params.sessionFile);

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -241,6 +241,29 @@ describe("resolveProviderCapabilities", () => {
     ).toBe(true);
   });
 
+  it("drops thinking blocks for MiniMax models via static fallback", () => {
+    // Plugin mock returns undefined for minimax — relies on PLUGIN_CAPABILITIES_FALLBACKS.
+    // This ensures the fix works even when plugin context (config/workspaceDir) is absent.
+    expect(
+      shouldDropThinkingBlocksForModel({
+        provider: "minimax",
+        modelId: "MiniMax-M2.7",
+      }),
+    ).toBe(true);
+    expect(
+      shouldDropThinkingBlocksForModel({
+        provider: "minimax-portal",
+        modelId: "MiniMax-M2.7",
+      }),
+    ).toBe(true);
+    expect(
+      shouldDropThinkingBlocksForModel({
+        provider: "minimax",
+        modelId: "MiniMax-M2.5",
+      }),
+    ).toBe(true);
+  });
+
   it("forwards config and workspace context to plugin capability lookup", () => {
     const config = { plugins: { enabled: true } };
     const env = { OPENCLAW_HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv;

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -53,6 +53,12 @@ const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities
       "mistralai",
     ],
   },
+  minimax: {
+    dropThinkingBlockModelHints: ["minimax"],
+  },
+  "minimax-portal": {
+    dropThinkingBlockModelHints: ["minimax"],
+  },
   moonshot: {
     openAiPayloadNormalizationMode: "moonshot-thinking",
   },

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -1,3 +1,4 @@
+import type { OpenClawConfig } from "../config/config.js";
 import { normalizeProviderId } from "./model-selection.js";
 import { isGoogleModelApi } from "./pi-embedded-helpers/google.js";
 import {
@@ -61,6 +62,9 @@ export function resolveTranscriptPolicy(params: {
   modelApi?: string | null;
   provider?: string | null;
   modelId?: string | null;
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
 }): TranscriptPolicy {
   const provider = normalizeProviderId(params.provider ?? "");
   const modelId = params.modelId ?? "";
@@ -77,6 +81,9 @@ export function resolveTranscriptPolicy(params: {
     shouldSanitizeGeminiThoughtSignaturesForModel({
       provider,
       modelId,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
     });
   const requiresOpenAiCompatibleToolIdSanitization =
     params.modelApi === "openai-completions" ||
@@ -88,7 +95,13 @@ export function resolveTranscriptPolicy(params: {
   // Anthropic Claude endpoints can reject replayed `thinking` blocks unless the
   // original signatures are preserved byte-for-byte. Drop them at send-time to
   // keep persisted sessions usable across follow-up turns.
-  const dropThinkingBlocks = shouldDropThinkingBlocksForModel({ provider, modelId });
+  const dropThinkingBlocks = shouldDropThinkingBlocksForModel({
+    provider,
+    modelId,
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
 
   const needsNonImageSanitize =
     isGoogle || isAnthropic || isMistral || shouldSanitizeGeminiThoughtSignaturesForProvider;

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -68,7 +68,7 @@ describe("stripHeartbeatToken", () => {
     });
   });
 
-  it("does not touch token in the middle", () => {
+  it("does not touch token in the middle in message mode", () => {
     expect(
       stripHeartbeatToken(`hello ${HEARTBEAT_TOKEN} there`, {
         mode: "message",
@@ -77,6 +77,44 @@ describe("stripHeartbeatToken", () => {
       shouldSkip: false,
       text: `hello ${HEARTBEAT_TOKEN} there`,
       didStrip: false,
+    });
+  });
+
+  it("strips token in the middle in heartbeat mode", () => {
+    expect(
+      stripHeartbeatToken(`Some preamble ${HEARTBEAT_TOKEN} actual reply`, {
+        mode: "heartbeat",
+      }),
+    ).toEqual({
+      shouldSkip: true,
+      text: "",
+      didStrip: true,
+    });
+  });
+
+  it("strips mid-text token and keeps long content after in heartbeat mode", () => {
+    const long = "B".repeat(DEFAULT_HEARTBEAT_ACK_MAX_CHARS + 1);
+    expect(
+      stripHeartbeatToken(`preamble ${HEARTBEAT_TOKEN} ${long}`, {
+        mode: "heartbeat",
+      }),
+    ).toEqual({
+      shouldSkip: false,
+      text: `preamble   ${long}`,
+      didStrip: true,
+    });
+  });
+
+  it("strips mid-text token with newlines and keeps long content after in heartbeat mode", () => {
+    const long = "B".repeat(DEFAULT_HEARTBEAT_ACK_MAX_CHARS + 1);
+    expect(
+      stripHeartbeatToken(`thinking prose\n${HEARTBEAT_TOKEN}\n\n${long}`, {
+        mode: "heartbeat",
+      }),
+    ).toEqual({
+      shouldSkip: false,
+      text: `thinking prose\n \n\n${long}`,
+      didStrip: true,
     });
   });
 

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -152,15 +152,27 @@ export function stripHeartbeatToken(
   const strippedNormalized = stripTokenAtEdges(trimmedNormalized);
   const picked =
     strippedOriginal.didStrip && strippedOriginal.text ? strippedOriginal : strippedNormalized;
+  let strippedText: string | undefined;
   if (!picked.didStrip) {
-    return { shouldSkip: false, text: trimmed, didStrip: false };
+    if (mode !== "heartbeat") {
+      return { shouldSkip: false, text: trimmed, didStrip: false };
+    }
+    // heartbeat mode: token was not at an edge — remove it from wherever it
+    // appears and collapse any double-blank lines left behind.
+    strippedText = trimmed
+      .split(HEARTBEAT_TOKEN)
+      .join(" ")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+  } else {
+    strippedText = picked.text;
   }
 
-  if (!picked.text) {
+  if (!strippedText) {
     return { shouldSkip: true, text: "", didStrip: true };
   }
 
-  const rest = picked.text.trim();
+  const rest = strippedText.trim();
   if (mode === "heartbeat") {
     if (rest.length <= maxAckChars) {
       return { shouldSkip: true, text: "", didStrip: true };


### PR DESCRIPTION
Fixes #58098.

## What

`stripTokenAtEdges` only stripped `HEARTBEAT_OK` when it appeared at the start or end of the reply. When the token landed in the middle — e.g. a model prefacing its output with a thinking preamble before emitting the token, then the actual reply — the while loop never set `didStrip`, and `stripHeartbeatToken` returned the full original text, token included.

## Fix

In `heartbeat` mode, when the edge loop finds nothing to strip, fall back to a `split/join` removal pass that removes the token from any position. The cleaned text then flows through the existing `maxAckChars` short-skip check, so a near-empty remainder after removal is still suppressed correctly.

`message` mode behaviour is unchanged — the existing test covering that case continues to pass.

## Tests

Four new cases in `src/auto-reply/heartbeat.test.ts`:

- message mode: token in middle is left alone (existing test, renamed for clarity)
- heartbeat mode: mid-text token stripped, short remainder skipped
- heartbeat mode: mid-text token stripped, long remainder delivered
- heartbeat mode: mid-text token with surrounding newlines, long remainder delivered

Ref: #17717 (same issue, closed by the author under the mistaken belief that commit `78277152c` had already addressed it — that commit only added a test for the unrelated `showOk: false` suppression path).