### PR TITLE
fix(android): resolve TLS handshake failure on Android 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Android/gateway: fix TLS handshake failure on Android 15 by extending custom trust managers to `X509ExtendedTrustManager` and removing redundant per-domain network security config entries. Fixes #59090. Thanks @whisky0809.
 - Doctor/WhatsApp: warn when Linux crontabs still run the legacy `ensure-whatsapp.sh` health check, which can misreport `Gateway inactive` when cron lacks the systemd user-bus environment. Fixes #60204. Thanks @mySebbe.
 - Slack/setup: print the generated app manifest as plain JSON instead of embedding it inside the framed setup note, so it can be copied into Slack without deleting border characters. Fixes #65751. Thanks @theDanielJLewis.
 - Channels/WhatsApp: route CLI logout through the live Gateway and stop runtime-backed listeners before channel removal, so removing a WhatsApp account does not leave the old socket replying until restart. Fixes #67746. Thanks @123Mismail.

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
@@ -20,9 +20,11 @@ import javax.net.ssl.SNIHostName
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLException
 import javax.net.ssl.SSLParameters
+import javax.net.ssl.SSLEngine
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509ExtendedTrustManager
 import javax.net.ssl.X509TrustManager
 
 data class GatewayTlsParams(
@@ -58,12 +60,28 @@ fun buildGatewayTlsConfig(
 
   @SuppressLint("CustomX509TrustManager")
   val trustManager =
-    object : X509TrustManager {
+    object : X509ExtendedTrustManager() {
       override fun checkClientTrusted(
         chain: Array<X509Certificate>,
         authType: String,
       ) {
         defaultTrust.checkClientTrusted(chain, authType)
+      }
+
+      override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String, socket: java.net.Socket) {
+        if (defaultTrust is X509ExtendedTrustManager) {
+          (defaultTrust as X509ExtendedTrustManager).checkClientTrusted(chain, authType, socket)
+        } else {
+          checkClientTrusted(chain, authType)
+        }
+      }
+
+      override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String, engine: SSLEngine) {
+        if (defaultTrust is X509ExtendedTrustManager) {
+          (defaultTrust as X509ExtendedTrustManager).checkClientTrusted(chain, authType, engine)
+        } else {
+          checkClientTrusted(chain, authType)
+        }
       }
 
       override fun checkServerTrusted(
@@ -83,6 +101,22 @@ fun buildGatewayTlsConfig(
           return
         }
         defaultTrust.checkServerTrusted(chain, authType)
+      }
+
+      override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String, socket: java.net.Socket) {
+        if (expected == null && !params.allowTOFU && defaultTrust is X509ExtendedTrustManager) {
+          (defaultTrust as X509ExtendedTrustManager).checkServerTrusted(chain, authType, socket)
+        } else {
+          checkServerTrusted(chain, authType)
+        }
+      }
+
+      override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String, engine: SSLEngine) {
+        if (expected == null && !params.allowTOFU && defaultTrust is X509ExtendedTrustManager) {
+          (defaultTrust as X509ExtendedTrustManager).checkServerTrusted(chain, authType, engine)
+        } else {
+          checkServerTrusted(chain, authType)
+        }
       }
 
       override fun getAcceptedIssuers(): Array<X509Certificate> = defaultTrust.acceptedIssuers
@@ -117,11 +151,19 @@ suspend fun probeGatewayTlsFingerprint(
     val fingerprintRef = AtomicReference<String?>(null)
     val probeTrustManager =
       @SuppressLint("CustomX509TrustManager")
-      object : X509TrustManager {
+      object : X509ExtendedTrustManager() {
         override fun checkClientTrusted(
           chain: Array<X509Certificate>,
           authType: String,
         ): Unit = throw CertificateException("gateway TLS probe does not accept client certificates")
+
+        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String, socket: java.net.Socket) {
+          checkClientTrusted(chain, authType)
+        }
+
+        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String, engine: SSLEngine) {
+          checkClientTrusted(chain, authType)
+        }
 
         override fun checkServerTrusted(
           chain: Array<X509Certificate>,
@@ -130,6 +172,14 @@ suspend fun probeGatewayTlsFingerprint(
           if (chain.isEmpty()) throw CertificateException("empty certificate chain")
           fingerprintRef.set(sha256Hex(chain[0].encoded))
           throw CertificateException("gateway TLS probe captured fingerprint")
+        }
+
+        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String, socket: java.net.Socket) {
+          checkServerTrusted(chain, authType)
+        }
+
+        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String, engine: SSLEngine) {
+          checkServerTrusted(chain, authType)
         }
 
         override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()

--- a/apps/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/android/app/src/main/res/xml/network_security_config.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config xmlns:tools="http://schemas.android.com/tools">
-  <!-- This app is primarily used on a trusted tailnet; allow cleartext for IP-based endpoints too. -->
+  <!-- This app is primarily used on a trusted tailnet; allow cleartext for IP-based endpoints too.
+       base-config covers all domains — no domain-config entries needed. On Android 15+, per-domain
+       configs cause Android's RootTrustManager to require the hostname-aware checkServerTrusted
+       overload; custom X509TrustManagers must implement and forward this overload with hostname
+       context to the platform trust manager to avoid interoperability issues. -->
   <base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration" />
-  <!-- Allow HTTP for tailnet/local dev endpoints (e.g. canvas/background web). -->
-  <domain-config cleartextTrafficPermitted="true">
-    <domain includeSubdomains="true">openclaw.local</domain>
-  </domain-config>
-  <domain-config cleartextTrafficPermitted="true">
-    <domain includeSubdomains="true">ts.net</domain>
-  </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Summary

- Fixes a TLS handshake crash on Android 15 devices during gateway onboarding
- Android's `RootTrustManager` requires hostname-aware `checkServerTrusted` when `<domain-config>` entries exist in `network_security_config.xml`, but the custom `X509TrustManager` only implemented the 2-arg overload

## Changes

Two defense-in-depth fixes (either alone resolves it, both prevent regression):

1. **`network_security_config.xml`** — Remove redundant `<domain-config>` entries. The `<base-config cleartextTrafficPermitted="true">` already covers all domains, so the per-domain entries were unnecessary and triggered the stricter codepath.

2. **`GatewayTls.kt`** — Both custom trust managers (`buildGatewayTlsConfig` and `probeGatewayTlsFingerprint`) now extend `X509ExtendedTrustManager` instead of `X509TrustManager`, implementing the `Socket` and `SSLEngine` overloads that Android 15's `RootTrustManager` requires. The socket/engine overloads forward hostname context to the platform trust manager on the default-trust path.

## Error

```
Gateway error: Domain specific configurations require that hostname aware
checkServerTrusted(X509Certificate[], String, String) is used
```

## Test plan

- [x] Tested on Fairphone 6 (Android 15) connecting to a Tailscale-served gateway
- [x] TLS handshake succeeds, TOFU fingerprint prompt appears, pairing completes
- [ ] `pnpm build && pnpm check && pnpm test` — not run (no full dev environment set up; Android-only change, device-tested)

## AI-Assisted PR 🤖

- [x] AI-assisted (Claude Code / Claude Opus 4.6)
- [x] Degree of testing: **device-tested on real hardware** (Fairphone 6, Android 15); unit/integration test suite not run
- [x] I understand what this code does: extends `X509ExtendedTrustManager` to satisfy Android 15's `instanceof` check in `RootTrustManager`, and removes `<domain-config>` entries that trigger the stricter codepath
- [x] Bot review conversations resolved/replied to

🤖 Generated with [Claude Code](https://claude.ai/claude-code)