### PR TITLE
fix(voice-call): pin plivo callback origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Docs: https://docs.openclaw.ai
 - Memory/QMD: keep `memory_search` session-hit paths roundtrip-safe when exported session markdown lives under the workspace `qmd/` directory, so `memory_get` can read the exact returned path instead of failing on the generic `qmd/sessions/...` alias. (#43519) Thanks @holgergruenhagen and @vincentkoc.
 - Memory/QMD: treat null-byte collection corruption the same when QMD surfaces it as `ENOENT`, so managed-collection repair still rebuilds and retries instead of leaving QMD stuck on a broken path. Thanks @vincentkoc.
 - Memory/QMD: stop rewriting Han/CJK BM25 queries before `qmd search`, so OpenClaw search semantics match direct QMD results for mixed and spaced Chinese queries. Thanks @vincentkoc.
+- Voice call/Plivo: pin stored callback bases to the configured public webhook URL so later call-control redirects stay on the intended origin even if webhook transport metadata differs. Thanks @zsxsoft and @vincentkoc.
 - Agents/memory flush: keep daily memory flush files append-only during embedded attempts so compaction writes do not overwrite earlier notes. (#53725) Thanks @HPluseven.
 - Web UI/markdown: stop bare auto-links from swallowing adjacent CJK text while preserving valid mixed-script path and query characters in rendered links. (#48410) Thanks @jnuyao.
 - BlueBubbles/iMessage: coalesce URL-only inbound messages with their link-preview balloon again so sharing a bare link no longer drops the URL from agent context. Thanks @vincentkoc.

--- a/extensions/voice-call/src/providers/plivo.test.ts
+++ b/extensions/voice-call/src/providers/plivo.test.ts
@@ -64,4 +64,30 @@ describe("PlivoProvider", () => {
       "plivo:v3:verified",
     );
   });
+
+  it("pins stored callback bases to publicUrl instead of request Host", () => {
+    const provider = new PlivoProvider(
+      {
+        authId: "MA000000000000000000",
+        authToken: "test-token",
+      },
+      {
+        publicUrl: "https://voice.openclaw.ai/voice/webhook?provider=plivo",
+      },
+    );
+
+    provider.parseWebhookEvent({
+      headers: { host: "attacker.example" },
+      rawBody:
+        "CallUUID=call-uuid&CallStatus=in-progress&Direction=outbound&From=%2B15550000000&To=%2B15550000001&Event=StartApp",
+      url: "https://attacker.example/voice/webhook?provider=plivo&flow=answer&callId=internal-call-id",
+      method: "POST",
+      query: { provider: "plivo", flow: "answer", callId: "internal-call-id" },
+    });
+
+    const callbackMap = (provider as unknown as { callUuidToWebhookUrl: Map<string, string> })
+      .callUuidToWebhookUrl;
+
+    expect(callbackMap.get("call-uuid")).toBe("https://voice.openclaw.ai/voice/webhook");
+  });
 });

--- a/extensions/voice-call/src/providers/plivo.ts
+++ b/extensions/voice-call/src/providers/plivo.ts
@@ -544,6 +544,13 @@ export class PlivoProvider implements VoiceCallProvider {
 
   private baseWebhookUrlFromCtx(ctx: WebhookContext): string | null {
     try {
+      if (this.options.publicUrl) {
+        const base = new URL(this.options.publicUrl);
+        const requestUrl = new URL(ctx.url);
+        base.pathname = requestUrl.pathname;
+        return `${base.origin}${base.pathname}`;
+      }
+
       const u = new URL(
         reconstructWebhookUrl(ctx, {
           allowedHosts: this.options.webhookSecurity?.allowedHosts,


### PR DESCRIPTION
## Summary

- Problem: stored Plivo callback bases could drift to the request host instead of the configured public webhook origin.
- Why it matters: later call-control redirects could be pinned to an unintended origin when transport metadata differs from the configured public URL.
- What changed: derive stored callback bases from the configured public webhook origin while preserving the active request path, and add regression coverage for the stored callback map.
- What did NOT change (scope boundary): provider auth, webhook replay handling order, and other voice-call providers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the Plivo provider stored callback bases from request transport metadata even when verification was anchored to the configured `publicUrl`.
- Missing detection / guardrail: no regression test covered hostile request-host metadata while `publicUrl` was configured.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: callback-base persistence kept using request reconstruction instead of the configured public webhook origin.
- If unknown, what was ruled out: this PR does not change replay-key derivation or other provider implementations.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/voice-call/src/providers/plivo.test.ts`
- Scenario the test should lock in: a hostile request host must not poison the stored callback base when `publicUrl` is configured.
- Why this is the smallest reliable guardrail: it exercises the exact persistence path without requiring external provider traffic.
- Existing test that already covers this (if any): none.
- If no new test is added, why not:

## User-visible / Behavior Changes

- Plivo deployments with a configured public webhook URL now keep later call-control redirects pinned to that configured origin instead of the raw request host.

## Diagram (if applicable)

```text
Before:
[callback request] -> [store request host as callback base] -> [later redirect uses drifted origin]

After:
[callback request] -> [store configured public origin + request path] -> [later redirect stays on intended origin]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local worktree
- Model/provider: N/A
- Integration/channel (if any): voice-call / Plivo
- Relevant config (redacted): `publicUrl` configured for the voice-call webhook

### Steps

1. Run `pnpm test -- extensions/voice-call/src/providers/plivo.test.ts`.
2. Run `pnpm test -- extensions/voice-call/src/webhook.test.ts`.
3. Run `pnpm check`.

### Expected

- Voice-call targeted tests pass.
- `pnpm check` reflects current repo state.

### Actual

- Targeted tests passed.
- `pnpm check` failed on untouched `src/tasks/flow-registry.ts:252-253` with existing `string | null` to `string | undefined` type drift.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: hostile request host with configured `publicUrl`; existing webhook replay tests remain green.
- Edge cases checked: callback base keeps the request path while pinning the configured public origin.
- What you did **not** verify: full repo green state because `pnpm check` is currently blocked by unrelated `src/tasks/flow-registry.ts` type errors.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: deployments that implicitly relied on raw request-host reconstruction will now prefer the configured public webhook origin.
  - Mitigation: that configured public URL is already the intended callback contract and now matches later redirect behavior.
