### PR TITLE
Plugins: preserve prompt build system prompt precedence

### DIFF
--- a/src/plugins/hooks.phase-hooks.test.ts
+++ b/src/plugins/hooks.phase-hooks.test.ts
@@ -77,7 +77,7 @@ describe("phase hooks merger", () => {
         },
         {
           pluginId: "low",
-          result: { prependContext: "context B" },
+          result: { prependContext: "context B", systemPrompt: "system B" },
           priority: 1,
         },
       ],

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -201,7 +201,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     acc: PluginHookBeforePromptBuildResult | undefined,
     next: PluginHookBeforePromptBuildResult,
   ): PluginHookBeforePromptBuildResult => ({
-    systemPrompt: lastDefined(acc?.systemPrompt, next.systemPrompt),
+    // Keep the first defined system prompt so higher-priority hooks win.
+    systemPrompt: firstDefined(acc?.systemPrompt, next.systemPrompt),
     prependContext: concatOptionalTextSegments({
       left: acc?.prependContext,
       right: next.prependContext,


### PR DESCRIPTION
## Summary
- Preserve the first defined `systemPrompt` when merging `before_prompt_build` hook results
- Extend regression coverage so conflicting `systemPrompt` values still honor hook priority

## Changes
- Switched `mergeBeforePromptBuild` to use `firstDefined(...)` for `systemPrompt`, matching the higher-priority-wins behavior already used by `before_model_resolve`
- Updated the phase-hook merger test so both high- and low-priority hooks return `systemPrompt` values and the higher-priority value is preserved

## Validation
- Ran `pnpm test -- src/plugins/hooks.phase-hooks.test.ts`
- Ran `pnpm check`
- Ran `pnpm build`
- Ran local agentic review with `claude -p "/review"` and no issues were reported

## Notes
- A broader local `pnpm test` run failed only in `src/daemon/service-env.test.ts` because this environment defaulted Linux `NODE_EXTRA_CA_CERTS` to `/etc/ssl/certs/ca-certificates.crt`
