### PR TITLE
fix(cron): surface exec timeouts in isolated cron runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Docs: https://docs.openclaw.ai
 - Dotenv/workspace overrides: block workspace `.env` files from overriding `OPENCLAW_PINNED_PYTHON` and `OPENCLAW_PINNED_WRITE_PYTHON` so trusted helper interpreters cannot be redirected by repo-local env injection. (#58473) Thanks @eleqtrizit.
 - Plugins/install: accept JSON5 syntax in `openclaw.plugin.json` and bundle `plugin.json` manifests during install/validation, so third-party plugins with trailing commas, comments, or unquoted keys no longer fail to install. (#59084) Thanks @singleGanghood.
 - Telegram/exec approvals: rewrite shared `/approve … allow-always` callback payloads to `/approve … always` before Telegram button rendering so plugin approval IDs still fit Telegram's `callback_data` limit and keep the Allow Always action visible. (#59217) Thanks @jameslcowan.
+- Cron/exec timeouts: surface timed-out `exec` and `bash` failures in isolated cron runs even when `verbose: off`, including custom session-target cron jobs, so scheduled runs stop failing silently. (#58247) Thanks @skainguyen1412.
 
 ## 2026.4.2
 

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -52,6 +52,7 @@ export type ExecToolDetails =
       exitCode: number | null;
       durationMs: number;
       aggregated: string;
+      timedOut?: boolean;
       cwd?: string;
     }
   | {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -73,6 +73,7 @@ function buildExecForegroundResult(params: {
       exitCode: params.outcome.exitCode ?? null,
       durationMs: params.outcome.durationMs,
       aggregated: params.outcome.aggregated,
+      timedOut: params.outcome.timedOut,
       cwd: params.cwd,
     });
   }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1311,6 +1311,7 @@ export async function runEmbeddedPiAgent(
             lastAssistant: attempt.lastAssistant,
             lastToolError: attempt.lastToolError,
             config: params.config,
+            isCronTrigger: params.trigger === "cron",
             sessionKey: params.sessionKey ?? params.sessionId,
             provider: activeErrorContext.provider,
             model: activeErrorContext.model,

--- a/src/agents/pi-embedded-runner/run/payloads.test-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test-helpers.ts
@@ -9,6 +9,7 @@ export function buildPayloads(overrides: Partial<BuildPayloadParams> = {}) {
     assistantTexts: [],
     toolMetas: [],
     lastAssistant: undefined,
+    isCronTrigger: false,
     sessionKey: "session:telegram",
     inlineToolResultsAllowed: false,
     verboseLevel: "off",

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -18,6 +18,7 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     const payloads = buildPayloads({
       lastToolError: {
         toolName: "exec",
+        timedOut: true,
         error:
           "Command timed out after 1800 seconds. If this command is expected to take longer, re-run with a higher timeout (e.g., exec timeout=300).",
       },
@@ -29,6 +30,14 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
       title: "Exec",
       detail:
         "Command timed out after 1800 seconds. If this command is expected to take longer, re-run with a higher timeout (e.g., exec timeout=300).",
+    });
+  });
+
+  it("keeps non-timeout exec tool errors suppressed for cron sessions when verbose mode is off", () => {
+    expectNoPayloads({
+      lastToolError: { toolName: "exec", error: "Command not found" },
+      sessionKey: "agent:main:cron:job-1",
+      verboseLevel: "off",
     });
   });
 

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -33,6 +33,24 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("surfaces timed-out exec tool errors for cron-triggered custom session keys", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        timedOut: true,
+        error: "Command timed out after 1800 seconds.",
+      },
+      sessionKey: "agent:main:project-alpha",
+      isCronTrigger: true,
+      verboseLevel: "off",
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Exec",
+      detail: "Command timed out after 1800 seconds.",
+    });
+  });
+
   it("keeps non-timeout exec tool errors suppressed for cron sessions when verbose mode is off", () => {
     expectNoPayloads({
       lastToolError: { toolName: "exec", error: "Command not found" },

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -14,6 +14,24 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("surfaces exec tool errors for cron sessions even when verbose mode is off", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        error:
+          "Command timed out after 1800 seconds. If this command is expected to take longer, re-run with a higher timeout (e.g., exec timeout=300).",
+      },
+      sessionKey: "agent:main:cron:job-1",
+      verboseLevel: "off",
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Exec",
+      detail:
+        "Command timed out after 1800 seconds. If this command is expected to take longer, re-run with a higher timeout (e.g., exec timeout=300).",
+    });
+  });
+
   it("shows exec tool errors when verbose mode is on", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "exec", error: "command failed" },

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -5,6 +5,7 @@ import type { ReasoningLevel, VerboseLevel } from "../../../auto-reply/thinking.
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { formatToolAggregate } from "../../../auto-reply/tool-meta.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import { isCronSessionKey } from "../../../routing/session-key.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
   formatAssistantErrorText,
