### PR TITLE
fix(android): stabilize gateway reconnect and onboarding node gating

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -91,6 +91,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val manualPort: StateFlow<Int> = prefs.manualPort
   val manualTls: StateFlow<Boolean> = prefs.manualTls
   val gatewayToken: StateFlow<String> = prefs.gatewayToken
+  val gatewayBootstrapToken: StateFlow<String> = prefs.gatewayBootstrapToken
   val onboardingCompleted: StateFlow<Boolean> = prefs.onboardingCompleted
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
   val speakerEnabled: StateFlow<Boolean> = prefs.speakerEnabled

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
@@ -72,6 +72,7 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
   val manualTls by viewModel.manualTls.collectAsState()
   val manualEnabled by viewModel.manualEnabled.collectAsState()
   val gatewayToken by viewModel.gatewayToken.collectAsState()
+  val gatewayBootstrapToken by viewModel.gatewayBootstrapToken.collectAsState()
   val pendingTrust by viewModel.pendingGatewayTrust.collectAsState()
 
   var advancedOpen by rememberSaveable { mutableStateOf(false) }
@@ -244,6 +245,7 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
               manualHost = manualHostInput,
               manualPort = manualPortInput,
               manualTls = manualTlsInput,
+              fallbackBootstrapToken = gatewayBootstrapToken,
               fallbackToken = gatewayToken,
               fallbackPassword = passwordInput,
             )

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -40,6 +40,7 @@ internal fun resolveGatewayConnectConfig(
   manualHost: String,
   manualPort: String,
   manualTls: Boolean,
+  fallbackBootstrapToken: String,
   fallbackToken: String,
   fallbackPassword: String,
 ): GatewayConnectConfig? {
@@ -75,7 +76,12 @@ internal fun resolveGatewayConnectConfig(
     host = parsed.host,
     port = parsed.port,
     tls = parsed.tls,
-    bootstrapToken = "",
+    bootstrapToken =
+      if (fallbackToken.isBlank() && fallbackPassword.isBlank()) {
+        fallbackBootstrapToken.trim()
+      } else {
+        ""
+      },
     token = fallbackToken.trim(),
     password = fallbackPassword.trim(),
   )

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -229,8 +229,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
   var manualTls by rememberSaveable { mutableStateOf(false) }
   var gatewayError by rememberSaveable { mutableStateOf<String?>(null) }
   var attemptedConnect by rememberSaveable { mutableStateOf(false) }
-  val canFinishOnboarding =
-    isConnected || (gatewayInputMode == GatewayInputMode.SetupCode && isNodeConnected)
+  val canFinishOnboarding = canFinishOnboarding(isConnected = isConnected, isNodeConnected = isNodeConnected)
 
   val lifecycleOwner = LocalLifecycleOwner.current
   val qrScannerOptions =
@@ -910,6 +909,10 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
       }
     }
   }
+}
+
+internal fun canFinishOnboarding(isConnected: Boolean, isNodeConnected: Boolean): Boolean {
+  return isConnected && isNodeConnected
 }
 
 @Composable

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -158,6 +158,7 @@ class GatewayConfigResolverTest {
         manualHost = "",
         manualPort = "",
         manualTls = true,
+        fallbackBootstrapToken = "",
         fallbackToken = "shared-token",
         fallbackPassword = "shared-password",
       )
@@ -182,6 +183,7 @@ class GatewayConfigResolverTest {
         manualHost = "",
         manualPort = "",
         manualTls = true,
+        fallbackBootstrapToken = "",
         fallbackToken = "shared-token",
         fallbackPassword = "shared-password",
       )
@@ -192,6 +194,47 @@ class GatewayConfigResolverTest {
     assertEquals("bootstrap-1", resolved?.bootstrapToken)
     assertNull(resolved?.token?.takeIf { it.isNotEmpty() })
     assertNull(resolved?.password?.takeIf { it.isNotEmpty() })
+  }
+
+  @Test
+  fun resolveGatewayConnectConfigManualPreservesBootstrapTokenWhenNoReplacementAuthExists() {
+    val resolved =
+      resolveGatewayConnectConfig(
+        useSetupCode = false,
+        setupCode = "",
+        manualHost = "192.168.31.100",
+        manualPort = "18789",
+        manualTls = false,
+        fallbackBootstrapToken = "bootstrap-1",
+        fallbackToken = "",
+        fallbackPassword = "",
+      )
+
+    assertEquals("192.168.31.100", resolved?.host)
+    assertEquals(18789, resolved?.port)
+    assertEquals(false, resolved?.tls)
+    assertEquals("bootstrap-1", resolved?.bootstrapToken)
+    assertEquals("", resolved?.token)
+    assertEquals("", resolved?.password)
+  }
+
+  @Test
+  fun resolveGatewayConnectConfigManualDropsBootstrapTokenWhenReplacementPasswordExists() {
+    val resolved =
+      resolveGatewayConnectConfig(
+        useSetupCode = false,
+        setupCode = "",
+        manualHost = "192.168.31.100",
+        manualPort = "18789",
+        manualTls = false,
+        fallbackBootstrapToken = "bootstrap-1",
+        fallbackToken = "",
+        fallbackPassword = "password-1",
+      )
+
+    assertEquals("", resolved?.bootstrapToken)
+    assertEquals("", resolved?.token)
+    assertEquals("password-1", resolved?.password)
   }
 
   private fun encodeSetupCode(payloadJson: String): String {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -16,6 +16,11 @@ class OnboardingFlowLogicTest {
   }
 
   @Test
+  fun blocksFinishWhenOnlyNodeIsConnected() {
+    assertFalse(canFinishOnboarding(isConnected = false, isNodeConnected = true))
+  }
+
+  @Test
   fun allowsFinishOnlyWhenOperatorAndNodeAreConnected() {
     assertTrue(canFinishOnboarding(isConnected = true, isNodeConnected = true))
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -1,0 +1,22 @@
+package ai.openclaw.app.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OnboardingFlowLogicTest {
+  @Test
+  fun blocksFinishWhenOnlyOperatorIsConnected() {
+    assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = false))
+  }
+
+  @Test
+  fun blocksFinishWhenDisconnected() {
+    assertFalse(canFinishOnboarding(isConnected = false, isNodeConnected = false))
+  }
+
+  @Test
+  fun allowsFinishOnlyWhenOperatorAndNodeAreConnected() {
+    assertTrue(canFinishOnboarding(isConnected = true, isNodeConnected = true))
+  }
+}


### PR DESCRIPTION
## Summary
- preserve cached bootstrap auth when reconnecting via manual endpoint changes without replacement shared auth
- require both operator and node connection before onboarding can finish
- cover both fixes with focused Android unit tests

## Testing
- cd apps/android && ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.GatewayConfigResolverTest --tests ai.openclaw.app.GatewayBootstrapAuthTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest
- cd apps/android && ./gradlew :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.ui.GatewayConfigResolverTest --tests ai.openclaw.app.GatewayBootstrapAuthTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest
- adb live validation on Android device against local gateway: confirmed full `Connected` after approving pending node pairing request and verified repeated cold starts