### PR TITLE
fix(discord): add total timeout for large attachment downloads (#41175, #57864)

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -55,6 +55,10 @@ import {
 import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-context.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
 import { resolveDiscordAutoThreadReplyPlan, resolveDiscordThreadStarter } from "./threading.js";
+import {
+  DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
+  DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
+} from "./timeouts.js";
 import { sendTyping } from "./typing.js";
 
 function sleep(ms: number): Promise<void> {
@@ -130,7 +134,14 @@ export async function processDiscordMessage(
   }
 
   const ssrfPolicy = cfg.browser?.ssrfPolicy;
-  const mediaList = await resolveMediaList(message, mediaMaxBytes, discordRestFetch, ssrfPolicy);
+  const mediaList = await resolveMediaList(
+    message,
+    mediaMaxBytes,
+    discordRestFetch,
+    ssrfPolicy,
+    DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
+    DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
+  );
   if (isProcessAborted(abortSignal)) {
     return;
   }
@@ -139,6 +150,8 @@ export async function processDiscordMessage(
     mediaMaxBytes,
     discordRestFetch,
     ssrfPolicy,
+    DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
+    DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
   );
   if (isProcessAborted(abortSignal)) {
     return;

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -298,6 +298,75 @@ describe("resolveForwardedMediaList", () => {
     expect(result).toEqual([]);
     expect(fetchRemoteMedia).not.toHaveBeenCalled();
   });
+
+  it("passes readIdleTimeoutMs to forwarded attachment downloads", async () => {
+    const attachment = {
+      id: "att-fwd-timeout",
+      url: "https://cdn.discordapp.com/attachments/1/fwd-timeout.png",
+      filename: "fwd-timeout.png",
+      content_type: "image/png",
+    };
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/fwd-timeout.png",
+      contentType: "image/png",
+    });
+
+    await resolveForwardedMediaList(
+      asMessage({
+        rawData: {
+          message_snapshots: [{ message: { attachments: [attachment] } }],
+        },
+      }),
+      512,
+      undefined,
+      undefined,
+      60000,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        readIdleTimeoutMs: 60000,
+      }),
+    );
+  });
+
+  it("passes readIdleTimeoutMs to forwarded sticker downloads", async () => {
+    const sticker = {
+      id: "sticker-fwd-timeout",
+      name: "fwd-timeout-sticker",
+      format_type: StickerFormatType.PNG,
+    };
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("sticker"),
+      contentType: "image/png",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/fwd-sticker-timeout.png",
+      contentType: "image/png",
+    });
+
+    await resolveForwardedMediaList(
+      asMessage({
+        rawData: {
+          message_snapshots: [{ message: { sticker_items: [sticker] } }],
+        },
+      }),
+      512,
+      undefined,
+      undefined,
+      60000,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        readIdleTimeoutMs: 60000,
+      }),
+    );
+  });
 });
 
 describe("resolveMediaList", () => {
@@ -485,6 +554,95 @@ describe("resolveMediaList", () => {
         placeholder: "<media:sticker>",
       },
     ]);
+  });
+
+  it("passes readIdleTimeoutMs to fetchRemoteMedia for attachments", async () => {
+    const attachment = {
+      id: "att-timeout",
+      url: "https://cdn.discordapp.com/attachments/1/timeout.png",
+      filename: "timeout.png",
+      content_type: "image/png",
+    };
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/timeout.png",
+      contentType: "image/png",
+    });
+
+    await resolveMediaList(
+      asMessage({
+        attachments: [attachment],
+      }),
+      512,
+      undefined,
+      undefined,
+      60000,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        readIdleTimeoutMs: 60000,
+      }),
+    );
+  });
+
+  it("passes readIdleTimeoutMs to fetchRemoteMedia for stickers", async () => {
+    const sticker = {
+      id: "sticker-timeout",
+      name: "timeout-sticker",
+      format_type: StickerFormatType.PNG,
+    };
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("sticker"),
+      contentType: "image/png",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/sticker-timeout.png",
+      contentType: "image/png",
+    });
+
+    await resolveMediaList(
+      asMessage({
+        stickers: [sticker],
+      }),
+      512,
+      undefined,
+      undefined,
+      60000,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        readIdleTimeoutMs: 60000,
+      }),
+    );
+  });
+
+  it("keeps attachment metadata when download times out", async () => {
+    const attachment = {
+      id: "att-timeout-fallback",
+      url: "https://cdn.discordapp.com/attachments/1/timeout-fallback.png",
+      filename: "timeout-fallback.png",
+      content_type: "image/png",
+    };
+    fetchRemoteMedia.mockRejectedValueOnce(
+      new Error("Media download stalled: no data received for 60000ms"),
+    );
+
+    const result = await resolveMediaList(
+      asMessage({
+        attachments: [attachment],
+      }),
+      512,
+      undefined,
+      undefined,
+      60000,
+    );
+
+    expectAttachmentImageFallback({ result, attachment });
   });
 });
 
