### PR TITLE
feat: add thinkingByChannel - per-channel thinking level overrides

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import type { ExecToolDefaults } from "../../agents/bash-tools.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
+import { resolveChannelThinkingOverride } from "../../channels/thinking-overrides.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import {
@@ -429,6 +430,19 @@ export async function runPreparedReply(
   let prefixedCommandBody = mediaNote
     ? [mediaNote, mediaReplyHint, prefixedBody ?? ""].filter(Boolean).join("\n").trim()
     : prefixedBody;
+  if (!resolvedThinkLevel) {
+    const channelThinkOverride = resolveChannelThinkingOverride({
+      cfg,
+      channel: sessionCtx.Provider,
+      groupId: resolveGroupSessionKey(sessionCtx)?.id ?? undefined,
+      groupChannel: sessionCtx.GroupChannel?.trim() ?? sessionCtx.GroupSubject?.trim(),
+      groupSubject: sessionCtx.GroupSubject?.trim(),
+      parentSessionKey: sessionCtx.ParentSessionKey,
+    });
+    if (channelThinkOverride) {
+      resolvedThinkLevel = channelThinkOverride.thinking;
+    }
+  }
   if (!resolvedThinkLevel) {
     resolvedThinkLevel = await modelState.resolveDefaultThinkingLevel();
   }

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -16,6 +16,7 @@ import { normalizeToolName } from "../agents/tool-policy-shared.js";
 import type { EffectiveToolInventoryResult } from "../agents/tools-effective-inventory.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../agents/usage.js";
 import { resolveChannelModelOverride } from "../channels/model-overrides.js";
+import { resolveChannelThinkingOverride } from "../channels/thinking-overrides.js";
 import { isCommandFlagEnabled } from "../config/commands.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
@@ -693,9 +694,30 @@ export function buildStatusMessage(args: StatusArgs): string {
     provider: activeProvider,
     model: activeModel,
   });
