### PR TITLE
fix(media): drop sensitive headers on cross-origin redirects [AI]

### DIFF
--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -111,18 +111,30 @@ function isRedirectStatus(status: number): boolean {
   return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
 }
 
+export function retainSafeHeadersForCrossOriginRedirectHeaders(
+  headers?: HeadersInit,
+): Record<string, string> | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  const incoming = new Headers(headers);
+  const safeHeaders = new Headers();
+  for (const [key, value] of incoming.entries()) {
+    if (CROSS_ORIGIN_REDIRECT_SAFE_HEADERS.has(key.toLowerCase())) {
+      safeHeaders.set(key, value);
+    }
+  }
+  return Object.fromEntries(safeHeaders.entries());
+}
+
 function retainSafeHeadersForCrossOriginRedirect(init?: RequestInit): RequestInit | undefined {
   if (!init?.headers) {
     return init;
   }
-  const incoming = new Headers(init.headers);
-  const headers = new Headers();
-  for (const [key, value] of incoming.entries()) {
-    if (CROSS_ORIGIN_REDIRECT_SAFE_HEADERS.has(key.toLowerCase())) {
-      headers.set(key, value);
-    }
-  }
-  return { ...init, headers };
+  return {
+    ...init,
+    headers: retainSafeHeadersForCrossOriginRedirectHeaders(init.headers),
+  };
 }
 
 export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<GuardedFetchResult> {

--- a/src/media/store.redirect.test.ts
+++ b/src/media/store.redirect.test.ts
@@ -63,9 +63,12 @@ async function expectRedirectSaveResult(params: {
   expectedText: string;
   expectedContentType: string;
   expectedExtension: string;
+  headers?: Record<string, string>;
+  assertRequests?: () => void;
 }) {
-  const saved = await saveMediaSource("https://example.com/start");
+  const saved = await saveMediaSource("https://example.com/start", params.headers);
   expect(mockRequest).toHaveBeenCalledTimes(2);
+  params.assertRequests?.();
   expect(saved.contentType).toBe(params.expectedContentType);
   expect(path.extname(saved.path)).toBe(params.expectedExtension);
   expect(await fs.readFile(saved.path, "utf8")).toBe(params.expectedText);
@@ -130,6 +133,56 @@ describe("media store redirects", () => {
       expectedText: "redirected",
       expectedContentType: "text/plain",
       expectedExtension: ".txt",
+    });
+  });
+
+  it("drops sensitive headers on cross-origin redirects", async () => {
+    let call = 0;
+    mockRequest.mockImplementation((_url, _opts, cb) => {
+      call += 1;
+      if (call === 1) {
+        const exchange = mockRedirectExchange({ location: "https://other.example/final" });
+        exchange.send(cb);
+        return exchange.req;
+      }
+
+      const exchange = mockSuccessfulTextExchange({
+        text: "redirected",
+        contentType: "text/plain",
+      });
+      exchange.send(cb);
+      return exchange.req;
+    });
+
+    await expectRedirectSaveResult({
+      expectedText: "redirected",
+      expectedContentType: "text/plain",
+      expectedExtension: ".txt",
+      headers: {
+        Accept: "text/plain",
+        Authorization: "Bearer secret-token",
+        "User-Agent": "OpenClawTest/1.0",
+      },
+      assertRequests: () => {
+        expect(mockRequest.mock.calls[0]?.[1]).toMatchObject({
+          headers: {
+            Accept: "text/plain",
+            Authorization: "Bearer secret-token",
+            "User-Agent": "OpenClawTest/1.0",
+          },
+        });
+        expect(mockRequest.mock.calls[1]?.[1]).toMatchObject({
+          headers: {
+            accept: "text/plain",
+            "user-agent": "OpenClawTest/1.0",
+          },
+        });
+        expect(mockRequest.mock.calls[1]?.[1]).not.toMatchObject({
+          headers: {
+            authorization: expect.any(String),
+          },
+        });
+      },
     });
   });
 

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -6,6 +6,7 @@ import { request as httpsRequest } from "node:https";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { SafeOpenError, readLocalFileSafely } from "../infra/fs-safe.js";
+import { retainSafeHeadersForCrossOriginRedirectHeaders } from "../infra/net/fetch-guard.js";
 import { resolvePinnedHostname } from "../infra/net/ssrf.js";
 import { resolveConfigDir } from "../utils.js";
 import { detectMime, extensionForMime } from "./mime.js";
