### PR TITLE
fix: skip stale-socket restart when Discord channel is still connected

### DIFF
--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -125,6 +125,12 @@ export function evaluateChannelHealth(
     }
     const eventAge = policy.now - snapshot.lastEventAt;
     if (eventAge > policy.staleEventThresholdMs) {
+      // Same guard: if the transport still considers itself connected, the
+      // lack of dispatch events does not mean the socket is dead — it may
+      // simply be an idle channel with no user activity.
+      if (snapshot.connected) {
+        return { healthy: true, reason: "healthy" };
+      }
       return { healthy: false, reason: "stale-socket" };
     }
   }


### PR DESCRIPTION
The health monitor incorrectly classified idle-but-connected Discord channels as `stale-socket`, triggering unnecessary restarts every ~35 min on low-traffic servers.

Since Discord Gateway uses a single WebSocket for both heartbeats and dispatch events, `connected === true` reliably indicates a healthy connection. No user activity does not imply a dead socket.

**Change:** Add a `snapshot.connected === true` guard before returning `stale-socket` in the `eventAge > staleEventThresholdMs` branch of `evaluateChannelHealth()`.

Fixes #58339