### PR TITLE
fix(qmd): apply han normalization only to lexical sub-queries

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1444,7 +1444,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("keeps original Han queries in qmd query mode", async () => {
+  it("keeps original Han queries in qmd query mode for vector and hyde, but normalizes lex", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -1454,12 +1454,14 @@ describe("QmdMemoryManager", () => {
           searchMode: "query",
           update: { interval: "0s", debounceMs: 60_000, onBoot: false },
           paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
         },
       },
     } as OpenClawConfig;
-    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "query") {
-        const child = createMockChild({ autoClose: false });
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (cmd.includes("mcporter") && args[0] === "call") {
         emitAndClose(child, "stdout", "[]");
         return child;
       }
@@ -1467,14 +1469,28 @@ describe("QmdMemoryManager", () => {
     });
 
     const { manager } = await createManager();
+    // Force v2 MCP tool resolving
+    (manager as any).qmdMcpToolVersion = "v2";
+    
     await expect(
       manager.search("記憶系統升級 QMD", { sessionKey: "agent:main:slack:dm:u123" }),
     ).resolves.toEqual([]);
 
-    const queryCall = spawnMock.mock.calls.find(
-      (call: unknown[]) => (call[1] as string[])?.[0] === "query",
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && call[0].includes("mcporter") && (call[1] as string[])?.[0] === "call",
     );
-    expect(queryCall?.[1]?.[1]).toBe("記憶系統升級 QMD");
+    expect(mcporterCall).toBeDefined();
+    
+    const callArgs = mcporterCall?.[1] as string[];
+    const jsonArgsIndex = callArgs.indexOf("--args") + 1;
+    const parsedArgs = JSON.parse(callArgs[jsonArgsIndex]);
+    
+    expect(parsedArgs.searches).toEqual([
+      { type: "lex", query: "記憶 憶系 系統 統升 升級 qmd" },
+      { type: "vec", query: "記憶系統升級 QMD" },
+      { type: "hyde", query: "記憶系統升級 QMD" },
+    ]);
+    
     await manager.close();
   });
 

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1418,19 +1418,21 @@ export class QmdMemoryManager implements MemorySearchManager {
     query: string,
     searchCommand?: string,
   ): Array<{ type: string; query: string }> {
+    const normalizedQuery = searchCommand === "search" ? normalizeHanBm25Query(query) : query;
     switch (searchCommand) {
       case "search":
         // BM25 keyword search only
-        return [{ type: "lex", query }];
+        return [{ type: "lex", query: normalizedQuery }];
       case "vsearch":
         // Vector search only
-        return [{ type: "vec", query }];
+        return [{ type: "vec", query: normalizedQuery }];
       case "query":
       case undefined:
       default:
         // Full hybrid: lex + vec + hyde (query expansion)
+        // Only normalize the lexical component; keep the original for semantic matches.
         return [
-          { type: "lex", query },
+          { type: "lex", query: normalizeHanBm25Query(query) },
           { type: "vec", query },
           { type: "hyde", query },
         ];


### PR DESCRIPTION
Fixes #58055. When using the QMD v2 \query\ tool, the raw user query is now passed intact to the vector and hyde sub-queries, while the lexical (BM25) sub-query continues to use the Han-normalized query. This prevents vector/hyde search degradation when searching with Chinese characters.

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:
- Missing detection / guardrail:
- Prior context (`git blame`, prior PR, issue, or refactor if known):
- Why this regressed now:
- If unknown, what was ruled out:

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

Fixes #58055

**Summary**
When using the QMD v2 `query` tool (hybrid search), OpenClaw was applying `normalizeHanBm25Query` to the entire query before passing it to QMD. This meant that the Han-normalized (space-separated bigrams) query was being sent not just to the `lex` sub-query, but also to the `vec` and `hyde` sub-queries. This aggressively degraded vector similarity matching and semantic expansion for Chinese queries, leading to empty results.

This PR fixes the issue by only applying Han normalization to the `lex` component, while preserving the raw, original query text for `vec` and `hyde`.

**Changes**
- In `extensions/memory-core/src/memory/qmd-manager.ts`, updated `buildV2Searches` to conditionally normalize the `query` field based on the search type.
- Updated `qmd-manager.test.ts` to assert that the `lex` query gets normalized while `vec` and `hyde` use the original query string.