### PR TITLE
fix(gateway): prevent session death loop on overloaded fallback

### DIFF
--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -560,7 +560,7 @@ describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
       const groqAttempts = runEmbeddedAttemptMock.mock.calls.filter(
         (call) => (call[0] as { provider?: string })?.provider === "groq",
       );
-      expect(openaiAttempts.length).toBeLessThanOrEqual(2);
+      expect(openaiAttempts.length).toBe(2);
       expect(groqAttempts.length).toBe(1);
     });
   });

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -479,4 +479,89 @@ describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
       expect(firstCall?.provider).toBe("openai");
     });
   });
+
+  it("caps overloaded profile rotations and escalates to cross-provider fallback (#58348)", async () => {
+    // When a provider has multiple auth profiles and all return overloaded_error,
+    // the runner should not exhaust all profiles before falling back. It should
+    // cap profile rotations at MAX_OVERLOAD_PROFILE_ROTATIONS (1) and escalate
+    // to cross-provider fallback immediately.
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      // Write auth store with multiple profiles for openai
+      await fs.writeFile(
+        path.join(agentDir, "auth-profiles.json"),
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "openai:p1": { type: "api_key", provider: "openai", key: "sk-openai-1" },
+            "openai:p2": { type: "api_key", provider: "openai", key: "sk-openai-2" },
+            "openai:p3": { type: "api_key", provider: "openai", key: "sk-openai-3" },
+            "groq:p1": { type: "api_key", provider: "groq", key: "sk-groq" },
+          },
+          usageStats: {
+            "openai:p1": { lastUsed: 1 },
+            "openai:p2": { lastUsed: 2 },
+            "openai:p3": { lastUsed: 3 },
+            "groq:p1": { lastUsed: 4 },
+          },
+        }),
+      );
+
+      runEmbeddedAttemptMock.mockImplementation(async (params: unknown) => {
+        const attemptParams = params as {
+          provider: string;
+          modelId: string;
+          authProfileId?: string;
+        };
+        if (attemptParams.provider === "openai") {
+          return makeEmbeddedRunnerAttempt({
+            assistantTexts: [],
+            lastAssistant: buildEmbeddedRunnerAssistant({
+              provider: "openai",
+              model: "mock-1",
+              stopReason: "error",
+              errorMessage: OVERLOADED_ERROR_PAYLOAD,
+            }),
+          });
+        }
+        if (attemptParams.provider === "groq") {
+          return makeEmbeddedRunnerAttempt({
+            assistantTexts: ["fallback ok"],
+            lastAssistant: buildEmbeddedRunnerAssistant({
+              provider: "groq",
+              model: "mock-2",
+              stopReason: "stop",
+              content: [{ type: "text", text: "fallback ok" }],
+            }),
+          });
+        }
+        throw new Error(`Unexpected provider ${attemptParams.provider}`);
+      });
+
+      const result = await runEmbeddedFallback({
+        agentDir,
+        workspaceDir,
+        sessionKey: "agent:test:overloaded-multi-profile-cap",
+        runId: "run:overloaded-multi-profile-cap",
+      });
+
+      // Should fall back to groq instead of exhausting all 3 openai profiles
+      expect(result.provider).toBe("groq");
+      expect(result.model).toBe("mock-2");
+      expect(result.result.payloads?.[0]?.text ?? "").toContain("fallback ok");
+
+      // With MAX_OVERLOAD_PROFILE_ROTATIONS=1, we expect:
+      // - 1 initial openai attempt (p1)
+      // - 1 rotation to p2 (capped)
+      // - escalation to groq (1 attempt)
+      // Total: 3 attempts, NOT 4 (which would mean all 3 openai profiles tried)
+      const openaiAttempts = runEmbeddedAttemptMock.mock.calls.filter(
+        (call) => (call[0] as { provider?: string })?.provider === "openai",
+      );
+      const groqAttempts = runEmbeddedAttemptMock.mock.calls.filter(
+        (call) => (call[0] as { provider?: string })?.provider === "groq",
+      );
+      expect(openaiAttempts.length).toBeLessThanOrEqual(2);
+      expect(groqAttempts.length).toBe(1);
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -75,6 +75,7 @@ import {
   buildErrorAgentMeta,
   buildUsageAgentMetaFields,
   createCompactionDiagId,
+  MAX_OVERLOAD_PROFILE_ROTATIONS,
   OVERLOAD_FAILOVER_BACKOFF_POLICY,
   resolveActiveErrorContext,
   resolveMaxRunRetryIterations,
@@ -316,6 +317,7 @@ export async function runEmbeddedPiAgent(
       let autoCompactionCount = 0;
       let runLoopIterations = 0;
       let overloadFailoverAttempts = 0;
+      let overloadProfileRotations = 0;
       let timeoutCompactionAttempts = 0;
       const maybeMarkAuthProfileFailure = async (failure: {
         profileId?: string;
@@ -1198,6 +1200,31 @@ export async function runEmbeddedPiAgent(
 
             const rotated = await advanceAuthProfile();
             if (rotated) {
+              // For overloaded errors, cap profile rotations: overloaded is a
+              // provider-level capacity issue, not an auth-profile issue.
+              // Rotating more profiles just wastes time with backoff delays.
+              // See: https://github.com/openclaw/openclaw/issues/58348
+              if (assistantFailoverReason === "overloaded") {
+                overloadProfileRotations += 1;
+                if (
+                  overloadProfileRotations > MAX_OVERLOAD_PROFILE_ROTATIONS &&
+                  fallbackConfigured
+                ) {
+                  logAssistantFailoverDecision("rotate_profile");
+                  const message = lastAssistant?.errorMessage?.trim() || "Provider is overloaded.";
+                  const status = resolveFailoverStatus("overloaded");
+                  log.warn(
+                    `overload profile rotation cap reached for ${provider}/${modelId} after ${overloadProfileRotations} rotations; escalating to model fallback`,
+                  );
+                  throw new FailoverError(message, {
+                    reason: "overloaded",
+                    provider: activeErrorContext.provider,
+                    model: activeErrorContext.model,
+                    profileId: lastProfileId,
+                    status,
+                  });
+                }
+              }
               logAssistantFailoverDecision("rotate_profile");
               await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
               continue;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -8,6 +8,7 @@ import {
 import { computeBackoff, sleepWithAbort } from "../../infra/backoff.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
+import { sanitizeForLog } from "../../terminal/ansi.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { hasConfiguredModelFallbacks } from "../agent-scope.js";
@@ -1198,33 +1199,35 @@ export async function runEmbeddedPiAgent(
               }
             }
 
-            const rotated = await advanceAuthProfile();
-            if (rotated) {
-              // For overloaded errors, cap profile rotations: overloaded is a
-              // provider-level capacity issue, not an auth-profile issue.
-              // Rotating more profiles just wastes time with backoff delays.
-              // See: https://github.com/openclaw/openclaw/issues/58348
-              if (assistantFailoverReason === "overloaded") {
-                overloadProfileRotations += 1;
-                if (
-                  overloadProfileRotations > MAX_OVERLOAD_PROFILE_ROTATIONS &&
-                  fallbackConfigured
-                ) {
-                  logAssistantFailoverDecision("rotate_profile");
-                  const message = lastAssistant?.errorMessage?.trim() || "Provider is overloaded.";
-                  const status = resolveFailoverStatus("overloaded");
-                  log.warn(
-                    `overload profile rotation cap reached for ${provider}/${modelId} after ${overloadProfileRotations} rotations; escalating to model fallback`,
-                  );
-                  throw new FailoverError(message, {
+            // For overloaded errors, check the rotation cap *before* calling
+            // advanceAuthProfile() to avoid a wasted auth-profile setup cycle.
+            // advanceAuthProfile() runs applyApiKeyInfo() which initialises the
+            // next profile — costly work that is pointless when we already know
+            // we will escalate to cross-provider fallback.
+            // See: https://github.com/openclaw/openclaw/issues/58348
+            if (assistantFailoverReason === "overloaded") {
+              overloadProfileRotations += 1;
+              if (overloadProfileRotations > MAX_OVERLOAD_PROFILE_ROTATIONS && fallbackConfigured) {
+                const status = resolveFailoverStatus("overloaded");
+                log.warn(
+                  `overload profile rotation cap reached for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)} after ${overloadProfileRotations} rotations; escalating to model fallback`,
+                );
+                logAssistantFailoverDecision("fallback_model", { status });
+                throw new FailoverError(
+                  "The AI service is temporarily overloaded. Please try again in a moment.",
+                  {
                     reason: "overloaded",
                     provider: activeErrorContext.provider,
                     model: activeErrorContext.model,
                     profileId: lastProfileId,
                     status,
-                  });
-                }
+                  },
+                );
               }
+            }
+
+            const rotated = await advanceAuthProfile();
+            if (rotated) {
               logAssistantFailoverDecision("rotate_profile");
               await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
               continue;

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -34,6 +34,14 @@ export const OVERLOAD_FAILOVER_BACKOFF_POLICY: BackoffPolicy = {
   jitter: 0.2,
 };
 
+// Maximum number of auth-profile rotations to attempt for overloaded errors
+// before escalating to cross-provider fallback. Overloaded is a provider-level
+// capacity issue — rotating auth profiles on the same provider is unlikely to
+// help and wastes time with backoff delays. A cap of 1 allows one probe attempt
+// (in case the overload was transient) before giving up on the provider.
+// See: https://github.com/openclaw/openclaw/issues/58348
+export const MAX_OVERLOAD_PROFILE_ROTATIONS = 1;
+
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
 const ANTHROPIC_MAGIC_STRING_REPLACEMENT = "ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)";
 

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch.js";
 import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions } from "../types.js";
+import { MAX_LIVE_SWITCH_RETRIES } from "./agent-runner-execution.js";
 import type { FollowupRun } from "./queue.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
@@ -391,8 +392,8 @@ describe("runAgentTurnWithFallback", () => {
     // After MAX_LIVE_SWITCH_RETRIES (2) the loop must break instead of continuing
     // forever. The result should be a final error, not an infinite hang.
     expect(result.kind).toBe("final");
-    // 1 initial + 2 retries = 3 total invocations at most
-    expect(switchCallCount).toBeLessThanOrEqual(3);
+    // 1 initial + MAX_LIVE_SWITCH_RETRIES retries = exact total invocations
+    expect(switchCallCount).toBe(1 + MAX_LIVE_SWITCH_RETRIES);
   });
 
   it("propagates auth profile state on bounded live model switch retries (#58348)", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -338,4 +338,147 @@ describe("runAgentTurnWithFallback", () => {
     expect(followupRun.run.provider).toBe("openai");
     expect(followupRun.run.model).toBe("gpt-5.4");
   });
+
+  it("breaks out of the retry loop when LiveSessionModelSwitchError is thrown repeatedly (#58348)", async () => {
+    // Simulate a scenario where the persisted session selection keeps conflicting
+    // with the fallback model, causing LiveSessionModelSwitchError on every attempt.
+    // The outer loop must be bounded to prevent a session death loop.
+    let switchCallCount = 0;
+    state.runWithModelFallbackMock.mockImplementation(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => {
+        switchCallCount++;
+        return {
+          result: await params.run("anthropic", "claude"),
+          provider: "anthropic",
+          model: "claude",
+          attempts: [],
+        };
+      },
+    );
+    state.runEmbeddedPiAgentMock.mockImplementation(async () => {
+      throw new LiveSessionModelSwitchError({
+        provider: "openai",
+        model: "gpt-5.4",
+      });
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun,
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    // After MAX_LIVE_SWITCH_RETRIES (2) the loop must break instead of continuing
+    // forever. The result should be a final error, not an infinite hang.
+    expect(result.kind).toBe("final");
+    // 1 initial + 2 retries = 3 total invocations at most
+    expect(switchCallCount).toBeLessThanOrEqual(3);
+  });
+
+  it("propagates auth profile state on bounded live model switch retries (#58348)", async () => {
+    let invocation = 0;
+    state.runWithModelFallbackMock.mockImplementation(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => {
+        invocation++;
+        if (invocation <= 2) {
+          return {
+            result: await params.run("anthropic", "claude"),
+            provider: "anthropic",
+            model: "claude",
+            attempts: [],
+          };
+        }
+        // Third invocation succeeds with the switched model
+        return {
+          result: await params.run("openai", "gpt-5.4"),
+          provider: "openai",
+          model: "gpt-5.4",
+          attempts: [],
+        };
+      },
+    );
+    state.runEmbeddedPiAgentMock
+      .mockImplementationOnce(async () => {
+        throw new LiveSessionModelSwitchError({
+          provider: "openai",
+          model: "gpt-5.4",
+          authProfileId: "profile-b",
+          authProfileIdSource: "user",
+        });
+      })
+      .mockImplementationOnce(async () => {
+        throw new LiveSessionModelSwitchError({
+          provider: "openai",
+          model: "gpt-5.4",
+          authProfileId: "profile-c",
+          authProfileIdSource: "auto",
+        });
+      })
+      .mockImplementationOnce(async () => {
+        return {
+          payloads: [{ text: "finally ok" }],
+          meta: {
+            agentMeta: {
+              sessionId: "session",
+              provider: "openai",
+              model: "gpt-5.4",
+            },
+          },
+        };
+      });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun,
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    // Two switches (within the limit of 2) then success on third attempt
+    expect(result.kind).toBe("success");
+    expect(state.runEmbeddedPiAgentMock).toHaveBeenCalledTimes(3);
+    expect(followupRun.run.provider).toBe("openai");
+    expect(followupRun.run.model).toBe("gpt-5.4");
+    expect(followupRun.run.authProfileId).toBe("profile-c");
+    expect(followupRun.run.authProfileIdSource).toBe("auto");
+  });
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -179,6 +179,8 @@ export async function runAgentTurnWithFallback(params: {
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
   let didResetAfterCompactionFailure = false;
   let didRetryTransientHttpError = false;
+  let liveModelSwitchRetries = 0;
+  const MAX_LIVE_SWITCH_RETRIES = 2;
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
   );
@@ -614,6 +616,27 @@ export async function runAgentTurnWithFallback(params: {
       break;
     } catch (err) {
       if (err instanceof LiveSessionModelSwitchError) {
+        liveModelSwitchRetries += 1;
+        if (liveModelSwitchRetries > MAX_LIVE_SWITCH_RETRIES) {
+          // Prevent infinite loop when persisted session selection keeps
+          // conflicting with fallback model choices (e.g. overloaded primary
+          // triggers fallback, but session store keeps pulling back to the
+          // overloaded model). Surface the last error to the user instead.
+          // See: https://github.com/openclaw/openclaw/issues/58348
+          defaultRuntime.error(
+            `Live model switch failed after ${MAX_LIVE_SWITCH_RETRIES} retries ` +
+              `(${err.provider}/${err.model}). The requested model may be unavailable.`,
+          );
+          return {
+            kind: "final",
+            payload: {
+              text:
+                "⚠️ Agent failed before reply: model switch could not be completed. " +
+                "The requested model may be temporarily unavailable.\n" +
+                "Logs: openclaw logs --follow",
+            },
+          };
+        }
         params.followupRun.run.provider = err.provider;
         params.followupRun.run.model = err.model;
         params.followupRun.run.authProfileId = err.authProfileId;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -31,6 +31,7 @@ import {
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { defaultRuntime } from "../../runtime.js";
+import { sanitizeForLog } from "../../terminal/ansi.js";
 import {
   isMarkdownCapableMessageChannel,
   resolveMessageChannel,
@@ -55,6 +56,12 @@ import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.runtime.js";
 import type { TypingSignaler } from "./typing-mode.js";
+
+// Maximum number of LiveSessionModelSwitchError retries before surfacing a
+// user-visible error. Prevents infinite ping-pong when the persisted session
+// selection keeps conflicting with fallback model choices.
+// See: https://github.com/openclaw/openclaw/issues/58348
+export const MAX_LIVE_SWITCH_RETRIES = 2;
 
 export type RuntimeFallbackAttempt = {
   provider: string;
@@ -180,7 +187,6 @@ export async function runAgentTurnWithFallback(params: {
   let didResetAfterCompactionFailure = false;
   let didRetryTransientHttpError = false;
   let liveModelSwitchRetries = 0;
-  const MAX_LIVE_SWITCH_RETRIES = 2;
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
   );
@@ -625,15 +631,18 @@ export async function runAgentTurnWithFallback(params: {
           // See: https://github.com/openclaw/openclaw/issues/58348
           defaultRuntime.error(
             `Live model switch failed after ${MAX_LIVE_SWITCH_RETRIES} retries ` +
-              `(${err.provider}/${err.model}). The requested model may be unavailable.`,
+              `(${sanitizeForLog(err.provider)}/${sanitizeForLog(err.model)}). The requested model may be unavailable.`,
           );
+          const switchErrorText = shouldSurfaceToControlUi
+            ? "⚠️ Agent failed before reply: model switch could not be completed. " +
+              "The requested model may be temporarily unavailable.\n" +
+              "Logs: openclaw logs --follow"
+            : "⚠️ Agent failed before reply: model switch could not be completed. " +
+              "The requested model may be temporarily unavailable. Please try again shortly.";
           return {
             kind: "final",
             payload: {
-              text:
-                "⚠️ Agent failed before reply: model switch could not be completed. " +
-                "The requested model may be temporarily unavailable.\n" +
-                "Logs: openclaw logs --follow",
+              text: switchErrorText,
             },
           };
         }


### PR DESCRIPTION
### Summary

- **Problem**: When a provider (e.g., Anthropic) returns `overloaded_error`, the session enters a "death loop" — a zombie state where it silently stops responding to all new messages without surfacing any error to the user. Observed 97 unbounded retries in production logs over 9 days, with 4+ confirmed incidents. The bot simply goes silent and never recovers.
- **Root Cause**: Two compounding defects create the death loop:
  1. **Unbounded `LiveSessionModelSwitchError` retry in `src/auto-reply/reply/agent-runner-execution.ts` (line 618)**: The `while(true)` loop catches `LiveSessionModelSwitchError` and `continue`s without any retry limit. When the overloaded primary model triggers fallback to a different model, the inner `runEmbeddedPiAgent` detects a mismatch with the persisted session selection and throws `LiveSessionModelSwitchError`. The outer loop rewrites `followupRun.run.provider/model` back to the switched model and retries, but the persisted session keeps pulling back to the overloaded primary, creating an infinite ping-pong.
  2. **Wasteful auth-profile rotation for overloaded errors in `src/agents/pi-embedded-runner/run.ts` (line 1200)**: When `shouldRotate` is true for an `overloaded` error, the runner rotates through all available auth profiles for the same provider. Since overload is a provider-level capacity issue (not per-key), this is futile and only adds unnecessary backoff delays (exponential, up to 30s per rotation) before finally escalating to cross-provider fallback.
- **Fix**:
  1. Added `MAX_LIVE_SWITCH_RETRIES = 2` guard in `agent-runner-execution.ts`. When exceeded, the function immediately returns `{ kind: "final" }` with a user-visible error message instead of continuing forever. This directly prevents the zombie state.
  2. Added `MAX_OVERLOAD_PROFILE_ROTATIONS = 1` cap in `run.ts` specifically for `assistantFailoverReason === "overloaded"`. After one probe rotation (to handle transient blips), the runner throws `FailoverError` to escalate immediately to cross-provider fallback, bypassing remaining same-provider profiles.
  Both guards are scoped exclusively to their respective error types, preserving existing behavior for all other error classes (rate_limit, auth, billing, etc.).
- **What changed**:
  - `src/auto-reply/reply/agent-runner-execution.ts`: Added `liveModelSwitchRetries` counter and `MAX_LIVE_SWITCH_RETRIES` guard. On exhaustion, returns `kind: "final"` with a user-facing error message.
  - `src/agents/pi-embedded-runner/run.ts`: Added `overloadProfileRotations` counter. When `overloaded` rotations exceed `MAX_OVERLOAD_PROFILE_ROTATIONS`, throws `FailoverError` to escalate to cross-provider fallback.
  - `src/agents/pi-embedded-runner/run/helpers.ts`: Exported `MAX_OVERLOAD_PROFILE_ROTATIONS = 1` constant with documentation.
  - `src/auto-reply/reply/agent-runner-execution.test.ts`: Added 2 tests — infinite loop prevention and auth profile state propagation across bounded retries.
  - `src/agents/model-fallback.run-embedded.e2e.test.ts`: Added e2e test for multi-profile overload rotation capping.
- **What did NOT change (scope boundary)**:
  - Did not change how `overloaded_error` is parsed or classified (`failover-matches.ts`, `failover-error.ts`).
  - Did not change retry/rotation behavior for non-overloaded errors (rate_limit, auth, billing, context_overflow).
  - Did not modify the cron isolated-agent path (`src/cron/isolated-agent/run.ts`), which already has its own bounded retry logic.
  - Did not change the `OVERLOAD_FAILOVER_BACKOFF_POLICY` timing constants.

### Reproduction

1. Configure an agent with primary model `anthropic/claude-opus` and fallback chain `[openai/gpt-5.4, groq/llama]`.
2. Configure multiple auth profiles for the Anthropic provider.
3. Start a session and pin it to `anthropic/claude-opus`.
4. Simulate persistent `overloaded_error` from all Anthropic endpoints.
5. **Without fix**: The agent enters an infinite `LiveSessionModelSwitchError` loop, never replies, and the session becomes a zombie. Logs show 97+ retries with no termination.
6. **With fix**: After 2 switch retries, the agent returns a user-visible error message. At the inner runner level, after 1 profile rotation, it escalates to the next provider in the fallback chain.

### Risk / Mitigation

- **Risk**: The `MAX_LIVE_SWITCH_RETRIES = 2` limit could prematurely terminate legitimate rapid model switches if a user triggers multiple valid switches in quick succession.
- **Mitigation**: Legitimate model switches typically require at most one retry to align session state. The limit of 2 provides sufficient buffer. The `MAX_OVERLOAD_PROFILE_ROTATIONS = 1` cap only applies to `overloaded` errors and still allows one probe attempt for transient blips. Both limits are tested with dedicated unit and e2e tests that verify exact retry counts and state propagation.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Agent Runner
- [x] Fallback Policy

### Linked Issue/PR

Fixes #58348