### PR TITLE
fix(web-fetch): preserve strict pinning behind env proxy

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,7 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
-import { hasEnvHttpProxyConfigured } from "../../infra/net/proxy-env.js";
+import { resolveEnvHttpProxyUrl } from "../../infra/net/proxy-env.js";
 import { SsrFBlockedError } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import type { RuntimeWebFetchFirecrawlMetadata } from "../../secrets/runtime-web-tools.js";
@@ -535,21 +535,23 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   let res: Response;
   let release: (() => Promise<void>) | null = null;
   let finalUrl = params.url;
-  const usesEnvHttpProxy = hasEnvHttpProxyConfigured(
-    parsedUrl.protocol === "https:" ? "https" : "http",
-  );
+  const envHttpProxyUrl =
+    parsedUrl.protocol === "https:" ? resolveEnvHttpProxyUrl("https") : undefined;
   try {
     const result = await fetchWithWebToolsNetworkGuard({
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
-      // Direct web_fetch owns its transport selection. When an env proxy is
-      // configured, prefer the proxy-aware dispatcher but keep the strict SSRF
-      // guard path so pinned destination routing still applies.
-      ...(usesEnvHttpProxy
+      // Strict web_fetch keeps destination pinning for untrusted URLs. For
+      // HTTPS targets, explicit proxy mode can preserve that binding by sending
+      // the pinned lookup on the request hop through the proxy. Plain HTTP
+      // targets intentionally stay on the direct strict path because explicit
+      // proxy pinning is not supported there.
+      ...(envHttpProxyUrl
         ? {
             dispatcherPolicy: {
-              mode: "env-proxy" as const,
+              mode: "explicit-proxy" as const,
+              proxyUrl: envHttpProxyUrl,
             },
           }
         : {}),

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,6 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
+import { hasEnvHttpProxyConfigured } from "../../infra/net/proxy-env.js";
 import { SsrFBlockedError } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import type { RuntimeWebFetchFirecrawlMetadata } from "../../secrets/runtime-web-tools.js";
@@ -534,11 +535,21 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   let res: Response;
   let release: (() => Promise<void>) | null = null;
   let finalUrl = params.url;
+  const usesEnvHttpProxy = hasEnvHttpProxyConfigured(
+    parsedUrl.protocol === "https:" ? "https" : "http",
+  );
   try {
     const result = await fetchWithWebToolsNetworkGuard({
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      ...(usesEnvHttpProxy
+        ? {
+            dispatcherPolicy: {
+              mode: "env-proxy" as const,
+            },
+          }
+        : {}),
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -543,6 +543,9 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      // Direct web_fetch owns its transport selection. When an env proxy is
+      // configured, prefer the proxy-aware dispatcher but keep the strict SSRF
+      // guard path so pinned destination routing still applies.
       ...(usesEnvHttpProxy
         ? {
             dispatcherPolicy: {

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -255,7 +255,7 @@ describe("web_fetch extraction fallbacks", () => {
     expect(details?.warning).toContain("Response body truncated");
   });
 
-  it("keeps DNS pinning for untrusted web_fetch URLs even when HTTP_PROXY is configured", async () => {
+  it("uses the env proxy dispatcher for web_fetch when HTTP_PROXY is configured", async () => {
     vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
     const mockFetch = installMockFetch((input: RequestInfo | URL) =>
       Promise.resolve({
@@ -274,7 +274,7 @@ describe("web_fetch extraction fallbacks", () => {
       | (RequestInit & { dispatcher?: unknown })
       | undefined;
     expect(requestInit?.dispatcher).toBeDefined();
-    expect(requestInit?.dispatcher).not.toBeInstanceOf(EnvHttpProxyAgent);
+    expect(requestInit?.dispatcher).toBeInstanceOf(EnvHttpProxyAgent);
   });
 
   // NOTE: Test for wrapping url/finalUrl/warning fields requires DNS mocking.

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -1,4 +1,4 @@
-import { EnvHttpProxyAgent } from "undici";
+import { EnvHttpProxyAgent, ProxyAgent } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ssrf from "../../infra/net/ssrf.js";
 import { resolveRequestUrl } from "../../plugin-sdk/request-url.js";
@@ -255,7 +255,7 @@ describe("web_fetch extraction fallbacks", () => {
     expect(details?.warning).toContain("Response body truncated");
   });
 
-  it("uses the env proxy dispatcher for web_fetch when HTTP_PROXY is configured", async () => {
+  it("uses the explicit proxy dispatcher for HTTPS web_fetch when an env HTTP proxy is configured", async () => {
     vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
     const mockFetch = installMockFetch((input: RequestInfo | URL) =>
       Promise.resolve({
@@ -274,7 +274,34 @@ describe("web_fetch extraction fallbacks", () => {
       | (RequestInit & { dispatcher?: unknown })
       | undefined;
     expect(requestInit?.dispatcher).toBeDefined();
-    expect(requestInit?.dispatcher).toBeInstanceOf(EnvHttpProxyAgent);
+    expect(requestInit?.dispatcher).toBeInstanceOf(ProxyAgent);
+    expect(requestInit?.dispatcher).not.toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
+  it("uses a pinned non-proxy dispatcher for web_fetch when no env HTTP proxy is configured", async () => {
+    vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("http_proxy", "");
+    vi.stubEnv("https_proxy", "");
+    const mockFetch = installMockFetch((input: RequestInfo | URL) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: makeFetchHeaders({ "content-type": "text/plain" }),
+        text: async () => "direct body",
+        url: resolveRequestUrl(input),
+      } as Response),
+    );
+    const tool = createFetchTool({ firecrawl: { enabled: false } });
+
+    await tool?.execute?.("call", { url: "https://example.com/direct" });
+
+    const requestInit = mockFetch.mock.calls[0]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+    expect(requestInit?.dispatcher).toBeDefined();
+    expect(requestInit?.dispatcher).not.toBeInstanceOf(EnvHttpProxyAgent);
+    expect(requestInit?.dispatcher).not.toBeInstanceOf(ProxyAgent);
   });
 
   // NOTE: Test for wrapping url/finalUrl/warning fields requires DNS mocking.


### PR DESCRIPTION
## Summary

AI-assisted: Codex

- Problem: `web_fetch` can bypass `HTTP_PROXY`/`HTTPS_PROXY` on the strict direct-fetch path, so HTTPS fetches fail in proxy-required environments even when other tools or `curl` work. A naive `env-proxy` switch would restore proxying but weaken strict destination pinning for untrusted URLs.
- Why it matters: proxy-only deployments need a usable outbound path, but `web_fetch` still has to preserve the strict SSRF guarantee that requests stay bound to the already-validated destination.
- What changed: `web_fetch` now resolves the matching env proxy URL for HTTPS targets and routes the strict path through `dispatcherPolicy: { mode: "explicit-proxy", proxyUrl }`, which preserves pinned lookup on the request hop. I also added positive and negative unit coverage for the proxy and non-proxy dispatcher selections.
- What did NOT change (scope boundary): trusted endpoint routing for Firecrawl/web search is unchanged, plain HTTP `web_fetch` still stays on the existing direct strict path, and the broader SSRF guard behavior was not relaxed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32947
- Related #38986
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: strict `web_fetch` always used the direct guarded path, so proxy-required environments had no usable transport for HTTPS fetches.
- Missing detection / guardrail: the original patch direction covered env-proxy transport selection but did not preserve the strict end-to-end pinning guarantee; the updated fix now keeps that boundary explicit.
- Prior context (`git blame`, prior PR, issue, or refactor if known): trusted Firecrawl/search paths already rely on operator-trusted proxy routing, while direct `web_fetch` uses the stricter SSRF-pinned path for untrusted URLs.
- Why this regressed now: the current implementation correctly favored strict routing by default, but that left proxy-only environments without an HTTPS transport.
- If unknown, what was ruled out: not a general network outage; public fetch works via `curl` in the same environment.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/tools/web-tools.fetch.test.ts`
- Scenario the test should lock in: HTTPS `web_fetch` uses an explicit proxy dispatcher when an env proxy is configured, and falls back to a pinned non-proxy dispatcher when no matching env proxy is present.
- Why this is the smallest reliable guardrail: the bug is in transport selection before extraction logic, so focused unit coverage on the fetch call shape is enough.
- Existing test that already covers this (if any): SSRF dispatcher tests already cover the lower-level proxy/pinning behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`web_fetch` can now succeed for HTTPS targets in proxy-required environments while preserving the strict SSRF routing guarantees for untrusted URLs.

## Diagram (if applicable)

```text
Before:
web_fetch (HTTPS) -> strict guarded fetch -> direct dispatcher only -> fetch failed behind proxy-only network

After:
web_fetch (HTTPS) -> strict guarded fetch + explicit proxy dispatcher -> proxy route with pinned request lookup -> fetch succeeds
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: HTTPS `web_fetch` can now use the configured env proxy, but it does so through the strict `explicit-proxy` path so the validated pinned lookup is preserved on the request hop. Plain HTTP remains on the old direct strict path because explicit-proxy pinning is not supported there.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (WSL)
- Runtime/container: Node v22.21.0, pnpm 10.32.1
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `HTTP_PROXY`/`HTTPS_PROXY` configured, `web_fetch` enabled

### Steps

1. Configure `HTTP_PROXY`/`HTTPS_PROXY` in an environment where direct outbound HTTPS fetch is blocked.
2. Run `web_fetch` against a public HTTPS URL.
3. Observe the dispatcher selected by the tool.

### Expected

- `web_fetch` uses the configured proxy path for HTTPS and returns content for reachable public URLs.

### Actual

- Before this patch, the strict direct fetch path bypassed the env proxy and could fail with `fetch failed`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `corepack pnpm exec vitest run src/agents/tools/web-tools.fetch.test.ts src/infra/net/ssrf.dispatcher.test.ts src/infra/net/fetch-guard.ssrf.test.ts`, `corepack pnpm exec oxlint --type-aware src/agents/tools/web-fetch.ts src/agents/tools/web-tools.fetch.test.ts`, `corepack pnpm exec oxfmt --check src/agents/tools/web-fetch.ts src/agents/tools/web-tools.fetch.test.ts`
- Edge cases checked: HTTPS with env proxy uses explicit proxy dispatch; no env proxy keeps the pinned non-proxy dispatcher; plain HTTP remains on the direct strict path.
- What you did **not** verify: full repo test suite, end-to-end proxy repro inside upstream checkout.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: proxy-enabled HTTPS environments now take a different dispatcher path for direct `web_fetch` calls.
  - Mitigation: keep the strict SSRF boundary via `explicit-proxy` and add focused unit coverage for both proxy and non-proxy transport selection.
