### PR TITLE
Media: secure image temp dirs

### DIFF
--- a/scripts/check-no-random-messaging-tmp.mjs
+++ b/scripts/check-no-random-messaging-tmp.mjs
@@ -9,10 +9,11 @@ import {
   unwrapExpression,
 } from "./lib/ts-guard-utils.mjs";
 
-const sourceRoots = [
+export const messagingTmpdirGuardSourceRoots = [
   "src/channels",
   "src/infra/outbound",
   "src/line",
+  "src/media",
   "src/media-understanding",
   "extensions",
 ];
@@ -72,7 +73,7 @@ export function findMessagingTmpdirCallLines(content, fileName = "source.ts") {
 export async function main() {
   await runCallsiteGuard({
     importMetaUrl: import.meta.url,
-    sourceRoots,
+    sourceRoots: messagingTmpdirGuardSourceRoots,
     findCallLines: findMessagingTmpdirCallLines,
     skipRelativePath: (relativePath) => allowedRelativePaths.has(relativePath),
     header: "Found os.tmpdir()/tmpdir() usage in messaging/channel runtime sources:",

--- a/src/media/image-ops.tempdir.test.ts
+++ b/src/media/image-ops.tempdir.test.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+
+describe("image-ops temp dir", () => {
+  let createdTempDir = "";
+
+  beforeEach(() => {
+    process.env.OPENCLAW_IMAGE_BACKEND = "sips";
+    const originalMkdtemp = fs.mkdtemp.bind(fs);
+    vi.spyOn(fs, "mkdtemp").mockImplementation(async (prefix) => {
+      createdTempDir = await originalMkdtemp(prefix);
+      return createdTempDir;
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCLAW_IMAGE_BACKEND;
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("creates sips temp dirs under the secured OpenClaw tmp root", async () => {
+    const { getImageMetadata } = await import("./image-ops.js");
+    const secureRoot = resolvePreferredOpenClawTmpDir();
+
+    await getImageMetadata(Buffer.from("image"));
+
+    expect(fs.mkdtemp).toHaveBeenCalledTimes(1);
+    expect(fs.mkdtemp).toHaveBeenCalledWith(path.join(secureRoot, "openclaw-img-"));
+    expect(createdTempDir.startsWith(path.join(secureRoot, "openclaw-img-"))).toBe(true);
+    await expect(fs.access(createdTempDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runExec } from "../process/exec.js";
 
 type Sharp = typeof import("sharp");
@@ -134,7 +134,7 @@ function readJpegExifOrientation(buffer: Buffer): number | null {
 }
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-img-"));
+  const dir = await fs.mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-img-"));
   try {
     return await fn(dir);
   } finally {

--- a/test/scripts/check-no-random-messaging-tmp.test.ts
+++ b/test/scripts/check-no-random-messaging-tmp.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { findMessagingTmpdirCallLines } from "../../scripts/check-no-random-messaging-tmp.mjs";
+import {
+  findMessagingTmpdirCallLines,
+  messagingTmpdirGuardSourceRoots,
+} from "../../scripts/check-no-random-messaging-tmp.mjs";
 
 describe("check-no-random-messaging-tmp", () => {
   it("finds os.tmpdir calls imported from node:os", () => {
@@ -40,5 +43,9 @@ describe("check-no-random-messaging-tmp", () => {
       const dir = tmpdir();
     `;
     expect(findMessagingTmpdirCallLines(source)).toEqual([]);
+  });
+
+  it("guards src/media against host tmpdir usage", () => {
+    expect(messagingTmpdirGuardSourceRoots).toContain("src/media");
   });
 });


### PR DESCRIPTION
## Summary
- Routes sips image operations through the shared OpenClaw temp root
- Extends the tmpdir guard to cover `src/media`

## Changes
- Updated `src/media/image-ops.ts` to create temporary image work directories with `resolvePreferredOpenClawTmpDir()`
- Added `src/media/image-ops.tempdir.test.ts` to verify the sips path uses the shared temp root and cleans up its temp directory
- Exported the tmpdir guard roots and added a regression test that keeps `src/media` under guard coverage

## Validation
- Ran `pnpm test -- src/media/image-ops.tempdir.test.ts test/scripts/check-no-random-messaging-tmp.test.ts src/media/image-ops.helpers.test.ts`
- Ran `pnpm check`
- Ran local agentic review with `claude -p "/review"` and addressed the actionable test hardening feedback

## Notes
- Residual risk or follow-up: the new media regression test exercises temp-root selection and cleanup on the sips path, but it does not run the real `sips` binary on Linux
