### PR TITLE
fix(android): resolve TLS handshake failure on Android 15

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
@@ -16,7 +16,9 @@ import javax.net.ssl.SSLParameters
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.SNIHostName
 import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLEngine
 import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509ExtendedTrustManager
 import javax.net.ssl.X509TrustManager
 
 data class GatewayTlsParams(
@@ -41,9 +43,17 @@ fun buildGatewayTlsConfig(
   val defaultTrust = defaultTrustManager()
   @SuppressLint("CustomX509TrustManager")
   val trustManager =
-    object : X509TrustManager {
+    object : X509ExtendedTrustManager() {
       override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {
         defaultTrust.checkClientTrusted(chain, authType)
+      }
+
+      override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String, socket: java.net.Socket) {
+        checkClientTrusted(chain, authType)
+      }
+
+      override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String, engine: SSLEngine) {
+        checkClientTrusted(chain, authType)
       }
 
       override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
@@ -60,6 +70,14 @@ fun buildGatewayTlsConfig(
           return
         }
         defaultTrust.checkServerTrusted(chain, authType)
+      }
+
+      override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String, socket: java.net.Socket) {
+        checkServerTrusted(chain, authType)
+      }
+
+      override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String, engine: SSLEngine) {
+        checkServerTrusted(chain, authType)
       }
 
       override fun getAcceptedIssuers(): Array<X509Certificate> = defaultTrust.acceptedIssuers
@@ -93,11 +111,15 @@ suspend fun probeGatewayTlsFingerprint(
   return withContext(Dispatchers.IO) {
     val trustAll =
       @SuppressLint("CustomX509TrustManager", "TrustAllX509TrustManager")
-      object : X509TrustManager {
+      object : X509ExtendedTrustManager() {
         @SuppressLint("TrustAllX509TrustManager")
         override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
+        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String, socket: java.net.Socket) {}
+        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String, engine: SSLEngine) {}
         @SuppressLint("TrustAllX509TrustManager")
         override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
+        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String, socket: java.net.Socket) {}
+        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String, engine: SSLEngine) {}
         override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
       }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
@@ -49,11 +49,19 @@ fun buildGatewayTlsConfig(
       }
 
       override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String, socket: java.net.Socket) {
-        checkClientTrusted(chain, authType)
+        if (defaultTrust is X509ExtendedTrustManager) {
+          (defaultTrust as X509ExtendedTrustManager).checkClientTrusted(chain, authType, socket)
+        } else {
+          checkClientTrusted(chain, authType)
+        }
       }
 
       override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String, engine: SSLEngine) {
-        checkClientTrusted(chain, authType)
+        if (defaultTrust is X509ExtendedTrustManager) {
+          (defaultTrust as X509ExtendedTrustManager).checkClientTrusted(chain, authType, engine)
+        } else {
+          checkClientTrusted(chain, authType)
+        }
       }
 
       override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
@@ -73,11 +81,19 @@ fun buildGatewayTlsConfig(
       }
 
       override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String, socket: java.net.Socket) {
-        checkServerTrusted(chain, authType)
+        if (expected == null && !params.allowTOFU && defaultTrust is X509ExtendedTrustManager) {
+          (defaultTrust as X509ExtendedTrustManager).checkServerTrusted(chain, authType, socket)
+        } else {
+          checkServerTrusted(chain, authType)
+        }
       }
 
       override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String, engine: SSLEngine) {
-        checkServerTrusted(chain, authType)
+        if (expected == null && !params.allowTOFU && defaultTrust is X509ExtendedTrustManager) {
+          (defaultTrust as X509ExtendedTrustManager).checkServerTrusted(chain, authType, engine)
+        } else {
+          checkServerTrusted(chain, authType)
+        }
       }
 
       override fun getAcceptedIssuers(): Array<X509Certificate> = defaultTrust.acceptedIssuers

--- a/apps/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/android/app/src/main/res/xml/network_security_config.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config xmlns:tools="http://schemas.android.com/tools">
   <!-- This app is primarily used on a trusted tailnet; allow cleartext for IP-based endpoints too.
-       base-config covers all domains — no domain-config entries needed. Avoid adding domain-config
-       unless required: per-domain configs force Android's RootTrustManager to require hostname-aware
-       checkServerTrusted, which breaks custom X509TrustManagers that lack the overload. -->
+       base-config covers all domains — no domain-config entries needed. On Android 15+, per-domain
+       configs cause Android's RootTrustManager to require the hostname-aware checkServerTrusted
+       overload; custom X509TrustManagers must implement and forward this overload with hostname
+       context to the platform trust manager to avoid interoperability issues. -->
   <base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration" />
 </network-security-config>

--- a/apps/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/android/app/src/main/res/xml/network_security_config.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config xmlns:tools="http://schemas.android.com/tools">
-  <!-- This app is primarily used on a trusted tailnet; allow cleartext for IP-based endpoints too. -->
+  <!-- This app is primarily used on a trusted tailnet; allow cleartext for IP-based endpoints too.
+       base-config covers all domains — no domain-config entries needed. Avoid adding domain-config
+       unless required: per-domain configs force Android's RootTrustManager to require hostname-aware
+       checkServerTrusted, which breaks custom X509TrustManagers that lack the overload. -->
   <base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration" />
-  <!-- Allow HTTP for tailnet/local dev endpoints (e.g. canvas/background web). -->
-  <domain-config cleartextTrafficPermitted="true">
-    <domain includeSubdomains="true">openclaw.local</domain>
-  </domain-config>
-  <domain-config cleartextTrafficPermitted="true">
-    <domain includeSubdomains="true">ts.net</domain>
-  </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Summary

- Fixes a TLS handshake crash on Android 15 devices during gateway onboarding
- Android's `RootTrustManager` requires hostname-aware `checkServerTrusted` when `<domain-config>` entries exist in `network_security_config.xml`, but the custom `X509TrustManager` only implemented the 2-arg overload

## Changes

Two defense-in-depth fixes (either alone resolves it, both prevent regression):

1. **`network_security_config.xml`** — Remove redundant `<domain-config>` entries. The `<base-config cleartextTrafficPermitted="true">` already covers all domains, so the per-domain entries were unnecessary and triggered the stricter codepath.

2. **`GatewayTls.kt`** — Both custom trust managers (`buildGatewayTlsConfig` and `probeGatewayTlsFingerprint`) now extend `X509ExtendedTrustManager` instead of `X509TrustManager`, implementing the `Socket` and `SSLEngine` overloads that Android 15's `RootTrustManager` requires. The socket/engine overloads forward hostname context to the platform trust manager on the default-trust path.

## Error

```
Gateway error: Domain specific configurations require that hostname aware
checkServerTrusted(X509Certificate[], String, String) is used
```

## Test plan

- [x] Tested on Fairphone 6 (Android 15) connecting to a Tailscale-served gateway
- [x] TLS handshake succeeds, TOFU fingerprint prompt appears, pairing completes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)