### PR TITLE
fix(config): redact Nostr privateKey in config views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,7 @@ Docs: https://docs.openclaw.ai
 - Message tool/buttons: keep the shared `buttons` schema optional in merged tool definitions so plain `action=send` calls stop failing validation when no buttons are provided. (#54418) Thanks @adzendo.
 - Agents/openai-compatible tool calls: deduplicate repeated tool call ids across live assistant messages and replayed history so OpenAI-compatible backends no longer reject duplicate `tool_call_id` values with HTTP 400. (#40996) Thanks @xaeon2026.
 - Models/openai-completions: default non-native OpenAI-compatible providers to omit tool-definition `strict` fields unless users explicitly opt back in, so tool calling keeps working on providers that reject that option. (#45497) Thanks @sahancava.
+- Nostr/config: redact `channels.nostr.privateKey` in config snapshots and Control UI config views, so Nostr signing keys no longer appear in plain text. Thanks @ccreater222.
 - Subagents/announcements: preserve the requester agent id for inline deterministic tool spawns so named agents without channel bindings can still announce completions through the correct owner session. (#55437) Thanks @kAIborg24.
 - Telegram/Anthropic streaming: replace raw invalid stream-order provider errors with a safe retry message so internal `message_start/message_stop` failures do not leak into chats. (#55408) Thanks @imydal.
 - Plugins/context engines: retry strict legacy `assemble()` calls without the new `prompt` field when older engines reject it, preserving prompt-aware retrieval compatibility for pre-prompt plugins. (#50848) thanks @danhdoan.

--- a/extensions/nostr/src/channel.test.ts
+++ b/extensions/nostr/src/channel.test.ts
@@ -227,7 +227,7 @@ describe("nostr account helpers", () => {
       expect(listNostrAccountIds(cfg)).toEqual(["work"]);
     });
 
-    it("treats SecretRef privateKey as configured", () => {
+    it("does not treat unresolved SecretRef privateKey as configured", () => {
       const cfg = {
         channels: {
           nostr: {
@@ -239,7 +239,7 @@ describe("nostr account helpers", () => {
           },
         },
       };
-      expect(listNostrAccountIds(cfg)).toEqual(["default"]);
+      expect(listNostrAccountIds(cfg)).toEqual([]);
     });
   });
 
@@ -329,7 +329,7 @@ describe("nostr account helpers", () => {
       expect(account.publicKey).toBe("");
     });
 
-    it("treats SecretRef privateKey as configured without trimming objects", () => {
+    it("does not treat unresolved SecretRef privateKey as configured", () => {
       const secretRef = {
         source: "env" as const,
         provider: "default",
@@ -344,7 +344,7 @@ describe("nostr account helpers", () => {
       };
       const account = resolveNostrAccount({ cfg });
 
-      expect(account.configured).toBe(true);
+      expect(account.configured).toBe(false);
       expect(account.privateKey).toBe("");
       expect(account.publicKey).toBe("");
       expect(account.config.privateKey).toEqual(secretRef);
@@ -372,7 +372,7 @@ describe("nostr account helpers", () => {
   });
 
   describe("setup wizard", () => {
-    it("treats SecretRef privateKey as already configured", () => {
+    it("keeps unresolved SecretRef privateKey visible without marking the account configured", () => {
       const secretRef = {
         source: "env" as const,
         provider: "default",
@@ -391,7 +391,7 @@ describe("nostr account helpers", () => {
       }
 
       expect(credential.inspect({ cfg, accountId: "default" })).toEqual({
-        accountConfigured: true,
+        accountConfigured: false,
         hasConfiguredValue: true,
         resolvedValue: undefined,
         envValue: undefined,

--- a/extensions/nostr/src/channel.test.ts
+++ b/extensions/nostr/src/channel.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../test/helpers/plugins/setup-wizard.js";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { nostrPlugin } from "./channel.js";
+import { nostrSetupWizard } from "./setup-surface.js";
 import {
   TEST_HEX_PRIVATE_KEY,
   TEST_SETUP_RELAY_URLS,
@@ -225,6 +226,21 @@ describe("nostr account helpers", () => {
       const cfg = createConfiguredNostrCfg({ defaultAccount: "work" });
       expect(listNostrAccountIds(cfg)).toEqual(["work"]);
     });
+
+    it("treats SecretRef privateKey as configured", () => {
+      const cfg = {
+        channels: {
+          nostr: {
+            privateKey: {
+              source: "env",
+              provider: "default",
+              id: "NOSTR_PRIVATE_KEY",
+            },
+          },
+        },
+      };
+      expect(listNostrAccountIds(cfg)).toEqual(["default"]);
+    });
   });
 
   describe("resolveDefaultNostrAccountId", () => {
@@ -313,6 +329,27 @@ describe("nostr account helpers", () => {
       expect(account.publicKey).toBe("");
     });
 
+    it("treats SecretRef privateKey as configured without trimming objects", () => {
+      const secretRef = {
+        source: "env" as const,
+        provider: "default",
+        id: "NOSTR_PRIVATE_KEY",
+      };
+      const cfg = {
+        channels: {
+          nostr: {
+            privateKey: secretRef,
+          },
+        },
+      };
+      const account = resolveNostrAccount({ cfg });
+
+      expect(account.configured).toBe(true);
+      expect(account.privateKey).toBe("");
+      expect(account.publicKey).toBe("");
+      expect(account.config.privateKey).toEqual(secretRef);
+    });
+
     it("preserves all config options", () => {
       const cfg = createConfiguredNostrCfg({
         name: "Bot",
@@ -330,6 +367,34 @@ describe("nostr account helpers", () => {
         relays: ["wss://relay1", "wss://relay2"],
         dmPolicy: "allowlist",
         allowFrom: ["pubkey1", "pubkey2"],
+      });
+    });
+  });
+
+  describe("setup wizard", () => {
+    it("treats SecretRef privateKey as already configured", () => {
+      const secretRef = {
+        source: "env" as const,
+        provider: "default",
+        id: "NOSTR_PRIVATE_KEY",
+      };
+      const cfg = {
+        channels: {
+          nostr: {
+            privateKey: secretRef,
+          },
+        },
+      };
+      const credential = nostrSetupWizard.credentials?.[0];
+      if (!credential?.inspect) {
+        throw new Error("nostr setup credential inspect missing");
+      }
+
+      expect(credential.inspect({ cfg, accountId: "default" })).toEqual({
+        accountConfigured: true,
+        hasConfiguredValue: true,
+        resolvedValue: undefined,
+        envValue: undefined,
       });
     });
   });

--- a/extensions/nostr/src/config-schema.ts
+++ b/extensions/nostr/src/config-schema.ts
@@ -4,6 +4,7 @@ import {
   DmPolicySchema,
   MarkdownConfigSchema,
 } from "openclaw/plugin-sdk/channel-config-primitives";
+import { buildSecretInputSchema } from "openclaw/plugin-sdk/secret-input";
 import { z } from "openclaw/plugin-sdk/zod";
 
 /**
@@ -73,7 +74,7 @@ export const NostrConfigSchema = z.object({
   markdown: MarkdownConfigSchema,
 
   /** Private key in hex or nsec bech32 format */
-  privateKey: z.string().optional(),
+  privateKey: buildSecretInputSchema().optional(),
 
   /** WebSocket relay URLs to connect to */
   relays: z.array(z.string()).optional(),

--- a/extensions/nostr/src/setup-surface.ts
+++ b/extensions/nostr/src/setup-surface.ts
@@ -2,6 +2,10 @@ import type { ChannelSetupAdapter } from "openclaw/plugin-sdk/channel-setup";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
 import {
+  hasConfiguredSecretInput,
+  normalizeSecretInputString,
+} from "openclaw/plugin-sdk/secret-input";
+import {
   createTopLevelChannelParsedAllowFromPrompt,
   createTopLevelChannelDmPolicy,
   createStandardChannelSetupStatus,
@@ -165,7 +169,7 @@ export const nostrSetupWizard: ChannelSetupWizard = {
     isAvailable: ({ cfg, accountId }) =>
       accountId === DEFAULT_ACCOUNT_ID &&
       Boolean(process.env.NOSTR_PRIVATE_KEY?.trim()) &&
-      !resolveNostrAccount({ cfg, accountId }).config.privateKey?.trim(),
+      !hasConfiguredSecretInput(resolveNostrAccount({ cfg, accountId }).config.privateKey),
     apply: async ({ cfg }) =>
       patchTopLevelChannelConfigSection({
         cfg,
@@ -191,8 +195,8 @@ export const nostrSetupWizard: ChannelSetupWizard = {
         const account = resolveNostrAccount({ cfg, accountId });
         return {
           accountConfigured: account.configured,
-          hasConfiguredValue: Boolean(account.config.privateKey?.trim()),
-          resolvedValue: account.config.privateKey?.trim(),
+          hasConfiguredValue: hasConfiguredSecretInput(account.config.privateKey),
+          resolvedValue: normalizeSecretInputString(account.config.privateKey),
           envValue: process.env.NOSTR_PRIVATE_KEY?.trim(),
         };
       },

--- a/extensions/nostr/src/types.ts
+++ b/extensions/nostr/src/types.ts
@@ -7,6 +7,11 @@ import {
   listCombinedAccountIds,
   resolveListedDefaultAccountId,
 } from "openclaw/plugin-sdk/account-resolution";
+import {
+  hasConfiguredSecretInput,
+  normalizeSecretInputString,
+  type SecretInput,
+} from "openclaw/plugin-sdk/secret-input";
 import type { OpenClawConfig } from "../api.js";
 import type { NostrProfile } from "./config-schema.js";
 import { DEFAULT_RELAYS } from "./default-relays.js";
@@ -16,7 +21,7 @@ export interface NostrAccountConfig {
   enabled?: boolean;
   name?: string;
   defaultAccount?: string;
-  privateKey?: string;
+  privateKey?: SecretInput;
   relays?: string[];
   dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
   allowFrom?: Array<string | number>;
@@ -51,7 +56,7 @@ export function listNostrAccountIds(cfg: OpenClawConfig): string[] {
     | undefined;
   return listCombinedAccountIds({
     configuredAccountIds: [],
-    implicitAccountId: nostrCfg?.privateKey
+    implicitAccountId: hasConfiguredSecretInput(nostrCfg?.privateKey)
       ? (resolveConfiguredDefaultNostrAccountId(cfg) ?? DEFAULT_ACCOUNT_ID)
       : undefined,
   });
@@ -80,11 +85,11 @@ export function resolveNostrAccount(opts: {
     | undefined;
 
   const baseEnabled = nostrCfg?.enabled !== false;
-  const privateKey = nostrCfg?.privateKey ?? "";
-  const configured = Boolean(privateKey.trim());
+  const privateKey = normalizeSecretInputString(nostrCfg?.privateKey) ?? "";
+  const configured = hasConfiguredSecretInput(nostrCfg?.privateKey);
 
   let publicKey = "";
-  if (configured) {
+  if (privateKey) {
     try {
       publicKey = getPublicKeyFromPrivate(privateKey);
     } catch {

--- a/extensions/nostr/src/types.ts
+++ b/extensions/nostr/src/types.ts
@@ -7,11 +7,7 @@ import {
   listCombinedAccountIds,
   resolveListedDefaultAccountId,
 } from "openclaw/plugin-sdk/account-resolution";
-import {
-  hasConfiguredSecretInput,
-  normalizeSecretInputString,
-  type SecretInput,
-} from "openclaw/plugin-sdk/secret-input";
+import { normalizeSecretInputString, type SecretInput } from "openclaw/plugin-sdk/secret-input";
 import type { OpenClawConfig } from "../api.js";
 import type { NostrProfile } from "./config-schema.js";
 import { DEFAULT_RELAYS } from "./default-relays.js";
@@ -54,9 +50,10 @@ export function listNostrAccountIds(cfg: OpenClawConfig): string[] {
   const nostrCfg = (cfg.channels as Record<string, unknown> | undefined)?.nostr as
     | NostrAccountConfig
     | undefined;
+  const privateKey = normalizeSecretInputString(nostrCfg?.privateKey);
   return listCombinedAccountIds({
     configuredAccountIds: [],
-    implicitAccountId: hasConfiguredSecretInput(nostrCfg?.privateKey)
+    implicitAccountId: privateKey
       ? (resolveConfiguredDefaultNostrAccountId(cfg) ?? DEFAULT_ACCOUNT_ID)
       : undefined,
   });
@@ -86,7 +83,7 @@ export function resolveNostrAccount(opts: {
 
   const baseEnabled = nostrCfg?.enabled !== false;
   const privateKey = normalizeSecretInputString(nostrCfg?.privateKey) ?? "";
-  const configured = hasConfiguredSecretInput(nostrCfg?.privateKey);
+  const configured = Boolean(privateKey);
 
   let publicKey = "";
   if (privateKey) {

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -8762,7 +8762,70 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           additionalProperties: false,
         },
         privateKey: {
-          type: "string",
+          anyOf: [
+            {
+              type: "string",
+            },
+            {
+              oneOf: [
+                {
+                  type: "object",
+                  properties: {
+                    source: {
+                      type: "string",
+                      const: "env",
+                    },
+                    provider: {
+                      type: "string",
+                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                    },
+                    id: {
+                      type: "string",
+                      pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                    },
+                  },
+                  required: ["source", "provider", "id"],
+                  additionalProperties: false,
+                },
+                {
+                  type: "object",
+                  properties: {
+                    source: {
+                      type: "string",
+                      const: "file",
+                    },
+                    provider: {
+                      type: "string",
+                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                    },
+                    id: {
+                      type: "string",
+                    },
+                  },
+                  required: ["source", "provider", "id"],
+                  additionalProperties: false,
+                },
+                {
+                  type: "object",
+                  properties: {
+                    source: {
+                      type: "string",
+                      const: "exec",
+                    },
+                    provider: {
+                      type: "string",
+                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                    },
+                    id: {
+                      type: "string",
+                    },
+                  },
+                  required: ["source", "provider", "id"],
+                  additionalProperties: false,
+                },
+              ],
+            },
+          ],
         },
         relays: {
           type: "array",
@@ -8825,6 +8888,11 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
       },
       additionalProperties: false,
+    },
+    uiHints: {
+      privateKey: {
+        sensitive: true,
+      },
     },
   },
   {

--- a/src/config/redact-snapshot.schema.test.ts
+++ b/src/config/redact-snapshot.schema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { REDACTED_SENTINEL, redactConfigSnapshot } from "./redact-snapshot.js";
 import { makeSnapshot, restoreRedactedValues } from "./redact-snapshot.test-helpers.js";
 import { redactSnapshotTestHints as mainSchemaHints } from "./redact-snapshot.test-hints.js";
+import { buildConfigSchema } from "./schema.js";
 
 describe("realredactConfigSnapshot_real", () => {
   it("main schema redact works (samples)", () => {
@@ -33,5 +34,26 @@ describe("realredactConfigSnapshot_real", () => {
     const restored = restoreRedactedValues(result.config, snapshot.config, mainSchemaHints);
     expect(restored.agents.defaults.memorySearch.remote.apiKey).toBe("1234");
     expect(restored.agents.list[0].memorySearch.remote.apiKey).toBe("6789");
+  });
+
+  it("redacts bundled channel private keys from generated schema hints", () => {
+    const hints = buildConfigSchema().uiHints;
+    const snapshot = makeSnapshot({
+      channels: {
+        nostr: {
+          privateKey: "nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5",
+          relays: ["wss://relay.example.com"],
+        },
+      },
+    });
+
+    const result = redactConfigSnapshot(snapshot, hints);
+    const channels = result.config.channels as Record<string, Record<string, unknown>>;
+    expect(channels.nostr.privateKey).toBe(REDACTED_SENTINEL);
+
+    const restored = restoreRedactedValues(result.config, snapshot.config, hints);
+    expect(restored.channels.nostr.privateKey).toBe(
+      "nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5",
+    );
   });
 });

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -841,6 +841,30 @@ describe("redactConfigSnapshot", () => {
     expectGatewayAuthFieldValue(result, "password", REDACTED_SENTINEL);
   });
 
+  it("redacts privateKey paths even when absent from uiHints (defense in depth)", () => {
+    const hints: ConfigUiHints = {
+      "some.other.path": { sensitive: true },
+    };
+    const snapshot = makeSnapshot({
+      channels: {
+        nostr: {
+          privateKey: "nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5",
+          relays: ["wss://relay.example.com"],
+        },
+      },
+    });
+
+    const result = redactConfigSnapshot(snapshot, hints);
+    const channels = result.config.channels as Record<string, Record<string, unknown>>;
+    expect(channels.nostr.privateKey).toBe(REDACTED_SENTINEL);
+    expect(channels.nostr.relays).toEqual(["wss://relay.example.com"]);
+
+    const restored = restoreRedactedValues(result.config, snapshot.config, hints);
+    expect(restored.channels.nostr.privateKey).toBe(
+      "nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5",
+    );
+  });
+
   it("redacts and restores dynamic env catchall secrets when uiHints miss the path", () => {
     const hints: ConfigUiHints = {
       "some.other.path": { sensitive: true },

--- a/src/config/schema.hints.test.ts
+++ b/src/config/schema.hints.test.ts
@@ -47,6 +47,8 @@ describe("isSensitiveConfigPath", () => {
     expect(isSensitiveConfigPath("channels.irc.nickserv.password")).toBe(true);
     expect(isSensitiveConfigPath("channels.feishu.encryptKey")).toBe(true);
     expect(isSensitiveConfigPath("channels.feishu.accounts.default.encryptKey")).toBe(true);
+    expect(isSensitiveConfigPath("channels.nostr.privateKey")).toBe(true);
+    expect(isSensitiveConfigPath("channels.nostr.accounts.default.privateKey")).toBe(true);
   });
 });
 

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -137,6 +137,7 @@ const SENSITIVE_PATTERNS = [
   /secret/i,
   /api.?key/i,
   /encrypt.?key/i,
+  /private.?key/i,
   /serviceaccount(?:ref)?$/i,
 ];
 


### PR DESCRIPTION
## Summary

- Problem: `channels.nostr.privateKey` could miss redaction when config views relied on generic path heuristics instead of generated sensitive hints.
- Why it matters: config snapshots and UI config views should never show the Nostr signing key in plaintext.
- What changed: the Nostr config schema now uses the shared secret-input helper, generated bundled-channel metadata marks `privateKey` sensitive, and config redaction now treats `privateKey` as sensitive in the fallback matcher with focused regression coverage.
- What did NOT change (scope boundary): no docs, no unrelated config refactors, no broader redaction heuristic rewrite.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the bundled Nostr channel declared `privateKey` as a plain `z.string()` field, so the generated config UI hints did not mark it sensitive.
- Missing detection / guardrail: the generic redaction fallback matched `token`, `password`, `secret`, `apiKey`, and `encryptKey`, but not `privateKey`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the preserved branch already switched the Nostr schema to `buildSecretInputSchema()` and regenerated bundled channel metadata; this follow-up keeps the fallback matcher aligned.
- Why this regressed now: the Nostr config schema never opted into the shared secret-input registration path.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/redact-snapshot.schema.test.ts`, `src/config/redact-snapshot.test.ts`, `src/config/schema.hints.test.ts`
- Scenario the test should lock in: generated Nostr config hints redact `channels.nostr.privateKey`, and the fallback matcher still redacts `privateKey` paths when `uiHints` are missing.
- Why this is the smallest reliable guardrail: the bug is in config schema sensitivity metadata plus the redaction fallback matcher, so direct config redaction tests are the narrowest proof.
- Existing test that already covers this (if any): the branch already added the real-schema round-trip coverage in `src/config/redact-snapshot.schema.test.ts`.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `channels.nostr.privateKey` is redacted in config snapshots and config views instead of being shown in plain text.

## Diagram (if applicable)

```text
Before:
[config snapshot/view] -> [nostr.privateKey plain string] -> [plaintext shown]

After:
[config snapshot/view] -> [sensitive hint or privateKey fallback] -> [__OPENCLAW_REDACTED__]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: this narrows secret exposure by ensuring existing config views redact `privateKey` consistently.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Nostr config schema
- Relevant config (redacted): `channels.nostr.privateKey=<redacted>`

### Steps

1. Configure `channels.nostr.privateKey` in the config snapshot.
2. Redact the snapshot with generated config schema hints, or with missing `uiHints` so fallback matching is exercised.
3. Inspect the returned config object.

### Expected

- `channels.nostr.privateKey` is replaced with `__OPENCLAW_REDACTED__`.

### Actual

- Before this fix, the generated hint path missed the field and the fallback matcher did not classify `privateKey` as sensitive.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reran the focused config redaction tests for schema hints, generic fallback, and generated-schema round-trip coverage.
- Edge cases checked: `privateKey` still redacts when `uiHints` miss the path; non-secret sibling fields like `relays` remain unchanged.
- What you did **not** verify: full `pnpm check` stayed stuck in the quiet `pnpm tsgo` phase under this worktree; I did not wait for a full green `check` before opening.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: broadening the fallback matcher could redact a benign `privateKey` field in a future plugin config.
  - Mitigation: this repo already treats `privateKey` as secret material in config surfaces, and `sensitive: false` uiHints still override the fallback when needed.
