### PR TITLE
fix(qqbot): align speech schema and setup validation

### DIFF
--- a/extensions/qqbot/openclaw.plugin.json
+++ b/extensions/qqbot/openclaw.plugin.json
@@ -131,7 +131,8 @@
         "additionalProperties": {
           "$ref": "#/$defs/account"
         }
-      }
+      },
+      "defaultAccount": { "type": "string" }
     }
   }
 }

--- a/extensions/qqbot/openclaw.plugin.json
+++ b/extensions/qqbot/openclaw.plugin.json
@@ -21,6 +21,41 @@
           "transcodeEnabled": { "type": "boolean" }
         }
       },
+      "speechQueryParams": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "tts": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "provider": { "type": "string" },
+          "baseUrl": { "type": "string" },
+          "apiKey": { "type": "string" },
+          "model": { "type": "string" },
+          "voice": { "type": "string" },
+          "authStyle": {
+            "type": "string",
+            "enum": ["bearer", "api-key"]
+          },
+          "queryParams": { "$ref": "#/$defs/speechQueryParams" },
+          "speed": { "type": "number" }
+        }
+      },
+      "stt": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "provider": { "type": "string" },
+          "baseUrl": { "type": "string" },
+          "apiKey": { "type": "string" },
+          "model": { "type": "string" }
+        }
+      },
       "secretRef": {
         "type": "object",
         "additionalProperties": false,
@@ -83,6 +118,8 @@
         "items": { "type": "string" }
       },
       "audioFormatPolicy": { "$ref": "#/$defs/audioFormatPolicy" },
