### PR TITLE
fix(acp): use target workspace for cross-agent ACP spawns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/replies: preserve explicit topic targets when `replyTo` is present while still inheriting the current topic for same-chat replies without an explicit topic. (#59634) Thanks @dashhuang.
 - Telegram/reactions: preserve `reactionNotifications: "own"` across gateway restarts by persisting sent-message ownership state instead of treating cold cache as a permissive fallback. (#59207) Thanks @samzong.
 - Telegram/media: preserve `<media:...>` placeholders and `file_id` in captioned messages when Bot API downloads fail, so agents still receive media context. (#59948) Thanks @v1p0r.
+- ACP/agents: inherit the target agent workspace for cross-agent ACP spawns, keep missing target workspaces on the backend default cwd path, and surface real access errors instead of silently running in the wrong tree. (#58438) Thanks @zssggle-rgb.
 - Telegram/media: keep inbound image attachments readable on upgraded installs where legacy state roots still differ from the managed config-dir media cache. (#59971) Thanks @neeravmakwana.
 - Telegram/local Bot API: thread `channels.telegram.apiRoot` through buffered reply-media and album downloads so self-hosted Bot API file paths stop falling back to `api.telegram.org` and 404ing. (#59544) Thanks @SARAMALI15792.
 - Telegram/media: add `channels.telegram.network.dangerouslyAllowPrivateNetwork` for trusted fake-IP or transparent-proxy environments where Telegram media downloads resolve `api.telegram.org` to private/internal/special-use addresses.

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as acpSessionManager from "../acp/control-plane/manager.js";
 import type { AcpInitializeSessionInput } from "../acp/control-plane/manager.types.js";
@@ -536,6 +539,111 @@ describe("spawnAcpDirect", () => {
       to: "channel:child-thread",
       threadId: "child-thread",
     });
+  });
+
+  it("uses the target agent workspace for cross-agent ACP spawns when cwd is omitted", async () => {
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-spawn-"));
+    try {
+      const mainWorkspace = path.join(workspaceRoot, "main");
+      const targetWorkspace = path.join(workspaceRoot, "claude-code");
+      await fs.mkdir(mainWorkspace, { recursive: true });
+      await fs.mkdir(targetWorkspace, { recursive: true });
+
+      replaceSpawnConfig({
+        ...hoisted.state.cfg,
+        acp: {
+          ...hoisted.state.cfg.acp,
+          allowedAgents: ["codex", "claude-code"],
+        },
+        agents: {
+          list: [
+            {
+              id: "main",
+              default: true,
+              workspace: mainWorkspace,
+            },
+            {
+              id: "claude-code",
+              workspace: targetWorkspace,
+            },
+          ],
+        },
+      });
+
+      const result = await spawnAcpDirect(
+        {
+          task: "Inspect the queue owner state",
+          agentId: "claude-code",
+          mode: "run",
+        },
+        {
+          agentSessionKey: "agent:main:main",
+        },
+      );
+
+      expect(result.status).toBe("accepted");
+      expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: expect.stringMatching(/^agent:claude-code:acp:/),
+          agent: "claude-code",
+          cwd: targetWorkspace,
+        }),
+      );
+    } finally {
+      await fs.rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to backend default cwd when the inherited target workspace does not exist", async () => {
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-spawn-"));
+    try {
+      const mainWorkspace = path.join(workspaceRoot, "main");
+      const missingTargetWorkspace = path.join(workspaceRoot, "claude-code-missing");
+      await fs.mkdir(mainWorkspace, { recursive: true });
+
+      replaceSpawnConfig({
+        ...hoisted.state.cfg,
+        acp: {
+          ...hoisted.state.cfg.acp,
+          allowedAgents: ["codex", "claude-code"],
+        },
+        agents: {
+          list: [
+            {
+              id: "main",
+              default: true,
+              workspace: mainWorkspace,
+            },
+            {
+              id: "claude-code",
+              workspace: missingTargetWorkspace,
+            },
+          ],
+        },
+      });
+
+      const result = await spawnAcpDirect(
+        {
+          task: "Inspect the queue owner state",
+          agentId: "claude-code",
+          mode: "run",
+        },
+        {
+          agentSessionKey: "agent:main:main",
+        },
+      );
+
+      expect(result.status).toBe("accepted");
+      expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: expect.stringMatching(/^agent:claude-code:acp:/),
+          agent: "claude-code",
+          cwd: undefined,
+        }),
+      );
+    } finally {
+      await fs.rm(workspaceRoot, { recursive: true, force: true });
+    }
   });
 
   it("binds LINE ACP sessions to the current conversation when the channel has no native threads", async () => {

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -646,6 +646,62 @@ describe("spawnAcpDirect", () => {
     }
   });
 
+  it("surfaces non-missing target workspace access failures instead of silently dropping cwd", async () => {
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-spawn-"));
+    const accessSpy = vi.spyOn(fs, "access");
+    try {
+      const mainWorkspace = path.join(workspaceRoot, "main");
+      const targetWorkspace = path.join(workspaceRoot, "claude-code");
+      await fs.mkdir(mainWorkspace, { recursive: true });
+      await fs.mkdir(targetWorkspace, { recursive: true });
+
+      replaceSpawnConfig({
+        ...hoisted.state.cfg,
+        acp: {
+          ...hoisted.state.cfg.acp,
+          allowedAgents: ["codex", "claude-code"],
+        },
+        agents: {
+          list: [
+            {
+              id: "main",
+              default: true,
+              workspace: mainWorkspace,
+            },
+            {
+              id: "claude-code",
+              workspace: targetWorkspace,
+            },
+          ],
+        },
+      });
+
+      accessSpy.mockRejectedValueOnce(
+        Object.assign(new Error("permission denied"), { code: "EACCES" }),
+      );
+
+      const result = await spawnAcpDirect(
+        {
+          task: "Inspect the queue owner state",
+          agentId: "claude-code",
+          mode: "run",
+        },
+        {
+          agentSessionKey: "agent:main:main",
+        },
+      );
+
+      expect(result).toEqual({
+        status: "error",
+        error: "permission denied",
+      });
+      expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
+    } finally {
+      accessSpy.mockRestore();
+      await fs.rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   it("binds LINE ACP sessions to the current conversation when the channel has no native threads", async () => {
     enableLineCurrentConversationBindings();
     hoisted.sessionBindingBindMock.mockImplementationOnce(

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -382,8 +382,12 @@ async function resolveRuntimeCwdForAcpSpawn(params: {
   try {
     await fs.access(params.resolvedCwd);
     return params.resolvedCwd;
-  } catch {
-    return undefined;
+  } catch (error) {
+    const code = error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return undefined;
+    }
+    throw error;
   }
 }
 

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import fs from "node:fs/promises";
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import {
   cleanupFailedAcpSpawn,
@@ -58,6 +59,7 @@ import {
 } from "./acp-spawn-parent-stream.js";
 import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
+import { resolveSpawnedWorkspaceInheritance } from "./spawned-context.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
@@ -365,6 +367,24 @@ function summarizeError(err: unknown): string {
     return err;
   }
   return "error";
+}
+
+async function resolveRuntimeCwdForAcpSpawn(params: {
+  resolvedCwd?: string;
+  explicitCwd?: string;
+}): Promise<string | undefined> {
+  if (!params.resolvedCwd) {
+    return undefined;
+  }
+  if (typeof params.explicitCwd === "string" && params.explicitCwd.trim()) {
+    return params.resolvedCwd;
+  }
+  try {
+    await fs.access(params.resolvedCwd);
+    return params.resolvedCwd;
+  } catch {
+    return undefined;
+  }
 }
 
 function resolveRequesterInternalSessionKey(params: {
@@ -918,6 +938,16 @@ export async function spawnAcpDirect(
 
   const sessionKey = `agent:${targetAgentId}:acp:${crypto.randomUUID()}`;
   const runtimeMode = resolveAcpSessionMode(spawnMode);
+  const resolvedCwd = resolveSpawnedWorkspaceInheritance({
+    config: cfg,
+    targetAgentId,
+    requesterSessionKey: ctx.agentSessionKey,
+    explicitWorkspaceDir: params.cwd,
+  });
+  const runtimeCwd = await resolveRuntimeCwdForAcpSpawn({
+    resolvedCwd,
+    explicitCwd: params.cwd,
+  });
 
   let preparedBinding: PreparedAcpThreadBinding | null = null;
   if (requestThreadBinding) {
@@ -958,7 +988,7 @@ export async function spawnAcpDirect(
       targetAgentId,
       runtimeMode,
       resumeSessionId: params.resumeSessionId,
-      cwd: params.cwd,
+      cwd: runtimeCwd,
     });
     initializedRuntime = initializedSession.runtimeCloseHandle;
 


### PR DESCRIPTION
## Summary
- resolve ACP spawn cwd with the same workspace inheritance helper used by spawned agent sessions
- prefer the target agent workspace for cross-agent ACP spawns when no explicit `cwd` is provided
- add a regression test that covers spawning `claude-code` from a `main` session

## Validation
- `pnpm exec vitest run src/agents/acp-spawn.test.ts`
- `pnpm lint src/agents/acp-spawn.ts src/agents/acp-spawn.test.ts`
- `pnpm check`

Fixes #58420