### PR TITLE
feat(skills): add per-skill model routing via SKILL.md frontmatter

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -92,6 +92,12 @@ import {
   applySkillEnvOverridesFromSnapshot,
   resolveSkillsPromptForRun,
 } from "../../skills.js";
+import {
+  buildSkillModelMap,
+  createActiveSkillModelContext,
+  wrapReadToolWithSkillModelDetect,
+  wrapStreamFnSkillModelRouter,
+} from "../../skills/model-router.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
@@ -354,6 +360,11 @@ export async function runEmbeddedAttempt(
           config: params.config,
         });
 
+    // Build skill→model map for model routing. Created once per attempt; the
+    // read-tool interceptor and StreamFn ModelRouter wrapper share the context.
+    const skillModelMap = buildSkillModelMap(skillEntries ?? [], params.modelRegistry);
+    const activeSkillModelCtx = createActiveSkillModelContext();
+
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
@@ -476,8 +487,17 @@ export async function runEmbeddedAttempt(
           },
         });
     const toolsEnabled = supportsModelTools(params.model);
+    // Wrap the read tool to detect SKILL.md loads and set the active skill model.
+    const toolsForRun =
+      skillModelMap.size > 0
+        ? toolsRaw.map((t) =>
+            t.name === "read"
+              ? wrapReadToolWithSkillModelDetect(t, skillModelMap, activeSkillModelCtx)
+              : t,
+          )
+        : toolsRaw;
     const tools = sanitizeToolsForGoogle({
-      tools: toolsEnabled ? toolsRaw : [],
+      tools: toolsEnabled ? toolsForRun : [],
       provider: params.provider,
     });
     const clientTools = toolsEnabled ? params.clientTools : undefined;
@@ -905,6 +925,15 @@ export async function runEmbeddedAttempt(
         model: params.model,
       });
 