+      "tts": { "$ref": "#/$defs/tts" },
+      "stt": { "$ref": "#/$defs/stt" },
       "urlDirectUpload": { "type": "boolean" },
       "upgradeUrl": { "type": "string" },
       "upgradeMode": {

--- a/extensions/qqbot/src/channel.setup.ts
+++ b/extensions/qqbot/src/channel.setup.ts
@@ -33,9 +33,18 @@ function parseQQBotInlineToken(token: string): { appId: string; clientSecret: st
   return { appId, clientSecret };
 }
 
-export function validateQQBotSetupInput(input: ChannelSetupInput): string | null {
+export function validateQQBotSetupInput(params: {
+  accountId: string;
+  input: ChannelSetupInput;
+}): string | null {
+  const { accountId, input } = params;
+
   if (!input.token && !input.tokenFile && !input.useEnv) {
     return "QQBot requires --token (format: appId:clientSecret) or --use-env";
+  }
+
+  if (input.useEnv && accountId !== DEFAULT_ACCOUNT_ID) {
+    return "QQBot --use-env only supports the default account";
   }
 
   if (input.token && !parseQQBotInlineToken(input.token)) {
@@ -50,6 +59,10 @@ export function applyQQBotSetupAccountConfig(params: {
   accountId: string;
   input: ChannelSetupInput;
 }): OpenClawConfig {
+  if (params.input.useEnv && params.accountId !== DEFAULT_ACCOUNT_ID) {
+    return params.cfg;
+  }
+
   let appId = "";
   let clientSecret = "";
 
@@ -151,7 +164,7 @@ export const qqbotSetupPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
         accountId,
         name,
       }),
-    validateInput: ({ input }) => validateQQBotSetupInput(input),
+    validateInput: ({ accountId, input }) => validateQQBotSetupInput({ accountId, input }),
     applyAccountConfig: ({ cfg, accountId, input }) =>
       applyQQBotSetupAccountConfig({ cfg, accountId, input }),
   },

--- a/extensions/qqbot/src/channel.setup.ts
+++ b/extensions/qqbot/src/channel.setup.ts
@@ -62,7 +62,7 @@ export function applyQQBotSetupAccountConfig(params: {
     clientSecret = parsed.clientSecret;
   }
 
-  if (!appId && !params.input.tokenFile) {
+  if (!appId && !params.input.tokenFile && !params.input.useEnv) {
     return params.cfg;
   }
 

--- a/extensions/qqbot/src/channel.setup.ts
+++ b/extensions/qqbot/src/channel.setup.ts
@@ -1,3 +1,4 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import {
   applyAccountNameToChannelSection,
@@ -5,6 +6,7 @@ import {
   setAccountEnabledInConfigSection,
 } from "openclaw/plugin-sdk/core";
 import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
+import type { ChannelSetupInput } from "openclaw/plugin-sdk/setup";
 import { qqbotChannelConfigSchema } from "./config-schema.js";
 import {
   DEFAULT_ACCOUNT_ID,
@@ -15,6 +17,66 @@ import {
 } from "./config.js";
 import { qqbotSetupWizard } from "./setup-surface.js";
 import type { ResolvedQQBotAccount } from "./types.js";
+
+function parseQQBotInlineToken(token: string): { appId: string; clientSecret: string } | null {
+  const colonIdx = token.indexOf(":");
+  if (colonIdx <= 0 || colonIdx === token.length - 1) {
+    return null;
+  }
+
+  const appId = token.slice(0, colonIdx).trim();
+  const clientSecret = token.slice(colonIdx + 1).trim();
+  if (!appId || !clientSecret) {
+    return null;
+  }
+
+  return { appId, clientSecret };
+}
+
+export function validateQQBotSetupInput(input: ChannelSetupInput): string | null {
+  if (!input.token && !input.tokenFile && !input.useEnv) {
+    return "QQBot requires --token (format: appId:clientSecret) or --use-env";
+  }
+
+  if (input.token && !parseQQBotInlineToken(input.token)) {
+    return "QQBot --token must be in appId:clientSecret format";
+  }
+
+  return null;
+}
+
+export function applyQQBotSetupAccountConfig(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  input: ChannelSetupInput;
+}): OpenClawConfig {
+  let appId = "";
+  let clientSecret = "";
+
+  if (params.input.token) {
+    const parsed = parseQQBotInlineToken(params.input.token);
+    if (!parsed) {
+      return params.cfg;
+    }
+    appId = parsed.appId;
+    clientSecret = parsed.clientSecret;
+  }
+
+  if (!appId && !params.input.tokenFile) {
+    return params.cfg;
+  }
+
+  // When only --token-file is provided, appId will be empty here.
+  // This is by design: --token-file supplies the clientSecret only,
+  // not the appId. The appId is expected to come from the env var
+  // QQBOT_APP_ID or be set separately in the config file.
+  return applyQQBotAccountConfig(params.cfg, params.accountId, {
+    appId,
+    clientSecret,
+    clientSecretFile: params.input.tokenFile,
+    name: params.input.name,
+  });
+}
 
 /**
  * Setup-only QQBot plugin — lightweight subset used during `openclaw onboard`
@@ -89,42 +151,8 @@ export const qqbotSetupPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
         accountId,
         name,
       }),
-    validateInput: ({ input }) => {
-      if (!input.token && !input.tokenFile && !input.useEnv) {
-        return "QQBot requires --token (format: appId:clientSecret) or --use-env";
-      }
-      return null;
-    },
-    applyAccountConfig: ({ cfg, accountId, input }) => {
-      let appId = "";
-      let clientSecret = "";
-
-      if (input.token) {
-        const colonIdx = input.token.indexOf(":");
-        if (colonIdx > 0) {
-          appId = input.token.slice(0, colonIdx);
-          clientSecret = input.token.slice(colonIdx + 1);
-        } else {
-          // Token must be in appId:clientSecret format; skip config write if malformed.
-          return cfg;
-        }
-      }
-
-      if (!appId && !input.tokenFile) {
-        // No valid credentials provided; skip config write.
-        return cfg;
-      }
-
-      // When only --token-file is provided, appId will be empty here.
-      // This is by design: --token-file supplies the clientSecret only,
-      // not the appId. The appId is expected to come from the env var
-      // QQBOT_APP_ID or be set separately in the config file.
-      return applyQQBotAccountConfig(cfg, accountId, {
-        appId,
-        clientSecret,
-        clientSecretFile: input.tokenFile,
-        name: input.name,
-      });
-    },
+    validateInput: ({ input }) => validateQQBotSetupInput(input),
+    applyAccountConfig: ({ cfg, accountId, input }) =>
+      applyQQBotSetupAccountConfig({ cfg, accountId, input }),
   },
 };

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -117,7 +117,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
         accountId,
         name,
       }),
-    validateInput: ({ input }) => validateQQBotSetupInput(input),
+    validateInput: ({ accountId, input }) => validateQQBotSetupInput({ accountId, input }),
     applyAccountConfig: ({ cfg, accountId, input }) =>
       applyQQBotSetupAccountConfig({ cfg, accountId, input }),
   },

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -7,10 +7,10 @@ import {
 } from "openclaw/plugin-sdk/core";
 import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
 import { initApiConfig } from "./api.js";
+import { applyQQBotSetupAccountConfig, validateQQBotSetupInput } from "./channel.setup.js";
 import { qqbotChannelConfigSchema } from "./config-schema.js";
 import {
   DEFAULT_ACCOUNT_ID,
-  applyQQBotAccountConfig,
   listQQBotAccountIds,
   resolveQQBotAccount,
   resolveDefaultQQBotAccountId,
@@ -117,31 +117,9 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
         accountId,
         name,
       }),
-    validateInput: ({ input }) => {
-      if (!input.token && !input.tokenFile && !input.useEnv) {
-        return "QQBot requires --token (format: appId:clientSecret) or --use-env";
-      }
-      return null;
-    },
-    applyAccountConfig: ({ cfg, accountId, input }) => {
-      let appId = "";
-      let clientSecret = "";
-
-      if (input.token) {
-        const colonIdx = input.token.indexOf(":");
-        if (colonIdx > 0) {
-          appId = input.token.slice(0, colonIdx);
-          clientSecret = input.token.slice(colonIdx + 1);
-        }
-      }
-
-      return applyQQBotAccountConfig(cfg, accountId, {
-        appId,
-        clientSecret,
-        clientSecretFile: input.tokenFile,
-        name: input.name,
-      });
-    },
+    validateInput: ({ input }) => validateQQBotSetupInput(input),
+    applyAccountConfig: ({ cfg, accountId, input }) =>
+      applyQQBotSetupAccountConfig({ cfg, accountId, input }),
   },
   messaging: {
     /** Normalize common QQ Bot target formats into the canonical qqbot:... form. */

--- a/extensions/qqbot/src/config-schema.ts
+++ b/extensions/qqbot/src/config-schema.ts
@@ -63,5 +63,6 @@ export const QQBotConfigSchema = QQBotAccountSchema.extend({
   tts: QQBotTtsSchema,
   stt: QQBotSttSchema,
   accounts: z.object({}).catchall(QQBotAccountSchema).optional(),
+  defaultAccount: z.string().optional(),
 });
 export const qqbotChannelConfigSchema = buildChannelConfigSchema(QQBotConfigSchema);

--- a/extensions/qqbot/src/config-schema.ts
+++ b/extensions/qqbot/src/config-schema.ts
@@ -1,6 +1,5 @@
 import {
   AllowFromListSchema,
-  buildCatchallMultiAccountChannelSchema,
   buildChannelConfigSchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { buildSecretInputSchema } from "openclaw/plugin-sdk/secret-input";
@@ -14,21 +13,55 @@ const AudioFormatPolicySchema = z
   })
   .optional();
 
-const QQBotAccountSchema = z.object({
-  enabled: z.boolean().optional(),
-  name: z.string().optional(),
-  appId: z.string().optional(),
-  clientSecret: buildSecretInputSchema().optional(),
-  clientSecretFile: z.string().optional(),
-  allowFrom: AllowFromListSchema,
-  systemPrompt: z.string().optional(),
-  markdownSupport: z.boolean().optional(),
-  voiceDirectUploadFormats: z.array(z.string()).optional(),
-  audioFormatPolicy: AudioFormatPolicySchema,
-  urlDirectUpload: z.boolean().optional(),
-  upgradeUrl: z.string().optional(),
-  upgradeMode: z.enum(["doc", "hot-reload"]).optional(),
-});
+const QQBotSpeechQueryParamsSchema = z.record(z.string(), z.string()).optional();
 
-export const QQBotConfigSchema = buildCatchallMultiAccountChannelSchema(QQBotAccountSchema);
+const QQBotTtsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    provider: z.string().optional(),
+    baseUrl: z.string().optional(),
+    apiKey: z.string().optional(),
+    model: z.string().optional(),
+    voice: z.string().optional(),
+    authStyle: z.enum(["bearer", "api-key"]).optional(),
+    queryParams: QQBotSpeechQueryParamsSchema,
+    speed: z.number().optional(),
+  })
+  .strict()
+  .optional();
+
+const QQBotSttSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    provider: z.string().optional(),
+    baseUrl: z.string().optional(),
+    apiKey: z.string().optional(),
+    model: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
+const QQBotAccountSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    name: z.string().optional(),
+    appId: z.string().optional(),
+    clientSecret: buildSecretInputSchema().optional(),
+    clientSecretFile: z.string().optional(),
+    allowFrom: AllowFromListSchema,
+    systemPrompt: z.string().optional(),
+    markdownSupport: z.boolean().optional(),
+    voiceDirectUploadFormats: z.array(z.string()).optional(),
+    audioFormatPolicy: AudioFormatPolicySchema,
+    urlDirectUpload: z.boolean().optional(),
+    upgradeUrl: z.string().optional(),
+    upgradeMode: z.enum(["doc", "hot-reload"]).optional(),
+  })
+  .strict();
+
+export const QQBotConfigSchema = QQBotAccountSchema.extend({
+  tts: QQBotTtsSchema,
+  stt: QQBotSttSchema,
+  accounts: z.object({}).catchall(QQBotAccountSchema).optional(),
+});
 export const qqbotChannelConfigSchema = buildChannelConfigSchema(QQBotConfigSchema);

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -277,4 +277,42 @@ describe("qqbot config", () => {
       },
     });
   });
