### PR TITLE
Gateway hooks: add systemPrompt support for Gmail preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Breaking
 
+- Hooks: `hooks.mappings[].systemPrompt` is literal text only; `{{...}}` placeholders are no longer expanded from the webhook payload (use `messageTemplate` / other templated fields for dynamic content). This blocks prompt-injection via subject/body into the system channel.
 - Providers/Qwen: remove the deprecated `qwen-portal-auth` OAuth integration for `portal.qwen.ai`; migrate to Model Studio with `openclaw onboard --auth-choice modelstudio-api-key`. (#52709) Thanks @pomelo-nwu.
 - Config/Doctor: drop automatic config migrations older than two months; very old legacy keys now fail validation instead of being rewritten on load or by `openclaw doctor`.
 

--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -16723,7 +16723,7 @@
         "network"
       ],
       "label": "Google Chat",
-      "help": "Google Workspace Chat app via HTTP webhooks.",
+      "help": "Google Workspace Chat app with HTTP webhook.",
       "hasChildren": true
     },
     {
@@ -20991,7 +20991,7 @@
         "network"
       ],
       "label": "LINE",
-      "help": "LINE Messaging API bot for Japan/Taiwan/Thailand markets.",
+      "help": "LINE Messaging API webhook bot.",
       "hasChildren": true
     },
     {
@@ -21600,7 +21600,10 @@
     {
       "path": "channels.matrix.accessToken",
       "kind": "channel",
-      "type": "string",
+      "type": [
+        "object",
+        "string"
+      ],
       "required": false,
       "deprecated": false,
       "sensitive": true,
@@ -21611,6 +21614,36 @@
         "network",
         "security"
       ],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.matrix.accessToken.id",
+      "kind": "channel",
+      "type": "string",
+      "required": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.matrix.accessToken.provider",
+      "kind": "channel",
+      "type": "string",
+      "required": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.matrix.accessToken.source",
+      "kind": "channel",
+      "type": "string",
+      "required": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
       "hasChildren": false
     },
     {
@@ -23862,6 +23895,16 @@
       "kind": "channel",
       "type": "string",
       "required": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.msteams.blockStreaming",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -44763,6 +44806,26 @@
     },
     {
       "path": "models.providers.*.models.*.compat.toolSchemaProfile",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "models.providers.*.models.*.compat.unsupportedToolSchemaKeywords",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "models.providers.*.models.*.compat.unsupportedToolSchemaKeywords.*",
       "kind": "core",
       "type": "string",
       "required": false,

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5554}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5560}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1472,7 +1472,7 @@
 {"recordType":"path","path":"channels.feishu.webhookHost","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.webhookPath","kind":"channel","type":"string","required":true,"defaultValue":"/feishu/events","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.webhookPort","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.googlechat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Google Chat","help":"Google Workspace Chat app via HTTP webhooks.","hasChildren":true}
