### PR TITLE
fix(installer): prevent apt-get hanging on fresh Ubuntu 24.04

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -572,10 +572,10 @@ install_build_tools_linux() {
     if command -v apt-get &> /dev/null; then
         if is_root; then
             run_quiet_step "Updating package index" apt-get update -qq
-            run_quiet_step "Installing build tools" apt-get install -y -qq build-essential python3 make g++ cmake
+            run_quiet_step "Installing build tools" apt-get install -y -qq -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold build-essential python3 make g++ cmake
         else
             run_quiet_step "Updating package index" sudo apt-get update -qq
-            run_quiet_step "Installing build tools" sudo apt-get install -y -qq build-essential python3 make g++ cmake
+            run_quiet_step "Installing build tools" sudo apt-get install -y -qq -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold build-essential python3 make g++ cmake
         fi
         return 0
     fi
@@ -1435,10 +1435,10 @@ install_node() {
             download_file "https://deb.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
             if is_root; then
                 run_quiet_step "Configuring NodeSource repository" bash "$tmp"
-                run_quiet_step "Installing Node.js" apt-get install -y -qq nodejs
+                run_quiet_step "Installing Node.js" apt-get install -y -qq -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold nodejs
             else
                 run_quiet_step "Configuring NodeSource repository" sudo -E bash "$tmp"
-                run_quiet_step "Installing Node.js" sudo apt-get install -y -qq nodejs
+                run_quiet_step "Installing Node.js" sudo apt-get install -y -qq -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold nodejs
             fi
         elif command -v dnf &> /dev/null; then
             local tmp
@@ -1527,10 +1527,10 @@ install_git() {
         if command -v apt-get &> /dev/null; then
             if is_root; then
                 run_quiet_step "Updating package index" apt-get update -qq
-                run_quiet_step "Installing Git" apt-get install -y -qq git
+                run_quiet_step "Installing Git" apt-get install -y -qq -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold git
             else
                 run_quiet_step "Updating package index" sudo apt-get update -qq
-                run_quiet_step "Installing Git" sudo apt-get install -y -qq git
+                run_quiet_step "Installing Git" sudo apt-get install -y -qq -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold git
             fi
         elif command -v pacman &> /dev/null || is_arch_linux; then
             if is_root; then
@@ -2263,6 +2263,12 @@ main() {
     print_installer_banner
     print_gum_status
     detect_os_or_die
+
+    # Prevent interactive dpkg prompts (needrestart, tzdata, etc.) that hang
+    # in a curl|bash pipe context.  Ubuntu 24.04+ ships needrestart by default.
+    if [[ "$OS" == "linux" ]]; then
+        export DEBIAN_FRONTEND=noninteractive
+    fi
 
     local detected_checkout=""
     detected_checkout="$(detect_openclaw_checkout "$PWD" || true)"


### PR DESCRIPTION
## Summary

Fixes #41146

On fresh Ubuntu 24.04 LTS, `curl -fsSL https://openclaw.ai/install.sh | bash` hangs indefinitely at step [1/3] during build-tools / Node.js installation. Three independent users confirmed the hang.

**Root cause:** Ubuntu 24.04 ships `needrestart` by default, which triggers interactive dpkg prompts during `apt-get install`. Since stdin is a pipe (not a TTY), these prompts block forever. The `-y -qq` flags only suppress apt-level confirmation — they do not suppress dpkg-triggered dialogs.

**Fix (two parts):**

1. **`export DEBIAN_FRONTEND=noninteractive`** on Linux before any `apt-get` calls — suppresses all interactive frontend prompts including `needrestart` service-restart dialogs and `tzdata` timezone selection.

2. **`-o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold`** on all six `apt-get install` invocations — auto-accepts default config file choices during package upgrades, preventing another class of interactive prompt.

This matches the pattern already used in every Dockerfile in the repo (6 occurrences of `DEBIAN_FRONTEND=noninteractive`) and in the install-script test harness (`scripts/test-install-sh-docker.sh` lines 34, 61, 81).

## Test plan

- [ ] Verify `bash -n scripts/install.sh` passes (shell syntax check) — confirmed locally
- [ ] All pre-commit checks pass (tsgo, oxlint, conflict markers) — confirmed locally
- [ ] Run `scripts/test-install-sh-docker.sh` against a fresh `ubuntu:24.04` image to confirm the install completes without hanging
- [ ] Verify macOS install path is unaffected (the `DEBIAN_FRONTEND` export is gated on `OS == "linux"`)