@@ -207,7 +208,11 @@ async function downloadToFile(
               return;
             }
             const redirectUrl = new URL(location, url).href;
-            resolve(downloadToFile(redirectUrl, dest, headers, maxRedirects - 1));
+            const redirectHeaders =
+              new URL(redirectUrl).origin === parsedUrl.origin
+                ? headers
+                : retainSafeHeadersForCrossOriginRedirectHeaders(headers);
+            resolve(downloadToFile(redirectUrl, dest, redirectHeaders, maxRedirects - 1));
             return;
           }
           if (!res.statusCode || res.statusCode >= 400) {


### PR DESCRIPTION
## Summary

- **Problem:** When the media store follows HTTP redirects to a different origin, request headers (including sensitive ones like `Authorization`) were forwarded unchanged, potentially leaking credentials to untrusted hosts.
- **Why it matters:** Cross-origin redirect header leakage is a recognized class of credential-exposure vulnerability; any caller that passes auth headers when downloading media could inadvertently send them to a third-party server.
- **What changed:** Added origin comparison in `downloadToFile`'s redirect handler and stripped headers to the CORS-safe allowlist (`retainSafeHeadersForCrossOriginRedirectHeaders`) when redirecting cross-origin. Extracted that helper as an exported function in `fetch-guard.ts` so it can be reused. Added a focused regression test in `store.redirect.test.ts`.
- **What did NOT change:** Same-origin redirect behavior is unchanged; all other SSRF / DNS-pinning logic in `fetch-guard.ts` is untouched.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Auth / tokens
- [x] Memory / storage

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `downloadToFile` forwarded the full caller-supplied headers on every hop, including cross-origin hops, with no origin check.
- Missing detection / guardrail: No test exercised a cross-origin redirect scenario with sensitive headers.
- Prior context: The SSRF guard in `fetch-guard.ts` already contained the safe-headers allowlist but it was only applied to the undici dispatcher path, not to the manual redirect loop in `store.ts`.
- Why this regressed now: The manual redirect loop was added separately from the undici dispatcher path, so the header-stripping logic was never applied there.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file: `src/media/store.redirect.test.ts`
- Scenario the test should lock in: On a cross-origin redirect, `Authorization` header is absent from the second request; `Accept` and `User-Agent` are retained.
- Why this is the smallest reliable guardrail: It mocks at the fetch boundary, controls redirect location, and asserts per-request header presence without requiring live network.
- Existing test that already covers this (if any): None prior to this PR.
- If no new test is added, why not: N/A — test is added.

## User-visible / Behavior Changes

None for typical users. Media downloads that follow cross-origin redirects will no longer forward `Authorization` or other sensitive headers to the redirect target. Downloads that stay on the same origin are unchanged.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? **Yes** — sensitive headers are now stripped before following cross-origin redirects.
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: The change is strictly additive-restriction; it can only prevent headers from being sent, never cause new ones to be sent. Same-origin behavior is guarded by the explicit origin comparison.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / Bun
- Model/provider: N/A
- Integration/channel (if any): Media pipeline

### Steps

1. Initiate a media download with an `Authorization` header where the server returns a 301/302 to a different origin.
2. Observe that the second request to the redirect target no longer carries `Authorization`.

### Expected

- Second-hop request omits `Authorization`; retains safe headers (Accept, User-Agent).

### Actual (before fix)

- Second-hop request carried `Authorization` unchanged.

## Evidence

- [x] Failing test/log before + passing after — new test `"drops sensitive headers on cross-origin redirects"` in `src/media/store.redirect.test.ts`.

## Human Verification (required)

This PR was generated by OpenAI Codex and reviewed with Claude Code (AI-assisted). No human-verified manual repro was performed beyond automated tests.

- Verified scenarios: Cross-origin redirect drops sensitive headers (automated test).
- Edge cases checked: Same-origin redirect retains all headers (existing behavior, not regressed).
- What you did **not** verify: Live network cross-origin redirect with a real media URL.

## AI/Vibe-Coded PR

- [x] Mark as AI-assisted — generated by OpenAI Codex, PR assembled with Claude Code
- [x] Lightly tested (automated seam test added; no manual end-to-end verification)
- [ ] Prompts/session logs available on request
- [x] Code reviewed and understood before submission

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: A caller that relied on forwarding `Authorization` across origins (non-standard) would silently stop sending it.
  - Mitigation: This matches browser and spec behavior for cross-origin redirects; no legitimate use case should depend on forwarding credentials cross-origin.