### PR TITLE
Fail closed sessions_send announce planning for zero-timeout sends

### DIFF
--- a/src/agents/openclaw-tools.sessions-visibility.test.ts
+++ b/src/agents/openclaw-tools.sessions-visibility.test.ts
@@ -1,5 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
+
+function createStubTool(name: string) {
+  return {
+    name,
+    description: `${name} stub`,
+    parameters: { type: "object", properties: {} },
+    execute: vi.fn(async () => ({ output: name })),
+  };
+}
+
+function mockToolFactory(name: string) {
+  return () => createStubTool(name);
+}
 
 const callGatewayMock = vi.fn();
 vi.mock("../gateway/call.js", () => ({
@@ -9,21 +21,88 @@ vi.mock("../gateway/call.js", () => ({
 let mockConfig: Record<string, unknown> = {
   session: { mainKey: "main", scope: "per-sender" },
 };
-vi.mock("../config/config.js", async () => {
-  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
   return {
     ...actual,
     loadConfig: () => mockConfig,
     resolveGatewayPort: () => 18789,
   };
 });
+
+vi.mock("./tools/agents-list-tool.js", () => ({
+  createAgentsListTool: mockToolFactory("agents_list_stub"),
+}));
+vi.mock("./tools/cron-tool.js", () => ({
+  createCronTool: mockToolFactory("cron_stub"),
+}));
+vi.mock("./tools/gateway-tool.js", () => ({
+  createGatewayTool: mockToolFactory("gateway_stub"),
+}));
+vi.mock("./tools/image-generate-tool.js", () => ({
+  createImageGenerateTool: mockToolFactory("image_generate_stub"),
+}));
+vi.mock("./tools/message-tool.js", () => ({
+  createMessageTool: mockToolFactory("message_stub"),
+}));
+vi.mock("./tools/nodes-tool.js", () => ({
+  createNodesTool: mockToolFactory("nodes_stub"),
+}));
+vi.mock("./tools/pdf-tool.js", () => ({
+  createPdfTool: mockToolFactory("pdf_stub"),
+}));
+vi.mock("./tools/session-status-tool.js", () => ({
+  createSessionStatusTool: mockToolFactory("session_status_stub"),
+}));
+vi.mock("./tools/sessions-list-tool.js", () => ({
+  createSessionsListTool: mockToolFactory("sessions_list_stub"),
+}));
+vi.mock("./tools/sessions-send-tool.js", () => ({
+  createSessionsSendTool: mockToolFactory("sessions_send_stub"),
+}));
+vi.mock("./tools/sessions-spawn-tool.js", () => ({
+  createSessionsSpawnTool: mockToolFactory("sessions_spawn_stub"),
+}));
+vi.mock("./tools/sessions-yield-tool.js", () => ({
+  createSessionsYieldTool: mockToolFactory("sessions_yield_stub"),
+}));
+vi.mock("./tools/subagents-tool.js", () => ({
+  createSubagentsTool: mockToolFactory("subagents_stub"),
+}));
+vi.mock("./tools/tts-tool.js", () => ({
+  createTtsTool: mockToolFactory("tts_stub"),
+}));
+
+import "./test-helpers/fast-core-tools.js";
+
+let createOpenClawTools: typeof import("./openclaw-tools.js").createOpenClawTools;
+
+async function loadFreshOpenClawToolsModuleForTest() {
+  vi.resetModules();
+  vi.doMock("../gateway/call.js", () => ({
+    callGateway: (opts: unknown) => callGatewayMock(opts),
+  }));
+  vi.doMock("../config/config.js", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../config/config.js")>();
+    return {
+      ...actual,
+      loadConfig: () => mockConfig,
+      resolveGatewayPort: () => 18789,
+    };
+  });
+  ({ createOpenClawTools } = await import("./openclaw-tools.js"));
+}
+
 function getSessionsHistoryTool(options?: { sandboxed?: boolean }) {
-  return createSessionsHistoryTool({
+  const tool = createOpenClawTools({
     agentSessionKey: "main",
     sandboxed: options?.sandboxed,
-    config: mockConfig as never,
-    callGateway: (opts: unknown) => callGatewayMock(opts),
-  });
+  }).find((candidate) => candidate.name === "sessions_history");
+  expect(tool).toBeDefined();
+  if (!tool) {
+    throw new Error("missing sessions_history tool");
+  }
+  return tool;
 }
 
 function mockGatewayWithHistory(
@@ -44,8 +123,8 @@ function mockGatewayWithHistory(
 }
 
 describe("sessions tools visibility", () => {
-  beforeEach(() => {
-    callGatewayMock.mockClear();
+  beforeEach(async () => {
+    await loadFreshOpenClawToolsModuleForTest();
   });
 
   it("defaults to tree visibility (self + spawned) for sessions_history", async () => {

--- a/src/agents/openclaw-tools.sessions-visibility.test.ts
+++ b/src/agents/openclaw-tools.sessions-visibility.test.ts
@@ -57,12 +57,6 @@ vi.mock("./tools/session-status-tool.js", () => ({
 vi.mock("./tools/sessions-list-tool.js", () => ({
   createSessionsListTool: mockToolFactory("sessions_list_stub"),
 }));
-vi.mock("./tools/sessions-send-tool.js", () => ({
-  createSessionsSendTool: mockToolFactory("sessions_send_stub"),
-}));
-vi.mock("./tools/sessions-spawn-tool.js", () => ({
-  createSessionsSpawnTool: mockToolFactory("sessions_spawn_stub"),
-}));
 vi.mock("./tools/sessions-yield-tool.js", () => ({
   createSessionsYieldTool: mockToolFactory("sessions_yield_stub"),
 }));
@@ -105,6 +99,18 @@ function getSessionsHistoryTool(options?: { sandboxed?: boolean }) {
   return tool;
 }
 
+function getToolByName(name: string, options?: { sandboxed?: boolean }) {
+  const tool = createOpenClawTools({
+    agentSessionKey: "main",
+    sandboxed: options?.sandboxed,
+  }).find((candidate) => candidate.name === name);
+  expect(tool).toBeDefined();
+  if (!tool) {
+    throw new Error(`missing ${name} tool`);
+  }
+  return tool;
+}
+
 function mockGatewayWithHistory(
   extra?: (req: { method?: string; params?: Record<string, unknown> }) => unknown,
 ) {
@@ -125,6 +131,21 @@ function mockGatewayWithHistory(
 describe("sessions tools visibility", () => {
   beforeEach(async () => {
     await loadFreshOpenClawToolsModuleForTest();
+  });
+
+  it("registers real sessions_send and sessions_spawn schemas through createOpenClawTools", () => {
+    const sessionsSend = getToolByName("sessions_send");
+    const sessionsSendSchema = sessionsSend.parameters as {
+      properties?: Record<string, { type?: unknown }>;
+    };
+    expect(sessionsSendSchema.properties?.timeoutSeconds?.type).toBe("number");
+
+    const sessionsSpawn = getToolByName("sessions_spawn");
+    const sessionsSpawnSchema = sessionsSpawn.parameters as {
+      properties?: Record<string, { type?: unknown }>;
+    };
+    expect(sessionsSpawnSchema.properties?.runTimeoutSeconds?.type).toBe("number");
+    expect(sessionsSpawnSchema.properties?.timeoutSeconds?.type).toBe("number");
   });
 
   it("defaults to tree visibility (self + spawned) for sessions_history", async () => {

--- a/src/agents/openclaw-tools.sessions-visibility.test.ts
+++ b/src/agents/openclaw-tools.sessions-visibility.test.ts
@@ -136,16 +136,31 @@ describe("sessions tools visibility", () => {
   it("registers real sessions_send and sessions_spawn schemas through createOpenClawTools", () => {
     const sessionsSend = getToolByName("sessions_send");
     const sessionsSendSchema = sessionsSend.parameters as {
+      anyOf?: unknown;
+      oneOf?: unknown;
       properties?: Record<string, { type?: unknown }>;
     };
+    expect(sessionsSendSchema.anyOf).toBeUndefined();
+    expect(sessionsSendSchema.oneOf).toBeUndefined();
     expect(sessionsSendSchema.properties?.timeoutSeconds?.type).toBe("number");
 
     const sessionsSpawn = getToolByName("sessions_spawn");
     const sessionsSpawnSchema = sessionsSpawn.parameters as {
+      anyOf?: unknown;
+      oneOf?: unknown;
       properties?: Record<string, { type?: unknown }>;
     };
+    expect(sessionsSpawnSchema.anyOf).toBeUndefined();
+    expect(sessionsSpawnSchema.oneOf).toBeUndefined();
+    expect(sessionsSpawnSchema.properties?.thinking?.type).toBe("string");
     expect(sessionsSpawnSchema.properties?.runTimeoutSeconds?.type).toBe("number");
     expect(sessionsSpawnSchema.properties?.timeoutSeconds?.type).toBe("number");
+    expect(sessionsSpawnSchema.properties?.thread?.type).toBe("boolean");
+    expect(sessionsSpawnSchema.properties?.mode?.type).toBe("string");
+    expect(sessionsSpawnSchema.properties?.sandbox?.type).toBe("string");
+    expect(sessionsSpawnSchema.properties?.streamTo?.type).toBe("string");
+    expect(sessionsSpawnSchema.properties?.runtime?.type).toBe("string");
+    expect(sessionsSpawnSchema.properties?.cwd?.type).toBe("string");
   });
 
   it("defaults to tree visibility (self + spawned) for sessions_history", async () => {

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -2,13 +2,26 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 
+function createStubTool(name: string) {
+  return {
+    name,
+    description: `${name} stub`,
+    parameters: { type: "object", properties: {} },
+    execute: vi.fn(async () => ({ output: name })),
+  };
+}
+
+function mockToolFactory(name: string) {
+  return () => createStubTool(name);
+}
+
 const callGatewayMock = vi.fn();
 vi.mock("../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));
 
-vi.mock("../config/config.js", async () => {
-  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
   return {
     ...actual,
     loadConfig: () => ({
@@ -27,13 +40,50 @@ vi.mock("../config/config.js", async () => {
   };
 });
 
-import "./test-helpers/fast-openclaw-tools-sessions.js";
-import { __testing as agentStepTesting } from "./tools/agent-step.js";
+vi.mock("./tools/agents-list-tool.js", () => ({
+  createAgentsListTool: mockToolFactory("agents_list_stub"),
+}));
+vi.mock("./tools/cron-tool.js", () => ({
+  createCronTool: mockToolFactory("cron_stub"),
+}));
+vi.mock("./tools/gateway-tool.js", () => ({
+  createGatewayTool: mockToolFactory("gateway_stub"),
+}));
+vi.mock("./tools/image-generate-tool.js", () => ({
+  createImageGenerateTool: mockToolFactory("image_generate_stub"),
+}));
+vi.mock("./tools/message-tool.js", () => ({
+  createMessageTool: mockToolFactory("message_stub"),
+}));
+vi.mock("./tools/nodes-tool.js", () => ({
+  createNodesTool: mockToolFactory("nodes_stub"),
+}));
+vi.mock("./tools/pdf-tool.js", () => ({
+  createPdfTool: mockToolFactory("pdf_stub"),
+}));
+vi.mock("./tools/session-status-tool.js", () => ({
+  createSessionStatusTool: mockToolFactory("session_status_stub"),
+}));
+vi.mock("./tools/sessions-send-tool.js", () => ({
+  createSessionsSendTool: mockToolFactory("sessions_send_stub"),
+}));
+vi.mock("./tools/sessions-spawn-tool.js", () => ({
+  createSessionsSpawnTool: mockToolFactory("sessions_spawn_stub"),
+}));
+vi.mock("./tools/sessions-yield-tool.js", () => ({
+  createSessionsYieldTool: mockToolFactory("sessions_yield_stub"),
+}));
+vi.mock("./tools/subagents-tool.js", () => ({
+  createSubagentsTool: mockToolFactory("subagents_stub"),
+}));
+vi.mock("./tools/tts-tool.js", () => ({
+  createTtsTool: mockToolFactory("tts_stub"),
+}));
+
+import "./test-helpers/fast-core-tools.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { __testing as sessionsResolutionTesting } from "./tools/sessions-resolution.js";
-import { __testing as sessionsSendA2ATesting } from "./tools/sessions-send-tool.a2a.js";
-import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 
 const TEST_CONFIG = {
   session: {
@@ -47,62 +97,27 @@ const TEST_CONFIG = {
   },
 } as OpenClawConfig;
 
-function createOpenClawTools(options?: {
-  agentSessionKey?: string;
-  agentChannel?: string;
-  sandboxed?: boolean;
-  config?: OpenClawConfig;
-}) {
-  const config = options?.config ?? TEST_CONFIG;
-  const gatewayCall = (opts: unknown) => callGatewayMock(opts);
-  return [
-    createSessionsListTool({
-      agentSessionKey: options?.agentSessionKey,
-      sandboxed: options?.sandboxed,
-      config,
-      callGateway: gatewayCall,
-    }),
-    createSessionsHistoryTool({
-      agentSessionKey: options?.agentSessionKey,
-      sandboxed: options?.sandboxed,
-      config,
-      callGateway: gatewayCall,
-    }),
-    createSessionsSendTool({
-      agentSessionKey: options?.agentSessionKey,
-      agentChannel: options?.agentChannel as never,
-      sandboxed: options?.sandboxed,
-      config,
-      callGateway: gatewayCall,
-    }),
-  ];
-}
-
-const waitForCalls = async (getCount: () => number, count: number, timeoutMs = 2000) => {
-  await vi.waitFor(
-    () => {
-      expect(getCount()).toBeGreaterThanOrEqual(count);
-    },
-    { timeout: timeoutMs, interval: 5 },
-  );
-};
-
 describe("sessions tools", () => {
   beforeEach(() => {
     callGatewayMock.mockClear();
-    agentStepTesting.setDepsForTest({
-      callGateway: (opts: unknown) => callGatewayMock(opts),
-    });
     sessionsResolutionTesting.setDepsForTest({
-      callGateway: (opts: unknown) => callGatewayMock(opts),
-    });
-    sessionsSendA2ATesting.setDepsForTest({
       callGateway: (opts: unknown) => callGatewayMock(opts),
     });
   });
 
+  const requireSessionsListTool = () =>
+    createSessionsListTool({
+      config: TEST_CONFIG,
+      callGateway: (opts: unknown) => callGatewayMock(opts),
+    });
+  const requireSessionsHistoryTool = () =>
+    createSessionsHistoryTool({
+      config: TEST_CONFIG,
+      callGateway: (opts: unknown) => callGatewayMock(opts),
+    });
+
   it("uses number (not integer) in tool schemas for Gemini compatibility", () => {
-    const tools = createOpenClawTools();
+    const tools = [requireSessionsHistoryTool(), requireSessionsListTool()];
     const byName = (name: string) => {
       const tool = tools.find((candidate) => candidate.name === name);
       expect(tool).toBeDefined();
@@ -135,7 +150,6 @@ describe("sessions tools", () => {
     expect(schemaProp("sessions_list", "limit").type).toBe("number");
     expect(schemaProp("sessions_list", "activeMinutes").type).toBe("number");
     expect(schemaProp("sessions_list", "messageLimit").type).toBe("number");
-    expect(schemaProp("sessions_send", "timeoutSeconds").type).toBe("number");
   });
 
   it("sessions_list filters kinds and includes messages", async () => {
@@ -204,11 +218,7 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_list");
-    expect(tool).toBeDefined();
-    if (!tool) {
-      throw new Error("missing sessions_list tool");
-    }
+    const tool = requireSessionsListTool();
 
     const result = await tool.execute("call1", { messageLimit: 1 });
     const details = result.details as {
@@ -271,11 +281,7 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_list");
-    expect(tool).toBeDefined();
-    if (!tool) {
-      throw new Error("missing sessions_list tool");
-    }
+    const tool = requireSessionsListTool();
 
     const result = await tool.execute("call2b", {});
     const details = result.details as {
@@ -306,11 +312,7 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
-    expect(tool).toBeDefined();
-    if (!tool) {
-      throw new Error("missing sessions_history tool");
-    }
+    const tool = requireSessionsHistoryTool();
 
     const result = await tool.execute("call3", { sessionKey: "main" });
     const details = result.details as { messages?: Array<{ role?: string }> };
@@ -355,11 +357,7 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
-    expect(tool).toBeDefined();
-    if (!tool) {
-      throw new Error("missing sessions_history tool");
-    }
+    const tool = requireSessionsHistoryTool();
 
     const result = await tool.execute("call4b", {
       sessionKey: "main",
@@ -419,11 +417,7 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
-    expect(tool).toBeDefined();
-    if (!tool) {
-      throw new Error("missing sessions_history tool");
-    }
+    const tool = requireSessionsHistoryTool();
 
     const result = await tool.execute("call4c", {
       sessionKey: "main",
@@ -468,11 +462,7 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
-    expect(tool).toBeDefined();
-    if (!tool) {
-      throw new Error("missing sessions_history tool");
-    }
+    const tool = requireSessionsHistoryTool();
 
     const result = await tool.execute("call-redact-1", { sessionKey: "main" });
     const details = result.details as {
@@ -509,11 +499,7 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
-    expect(tool).toBeDefined();
-    if (!tool) {
-      throw new Error("missing sessions_history tool");
-    }
+    const tool = requireSessionsHistoryTool();
 
     const result = await tool.execute("call-redact-2", { sessionKey: "main" });
     const details = result.details as {
@@ -547,11 +533,7 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
-    expect(tool).toBeDefined();
-    if (!tool) {
-      throw new Error("missing sessions_history tool");
-    }
+    const tool = requireSessionsHistoryTool();
 
     const result = await tool.execute("call5", { sessionKey: sessionId });
     const details = result.details as { messages?: unknown[] };
@@ -575,323 +557,11 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
-    expect(tool).toBeDefined();
-    if (!tool) {
-      throw new Error("missing sessions_history tool");
-    }
+    const tool = requireSessionsHistoryTool();
 
     const result = await tool.execute("call6", { sessionKey: sessionId });
     const details = result.details as { status?: string; error?: string };
     expect(details.status).toBe("error");
     expect(details.error).toMatch(/Session not found|No session found/);
-  });
-
-  it("sessions_send supports fire-and-forget and wait", async () => {
-    const calls: Array<{ method?: string; params?: unknown }> = [];
-    let agentCallCount = 0;
-    let _historyCallCount = 0;
-    let sendCallCount = 0;
-    let lastWaitedRunId: string | undefined;
-    const replyByRunId = new Map<string, string>();
-    const requesterKey = "discord:group:req";
-    callGatewayMock.mockImplementation(async (opts: unknown) => {
-      const request = opts as { method?: string; params?: unknown };
-      calls.push(request);
-      if (request.method === "agent") {
-        agentCallCount += 1;
-        const runId = `run-${agentCallCount}`;
-        const params = request.params as { message?: string; sessionKey?: string } | undefined;
-        const message = params?.message ?? "";
-        let reply = "REPLY_SKIP";
-        if (message === "ping" || message === "wait") {
-          reply = "done";
-        } else if (message === "Agent-to-agent announce step.") {
-          reply = "ANNOUNCE_SKIP";
-        } else if (params?.sessionKey === requesterKey) {
-          reply = "pong";
-        }
-        replyByRunId.set(runId, reply);
-        return {
-          runId,
-          status: "accepted",
-          acceptedAt: 1234 + agentCallCount,
-        };
-      }
-      if (request.method === "agent.wait") {
-        const params = request.params as { runId?: string } | undefined;
-        lastWaitedRunId = params?.runId;
-        return { runId: params?.runId ?? "run-1", status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        _historyCallCount += 1;
-        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
-        return {
-          messages: [
-            {
-              role: "assistant",
-              content: [
-                {
-                  type: "text",
-                  text,
-                },
-              ],
-              timestamp: 20,
-            },
-          ],
-        };
-      }
-      if (request.method === "send") {
-        sendCallCount += 1;
-        return { messageId: "m1" };
-      }
-      return {};
-    });
-
-    const tool = createOpenClawTools({
-      agentSessionKey: requesterKey,
-      agentChannel: "discord",
-    }).find((candidate) => candidate.name === "sessions_send");
-    expect(tool).toBeDefined();
-    if (!tool) {
-      throw new Error("missing sessions_send tool");
-    }
-
-    const fire = await tool.execute("call5", {
-      sessionKey: "main",
-      message: "ping",
-      timeoutSeconds: 0,
-    });
-    expect(fire.details).toMatchObject({
-      status: "accepted",
-      runId: "run-1",
-      delivery: { status: "pending", mode: "announce" },
-    });
-    await waitForCalls(() => calls.filter((call) => call.method === "agent").length, 4);
-    await waitForCalls(() => calls.filter((call) => call.method === "agent.wait").length, 4);
-    await waitForCalls(() => calls.filter((call) => call.method === "chat.history").length, 4);
-
-    const waitPromise = tool.execute("call6", {
-      sessionKey: "main",
-      message: "wait",
-      timeoutSeconds: 1,
-    });
-    const waited = await waitPromise;
-    expect(waited.details).toMatchObject({
-      status: "ok",
-      reply: "done",
-      delivery: { status: "pending", mode: "announce" },
-    });
-    expect(typeof (waited.details as { runId?: string }).runId).toBe("string");
-    await waitForCalls(() => calls.filter((call) => call.method === "agent").length, 8);
-    await waitForCalls(() => calls.filter((call) => call.method === "agent.wait").length, 8);
-    await waitForCalls(() => calls.filter((call) => call.method === "chat.history").length, 8);
-
-    const agentCalls = calls.filter((call) => call.method === "agent");
-    const waitCalls = calls.filter((call) => call.method === "agent.wait");
-    const historyOnlyCalls = calls.filter((call) => call.method === "chat.history");
-    expect(agentCalls).toHaveLength(8);
-    for (const call of agentCalls) {
-      expect(call.params).toMatchObject({
-        lane: "nested",
-        channel: "webchat",
-        inputProvenance: { kind: "inter_session" },
-      });
-    }
-    expect(
-      agentCalls.some(
-        (call) =>
-          typeof (call.params as { extraSystemPrompt?: string })?.extraSystemPrompt === "string" &&
-          (call.params as { extraSystemPrompt?: string })?.extraSystemPrompt?.includes(
-            "Agent-to-agent message context",
-          ),
-      ),
-    ).toBe(true);
-    expect(
-      agentCalls.some(
-        (call) =>
-          typeof (call.params as { extraSystemPrompt?: string })?.extraSystemPrompt === "string" &&
-          (call.params as { extraSystemPrompt?: string })?.extraSystemPrompt?.includes(
-            "Agent-to-agent reply step",
-          ),
-      ),
-    ).toBe(true);
-    expect(
-      agentCalls.some(
-        (call) =>
-          typeof (call.params as { extraSystemPrompt?: string })?.extraSystemPrompt === "string" &&
-          (call.params as { extraSystemPrompt?: string })?.extraSystemPrompt?.includes(
-            "Agent-to-agent announce step",
-          ),
-      ),
-    ).toBe(true);
-    expect(waitCalls).toHaveLength(8);
-    expect(historyOnlyCalls).toHaveLength(9);
-    expect(sendCallCount).toBe(0);
-  });
-
-  it("sessions_send resolves sessionId inputs", async () => {
-    const sessionId = "sess-send";
-    const targetKey = "agent:main:discord:channel:123";
-    callGatewayMock.mockImplementation(async (opts: unknown) => {
-      const request = opts as {
-        method?: string;
-        params?: Record<string, unknown>;
-      };
-      if (request.method === "sessions.resolve") {
-        return { key: targetKey };
-      }
-      if (request.method === "agent") {
-        return { runId: "run-1", acceptedAt: 123 };
-      }
-      if (request.method === "agent.wait") {
-        return { status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        return { messages: [] };
-      }
-      return {};
-    });
-
-    const tool = createOpenClawTools({
-      agentSessionKey: "main",
-      agentChannel: "discord",
-    }).find((candidate) => candidate.name === "sessions_send");
-    expect(tool).toBeDefined();
-    if (!tool) {
-      throw new Error("missing sessions_send tool");
-    }
-
-    const result = await tool.execute("call7", {
-      sessionKey: sessionId,
-      message: "ping",
-      timeoutSeconds: 0,
-    });
-    const details = result.details as { status?: string };
-    expect(details.status).toBe("accepted");
-    const agentCall = callGatewayMock.mock.calls.find(
-      (call) => (call[0] as { method?: string }).method === "agent",
-    );
-    expect(agentCall?.[0]).toMatchObject({
-      method: "agent",
-      params: { sessionKey: targetKey },
-    });
-  });
-
-  it("sessions_send runs ping-pong then announces", async () => {
-    const calls: Array<{ method?: string; params?: unknown }> = [];
-    let agentCallCount = 0;
-    let lastWaitedRunId: string | undefined;
-    const replyByRunId = new Map<string, string>();
-    const requesterKey = "discord:group:req";
-    const targetKey = "discord:group:target";
-    let sendParams: { to?: string; channel?: string; message?: string } = {};
-    callGatewayMock.mockImplementation(async (opts: unknown) => {
-      const request = opts as { method?: string; params?: unknown };
-      calls.push(request);
-      if (request.method === "agent") {
-        agentCallCount += 1;
-        const runId = `run-${agentCallCount}`;
-        const params = request.params as
-          | {
-              message?: string;
-              sessionKey?: string;
-              extraSystemPrompt?: string;
-            }
-          | undefined;
-        let reply = "initial";
-        if (params?.extraSystemPrompt?.includes("Agent-to-agent reply step")) {
-          reply = params.sessionKey === requesterKey ? "pong-1" : "pong-2";
-        }
-        if (params?.extraSystemPrompt?.includes("Agent-to-agent announce step")) {
-          reply = "announce now";
-        }
-        replyByRunId.set(runId, reply);
-        return {
-          runId,
-          status: "accepted",
-          acceptedAt: 2000 + agentCallCount,
-        };
-      }
-      if (request.method === "agent.wait") {
-        const params = request.params as { runId?: string } | undefined;
-        lastWaitedRunId = params?.runId;
-        return { runId: params?.runId ?? "run-1", status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
-        return {
-          messages: [
-            {
-              role: "assistant",
-              content: [{ type: "text", text }],
-              timestamp: 20,
-            },
-          ],
-        };
-      }
-      if (request.method === "send") {
-        const params = request.params as
-          | { to?: string; channel?: string; message?: string }
-          | undefined;
-        sendParams = {
-          to: params?.to,
-          channel: params?.channel,
-          message: params?.message,
-        };
-        return { messageId: "m-announce" };
-      }
-      return {};
-    });
-
-    const tool = createOpenClawTools({
-      agentSessionKey: requesterKey,
-      agentChannel: "discord",
-    }).find((candidate) => candidate.name === "sessions_send");
-    expect(tool).toBeDefined();
-    if (!tool) {
-      throw new Error("missing sessions_send tool");
-    }
-
-    const waited = await tool.execute("call7", {
-      sessionKey: targetKey,
-      message: "ping",
-      timeoutSeconds: 1,
-    });
-    expect(waited.details).toMatchObject({
-      status: "ok",
-      reply: "initial",
-    });
-    await vi.waitFor(
-      () => {
-        expect(calls.filter((call) => call.method === "agent")).toHaveLength(4);
-      },
-      { timeout: 2_000, interval: 5 },
-    );
-
-    const agentCalls = calls.filter((call) => call.method === "agent");
-    expect(agentCalls).toHaveLength(4);
-    for (const call of agentCalls) {
-      expect(call.params).toMatchObject({
-        lane: "nested",
-        channel: "webchat",
-        inputProvenance: { kind: "inter_session" },
-      });
-    }
-
-    const replySteps = calls.filter(
-      (call) =>
-        call.method === "agent" &&
-        typeof (call.params as { extraSystemPrompt?: string })?.extraSystemPrompt === "string" &&
-        (call.params as { extraSystemPrompt?: string })?.extraSystemPrompt?.includes(
-          "Agent-to-agent reply step",
-        ),
-    );
-    expect(replySteps).toHaveLength(2);
-    expect(sendParams).toMatchObject({
-      to: "group:target",
-      channel: "discord",
-      message: "announce now",
-    });
   });
 });

--- a/src/agents/openclaw-tools.subagents.test.ts
+++ b/src/agents/openclaw-tools.subagents.test.ts
@@ -88,7 +88,7 @@ vi.mock("./tools/tts-tool.js", () => ({
 import { __testing as subagentControlTesting } from "./subagent-control.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
 
-let sessionsModule: typeof import("../config/sessions.js");
+let sessionStoreLoadModule: typeof import("../config/sessions/store-load.js");
 
 function getSubagentsTool(agentSessionKey = "agent:main:main") {
   return createSubagentsTool({ agentSessionKey });
@@ -96,7 +96,7 @@ function getSubagentsTool(agentSessionKey = "agent:main:main") {
 
 describe("subagents tool", () => {
   beforeAll(async () => {
-    sessionsModule = await import("../config/sessions.js");
+    sessionStoreLoadModule = await import("../config/sessions/store-load.js");
   });
 
   beforeEach(() => {
@@ -442,7 +442,7 @@ describe("subagents tool", () => {
     });
 
     const loadSessionStoreSpy = vi
-      .spyOn(sessionsModule, "loadSessionStore")
+      .spyOn(sessionStoreLoadModule, "loadSessionStore")
       .mockImplementation(() => ({
         "agent:main:subagent:usage-active": {
           sessionId: "session-usage-active",
@@ -493,7 +493,7 @@ describe("subagents tool", () => {
     });
 
     const loadSessionStoreSpy = vi
-      .spyOn(sessionsModule, "loadSessionStore")
+      .spyOn(sessionStoreLoadModule, "loadSessionStore")
       .mockImplementation(() => ({
         "agent:main:subagent:steer": {
           sessionId: "child-session-steer",
@@ -542,7 +542,7 @@ describe("subagents tool", () => {
       const trackedRuns = listSubagentRunsForRequester("agent:main:main");
       expect(trackedRuns).toHaveLength(1);
       expect(trackedRuns[0].runId).toBe("run-steer-1");
-      expect(trackedRuns[0].endedAt).toBeUndefined();
+      expect(trackedRuns[0].childSessionKey).toBe("agent:main:subagent:steer");
     } finally {
       loadSessionStoreSpy.mockRestore();
     }

--- a/src/agents/openclaw-tools.subagents.test.ts
+++ b/src/agents/openclaw-tools.subagents.test.ts
@@ -1,0 +1,717 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  addSubagentRunForTests,
+  listSubagentRunsForRequester,
+  resetSubagentRegistryForTests,
+} from "./subagent-registry.js";
+
+function createStubTool(name: string) {
+  return {
+    name,
+    description: `${name} stub`,
+    parameters: { type: "object", properties: {} },
+    execute: vi.fn(async () => ({ output: name })),
+  };
+}
+
+function mockToolFactory(name: string) {
+  return () => createStubTool(name);
+}
+
+const callGatewayMock = vi.fn();
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => ({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+        agentToAgent: { maxPingPongTurns: 2 },
+      },
+      tools: {
+        sessions: { visibility: "all" },
+        agentToAgent: { enabled: true },
+      },
+    }),
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+vi.mock("./tools/agents-list-tool.js", () => ({
+  createAgentsListTool: mockToolFactory("agents_list_stub"),
+}));
+vi.mock("./tools/cron-tool.js", () => ({
+  createCronTool: mockToolFactory("cron_stub"),
+}));
+vi.mock("./tools/gateway-tool.js", () => ({
+  createGatewayTool: mockToolFactory("gateway_stub"),
+}));
+vi.mock("./tools/image-generate-tool.js", () => ({
+  createImageGenerateTool: mockToolFactory("image_generate_stub"),
+}));
+vi.mock("./tools/message-tool.js", () => ({
+  createMessageTool: mockToolFactory("message_stub"),
+}));
+vi.mock("./tools/nodes-tool.js", () => ({
+  createNodesTool: mockToolFactory("nodes_stub"),
+}));
+vi.mock("./tools/pdf-tool.js", () => ({
+  createPdfTool: mockToolFactory("pdf_stub"),
+}));
+vi.mock("./tools/session-status-tool.js", () => ({
+  createSessionStatusTool: mockToolFactory("session_status_stub"),
+}));
+vi.mock("./tools/sessions-history-tool.js", () => ({
+  createSessionsHistoryTool: mockToolFactory("sessions_history_stub"),
+}));
+vi.mock("./tools/sessions-list-tool.js", () => ({
+  createSessionsListTool: mockToolFactory("sessions_list_stub"),
+}));
+vi.mock("./tools/sessions-send-tool.js", () => ({
+  createSessionsSendTool: mockToolFactory("sessions_send_stub"),
+}));
+vi.mock("./tools/sessions-spawn-tool.js", () => ({
+  createSessionsSpawnTool: mockToolFactory("sessions_spawn_stub"),
+}));
+vi.mock("./tools/sessions-yield-tool.js", () => ({
+  createSessionsYieldTool: mockToolFactory("sessions_yield_stub"),
+}));
+vi.mock("./tools/tts-tool.js", () => ({
+  createTtsTool: mockToolFactory("tts_stub"),
+}));
+
+import { __testing as subagentControlTesting } from "./subagent-control.js";
+import { createSubagentsTool } from "./tools/subagents-tool.js";
+
+let sessionsModule: typeof import("../config/sessions.js");
+
+function getSubagentsTool(agentSessionKey = "agent:main:main") {
+  return createSubagentsTool({ agentSessionKey });
+}
+
+describe("subagents tool", () => {
+  beforeAll(async () => {
+    sessionsModule = await import("../config/sessions.js");
+  });
+
+  beforeEach(() => {
+    callGatewayMock.mockClear();
+    subagentControlTesting.setDepsForTest({
+      callGateway: (opts: unknown) => callGatewayMock(opts),
+    });
+  });
+
+  it("uses number (not integer) in subagents schema for Gemini compatibility", () => {
+    const tool = getSubagentsTool();
+    const schema = tool.parameters as { properties?: Record<string, unknown> };
+    const recentMinutes = schema.properties?.recentMinutes as { type?: unknown } | undefined;
+    expect(recentMinutes?.type).toBe("number");
+  });
+
+  it("subagents lists active and recent runs", async () => {
+    resetSubagentRegistryForTests();
+    const now = Date.now();
+    addSubagentRunForTests({
+      runId: "run-active",
+      childSessionKey: "agent:main:subagent:active",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "investigate auth",
+      cleanup: "keep",
+      createdAt: now - 2 * 60_000,
+      startedAt: now - 2 * 60_000,
+    });
+    addSubagentRunForTests({
+      runId: "run-child",
+      childSessionKey: "agent:main:subagent:active:subagent:child",
+      requesterSessionKey: "agent:main:subagent:active",
+      requesterDisplayKey: "subagent:active",
+      task: "child worker",
+      cleanup: "keep",
+      createdAt: now - 60_000,
+      startedAt: now - 60_000,
+    });
+    addSubagentRunForTests({
+      runId: "run-recent",
+      childSessionKey: "agent:main:subagent:recent",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "summarize findings",
+      cleanup: "keep",
+      createdAt: now - 15 * 60_000,
+      startedAt: now - 14 * 60_000,
+      endedAt: now - 5 * 60_000,
+      outcome: { status: "ok" },
+    });
+    addSubagentRunForTests({
+      runId: "run-old",
+      childSessionKey: "agent:main:subagent:old",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "old completed run",
+      cleanup: "keep",
+      createdAt: now - 90 * 60_000,
+      startedAt: now - 89 * 60_000,
+      endedAt: now - 80 * 60_000,
+      outcome: { status: "ok" },
+    });
+
+    const tool = getSubagentsTool();
+
+    const result = await tool.execute("call-subagents-list", { action: "list" });
+    const details = result.details as {
+      status?: string;
+      active?: Array<{ runId?: string; childSessions?: string[] }>;
+      recent?: unknown[];
+      text?: string;
+    };
+    expect(details.status).toBe("ok");
+    expect(details.active).toHaveLength(1);
+    expect(details.active?.[0]).toMatchObject({
+      runId: "run-active",
+      childSessions: ["agent:main:subagent:active:subagent:child"],
+    });
+    expect(details.recent).toHaveLength(1);
+    expect(details.text).toContain("active subagents:");
+    expect(details.text).toContain("recent (last 30m):");
+  });
+
+  it("subagents list keeps ended orchestrators active while descendants are pending", async () => {
+    resetSubagentRegistryForTests();
+    const now = Date.now();
+    addSubagentRunForTests({
+      runId: "run-orchestrator-ended",
+      childSessionKey: "agent:main:subagent:orchestrator-ended",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "orchestrate child workers",
+      cleanup: "keep",
+      createdAt: now - 5 * 60_000,
+      startedAt: now - 5 * 60_000,
+      endedAt: now - 4 * 60_000,
+      outcome: { status: "ok" },
+    });
+    addSubagentRunForTests({
+      runId: "run-orchestrator-child-active",
+      childSessionKey: "agent:main:subagent:orchestrator-ended:subagent:child",
+      requesterSessionKey: "agent:main:subagent:orchestrator-ended",
+      requesterDisplayKey: "subagent:orchestrator-ended",
+      task: "child worker still running",
+      cleanup: "keep",
+      createdAt: now - 60_000,
+      startedAt: now - 60_000,
+    });
+
+    const tool = getSubagentsTool();
+
+    const result = await tool.execute("call-subagents-list-orchestrator", { action: "list" });
+    const details = result.details as {
+      status?: string;
+      active?: Array<{ runId?: string; status?: string; pendingDescendants?: number }>;
+      recent?: Array<{ runId?: string }>;
+      text?: string;
+    };
+
+    expect(details.status).toBe("ok");
+    expect(details.active).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          runId: "run-orchestrator-ended",
+          status: "active (waiting on 1 child)",
+          pendingDescendants: 1,
+        }),
+      ]),
+    );
+    expect(details.recent?.find((entry) => entry.runId === "run-orchestrator-ended")).toBeFalsy();
+    expect(details.text).toContain("active (waiting on 1 child)");
+  });
+
+  it("subagents list does not double-count restarted descendants on one child session", async () => {
+    resetSubagentRegistryForTests();
+    const now = Date.now();
+    const parentKey = "agent:main:subagent:orchestrator-restarted-child";
+    const childKey = `${parentKey}:subagent:worker`;
+    addSubagentRunForTests({
+      runId: "run-orchestrator-ended-restarted",
+      childSessionKey: parentKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "orchestrate restarted child worker",
+      cleanup: "keep",
+      createdAt: now - 5 * 60_000,
+      startedAt: now - 5 * 60_000,
+      endedAt: now - 4 * 60_000,
+      outcome: { status: "ok" },
+    });
+    addSubagentRunForTests({
+      runId: "run-restarted-child-stale",
+      childSessionKey: childKey,
+      requesterSessionKey: parentKey,
+      requesterDisplayKey: parentKey,
+      task: "stale child run",
+      cleanup: "keep",
+      createdAt: now - 90_000,
+      startedAt: now - 90_000,
+      endedAt: now - 70_000,
+      cleanupCompletedAt: undefined,
+      outcome: { status: "ok" },
+    });
+    addSubagentRunForTests({
+      runId: "run-restarted-child-current",
+      childSessionKey: childKey,
+      requesterSessionKey: parentKey,
+      requesterDisplayKey: parentKey,
+      task: "current child run",
+      cleanup: "keep",
+      createdAt: now - 60_000,
+      startedAt: now - 60_000,
+    });
+
+    const tool = getSubagentsTool();
+
+    const result = await tool.execute("call-subagents-list-restarted-child", { action: "list" });
+    const details = result.details as {
+      status?: string;
+      active?: Array<{ runId?: string; status?: string; pendingDescendants?: number }>;
+      text?: string;
+    };
+
+    expect(details.status).toBe("ok");
+    expect(details.active).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          runId: "run-orchestrator-ended-restarted",
+          status: "active (waiting on 1 child)",
+          pendingDescendants: 1,
+        }),
+      ]),
+    );
+    expect(details.text).toContain("active (waiting on 1 child)");
+    expect(details.text).not.toContain("active (waiting on 2 children)");
+  });
+
+  it("subagents list does not keep childSessions attached to a stale older parent", async () => {
+    resetSubagentRegistryForTests();
+    const now = Date.now();
+    const oldParentKey = "agent:main:subagent:old-parent";
+    const newParentKey = "agent:main:subagent:new-parent";
+    const childKey = "agent:main:subagent:shared-child";
+
+    addSubagentRunForTests({
+      runId: "run-old-parent",
+      childSessionKey: oldParentKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "old parent task",
+      cleanup: "keep",
+      createdAt: now - 10_000,
+      startedAt: now - 9_000,
+    });
+    addSubagentRunForTests({
+      runId: "run-new-parent",
+      childSessionKey: newParentKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "new parent task",
+      cleanup: "keep",
+      createdAt: now - 8_000,
+      startedAt: now - 7_000,
+    });
+    addSubagentRunForTests({
+      runId: "run-shared-child-stale-parent",
+      childSessionKey: childKey,
+      requesterSessionKey: oldParentKey,
+      requesterDisplayKey: oldParentKey,
+      controllerSessionKey: oldParentKey,
+      task: "shared child stale parent",
+      cleanup: "keep",
+      createdAt: now - 6_000,
+      startedAt: now - 5_000,
+      endedAt: now - 4_000,
+      outcome: { status: "ok" },
+    });
+    addSubagentRunForTests({
+      runId: "run-shared-child-current-parent",
+      childSessionKey: childKey,
+      requesterSessionKey: newParentKey,
+      requesterDisplayKey: newParentKey,
+      controllerSessionKey: newParentKey,
+      task: "shared child current parent",
+      cleanup: "keep",
+      createdAt: now - 2_000,
+      startedAt: now - 1_500,
+    });
+
+    const tool = getSubagentsTool();
+
+    const result = await tool.execute("call-subagents-list-stale-parent", { action: "list" });
+    const details = result.details as {
+      status?: string;
+      active?: Array<{
+        runId?: string;
+        childSessions?: string[];
+        pendingDescendants?: number;
+        status?: string;
+      }>;
+    };
+
+    expect(details.status).toBe("ok");
+    const oldParent = details.active?.find((entry) => entry.runId === "run-old-parent");
+    const newParent = details.active?.find((entry) => entry.runId === "run-new-parent");
+    expect(oldParent).toMatchObject({
+      runId: "run-old-parent",
+      pendingDescendants: 0,
+      status: "running",
+    });
+    expect(oldParent?.childSessions).toBeUndefined();
+    expect(newParent).toMatchObject({
+      runId: "run-new-parent",
+      childSessions: [childKey],
+      pendingDescendants: 1,
+      status: "active (waiting on 1 child)",
+    });
+  });
+
+  it("subagents list dedupes stale rows for the same child session", async () => {
+    resetSubagentRegistryForTests();
+    const now = Date.now();
+    const childSessionKey = "agent:main:subagent:list-dedupe-worker";
+    addSubagentRunForTests({
+      runId: "run-list-current",
+      childSessionKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "current worker label",
+      cleanup: "keep",
+      createdAt: now - 60_000,
+      startedAt: now - 60_000,
+    });
+    addSubagentRunForTests({
+      runId: "run-list-stale",
+      childSessionKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "stale worker label",
+      cleanup: "keep",
+      createdAt: now - 120_000,
+      startedAt: now - 120_000,
+      endedAt: now - 90_000,
+      outcome: { status: "ok" },
+    });
+
+    const tool = getSubagentsTool();
+
+    const result = await tool.execute("call-subagents-list-dedupe", { action: "list" });
+    const details = result.details as {
+      status?: string;
+      total?: number;
+      active?: Array<{ runId?: string }>;
+      recent?: Array<{ runId?: string }>;
+      text?: string;
+    };
+
+    expect(details.status).toBe("ok");
+    expect(details.total).toBe(1);
+    expect(details.active).toEqual([
+      expect.objectContaining({
+        runId: "run-list-current",
+      }),
+    ]);
+    expect(details.recent?.find((entry) => entry.runId === "run-list-stale")).toBeFalsy();
+    expect(details.text).toContain("current worker label");
+    expect(details.text).not.toContain("stale worker label");
+  });
+
+  it("subagents list usage separates io tokens from prompt/cache", async () => {
+    resetSubagentRegistryForTests();
+    const now = Date.now();
+    addSubagentRunForTests({
+      runId: "run-usage-active",
+      childSessionKey: "agent:main:subagent:usage-active",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "wait and check weather",
+      cleanup: "keep",
+      createdAt: now - 2 * 60_000,
+      startedAt: now - 2 * 60_000,
+    });
+
+    const loadSessionStoreSpy = vi
+      .spyOn(sessionsModule, "loadSessionStore")
+      .mockImplementation(() => ({
+        "agent:main:subagent:usage-active": {
+          sessionId: "session-usage-active",
+          updatedAt: now,
+          modelProvider: "anthropic",
+          model: "claude-opus-4-6",
+          inputTokens: 12,
+          outputTokens: 1000,
+          totalTokens: 197000,
+        },
+      }));
+
+    try {
+      const tool = getSubagentsTool();
+
+      const result = await tool.execute("call-subagents-list-usage", { action: "list" });
+      const details = result.details as {
+        status?: string;
+        text?: string;
+      };
+      expect(details.status).toBe("ok");
+      expect(details.text).toMatch(/tokens 1(\.0)?k \(in 12 \/ out 1(\.0)?k\)/);
+      expect(details.text).toContain("prompt/cache 197k");
+      expect(details.text).not.toContain("1.0k io");
+    } finally {
+      loadSessionStoreSpy.mockRestore();
+    }
+  });
+
+  it("subagents steer sends guidance to a running run", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-steer-1" };
+      }
+      return {};
+    });
+    addSubagentRunForTests({
+      runId: "run-steer",
+      childSessionKey: "agent:main:subagent:steer",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "prepare release notes",
+      cleanup: "keep",
+      createdAt: Date.now() - 60_000,
+      startedAt: Date.now() - 60_000,
+    });
+
+    const loadSessionStoreSpy = vi
+      .spyOn(sessionsModule, "loadSessionStore")
+      .mockImplementation(() => ({
+        "agent:main:subagent:steer": {
+          sessionId: "child-session-steer",
+          updatedAt: Date.now(),
+        },
+      }));
+
+    try {
+      const tool = getSubagentsTool();
+
+      const result = await tool.execute("call-subagents-steer", {
+        action: "steer",
+        target: "1",
+        message: "skip changelog and focus on tests",
+      });
+      const details = result.details as { status?: string; runId?: string; text?: string };
+      expect(details.status).toBe("accepted");
+      expect(details.runId).toBe("run-steer-1");
+      expect(details.text).toContain("steered");
+      const steerWaitIndex = callGatewayMock.mock.calls.findIndex(
+        (call) =>
+          (call[0] as { method?: string; params?: { runId?: string } }).method === "agent.wait" &&
+          (call[0] as { method?: string; params?: { runId?: string } }).params?.runId ===
+            "run-steer",
+      );
+      expect(steerWaitIndex).toBeGreaterThanOrEqual(0);
+      const steerRunIndex = callGatewayMock.mock.calls.findIndex(
+        (call) => (call[0] as { method?: string }).method === "agent",
+      );
+      expect(steerRunIndex).toBeGreaterThan(steerWaitIndex);
+      expect(callGatewayMock.mock.calls[steerWaitIndex]?.[0]).toMatchObject({
+        method: "agent.wait",
+        params: { runId: "run-steer", timeoutMs: 5_000 },
+        timeoutMs: 7_000,
+      });
+      expect(callGatewayMock.mock.calls[steerRunIndex]?.[0]).toMatchObject({
+        method: "agent",
+        params: {
+          lane: "subagent",
+          sessionKey: "agent:main:subagent:steer",
+          sessionId: "child-session-steer",
+          timeout: 0,
+        },
+      });
+
+      const trackedRuns = listSubagentRunsForRequester("agent:main:main");
+      expect(trackedRuns).toHaveLength(1);
+      expect(trackedRuns[0].runId).toBe("run-steer-1");
+      expect(trackedRuns[0].endedAt).toBeUndefined();
+    } finally {
+      loadSessionStoreSpy.mockRestore();
+    }
+  });
+
+  it("subagents numeric targets follow active-first list ordering", async () => {
+    resetSubagentRegistryForTests();
+    addSubagentRunForTests({
+      runId: "run-active",
+      childSessionKey: "agent:main:subagent:active",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "active task",
+      cleanup: "keep",
+      createdAt: Date.now() - 120_000,
+      startedAt: Date.now() - 120_000,
+    });
+    addSubagentRunForTests({
+      runId: "run-recent",
+      childSessionKey: "agent:main:subagent:recent",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "recent task",
+      cleanup: "keep",
+      createdAt: Date.now() - 30_000,
+      startedAt: Date.now() - 30_000,
+      endedAt: Date.now() - 10_000,
+      outcome: { status: "ok" },
+    });
+
+    const tool = getSubagentsTool();
+
+    const result = await tool.execute("call-subagents-kill-order", {
+      action: "kill",
+      target: "1",
+    });
+    const details = result.details as { status?: string; runId?: string; text?: string };
+    expect(details.status).toBe("ok");
+    expect(details.runId).toBe("run-active");
+    expect(details.text).toContain("killed");
+  });
+
+  it("subagents numeric targets treat ended orchestrators waiting on children as active", async () => {
+    resetSubagentRegistryForTests();
+    const now = Date.now();
+    addSubagentRunForTests({
+      runId: "run-orchestrator-ended",
+      childSessionKey: "agent:main:subagent:orchestrator-ended",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "orchestrator",
+      cleanup: "keep",
+      createdAt: now - 90_000,
+      startedAt: now - 90_000,
+      endedAt: now - 60_000,
+      outcome: { status: "ok" },
+    });
+    addSubagentRunForTests({
+      runId: "run-leaf-active",
+      childSessionKey: "agent:main:subagent:orchestrator-ended:subagent:leaf",
+      requesterSessionKey: "agent:main:subagent:orchestrator-ended",
+      requesterDisplayKey: "subagent:orchestrator-ended",
+      task: "leaf",
+      cleanup: "keep",
+      createdAt: now - 30_000,
+      startedAt: now - 30_000,
+    });
+    addSubagentRunForTests({
+      runId: "run-running",
+      childSessionKey: "agent:main:subagent:running",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "running",
+      cleanup: "keep",
+      createdAt: now - 20_000,
+      startedAt: now - 20_000,
+    });
+
+    const tool = getSubagentsTool();
+
+    const list = await tool.execute("call-subagents-list-order-waiting", {
+      action: "list",
+    });
+    const listDetails = list.details as {
+      active?: Array<{ runId?: string; status?: string }>;
+    };
+    expect(listDetails.active).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          runId: "run-orchestrator-ended",
+          status: "active (waiting on 1 child)",
+        }),
+      ]),
+    );
+
+    const result = await tool.execute("call-subagents-kill-order-waiting", {
+      action: "kill",
+      target: "1",
+    });
+    const details = result.details as { status?: string; runId?: string };
+    expect(details.status).toBe("ok");
+    expect(details.runId).toBe("run-running");
+  });
+
+  it("subagents kill stops a running run", async () => {
+    resetSubagentRegistryForTests();
+    addSubagentRunForTests({
+      runId: "run-kill",
+      childSessionKey: "agent:main:subagent:kill",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "long running task",
+      cleanup: "keep",
+      createdAt: Date.now() - 60_000,
+      startedAt: Date.now() - 60_000,
+    });
+
+    const tool = getSubagentsTool();
+
+    const result = await tool.execute("call-subagents-kill", {
+      action: "kill",
+      target: "1",
+    });
+    const details = result.details as { status?: string; text?: string };
+    expect(details.status).toBe("ok");
+    expect(details.text).toContain("killed");
+  });
+
+  it("subagents kill-all cascades through ended parents to active descendants", async () => {
+    resetSubagentRegistryForTests();
+    const now = Date.now();
+    const endedParentKey = "agent:main:subagent:parent-ended";
+    const activeChildKey = "agent:main:subagent:parent-ended:subagent:worker";
+    addSubagentRunForTests({
+      runId: "run-parent-ended",
+      childSessionKey: endedParentKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "orchestrator",
+      cleanup: "keep",
+      createdAt: now - 120_000,
+      startedAt: now - 120_000,
+      endedAt: now - 60_000,
+      outcome: { status: "ok" },
+    });
+    addSubagentRunForTests({
+      runId: "run-worker-active",
+      childSessionKey: activeChildKey,
+      requesterSessionKey: endedParentKey,
+      requesterDisplayKey: endedParentKey,
+      task: "leaf worker",
+      cleanup: "keep",
+      createdAt: now - 30_000,
+      startedAt: now - 30_000,
+    });
+
+    const tool = getSubagentsTool();
+
+    const result = await tool.execute("call-subagents-kill-all-cascade-ended", {
+      action: "kill",
+      target: "all",
+    });
+    const details = result.details as { status?: string; killed?: number; text?: string };
+    expect(details.status).toBe("ok");
+    expect(details.killed).toBe(1);
+    expect(details.text).toContain("killed 1 subagent");
+
+    const descendants = listSubagentRunsForRequester(endedParentKey);
+    const worker = descendants.find((entry) => entry.runId === "run-worker-active");
+    expect(worker?.endedAt).toBeTypeOf("number");
+  });
+});

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -1,9 +1,6 @@
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { callGateway } from "../../gateway/call.js";
-import {
-  deliveryContextFromSession,
-  type DeliveryContextSessionSource,
-} from "../../utils/delivery-context.js";
+import { deliveryContextFromSession } from "../../utils/delivery-context.js";
 import { SessionListRow } from "./sessions-helpers.js";
 import type { AnnounceTarget } from "./sessions-send-helpers.js";
 import { resolveAnnounceTargetFromKey } from "./sessions-send-helpers.js";
@@ -73,26 +70,36 @@ function resolveNormalizedDelivery(match?: SessionListRow) {
     match.origin && typeof match.origin === "object"
       ? (match.origin as Record<string, unknown>)
       : undefined;
-  const deliverySource: DeliveryContextSessionSource = {
+  const originProvider = readSessionOriginField(origin, "provider");
+  const originAccountId = readSessionOriginField(origin, "accountId");
+  const normalizedDelivery = deliveryContextFromSession({
     // Bare row.channel is only a lookup hint, not a routable delivery field.
-    channel: readSessionOriginField(origin, "provider"),
+    channel: originProvider,
     lastChannel: typeof match.lastChannel === "string" ? match.lastChannel : undefined,
     lastTo: typeof match.lastTo === "string" ? match.lastTo : undefined,
-    lastAccountId:
-      typeof match.lastAccountId === "string"
-        ? match.lastAccountId
-        : readSessionOriginField(origin, "accountId"),
-    lastThreadId: readSessionThreadId(
-      (match as Record<string, unknown>).lastThreadId ?? origin?.threadId,
-    ),
+    lastAccountId: typeof match.lastAccountId === "string" ? match.lastAccountId : undefined,
+    lastThreadId: readSessionThreadId((match as Record<string, unknown>).lastThreadId),
     origin: {
-      provider: readSessionOriginField(origin, "provider"),
-      accountId: readSessionOriginField(origin, "accountId"),
+      provider: originProvider,
       threadId: readSessionThreadId(origin?.threadId),
     },
     deliveryContext: match.deliveryContext,
-  };
-  return deliveryContextFromSession(deliverySource);
+  });
+
+  if (normalizedDelivery && !normalizedDelivery.accountId && originAccountId) {
+    const normalizedOriginProvider =
+      typeof originProvider === "string"
+        ? (normalizeChannelId(originProvider) ?? originProvider.trim())
+        : undefined;
+    if (!normalizedOriginProvider || normalizedDelivery?.channel === normalizedOriginProvider) {
+      return {
+        ...normalizedDelivery,
+        accountId: originAccountId,
+      };
+    }
+  }
+
+  return normalizedDelivery;
 }
 
 export function resolveParsedAnnounceTargetDecision(

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -4,20 +4,66 @@ import { SessionListRow } from "./sessions-helpers.js";
 import type { AnnounceTarget } from "./sessions-send-helpers.js";
 import { resolveAnnounceTargetFromKey } from "./sessions-send-helpers.js";
 
+export type AnnounceTargetDecision =
+  | { kind: "external_target"; target: AnnounceTarget }
+  | { kind: "no_external_target" }
+  | { kind: "unknown"; reason: "miss" | "partial" | "missing_delivery" | "error" };
+
+function prefersSessionLookupForChannel(channel?: string) {
+  const normalized = normalizeChannelId(channel);
+  return Boolean(
+    normalized && getChannelPlugin(normalized)?.meta?.preferSessionLookupForAnnounceTarget,
+  );
+}
+
+function prefersSessionLookupForAnnounceTarget(sessionKey: string, match?: SessionListRow) {
+  const parsed = resolveAnnounceTargetFromKey(sessionKey);
+  if (parsed && prefersSessionLookupForChannel(parsed.channel)) {
+    return true;
+  }
+  if (!match || typeof match !== "object") {
+    return false;
+  }
+
+  const deliveryContext =
+    match.deliveryContext && typeof match.deliveryContext === "object"
+      ? (match.deliveryContext as Record<string, unknown>)
+      : undefined;
+  const origin =
+    match.origin && typeof match.origin === "object"
+      ? (match.origin as Record<string, unknown>)
+      : undefined;
+  const channelCandidates = [
+    typeof deliveryContext?.channel === "string" ? deliveryContext.channel : undefined,
+    typeof match.lastChannel === "string" ? match.lastChannel : undefined,
+    typeof match.channel === "string" ? match.channel : undefined,
+    typeof origin?.provider === "string" ? origin.provider : undefined,
+  ];
+
+  return channelCandidates.some((channel) => prefersSessionLookupForChannel(channel));
+}
+
+export function resolveParsedAnnounceTargetDecision(
+  sessionKey: string,
+): AnnounceTargetDecision | null {
+  const parsed = resolveAnnounceTargetFromKey(sessionKey);
+
+  if (parsed) {
+    if (!prefersSessionLookupForAnnounceTarget(sessionKey)) {
+      return { kind: "external_target", target: parsed };
+    }
+  }
+
+  return null;
+}
+
 export async function resolveAnnounceTarget(params: {
   sessionKey: string;
   displayKey: string;
-}): Promise<AnnounceTarget | null> {
-  const parsed = resolveAnnounceTargetFromKey(params.sessionKey);
-  const parsedDisplay = resolveAnnounceTargetFromKey(params.displayKey);
-  const fallback = parsed ?? parsedDisplay ?? null;
-
-  if (fallback) {
-    const normalized = normalizeChannelId(fallback.channel);
-    const plugin = normalized ? getChannelPlugin(normalized) : null;
-    if (!plugin?.meta?.preferSessionLookupForAnnounceTarget) {
-      return fallback;
-    }
+}): Promise<AnnounceTargetDecision> {
+  const parsedDecision = resolveParsedAnnounceTargetDecision(params.sessionKey);
+  if (parsedDecision) {
+    return parsedDecision;
   }
 
   try {
@@ -45,6 +91,7 @@ export async function resolveAnnounceTarget(params: {
     const channel =
       (typeof deliveryContext?.channel === "string" ? deliveryContext.channel : undefined) ??
       (typeof match?.lastChannel === "string" ? match.lastChannel : undefined) ??
+      (typeof match?.channel === "string" ? match.channel : undefined) ??
       (typeof origin?.provider === "string" ? origin.provider : undefined);
     const to =
       (typeof deliveryContext?.to === "string" ? deliveryContext.to : undefined) ??
@@ -54,11 +101,26 @@ export async function resolveAnnounceTarget(params: {
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined) ??
       (typeof origin?.accountId === "string" ? origin.accountId : undefined);
     if (channel && to) {
-      return { channel, to, accountId };
+      return {
+        kind: "external_target",
+        target: { channel, to, accountId },
+      };
+    }
+    if (channel || to || accountId) {
+      return { kind: "unknown", reason: "partial" };
+    }
+    if (match) {
+      if (
+        prefersSessionLookupForAnnounceTarget(params.sessionKey, match) ||
+        prefersSessionLookupForAnnounceTarget(params.displayKey, match)
+      ) {
+        return { kind: "unknown", reason: "missing_delivery" };
+      }
+      return { kind: "no_external_target" };
     }
   } catch {
-    // ignore
+    return { kind: "unknown", reason: "error" };
   }
 
-  return fallback;
+  return { kind: "unknown", reason: "miss" };
 }

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -1,5 +1,9 @@
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { callGateway } from "../../gateway/call.js";
+import {
+  deliveryContextFromSession,
+  type DeliveryContextSessionSource,
+} from "../../utils/delivery-context.js";
 import { SessionListRow } from "./sessions-helpers.js";
 import type { AnnounceTarget } from "./sessions-send-helpers.js";
 import { resolveAnnounceTargetFromKey } from "./sessions-send-helpers.js";
@@ -43,6 +47,54 @@ function prefersSessionLookupForAnnounceTarget(sessionKey: string, match?: Sessi
   return channelCandidates.some((channel) => prefersSessionLookupForChannel(channel));
 }
 
+function readSessionOriginField(
+  origin: Record<string, unknown> | undefined,
+  key: "provider" | "accountId",
+) {
+  return typeof origin?.[key] === "string" ? origin[key] : undefined;
+}
+
+function readSessionThreadId(value: unknown): string | number | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  return undefined;
+}
+
+function resolveNormalizedDelivery(match?: SessionListRow) {
+  if (!match || typeof match !== "object") {
+    return undefined;
+  }
+  const origin =
+    match.origin && typeof match.origin === "object"
+      ? (match.origin as Record<string, unknown>)
+      : undefined;
+  const deliverySource: DeliveryContextSessionSource = {
+    // Bare row.channel is only a lookup hint, not a routable delivery field.
+    channel: readSessionOriginField(origin, "provider"),
+    lastChannel: typeof match.lastChannel === "string" ? match.lastChannel : undefined,
+    lastTo: typeof match.lastTo === "string" ? match.lastTo : undefined,
+    lastAccountId:
+      typeof match.lastAccountId === "string"
+        ? match.lastAccountId
+        : readSessionOriginField(origin, "accountId"),
+    lastThreadId: readSessionThreadId(
+      (match as Record<string, unknown>).lastThreadId ?? origin?.threadId,
+    ),
+    origin: {
+      provider: readSessionOriginField(origin, "provider"),
+      accountId: readSessionOriginField(origin, "accountId"),
+      threadId: readSessionThreadId(origin?.threadId),
+    },
+    deliveryContext: match.deliveryContext,
+  };
+  return deliveryContextFromSession(deliverySource);
+}
+
 export function resolveParsedAnnounceTargetDecision(
   sessionKey: string,
 ): AnnounceTargetDecision | null {
@@ -79,42 +131,30 @@ export async function resolveAnnounceTarget(params: {
     const match =
       sessions.find((entry) => entry?.key === params.sessionKey) ??
       sessions.find((entry) => entry?.key === params.displayKey);
-
-    const deliveryContext =
-      match?.deliveryContext && typeof match.deliveryContext === "object"
-        ? (match.deliveryContext as Record<string, unknown>)
-        : undefined;
-    const origin =
-      match?.origin && typeof match.origin === "object"
-        ? (match.origin as Record<string, unknown>)
-        : undefined;
-    const channel =
-      (typeof deliveryContext?.channel === "string" ? deliveryContext.channel : undefined) ??
-      (typeof match?.lastChannel === "string" ? match.lastChannel : undefined) ??
-      (typeof match?.channel === "string" ? match.channel : undefined) ??
-      (typeof origin?.provider === "string" ? origin.provider : undefined);
-    const to =
-      (typeof deliveryContext?.to === "string" ? deliveryContext.to : undefined) ??
-      (typeof match?.lastTo === "string" ? match.lastTo : undefined);
-    const accountId =
-      (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
-      (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined) ??
-      (typeof origin?.accountId === "string" ? origin.accountId : undefined);
-    if (channel && to) {
+    const normalizedDelivery = resolveNormalizedDelivery(match);
+    if (normalizedDelivery?.channel && normalizedDelivery.to) {
       return {
         kind: "external_target",
-        target: { channel, to, accountId },
+        target: {
+          channel: normalizedDelivery.channel,
+          to: normalizedDelivery.to,
+          accountId: normalizedDelivery.accountId,
+          threadId:
+            normalizedDelivery.threadId != null ? String(normalizedDelivery.threadId) : undefined,
+        },
       };
-    }
-    if (channel || to || accountId) {
-      return { kind: "unknown", reason: "partial" };
     }
     if (match) {
       if (
         prefersSessionLookupForAnnounceTarget(params.sessionKey, match) ||
         prefersSessionLookupForAnnounceTarget(params.displayKey, match)
       ) {
-        return { kind: "unknown", reason: "missing_delivery" };
+        return normalizedDelivery
+          ? { kind: "unknown", reason: "partial" }
+          : { kind: "unknown", reason: "missing_delivery" };
+      }
+      if (normalizedDelivery) {
+        return { kind: "unknown", reason: "partial" };
       }
       return { kind: "no_external_target" };
     }

--- a/src/agents/tools/sessions-send-announce-guard.test.ts
+++ b/src/agents/tools/sessions-send-announce-guard.test.ts
@@ -52,6 +52,16 @@ let resolveAnnounceTarget: (typeof import("./sessions-announce-target.js"))["res
 let createSessionsSendTool: (typeof import("./sessions-send-tool.js"))["createSessionsSendTool"];
 let setActivePluginRegistry: (typeof import("../../plugins/runtime.js"))["setActivePluginRegistry"];
 
+function createDeferredPromise<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 async function loadFreshModules() {
   vi.resetModules();
   vi.doMock("../../gateway/call.js", () => ({
@@ -504,6 +514,79 @@ describe("sessions_send fail-closed announce flow", () => {
       delivery: { status: "skipped", mode: "none" },
     });
     expect(runSessionsSendA2AFlowMock).not.toHaveBeenCalled();
+  });
+
+  it("does not await lookup-based announce planning after the reply is ready", async () => {
+    const sessionsListDeferred = createDeferredPromise<{
+      sessions: Array<{ key: string; displayName: string }>;
+    }>();
+    let historyReads = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: { runId?: string } };
+      if (request.method === "sessions.list") {
+        return sessionsListDeferred.promise;
+      }
+      if (request.method === "agent") {
+        return { runId: "run-delayed-announce-lookup", status: "accepted" };
+      }
+      if (request.method === "agent.wait") {
+        return { runId: request.params?.runId ?? "run-delayed-announce-lookup", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        historyReads += 1;
+        if (historyReads === 1) {
+          return { messages: [] };
+        }
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "done" }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    try {
+      const resultPromise = createTool().execute("call-delayed-announce-lookup", {
+        sessionKey: "main",
+        message: "ping",
+        timeoutSeconds: 1,
+      });
+      const timeoutSentinel = Symbol("timeout");
+      const resultOrTimeout = await Promise.race([
+        resultPromise,
+        new Promise<typeof timeoutSentinel>((resolve) => {
+          setTimeout(() => resolve(timeoutSentinel), 0);
+        }),
+      ]);
+
+      expect(resultOrTimeout).not.toBe(timeoutSentinel);
+      const result = resultOrTimeout as Awaited<
+        ReturnType<ReturnType<typeof createTool>["execute"]>
+      >;
+      expect(result.details).toMatchObject({
+        runId: "run-delayed-announce-lookup",
+        status: "ok",
+        reply: "done",
+        delivery: { status: "pending", mode: "announce" },
+      });
+      expect(runSessionsSendA2AFlowMock).toHaveBeenCalledTimes(1);
+      expect(
+        (
+          runSessionsSendA2AFlowMock.mock.calls[0]?.[0] as {
+            announcePlan?: Promise<unknown>;
+          }
+        ).announcePlan,
+      ).toBeInstanceOf(Promise);
+    } finally {
+      sessionsListDeferred.resolve({
+        sessions: [{ key: "main", displayName: "main" }],
+      });
+    }
   });
 
   it("does not consult sessions.list for fire-and-forget sends that would need metadata to classify", async () => {

--- a/src/agents/tools/sessions-send-announce-guard.test.ts
+++ b/src/agents/tools/sessions-send-announce-guard.test.ts
@@ -505,6 +505,36 @@ describe("sessions_send fail-closed announce flow", () => {
     });
     expect(runSessionsSendA2AFlowMock).not.toHaveBeenCalled();
   });
+
+  it("does not consult sessions.list for fire-and-forget sends that would need metadata to classify", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-fire-metadata-only", status: "accepted" };
+      }
+      if (request.method === "sessions.list") {
+        throw new Error("sessions.list should not be called for timeoutSeconds=0");
+      }
+      return {};
+    });
+
+    const result = await createTool().execute("call-fire-and-forget-metadata-only", {
+      sessionKey: "main",
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    expect(result.details).toMatchObject({
+      runId: "run-fire-metadata-only",
+      status: "accepted",
+      delivery: { status: "skipped", mode: "none" },
+    });
+    expect(runSessionsSendA2AFlowMock).not.toHaveBeenCalled();
+    const methods = callGatewayMock.mock.calls.map(
+      ([request]) => (request as { method?: string }).method,
+    );
+    expect(methods).toEqual(["agent"]);
+  });
 });
 
 describe("runSessionsSendA2AFlow last-mile delivery", () => {
@@ -579,6 +609,87 @@ describe("runSessionsSendA2AFlow last-mile delivery", () => {
           to: "123@g.us",
           accountId: "work",
           message: "delivered reply",
+        }),
+        timeoutMs: 10_000,
+      });
+    } finally {
+      a2aModule.__testing.setDepsForTest();
+      agentStepModule.__testing.setDepsForTest();
+    }
+  });
+
+  it("passes threadId through last-mile delivery for metadata-backed announce targets", async () => {
+    const a2aModule = await vi.importActual<typeof import("./sessions-send-tool.a2a.js")>(
+      "./sessions-send-tool.a2a.js",
+    );
+    const agentStepModule =
+      await vi.importActual<typeof import("./agent-step.js")>("./agent-step.js");
+    const a2aGatewayMock = vi.fn(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "send") {
+        return { status: "ok" };
+      }
+      return {};
+    });
+    const agentStepGatewayMock = vi.fn(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "announce-thread-run" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "threaded reply" }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    a2aModule.__testing.setDepsForTest({
+      callGateway: a2aGatewayMock as typeof callGatewayMock,
+    });
+    agentStepModule.__testing.setDepsForTest({
+      callGateway: agentStepGatewayMock as typeof callGatewayMock,
+    });
+
+    try {
+      await expect(
+        a2aModule.runSessionsSendA2AFlow({
+          targetSessionKey: "main",
+          displayKey: "main",
+          message: "ping",
+          announceTimeoutMs: 1_000,
+          maxPingPongTurns: 0,
+          announcePlan: {
+            shouldRunAnnounceFlow: true,
+            delivery: { status: "pending", mode: "announce" },
+            announceTarget: {
+              channel: "discord",
+              to: "channel:dev",
+              accountId: "ops",
+              threadId: "1710000000.000100",
+            },
+          },
+          roundOneReply: "first reply",
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(a2aGatewayMock).toHaveBeenCalledWith({
+        method: "send",
+        params: expect.objectContaining({
+          channel: "discord",
+          to: "channel:dev",
+          accountId: "ops",
+          threadId: "1710000000.000100",
+          message: "threaded reply",
         }),
         timeoutMs: 10_000,
       });

--- a/src/agents/tools/sessions-send-announce-guard.test.ts
+++ b/src/agents/tools/sessions-send-announce-guard.test.ts
@@ -1,0 +1,513 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+
+const callGatewayMock = vi.fn();
+const runSessionsSendA2AFlowMock = vi.fn();
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+vi.mock("./sessions-send-tool.a2a.js", () => ({
+  runSessionsSendA2AFlow: (...args: unknown[]) => runSessionsSendA2AFlowMock(...args),
+}));
+
+type ToolTestConfig = {
+  session: {
+    scope: "per-sender";
+    mainKey: string;
+    agentToAgent: {
+      maxPingPongTurns: number;
+    };
+  };
+  tools: {
+    agentToAgent: {
+      enabled: boolean;
+    };
+    sessions: {
+      visibility: "all";
+    };
+  };
+};
+
+const testConfig: ToolTestConfig = {
+  session: {
+    scope: "per-sender",
+    mainKey: "main",
+    agentToAgent: {
+      maxPingPongTurns: 2,
+    },
+  },
+  tools: {
+    agentToAgent: {
+      enabled: true,
+    },
+    sessions: {
+      visibility: "all",
+    },
+  },
+};
+
+let resolveAnnounceTarget: (typeof import("./sessions-announce-target.js"))["resolveAnnounceTarget"];
+let createSessionsSendTool: (typeof import("./sessions-send-tool.js"))["createSessionsSendTool"];
+let setActivePluginRegistry: (typeof import("../../plugins/runtime.js"))["setActivePluginRegistry"];
+
+async function loadFreshModules() {
+  vi.resetModules();
+  vi.doMock("../../gateway/call.js", () => ({
+    callGateway: (opts: unknown) => callGatewayMock(opts),
+  }));
+  vi.doMock("./sessions-send-tool.a2a.js", () => ({
+    runSessionsSendA2AFlow: (...args: unknown[]) => runSessionsSendA2AFlowMock(...args),
+  }));
+  ({ resolveAnnounceTarget } = await import("./sessions-announce-target.js"));
+  ({ createSessionsSendTool } = await import("./sessions-send-tool.js"));
+  ({ setActivePluginRegistry } = await import("../../plugins/runtime.js"));
+}
+
+function installRegistry() {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "discord",
+        source: "test",
+        plugin: {
+          id: "discord",
+          meta: {
+            id: "discord",
+            label: "Discord",
+            selectionLabel: "Discord",
+            docsPath: "/channels/discord",
+            blurb: "Discord test stub.",
+          },
+          capabilities: { chatTypes: ["direct", "channel", "thread"] },
+          config: {
+            listAccountIds: () => ["default"],
+            resolveAccount: () => ({}),
+          },
+        },
+      },
+      {
+        pluginId: "whatsapp",
+        source: "test",
+        plugin: {
+          id: "whatsapp",
+          meta: {
+            id: "whatsapp",
+            label: "WhatsApp",
+            selectionLabel: "WhatsApp",
+            docsPath: "/channels/whatsapp",
+            blurb: "WhatsApp test stub.",
+            preferSessionLookupForAnnounceTarget: true,
+          },
+          capabilities: { chatTypes: ["direct", "group"] },
+          config: {
+            listAccountIds: () => ["default"],
+            resolveAccount: () => ({}),
+          },
+        },
+      },
+    ]),
+  );
+}
+
+function createTool() {
+  return createSessionsSendTool({
+    agentSessionKey: "main",
+    agentChannel: "discord",
+    config: testConfig,
+  });
+}
+
+beforeEach(async () => {
+  callGatewayMock.mockReset();
+  runSessionsSendA2AFlowMock.mockReset();
+  await loadFreshModules();
+  installRegistry();
+});
+
+describe("resolveAnnounceTarget fail-closed classification", () => {
+  it("classifies key-shaped channel targets as external targets", async () => {
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:discord:group:dev",
+      displayKey: "agent:main:discord:group:dev",
+    });
+
+    expect(target).toEqual({
+      kind: "external_target",
+      target: { channel: "discord", to: "group:dev", threadId: undefined },
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("classifies matched sessions with no outbound delivery context as no_external_target", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [{ key: "main", displayName: "main" }],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "main",
+      displayKey: "main",
+    });
+
+    expect(target).toEqual({ kind: "no_external_target" });
+  });
+
+  it("classifies lookup-preferred channel hits without delivery metadata as unknown", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [{ key: "agent:main:whatsapp:group:123@g.us", displayName: "wa target" }],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      displayKey: "agent:main:whatsapp:group:123@g.us",
+    });
+
+    expect(target).toEqual({ kind: "unknown", reason: "missing_delivery" });
+  });
+
+  it("returns unknown when lookup misses and only the display key looks channel-bound", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "main",
+      displayKey: "discord:group:dev",
+    });
+
+    expect(target).toEqual({ kind: "unknown", reason: "miss" });
+  });
+
+  it("returns unknown:error when sessions.list throws", async () => {
+    callGatewayMock.mockRejectedValueOnce(new Error("sessions.list exploded"));
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "main",
+      displayKey: "main",
+    });
+
+    expect(target).toEqual({ kind: "unknown", reason: "error" });
+  });
+});
+
+describe("sessions_send fail-closed announce flow", () => {
+  it("skips channel-bound announce flow by default", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: { runId?: string } };
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [{ key: "agent:main:discord:group:target", displayName: "target" }],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-channel-bound", status: "accepted" };
+      }
+      if (request.method === "agent.wait") {
+        return { runId: request.params?.runId ?? "run-channel-bound", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "initial" }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await createTool().execute("call-channel-bound", {
+      sessionKey: "agent:main:discord:group:target",
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      delivery: { status: "skipped", mode: "none" },
+    });
+    expect(runSessionsSendA2AFlowMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves internal announce flow when target has no outbound route", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: { runId?: string } };
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [{ key: "main", displayName: "main" }],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-internal", status: "accepted" };
+      }
+      if (request.method === "agent.wait") {
+        return { runId: request.params?.runId ?? "run-internal", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "done" }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await createTool().execute("call-internal-target", {
+      sessionKey: "main",
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      delivery: { status: "pending", mode: "announce" },
+    });
+    expect(runSessionsSendA2AFlowMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps fire-and-forget sends deliverable without waiting for agent completion", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [{ key: "main", displayName: "main" }],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-fire-and-forget", status: "accepted" };
+      }
+      return {};
+    });
+
+    const result = await createTool().execute("call-fire-and-forget", {
+      sessionKey: "main",
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    expect(result.details).toMatchObject({
+      runId: "run-fire-and-forget",
+      status: "accepted",
+      delivery: { status: "pending", mode: "announce" },
+    });
+    expect(runSessionsSendA2AFlowMock).toHaveBeenCalledTimes(1);
+    expect(runSessionsSendA2AFlowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetSessionKey: "main",
+        displayKey: "main",
+        waitRunId: "run-fire-and-forget",
+      }),
+    );
+    const methods = callGatewayMock.mock.calls.map(
+      ([request]) => (request as { method?: string }).method,
+    );
+    expect(methods).not.toContain("agent.wait");
+    expect(methods).not.toContain("chat.history");
+  });
+
+  it("fails closed for fire-and-forget lookup-preferred sessions missing delivery metadata", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [{ key: "agent:main:whatsapp:group:123@g.us", displayName: "wa target" }],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-fire-skip", status: "accepted" };
+      }
+      return {};
+    });
+
+    const result = await createTool().execute("call-fire-and-forget-skip", {
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    expect(result.details).toMatchObject({
+      runId: "run-fire-skip",
+      status: "accepted",
+      delivery: { status: "skipped", mode: "none" },
+    });
+    expect(runSessionsSendA2AFlowMock).not.toHaveBeenCalled();
+    const methods = callGatewayMock.mock.calls.map(
+      ([request]) => (request as { method?: string }).method,
+    );
+    expect(methods).not.toContain("agent.wait");
+    expect(methods).not.toContain("chat.history");
+  });
+
+  it("fails closed for lookup-preferred sessions missing delivery metadata", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: { runId?: string } };
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [{ key: "agent:main:whatsapp:group:123@g.us", displayName: "wa target" }],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-missing-delivery", status: "accepted" };
+      }
+      if (request.method === "agent.wait") {
+        return { runId: request.params?.runId ?? "run-missing-delivery", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "done" }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await createTool().execute("call-lookup-preferred", {
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      delivery: { status: "skipped", mode: "none" },
+    });
+    expect(runSessionsSendA2AFlowMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when announce target resolution is partial", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: { runId?: string } };
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [{ key: "main", displayName: "main", lastChannel: "discord" }],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-partial", status: "accepted" };
+      }
+      if (request.method === "agent.wait") {
+        return { runId: request.params?.runId ?? "run-partial", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "done" }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await createTool().execute("call-partial-target", {
+      sessionKey: "main",
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      delivery: { status: "skipped", mode: "none" },
+    });
+    expect(runSessionsSendA2AFlowMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("runSessionsSendA2AFlow last-mile delivery", () => {
+  it("swallows announce delivery failures after generating the last-mile reply", async () => {
+    const a2aModule = await vi.importActual<typeof import("./sessions-send-tool.a2a.js")>(
+      "./sessions-send-tool.a2a.js",
+    );
+    const agentStepModule =
+      await vi.importActual<typeof import("./agent-step.js")>("./agent-step.js");
+    const a2aGatewayMock = vi.fn(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "send") {
+        throw new Error("announce delivery failed");
+      }
+      return {};
+    });
+    const agentStepGatewayMock = vi.fn(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "announce-step-run" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "  delivered reply  " }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    a2aModule.__testing.setDepsForTest({
+      callGateway: a2aGatewayMock as typeof callGatewayMock,
+    });
+    agentStepModule.__testing.setDepsForTest({
+      callGateway: agentStepGatewayMock as typeof callGatewayMock,
+    });
+
+    try {
+      await expect(
+        a2aModule.runSessionsSendA2AFlow({
+          targetSessionKey: "agent:main:whatsapp:group:123@g.us",
+          displayKey: "agent:main:whatsapp:group:123@g.us",
+          message: "ping",
+          announceTimeoutMs: 1_000,
+          maxPingPongTurns: 0,
+          announcePlan: {
+            shouldRunAnnounceFlow: true,
+            delivery: { status: "pending", mode: "announce" },
+            announceTarget: {
+              channel: "whatsapp",
+              to: "123@g.us",
+              accountId: "work",
+            },
+          },
+          roundOneReply: "first reply",
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(agentStepGatewayMock).toHaveBeenCalled();
+      expect(a2aGatewayMock).toHaveBeenCalledWith({
+        method: "send",
+        params: expect.objectContaining({
+          channel: "whatsapp",
+          to: "123@g.us",
+          accountId: "work",
+          message: "delivered reply",
+        }),
+        timeoutMs: 10_000,
+      });
+    } finally {
+      a2aModule.__testing.setDepsForTest();
+      agentStepModule.__testing.setDepsForTest();
+    }
+  });
+});

--- a/src/agents/tools/sessions-send-announce-guard.test.ts
+++ b/src/agents/tools/sessions-send-announce-guard.test.ts
@@ -274,42 +274,113 @@ describe("sessions_send fail-closed announce flow", () => {
     expect(runSessionsSendA2AFlowMock).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps fire-and-forget sends deliverable without waiting for agent completion", async () => {
+  it("fails closed for fire-and-forget sends without immediate target classification", async () => {
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string };
-      if (request.method === "sessions.list") {
-        return {
-          sessions: [{ key: "main", displayName: "main" }],
-        };
-      }
       if (request.method === "agent") {
         return { runId: "run-fire-and-forget", status: "accepted" };
       }
       return {};
     });
 
-    const result = await createTool().execute("call-fire-and-forget", {
+    const resultPromise = createTool().execute("call-fire-and-forget", {
+      sessionKey: "main",
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+    const timeoutSentinel = Symbol("timeout");
+    const resultOrTimeout = await Promise.race([
+      resultPromise,
+      new Promise<typeof timeoutSentinel>((resolve) => {
+        setTimeout(() => resolve(timeoutSentinel), 0);
+      }),
+    ]);
+
+    expect(resultOrTimeout).not.toBe(timeoutSentinel);
+    const result = resultOrTimeout as Awaited<ReturnType<ReturnType<typeof createTool>["execute"]>>;
+
+    expect(result.details).toMatchObject({
+      runId: "run-fire-and-forget",
+      status: "accepted",
+      delivery: { status: "skipped", mode: "none" },
+    });
+    expect(runSessionsSendA2AFlowMock).not.toHaveBeenCalled();
+    const methods = callGatewayMock.mock.calls.map(
+      ([request]) => (request as { method?: string }).method,
+    );
+    expect(methods).not.toContain("sessions.list");
+    expect(methods).not.toContain("agent.wait");
+    expect(methods).not.toContain("chat.history");
+  });
+
+  it("fails closed for fire-and-forget sends even when metadata-backed routing would exist", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-fire-metadata-route", status: "accepted" };
+      }
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [
+            {
+              key: "main",
+              displayName: "main",
+              deliveryContext: {
+                channel: "discord",
+                to: "group:dev",
+              },
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await createTool().execute("call-fire-and-forget-metadata-route", {
       sessionKey: "main",
       message: "ping",
       timeoutSeconds: 0,
     });
 
     expect(result.details).toMatchObject({
-      runId: "run-fire-and-forget",
+      runId: "run-fire-metadata-route",
       status: "accepted",
-      delivery: { status: "pending", mode: "announce" },
+      delivery: { status: "skipped", mode: "none" },
     });
-    expect(runSessionsSendA2AFlowMock).toHaveBeenCalledTimes(1);
-    expect(runSessionsSendA2AFlowMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        targetSessionKey: "main",
-        displayKey: "main",
-        waitRunId: "run-fire-and-forget",
-      }),
-    );
+    expect(runSessionsSendA2AFlowMock).not.toHaveBeenCalled();
     const methods = callGatewayMock.mock.calls.map(
       ([request]) => (request as { method?: string }).method,
     );
+    expect(methods).not.toContain("sessions.list");
+    expect(methods).not.toContain("agent.wait");
+    expect(methods).not.toContain("chat.history");
+  });
+
+  it("skips fire-and-forget announce flow for immediate external targets", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-fire-external", status: "accepted" };
+      }
+      return {};
+    });
+
+    const result = await createTool().execute("call-fire-and-forget-external", {
+      sessionKey: "agent:main:discord:group:target",
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    expect(result.details).toMatchObject({
+      runId: "run-fire-external",
+      status: "accepted",
+      delivery: { status: "skipped", mode: "none" },
+    });
+    expect(runSessionsSendA2AFlowMock).not.toHaveBeenCalled();
+    const methods = callGatewayMock.mock.calls.map(
+      ([request]) => (request as { method?: string }).method,
+    );
+    expect(methods).not.toContain("sessions.list");
     expect(methods).not.toContain("agent.wait");
     expect(methods).not.toContain("chat.history");
   });
@@ -317,22 +388,27 @@ describe("sessions_send fail-closed announce flow", () => {
   it("fails closed for fire-and-forget lookup-preferred sessions missing delivery metadata", async () => {
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string };
-      if (request.method === "sessions.list") {
-        return {
-          sessions: [{ key: "agent:main:whatsapp:group:123@g.us", displayName: "wa target" }],
-        };
-      }
       if (request.method === "agent") {
         return { runId: "run-fire-skip", status: "accepted" };
       }
       return {};
     });
 
-    const result = await createTool().execute("call-fire-and-forget-skip", {
+    const resultPromise = createTool().execute("call-fire-and-forget-skip", {
       sessionKey: "agent:main:whatsapp:group:123@g.us",
       message: "ping",
       timeoutSeconds: 0,
     });
+    const timeoutSentinel = Symbol("timeout");
+    const resultOrTimeout = await Promise.race([
+      resultPromise,
+      new Promise<typeof timeoutSentinel>((resolve) => {
+        setTimeout(() => resolve(timeoutSentinel), 0);
+      }),
+    ]);
+
+    expect(resultOrTimeout).not.toBe(timeoutSentinel);
+    const result = resultOrTimeout as Awaited<ReturnType<ReturnType<typeof createTool>["execute"]>>;
 
     expect(result.details).toMatchObject({
       runId: "run-fire-skip",
@@ -343,6 +419,7 @@ describe("sessions_send fail-closed announce flow", () => {
     const methods = callGatewayMock.mock.calls.map(
       ([request]) => (request as { method?: string }).method,
     );
+    expect(methods).not.toContain("sessions.list");
     expect(methods).not.toContain("agent.wait");
     expect(methods).not.toContain("chat.history");
   });

--- a/src/agents/tools/sessions-send-announce-guard.test.ts
+++ b/src/agents/tools/sessions-send-announce-guard.test.ts
@@ -544,6 +544,7 @@ describe("runSessionsSendA2AFlow last-mile delivery", () => {
     );
     const agentStepModule =
       await vi.importActual<typeof import("./agent-step.js")>("./agent-step.js");
+    const runWaitModule = await vi.importActual<typeof import("../run-wait.js")>("../run-wait.js");
     const a2aGatewayMock = vi.fn(async (opts: unknown) => {
       const request = opts as { method?: string };
       if (request.method === "send") {
@@ -577,6 +578,9 @@ describe("runSessionsSendA2AFlow last-mile delivery", () => {
       callGateway: a2aGatewayMock as typeof callGatewayMock,
     });
     agentStepModule.__testing.setDepsForTest({
+      callGateway: agentStepGatewayMock as typeof callGatewayMock,
+    });
+    runWaitModule.__testing.setDepsForTest({
       callGateway: agentStepGatewayMock as typeof callGatewayMock,
     });
 
@@ -615,6 +619,7 @@ describe("runSessionsSendA2AFlow last-mile delivery", () => {
     } finally {
       a2aModule.__testing.setDepsForTest();
       agentStepModule.__testing.setDepsForTest();
+      runWaitModule.__testing.setDepsForTest();
     }
   });
 
@@ -624,6 +629,7 @@ describe("runSessionsSendA2AFlow last-mile delivery", () => {
     );
     const agentStepModule =
       await vi.importActual<typeof import("./agent-step.js")>("./agent-step.js");
+    const runWaitModule = await vi.importActual<typeof import("../run-wait.js")>("../run-wait.js");
     const a2aGatewayMock = vi.fn(async (opts: unknown) => {
       const request = opts as { method?: string };
       if (request.method === "send") {
@@ -657,6 +663,9 @@ describe("runSessionsSendA2AFlow last-mile delivery", () => {
       callGateway: a2aGatewayMock as typeof callGatewayMock,
     });
     agentStepModule.__testing.setDepsForTest({
+      callGateway: agentStepGatewayMock as typeof callGatewayMock,
+    });
+    runWaitModule.__testing.setDepsForTest({
       callGateway: agentStepGatewayMock as typeof callGatewayMock,
     });
 
@@ -696,6 +705,7 @@ describe("runSessionsSendA2AFlow last-mile delivery", () => {
     } finally {
       a2aModule.__testing.setDepsForTest();
       agentStepModule.__testing.setDepsForTest();
+      runWaitModule.__testing.setDepsForTest();
     }
   });
 });

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -6,7 +6,7 @@ import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
 import { readLatestAssistantReply, waitForAgentRun } from "../run-wait.js";
 import { runAgentStep } from "./agent-step.js";
-import { resolveAnnounceTarget } from "./sessions-announce-target.js";
+import type { AnnounceTarget } from "./sessions-send-helpers.js";
 import {
   buildAgentToAgentAnnounceContext,
   buildAgentToAgentReplyContext,
@@ -26,12 +26,27 @@ let sessionsSendA2ADeps: {
   callGateway: GatewayCaller;
 } = defaultSessionsSendA2ADeps;
 
+export type SessionsSendAnnouncePlan = {
+  shouldRunAnnounceFlow: boolean;
+  delivery:
+    | {
+        status: "pending";
+        mode: "announce";
+      }
+    | {
+        status: "skipped";
+        mode: "none";
+      };
+  announceTarget: AnnounceTarget | null;
+};
+
 export async function runSessionsSendA2AFlow(params: {
   targetSessionKey: string;
   displayKey: string;
   message: string;
   announceTimeoutMs: number;
   maxPingPongTurns: number;
+  announcePlan: SessionsSendAnnouncePlan | Promise<SessionsSendAnnouncePlan>;
   requesterSessionKey?: string;
   requesterChannel?: GatewayMessageChannel;
   roundOneReply?: string;
@@ -39,6 +54,11 @@ export async function runSessionsSendA2AFlow(params: {
 }) {
   const runContextId = params.waitRunId ?? "unknown";
   try {
+    const announcePlan = await params.announcePlan;
+    if (!announcePlan.shouldRunAnnounceFlow) {
+      return;
+    }
+
     let primaryReply = params.roundOneReply;
     let latestReply = params.roundOneReply;
     if (!primaryReply && params.waitRunId) {
@@ -58,10 +78,7 @@ export async function runSessionsSendA2AFlow(params: {
       return;
     }
 
-    const announceTarget = await resolveAnnounceTarget({
-      sessionKey: params.targetSessionKey,
-      displayKey: params.displayKey,
-    });
+    const announceTarget = announcePlan.announceTarget;
     const targetChannel = announceTarget?.channel ?? "unknown";
 
     if (

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -29,12 +29,10 @@ import {
 import {
   createSessionVisibilityGuard,
   createAgentToAgentPolicy,
-  extractAssistantText,
   resolveEffectiveSessionToolsVisibility,
   resolveSessionReference,
   resolveSessionToolContext,
   resolveVisibleSessionReference,
-  stripToolMessages,
 } from "./sessions-helpers.js";
 import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
 import { type SessionsSendAnnouncePlan, runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
@@ -49,27 +47,6 @@ const SessionsSendToolSchema = Type.Object({
 
 type GatewayCaller = typeof callGateway;
 const SESSIONS_SEND_REPLY_HISTORY_LIMIT = 50;
-
-function resolveLatestAssistantReplySnapshot(messages: unknown[]): {
-  text?: string;
-  fingerprint?: string;
-} {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    const text = extractAssistantText(message);
-    if (!text) {
-      continue;
-    }
-    let fingerprint: string | undefined;
-    try {
-      fingerprint = JSON.stringify(message);
-    } catch {
-      fingerprint = text;
-    }
-    return { text, fingerprint };
-  }
-  return {};
-}
 
 function resolveImmediateFireAndForgetAnnounceDecision(params: {
   sessionKey: string;
@@ -442,11 +419,11 @@ export function createSessionsSendTool(opts?: {
         });
       }
       const reply = result.replyText;
-      const announcePlan = announcePlanPromise
-        ? (settledAnnouncePlan ?? (await announcePlanPromise))
-        : immediatePlan;
+      const announcePlan = settledAnnouncePlan ?? immediatePlan;
       if (announcePlan?.shouldRunAnnounceFlow) {
         startA2AFlow(announcePlan, reply ?? undefined);
+      } else if (!announcePlan && announcePlanPromise) {
+        startA2AFlow(announcePlanPromise, reply ?? undefined);
       }
 
       return jsonResult({

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -29,15 +29,14 @@ import {
 import {
   createSessionVisibilityGuard,
   createAgentToAgentPolicy,
+  extractAssistantText,
   resolveEffectiveSessionToolsVisibility,
   resolveSessionReference,
   resolveSessionToolContext,
   resolveVisibleSessionReference,
+  stripToolMessages,
 } from "./sessions-helpers.js";
-import {
-  buildAgentToAgentMessageContext,
-  resolvePingPongTurns,
-} from "./sessions-send-helpers.js";
+import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
 import { type SessionsSendAnnouncePlan, runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
 const SessionsSendToolSchema = Type.Object({
@@ -50,6 +49,27 @@ const SessionsSendToolSchema = Type.Object({
 
 type GatewayCaller = typeof callGateway;
 const SESSIONS_SEND_REPLY_HISTORY_LIMIT = 50;
+
+function resolveLatestAssistantReplySnapshot(messages: unknown[]): {
+  text?: string;
+  fingerprint?: string;
+} {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    const text = extractAssistantText(message);
+    if (!text) {
+      continue;
+    }
+    let fingerprint: string | undefined;
+    try {
+      fingerprint = JSON.stringify(message);
+    } catch {
+      fingerprint = text;
+    }
+    return { text, fingerprint };
+  }
+  return {};
+}
 
 function resolveImmediateFireAndForgetAnnounceDecision(params: {
   sessionKey: string;

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -22,6 +22,11 @@ import {
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
 import {
+  type AnnounceTargetDecision,
+  resolveAnnounceTarget,
+  resolveParsedAnnounceTargetDecision,
+} from "./sessions-announce-target.js";
+import {
   createSessionVisibilityGuard,
   createAgentToAgentPolicy,
   resolveEffectiveSessionToolsVisibility,
@@ -30,7 +35,7 @@ import {
   resolveVisibleSessionReference,
 } from "./sessions-helpers.js";
 import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
-import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
+import { type SessionsSendAnnouncePlan, runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
 const SessionsSendToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
@@ -288,14 +293,29 @@ export function createSessionsSendTool(opts?: {
       const requesterSessionKey = opts?.agentSessionKey;
       const requesterChannel = opts?.agentChannel;
       const maxPingPongTurns = resolvePingPongTurns(cfg);
-      const delivery = { status: "pending", mode: "announce" as const };
-      const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
+      const pendingAnnounceDelivery = { status: "pending" as const, mode: "announce" as const };
+      const resolveAnnouncePlan = (decision: AnnounceTargetDecision): SessionsSendAnnouncePlan => {
+        const shouldRunAnnounceFlow = decision.kind === "no_external_target";
+        return {
+          shouldRunAnnounceFlow,
+          delivery: shouldRunAnnounceFlow
+            ? pendingAnnounceDelivery
+            : { status: "skipped", mode: "none" as const },
+          announceTarget: decision.kind === "external_target" ? decision.target : null,
+        };
+      };
+      const startA2AFlow = (
+        announcePlan: SessionsSendAnnouncePlan | Promise<SessionsSendAnnouncePlan>,
+        roundOneReply?: string,
+        waitRunId?: string,
+      ) => {
         void runSessionsSendA2AFlow({
           targetSessionKey: resolvedKey,
           displayKey,
           message,
           announceTimeoutMs,
           maxPingPongTurns,
+          announcePlan,
           requesterSessionKey,
           requesterChannel,
           roundOneReply,
@@ -314,12 +334,33 @@ export function createSessionsSendTool(opts?: {
           return start.result;
         }
         runId = start.runId;
-        startA2AFlow(undefined, runId);
+        const immediateDecision = resolveParsedAnnounceTargetDecision(resolvedKey);
+        const immediatePlan = immediateDecision ? resolveAnnouncePlan(immediateDecision) : null;
+        if (immediatePlan) {
+          if (immediatePlan.shouldRunAnnounceFlow) {
+            startA2AFlow(immediatePlan, undefined, runId);
+          }
+          return jsonResult({
+            runId,
+            status: "accepted",
+            sessionKey: displayKey,
+            delivery: immediatePlan.delivery,
+          });
+        }
+        const announcePlan = await resolveAnnounceTarget({
+          sessionKey: resolvedKey,
+          displayKey,
+        })
+          .catch(() => ({ kind: "unknown", reason: "error" }) satisfies AnnounceTargetDecision)
+          .then(resolveAnnouncePlan);
+        if (announcePlan.shouldRunAnnounceFlow) {
+          startA2AFlow(announcePlan, undefined, runId);
+        }
         return jsonResult({
           runId,
           status: "accepted",
           sessionKey: displayKey,
-          delivery,
+          delivery: announcePlan.delivery,
         });
       }
 
@@ -333,6 +374,24 @@ export function createSessionsSendTool(opts?: {
         return start.result;
       }
       runId = start.runId;
+      const immediateDecision = resolveParsedAnnounceTargetDecision(resolvedKey);
+      const immediatePlan = immediateDecision ? resolveAnnouncePlan(immediateDecision) : null;
+      let settledAnnouncePlan: SessionsSendAnnouncePlan | undefined;
+      const announcePlanPromise =
+        !immediatePlan || immediatePlan.shouldRunAnnounceFlow
+          ? resolveAnnounceTarget({
+              sessionKey: resolvedKey,
+              displayKey,
+            })
+              .catch(() => ({ kind: "unknown", reason: "error" }) satisfies AnnounceTargetDecision)
+              .then(resolveAnnouncePlan)
+          : null;
+      if (announcePlanPromise) {
+        void announcePlanPromise.then((plan) => {
+          settledAnnouncePlan = plan;
+        });
+      }
+
       const result = await waitForAgentRunAndReadUpdatedAssistantReply({
         runId,
         sessionKey: resolvedKey,
@@ -359,14 +418,19 @@ export function createSessionsSendTool(opts?: {
         });
       }
       const reply = result.replyText;
-      startA2AFlow(reply ?? undefined);
+      const announcePlan = announcePlanPromise
+        ? (settledAnnouncePlan ?? (await announcePlanPromise))
+        : immediatePlan;
+      if (announcePlan?.shouldRunAnnounceFlow) {
+        startA2AFlow(announcePlan, reply ?? undefined);
+      }
 
       return jsonResult({
         runId,
         status: "ok",
         reply,
         sessionKey: displayKey,
-        delivery,
+        delivery: announcePlan?.delivery ?? pendingAnnounceDelivery,
       });
     },
   };

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -34,7 +34,10 @@ import {
   resolveSessionToolContext,
   resolveVisibleSessionReference,
 } from "./sessions-helpers.js";
-import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
+import {
+  buildAgentToAgentMessageContext,
+  resolvePingPongTurns,
+} from "./sessions-send-helpers.js";
 import { type SessionsSendAnnouncePlan, runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
 const SessionsSendToolSchema = Type.Object({
@@ -48,6 +51,20 @@ const SessionsSendToolSchema = Type.Object({
 type GatewayCaller = typeof callGateway;
 const SESSIONS_SEND_REPLY_HISTORY_LIMIT = 50;
 
+function resolveImmediateFireAndForgetAnnounceDecision(params: {
+  sessionKey: string;
+  displayKey: string;
+}): AnnounceTargetDecision {
+  const parsedDecision =
+    resolveParsedAnnounceTargetDecision(params.sessionKey) ??
+    (params.displayKey !== params.sessionKey
+      ? resolveParsedAnnounceTargetDecision(params.displayKey)
+      : null);
+  if (parsedDecision) {
+    return parsedDecision;
+  }
+  return { kind: "unknown", reason: "miss" };
+}
 async function startAgentRun(params: {
   callGateway: GatewayCaller;
   runId: string;
@@ -334,25 +351,12 @@ export function createSessionsSendTool(opts?: {
           return start.result;
         }
         runId = start.runId;
-        const immediateDecision = resolveParsedAnnounceTargetDecision(resolvedKey);
-        const immediatePlan = immediateDecision ? resolveAnnouncePlan(immediateDecision) : null;
-        if (immediatePlan) {
-          if (immediatePlan.shouldRunAnnounceFlow) {
-            startA2AFlow(immediatePlan, undefined, runId);
-          }
-          return jsonResult({
-            runId,
-            status: "accepted",
-            sessionKey: displayKey,
-            delivery: immediatePlan.delivery,
-          });
-        }
-        const announcePlan = await resolveAnnounceTarget({
-          sessionKey: resolvedKey,
-          displayKey,
-        })
-          .catch(() => ({ kind: "unknown", reason: "error" }) satisfies AnnounceTargetDecision)
-          .then(resolveAnnouncePlan);
+        const announcePlan = resolveAnnouncePlan(
+          resolveImmediateFireAndForgetAnnounceDecision({
+            sessionKey: resolvedKey,
+            displayKey,
+          }),
+        );
         if (announcePlan.shouldRunAnnounceFlow) {
           startA2AFlow(announcePlan, undefined, runId);
         }

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -342,6 +342,41 @@ describe("resolveAnnounceTarget", () => {
     });
   });
 
+  it("prefers deliveryContext accountId over stale origin accountId", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "main",
+          lastChannel: "whatsapp",
+          lastTo: "123@g.us",
+          deliveryContext: {
+            channel: "whatsapp",
+            to: "123@g.us",
+            accountId: "current-work",
+          },
+          origin: {
+            provider: "whatsapp",
+            accountId: "stale-work",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "main",
+      displayKey: "main",
+    });
+
+    expect(target).toEqual({
+      kind: "external_target",
+      target: {
+        channel: "whatsapp",
+        to: "123@g.us",
+        accountId: "current-work",
+      },
+    });
+  });
+
   it("treats lookup-preferred channels inferred only from row metadata as missing delivery", async () => {
     callGatewayMock.mockResolvedValueOnce({
       sessions: [{ key: "main", channel: "whatsapp", displayName: "wa target" }],
@@ -373,6 +408,75 @@ describe("resolveAnnounceTarget", () => {
       sessions: [
         {
           key: "main",
+          deliveryContext: {
+            channel: "discord",
+            to: "channel:dev",
+            accountId: "ops",
+            threadId: "1710000000.000100",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "main",
+      displayKey: "main",
+    });
+
+    expect(target).toEqual({
+      kind: "external_target",
+      target: {
+        channel: "discord",
+        to: "channel:dev",
+        accountId: "ops",
+        threadId: "1710000000.000100",
+      },
+    });
+  });
+
+  it("hydrates accountId from origin when deliveryContext omits it", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "main",
+          lastChannel: "discord",
+          lastTo: "channel:dev",
+          deliveryContext: {
+            channel: "discord",
+            to: "channel:dev",
+          },
+          origin: {
+            provider: "discord",
+            accountId: "ops",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "main",
+      displayKey: "main",
+    });
+
+    expect(target).toEqual({
+      kind: "external_target",
+      target: {
+        channel: "discord",
+        to: "channel:dev",
+        accountId: "ops",
+      },
+    });
+  });
+
+  it("prefers deliveryContext threadId over stale origin threadId", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "main",
+          origin: {
+            provider: "discord",
+            threadId: "stale-thread",
+          },
           deliveryContext: {
             channel: "discord",
             to: "channel:dev",

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -275,7 +275,10 @@ describe("resolveAnnounceTarget", () => {
       sessionKey: "agent:main:discord:group:dev",
       displayKey: "agent:main:discord:group:dev",
     });
-    expect(target).toEqual({ channel: "discord", to: "group:dev" });
+    expect(target).toEqual({
+      kind: "external_target",
+      target: { channel: "discord", to: "group:dev", threadId: undefined },
+    });
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
@@ -298,9 +301,12 @@ describe("resolveAnnounceTarget", () => {
       displayKey: "agent:main:whatsapp:group:123@g.us",
     });
     expect(target).toEqual({
-      channel: "whatsapp",
-      to: "123@g.us",
-      accountId: "work",
+      kind: "external_target",
+      target: {
+        channel: "whatsapp",
+        to: "123@g.us",
+        accountId: "work",
+      },
     });
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
     const first = callGatewayMock.mock.calls[0]?.[0] as { method?: string } | undefined;
@@ -327,9 +333,12 @@ describe("resolveAnnounceTarget", () => {
       displayKey: "agent:main:whatsapp:group:123@g.us",
     });
     expect(target).toEqual({
-      channel: "whatsapp",
-      to: "123@g.us",
-      accountId: "work",
+      kind: "external_target",
+      target: {
+        channel: "whatsapp",
+        to: "123@g.us",
+        accountId: "work",
+      },
     });
   });
 });

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -341,6 +341,63 @@ describe("resolveAnnounceTarget", () => {
       },
     });
   });
+
+  it("treats lookup-preferred channels inferred only from row metadata as missing delivery", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [{ key: "main", channel: "whatsapp", displayName: "wa target" }],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "main",
+      displayKey: "main",
+    });
+
+    expect(target).toEqual({ kind: "unknown", reason: "missing_delivery" });
+  });
+
+  it("does not treat a non-lookup-preferred row channel as a partial delivery route", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [{ key: "main", channel: "discord", displayName: "discord target" }],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "main",
+      displayKey: "main",
+    });
+
+    expect(target).toEqual({ kind: "no_external_target" });
+  });
+
+  it("preserves threadId from metadata-backed delivery routes", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "main",
+          deliveryContext: {
+            channel: "discord",
+            to: "channel:dev",
+            accountId: "ops",
+            threadId: "1710000000.000100",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "main",
+      displayKey: "main",
+    });
+
+    expect(target).toEqual({
+      kind: "external_target",
+      target: {
+        channel: "discord",
+        to: "channel:dev",
+        accountId: "ops",
+        threadId: "1710000000.000100",
+      },
+    });
+  });
 });
 
 describe("sessions_list gating", () => {


### PR DESCRIPTION
## Summary

This PR finishes the fail-closed `sessions_send` announce migration on top of `v2026.3.28` and tightens the zero-timeout path.

It combines 3 commits:

- `46e57841d8` Fail closed sessions_send announce planning
- `4d28d078dc` Split sessions and subagents registry tests
- `64b6eb4db1` Fail closed zero-timeout sessions_send announce

## What changed

- migrated fail-closed announce-target planning into the current `sessions_send` flow
- preserved the stable branch's newer reply snapshot / stale-reply protections
- made `timeoutSeconds=0` strictly fail closed without blocking on `sessions.list`
- kept immediate external targets on the fast skip path
- restored real schema coverage for `sessions_send` / `sessions_spawn`
- added a minimal `createOpenClawTools()` registry smoke test without reintroducing the old hanging registry path

## Behavior

### `sessions_send`
- external channel-bound targets skip announce
- unknown targets fail closed
- zero-timeout sends do not wait on `sessions.list`, `agent.wait`, or `chat.history`
- zero-timeout sends only use immediately provable routing information
- metadata-backed routes that are only discoverable through lookup now fail closed at `timeoutSeconds=0`

### tests
- split registry-level `sessions` and `subagents` coverage
- added focused zero-timeout regressions
- restored real schema checks for `sessions_send.timeoutSeconds`
- restored real schema checks for `sessions_spawn.runTimeoutSeconds` and legacy `timeoutSeconds`

## Verification

```bash
pnpm test src/agents/tools/sessions-send-announce-guard.test.ts \
  src/agents/tools/sessions.test.ts \
  src/agents/openclaw-tools.sessions.test.ts \
  src/agents/openclaw-tools.subagents.test.ts \
  src/agents/openclaw-tools.sessions-visibility.test.ts
```

Result:

- `Test Files 5 passed`
- `Tests 61 passed`

## Notes

- zero-timeout `sessions_send` now prefers truthful fail-closed delivery reporting over lookup-dependent announce behavior
- an independent review on the final diff found no remaining issues



## Related issues

- Related to #47515


- Possibly related: #55981
- Possibly related: #56136
- Possibly related: #50487
