### PR TITLE
fix(telegram): add resolveSessionTarget for forum topic announce delivery

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -529,6 +529,14 @@ export const telegramPlugin = createChatChannelPlugin({
       },
     },
     messaging: {
+      resolveSessionTarget: ({ kind, id }) => {
+        // Return raw numeric chat ID for announce delivery.
+        // Caller passes kind and id separately; threadId handled by caller.
+        if (kind === "group" || kind === "channel") {
+          return id;
+        }
+        return undefined;
+      },
       normalizeTarget: normalizeTelegramMessagingTarget,
       parseExplicitTarget: ({ raw }) => parseTelegramExplicitTarget(raw),
       inferTargetChatType: ({ to }) => parseTelegramExplicitTarget(to).chatType,

--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -87,6 +87,12 @@ describe("resolveAnnounceTargetFromKey", () => {
             },
             capabilities: { chatTypes: ["direct", "group", "thread"] },
             messaging: {
+              resolveSessionTarget: ({ kind, id }: { kind: string; id: string }) => {
+                if (kind === "group" || kind === "channel") {
+                  return id;
+                }
+                return undefined;
+              },
               normalizeTarget: (raw: string) => raw.replace(/^group:/, ""),
             },
             config: {


### PR DESCRIPTION
## Summary

- **Problem**: Telegram forum topic sessions use keys like `agent:main:telegram:group:-1003284013439:topic:42`. When announce delivery resolves the target via `resolveAnnounceTargetFromKey`, it constructs `group:-1003284013439` and passes it to `normalizeTarget`. The Telegram normalizer fails to parse the `group:` prefix without a `telegram:` namespace, returns `undefined`, and the malformed recipient is used verbatim.
- **Why it matters**: All announce deliveries to Telegram forum topic sessions fail silently.
- **What changed**: Added `resolveSessionTarget` to the Telegram channel plugin messaging adapter. Updated test stub.
- **What did NOT change**: `normalizeTarget` remains as fallback.

## Change Type

- [x] Bug fix

## Scope

- [x] Channels (Telegram)

## Linked Issue

Fixes #57918

## User-visible / Behavior Changes

Announce deliveries to Telegram forum topic sessions now correctly resolve the chat ID.

## Security Impact

- Permissions or access control? **No**
- Secrets, tokens, or credentials? **No**
- Network requests or external connections? **No**
- Command execution or tool invocation? **No**
- Data access patterns or storage? **No**

## Evidence

- Test case `sessions-send-helpers.test.ts` line 97-102 validates `to: "-100123"` with `threadId: "99"`
- All 4 tests pass
- Matches Discord and Slack `resolveSessionTarget` pattern

## Human Verification

- [x] Test stub mirrors production implementation
- [x] Discord/Slack use same pattern
- [x] normalizeTarget fallback still works
- [ ] Not verified on live Telegram forum topic (no test environment)

## Review Conversations

- [x] Replied to / resolved all bot review conversations

## Compatibility / Migration

Backward compatible. No config changes.

## Failure Recovery

Revert single commit. Watch for forum topic announce delivery failures.

## Risks and Mitigations

None.

🤖 AI-assisted (Claude Code). Reviewed code, traced full delivery path, verified against Discord/Slack implementations.