### PR TITLE
fix(whatsapp): send unavailable presence on connect to restore phone notifications

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -69,12 +69,17 @@ export async function monitorWebInbox(options: {
   };
 
   try {
-    await sock.sendPresenceUpdate("available");
+    // Send 'unavailable' instead of 'available' to prevent WhatsApp from suppressing
+    // push notifications on the phone. When a linked device announces itself as available/online,
+    // WhatsApp routes messages silently to the device and stops sending phone notifications.
+    // Marking as unavailable preserves normal phone notification behavior while keeping
+    // the gateway fully functional. See: https://github.com/openclaw/openclaw/issues/30286
+    await sock.sendPresenceUpdate("unavailable");
     if (shouldLogVerbose()) {
-      logVerbose("Sent global 'available' presence on connect");
+      logVerbose("Sent global 'unavailable' presence on connect (preserves phone notifications)");
     }
   } catch (err) {
-    logVerbose(`Failed to send 'available' presence on connect: ${String(err)}`);
+    logVerbose(`Failed to send 'unavailable' presence on connect: ${String(err)}`);
   }
 
   const self = await readWebSelfIdentity(

--- a/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test.ts
@@ -83,7 +83,7 @@ describe("web monitor inbox", () => {
         fromMe: false,
       },
     ]);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("unavailable");
     await listener.close();
   });
 

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
@@ -93,7 +93,7 @@ describe("web monitor inbox", () => {
     });
 
     const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("unavailable");
     const messageId = nextMessageId("stream");
     const upsert = buildNotifyMessageUpsert({
       id: messageId,
@@ -117,7 +117,7 @@ describe("web monitor inbox", () => {
         fromMe: false,
       },
     ]);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("unavailable");
     expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("composing", "999@s.whatsapp.net");
     expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
       text: "pong",


### PR DESCRIPTION
## Problem

When OpenClaw connects via WhatsApp Web (Baileys), it announces presence as `available` on connect. WhatsApp treats this as an active desktop session and suppresses **all** push notifications on the phone — not just chats the gateway is monitoring.

This affects 100% of personal WhatsApp users running OpenClaw. Closes #30286.

## Root cause

In `extensions/whatsapp/src/inbound/monitor.ts`:

```ts
await sock.sendPresenceUpdate("available"); // ← suppresses phone notifications
```

Baileys documents this behavior explicitly:
> *"By default, Baileys sets your presence as online on connect. This will stop sending notifications to your phone."*

## Fix

Change the initial presence update to `unavailable`:

```ts
await sock.sendPresenceUpdate("unavailable");
```

This tells WhatsApp the linked device is passive/background, restoring normal phone notification behavior. The gateway continues to receive and process all messages normally.

## Precedent

Beeper (which also uses Baileys) applies exactly this fix — their users receive phone notifications normally while the bot remains connected.

## Changes

- `extensions/whatsapp/src/inbound/monitor.ts`: change `available` → `unavailable` with explanatory comment
- Two test files updated to assert `unavailable` instead of `available`

## Testing

Manually verified: with this patch applied, phone notifications resume immediately after gateway restart while the WhatsApp channel continues to function normally.