### PR TITLE
fix: omit disabled OpenAI reasoning payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ Docs: https://docs.openclaw.ai
 - Voice Call/media stream: cap inbound WebSocket frame size before `start` validation so oversized pre-start frames are dropped before JSON parsing. Thanks @Kazamayc and @vincentkoc.
 - Voice call/Plivo: pin stored callback bases to the configured public webhook URL so later call-control redirects stay on the intended origin even if webhook transport metadata differs. Thanks @zsxsoft and @vincentkoc.
 - Web UI/markdown: stop bare auto-links from swallowing adjacent CJK text while preserving valid mixed-script path and query characters in rendered links. (#48410) Thanks @jnuyao.
+- OpenAI/Responses: omit disabled reasoning payloads across OpenAI, Codex, and Azure OpenAI request builders so GPT-5 endpoints no longer reject `reasoning.effort: "none"`. (#58208) Thanks @jalehman.
 - WhatsApp/outbound: restore runtime send/action routing and outbound compatibility after the recent channel seam refactor so outbound sends, reactions, and related media actions keep reaching the active session.
 - xAI/Responses: normalize image-bearing tool results for xAI responses payloads, including OpenResponses-style `input_image.source` parts, so image tool replays no longer 422 on the follow-up turn. (#58017) Thanks @neeravmakwana.
 - Zalo/webhooks: scope replay dedupe to the authenticated target so one configured account can no longer cause same-id inbound events for another target to be dropped. Thanks @smaeljaish771 and @vincentkoc.

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -1764,6 +1764,36 @@ describe("createOpenAIWebSocketStreamFn", () => {
     expect(sent.reasoning).toEqual({ effort: "high", summary: "auto" });
   });
 
+  it("omits response.create reasoning when reasoningEffort is none", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-reason-none");
+    const opts = { reasoningEffort: "none" };
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+      opts as unknown as Parameters<typeof streamFn>[2],
+    );
+    await new Promise<void>((resolve, reject) => {
+      queueMicrotask(async () => {
+        try {
+          await new Promise((r) => setImmediate(r));
+          MockManager.lastInstance!.simulateEvent({
+            type: "response.completed",
+            response: makeResponseObject("resp-reason-none", "Short answer"),
+          });
+          for await (const _ of await resolveStream(stream)) {
+            /* consume */
+          }
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+    const sent = MockManager.lastInstance!.sentEvents[0] as Record<string, unknown>;
+    expect(sent.type).toBe("response.create");
+    expect(sent).not.toHaveProperty("reasoning");
+  });
+
   it("applies onPayload mutations before sending response.create", async () => {
     const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-onpayload");
     const stream = streamFn(
@@ -1802,7 +1832,6 @@ describe("createOpenAIWebSocketStreamFn", () => {
     expect(sent.text).toEqual({ verbosity: "low" });
     expect(sent.service_tier).toBe("priority");
   });
-
   it("forwards topP and toolChoice to response.create", async () => {
     const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-topp");
     const opts = { topP: 0.9, toolChoice: "auto" };

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -459,7 +459,10 @@ export function createOpenAIWebSocketStreamFn(
       if (streamOpts?.toolChoice !== undefined) {
         extraParams.tool_choice = streamOpts.toolChoice;
       }
-      if (streamOpts?.reasoningEffort || streamOpts?.reasoningSummary) {
+      if (
+        streamOpts?.reasoningEffort !== "none" &&
+        (streamOpts?.reasoningEffort || streamOpts?.reasoningSummary)
+      ) {
         const reasoning: { effort?: string; summary?: string } = {};
         if (streamOpts.reasoningEffort !== undefined) {
           reasoning.effort = streamOpts.reasoningEffort as string;

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1919,6 +1919,24 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.store).toBe(true);
   });
 
+  it("strips disabled OpenAI reasoning payloads instead of sending effort:none", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5-mini",
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5-mini",
+        baseUrl: "https://api.openai.com/v1",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        reasoning: { effort: "none" },
+      },
+    });
+    expect(payload).not.toHaveProperty("reasoning");
+  });
+
   it("injects configured OpenAI service_tier into Responses payloads", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "openai",

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1937,6 +1937,24 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("reasoning");
   });
 
+  it("strips disabled Azure OpenAI Responses reasoning payloads", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "azure-openai-responses",
+      applyModelId: "gpt-5-mini",
+      model: {
+        api: "azure-openai-responses",
+        provider: "azure-openai-responses",
+        id: "gpt-5-mini",
+        baseUrl: "https://myresource.openai.azure.com/openai/v1",
+      } as unknown as Model<"azure-openai-responses">,
+      payload: {
+        store: false,
+        reasoning: { effort: "none" },
+      },
+    });
+    expect(payload).not.toHaveProperty("reasoning");
+  });
+
   it("injects configured OpenAI service_tier into Responses payloads", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "openai",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -34,6 +34,7 @@ import {
   createOpenAIAttributionHeadersWrapper,
   createOpenAIDefaultTransportWrapper,
   createOpenAIFastModeWrapper,
+  createOpenAIReasoningCompatibilityWrapper,
   createOpenAIResponsesContextManagementWrapper,
   createOpenAIServiceTierWrapper,
   createOpenAITextVerbosityWrapper,
@@ -459,6 +460,15 @@ function applyPostPluginStreamWrappers(
     ctx.effectiveExtraParams,
   );
 
+  if (
+    ctx.provider === "openai" ||
+    ctx.provider === "openai-codex" ||
+    ctx.provider === "azure-openai" ||
+    ctx.provider === "azure-openai-responses"
+  ) {
+    ctx.agent.streamFn = createOpenAIReasoningCompatibilityWrapper(ctx.agent.streamFn);
+  }
+
   const rawParallelToolCalls = resolveAliasedParamValue(
     [ctx.resolvedExtraParams, ctx.override],
     "parallel_tool_calls",
@@ -518,7 +528,6 @@ export function applyExtraParamsToAgent(
     agentId,
     resolvedExtraParams,
   });
-
   const wrapperContext: ApplyExtraParamsContext = {
     agent,
     cfg,

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -10,6 +10,12 @@ type OpenAITextVerbosity = "low" | "medium" | "high";
 
 const OPENAI_RESPONSES_APIS = new Set(["openai-responses", "azure-openai-responses"]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai", "azure-openai-responses"]);
+const OPENAI_REASONING_COMPAT_PROVIDERS = new Set([
+  "openai",
+  "openai-codex",
+  "azure-openai",
+  "azure-openai-responses",
+]);
 
 function isDirectOpenAIBaseUrl(baseUrl: unknown): boolean {
   if (typeof baseUrl !== "string" || !baseUrl.trim()) {
@@ -188,6 +194,41 @@ function shouldStripResponsesPromptCache(model: { api?: unknown; baseUrl?: unkno
   return !isDirectOpenAIBaseUrl(model.baseUrl);
 }
 
+function shouldApplyOpenAIReasoningCompatibility(model: {
+  api?: unknown;
+  provider?: unknown;
+}): boolean {
+  if (typeof model.api !== "string" || typeof model.provider !== "string") {
+    return false;
+  }
+  if (
+    model.api !== "openai-completions" &&
+    model.api !== "openai-responses" &&
+    model.api !== "openai-codex-responses"
+  ) {
+    return false;
+  }
+  return OPENAI_REASONING_COMPAT_PROVIDERS.has(model.provider);
+}
+
+function stripDisabledOpenAIReasoningPayload(payloadObj: Record<string, unknown>): void {
+  const reasoning = payloadObj.reasoning;
+  if (reasoning === "none") {
+    delete payloadObj.reasoning;
+    return;
+  }
+  if (!reasoning || typeof reasoning !== "object" || Array.isArray(reasoning)) {
+    return;
+  }
+
+  // GPT-5 models reject `reasoning.effort: "none"`. Treat the disabled effort
+  // as "reasoning omitted" instead of forwarding an unsupported value.
+  const reasoningObj = reasoning as Record<string, unknown>;
+  if (reasoningObj.effort === "none") {
+    delete payloadObj.reasoning;
+  }
+}
+
 function applyOpenAIResponsesPayloadOverrides(params: {
   payloadObj: Record<string, unknown>;
   forceStore: boolean;
@@ -350,6 +391,20 @@ export function createOpenAIResponsesContextManagementWrapper(
         }
         return originalOnPayload?.(payload, model);
       },
+    });
+  };
+}
+
+export function createOpenAIReasoningCompatibilityWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (!shouldApplyOpenAIReasoningCompatibility(model)) {
+      return underlying(model, context, options);
+    }
+    return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
+      stripDisabledOpenAIReasoningPayload(payloadObj);
     });
   };
 }

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -204,7 +204,8 @@ function shouldApplyOpenAIReasoningCompatibility(model: {
   if (
     model.api !== "openai-completions" &&
     model.api !== "openai-responses" &&
-    model.api !== "openai-codex-responses"
+    model.api !== "openai-codex-responses" &&
+    model.api !== "azure-openai-responses"
   ) {
     return false;
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenAI-compatible request builders still emit `reasoning.effort: "none"` when reasoning is disabled.
- Why it matters: GPT-5 models reject that unsupported value with a 400 instead of treating disabled reasoning as omitted.
- What changed: the websocket `response.create` builder and OpenAI-compatible payload wrapper now omit disabled reasoning payloads, and focused regression tests cover both paths.
- What did NOT change (scope boundary): enabled reasoning payloads and unrelated OpenAI request parameters are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: disabled reasoning was represented as a literal `reasoning.effort: "none"` payload instead of omitting `reasoning` entirely for OpenAI-compatible APIs.
- Missing detection / guardrail: there was no regression coverage for disabled reasoning in the shared OpenAI wrapper path or the websocket `response.create` builder.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: stricter GPT-5 request validation rejects the unsupported `none` effort value.
- If unknown, what was ruled out: enabled reasoning payloads and unrelated OpenAI request fields were ruled out because they already serialize correctly.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openai-ws-stream.test.ts`, `src/agents/pi-embedded-runner-extraparams.test.ts`
- Scenario the test should lock in: disabled reasoning for OpenAI-compatible requests omits `reasoning` instead of sending `effort: "none"`.
- Why this is the smallest reliable guardrail: both regressions occur in request-building code paths that are already directly covered by focused agent tests.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

OpenAI-compatible requests now omit disabled reasoning payloads, preventing GPT-5 requests from failing on `reasoning.effort: "none"`.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22, pnpm
- Model/provider: OpenAI-compatible request builders
- Integration/channel (if any): OpenAI websocket + embedded runner wrapper path
- Relevant config (redacted): targeted test harnesses

### Steps

1. Build an OpenAI-compatible request with reasoning disabled.
2. Inspect the outgoing websocket `response.create` payload and the wrapped request payload.
3. Verify whether a `reasoning` block is sent.

### Expected

- Disabled reasoning is represented by omitting `reasoning` entirely.

### Actual

- Before this fix, the payload could include `reasoning.effort: "none"`, which GPT-5 rejects.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- src/agents/openai-ws-stream.test.ts src/agents/pi-embedded-runner-extraparams.test.ts` and confirmed both request-building paths pass with the new regression coverage.
- Edge cases checked: confirmed enabled reasoning payloads still serialize, and `onPayload` mutations are still applied in the websocket path.
- What you did **not** verify: a live OpenAI API roundtrip with a real GPT-5 model.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: downstream code that intentionally relied on forwarding `reasoning.effort: "none"` will now see the field omitted instead.
  - Mitigation: GPT-5 rejects the old value, and the change is limited to the disabled-reasoning case while preserving enabled reasoning payloads.
