### PR TITLE
Exec approvals: reject shell init-file script matches

### DIFF
--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -120,6 +120,30 @@ describe("resolveAllowAlwaysPatterns", () => {
     expect(second.allowlistSatisfied).toBe(true);
   }
 
+  function expectShellScriptFallbackRejected(command: string) {
+    const { dir, scriptsDir, script, env, safeBins } = createShellScriptFixture();
+    const rcFile = path.join(scriptsDir, "evilrc");
+    fs.writeFileSync(rcFile, "echo blocked\n");
+
+    const { persisted } = resolvePersistedPatterns({
+      command,
+      dir,
+      env,
+      safeBins,
+    });
+    expect(persisted).toEqual([]);
+
+    const second = evaluateShellAllowlist({
+      command,
+      allowlist: [{ pattern: script }],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(false);
+  }
+
   function expectPositionalArgvCarrierRejected(command: string) {
     const dir = makeTempDir();
     const touch = makeExecutable(dir, "touch");
@@ -281,6 +305,32 @@ describe("resolveAllowAlwaysPatterns", () => {
       env,
       safeBins,
     });
+  });
+
+  it("rejects shell rc and init-file options as persisted or allowlisted script paths", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    for (const command of [
+      "bash --rcfile scripts/evilrc scripts/save_crystal.sh",
+      "bash --init-file scripts/evilrc scripts/save_crystal.sh",
+      "bash --startup-file scripts/evilrc scripts/save_crystal.sh",
+    ]) {
+      expectShellScriptFallbackRejected(command);
+    }
+  });
+
+  it("rejects shell rc and init-file equals options as persisted or allowlisted script paths", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    for (const command of [
+      "bash --rcfile=scripts/evilrc scripts/save_crystal.sh",
+      "bash --init-file=scripts/evilrc scripts/save_crystal.sh",
+      "bash --startup-file=scripts/evilrc scripts/save_crystal.sh",
+    ]) {
+      expectShellScriptFallbackRejected(command);
+    }
   });
 
   it("rejects shell-wrapper positional argv carriers", () => {

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -504,16 +504,19 @@ function isShellWrapperSegment(segment: ExecCommandSegment): boolean {
   return hasSegmentExecutableMatch(segment, isShellWrapperExecutable);
 }
 
-const SHELL_WRAPPER_OPTIONS_WITH_VALUE = new Set([
-  "-c",
-  "--command",
-  "-o",
-  "-O",
-  "+O",
+const SHELL_WRAPPER_OPTIONS_WITH_VALUE = new Set(["-c", "--command", "-o", "-O", "+O"]);
+
+const SHELL_WRAPPER_DISQUALIFYING_SCRIPT_OPTIONS = [
   "--rcfile",
   "--init-file",
   "--startup-file",
-]);
+] as const;
+
+function hasDisqualifyingShellWrapperScriptOption(token: string): boolean {
+  return SHELL_WRAPPER_DISQUALIFYING_SCRIPT_OPTIONS.some(
+    (option) => token === option || token.startsWith(`${option}=`),
+  );
+}
 
 function resolveShellWrapperScriptCandidatePath(params: {
   segment: ExecCommandSegment;
@@ -546,6 +549,9 @@ function resolveShellWrapperScriptCandidatePath(params: {
       return undefined;
     }
     if (token === "-s" || /^-[^-]*s[^-]*$/i.test(token)) {
+      return undefined;
+    }
+    if (hasDisqualifyingShellWrapperScriptOption(token)) {
       return undefined;
     }
     if (SHELL_WRAPPER_OPTIONS_WITH_VALUE.has(token)) {


### PR DESCRIPTION
## Summary

- Problem: shell wrapper script-path matching treated init-file flags like ordinary value-taking options and still resolved the trailing script path.
- Why it matters: commands such as `bash --rcfile ... scripts/save_crystal.sh` could inherit the same approval match as a plain script invocation.
- What changed: `--rcfile`, `--init-file`, and `--startup-file` now disqualify shell-script fallback matching, including `--opt=value` forms.
- What did NOT change (scope boundary): inline-command matching, safe-bin handling, dispatch-wrapper behavior, and Windows-specific flows.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: shell-script fallback resolution grouped init-file flags with benign value-taking options, so matching skipped over them and continued to the trailing script token.
- Missing detection / guardrail: there was no regression coverage for init-file flags in shell-script fallback matching.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this sits in the shell-wrapper script-path matching logic added to support persisted and explicit script allowlist entries.
- Why this regressed now: once script-path fallback matching was added, init-file flags were treated as skip-and-continue argv instead of a stop condition.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/exec-approvals-allow-always.test.ts`
- Scenario the test should lock in: shell wrappers that use init-file options must not persist or satisfy a script-path allowlist match.
- Why this is the smallest reliable guardrail: the bug is confined to argv parsing in the shared shell-script fallback helper.
- Existing test that already covers this (if any): existing shell-wrapper tests cover `-c`, `-s`, positional carriers, and dispatch wrappers, but not init-file flags.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Commands that use shell init-file options no longer qualify for shell-script allowlist fallback matching. Plain shell-script invocations without those options are unchanged.

## Diagram (if applicable)

```text
Before:
bash --rcfile evilrc allowed.sh -> fallback resolved allowed.sh -> script-path match

After:
bash --rcfile evilrc allowed.sh -> fallback stops on --rcfile -> normal approval path
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this narrows shell-script fallback matching so init-file flags no longer inherit the same approval match as a plain script invocation.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 22, pnpm 10.32.1
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): exec approvals configured in allowlist mode with a persisted or explicit script entry

### Steps

1. Persist or configure an allowlist entry for `scripts/save_crystal.sh`.
2. Run `bash --rcfile scripts/evilrc scripts/save_crystal.sh` or an equivalent `--init-file` / `--startup-file` form.
3. Check whether shell-script fallback still resolves the trailing script path.

### Expected

- Init-file flags should stop shell-script fallback matching and require the normal approval path.

### Actual

- The new tests verify those argv forms no longer persist or satisfy a script-path match.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/infra/exec-approvals-allow-always.test.ts`, `pnpm test -- src/infra/exec-approvals.test.ts`, `pnpm build`, pre-commit `pnpm check`, and `claude -p "/review"`.
- Edge cases checked: `--opt value` and `--opt=value` forms for `--rcfile`, `--init-file`, and `--startup-file`.
- What you did **not** verify: live shell behavior on Windows or shell-specific runtime semantics outside the parser-level coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: shell-wrapper invocations that previously matched by trailing script path while also using init-file flags will now fall back to normal approval.
  - Mitigation: the change is intentionally narrow and leaves plain script-path matching unchanged.
