### PR TITLE
fix: scope session create aliases to requested agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Gateway/sessions: scope bare `sessions.create` aliases like `main` to the requested agent while preserving the canonical `global` and `unknown` sentinel keys. (#58207) Thanks @jalehman.
+- Gateway/sessions: scope bare `sessions.create` aliases like `main` to the requested agent while preserving the canonical `global` and `unknown` sentinel keys. (#58207) thanks @jalehman.
 - Matrix/multi-account: keep room-level `account` scoping, inherited room overrides, and implicit account selection consistent across top-level default auth, named accounts, and cached-credential env setups. (#58449) thanks @Daanvdplas and @gumadeiras.
 - Config/Discord: coerce safe integer numeric Discord IDs to strings during config validation, keep unsafe or precision-losing numeric snowflakes rejected, and align `openclaw doctor` repair guidance with the same fail-closed behavior. (#45125) Thanks @moliendocode.
 
@@ -73,6 +73,7 @@ Docs: https://docs.openclaw.ai
 - Auth/OpenAI Codex: persist plugin-refreshed OAuth credentials to `auth-profiles.json` before returning them, so rotated Codex refresh tokens survive restart and stop falling into `refresh_token_reused` loops. (#53082)
 - Discord/gateway: hand reconnect ownership back to Carbon, keep runtime status aligned with close/reconnect state, and force-stop sockets that open without reaching READY so Discord monitors recover promptly instead of waiting on stale health timeouts. (#59019) Thanks @obviyus
 - Config/Telegram: migrate removed `channels.telegram.groupMentionsOnly` into `channels.telegram.groups["*"].requireMention` on load so legacy configs no longer crash at startup. (#55336) thanks @jameslcowan.
+
 ## 2026.3.31
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,6 +405,7 @@ Docs: https://docs.openclaw.ai
 - OpenShell and ACP file boundaries: skip symlinks and preserve trusted host-only directories during OpenShell mirror sync, and route ACP attachment reads through the shared attachment cache so local files outside allowed roots are no longer forwarded. (#57693, #57690)
 - Channel/webhook authorization: skip Discord audio preflight transcription for unauthorized guild senders, add a shared pre-auth in-flight guard to Synology Chat webhooks, and validate Microsoft Teams bearer auth before JSON body parsing. (#57695, #57722, #57686)
 - Infra/randomness: replace `Math.random()` in affected identifier and delay-jitter paths with shared secure-random helpers, including UI UUID generation. (#57744)
+- Gateway/sessions: scope bare `sessions.create` aliases like `main` to the requested agent while preserving the canonical `global` and `unknown` sentinel keys. (#58207) Thanks @jalehman.
 
 ## 2026.3.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Gateway/sessions: scope bare `sessions.create` aliases like `main` to the requested agent while preserving the canonical `global` and `unknown` sentinel keys. (#58207) thanks @jalehman.
 - Matrix/multi-account: keep room-level `account` scoping, inherited room overrides, and implicit account selection consistent across top-level default auth, named accounts, and cached-credential env setups. (#58449) thanks @Daanvdplas and @gumadeiras.
 - Config/Discord: coerce safe integer numeric Discord IDs to strings during config validation, keep unsafe or precision-losing numeric snowflakes rejected, and align `openclaw doctor` repair guidance with the same fail-closed behavior. (#45125) Thanks @moliendocode.
+- Gateway/sessions: scope bare `sessions.create` aliases like `main` to the requested agent while preserving the canonical `global` and `unknown` sentinel keys. (#58207) thanks @jalehman.
 
 ## 2026.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/sessions: scope bare `sessions.create` aliases like `main` to the requested agent while preserving the canonical `global` and `unknown` sentinel keys. (#58207) Thanks @jalehman.
 - Matrix/multi-account: keep room-level `account` scoping, inherited room overrides, and implicit account selection consistent across top-level default auth, named accounts, and cached-credential env setups. (#58449) thanks @Daanvdplas and @gumadeiras.
 - Config/Discord: coerce safe integer numeric Discord IDs to strings during config validation, keep unsafe or precision-losing numeric snowflakes rejected, and align `openclaw doctor` repair guidance with the same fail-closed behavior. (#45125) Thanks @moliendocode.
 
@@ -72,7 +73,6 @@ Docs: https://docs.openclaw.ai
 - Auth/OpenAI Codex: persist plugin-refreshed OAuth credentials to `auth-profiles.json` before returning them, so rotated Codex refresh tokens survive restart and stop falling into `refresh_token_reused` loops. (#53082)
 - Discord/gateway: hand reconnect ownership back to Carbon, keep runtime status aligned with close/reconnect state, and force-stop sockets that open without reaching READY so Discord monitors recover promptly instead of waiting on stale health timeouts. (#59019) Thanks @obviyus
 - Config/Telegram: migrate removed `channels.telegram.groupMentionsOnly` into `channels.telegram.groups["*"].requireMention` on load so legacy configs no longer crash at startup. (#55336) thanks @jameslcowan.
-
 ## 2026.3.31
 
 ### Breaking
@@ -405,7 +405,6 @@ Docs: https://docs.openclaw.ai
 - OpenShell and ACP file boundaries: skip symlinks and preserve trusted host-only directories during OpenShell mirror sync, and route ACP attachment reads through the shared attachment cache so local files outside allowed roots are no longer forwarded. (#57693, #57690)
 - Channel/webhook authorization: skip Discord audio preflight transcription for unauthorized guild senders, add a shared pre-auth in-flight guard to Synology Chat webhooks, and validate Microsoft Teams bearer auth before JSON body parsing. (#57695, #57722, #57686)
 - Infra/randomness: replace `Math.random()` in affected identifier and delay-jitter paths with shared secure-random helpers, including UI UUID generation. (#57744)
-- Gateway/sessions: scope bare `sessions.create` aliases like `main` to the requested agent while preserving the canonical `global` and `unknown` sentinel keys. (#58207) Thanks @jalehman.
 
 ## 2026.3.28
 

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -696,12 +696,15 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       }
       canonicalParentSessionKey = parent.canonicalKey;
     }
+    const loweredRequestedKey = requestedKey?.toLowerCase();
     const key = requestedKey
-      ? toAgentStoreSessionKey({
-          agentId,
-          requestKey: requestedKey,
-          mainKey: cfg.session?.mainKey,
-        })
+      ? loweredRequestedKey === "global" || loweredRequestedKey === "unknown"
+        ? loweredRequestedKey
+        : toAgentStoreSessionKey({
+            agentId,
+            requestKey: requestedKey,
+            mainKey: cfg.session?.mainKey,
+          })
       : buildDashboardSessionKey(agentId);
     const target = resolveGatewaySessionStoreTarget({ cfg, key });
     const targetAgentId = resolveAgentIdFromSessionKey(target.canonicalKey);

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -28,6 +28,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
+  toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
 import { GATEWAY_CLIENT_IDS } from "../protocol/client-info.js";
 import {
@@ -695,7 +696,13 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       }
       canonicalParentSessionKey = parent.canonicalKey;
     }
-    const key = requestedKey ?? buildDashboardSessionKey(agentId);
+    const key = requestedKey
+      ? toAgentStoreSessionKey({
+          agentId,
+          requestKey: requestedKey,
+          mainKey: cfg.session?.mainKey,
+        })
+      : buildDashboardSessionKey(agentId);
     const target = resolveGatewaySessionStoreTarget({ cfg, key });
     const targetAgentId = resolveAgentIdFromSessionKey(target.canonicalKey);
     const created = await updateSessionStore(target.storePath, async (store) => {

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -379,6 +379,37 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
+  test("sessions.create scopes the main alias to the requested agent", async () => {
+    const { storePath } = await createSessionStoreDir();
+    const { ws } = await openClient();
+
+    const created = await rpcReq<{
+      key?: string;
+      sessionId?: string;
+      entry?: {
+        sessionFile?: string;
+      };
+    }>(ws, "sessions.create", {
+      key: "main",
+      agentId: "longmemeval",
+    });
+
+    expect(created.ok).toBe(true);
+    expect(created.payload?.key).toBe("agent:longmemeval:main");
+    expect(created.payload?.entry?.sessionFile).toBeTruthy();
+
+    const rawStore = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      {
+        sessionId?: string;
+      }
+    >;
+    expect(rawStore["agent:longmemeval:main"]?.sessionId).toBe(created.payload?.sessionId);
+    expect(rawStore["agent:main:main"]).toBeUndefined();
+
+    ws.close();
+  });
+
   test("sessions.create rejects unknown parentSessionKey", async () => {
     await createSessionStoreDir();
     const { ws } = await openClient();

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -410,6 +410,54 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
+  test("sessions.create preserves global and unknown sentinel keys", async () => {
+    const { storePath } = await createSessionStoreDir();
+    const { ws } = await openClient();
+
+    const globalCreated = await rpcReq<{
+      key?: string;
+      sessionId?: string;
+      entry?: {
+        sessionFile?: string;
+      };
+    }>(ws, "sessions.create", {
+      key: "global",
+      agentId: "longmemeval",
+    });
+
+    expect(globalCreated.ok).toBe(true);
+    expect(globalCreated.payload?.key).toBe("global");
+    expect(globalCreated.payload?.entry?.sessionFile).toBeTruthy();
+
+    const unknownCreated = await rpcReq<{
+      key?: string;
+      sessionId?: string;
+      entry?: {
+        sessionFile?: string;
+      };
+    }>(ws, "sessions.create", {
+      key: "unknown",
+      agentId: "longmemeval",
+    });
+
+    expect(unknownCreated.ok).toBe(true);
+    expect(unknownCreated.payload?.key).toBe("unknown");
+    expect(unknownCreated.payload?.entry?.sessionFile).toBeTruthy();
+
+    const rawStore = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      {
+        sessionId?: string;
+      }
+    >;
+    expect(rawStore.global?.sessionId).toBe(globalCreated.payload?.sessionId);
+    expect(rawStore.unknown?.sessionId).toBe(unknownCreated.payload?.sessionId);
+    expect(rawStore["agent:longmemeval:global"]).toBeUndefined();
+    expect(rawStore["agent:longmemeval:unknown"]).toBeUndefined();
+
+    ws.close();
+  });
+
   test("sessions.create rejects unknown parentSessionKey", async () => {
     await createSessionStoreDir();
     const { ws } = await openClient();

--- a/test/scripts/test-parallel.test.ts
+++ b/test/scripts/test-parallel.test.ts
@@ -30,6 +30,7 @@ const clearPlannerShardEnv = (env) => {
   delete nextEnv.OPENCLAW_TEST_INCLUDE_EXTENSIONS;
   delete nextEnv.OPENCLAW_TEST_INCLUDE_CHANNELS;
   delete nextEnv.OPENCLAW_TEST_INCLUDE_GATEWAY;
+  delete nextEnv.OPENCLAW_TEST_UNIT_FAST_BATCH_TARGET_MS;
   return nextEnv;
 };
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `sessions.create` canonicalizes a bare session key like `main` without scoping it to an explicitly requested agent.
- Why it matters: callers can create or update the default agent session when they intended to target a different agent.
- What changed: the gateway now resolves caller-provided session aliases against the requested agent and adds a regression test for a bare `main` key with an explicit non-default agent.
- What did NOT change (scope boundary): already-qualified agent session keys and default dashboard session creation behavior stay the same.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the `sessions.create` path canonicalized caller-provided keys without threading the explicit `agentId` into alias resolution.
- Missing detection / guardrail: there was no regression test covering a bare key plus an explicit `agentId`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: the bug exists whenever callers rely on a relative key while targeting a non-default agent.
- If unknown, what was ruled out: unrelated already-qualified agent keys were ruled out because they already resolve correctly.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
- Scenario the test should lock in: `sessions.create` with `key="main"` and an explicit non-default `agentId` returns and stores that agent's canonical main key.
- Why this is the smallest reliable guardrail: the bug sits in the gateway request handler's canonicalization path, so the gateway test exercises the full method without broader E2E setup.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Gateway `sessions.create` now resolves bare aliases like `main` against the requested agent instead of the default agent.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22, pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway sessions RPC
- Relevant config (redacted): test session store

### Steps

1. Call `sessions.create` with `key: "main"` and an explicit non-default `agentId`.
2. Inspect the returned canonical key and the session store entry written by the gateway.
3. Compare the result with the requested agent.

### Expected

- The returned key and stored entry are scoped to the requested agent.

### Actual

- Before this fix, a bare alias could resolve through the default-agent path instead.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- src/gateway/server.sessions.gateway-server-sessions-a.test.ts -t "scopes the main alias to the requested agent"`.
- Edge cases checked: confirmed the handler still only rewrites caller-provided bare aliases and leaves qualified keys alone.
- What you did **not** verify: a full multi-client gateway session flow outside the focused test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: callers that accidentally depended on the old default-agent aliasing behavior will now target the explicitly requested agent.
  - Mitigation: the change only affects bare aliases when `agentId` is explicitly provided, and the new regression test locks that intended behavior in.
