### PR TITLE
iOS: restrict A2UI action dispatch to trusted canvas URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - ACP/Windows spawn: fail closed on unresolved `.cmd` and `.bat` OpenClaw wrappers unless a caller explicitly opts into shell fallback, so Windows ACP launches do not silently drop into shell-mediated execution when wrapper unwrapping fails. (#58436) Thanks @eleqtrizit.
 - Exec/Windows: prefer strict-inline-eval denial over generic allowlist prompts for interpreter carriers, while keeping persisted Windows allow-always approvals argv-bound. (#59780) Thanks @luoyanglang.
 - Gateway/connect: omit admin-scoped config and auth metadata from lower-privilege `hello-ok` snapshots while preserving those fields for admin reconnects. (#58469) Thanks @eleqtrizit.
+- iOS/canvas: restrict A2UI bridge trust to the bundled scaffold and exact capability-backed remote canvas URLs, so generic `canvas.navigate` and `canvas.present` loads no longer gain action-dispatch authority. (#58471) Thanks @eleqtrizit.
 
 ## 2026.4.2-beta.1
 

--- a/apps/ios/Sources/Model/NodeAppModel+Canvas.swift
+++ b/apps/ios/Sources/Model/NodeAppModel+Canvas.swift
@@ -33,6 +33,19 @@ extension NodeAppModel {
         return base.appendingPathComponent("__openclaw__/a2ui/").absoluteString + "?platform=ios"
     }
 
+    /// Normalize a URL string for trust comparison: lowercase scheme/host and strip fragment.
+    /// This matches the normalization applied by ScreenController.isTrustedCanvasUIURL so that
+    /// SPA hash-routing fragments and scheme/host casing do not silently prevent trust being set.
+    static func normalizeURLForTrustComparison(_ raw: String) -> String {
+        guard let url = URL(string: raw),
+              var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return raw }
+        components.fragment = nil
+        components.scheme = components.scheme?.lowercased()
+        components.host = components.host?.lowercased()
+        return components.url?.absoluteString ?? raw
+    }
+
     func showA2UIOnConnectIfNeeded() async {
         await MainActor.run {
             // Keep the bundled home canvas as the default connected view.

--- a/apps/ios/Sources/Model/NodeAppModel+Canvas.swift
+++ b/apps/ios/Sources/Model/NodeAppModel+Canvas.swift
@@ -46,7 +46,7 @@ extension NodeAppModel {
         guard let initialUrl = await self.resolveA2UIHostURLWithCapabilityRefresh() else {
             return .hostNotConfigured
         }
-        self.screen.navigate(to: initialUrl)
+        self.screen.navigate(to: initialUrl, trustA2UIActions: true)
         if await self.screen.waitForA2UIReady(timeoutMs: timeoutMs) {
             return .ready(initialUrl)
         }
@@ -54,7 +54,7 @@ extension NodeAppModel {
         // First render can fail when scoped capability rotates between reconnects.
         guard await self.gatewaySession.refreshNodeCanvasCapability() else { return .hostUnavailable }
         guard let refreshedUrl = await self.resolveA2UIHostURL() else { return .hostUnavailable }
-        self.screen.navigate(to: refreshedUrl)
+        self.screen.navigate(to: refreshedUrl, trustA2UIActions: true)
         if await self.screen.waitForA2UIReady(timeoutMs: timeoutMs) {
             return .ready(refreshedUrl)
         }

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -852,10 +852,7 @@ final class NodeAppModel {
                 self.screen.showDefaultCanvas()
             } else {
                 let trustedA2UIURL = await self.resolveA2UIHostURL()
-                // Raw string equality is intentional: resolveA2UIHostURL() always returns a
-                // canonically lower-cased URL via URL.absoluteString, so this is consistent
-                // with the normalised comparison used downstream in isTrustedCanvasUIURL.
-                self.screen.navigate(to: url, trustA2UIActions: trustedA2UIURL == url)
+                self.screen.navigate(to: url, trustA2UIActions: trustedA2UIURL == Self.normalizeURLForTrustComparison(url))
             }
             return BridgeInvokeResponse(id: req.id, ok: true)
         case OpenClawCanvasCommand.hide.rawValue:
@@ -864,8 +861,7 @@ final class NodeAppModel {
         case OpenClawCanvasCommand.navigate.rawValue:
             let params = try Self.decodeParams(OpenClawCanvasNavigateParams.self, from: req.paramsJSON)
             let trustedA2UIURL = await self.resolveA2UIHostURL()
-            // Raw string equality is intentional: see canvas.present comment above.
-            self.screen.navigate(to: params.url, trustA2UIActions: trustedA2UIURL == params.url)
+            self.screen.navigate(to: params.url, trustA2UIActions: trustedA2UIURL == Self.normalizeURLForTrustComparison(params.url))
             return BridgeInvokeResponse(id: req.id, ok: true)
         case OpenClawCanvasCommand.evalJS.rawValue:
             let params = try Self.decodeParams(OpenClawCanvasEvalParams.self, from: req.paramsJSON)

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -860,8 +860,9 @@ final class NodeAppModel {
             return BridgeInvokeResponse(id: req.id, ok: true)
         case OpenClawCanvasCommand.navigate.rawValue:
             let params = try Self.decodeParams(OpenClawCanvasNavigateParams.self, from: req.paramsJSON)
+            let trimmedURL = params.url.trimmingCharacters(in: .whitespacesAndNewlines)
             let trustedA2UIURL = await self.resolveA2UIHostURL()
-            self.screen.navigate(to: params.url, trustA2UIActions: trustedA2UIURL == Self.normalizeURLForTrustComparison(params.url))
+            self.screen.navigate(to: trimmedURL, trustA2UIActions: trustedA2UIURL == Self.normalizeURLForTrustComparison(trimmedURL))
             return BridgeInvokeResponse(id: req.id, ok: true)
         case OpenClawCanvasCommand.evalJS.rawValue:
             let params = try Self.decodeParams(OpenClawCanvasEvalParams.self, from: req.paramsJSON)

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -851,7 +851,8 @@ final class NodeAppModel {
             if url.isEmpty {
                 self.screen.showDefaultCanvas()
             } else {
-                self.screen.navigate(to: url)
+                let trustedA2UIURL = await self.resolveA2UIHostURL()
+                self.screen.navigate(to: url, trustA2UIActions: trustedA2UIURL == url)
             }
             return BridgeInvokeResponse(id: req.id, ok: true)
         case OpenClawCanvasCommand.hide.rawValue:
@@ -859,7 +860,8 @@ final class NodeAppModel {
             return BridgeInvokeResponse(id: req.id, ok: true)
         case OpenClawCanvasCommand.navigate.rawValue:
             let params = try Self.decodeParams(OpenClawCanvasNavigateParams.self, from: req.paramsJSON)
-            self.screen.navigate(to: params.url)
+            let trustedA2UIURL = await self.resolveA2UIHostURL()
+            self.screen.navigate(to: params.url, trustA2UIActions: trustedA2UIURL == params.url)
             return BridgeInvokeResponse(id: req.id, ok: true)
         case OpenClawCanvasCommand.evalJS.rawValue:
             let params = try Self.decodeParams(OpenClawCanvasEvalParams.self, from: req.paramsJSON)

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -852,6 +852,9 @@ final class NodeAppModel {
                 self.screen.showDefaultCanvas()
             } else {
                 let trustedA2UIURL = await self.resolveA2UIHostURL()
+                // Raw string equality is intentional: resolveA2UIHostURL() always returns a
+                // canonically lower-cased URL via URL.absoluteString, so this is consistent
+                // with the normalised comparison used downstream in isTrustedCanvasUIURL.
                 self.screen.navigate(to: url, trustA2UIActions: trustedA2UIURL == url)
             }
             return BridgeInvokeResponse(id: req.id, ok: true)
@@ -861,6 +864,7 @@ final class NodeAppModel {
         case OpenClawCanvasCommand.navigate.rawValue:
             let params = try Self.decodeParams(OpenClawCanvasNavigateParams.self, from: req.paramsJSON)
             let trustedA2UIURL = await self.resolveA2UIHostURL()
+            // Raw string equality is intentional: see canvas.present comment above.
             self.screen.navigate(to: params.url, trustA2UIActions: trustedA2UIURL == params.url)
             return BridgeInvokeResponse(id: req.id, ok: true)
         case OpenClawCanvasCommand.evalJS.rawValue:

--- a/apps/ios/Sources/Screen/ScreenController.swift
+++ b/apps/ios/Sources/Screen/ScreenController.swift
@@ -7,6 +7,7 @@ import WebKit
 @Observable
 final class ScreenController {
     private weak var activeWebView: WKWebView?
+    private var trustedRemoteA2UIURL: URL?
 
     var urlString: String = ""
     var errorText: String?
@@ -26,10 +27,11 @@ final class ScreenController {
         self.reload()
     }
 
-    func navigate(to urlString: String) {
+    func navigate(to urlString: String, trustA2UIActions: Bool = false) {
         let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
             self.urlString = ""
+            self.trustedRemoteA2UIURL = nil
             self.reload()
             return
         }
@@ -43,6 +45,7 @@ final class ScreenController {
             return
         }
         self.urlString = (trimmed == "/" ? "" : trimmed)
+        self.trustedRemoteA2UIURL = trustA2UIActions ? Self.normalizeTrustedRemoteA2UIURL(from: trimmed) : nil
         self.reload()
     }
 
@@ -72,6 +75,7 @@ final class ScreenController {
 
     func showDefaultCanvas() {
         self.urlString = ""
+        self.trustedRemoteA2UIURL = nil
         self.reload()
     }
 
@@ -237,28 +241,17 @@ final class ScreenController {
         subdirectory: "CanvasScaffold")
 
     func isTrustedCanvasUIURL(_ url: URL) -> Bool {
-        guard url.isFileURL else { return false }
-        let std = url.standardizedFileURL
-        if let expected = Self.canvasScaffoldURL,
-           std == expected.standardizedFileURL
-        {
-            return true
+        if url.isFileURL {
+            let std = url.standardizedFileURL
+            if let expected = Self.canvasScaffoldURL,
+               std == expected.standardizedFileURL
+            {
+                return true
+            }
+            return false
         }
-        return false
-    }
-
-    private func applyScrollBehavior() {
-        guard let webView = self.activeWebView else { return }
-        let trimmed = self.urlString.trimmingCharacters(in: .whitespacesAndNewlines)
-        let allowScroll = !trimmed.isEmpty
-        let scrollView = webView.scrollView
-        // Default canvas needs raw touch events; external pages should scroll.
-        scrollView.isScrollEnabled = allowScroll
-        scrollView.bounces = allowScroll
-    }
-
-    func isLocalNetworkCanvasURL(_ url: URL) -> Bool {
-        LocalNetworkURLSupport.isLocalNetworkHTTPURL(url)
+        guard let trusted = self.trustedRemoteA2UIURL else { return false }
+        return Self.normalizeTrustedRemoteA2UIURL(from: url) == trusted
     }
 
     nonisolated static func parseA2UIActionBody(_ body: Any) -> [String: Any]? {
@@ -277,6 +270,36 @@ final class ScreenController {
             return mapped.isEmpty ? nil : mapped
         }
         return nil
+    }
+
+    private func applyScrollBehavior() {
+        guard let webView = self.activeWebView else { return }
+        let trimmed = self.urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        let allowScroll = !trimmed.isEmpty
+        let scrollView = webView.scrollView
+        // Default canvas needs raw touch events; external pages should scroll.
+        scrollView.isScrollEnabled = allowScroll
+        scrollView.bounces = allowScroll
+    }
+
+    private static func normalizeTrustedRemoteA2UIURL(from raw: String) -> URL? {
+        guard let url = URL(string: raw) else { return nil }
+        return self.normalizeTrustedRemoteA2UIURL(from: url)
+    }
+
+    private static func normalizeTrustedRemoteA2UIURL(from url: URL) -> URL? {
+        guard !url.isFileURL else { return nil }
+        guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
+            return nil
+        }
+        guard let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines), !host.isEmpty else {
+            return nil
+        }
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.scheme = scheme
+        components?.host = host.lowercased()
+        components?.fragment = nil
+        return components?.url
     }
 }
 

--- a/apps/ios/Sources/Screen/ScreenWebView.swift
+++ b/apps/ios/Sources/Screen/ScreenWebView.swift
@@ -180,12 +180,7 @@ private final class CanvasA2UIActionMessageHandler: NSObject, WKScriptMessageHan
         guard let controller else { return }
 
         guard let url = message.webView?.url else { return }
-        if url.isFileURL {
-            guard controller.isTrustedCanvasUIURL(url) else { return }
-        } else {
-            // For security, only accept actions from local-network pages (e.g. the canvas host).
-            guard controller.isLocalNetworkCanvasURL(url) else { return }
-        }
+        guard controller.isTrustedCanvasUIURL(url) else { return }
 
         guard let body = ScreenController.parseA2UIActionBody(message.body) else { return }
 

--- a/apps/ios/Tests/ScreenControllerTests.swift
+++ b/apps/ios/Tests/ScreenControllerTests.swift
@@ -72,6 +72,8 @@ private func mountScreen(_ screen: ScreenController) throws -> (ScreenWebViewCoo
         screen.navigate(to: trusted, trustA2UIActions: true)
 
         #expect(screen.isTrustedCanvasUIURL(URL(string: trusted)!) == true)
+        // Fragment differences must not affect trust (SPA hash routing).
+        #expect(screen.isTrustedCanvasUIURL(URL(string: "https://node.ts.net:18789/__openclaw__/a2ui/?platform=ios#step2")!) == true)
         #expect(screen.isTrustedCanvasUIURL(URL(string: "https://node.ts.net:18789/__openclaw__/a2ui/?platform=android")!) == false)
         #expect(screen.isTrustedCanvasUIURL(URL(string: "https://node.ts.net:18789/__openclaw__/canvas/")!) == false)
         #expect(screen.isTrustedCanvasUIURL(URL(string: "https://evil.ts.net:18789/__openclaw__/a2ui/?platform=ios")!) == false)

--- a/apps/ios/Tests/ScreenControllerTests.swift
+++ b/apps/ios/Tests/ScreenControllerTests.swift
@@ -66,17 +66,24 @@ private func mountScreen(_ screen: ScreenController) throws -> (ScreenWebViewCoo
         }
     }
 
-    @Test @MainActor func localNetworkCanvasURLsAreAllowed() {
+    @Test @MainActor func trustedRemoteA2UIURLMustMatchExactly() {
         let screen = ScreenController()
-        #expect(screen.isLocalNetworkCanvasURL(URL(string: "http://localhost:18789/")!) == true)
-        #expect(screen.isLocalNetworkCanvasURL(URL(string: "http://openclaw.local:18789/")!) == true)
-        #expect(screen.isLocalNetworkCanvasURL(URL(string: "http://peters-mac-studio-1:18789/")!) == true)
-        #expect(screen.isLocalNetworkCanvasURL(URL(string: "https://peters-mac-studio-1.ts.net:18789/")!) == true)
-        #expect(screen.isLocalNetworkCanvasURL(URL(string: "http://192.168.0.10:18789/")!) == true)
-        #expect(screen.isLocalNetworkCanvasURL(URL(string: "http://10.0.0.10:18789/")!) == true)
-        #expect(screen.isLocalNetworkCanvasURL(URL(string: "http://100.123.224.76:18789/")!) == true) // Tailscale CGNAT
-        #expect(screen.isLocalNetworkCanvasURL(URL(string: "https://example.com/")!) == false)
-        #expect(screen.isLocalNetworkCanvasURL(URL(string: "http://8.8.8.8/")!) == false)
+        let trusted = "https://node.ts.net:18789/__openclaw__/a2ui/?platform=ios"
+        screen.navigate(to: trusted, trustA2UIActions: true)
+
+        #expect(screen.isTrustedCanvasUIURL(URL(string: trusted)!) == true)
+        #expect(screen.isTrustedCanvasUIURL(URL(string: "https://node.ts.net:18789/__openclaw__/a2ui/?platform=android")!) == false)
+        #expect(screen.isTrustedCanvasUIURL(URL(string: "https://node.ts.net:18789/__openclaw__/canvas/")!) == false)
+        #expect(screen.isTrustedCanvasUIURL(URL(string: "https://evil.ts.net:18789/__openclaw__/a2ui/?platform=ios")!) == false)
+        #expect(screen.isTrustedCanvasUIURL(URL(string: "http://192.168.0.10:18789/")!) == false)
+    }
+
+    @Test @MainActor func genericNavigationClearsTrustedRemoteA2UIURL() {
+        let screen = ScreenController()
+        screen.navigate(to: "https://node.ts.net:18789/__openclaw__/a2ui/?platform=ios", trustA2UIActions: true)
+        screen.navigate(to: "https://evil.ts.net:18789/")
+
+        #expect(screen.isTrustedCanvasUIURL(URL(string: "https://node.ts.net:18789/__openclaw__/a2ui/?platform=ios")!) == false)
     }
 
     @Test func parseA2UIActionBodyAcceptsJSONString() throws {


### PR DESCRIPTION
## Summary
- Restricts iOS A2UI action dispatch to the in-app canvas scaffold and the active trusted remote A2UI URL
- Keeps generic canvas navigation from granting action-dispatch trust on its own

## Changes
- Updated the iOS screen controller to track an explicit trusted remote A2UI URL instead of treating generic local-network pages as action-capable
- Wired node-driven A2UI loads and exact capability-backed `canvas.navigate` / `canvas.present` calls to opt into that trust explicitly
- Replaced the broad local-network test with exact-match regression coverage for trusted and untrusted remote URLs

## Validation
- Reviewed the affected iOS bridge and canvas navigation paths locally
- Confirmed the A2UI bridge handler no longer authorizes generic local-network pages in the touched code paths
- Ran local agentic review via `claude -p "/review"`; it requested PR context and could not complete before PR creation in this environment
- Apple toolchain validation was not run locally here because this environment does not provide `xcodebuild` or `xcodegen`

## Notes
- Residual risk or follow-up: iOS XCTest / Xcode validation should run in a macOS environment before landing
