### PR TITLE
fix(auth): persist plugin-refreshed OAuth credentials to disk

### DIFF
--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -185,6 +185,15 @@ async function refreshOAuthTokenWithLock(params: {
       context: cred,
     });
     if (pluginRefreshed) {
+      // Save refreshed credentials — single-use refresh tokens (e.g. OpenAI Codex)
+      // are invalidated on use, so the new token pair must be persisted immediately.
+      store.profiles[params.profileId] = {
+        ...cred,
+        ...pluginRefreshed,
+        type: "oauth",
+      };
+      saveAuthProfileStore(store, params.agentDir);
+
       return {
         apiKey: await buildOAuthApiKey(cred.provider, pluginRefreshed),
         newCredentials: pluginRefreshed,


### PR DESCRIPTION
## Summary

- The plugin refresh path in `refreshOAuthTokenWithLock` returned new credentials without saving them to `auth-profiles.json`
- For providers with single-use refresh tokens (e.g. OpenAI Codex), the old token is invalidated on use, so failing to persist the new pair causes every subsequent refresh attempt to fail with `refresh_token_reused`
- Added `saveAuthProfileStore` call before the return, matching the existing pi-ai refresh path behavior

## Root cause

Introduced in e627a5069f (`refactor(plugins): move auth profile hooks into providers`), the `pluginRefreshed` branch was added without the corresponding save:

```typescript
if (pluginRefreshed) {
  return {
    apiKey: await buildOAuthApiKey(cred.provider, pluginRefreshed),
    newCredentials: pluginRefreshed,
    // ← missing saveAuthProfileStore!
  };
}
```

## Test plan

- [x] Existing `oauth.openai-codex-refresh-fallback.test.ts` passes (3/3)
- [x] `pnpm check` passes
- [ ] Verify on a live OpenAI Codex OAuth setup: after access token expires, refresh should persist new token pair and subsequent requests should work without re-login


🤖 Generated with [Claude Code](https://claude.com/claude-code)