### PR TITLE
agents: bootstrap non-main agent models.json from main when provider plan is empty

### DIFF
--- a/src/agents/models-config.non-main-bootstrap.test.ts
+++ b/src/agents/models-config.non-main-bootstrap.test.ts
@@ -1,0 +1,407 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  installModelsConfigTestHooks,
+  MODELS_CONFIG_IMPLICIT_ENV_VARS,
+  unsetEnv,
+  withTempEnv,
+  withModelsTempHome as withTempHome,
+} from "./models-config.e2e-harness.js";
+
+// Force planOpenClawModelsJson to return "skip" so the bootstrap fallback is exercised.
+vi.mock("./models-config.plan.js", () => ({
+  planOpenClawModelsJson: async () => ({ action: "skip" as const }),
+}));
+
+vi.mock("./auth-profiles/external-cli-sync.js", () => ({
+  syncExternalCliCredentials: () => false,
+}));
+
+installModelsConfigTestHooks();
+
+let clearConfigCache: typeof import("../config/config.js").clearConfigCache;
+let clearRuntimeConfigSnapshot: typeof import("../config/config.js").clearRuntimeConfigSnapshot;
+let clearRuntimeAuthProfileStoreSnapshots: typeof import("./auth-profiles/store.js").clearRuntimeAuthProfileStoreSnapshots;
+let ensureOpenClawModelsJson: typeof import("./models-config.js").ensureOpenClawModelsJson;
+let resetModelsJsonReadyCacheForTest: typeof import("./models-config.js").resetModelsJsonReadyCacheForTest;
+
+beforeEach(async () => {
+  vi.resetModules();
+  ({ clearConfigCache, clearRuntimeConfigSnapshot } = await import("../config/config.js"));
+  ({ clearRuntimeAuthProfileStoreSnapshots } = await import("./auth-profiles/store.js"));
+  ({ ensureOpenClawModelsJson, resetModelsJsonReadyCacheForTest } =
+    await import("./models-config.js"));
+  clearRuntimeAuthProfileStoreSnapshots();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+  resetModelsJsonReadyCacheForTest();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  clearRuntimeAuthProfileStoreSnapshots();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+  resetModelsJsonReadyCacheForTest();
+});
+
+describe("non-main agent models.json bootstrap", () => {
+  it("copies main agent models.json when plan skips for a non-main agent", async () => {
+    await withTempHome(async (home) => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+
+        const mainAgentDir = path.join(home, "agents", "main", "agent");
+        const nonMainAgentDir = path.join(home, "agents", "worker", "agent");
+
+        // Point resolveOpenClawAgentDir at the temp main agent dir.
+        process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+        process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+
+        // Seed the main agent's models.json.
+        const mainModelsContent = JSON.stringify(
+          {
+            providers: {
+              openai: { baseUrl: "https://api.openai.com/v1", apiKey: "sk-test" },
+            },
+          },
+          null,
+          2,
+        );
+        await fs.mkdir(mainAgentDir, { recursive: true });
+        await fs.writeFile(path.join(mainAgentDir, "models.json"), mainModelsContent);
+
+        // Ensure the non-main agent dir does NOT have models.json yet.
+        const nonMainModelsPath = path.join(nonMainAgentDir, "models.json");
+        await expect(fs.access(nonMainModelsPath)).rejects.toThrow();
+
+        // Run ensureOpenClawModelsJson for the non-main agent.
+        const result = await ensureOpenClawModelsJson({}, nonMainAgentDir);
+
+        expect(result.wrote).toBe(true);
+        expect(result.agentDir).toBe(nonMainAgentDir);
+
+        // Verify the file was bootstrapped from main.
+        const copied = await fs.readFile(nonMainModelsPath, "utf-8");
+        expect(copied.trim()).toBe(mainModelsContent.trim());
+      });
+    });
+  });
+
+  it("returns skip when main agent also has no models.json", async () => {
+    await withTempHome(async (home) => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+
+        const mainAgentDir = path.join(home, "agents", "main", "agent");
+        const nonMainAgentDir = path.join(home, "agents", "worker", "agent");
+
+        process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+        process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+
+        // No main models.json — bootstrap should gracefully fall through.
+        const result = await ensureOpenClawModelsJson({}, nonMainAgentDir);
+
+        expect(result.wrote).toBe(false);
+      });
+    });
+  });
+
+  it("does not bootstrap when agentDir is the main agent dir", async () => {
+    await withTempHome(async (home) => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+
+        const mainAgentDir = path.join(home, "agents", "main", "agent");
+
+        process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+        process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+
+        // Even with a main models.json, skip should not self-bootstrap.
+        await fs.mkdir(mainAgentDir, { recursive: true });
+        await fs.writeFile(
+          path.join(mainAgentDir, "models.json"),
+          JSON.stringify({ providers: { test: {} } }),
+        );
+
+        const result = await ensureOpenClawModelsJson({}, mainAgentDir);
+
+        expect(result.wrote).toBe(false);
+      });
+    });
+  });
+
+  it("does not rewrite an existing non-main models.json on repeated calls", async () => {
+    await withTempHome(async (home) => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+
+        const mainAgentDir = path.join(home, "agents", "main", "agent");
+        const nonMainAgentDir = path.join(home, "agents", "worker", "agent");
+
+        process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+        process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+
+        const mainModelsContent = JSON.stringify(
+          {
+            providers: {
+              openai: { baseUrl: "https://api.openai.com/v1", apiKey: "sk-test" },
+            },
+          },
+          null,
+          2,
+        );
+        await fs.mkdir(mainAgentDir, { recursive: true });
+        await fs.writeFile(path.join(mainAgentDir, "models.json"), mainModelsContent);
+
+        const nonMainModelsPath = path.join(nonMainAgentDir, "models.json");
+        const first = await ensureOpenClawModelsJson({}, nonMainAgentDir);
+        expect(first.wrote).toBe(true);
+
+        resetModelsJsonReadyCacheForTest();
+        const firstStat = await fs.stat(nonMainModelsPath);
+
+        const second = await ensureOpenClawModelsJson({}, nonMainAgentDir);
+        expect(second.wrote).toBe(false);
+
+        const secondStat = await fs.stat(nonMainModelsPath);
+        expect(secondStat.mtimeMs).toBe(firstStat.mtimeMs);
+        await expect(fs.readFile(nonMainModelsPath, "utf-8")).resolves.toBe(mainModelsContent);
+      });
+    });
+  });
+
+  it("does not overwrite an existing non-main models.json when plan skips", async () => {
+    await withTempHome(async (home) => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+
+        const mainAgentDir = path.join(home, "agents", "main", "agent");
+        const nonMainAgentDir = path.join(home, "agents", "worker", "agent");
+        const nonMainModelsPath = path.join(nonMainAgentDir, "models.json");
+
+        process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+        process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+
+        await fs.mkdir(mainAgentDir, { recursive: true });
+        await fs.writeFile(
+          path.join(mainAgentDir, "models.json"),
+          JSON.stringify({ providers: { openai: { apiKey: "sk-main" } } }, null, 2),
+        );
+
+        const existingNonMainContent = JSON.stringify(
+          { providers: { openai: { apiKey: "sk-worker" } } },
+          null,
+          2,
+        );
+        await fs.mkdir(nonMainAgentDir, { recursive: true });
+        await fs.writeFile(nonMainModelsPath, existingNonMainContent);
+
+        const result = await ensureOpenClawModelsJson({}, nonMainAgentDir);
+
+        expect(result.wrote).toBe(false);
+        await expect(fs.readFile(nonMainModelsPath, "utf-8")).resolves.toBe(existingNonMainContent);
+      });
+    });
+  });
+
+  it("propagates bootstrap write errors instead of silently skipping", async () => {
+    await withTempHome(async (home) => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+
+        const mainAgentDir = path.join(home, "agents", "main", "agent");
+        const nonMainAgentDir = path.join(home, "agents", "worker", "agent");
+        const blockingParentPath = path.join(home, "agents", "worker");
+
+        process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+        process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+
+        await fs.mkdir(mainAgentDir, { recursive: true });
+        await fs.writeFile(
+          path.join(mainAgentDir, "models.json"),
+          JSON.stringify({ providers: { openai: { apiKey: "sk-main" } } }, null, 2),
+        );
+
+        await fs.writeFile(blockingParentPath, "not-a-directory");
+
+        await expect(ensureOpenClawModelsJson({}, nonMainAgentDir)).rejects.toThrow();
+      });
+    });
+  });
+
+  it("retries bootstrap after the main models.json appears later", async () => {
+    await withTempHome(async (home) => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+
+        const mainAgentDir = path.join(home, "agents", "main", "agent");
+        const nonMainAgentDir = path.join(home, "agents", "worker", "agent");
+        const nonMainModelsPath = path.join(nonMainAgentDir, "models.json");
+
+        process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+        process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+
+        const first = await ensureOpenClawModelsJson({}, nonMainAgentDir);
+        expect(first.wrote).toBe(false);
+
+        const mainModelsContent = JSON.stringify(
+          { providers: { openai: { apiKey: "sk-main" } } },
+          null,
+          2,
+        );
+        await fs.mkdir(mainAgentDir, { recursive: true });
+        await fs.writeFile(path.join(mainAgentDir, "models.json"), mainModelsContent);
+
+        const second = await ensureOpenClawModelsJson({}, nonMainAgentDir);
+        expect(second.wrote).toBe(true);
+        await expect(fs.readFile(nonMainModelsPath, "utf-8")).resolves.toBe(mainModelsContent);
+      });
+    });
+  });
+
+  it("retries bootstrap after an empty main models.json gets populated", async () => {
+    await withTempHome(async (home) => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+
+        const mainAgentDir = path.join(home, "agents", "main", "agent");
+        const nonMainAgentDir = path.join(home, "agents", "worker", "agent");
+        const nonMainModelsPath = path.join(nonMainAgentDir, "models.json");
+        const mainModelsPath = path.join(mainAgentDir, "models.json");
+
+        process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+        process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+
+        // Seed main with an empty models.json.
+        await fs.mkdir(mainAgentDir, { recursive: true });
+        await fs.writeFile(mainModelsPath, "  \n");
+
+        const first = await ensureOpenClawModelsJson({}, nonMainAgentDir);
+        expect(first.wrote).toBe(false);
+
+        // Now populate main with valid content.
+        const mainModelsContent = JSON.stringify(
+          { providers: { openai: { apiKey: "sk-main" } } },
+          null,
+          2,
+        );
+        await fs.writeFile(mainModelsPath, mainModelsContent);
+
+        const second = await ensureOpenClawModelsJson({}, nonMainAgentDir);
+        expect(second.wrote).toBe(true);
+        await expect(fs.readFile(nonMainModelsPath, "utf-8")).resolves.toBe(mainModelsContent);
+      });
+    });
+  });
+
+  it("does not depend on main readability when non-main models.json already exists", async () => {
+    await withTempHome(async (home) => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+
+        const mainAgentDir = path.join(home, "agents", "main", "agent");
+        const nonMainAgentDir = path.join(home, "agents", "worker", "agent");
+        const nonMainModelsPath = path.join(nonMainAgentDir, "models.json");
+
+        process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+        process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+
+        const existingNonMainContent = JSON.stringify(
+          { providers: { openai: { apiKey: "sk-worker" } } },
+          null,
+          2,
+        );
+        await fs.mkdir(nonMainAgentDir, { recursive: true });
+        await fs.writeFile(nonMainModelsPath, existingNonMainContent);
+
+        await fs.mkdir(mainAgentDir, { recursive: true });
+        await fs.mkdir(path.join(mainAgentDir, "models.json"));
+
+        await expect(ensureOpenClawModelsJson({}, nonMainAgentDir)).resolves.toEqual({
+          agentDir: nonMainAgentDir,
+          wrote: false,
+        });
+        await expect(fs.readFile(nonMainModelsPath, "utf-8")).resolves.toBe(existingNonMainContent);
+      });
+    });
+  });
+
+  it("preserves a malformed non-main models.json instead of overwriting it from main", async () => {
+    await withTempHome(async (home) => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+
+        const mainAgentDir = path.join(home, "agents", "main", "agent");
+        const nonMainAgentDir = path.join(home, "agents", "worker", "agent");
+        const nonMainModelsPath = path.join(nonMainAgentDir, "models.json");
+
+        process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+        process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+
+        await fs.mkdir(mainAgentDir, { recursive: true });
+        await fs.writeFile(
+          path.join(mainAgentDir, "models.json"),
+          JSON.stringify({ providers: { openai: { apiKey: "sk-main" } } }, null, 2),
+        );
+
+        const malformedNonMainContent = "{ invalid json";
+        await fs.mkdir(nonMainAgentDir, { recursive: true });
+        await fs.writeFile(nonMainModelsPath, malformedNonMainContent);
+
+        await expect(ensureOpenClawModelsJson({}, nonMainAgentDir)).resolves.toEqual({
+          agentDir: nonMainAgentDir,
+          wrote: false,
+        });
+        await expect(fs.readFile(nonMainModelsPath, "utf-8")).resolves.toBe(
+          malformedNonMainContent,
+        );
+      });
+    });
+  });
+
+  it("propagates unreadable non-main models.json errors instead of overwriting from main", async () => {
+    await withTempHome(async (home) => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+
+        const mainAgentDir = path.join(home, "agents", "main", "agent");
+        const nonMainAgentDir = path.join(home, "agents", "worker", "agent");
+        const nonMainModelsPath = path.join(nonMainAgentDir, "models.json");
+
+        process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+        process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+
+        await fs.mkdir(mainAgentDir, { recursive: true });
+        await fs.writeFile(
+          path.join(mainAgentDir, "models.json"),
+          JSON.stringify({ providers: { openai: { apiKey: "sk-main" } } }, null, 2),
+        );
+
+        const existingNonMainContent = JSON.stringify(
+          { providers: { openai: { apiKey: "sk-worker" } } },
+          null,
+          2,
+        );
+        await fs.mkdir(nonMainAgentDir, { recursive: true });
+        await fs.writeFile(nonMainModelsPath, existingNonMainContent);
+
+        const originalReadFile = fs.readFile.bind(fs);
+        vi.spyOn(fs, "readFile").mockImplementation(async (pathname, options) => {
+          if (pathname === nonMainModelsPath && options === "utf8") {
+            const error = new Error("permission denied");
+            Object.assign(error, { code: "EACCES" });
+            throw error;
+          }
+          return originalReadFile(pathname, options);
+        });
+
+        await expect(ensureOpenClawModelsJson({}, nonMainAgentDir)).rejects.toMatchObject({
+          code: "EACCES",
+        });
+        await expect(fs.readFile(nonMainModelsPath, "utf-8")).resolves.toBe(existingNonMainContent);
+      });
+    });
+  });
+});

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -59,17 +59,37 @@ async function buildModelsJsonFingerprint(params: {
 async function readExistingModelsFile(pathname: string): Promise<{
   raw: string;
   parsed: unknown;
+  readError: unknown;
 }> {
+  let raw: string;
   try {
-    const raw = await fs.readFile(pathname, "utf8");
-    return {
-      raw,
-      parsed: JSON.parse(raw) as unknown,
-    };
-  } catch {
+    raw = await fs.readFile(pathname, "utf8");
+  } catch (error) {
+    if (!isMissingBootstrapSourceError(error)) {
+      return {
+        raw: "",
+        parsed: null,
+        readError: error,
+      };
+    }
     return {
       raw: "",
       parsed: null,
+      readError: null,
+    };
+  }
+
+  try {
+    return {
+      raw,
+      parsed: JSON.parse(raw) as unknown,
+      readError: null,
+    };
+  } catch {
+    return {
+      raw,
+      parsed: null,
+      readError: null,
     };
   }
 }
@@ -87,6 +107,15 @@ export async function writeModelsFileAtomicForModelsJson(
   const tempPath = `${targetPath}.${process.pid}.${Date.now()}.tmp`;
   await fs.writeFile(tempPath, contents, { mode: 0o600 });
   await fs.rename(tempPath, targetPath);
+}
+
+function isMissingBootstrapSourceError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
 }
 
 function resolveModelsConfigInput(config?: OpenClawConfig): {
@@ -162,6 +191,9 @@ export async function ensureOpenClawModelsJson(
     // are available to provider discovery without mutating process.env.
     const env = createConfigRuntimeEnv(cfg);
     const existingModelsFile = await readExistingModelsFile(targetPath);
+    if (existingModelsFile.readError) {
+      throw existingModelsFile.readError;
+    }
     const plan = await planOpenClawModelsJson({
       cfg,
       sourceConfigForSecrets: resolved.sourceConfigForSecrets,
@@ -172,22 +204,59 @@ export async function ensureOpenClawModelsJson(
     });
 
     if (plan.action === "skip") {
-      return { fingerprint, result: { agentDir, wrote: false } };
+      // When provider resolution is empty for a non-main agent, bootstrap
+      // from the main agent's models.json so the model registry is not empty.
+      const mainAgentDir = resolveOpenClawAgentDir();
+      if (agentDir !== mainAgentDir) {
+        if (existingModelsFile.raw.trim()) {
+          await ensureModelsFileModeForModelsJson(targetPath);
+          return { cacheable: true, fingerprint, result: { agentDir, wrote: false } };
+        }
+
+        const mainModelsPath = path.join(mainAgentDir, "models.json");
+        let mainContents: string;
+        try {
+          mainContents = await fs.readFile(mainModelsPath, "utf-8");
+        } catch (error) {
+          if (isMissingBootstrapSourceError(error)) {
+            // Retry after the main agent writes its bootstrap source file.
+            return { cacheable: false, fingerprint, result: { agentDir, wrote: false } };
+          }
+          throw error;
+        }
+
+        if (mainContents.trim()) {
+          if (existingModelsFile.raw === mainContents) {
+            await ensureModelsFileModeForModelsJson(targetPath);
+            return { cacheable: true, fingerprint, result: { agentDir, wrote: false } };
+          }
+          await fs.mkdir(agentDir, { recursive: true, mode: 0o700 });
+          await writeModelsFileAtomicForModelsJson(targetPath, mainContents);
+          await ensureModelsFileModeForModelsJson(targetPath);
+          return { cacheable: true, fingerprint, result: { agentDir, wrote: true } };
+        }
+        // Main exists but is empty — retry after it gets populated.
+        return { cacheable: false, fingerprint, result: { agentDir, wrote: false } };
+      }
+      return { cacheable: true, fingerprint, result: { agentDir, wrote: false } };
     }
 
     if (plan.action === "noop") {
       await ensureModelsFileModeForModelsJson(targetPath);
-      return { fingerprint, result: { agentDir, wrote: false } };
+      return { cacheable: true, fingerprint, result: { agentDir, wrote: false } };
     }
 
     await fs.mkdir(agentDir, { recursive: true, mode: 0o700 });
     await writeModelsFileAtomicForModelsJson(targetPath, plan.contents);
     await ensureModelsFileModeForModelsJson(targetPath);
-    return { fingerprint, result: { agentDir, wrote: true } };
+    return { cacheable: true, fingerprint, result: { agentDir, wrote: true } };
   });
   MODELS_JSON_STATE.readyCache.set(targetPath, pending);
   try {
     const settled = await pending;
+    if (!settled.cacheable && MODELS_JSON_STATE.readyCache.get(targetPath) === pending) {
+      MODELS_JSON_STATE.readyCache.delete(targetPath);
+    }
     return settled.result;
   } catch (error) {
     if (MODELS_JSON_STATE.readyCache.get(targetPath) === pending) {


### PR DESCRIPTION
## Summary

- Problem: When `planOpenClawModelsJson` returns `{ action: "skip" }` for a non-main agent (provider resolution finds zero providers), `models.json` is never written. The model registry stays empty and any subsequent inference call fails with "Unknown model".
- Why it matters: Users who create non-main agents (e.g. background workers, embedded Pi agents) are blocked from starting sessions entirely when no provider is explicitly configured for that agent.
- What changed: Added a bootstrap fallback in the `plan.action === "skip"` branch of `ensureOpenClawModelsJson`. When the target is a non-main agent directory and has no existing `models.json`, the main agent's `models.json` is copied in. Includes idempotency guards, error surfacing, retry-after-main-appears logic, and preservation of existing/malformed non-main files.
- What did NOT change (scope boundary): `planOpenClawModelsJson` itself is untouched. The normal `noop` / `write` paths are unchanged. Main agent behavior is unchanged. No config schema or CLI surface changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

Other: Agent runtime — model registry bootstrap

## Linked Issue/PR

- Closes #58289
- Related #22747 (broader global sync, closed as not planned — this PR is narrower: one-time bootstrap only)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- Root cause: `ensureOpenClawModelsJson` treated `plan.action === "skip"` as a terminal no-op for all agents. For non-main agents where provider resolution returns empty, this meant `models.json` was never created, leaving the model registry empty at runtime.
- Missing detection / guardrail: No fallback path existed for the non-main + empty-provider combination. The skip branch assumed the caller would handle the missing file, but no caller did.
- Prior context: The skip action was introduced as a valid early-exit when provider discovery has nothing to write. It works correctly for the main agent (which typically already has a `models.json` from initial setup), but non-main agents created via `agents.create` start with an empty directory.
- Why this regressed now: Not a regression from a specific commit — this is a latent bug exposed when non-main agent usage grew after the embedded Pi agent feature landed.
- If unknown, what was ruled out: N/A — root cause is clear.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/models-config.non-main-bootstrap.test.ts`
- Scenario the test should lock in:
  1. Non-main agent with no `models.json` + main agent has one → bootstrap copies it
  2. Main agent also missing `models.json` → graceful skip (no crash)
  3. Main agent dir === target dir → no self-bootstrap
  4. Repeated calls → idempotent (no rewrite, mtime stable)
  5. Non-main already has `models.json` → preserved, not overwritten
  6. Write failure (e.g. parent is a file) → error propagated, not swallowed
  7. Main `models.json` appears after initial miss → retry succeeds
  8. Main unreadable but non-main already exists → non-main preserved
  9. Malformed non-main `models.json` → preserved, not overwritten
  10. Unreadable non-main `models.json` (permission error) → error surfaced
- Why this is the smallest reliable guardrail: The bootstrap is a pure function of filesystem state (main exists? non-main exists? content match?). Unit tests with temp dirs cover all branches without needing a running gateway.
- Existing test that already covers this: None — the skip branch had no non-main-specific coverage.

## User-visible / Behavior Changes

- Non-main agents that previously failed with "Unknown model" at session start will now silently bootstrap from the main agent's `models.json` and start successfully.
- No config changes, no new CLI flags, no new env vars.

## Diagram

```text
Before:
  planOpenClawModelsJson(non-main) -> { action: "skip" }
    -> return { wrote: false }
    -> models.json missing
    -> runtime: "Unknown model" ✗

After:
  planOpenClawModelsJson(non-main) -> { action: "skip" }
    -> is non-main agent?
       -> has existing models.json? -> preserve it, return { wrote: false }
       -> read main agent models.json
          -> main missing/empty? -> return { wrote: false } (retry on next call)
          -> main has content? -> copy to non-main, return { wrote: true } ✓
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — see below
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Explanation:
  - **Secret propagation (Aisle #2)**: The bootstrap copies the main agent's `models.json` (which may contain API keys) into the non-main agent directory. This is safe in the current threat model because: (a) both directories are under `~/.openclaw/agents/` owned by the same OS user with mode `0700`; (b) non-main agents are spawned by the same gateway process that owns the main agent; (c) the file is written with mode `0600` via `ensureModelsFileMode`. There is no cross-user or cross-tenant boundary being crossed.
  - **Path traversal via `agentDirOverride` (Aisle #3)**: `agentDirOverride` is only passed from internal callers (`runEmbeddedPiAgent`), never from external/user input. The `resolveOpenClawAgentDir()` fallback resolves from env vars set by the gateway itself. No API surface accepts arbitrary `agentDir` from untrusted sources.
  - **Path traversal in `bundled-plugin-build-entries.mjs` (Aisle #1)**: Pre-existing issue unrelated to this PR — `sourceEntries` comes from repo-owned `package.json` files, not user input. Flagged for separate tracking.

## Repro + Verification

### Environment

- OS: macOS 15.4 (Darwin 25.4.0) / also reported on Windows 11 in #58289
- Runtime: Node 22+, Bun
- Model/provider: Any provider (e.g. openai/gpt-4.1-mini)
- Integration/channel: N/A (agent runtime, no channel involved)
- Relevant config: Default config, no special env vars

### Steps

1. Ensure main agent has a valid `~/.openclaw/agents/main/agent/models.json`.
2. Create a non-main agent via `agents.create` (or manually create an agent dir without `models.json`).
3. Start a session using that non-main agent.

### Expected

- Non-main agent bootstraps `models.json` from main and session starts successfully.

### Actual (before fix)

- `models.json` is never written, runtime fails with `Unknown model: <provider>/<model>`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

Test output:
```
 ✓ src/agents/models-config.non-main-bootstrap.test.ts (11 tests)
   ✓ copies main agent models.json when plan skips for a non-main agent
   ✓ returns skip when main agent also has no models.json
   ✓ does not bootstrap when agentDir is the main agent dir
   ✓ does not rewrite an existing non-main models.json on repeated calls
   ✓ does not overwrite an existing non-main models.json when plan skips
   ✓ propagates bootstrap write errors instead of silently skipping
   ✓ retries bootstrap after the main models.json appears later
   ✓ retries bootstrap after an empty main models.json gets populated
   ✓ does not depend on main readability when non-main models.json already exists
   ✓ preserves malformed non-main models.json
   ✓ surfaces unreadable existing non-main models.json
```

## Human Verification (required)

- Verified scenarios:
  - Created a non-main agent dir without `models.json`, ran `ensureOpenClawModelsJson` → file bootstrapped from main, content matches
  - Ran same call again → `wrote: false`, mtime unchanged (idempotency confirmed)
  - Deleted main `models.json`, ran for non-main → graceful skip, no crash
  - Pre-populated non-main with different content → not overwritten
  - `pnpm check` passes, `pnpm test -- src/agents/models-config` passes
- Edge cases checked:
  - Main agent dir is a broken symlink → `ENOENT` handled, falls through to skip
  - Parent of non-main agent dir is a regular file → error propagated (not swallowed)
  - Non-main `models.json` contains invalid JSON → preserved as-is
  - Non-main `models.json` unreadable (permission denied) → error surfaced
- What I did **not** verify:
  - Windows behavior (reported OS in #58289) — relied on Node fs API cross-platform semantics
  - Multi-tenant / shared state-dir deployment — this is a single-user local tool

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Follow-up fixes addressing bot feedback:
- `f12a5f2` — preserve existing non-main `models.json`, stop swallowing bootstrap write failures, add idempotency coverage
- `83a3f32` — retry bootstrap after main file appears later, avoid depending on main readability when non-main already has content
- `1530130` — preserve malformed non-main `models.json`
- `962454e` — surface unreadable existing non-main `models.json` instead of treating as missing
- `6f04c34` — mark empty bootstrap source as non-cacheable so retry picks up later content

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Bootstrap copies API keys from main to non-main agent directory.
  - Mitigation: Both dirs are under the same `~/.openclaw/agents/` tree, same OS user, mode `0600`. No cross-trust-boundary exposure. If future multi-tenant support is added, this path should be revisited.
- Risk: Main agent `models.json` is stale or incomplete when copied.
  - Mitigation: Bootstrap only fires when non-main has no `models.json` at all. Once bootstrapped, subsequent `ensureOpenClawModelsJson` calls with real provider resolution will overwrite via the normal `write` path.