@@ -58,13 +59,17 @@ function resolveToolErrorWarningPolicy(params: {
   hasUserFacingReply: boolean;
   suppressToolErrors: boolean;
   suppressToolErrorWarnings?: boolean;
+  sessionKey: string;
   verboseLevel?: VerboseLevel;
 }): ToolErrorWarningPolicy {
-  const includeDetails = isVerboseToolDetailEnabled(params.verboseLevel);
+  const normalizedToolName = params.lastToolError.toolName.trim().toLowerCase();
+  const isCronExecToolError =
+    (normalizedToolName === "exec" || normalizedToolName === "bash") &&
+    isCronSessionKey(params.sessionKey);
+  const includeDetails = isVerboseToolDetailEnabled(params.verboseLevel) || isCronExecToolError;
   if (params.suppressToolErrorWarnings) {
     return { showWarning: false, includeDetails };
   }
-  const normalizedToolName = params.lastToolError.toolName.trim().toLowerCase();
   if ((normalizedToolName === "exec" || normalizedToolName === "bash") && !includeDetails) {
     return { showWarning: false, includeDetails };
   }
@@ -289,6 +294,7 @@ export function buildEmbeddedRunPayloads(params: {
       hasUserFacingReply: hasUserFacingAssistantReply,
       suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+      sessionKey: params.sessionKey,
       verboseLevel: params.verboseLevel,
     });
 

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -60,6 +60,7 @@ function resolveToolErrorWarningPolicy(params: {
   hasUserFacingReply: boolean;
   suppressToolErrors: boolean;
   suppressToolErrorWarnings?: boolean;
+  isCronTrigger?: boolean;
   sessionKey: string;
   verboseLevel?: VerboseLevel;
 }): ToolErrorWarningPolicy {
@@ -67,7 +68,7 @@ function resolveToolErrorWarningPolicy(params: {
   const isCronTimedOutExecToolError =
     (normalizedToolName === "exec" || normalizedToolName === "bash") &&
     params.lastToolError.timedOut === true &&
-    isCronSessionKey(params.sessionKey);
+    (params.isCronTrigger === true || isCronSessionKey(params.sessionKey));
   const includeDetails =
     isVerboseToolDetailEnabled(params.verboseLevel) || isCronTimedOutExecToolError;
   if (params.suppressToolErrorWarnings) {
@@ -102,6 +103,7 @@ export function buildEmbeddedRunPayloads(params: {
   lastAssistant: AssistantMessage | undefined;
   lastToolError?: LastToolError;
   config?: OpenClawConfig;
+  isCronTrigger?: boolean;
   sessionKey: string;
   provider?: string;
   model?: string;
@@ -297,6 +299,7 @@ export function buildEmbeddedRunPayloads(params: {
       hasUserFacingReply: hasUserFacingAssistantReply,
       suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+      isCronTrigger: params.isCronTrigger,
       sessionKey: params.sessionKey,
       verboseLevel: params.verboseLevel,
     });

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -27,6 +27,7 @@ type LastToolError = {
   toolName: string;
   meta?: string;
   error?: string;
+  timedOut?: boolean;
   mutatingAction?: boolean;
   actionFingerprint?: string;
 };
@@ -63,10 +64,12 @@ function resolveToolErrorWarningPolicy(params: {
   verboseLevel?: VerboseLevel;
 }): ToolErrorWarningPolicy {
   const normalizedToolName = params.lastToolError.toolName.trim().toLowerCase();
-  const isCronExecToolError =
+  const isCronTimedOutExecToolError =
     (normalizedToolName === "exec" || normalizedToolName === "bash") &&
+    params.lastToolError.timedOut === true &&
     isCronSessionKey(params.sessionKey);
-  const includeDetails = isVerboseToolDetailEnabled(params.verboseLevel) || isCronExecToolError;
+  const includeDetails =
+    isVerboseToolDetailEnabled(params.verboseLevel) || isCronTimedOutExecToolError;
   if (params.suppressToolErrorWarnings) {
     return { showWarning: false, includeDetails };
   }

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -50,6 +50,7 @@ export type EmbeddedRunAttemptResult = {
     toolName: string;
     meta?: string;
     error?: string;
+    timedOut?: boolean;
     mutatingAction?: boolean;
     actionFingerprint?: string;
   };

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -238,6 +238,42 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
   });
 });
 
+describe("handleToolExecutionEnd timeout metadata", () => {
+  it("records timeout metadata for failed exec results", async () => {
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-timeout",
+        isError: true,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: "Command timed out after 1800 seconds.",
+            },
+          ],
+          details: {
+            status: "failed",
+            timedOut: true,
+            exitCode: null,
+            durationMs: 1_800_000,
+            aggregated: "",
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.lastToolError).toMatchObject({
+      toolName: "exec",
+      timedOut: true,
+    });
+  });
+});
+
 describe("handleToolExecutionEnd exec approval prompts", () => {
   it("emits a deterministic approval payload and marks assistant output suppressed", async () => {
     const { ctx } = createTestContext();

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -21,6 +21,7 @@ import {
   extractToolResultText,
   filterToolResultMediaUrls,
   isToolResultError,
+  isToolResultTimedOut,
   sanitizeToolResult,
 } from "./pi-embedded-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
@@ -503,6 +504,7 @@ export async function handleToolExecutionEnd(
       toolName,
       meta,
       error: errorMessage,
+      timedOut: isToolResultTimedOut(sanitizedResult) || undefined,
       mutatingAction: callSummary?.mutatingAction,
       actionFingerprint: callSummary?.actionFingerprint,
     };

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -21,6 +21,7 @@ export type ToolErrorSummary = {
   toolName: string;
   meta?: string;
   error?: string;
+  timedOut?: boolean;
   mutatingAction?: boolean;
   actionFingerprint?: string;
 };

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -330,6 +330,25 @@ export function isToolResultError(result: unknown): boolean {
   return normalized === "error" || normalized === "timeout";
 }
 
+export function isToolResultTimedOut(result: unknown): boolean {
+  if (!result || typeof result !== "object") {
+    return false;
+  }
+  const record = result as { details?: unknown };
+  const details = record.details;
+  if (!details || typeof details !== "object") {
+    return false;
+  }
+  const normalizedStatus =
+    typeof (details as { status?: unknown }).status === "string"
+      ? (details as { status?: string }).status?.trim().toLowerCase()
+      : undefined;
+  if (normalizedStatus === "timeout") {
+    return true;
+  }
+  return (details as { timedOut?: unknown }).timedOut === true;
+}
+
 export function extractToolErrorMessage(result: unknown): string | undefined {
   if (!result || typeof result !== "object") {
     return undefined;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: isolated cron runs can hit an `exec`/`bash` timeout, but the timeout warning is suppressed when cron is running with `verbose: off`, so the run can look like it failed silently.
- Why it matters: users do not get a visible failure signal for long-running cron jobs, which makes timeouts look like unexplained cron breakage instead of a tool timeout.
- What changed: cron session keys now surface `exec`/`bash` tool timeout errors in the embedded run payload even when verbose mode is off, and a regression test was added for that exact path.
- What did NOT change (scope boundary): this PR does not change `exec` timeout configuration, cron scheduling, retry behavior, or user backup script behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57963
- Related #20560
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: isolated cron runs default to `verbose: off`, and the embedded payload builder suppresses `exec`/`bash` tool failure warnings in non-verbose mode. That suppression also hid timeout failures for cron sessions, leaving no user-facing error payload.
- Missing detection / guardrail: there was coverage for generic non-verbose suppression, but no regression test asserting that cron sessions must still surface timeout failures.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the behavior appears related to the warning-policy change in #20560 after issue #20101, where `exec` warnings were gated behind verbose mode.
- Why this regressed now: isolated cron runs are especially sensitive because they run without interactive context and rely on the final payload for error visibility.
- If unknown, what was ruled out: ruled out missing timeout configurability; `exec` timeout configuration already exists and was not the root problem here.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/payloads.test.ts`
- Scenario the test should lock in: for a cron session key with `verbose: off`, an `exec` timeout error should still produce a visible warning payload instead of returning no payload.
- Why this is the smallest reliable guardrail: the bug is in payload-generation policy, so the most direct and stable guardrail is a unit test at the payload builder boundary.
- Existing test that already covers this (if any): existing tests covered generic non-verbose suppression for `exec`, but not the cron-specific exception needed here.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Isolated cron runs now show `exec`/`bash` timeout failures in the cron output even when verbose mode is off, instead of appearing to fail silently.

## Diagram (if applicable)

```text
Before:
[cron run] -> [exec timeout] -> [warning suppressed by verbose=off] -> [no visible cron error]

After:
[cron run] -> [exec timeout] -> [cron session exception in payload builder] -> [visible timeout warning]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout with `pnpm` / Vitest
- Model/provider: N/A
- Integration/channel (if any): isolated cron session
- Relevant config (redacted): cron isolated run with default `verbose: off`; `exec` timeout path

### Steps

1. Run an isolated cron flow, or directly build the embedded payload for a cron session key with `verbose: off`.
2. Inject or trigger an `exec` timeout failure.
3. Inspect the resulting cron payload.

### Expected

- The cron run should surface a visible timeout warning so the failure is actionable.

### Actual

- Before this fix, the timeout was captured internally but no user-facing cron warning payload was emitted.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the cron-session payload path locally before the fix, confirmed the timeout warning was suppressed in non-verbose mode, then verified the cron path now emits a visible warning payload; also ran `pnpm test -- src/agents/pi-embedded-runner/run/payloads.test.ts` and `pnpm test -- src/cron/service.issue-regressions.test.ts -t "applies timeoutSeconds to manual cron.run isolated executions"`.
- Edge cases checked: non-cron non-verbose behavior remains covered by the existing payload tests, so this change stays scoped to cron session keys plus `exec`/`bash` failures.
- What you did **not** verify: a full end-to-end real backup workload under the scheduler, or changes to timeout configuration behavior.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk:
  - Cron runs may now show timeout details that were previously hidden in non-verbose mode.
- Mitigation:
  - The change is intentionally narrow: it only applies to cron session keys and only for `exec`/`bash` tool failures; normal non-verbose suppression behavior remains unchanged outside cron.
