### PR TITLE
fix(gateway): prune empty node-pending-work state entries to prevent memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 - Slack/thread context: filter thread starter and history by the effective conversation allowlist without dropping valid open-room, DM, or group DM context. (#58380) Thanks @jacobtomlinson.
 - ACP/gateway reconnects: reject stale pre-ack ACP prompts after reconnect grace expiry so callers fail cleanly instead of hanging indefinitely when the gateway never confirms the run.
 - Providers/Copilot: classify native GitHub Copilot API hosts in the shared provider endpoint resolver and harden token-derived proxy endpoint parsing so Copilot base URL routing stays centralized and fails closed on malformed hints. Thanks @vincentkoc.
+- Gateway: prune empty `node-pending-work` state entries after explicit acknowledgments and natural expiry so the per-node state map no longer grows indefinitely. (#58179) Thanks @gavyngong.
 
 ## 2026.4.1-beta.1
 

--- a/src/gateway/node-pending-work.test.ts
+++ b/src/gateway/node-pending-work.test.ts
@@ -64,4 +64,21 @@ describe("node pending work", () => {
     expect(acked).toEqual({ revision: 0, removedItemIds: [] });
     expect(getNodePendingWorkStateCountForTests()).toBe(0);
   });
+
+  it("prunes the state entry once all explicit items are acknowledged", () => {
+    const { item } = enqueueNodePendingWork({ nodeId: "node-5", type: "status.request" });
+    expect(getNodePendingWorkStateCountForTests()).toBe(1);
+
+    acknowledgeNodePendingWork({ nodeId: "node-5", itemIds: [item.id] });
+    expect(getNodePendingWorkStateCountForTests()).toBe(0);
+  });
+
+  it("prunes the state entry when all items expire naturally via drain", () => {
+    enqueueNodePendingWork({ nodeId: "node-6", type: "location.request", expiresInMs: 5_000 });
+    expect(getNodePendingWorkStateCountForTests()).toBe(1);
+
+    // Drain well after the item has expired (Date.now() + 60s > enqueue time + 5s)
+    drainNodePendingWork("node-6", { nowMs: Date.now() + 60_000 });
+    expect(getNodePendingWorkStateCountForTests()).toBe(0);
+  });
 });

--- a/src/gateway/node-pending-work.ts
+++ b/src/gateway/node-pending-work.ts
@@ -71,6 +71,12 @@ function pruneExpired(state: NodePendingWorkState, nowMs: number): boolean {
   return changed;
 }
 
+function pruneStateIfEmpty(nodeId: string, state: NodePendingWorkState) {
+  if (state.itemsById.size === 0) {
+    stateByNodeId.delete(nodeId);
+  }
+}
+
 function sortedItems(state: NodePendingWorkState): NodePendingWorkItem[] {
   return [...state.itemsById.values()].toSorted((a, b) => {
     const priorityDelta = PRIORITY_RANK[b.priority] - PRIORITY_RANK[a.priority];
@@ -138,6 +144,7 @@ export function drainNodePendingWork(nodeId: string, opts: DrainOptions = {}): D
   const revision = state?.revision ?? 0;
   if (state) {
     pruneExpired(state, nowMs);
+    pruneStateIfEmpty(normalizedNodeId, state);
   }
   const maxItems = Math.min(MAX_ITEMS, Math.max(1, Math.trunc(opts.maxItems ?? DEFAULT_MAX_ITEMS)));
   const explicitItems = state ? sortedItems(state) : [];
@@ -181,6 +188,7 @@ export function acknowledgeNodePendingWork(params: { nodeId: string; itemIds: st
   if (removedItemIds.length > 0) {
     state.revision += 1;
   }
+  pruneStateIfEmpty(nodeId, state);
   return { revision: state.revision, removedItemIds };
 }
 


### PR DESCRIPTION
## Summary

Fixes a memory leak in `src/gateway/node-pending-work.ts` where `stateByNodeId` map entries were never removed after all pending-work items were consumed, causing unbounded map growth over time.

## Changes

- **`src/gateway/node-pending-work.ts`**:
  - Extract `pruneStateIfEmpty(nodeId, state)` helper that deletes the map entry when `itemsById` reaches size 0.
  - Call it in `acknowledgeNodePendingWork` after items are removed (primary leak path).
  - Call it in `drainNodePendingWork` after `pruneExpired` (secondary leak path: items that expire naturally without being acknowledged).
- **`src/gateway/node-pending-work.test.ts`**:
  - Add regression test: enqueue → acknowledge → assert map size drops to 0.
  - Add regression test: enqueue with `expiresInMs` → drain after expiry → assert map size drops to 0.