### PR TITLE
fix(infra): eliminate TOCTOU race in security-critical file reads

### DIFF
--- a/src/infra/device-auth-store.ts
+++ b/src/infra/device-auth-store.ts
@@ -23,11 +23,16 @@ function resolveDeviceAuthPath(env: NodeJS.ProcessEnv = process.env): string {
 }
 
 function readStore(filePath: string): DeviceAuthStore | null {
+  let raw: string;
   try {
-    if (!fs.existsSync(filePath)) {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return null;
     }
-    const raw = fs.readFileSync(filePath, "utf8");
+    throw err;
+  }
+  try {
     return safeParseJsonWithSchema(DeviceAuthStoreSchema, raw);
   } catch {
     return null;

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -66,42 +66,40 @@ export function loadOrCreateDeviceIdentity(
   filePath: string = resolveDefaultIdentityPath(),
 ): DeviceIdentity {
   try {
-    if (fs.existsSync(filePath)) {
-      const raw = fs.readFileSync(filePath, "utf8");
-      const parsed = JSON.parse(raw) as StoredIdentity;
-      if (
-        parsed?.version === 1 &&
-        typeof parsed.deviceId === "string" &&
-        typeof parsed.publicKeyPem === "string" &&
-        typeof parsed.privateKeyPem === "string"
-      ) {
-        const derivedId = fingerprintPublicKey(parsed.publicKeyPem);
-        if (derivedId && derivedId !== parsed.deviceId) {
-          const updated: StoredIdentity = {
-            ...parsed,
-            deviceId: derivedId,
-          };
-          fs.writeFileSync(filePath, `${JSON.stringify(updated, null, 2)}\n`, { mode: 0o600 });
-          try {
-            fs.chmodSync(filePath, 0o600);
-          } catch {
-            // best-effort
-          }
-          return {
-            deviceId: derivedId,
-            publicKeyPem: parsed.publicKeyPem,
-            privateKeyPem: parsed.privateKeyPem,
-          };
+    const raw = fs.readFileSync(filePath, "utf8");
+    const parsed = JSON.parse(raw) as StoredIdentity;
+    if (
+      parsed?.version === 1 &&
+      typeof parsed.deviceId === "string" &&
+      typeof parsed.publicKeyPem === "string" &&
+      typeof parsed.privateKeyPem === "string"
+    ) {
+      const derivedId = fingerprintPublicKey(parsed.publicKeyPem);
+      if (derivedId && derivedId !== parsed.deviceId) {
+        const updated: StoredIdentity = {
+          ...parsed,
+          deviceId: derivedId,
+        };
+        fs.writeFileSync(filePath, `${JSON.stringify(updated, null, 2)}\n`, { mode: 0o600 });
+        try {
+          fs.chmodSync(filePath, 0o600);
+        } catch {
+          // best-effort
         }
         return {
-          deviceId: parsed.deviceId,
+          deviceId: derivedId,
           publicKeyPem: parsed.publicKeyPem,
           privateKeyPem: parsed.privateKeyPem,
         };
       }
+      return {
+        deviceId: parsed.deviceId,
+        publicKeyPem: parsed.publicKeyPem,
+        privateKeyPem: parsed.privateKeyPem,
+      };
     }
   } catch {
-    // fall through to regenerate
+    // fall through to regenerate (ENOENT = no file, other errors = corrupt/unreadable)
   }
 
   const identity = generateIdentity();

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -323,17 +323,22 @@ function generateToken(): string {
 
 export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
   const filePath = resolveExecApprovalsPath();
-  if (!fs.existsSync(filePath)) {
-    const file = normalizeExecApprovals({ version: 1, agents: {} });
-    return {
-      path: filePath,
-      exists: false,
-      raw: null,
-      file,
-      hash: hashExecApprovalsRaw(null),
-    };
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      const file = normalizeExecApprovals({ version: 1, agents: {} });
+      return {
+        path: filePath,
+        exists: false,
+        raw: null,
+        file,
+        hash: hashExecApprovalsRaw(null),
+      };
+    }
+    throw err;
   }
-  const raw = fs.readFileSync(filePath, "utf8");
   let parsed: ExecApprovalsFile | null = null;
   try {
     parsed = JSON.parse(raw) as ExecApprovalsFile;
@@ -355,11 +360,16 @@ export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
 
 export function loadExecApprovals(): ExecApprovalsFile {
   const filePath = resolveExecApprovalsPath();
+  let raw: string;
   try {
-    if (!fs.existsSync(filePath)) {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return normalizeExecApprovals({ version: 1, agents: {} });
     }
-    const raw = fs.readFileSync(filePath, "utf8");
+    throw err;
+  }
+  try {
     const parsed = JSON.parse(raw) as ExecApprovalsFile;
     if (parsed?.version !== 1) {
       return normalizeExecApprovals({ version: 1, agents: {} });


### PR DESCRIPTION
## Summary
- Replace `existsSync()` → `readFileSync()` TOCTOU pattern with single `try-catch` that handles `ENOENT` directly
- Focused on security-critical paths: exec-approvals, device-identity, device-auth-store
- Prevents potential privilege escalation via file swap between existence check and read

## Change Type
- [x] Bug fix (security hardening)

## Test plan
- [ ] Existing unit tests pass
- [ ] Manual verification: delete/rename config files while gateway is running
- [ ] Verify ENOENT returns default values as before
- [ ] Verify non-ENOENT errors still propagate

🤖 Generated with [Claude Code](https://claude.com/claude-code)