### PR TITLE
Plugins: add before_model_call and after_model_call hooks

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.model-call-hooks.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.model-call-hooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildBeforeModelCallEvent } from "./attempt.js";
+import { buildBeforeModelCallEvent, buildModelCallId } from "./attempt.js";
 
 describe("buildBeforeModelCallEvent", () => {
   it("includes the composed system prompt with the provider request messages", () => {
@@ -68,5 +68,24 @@ describe("buildBeforeModelCallEvent", () => {
     });
     expect(Object.keys(event)).not.toContain("api");
     expect(Object.keys(event)).not.toContain("systemPrompt");
+  });
+});
+
+describe("buildModelCallId", () => {
+  it("includes session identity so retries under the same runId stay unique", () => {
+    expect(
+      buildModelCallId({
+        runId: "run-1",
+        sessionId: "session-a",
+        sequence: 1,
+      }),
+    ).toBe("run-1-session-a-1");
+    expect(
+      buildModelCallId({
+        runId: "run-1",
+        sessionId: "session-b",
+        sequence: 1,
+      }),
+    ).toBe("run-1-session-b-1");
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.model-call-hooks.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.model-call-hooks.test.ts
@@ -47,4 +47,26 @@ describe("buildBeforeModelCallEvent", () => {
     expect(event.requestMessages).toBe(requestMessages);
     expect(event.systemPrompt).toBeUndefined();
   });
+
+  it("omits optional fields when they are not provided", () => {
+    const event = buildBeforeModelCallEvent({
+      runId: "run-3",
+      sessionId: "session-3",
+      provider: "openai",
+      model: "gpt-5.4",
+      callId: "run-3-1",
+      requestMessages: [],
+    });
+
+    expect(event).toEqual({
+      runId: "run-3",
+      sessionId: "session-3",
+      provider: "openai",
+      model: "gpt-5.4",
+      callId: "run-3-1",
+      requestMessages: [],
+    });
+    expect(Object.keys(event)).not.toContain("api");
+    expect(Object.keys(event)).not.toContain("systemPrompt");
+  });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.model-call-hooks.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.model-call-hooks.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildBeforeModelCallEvent } from "./attempt.js";
+
+describe("buildBeforeModelCallEvent", () => {
+  it("includes the composed system prompt with the provider request messages", () => {
+    const requestMessages = [{ role: "user", content: "hello" }];
+
+    expect(
+      buildBeforeModelCallEvent({
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "bailian",
+        model: "qwen-plus",
+        api: "openai-chat",
+        callId: "run-1-1",
+        systemPrompt: "You are a precise system.",
+        requestMessages,
+      }),
+    ).toEqual({
+      runId: "run-1",
+      sessionId: "session-1",
+      provider: "bailian",
+      model: "qwen-plus",
+      api: "openai-chat",
+      callId: "run-1-1",
+      systemPrompt: "You are a precise system.",
+      requestMessages,
+    });
+  });
+
+  it("preserves the exact requestMessages payload for downstream hook consumers", () => {
+    const requestMessages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: [{ type: "tool_use", id: "tool-1", name: "read" }] },
+    ];
+
+    const event = buildBeforeModelCallEvent({
+      runId: "run-2",
+      sessionId: "session-2",
+      provider: "openai",
+      model: "gpt-5.4",
+      api: "openai-chat",
+      callId: "run-2-1",
+      requestMessages,
+    });
+
+    expect(event.requestMessages).toBe(requestMessages);
+    expect(event.systemPrompt).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -550,6 +550,32 @@ export function wrapStreamFnTrimToolCallNames(
   };
 }
 
+export function normalizeOutboundReplayToolCalls(params: {
+  messages: AgentMessage[];
+  allowedToolNames?: Set<string>;
+  transcriptPolicy?: Pick<TranscriptPolicy, "validateGeminiTurns" | "validateAnthropicTurns">;
+}): AgentMessage[] {
+  const sanitized = sanitizeReplayToolCallInputs(params.messages, params.allowedToolNames);
+  if (sanitized.messages === params.messages) {
+    return params.messages;
+  }
+
+  let nextMessages = sanitizeToolUseResultPairing(sanitized.messages);
+  if (params.transcriptPolicy?.validateAnthropicTurns) {
+    nextMessages = sanitizeAnthropicReplayToolResults(nextMessages);
+  }
+  if (sanitized.droppedAssistantMessages > 0 || params.transcriptPolicy?.validateAnthropicTurns) {
+    if (params.transcriptPolicy?.validateGeminiTurns) {
+      nextMessages = validateGeminiTurns(nextMessages);
+    }
+    if (params.transcriptPolicy?.validateAnthropicTurns) {
+      nextMessages = validateAnthropicTurns(nextMessages);
+    }
+  }
+
+  return nextMessages;
+}
+
 export function wrapStreamFnSanitizeMalformedToolCalls(
   baseFn: StreamFn,
   allowedToolNames?: Set<string>,
@@ -561,21 +587,13 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
     if (!Array.isArray(messages)) {
       return baseFn(model, context, options);
     }
-    const sanitized = sanitizeReplayToolCallInputs(messages as AgentMessage[], allowedToolNames);
-    if (sanitized.messages === messages) {
+    const nextMessages = normalizeOutboundReplayToolCalls({
+      messages: messages as AgentMessage[],
+      allowedToolNames,
+      transcriptPolicy,
+    });
+    if (nextMessages === messages) {
       return baseFn(model, context, options);
-    }
-    let nextMessages = sanitizeToolUseResultPairing(sanitized.messages);
-    if (transcriptPolicy?.validateAnthropicTurns) {
-      nextMessages = sanitizeAnthropicReplayToolResults(nextMessages);
-    }
-    if (sanitized.droppedAssistantMessages > 0 || transcriptPolicy?.validateAnthropicTurns) {
-      if (transcriptPolicy?.validateGeminiTurns) {
-        nextMessages = validateGeminiTurns(nextMessages);
-      }
-      if (transcriptPolicy?.validateAnthropicTurns) {
-        nextMessages = validateAnthropicTurns(nextMessages);
-      }
     }
     const nextContext = {
       ...(context as unknown as Record<string, unknown>),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -245,6 +245,28 @@ export function resolveEmbeddedAgentStreamFn(params: {
   return currentStreamFn;
 }
 
+export function buildBeforeModelCallEvent(params: {
+  runId: string;
+  sessionId: string;
+  provider: string;
+  model: string;
+  api?: string;
+  callId: string;
+  systemPrompt?: string;
+  requestMessages: unknown[];
+}) {
+  return {
+    runId: params.runId,
+    sessionId: params.sessionId,
+    provider: params.provider,
+    model: params.model,
+    api: params.api,
+    callId: params.callId,
+    systemPrompt: params.systemPrompt,
+    requestMessages: params.requestMessages,
+  };
+}
+
 function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
   const content = (msg as { content?: unknown }).content;
   if (typeof content === "string") {
@@ -1075,6 +1097,125 @@ export async function runEmbeddedAttempt(
           idleTimeoutMs,
           (error) => idleTimeoutTrigger?.(error),
         );
+      }
+
+      // Wrap streamFn to fire before_model_call / after_model_call hooks around
+      // every real provider invocation so plugins can observe the exact messages
+      // sent to the model and the outcome of each call.
+      if (hookRunner?.hasHooks("before_model_call") || hookRunner?.hasHooks("after_model_call")) {
+        const innerForHooks = activeSession.agent.streamFn;
+        let modelCallCounter = 0;
+        activeSession.agent.streamFn = (model, context, options) => {
+          const callId = `${params.runId}-${++modelCallCounter}`;
+          const hookCtxForCall = {
+            runId: params.runId,
+            agentId: sessionAgentId,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+            workspaceDir: params.workspaceDir,
+            messageProvider: params.messageProvider ?? undefined,
+            trigger: params.trigger,
+            channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+          };
+          const requestMessages = (context as unknown as { messages?: unknown[] }).messages ?? [];
+          if (hookRunner?.hasHooks("before_model_call")) {
+            hookRunner
+              .runBeforeModelCall(
+                buildBeforeModelCallEvent({
+                  runId: params.runId,
+                  sessionId: params.sessionId,
+                  provider: params.provider,
+                  model: params.modelId,
+                  api: params.model.api,
+                  callId,
+                  systemPrompt: systemPromptText,
+                  requestMessages,
+                }),
+                hookCtxForCall,
+              )
+              .catch((err) => {
+                log.warn(`before_model_call hook failed: ${String(err)}`);
+              });
+          }
+          const startMs = Date.now();
+          const result = innerForHooks(model, context, options);
+          // Wrap the stream to intercept .result() and capture the response
+          // message for the after_model_call hook. The stream is an async
+          // iterable with a .result() method that resolves to the full
+          // AssistantMessage once the stream is consumed.
+          if (hookRunner?.hasHooks("after_model_call")) {
+            const fireAfterModelCall = (responseMessage?: unknown, error?: string) => {
+              hookRunner
+                .runAfterModelCall(
+                  {
+                    runId: params.runId,
+                    sessionId: params.sessionId,
+                    provider: params.provider,
+                    model: params.modelId,
+                    api: params.model.api,
+                    callId,
+                    durationMs: Date.now() - startMs,
+                    ...(error != null ? { error } : {}),
+                    ...(responseMessage != null ? { responseMessage } : {}),
+                  },
+                  hookCtxForCall,
+                )
+                .catch((hookErr) => {
+                  log.warn(`after_model_call hook failed: ${String(hookErr)}`);
+                });
+            };
+
+            // Wrap the resolved stream to intercept .result() and capture
+            // the full assistant message for the after_model_call hook.
+            const wrapStreamForAfterHook = (stream: unknown) => {
+              if (
+                stream &&
+                typeof stream === "object" &&
+                "result" in stream &&
+                typeof (stream as { result: unknown }).result === "function"
+              ) {
+                const originalResult = (stream as { result: () => Promise<unknown> }).result.bind(
+                  stream,
+                );
+                (stream as { result: () => Promise<unknown> }).result = async () => {
+                  try {
+                    const message = await originalResult();
+                    fireAfterModelCall(message);
+                    return message;
+                  } catch (err) {
+                    fireAfterModelCall(undefined, String(err));
+                    throw err;
+                  }
+                };
+              } else {
+                // Fallback: no .result() method; fire without response
+                Promise.resolve(stream).then(
+                  () => fireAfterModelCall(),
+                  (err) => fireAfterModelCall(undefined, String(err)),
+                );
+              }
+              return stream;
+            };
+
+            // Handle both sync and async (Promise-wrapped) stream returns
+            if (
+              result &&
+              typeof result === "object" &&
+              "then" in result &&
+              typeof (result as { then: unknown }).then === "function"
+            ) {
+              return (result as Promise<unknown>).then(
+                (resolved) => wrapStreamForAfterHook(resolved),
+                (err) => {
+                  fireAfterModelCall(undefined, String(err));
+                  throw err;
+                },
+              ) as typeof result;
+            }
+            wrapStreamForAfterHook(result);
+          }
+          return result;
+        };
       }
 
       try {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
-import { streamSimple } from "@mariozechner/pi-ai";
+import { streamSimple, type Api, type Model } from "@mariozechner/pi-ai";
 import {
   createAgentSession,
   DefaultResourceLoader,
@@ -95,7 +95,7 @@ import {
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
-import { resolveTranscriptPolicy } from "../../transcript-policy.js";
+import { resolveTranscriptPolicy, type TranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { isCacheTtlEligibleProvider } from "../cache-ttl.js";
@@ -260,11 +260,47 @@ export function buildBeforeModelCallEvent(params: {
     sessionId: params.sessionId,
     provider: params.provider,
     model: params.model,
-    api: params.api,
     callId: params.callId,
-    systemPrompt: params.systemPrompt,
     requestMessages: params.requestMessages,
+    ...(params.api != null ? { api: params.api } : {}),
+    ...(params.systemPrompt != null ? { systemPrompt: params.systemPrompt } : {}),
   };
+}
+
+function resolveBeforeModelCallRequestMessages(params: {
+  context: unknown;
+  transcriptPolicy: TranscriptPolicy;
+  model: Model<Api>;
+}): unknown[] {
+  const messages = (params.context as { messages?: unknown[] } | null | undefined)?.messages;
+  if (!Array.isArray(messages)) {
+    return [];
+  }
+
+  let normalized = messages;
+
+  if (params.transcriptPolicy.dropThinkingBlocks) {
+    normalized = dropThinkingBlocks(normalized as unknown as AgentMessage[]) as unknown[];
+  }
+
+  if (params.transcriptPolicy.sanitizeToolCallIds && params.transcriptPolicy.toolCallIdMode) {
+    normalized = sanitizeToolCallIdsForCloudCodeAssist(
+      normalized as AgentMessage[],
+      params.transcriptPolicy.toolCallIdMode,
+    ) as unknown[];
+  }
+
+  if (
+    params.model.api === "openai-responses" ||
+    params.model.api === "azure-openai-responses" ||
+    params.model.api === "openai-codex-responses"
+  ) {
+    normalized = downgradeOpenAIFunctionCallReasoningPairs(
+      normalized as AgentMessage[],
+    ) as unknown[];
+  }
+
+  return normalized;
 }
 
 function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
@@ -1117,7 +1153,11 @@ export async function runEmbeddedAttempt(
             trigger: params.trigger,
             channelId: params.messageChannel ?? params.messageProvider ?? undefined,
           };
-          const requestMessages = (context as unknown as { messages?: unknown[] }).messages ?? [];
+          const requestMessages = resolveBeforeModelCallRequestMessages({
+            context,
+            transcriptPolicy,
+            model: params.model,
+          });
           if (hookRunner?.hasHooks("before_model_call")) {
             hookRunner
               .runBeforeModelCall(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1142,6 +1142,11 @@ export async function runEmbeddedAttempt(
         const innerForHooks = activeSession.agent.streamFn;
         let modelCallCounter = 0;
         activeSession.agent.streamFn = (model, context, options) => {
+          const signal = runAbortController.signal as AbortSignal & { reason?: unknown };
+          if (yieldDetected && signal.aborted && signal.reason === "sessions_yield") {
+            return innerForHooks(model, context, options);
+          }
+
           const callId = `${params.runId}-${++modelCallCounter}`;
           const hookCtxForCall = {
             runId: params.runId,
@@ -1178,83 +1183,90 @@ export async function runEmbeddedAttempt(
               });
           }
           const startMs = Date.now();
-          const result = innerForHooks(model, context, options);
-          // Wrap the stream to intercept .result() and capture the response
-          // message for the after_model_call hook. The stream is an async
-          // iterable with a .result() method that resolves to the full
-          // AssistantMessage once the stream is consumed.
-          if (hookRunner?.hasHooks("after_model_call")) {
-            const fireAfterModelCall = (responseMessage?: unknown, error?: string) => {
-              hookRunner
-                .runAfterModelCall(
-                  {
-                    runId: params.runId,
-                    sessionId: params.sessionId,
-                    provider: params.provider,
-                    model: params.modelId,
-                    api: params.model.api,
-                    callId,
-                    durationMs: Date.now() - startMs,
-                    ...(error != null ? { error } : {}),
-                    ...(responseMessage != null ? { responseMessage } : {}),
-                  },
-                  hookCtxForCall,
-                )
-                .catch((hookErr) => {
-                  log.warn(`after_model_call hook failed: ${String(hookErr)}`);
-                });
-            };
+          const fireAfterModelCall = (responseMessage?: unknown, error?: string) => {
+            if (!hookRunner?.hasHooks("after_model_call")) {
+              return;
+            }
+            hookRunner
+              .runAfterModelCall(
+                {
+                  runId: params.runId,
+                  sessionId: params.sessionId,
+                  provider: params.provider,
+                  model: params.modelId,
+                  api: params.model.api,
+                  callId,
+                  durationMs: Date.now() - startMs,
+                  ...(error != null ? { error } : {}),
+                  ...(responseMessage != null ? { responseMessage } : {}),
+                },
+                hookCtxForCall,
+              )
+              .catch((hookErr) => {
+                log.warn(`after_model_call hook failed: ${String(hookErr)}`);
+              });
+          };
 
-            // Wrap the resolved stream to intercept .result() and capture
-            // the full assistant message for the after_model_call hook.
-            const wrapStreamForAfterHook = (stream: unknown) => {
+          try {
+            const result = innerForHooks(model, context, options);
+
+            // Wrap the stream to intercept .result() and capture the response
+            // message for the after_model_call hook. The stream is an async
+            // iterable with a .result() method that resolves to the full
+            // AssistantMessage once the stream is consumed.
+            if (hookRunner?.hasHooks("after_model_call")) {
+              const wrapStreamForAfterHook = (stream: unknown) => {
+                if (
+                  stream &&
+                  typeof stream === "object" &&
+                  "result" in stream &&
+                  typeof (stream as { result: unknown }).result === "function"
+                ) {
+                  const originalResult = (stream as { result: () => Promise<unknown> }).result.bind(
+                    stream,
+                  );
+                  (stream as { result: () => Promise<unknown> }).result = async () => {
+                    try {
+                      const message = await originalResult();
+                      fireAfterModelCall(message);
+                      return message;
+                    } catch (err) {
+                      fireAfterModelCall(undefined, String(err));
+                      throw err;
+                    }
+                  };
+                } else {
+                  // Fallback: no .result() method; fire without response
+                  Promise.resolve(stream).then(
+                    () => fireAfterModelCall(),
+                    (err) => fireAfterModelCall(undefined, String(err)),
+                  );
+                }
+                return stream;
+              };
+
+              // Handle both sync and async (Promise-wrapped) stream returns
               if (
-                stream &&
-                typeof stream === "object" &&
-                "result" in stream &&
-                typeof (stream as { result: unknown }).result === "function"
+                result &&
+                typeof result === "object" &&
+                "then" in result &&
+                typeof (result as { then: unknown }).then === "function"
               ) {
-                const originalResult = (stream as { result: () => Promise<unknown> }).result.bind(
-                  stream,
-                );
-                (stream as { result: () => Promise<unknown> }).result = async () => {
-                  try {
-                    const message = await originalResult();
-                    fireAfterModelCall(message);
-                    return message;
-                  } catch (err) {
+                return (result as Promise<unknown>).then(
+                  (resolved) => wrapStreamForAfterHook(resolved),
+                  (err) => {
                     fireAfterModelCall(undefined, String(err));
                     throw err;
-                  }
-                };
-              } else {
-                // Fallback: no .result() method; fire without response
-                Promise.resolve(stream).then(
-                  () => fireAfterModelCall(),
-                  (err) => fireAfterModelCall(undefined, String(err)),
-                );
+                  },
+                ) as typeof result;
               }
-              return stream;
-            };
-
-            // Handle both sync and async (Promise-wrapped) stream returns
-            if (
-              result &&
-              typeof result === "object" &&
-              "then" in result &&
-              typeof (result as { then: unknown }).then === "function"
-            ) {
-              return (result as Promise<unknown>).then(
-                (resolved) => wrapStreamForAfterHook(resolved),
-                (err) => {
-                  fireAfterModelCall(undefined, String(err));
-                  throw err;
-                },
-              ) as typeof result;
+              wrapStreamForAfterHook(result);
             }
-            wrapStreamForAfterHook(result);
+            return result;
+          } catch (err) {
+            fireAfterModelCall(undefined, String(err));
+            throw err;
           }
-          return result;
         };
       }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1158,10 +1158,23 @@ export async function runEmbeddedAttempt(
             trigger: params.trigger,
             channelId: params.messageChannel ?? params.messageProvider ?? undefined,
           };
+          const runtimeModel = model as { id?: unknown; api?: unknown; provider?: unknown };
+          const runtimeModelId =
+            typeof runtimeModel.id === "string" && runtimeModel.id.length > 0
+              ? runtimeModel.id
+              : params.modelId;
+          const runtimeModelApi =
+            typeof runtimeModel.api === "string" && runtimeModel.api.length > 0
+              ? runtimeModel.api
+              : params.model.api;
+          const runtimeProvider =
+            typeof runtimeModel.provider === "string" && runtimeModel.provider.length > 0
+              ? runtimeModel.provider
+              : params.provider;
           const requestMessages = resolveBeforeModelCallRequestMessages({
             context,
             transcriptPolicy,
-            model: params.model,
+            model: model,
           });
           if (hookRunner?.hasHooks("before_model_call")) {
             hookRunner
@@ -1169,9 +1182,9 @@ export async function runEmbeddedAttempt(
                 buildBeforeModelCallEvent({
                   runId: params.runId,
                   sessionId: params.sessionId,
-                  provider: params.provider,
-                  model: params.modelId,
-                  api: params.model.api,
+                  provider: runtimeProvider,
+                  model: runtimeModelId,
+                  api: runtimeModelApi,
                   callId,
                   systemPrompt: systemPromptText,
                   requestMessages,
@@ -1192,9 +1205,9 @@ export async function runEmbeddedAttempt(
                 {
                   runId: params.runId,
                   sessionId: params.sessionId,
-                  provider: params.provider,
-                  model: params.modelId,
-                  api: params.model.api,
+                  provider: runtimeProvider,
+                  model: runtimeModelId,
+                  api: runtimeModelApi,
                   callId,
                   durationMs: Date.now() - startMs,
                   ...(error != null ? { error } : {}),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -165,6 +165,7 @@ import {
   wrapStreamFnRepairMalformedToolCallArguments,
 } from "./attempt.tool-call-argument-repair.js";
 import {
+  normalizeOutboundReplayToolCalls,
   wrapStreamFnSanitizeMalformedToolCalls,
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.tool-call-normalization.js";
@@ -275,6 +276,7 @@ function resolveBeforeModelCallRequestMessages(params: {
   context: unknown;
   transcriptPolicy: TranscriptPolicy;
   model: Model<Api>;
+  allowedToolNames?: Set<string>;
 }): unknown[] {
   const messages = (params.context as { messages?: unknown[] } | null | undefined)?.messages;
   if (!Array.isArray(messages)) {
@@ -303,6 +305,15 @@ function resolveBeforeModelCallRequestMessages(params: {
       normalized as AgentMessage[],
     ) as unknown[];
   }
+
+  normalized = normalizeOutboundReplayToolCalls({
+    messages: normalized as AgentMessage[],
+    allowedToolNames: params.allowedToolNames,
+    transcriptPolicy: {
+      validateGeminiTurns: params.transcriptPolicy.validateGeminiTurns,
+      validateAnthropicTurns: params.transcriptPolicy.validateAnthropicTurns,
+    },
+  }) as unknown[];
 
   return normalized;
 }
@@ -1183,6 +1194,7 @@ export async function runEmbeddedAttempt(
             context,
             transcriptPolicy,
             model: model,
+            allowedToolNames,
           });
           if (hookRunner?.hasHooks("before_model_call")) {
             hookRunner

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -267,6 +267,10 @@ export function buildBeforeModelCallEvent(params: {
   };
 }
 
+export function buildModelCallId(params: { runId: string; sessionId: string; sequence: number }) {
+  return `${params.runId}-${params.sessionId}-${params.sequence}`;
+}
+
 function resolveBeforeModelCallRequestMessages(params: {
   context: unknown;
   transcriptPolicy: TranscriptPolicy;
@@ -1147,7 +1151,11 @@ export async function runEmbeddedAttempt(
             return innerForHooks(model, context, options);
           }
 
-          const callId = `${params.runId}-${++modelCallCounter}`;
+          const callId = buildModelCallId({
+            runId: params.runId,
+            sessionId: params.sessionId,
+            sequence: ++modelCallCounter,
+          });
           const hookCtxForCall = {
             runId: params.runId,
             agentId: sessionAgentId,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -27,6 +27,8 @@ import type {
   PluginHookInboundClaimResult,
   PluginHookLlmInputEvent,
   PluginHookLlmOutputEvent,
+  PluginHookBeforeModelCallEvent,
+  PluginHookAfterModelCallEvent,
   PluginHookBeforeResetEvent,
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
@@ -75,6 +77,8 @@ export type {
   PluginHookBeforePromptBuildResult,
   PluginHookLlmInputEvent,
   PluginHookLlmOutputEvent,
+  PluginHookBeforeModelCallEvent,
+  PluginHookAfterModelCallEvent,
   PluginHookAgentEndEvent,
   PluginHookBeforeCompactionEvent,
   PluginHookBeforeResetEvent,
@@ -540,6 +544,30 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
    */
   async function runLlmOutput(event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext) {
     return runVoidHook("llm_output", event, ctx);
+  }
+
+  /**
+   * Run before_model_call hook.
+   * Fires before each real provider model invocation (streamFn call).
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runBeforeModelCall(
+    event: PluginHookBeforeModelCallEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<void> {
+    return runVoidHook("before_model_call", event, ctx);
+  }
+
+  /**
+   * Run after_model_call hook.
+   * Fires after each real provider model invocation completes or errors.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runAfterModelCall(
+    event: PluginHookAfterModelCallEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<void> {
+    return runVoidHook("after_model_call", event, ctx);
   }
 
   /**
@@ -1043,6 +1071,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runBeforeAgentStart,
     runLlmInput,
     runLlmOutput,
+    runBeforeModelCall,
+    runAfterModelCall,
     runAgentEnd,
     runBeforeCompaction,
     runAfterCompaction,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1799,6 +1799,8 @@ export type PluginHookName =
   | "before_agent_start"
   | "llm_input"
   | "llm_output"
+  | "before_model_call"
+  | "after_model_call"
   | "agent_end"
   | "before_compaction"
   | "after_compaction"
@@ -1828,6 +1830,8 @@ export const PLUGIN_HOOK_NAMES = [
   "before_agent_start",
   "llm_input",
   "llm_output",
+  "before_model_call",
+  "after_model_call",
   "agent_end",
   "before_compaction",
   "after_compaction",
@@ -1997,6 +2001,52 @@ export type PluginHookLlmOutputEvent = {
     cacheWrite?: number;
     total?: number;
   };
+};
+
+// before_model_call hook — fires before each real provider model invocation
+export type PluginHookBeforeModelCallEvent = {
+  /** Stable run identifier for this agent invocation. */
+  runId: string;
+  /** Ephemeral session UUID. */
+  sessionId: string;
+  /** Provider identifier (e.g. "anthropic", "openai"). */
+  provider: string;
+  /** Model identifier (e.g. "sonnet-4.6"). */
+  model: string;
+  /** Provider API type (e.g. "anthropic-messages", "openai-chat"). */
+  api?: string;
+  /** Unique identifier for this individual model call. */
+  callId: string;
+  /** The resolved system prompt sent alongside the provider request. */
+  systemPrompt?: string;
+  /** The messages array sent to the provider. */
+  requestMessages: unknown[];
+};
+
+// after_model_call hook — fires after each real provider model invocation completes
+export type PluginHookAfterModelCallEvent = {
+  /** Stable run identifier for this agent invocation. */
+  runId: string;
+  /** Ephemeral session UUID. */
+  sessionId: string;
+  /** Provider identifier (e.g. "anthropic", "openai"). */
+  provider: string;
+  /** Model identifier (e.g. "sonnet-4.6"). */
+  model: string;
+  /** Provider API type (e.g. "anthropic-messages", "openai-chat"). */
+  api?: string;
+  /** Unique identifier for this individual model call (matches before_model_call). */
+  callId: string;
+  /** Error message if the model call failed. */
+  error?: string;
+  /** Duration of the model call in milliseconds. */
+  durationMs?: number;
+  /**
+   * The assistant message returned by this model call (available after the
+   * stream is fully consumed). Contains the complete response including text
+   * content, tool_use blocks, stop reason, and usage metadata.
+   */
+  responseMessage?: unknown;
 };
 
 // agent_end hook
@@ -2486,6 +2536,14 @@ export type PluginHookHandlerMap = {
   llm_input: (event: PluginHookLlmInputEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
   llm_output: (
     event: PluginHookLlmOutputEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<void> | void;
+  before_model_call: (
+    event: PluginHookBeforeModelCallEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<void> | void;
+  after_model_call: (
+    event: PluginHookAfterModelCallEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<void> | void;
   agent_end: (event: PluginHookAgentEndEvent, ctx: PluginHookAgentContext) => Promise<void> | void;

--- a/src/plugins/wired-hooks-llm.test.ts
+++ b/src/plugins/wired-hooks-llm.test.ts
@@ -6,8 +6,8 @@ const hookCtx = {
   sessionId: "session-1",
 };
 
-async function expectLlmHookCall(params: {
-  hookName: "llm_input" | "llm_output";
+async function expectHookCall(params: {
+  hookName: "llm_input" | "llm_output" | "before_model_call" | "after_model_call";
   event: Record<string, unknown>;
   expectedEvent: Record<string, unknown>;
 }) {
@@ -22,12 +22,25 @@ async function expectLlmHookCall(params: {
       } as Parameters<typeof runner.runLlmInput>[0],
       hookCtx,
     );
-  } else {
+  } else if (params.hookName === "llm_output") {
     await runner.runLlmOutput(
       {
         ...params.event,
         assistantTexts: [...((params.event.assistantTexts as string[] | undefined) ?? [])],
       } as Parameters<typeof runner.runLlmOutput>[0],
+      hookCtx,
+    );
+  } else if (params.hookName === "before_model_call") {
+    await runner.runBeforeModelCall(
+      {
+        ...params.event,
+        requestMessages: [...((params.event.requestMessages as unknown[] | undefined) ?? [])],
+      } as Parameters<typeof runner.runBeforeModelCall>[0],
+      hookCtx,
+    );
+  } else {
+    await runner.runAfterModelCall(
+      params.event as Parameters<typeof runner.runAfterModelCall>[0],
       hookCtx,
     );
   }
@@ -59,7 +72,6 @@ describe("llm hook runner methods", () => {
     {
       name: "runLlmOutput invokes registered llm_output hooks",
       hookName: "llm_output" as const,
-      methodName: "runLlmOutput" as const,
       event: {
         runId: "run-1",
         sessionId: "session-1",
@@ -75,8 +87,46 @@ describe("llm hook runner methods", () => {
       },
       expectedEvent: { runId: "run-1", assistantTexts: ["hi"] },
     },
+    {
+      name: "runBeforeModelCall invokes registered before_model_call hooks",
+      hookName: "before_model_call" as const,
+      event: {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        api: "openai-chat",
+        callId: "run-1-1",
+        systemPrompt: "be helpful",
+        requestMessages: [{ role: "user", content: "hello" }],
+      },
+      expectedEvent: {
+        runId: "run-1",
+        callId: "run-1-1",
+        requestMessages: [{ role: "user", content: "hello" }],
+      },
+    },
+    {
+      name: "runAfterModelCall invokes registered after_model_call hooks",
+      hookName: "after_model_call" as const,
+      event: {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        api: "openai-chat",
+        callId: "run-1-1",
+        durationMs: 12,
+        responseMessage: { role: "assistant", content: "hi" },
+      },
+      expectedEvent: {
+        runId: "run-1",
+        callId: "run-1-1",
+        responseMessage: { role: "assistant", content: "hi" },
+      },
+    },
   ] as const)("$name", async ({ hookName, expectedEvent, event }) => {
-    await expectLlmHookCall({ hookName, event, expectedEvent });
+    await expectHookCall({ hookName, event, expectedEvent });
   });
 
   it("hasHooks returns true for registered llm hooks", () => {
@@ -84,5 +134,14 @@ describe("llm hook runner methods", () => {
 
     expect(runner.hasHooks("llm_input")).toBe(true);
     expect(runner.hasHooks("llm_output")).toBe(false);
+  });
+
+  it("hasHooks returns true for registered model call hooks", () => {
+    const { runner } = createHookRunnerWithRegistry([
+      { hookName: "before_model_call", handler: vi.fn() },
+    ]);
+
+    expect(runner.hasHooks("before_model_call")).toBe(true);
+    expect(runner.hasHooks("after_model_call")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `llm_input` / `llm_output` do not expose each real provider invocation, so plugins cannot observe per-call model input/output in embedded runs.
- Why it matters: this makes model-call-level observability incomplete and blocks clean tracing/debugging for issue #57653.
- What changed: added additive `before_model_call` / `after_model_call` hooks, wired them around embedded runner `streamFn` provider invocations, and added tests for the new hook surface.
- What did NOT change (scope boundary): this does not change model selection, prompt construction, tool execution behavior, or mutate provider requests/responses.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #57653
- [x] This PR fixes a bug or regression


## Root Cause / Regression History (if applicable)

- Root cause: the current hook surface exposes high-level LLM lifecycle events, but not the seam around each real provider call inside embedded runs.
- Missing detection / guardrail: there was no hook contract or test coverage asserting per-call model hook emission around `streamFn`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #57653 describes the missing observability gap.
- Why this regressed now: this appears to be a missing hook seam rather than a recent behavioral regression.
- If unknown, what was ruled out: ruled out tool hook coverage and high-level `llm_input` / `llm_output` as sufficient substitutes, because they do not map 1:1 to each real provider invocation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/plugins/wired-hooks-llm.test.ts`
  - `src/agents/pi-embedded-runner/run/attempt.model-call-hooks.test.ts`
- Scenario the test should lock in: the new hook runner methods are callable for `before_model_call` / `after_model_call`, and embedded-run payload construction preserves the exact request payload passed to hook consumers.
- Why this is the smallest reliable guardrail: it verifies the new hook contract and payload shape directly without introducing broad unrelated embedded-run setup.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Plugins can now observe each real model call in embedded runs through `before_model_call` and `after_model_call`.

## Diagram (if applicable)

```text
Before:
plugin hooks -> llm_input -> internal model activity -> llm_output

After:
plugin hooks -> llm_input -> before_model_call -> provider call -> after_model_call -> llm_output
```


## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - This adds a new additive hook surface for plugins to observe per-call model request/response payloads.
  - It does not mutate requests, add network behavior, or change command execution paths.
  - Existing hook behavior remains unchanged.


## Repro + Verification

### Environment

- OS: local Linux dev environment
- Runtime/container: Node + pnpm test wrapper
- Model/provider: N/A for targeted tests
- Integration/channel (if any): embedded runner
- Relevant config (redacted): default local test configuration

### Steps

1. Add `before_model_call` / `after_model_call` hook types and runner wiring.
2. Wire the hooks around embedded runner `streamFn` provider invocations.
3. Run targeted tests for the new hook surface and embedded-run payload forwarding.

### Expected

- Plugins can observe each real provider model call in embedded runs.
- Hook payloads include the request side before the call and the response/error side after the call.

### Actual

- The new hooks are emitted by the hook runner and the embedded-run payload contract is covered by targeted tests.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test output snippets:

```text
$ pnpm test -- src/plugins/wired-hooks-llm.test.ts

> openclaw@2026.3.30 test /home/yangpengtao/github_proj/openclaw
> node scripts/test-parallel.mjs -- src/plugins/wired-hooks-llm.test.ts

[test-parallel] start unit workers=2 filters=1
[test-parallel] done unit code=0 elapsed=5.9s
[test-parallel] summary failurePolicy=fail-fast failedUnits=0 failedTestFiles=0 infraFailures=0
[test-parallel] summary artifact /tmp/openclaw-test-parallel-Hp87ke/summary-report.json
```

```text
$ pnpm test -- src/agents/pi-embedded-runner/run/attempt.model-call-hooks.test.ts

> openclaw@2026.3.30 test /home/yangpengtao/github_proj/openclaw
> node scripts/test-parallel.mjs -- src/agents/pi-embedded-runner/run/attempt.model-call-hooks.test.ts

[test-parallel] start base workers=2 filters=1
[test-parallel] done base code=0 elapsed=28.6s
[test-parallel] summary failurePolicy=fail-fast failedUnits=0 failedTestFiles=0 infraFailures=0
[test-parallel] summary artifact /tmp/openclaw-test-parallel-89a23W/summary-report.json
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Ran `pnpm test -- src/plugins/wired-hooks-llm.test.ts`
  - Ran `pnpm test -- src/agents/pi-embedded-runner/run/attempt.model-call-hooks.test.ts`
- Edge cases checked:
  - `before_model_call` / `after_model_call` hook registration through the hook runner
  - request message payload preservation in the embedded-run builder path
  - optional `systemPrompt` omission behavior in the builder path
- What you did **not** verify:
  - full end-to-end plugin consumption with a real external observability plugin
  - multi-call live provider traces outside targeted test coverage

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk:
  - The new hooks expose additional model-call payloads to plugins, so hook consumers may rely on this new contract.
- Mitigation:
  - The change is additive, leaves existing hooks untouched, and includes targeted tests for the new hook names and payload shape.
