### PR TITLE
build: move pnpm minimum release age to workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1249,10 +1249,6 @@
   },
   "packageManager": "pnpm@10.32.1",
   "pnpm": {
-    "minimumReleaseAge": 2880,
-    "minimumReleaseAgeExclude": [
-      "@mariozechner/*"
-    ],
     "overrides": {
       "hono": "4.12.9",
       "@hono/node-server": "1.19.10",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,13 @@ packages:
   - packages/*
   - extensions/*
 
+# Delay new releases by 48h to reduce exposure to compromised packages,
+# while allowing our explicitly trusted Pi packages to update immediately.
+minimumReleaseAge: 2880
+
+minimumReleaseAgeExclude:
+  - "@mariozechner/*"
+
 onlyBuiltDependencies:
   - "@lydell/node-pty"
   - "@matrix-org/matrix-sdk-crypto-nodejs"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,12 +4,10 @@ packages:
   - packages/*
   - extensions/*
 
-# Delay new releases by 48h to reduce exposure to compromised packages,
-# while allowing our explicitly trusted Pi packages to update immediately.
 minimumReleaseAge: 2880
 
-minimumReleaseAgeExclude:
-  - "@mariozechner/*"
+# minimumReleaseAgeExclude:
+#   - "@mariozechner/*"
 
 onlyBuiltDependencies:
   - "@lydell/node-pty"


### PR DESCRIPTION
## Summary
Move the workspace `minimumReleaseAge` policy out of `package.json` and into `pnpm-workspace.yaml`, where pnpm 10.32.1 actually reads and enforces it.

## Changes
- remove the stale `pnpm.minimumReleaseAge` and `pnpm.minimumReleaseAgeExclude` entries from `package.json`
- add `minimumReleaseAge: 2880` to `pnpm-workspace.yaml`
- add `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` with the scoped wildcard `@mariozechner/*`

## Validation
- `pnpm config get minimumReleaseAge` -> `2880`
- `pnpm config get minimumReleaseAgeExclude --json` -> `["@mariozechner/*"]`
- `pnpm install --frozen-lockfile --ignore-scripts`
- commit hooks passed via `scripts/committer`, including `pnpm check`
- temp-project proof with `pnpm@11.0.0-beta.6`:
  - `package.json` `pnpm.minimumReleaseAge=2880` allowed install
  - `pnpm-workspace.yaml` `minimumReleaseAge: 2880` failed with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`
- temp-project proof with `@biomejs/biome@2.4.10`:
  - `package.json` `pnpm.minimumReleaseAge=2880` allowed install
  - `pnpm-workspace.yaml` `minimumReleaseAge: 2880` failed with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`

## Linked Issues
- none
