### PR TITLE
fix(exec): unwrap transparent approval wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ Docs: https://docs.openclaw.ai
 - Config/SecretRef + Control UI: harden SecretRef redaction round-trip restore, block unsafe raw fallback (force Form mode when raw is unavailable), and preflight submitted-config SecretRefs before config write RPC persistence. (#58044) Thanks @joshavant.
 - Config/Telegram: migrate removed `channels.telegram.groupMentionsOnly` into `channels.telegram.groups["*"].requireMention` on load so legacy configs no longer crash at startup. (#55336) thanks @jameslcowan.
 - Gateway/SecretRef: resolve restart token drift checks with merged service/runtime env sources and hard-fail unsupported mutable SecretRef plus OAuth-profile combinations so restart warnings and policy enforcement match runtime behavior. (#58141) Thanks @joshavant.
+- Exec approvals: unwrap `caffeinate` and `sandbox-exec` before persisting allow-always trust so later shell payload changes still require a fresh approval. Thanks @tdjackey and @vincentkoc.
 
 ## 2026.3.28
 

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -26,6 +26,7 @@ const ENV_INLINE_VALUE_PREFIXES = [
 ] as const;
 const ENV_FLAG_OPTIONS = new Set(["-i", "--ignore-environment", "-0", "--null"]);
 const NICE_OPTIONS_WITH_VALUE = new Set(["-n", "--adjustment", "--priority"]);
+const CAFFEINATE_OPTIONS_WITH_VALUE = new Set(["-t", "-w"]);
 const STDBUF_OPTIONS_WITH_VALUE = new Set(["-i", "--input", "-o", "--output", "-e", "--error"]);
 const TIME_FLAG_OPTIONS = new Set([
   "-a",
@@ -44,6 +45,7 @@ const TIME_FLAG_OPTIONS = new Set([
 const TIME_OPTIONS_WITH_VALUE = new Set(["-f", "--format", "-o", "--output"]);
 const BSD_SCRIPT_FLAG_OPTIONS = new Set(["-a", "-d", "-k", "-p", "-q", "-r"]);
 const BSD_SCRIPT_OPTIONS_WITH_VALUE = new Set(["-F", "-t"]);
+const SANDBOX_EXEC_OPTIONS_WITH_VALUE = new Set(["-f", "-p", "-D"]);
 const TIMEOUT_FLAG_OPTIONS = new Set(["--foreground", "--preserve-status", "-v", "--verbose"]);
 const TIMEOUT_OPTIONS_WITH_VALUE = new Set(["-k", "--kill-after", "-s", "--signal"]);
 
@@ -224,6 +226,20 @@ function unwrapNiceInvocation(argv: string[]): string[] | null {
   });
 }
 
+function unwrapCaffeinateInvocation(argv: string[]): string[] | null {
+  return unwrapDashOptionInvocation(argv, {
+    onFlag: (flag, lower) => {
+      if (flag === "-d" || flag === "-i" || flag === "-m" || flag === "-s" || flag === "-u") {
+        return "continue";
+      }
+      if (CAFFEINATE_OPTIONS_WITH_VALUE.has(flag)) {
+        return lower !== flag || lower.includes("=") ? "continue" : "consume-next";
+      }
+      return "invalid";
+    },
+  });
+}
+
 function unwrapNohupInvocation(argv: string[]): string[] | null {
   return scanWrapperInvocation(argv, {
     separators: new Set(["--"]),
@@ -232,6 +248,17 @@ function unwrapNohupInvocation(argv: string[]): string[] | null {
         return "stop";
       }
       return lower === "--help" || lower === "--version" ? "continue" : "invalid";
+    },
+  });
+}
+
+function unwrapSandboxExecInvocation(argv: string[]): string[] | null {
+  return unwrapDashOptionInvocation(argv, {
+    onFlag: (flag, lower) => {
+      if (SANDBOX_EXEC_OPTIONS_WITH_VALUE.has(flag)) {
+        return lower !== flag || lower.includes("=") ? "continue" : "consume-next";
+      }
+      return "invalid";
     },
   });
 }
@@ -327,6 +354,7 @@ type DispatchWrapperSpec = {
 };
 
 const DISPATCH_WRAPPER_SPECS: readonly DispatchWrapperSpec[] = [
+  { name: "caffeinate", unwrap: unwrapCaffeinateInvocation, transparentUsage: true },
   { name: "chrt" },
   { name: "doas" },
   {
@@ -337,6 +365,7 @@ const DISPATCH_WRAPPER_SPECS: readonly DispatchWrapperSpec[] = [
   { name: "ionice" },
   { name: "nice", unwrap: unwrapNiceInvocation, transparentUsage: true },
   { name: "nohup", unwrap: unwrapNohupInvocation, transparentUsage: true },
+  { name: "sandbox-exec", unwrap: unwrapSandboxExecInvocation, transparentUsage: true },
   { name: "script", unwrap: unwrapScriptInvocation, transparentUsage: true },
   { name: "setsid" },
   { name: "stdbuf", unwrap: unwrapStdbufInvocation, transparentUsage: true },

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -45,7 +45,7 @@ const TIME_FLAG_OPTIONS = new Set([
 const TIME_OPTIONS_WITH_VALUE = new Set(["-f", "--format", "-o", "--output"]);
 const BSD_SCRIPT_FLAG_OPTIONS = new Set(["-a", "-d", "-k", "-p", "-q", "-r"]);
 const BSD_SCRIPT_OPTIONS_WITH_VALUE = new Set(["-F", "-t"]);
-const SANDBOX_EXEC_OPTIONS_WITH_VALUE = new Set(["-f", "-p", "-D"]);
+const SANDBOX_EXEC_OPTIONS_WITH_VALUE = new Set(["-f", "-p", "-d"]);
 const TIMEOUT_FLAG_OPTIONS = new Set(["--foreground", "--preserve-status", "-v", "--verbose"]);
 const TIMEOUT_OPTIONS_WITH_VALUE = new Set(["-k", "--kill-after", "-s", "--signal"]);
 

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -568,6 +568,23 @@ $0 \\"$1\\"" touch {marker}`);
     });
   });
 
+  it("prevents allow-always bypass for caffeinate wrapper chains", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const echo = makeExecutable(dir, "echo");
+    makeExecutable(dir, "id");
+    const env = makePathEnv(dir);
+    expectAllowAlwaysBypassBlocked({
+      dir,
+      firstCommand: "/usr/bin/caffeinate -d -w 42 /bin/zsh -lc 'echo warmup-ok'",
+      secondCommand: "/usr/bin/caffeinate -d -w 42 /bin/zsh -lc 'id > marker'",
+      env,
+      persistedPattern: echo,
+    });
+  });
+
   it("prevents allow-always bypass for dispatch-wrapper + shell-wrapper chains", () => {
     if (process.platform === "win32") {
       return;
@@ -580,6 +597,24 @@ $0 \\"$1\\"" touch {marker}`);
       dir,
       firstCommand: "/usr/bin/nice /bin/zsh -lc 'echo warmup-ok'",
       secondCommand: "/usr/bin/nice /bin/zsh -lc 'id > marker'",
+      env,
+      persistedPattern: echo,
+    });
+  });
+
+  it("prevents allow-always bypass for sandbox-exec wrapper chains", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const echo = makeExecutable(dir, "echo");
+    makeExecutable(dir, "id");
+    const env = makePathEnv(dir);
+    expectAllowAlwaysBypassBlocked({
+      dir,
+      firstCommand:
+        "/usr/bin/sandbox-exec -p '(deny default) (allow process*)' /bin/zsh -lc 'echo warmup-ok'",
+      secondCommand: "/usr/bin/sandbox-exec -p '(allow default)' /bin/zsh -lc 'id > marker'",
       env,
       persistedPattern: echo,
     });

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -62,6 +62,8 @@ describe("normalizeExecutableToken", () => {
 describe("wrapper classification", () => {
   test.each([
     { token: "sudo", dispatch: true, shell: false },
+    { token: "caffeinate", dispatch: true, shell: false },
+    { token: "sandbox-exec", dispatch: true, shell: false },
     { token: "script", dispatch: true, shell: false },
     { token: "time", dispatch: true, shell: false },
     { token: "timeout.exe", dispatch: true, shell: false },
@@ -131,6 +133,10 @@ describe("unwrapEnvInvocation", () => {
 describe("unwrapKnownDispatchWrapperInvocation", () => {
   test.each([
     {
+      argv: ["caffeinate", "-d", "-w", "42", "bash", "-lc", "echo hi"],
+      expected: { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] },
+    },
+    {
       argv: ["env", "--", "bash", "-lc", "echo hi"],
       expected: { kind: "unwrapped", wrapper: "env", argv: ["bash", "-lc", "echo hi"] },
     },
@@ -163,6 +169,14 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
     {
       argv: ["timeout", "--signal=TERM", "5s", "bash", "-lc", "echo hi"],
       expected: { kind: "unwrapped", wrapper: "timeout", argv: ["bash", "-lc", "echo hi"] },
+    },
+    {
+      argv: ["sandbox-exec", "-p", "(allow default)", "bash", "-lc", "echo hi"],
+      expected: {
+        kind: "unwrapped",
+        wrapper: "sandbox-exec",
+        argv: ["bash", "-lc", "echo hi"],
+      },
     },
     {
       argv: ["script", "-q", "/dev/null"],
@@ -202,6 +216,11 @@ describe("resolveDispatchWrapperTrustPlan", () => {
 
   test.each([
     {
+      argv: ["caffeinate", "-d", "-t", "60", "bash", "-lc", "echo hi"],
+      wrapper: "caffeinate",
+      effectiveArgv: ["bash", "-lc", "echo hi"],
+    },
+    {
       argv: ["nice", "-n", "5", "bash", "-lc", "echo hi"],
       wrapper: "nice",
       effectiveArgv: ["bash", "-lc", "echo hi"],
@@ -209,6 +228,11 @@ describe("resolveDispatchWrapperTrustPlan", () => {
     {
       argv: ["nohup", "--", "bash", "-lc", "echo hi"],
       wrapper: "nohup",
+      effectiveArgv: ["bash", "-lc", "echo hi"],
+    },
+    {
+      argv: ["sandbox-exec", "-p", "(allow default)", "bash", "-lc", "echo hi"],
+      wrapper: "sandbox-exec",
       effectiveArgv: ["bash", "-lc", "echo hi"],
     },
     {

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -179,6 +179,14 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
       },
     },
     {
+      argv: ["sandbox-exec", "-D", "PROFILE", "bash", "-lc", "echo hi"],
+      expected: {
+        kind: "unwrapped",
+        wrapper: "sandbox-exec",
+        argv: ["bash", "-lc", "echo hi"],
+      },
+    },
+    {
       argv: ["script", "-q", "/dev/null"],
       expected: { kind: "blocked", wrapper: "script" },
     },
@@ -232,6 +240,11 @@ describe("resolveDispatchWrapperTrustPlan", () => {
     },
     {
       argv: ["sandbox-exec", "-p", "(allow default)", "bash", "-lc", "echo hi"],
+      wrapper: "sandbox-exec",
+      effectiveArgv: ["bash", "-lc", "echo hi"],
+    },
+    {
+      argv: ["sandbox-exec", "-D", "PROFILE", "bash", "-lc", "echo hi"],
       wrapper: "sandbox-exec",
       effectiveArgv: ["bash", "-lc", "echo hi"],
     },

--- a/src/infra/exec-wrapper-trust-plan.test.ts
+++ b/src/infra/exec-wrapper-trust-plan.test.ts
@@ -4,6 +4,19 @@ import { resolveExecWrapperTrustPlan } from "./exec-wrapper-trust-plan.js";
 describe("resolveExecWrapperTrustPlan", () => {
   test.each([
     {
+      name: "unwraps transparent caffeinate wrappers before shell policy checks",
+      enabled: process.platform !== "win32",
+      argv: ["/usr/bin/caffeinate", "-d", "-w", "42", "sh", "-lc", "echo hi"],
+      expected: {
+        argv: ["sh", "-lc", "echo hi"],
+        policyArgv: ["sh", "-lc", "echo hi"],
+        wrapperChain: ["caffeinate"],
+        policyBlocked: false,
+        shellWrapperExecutable: true,
+        shellInlineCommand: "echo hi",
+      },
+    },
+    {
       name: "unwraps dispatch wrappers and shell multiplexers into one trust plan",
       enabled: process.platform !== "win32",
       argv: ["/usr/bin/time", "-p", "busybox", "sh", "-lc", "echo hi"],
@@ -24,6 +37,19 @@ describe("resolveExecWrapperTrustPlan", () => {
         argv: ["sh", "-lc", "echo hi"],
         policyArgv: ["sh", "-lc", "echo hi"],
         wrapperChain: ["script"],
+        policyBlocked: false,
+        shellWrapperExecutable: true,
+        shellInlineCommand: "echo hi",
+      },
+    },
+    {
+      name: "unwraps sandbox-exec wrappers before evaluating nested shell payloads",
+      enabled: process.platform !== "win32",
+      argv: ["/usr/bin/sandbox-exec", "-p", "(allow default)", "sh", "-lc", "echo hi"],
+      expected: {
+        argv: ["sh", "-lc", "echo hi"],
+        policyArgv: ["sh", "-lc", "echo hi"],
+        wrapperChain: ["sandbox-exec"],
         policyBlocked: false,
         shellWrapperExecutable: true,
         shellInlineCommand: "echo hi",


### PR DESCRIPTION
## Summary

- Problem: transparent wrapper handling persisted allow-always trust to `caffeinate` / `sandbox-exec` instead of the carried command
- Why it matters: a later shell payload change could inherit approval bound to the outer carrier instead of the inner executable
- What changed: unwrap `caffeinate` and `sandbox-exec` in dispatch wrapper resolution and add trust-plan plus allow-always regression coverage
- What did NOT change (scope boundary): this does not change unrelated wrapper families or the broader approval model

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Implementation Notes

- `dispatch-wrapper-resolution` now unwraps `caffeinate` and `sandbox-exec` before trust derivation
- wrapper trust-plan tests cover both carriers
- allow-always coverage now rejects wrapper-chain payload swaps for both carriers

## Verification

- Verified scenarios: `pnpm check`; `pnpm test -- src/infra/exec-wrapper-resolution.test.ts src/infra/exec-approvals-allow-always.test.ts src/infra/exec-wrapper-trust-plan.test.ts`
- Edge cases checked: nested shell payloads under both wrapper families
- What you did **not** verify: full `pnpm build`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: wrapper parsing could over-match unusual carrier invocations
  - Mitigation: targeted resolution and allow-always regression tests cover supported flag shapes
