### PR TITLE
feat: add before_block_reply plugin hook for block streaming interception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Hooks/session routing: rebind hook-triggered `agent:` session keys to the actual target agent before isolated dispatch so dedicated hook agents keep their own session-scoped tool and plugin identity. Thanks @kexinoh and @vincentkoc.
 - Outbound media/local files: piggyback host-local `MEDIA:` reads on the configured fs policy instead of a separate media-root check, so generated files outside the workspace can send when `tools.fs.workspaceOnly=false` while plaintext-like host files stay blocked by the outbound media allowlist.
 - Gateway/auth: reject mismatched browser `Origin` headers on trusted-proxy HTTP operator requests while keeping origin-less headless proxy clients working. Thanks @AntAISecurityLab and @vincentkoc.
 - Plugins/startup: block workspace `.env` from overriding `OPENCLAW_BUNDLED_PLUGINS_DIR`, so bundled plugin trust roots only come from inherited runtime env or package resolution instead of repo-local dotenv files. Thanks @nexrin and @vincentkoc.

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -1,6 +1,6 @@
 import type { ImageContent } from "@mariozechner/pi-ai";
 import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
-import type { ReplyPayload } from "../../../auto-reply/types.js";
+import type { BlockReplyContext, ReplyPayload } from "../../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import type { enqueueCommand } from "../../../process/command-queue.js";
@@ -110,8 +110,8 @@ export type RunEmbeddedPiAgentParams = {
   shouldEmitToolOutput?: () => boolean;
   onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
-  onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
-  onBlockReplyFlush?: () => void | Promise<void>;
+  onBlockReply?: (payload: BlockReplyPayload, context?: BlockReplyContext) => void | Promise<void>;
+  onBlockReplyFlush?: (context?: BlockReplyContext) => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -100,16 +100,16 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     });
   }
 
-  ctx.flushBlockReplyBuffer();
+  ctx.flushBlockReplyBuffer({ trigger: "run_end" });
   const pendingToolMediaReply = consumePendingToolMediaReply(ctx.state);
   if (pendingToolMediaReply && hasAssistantVisibleReply(pendingToolMediaReply)) {
-    ctx.emitBlockReply(pendingToolMediaReply);
+    ctx.emitBlockReply(pendingToolMediaReply, { trigger: "run_end" });
   }
   // Flush the reply pipeline so the response reaches the channel before
   // compaction wait blocks the run.  This mirrors the pattern used by
   // handleToolExecutionStart and ensures delivery is not held hostage to
   // long-running compaction (#35074).
-  void ctx.params.onBlockReplyFlush?.();
+  void ctx.params.onBlockReplyFlush?.({ trigger: "run_end" });
 
   ctx.state.blockState.thinking = false;
   ctx.state.blockState.final = false;

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -328,7 +328,10 @@ export function handleMessageUpdate(
     ctx.blockChunking &&
     ctx.state.blockReplyBreak === "text_end"
   ) {
-    ctx.blockChunker?.drain({ force: false, emit: ctx.emitBlockChunk });
+    ctx.blockChunker?.drain({
+      force: false,
+      emit: (text) => ctx.emitBlockChunk(text, { trigger: "text_end" }),
+    });
   }
 
   if (
@@ -336,7 +339,7 @@ export function handleMessageUpdate(
     evtType === "text_end" &&
     ctx.state.blockReplyBreak === "text_end"
   ) {
-    ctx.flushBlockReplyBuffer();
+    ctx.flushBlockReplyBuffer({ trigger: "text_end" });
   }
 }
 
@@ -426,12 +429,15 @@ export function handleMessageEnd(
   });
 
   const onBlockReply = ctx.params.onBlockReply;