+      // Route LLM calls to the skill-declared model when a SKILL.md with a
+      // model override has been read during this run attempt.
+      if (skillModelMap.size > 0) {
+        activeSession.agent.streamFn = wrapStreamFnSkillModelRouter(
+          activeSession.agent.streamFn,
+          activeSkillModelCtx,
+        );
+      }
+
       const { effectiveExtraParams } = applyExtraParamsToAgent(
         activeSession.agent,
         params.config,
@@ -992,7 +1021,6 @@ export async function runEmbeddedAttempt(
 
       if (
         params.model.api === "openai-responses" ||
-        params.model.api === "azure-openai-responses" ||
         params.model.api === "openai-codex-responses"
       ) {
         const inner = activeSession.agent.streamFn;
@@ -1477,7 +1505,6 @@ export async function runEmbeddedAttempt(
             workspaceDir: effectiveWorkspace,
             model: params.model,
             existingImages: params.images,
-            imageOrder: params.imageOrder,
             maxBytes: MAX_IMAGE_BYTES,
             maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
             workspaceOnly: effectiveFsWorkspaceOnly,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1021,6 +1021,7 @@ export async function runEmbeddedAttempt(
 
       if (
         params.model.api === "openai-responses" ||
+        params.model.api === "azure-openai-responses" ||
         params.model.api === "openai-codex-responses"
       ) {
         const inner = activeSession.agent.streamFn;
@@ -1505,6 +1506,7 @@ export async function runEmbeddedAttempt(
             workspaceDir: effectiveWorkspace,
             model: params.model,
             existingImages: params.images,
+            imageOrder: params.imageOrder,
             maxBytes: MAX_IMAGE_BYTES,
             maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
             workspaceOnly: effectiveFsWorkspaceOnly,

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -1,6 +1,37 @@
+import * as fs from "node:fs";
+import type { Skill } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadWorkspaceSkillEntries, type SkillEntry, type SkillSnapshot } from "../skills.js";
+import {
+  parseFrontmatter,
+  resolveOpenClawMetadata,
+  resolveSkillInvocationPolicy,
+} from "../skills/frontmatter.js";
 import { resolveSkillRuntimeConfig } from "../skills/runtime-config.js";
+
+/**
+ * Build SkillEntry objects from an already-resolved Skill list by reading
+ * each SKILL.md file.  Used when a cached skillsSnapshot skips the full
+ * directory scan, so that model-routing and other metadata-dependent features
+ * still have access to the parsed frontmatter.
+ */
+function buildSkillEntriesFromResolvedSkills(skills: Skill[]): SkillEntry[] {
+  return skills.map((skill) => {
+    let frontmatter = {};
+    try {
+      const raw = fs.readFileSync(skill.filePath, "utf-8");
+      frontmatter = parseFrontmatter(raw);
+    } catch {
+      // ignore unreadable skill files
+    }
+    return {
+      skill,
+      frontmatter,
+      metadata: resolveOpenClawMetadata(frontmatter),
+      invocation: resolveSkillInvocationPolicy(frontmatter),
+    };
+  });
+}
 
 export function resolveEmbeddedRunSkillEntries(params: {
   workspaceDir: string;
@@ -12,10 +43,19 @@ export function resolveEmbeddedRunSkillEntries(params: {
 } {
   const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
   const config = resolveSkillRuntimeConfig(params.config);
+
+  if (!shouldLoadSkillEntries && params.skillsSnapshot?.resolvedSkills) {
+    // Build SkillEntry objects from the cached Skill list so that features
+    // like skill-level model routing can read frontmatter metadata even when
+    // the full skill-directory scan is skipped.
+    return {
+      shouldLoadSkillEntries: false,
+      skillEntries: buildSkillEntriesFromResolvedSkills(params.skillsSnapshot.resolvedSkills),
+    };
+  }
+
   return {
-    shouldLoadSkillEntries,
-    skillEntries: shouldLoadSkillEntries
-      ? loadWorkspaceSkillEntries(params.workspaceDir, { config })
-      : [],
+    shouldLoadSkillEntries: true,
+    skillEntries: loadWorkspaceSkillEntries(params.workspaceDir, { config }),
   };
 }

--- a/src/agents/skills.test-helpers.ts
+++ b/src/agents/skills.test-helpers.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createSyntheticSourceInfo, type Skill } from "@mariozechner/pi-coding-agent";
+import { type Skill } from "@mariozechner/pi-coding-agent";
 
 export async function writeSkill(params: {
   dir: string;
@@ -37,12 +37,6 @@ export function createCanonicalFixtureSkill(params: {
     filePath: params.filePath,
     baseDir: params.baseDir,
     source: params.source,
-    sourceInfo: createSyntheticSourceInfo(params.filePath, {
-      source: params.source,
-      baseDir: params.baseDir,
-      scope: "project",
-      origin: "top-level",
-    }),
     disableModelInvocation: params.disableModelInvocation ?? false,
   };
 }

--- a/src/agents/skills.test-helpers.ts
+++ b/src/agents/skills.test-helpers.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { type Skill } from "@mariozechner/pi-coding-agent";
+import { createSyntheticSourceInfo, type Skill } from "@mariozechner/pi-coding-agent";
 
 export async function writeSkill(params: {
   dir: string;
@@ -37,6 +37,12 @@ export function createCanonicalFixtureSkill(params: {
     filePath: params.filePath,
     baseDir: params.baseDir,
     source: params.source,
+    sourceInfo: createSyntheticSourceInfo(params.filePath, {
+      source: params.source,
+      baseDir: params.baseDir,
+      scope: "project",
+      origin: "top-level",
+    }),
     disableModelInvocation: params.disableModelInvocation ?? false,
   };
 }

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -202,6 +202,12 @@ export function resolveOpenClawMetadata(
     os: osRaw.length > 0 ? osRaw : undefined,
     requires: requires,
     install: install.length > 0 ? install : undefined,
+    model:
+      typeof metadataObj.model === "string" ? metadataObj.model.trim() || undefined : undefined,
+    modelProfile:
+      typeof metadataObj.modelProfile === "string"
+        ? metadataObj.modelProfile.trim() || undefined
+        : undefined,
   };
 }
 

--- a/src/agents/skills/model-router.test.ts
+++ b/src/agents/skills/model-router.test.ts
@@ -1,0 +1,265 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import type { AnyAgentTool } from "../pi-tools.types.js";
+import {
+  buildSkillModelMap,
+  createActiveSkillModelContext,
+  resolveModelByProfile,
+  wrapReadToolWithSkillModelDetect,
+  wrapStreamFnSkillModelRouter,
+} from "./model-router.js";
+import type { SkillEntry } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeModel(provider: string, id: string, extra: Partial<Model<Api>> = {}): Model<Api> {
+  return { provider, id, name: id, ...extra } as Model<Api>;
+}
+
+function makeRegistry(models: Model<Api>[]): ModelRegistry {
+  return {
+    getAvailable: () => models,
+    find: (provider: string, modelId: string) =>
+      models.find((m) => m.provider === provider && m.id === modelId) ?? null,
+  } as unknown as ModelRegistry;
+}
+
+function makeSkillEntry(
+  name: string,
+  filePath: string,
+  metadata: Partial<{ model: string; modelProfile: string }> = {},
+): SkillEntry {
+  return {
+    skill: { name, filePath } as unknown as SkillEntry["skill"],
+    frontmatter: {},
+    metadata: Object.keys(metadata).length > 0 ? (metadata as SkillEntry["metadata"]) : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveModelByProfile
+// ---------------------------------------------------------------------------
+
+describe("resolveModelByProfile", () => {
+  const haiku = makeModel("anthropic", "claude-haiku-4-5");
+  const sonnet = makeModel("anthropic", "claude-sonnet-4-6");
+  const opus = makeModel("anthropic", "claude-opus-4-6");
+  const flash = makeModel("google", "gemini-flash-2.0");
+  const visionModel = makeModel("openai", "gpt-vision", { input: ["text", "image"] } as Partial<
+    Model<Api>
+  >);
+  const registry = makeRegistry([haiku, sonnet, opus, flash, visionModel]);
+
+  it("resolves 'fast' to a model with fast-tier id substring", () => {
+    const result = resolveModelByProfile("fast", registry);
+    expect(result?.id).toMatch(/haiku|flash|mini|small|nano/i);
+  });
+
+  it("resolves 'powerful' to an opus/pro model", () => {
+    const result = resolveModelByProfile("powerful", registry);
+    expect(result?.id).toMatch(/opus|pro|large|max/i);
+  });
+
+  it("resolves 'balanced' to a sonnet/medium model", () => {
+    const result = resolveModelByProfile("balanced", registry);
+    expect(result?.id).toMatch(/sonnet|medium/i);
+  });
+
+  it("resolves 'vision' to a model that accepts image input", () => {
+    const result = resolveModelByProfile("vision", registry);
+    expect(result?.input).toContain("image");
+  });
+
+  it("returns undefined for unknown profile", () => {
+    const result = resolveModelByProfile("unicorn-tier", registry);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    const result = resolveModelByProfile("", registry);
+    expect(result).toBeUndefined();
+  });
+
+  it("is case-insensitive for the profile name", () => {
+    const result = resolveModelByProfile("FAST", registry);
+    expect(result).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSkillModelMap
+// ---------------------------------------------------------------------------
+
+describe("buildSkillModelMap", () => {
+  const opus = makeModel("anthropic", "claude-opus-4-6");
+  const haiku = makeModel("anthropic", "claude-haiku-4-5");
+  const registry = makeRegistry([opus, haiku]);
+
+  it("resolves explicit model field", () => {
+    const entry = makeSkillEntry("my-skill", "/workspace/skills/my-skill/SKILL.md", {
+      model: "anthropic/claude-opus-4-6",
+    });
+    const map = buildSkillModelMap([entry], registry);
+    expect(map.size).toBe(1);
+    const key = [...map.keys()][0];
+    expect(key).toContain("SKILL.md");
+    expect(map.get(key)).toMatchObject({ provider: "anthropic", id: "claude-opus-4-6" });
+  });
+
+  it("resolves modelProfile field", () => {
+    const entry = makeSkillEntry("/workspace/skills/quick/SKILL.md", "quick", {
+      modelProfile: "fast",
+    });
+    const map = buildSkillModelMap([entry], registry);
+    expect(map.size).toBe(1);
+    expect([...map.values()][0]?.id).toMatch(/haiku|flash|mini|small|nano/i);
+  });
+
+  it("skips entry when model not in registry", () => {
+    const entry = makeSkillEntry("missing", "/workspace/skills/missing/SKILL.md", {
+      model: "openai/gpt-nonexistent",
+    });
+    const map = buildSkillModelMap([entry], registry);
+    expect(map.size).toBe(0);
+  });
+
+  it("skips entry when model field is malformed (no slash)", () => {
+    const entry = makeSkillEntry("bad", "/workspace/skills/bad/SKILL.md", {
+      model: "no-slash-here",
+    });
+    const map = buildSkillModelMap([entry], registry);
+    expect(map.size).toBe(0);
+  });
+
+  it("skips entry when modelProfile resolves to nothing", () => {
+    const entry = makeSkillEntry("noprofile", "/workspace/skills/noprofile/SKILL.md", {
+      modelProfile: "imaginary-tier",
+    });
+    const map = buildSkillModelMap([entry], registry);
+    expect(map.size).toBe(0);
+  });
+
+  it("returns empty map when no entries have model metadata", () => {
+    const entries = [
+      makeSkillEntry("a", "/workspace/skills/a/SKILL.md"),
+      makeSkillEntry("b", "/workspace/skills/b/SKILL.md"),
+    ];
+    const map = buildSkillModelMap(entries, registry);
+    expect(map.size).toBe(0);
+  });
+
+  it("returns empty map for empty skill entries", () => {
+    expect(buildSkillModelMap([], registry).size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapReadToolWithSkillModelDetect
+// ---------------------------------------------------------------------------
+
+describe("wrapReadToolWithSkillModelDetect", () => {
+  const opus = makeModel("anthropic", "claude-opus-4-6");
+  const skillFilePath = "/workspace/skills/deep/SKILL.md";
+
+  // pi-coding-agent execute signature: (toolCallId, args, signal)
+  type ReadExecute = (toolCallId: unknown, args: unknown) => Promise<unknown>;
+
+  function makeReadTool(onExecute?: (toolCallId: unknown, args: unknown) => void): AnyAgentTool {
+    return {
+      name: "read",
+      execute: vi.fn(async (toolCallId: unknown, args: unknown) => {
+        onExecute?.(toolCallId, args);
+        return "file content";
+      }),
+    } as unknown as AnyAgentTool;
+  }
+
+  it("sets ctx.activeModel when SKILL.md path is in map", async () => {
+    const skillModelMap = new Map([[skillFilePath, opus]]);
+    const ctx = createActiveSkillModelContext();
+    const tool = wrapReadToolWithSkillModelDetect(makeReadTool(), skillModelMap, ctx);
+
+    await (tool.execute as unknown as ReadExecute)("call-1", { path: skillFilePath });
+    expect(ctx.activeModel).toMatchObject({ id: "claude-opus-4-6" });
+  });
+
+  it("does NOT set ctx.activeModel for a non-SKILL.md path", async () => {
+    const skillModelMap = new Map([[skillFilePath, opus]]);
+    const ctx = createActiveSkillModelContext();
+    const tool = wrapReadToolWithSkillModelDetect(makeReadTool(), skillModelMap, ctx);
+
+    await (tool.execute as unknown as ReadExecute)("call-1", { path: "/workspace/src/foo.ts" });
+    expect(ctx.activeModel).toBeUndefined();
+  });
+
+  it("does NOT set ctx.activeModel for a SKILL.md path not in map", async () => {
+    const skillModelMap = new Map([[skillFilePath, opus]]);
+    const ctx = createActiveSkillModelContext();
+    const tool = wrapReadToolWithSkillModelDetect(makeReadTool(), skillModelMap, ctx);
+
+    await (tool.execute as unknown as ReadExecute)("call-1", {
+      path: "/workspace/skills/other/SKILL.md",
+    });
+    expect(ctx.activeModel).toBeUndefined();
+  });
+
+  it("returns original tool when skillModelMap is empty", () => {
+    const original = makeReadTool();
+    const result = wrapReadToolWithSkillModelDetect(
+      original,
+      new Map(),
+      createActiveSkillModelContext(),
+    );
+    expect(result).toBe(original);
+  });
+
+  it("still returns the original tool result", async () => {
+    const skillModelMap = new Map([[skillFilePath, opus]]);
+    const ctx = createActiveSkillModelContext();
+    const tool = wrapReadToolWithSkillModelDetect(makeReadTool(), skillModelMap, ctx);
+
+    const result = await (tool.execute as unknown as ReadExecute)("call-1", {
+      path: skillFilePath,
+    });
+    expect(result).toBe("file content");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapStreamFnSkillModelRouter
+// ---------------------------------------------------------------------------
+
+describe("wrapStreamFnSkillModelRouter", () => {
+  const defaultModel = makeModel("anthropic", "claude-sonnet-4-6");
+  const overrideModel = makeModel("anthropic", "claude-opus-4-6");
+
+  it("passes the override model when ctx.activeModel is set", () => {
+    const ctx = createActiveSkillModelContext();
+    ctx.activeModel = overrideModel;
+
+    const baseFn = vi.fn(() => ({ [Symbol.asyncIterator]: async function* () {} }));
+    const wrapped = wrapStreamFnSkillModelRouter(
+      baseFn as unknown as Parameters<typeof wrapStreamFnSkillModelRouter>[0],
+      ctx,
+    );
+
+    wrapped(defaultModel as unknown as Parameters<typeof wrapped>[0], { messages: [] }, {});
+    expect(baseFn).toHaveBeenCalledWith(overrideModel, { messages: [] }, {});
+  });
+
+  it("passes the original model when ctx.activeModel is undefined", () => {
+    const ctx = createActiveSkillModelContext();
+
+    const baseFn = vi.fn(() => ({ [Symbol.asyncIterator]: async function* () {} }));
+    const wrapped = wrapStreamFnSkillModelRouter(
+      baseFn as unknown as Parameters<typeof wrapStreamFnSkillModelRouter>[0],
+      ctx,
+    );
+
+    wrapped(defaultModel as unknown as Parameters<typeof wrapped>[0], { messages: [] }, {});
+    expect(baseFn).toHaveBeenCalledWith(defaultModel, { messages: [] }, {});
+  });
+});

--- a/src/agents/skills/model-router.test.ts
+++ b/src/agents/skills/model-router.test.ts
@@ -110,7 +110,7 @@ describe("buildSkillModelMap", () => {
   });
 
   it("resolves modelProfile field", () => {
-    const entry = makeSkillEntry("/workspace/skills/quick/SKILL.md", "quick", {
+    const entry = makeSkillEntry("quick", "/workspace/skills/quick/SKILL.md", {
       modelProfile: "fast",
     });
     const map = buildSkillModelMap([entry], registry);
@@ -204,6 +204,28 @@ describe("wrapReadToolWithSkillModelDetect", () => {
       path: "/workspace/skills/other/SKILL.md",
     });
     expect(ctx.activeModel).toBeUndefined();
+  });
+
+  it("resets ctx.activeModel to undefined when reading a SKILL.md NOT in the map", async () => {
+    const skillModelMap = new Map([[skillFilePath, opus]]);
+    const ctx = createActiveSkillModelContext();
+    ctx.activeModel = opus; // simulate skill-A already active
+    const tool = wrapReadToolWithSkillModelDetect(makeReadTool(), skillModelMap, ctx);
+
+    await (tool.execute as unknown as ReadExecute)("call-1", {
+      path: "/workspace/skills/other/SKILL.md",
+    });
+    expect(ctx.activeModel).toBeUndefined();
+  });
+
+  it("does NOT reset ctx.activeModel when reading a non-SKILL.md file", async () => {
+    const skillModelMap = new Map([[skillFilePath, opus]]);
+    const ctx = createActiveSkillModelContext();
+    ctx.activeModel = opus; // simulate skill-A already active
+    const tool = wrapReadToolWithSkillModelDetect(makeReadTool(), skillModelMap, ctx);
+
+    await (tool.execute as unknown as ReadExecute)("call-1", { path: "/workspace/src/foo.ts" });
+    expect(ctx.activeModel).toMatchObject({ id: "claude-opus-4-6" });
   });
 
   it("returns original tool when skillModelMap is empty", () => {

--- a/src/agents/skills/model-router.ts
+++ b/src/agents/skills/model-router.ts
@@ -181,7 +181,12 @@ export function wrapReadToolWithSkillModelDetect(
           log.debug(
             `[model-router] skill model override set to ${override.provider}/${override.id} (from ${normalized})`,
           );
+        } else if (path.basename(normalized) === "SKILL.md") {
+          // Reading a SKILL.md that has no model override — reset to session default
+          ctx.activeModel = undefined;
+          log.debug(`[model-router] skill model override cleared (no override for ${normalized})`);
         }
+        // Other file reads leave activeModel unchanged
       }
       // oxlint-disable-next-line typescript/no-explicit-any
       return (tool.execute as (...a: any[]) => unknown)(toolCallId, argsObj, ...rest);

--- a/src/agents/skills/model-router.ts
+++ b/src/agents/skills/model-router.ts
@@ -1,0 +1,206 @@
+import * as path from "node:path";
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const log = createSubsystemLogger("skill-model-router");
+import type { AnyAgentTool } from "../pi-tools.types.js";
+import type { SkillEntry } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Active skill model context — one instance per run attempt, shared by the
+// read-tool interceptor and the StreamFn ModelRouter wrapper.
+// ---------------------------------------------------------------------------
+
+export type ActiveSkillModelContext = {
+  activeModel: Model<Api> | undefined;
+};
+
+export function createActiveSkillModelContext(): ActiveSkillModelContext {
+  return { activeModel: undefined };
+}
+
+// ---------------------------------------------------------------------------
+// Profile-based model resolution
+// ---------------------------------------------------------------------------
+
+const PROFILE_HINTS: Record<string, string[]> = {
+  fast: ["haiku", "flash", "mini", "small", "nano"],
+  powerful: ["opus", "pro", "large", "max"],
+  large: ["opus", "pro", "large", "max"],
+  balanced: ["sonnet", "medium"],
+};
+
+/**
+ * Resolve a capability-tier profile name (e.g. "fast", "powerful") to the
+ * best available model in the registry.  Returns `undefined` when no model
+ * matches or the profile is unknown.
+ */
+export function resolveModelByProfile(
+  profile: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  const key = profile.trim().toLowerCase();
+  if (!key) {
+    return undefined;
+  }
+
+  const available = (modelRegistry as unknown as { getAvailable(): Model<Api>[] }).getAvailable();
+
+  // Special case: "vision" — prefer models that accept image input
+  if (key === "vision") {
+    return available.find((m) => m.input?.includes("image")) as Model<Api> | undefined;
+  }
+
+  const hints = PROFILE_HINTS[key];
+  if (!hints) {
+    log.debug(`[model-router] unknown model profile "${profile}", skipping override`);
+    return undefined;
+  }
+
+  for (const hint of hints) {
+    const match = available.find(
+      (m) => m.id.toLowerCase().includes(hint) || (m.name ?? "").toLowerCase().includes(hint),
+    ) as Model<Api> | undefined;
+    if (match) {
+      return match;
+    }
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Build the skill → model map once at the start of a run attempt.
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a map from absolute SKILL.md file path → Model to use when that
+ * skill is active.  Only skills with a `model` or `modelProfile` metadata
+ * field that resolves against the user's registry are included.
+ */
+export function buildSkillModelMap(
+  skillEntries: SkillEntry[],
+  modelRegistry: ModelRegistry,
+): Map<string, Model<Api>> {
+  const map = new Map<string, Model<Api>>();
+
+  log.debug(`[model-router] buildSkillModelMap: ${skillEntries.length} entries`);
+
+  for (const entry of skillEntries) {
+    const filePath: string | undefined = (entry.skill as unknown as { filePath?: string }).filePath;
+    if (!filePath) {
+      log.debug(`[model-router] skill "${entry.skill.name}" has no filePath, skipping`);
+      continue;
+    }
+
+    const { model: modelField, modelProfile } = entry.metadata ?? {};
+    log.debug(
+      `[model-router] skill "${entry.skill.name}" filePath=${filePath} model=${modelField ?? "none"} modelProfile=${modelProfile ?? "none"}`,
+    );
+
+    if (modelField) {
+      const slashIdx = modelField.indexOf("/");
+      if (slashIdx <= 0) {
+        log.debug(
+          `[model-router] skill "${entry.skill.name}" has invalid model "${modelField}" (expected "provider/modelId"), skipping`,
+        );
+        continue;
+      }
+      const provider = modelField.slice(0, slashIdx);
+      const modelId = modelField.slice(slashIdx + 1);
+      const resolved = (
+        modelRegistry as unknown as { find(p: string, m: string): Model<Api> | null | undefined }
+      ).find(provider, modelId);
+      if (resolved) {
+        map.set(path.resolve(filePath), resolved);
+      } else {
+        log.debug(
+          `[model-router] skill "${entry.skill.name}" requests model "${modelField}" which is not available in the registry, skipping override`,
+        );
+      }
+    } else if (modelProfile) {
+      const resolved = resolveModelByProfile(modelProfile, modelRegistry);
+      if (resolved) {
+        map.set(path.resolve(filePath), resolved);
+      } else {
+        log.debug(
+          `[model-router] skill "${entry.skill.name}" profile "${modelProfile}" matched no available model, skipping override`,
+        );
+      }
+    }
+  }
+
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Read-tool interceptor — sets activeModel synchronously before pi-agent-core
+// processes the tool result and issues the next LLM call.
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps the `read` tool so that reading a SKILL.md whose path is in
+ * `skillModelMap` updates `ctx.activeModel` before the result is returned.
+ * If `skillModelMap` is empty the original tool is returned unchanged.
+ */
+export function wrapReadToolWithSkillModelDetect(
+  tool: AnyAgentTool,
+  skillModelMap: Map<string, Model<Api>>,
+  ctx: ActiveSkillModelContext,
+): AnyAgentTool {
+  if (skillModelMap.size === 0) {
+    return tool;
+  }
+  return {
+    ...tool,
+    execute: async (toolCallId: unknown, argsObj: unknown, ...rest: unknown[]) => {
+      // pi-coding-agent execute signature: (toolCallId, args, signal)
+      // argsObj is { path, offset?, limit? } for the read tool.
+      // Note: LLMs sometimes use field aliases ("file", "filename") instead of "path".
+      const argsRecord =
+        argsObj != null && typeof argsObj === "object" ? (argsObj as Record<string, unknown>) : {};
+      const rawFilePath =
+        typeof argsRecord.path === "string"
+          ? argsRecord.path
+          : typeof argsRecord.file === "string"
+            ? argsRecord.file
+            : typeof argsRecord.filename === "string"
+              ? argsRecord.filename
+              : "";
+      const filePath = rawFilePath.trim();
+      log.debug(
+        `[model-router] read tool wrapper: toolCallId=${String(toolCallId)} argsKeys=${Object.keys(argsRecord).join(",")} filePath=${filePath}`,
+      );
+      if (filePath) {
+        const normalized = path.resolve(filePath);
+        const override = skillModelMap.get(normalized);
+        if (override) {
+          ctx.activeModel = override;
+          log.debug(
+            `[model-router] skill model override set to ${override.provider}/${override.id} (from ${normalized})`,
+          );
+        }
+      }
+      // oxlint-disable-next-line typescript/no-explicit-any
+      return (tool.execute as (...a: any[]) => unknown)(toolCallId, argsObj, ...rest);
+    },
+  } as AnyAgentTool;
+}
+
+// ---------------------------------------------------------------------------
+// StreamFn ModelRouter wrapper — substitutes the model on every LLM call.
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps `baseFn` so that when `ctx.activeModel` is set every LLM call uses
+ * the override model instead of the session default.  Zero overhead when
+ * `ctx.activeModel` is undefined.
+ */
+export function wrapStreamFnSkillModelRouter(
+  baseFn: StreamFn,
+  ctx: ActiveSkillModelContext,
+): StreamFn {
+  return (model, context, options) => baseFn(ctx.activeModel ?? model, context, options);
+}

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -30,6 +30,10 @@ export type OpenClawSkillMetadata = {
     config?: string[];
   };
   install?: SkillInstallSpec[];
+  /** Fully-qualified model to route to when this skill is active, e.g. "anthropic/claude-opus-4-6". */
+  model?: string;
+  /** Capability-tier hint resolved against available models, e.g. "fast" | "balanced" | "powerful" | "vision". */
+  modelProfile?: string;
 };
 
 export type SkillInvocationPolicy = {


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw picks one model for the entire session. Different skills have different computational needs — a fast lookup doesn't need the same model as deep document analysis or image understanding. There is no way for skill authors to encode which model performs their skill best.
- **Why it matters:** With multiple providers configured, the session default is always a compromise. Skill authors know which model fits their skill — but today that knowledge has nowhere to live.
- **What changed:** Two optional frontmatter fields (`model`, `modelProfile`) on `OpenClawSkillMetadata`. When the agent reads a SKILL.md that declares one of these, subsequent LLM calls in that run switch to the declared model if available in the registry. Also fixes a bug in `skills-runtime.ts` where the cached snapshot path returned empty `skillEntries`, making any frontmatter-dependent feature a no-op.
- **What did NOT change:** Default behavior is unchanged when no skill declares a model. All wrappers are no-ops when `skillModelMap.size === 0`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: When `skillsSnapshot.resolvedSkills` is cached (normal operation after first load), `resolveEmbeddedRunSkillEntries` returned `skillEntries: []`. This meant `buildSkillModelMap` always received 0 entries and the routing wrappers were never applied.
- Missing detection / guardrail: No test covered the cached-snapshot code path for metadata-dependent features.
- Prior context: `skills-runtime.ts` — the cached path was intentionally skipping the full directory scan for performance, but had no equivalent `SkillEntry[]` build from the cached `Skill[]`.
- Why this regressed now: New feature exposed the gap; pre-existing code path was never exercised by model-routing or similar metadata consumers.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/skills/model-router.test.ts`
- Scenario the test should lock in: `buildSkillModelMap` receives non-empty entries and produces a routing map.
- Why this is the smallest reliable guardrail: The map-building logic is pure and fully unit-testable without Docker or live models.
- Existing test that already covers this (if any): None prior.
- If no new test is added, why not: N/A — 21 new tests added.

## User-visible / Behavior Changes

Skill authors can now declare a preferred model in `SKILL.md` frontmatter:

```yaml
metadata:
  { "openclaw": { "model": "anthropic/claude-opus-4-6" } }
```

Or with a capability profile resolved against the user's configured providers:

```yaml
metadata:
  { "openclaw": { "modelProfile": "fast" } }
```

Profiles: `fast`, `balanced`, `powerful` / `large`, `vision`. If the declared model is not in the user's registry, the session default is used silently — no error, no interruption.

## Diagram (if applicable)

```text
Before:
Agent reads SKILL.md -> session default model used for all LLM calls

After:
Agent reads SKILL.md -> read-tool interceptor fires
  -> model resolved from registry
  -> activeModel set on shared context
Next LLM call -> StreamFn wrapper: activeModel ?? sessionDefault
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — model switching reuses the existing provider/auth already configured by the user
- Command/tool execution surface changed? No — read tool is intercepted (wrapped), not replaced
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Docker (Debian bookworm)
- Runtime/container: openclaw-agent Docker container
- Model/provider: Anthropic (claude-sonnet-4-6 default, claude-opus-4-6 via skill routing)
- Integration/channel: local agent (`--local`)
- Relevant config: `extraDirs: ["/app/sovyr-skills"]`, both Anthropic and MiniMax providers configured

### Steps

1. Add `model: "anthropic/claude-opus-4-6"` to a skill's `openclaw` frontmatter block
2. Run agent with `--log-level debug`
3. Ask agent to use that skill

### Expected

- `[model-router] skill model override set to anthropic/claude-opus-4-6` in logs
- Subsequent LLM calls use Opus

### Actual

- Confirmed in Docker end-to-end: agent starts on `claude-sonnet-4-6`, reads skill, switches to `claude-opus-4-6` for subsequent calls

## Evidence

- [x] Trace/log snippets

```
[skill-model-router] [model-router] buildSkillModelMap: 12 entries
[skill-model-router] [model-router] skill model override set to anthropic/claude-opus-4-6 (from /app/sovyr-skills/test-model-routing/SKILL.md)
```

- [x] Failing test/log before + passing after: `buildSkillModelMap: 0 entries` before fix, `12 entries` after

## Human Verification (required)

- Verified scenarios: skill declared with `model:` field routes to correct provider/model in Docker; fallback to session default when model not in registry (removed from config); 21 unit tests pass locally
- Edge cases checked: empty skill list, malformed model field (no `/`), unknown `modelProfile`, model not in registry
- What you did **not** verify: `modelProfile` end-to-end in Docker (unit-tested only); MiniMax provider routing (Anthropic only tested)

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `wrapReadToolWithSkillModelDetect` fires on every `read` tool call, not just SKILL.md reads.
  - Mitigation: The interceptor only sets `activeModel` when the path is in `skillModelMap` (O(1) map lookup). For all other reads it is a no-op. When `skillModelMap.size === 0` the original tool is returned unwrapped.