### PR TITLE
test(web-fetch): lock strict proxy boundary

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -387,6 +387,10 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      // Direct web_fetch stays on the strict pinned-routing path even when
+      // env proxies are configured; otherwise HTTP_PROXY / HTTPS_PROXY from
+      // the environment would be honored for untrusted user-supplied URLs.
+      // Trusted env-proxy routing is reserved for operator-trusted endpoints.
       lookupFn: params.lookupFn,
       init: {
         headers: {

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -1,4 +1,4 @@
-import { EnvHttpProxyAgent } from "undici";
+import { EnvHttpProxyAgent, ProxyAgent } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LookupFn } from "../../infra/net/ssrf.js";
 import { resolveRequestUrl } from "../../plugin-sdk/request-url.js";
@@ -273,6 +273,7 @@ describe("web_fetch extraction fallbacks", () => {
       | undefined;
     expect(requestInit?.dispatcher).toBeDefined();
     expect(requestInit?.dispatcher).not.toBeInstanceOf(EnvHttpProxyAgent);
+    expect(requestInit?.dispatcher).not.toBeInstanceOf(ProxyAgent);
   });
 
   // NOTE: Test for wrapping url/finalUrl/warning fields requires DNS mocking.

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -119,6 +119,7 @@ describe("fetchWithSsrFGuard hardening", () => {
       } else {
         expect(requestInit.dispatcher).toBeDefined();
         expect(getDispatcherClassName(requestInit.dispatcher)).not.toBe("EnvHttpProxyAgent");
+        expect(getDispatcherClassName(requestInit.dispatcher)).not.toBe("ProxyAgent");
       }
       return okResponse();
     });


### PR DESCRIPTION
## Summary

AI-assisted: Codex

- Problem: the earlier proxy-support attempt showed that the strict vs trusted proxy boundary around `web_fetch` is easy to misread. Existing tests only ruled out `EnvHttpProxyAgent`, so a future change could still route strict `web_fetch` through another proxy dispatcher without tripping the intended guardrail.
- Why it matters: strict `web_fetch` intentionally avoids proxy routing for untrusted URLs so the SSRF-pinned destination binding stays intact. That boundary should be explicit in both code and tests.
- What changed: added a short clarifying comment in `web-fetch.ts`, tightened the direct `web_fetch` test to reject both `EnvHttpProxyAgent` and `ProxyAgent`, and tightened the lower-level strict fetch-guard test to assert the same boundary when `HTTP_PROXY` is present.
- What did NOT change (scope boundary): no runtime proxy support was added, no trusted env-proxy behavior changed, and this PR does not resolve proxy-only `web_fetch` environments.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #32947
- Follow-up to #58171
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the strict/trusted proxy split was under-specified at the call site, and the tests only ruled out one proxy dispatcher class.
- Missing detection / guardrail: a strict-path regression to another proxy dispatcher (for example `ProxyAgent`) would not have failed the old assertions.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #58171 tried to restore env-proxy support for direct `web_fetch`, but review showed that doing so would weaken the strict SSRF destination-pinning guarantee.
- Why this regressed now: the earlier PR surfaced that the intended boundary was clear in design but not tight enough in tests/comments.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/tools/web-tools.fetch.test.ts`, `src/infra/net/fetch-guard.ssrf.test.ts`
- Scenario the test should lock in: strict `web_fetch` and strict guarded fetch keep using the pinned direct dispatcher even when `HTTP_PROXY` is configured.
- Why this is the smallest reliable guardrail: the invariant is about dispatcher selection at the network boundary, so focused unit tests are enough.
- Existing test that already covers this (if any): the existing tests already covered the strict/trusted mode split; this change tightens the assertions so alternate proxy dispatchers are also rejected.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

No runtime behavior change. This PR only clarifies and locks the current strict proxy boundary.

## Diagram (if applicable)

```text
Strict web_fetch + HTTP_PROXY present
  -> keep pinned direct dispatcher
  -> do not switch to env-proxy / explicit proxy routing

Trusted env-proxy mode
  -> may route through EnvHttpProxyAgent
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (WSL)
- Runtime/container: Node v22.21.0, pnpm 10.32.1
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `HTTP_PROXY` configured for the strict-path tests

### Steps

1. Configure `HTTP_PROXY` in the test environment.
2. Execute strict `web_fetch` and strict fetch-guard tests.
3. Inspect the dispatcher chosen for those requests.

### Expected

- Strict `web_fetch` stays on a pinned non-proxy dispatcher even when env proxy variables are present.

### Actual

- The old tests only guaranteed “not `EnvHttpProxyAgent`”, leaving room for a future regression to another proxy dispatcher.

## Evidence

Attach at least one:

- [x] Passing tests
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `corepack pnpm exec vitest run src/agents/tools/web-tools.fetch.test.ts src/infra/net/fetch-guard.ssrf.test.ts`, `corepack pnpm exec oxlint --type-aware src/agents/tools/web-fetch.ts src/agents/tools/web-tools.fetch.test.ts src/infra/net/fetch-guard.ssrf.test.ts`, `corepack pnpm exec oxfmt --check src/agents/tools/web-fetch.ts src/agents/tools/web-tools.fetch.test.ts src/infra/net/fetch-guard.ssrf.test.ts`
- Edge cases checked: strict mode with `HTTP_PROXY` present still avoids both env-proxy and explicit-proxy dispatcher classes.
- What you did **not** verify: full repo test suite, end-to-end proxy behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: low; this only tightens comments and test assertions around an existing invariant.
  - Mitigation: focused unit coverage at both the tool and lower-level guarded-fetch layers.
