### PR TITLE
Fix: /reset and /new commands now revert model to default (Resolves #58302)

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1573,7 +1573,7 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
-  it("preserves selected auth profile overrides across /new and /reset", async () => {
+  it("preserves selected auth profile overrides across /new and /reset but clears model overrides", async () => {
     const storePath = await createStorePath("openclaw-reset-model-auth-");
     const sessionKey = "agent:main:telegram:dm:user-model-auth";
     const existingSessionId = "existing-session-model-auth";
@@ -1594,11 +1594,11 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     } as const;
     const cases = [
       {
-        name: "new preserves selected auth profile overrides",
+        name: "new preserves selected auth profile overrides but clears model overrides",
         body: "/new",
       },
       {
-        name: "reset preserves selected auth profile overrides",
+        name: "reset preserves selected auth profile overrides but clears model overrides",
         body: "/reset",
       },
     ] as const;
@@ -1634,9 +1634,12 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       expect(result.isNewSession, testCase.name).toBe(true);
       expect(result.resetTriggered, testCase.name).toBe(true);
       expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
+      // Model overrides are cleared on reset so the session reverts to the
+      // default model configured in openclaw.json.
+      expect(result.sessionEntry.modelOverride, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.providerOverride, testCase.name).toBeUndefined();
+      // Auth profile overrides are preserved so the user's auth selection persists.
       expect(result.sessionEntry, testCase.name).toMatchObject({
-        providerOverride: overrides.providerOverride,
-        modelOverride: overrides.modelOverride,
         authProfileOverride: overrides.authProfileOverride,
         authProfileOverrideSource: overrides.authProfileOverrideSource,
         authProfileOverrideCompactionCount: overrides.authProfileOverrideCompactionCount,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -444,13 +444,13 @@ export async function initSessionState(params: {
     // When a reset trigger (/new, /reset) starts a new session, carry over
     // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto)
     // so the user doesn't have to re-enable them every time.
+    // Model overrides are intentionally NOT carried over so that the new
+    // session reverts to the default model configured in openclaw.json.
     if (resetTriggered && entry) {
       persistedThinking = entry.thinkingLevel;
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
       persistedAuthProfileOverride = entry.authProfileOverride;
       persistedAuthProfileOverrideSource = entry.authProfileOverrideSource;
       persistedAuthProfileOverrideCompactionCount = entry.authProfileOverrideCompactionCount;


### PR DESCRIPTION
Fixes #58302.

## Problem

When a user switched models during a session (e.g. via `/model provider/model-id`) and then ran `/reset` or `/new`, the new session inherited the `modelOverride`/`providerOverride` from the previous session instead of reverting to the default model configured in `agents.defaults.model.primary` in `openclaw.json`.

The session transcript showed a `model_change` event with `parentId: null` immediately after session creation — meaning the persisted override was applied before any user input, overriding the config file default.

## Fix

Remove `modelOverride` and `providerOverride` from the fields carried over during a reset-triggered new session (`src/auto-reply/reply/session.ts`). All other user preferences (thinking level, TTS, verbose, reasoning, auth profile, CLI bindings, etc.) continue to persist across `/reset` and `/new` as before.

The distinction: model choice is a per-session setting that should revert to the configured default on reset; communication-style preferences (thinking, TTS, verbose) are user-level settings that reasonably persist.

Note: `/new provider/model` and `/reset provider/model` still work correctly — `applyResetModelOverride` sets the model after the reset and is unaffected by this change.

## Testing

- Updated the existing `"preserves selected auth profile overrides"` test to verify `modelOverride` and `providerOverride` are `undefined` after reset while auth profile, CLI session bindings, and behavior overrides remain.
- All 59 session tests pass; session-reset-model tests (3) pass.
- `pnpm check` passes (lint, types, architecture guards).