### PR TITLE
fix(plugins): guard marketplace archive downloads

### DIFF
--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -368,6 +368,38 @@ describe("marketplace plugins", () => {
     });
   });
 
+  it("rejects Windows drive-relative archive filenames from redirects", async () => {
+    await withTempDir(async (rootDir) => {
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response: new Response(new Blob([Buffer.from("tgz-bytes")]), {
+          status: 200,
+        }),
+        finalUrl: "https://cdn.example.com/C:plugin.tgz",
+        release: vi.fn(async () => undefined),
+      });
+      const manifestPath = await writeMarketplaceManifest(rootDir, {
+        plugins: [
+          {
+            name: "frontend-design",
+            source: "https://example.com/frontend-design.tgz",
+          },
+        ],
+      });
+
+      const result = await installPluginFromMarketplace({
+        marketplace: manifestPath,
+        plugin: "frontend-design",
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        error:
+          "failed to download https://example.com/frontend-design.tgz: invalid download filename",
+      });
+      expect(installPluginFromPathMock).not.toHaveBeenCalled();
+    });
+  });
+
   it("falls back to the default archive timeout when the caller passes NaN", async () => {
     await withTempDir(async (rootDir) => {
       fetchWithSsrFGuardMock.mockResolvedValueOnce({

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -331,12 +331,40 @@ describe("marketplace plugins", () => {
         ok: false,
         error: "failed to download https://example.com/frontend-design.tgz: empty response body",
       });
-      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
-        url: "https://example.com/frontend-design.tgz",
-        auditContext: "marketplace-plugin-download",
-      });
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/frontend-design.tgz",
+          timeoutMs: 120_000,
+          auditContext: "marketplace-plugin-download",
+        }),
+      );
       expect(installPluginFromPathMock).not.toHaveBeenCalled();
       expect(release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("returns a structured error for invalid archive URLs", async () => {
+    await withTempDir(async (rootDir) => {
+      const manifestPath = await writeMarketplaceManifest(rootDir, {
+        plugins: [
+          {
+            name: "frontend-design",
+            source: "https://%/frontend-design.tgz",
+          },
+        ],
+      });
+
+      const result = await installPluginFromMarketplace({
+        marketplace: manifestPath,
+        plugin: "frontend-design",
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        error: "failed to download https://%/frontend-design.tgz: Invalid URL",
+      });
+      expect(installPluginFromPathMock).not.toHaveBeenCalled();
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
     });
   });
 
@@ -379,10 +407,13 @@ describe("marketplace plugins", () => {
         marketplacePlugin: "frontend-design",
         marketplaceSource: manifestPath,
       });
-      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
-        url: "https://example.com/frontend-design.tgz",
-        auditContext: "marketplace-plugin-download",
-      });
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/frontend-design.tgz",
+          timeoutMs: 120_000,
+          auditContext: "marketplace-plugin-download",
+        }),
+      );
       expect(installPluginFromPathMock).toHaveBeenCalledWith(
         expect.objectContaining({
           path: expect.stringMatching(/[\\/]frontend-design\.tgz$/),
@@ -396,14 +427,12 @@ describe("marketplace plugins", () => {
     await withTempDir(async (rootDir) => {
       const beforeTempDirs = await listMarketplaceDownloadTempDirs();
       fetchWithSsrFGuardMock.mockResolvedValueOnce({
-        response: {
-          ok: true,
-          body: {
-            pipeTo: vi.fn(async () => {
-              throw new Error("stream failed");
-            }),
+        response: new Response("x".repeat(1024), {
+          status: 200,
+          headers: {
+            "content-length": String(300 * 1024 * 1024),
           },
-        } as unknown as Response,
+        }),
         finalUrl: "https://cdn.example.com/releases/frontend-design.tgz",
         release: vi.fn(async () => undefined),
       });
@@ -423,7 +452,9 @@ describe("marketplace plugins", () => {
 
       expect(result).toEqual({
         ok: false,
-        error: "failed to download https://example.com/frontend-design.tgz: stream failed",
+        error:
+          "failed to download https://example.com/frontend-design.tgz: " +
+          "download too large: 314572800 bytes (limit: 268435456 bytes)",
       });
       expect(await listMarketplaceDownloadTempDirs()).toEqual(beforeTempDirs);
       expect(installPluginFromPathMock).not.toHaveBeenCalled();

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -539,6 +539,60 @@ describe("marketplace plugins", () => {
     });
   });
 
+  it("rejects oversized streamed archive responses without falling back to arrayBuffer", async () => {
+    await withTempDir(async (rootDir) => {
+      const arrayBuffer = vi.fn(async () => new Uint8Array([1, 2, 3]).buffer);
+      const reader = {
+        read: vi
+          .fn()
+          .mockResolvedValueOnce({
+            done: false,
+            value: {
+              length: 256 * 1024 * 1024 + 1,
+            } as Uint8Array,
+          })
+          .mockResolvedValueOnce({ done: true, value: undefined }),
+        cancel: vi.fn(async () => undefined),
+        releaseLock: vi.fn(),
+      };
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response: {
+          ok: true,
+          status: 200,
+          body: {
+            getReader: () => reader,
+          } as unknown as Response["body"],
+          headers: new Headers(),
+          arrayBuffer,
+        } as unknown as Response,
+        finalUrl: "https://cdn.example.com/releases/frontend-design.tgz",
+        release: vi.fn(async () => undefined),
+      });
+      const manifestPath = await writeMarketplaceManifest(rootDir, {
+        plugins: [
+          {
+            name: "frontend-design",
+            source: "https://example.com/frontend-design.tgz",
+          },
+        ],
+      });
+
+      const result = await installPluginFromMarketplace({
+        marketplace: manifestPath,
+        plugin: "frontend-design",
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        error:
+          "failed to download https://example.com/frontend-design.tgz: " +
+          "download too large: 268435457 bytes (limit: 268435456 bytes)",
+      });
+      expect(arrayBuffer).not.toHaveBeenCalled();
+      expect(installPluginFromPathMock).not.toHaveBeenCalled();
+    });
+  });
+
   it("cleans up a partial download temp dir when streaming the archive fails", async () => {
     await withTempDir(async (rootDir) => {
       const beforeTempDirs = await listMarketplaceDownloadTempDirs();

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -297,10 +297,12 @@ describe("marketplace plugins", () => {
 
   it("returns a structured error for archive downloads with an empty response body", async () => {
     await withTempDir(async (rootDir) => {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async () => new Response(null, { status: 200 })),
-      );
+      const release = vi.fn(async () => undefined);
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response: new Response(null, { status: 200 }),
+        finalUrl: "https://example.com/frontend-design.tgz",
+        release,
+      });
       const manifestPath = await writeMarketplaceManifest(rootDir, {
         plugins: [
           {
@@ -322,6 +324,86 @@ describe("marketplace plugins", () => {
       expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
         url: "https://example.com/frontend-design.tgz",
         auditContext: "marketplace-plugin-download",
+      });
+      expect(installPluginFromPathMock).not.toHaveBeenCalled();
+      expect(release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("downloads archive plugin sources through the SSRF guard", async () => {
+    await withTempDir(async (rootDir) => {
+      const release = vi.fn(async () => undefined);
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response: new Response(new Blob([Buffer.from("tgz-bytes")]), {
+          status: 200,
+        }),
+        finalUrl: "https://cdn.example.com/releases/frontend-design.tgz",
+        release,
+      });
+      installPluginFromPathMock.mockResolvedValue({
+        ok: true,
+        pluginId: "frontend-design",
+        targetDir: "/tmp/frontend-design",
+        version: "0.1.0",
+        extensions: ["index.ts"],
+      });
+      const manifestPath = await writeMarketplaceManifest(rootDir, {
+        plugins: [
+          {
+            name: "frontend-design",
+            source: "https://example.com/frontend-design.tgz",
+          },
+        ],
+      });
+
+      const result = await installPluginFromMarketplace({
+        marketplace: manifestPath,
+        plugin: "frontend-design",
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        pluginId: "frontend-design",
+        marketplacePlugin: "frontend-design",
+        marketplaceSource: manifestPath,
+      });
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+        url: "https://example.com/frontend-design.tgz",
+        auditContext: "marketplace-plugin-download",
+      });
+      expect(installPluginFromPathMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: expect.stringMatching(/[\\/]frontend-design\.tgz$/),
+        }),
+      );
+      expect(release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("returns a structured error when the SSRF guard rejects an archive URL", async () => {
+    await withTempDir(async (rootDir) => {
+      fetchWithSsrFGuardMock.mockRejectedValueOnce(
+        new Error("Blocked hostname (not in allowlist): 169.254.169.254"),
+      );
+      const manifestPath = await writeMarketplaceManifest(rootDir, {
+        plugins: [
+          {
+            name: "frontend-design",
+            source: "https://example.com/frontend-design.tgz",
+          },
+        ],
+      });
+
+      const result = await installPluginFromMarketplace({
+        marketplace: manifestPath,
+        plugin: "frontend-design",
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        error:
+          "failed to download https://example.com/frontend-design.tgz: " +
+          "Blocked hostname (not in allowlist): 169.254.169.254",
       });
       expect(installPluginFromPathMock).not.toHaveBeenCalled();
     });

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -55,6 +55,16 @@ async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
   }
 }
 
+async function listMarketplaceDownloadTempDirs(): Promise<string[]> {
+  const entries = await fs.readdir(os.tmpdir(), { withFileTypes: true });
+  return entries
+    .filter(
+      (entry) => entry.isDirectory() && entry.name.startsWith("openclaw-marketplace-download-"),
+    )
+    .map((entry) => entry.name)
+    .toSorted();
+}
+
 async function writeMarketplaceManifest(rootDir: string, manifest: unknown): Promise<string> {
   const manifestPath = path.join(rootDir, ".claude-plugin", "marketplace.json");
   await fs.mkdir(path.dirname(manifestPath), { recursive: true });
@@ -332,12 +342,14 @@ describe("marketplace plugins", () => {
 
   it("downloads archive plugin sources through the SSRF guard", async () => {
     await withTempDir(async (rootDir) => {
-      const release = vi.fn(async () => undefined);
+      const release = vi.fn(async () => {
+        throw new Error("dispatcher close failed");
+      });
       fetchWithSsrFGuardMock.mockResolvedValueOnce({
         response: new Response(new Blob([Buffer.from("tgz-bytes")]), {
           status: 200,
         }),
-        finalUrl: "https://cdn.example.com/releases/frontend-design.tgz",
+        finalUrl: "https://cdn.example.com/releases/12345",
         release,
       });
       installPluginFromPathMock.mockResolvedValue({
@@ -377,6 +389,44 @@ describe("marketplace plugins", () => {
         }),
       );
       expect(release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("cleans up a partial download temp dir when streaming the archive fails", async () => {
+    await withTempDir(async (rootDir) => {
+      const beforeTempDirs = await listMarketplaceDownloadTempDirs();
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response: {
+          ok: true,
+          body: {
+            pipeTo: vi.fn(async () => {
+              throw new Error("stream failed");
+            }),
+          },
+        } as unknown as Response,
+        finalUrl: "https://cdn.example.com/releases/frontend-design.tgz",
+        release: vi.fn(async () => undefined),
+      });
+      const manifestPath = await writeMarketplaceManifest(rootDir, {
+        plugins: [
+          {
+            name: "frontend-design",
+            source: "https://example.com/frontend-design.tgz",
+          },
+        ],
+      });
+
+      const result = await installPluginFromMarketplace({
+        marketplace: manifestPath,
+        plugin: "frontend-design",
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        error: "failed to download https://example.com/frontend-design.tgz: stream failed",
+      });
+      expect(await listMarketplaceDownloadTempDirs()).toEqual(beforeTempDirs);
+      expect(installPluginFromPathMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -368,6 +368,51 @@ describe("marketplace plugins", () => {
     });
   });
 
+  it("falls back to the default archive timeout when the caller passes NaN", async () => {
+    await withTempDir(async (rootDir) => {
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response: new Response(new Blob([Buffer.from("tgz-bytes")]), {
+          status: 200,
+        }),
+        finalUrl: "https://cdn.example.com/releases/12345",
+        release: vi.fn(async () => undefined),
+      });
+      installPluginFromPathMock.mockResolvedValue({
+        ok: true,
+        pluginId: "frontend-design",
+        targetDir: "/tmp/frontend-design",
+        version: "0.1.0",
+        extensions: ["index.ts"],
+      });
+      const manifestPath = await writeMarketplaceManifest(rootDir, {
+        plugins: [
+          {
+            name: "frontend-design",
+            source: "https://example.com/frontend-design.tgz",
+          },
+        ],
+      });
+
+      const result = await installPluginFromMarketplace({
+        marketplace: manifestPath,
+        plugin: "frontend-design",
+        timeoutMs: Number.NaN,
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        pluginId: "frontend-design",
+      });
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/frontend-design.tgz",
+          timeoutMs: 120_000,
+          auditContext: "marketplace-plugin-download",
+        }),
+      );
+    });
+  });
+
   it("downloads archive plugin sources through the SSRF guard", async () => {
     await withTempDir(async (rootDir) => {
       const release = vi.fn(async () => {
@@ -423,6 +468,45 @@ describe("marketplace plugins", () => {
     });
   });
 
+  it("rejects non-streaming archive responses before buffering them", async () => {
+    await withTempDir(async (rootDir) => {
+      const arrayBuffer = vi.fn(async () => new Uint8Array([1, 2, 3]).buffer);
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response: {
+          ok: true,
+          status: 200,
+          body: {} as Response["body"],
+          headers: new Headers(),
+          arrayBuffer,
+        } as unknown as Response,
+        finalUrl: "https://cdn.example.com/releases/frontend-design.tgz",
+        release: vi.fn(async () => undefined),
+      });
+      const manifestPath = await writeMarketplaceManifest(rootDir, {
+        plugins: [
+          {
+            name: "frontend-design",
+            source: "https://example.com/frontend-design.tgz",
+          },
+        ],
+      });
+
+      const result = await installPluginFromMarketplace({
+        marketplace: manifestPath,
+        plugin: "frontend-design",
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        error:
+          "failed to download https://example.com/frontend-design.tgz: " +
+          "streaming response body unavailable",
+      });
+      expect(arrayBuffer).not.toHaveBeenCalled();
+      expect(installPluginFromPathMock).not.toHaveBeenCalled();
+    });
+  });
+
   it("cleans up a partial download temp dir when streaming the archive fails", async () => {
     await withTempDir(async (rootDir) => {
       const beforeTempDirs = await listMarketplaceDownloadTempDirs();
@@ -457,6 +541,49 @@ describe("marketplace plugins", () => {
           "download too large: 314572800 bytes (limit: 268435456 bytes)",
       });
       expect(await listMarketplaceDownloadTempDirs()).toEqual(beforeTempDirs);
+      expect(installPluginFromPathMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("sanitizes archive download errors before returning them", async () => {
+    await withTempDir(async (rootDir) => {
+      fetchWithSsrFGuardMock.mockRejectedValueOnce(
+        new Error(
+          "blocked\n\u001b[31mAuthorization: Bearer sk-1234567890abcdefghijklmnop\u001b[0m",
+        ),
+      );
+      const manifestPath = await writeMarketplaceManifest(rootDir, {
+        plugins: [
+          {
+            name: "frontend-design",
+            source: "https://user:pass@example.com/frontend-design.tgz",
+          },
+        ],
+      });
+
+      const result = await installPluginFromMarketplace({
+        marketplace: manifestPath,
+        plugin: "frontend-design",
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        return;
+      }
+      expect(result.error).toContain(
+        "failed to download https://***:***@example.com/frontend-design.tgz:",
+      );
+      expect(result.error).toContain("Authorization: Bearer sk-123…mnop");
+      expect(result.error).not.toContain("user:pass@");
+      let hasControlChars = false;
+      for (const char of result.error) {
+        const codePoint = char.codePointAt(0);
+        if (codePoint != null && (codePoint < 0x20 || codePoint === 0x7f)) {
+          hasControlChars = true;
+          break;
+        }
+      }
+      expect(hasControlChars).toBe(false);
       expect(installPluginFromPathMock).not.toHaveBeenCalled();
     });
   });

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -589,6 +589,7 @@ function resolveSafeMarketplaceDownloadFileName(url: string, fallback: string): 
   if (
     fileName === "." ||
     fileName === ".." ||
+    /^[a-zA-Z]:/.test(fileName) ||
     path.isAbsolute(fileName) ||
     fileName.includes("/") ||
     fileName.includes("\\")

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -1,16 +1,17 @@
-import { createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { Writable } from "node:stream";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { resolveOsHomeRelativePath } from "../infra/home-dir.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import { readResponseWithLimit } from "../media/read-response-with-limit.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveUserPath } from "../utils.js";
 import { installPluginFromPath, type InstallPluginResult } from "./install.js";
 
 const DEFAULT_GIT_TIMEOUT_MS = 120_000;
+const DEFAULT_MARKETPLACE_DOWNLOAD_TIMEOUT_MS = 120_000;
+const MAX_MARKETPLACE_ARCHIVE_BYTES = 256 * 1024 * 1024;
 const MARKETPLACE_MANIFEST_CANDIDATES = [
   path.join(".claude-plugin", "marketplace.json"),
   "marketplace.json",
@@ -579,7 +580,25 @@ async function loadMarketplace(params: {
   };
 }
 
-async function downloadUrlToTempFile(url: string): Promise<
+function resolveSafeMarketplaceDownloadFileName(url: string, fallback: string): string {
+  const pathname = new URL(url).pathname;
+  const fileName = path.basename(pathname).trim() || fallback;
+  if (
+    fileName === "." ||
+    fileName === ".." ||
+    path.isAbsolute(fileName) ||
+    fileName.includes("/") ||
+    fileName.includes("\\")
+  ) {
+    throw new Error("invalid download filename");
+  }
+  return fileName;
+}
+
+async function downloadUrlToTempFile(
+  url: string,
+  timeoutMs?: number,
+): Promise<
   | {
       ok: true;
       path: string;
@@ -590,12 +609,17 @@ async function downloadUrlToTempFile(url: string): Promise<
       error: string;
     }
 > {
-  const sourcePathname = new URL(url).pathname;
-  const sourceFileName = path.basename(sourcePathname) || "plugin.tgz";
+  let sourceFileName = "plugin.tgz";
   let tmpDir: string | undefined;
   try {
+    sourceFileName = resolveSafeMarketplaceDownloadFileName(url, sourceFileName);
+    const downloadTimeoutMs = Math.max(
+      1_000,
+      Math.floor(timeoutMs ?? DEFAULT_MARKETPLACE_DOWNLOAD_TIMEOUT_MS),
+    );
     const { response, finalUrl, release } = await fetchWithSsrFGuard({
       url,
+      timeoutMs: downloadTimeoutMs,
       auditContext: "marketplace-plugin-download",
     });
     try {
@@ -606,14 +630,33 @@ async function downloadUrlToTempFile(url: string): Promise<
         return { ok: false, error: `failed to download ${url}: empty response body` };
       }
 
-      const finalPathname = new URL(finalUrl).pathname;
-      const finalFileName = path.basename(finalPathname) || sourceFileName;
+      const contentLength = response.headers.get("content-length");
+      if (contentLength) {
+        const size = Number(contentLength);
+        if (Number.isFinite(size) && size > MAX_MARKETPLACE_ARCHIVE_BYTES) {
+          throw new Error(
+            `download too large: ${size} bytes (limit: ${MAX_MARKETPLACE_ARCHIVE_BYTES} bytes)`,
+          );
+        }
+      }
+
+      const finalFileName = resolveSafeMarketplaceDownloadFileName(finalUrl, sourceFileName);
       const fileName = resolveArchiveKind(finalFileName) ? finalFileName : sourceFileName;
       tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-marketplace-download-"));
       const createdTmpDir = tmpDir;
-      const targetPath = path.join(createdTmpDir, fileName);
-      const fileStream = createWriteStream(targetPath);
-      await response.body.pipeTo(Writable.toWeb(fileStream));
+      const targetPath = path.resolve(createdTmpDir, fileName);
+      const relativeTargetPath = path.relative(createdTmpDir, targetPath);
+      if (relativeTargetPath === ".." || relativeTargetPath.startsWith(`..${path.sep}`)) {
+        throw new Error("invalid download filename");
+      }
+      const buffer = await readResponseWithLimit(response, MAX_MARKETPLACE_ARCHIVE_BYTES, {
+        chunkTimeoutMs: downloadTimeoutMs,
+        onOverflow: ({ size, maxBytes }) =>
+          new Error(`download too large: ${size} bytes (limit: ${maxBytes} bytes)`),
+        onIdleTimeout: ({ chunkTimeoutMs }) =>
+          new Error(`download timed out after ${chunkTimeoutMs}ms`),
+      });
+      await fs.writeFile(targetPath, buffer);
       return {
         ok: true,
         path: targetPath,
@@ -719,7 +762,7 @@ async function resolveMarketplaceEntryInstallPath(params: {
   if (params.source.kind === "path") {
     if (isHttpUrl(params.source.path)) {
       if (resolveArchiveKind(params.source.path)) {
-        return await downloadUrlToTempFile(params.source.path);
+        return await downloadUrlToTempFile(params.source.path, params.timeoutMs);
       }
       return {
         ok: false,
@@ -769,7 +812,7 @@ async function resolveMarketplaceEntryInstallPath(params: {
   }
 
   if (resolveArchiveKind(params.source.url)) {
-    return await downloadUrlToTempFile(params.source.url);
+    return await downloadUrlToTempFile(params.source.url, params.timeoutMs);
   }
 
   if (!normalizeGitCloneSource(params.source.url)) {

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -590,6 +590,9 @@ async function downloadUrlToTempFile(url: string): Promise<
       error: string;
     }
 > {
+  const sourcePathname = new URL(url).pathname;
+  const sourceFileName = path.basename(sourcePathname) || "plugin.tgz";
+  let tmpDir: string | undefined;
   try {
     const { response, finalUrl, release } = await fetchWithSsrFGuard({
       url,
@@ -603,23 +606,28 @@ async function downloadUrlToTempFile(url: string): Promise<
         return { ok: false, error: `failed to download ${url}: empty response body` };
       }
 
-      const pathname = new URL(finalUrl).pathname;
-      const fileName = path.basename(pathname) || "plugin.tgz";
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-marketplace-download-"));
-      const targetPath = path.join(tmpDir, fileName);
+      const finalPathname = new URL(finalUrl).pathname;
+      const finalFileName = path.basename(finalPathname) || sourceFileName;
+      const fileName = resolveArchiveKind(finalFileName) ? finalFileName : sourceFileName;
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-marketplace-download-"));
+      const createdTmpDir = tmpDir;
+      const targetPath = path.join(createdTmpDir, fileName);
       const fileStream = createWriteStream(targetPath);
       await response.body.pipeTo(Writable.toWeb(fileStream));
       return {
         ok: true,
         path: targetPath,
         cleanup: async () => {
-          await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+          await fs.rm(createdTmpDir, { recursive: true, force: true }).catch(() => undefined);
         },
       };
     } finally {
-      await release();
+      await release().catch(() => undefined);
     }
   } catch (error) {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+    }
     return {
       ok: false,
       error: `failed to download ${url}: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -590,33 +590,40 @@ async function downloadUrlToTempFile(url: string): Promise<
       error: string;
     }
 > {
-  const { response, release } = await fetchWithSsrFGuard({
-    url,
-    auditContext: "marketplace-plugin-download",
-  });
   try {
-    if (!response.ok) {
-      return { ok: false, error: `failed to download ${url}: HTTP ${response.status}` };
-    }
-    if (!response.body) {
-      return { ok: false, error: `failed to download ${url}: empty response body` };
-    }
+    const { response, finalUrl, release } = await fetchWithSsrFGuard({
+      url,
+      auditContext: "marketplace-plugin-download",
+    });
+    try {
+      if (!response.ok) {
+        return { ok: false, error: `failed to download ${url}: HTTP ${response.status}` };
+      }
+      if (!response.body) {
+        return { ok: false, error: `failed to download ${url}: empty response body` };
+      }
 
-    const pathname = new URL(url).pathname;
-    const fileName = path.basename(pathname) || "plugin.tgz";
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-marketplace-download-"));
-    const targetPath = path.join(tmpDir, fileName);
-    const fileStream = createWriteStream(targetPath);
-    await response.body.pipeTo(Writable.toWeb(fileStream));
+      const pathname = new URL(finalUrl).pathname;
+      const fileName = path.basename(pathname) || "plugin.tgz";
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-marketplace-download-"));
+      const targetPath = path.join(tmpDir, fileName);
+      const fileStream = createWriteStream(targetPath);
+      await response.body.pipeTo(Writable.toWeb(fileStream));
+      return {
+        ok: true,
+        path: targetPath,
+        cleanup: async () => {
+          await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+        },
+      };
+    } finally {
+      await release();
+    }
+  } catch (error) {
     return {
-      ok: true,
-      path: targetPath,
-      cleanup: async () => {
-        await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
-      },
+      ok: false,
+      error: `failed to download ${url}: ${error instanceof Error ? error.message : String(error)}`,
     };
-  } finally {
-    await release();
   }
 }
 

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -2,10 +2,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { resolveArchiveKind } from "../infra/archive.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { resolveOsHomeRelativePath } from "../infra/home-dir.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { readResponseWithLimit } from "../media/read-response-with-limit.js";
 import { runCommandWithTimeout } from "../process/exec.js";
+import { redactSensitiveUrlLikeString } from "../shared/net/redact-sensitive-url.js";
+import { sanitizeForLog } from "../terminal/ansi.js";
 import { resolveUserPath } from "../utils.js";
 import { installPluginFromPath, type InstallPluginResult } from "./install.js";
 
@@ -595,6 +598,29 @@ function resolveSafeMarketplaceDownloadFileName(url: string, fallback: string): 
   return fileName;
 }
 
+function resolveMarketplaceDownloadTimeoutMs(timeoutMs?: number): number {
+  const resolvedTimeoutMs =
+    typeof timeoutMs === "number" && Number.isFinite(timeoutMs)
+      ? timeoutMs
+      : DEFAULT_MARKETPLACE_DOWNLOAD_TIMEOUT_MS;
+  return Math.max(1_000, Math.floor(resolvedTimeoutMs));
+}
+
+function formatMarketplaceDownloadError(url: string, detail: string): string {
+  return (
+    `failed to download ${sanitizeForLog(redactSensitiveUrlLikeString(url))}: ` +
+    sanitizeForLog(detail)
+  );
+}
+
+function hasStreamingResponseBody(
+  response: Response,
+): response is Response & { body: ReadableStream<Uint8Array> } {
+  return Boolean(
+    response.body && typeof (response.body as { getReader?: unknown }).getReader === "function",
+  );
+}
+
 async function downloadUrlToTempFile(
   url: string,
   timeoutMs?: number,
@@ -613,10 +639,7 @@ async function downloadUrlToTempFile(
   let tmpDir: string | undefined;
   try {
     sourceFileName = resolveSafeMarketplaceDownloadFileName(url, sourceFileName);
-    const downloadTimeoutMs = Math.max(
-      1_000,
-      Math.floor(timeoutMs ?? DEFAULT_MARKETPLACE_DOWNLOAD_TIMEOUT_MS),
-    );
+    const downloadTimeoutMs = resolveMarketplaceDownloadTimeoutMs(timeoutMs);
     const { response, finalUrl, release } = await fetchWithSsrFGuard({
       url,
       timeoutMs: downloadTimeoutMs,
@@ -624,10 +647,23 @@ async function downloadUrlToTempFile(
     });
     try {
       if (!response.ok) {
-        return { ok: false, error: `failed to download ${url}: HTTP ${response.status}` };
+        return {
+          ok: false,
+          error: formatMarketplaceDownloadError(url, `HTTP ${response.status}`),
+        };
       }
       if (!response.body) {
-        return { ok: false, error: `failed to download ${url}: empty response body` };
+        return {
+          ok: false,
+          error: formatMarketplaceDownloadError(url, "empty response body"),
+        };
+      }
+      // Fail closed unless we can stream and enforce the archive size bound incrementally.
+      if (!hasStreamingResponseBody(response)) {
+        return {
+          ok: false,
+          error: formatMarketplaceDownloadError(url, "streaming response body unavailable"),
+        };
       }
 
       const contentLength = response.headers.get("content-length");
@@ -673,7 +709,7 @@ async function downloadUrlToTempFile(
     }
     return {
       ok: false,
-      error: `failed to download ${url}: ${error instanceof Error ? error.message : String(error)}`,
+      error: formatMarketplaceDownloadError(url, formatErrorMessage(error)),
     };
   }
 }

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -5,7 +5,6 @@ import { resolveArchiveKind } from "../infra/archive.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveOsHomeRelativePath } from "../infra/home-dir.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
-import { readResponseWithLimit } from "../media/read-response-with-limit.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { redactSensitiveUrlLikeString } from "../shared/net/redact-sensitive-url.js";
 import { sanitizeForLog } from "../terminal/ansi.js";
@@ -622,6 +621,95 @@ function hasStreamingResponseBody(
   );
 }
 
+async function readMarketplaceChunkWithTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  chunkTimeoutMs: number,
+): Promise<Awaited<ReturnType<typeof reader.read>>> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+
+  return await new Promise((resolve, reject) => {
+    const clear = () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+    };
+
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      clear();
+      void reader.cancel().catch(() => undefined);
+      reject(new Error(`download timed out after ${chunkTimeoutMs}ms`));
+    }, chunkTimeoutMs);
+
+    void reader.read().then(
+      (result) => {
+        clear();
+        if (!timedOut) {
+          resolve(result);
+        }
+      },
+      (err) => {
+        clear();
+        if (!timedOut) {
+          reject(err);
+        }
+      },
+    );
+  });
+}
+
+async function writeMarketplaceChunk(
+  fileHandle: Awaited<ReturnType<typeof fs.open>>,
+  chunk: Uint8Array,
+): Promise<void> {
+  let offset = 0;
+  while (offset < chunk.length) {
+    const { bytesWritten } = await fileHandle.write(chunk, offset, chunk.length - offset);
+    if (bytesWritten <= 0) {
+      throw new Error("failed to write download chunk");
+    }
+    offset += bytesWritten;
+  }
+}
+
+async function streamMarketplaceResponseToFile(params: {
+  response: Response & { body: ReadableStream<Uint8Array> };
+  targetPath: string;
+  maxBytes: number;
+  chunkTimeoutMs: number;
+}): Promise<void> {
+  const reader = params.response.body.getReader();
+  const fileHandle = await fs.open(params.targetPath, "wx");
+  let total = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await readMarketplaceChunkWithTimeout(reader, params.chunkTimeoutMs);
+      if (done) {
+        return;
+      }
+      if (!value?.length) {
+        continue;
+      }
+
+      const nextTotal = total + value.length;
+      if (nextTotal > params.maxBytes) {
+        throw new Error(`download too large: ${nextTotal} bytes (limit: ${params.maxBytes} bytes)`);
+      }
+
+      await writeMarketplaceChunk(fileHandle, value);
+      total = nextTotal;
+    }
+  } finally {
+    await fileHandle.close().catch(() => undefined);
+    try {
+      reader.releaseLock();
+    } catch {}
+  }
+}
+
 async function downloadUrlToTempFile(
   url: string,
   timeoutMs?: number,
@@ -686,14 +774,12 @@ async function downloadUrlToTempFile(
       if (relativeTargetPath === ".." || relativeTargetPath.startsWith(`..${path.sep}`)) {
         throw new Error("invalid download filename");
       }
-      const buffer = await readResponseWithLimit(response, MAX_MARKETPLACE_ARCHIVE_BYTES, {
+      await streamMarketplaceResponseToFile({
+        response,
+        targetPath,
+        maxBytes: MAX_MARKETPLACE_ARCHIVE_BYTES,
         chunkTimeoutMs: downloadTimeoutMs,
-        onOverflow: ({ size, maxBytes }) =>
-          new Error(`download too large: ${size} bytes (limit: ${maxBytes} bytes)`),
-        onIdleTimeout: ({ chunkTimeoutMs }) =>
-          new Error(`download timed out after ${chunkTimeoutMs}ms`),
       });
-      await fs.writeFile(targetPath, buffer);
       return {
         ok: true,
         path: targetPath,


### PR DESCRIPTION
## Summary

- Problem: marketplace archive installs fetched remote archives directly instead of using the shared guarded fetch helper used by other download flows.
- Why it matters: this path behaved differently from the rest of the download stack and surfaced remote download failures less consistently.
- What changed: marketplace archive downloads now use `fetchWithSsrFGuard`, derive temp filenames from the resolved final URL, and convert guarded-fetch failures into the normal structured install error shape.
- What did NOT change (scope boundary): marketplace source validation, git clone flows, and plugin install behavior outside archive downloads.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #: N/A
- Related #: N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the marketplace archive download helper kept a direct `fetch()` path while other remote download flows had already moved to the shared guarded fetch helper.
- Missing detection / guardrail: the marketplace archive path did not have a regression test asserting that archive downloads go through the guarded fetch helper.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this path lagged behind the broader guarded-fetch rollout in the repo.
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/marketplace.test.ts`
- Scenario the test should lock in: archive marketplace downloads use the guarded fetch helper, release it on success and empty-body failures, and surface rejected guarded fetches as structured install errors.
- Why this is the smallest reliable guardrail: it exercises the exact marketplace archive path without needing live network access.
- Existing test that already covers this (if any): updated empty-body archive download coverage in the same file.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Marketplace archive install failures now return structured download errors when the guarded fetch helper rejects the URL.
- Redirected archive downloads now derive their temp filename from the final resolved URL.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: Ubuntu
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): marketplace plugin install path
- Relevant config (redacted): default local dev setup

### Steps

1. Run `pnpm test -- src/plugins/marketplace.test.ts`.
2. Run `pnpm check`.
3. Run `claude -p "/review"` and apply any actionable feedback.

### Expected

- Marketplace archive downloads use the guarded fetch helper and return structured errors on failures.

### Actual

- `pnpm test -- src/plugins/marketplace.test.ts` passed.
- `pnpm check` passed.
- Local review flagged the rejected-guarded-fetch error path; this PR now returns a structured install error for that case and the targeted tests were rerun.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: successful archive download path uses the guarded fetch helper; empty-body responses still return the expected structured error; guarded-fetch rejection now returns a structured install error instead of throwing.
- Edge cases checked: redirect-derived filename selection via `finalUrl`; release handle cleanup on success and failure.
- What you did **not** verify: live marketplace installs against an external registry.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: `N/A`

## Risks and Mitigations

- Risk: marketplace installs that previously surfaced raw thrown errors now return a structured download failure instead.
  - Mitigation: added targeted unit coverage for empty-body and rejected-guarded-fetch paths, plus the normal `pnpm check` gate.
