### PR TITLE
fix(qqbot): restrict local media roots

### DIFF
--- a/extensions/qqbot/src/outbound.ts
+++ b/extensions/qqbot/src/outbound.ts
@@ -268,7 +268,12 @@ export async function sendPhoto(
   imagePath: string,
 ): Promise<OutboundResult> {
   const prefix = ctx.logPrefix ?? "[qqbot]";
-  const mediaPath = resolveQQBotLocalMediaPath(normalizePath(imagePath));
+  let mediaPath: string;
+  try {
+    mediaPath = resolveQQBotLocalMediaPath(normalizePath(imagePath));
+  } catch (err) {
+    return { channel: "qqbot", error: err instanceof Error ? err.message : String(err) };
+  }
   const isLocal = isLocalFilePath(mediaPath);
   const isHttp = mediaPath.startsWith("http://") || mediaPath.startsWith("https://");
   const isData = mediaPath.startsWith("data:");
@@ -397,7 +402,12 @@ export async function sendVoice(
   transcodeEnabled: boolean = true,
 ): Promise<OutboundResult> {
   const prefix = ctx.logPrefix ?? "[qqbot]";
-  const mediaPath = resolveQQBotLocalMediaPath(normalizePath(voicePath));
+  let mediaPath: string;
+  try {
+    mediaPath = resolveQQBotLocalMediaPath(normalizePath(voicePath));
+  } catch (err) {
+    return { channel: "qqbot", error: err instanceof Error ? err.message : String(err) };
+  }
   const isHttp = mediaPath.startsWith("http://") || mediaPath.startsWith("https://");
 
   if (isHttp) {
@@ -536,7 +546,12 @@ export async function sendVideoMsg(
   videoPath: string,
 ): Promise<OutboundResult> {
   const prefix = ctx.logPrefix ?? "[qqbot]";
-  const mediaPath = resolveQQBotLocalMediaPath(normalizePath(videoPath));
+  let mediaPath: string;
+  try {
+    mediaPath = resolveQQBotLocalMediaPath(normalizePath(videoPath));
+  } catch (err) {
+    return { channel: "qqbot", error: err instanceof Error ? err.message : String(err) };
+  }
   const isHttp = mediaPath.startsWith("http://") || mediaPath.startsWith("https://");
 
   if (isHttp && !shouldDirectUploadUrl(ctx.account)) {
@@ -657,7 +672,12 @@ export async function sendDocument(
   filePath: string,
 ): Promise<OutboundResult> {
   const prefix = ctx.logPrefix ?? "[qqbot]";
-  const mediaPath = resolveQQBotLocalMediaPath(normalizePath(filePath));
+  let mediaPath: string;
+  try {
+    mediaPath = resolveQQBotLocalMediaPath(normalizePath(filePath));
+  } catch (err) {
+    return { channel: "qqbot", error: err instanceof Error ? err.message : String(err) };
+  }
   const isHttp = mediaPath.startsWith("http://") || mediaPath.startsWith("https://");
   const fileName = sanitizeFileName(path.basename(mediaPath));
 
@@ -1263,7 +1283,12 @@ export async function sendProactiveMessage(
 /** Send rich media, auto-routing by media type and source. */
 export async function sendMedia(ctx: MediaOutboundContext): Promise<OutboundResult> {
   const { to, text, replyToId, account, mimeType } = ctx;
-  const mediaUrl = resolveQQBotLocalMediaPath(normalizePath(ctx.mediaUrl));
+  let mediaUrl: string;
+  try {
+    mediaUrl = resolveQQBotLocalMediaPath(normalizePath(ctx.mediaUrl));
+  } catch (err) {
+    return { channel: "qqbot", error: err instanceof Error ? err.message : String(err) };
+  }
 
   if (!account.appId || !account.clientSecret) {
     return { channel: "qqbot", error: "QQBot not configured (missing appId or clientSecret)" };

--- a/extensions/qqbot/src/reply-dispatcher.ts
+++ b/extensions/qqbot/src/reply-dispatcher.ts
@@ -196,7 +196,13 @@ export async function handleStructuredPayload(
 
 async function handleImagePayload(ctx: ReplyContext, payload: MediaPayload): Promise<void> {
   const { target, account, log } = ctx;
-  let imageUrl = resolveQQBotLocalMediaPath(normalizePath(payload.path));
+  let imageUrl: string;
+  try {
+    imageUrl = resolveQQBotLocalMediaPath(normalizePath(payload.path));
+  } catch (err) {
+    log?.error(`[qqbot:${account.accountId}] Blocked image path: ${err}`);
+    return;
+  }
   const originalImagePath = payload.source === "file" ? imageUrl : undefined;
 
   if (payload.source === "file") {

--- a/extensions/qqbot/src/utils/audio-convert.ts
+++ b/extensions/qqbot/src/utils/audio-convert.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { decode, encode, isSilk } from "silk-wasm";
 import { debugLog, debugError, debugWarn } from "./debug-log.js";
 import { detectFfmpeg, isWindows } from "./platform.js";
@@ -346,7 +347,9 @@ export async function textToSpeechPCM(
 
       // MP3 responses must be decoded back into PCM.
       debugLog(`[tts] Decoding mp3 response (${rawBuffer.length} bytes) to PCM...`);
-      const tmpDir = path.join(fs.mkdtempSync(path.join(require("node:os").tmpdir(), "tts-")));
+      const tmpDir = path.join(
+        fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), "qqbot-tts-")),
+      );
       const tmpMp3 = path.join(tmpDir, "tts.mp3");
       fs.writeFileSync(tmpMp3, rawBuffer);
 

--- a/extensions/qqbot/src/utils/platform.test.ts
+++ b/extensions/qqbot/src/utils/platform.test.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getHomeDir, resolveQQBotLocalMediaPath } from "./platform.js";
+import { getHomeDir, getQQBotMediaDir, resolveQQBotLocalMediaPath } from "./platform.js";
 
 describe("qqbot local media path remapping", () => {
   const createdPaths: string[] = [];
@@ -65,5 +67,47 @@ describe("qqbot local media path remapping", () => {
     fs.writeFileSync(mediaFile, "image", "utf8");
 
     expect(resolveQQBotLocalMediaPath(mediaFile)).toBe(mediaFile);
+  });
+
+  it("blocks existing files outside QQ Bot-owned roots", () => {
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-outside-"));
+    createdPaths.push(outsideDir);
+    const outsideFile = path.join(outsideDir, "secret.txt");
+    fs.writeFileSync(outsideFile, "secret", "utf8");
+
+    expect(() => resolveQQBotLocalMediaPath(outsideFile)).toThrow(
+      "Local media path is outside allowed roots",
+    );
+  });
+
+  it("allows files under the preferred OpenClaw temp root", () => {
+    const tmpRoot = resolvePreferredOpenClawTmpDir();
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const tempDir = fs.mkdtempSync(path.join(tmpRoot, "qqbot-platform-test-"));
+    createdPaths.push(tempDir);
+    const tempFile = path.join(tempDir, "voice.mp3");
+    fs.writeFileSync(tempFile, "audio", "utf8");
+
+    expect(resolveQQBotLocalMediaPath(tempFile)).toBe(tempFile);
+  });
+
+  it("blocks symlink escapes from QQ Bot media roots", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-symlink-outside-"));
+    createdPaths.push(outsideDir);
+    const outsideFile = path.join(outsideDir, "secret.txt");
+    fs.writeFileSync(outsideFile, "secret", "utf8");
+
+    const mediaDir = fs.mkdtempSync(path.join(getQQBotMediaDir("downloads"), "symlink-test-"));
+    createdPaths.push(mediaDir);
+    const symlinkPath = path.join(mediaDir, "linked-secret.txt");
+    fs.symlinkSync(outsideFile, symlinkPath);
+
+    expect(() => resolveQQBotLocalMediaPath(symlinkPath)).toThrow(
+      "Local media path is outside allowed roots",
+    );
   });
 });

--- a/extensions/qqbot/src/utils/platform.ts
+++ b/extensions/qqbot/src/utils/platform.ts
@@ -9,6 +9,7 @@ import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { debugLog, debugWarn } from "./debug-log.js";
 
 // Basic platform information.
@@ -74,6 +75,10 @@ export function getQQBotMediaDir(...subPaths: string[]): string {
   return dir;
 }
 
+export function getQQBotWorkspaceDir(...subPaths: string[]): string {
+  return path.join(getHomeDir(), ".openclaw", "workspace", "qqbot", ...subPaths);
+}
+
 // Temporary directory helpers.
 
 /** Return the OS temp directory. */
@@ -120,19 +125,67 @@ function isPathWithinRoot(candidate: string, root: string): boolean {
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
+function tryRealpathSync(targetPath: string): string | null {
+  try {
+    return fs.realpathSync.native(targetPath);
+  } catch {
+    return null;
+  }
+}
+
+function getQQBotAllowedLocalRoots(): string[] {
+  return [
+    getQQBotMediaDir(),
+    getQQBotDataDir(),
+    getQQBotWorkspaceDir(),
+    resolvePreferredOpenClawTmpDir(),
+  ];
+}
+
+function isQQBotAllowedLocalPath(candidatePath: string): boolean {
+  const absoluteCandidate = path.resolve(candidatePath);
+  const candidateCanonicalPath = tryRealpathSync(absoluteCandidate);
+
+  for (const root of getQQBotAllowedLocalRoots()) {
+    const absoluteRoot = path.resolve(root);
+    const rootCanonicalPath = tryRealpathSync(absoluteRoot) ?? absoluteRoot;
+
+    if (candidateCanonicalPath) {
+      if (isPathWithinRoot(candidateCanonicalPath, rootCanonicalPath)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (isPathWithinRoot(absoluteCandidate, absoluteRoot)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Remap legacy or hallucinated QQ Bot local media paths to real files when possible.
  */
 export function resolveQQBotLocalMediaPath(p: string): string {
   const normalized = normalizePath(p);
-  if (!isLocalPath(normalized) || fs.existsSync(normalized)) {
+  if (!isLocalPath(normalized)) {
     return normalized;
+  }
+
+  const absolutePath = path.resolve(normalized);
+  if (fs.existsSync(absolutePath)) {
+    if (!isQQBotAllowedLocalPath(absolutePath)) {
+      throw new Error(`[qqbot] Local media path is outside allowed roots: ${normalized}`);
+    }
+    return absolutePath;
   }
 
   const homeDir = getHomeDir();
   const mediaRoot = getQQBotMediaDir();
   const dataRoot = getQQBotDataDir();
-  const workspaceRoot = path.join(homeDir, ".openclaw", "workspace", "qqbot");
+  const workspaceRoot = getQQBotWorkspaceDir();
   const candidateRoots = [
     { from: workspaceRoot, to: mediaRoot },
     { from: dataRoot, to: mediaRoot },
@@ -140,18 +193,22 @@ export function resolveQQBotLocalMediaPath(p: string): string {
   ];
 
   for (const { from, to } of candidateRoots) {
-    if (!isPathWithinRoot(normalized, from)) {
+    if (!isPathWithinRoot(absolutePath, from)) {
       continue;
     }
-    const relative = path.relative(from, normalized);
+    const relative = path.relative(from, absolutePath);
     const candidate = path.join(to, relative);
-    if (fs.existsSync(candidate)) {
+    if (fs.existsSync(candidate) && isQQBotAllowedLocalPath(candidate)) {
       debugWarn(`[platform] Remapped missing QQBot media path ${normalized} -> ${candidate}`);
       return candidate;
     }
   }
 
-  return normalized;
+  if (!isQQBotAllowedLocalPath(absolutePath)) {
+    throw new Error(`[qqbot] Local media path is outside allowed roots: ${normalized}`);
+  }
+
+  return absolutePath;
 }
 
 // Filename normalization.


### PR DESCRIPTION
## Summary
- Restrict QQ Bot local media reads to OpenClaw-owned storage roots
- Preserve legacy QQ Bot workspace remapping while blocking unrelated host paths

## Changes
- Hardened QQ Bot local path resolution with allowlisted roots and symlink-aware checks
- Returned blocked-path errors from outbound and structured payload send paths instead of allowing uncaught reads
- Moved QQ Bot TTS scratch MP3 decoding into the OpenClaw temp root and added regression coverage for blocked and allowed paths

## Validation
- Ran `corepack pnpm test -- extensions/qqbot/src/utils/platform.test.ts`
- Ran `PATH="/app/.local/bin:$PATH" corepack pnpm check`
- Ran `PATH="/app/.local/bin:$PATH" corepack pnpm build`
- Ran local agentic review with `claude -p "/review"`; it requested PR context before producing feedback

## Notes
- Residual risk or follow-up: there is still a normal time-of-check/time-of-use window between path validation and file open, but arbitrary host-file reads are no longer accepted through QQ Bot local media paths
- Reviewed openclaw/openclaw#58453 during intake; this branch keeps the centralized boundary fix because the earlier branch only covered a narrower subset of QQ Bot paths