@@ -698,5 +856,148 @@ describe("resolveDiscordChannelInfo", () => {
     expect(first).toBeNull();
     expect(second).toBeNull();
     expect(fetchChannel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveMediaList with timeout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("times out slow attachment downloads and returns fallback", async () => {
+    const attachment = {
+      id: "att-1",
+      filename: "large-video.mp4",
+      url: "https://cdn.discordapp.com/attachments/123/456/large-video.mp4",
+      content_type: "video/mp4",
+    };
+
+    fetchRemoteMedia.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              buffer: Buffer.from("fake-video-data"),
+              contentType: "video/mp4",
+              fileName: "large-video.mp4",
+            });
+          }, 200);
+        }),
+    );
+
+    const result = await resolveMediaList(
+      asMessage({
+        attachments: [attachment],
+      }),
+      10_000_000,
+      undefined,
+      undefined,
+      60_000,
+      100,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
+    expect(saveMediaBuffer).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        path: attachment.url,
+        contentType: "video/mp4",
+        placeholder: "<media:video>",
+      },
+    ]);
+  });
+
+  it("completes fast attachment downloads within timeout", async () => {
+    const attachment = {
+      id: "att-2",
+      filename: "small-image.png",
+      url: "https://cdn.discordapp.com/attachments/123/456/small-image.png",
+      content_type: "image/png",
+    };
+
+    fetchRemoteMedia.mockResolvedValue({
+      buffer: Buffer.from("fake-image-data"),
+      contentType: "image/png",
+      fileName: "small-image.png",
+    });
+
+    saveMediaBuffer.mockResolvedValue({
+      path: "/tmp/discord-media/small-image.png",
+      contentType: "image/png",
+    });
+
+    const result = await resolveMediaList(
+      asMessage({
+        attachments: [attachment],
+      }),
+      10_000_000,
+      undefined,
+      undefined,
+      60_000,
+      5000,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
+    expect(saveMediaBuffer).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      {
+        path: "/tmp/discord-media/small-image.png",
+        contentType: "image/png",
+        placeholder: "<media:image>",
+      },
+    ]);
+  });
+
+  it("times out forwarded media downloads and returns fallback", async () => {
+    fetchRemoteMedia.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              buffer: Buffer.from("fake-data"),
+              contentType: "image/png",
+            });
+          }, 200);
+        }),
+    );
+
+    const result = await resolveForwardedMediaList(
+      asMessage({
+        content: "",
+        rawData: {
+          message_snapshots: [
+            {
+              message: {
+                content: "Forwarded message",
+                attachments: [
+                  {
+                    id: "fwd-att-1",
+                    filename: "forwarded.png",
+                    url: "https://cdn.discordapp.com/attachments/111/222/forwarded.png",
+                    content_type: "image/png",
+                  },
+                ],
+                author: { id: "u1", username: "Alice" },
+              },
+            },
+          ],
+        },
+      }),
+      10_000_000,
+      undefined,
+      undefined,
+      60_000,
+      100,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
+    expect(saveMediaBuffer).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        path: "https://cdn.discordapp.com/attachments/111/222/forwarded.png",
+        contentType: "image/png",
+        placeholder: "<media:image>",
+      },
+    ]);
   });
 });