+  const channelThinkNote = (() => {
+    if (!args.config || !entry) {
+      return undefined;
+    }
+    if (args.resolvedThink || entry.thinkingLevel) {
+      return undefined;
+    }
+    const channelThinkOverride = resolveChannelThinkingOverride({
+      cfg: args.config,
+      channel: entry.channel ?? entry.origin?.provider,
+      groupId: entry.groupId,
+      groupChannel: entry.groupChannel,
+      groupSubject: entry.subject,
+      parentSessionKey: args.parentSessionKey,
+    });
+    if (!channelThinkOverride) {
+      return undefined;
+    }
+    return "channel override";
+  })();
+  const thinkNote = channelThinkNote ? ` (${channelThinkNote})` : "";
   const optionParts = [
     `Runtime: ${runtime.label}`,
-    `Think: ${thinkLevel}`,
+    `Think: ${thinkLevel}${thinkNote}`,
     fastMode ? "Fast: on" : null,
     textVerbosity ? `Text: ${textVerbosity}` : null,
     verboseLabel,

--- a/src/channels/thinking-overrides.test.ts
+++ b/src/channels/thinking-overrides.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveChannelThinkingOverride } from "./thinking-overrides.js";
+
+describe("resolveChannelThinkingOverride", () => {
+  it("returns null when no thinkingByChannel configured", () => {
+    const result = resolveChannelThinkingOverride({
+      cfg: { channels: {} } as unknown as OpenClawConfig,
+      channel: "discord",
+      groupId: "123",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when channel is empty", () => {
+    const result = resolveChannelThinkingOverride({
+      cfg: {
+        channels: {
+          thinkingByChannel: { discord: { "123": "off" } },
+        },
+      } as unknown as OpenClawConfig,
+      channel: "",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when channel provider has no entries", () => {
+    const result = resolveChannelThinkingOverride({
+      cfg: {
+        channels: {
+          thinkingByChannel: { telegram: { "123": "off" } },
+        },
+      } as unknown as OpenClawConfig,
+      channel: "discord",
+      groupId: "456",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("matches by group id", () => {
+    const result = resolveChannelThinkingOverride({
+      cfg: {
+        channels: {
+          thinkingByChannel: {
+            discord: { "1488556514485735486": "off", "*": "high" },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      channel: "discord",
+      groupId: "1488556514485735486",
+    });
+    expect(result).toEqual({
+      channel: "discord",
+      thinking: "off",
+      matchKey: "1488556514485735486",
+      matchSource: "direct",
+    });
+  });
+
+  it("falls back to wildcard when group id does not match", () => {
+    const result = resolveChannelThinkingOverride({
+      cfg: {
+        channels: {
+          thinkingByChannel: {
+            discord: { "1488556514485735486": "off", "*": "high" },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      channel: "discord",
+      groupId: "999999999999999999",
+    });
+    expect(result).toEqual({
+      channel: "discord",
+      thinking: "high",
+      matchKey: "*",
+      matchSource: "wildcard",
+    });
+  });
+
+  it("returns null when no match and no wildcard", () => {
+    const result = resolveChannelThinkingOverride({
+      cfg: {
+        channels: {
+          thinkingByChannel: {
+            discord: { "1488556514485735486": "off" },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      channel: "discord",
+      groupId: "999999999999999999",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("normalizes thinking level values", () => {
+    const result = resolveChannelThinkingOverride({
+      cfg: {
+        channels: {
+          thinkingByChannel: {
+            discord: { "123": "adaptive" },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      channel: "discord",
+      groupId: "123",
+    });
+    expect(result?.thinking).toBe("adaptive");
+  });
+
+  it("returns null for invalid thinking level", () => {
+    const result = resolveChannelThinkingOverride({
+      cfg: {
+        channels: {
+          thinkingByChannel: {
+            discord: { "123": "invalid-level" },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      channel: "discord",
+      groupId: "123",
+    });
+    expect(result).toBeNull();
+  });
+
+  it.each([
+    {
+      name: "matches parent group id when topic suffix is present",
+      input: {
+        cfg: {
+          channels: {
+            thinkingByChannel: {
+              telegram: { "-100123": "low" },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        channel: "telegram",
+        groupId: "-100123:topic:99",
+      },
+      expected: { thinking: "low", matchKey: "-100123" },
+    },
+    {
+      name: "prefers topic-specific match over parent group id",
+      input: {
+        cfg: {
+          channels: {
+            thinkingByChannel: {
+              telegram: {
+                "-100123": "low",
+                "-100123:topic:99": "high",
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        channel: "telegram",
+        groupId: "-100123:topic:99",
+      },
+      expected: { thinking: "high", matchKey: "-100123:topic:99" },
+    },
+  ] as const)("$name", ({ input, expected }) => {
+    const resolved = resolveChannelThinkingOverride(input);
+    expect(resolved?.thinking).toBe(expected.thinking);
+    expect(resolved?.matchKey).toBe(expected.matchKey);
+  });
+});

--- a/src/channels/thinking-overrides.ts
+++ b/src/channels/thinking-overrides.ts
@@ -1,0 +1,162 @@
+import type { ThinkLevel } from "../auto-reply/thinking.shared.js";
+import { normalizeThinkLevel } from "../auto-reply/thinking.shared.js";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  parseSessionConversationRef,
+  parseThreadSessionSuffix,
+} from "../sessions/session-key-utils.js";
+import { normalizeMessageChannel } from "../utils/message-channel.js";
+import {
+  buildChannelKeyCandidates,
+  normalizeChannelSlug,
+  resolveChannelEntryMatchWithFallback,
+  type ChannelMatchSource,
+} from "./channel-config.js";
+
+export type ChannelThinkingOverride = {
+  channel: string;
+  thinking: ThinkLevel;
+  matchKey?: string;
+  matchSource?: ChannelMatchSource;
+};
+
+type ChannelThinkingByChannelConfig = Record<string, Record<string, string>>;
+
+type ChannelThinkingOverrideParams = {
+  cfg: OpenClawConfig;
+  channel?: string | null;
+  groupId?: string | null;
+  groupChannel?: string | null;
+  groupSubject?: string | null;
+  parentSessionKey?: string | null;
+};
+
+function resolveProviderEntry(
+  thinkingByChannel: ChannelThinkingByChannelConfig | undefined,
+  channel: string,
+): Record<string, string> | undefined {
+  const normalized = normalizeMessageChannel(channel) ?? channel.trim().toLowerCase();
+  return (
+    thinkingByChannel?.[normalized] ??
+    thinkingByChannel?.[
+      Object.keys(thinkingByChannel ?? {}).find((key) => {
+        const normalizedKey = normalizeMessageChannel(key) ?? key.trim().toLowerCase();
+        return normalizedKey === normalized;
+      }) ?? ""
+    ]
+  );
+}
+
+function resolveParentGroupId(
+  groupId: string | undefined,
+  channelHint?: string | null,
+): string | undefined {
+  const raw = groupId?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  const parent = parseThreadSessionSuffix(raw, { channelHint }).baseSessionKey?.trim();
+  return parent && parent !== raw ? parent : undefined;
+}
+
+function resolveSenderScopedParentGroupId(groupId: string | undefined): string | undefined {
+  const raw = groupId?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  const parent = raw.replace(/:sender:[^:]+$/i, "").trim();
+  return parent && parent !== raw ? parent : undefined;
+}
+
+function resolveGroupIdFromSessionKey(sessionKey?: string | null): string | undefined {
+  return parseSessionConversationRef(sessionKey)?.id;
+}
+
+function buildChannelCandidates(
+  params: Pick<
+    ChannelThinkingOverrideParams,
+    "channel" | "groupId" | "groupChannel" | "groupSubject" | "parentSessionKey"
+  >,
+) {
+  const normalizedChannel =
+    normalizeMessageChannel(params.channel ?? "") ?? params.channel?.trim().toLowerCase();
+  const groupId = params.groupId?.trim();
+  const senderParentGroupId = resolveSenderScopedParentGroupId(groupId);
+  const parentGroupId = resolveParentGroupId(groupId, normalizedChannel);
+  const parentGroupIdFromSession = resolveGroupIdFromSessionKey(params.parentSessionKey);
+  const senderParentGroupIdFromSession = resolveSenderScopedParentGroupId(parentGroupIdFromSession);
+  const parentGroupIdResolved =
+    resolveParentGroupId(parentGroupIdFromSession, normalizedChannel) ?? parentGroupIdFromSession;
+  const senderParentResolved =
+    resolveParentGroupId(senderParentGroupId, normalizedChannel) ?? senderParentGroupId;
+  const senderParentFromSessionResolved =
+    resolveParentGroupId(senderParentGroupIdFromSession, normalizedChannel) ??
+    senderParentGroupIdFromSession;
+  const groupChannel = params.groupChannel?.trim();
+  const groupSubject = params.groupSubject?.trim();
+  const channelBare = groupChannel ? groupChannel.replace(/^#/, "") : undefined;
+  const subjectBare = groupSubject ? groupSubject.replace(/^#/, "") : undefined;
+  const channelSlug = channelBare ? normalizeChannelSlug(channelBare) : undefined;
+  const subjectSlug = subjectBare ? normalizeChannelSlug(subjectBare) : undefined;
+
+  return buildChannelKeyCandidates(
+    groupId,
+    senderParentGroupId,
+    senderParentResolved,
+    parentGroupId,
+    parentGroupIdFromSession,
+    senderParentGroupIdFromSession,
+    senderParentFromSessionResolved,
+    parentGroupIdResolved,
+    groupChannel,
+    channelBare,
+    channelSlug,
+    groupSubject,
+    subjectBare,
+    subjectSlug,
+  );
+}
+
+export function resolveChannelThinkingOverride(
+  params: ChannelThinkingOverrideParams,
+): ChannelThinkingOverride | null {
+  const channel = params.channel?.trim();
+  if (!channel) {
+    return null;
+  }
+  const thinkingByChannel = (params.cfg.channels as Record<string, unknown> | undefined)
+    ?.thinkingByChannel as ChannelThinkingByChannelConfig | undefined;
+  if (!thinkingByChannel) {
+    return null;
+  }
+  const providerEntries = resolveProviderEntry(thinkingByChannel, channel);
+  if (!providerEntries) {
+    return null;
+  }
+
+  const candidates = buildChannelCandidates(params);
+  if (candidates.length === 0) {
+    return null;
+  }
+  const match = resolveChannelEntryMatchWithFallback({
+    entries: providerEntries,
+    keys: candidates,
+    wildcardKey: "*",
+    normalizeKey: (value) => value.trim().toLowerCase(),
+  });
+  const raw = match.entry ?? match.wildcardEntry;
+  if (typeof raw !== "string") {
+    return null;
+  }
+  const thinking = normalizeThinkLevel(raw.trim());
+  if (!thinking) {
+    return null;
+  }
+
+  return {
+    channel: normalizeMessageChannel(channel) ?? channel.trim().toLowerCase(),
+    thinking,
+    matchKey: match.matchKey,
+    matchSource: match.matchSource,
+  };
+}

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1448,6 +1448,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Allow Mattermost to write config in response to channel events/commands (default: true).",
   "channels.modelByChannel":
     "Map provider -> channel id -> model override (values are provider/model or aliases).",
+  "channels.thinkingByChannel":
+    "Map provider -> channel id -> thinking level override (off, minimal, low, medium, high, xhigh, adaptive).",
   "messages.suppressToolErrors":
     "When true, suppress ⚠️ tool-error warnings from being shown to the user. The agent already sees errors in context and can retry. Default: false.",
   "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -92,7 +92,11 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
 };
 
 const CHANNEL_NAMESPACE_PREFIX = "channels.";
-const CHANNEL_KERNEL_HINT_PREFIXES = ["channels.defaults", "channels.modelByChannel"] as const;
+const CHANNEL_KERNEL_HINT_PREFIXES = [
+  "channels.defaults",
+  "channels.modelByChannel",
+  "channels.thinkingByChannel",
+] as const;
 
 function isKernelOwnedChannelHintPath(path: string): boolean {
   if (path === "channels") {

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -739,6 +739,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.defaults.heartbeat.useIndicator": "Heartbeat Use Indicator",
   "channels.mattermost": "Mattermost",
   "channels.modelByChannel": "Channel Model Overrides",
+  "channels.thinkingByChannel": "Channel Thinking Overrides",
   "channels.matrix.allowBots": "Matrix Allow Bot Messages",
   "channels.mattermost.botToken": "Mattermost Bot Token",
   "channels.mattermost.baseUrl": "Mattermost Base URL",

--- a/src/config/types.channels.ts
+++ b/src/config/types.channels.ts
@@ -24,6 +24,7 @@ export type ChannelDefaultsConfig = {
 };
 
 export type ChannelModelByChannelConfig = Record<string, Record<string, string>>;
+export type ChannelThinkingByChannelConfig = Record<string, Record<string, string>>;
 
 /**
  * Base type for extension channel config sections.
@@ -47,6 +48,8 @@ export interface ChannelsConfig {
   defaults?: ChannelDefaultsConfig;
   /** Map provider -> channel id -> model override. */
   modelByChannel?: ChannelModelByChannelConfig;
+  /** Map provider -> channel id -> thinking level override. */
+  thinkingByChannel?: ChannelThinkingByChannelConfig;
   /** Channel sections are plugin-owned; concrete channel files augment this interface. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;

--- a/src/config/zod-schema.providers.ts
+++ b/src/config/zod-schema.providers.ts
@@ -23,6 +23,13 @@ const ChannelModelByChannelSchema = z
   .record(z.string(), z.record(z.string(), z.string()))
   .optional();
 
+const ChannelThinkingByChannelSchema = z
+  .record(
+    z.string(),
+    z.record(z.string(), z.enum(["off", "minimal", "low", "medium", "high", "xhigh", "adaptive"])),
+  )
+  .optional();
+
 const directChannelRuntimeSchemas = new Map<
   string,
   { safeParse: (value: unknown) => ReturnType<z.ZodTypeAny["safeParse"]> }
@@ -112,6 +119,7 @@ export const ChannelsSchema: z.ZodType<ChannelsConfig | undefined> = z
       .strict()
       .optional(),
     modelByChannel: ChannelModelByChannelSchema,
+    thinkingByChannel: ChannelThinkingByChannelSchema,
   })
   .passthrough() // Allow extension channel configs (nostr, matrix, zalo, etc.)
   .superRefine((value, ctx) => {


### PR DESCRIPTION
## Summary

Adds `channels.thinkingByChannel` config to override thinking level per channel/group, analogous to the existing `modelByChannel`.

## Motivation

Currently there is no way to set different thinking levels per channel. The thinking level resolves from per-message directive → session override → per-model config → global `thinkingDefault` → model catalog default, with no channel-awareness in the chain.

This is useful for running specific channels (e.g. a "fast" channel for quick interactions) with thinking disabled for lower latency, while keeping high thinking for the rest of the instance including subagents.

## Config

```json
{
  "channels": {
    "thinkingByChannel": {
      "discord": {
        "<channel_id>": "off",
        "*": "high"
      }
    }
  }
}
```

Valid values: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `adaptive`

## Resolution Priority

1. Per-message directive (`/think off`)
2. Session-level `thinkingLevel` override
3. **Channel thinking override (`thinkingByChannel`)** ← NEW
4. Per-model config (`agents.defaults.models.*.params.thinking`)
5. Global `thinkingDefault`
6. Model catalog default

## Changes

- New `src/channels/thinking-overrides.ts` with `resolveChannelThinkingOverride()` - uses the same channel matching logic as `modelByChannel` (group ID, channel name, slug, wildcard, parent/topic resolution)
- Wired into `src/auto-reply/reply/get-reply-run.ts` thinking resolution chain
- Shows `(channel override)` in `/status` when active
- Zod schema validates thinking level enum values
- Config types, help text, hints, and labels all updated
- 10 unit tests covering: match by ID, wildcard fallback, no match, topic/parent matching, invalid levels, empty config

## Testing

```bash
pnpm vitest run src/channels/thinking-overrides.test.ts
# 10 tests pass
```

cc @nichochar @AriPerkkio