### PR TITLE
fix(telegram): add resolveSessionTarget to fix announce delivery for forum topics

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -548,6 +548,7 @@ export const telegramPlugin = createChatChannelPlugin({
     },
     messaging: {
       normalizeTarget: normalizeTelegramMessagingTarget,
+      resolveSessionTarget: ({ id }) => id,
       parseExplicitTarget: ({ raw }) => parseTelegramExplicitTarget(raw),
       inferTargetChatType: ({ to }) => parseTelegramExplicitTarget(to).chatType,
       formatTargetDisplay: ({ target, display, kind }) => {

--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -66,6 +66,7 @@ describe("resolveAnnounceTargetFromKey", () => {
             capabilities: { chatTypes: ["direct", "group", "thread"] },
             messaging: {
               normalizeTarget: (raw: string) => raw.replace(/^group:/, ""),
+              resolveSessionTarget: ({ id }: { id: string }) => id,
             },
             config: {
               listAccountIds: () => ["default"],


### PR DESCRIPTION
## Summary

- Adds the missing `resolveSessionTarget` hook to the Telegram channel plugin, fixing announce delivery for forum topic sessions in multi-agent async delegations.
- Without this hook, `resolveAnnounceTargetFromKey` falls back to the malformed `"group:<chatId>"` target string, which Telegram rejects with "must be a numeric chat ID".
- Discord and Slack already implement this hook; this change brings Telegram to parity.

Fixes #57918

## Root cause

`resolveAnnounceTargetFromKey()` in `sessions-send-helpers.ts` constructs a `genericTarget = "group:<chatId>"` from the session key. It then calls `resolveSessionTarget` (if available) or falls back to `normalizeTarget`. Telegram did not implement `resolveSessionTarget`, and its `normalizeTarget` (`normalizeTelegramMessagingTarget`) returns `undefined` for bare `"group:<chatId>"` input (because `stripTelegramInternalPrefixes` only strips the `group:` prefix when preceded by `telegram:`). The final fallback returns the raw `"group:<chatId>"` string, which fails at send time.

## Changes

| File | Change |
|------|--------|
| `extensions/telegram/src/channel.ts` | Add `resolveSessionTarget: ({ id }) => id` to the messaging adapter |
| `src/agents/tools/sessions-send-helpers.test.ts` | Update Telegram test stub to include `resolveSessionTarget` matching real behavior |

## Test plan

- [x] `pnpm test -- sessions-send-helpers.test.ts` — 3/3 passed
- [x] `pnpm check` — lint, typecheck, format all pass
- [x] Manual verification: configure two agents with Telegram forum topic, trigger async `sessions_send` (timeoutSeconds: 0), confirm announce delivery reaches the correct topic