--- a/extensions/discord/src/monitor/message-utils.ts
+++ b/extensions/discord/src/monitor/message-utils.ts
@@ -211,6 +211,8 @@ export async function resolveMediaList(
   maxBytes: number,
   fetchImpl?: FetchLike,
   ssrfPolicy?: SsrFPolicy,
+  readIdleTimeoutMs?: number,
+  totalTimeoutMs?: number,
 ): Promise<DiscordMediaInfo[]> {
   const out: DiscordMediaInfo[] = [];
   const resolvedSsrFPolicy = resolveDiscordMediaSsrFPolicy(ssrfPolicy);
@@ -221,6 +223,8 @@ export async function resolveMediaList(
     errorPrefix: "discord: failed to download attachment",
     fetchImpl,
     ssrfPolicy: resolvedSsrFPolicy,
+    readIdleTimeoutMs,
+    totalTimeoutMs,
   });
   await appendResolvedMediaFromStickers({
     stickers: resolveDiscordMessageStickers(message),
@@ -229,6 +233,8 @@ export async function resolveMediaList(
     errorPrefix: "discord: failed to download sticker",
     fetchImpl,
     ssrfPolicy: resolvedSsrFPolicy,
+    readIdleTimeoutMs,
+    totalTimeoutMs,
   });
   return out;
 }
