### PR TITLE
feat(telegram): add heartbeat supervisor for silent network outage detection

### DIFF
--- a/extensions/telegram/src/heartbeat.test.ts
+++ b/extensions/telegram/src/heartbeat.test.ts
@@ -1,0 +1,396 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const probeTelegramMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./probe.js", () => ({
+  probeTelegram: probeTelegramMock,
+}));
+
+let HeartbeatSupervisor: typeof import("./heartbeat.js").HeartbeatSupervisor;
+type HeartbeatOpts = ConstructorParameters<typeof import("./heartbeat.js").HeartbeatSupervisor>[0];
+
+describe("HeartbeatSupervisor (threshold)", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    probeTelegramMock.mockReset();
+    ({ HeartbeatSupervisor } = await import("./heartbeat.js"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function captureInterval() {
+    let heartbeatCallback: (() => void) | undefined;
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((fn) => {
+      heartbeatCallback = fn as () => void;
+      return 2 as unknown as ReturnType<typeof setInterval>;
+    });
+    vi.spyOn(globalThis, "clearInterval").mockImplementation(() => {});
+    return {
+      setIntervalSpy,
+      tick: () => {
+        if (!heartbeatCallback) {
+          throw new Error("setInterval callback not captured");
+        }
+        return heartbeatCallback();
+      },
+    };
+  }
+
+  function makeOpts(overrides: Partial<HeartbeatOpts> = {}): HeartbeatOpts {
+    const base: HeartbeatOpts = {
+      apiBase: "https://api.telegram.org",
+      token: "test-token",
+      log: vi.fn(),
+      onOutageDetected: vi.fn(),
+      onRecovered: vi.fn(),
+    };
+    return { ...base, ...overrides };
+  }
+
+  it("does not fire onOutageDetected on successful probes", async () => {
+    probeTelegramMock.mockResolvedValue({ ok: true, elapsedMs: 10, error: null });
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts();
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      await tick();
+      await tick();
+      await tick();
+
+      expect(opts.onOutageDetected).not.toHaveBeenCalled();
+      expect(probeTelegramMock).toHaveBeenCalledTimes(3);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("fires onOutageDetected after exactly failureThreshold (3) consecutive failures", async () => {
+    probeTelegramMock.mockResolvedValue({ ok: false, elapsedMs: 5, error: "timeout" });
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts({ failureThreshold: 3 });
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      await tick();
+      expect(opts.onOutageDetected).not.toHaveBeenCalled();
+
+      await tick();
+      expect(opts.onOutageDetected).not.toHaveBeenCalled();
+
+      await tick();
+      expect(opts.onOutageDetected).toHaveBeenCalledTimes(1);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("fires onOutageDetected only once per outage even after more failures", async () => {
+    probeTelegramMock.mockResolvedValue({ ok: false, elapsedMs: 5, error: "timeout" });
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts({ failureThreshold: 3 });
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      for (let i = 0; i < 6; i++) {
+        await tick();
+      }
+
+      expect(opts.onOutageDetected).toHaveBeenCalledTimes(1);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("fires onRecovered once after a successful probe following an outage", async () => {
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts({ failureThreshold: 3 });
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      // 3 failures → outage
+      probeTelegramMock.mockResolvedValue({ ok: false, elapsedMs: 5, error: "timeout" });
+      await tick();
+      await tick();
+      await tick();
+      expect(opts.onOutageDetected).toHaveBeenCalledTimes(1);
+      expect(opts.onRecovered).not.toHaveBeenCalled();
+
+      // 1 success → recovery
+      probeTelegramMock.mockResolvedValue({ ok: true, elapsedMs: 10, error: null });
+      await tick();
+      expect(opts.onRecovered).toHaveBeenCalledTimes(1);
+
+      // Additional successes do not re-fire onRecovered
+      await tick();
+      expect(opts.onRecovered).toHaveBeenCalledTimes(1);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("resets failure counter on success before threshold is reached", async () => {
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts({ failureThreshold: 3 });
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      probeTelegramMock.mockResolvedValue({ ok: false, elapsedMs: 5, error: "err" });
+      await tick();
+      await tick();
+
+      // Success resets the counter
+      probeTelegramMock.mockResolvedValue({ ok: true, elapsedMs: 10, error: null });
+      await tick();
+
+      // 2 more failures should not reach threshold (only 2, not 3)
+      probeTelegramMock.mockResolvedValue({ ok: false, elapsedMs: 5, error: "err" });
+      await tick();
+      await tick();
+
+      expect(opts.onOutageDetected).not.toHaveBeenCalled();
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("does not call probeTelegram when abortSignal is already aborted", async () => {
+    const abort = new AbortController();
+    abort.abort();
+
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts({ abortSignal: abort.signal });
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      await tick();
+
+      expect(probeTelegramMock).not.toHaveBeenCalled();
+      expect(opts.onOutageDetected).not.toHaveBeenCalled();
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("suppresses onOutageDetected when signal fires mid-probe", async () => {
+    const abort = new AbortController();
+    probeTelegramMock.mockImplementation(async () => {
+      abort.abort();
+      return { ok: false, elapsedMs: 5, error: "err" };
+    });
+
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts({ abortSignal: abort.signal, failureThreshold: 1 });
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      await tick();
+
+      expect(probeTelegramMock).toHaveBeenCalledTimes(1);
+      expect(opts.onOutageDetected).not.toHaveBeenCalled();
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("stop() clears the interval", () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation(() => {});
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation(() => {
+      return 42 as unknown as ReturnType<typeof setInterval>;
+    });
+
+    try {
+      const supervisor = new HeartbeatSupervisor(makeOpts());
+      supervisor.start();
+      supervisor.stop();
+
+      expect(clearIntervalSpy).toHaveBeenCalledWith(42);
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
+  });
+
+  it("calling start() twice does not register a second interval", () => {
+    let callCount = 0;
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation(() => {
+      callCount += 1;
+      return callCount as unknown as ReturnType<typeof setInterval>;
+    });
+    vi.spyOn(globalThis, "clearInterval").mockImplementation(() => {});
+
+    try {
+      const supervisor = new HeartbeatSupervisor(makeOpts());
+      supervisor.start();
+      supervisor.start();
+
+      expect(callCount).toBe(1);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("does not overlap probes when a tick fires while a probe is in-flight", async () => {
+    let resolveProbe: ((v: { ok: boolean; elapsedMs: number; error: null }) => void) | undefined;
+    probeTelegramMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveProbe = resolve;
+        }),
+    );
+
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts();
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      // Start first probe (stays pending)
+      const firstTick = tick();
+
+      // Second tick fires while first is in-flight — should be skipped
+      await tick();
+
+      expect(probeTelegramMock).toHaveBeenCalledTimes(1);
+
+      // Resolve first probe
+      resolveProbe!({ ok: true, elapsedMs: 10, error: null });
+      await firstTick;
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("does not fire callbacks after stop() when an in-flight probe resolves", async () => {
+    let resolveProbe:
+      | ((v: { ok: boolean; elapsedMs: number; error: string | null }) => void)
+      | undefined;
+    probeTelegramMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveProbe = resolve;
+        }),
+    );
+
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts({ failureThreshold: 1 });
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      const firstTick = tick();
+      supervisor.stop();
+      resolveProbe?.({ ok: false, elapsedMs: 5, error: "timeout" });
+      await firstTick;
+
+      expect(opts.onOutageDetected).not.toHaveBeenCalled();
+      expect(opts.onRecovered).not.toHaveBeenCalled();
+      expect(opts.log).not.toHaveBeenCalled();
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("logs failure count on each failed probe without leaking token or URL", async () => {
+    probeTelegramMock.mockResolvedValue({ ok: false, elapsedMs: 5, error: "connection refused" });
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts({
+        token: "SECRET_TOKEN_VALUE",
+        apiBase: "https://secret-api.example.com",
+        failureThreshold: 3,
+      });
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      await tick();
+
+      expect(opts.log).toHaveBeenCalledTimes(1);
+      const logLine = (opts.log as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+      expect(logLine).toContain("connection refused");
+      expect(logLine).toContain("[1/3]");
+      expect(logLine).not.toContain("SECRET_TOKEN_VALUE");
+      expect(logLine).not.toContain("secret-api.example.com");
+      expect(probeTelegramMock).toHaveBeenCalledWith("SECRET_TOKEN_VALUE", 10_000, {
+        apiRoot: "https://secret-api.example.com",
+      });
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("calls onRecovered after a successful probe following an outage", async () => {
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts({ failureThreshold: 3 });
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      probeTelegramMock.mockResolvedValue({ ok: false, elapsedMs: 5, error: "err" });
+      await tick();
+      await tick();
+      await tick();
+
+      probeTelegramMock.mockResolvedValue({ ok: true, elapsedMs: 10, error: null });
+      await tick();
+
+      expect(opts.onRecovered).toHaveBeenCalledTimes(1);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("can trigger a second outage after recovery", async () => {
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts({ failureThreshold: 2 });
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      // First outage
+      probeTelegramMock.mockResolvedValue({ ok: false, elapsedMs: 5, error: "err" });
+      await tick();
+      await tick();
+      expect(opts.onOutageDetected).toHaveBeenCalledTimes(1);
+
+      // Recovery
+      probeTelegramMock.mockResolvedValue({ ok: true, elapsedMs: 10, error: null });
+      await tick();
+      expect(opts.onRecovered).toHaveBeenCalledTimes(1);
+
+      // Second outage
+      probeTelegramMock.mockResolvedValue({ ok: false, elapsedMs: 5, error: "err" });
+      await tick();
+      await tick();
+      expect(opts.onOutageDetected).toHaveBeenCalledTimes(2);
+
+      // Second recovery
+      probeTelegramMock.mockResolvedValue({ ok: true, elapsedMs: 10, error: null });
+      await tick();
+      expect(opts.onRecovered).toHaveBeenCalledTimes(2);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+});

--- a/extensions/telegram/src/heartbeat.test.ts
+++ b/extensions/telegram/src/heartbeat.test.ts
@@ -332,6 +332,7 @@ describe("HeartbeatSupervisor (threshold)", () => {
       expect(logLine).not.toContain("secret-api.example.com");
       expect(probeTelegramMock).toHaveBeenCalledWith("SECRET_TOKEN_VALUE", 10_000, {
         apiRoot: "https://secret-api.example.com",
+        proxyUrl: undefined,
       });
     } finally {
       setIntervalSpy.mockRestore();
@@ -389,6 +390,26 @@ describe("HeartbeatSupervisor (threshold)", () => {
       probeTelegramMock.mockResolvedValue({ ok: true, elapsedMs: 10, error: null });
       await tick();
       expect(opts.onRecovered).toHaveBeenCalledTimes(2);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("forwards proxyUrl to probeTelegram when provided", async () => {
+    probeTelegramMock.mockResolvedValue({ ok: true, elapsedMs: 10, error: null });
+    const { setIntervalSpy, tick } = captureInterval();
+
+    try {
+      const opts = makeOpts({ proxyUrl: "http://proxy.example.com:3128" });
+      const supervisor = new HeartbeatSupervisor(opts);
+      supervisor.start();
+
+      await tick();
+
+      expect(probeTelegramMock).toHaveBeenCalledWith("test-token", 10_000, {
+        apiRoot: "https://api.telegram.org",
+        proxyUrl: "http://proxy.example.com:3128",
+      });
     } finally {
       setIntervalSpy.mockRestore();
     }

--- a/extensions/telegram/src/heartbeat.ts
+++ b/extensions/telegram/src/heartbeat.ts
@@ -1,0 +1,107 @@
+import { probeTelegram } from "./probe.js";
+
+export type HeartbeatSupervisorOpts = {
+  /** Pre-resolved Telegram API base URL (e.g. "https://api.telegram.org"). */
+  apiBase: string;
+  token: string;
+  /** Shared abort signal; heartbeat stops when aborted. */
+  abortSignal?: AbortSignal;
+  /** How often to run a probe (ms). @default 30_000 */
+  intervalMs?: number;
+  /** Number of consecutive failures before firing onOutageDetected. @default 3 */
+  failureThreshold?: number;
+  /** Timeout budget for each probe call (ms). @default 10_000 */
+  probeTimeoutMs?: number;
+  /** Called once after failureThreshold consecutive probe failures. */
+  onOutageDetected: () => void;
+  /** Called once after a successful probe following an outage. */
+  onRecovered: () => void;
+  log: (line: string) => void;
+};
+
+const DEFAULT_INTERVAL_MS = 30_000;
+const DEFAULT_FAILURE_THRESHOLD = 3;
+const DEFAULT_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Threshold-based heartbeat supervisor for Telegram API connectivity.
+ *
+ * Runs periodic silent probes via probeTelegram(). Fires onOutageDetected
+ * after exactly `failureThreshold` consecutive failures (once per outage),
+ * and fires onRecovered once when a subsequent probe succeeds.
+ *
+ * Call start() once; call stop() in a finally block.
+ */
+export class HeartbeatSupervisor {
+  #intervalHandle: ReturnType<typeof setInterval> | undefined;
+  #consecutiveFailures = 0;
+  #inOutage = false;
+  #probeInFlight = false;
+  #stopped = false;
+
+  readonly #intervalMs: number;
+  readonly #failureThreshold: number;
+  readonly #probeTimeoutMs: number;
+
+  constructor(private readonly opts: HeartbeatSupervisorOpts) {
+    this.#intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.#failureThreshold = opts.failureThreshold ?? DEFAULT_FAILURE_THRESHOLD;
+    this.#probeTimeoutMs = opts.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  }
+
+  start(): void {
+    if (this.#intervalHandle !== undefined) {
+      return;
+    }
+    this.#stopped = false;
+    this.#intervalHandle = setInterval(() => {
+      void this.#tick();
+    }, this.#intervalMs);
+    // Allow Node to exit even if the interval is still pending.
+    this.#intervalHandle.unref?.();
+  }
+
+  stop(): void {
+    this.#stopped = true;
+    if (this.#intervalHandle !== undefined) {
+      clearInterval(this.#intervalHandle);
+      this.#intervalHandle = undefined;
+    }
+  }
+
+  async #tick(): Promise<void> {
+    if (this.#stopped || this.opts.abortSignal?.aborted || this.#probeInFlight) {
+      return;
+    }
+
+    this.#probeInFlight = true;
+    try {
+      const result = await probeTelegram(this.opts.token, this.#probeTimeoutMs, {
+        apiRoot: this.opts.apiBase,
+      });
+
+      if (this.#stopped || this.opts.abortSignal?.aborted) {
+        return;
+      }
+
+      if (result.ok) {
+        if (this.#inOutage) {
+          this.#inOutage = false;
+          this.opts.onRecovered();
+        }
+        this.#consecutiveFailures = 0;
+      } else {
+        this.#consecutiveFailures += 1;
+        this.opts.log(
+          `[telegram][heartbeat] probe failed (${result.error ?? "unknown error"}) [${this.#consecutiveFailures}/${this.#failureThreshold}]`,
+        );
+        if (this.#consecutiveFailures >= this.#failureThreshold && !this.#inOutage) {
+          this.#inOutage = true;
+          this.opts.onOutageDetected();
+        }
+      }
+    } finally {
+      this.#probeInFlight = false;
+    }
+  }
+}

--- a/extensions/telegram/src/heartbeat.ts
+++ b/extensions/telegram/src/heartbeat.ts
@@ -4,6 +4,8 @@ export type HeartbeatSupervisorOpts = {
   /** Pre-resolved Telegram API base URL (e.g. "https://api.telegram.org"). */
   apiBase: string;
   token: string;
+  /** Optional proxy URL forwarded to each probe (e.g. "http://proxy:3128"). */
+  proxyUrl?: string;
   /** Shared abort signal; heartbeat stops when aborted. */
   abortSignal?: AbortSignal;
   /** How often to run a probe (ms). @default 30_000 */
@@ -78,6 +80,7 @@ export class HeartbeatSupervisor {
     try {
       const result = await probeTelegram(this.opts.token, this.#probeTimeoutMs, {
         apiRoot: this.opts.apiBase,
+        proxyUrl: this.opts.proxyUrl,
       });
 
       if (this.#stopped || this.opts.abortSignal?.aborted) {

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -322,6 +322,7 @@ vi.mock("./webhook.js", () => ({
 
 vi.mock("./fetch.js", () => ({
   resolveTelegramTransport: resolveTelegramTransportSpy,
+  resolveTelegramApiBase: (apiRoot?: string) => apiRoot ?? "https://api.telegram.org",
 }));
 
 vi.mock("./update-offset-store.js", () => ({

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -323,6 +323,7 @@ vi.mock("./webhook.js", () => ({
 vi.mock("./fetch.js", () => ({
   resolveTelegramTransport: resolveTelegramTransportSpy,
   resolveTelegramApiBase: (apiRoot?: string) => apiRoot ?? "https://api.telegram.org",
+  resolveTelegramFetch: () => globalThis.fetch,
 }));
 
 vi.mock("./update-offset-store.js", () => ({

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -9,7 +9,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { TelegramExecApprovalHandler } from "./exec-approvals-handler.js";
-import { resolveTelegramTransport } from "./fetch.js";
+import { resolveTelegramApiBase, resolveTelegramTransport } from "./fetch.js";
 import {
   isRecoverableTelegramNetworkError,
   isTelegramPollingNetworkError,
@@ -202,6 +202,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       log,
       telegramTransport,
       createTelegramTransport: createTelegramTransportForPolling,
+      apiBase: resolveTelegramApiBase(account.config.apiRoot?.trim() || undefined),
     });
     await pollingSession.runUntilAbort();
   } finally {

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -203,6 +203,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       telegramTransport,
       createTelegramTransport: createTelegramTransportForPolling,
       apiBase: resolveTelegramApiBase(account.config.apiRoot?.trim() || undefined),
+      proxyUrl: account.config.proxy?.trim() || undefined,
     });
     await pollingSession.runUntilAbort();
   } finally {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -5,6 +5,8 @@ const createTelegramBotMock = vi.hoisted(() => vi.fn());
 const isRecoverableTelegramNetworkErrorMock = vi.hoisted(() => vi.fn(() => true));
 const computeBackoffMock = vi.hoisted(() => vi.fn(() => 0));
 const sleepWithAbortMock = vi.hoisted(() => vi.fn(async () => undefined));
+const heartbeatStartMock = vi.hoisted(() => vi.fn());
+const heartbeatStopMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@grammyjs/runner", () => ({
   run: runMock,
@@ -30,6 +32,13 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
     sleepWithAbort: sleepWithAbortMock,
   };
 });
+
+vi.mock("./heartbeat.js", () => ({
+  HeartbeatSupervisor: class {
+    start = heartbeatStartMock;
+    stop = heartbeatStopMock;
+  },
+}));
 
 let TelegramPollingSession: typeof import("./polling-session.js").TelegramPollingSession;
 
@@ -142,6 +151,8 @@ describe("TelegramPollingSession", () => {
     isRecoverableTelegramNetworkErrorMock.mockReset().mockReturnValue(true);
     computeBackoffMock.mockReset().mockReturnValue(0);
     sleepWithAbortMock.mockReset().mockResolvedValue(undefined);
+    heartbeatStartMock.mockReset();
+    heartbeatStopMock.mockReset();
     ({ TelegramPollingSession } = await import("./polling-session.js"));
   });
 
@@ -866,5 +877,38 @@ describe("TelegramPollingSession", () => {
 
     expectTelegramBotTransportSequence(transport1, transport1);
     expect(createTelegramTransport).not.toHaveBeenCalled();
+  });
+
+  it("starts HeartbeatSupervisor when apiBase is provided", async () => {
+    const abort = new AbortController();
+    createTelegramBotMock.mockReturnValue(makeBot());
+    runMock.mockImplementation(() => ({
+      task: async () => {
+        abort.abort();
+      },
+      stop: vi.fn(async () => undefined),
+      isRunning: () => false,
+    }));
+
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log: () => undefined,
+      telegramTransport: makeTelegramTransport(),
+      createTelegramTransport: () => makeTelegramTransport(),
+      apiBase: "https://api.telegram.org",
+    });
+
+    await session.runUntilAbort();
+
+    expect(heartbeatStartMock).toHaveBeenCalledTimes(1);
+    expect(heartbeatStopMock).toHaveBeenCalled();
   });
 });

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -33,8 +33,15 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
   };
 });
 
+const capturedHeartbeatOpts = vi.hoisted(() => ({
+  current: null as null | Record<string, unknown>,
+}));
+
 vi.mock("./heartbeat.js", () => ({
   HeartbeatSupervisor: class {
+    constructor(opts: Record<string, unknown>) {
+      capturedHeartbeatOpts.current = opts;
+    }
     start = heartbeatStartMock;
     stop = heartbeatStopMock;
   },
@@ -910,5 +917,101 @@ describe("TelegramPollingSession", () => {
 
     expect(heartbeatStartMock).toHaveBeenCalledTimes(1);
     expect(heartbeatStopMock).toHaveBeenCalled();
+  });
+
+  it("forwards proxyUrl to HeartbeatSupervisor when provided", async () => {
+    const abort = new AbortController();
+    createTelegramBotMock.mockReturnValue(makeBot());
+    runMock.mockImplementation(() => ({
+      task: async () => {
+        abort.abort();
+      },
+      stop: vi.fn(async () => undefined),
+      isRunning: () => false,
+    }));
+
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log: () => undefined,
+      telegramTransport: makeTelegramTransport(),
+      createTelegramTransport: () => makeTelegramTransport(),
+      apiBase: "https://api.telegram.org",
+      proxyUrl: "http://proxy.example.com:3128",
+    });
+
+    await session.runUntilAbort();
+
+    expect(capturedHeartbeatOpts.current).toMatchObject({
+      apiBase: "https://api.telegram.org",
+      proxyUrl: "http://proxy.example.com:3128",
+    });
+  });
+
+  it("stops polling cycle immediately when cycleAbortSignal is pre-aborted", async () => {
+    const abort = new AbortController();
+    // Capture HeartbeatSupervisor onOutageDetected to fire it before #runPollingCycle
+    let triggerOutage: (() => void) | undefined;
+    let resolveTaskSetup: (() => void) | undefined;
+
+    createTelegramBotMock.mockImplementation(async () => {
+      // While #createPollingBot is awaiting, fire the outage so cycleAbortController
+      // is aborted BEFORE addEventListener is registered in #runPollingCycle.
+      await new Promise<void>((r) => {
+        resolveTaskSetup = r;
+      });
+      return makeBot();
+    });
+
+    let cycleCount = 0;
+    runMock.mockImplementation(() => {
+      cycleCount += 1;
+      return {
+        task: async () => {
+          // Second cycle: abort the main signal to exit
+          abort.abort();
+        },
+        stop: vi.fn(async () => undefined),
+        isRunning: () => false,
+      };
+    });
+
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log: () => undefined,
+      telegramTransport: makeTelegramTransport(),
+      createTelegramTransport: () => makeTelegramTransport(),
+      apiBase: "https://api.telegram.org",
+    });
+
+    // Capture the onOutageDetected from the constructed supervisor
+    triggerOutage = (capturedHeartbeatOpts.current as { onOutageDetected?: () => void })
+      ?.onOutageDetected;
+
+    const runPromise = session.runUntilAbort();
+
+    // Fire outage while #createPollingBot is suspended, before addEventListener
+    triggerOutage?.();
+    resolveTaskSetup?.();
+
+    await runPromise;
+
+    // The session should have restarted the cycle (cycleAbort triggered restart)
+    expect(cycleCount).toBeGreaterThanOrEqual(1);
   });
 });

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -59,6 +59,8 @@ type TelegramPollingSessionOpts = {
   createTelegramTransport?: () => TelegramTransport;
   /** Pre-resolved Telegram API base URL. Enables the heartbeat supervisor when set. */
   apiBase?: string;
+  /** Optional proxy URL forwarded to heartbeat probes. */
+  proxyUrl?: string;
 };
 
 export class TelegramPollingSession {
@@ -99,6 +101,7 @@ export class TelegramPollingSession {
       ? new HeartbeatSupervisor({
           apiBase: this.opts.apiBase,
           token: this.opts.token,
+          proxyUrl: this.opts.proxyUrl,
           abortSignal: this.opts.abortSignal,
           log: this.opts.log,
           onOutageDetected: () => {
@@ -411,6 +414,9 @@ export class TelegramPollingSession {
 
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
     cycleAbortSignal?.addEventListener("abort", stopOnCycleAbort, { once: true });
+    if (cycleAbortSignal?.aborted) {
+      stopOnCycleAbort();
+    }
     try {
       await Promise.race([runner.task(), forceCyclePromise]);
       if (this.opts.abortSignal?.aborted) {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -8,6 +8,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 import { type TelegramTransport } from "./fetch.js";
+import { HeartbeatSupervisor } from "./heartbeat.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { TelegramPollingTransportState } from "./polling-transport-state.js";
 
@@ -56,6 +57,8 @@ type TelegramPollingSessionOpts = {
   telegramTransport?: TelegramTransport;
   /** Rebuild Telegram transport after stall/network recovery when marked dirty. */
   createTelegramTransport?: () => TelegramTransport;
+  /** Pre-resolved Telegram API base URL. Enables the heartbeat supervisor when set. */
+  apiBase?: string;
 };
 
 export class TelegramPollingSession {
@@ -91,24 +94,46 @@ export class TelegramPollingSession {
   }
 
   async runUntilAbort(): Promise<void> {
-    while (!this.opts.abortSignal?.aborted) {
-      const bot = await this.#createPollingBot();
-      if (!bot) {
-        continue;
-      }
+    let cycleAbortController: AbortController | undefined;
+    const heartbeat = this.opts.apiBase
+      ? new HeartbeatSupervisor({
+          apiBase: this.opts.apiBase,
+          token: this.opts.token,
+          abortSignal: this.opts.abortSignal,
+          log: this.opts.log,
+          onOutageDetected: () => {
+            cycleAbortController?.abort();
+          },
+          onRecovered: () => {
+            this.opts.log("[telegram][heartbeat] connectivity recovered, polling will resume");
+          },
+        })
+      : undefined;
 
-      const cleanupState = await this.#ensureWebhookCleanup(bot);
-      if (cleanupState === "retry") {
-        continue;
-      }
-      if (cleanupState === "exit") {
-        return;
-      }
+    heartbeat?.start();
+    try {
+      while (!this.opts.abortSignal?.aborted) {
+        cycleAbortController = new AbortController();
+        const bot = await this.#createPollingBot();
+        if (!bot) {
+          continue;
+        }
 
-      const state = await this.#runPollingCycle(bot);
-      if (state === "exit") {
-        return;
+        const cleanupState = await this.#ensureWebhookCleanup(bot);
+        if (cleanupState === "retry") {
+          continue;
+        }
+        if (cleanupState === "exit") {
+          return;
+        }
+
+        const state = await this.#runPollingCycle(bot, cycleAbortController.signal);
+        if (state === "exit") {
+          return;
+        }
       }
+    } finally {
+      heartbeat?.stop();
     }
   }
 
@@ -200,7 +225,10 @@ export class TelegramPollingSession {
     }
   }
 
-  async #runPollingCycle(bot: TelegramBot): Promise<"continue" | "exit"> {
+  async #runPollingCycle(
+    bot: TelegramBot,
+    cycleAbortSignal?: AbortSignal,
+  ): Promise<"continue" | "exit"> {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
@@ -288,6 +316,7 @@ export class TelegramPollingSession {
       this.opts.abortSignal.addEventListener("abort", abortFetch, { once: true });
     }
     let stopPromise: Promise<void> | undefined;
+    let heartbeatRestarted = false;
     let stalledRestart = false;
     let forceCycleTimer: ReturnType<typeof setTimeout> | undefined;
     let forceCycleResolve: (() => void) | undefined;
@@ -314,6 +343,14 @@ export class TelegramPollingSession {
       if (this.opts.abortSignal?.aborted) {
         void stopRunner();
       }
+    };
+    const stopOnCycleAbort = () => {
+      if (!cycleAbortSignal?.aborted) {
+        return;
+      }
+      heartbeatRestarted = true;
+      this.#transportState.markDirty();
+      void stopRunner();
     };
 
     const watchdog = setInterval(() => {
@@ -373,6 +410,7 @@ export class TelegramPollingSession {
     }, POLL_WATCHDOG_INTERVAL_MS);
 
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+    cycleAbortSignal?.addEventListener("abort", stopOnCycleAbort, { once: true });
     try {
       await Promise.race([runner.task(), forceCyclePromise]);
       if (this.opts.abortSignal?.aborted) {
@@ -380,9 +418,11 @@ export class TelegramPollingSession {
       }
       const reason = stalledRestart
         ? "polling stall detected"
-        : this.#forceRestarted
-          ? "unhandled network error"
-          : "runner stopped (maxRetryTime exceeded or graceful stop)";
+        : heartbeatRestarted
+          ? "heartbeat outage detected"
+          : this.#forceRestarted
+            ? "unhandled network error"
+            : "runner stopped (maxRetryTime exceeded or graceful stop)";
       this.#forceRestarted = false;
       this.opts.log(
         `[telegram][diag] polling cycle finished reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}`,
@@ -423,6 +463,7 @@ export class TelegramPollingSession {
       }
       this.opts.abortSignal?.removeEventListener("abort", abortFetch);
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
+      cycleAbortSignal?.removeEventListener("abort", stopOnCycleAbort);
       await waitForGracefulStop(stopRunner);
       await waitForGracefulStop(stopBot);
       this.#activeRunner = undefined;


### PR DESCRIPTION
## Background

In production deployments, the existing polling watchdog detects stalls when `getUpdates` hangs, but it **cannot detect silent TCP drops** — when the network connection dies without any error signal. In these cases, the bot can sit idle for 20+ minutes before any recovery attempt.

### Related issues

- #54708 — Message Loss on Telegram Network Failure
- #52116 — Telegram polling client gets permanently stuck after transient network failure
- #54513 — Telegram polling has no stall detection (unlike Slack health-monitor)
- #55406 — Telegram polling can restart into not-started state after connectivity loss
- #47458 — Polling stall loop — getUpdates hangs, restart never recovers
- #41704 — Telegram polling stalls indefinitely when proxy TCP connection drops silently
- #42782 — [Feature Request] Add health-monitor auto-reconnect for Telegram polling
- #44396 — Telegram polling stall (~95s) causes significant message delivery delay

## What changed

### New: `HeartbeatSupervisor` (`extensions/telegram/src/heartbeat.ts`)

A threshold-based heartbeat supervisor that runs periodic `getMe` probes using the existing `probeTelegram()` function from `probe.ts`:

- Runs on a configurable interval (default: 30s)
- Counts consecutive probe failures
- Fires `onOutageDetected` after reaching the failure threshold (default: 3)
- Fires `onRecovered` once when connectivity returns
- **Security:** Reuses `probeTelegram()` which already handles transport safely. Error messages are logged without the bot token or full URL — only the method name, error description, and failure counter.

### Modified: `TelegramPollingSession` (`extensions/telegram/src/polling-session.ts`)

- Integrates `HeartbeatSupervisor` in `runUntilAbort()` when `apiBase` is provided
- `onOutageDetected` aborts the **current polling cycle only** via a cycle-scoped `AbortController` (not the global abort signal), so the outer loop can restart cleanly
- `onRecovered` logs recovery; the polling loop restarts naturally
- Supervisor starts before the polling loop, stops in `finally`
- **The existing watchdog is untouched** — both mechanisms work independently

### Modified: `monitor.ts`

- Passes `apiBase` (from `resolveTelegramApiBase()`) to `TelegramPollingSession`

## Tests

- **14 new tests** in `heartbeat.test.ts`: threshold behavior, recovery, abort signal, overlap prevention, token-never-in-logs assertion
- **1 new test** in `polling-session.test.ts`: verifies `HeartbeatSupervisor` starts when `apiBase` is provided
- **All 9 existing** `polling-session.test.ts` tests pass unchanged

```
Test Files  2 passed (2)
     Tests  24 passed (24)
```

## How to test

```bash
pnpm vitest run extensions/telegram/src/heartbeat.test.ts extensions/telegram/src/polling-session.test.ts
```

For manual QA: deploy with a Telegram bot, kill network connectivity for 2+ minutes, observe logs for `[telegram][heartbeat] probe failed` → outage detection → recovery on reconnect.