### PR TITLE
node-host: bind pnpm dlx approval scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/exec approvals: rewrite shared `/approve … allow-always` callback payloads to `/approve … always` before Telegram button rendering so plugin approval IDs still fit Telegram's `callback_data` limit and keep the Allow Always action visible. (#59217) Thanks @jameslcowan.
 - Cron/exec timeouts: surface timed-out `exec` and `bash` failures in isolated cron runs even when `verbose: off`, including custom session-target cron jobs, so scheduled runs stop failing silently. (#58247) Thanks @skainguyen1412.
 - Telegram/exec approvals: fall back to the origin session key for async approval followups and keep resume-failure status delivery sanitized so Telegram followups still land without leaking raw exec metadata. (#59351) Thanks @seonang.
+- Node-host/exec approvals: bind `pnpm dlx` invocations through the approval planner's mutable-script path so the effective runtime command is resolved for approval instead of being left unbound. (#58374)
 
 ## 2026.4.2
 

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -6,6 +6,7 @@ import { formatExecCommand } from "../infra/system-run-command.js";
 import {
   buildSystemRunApprovalPlan,
   hardenApprovedExecutionPaths,
+  revalidateApprovedMutableFileOperand,
   resolveMutableFileOperandSnapshotSync,
 } from "./invoke-system-run-plan.js";
 
@@ -488,6 +489,20 @@ describe("hardenApprovedExecutionPaths", () => {
       expectedArgvIndex: 3,
     },
     {
+      name: "pnpm dlx tsx file",
+      argv: ["pnpm", "dlx", "tsx", "./run.ts"],
+      scriptName: "run.ts",
+      initialBody: 'console.log("SAFE");\n',
+      expectedArgvIndex: 3,
+    },
+    {
+      name: "pnpm reporter dlx package tsx file",
+      argv: ["pnpm", "--reporter", "silent", "dlx", "--package", "tsx", "tsx", "./run.ts"],
+      scriptName: "run.ts",
+      initialBody: 'console.log("SAFE");\n',
+      expectedArgvIndex: 7,
+    },
+    {
       name: "pnpm reporter exec tsx file",
       argv: ["pnpm", "--reporter", "silent", "exec", "tsx", "./run.ts"],
       scriptName: "run.ts",
@@ -608,6 +623,66 @@ describe("hardenApprovedExecutionPaths", () => {
         try {
           testCase.setup?.(tmp);
           expectRuntimeApprovalDenied(testCase.command, tmp);
+        } finally {
+          fs.rmSync(tmp, { recursive: true, force: true });
+        }
+      },
+    });
+  });
+
+  it("detects rewritten script operands for pnpm dlx approval plans", () => {
+    withFakeRuntimeBins({
+      binNames: ["pnpm", "tsx"],
+      run: () => {
+        withScriptOperandPlanFixture(
+          {
+            tmpPrefix: "openclaw-pnpm-dlx-approval-",
+            fixture: {
+              name: "pnpm dlx rewritten script",
+              argv: ["pnpm", "dlx", "tsx", "./run.ts"],
+              scriptName: "run.ts",
+              initialBody: 'console.log("SAFE");\n',
+              expectedArgvIndex: 3,
+            },
+          },
+          (fixture, tmp) => {
+            const prepared = buildSystemRunApprovalPlan({
+              command: fixture.command,
+              cwd: tmp,
+            });
+            expect(prepared.ok).toBe(true);
+            if (!prepared.ok) {
+              throw new Error("unreachable");
+            }
+            expect(prepared.plan.mutableFileOperand).toBeDefined();
+            fs.writeFileSync(fixture.scriptPath, 'console.log("PWNED");\n');
+            expect(
+              revalidateApprovedMutableFileOperand({
+                snapshot: prepared.plan.mutableFileOperand!,
+                argv: prepared.plan.argv,
+                cwd: prepared.plan.cwd ?? tmp,
+              }),
+            ).toBe(false);
+          },
+        );
+      },
+    });
+  });
+
+  it("does not bind pnpm dlx shell-mode commands to a mutable file operand", () => {
+    withFakeRuntimeBins({
+      binNames: ["pnpm", "tsx"],
+      run: () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pnpm-dlx-shell-mode-"));
+        try {
+          fs.writeFileSync(path.join(tmp, "run.ts"), 'console.log("SAFE");\n');
+          expect(
+            resolveMutableFileOperandSnapshotSync({
+              argv: ["pnpm", "dlx", "--shell-mode", "tsx ./run.ts"],
+              cwd: tmp,
+              shellCommand: null,
+            }),
+          ).toEqual({ ok: true, snapshot: null });
         } finally {
           fs.rmSync(tmp, { recursive: true, force: true });
         }

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -768,6 +768,22 @@ describe("hardenApprovedExecutionPaths", () => {
     });
   });
 
+  it("allows pnpm dlx package binaries with data-like runtime names", () => {
+    withFakeRuntimeBin({
+      binName: "pnpm",
+      run: () => {
+        const tmp = fs.mkdtempSync(
+          path.join(os.tmpdir(), "openclaw-pnpm-dlx-package-runtime-token-"),
+        );
+        try {
+          expectApprovalPlanWithoutMutableOperand(["pnpm", "dlx", "cowsay", "node"], tmp);
+        } finally {
+          fs.rmSync(tmp, { recursive: true, force: true });
+        }
+      },
+    });
+  });
+
   it("allows pnpm dlx package binaries with local file arguments", () => {
     withFakeRuntimeBins({
       binNames: ["pnpm", "eslint"],

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -534,6 +534,20 @@ describe("hardenApprovedExecutionPaths", () => {
       expectedArgvIndex: 3,
     },
     {
+      name: "pnpm workspace-root exec tsx file",
+      argv: ["pnpm", "-w", "exec", "tsx", "./run.ts"],
+      scriptName: "run.ts",
+      initialBody: 'console.log("SAFE");\n',
+      expectedArgvIndex: 4,
+    },
+    {
+      name: "pnpm workspace-root dlx tsx file",
+      argv: ["pnpm", "-w", "dlx", "tsx", "./run.ts"],
+      scriptName: "run.ts",
+      initialBody: 'console.log("SAFE");\n',
+      expectedArgvIndex: 4,
+    },
+    {
       name: "pnpm dlx tsx file",
       argv: ["pnpm", "dlx", "tsx", "./run.ts"],
       scriptName: "run.ts",

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -496,6 +496,13 @@ describe("hardenApprovedExecutionPaths", () => {
       expectedArgvIndex: 3,
     },
     {
+      name: "pnpm pre-dlx package-equals tsx file",
+      argv: ["pnpm", "--package=tsx", "dlx", "tsx", "./run.ts"],
+      scriptName: "run.ts",
+      initialBody: 'console.log("SAFE");\n',
+      expectedArgvIndex: 4,
+    },
+    {
       name: "pnpm reporter dlx package tsx file",
       argv: ["pnpm", "--reporter", "silent", "dlx", "--package", "tsx", "tsx", "./run.ts"],
       scriptName: "run.ts",
@@ -508,6 +515,13 @@ describe("hardenApprovedExecutionPaths", () => {
       scriptName: "run.ts",
       initialBody: 'console.log("SAFE");\n',
       expectedArgvIndex: 7,
+    },
+    {
+      name: "pnpm silent dlx tsx file",
+      argv: ["pnpm", "dlx", "-s", "tsx", "./run.ts"],
+      scriptName: "run.ts",
+      initialBody: 'console.log("SAFE");\n',
+      expectedArgvIndex: 4,
     },
     {
       name: "pnpm reporter exec tsx file",

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -534,6 +534,13 @@ describe("hardenApprovedExecutionPaths", () => {
       expectedArgvIndex: 3,
     },
     {
+      name: "pnpm parallel exec tsx file",
+      argv: ["pnpm", "--parallel", "exec", "tsx", "./run.ts"],
+      scriptName: "run.ts",
+      initialBody: 'console.log("SAFE");\n',
+      expectedArgvIndex: 4,
+    },
+    {
       name: "pnpm workspace-root exec tsx file",
       argv: ["pnpm", "-w", "exec", "tsx", "./run.ts"],
       scriptName: "run.ts",

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -503,6 +503,13 @@ describe("hardenApprovedExecutionPaths", () => {
       expectedArgvIndex: 7,
     },
     {
+      name: "pnpm reporter dlx short-package tsx file",
+      argv: ["pnpm", "--reporter", "silent", "dlx", "-p", "tsx", "tsx", "./run.ts"],
+      scriptName: "run.ts",
+      initialBody: 'console.log("SAFE");\n',
+      expectedArgvIndex: 7,
+    },
+    {
       name: "pnpm reporter exec tsx file",
       argv: ["pnpm", "--reporter", "silent", "exec", "tsx", "./run.ts"],
       scriptName: "run.ts",

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -285,6 +285,15 @@ const unsafeRuntimeInvocationCases: UnsafeRuntimeInvocationCase[] = [
     },
   },
   {
+    name: "rejects pnpm dlx invocations with unrecognized global flags that take a value before dlx",
+    binName: "pnpm",
+    tmpPrefix: "openclaw-pnpm-dlx-unknown-prefix-value-",
+    command: ["pnpm", "--future-flag", "value", "dlx", "tsx", "./run.ts"],
+    setup: (tmp) => {
+      fs.writeFileSync(path.join(tmp, "run.ts"), 'console.log("SAFE")\n');
+    },
+  },
+  {
     name: "rejects pnpm dlx invocations with unrecognized flags after a global option terminator",
     binName: "pnpm",
     tmpPrefix: "openclaw-pnpm-dlx-global-double-dash-",
@@ -777,6 +786,22 @@ describe("hardenApprovedExecutionPaths", () => {
         );
         try {
           expectApprovalPlanWithoutMutableOperand(["pnpm", "dlx", "cowsay", "node"], tmp);
+        } finally {
+          fs.rmSync(tmp, { recursive: true, force: true });
+        }
+      },
+    });
+  });
+
+  it("allows pnpm dlx package binaries with multi-token data-like runtime names", () => {
+    withFakeRuntimeBin({
+      binName: "pnpm",
+      run: () => {
+        const tmp = fs.mkdtempSync(
+          path.join(os.tmpdir(), "openclaw-pnpm-dlx-package-runtime-token-multi-"),
+        );
+        try {
+          expectApprovalPlanWithoutMutableOperand(["pnpm", "dlx", "cowsay", "node", "hello"], tmp);
         } finally {
           fs.rmSync(tmp, { recursive: true, force: true });
         }

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -839,6 +839,24 @@ describe("hardenApprovedExecutionPaths", () => {
     });
   });
 
+  it("allows pnpm dlx package binaries with interpreter-like data tails", () => {
+    withFakeRuntimeBin({
+      binName: "pnpm",
+      run: () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pnpm-dlx-package-data-tail-"));
+        try {
+          fs.writeFileSync(path.join(tmp, "run.ts"), 'console.log("SAFE");\n');
+          expectApprovalPlanWithoutMutableOperand(
+            ["pnpm", "dlx", "cowsay", "tsx", "./run.ts"],
+            tmp,
+          );
+        } finally {
+          fs.rmSync(tmp, { recursive: true, force: true });
+        }
+      },
+    });
+  });
+
   it("treats -- as the end of pnpm dlx option parsing", () => {
     withFakeRuntimeBins({
       binNames: ["pnpm", "tsx"],

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -284,6 +284,15 @@ const unsafeRuntimeInvocationCases: UnsafeRuntimeInvocationCase[] = [
       fs.writeFileSync(path.join(tmp, "run.ts"), 'console.log("SAFE")\n');
     },
   },
+  {
+    name: "rejects pnpm dlx invocations with unrecognized flags after a global option terminator",
+    binName: "pnpm",
+    tmpPrefix: "openclaw-pnpm-dlx-global-double-dash-",
+    command: ["pnpm", "--", "dlx", "--future-flag", "tsx", "./run.ts"],
+    setup: (tmp) => {
+      fs.writeFileSync(path.join(tmp, "run.ts"), 'console.log("SAFE")\n');
+    },
+  },
 ];
 
 describe("hardenApprovedExecutionPaths", () => {
@@ -521,6 +530,13 @@ describe("hardenApprovedExecutionPaths", () => {
       scriptName: "run.ts",
       initialBody: 'console.log("SAFE");\n',
       expectedArgvIndex: 3,
+    },
+    {
+      name: "pnpm global double-dash dlx tsx file",
+      argv: ["pnpm", "--", "dlx", "tsx", "./run.ts"],
+      scriptName: "run.ts",
+      initialBody: 'console.log("SAFE");\n',
+      expectedArgvIndex: 4,
     },
     {
       name: "pnpm pre-dlx package-equals tsx file",

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -768,6 +768,22 @@ describe("hardenApprovedExecutionPaths", () => {
     });
   });
 
+  it("allows pnpm dlx package binaries with local file arguments", () => {
+    withFakeRuntimeBins({
+      binNames: ["pnpm", "eslint"],
+      run: () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pnpm-dlx-package-file-"));
+        try {
+          fs.mkdirSync(path.join(tmp, "src"), { recursive: true });
+          fs.writeFileSync(path.join(tmp, "src", "index.ts"), 'console.log("SAFE");\n');
+          expectApprovalPlanWithoutMutableOperand(["pnpm", "dlx", "eslint", "src/index.ts"], tmp);
+        } finally {
+          fs.rmSync(tmp, { recursive: true, force: true });
+        }
+      },
+    });
+  });
+
   it("treats -- as the end of pnpm dlx option parsing", () => {
     withFakeRuntimeBins({
       binNames: ["pnpm", "tsx"],

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -257,6 +257,15 @@ const unsafeRuntimeInvocationCases: UnsafeRuntimeInvocationCase[] = [
       fs.writeFileSync(path.join(tmp, "run.js"), 'console.log("SAFE")\n');
     },
   },
+  {
+    name: "rejects pnpm dlx invocations with unrecognized flags that cannot be safely bound",
+    binName: "pnpm",
+    tmpPrefix: "openclaw-pnpm-dlx-unknown-flag-",
+    command: ["pnpm", "dlx", "--future-flag", "tsx", "./run.ts"],
+    setup: (tmp) => {
+      fs.writeFileSync(path.join(tmp, "run.ts"), 'console.log("SAFE")\n');
+    },
+  },
 ];
 
 describe("hardenApprovedExecutionPaths", () => {

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -174,6 +174,15 @@ function expectRuntimeApprovalDenied(command: string[], cwd: string) {
   expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
 }
 
+function expectApprovalPlanWithoutMutableOperand(command: string[], cwd: string) {
+  const prepared = buildSystemRunApprovalPlan({ command, cwd });
+  expect(prepared.ok).toBe(true);
+  if (!prepared.ok) {
+    throw new Error("unreachable");
+  }
+  expect(prepared.plan.mutableFileOperand).toBeUndefined();
+}
+
 const unsafeRuntimeInvocationCases: UnsafeRuntimeInvocationCase[] = [
   {
     name: "rejects bun package script names that do not bind a concrete file",
@@ -262,6 +271,15 @@ const unsafeRuntimeInvocationCases: UnsafeRuntimeInvocationCase[] = [
     binName: "pnpm",
     tmpPrefix: "openclaw-pnpm-dlx-unknown-flag-",
     command: ["pnpm", "dlx", "--future-flag", "tsx", "./run.ts"],
+    setup: (tmp) => {
+      fs.writeFileSync(path.join(tmp, "run.ts"), 'console.log("SAFE")\n');
+    },
+  },
+  {
+    name: "rejects pnpm dlx invocations with unrecognized global flags before dlx when they hide a mutable script",
+    binName: "pnpm",
+    tmpPrefix: "openclaw-pnpm-dlx-unknown-prefix-",
+    command: ["pnpm", "--future-flag", "dlx", "tsx", "./run.ts"],
     setup: (tmp) => {
       fs.writeFileSync(path.join(tmp, "run.ts"), 'console.log("SAFE")\n');
     },
@@ -716,6 +734,43 @@ describe("hardenApprovedExecutionPaths", () => {
         } finally {
           fs.rmSync(tmp, { recursive: true, force: true });
         }
+      },
+    });
+  });
+
+  it("allows pnpm dlx package binaries that do not bind a mutable local file", () => {
+    withFakeRuntimeBin({
+      binName: "pnpm",
+      run: () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pnpm-dlx-package-bin-"));
+        try {
+          expectApprovalPlanWithoutMutableOperand(["pnpm", "dlx", "cowsay", "hello"], tmp);
+        } finally {
+          fs.rmSync(tmp, { recursive: true, force: true });
+        }
+      },
+    });
+  });
+
+  it("treats -- as the end of pnpm dlx option parsing", () => {
+    withFakeRuntimeBins({
+      binNames: ["pnpm", "tsx"],
+      run: () => {
+        withScriptOperandPlanFixture(
+          {
+            tmpPrefix: "openclaw-pnpm-dlx-double-dash-",
+            fixture: {
+              name: "pnpm dlx double dash",
+              argv: ["pnpm", "dlx", "--", "tsx", "./run.ts"],
+              scriptName: "run.ts",
+              initialBody: 'console.log("SAFE");\n',
+              expectedArgvIndex: 4,
+            },
+          },
+          (fixture, tmp) => {
+            expectMutableFileOperandApprovalPlan(fixture, tmp);
+          },
+        );
       },
     });
   });

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -185,6 +185,8 @@ const PNPM_FLAG_OPTIONS = new Set([
   "-r",
 ]);
 
+const PNPM_DLX_OPTIONS_WITH_VALUE = new Set(["--allow-build", "--package"]);
+
 type FileOperandCollection = {
   hits: number[];
   sawOptionValueFile: boolean;
@@ -345,6 +347,9 @@ function unwrapPnpmExecInvocation(argv: string[]): string[] | null {
         const tail = argv.slice(idx + 1);
         return tail[0] === "--" ? (tail.length > 1 ? tail.slice(1) : null) : tail;
       }
+      if (token === "dlx") {
+        return unwrapPnpmDlxInvocation(argv.slice(idx + 1));
+      }
       if (token === "node") {
         const tail = argv.slice(idx + 1);
         const normalizedTail = tail[0] === "--" ? tail.slice(1) : tail;
@@ -354,6 +359,40 @@ function unwrapPnpmExecInvocation(argv: string[]): string[] | null {
     }
     const [flag] = token.toLowerCase().split("=", 2);
     if (PNPM_OPTIONS_WITH_VALUE.has(flag)) {
+      idx += token.includes("=") ? 1 : 2;
+      continue;
+    }
+    if (PNPM_FLAG_OPTIONS.has(flag)) {
+      idx += 1;
+      continue;
+    }
+    return null;
+  }
+  return null;
+}
+
+function unwrapPnpmDlxInvocation(argv: string[]): string[] | null {
+  let idx = 0;
+  while (idx < argv.length) {
+    const token = argv[idx]?.trim() ?? "";
+    if (!token) {
+      idx += 1;
+      continue;
+    }
+    if (token === "--") {
+      idx += 1;
+      continue;
+    }
+    if (!token.startsWith("-")) {
+      // Once dlx-specific flags are stripped, the first positional token is the
+      // package binary pnpm will execute inside the temporary environment.
+      return argv.slice(idx);
+    }
+    const [flag] = token.toLowerCase().split("=", 2);
+    if (flag === "-c" || flag === "--shell-mode") {
+      return null;
+    }
+    if (PNPM_OPTIONS_WITH_VALUE.has(flag) || PNPM_DLX_OPTIONS_WITH_VALUE.has(flag)) {
       idx += token.includes("=") ? 1 : 2;
       continue;
     }

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -183,6 +183,7 @@ const PNPM_FLAG_OPTIONS = new Set([
   "--silent",
   "--workspace-root",
   "-r",
+  "-s",
 ]);
 
 const PNPM_DLX_OPTIONS_WITH_VALUE = new Set(["--allow-build", "--package", "-p"]);
@@ -358,7 +359,7 @@ function unwrapPnpmExecInvocation(argv: string[]): string[] | null {
       return null;
     }
     const [flag] = token.toLowerCase().split("=", 2);
-    if (PNPM_OPTIONS_WITH_VALUE.has(flag)) {
+    if (PNPM_OPTIONS_WITH_VALUE.has(flag) || PNPM_DLX_OPTIONS_WITH_VALUE.has(flag)) {
       idx += token.includes("=") ? 1 : 2;
       continue;
     }

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -865,7 +865,7 @@ function pnpmDlxInvocationNeedsFailClosedBinding(argv: string[], cwd: string | u
       idx += 1;
       continue;
     }
-    return pnpmDlxTailMayNeedStableBinding(argv.slice(idx + 1), cwd);
+    return true;
   }
 
   return false;
@@ -915,13 +915,7 @@ function pnpmDlxTailMayNeedStableBinding(argv: string[], cwd: string | undefined
       cwd,
       shellCommand: null,
     });
-    if (!snapshot.ok) {
-      if (candidateArgv.length > 1) {
-        return true;
-      }
-      continue;
-    }
-    if (snapshot.snapshot) {
+    if (snapshot.ok && snapshot.snapshot) {
       return true;
     }
   }

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -184,6 +184,7 @@ const PNPM_FLAG_OPTIONS = new Set([
   "--workspace-root",
   "-r",
   "-s",
+  "-w",
 ]);
 
 const PNPM_DLX_OPTIONS_WITH_VALUE = new Set(["--allow-build", "--package", "-p"]);

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -898,29 +898,19 @@ function pnpmDlxTailNeedsFailClosedBinding(argv: string[], cwd: string | undefin
       idx += 1;
       continue;
     }
-    return pnpmDlxTailMayNeedStableBinding(argv.slice(idx + 1), cwd);
+    return true;
   }
 
   return true;
 }
 
 function pnpmDlxTailMayNeedStableBinding(argv: string[], cwd: string | undefined): boolean {
-  for (let idx = 0; idx < argv.length; idx += 1) {
-    const token = argv[idx]?.trim() ?? "";
-    if (!token || token === "--") {
-      continue;
-    }
-    const candidateArgv = argv.slice(idx);
-    const snapshot = resolveMutableFileOperandSnapshotSync({
-      argv: candidateArgv,
-      cwd,
-      shellCommand: null,
-    });
-    if (snapshot.ok && snapshot.snapshot) {
-      return true;
-    }
-  }
-  return false;
+  const snapshot = resolveMutableFileOperandSnapshotSync({
+    argv,
+    cwd,
+    shellCommand: null,
+  });
+  return snapshot.ok && snapshot.snapshot !== null;
 }
 
 export function resolveMutableFileOperandSnapshotSync(params: {

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -179,6 +179,7 @@ const PNPM_OPTIONS_WITH_VALUE = new Set([
 const PNPM_FLAG_OPTIONS = new Set([
   "--aggregate-output",
   "--color",
+  "--parallel",
   "--recursive",
   "--silent",
   "--workspace-root",

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -847,7 +847,8 @@ function pnpmDlxInvocationNeedsFailClosedBinding(argv: string[], cwd: string | u
       continue;
     }
     if (token === "--") {
-      return false;
+      idx += 1;
+      continue;
     }
     if (!token.startsWith("-")) {
       if (token !== "dlx") {

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -915,7 +915,13 @@ function pnpmDlxTailMayNeedStableBinding(argv: string[], cwd: string | undefined
       cwd,
       shellCommand: null,
     });
-    if (!snapshot.ok || snapshot.snapshot) {
+    if (!snapshot.ok) {
+      if (candidateArgv.length > 1) {
+        return true;
+      }
+      continue;
+    }
+    if (snapshot.snapshot) {
       return true;
     }
   }

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -918,9 +918,6 @@ function pnpmDlxTailMayNeedStableBinding(argv: string[], cwd: string | undefined
     if (!snapshot.ok || snapshot.snapshot) {
       return true;
     }
-    if (resolvesToExistingFileSync(candidateArgv[0] ?? "", cwd)) {
-      return true;
-    }
   }
   return false;
 }

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -820,6 +820,9 @@ function requiresStableInterpreterApprovalBindingWithShellCommand(params: {
   if (params.shellCommand !== null) {
     return shellPayloadNeedsStableBinding(params.shellCommand, params.cwd);
   }
+  if (pnpmDlxInvocationNeedsFailClosedBinding(params.argv)) {
+    return true;
+  }
   const unwrapped = unwrapArgvForMutableOperand(params.argv);
   const executable = normalizeExecutableToken(unwrapped.argv[0] ?? "");
   if (!executable) {
@@ -829,6 +832,77 @@ function requiresStableInterpreterApprovalBindingWithShellCommand(params: {
     return false;
   }
   return isMutableScriptRunner(executable);
+}
+
+function pnpmDlxInvocationNeedsFailClosedBinding(argv: string[]): boolean {
+  if (normalizePackageManagerExecToken(argv[0] ?? "") !== "pnpm") {
+    return false;
+  }
+
+  let idx = 1;
+  while (idx < argv.length) {
+    const token = argv[idx]?.trim() ?? "";
+    if (!token) {
+      idx += 1;
+      continue;
+    }
+    if (token === "--") {
+      idx += 1;
+      continue;
+    }
+    if (!token.startsWith("-")) {
+      if (token !== "dlx") {
+        return false;
+      }
+      return pnpmDlxTailNeedsFailClosedBinding(argv.slice(idx + 1));
+    }
+    const [flag] = token.toLowerCase().split("=", 2);
+    if (PNPM_OPTIONS_WITH_VALUE.has(flag) || PNPM_DLX_OPTIONS_WITH_VALUE.has(flag)) {
+      idx += token.includes("=") ? 1 : 2;
+      continue;
+    }
+    if (PNPM_FLAG_OPTIONS.has(flag)) {
+      idx += 1;
+      continue;
+    }
+    return false;
+  }
+
+  return false;
+}
+
+function pnpmDlxTailNeedsFailClosedBinding(argv: string[]): boolean {
+  let idx = 0;
+  while (idx < argv.length) {
+    const token = argv[idx]?.trim() ?? "";
+    if (!token) {
+      idx += 1;
+      continue;
+    }
+    if (token === "--") {
+      idx += 1;
+      continue;
+    }
+    if (!token.startsWith("-")) {
+      // A concrete dlx command should either bind cleanly or fail closed.
+      return true;
+    }
+    const [flag] = token.toLowerCase().split("=", 2);
+    if (flag === "-c" || flag === "--shell-mode") {
+      return false;
+    }
+    if (PNPM_OPTIONS_WITH_VALUE.has(flag) || PNPM_DLX_OPTIONS_WITH_VALUE.has(flag)) {
+      idx += token.includes("=") ? 1 : 2;
+      continue;
+    }
+    if (PNPM_FLAG_OPTIONS.has(flag)) {
+      idx += 1;
+      continue;
+    }
+    return true;
+  }
+
+  return true;
 }
 
 export function resolveMutableFileOperandSnapshotSync(params: {

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -185,7 +185,7 @@ const PNPM_FLAG_OPTIONS = new Set([
   "-r",
 ]);
 
-const PNPM_DLX_OPTIONS_WITH_VALUE = new Set(["--allow-build", "--package"]);
+const PNPM_DLX_OPTIONS_WITH_VALUE = new Set(["--allow-build", "--package", "-p"]);
 
 type FileOperandCollection = {
   hits: number[];

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -381,8 +381,8 @@ function unwrapPnpmDlxInvocation(argv: string[]): string[] | null {
       continue;
     }
     if (token === "--") {
-      idx += 1;
-      continue;
+      const tail = argv.slice(idx + 1);
+      return tail.length > 0 ? tail : null;
     }
     if (!token.startsWith("-")) {
       // Once dlx-specific flags are stripped, the first positional token is the
@@ -820,7 +820,7 @@ function requiresStableInterpreterApprovalBindingWithShellCommand(params: {
   if (params.shellCommand !== null) {
     return shellPayloadNeedsStableBinding(params.shellCommand, params.cwd);
   }
-  if (pnpmDlxInvocationNeedsFailClosedBinding(params.argv)) {
+  if (pnpmDlxInvocationNeedsFailClosedBinding(params.argv, params.cwd)) {
     return true;
   }
   const unwrapped = unwrapArgvForMutableOperand(params.argv);
@@ -834,7 +834,7 @@ function requiresStableInterpreterApprovalBindingWithShellCommand(params: {
   return isMutableScriptRunner(executable);
 }
 
-function pnpmDlxInvocationNeedsFailClosedBinding(argv: string[]): boolean {
+function pnpmDlxInvocationNeedsFailClosedBinding(argv: string[], cwd: string | undefined): boolean {
   if (normalizePackageManagerExecToken(argv[0] ?? "") !== "pnpm") {
     return false;
   }
@@ -847,14 +847,13 @@ function pnpmDlxInvocationNeedsFailClosedBinding(argv: string[]): boolean {
       continue;
     }
     if (token === "--") {
-      idx += 1;
-      continue;
+      return false;
     }
     if (!token.startsWith("-")) {
       if (token !== "dlx") {
         return false;
       }
-      return pnpmDlxTailNeedsFailClosedBinding(argv.slice(idx + 1));
+      return pnpmDlxTailNeedsFailClosedBinding(argv.slice(idx + 1), cwd);
     }
     const [flag] = token.toLowerCase().split("=", 2);
     if (PNPM_OPTIONS_WITH_VALUE.has(flag) || PNPM_DLX_OPTIONS_WITH_VALUE.has(flag)) {
@@ -865,13 +864,13 @@ function pnpmDlxInvocationNeedsFailClosedBinding(argv: string[]): boolean {
       idx += 1;
       continue;
     }
-    return false;
+    return pnpmDlxTailMayNeedStableBinding(argv.slice(idx + 1), cwd);
   }
 
   return false;
 }
 
-function pnpmDlxTailNeedsFailClosedBinding(argv: string[]): boolean {
+function pnpmDlxTailNeedsFailClosedBinding(argv: string[], cwd: string | undefined): boolean {
   let idx = 0;
   while (idx < argv.length) {
     const token = argv[idx]?.trim() ?? "";
@@ -880,12 +879,10 @@ function pnpmDlxTailNeedsFailClosedBinding(argv: string[]): boolean {
       continue;
     }
     if (token === "--") {
-      idx += 1;
-      continue;
+      return pnpmDlxTailMayNeedStableBinding(argv.slice(idx + 1), cwd);
     }
     if (!token.startsWith("-")) {
-      // A concrete dlx command should either bind cleanly or fail closed.
-      return true;
+      return pnpmDlxTailMayNeedStableBinding(argv.slice(idx), cwd);
     }
     const [flag] = token.toLowerCase().split("=", 2);
     if (flag === "-c" || flag === "--shell-mode") {
@@ -899,10 +896,32 @@ function pnpmDlxTailNeedsFailClosedBinding(argv: string[]): boolean {
       idx += 1;
       continue;
     }
-    return true;
+    return pnpmDlxTailMayNeedStableBinding(argv.slice(idx + 1), cwd);
   }
 
   return true;
+}
+
+function pnpmDlxTailMayNeedStableBinding(argv: string[], cwd: string | undefined): boolean {
+  for (let idx = 0; idx < argv.length; idx += 1) {
+    const token = argv[idx]?.trim() ?? "";
+    if (!token || token === "--") {
+      continue;
+    }
+    const candidateArgv = argv.slice(idx);
+    const snapshot = resolveMutableFileOperandSnapshotSync({
+      argv: candidateArgv,
+      cwd,
+      shellCommand: null,
+    });
+    if (!snapshot.ok || snapshot.snapshot) {
+      return true;
+    }
+    if (resolvesToExistingFileSync(candidateArgv[0] ?? "", cwd)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function resolveMutableFileOperandSnapshotSync(params: {


### PR DESCRIPTION
## Summary
- keeps `pnpm dlx` invocations in the approval planner on the same mutable-script binding path already used for `pnpm exec`
- skips `dlx` option forms that still expose a concrete runtime command and leaves shell-mode invocations unbound on purpose

## Changes
- added `pnpm dlx` unwrapping in `src/node-host/invoke-system-run-plan.ts` so planner binding reaches the effective runtime/script argv
- added regression coverage for plain `pnpm dlx`, option-bearing `pnpm dlx`, rewrite detection after approval, and shell-mode non-binding behavior

## Validation
- ran `pnpm test -- src/node-host/invoke-system-run-plan.test.ts`
- ran `pnpm check`
- ran local agentic review with `claude -p "/review"` and added follow-up coverage for `--shell-mode`

## Notes
- residual risk or follow-up: `pnpm dlx --shell-mode` still does not produce a mutable file binding because the planner cannot safely reason about the shell payload