-  const emitBlockReplySafely = (payload: Parameters<NonNullable<typeof onBlockReply>>[0]) => {
+  const emitBlockReplySafely = (
+    payload: Parameters<NonNullable<typeof onBlockReply>>[0],
+    context?: { trigger?: "text_end" | "message_end" },
+  ) => {
     if (!onBlockReply) {
       return;
     }
     void Promise.resolve()
-      .then(() => onBlockReply(payload))
+      .then(() => onBlockReply(payload, context))
       .catch((err) => {
         ctx.log.warn(`block reply callback failed: ${String(err)}`);
       });
@@ -450,7 +456,10 @@ export function handleMessageEnd(
       return;
     }
     ctx.state.lastReasoningSent = formattedReasoning;
-    emitBlockReplySafely({ text: formattedReasoning, isReasoning: true });
+    emitBlockReplySafely(
+      { text: formattedReasoning, isReasoning: true },
+      { trigger: "message_end" },
+    );
   };
 
   if (shouldEmitReasoningBeforeAnswer) {
@@ -459,6 +468,7 @@ export function handleMessageEnd(
 
   const emitSplitResultAsBlockReply = (
     splitResult: ReturnType<typeof ctx.consumeReplyDirectives> | null | undefined,
+    trigger: "text_end" | "message_end",
   ) => {
     if (!splitResult || !onBlockReply) {
       return;
@@ -473,14 +483,17 @@ export function handleMessageEnd(
     } = splitResult;
     // Emit if there's content OR audioAsVoice flag (to propagate the flag).
     if (hasAssistantVisibleReply({ text: cleanedText, mediaUrls, audioAsVoice })) {
-      ctx.emitBlockReply({
-        text: cleanedText,
-        mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
-        audioAsVoice,
-        replyToId,
-        replyToTag,
-        replyToCurrent,
-      });
+      ctx.emitBlockReply(
+        {
+          text: cleanedText,
+          mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
+          audioAsVoice,
+          replyToId,
+          replyToTag,
+          replyToCurrent,
+        },
+        { trigger },
+      );
     }
   };
 
@@ -492,7 +505,10 @@ export function handleMessageEnd(
     onBlockReply
   ) {
     if (ctx.blockChunker?.hasBuffered()) {
-      ctx.blockChunker.drain({ force: true, emit: ctx.emitBlockChunk });
+      ctx.blockChunker.drain({
+        force: true,
+        emit: (text) => ctx.emitBlockChunk(text, { trigger: "message_end" }),
+      });
       ctx.blockChunker.reset();
     } else if (text !== ctx.state.lastBlockReplyText) {
       // Check for duplicates before emitting (same logic as emitBlockChunk).
@@ -508,7 +524,10 @@ export function handleMessageEnd(
         );
       } else {
         ctx.state.lastBlockReplyText = text;
-        emitSplitResultAsBlockReply(ctx.consumeReplyDirectives(text, { final: true }));
+        emitSplitResultAsBlockReply(
+          ctx.consumeReplyDirectives(text, { final: true }),
+          "message_end",
+        );
       }
     }
   }
@@ -521,7 +540,7 @@ export function handleMessageEnd(
   }
 
   if (!ctx.params.silentExpected && ctx.state.blockReplyBreak === "text_end" && onBlockReply) {
-    emitSplitResultAsBlockReply(ctx.consumeReplyDirectives("", { final: true }));
+    emitSplitResultAsBlockReply(ctx.consumeReplyDirectives("", { final: true }), "text_end");
   }
 
   ctx.state.deltaBuffer = "";

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -331,9 +331,9 @@ export async function handleToolExecutionStart(
   evt: AgentEvent & { toolName: string; toolCallId: string; args: unknown },
 ) {
   // Flush pending block replies to preserve message boundaries before tool execution.
-  ctx.flushBlockReplyBuffer();
+  ctx.flushBlockReplyBuffer({ trigger: "tool_start" });
   if (ctx.params.onBlockReplyFlush) {
-    await ctx.params.onBlockReplyFlush();
+    await ctx.params.onBlockReplyFlush({ trigger: "tool_start" });
   }
 
   const rawToolName = String(evt.toolName);

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -1,6 +1,7 @@
 import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ReplyDirectiveParseResult } from "../auto-reply/reply/reply-directives.js";
 import type { ReasoningLevel } from "../auto-reply/thinking.js";
+import type { BlockReplyContext } from "../auto-reply/types.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
@@ -100,8 +101,8 @@ export type EmbeddedPiSubscribeContext = {
     text: string,
     state: { thinking: boolean; final: boolean; inlineCode?: InlineCodeState },
   ) => string;
-  emitBlockChunk: (text: string) => void;
-  flushBlockReplyBuffer: () => void;
+  emitBlockChunk: (text: string, context?: BlockReplyContext) => void;
+  flushBlockReplyBuffer: (context?: BlockReplyContext) => void;
   emitReasoningStream: (text: string) => void;
   consumeReplyDirectives: (
     text: string,
@@ -127,7 +128,7 @@ export type EmbeddedPiSubscribeContext = {
   incrementCompactionCount: () => void;
   getUsageTotals: () => NormalizedUsage | undefined;
   getCompactionCount: () => number;
-  emitBlockReply: (payload: BlockReplyPayload) => void;
+  emitBlockReply: (payload: BlockReplyPayload, context?: BlockReplyContext) => void;
 };
 
 /**
@@ -170,7 +171,7 @@ export type ToolHandlerContext = {
   state: ToolHandlerState;
   log: EmbeddedSubscribeLogger;
   hookRunner?: HookRunner;
-  flushBlockReplyBuffer: () => void;
+  flushBlockReplyBuffer: (context?: BlockReplyContext) => void;
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;
   emitToolSummary: (toolName?: string, meta?: string) => void;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -3,6 +3,7 @@ import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streaming-directives.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
+import type { BlockReplyContext } from "../auto-reply/types.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
@@ -110,18 +111,19 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     Boolean(text && isSilentReplyText(text, SILENT_REPLY_TOKEN));
   const emitBlockReplySafely = (
     payload: Parameters<NonNullable<SubscribeEmbeddedPiSessionParams["onBlockReply"]>>[0],
+    context?: BlockReplyContext,
   ) => {
     if (!params.onBlockReply) {
       return;
     }
     void Promise.resolve()
-      .then(() => params.onBlockReply?.(payload))
+      .then(() => params.onBlockReply?.(payload, context))
       .catch((err) => {
         log.warn(`block reply callback failed: ${String(err)}`);
       });
   };
-  const emitBlockReply = (payload: BlockReplyPayload) => {
-    emitBlockReplySafely(consumePendingToolMediaIntoReply(state, payload));
+  const emitBlockReply = (payload: BlockReplyPayload, context?: BlockReplyContext) => {
+    emitBlockReplySafely(consumePendingToolMediaIntoReply(state, payload), context);
   };
 
   const resetAssistantMessageState = (nextAssistantTextBaseline: number) => {
@@ -492,7 +494,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     return output;
   };
 
-  const emitBlockChunk = (text: string) => {
+  const emitBlockChunk = (text: string, context?: BlockReplyContext) => {
     if (state.suppressBlockChunks || params.silentExpected) {
       return;
     }
@@ -539,14 +541,17 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
       return;
     }
-    emitBlockReply({
-      text: cleanedText,
-      mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
-      audioAsVoice,
-      replyToId,
-      replyToTag,
-      replyToCurrent,
-    });
+    emitBlockReply(
+      {
+        text: cleanedText,
+        mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
+        audioAsVoice,
+        replyToId,
+        replyToTag,
+        replyToCurrent,
+      },
+      context,
+    );
   };
 
   const consumeReplyDirectives = (text: string, options?: { final?: boolean }) =>
@@ -554,17 +559,17 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const consumePartialReplyDirectives = (text: string, options?: { final?: boolean }) =>
     partialReplyDirectiveAccumulator.consume(text, options);
 
-  const flushBlockReplyBuffer = () => {
+  const flushBlockReplyBuffer = (context?: BlockReplyContext) => {
     if (!params.onBlockReply) {
       return;
     }
     if (blockChunker?.hasBuffered()) {
-      blockChunker.drain({ force: true, emit: emitBlockChunk });
+      blockChunker.drain({ force: true, emit: (text) => emitBlockChunk(text, context) });
       blockChunker.reset();
       return;
     }
     if (state.blockBuffer.length > 0) {
-      emitBlockChunk(state.blockBuffer);
+      emitBlockChunk(state.blockBuffer, context);
       state.blockBuffer = "";
     }
   };

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -1,6 +1,6 @@
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type { ReasoningLevel, VerboseLevel } from "../auto-reply/thinking.js";
-import type { ReplyPayload } from "../auto-reply/types.js";
+import type { BlockReplyContext, ReplyPayload } from "../auto-reply/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";
@@ -21,9 +21,9 @@ export type SubscribeEmbeddedPiSessionParams = {
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   /** Called when a thinking/reasoning block ends (</think> tag processed). */
   onReasoningEnd?: () => void | Promise<void>;
-  onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
+  onBlockReply?: (payload: BlockReplyPayload, context?: BlockReplyContext) => void | Promise<void>;
   /** Flush pending block replies (e.g., before tool execution to preserve message boundaries). */
-  onBlockReplyFlush?: () => void | Promise<void>;
+  onBlockReplyFlush?: (context?: BlockReplyContext) => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;
   onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -216,10 +216,7 @@ export function createBlockReplyPipeline(params: {
       sendPayload(payload, context, /* bypassSeenCheck */ false);
       return;
     }
-    if (context?.trigger) {
-      sendPayload(payload, context, /* bypassSeenCheck */ false);
-      return;
-    }
+
     if (coalescer) {
       const payloadKey = createBlockReplyPayloadKey(payload);
       if (seenKeys.has(payloadKey) || pendingKeys.has(payloadKey) || bufferedKeys.has(payloadKey)) {

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -1,11 +1,11 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "../../globals.js";
-import type { ReplyPayload } from "../types.js";
+import type { BlockReplyContext, ReplyPayload } from "../types.js";
 import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
 import type { BlockStreamingCoalescing } from "./block-streaming.js";
 
 export type BlockReplyPipeline = {
-  enqueue: (payload: ReplyPayload) => void;
+  enqueue: (payload: ReplyPayload, context?: BlockReplyContext) => void;
   flush: (options?: { force?: boolean }) => Promise<void>;
   stop: () => void;
   hasBuffered: () => boolean;
@@ -74,10 +74,7 @@ const withTimeout = async <T>(
 };
 
 export function createBlockReplyPipeline(params: {
-  onBlockReply: (
-    payload: ReplyPayload,
-    options?: { abortSignal?: AbortSignal; timeoutMs?: number },
-  ) => Promise<void> | void;
+  onBlockReply: (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> | void;
   timeoutMs: number;
   coalescing?: BlockStreamingCoalescing;
   buffer?: BlockReplyBuffer;
@@ -95,7 +92,11 @@ export function createBlockReplyPipeline(params: {
   let didStream = false;
   let didLogTimeout = false;
 
-  const sendPayload = (payload: ReplyPayload, bypassSeenCheck: boolean = false) => {
+  const sendPayload = (
+    payload: ReplyPayload,
+    context?: BlockReplyContext,
+    bypassSeenCheck: boolean = false,
+  ) => {
     if (aborted) {
       return;
     }
@@ -124,6 +125,7 @@ export function createBlockReplyPipeline(params: {
             onBlockReply(payload, {
               abortSignal: abortController.signal,
               timeoutMs,
+              trigger: context?.trigger,
             }),
           ),
           timeoutMs,
@@ -164,7 +166,7 @@ export function createBlockReplyPipeline(params: {
         shouldAbort: () => aborted,
         onFlush: (payload) => {
           bufferedKeys.clear();
-          sendPayload(payload, /* bypassSeenCheck */ true);
+          sendPayload(payload, undefined, /* bypassSeenCheck */ true);
         },
       })
     : null;
@@ -195,13 +197,13 @@ export function createBlockReplyPipeline(params: {
     }
     for (const payload of bufferedPayloads) {
       const finalPayload = buffer?.finalize?.(payload) ?? payload;
-      sendPayload(finalPayload, /* bypassSeenCheck */ true);
+      sendPayload(finalPayload, undefined, /* bypassSeenCheck */ true);
     }
     bufferedPayloads.length = 0;
     bufferedPayloadKeys.clear();
   };
 
-  const enqueue = (payload: ReplyPayload) => {
+  const enqueue = (payload: ReplyPayload, context?: BlockReplyContext) => {
     if (aborted) {
       return;
     }
@@ -211,7 +213,11 @@ export function createBlockReplyPipeline(params: {
     const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
     if (hasMedia) {
       void coalescer?.flush({ force: true });
-      sendPayload(payload, /* bypassSeenCheck */ false);
+      sendPayload(payload, context, /* bypassSeenCheck */ false);
+      return;
+    }
+    if (context?.trigger) {
+      sendPayload(payload, context, /* bypassSeenCheck */ false);
       return;
     }
     if (coalescer) {
@@ -224,7 +230,7 @@ export function createBlockReplyPipeline(params: {
       coalescer.enqueue(payload);
       return;
     }
-    sendPayload(payload, /* bypassSeenCheck */ false);
+    sendPayload(payload, context, /* bypassSeenCheck */ false);
   };
 
   const flush = async (options?: { force?: boolean }) => {

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -1,6 +1,13 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "../../globals.js";
 import type { BlockReplyContext, ReplyPayload } from "../types.js";
+
+function isBlockReplyCancelled(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err as Error & { isBlockReplyCancelled?: boolean }).isBlockReplyCancelled === true
+  );
+}
 import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
 import type { BlockStreamingCoalescing } from "./block-streaming.js";
 
@@ -151,6 +158,11 @@ export function createBlockReplyPipeline(params: {
               `block reply delivery timed out after ${timeoutMs}ms; skipping remaining block replies to preserve ordering`,
             );
           }
+          return;
+        }
+        if (isBlockReplyCancelled(err)) {
+          // Plugin cancelled this delivery via before_block_reply hook.
+          // Do not mark as sent so the content can appear in the final reply.
           return;
         }
         logVerbose(`block reply delivery failed: ${String(err)}`);

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -45,6 +45,7 @@ const hookMocks = vi.hoisted(() => ({
       async () => ({ status: "no_handler" as const }),
     ),
     runMessageReceived: vi.fn(async () => {}),
+    runBeforeBlockReply: vi.fn(async () => undefined),
     runBeforeDispatch: vi.fn<
       (_event: unknown, _ctx: unknown) => Promise<PluginHookBeforeDispatchResult | undefined>
     >(async () => undefined),

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -693,18 +693,43 @@ export async function dispatchReplyFromConfig(params: {
             if (payload.isReasoning === true) {
               return;
             }
+
+            let blockPayload = payload;
+            if (hookRunner?.hasHooks("before_block_reply")) {
+              const hookResult = await hookRunner.runBeforeBlockReply(
+                {
+                  text: blockPayload.text,
+                  mediaUrls: blockPayload.mediaUrls,
+                  isReasoning: blockPayload.isReasoning,
+                  trigger: context?.trigger,
+                },
+                {
+                  agentId: sessionKey
+                    ? resolveSessionAgentId({ sessionKey, config: cfg })
+                    : undefined,
+                  sessionKey,
+                  runId: params.replyOptions?.runId,
+                },
+              );
+              if (hookResult?.cancel === true) {
+                return;
+              }
+              if (hookResult?.text !== undefined) {
+                blockPayload = { ...blockPayload, text: hookResult.text };
+              }
+            }
             // Accumulate block text for TTS generation after streaming.
             // Exclude compaction status notices — they are informational UI
             // signals and must not be synthesised into the spoken reply.
-            if (payload.text && !payload.isCompactionNotice) {
+            if (blockPayload.text && !blockPayload.isCompactionNotice) {
               if (accumulatedBlockText.length > 0) {
                 accumulatedBlockText += "\n";
               }
-              accumulatedBlockText += payload.text;
+              accumulatedBlockText += blockPayload.text;
               blockCount++;
             }
             const ttsPayload = await maybeApplyTtsToPayload({
-              payload,
+              payload: blockPayload,
               cfg,
               channel: ttsChannel,
               kind: "block",

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,6 +1,20 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { isParentOwnedBackgroundAcpSession } from "../../acp/session-interaction-mode.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+
+/**
+ * Thrown when a `before_block_reply` plugin hook cancels delivery.
+ * The pipeline catch handler should treat this as "not sent" so the
+ * payload is not marked as delivered and can still appear in the
+ * final reply path.
+ */
+export class BlockReplyCancelledError extends Error {
+  readonly isBlockReplyCancelled = true;
+  constructor() {
+    super("block reply cancelled by before_block_reply hook");
+    this.name = "BlockReplyCancelledError";
+  }
+}
 import {
   resolveConversationBindingRecord,
   touchConversationBindingRecord,
@@ -700,6 +714,8 @@ export async function dispatchReplyFromConfig(params: {
                 {
                   text: blockPayload.text,
                   mediaUrls: blockPayload.mediaUrls,
+                  // Note: isReasoning is always falsy here because reasoning
+                  // payloads are returned early above. Included for API completeness.
                   isReasoning: blockPayload.isReasoning,
                   trigger: context?.trigger,
                 },
@@ -712,7 +728,9 @@ export async function dispatchReplyFromConfig(params: {
                 },
               );
               if (hookResult?.cancel === true) {
-                return;
+                // Throw a typed error so the pipeline does not mark this payload
+                // as delivered (which would suppress it in the final reply path).
+                throw new BlockReplyCancelledError();
               }
               if (hookResult?.text !== undefined) {
                 blockPayload = { ...blockPayload, text: hookResult.text };

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -68,8 +68,8 @@ export function createBlockReplyDeliveryHandler(params: {
   blockStreamingEnabled: boolean;
   blockReplyPipeline: BlockReplyPipeline | null;
   directlySentBlockKeys: Set<string>;
-}): (payload: ReplyPayload) => Promise<void> {
-  return async (payload) => {
+}): (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> {
+  return async (payload, context) => {
     const { text, skip } = params.normalizeStreamingText(payload);
     if (skip && !resolveSendableOutboundReplyParts(payload).hasMedia) {
       return;
@@ -122,18 +122,18 @@ export function createBlockReplyDeliveryHandler(params: {
 
     // Use pipeline if available (block streaming enabled), otherwise send directly.
     if (params.blockStreamingEnabled && params.blockReplyPipeline) {
-      params.blockReplyPipeline.enqueue(blockPayload);
+      params.blockReplyPipeline.enqueue(blockPayload, context);
     } else if (params.blockStreamingEnabled) {
       // Send directly when flushing before tool execution (no pipeline but streaming enabled).
       // Track sent key to avoid duplicate in final payloads.
       params.directlySentBlockKeys.add(createBlockReplyContentKey(blockPayload));
-      await params.onBlockReply(blockPayload);
+      await params.onBlockReply(blockPayload, context);
     } else if (blockHasMedia) {
       // When block streaming is disabled, text-only block replies are accumulated into the
       // final response. Media cannot be reconstructed later, so send it immediately and let
       // the assistant's final text arrive through the normal final-reply path.
       params.directlySentBlockKeys.add(createBlockReplyContentKey(blockPayload));
-      await params.onBlockReply({ ...blockPayload, text: undefined });
+      await params.onBlockReply({ ...blockPayload, text: undefined }, context);
     }
     // When streaming is disabled entirely, text-only blocks are accumulated in final text.
   };

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -3,9 +3,12 @@ import type { InteractiveReply } from "../interactive/payload.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import type { TypingController } from "./reply/typing.js";
 
+export type BlockReplyFlushTrigger = "tool_start" | "text_end" | "message_end" | "run_end";
+
 export type BlockReplyContext = {
   abortSignal?: AbortSignal;
   timeoutMs?: number;
+  trigger?: BlockReplyFlushTrigger;
 };
 
 /** Context passed to onModelSelected callback with actual model used. */

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -297,22 +297,22 @@ describe("gateway hooks helpers", () => {
     expect(resolvedKey).toEqual({ ok: true, value: "hook:ingress" });
   });
 
-  test("normalizeHookDispatchSessionKey strips duplicate target agent prefix", () => {
+  test("normalizeHookDispatchSessionKey preserves target agent scope", () => {
     expect(
       normalizeHookDispatchSessionKey({
         sessionKey: "agent:hooks:slack:channel:c123",
         targetAgentId: "hooks",
       }),
-    ).toBe("slack:channel:c123");
+    ).toBe("agent:hooks:slack:channel:c123");
   });
 
-  test("normalizeHookDispatchSessionKey preserves non-target agent scoped keys", () => {
+  test("normalizeHookDispatchSessionKey rebinds non-target agent scoped keys to the target agent", () => {
     expect(
       normalizeHookDispatchSessionKey({
         sessionKey: "agent:main:slack:channel:c123",
         targetAgentId: "hooks",
       }),
-    ).toBe("agent:main:slack:channel:c123");
+    ).toBe("agent:hooks:slack:channel:c123");
   });
 
   test("resolveHooksConfig validates defaultSessionKey and generated fallback against prefixes", () => {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -127,7 +127,7 @@ function resolveAllowedSessionKeyPrefixes(raw: string[] | undefined): string[] |
   return set.size > 0 ? Array.from(set) : undefined;
 }
 
-function isSessionKeyAllowedByPrefix(sessionKey: string, prefixes: string[]): boolean {
+export function isSessionKeyAllowedByPrefix(sessionKey: string, prefixes: string[]): boolean {
   const normalized = sessionKey.trim().toLowerCase();
   if (!normalized) {
     return false;
@@ -349,10 +349,7 @@ export function normalizeHookDispatchSessionKey(params: {
     return trimmed;
   }
   const targetAgentId = normalizeAgentId(params.targetAgentId);
-  if (parsed.agentId !== targetAgentId) {
-    return `agent:${parsed.agentId}:${parsed.rest}`;
-  }
-  return parsed.rest;
+  return `agent:${targetAgentId}:${parsed.rest}`;
 }
 
 export function normalizeAgentPayload(payload: Record<string, unknown>):

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -40,9 +40,11 @@ import {
   extractHookToken,
   getHookAgentPolicyError,
   getHookChannelError,
+  getHookSessionKeyPrefixError,
   type HookAgentDispatchPayload,
   type HooksConfigResolved,
   isHookAgentAllowed,
+  isSessionKeyAllowedByPrefix,
   normalizeAgentPayload,
   normalizeHookHeaders,
   resolveHookIdempotencyKey,
@@ -615,6 +617,14 @@ export function createHooksRequestHandler(
         sessionKey: sessionKey.value,
         targetAgentId,
       });
+      const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
+      if (
+        allowedPrefixes &&
+        !isSessionKeyAllowedByPrefix(normalizedDispatchSessionKey, allowedPrefixes)
+      ) {
+        sendJson(res, 400, { ok: false, error: getHookSessionKeyPrefixError(allowedPrefixes) });
+        return true;
+      }
       const runId = dispatchAgentHook({
         ...normalized.value,
         idempotencyKey,
@@ -676,6 +686,14 @@ export function createHooksRequestHandler(
             sessionKey: sessionKey.value,
             targetAgentId,
           });
+          const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
+          if (
+            allowedPrefixes &&
+            !isSessionKeyAllowedByPrefix(normalizedDispatchSessionKey, allowedPrefixes)
+          ) {
+            sendJson(res, 400, { ok: false, error: getHookSessionKeyPrefixError(allowedPrefixes) });
+            return true;
+          }
           const replayKey = buildHookReplayCacheKey({
             pathKey: subPath || "mapping",
             token,

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -328,7 +328,7 @@ describe("gateway server hooks", () => {
     });
   });
 
-  test("normalizes duplicate target-agent prefixes before isolated dispatch", async () => {
+  test("preserves target-agent prefixes before isolated dispatch", async () => {
     testState.hooksConfig = {
       enabled: true,
       token: HOOK_TOKEN,
@@ -352,8 +352,59 @@ describe("gateway server hooks", () => {
         | { sessionKey?: string; job?: { agentId?: string } }
         | undefined;
       expect(routedCall?.job?.agentId).toBe("hooks");
-      expect(routedCall?.sessionKey).toBe("slack:channel:c123");
+      expect(routedCall?.sessionKey).toBe("agent:hooks:slack:channel:c123");
       drainSystemEvents(resolveMainKey());
+    });
+  });
+
+  test("rebinds mismatched agent prefixes to the hook target before isolated dispatch", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:"],
+    };
+    setMainAndHooksAgents();
+    await withGatewayServer(async ({ port }) => {
+      mockIsolatedRunOkOnce();
+
+      const resAgent = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        name: "Email",
+        agentId: "hooks",
+        sessionKey: "agent:main:slack:channel:c123",
+      });
+      expect(resAgent.status).toBe(200);
+      await waitForSystemEvent();
+
+      const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | { sessionKey?: string; job?: { agentId?: string } }
+        | undefined;
+      expect(routedCall?.job?.agentId).toBe("hooks");
+      expect(routedCall?.sessionKey).toBe("agent:hooks:slack:channel:c123");
+      drainSystemEvents(resolveMainKey());
+    });
+  });
+
+  test("rejects rebinding into a session namespace that is not allowlisted", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:main:"],
+    };
+    setMainAndHooksAgents();
+    await withGatewayServer(async ({ port }) => {
+      const denied = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        name: "Email",
+        agentId: "hooks",
+        sessionKey: "agent:main:slack:channel:c123",
+      });
+      expect(denied.status).toBe(400);
+      const body = (await denied.json()) as { error?: string };
+      expect(body.error).toContain("sessionKey must start with one of");
+      expect(cronIsolatedRun).not.toHaveBeenCalled();
     });
   });
 

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -42,10 +42,7 @@ export function createGatewayHooksRequestHandler(params: {
   };
 
   const dispatchAgentHook = (value: HookAgentDispatchPayload) => {
-    const sessionKey = normalizeHookDispatchSessionKey({
-      sessionKey: value.sessionKey,
-      targetAgentId: value.agentId,
-    });
+    const sessionKey = value.sessionKey;
     const mainSessionKey = resolveMainSessionKeyFromConfig();
     const jobId = randomUUID();
     const now = Date.now();

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -35,6 +35,8 @@ import type {
   PluginHookGatewayStopEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
+  PluginHookBeforeBlockReplyEvent,
+  PluginHookBeforeBlockReplyResult,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
   PluginHookMessageSentEvent,
@@ -84,6 +86,8 @@ export type {
   PluginHookAfterCompactionEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
+  PluginHookBeforeBlockReplyEvent,
+  PluginHookBeforeBlockReplyResult,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
   PluginHookMessageSentEvent,
@@ -631,6 +635,35 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   /**
+   * Run before_block_reply hook.
+   * Allows plugins to modify or cancel block replies before delivery.
+   * Runs sequentially.
+   */
+  async function runBeforeBlockReply(
+    event: PluginHookBeforeBlockReplyEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookBeforeBlockReplyResult | undefined> {
+    return runModifyingHook<"before_block_reply", PluginHookBeforeBlockReplyResult>(
+      "before_block_reply",
+      event,
+      ctx,
+      {
+        mergeResults: (acc, next) => {
+          if (acc?.cancel === true) {
+            return acc;
+          }
+          return {
+            text: lastDefined(acc?.text, next.text),
+            cancel: stickyTrue(acc?.cancel, next.cancel),
+          };
+        },
+        shouldStop: (result) => result.cancel === true,
+        terminalLabel: "cancel=true",
+      },
+    );
+  }
+
+  /**
    * Run before_dispatch hook.
    * Allows plugins to inspect or handle a message before model dispatch.
    * First handler returning { handled: true } wins.
@@ -1052,6 +1085,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runInboundClaimForPlugin,
     runInboundClaimForPluginOutcome,
     runMessageReceived,
+    runBeforeBlockReply,
     runBeforeDispatch,
     runMessageSending,
     runMessageSent,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1808,6 +1808,7 @@ export type PluginHookName =
   | "before_reset"
   | "inbound_claim"
   | "message_received"
+  | "before_block_reply"
   | "message_sending"
   | "message_sent"
   | "before_tool_call"
@@ -1837,6 +1838,7 @@ export const PLUGIN_HOOK_NAMES = [
   "before_reset",
   "inbound_claim",
   "message_received",
+  "before_block_reply",
   "message_sending",
   "message_sent",
   "before_tool_call",
@@ -2118,6 +2120,19 @@ export type PluginHookMessageReceivedEvent = {
   content: string;
   timestamp?: number;
   metadata?: Record<string, unknown>;
+};
+
+// before_block_reply hook
+export type PluginHookBeforeBlockReplyEvent = {
+  text?: string;
+  mediaUrls?: string[];
+  isReasoning?: boolean;
+  trigger?: "tool_start" | "text_end" | "message_end" | "run_end";
+};
+
+export type PluginHookBeforeBlockReplyResult = {
+  text?: string;
+  cancel?: boolean;
 };
 
 // message_sending hook
@@ -2516,6 +2531,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookMessageReceivedEvent,
     ctx: PluginHookMessageContext,
   ) => Promise<void> | void;
+  before_block_reply: (
+    event: PluginHookBeforeBlockReplyEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookBeforeBlockReplyResult | void> | PluginHookBeforeBlockReplyResult | void;
   message_sending: (
     event: PluginHookMessageSendingEvent,
     ctx: PluginHookMessageContext,


### PR DESCRIPTION
## Problem

OpenClaw's block streaming path flushes the reply buffer on every `tool_execution_start` event, causing pre-tool narration text to post as separate Slack messages (fragmentation). The final delivery path may also re-post the same content (duplication). This double-message bug has been a persistent issue across all fleet nodes.

## Solution

Adds a new `before_block_reply` plugin hook that fires before any block reply payload is delivered to a channel. Plugins can:
- **Inspect** the payload and its trigger context
- **Modify** the text (`{ text: '...' }`)
- **Cancel** delivery entirely (`{ cancel: true }`)

Each block reply now carries a `trigger` context field indicating why the flush is happening:
- `tool_start` — narration flushed before a tool call
- `text_end` — natural text block boundary
- `message_end` — final assistant message
- `run_end` — safety flush at end of run

This enables plugins like `slack-plan-block` to intercept tool-start narration and route it into task cards instead of posting as separate messages, while allowing final answers through normally.

## Implementation

- Follows the existing `message_sending` hook pattern (modifying hook with sequential execution)
- `mergeResults` combines text modifications; `cancel` is sticky
- `shouldStop` short-circuits on `cancel=true`
- Trigger context threaded through the entire block reply pipeline (14 files)
- No behavioral changes without a plugin registered — fully backwards compatible

## Files changed (14)

- `src/plugins/types.ts` — hook name, event/result types, handler map
- `src/plugins/hooks.ts` — `runBeforeBlockReply` runner
- `src/auto-reply/types.ts` — `BlockReplyFlushTrigger` type
- `src/auto-reply/reply/dispatch-from-config.ts` — hook call site in `onBlockReply`
- `src/auto-reply/reply/block-reply-pipeline.ts` — context threading
- `src/auto-reply/reply/reply-delivery.ts` — context threading
- `src/agents/pi-embedded-subscribe.ts` — context threading
- `src/agents/pi-embedded-subscribe.types.ts` — signature updates
- `src/agents/pi-embedded-subscribe.handlers.tools.ts` — `tool_start` trigger
- `src/agents/pi-embedded-subscribe.handlers.messages.ts` — `text_end`/`message_end` triggers
- `src/agents/pi-embedded-subscribe.handlers.lifecycle.ts` — `run_end` trigger
- `src/agents/pi-embedded-subscribe.handlers.types.ts` — signature updates
- `src/agents/pi-embedded-runner/run/params.ts` — signature updates
- `src/auto-reply/reply/dispatch-from-config.test.ts` — import update