### PR TITLE
Canvas Host: build default status with DOM nodes

### DIFF
--- a/src/canvas-host/server.test.ts
+++ b/src/canvas-host/server.test.ts
@@ -145,6 +145,8 @@ describe("canvas host", () => {
       expect(html).toContain("Interactive test page");
       expect(html).toContain("openclawSendUserAction");
       expect(html).toContain(CANVAS_WS_PATH);
+      expect(html).toContain('document.createElement("span")');
+      expect(html).not.toContain("statusEl.innerHTML");
     } finally {
       await server.close();
     }

--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -121,11 +121,18 @@ function defaultIndexHTML() {
         typeof window.openclawCanvasA2UIAction.postMessage === "function")
     );
   const hasHelper = () => typeof window.openclawSendUserAction === "function";
-  statusEl.innerHTML =
-    "Bridge: " +
-    (hasHelper() ? "<span class='ok'>ready</span>" : "<span class='bad'>missing</span>") +
-    " · iOS=" + (hasIOS() ? "yes" : "no") +
-    " · Android=" + (hasAndroid() ? "yes" : "no");
+  const helperReady = hasHelper();
+  statusEl.textContent = "";
+  statusEl.appendChild(document.createTextNode("Bridge: "));
+  const bridgeStatus = document.createElement("span");
+  bridgeStatus.className = helperReady ? "ok" : "bad";
+  bridgeStatus.textContent = helperReady ? "ready" : "missing";
+  statusEl.appendChild(bridgeStatus);
+  statusEl.appendChild(
+    document.createTextNode(
+      " · iOS=" + (hasIOS() ? "yes" : "no") + " · Android=" + (hasAndroid() ? "yes" : "no"),
+    ),
+  );
 
   const onStatus = (ev) => {
     const d = ev && ev.detail || {};


### PR DESCRIPTION
## Summary
- Updates the default canvas host page to build its status line with DOM nodes instead of HTML string injection
- Keeps the rendered status text and styling unchanged for the fallback test page

## Changes
- Replaced the `status` element HTML-string assignment with `createElement`, `createTextNode`, and `textContent`
- Added a regression assertion that the generated fallback page no longer includes the old `statusEl.innerHTML` path

## Validation
- Ran `pnpm test -- src/canvas-host/server.test.ts src/canvas-host/server.state-dir.test.ts`
- Ran `pnpm check`
- Ran `pnpm build`
- Ran local agentic review with `claude -p "/review"` and there was no actionable follow-up

## Notes
- Scope is limited to the generated fallback canvas host page and its tests
- No config or migration changes