+{"recordType":"path","path":"channels.googlechat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Google Chat","help":"Google Workspace Chat app with HTTP webhook.","hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.accounts.*.actions","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1868,7 +1868,7 @@
 {"recordType":"path","path":"channels.irc.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.irc.tls","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.irc.username","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.line","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"LINE","help":"LINE Messaging API bot for Japan/Taiwan/Thailand markets.","hasChildren":true}
+{"recordType":"path","path":"channels.line","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"LINE","help":"LINE Messaging API webhook bot.","hasChildren":true}
 {"recordType":"path","path":"channels.line.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.line.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.line.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1921,7 +1921,10 @@
 {"recordType":"path","path":"channels.line.tokenFile","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.line.webhookPath","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Matrix","help":"open protocol; install the plugin to enable.","hasChildren":true}
-{"recordType":"path","path":"channels.matrix.accessToken","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":true,"tags":["access","auth","channels","network","security"],"hasChildren":false}
+{"recordType":"path","path":"channels.matrix.accessToken","kind":"channel","type":["object","string"],"required":false,"deprecated":false,"sensitive":true,"tags":["access","auth","channels","network","security"],"hasChildren":true}
+{"recordType":"path","path":"channels.matrix.accessToken.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.matrix.accessToken.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.matrix.accessToken.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.matrix.accounts.*","kind":"channel","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.ackReaction","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2127,6 +2130,7 @@
 {"recordType":"path","path":"channels.msteams.appPassword.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.appPassword.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.appPassword.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.msteams.blockStreaming","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.blockStreamingCoalesce","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.msteams.blockStreamingCoalesce.idleMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.blockStreamingCoalesce.maxChars","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3950,6 +3954,8 @@
 {"recordType":"path","path":"models.providers.*.models.*.compat.thinkingFormat","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.compat.toolCallArgumentsEncoding","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.compat.toolSchemaProfile","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"models.providers.*.models.*.compat.unsupportedToolSchemaKeywords","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"models.providers.*.models.*.compat.unsupportedToolSchemaKeywords.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.contextWindow","kind":"core","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.cost","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"models.providers.*.models.*.cost.cacheRead","kind":"core","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/docs/automation/gmail-pubsub.md
+++ b/docs/automation/gmail-pubsub.md
@@ -48,6 +48,7 @@ that sets `deliver` + optional `channel`/`to`:
         wakeMode: "now",
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
+        systemPrompt: "You are processing an incoming email notification. Summarize the content accurately without adding information not present in the email. If action is required, state it clearly. Do not invent details.",
         messageTemplate: "New email from {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}\n{{messages[0].body}}",
         model: "openai/gpt-5.2-mini",
         deliver: true,

--- a/docs/automation/gmail-pubsub.md
+++ b/docs/automation/gmail-pubsub.md
@@ -48,6 +48,7 @@ that sets `deliver` + optional `channel`/`to`:
         wakeMode: "now",
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
+        // systemPrompt is literal only (no {{...}}); use messageTemplate for email fields.
         systemPrompt: "You are processing an incoming email notification. Summarize the content accurately without adding information not present in the email. If action is required, state it clearly. Do not invent details.",
         messageTemplate: "New email from {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}\n{{messages[0].body}}",
         model: "openai/gpt-5.2-mini",

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -394,6 +394,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
         wakeMode: "now",
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
+        systemPrompt: "You are processing an incoming email notification. Summarize the content accurately without adding information not present in the email. If action is required, state it clearly. Do not invent details.",
         messageTemplate: "From: {{messages[0].from}}\nSubject: {{messages[0].subject}}",
         textTemplate: "{{messages[0].snippet}}",
         deliver: true,

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -394,6 +394,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
         wakeMode: "now",
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
+        // systemPrompt: literal only — no {{...}} expansion (use messageTemplate for payload fields).
         systemPrompt: "You are processing an incoming email notification. Summarize the content accurately without adding information not present in the email. If action is required, state it clearly. Do not invent details.",
         messageTemplate: "From: {{messages[0].from}}\nSubject: {{messages[0].subject}}",
         textTemplate: "{{messages[0].snippet}}",

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2692,7 +2692,8 @@ Auth: `Authorization: Bearer <token>` or `x-openclaw-token: <token>`.
 
 - `match.path` matches sub-path after `/hooks` (e.g. `/hooks/gmail` → `gmail`).
 - `match.source` matches a payload field for generic paths.
-- Templates like `{{messages[0].subject}}` read from the payload.
+- Templates like `{{messages[0].subject}}` read from the payload (`messageTemplate`, `sessionKey`, `textTemplate`, `name`, etc.).
+- `systemPrompt` is literal text only: `{{...}}` is not expanded. Put payload-driven content in `messageTemplate` so it stays on the user-message / external-content path.
 - `transform` can point to a JS/TS module returning a hook action.
   - `transform.module` must be a relative path and stays within `hooks.transformsDir` (absolute paths and traversal are rejected).
 - `agentId` routes to a specific agent; unknown IDs fall back to default.

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -9208,6 +9208,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                 sessionKey: {
                   type: "string",
                 },
+                systemPrompt: {
+                  type: "string",
+                },
                 messageTemplate: {
                   type: "string",
                 },
@@ -14558,6 +14561,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
       help: "Explicit session key override for mapping-delivered messages to control thread continuity. Use stable scoped keys so repeated events correlate without leaking into unrelated conversations.",
       tags: ["security", "storage"],
       sensitive: true,
+    },
+    "hooks.mappings[].systemPrompt": {
+      label: "Hook Mapping System Prompt",
+      help: "Literal extra system instructions for hook agent runs; `{{...}}` is not expanded from the webhook payload. Put dynamic payload text in messageTemplate so it stays on the user-message / external-content path.",
+      tags: ["advanced"],
     },
     "hooks.mappings[].messageTemplate": {
       label: "Hook Mapping Message Template",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1277,6 +1277,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Target agent ID for mapping execution when action routing should not use defaults. Use dedicated automation agents to isolate webhook behavior from interactive operator sessions.",
   "hooks.mappings[].sessionKey":
     "Explicit session key override for mapping-delivered messages to control thread continuity. Use stable scoped keys so repeated events correlate without leaking into unrelated conversations.",
+  "hooks.mappings[].systemPrompt":
+    "Literal extra system instructions for hook agent runs; `{{...}}` is not expanded from the webhook payload. Put dynamic payload text in messageTemplate so it stays on the user-message / external-content path.",
   "hooks.mappings[].messageTemplate":
     "Template for synthesizing structured mapping input into the final message content sent to the target action path. Keep templates deterministic so downstream parsing and behavior remain stable.",
   "hooks.mappings[].textTemplate":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -612,6 +612,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "hooks.mappings[].name": "Hook Mapping Name",
   "hooks.mappings[].agentId": "Hook Mapping Agent ID",
   "hooks.mappings[].sessionKey": "Hook Mapping Session Key",
+  "hooks.mappings[].systemPrompt": "Hook Mapping System Prompt",
   "hooks.mappings[].messageTemplate": "Hook Mapping Message Template",
   "hooks.mappings[].textTemplate": "Hook Mapping Text Template",
   "hooks.mappings[].deliver": "Hook Mapping Deliver Reply",

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -17,6 +17,7 @@ export type HookMappingConfig = {
   /** Route this hook to a specific agent (unknown ids fall back to the default agent). */
   agentId?: string;
   sessionKey?: string;
+  systemPrompt?: string;
   messageTemplate?: string;
   textTemplate?: string;
   deliver?: boolean;

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -17,6 +17,10 @@ export type HookMappingConfig = {
   /** Route this hook to a specific agent (unknown ids fall back to the default agent). */
   agentId?: string;
   sessionKey?: string;
+  /**
+   * Extra system instructions for agent hook runs. Literal config text only: `{{...}}` is not expanded
+   * (use `messageTemplate` for payload-driven content so external fields stay in the user message / wrapping path).
+   */
   systemPrompt?: string;
   messageTemplate?: string;
   textTemplate?: string;

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -45,6 +45,7 @@ export const HookMappingSchema = z
     name: z.string().optional(),
     agentId: z.string().optional(),
     sessionKey: z.string().optional().register(sensitive),
+    systemPrompt: z.string().optional(),
     messageTemplate: z.string().optional(),
     textTemplate: z.string().optional(),
     deliver: z.boolean().optional(),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -486,6 +486,7 @@ export async function runCronIsolatedAgentTurn(params: {
               timeoutMs,
               runId: cronSession.sessionEntry.sessionId,
               cliSessionId,
+              extraSystemPrompt: agentPayload?.systemPrompt,
               bootstrapPromptWarningSignaturesSeen,
               bootstrapPromptWarningSignature,
             });
@@ -537,6 +538,7 @@ export async function runCronIsolatedAgentTurn(params: {
             abortSignal,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,
+            extraSystemPrompt: agentPayload?.systemPrompt,
           });
           bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
             result.meta?.systemPromptReport,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -85,6 +85,7 @@ export type CronPayloadPatch = { kind: "systemEvent"; text?: string } | CronAgen
 
 type CronAgentTurnPayloadFields = {
   message: string;
+  systemPrompt?: string;
   /** Optional model override (provider/model or alias). */
   model?: string;
   /** Optional per-job fallback models; overrides agent/global fallbacks when defined. */

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -20,6 +20,7 @@ describe("hooks mapping", () => {
   function createGmailAgentMapping(params: {
     id: string;
     messageTemplate: string;
+    systemPrompt?: string;
     model?: string;
     agentId?: string;
   }) {
@@ -28,6 +29,7 @@ describe("hooks mapping", () => {
       match: { path: "gmail" },
       action: "agent" as const,
       messageTemplate: params.messageTemplate,
+      ...(params.systemPrompt ? { systemPrompt: params.systemPrompt } : {}),
       ...(params.model ? { model: params.model } : {}),
       ...(params.agentId ? { agentId: params.agentId } : {}),
     };
@@ -126,6 +128,22 @@ describe("hooks mapping", () => {
       ],
     });
     expectAgentMessage(result, "Subject: Hello");
+  });
+
+  it("renders system prompt template from payload", async () => {
+    const result = await applyGmailMappings({
+      mappings: [
+        createGmailAgentMapping({
+          id: "demo",
+          systemPrompt: "Summarize email: {{messages[0].subject}}",
+          messageTemplate: "Subject: {{messages[0].subject}}",
+        }),
+      ],
+    });
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.systemPrompt).toBe("Summarize email: Hello");
+    }
   });
 
   it("passes model override from mapping", async () => {

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -130,7 +130,7 @@ describe("hooks mapping", () => {
     expectAgentMessage(result, "Subject: Hello");
   });
 
-  it("renders system prompt template from payload", async () => {
+  it("keeps system prompt literal (does not expand {{...}} from payload)", async () => {
     const result = await applyGmailMappings({
       mappings: [
         createGmailAgentMapping({
@@ -142,7 +142,8 @@ describe("hooks mapping", () => {
     });
     expect(result?.ok).toBe(true);
     if (result?.ok && result.action?.kind === "agent") {
-      expect(result.action.systemPrompt).toBe("Summarize email: Hello");
+      expect(result.action.systemPrompt).toBe("Summarize email: {{messages[0].subject}}");
+      expect(result.action.message).toBe("Subject: Hello");
     }
   });
 

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -13,6 +13,7 @@ export type HookMappingResolved = {
   name?: string;
   agentId?: string;
   sessionKey?: string;
+  systemPrompt?: string;
   messageTemplate?: string;
   textTemplate?: string;
   deliver?: boolean;
@@ -46,6 +47,7 @@ export type HookAction =
   | {
       kind: "agent";
       message: string;
+      systemPrompt?: string;
       name?: string;
       agentId?: string;
       wakeMode: "now" | "next-heartbeat";
@@ -73,6 +75,8 @@ const hookPresetMappings: Record<string, HookMappingConfig[]> = {
       wakeMode: "now",
       name: "Gmail",
       sessionKey: "hook:gmail:{{messages[0].id}}",
+      systemPrompt:
+        "You are processing an incoming email notification.\nSummarize the content accurately without adding information not present in the email.\nIf action is required, state it clearly.\nDo not invent details.",
       messageTemplate:
         "New email from {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}\n{{messages[0].body}}",
     },
@@ -86,6 +90,7 @@ type HookTransformResult = Partial<{
   text: string;
   mode: "now" | "next-heartbeat";
   message: string;
+  systemPrompt: string;
   agentId: string;
   wakeMode: "now" | "next-heartbeat";
   name: string;
@@ -208,6 +213,7 @@ function normalizeHookMapping(
     name: mapping.name,
     agentId: mapping.agentId?.trim() || undefined,
     sessionKey: mapping.sessionKey,
+    systemPrompt: mapping.systemPrompt,
     messageTemplate: mapping.messageTemplate,
     textTemplate: mapping.textTemplate,
     deliver: mapping.deliver,
@@ -252,11 +258,13 @@ function buildActionFromMapping(
     };
   }
   const message = renderTemplate(mapping.messageTemplate ?? "", ctx);
+  const systemPrompt = renderOptional(mapping.systemPrompt, ctx);
   return {
     ok: true,
     action: {
       kind: "agent",
       message,
+      systemPrompt,
       name: renderOptional(mapping.name, ctx),
       agentId: mapping.agentId,
       wakeMode: mapping.wakeMode ?? "now",
@@ -290,11 +298,16 @@ function mergeAction(
   const baseAgent = base.kind === "agent" ? base : undefined;
   const message =
     typeof override.message === "string" ? override.message : (baseAgent?.message ?? "");
+  const systemPrompt =
+    typeof override.systemPrompt === "string"
+      ? override.systemPrompt
+      : (baseAgent?.systemPrompt ?? undefined);
   const wakeMode =
     override.wakeMode === "next-heartbeat" ? "next-heartbeat" : (baseAgent?.wakeMode ?? "now");
   return validateAction({
     kind: "agent",
     message,
+    systemPrompt,
     wakeMode,
     name: override.name ?? baseAgent?.name,
     agentId: override.agentId ?? baseAgent?.agentId,

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -258,7 +258,9 @@ function buildActionFromMapping(
     };
   }
   const message = renderTemplate(mapping.messageTemplate ?? "", ctx);
-  const systemPrompt = renderOptional(mapping.systemPrompt, ctx);
+  // systemPrompt must stay operator-controlled literal text — do not run {{...}} expansion
+  // from webhook payload (would let attacker-controlled fields become system-role instructions).
+  const systemPrompt = literalHookSystemPrompt(mapping.systemPrompt);
   return {
     ok: true,
     action: {
@@ -444,6 +446,14 @@ function normalizeMatchPath(raw?: string): string | undefined {
     return undefined;
   }
   return trimmed.replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function literalHookSystemPrompt(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 function renderOptional(value: string | undefined, ctx: HookMappingContext) {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -201,6 +201,7 @@ export function normalizeWakePayload(
 
 export type HookAgentPayload = {
   message: string;
+  systemPrompt?: string;
   name: string;
   agentId?: string;
   idempotencyKey?: string;

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -684,6 +684,7 @@ export function createHooksRequestHandler(
               sessionKey:
                 mapped.action.sessionKey ?? hooksConfig.sessionPolicy.defaultSessionKey ?? null,
               message: mapped.action.message,
+              systemPrompt: mapped.action.systemPrompt ?? null,
               name: mapped.action.name ?? "Hook",
               wakeMode: mapped.action.wakeMode,
               deliver: resolveHookDeliver(mapped.action.deliver),
@@ -701,6 +702,7 @@ export function createHooksRequestHandler(
           }
           const runId = dispatchAgentHook({
             message: mapped.action.message,
+            systemPrompt: mapped.action.systemPrompt,
             name: mapped.action.name ?? "Hook",
             idempotencyKey,
             agentId: targetAgentId,

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -218,6 +218,7 @@ describe("gateway server hooks", () => {
         {
           match: { path: "gmail" },
           action: "agent",
+          systemPrompt: "Summarize: {{messages[0].subject}}",
           messageTemplate: "New email from {{messages[0].from}}",
           sessionKey: "main",
         },
@@ -236,10 +237,11 @@ describe("gateway server hooks", () => {
 
       const call = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         sessionKey?: string;
-        job?: { payload?: { externalContentSource?: string } };
+        job?: { payload?: { externalContentSource?: string; systemPrompt?: string } };
       };
       expect(call?.sessionKey).toBe("main");
       expect(call?.job?.payload?.externalContentSource).toBe("gmail");
+      expect(call?.job?.payload?.systemPrompt).toBe("Summarize: Hello");
       drainSystemEvents(resolveMainKey());
     });
   });

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -241,7 +241,7 @@ describe("gateway server hooks", () => {
       };
       expect(call?.sessionKey).toBe("main");
       expect(call?.job?.payload?.externalContentSource).toBe("gmail");
-      expect(call?.job?.payload?.systemPrompt).toBe("Summarize: Hello");
+      expect(call?.job?.payload?.systemPrompt).toBe("Summarize: {{messages[0].subject}}");
       drainSystemEvents(resolveMainKey());
     });
   });

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -62,6 +62,7 @@ export function createGatewayHooksRequestHandler(params: {
       payload: {
         kind: "agentTurn",
         message: value.message,
+        systemPrompt: value.systemPrompt,
         model: value.model,
         thinking: value.thinking,
         timeoutSeconds: value.timeoutSeconds,


### PR DESCRIPTION
## Summary

* Problem: The Gmail hook preset formats the incoming email using `messageTemplate` but provides no dedicated system-level instructions to the isolated agent run.
* Why it matters: Without clear system-level guidance, lightweight models may guess the task or mix instructions with email content, increasing hallucinations/inconsistent behavior.
* What changed: Added optional `systemPrompt` support to hook mappings/presets and shipped a default `systemPrompt` for the built-in Gmail preset. The prompt is passed as literal text (no `{{...}}` expansion) through the hook → cron isolated run → agent runner plumbing.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: #57791


## Root Cause / Regression History (if applicable)

- Root cause: Gmail preset had only `messageTemplate` (email content as user message) and lacked a system-role instruction channel.
- Missing detection / guardrail: N/A
- Prior context: N/A
- Why this regressed now: N/A (feature gap)

## Regression Test Plan (if applicable)

- Coverage level Unit test + Seam / integration test
- Target test or file:
  - `src/gateway/hooks-mapping.test.ts`
  - `src/gateway/server.hooks.test.ts`
- Scenario the test should lock in:
  - `systemPrompt` is kept as literal text (no `{{...}}` expansion) and is carried into the dispatched cron job payload for mapped Gmail hook runs.
- Why this is the smallest reliable guardrail:
  - Covers both rendering and HTTP→dispatch plumbing; avoids dependency on real model providers.

## User-visible / Behavior Changes

- Gmail hook-triggered agent runs now receive a dedicated `systemPrompt` as system-role instructions (default from the Gmail preset, or overridden per mapping).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node (repo default)
- Model/provider: any (validated via plumbing/tests)
- Integration/channel: Gmail hook preset (`/hooks/gmail`)
- Relevant config (redacted):

### Steps

1. Enable hooks and enable Gmail preset (`hooks.presets: ["gmail"]`).
2. (Optional) Override the Gmail mapping with `hooks.mappings[].systemPrompt`.
3. Trigger Gmail hook delivery to `/hooks/gmail`.

### Expected

- Isolated agent run receives the hook `systemPrompt` as system-role instructions, separate from the email/user content.

### Actual

- Hook mapping rendering + server dispatch/tests verify `systemPrompt` is present in the dispatched cron payload.

## Evidence

- Tests:
  - `pnpm test -- src/gateway/hooks-mapping.test.ts src/gateway/server.hooks.test.ts`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` (new optional field: `hooks.mappings[].systemPrompt`)
- Migration needed? `No`

## Risks and Mitigations

- Risk: Slight prompt/behavior change for Gmail hook runs due to added system-role instructions.
- Mitigation: `systemPrompt` is optional, existing email rendering via `messageTemplate` is unchanged, and scoped tests cover the plumbing.