### PR TITLE
fix: catch LiveSessionModelSwitchError in cron isolated agent runs

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -14,6 +14,7 @@ import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { resolveNestedAgentLane } from "../../agents/lanes.js";
+import { LiveSessionModelSwitchError } from "../../agents/live-model-switch.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider, resolveThinkingDefault } from "../../agents/model-selection.js";
@@ -557,7 +558,39 @@ export async function runCronIsolatedAgentTurn(params: {
       runEndedAt = Date.now();
     };
 
-    await runPrompt(commandBody);
+    // Retry loop: if the isolated session starts with the wrong model (e.g. the
+    // gateway default) and the runner detects a LiveSessionModelSwitchError, we
+    // restart with the model requested by the error — mirroring the retry logic
+    // in the main agent runner (agent-runner-execution.ts). Without this, cron
+    // jobs that specify a model different from the agent primary always fail or
+    // silently run with the wrong model.
+    // See: https://github.com/openclaw/openclaw/issues/58065
+    while (true) {
+      try {
+        await runPrompt(commandBody);
+        break;
+      } catch (err) {
+        if (err instanceof LiveSessionModelSwitchError) {
+          provider = err.provider;
+          model = err.model;
+          fallbackProvider = err.provider;
+          fallbackModel = err.model;
+          cronSession.sessionEntry.modelProvider = err.provider;
+          cronSession.sessionEntry.model = err.model;
+          // Persist the corrected model before retrying so sessions_list
+          // reflects the real model even if the retry also fails.
+          try {
+            await persistSessionEntry();
+          } catch (persistErr) {
+            logWarn(
+              `[cron:${params.job.id}] Failed to persist model switch session entry: ${String(persistErr)}`,
+            );
+          }
+          continue;
+        }
+        throw err;
+      }
+    }
     if (!runResult) {
       throw new Error("cron isolated run returned no result");
     }


### PR DESCRIPTION
## Summary

Fixes a regression where cron jobs configured with a specific `payload.model` override always ran with the agent's default model instead of the specified override.

## Root Cause

When `runEmbeddedPiAgent` detects a model mismatch between the current in-flight session and the persisted session store, it throws `LiveSessionModelSwitchError`. The main agent runner already handles this in a retry loop. However, the cron isolated session runner (`cron/isolated-agent/run.ts`) had no such retry logic — so any cron job with a `payload.model` different from the agent's primary model would hit this error and silently fall back to the agent default.

## Changes

- Wrap the initial `runPrompt(commandBody)` call in a `while(true)` retry loop that catches `LiveSessionModelSwitchError`
- On catch: update `provider`/`model` state, update the session entry, persist the corrected model, then `continue`
- Mirrors the existing retry pattern in `agent-runner-execution.ts` exactly

## Files Changed

- `src/cron/isolated-agent/run.ts` — adds `LiveSessionModelSwitchError` import and retry loop

Fixes openclaw/openclaw#58065