### PR TITLE
fix(core): prevent silent session reset during heartbeat runs

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -32,6 +32,20 @@ import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { defaultRuntime } from "../../runtime.js";
 import { sanitizeForLog } from "../../terminal/ansi.js";
+
+/** Hash-prefix a session key so logs are correlatable but not directly identifying. */
+function safeSessionId(id: string): string {
+  return crypto.createHash("sha256").update(id).digest("hex").slice(0, 12);
+}
+
+/** Truncate + sanitize a provider error message for safe logging. */
+function safeErrorSummary(msg: string, maxLen = 200): string {
+  const truncated = msg.length > maxLen ? msg.slice(0, maxLen) + "…" : msg;
+  return sanitizeForLog(truncated).replace(
+    /(api[_\-]?key|token|secret|authorization|bearer)\s*[=:]\s*\S+/gi,
+    "$1=<redacted>",
+  );
+}
 import {
   isMarkdownCapableMessageChannel,
   resolveMessageChannel,
@@ -603,11 +617,11 @@ export async function runAgentTurnWithFallback(params: {
       ) {
         if (params.isHeartbeat) {
           defaultRuntime.error(
-            `Heartbeat run hit context overflow — skipping session reset to preserve conversation history (${sanitizeForLog(embeddedError.message)})`,
+            `Heartbeat run hit context overflow — skipping session reset to preserve conversation history (${safeErrorSummary(embeddedError.message)})`,
           );
           return {
             kind: "final",
-            payload: { text: "" },
+            payload: { text: "", isError: true },
           };
         }
         if (await params.resetSessionAfterCompactionFailure(embeddedError.message)) {
@@ -623,11 +637,11 @@ export async function runAgentTurnWithFallback(params: {
       if (embeddedError?.kind === "role_ordering") {
         if (params.isHeartbeat) {
           defaultRuntime.error(
-            `Heartbeat run hit role ordering conflict — skipping session reset to preserve conversation history (${sanitizeForLog(embeddedError.message)})`,
+            `Heartbeat run hit role ordering conflict — skipping session reset to preserve conversation history (${safeErrorSummary(embeddedError.message)})`,
           );
           return {
             kind: "final",
-            payload: { text: "" },
+            payload: { text: "", isError: true },
           };
         }
         const didReset = await params.resetSessionAfterRoleOrderingConflict(embeddedError.message);
@@ -692,11 +706,11 @@ export async function runAgentTurnWithFallback(params: {
       if (isCompactionFailure && !didResetAfterCompactionFailure) {
         if (params.isHeartbeat) {
           defaultRuntime.error(
-            `Heartbeat run hit compaction failure — skipping session reset to preserve conversation history (${sanitizeForLog(message)})`,
+            `Heartbeat run hit compaction failure — skipping session reset to preserve conversation history (${safeErrorSummary(message)})`,
           );
           return {
             kind: "final",
-            payload: { text: "" },
+            payload: { text: "", isError: true },
           };
         }
         if (await params.resetSessionAfterCompactionFailure(message)) {
@@ -712,11 +726,11 @@ export async function runAgentTurnWithFallback(params: {
       if (isRoleOrderingError) {
         if (params.isHeartbeat) {
           defaultRuntime.error(
-            `Heartbeat run hit role ordering error — skipping session reset to preserve conversation history (${sanitizeForLog(message)})`,
+            `Heartbeat run hit role ordering error — skipping session reset to preserve conversation history (${safeErrorSummary(message)})`,
           );
           return {
             kind: "final",
-            payload: { text: "" },
+            payload: { text: "", isError: true },
           };
         }
         const didReset = await params.resetSessionAfterRoleOrderingConflict(message);
@@ -740,11 +754,11 @@ export async function runAgentTurnWithFallback(params: {
       ) {
         if (params.isHeartbeat) {
           defaultRuntime.error(
-            `Heartbeat run hit Gemini session corruption — skipping session reset to preserve conversation history (${sanitizeForLog(params.sessionKey)})`,
+            `Heartbeat run hit Gemini session corruption — skipping session reset to preserve conversation history (session=${safeSessionId(params.sessionKey)})`,
           );
           return {
             kind: "final",
-            payload: { text: "" },
+            payload: { text: "", isError: true },
           };
         }
         const sessionKey = params.sessionKey;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -592,22 +592,44 @@ export async function runAgentTurnWithFallback(params: {
 
       // Some embedded runs surface context overflow as an error payload instead of throwing.
       // Treat those as a session-level failure and auto-recover by starting a fresh session.
+      // Heartbeat runs must never reset the user's session — the heartbeat should
+      // fail gracefully instead of silently destroying conversation history.
+      // See: https://github.com/openclaw/openclaw/issues/58409
       const embeddedError = runResult.meta?.error;
       if (
         embeddedError &&
         isContextOverflowError(embeddedError.message) &&
-        !didResetAfterCompactionFailure &&
-        (await params.resetSessionAfterCompactionFailure(embeddedError.message))
+        !didResetAfterCompactionFailure
       ) {
-        didResetAfterCompactionFailure = true;
-        return {
-          kind: "final",
-          payload: {
-            text: "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
-          },
-        };
+        if (params.isHeartbeat) {
+          defaultRuntime.error(
+            `Heartbeat run hit context overflow — skipping session reset to preserve conversation history (${embeddedError.message})`,
+          );
+          return {
+            kind: "final",
+            payload: { text: "" },
+          };
+        }
+        if (await params.resetSessionAfterCompactionFailure(embeddedError.message)) {
+          didResetAfterCompactionFailure = true;
+          return {
+            kind: "final",
+            payload: {
+              text: "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
+            },
+          };
+        }
       }
       if (embeddedError?.kind === "role_ordering") {
+        if (params.isHeartbeat) {
+          defaultRuntime.error(
+            `Heartbeat run hit role ordering conflict — skipping session reset to preserve conversation history (${embeddedError.message})`,
+          );
+          return {
+            kind: "final",
+            payload: { text: "" },
+          };
+        }
         const didReset = await params.resetSessionAfterRoleOrderingConflict(embeddedError.message);
         if (didReset) {
           return {
@@ -664,20 +686,39 @@ export async function runAgentTurnWithFallback(params: {
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
       const isTransientHttp = isTransientHttpError(message);
 
-      if (
-        isCompactionFailure &&
-        !didResetAfterCompactionFailure &&
-        (await params.resetSessionAfterCompactionFailure(message))
-      ) {
-        didResetAfterCompactionFailure = true;
-        return {
-          kind: "final",
-          payload: {
-            text: "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
-          },
-        };
+      // Heartbeat runs must never reset the user's session — the heartbeat
+      // should fail gracefully instead of silently destroying conversation
+      // history. See: https://github.com/openclaw/openclaw/issues/58409
+      if (isCompactionFailure && !didResetAfterCompactionFailure) {
+        if (params.isHeartbeat) {
+          defaultRuntime.error(
+            `Heartbeat run hit compaction failure — skipping session reset to preserve conversation history (${message})`,
+          );
+          return {
+            kind: "final",
+            payload: { text: "" },
+          };
+        }
+        if (await params.resetSessionAfterCompactionFailure(message)) {
+          didResetAfterCompactionFailure = true;
+          return {
+            kind: "final",
+            payload: {
+              text: "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
+            },
+          };
+        }
       }
       if (isRoleOrderingError) {
+        if (params.isHeartbeat) {
+          defaultRuntime.error(
+            `Heartbeat run hit role ordering error — skipping session reset to preserve conversation history (${message})`,
+          );
+          return {
+            kind: "final",
+            payload: { text: "" },
+          };
+        }
         const didReset = await params.resetSessionAfterRoleOrderingConflict(message);
         if (didReset) {
           return {
@@ -689,13 +730,23 @@ export async function runAgentTurnWithFallback(params: {
         }
       }
 
-      // Auto-recover from Gemini session corruption by resetting the session
+      // Auto-recover from Gemini session corruption by resetting the session.
+      // Heartbeat runs skip this destructive path to avoid silent data loss.
       if (
         isSessionCorruption &&
         params.sessionKey &&
         params.activeSessionStore &&
         params.storePath
       ) {
+        if (params.isHeartbeat) {
+          defaultRuntime.error(
+            `Heartbeat run hit Gemini session corruption — skipping session reset to preserve conversation history (${params.sessionKey})`,
+          );
+          return {
+            kind: "final",
+            payload: { text: "" },
+          };
+        }
         const sessionKey = params.sessionKey;
         const corruptedSessionId = params.getActiveSessionEntry()?.sessionId;
         defaultRuntime.error(

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -41,9 +41,18 @@ function safeSessionId(id: string): string {
 /** Truncate + sanitize a provider error message for safe logging. */
 function safeErrorSummary(msg: string, maxLen = 200): string {
   const truncated = msg.length > maxLen ? msg.slice(0, maxLen) + "…" : msg;
-  return sanitizeForLog(truncated).replace(
-    /(api[_-]?key|token|secret|authorization|bearer)\s*[=:]\s*\S+/gi,
-    "$1=<redacted>",
+  const sanitized = sanitizeForLog(truncated);
+  return (
+    sanitized
+      // "Authorization: Bearer <token>" or "Authorization=<token>"
+      .replace(/(authorization\s*[:=]\s*)(bearer\s+)?([^\s,;]+)/gi, "$1<redacted>")
+      // Standalone "Bearer <token>"
+      .replace(/\bbearer\s+([^\s,;]+)/gi, "bearer <redacted>")
+      // JSON-ish secret fields: api_key=xxx, token: "xxx", secret='xxx'
+      .replace(
+        /\b(api[_-]?key|token|secret)\b\s*[:=]\s*["']?([^\s"',;]+)/gi,
+        "$1=<redacted>",
+      )
   );
 }
 import {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -603,7 +603,7 @@ export async function runAgentTurnWithFallback(params: {
       ) {
         if (params.isHeartbeat) {
           defaultRuntime.error(
-            `Heartbeat run hit context overflow — skipping session reset to preserve conversation history (${embeddedError.message})`,
+            `Heartbeat run hit context overflow — skipping session reset to preserve conversation history (${sanitizeForLog(embeddedError.message)})`,
           );
           return {
             kind: "final",
@@ -623,7 +623,7 @@ export async function runAgentTurnWithFallback(params: {
       if (embeddedError?.kind === "role_ordering") {
         if (params.isHeartbeat) {
           defaultRuntime.error(
-            `Heartbeat run hit role ordering conflict — skipping session reset to preserve conversation history (${embeddedError.message})`,
+            `Heartbeat run hit role ordering conflict — skipping session reset to preserve conversation history (${sanitizeForLog(embeddedError.message)})`,
           );
           return {
             kind: "final",
@@ -692,7 +692,7 @@ export async function runAgentTurnWithFallback(params: {
       if (isCompactionFailure && !didResetAfterCompactionFailure) {
         if (params.isHeartbeat) {
           defaultRuntime.error(
-            `Heartbeat run hit compaction failure — skipping session reset to preserve conversation history (${message})`,
+            `Heartbeat run hit compaction failure — skipping session reset to preserve conversation history (${sanitizeForLog(message)})`,
           );
           return {
             kind: "final",
@@ -712,7 +712,7 @@ export async function runAgentTurnWithFallback(params: {
       if (isRoleOrderingError) {
         if (params.isHeartbeat) {
           defaultRuntime.error(
-            `Heartbeat run hit role ordering error — skipping session reset to preserve conversation history (${message})`,
+            `Heartbeat run hit role ordering error — skipping session reset to preserve conversation history (${sanitizeForLog(message)})`,
           );
           return {
             kind: "final",
@@ -740,7 +740,7 @@ export async function runAgentTurnWithFallback(params: {
       ) {
         if (params.isHeartbeat) {
           defaultRuntime.error(
-            `Heartbeat run hit Gemini session corruption — skipping session reset to preserve conversation history (${params.sessionKey})`,
+            `Heartbeat run hit Gemini session corruption — skipping session reset to preserve conversation history (${sanitizeForLog(params.sessionKey)})`,
           );
           return {
             kind: "final",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -42,7 +42,7 @@ function safeSessionId(id: string): string {
 function safeErrorSummary(msg: string, maxLen = 200): string {
   const truncated = msg.length > maxLen ? msg.slice(0, maxLen) + "…" : msg;
   return sanitizeForLog(truncated).replace(
-    /(api[_\-]?key|token|secret|authorization|bearer)\s*[=:]\s*\S+/gi,
+    /(api[_-]?key|token|secret|authorization|bearer)\s*[=:]\s*\S+/gi,
     "$1=<redacted>",
   );
 }

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1809,6 +1809,94 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
   });
 
+  it("does not reset session on embedded context overflow during heartbeat run", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const sessionId = "session-heartbeat-embedded-overflow";
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const sessionEntry: SessionEntry = {
+        sessionId,
+        updatedAt: Date.now(),
+        sessionFile: transcriptPath,
+      };
+      const sessionStore = { main: sessionEntry };
+
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "important-conversation-data", "utf-8");
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
+        payloads: [{ text: "context overflow", isError: true }],
+        meta: {
+          error: {
+            kind: "context_overflow",
+            message: 'Summarization failed: 400 {"message":"prompt is too long"}',
+          },
+        },
+      }));
+
+      const { run } = createMinimalRun({
+        opts: { isHeartbeat: true },
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      await run();
+
+      // Session must NOT have been reset
+      expect(sessionStore.main.sessionId).toBe(sessionId);
+      await expect(fs.access(transcriptPath)).resolves.toBeUndefined();
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(persisted.main.sessionId).toBe(sessionId);
+    });
+  });
+
+  it("does not reset session on embedded role ordering error during heartbeat run", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const sessionId = "session-heartbeat-embedded-role";
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const sessionEntry: SessionEntry = {
+        sessionId,
+        updatedAt: Date.now(),
+        sessionFile: transcriptPath,
+      };
+      const sessionStore = { main: sessionEntry };
+
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "important-conversation-data", "utf-8");
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
+        payloads: [{ text: "role conflict", isError: true }],
+        meta: {
+          error: {
+            kind: "role_ordering",
+            message: 'roles must alternate between "user" and "assistant"',
+          },
+        },
+      }));
+
+      const { run } = createMinimalRun({
+        opts: { isHeartbeat: true },
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      await run();
+
+      // Session must NOT have been reset
+      expect(sessionStore.main.sessionId).toBe(sessionId);
+      await expect(fs.access(transcriptPath)).resolves.toBeUndefined();
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(persisted.main.sessionId).toBe(sessionId);
+    });
+  });
+
   it("rewrites Bun socket errors into friendly text", async () => {
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
       payloads: [

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1694,6 +1694,121 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
   });
 
+  // Regression: heartbeat runs must never reset the user's session.
+  // See: https://github.com/openclaw/openclaw/issues/58409
+  it("does not reset session on compaction failure during heartbeat run", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const sessionId = "session-heartbeat-compaction";
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const sessionEntry: SessionEntry = {
+        sessionId,
+        updatedAt: Date.now(),
+        sessionFile: transcriptPath,
+      };
+      const sessionStore = { main: sessionEntry };
+
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "important-conversation-data", "utf-8");
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+        throw new Error(
+          'Context overflow: Summarization failed: 400 {"message":"prompt is too long"}',
+        );
+      });
+
+      const { run } = createMinimalRun({
+        opts: { isHeartbeat: true },
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      await run();
+
+      // Session must NOT have been reset
+      expect(sessionStore.main.sessionId).toBe(sessionId);
+      // Transcript must still exist on disk
+      await expect(fs.access(transcriptPath)).resolves.toBeUndefined();
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(persisted.main.sessionId).toBe(sessionId);
+    });
+  });
+
+  it("does not reset session on Gemini corruption during heartbeat run", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { storePath, sessionEntry, sessionStore, transcriptPath } =
+        await writeCorruptGeminiSessionFixture({
+          stateDir,
+          sessionId: "session-heartbeat-corrupt",
+          persistStore: true,
+        });
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+        throw new Error(
+          "function call turn comes immediately after a user turn or after a function response turn",
+        );
+      });
+
+      const { run } = createMinimalRun({
+        opts: { isHeartbeat: true },
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      await run();
+
+      // Session entry must still be present (not deleted)
+      expect(sessionStore.main).toBeDefined();
+      expect(sessionStore.main.sessionId).toBe("session-heartbeat-corrupt");
+      // Transcript must still exist on disk
+      await expect(fs.access(transcriptPath)).resolves.toBeUndefined();
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(persisted.main).toBeDefined();
+    });
+  });
+
+  it("does not reset session on role ordering error during heartbeat run", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const sessionId = "session-heartbeat-role";
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const sessionEntry: SessionEntry = {
+        sessionId,
+        updatedAt: Date.now(),
+        sessionFile: transcriptPath,
+      };
+      const sessionStore = { main: sessionEntry };
+
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "important-conversation-data", "utf-8");
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+        throw new Error("400 Incorrect role information");
+      });
+
+      const { run } = createMinimalRun({
+        opts: { isHeartbeat: true },
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      await run();
+
+      // Session must NOT have been reset
+      expect(sessionStore.main.sessionId).toBe(sessionId);
+      await expect(fs.access(transcriptPath)).resolves.toBeUndefined();
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(persisted.main.sessionId).toBe(sessionId);
+    });
+  });
+
   it("rewrites Bun socket errors into friendly text", async () => {
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
       payloads: [

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1422,4 +1422,58 @@ describe("runHeartbeatOnce", () => {
       replySpy.mockRestore();
     }
   });
+
+  // Regression: non-empty error payloads (e.g. rate-limit fallback messages)
+  // must still be delivered through the normal heartbeat alert path.
+  // The isError guard must only intercept empty error sentinels.
+  // See: https://github.com/openclaw/openclaw/issues/58409
+  it("delivers non-empty error payloads instead of masking them as failed", async () => {
+    const tmpDir = await createCaseDir("hb-nonempty-error");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+        }),
+      );
+
+      // Simulate a non-empty error payload (e.g. rate-limit fallback message)
+      replySpy.mockResolvedValue({ text: "Rate limit exceeded, please retry later.", isError: true });
+      const sendWhatsApp = vi
+        .fn<
+          (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+        >()
+        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+      const res = await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(sendWhatsApp),
+      });
+
+      // Non-empty error payloads must NOT be intercepted — they should be delivered
+      expect(res.status).toBe("ran");
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
 });

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1367,4 +1367,59 @@ describe("runHeartbeatOnce", () => {
       replySpy.mockRestore();
     }
   });
+
+  // Regression: heartbeat error payloads must surface as "failed", not "ok-empty".
+  // See: https://github.com/openclaw/openclaw/issues/58409
+  it("returns failed status when agent reply has isError flag", async () => {
+    const tmpDir = await createCaseDir("hb-error-payload");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+        }),
+      );
+
+      // Simulate an error payload returned by the heartbeat guard
+      replySpy.mockResolvedValue({ text: "", isError: true });
+      const sendWhatsApp = vi
+        .fn<
+          (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+        >()
+        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+      const res = await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(sendWhatsApp),
+      });
+
+      expect(res.status).toBe("failed");
+      if (res.status === "failed") {
+        expect(res.reason).toContain("error payload");
+      }
+      // Must NOT have sent any message to the user
+      expect(sendWhatsApp).toHaveBeenCalledTimes(0);
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -737,6 +737,27 @@ export async function runHeartbeatOnce(opts: {
       ? resolveHeartbeatReasoningPayloads(replyResult).filter((payload) => payload !== replyPayload)
       : [];
 
+    // Heartbeat failure: the agent layer returned an error payload (e.g. context
+    // overflow, compaction failure, session corruption) but intentionally skipped
+    // a destructive session reset.  Surface this as a proper "failed" event so
+    // monitoring / indicators reflect the real outcome instead of masking it as
+    // "ok-empty".  See: https://github.com/openclaw/openclaw/issues/58409
+    if (replyPayload?.isError) {
+      await restoreHeartbeatUpdatedAt({ storePath, sessionKey, updatedAt: previousUpdatedAt });
+      await pruneHeartbeatTranscript(transcriptState);
+      const reason = "heartbeat agent run returned an error payload";
+      emitHeartbeatEvent({
+        status: "failed",
+        reason,
+        durationMs: Date.now() - startedAt,
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
+        accountId: delivery.accountId,
+        indicatorType: visibility.useIndicator ? resolveIndicatorType("failed") : undefined,
+      });
+      log.error(`heartbeat failed: ${reason}`);
+      return { status: "failed", reason };
+    }
+
     if (!replyPayload || !hasOutboundReplyContent(replyPayload)) {
       await restoreHeartbeatUpdatedAt({
         storePath,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -737,12 +737,16 @@ export async function runHeartbeatOnce(opts: {
       ? resolveHeartbeatReasoningPayloads(replyResult).filter((payload) => payload !== replyPayload)
       : [];
 
-    // Heartbeat failure: the agent layer returned an error payload (e.g. context
-    // overflow, compaction failure, session corruption) but intentionally skipped
-    // a destructive session reset.  Surface this as a proper "failed" event so
-    // monitoring / indicators reflect the real outcome instead of masking it as
-    // "ok-empty".  See: https://github.com/openclaw/openclaw/issues/58409
-    if (replyPayload?.isError) {
+    // Heartbeat failure: the agent layer returned an empty error sentinel
+    // (e.g. context overflow, compaction failure, session corruption) but
+    // intentionally skipped a destructive session reset.  Surface this as a
+    // proper "failed" event so monitoring / indicators reflect the real outcome
+    // instead of masking it as "ok-empty".
+    // Guard is narrowed to empty-text error sentinels so that non-empty error
+    // payloads (e.g. rate-limit/overload fallback messages) still flow through
+    // the normal heartbeat alert delivery path.
+    // See: https://github.com/openclaw/openclaw/issues/58409
+    if (replyPayload?.isError && !hasOutboundReplyContent(replyPayload)) {
       await restoreHeartbeatUpdatedAt({ storePath, sessionKey, updatedAt: previousUpdatedAt });
       await pruneHeartbeatTranscript(transcriptState);
       const reason = "heartbeat agent run returned an error payload";


### PR DESCRIPTION
### Summary

- **Problem**: When a heartbeat run encounters a context overflow, role ordering conflict, or Gemini session corruption, it silently resets the user's session. This causes catastrophic data loss (e.g., 8,323 messages lost) without any warning, as the old transcript is archived into a `.reset.<timestamp>` file and a fresh session is started. The issue is located in `src/auto-reply/reply/agent-runner-execution.ts`.
- **Root Cause**: The `runAgentTurnWithFallback` function contains automatic session recovery paths (for compaction failures, role ordering errors, and Gemini corruption) that are designed for user-initiated turns. However, these destructive paths are not guarded against heartbeat runs. While the `isHeartbeat` flag is passed into the function, it is only used for typing signals and token stripping, but never to prevent session resets. Since heartbeat runs often send the full conversation history, they are highly susceptible to context overflows, triggering the reset.
- **Fix**: Added `if (params.isHeartbeat)` guards to the three session reset paths in `agent-runner-execution.ts`. If a heartbeat run encounters these errors, it now logs the error and returns an empty payload, allowing the heartbeat to fail gracefully without destroying the user's conversation history. This avoids side effects because it strictly scopes the bypass to heartbeat runs, leaving the auto-recovery behavior intact for normal user messages.
- **What changed**:
  - `src/auto-reply/reply/agent-runner-execution.ts`: Added heartbeat guards to five session-reset paths — two in the post-run embedded-error branch (context overflow and role ordering) and three in the catch block (compaction failure, role ordering error, Gemini session corruption). All log interpolations use sanitizeForLog() to prevent log forging (CWE-117).
  - `src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`: Added five regression tests to ensure heartbeat runs do not reset sessions across all guarded paths (compaction failure, Gemini corruption, role ordering — both thrown exceptions and embedded errors).
- **What did NOT change (scope boundary)**: Normal user-initiated runs will still auto-recover and reset sessions when encountering these errors. The session resolution logic (`resolveHeartbeatSession`) remains untouched.

### Reproduction

1. Enable heartbeats for an agent (`agents.defaults.heartbeat.every`).
2. Fill the session history until it exceeds the model's context limit (or manually trigger a compaction failure).
3. Wait for the heartbeat to trigger.
4. Observe that the session is silently reset (a `.reset.<timestamp>` file is created) and the conversation history is lost.

### Risk / Mitigation

- **Risk**: Heartbeat runs might get permanently stuck if they consistently hit context overflow without resetting the session.
- **Mitigation**: This is preferable to silent data loss. The error is logged, and the user can manually intervene (e.g., by using `/new` or clearing context). Added comprehensive e2e tests to ensure the session and transcript remain intact during these failures.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Core (Agent Runner)
- [x] Heartbeat System

### Linked Issue/PR

Fixes #58409