### PR TITLE
fix(tlon): preserve explicit empty settings during migration

### DIFF
--- a/extensions/tlon/src/monitor/index.ts
+++ b/extensions/tlon/src/monitor/index.ts
@@ -27,6 +27,7 @@ import {
   applyTlonSettingsOverrides,
   buildTlonSettingsMigrations,
   mergeUniqueStrings,
+  shouldMigrateTlonSetting,
 } from "./settings-helpers.js";
 import {
   extractMessageText,
@@ -180,13 +181,7 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
     const migrations = buildTlonSettingsMigrations(account, currentSettings);
 
     for (const { key, fileValue, settingsValue } of migrations) {
-      // Only migrate if file has a value and settings store doesn't
-      const hasFileValue = Array.isArray(fileValue) ? fileValue.length > 0 : fileValue != null;
-      const hasSettingsValue = Array.isArray(settingsValue)
-        ? settingsValue.length > 0
-        : settingsValue != null;
-
-      if (hasFileValue && !hasSettingsValue) {
+      if (shouldMigrateTlonSetting(fileValue, settingsValue)) {
         try {
           await api!.poke({
             app: "settings",

--- a/extensions/tlon/src/monitor/settings-helpers.test.ts
+++ b/extensions/tlon/src/monitor/settings-helpers.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { TlonResolvedAccount } from "../types.js";
-import { applyTlonSettingsOverrides } from "./settings-helpers.js";
+import {
+  applyTlonSettingsOverrides,
+  buildTlonSettingsMigrations,
+  shouldMigrateTlonSetting,
+} from "./settings-helpers.js";
 
 const baseAccount: TlonResolvedAccount = {
   accountId: "default",
@@ -21,6 +25,58 @@ const baseAccount: TlonResolvedAccount = {
   defaultAuthorizedShips: ["~nec"],
   ownerShip: "~marzod",
 };
+
+describe("shouldMigrateTlonSetting", () => {
+  it("does not rehydrate explicit empty-array revocations during startup migration", () => {
+    const migrations = buildTlonSettingsMigrations(baseAccount, {
+      dmAllowlist: [],
+      groupInviteAllowlist: [],
+      defaultAuthorizedShips: [],
+    });
+
+    expect(
+      Object.fromEntries(
+        migrations
+          .filter((migration) =>
+            ["dmAllowlist", "groupInviteAllowlist", "defaultAuthorizedShips"].includes(
+              migration.key,
+            ),
+          )
+          .map((migration) => [
+            migration.key,
+            shouldMigrateTlonSetting(migration.fileValue, migration.settingsValue),
+          ]),
+      ),
+    ).toEqual({
+      dmAllowlist: false,
+      groupInviteAllowlist: false,
+      defaultAuthorizedShips: false,
+    });
+  });
+
+  it("still seeds file-config allowlists on first run when settings are missing", () => {
+    const migrations = buildTlonSettingsMigrations(baseAccount, {});
+
+    expect(
+      Object.fromEntries(
+        migrations
+          .filter((migration) =>
+            ["dmAllowlist", "groupInviteAllowlist", "defaultAuthorizedShips"].includes(
+              migration.key,
+            ),
+          )
+          .map((migration) => [
+            migration.key,
+            shouldMigrateTlonSetting(migration.fileValue, migration.settingsValue),
+          ]),
+      ),
+    ).toEqual({
+      dmAllowlist: true,
+      groupInviteAllowlist: true,
+      defaultAuthorizedShips: true,
+    });
+  });
+});
 
 describe("applyTlonSettingsOverrides", () => {
   it("treats explicit empty settings allowlists as authoritative deny-all", () => {

--- a/extensions/tlon/src/monitor/settings-helpers.ts
+++ b/extensions/tlon/src/monitor/settings-helpers.ts
@@ -62,6 +62,12 @@ export function buildTlonSettingsMigrations(
   ];
 }
 
+export function shouldMigrateTlonSetting(fileValue: unknown, settingsValue: unknown): boolean {
+  const hasFileValue = Array.isArray(fileValue) ? fileValue.length > 0 : fileValue != null;
+  const hasSettingsValue = settingsValue != null;
+  return hasFileValue && !hasSettingsValue;
+}
+
 export function applyTlonSettingsOverrides(params: {
   account: TlonResolvedAccount;
   currentSettings: TlonSettingsStore;


### PR DESCRIPTION
## Summary
- Problem: startup migration treated empty settings-store arrays as missing and re-seeded file-config allowlists on restart
- Why it matters: explicit empty-array overrides should remain authoritative instead of being silently replaced by older file-config values
- What changed: extracted the migration predicate into `shouldMigrateTlonSetting()` and used it in the Tlon monitor startup migration so defined settings values, including `[]`, block reseeding
- What did NOT change (scope boundary): steady-state settings override behavior and unrelated Tlon monitor flows

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the startup migration used array length to decide whether a settings value existed, so `[]` was treated as missing
- Missing detection / guardrail: there was no regression coverage for restart-time migration when the settings store contained explicit empty arrays
- Prior context (`git blame`, prior PR, issue, or refactor if known): the startup migration path was added in `f4682742d9d16a58058492d5cb6d2d6e372b9cef`
- Why this regressed now: the migration guard used different semantics than the steady-state settings override paths
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/tlon/src/monitor/settings-helpers.test.ts`
- Scenario the test should lock in: explicit empty-array settings entries do not trigger startup reseeding, while missing entries still seed first-run values
- Why this is the smallest reliable guardrail: the bug is isolated to the migration predicate and does not require a live Urbit runtime to prove the branch condition
- Existing test that already covers this (if any): existing override tests already cover steady-state empty-array behavior
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Tlon startup now preserves explicit empty-array settings entries instead of reseeding the corresponding file-config values on restart.

## Diagram (if applicable)

```text
Before:
[settings store = []] -> [startup migration sees "missing"] -> [file-config allowlist rewritten]

After:
[settings store = []] -> [startup migration sees explicit value] -> [stored override preserved]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux x86_64
- Runtime/container: Node.js v22.22.1
- Model/provider: N/A
- Integration/channel (if any): Tlon monitor
- Relevant config (redacted): Tlon account with file-config allowlists and settings-store overrides

### Steps

1. Set a non-empty file-config allowlist for a Tlon account.
2. Set the corresponding settings-store entry to `[]`.
3. Restart the monitor and observe whether startup migration rewrites the stored value.

### Expected

- Explicit empty-array settings values remain authoritative and are not overwritten during startup migration.

### Actual

- This branch preserves the stored empty arrays and still migrates only when the settings entry is actually missing.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `pnpm test -- extensions/tlon/src/monitor/settings-helpers.test.ts`; ran `pnpm check`; ran `claude -p "/review"` and addressed the test-organization suggestion
- Edge cases checked: explicit `[]` settings entries block reseeding; missing settings entries still allow first-run migration
- What you did **not** verify: no live Urbit restart or end-to-end Tlon session was exercised locally

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: empty-array settings entries for migrated Tlon fields are now treated as explicit stored values instead of absent values
- Mitigation: regression tests cover both explicit empty-array preservation and first-run migration when settings are missing
