### PR TITLE
fix(nostr): verify inbound dm signatures before pairing replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Nostr/inbound DMs: verify inbound event signatures before pairing or sender-authorization side effects, so forged DM events no longer create pairing requests or trigger reply attempts. Thanks @smaeljaish771 and @vincentkoc.
 - LINE/outbound media: add LINE image, video, and audio outbound sends on the LINE-specific delivery path, including explicit preview/tracking handling for videos while keeping generic media sends on the existing image-only route. (#45826) Thanks @masatohoshino.
 - WhatsApp/reactions: agents can now react with emoji on incoming WhatsApp messages, enabling more natural conversational interactions like acknowledging a photo with ❤️ instead of typing a reply. Thanks @mcaxtr.
 - MCP: add remote HTTP/SSE server support for `mcp.servers` URL configs, including auth headers and safer config redaction for MCP credentials. (#50396) Thanks @dhananjai1729.

--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -168,6 +168,47 @@ describe("startNostrBus inbound guards", () => {
     bus.close();
   });
 
+  it("does not spend rate-limit buckets on blocked senders before authorization", async () => {
+    const onMessage = vi.fn(async () => {});
+    const authorizeSender = vi.fn(async ({ senderPubkey }: { senderPubkey: string }) =>
+      senderPubkey.startsWith("blocked") ? ("block" as const) : ("allow" as const),
+    );
+    const bus = await startNostrBus({
+      privateKey: TEST_HEX_PRIVATE_KEY,
+      onMessage,
+      authorizeSender,
+      onMetric: () => {},
+      guardPolicy: {
+        rateLimit: {
+          windowMs: 60_000,
+          maxGlobalPerWindow: 1,
+          maxPerSenderPerWindow: 1,
+          maxTrackedSenderKeys: 32,
+        },
+      },
+    });
+
+    await emitEvent(
+      createEvent({
+        id: "blocked-event",
+        pubkey: `blocked${"a".repeat(57)}`,
+      }),
+    );
+    await emitEvent(
+      createEvent({
+        id: "allowed-event",
+        pubkey: `allowed${"b".repeat(57)}`,
+      }),
+    );
+
+    expect(authorizeSender).toHaveBeenCalledTimes(2);
+    expect(mockState.decrypt).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(bus.getMetrics().eventsRejected.rateLimited).toBe(0);
+
+    bus.close();
+  });
+
   it("rejects far-future events before crypto", async () => {
     const onMessage = vi.fn(async () => {});
     const bus = await startNostrBus({

--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -101,7 +101,7 @@ describe("startNostrBus inbound guards", () => {
     mockState.handlers = null;
   });
 
-  it("checks sender authorization before verify/decrypt", async () => {
+  it("checks sender authorization after verify and before decrypt", async () => {
     const onMessage = vi.fn(async () => {});
     const authorizeSender = vi.fn(async () => "block" as const);
     const bus = await startNostrBus({
@@ -114,10 +114,32 @@ describe("startNostrBus inbound guards", () => {
     await emitEvent(createEvent());
 
     expect(authorizeSender).toHaveBeenCalledTimes(1);
-    expect(mockState.verifyEvent).not.toHaveBeenCalled();
+    expect(mockState.verifyEvent).toHaveBeenCalledTimes(1);
     expect(mockState.decrypt).not.toHaveBeenCalled();
     expect(onMessage).not.toHaveBeenCalled();
     expect(bus.getMetrics().eventsReceived).toBe(1);
+
+    bus.close();
+  });
+
+  it("rejects invalid signatures before sender authorization", async () => {
+    mockState.verifyEvent.mockReturnValueOnce(false);
+    const onMessage = vi.fn(async () => {});
+    const authorizeSender = vi.fn(async () => "allow" as const);
+    const bus = await startNostrBus({
+      privateKey: TEST_HEX_PRIVATE_KEY,
+      onMessage,
+      authorizeSender,
+      onMetric: () => {},
+    });
+
+    await emitEvent(createEvent());
+
+    expect(mockState.verifyEvent).toHaveBeenCalledTimes(1);
+    expect(authorizeSender).not.toHaveBeenCalled();
+    expect(mockState.decrypt).not.toHaveBeenCalled();
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(bus.getMetrics().eventsRejected.invalidSignature).toBe(1);
 
     bus.close();
   });

--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -257,6 +257,86 @@ describe("startNostrBus inbound guards", () => {
     bus.close();
   });
 
+  it("counts oversized ciphertext toward the global inbound rate limit", async () => {
+    const onMessage = vi.fn(async () => {});
+    const bus = await startNostrBus({
+      privateKey: TEST_HEX_PRIVATE_KEY,
+      onMessage,
+      onMetric: () => {},
+      guardPolicy: {
+        maxCiphertextBytes: 4,
+        rateLimit: {
+          windowMs: 60_000,
+          maxGlobalPerWindow: 1,
+          maxPerSenderPerWindow: 10,
+          maxTrackedSenderKeys: 32,
+        },
+      },
+    });
+
+    await emitEvent(
+      createEvent({
+        id: "oversized-global-1",
+        pubkey: `sender1${"a".repeat(57)}`,
+        content: "ciphertext-too-large",
+      }),
+    );
+    await emitEvent(
+      createEvent({
+        id: "oversized-global-2",
+        pubkey: `sender2${"b".repeat(57)}`,
+        content: "ciphertext-too-large",
+      }),
+    );
+
+    expect(bus.getMetrics().eventsRejected.oversizedCiphertext).toBe(1);
+    expect(bus.getMetrics().eventsRejected.rateLimited).toBe(1);
+    expect(mockState.verifyEvent).not.toHaveBeenCalled();
+    expect(mockState.decrypt).not.toHaveBeenCalled();
+    expect(onMessage).not.toHaveBeenCalled();
+
+    bus.close();
+  });
+
+  it("counts oversized ciphertext toward the per-sender inbound rate limit", async () => {
+    const onMessage = vi.fn(async () => {});
+    const bus = await startNostrBus({
+      privateKey: TEST_HEX_PRIVATE_KEY,
+      onMessage,
+      onMetric: () => {},
+      guardPolicy: {
+        maxCiphertextBytes: 4,
+        rateLimit: {
+          windowMs: 60_000,
+          maxGlobalPerWindow: 10,
+          maxPerSenderPerWindow: 1,
+          maxTrackedSenderKeys: 32,
+        },
+      },
+    });
+
+    await emitEvent(
+      createEvent({
+        id: "oversized-sender-1",
+        content: "ciphertext-too-large",
+      }),
+    );
+    await emitEvent(
+      createEvent({
+        id: "oversized-sender-2",
+        content: "ciphertext-too-large",
+      }),
+    );
+
+    expect(bus.getMetrics().eventsRejected.oversizedCiphertext).toBe(1);
+    expect(bus.getMetrics().eventsRejected.rateLimited).toBe(1);
+    expect(mockState.verifyEvent).not.toHaveBeenCalled();
+    expect(mockState.decrypt).not.toHaveBeenCalled();
+    expect(onMessage).not.toHaveBeenCalled();
+
+    bus.close();
+  });
+
   it("rejects far-future events before crypto", async () => {
     const onMessage = vi.fn(async () => {});
     const bus = await startNostrBus({

--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -209,6 +209,54 @@ describe("startNostrBus inbound guards", () => {
     bus.close();
   });
 
+  it("does not rate limit an allowed sender while another authorization is still pending", async () => {
+    const onMessage = vi.fn(async () => {});
+    let resolveBlocked: ((value: "block") => void) | undefined;
+    const blockedPromise = new Promise<"block">((resolve) => {
+      resolveBlocked = resolve;
+    });
+    const authorizeSender = vi
+      .fn<(params: { senderPubkey: string }) => Promise<"allow" | "block" | "pairing">>()
+      .mockImplementationOnce(async () => await blockedPromise)
+      .mockResolvedValueOnce("allow");
+    const bus = await startNostrBus({
+      privateKey: TEST_HEX_PRIVATE_KEY,
+      onMessage,
+      authorizeSender,
+      onMetric: () => {},
+      guardPolicy: {
+        rateLimit: {
+          windowMs: 60_000,
+          maxGlobalPerWindow: 1,
+          maxPerSenderPerWindow: 1,
+          maxTrackedSenderKeys: 32,
+        },
+      },
+    });
+
+    const blockedEventPromise = emitEvent(
+      createEvent({
+        id: "blocked-pending",
+        pubkey: `blocked${"a".repeat(57)}`,
+      }),
+    );
+    await emitEvent(
+      createEvent({
+        id: "allowed-during-pending-auth",
+        pubkey: `allowed${"b".repeat(57)}`,
+      }),
+    );
+    resolveBlocked?.("block");
+    await blockedEventPromise;
+
+    expect(authorizeSender).toHaveBeenCalledTimes(2);
+    expect(mockState.decrypt).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(bus.getMetrics().eventsRejected.rateLimited).toBe(0);
+
+    bus.close();
+  });
+
   it("rejects far-future events before crypto", async () => {
     const onMessage = vi.fn(async () => {});
     const bus = await startNostrBus({

--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -168,7 +168,7 @@ describe("startNostrBus inbound guards", () => {
     bus.close();
   });
 
-  it("does not spend rate-limit buckets on blocked senders before authorization", async () => {
+  it("does not let a blocked sender starve a different verified sender", async () => {
     const onMessage = vi.fn(async () => {});
     const authorizeSender = vi.fn(async ({ senderPubkey }: { senderPubkey: string }) =>
       senderPubkey.startsWith("blocked") ? ("block" as const) : ("allow" as const),
@@ -181,7 +181,7 @@ describe("startNostrBus inbound guards", () => {
       guardPolicy: {
         rateLimit: {
           windowMs: 60_000,
-          maxGlobalPerWindow: 1,
+          maxGlobalPerWindow: 2,
           maxPerSenderPerWindow: 1,
           maxTrackedSenderKeys: 32,
         },
@@ -253,7 +253,7 @@ describe("startNostrBus inbound guards", () => {
       guardPolicy: {
         rateLimit: {
           windowMs: 60_000,
-          maxGlobalPerWindow: 1,
+          maxGlobalPerWindow: 2,
           maxPerSenderPerWindow: 1,
           maxTrackedSenderKeys: 32,
         },
@@ -279,6 +279,36 @@ describe("startNostrBus inbound guards", () => {
     expect(mockState.decrypt).toHaveBeenCalledTimes(1);
     expect(onMessage).toHaveBeenCalledTimes(1);
     expect(bus.getMetrics().eventsRejected.rateLimited).toBe(0);
+
+    bus.close();
+  });
+
+  it("rate limits repeated invalid signatures before authorization work fans out", async () => {
+    mockState.verifyEvent.mockReturnValue(false);
+    const onMessage = vi.fn(async () => {});
+    const authorizeSender = vi.fn(async () => "allow" as const);
+    const bus = await startNostrBus({
+      privateKey: TEST_HEX_PRIVATE_KEY,
+      onMessage,
+      authorizeSender,
+      onMetric: () => {},
+      guardPolicy: {
+        rateLimit: {
+          windowMs: 60_000,
+          maxGlobalPerWindow: 1,
+          maxPerSenderPerWindow: 10,
+          maxTrackedSenderKeys: 32,
+        },
+      },
+    });
+
+    await emitEvent(createEvent({ id: "invalid-1" }));
+    await emitEvent(createEvent({ id: "invalid-2" }));
+
+    expect(mockState.verifyEvent).toHaveBeenCalledTimes(1);
+    expect(authorizeSender).not.toHaveBeenCalled();
+    expect(bus.getMetrics().eventsRejected.invalidSignature).toBe(1);
+    expect(bus.getMetrics().eventsRejected.rateLimited).toBe(1);
 
     bus.close();
   });
@@ -324,7 +354,7 @@ describe("startNostrBus inbound guards", () => {
     bus.close();
   });
 
-  it("counts oversized ciphertext toward the per-sender inbound rate limit", async () => {
+  it("does not spend per-sender buckets on oversized ciphertext before verification", async () => {
     const onMessage = vi.fn(async () => {});
     const bus = await startNostrBus({
       privateKey: TEST_HEX_PRIVATE_KEY,
@@ -353,12 +383,18 @@ describe("startNostrBus inbound guards", () => {
         content: "ciphertext-too-large",
       }),
     );
+    await emitEvent(
+      createEvent({
+        id: "allowed-after-oversized",
+        content: "ok",
+      }),
+    );
 
-    expect(bus.getMetrics().eventsRejected.oversizedCiphertext).toBe(1);
-    expect(bus.getMetrics().eventsRejected.rateLimited).toBe(1);
-    expect(mockState.verifyEvent).not.toHaveBeenCalled();
-    expect(mockState.decrypt).not.toHaveBeenCalled();
-    expect(onMessage).not.toHaveBeenCalled();
+    expect(bus.getMetrics().eventsRejected.oversizedCiphertext).toBe(2);
+    expect(bus.getMetrics().eventsRejected.rateLimited).toBe(0);
+    expect(mockState.verifyEvent).toHaveBeenCalledTimes(1);
+    expect(mockState.decrypt).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledTimes(1);
 
     bus.close();
   });

--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -209,6 +209,32 @@ describe("startNostrBus inbound guards", () => {
     bus.close();
   });
 
+  it("dedupes replayed verified events that authorization blocks", async () => {
+    const onMessage = vi.fn(async () => {});
+    const authorizeSender = vi.fn(async () => "block" as const);
+    const bus = await startNostrBus({
+      privateKey: TEST_HEX_PRIVATE_KEY,
+      onMessage,
+      authorizeSender,
+      onMetric: () => {},
+    });
+
+    const blockedEvent = createEvent({
+      id: "blocked-replay",
+      pubkey: `blocked${"a".repeat(57)}`,
+    });
+
+    await emitEvent(blockedEvent);
+    await emitEvent(blockedEvent);
+
+    expect(mockState.verifyEvent).toHaveBeenCalledTimes(1);
+    expect(authorizeSender).toHaveBeenCalledTimes(1);
+    expect(mockState.decrypt).not.toHaveBeenCalled();
+    expect(onMessage).not.toHaveBeenCalled();
+
+    bus.close();
+  });
+
   it("does not rate limit an allowed sender while another authorization is still pending", async () => {
     const onMessage = vi.fn(async () => {});
     let resolveBlocked: ((value: "block") => void) | undefined;

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -553,21 +553,6 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
         );
       };
 
-      updateRateLimiterSizeMetric();
-      if (globalRateLimiter.isRateLimited("global")) {
-        metrics.emit("rate_limit.global");
-        metrics.emit("event.rejected.rate_limited");
-        updateRateLimiterSizeMetric();
-        return;
-      }
-      if (perSenderRateLimiter.isRateLimited(event.pubkey)) {
-        metrics.emit("rate_limit.per_sender");
-        metrics.emit("event.rejected.rate_limited");
-        updateRateLimiterSizeMetric();
-        return;
-      }
-      updateRateLimiterSizeMetric();
-
       if (Buffer.byteLength(event.content, "utf8") > guardPolicy.maxCiphertextBytes) {
         metrics.emit("event.rejected.oversized_ciphertext");
         return;
@@ -589,6 +574,21 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
           return;
         }
       }
+
+      updateRateLimiterSizeMetric();
+      if (globalRateLimiter.isRateLimited("global")) {
+        metrics.emit("rate_limit.global");
+        metrics.emit("event.rejected.rate_limited");
+        updateRateLimiterSizeMetric();
+        return;
+      }
+      if (perSenderRateLimiter.isRateLimited(event.pubkey)) {
+        metrics.emit("rate_limit.per_sender");
+        metrics.emit("event.rejected.rate_limited");
+        updateRateLimiterSizeMetric();
+        return;
+      }
+      updateRateLimiterSizeMetric();
 
       // Mark seen AFTER verify (don't cache invalid IDs)
       seen.add(event.id);

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -64,7 +64,7 @@ export interface NostrBusOptions {
     reply: (text: string) => Promise<void>,
     meta: { eventId: string; createdAt: number },
   ) => Promise<void>;
-  /** Called before expensive crypto to allow sender policy checks (optional) */
+  /** Called after signature verification and before decrypt to allow sender policy checks (optional) */
   authorizeSender?: (params: {
     senderPubkey: string;
     reply: (text: string) => Promise<void>;
@@ -553,16 +553,6 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
         );
       };
 
-      if (authorizeSender) {
-        const decision = await authorizeSender({
-          senderPubkey: event.pubkey,
-          reply: replyTo,
-        });
-        if (decision !== "allow") {
-          return;
-        }
-      }
-
       updateRateLimiterSizeMetric();
       if (globalRateLimiter.isRateLimited("global")) {
         metrics.emit("rate_limit.global");
@@ -588,6 +578,16 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
         metrics.emit("event.rejected.invalid_signature");
         onError?.(new Error("Invalid signature"), `event ${event.id}`);
         return;
+      }
+
+      if (authorizeSender) {
+        const decision = await authorizeSender({
+          senderPubkey: event.pubkey,
+          reply: replyTo,
+        });
+        if (decision !== "allow") {
+          return;
+        }
       }
 
       // Mark seen AFTER verify (don't cache invalid IDs)

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -553,7 +553,28 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
         );
       };
 
+      const rejectIfRateLimited = (): boolean => {
+        updateRateLimiterSizeMetric();
+        if (globalRateLimiter.isRateLimited("global")) {
+          metrics.emit("rate_limit.global");
+          metrics.emit("event.rejected.rate_limited");
+          updateRateLimiterSizeMetric();
+          return true;
+        }
+        if (perSenderRateLimiter.isRateLimited(event.pubkey)) {
+          metrics.emit("rate_limit.per_sender");
+          metrics.emit("event.rejected.rate_limited");
+          updateRateLimiterSizeMetric();
+          return true;
+        }
+        updateRateLimiterSizeMetric();
+        return false;
+      };
+
       if (Buffer.byteLength(event.content, "utf8") > guardPolicy.maxCiphertextBytes) {
+        if (rejectIfRateLimited()) {
+          return;
+        }
         metrics.emit("event.rejected.oversized_ciphertext");
         return;
       }
@@ -575,20 +596,9 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
         }
       }
 
-      updateRateLimiterSizeMetric();
-      if (globalRateLimiter.isRateLimited("global")) {
-        metrics.emit("rate_limit.global");
-        metrics.emit("event.rejected.rate_limited");
-        updateRateLimiterSizeMetric();
+      if (rejectIfRateLimited()) {
         return;
       }
-      if (perSenderRateLimiter.isRateLimited(event.pubkey)) {
-        metrics.emit("rate_limit.per_sender");
-        metrics.emit("event.rejected.rate_limited");
-        updateRateLimiterSizeMetric();
-        return;
-      }
-      updateRateLimiterSizeMetric();
 
       // Mark seen AFTER verify (don't cache invalid IDs)
       seen.add(event.id);

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -553,7 +553,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
         );
       };
 
-      const rejectIfRateLimited = (): boolean => {
+      const rejectIfGlobalRateLimited = (): boolean => {
         updateRateLimiterSizeMetric();
         if (globalRateLimiter.isRateLimited("global")) {
           metrics.emit("rate_limit.global");
@@ -561,6 +561,12 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
           updateRateLimiterSizeMetric();
           return true;
         }
+        updateRateLimiterSizeMetric();
+        return false;
+      };
+
+      const rejectIfVerifiedSenderRateLimited = (): boolean => {
+        updateRateLimiterSizeMetric();
         if (perSenderRateLimiter.isRateLimited(event.pubkey)) {
           metrics.emit("rate_limit.per_sender");
           metrics.emit("event.rejected.rate_limited");
@@ -577,10 +583,14 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
       };
 
       if (Buffer.byteLength(event.content, "utf8") > guardPolicy.maxCiphertextBytes) {
-        if (rejectIfRateLimited()) {
+        if (rejectIfGlobalRateLimited()) {
           return;
         }
         metrics.emit("event.rejected.oversized_ciphertext");
+        return;
+      }
+
+      if (rejectIfGlobalRateLimited()) {
         return;
       }
 
@@ -588,6 +598,10 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
       if (!verifyEvent(event)) {
         metrics.emit("event.rejected.invalid_signature");
         onError?.(new Error("Invalid signature"), `event ${event.id}`);
+        return;
+      }
+
+      if (rejectIfVerifiedSenderRateLimited()) {
         return;
       }
 
@@ -600,10 +614,6 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
           markSeen();
           return;
         }
-      }
-
-      if (rejectIfRateLimited()) {
-        return;
       }
 
       // Mark seen AFTER verify (don't cache invalid IDs)

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -571,6 +571,11 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
         return false;
       };
 
+      const markSeen = () => {
+        seen.add(event.id);
+        metrics.emit("memory.seen_tracker_size", seen.size());
+      };
+
       if (Buffer.byteLength(event.content, "utf8") > guardPolicy.maxCiphertextBytes) {
         if (rejectIfRateLimited()) {
           return;
@@ -592,6 +597,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
           reply: replyTo,
         });
         if (decision !== "allow") {
+          markSeen();
           return;
         }
       }
@@ -601,8 +607,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
       }
 
       // Mark seen AFTER verify (don't cache invalid IDs)
-      seen.add(event.id);
-      metrics.emit("memory.seen_tracker_size", seen.size());
+      markSeen();
 
       // Decrypt the message
       let plaintext: string;


### PR DESCRIPTION
## Summary

- Problem: Nostr inbound DM handling ran sender authorization before event signature verification.
- Why it matters: forged DM events could create pairing requests and trigger reply attempts before the event was authenticated.
- What changed: moved sender authorization to run after `verifyEvent(event)` and before decrypt, updated the inbound guard tests, and added an `Unreleased` changelog line.
- What did NOT change: pairing behavior and sender policy decisions for valid signed events.

## Verification

- AI-assisted: yes
- Testing: fully tested on the touched surface
- Passed: `pnpm test -- extensions/nostr/src/nostr-bus.inbound.test.ts extensions/nostr/src/channel.inbound.test.ts`
- Current repo blocker: `pnpm check` and `pnpm build` both fail on the current tree in `src/tasks/flow-registry.ts` (`string | null` assigned to `string | undefined` at lines 252-253), outside this change.
