### PR TITLE
fix(exec): unwrap arch and xcrun dispatch wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ Docs: https://docs.openclaw.ai
 - Media/downloads: stop forwarding auth and cookie headers across cross-origin redirects during media saves, while preserving safe request headers for same-origin redirect chains. Thanks @AntAISecurityLab and @vincentkoc.
 - Doctor/plugins: skip false Matrix legacy-helper warnings when no migration plans exist, and keep bundled `enabledByDefault` plugins in the gateway startup set. (#57931) Thanks @dinakars777.
 - Zalo/webhooks: scope replay dedupe to the authenticated target so one configured account can no longer cause same-id inbound events for another target to be dropped. Thanks @smaeljaish771 and @vincentkoc.
+- Exec approvals/macOS: unwrap `arch` and `xcrun` before deriving shell payloads and allow-always patterns, so wrapper approvals stay bound to the carried command instead of the outer carrier. Thanks @tdjackey and @vincentkoc.
 - Matrix/CLI send: start one-off Matrix send clients before outbound delivery so `openclaw message send --channel matrix` restores E2EE in encrypted rooms instead of sending plain events. (#57936) Thanks @gumadeiras.
 - xAI/Responses: normalize image-bearing tool results for xAI responses payloads, including OpenResponses-style `input_image.source` parts, so image tool replays no longer 422 on the follow-up turn. (#58017) Thanks @neeravmakwana.
 - Cron/isolated sessions: carry the full live-session provider, model, and auth-profile selection across retry restarts so cron jobs with model overrides no longer fail or loop on mid-run model-switch requests. (#57972) Thanks @issaba1.

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -413,7 +413,6 @@ type DispatchWrapperSpec = {
 };
 
 const DISPATCH_WRAPPER_SPECS: readonly DispatchWrapperSpec[] = [
-  { name: "caffeinate", unwrap: unwrapCaffeinateInvocation, transparentUsage: true },
   {
     name: "arch",
     unwrap: (argv, platform) =>

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -384,6 +384,14 @@ function unwrapArchInvocation(argv: string[]): string[] | null {
   });
 }
 
+function supportsArchDispatchWrapper(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === "darwin";
+}
+
+function supportsXcrunDispatchWrapper(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === "darwin";
+}
+
 function unwrapXcrunInvocation(argv: string[]): string[] | null {
   return scanWrapperInvocation(argv, {
     onToken: (token, lower) => {
@@ -400,12 +408,18 @@ function unwrapXcrunInvocation(argv: string[]): string[] | null {
 
 type DispatchWrapperSpec = {
   name: string;
-  unwrap?: (argv: string[]) => string[] | null;
-  transparentUsage?: boolean | ((argv: string[]) => boolean);
+  unwrap?: (argv: string[], platform?: NodeJS.Platform) => string[] | null;
+  transparentUsage?: boolean | ((argv: string[], platform?: NodeJS.Platform) => boolean);
 };
 
 const DISPATCH_WRAPPER_SPECS: readonly DispatchWrapperSpec[] = [
-  { name: "arch", unwrap: unwrapArchInvocation, transparentUsage: true },
+  { name: "caffeinate", unwrap: unwrapCaffeinateInvocation, transparentUsage: true },
+  {
+    name: "arch",
+    unwrap: (argv, platform) =>
+      supportsArchDispatchWrapper(platform) ? unwrapArchInvocation(argv) : null,
+    transparentUsage: (_argv, platform) => supportsArchDispatchWrapper(platform),
+  },
   { name: "caffeinate", unwrap: unwrapCaffeinateInvocation, transparentUsage: true },
   { name: "chrt" },
   { name: "doas" },
@@ -425,7 +439,12 @@ const DISPATCH_WRAPPER_SPECS: readonly DispatchWrapperSpec[] = [
   { name: "taskset" },
   { name: "time", unwrap: unwrapTimeInvocation, transparentUsage: true },
   { name: "timeout", unwrap: unwrapTimeoutInvocation, transparentUsage: true },
-  { name: "xcrun", unwrap: unwrapXcrunInvocation, transparentUsage: true },
+  {
+    name: "xcrun",
+    unwrap: (argv, platform) =>
+      supportsXcrunDispatchWrapper(platform) ? unwrapXcrunInvocation(argv) : null,
+    transparentUsage: (_argv, platform) => supportsXcrunDispatchWrapper(platform),
+  },
 ];
 
 const DISPATCH_WRAPPER_SPEC_BY_NAME = new Map(
@@ -465,7 +484,10 @@ export function isDispatchWrapperExecutable(token: string): boolean {
   return DISPATCH_WRAPPER_SPEC_BY_NAME.has(normalizeExecutableToken(token));
 }
 
-export function unwrapKnownDispatchWrapperInvocation(argv: string[]): DispatchWrapperUnwrapResult {
+export function unwrapKnownDispatchWrapperInvocation(
+  argv: string[],
+  platform: NodeJS.Platform = process.platform,
+): DispatchWrapperUnwrapResult {
   const token0 = argv[0]?.trim();
   if (!token0) {
     return { kind: "not-wrapper" };
@@ -476,26 +498,31 @@ export function unwrapKnownDispatchWrapperInvocation(argv: string[]): DispatchWr
     return { kind: "not-wrapper" };
   }
   return spec.unwrap
-    ? unwrapDispatchWrapper(wrapper, spec.unwrap(argv))
+    ? unwrapDispatchWrapper(wrapper, spec.unwrap(argv, platform))
     : blockDispatchWrapper(wrapper);
 }
 
 export function unwrapDispatchWrappersForResolution(
   argv: string[],
   maxDepth = MAX_DISPATCH_WRAPPER_DEPTH,
+  platform: NodeJS.Platform = process.platform,
 ): string[] {
-  const plan = resolveDispatchWrapperTrustPlan(argv, maxDepth);
+  const plan = resolveDispatchWrapperTrustPlan(argv, maxDepth, platform);
   return plan.argv;
 }
 
-function isSemanticDispatchWrapperUsage(wrapper: string, argv: string[]): boolean {
+function isSemanticDispatchWrapperUsage(
+  wrapper: string,
+  argv: string[],
+  platform: NodeJS.Platform = process.platform,
+): boolean {
   const spec = DISPATCH_WRAPPER_SPEC_BY_NAME.get(wrapper);
   if (!spec?.unwrap) {
     return true;
   }
   const transparentUsage = spec.transparentUsage;
   if (typeof transparentUsage === "function") {
-    return !transparentUsage(argv);
+    return !transparentUsage(argv, platform);
   }
   return transparentUsage !== true;
 }
@@ -516,11 +543,12 @@ function blockedDispatchWrapperPlan(params: {
 export function resolveDispatchWrapperTrustPlan(
   argv: string[],
   maxDepth = MAX_DISPATCH_WRAPPER_DEPTH,
+  platform: NodeJS.Platform = process.platform,
 ): DispatchWrapperTrustPlan {
   let current = argv;
   const wrappers: string[] = [];
   for (let depth = 0; depth < maxDepth; depth += 1) {
-    const unwrap = unwrapKnownDispatchWrapperInvocation(current);
+    const unwrap = unwrapKnownDispatchWrapperInvocation(current, platform);
     if (unwrap.kind === "blocked") {
       return blockedDispatchWrapperPlan({
         argv: current,
@@ -532,7 +560,7 @@ export function resolveDispatchWrapperTrustPlan(
       break;
     }
     wrappers.push(unwrap.wrapper);
-    if (isSemanticDispatchWrapperUsage(unwrap.wrapper, current)) {
+    if (isSemanticDispatchWrapperUsage(unwrap.wrapper, current, platform)) {
       return blockedDispatchWrapperPlan({
         argv: current,
         wrappers,
@@ -542,7 +570,7 @@ export function resolveDispatchWrapperTrustPlan(
     current = unwrap.argv;
   }
   if (wrappers.length >= maxDepth) {
-    const overflow = unwrapKnownDispatchWrapperInvocation(current);
+    const overflow = unwrapKnownDispatchWrapperInvocation(current, platform);
     if (overflow.kind === "blocked" || overflow.kind === "unwrapped") {
       return blockedDispatchWrapperPlan({
         argv: current,

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -48,6 +48,22 @@ const BSD_SCRIPT_OPTIONS_WITH_VALUE = new Set(["-F", "-t"]);
 const SANDBOX_EXEC_OPTIONS_WITH_VALUE = new Set(["-f", "-p", "-d"]);
 const TIMEOUT_FLAG_OPTIONS = new Set(["--foreground", "--preserve-status", "-v", "--verbose"]);
 const TIMEOUT_OPTIONS_WITH_VALUE = new Set(["-k", "--kill-after", "-s", "--signal"]);
+const XCRUN_FLAG_OPTIONS = new Set([
+  "-k",
+  "--kill-cache",
+  "-l",
+  "--log",
+  "-n",
+  "--no-cache",
+  "-r",
+  "--run",
+  "-v",
+  "--verbose",
+]);
+
+function isArchSelectorToken(token: string): boolean {
+  return /^-[A-Za-z0-9_]+$/.test(token);
+}
 
 type WrapperScanDirective = "continue" | "consume-next" | "stop" | "invalid";
 
@@ -347,6 +363,41 @@ function unwrapTimeoutInvocation(argv: string[]): string[] | null {
   });
 }
 
+function unwrapArchInvocation(argv: string[]): string[] | null {
+  return scanWrapperInvocation(argv, {
+    onToken: (token, lower) => {
+      if (!token.startsWith("-") || token === "-") {
+        return "stop";
+      }
+      if (lower === "-32" || lower === "-64") {
+        return "continue";
+      }
+      if (lower === "-arch") {
+        return "consume-next";
+      }
+      // `arch` can also mutate the launched environment, which is not transparent.
+      if (lower === "-c" || lower === "-d" || lower === "-e" || lower === "-h") {
+        return "invalid";
+      }
+      return isArchSelectorToken(token) ? "continue" : "invalid";
+    },
+  });
+}
+
+function unwrapXcrunInvocation(argv: string[]): string[] | null {
+  return scanWrapperInvocation(argv, {
+    onToken: (token, lower) => {
+      if (!token.startsWith("-") || token === "-") {
+        return "stop";
+      }
+      if (XCRUN_FLAG_OPTIONS.has(lower)) {
+        return "continue";
+      }
+      return "invalid";
+    },
+  });
+}
+
 type DispatchWrapperSpec = {
   name: string;
   unwrap?: (argv: string[]) => string[] | null;
@@ -354,6 +405,7 @@ type DispatchWrapperSpec = {
 };
 
 const DISPATCH_WRAPPER_SPECS: readonly DispatchWrapperSpec[] = [
+  { name: "arch", unwrap: unwrapArchInvocation, transparentUsage: true },
   { name: "caffeinate", unwrap: unwrapCaffeinateInvocation, transparentUsage: true },
   { name: "chrt" },
   { name: "doas" },
@@ -373,6 +425,7 @@ const DISPATCH_WRAPPER_SPECS: readonly DispatchWrapperSpec[] = [
   { name: "taskset" },
   { name: "time", unwrap: unwrapTimeInvocation, transparentUsage: true },
   { name: "timeout", unwrap: unwrapTimeoutInvocation, transparentUsage: true },
+  { name: "xcrun", unwrap: unwrapXcrunInvocation, transparentUsage: true },
 ];
 
 const DISPATCH_WRAPPER_SPEC_BY_NAME = new Map(

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -75,6 +75,10 @@ function isKnownArchSelectorToken(token: string): boolean {
   );
 }
 
+function isKnownArchNameToken(token: string): boolean {
+  return isKnownArchSelectorToken(`-${token}`);
+}
+
 type WrapperScanDirective = "continue" | "consume-next" | "stop" | "invalid";
 
 function withWindowsExeAliases(names: readonly string[]): string[] {
@@ -374,8 +378,13 @@ function unwrapTimeoutInvocation(argv: string[]): string[] | null {
 }
 
 function unwrapArchInvocation(argv: string[]): string[] | null {
+  let expectsArchName = false;
   return scanWrapperInvocation(argv, {
     onToken: (token, lower) => {
+      if (expectsArchName) {
+        expectsArchName = false;
+        return isKnownArchNameToken(lower) ? "continue" : "invalid";
+      }
       if (!token.startsWith("-") || token === "-") {
         return "stop";
       }
@@ -383,7 +392,8 @@ function unwrapArchInvocation(argv: string[]): string[] | null {
         return "continue";
       }
       if (lower === "-arch") {
-        return "consume-next";
+        expectsArchName = true;
+        return "continue";
       }
       // `arch` can also mutate the launched environment, which is not transparent.
       if (lower === "-c" || lower === "-d" || lower === "-e" || lower === "-h") {

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -65,6 +65,16 @@ function isArchSelectorToken(token: string): boolean {
   return /^-[A-Za-z0-9_]+$/.test(token);
 }
 
+function isKnownArchSelectorToken(token: string): boolean {
+  return (
+    token === "-arm64" ||
+    token === "-arm64e" ||
+    token === "-i386" ||
+    token === "-x86_64" ||
+    token === "-x86_64h"
+  );
+}
+
 type WrapperScanDirective = "continue" | "consume-next" | "stop" | "invalid";
 
 function withWindowsExeAliases(names: readonly string[]): string[] {
@@ -379,7 +389,7 @@ function unwrapArchInvocation(argv: string[]): string[] | null {
       if (lower === "-c" || lower === "-d" || lower === "-e" || lower === "-h") {
         return "invalid";
       }
-      return isArchSelectorToken(token) ? "continue" : "invalid";
+      return isArchSelectorToken(token) && isKnownArchSelectorToken(lower) ? "continue" : "invalid";
     },
   });
 }

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -637,6 +637,30 @@ $0 \\"$1\\"" touch {marker}`);
     });
   });
 
+  it("prevents allow-always bypass for macOS dispatch-wrapper chains", () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+    const dir = makeTempDir();
+    const echo = makeExecutable(dir, "echo");
+    makeExecutable(dir, "id");
+    const env = makePathEnv(dir);
+    expectAllowAlwaysBypassBlocked({
+      dir,
+      firstCommand: "/usr/bin/arch -arm64 /bin/zsh -lc 'echo warmup-ok'",
+      secondCommand: "/usr/bin/arch -arm64 /bin/zsh -lc 'id > marker-arch'",
+      env,
+      persistedPattern: echo,
+    });
+    expectAllowAlwaysBypassBlocked({
+      dir,
+      firstCommand: "/usr/bin/xcrun /bin/zsh -lc 'echo warmup-ok'",
+      secondCommand: "/usr/bin/xcrun /bin/zsh -lc 'id > marker-xcrun'",
+      env,
+      persistedPattern: echo,
+    });
+  });
+
   it("prevents allow-always bypass for awk interpreters", () => {
     if (process.platform === "win32") {
       return;

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -227,6 +227,15 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
     expect(unwrapKnownDispatchWrapperInvocation(argv)).toEqual(expected);
   });
 
+  test("blocks arch dispatch unwrapping outside macOS", () => {
+    expect(
+      unwrapKnownDispatchWrapperInvocation(["arch", "-arm64", "bash", "-lc", "echo hi"], "linux"),
+    ).toEqual({
+      kind: "blocked",
+      wrapper: "arch",
+    });
+  });
+
   test.each(["chrt", "doas", "ionice", "setsid", "sudo", "taskset"])(
     "fails closed for blocked dispatch wrapper %s",
     (wrapper) => {
@@ -316,6 +325,21 @@ describe("resolveDispatchWrapperTrustPlan", () => {
       argv: ["bash", "-lc", "echo hi"],
       wrappers: ["nohup", "nice"],
       policyBlocked: false,
+    });
+  });
+
+  test("blocks arch trust unwrapping outside macOS", () => {
+    expect(
+      resolveDispatchWrapperTrustPlan(
+        ["arch", "-arm64", "bash", "-lc", "echo hi"],
+        undefined,
+        "linux",
+      ),
+    ).toEqual({
+      argv: ["arch", "-arm64", "bash", "-lc", "echo hi"],
+      wrappers: [],
+      policyBlocked: true,
+      blockedWrapper: "arch",
     });
   });
 

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -133,16 +133,6 @@ describe("unwrapEnvInvocation", () => {
 describe("unwrapKnownDispatchWrapperInvocation", () => {
   test.each([
     {
-      argv:
-        process.platform === "darwin"
-          ? ["arch", "-arm64", "bash", "-lc", "echo hi"]
-          : ["caffeinate", "-d", "-w", "42", "bash", "-lc", "echo hi"],
-      expected:
-        process.platform === "darwin"
-          ? { kind: "unwrapped", wrapper: "arch", argv: ["bash", "-lc", "echo hi"] }
-          : { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
       argv: ["caffeinate", "-d", "-w", "42", "bash", "-lc", "echo hi"],
       expected: { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] },
     },
@@ -258,14 +248,6 @@ describe("resolveDispatchWrapperTrustPlan", () => {
 
   test.each([
     {
-      argv:
-        process.platform === "darwin"
-          ? ["arch", "-arm64", "bash", "-lc", "echo hi"]
-          : ["caffeinate", "-d", "-t", "60", "bash", "-lc", "echo hi"],
-      wrapper: process.platform === "darwin" ? "arch" : "caffeinate",
-      effectiveArgv: ["bash", "-lc", "echo hi"],
-    },
-    {
       argv: ["caffeinate", "-d", "-t", "60", "bash", "-lc", "echo hi"],
       wrapper: "caffeinate",
       effectiveArgv: ["bash", "-lc", "echo hi"],
@@ -307,6 +289,11 @@ describe("resolveDispatchWrapperTrustPlan", () => {
     },
     ...(process.platform === "darwin"
       ? [
+          {
+            argv: ["arch", "-arm64", "bash", "-lc", "echo hi"],
+            wrapper: "arch",
+            effectiveArgv: ["bash", "-lc", "echo hi"],
+          },
           {
             argv: ["xcrun", "bash", "-lc", "echo hi"],
             wrapper: "xcrun",

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -210,7 +210,11 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
       expected: { kind: "blocked", wrapper: "arch" },
     },
     {
-      argv: ["arch", "-bogus", "bash", "-lc", "echo hi"],
+      argv: ["arch", "-arch", "bogus", "bash", "-lc", "echo hi"],
+      expected: { kind: "blocked", wrapper: "arch" },
+    },
+    {
+      argv: ["arch", "-arch", "bogus", "bash", "-lc", "echo hi"],
       expected: { kind: "blocked", wrapper: "arch" },
     },
     {

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -133,6 +133,16 @@ describe("unwrapEnvInvocation", () => {
 describe("unwrapKnownDispatchWrapperInvocation", () => {
   test.each([
     {
+      argv:
+        process.platform === "darwin"
+          ? ["arch", "-arm64", "bash", "-lc", "echo hi"]
+          : ["caffeinate", "-d", "-w", "42", "bash", "-lc", "echo hi"],
+      expected:
+        process.platform === "darwin"
+          ? { kind: "unwrapped", wrapper: "arch", argv: ["bash", "-lc", "echo hi"] }
+          : { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] },
+    },
+    {
       argv: ["caffeinate", "-d", "-w", "42", "bash", "-lc", "echo hi"],
       expected: { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] },
     },
@@ -187,6 +197,13 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
       },
     },
     {
+      argv: ["xcrun", "bash", "-lc", "echo hi"],
+      expected:
+        process.platform === "darwin"
+          ? { kind: "unwrapped", wrapper: "xcrun", argv: ["bash", "-lc", "echo hi"] }
+          : { kind: "blocked", wrapper: "xcrun" },
+    },
+    {
       argv: ["script", "-q", "/dev/null"],
       expected: { kind: "blocked", wrapper: "script" },
     },
@@ -197,6 +214,14 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
     {
       argv: ["timeout", "--bogus", "5s", "bash", "-lc", "echo hi"],
       expected: { kind: "blocked", wrapper: "timeout" },
+    },
+    {
+      argv: ["arch", "-e", "FOO=bar", "bash", "-lc", "echo hi"],
+      expected: { kind: "blocked", wrapper: "arch" },
+    },
+    {
+      argv: ["xcrun", "--sdk", "macosx", "bash", "-lc", "echo hi"],
+      expected: { kind: "blocked", wrapper: "xcrun" },
     },
   ])("unwraps known dispatch wrappers for %j", ({ argv, expected }) => {
     expect(unwrapKnownDispatchWrapperInvocation(argv)).toEqual(expected);
@@ -223,6 +248,14 @@ describe("resolveDispatchWrapperTrustPlan", () => {
   });
 
   test.each([
+    {
+      argv:
+        process.platform === "darwin"
+          ? ["arch", "-arm64", "bash", "-lc", "echo hi"]
+          : ["caffeinate", "-d", "-t", "60", "bash", "-lc", "echo hi"],
+      wrapper: process.platform === "darwin" ? "arch" : "caffeinate",
+      effectiveArgv: ["bash", "-lc", "echo hi"],
+    },
     {
       argv: ["caffeinate", "-d", "-t", "60", "bash", "-lc", "echo hi"],
       wrapper: "caffeinate",
@@ -263,6 +296,15 @@ describe("resolveDispatchWrapperTrustPlan", () => {
       wrapper: "timeout",
       effectiveArgv: ["bash", "-lc", "echo hi"],
     },
+    ...(process.platform === "darwin"
+      ? [
+          {
+            argv: ["xcrun", "bash", "-lc", "echo hi"],
+            wrapper: "xcrun",
+            effectiveArgv: ["bash", "-lc", "echo hi"],
+          },
+        ]
+      : []),
   ])("keeps transparent wrapper handling in sync for %s", ({ argv, wrapper, effectiveArgv }) => {
     expectTransparentDispatchWrapperCase({ argv, wrapper, effectiveArgv });
   });

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -210,6 +210,10 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
       expected: { kind: "blocked", wrapper: "arch" },
     },
     {
+      argv: ["arch", "-bogus", "bash", "-lc", "echo hi"],
+      expected: { kind: "blocked", wrapper: "arch" },
+    },
+    {
       argv: ["xcrun", "--sdk", "macosx", "bash", "-lc", "echo hi"],
       expected: { kind: "blocked", wrapper: "xcrun" },
     },

--- a/src/infra/system-run-command.test.ts
+++ b/src/infra/system-run-command.test.ts
@@ -236,6 +236,26 @@ describe("system run command helpers", () => {
 
   test.each([
     {
+      name: "resolveSystemRunCommand unwraps macOS dispatch wrappers before deriving shell previews",
+      run: () =>
+        resolveSystemRunCommand({
+          command: ["/usr/bin/arch", "-arm64", "/bin/sh", "-lc", "echo hi"],
+        }),
+      expectedShellPayload: process.platform === "darwin" ? "echo hi" : null,
+      expectedCommandText: '/usr/bin/arch -arm64 /bin/sh -lc "echo hi"',
+      expectedPreviewText: process.platform === "darwin" ? "echo hi" : null,
+    },
+    {
+      name: "resolveSystemRunCommand unwraps xcrun before deriving shell previews",
+      run: () =>
+        resolveSystemRunCommand({
+          command: ["/usr/bin/xcrun", "/bin/sh", "-lc", "echo hi"],
+        }),
+      expectedShellPayload: process.platform === "darwin" ? "echo hi" : null,
+      expectedCommandText: '/usr/bin/xcrun /bin/sh -lc "echo hi"',
+      expectedPreviewText: process.platform === "darwin" ? "echo hi" : null,
+    },
+    {
       name: "resolveSystemRunCommandRequest accepts legacy shell payloads but returns canonical command text",
       run: () =>
         resolveSystemRunCommandRequest({


### PR DESCRIPTION
## Summary

- Problem: macOS `arch` and `xcrun` wrapper chains were not treated like other transparent dispatch carriers during exec approval analysis.
- Why it matters: an allow-always decision could persist trust in the outer wrapper instead of the carried command, and command preview metadata stayed blind to the carried shell payload.
- What changed: added transparent unwrap handling for `arch` and `xcrun`, kept non-transparent `arch` env-mutation and `xcrun --sdk` forms blocked, and added focused regression coverage for wrapper parsing, allow-always persistence, and system-run display.
- What did NOT change (scope boundary): no policy model expansion beyond these two wrapper families and no docs changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #none
- Related #none
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `src/infra/dispatch-wrapper-resolution.ts` omitted `arch` and `xcrun` from the transparent dispatch-wrapper table, so trust planning and shell-payload extraction fell through with the outer wrapper argv intact.
- Missing detection / guardrail: no regression test covered these macOS-native wrapper carriers after earlier fixes for other transparent wrappers.
- Prior context (`git blame`, prior PR, issue, or refactor if known): existing wrapper hardening already covered `env`, `time`, `timeout`, `script`, and shell multiplexers, but not these two carriers.
- Why this regressed now: wrapper coverage expanded incrementally and these paths were left out.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/exec-wrapper-resolution.test.ts`, `src/infra/exec-approvals-allow-always.test.ts`, `src/infra/system-run-command.test.ts`
- Scenario the test should lock in: `arch` and `xcrun` unwrap to the carried command for transparent forms, reject non-transparent forms, persist the inner executable for allow-always, and surface the carried shell payload in system-run display.
- Why this is the smallest reliable guardrail: the regression originates in shared wrapper parsing, and these tests exercise the parser plus the two downstream behaviors that depended on it.
- Existing test that already covers this (if any): none for these two wrappers.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Allow-always approvals and command previews now follow the carried command for transparent macOS `arch` and `xcrun` wrapper chains.

## Diagram (if applicable)

```text
Before:
[arch/xcrun wrapper] -> [outer wrapper trusted] -> [changed inner shell payload still looks allowed]

After:
[arch/xcrun wrapper] -> [unwrap carried command] -> [approval and preview bind to inner command]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local worktree on `origin/main` base `2feb83babb`
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run an `arch` or `xcrun` wrapper chain that carries `/bin/sh -lc 'echo warmup-ok'` through allow-always pattern derivation.
2. Re-run the same wrapper with a different inner shell payload.
3. Inspect persisted patterns and system-run shell payload extraction before and after the patch.

### Expected

- Transparent wrapper chains resolve to the carried command.
- Allow-always persists the inner executable.
- System-run display exposes the carried shell payload and preview.

### Actual

- Verified with targeted tests and direct local reproduction after the patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: direct reproduction of allow-always pattern derivation and system-run payload extraction for `arch` and `xcrun`; targeted unit tests; `pnpm check`.
- Edge cases checked: `arch -e ...` stays blocked; `xcrun --sdk ...` stays blocked.
- What you did **not** verify: full `pnpm test`; no broader runtime/manual gateway session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: some semantic `xcrun` forms could be mistaken for transparent execution.
  - Mitigation: only the option-free/transparent subset is unwrapped; `--sdk` and other non-transparent forms stay blocked.
- Risk: `arch` env-mutating forms could accidentally gain preview/allowlist passthrough.
  - Mitigation: `-c`, `-d`, and `-e` stay non-transparent and return blocked behavior.

AI-assisted: yes. Fully tested on the touched surface.