@@ -238,6 +244,8 @@ export async function resolveForwardedMediaList(
   maxBytes: number,
   fetchImpl?: FetchLike,
   ssrfPolicy?: SsrFPolicy,
+  readIdleTimeoutMs?: number,
+  totalTimeoutMs?: number,
 ): Promise<DiscordMediaInfo[]> {
   const snapshots = resolveDiscordMessageSnapshots(message);
   if (snapshots.length === 0) {
@@ -253,6 +261,8 @@ export async function resolveForwardedMediaList(
       errorPrefix: "discord: failed to download forwarded attachment",
       fetchImpl,
       ssrfPolicy: resolvedSsrFPolicy,
+      readIdleTimeoutMs,
+      totalTimeoutMs,
     });
     await appendResolvedMediaFromStickers({
       stickers: snapshot.message ? resolveDiscordSnapshotStickers(snapshot.message) : [],
@@ -261,6 +271,8 @@ export async function resolveForwardedMediaList(
       errorPrefix: "discord: failed to download forwarded sticker",
       fetchImpl,
       ssrfPolicy: resolvedSsrFPolicy,
+      readIdleTimeoutMs,
+      totalTimeoutMs,
     });
   }
   return out;
@@ -273,6 +285,8 @@ async function appendResolvedMediaFromAttachments(params: {
   errorPrefix: string;
   fetchImpl?: FetchLike;
   ssrfPolicy?: SsrFPolicy;
+  readIdleTimeoutMs?: number;
+  totalTimeoutMs?: number;
 }) {
   const attachments = params.attachments;
   if (!attachments || attachments.length === 0) {
@@ -280,13 +294,32 @@ async function appendResolvedMediaFromAttachments(params: {
   }
   for (const attachment of attachments) {
     try {
-      const fetched = await fetchRemoteMedia({
+      const fetchPromise = fetchRemoteMedia({
         url: attachment.url,
         filePathHint: attachment.filename ?? attachment.url,
         maxBytes: params.maxBytes,
         fetchImpl: params.fetchImpl,
         ssrfPolicy: params.ssrfPolicy,
+        readIdleTimeoutMs: params.readIdleTimeoutMs,
       });
+
+      let fetched: Awaited<typeof fetchPromise>;
+      if (params.totalTimeoutMs) {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          const timeoutPromise = new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+              reject(new Error(`Media fetch timed out after ${params.totalTimeoutMs}ms`));
+            }, params.totalTimeoutMs);
+          });
+          fetched = await Promise.race([fetchPromise, timeoutPromise]);
+        } finally {
+          if (timer) clearTimeout(timer);
+        }
+      } else {
+        fetched = await fetchPromise;
+      }
+
       const saved = await saveMediaBuffer(
         fetched.buffer,
         fetched.contentType ?? attachment.content_type,
@@ -383,6 +416,8 @@ async function appendResolvedMediaFromStickers(params: {
   errorPrefix: string;
   fetchImpl?: FetchLike;
   ssrfPolicy?: SsrFPolicy;
+  readIdleTimeoutMs?: number;
+  totalTimeoutMs?: number;
 }) {
   const stickers = params.stickers;
   if (!stickers || stickers.length === 0) {
@@ -393,13 +428,32 @@ async function appendResolvedMediaFromStickers(params: {
     let lastError: unknown;
     for (const candidate of candidates) {
       try {
-        const fetched = await fetchRemoteMedia({
+        const fetchPromise = fetchRemoteMedia({
           url: candidate.url,
           filePathHint: candidate.fileName,
           maxBytes: params.maxBytes,
           fetchImpl: params.fetchImpl,
           ssrfPolicy: params.ssrfPolicy,
+          readIdleTimeoutMs: params.readIdleTimeoutMs,
         });
+
+        let fetched: Awaited<typeof fetchPromise>;
+        if (params.totalTimeoutMs) {
+          let timer: ReturnType<typeof setTimeout> | undefined;
+          try {
+            const timeoutPromise = new Promise<never>((_, reject) => {
+              timer = setTimeout(() => {
+                reject(new Error(`Media fetch timed out after ${params.totalTimeoutMs}ms`));
+              }, params.totalTimeoutMs);
+            });
+            fetched = await Promise.race([fetchPromise, timeoutPromise]);
+          } finally {
+            if (timer) clearTimeout(timer);
+          }
+        } else {
+          fetched = await fetchPromise;
+        }
+
         const saved = await saveMediaBuffer(
           fetched.buffer,
           fetched.contentType,

--- a/extensions/discord/src/monitor/timeouts.ts
+++ b/extensions/discord/src/monitor/timeouts.ts
@@ -2,6 +2,8 @@ const MAX_DISCORD_TIMEOUT_MS = 2_147_483_647;
 
 export const DISCORD_DEFAULT_LISTENER_TIMEOUT_MS = 120_000;
 export const DISCORD_DEFAULT_INBOUND_WORKER_TIMEOUT_MS = 30 * 60_000;
+export const DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS = 60_000;
+export const DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS = 120_000;
 
 function clampDiscordTimeoutMs(timeoutMs: number, minimumMs: number): number {
   return Math.max(minimumMs, Math.min(Math.floor(timeoutMs), MAX_DISCORD_TIMEOUT_MS));


### PR DESCRIPTION
## Problem

When a Discord message contains a large attachment (video mp4 ~8MB, images 15-17MB), the inbound worker hangs for up to **1800 seconds** (30 minutes), blocking all subsequent messages in that thread/channel.

**Root cause:** The existing `DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS` (60s) only triggers when there's no data flowing between chunks. For cases where the connection hangs at DNS/TCP level, or the server sends headers but stalls on body, the idle timeout never fires. The inbound worker blocks until its own 1800s timeout.

Fixes #41175, fixes #57864.

## Reproduction & Log Analysis

We reproduced this 3 times with an 8.4MB mp4 in a Discord thread:

1. User sends mp4 attachment in thread
2. **Zero media/attachment/download log entries appear** — the hang occurs silently
3. Exactly 1800 seconds later: `discord inbound worker timed out after 1800 seconds`
4. During the entire 30 minutes, all subsequent messages in the thread are blocked (even @mentions)

```
2026-03-31T16:00:20.420+08:00 [ERROR] discord inbound worker timed out after 1800 seconds
(channelId=1488440190283550811, messageId=1488440303852454060)
```

The complete absence of any media-related log between the message arrival and timeout confirms the hang is in the early fetch phase (`fetchRemoteMedia`), before any processing/base64 encoding occurs.

## Solution

1. **Added `DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS` (120s)** — an absolute ceiling on total download time per attachment, regardless of data flow rate
2. **`Promise.race()` wrapper** on `fetchRemoteMedia()` calls — if total timeout fires, the download is abandoned
3. **Graceful fallback** — when media fetch times out, the text portion of the message is still delivered to the agent with the attachment URL as a placeholder
4. Applied to both attachments and stickers, including forwarded messages

## Files Changed

- `extensions/discord/src/monitor/timeouts.ts` — new `DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS` constant
- `extensions/discord/src/monitor/message-utils.ts` — timeout wrapper with `Promise.race()`
- `extensions/discord/src/monitor/message-handler.process.ts` — pass timeout params
- `extensions/discord/src/monitor/message-utils.test.ts` — 3 new test cases

## Testing

- ✅ All existing Discord monitor tests pass (47 test files, 37 tests in message-utils)
- ✅ New timeout scenario tests pass:
  - `times out slow attachment downloads and returns fallback`
  - `completes fast attachment downloads within timeout`
  - `times out forwarded media downloads and returns fallback`
- ✅ Pre-commit hooks (formatting, linting, type checking) pass