+
+  it("rejects --use-env for named accounts across setup paths", () => {
+    const runtimeSetup = qqbotPlugin.setup;
+    const lightweightSetup = qqbotSetupPlugin.setup;
+    expect(runtimeSetup).toBeDefined();
+    expect(lightweightSetup).toBeDefined();
+
+    const input = { useEnv: true, name: "Env Bot" };
+
+    expect(
+      runtimeSetup!.validateInput?.({
+        cfg: {} as OpenClawConfig,
+        accountId: "bot2",
+        input,
+      }),
+    ).toBe("QQBot --use-env only supports the default account");
+    expect(
+      lightweightSetup!.validateInput?.({
+        cfg: {} as OpenClawConfig,
+        accountId: "bot2",
+        input,
+      }),
+    ).toBe("QQBot --use-env only supports the default account");
+    expect(
+      runtimeSetup!.applyAccountConfig?.({
+        cfg: {} as OpenClawConfig,
+        accountId: "bot2",
+        input,
+      }),
+    ).toEqual({});
+    expect(
+      lightweightSetup!.applyAccountConfig?.({
+        cfg: {} as OpenClawConfig,
+        accountId: "bot2",
+        input,
+      }),
+    ).toEqual({});
+  });
 });

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -41,8 +41,30 @@ describe("qqbot config", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("accepts defaultAccount in the manifest schema", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf-8"),
+    ) as { configSchema: Record<string, unknown> };
+
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "qqbot.manifest.default-account",
+      value: {
+        defaultAccount: "bot2",
+        accounts: {
+          bot2: {
+            appId: "654321",
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   it("accepts SecretRef-backed credentials in the runtime schema", () => {
     const parsed = QQBotConfigSchema.safeParse({
+      defaultAccount: "bot2",
       appId: "123456",
       clientSecret: {
         source: "env",

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -237,4 +237,44 @@ describe("qqbot config", () => {
       }),
     ).toEqual({});
   });
+
+  it("preserves the --use-env add flow across setup paths", () => {
+    const runtimeSetup = qqbotPlugin.setup;
+    const lightweightSetup = qqbotSetupPlugin.setup;
+    expect(runtimeSetup).toBeDefined();
+    expect(lightweightSetup).toBeDefined();
+
+    const input = { useEnv: true, name: "Env Bot" };
+
+    expect(
+      runtimeSetup!.applyAccountConfig?.({
+        cfg: {} as OpenClawConfig,
+        accountId: DEFAULT_ACCOUNT_ID,
+        input,
+      }),
+    ).toMatchObject({
+      channels: {
+        qqbot: {
+          enabled: true,
+          allowFrom: ["*"],
+          name: "Env Bot",
+        },
+      },
+    });
+    expect(
+      lightweightSetup!.applyAccountConfig?.({
+        cfg: {} as OpenClawConfig,
+        accountId: DEFAULT_ACCOUNT_ID,
+        input,
+      }),
+    ).toMatchObject({
+      channels: {
+        qqbot: {
+          enabled: true,
+          allowFrom: ["*"],
+          name: "Env Bot",
+        },
+      },
+    });
+  });
 });

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -1,10 +1,46 @@
+import fs from "node:fs";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { describe, expect, it } from "vitest";
+import { validateJsonSchemaValue } from "../../../src/plugins/schema-validator.js";
+import { qqbotPlugin } from "./channel.js";
 import { qqbotSetupPlugin } from "./channel.setup.js";
 import { QQBotConfigSchema } from "./config-schema.js";
 import { DEFAULT_ACCOUNT_ID, resolveQQBotAccount } from "./config.js";
 
 describe("qqbot config", () => {
+  it("accepts top-level speech overrides in the manifest schema", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf-8"),
+    ) as { configSchema: Record<string, unknown> };
+
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "qqbot.manifest.speech-overrides",
+      value: {
+        tts: {
+          provider: "openai",
+          baseUrl: "https://example.com/v1",
+          apiKey: "tts-key",
+          model: "gpt-4o-mini-tts",
+          voice: "alloy",
+          authStyle: "api-key",
+          queryParams: {
+            format: "wav",
+          },
+          speed: 1.1,
+        },
+        stt: {
+          provider: "openai",
+          baseUrl: "https://example.com/v1",
+          apiKey: "stt-key",
+          model: "whisper-1",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   it("accepts SecretRef-backed credentials in the runtime schema", () => {
     const parsed = QQBotConfigSchema.safeParse({
       appId: "123456",
@@ -36,6 +72,21 @@ describe("qqbot config", () => {
     });
 
     expect(parsed.success).toBe(true);
+  });
+
+  it("rejects account-level speech overrides that runtime does not consume", () => {
+    const parsed = QQBotConfigSchema.safeParse({
+      accounts: {
+        bot2: {
+          appId: "654321",
+          tts: {
+            provider: "openai",
+          },
+        },
+      },
+    });
+
+    expect(parsed.success).toBe(false);
   });
 
   it("preserves top-level media and upgrade config on the default account", () => {
@@ -147,5 +198,43 @@ describe("qqbot config", () => {
       appId: "102905186",
       clientSecret: "Oi2Mg1Mh2Ni3:Pl7TpBXuHe1OmAYwKi7W",
     });
+  });
+
+  it("rejects malformed --token consistently across setup paths", () => {
+    const runtimeSetup = qqbotPlugin.setup;
+    const lightweightSetup = qqbotSetupPlugin.setup;
+    expect(runtimeSetup).toBeDefined();
+    expect(lightweightSetup).toBeDefined();
+
+    const input = { token: "broken", name: "Bad" };
+
+    expect(
+      runtimeSetup!.validateInput?.({
+        cfg: {} as OpenClawConfig,
+        accountId: DEFAULT_ACCOUNT_ID,
+        input,
+      }),
+    ).toBe("QQBot --token must be in appId:clientSecret format");
+    expect(
+      lightweightSetup!.validateInput?.({
+        cfg: {} as OpenClawConfig,
+        accountId: DEFAULT_ACCOUNT_ID,
+        input,
+      }),
+    ).toBe("QQBot --token must be in appId:clientSecret format");
+    expect(
+      runtimeSetup!.applyAccountConfig?.({
+        cfg: {} as OpenClawConfig,
+        accountId: DEFAULT_ACCOUNT_ID,
+        input,
+      }),
+    ).toEqual({});
+    expect(
+      lightweightSetup!.applyAccountConfig?.({
+        cfg: {} as OpenClawConfig,
+        accountId: DEFAULT_ACCOUNT_ID,
+        input,
+      }),
+    ).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary
- declare qqbot top-level speech overrides in the manifest and runtime config schema
- reject malformed `--token` consistently across the runtime and setup-only QQBot setup paths
- add regression coverage so schema/setup drift is caught before bot review

## Testing
- ./node_modules/.bin/vitest run extensions/qqbot/src/config.test.ts extensions/qqbot/src/setup.test.ts
- ./node_modules/.bin/tsgo --singleThreaded
- pnpm build