### PR TITLE
fix: preserve Telegram topic routing in announce and delivery context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,6 +391,9 @@ Docs: https://docs.openclaw.ai
 - Telegram/splitting: replace proportional text estimate with verified HTML-length search so long messages split at word boundaries instead of mid-word; gracefully degrade when tag overhead exceeds the limit. (#56595)
 - Telegram/delivery: skip whitespace-only and hook-blanked text replies in bot delivery to prevent GrammyError 400 empty-text crashes. (#56620)
 - Telegram/send: validate `replyToMessageId` at all four API sinks with a shared normalizer that rejects non-numeric, NaN, and mixed-content strings. (#56587)
+- Telegram/cron topics: route announce target parsing through the Telegram extension seam and carry explicit `delivery.threadId` through cron delivery resolution, so legacy `group:` routes and topic-targeted cron sends keep their forum topic destination. (#58489) Thanks @cwmine.
+- Approvals/UI: keep the newest pending approval at the front of the Control UI queue so approving one request does not accidentally target an older expired id. Thanks @vincentkoc.
+- Plugin approvals: accept unique short approval-id prefixes on `plugin.approval.resolve`, matching exec approvals and restoring `/approve` fallback flows on chat approval surfaces. Thanks @vincentkoc.
 - Mistral: normalize OpenAI-compatible request flags so official Mistral API runs no longer fail with remaining `422 status code (no body)` chat errors.
 - Control UI/config: keep sensitive raw config hidden by default, replace the blank blocked editor with an explicit reveal-to-edit state, and restore raw JSON editing without auto-exposing secrets. Fixes #55322.
 - CLI/zsh: defer `compdef` registration until `compinit` is available so zsh completion loads cleanly with plugin managers and manual setups. (#56555)

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -204,6 +204,7 @@ Delivery config:
 - `delivery.mode`: `none` | `announce` | `webhook`.
 - `delivery.channel`: `last` or a specific channel.
 - `delivery.to`: channel-specific target (announce) or webhook URL (webhook mode).
+- `delivery.threadId`: optional explicit thread or topic id when the target channel supports threaded delivery.
 - `delivery.bestEffort`: avoid failing the job if announce delivery fails.
 
 Announce delivery suppresses messaging tool sends for the run; use `delivery.channel`/`delivery.to`
@@ -272,6 +273,7 @@ Isolated jobs can deliver output to a channel via the top-level `delivery` confi
 - `delivery.mode`: `announce` (channel delivery), `webhook` (HTTP POST), or `none`.
 - `delivery.channel`: `last` or any deliverable channel id, for example `discord`, `matrix`, `telegram`, or `whatsapp`.
 - `delivery.to`: channel-specific recipient target.
+- `delivery.threadId`: optional thread/topic override for channels like Telegram, Slack, Discord, or Matrix when you want a specific thread without encoding it into `delivery.to`.
 
 `announce` delivery is only valid for isolated jobs (`sessionTarget: "isolated"`).
 `webhook` delivery is valid for both main and isolated jobs.

--- a/extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts
@@ -99,7 +99,7 @@ describe("buildTelegramMessageContext DM topic threadId in deliveryContext (#889
     expect(ctx).not.toBeNull();
     expect(recordInboundSessionMock).toHaveBeenCalled();
 
-    expectRecordedRoute({ to: "telegram:-1001234567890", threadId: "99" });
+    expectRecordedRoute({ to: "telegram:-1001234567890:topic:99", threadId: "99" });
   });
 
   it("passes threadId to updateLastRoute for the forum General topic", async () => {
@@ -115,6 +115,6 @@ describe("buildTelegramMessageContext DM topic threadId in deliveryContext (#889
     expect(ctx).not.toBeNull();
     expect(recordInboundSessionMock).toHaveBeenCalled();
 
-    expectRecordedRoute({ to: "telegram:-1001234567890", threadId: "1" });
+    expectRecordedRoute({ to: "telegram:-1001234567890:topic:1", threadId: "1" });
   });
 });

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -280,7 +280,10 @@ export async function buildTelegramInboundContextPayload(params: {
         ? {
             sessionKey: updateLastRouteSessionKey,
             channel: "telegram",
-            to: `telegram:${chatId}`,
+            to:
+              isGroup && updateLastRouteThreadId != null
+                ? `telegram:${chatId}:topic:${updateLastRouteThreadId}`
+                : `telegram:${chatId}`,
             accountId: route.accountId,
             threadId: updateLastRouteThreadId,
             mainDmOwnerPin:

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { resolveAnnounceOrigin } from "./subagent-announce-delivery.js";
+
+describe("resolveAnnounceOrigin telegram forum topics", () => {
+  it("preserves stored forum topic thread ids when requester origin omits one for the same chat", () => {
+    expect(
+      resolveAnnounceOrigin(
+        {
+          lastChannel: "telegram",
+          lastTo: "telegram:-1001234567890:topic:99",
+          lastThreadId: 99,
+        },
+        {
+          channel: "telegram",
+          to: "telegram:-1001234567890",
+        },
+      ),
+    ).toEqual({
+      channel: "telegram",
+      to: "telegram:-1001234567890",
+      threadId: 99,
+    });
+  });
+
+  it("still strips stale thread ids when the stored telegram route points at a different chat", () => {
+    expect(
+      resolveAnnounceOrigin(
+        {
+          lastChannel: "telegram",
+          lastTo: "telegram:-1009999999999:topic:99",
+          lastThreadId: 99,
+        },
+        {
+          channel: "telegram",
+          to: "telegram:-1001234567890",
+        },
+      ),
+    ).toEqual({
+      channel: "telegram",
+      to: "telegram:-1001234567890",
+    });
+  });
+});

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -22,6 +22,26 @@ describe("resolveAnnounceOrigin telegram forum topics", () => {
     });
   });
 
+  it("preserves stored forum topic thread ids for legacy group-prefixed requester targets", () => {
+    expect(
+      resolveAnnounceOrigin(
+        {
+          lastChannel: "telegram",
+          lastTo: "telegram:-1001234567890:topic:99",
+          lastThreadId: 99,
+        },
+        {
+          channel: "telegram",
+          to: "group:-1001234567890",
+        },
+      ),
+    ).toEqual({
+      channel: "telegram",
+      to: "group:-1001234567890",
+      threadId: 99,
+    });
+  });
+
   it("still strips stale thread ids when the stored telegram route points at a different chat", () => {
     expect(
       resolveAnnounceOrigin(

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1,4 +1,5 @@
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
+import { parseExplicitTargetForChannel } from "../channels/plugins/target-parsing.js";
 import { loadConfig } from "../config/config.js";
 import {
   loadSessionStore,
@@ -92,42 +93,15 @@ function summarizeDeliveryError(error: unknown): string {
   }
 }
 
-function stripTelegramAnnouncePrefix(to: string): string {
-  let trimmed = to.trim();
-  let strippedTelegramPrefix = false;
-  while (true) {
-    const next = (() => {
-      if (/^(telegram|tg):/i.test(trimmed)) {
-        strippedTelegramPrefix = true;
-        return trimmed.replace(/^(telegram|tg):/i, "").trim();
-      }
-      if (strippedTelegramPrefix && /^group:/i.test(trimmed)) {
-        return trimmed.replace(/^group:/i, "").trim();
-      }
-      return trimmed;
-    })();
-    if (next === trimmed) {
-      return trimmed;
-    }
-    trimmed = next;
-  }
-}
-
 function parseTelegramAnnounceTarget(to: string): {
   chatId: string;
   chatType: "direct" | "group" | "unknown";
 } {
-  const normalized = stripTelegramAnnouncePrefix(to);
-  const topicMatch = /^(.+?):topic:(\d+)$/.exec(normalized);
-  const colonMatch = /^(.+):(\d+)$/.exec(normalized);
-  const chatId = topicMatch?.[1] ?? colonMatch?.[1] ?? normalized;
-  const trimmedChatId = chatId.trim();
-  const chatType = /^-?\d+$/.test(trimmedChatId)
-    ? trimmedChatId.startsWith("-")
-      ? "group"
-      : "direct"
-    : "unknown";
-  return { chatId: trimmedChatId, chatType };
+  const parsed = parseExplicitTargetForChannel("telegram", to);
+  const chatId = parsed?.to?.trim() ?? to.trim();
+  const chatType =
+    parsed?.chatType === "direct" || parsed?.chatType === "group" ? parsed.chatType : "unknown";
+  return { chatId, chatType };
 }
 
 function shouldStripThreadFromAnnounceEntry(

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -92,6 +92,79 @@ function summarizeDeliveryError(error: unknown): string {
   }
 }
 
+function stripTelegramAnnouncePrefix(to: string): string {
+  let trimmed = to.trim();
+  let strippedTelegramPrefix = false;
+  while (true) {
+    const next = (() => {
+      if (/^(telegram|tg):/i.test(trimmed)) {
+        strippedTelegramPrefix = true;
+        return trimmed.replace(/^(telegram|tg):/i, "").trim();
+      }
+      if (strippedTelegramPrefix && /^group:/i.test(trimmed)) {
+        return trimmed.replace(/^group:/i, "").trim();
+      }
+      return trimmed;
+    })();
+    if (next === trimmed) {
+      return trimmed;
+    }
+    trimmed = next;
+  }
+}
+
+function parseTelegramAnnounceTarget(to: string): {
+  chatId: string;
+  chatType: "direct" | "group" | "unknown";
+} {
+  const normalized = stripTelegramAnnouncePrefix(to);
+  const topicMatch = /^(.+?):topic:(\d+)$/.exec(normalized);
+  const colonMatch = /^(.+):(\d+)$/.exec(normalized);
+  const chatId = topicMatch?.[1] ?? colonMatch?.[1] ?? normalized;
+  const trimmedChatId = chatId.trim();
+  const chatType = /^-?\d+$/.test(trimmedChatId)
+    ? trimmedChatId.startsWith("-")
+      ? "group"
+      : "direct"
+    : "unknown";
+  return { chatId: trimmedChatId, chatType };
+}
+
+function shouldStripThreadFromAnnounceEntry(
+  normalizedRequester?: DeliveryContext,
+  normalizedEntry?: DeliveryContext,
+): boolean {
+  if (
+    !normalizedRequester?.to ||
+    normalizedRequester.threadId != null ||
+    normalizedEntry?.threadId == null
+  ) {
+    return false;
+  }
+  const requesterChannel = normalizedRequester.channel?.trim().toLowerCase();
+  if (requesterChannel && requesterChannel !== "telegram") {
+    return true;
+  }
+  if (!requesterChannel && !normalizedRequester.to.startsWith("telegram:")) {
+    return true;
+  }
+  try {
+    const requesterTarget = parseTelegramAnnounceTarget(normalizedRequester.to);
+    if (requesterTarget.chatType !== "group") {
+      return true;
+    }
+    const entryTarget = normalizedEntry.to
+      ? parseTelegramAnnounceTarget(normalizedEntry.to)
+      : undefined;
+    if (entryTarget && entryTarget.chatId !== requesterTarget.chatId) {
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 const TRANSIENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /\berrorcode=unavailable\b/i,
   /\bstatus\s*[:=]\s*"?unavailable\b/i,
@@ -196,9 +269,7 @@ export function resolveAnnounceOrigin(
     );
   }
   const entryForMerge =
-    normalizedRequester?.to &&
-    normalizedRequester.threadId == null &&
-    normalizedEntry?.threadId != null
+    normalizedEntry && shouldStripThreadFromAnnounceEntry(normalizedRequester, normalizedEntry)
       ? (() => {
           const { threadId: _ignore, ...rest } = normalizedEntry;
           return rest;

--- a/src/config/sessions/delivery-info.test.ts
+++ b/src/config/sessions/delivery-info.test.ts
@@ -123,6 +123,7 @@ describe("extractDeliveryInfo", () => {
       to: "group:98765",
       accountId: "main",
     });
+    storeState.store[baseKey].lastThreadId = "55";
 
     const result = extractDeliveryInfo(topicKey);
 
@@ -131,8 +132,33 @@ describe("extractDeliveryInfo", () => {
         channel: "telegram",
         to: "group:98765",
         accountId: "main",
+        threadId: "55",
       },
       threadId: "55",
+    });
+  });
+
+  it("falls back to session metadata thread ids when deliveryContext.threadId is missing", () => {
+    const sessionKey = "agent:main:telegram:group:98765";
+    storeState.store[sessionKey] = {
+      ...buildEntry({
+        channel: "telegram",
+        to: "group:98765",
+        accountId: "main",
+      }),
+      origin: { threadId: 77 },
+    };
+
+    const result = extractDeliveryInfo(sessionKey);
+
+    expect(result).toEqual({
+      deliveryContext: {
+        channel: "telegram",
+        to: "group:98765",
+        accountId: "main",
+        threadId: "77",
+      },
+      threadId: undefined,
     });
   });
 });

--- a/src/config/sessions/delivery-info.ts
+++ b/src/config/sessions/delivery-info.ts
@@ -15,7 +15,9 @@ export function parseSessionThreadInfo(sessionKey: string | undefined): {
 }
 
 export function extractDeliveryInfo(sessionKey: string | undefined): {
-  deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
+  deliveryContext:
+    | { channel?: string; to?: string; accountId?: string; threadId?: string }
+    | undefined;
   threadId: string | undefined;
 } {
   const { baseSessionKey, threadId } = parseSessionThreadInfo(sessionKey);
@@ -23,7 +25,9 @@ export function extractDeliveryInfo(sessionKey: string | undefined): {
     return { deliveryContext: undefined, threadId };
   }
 
-  let deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
+  let deliveryContext:
+    | { channel?: string; to?: string; accountId?: string; threadId?: string }
+    | undefined;
   try {
     const cfg = loadConfig();
     const storePath = resolveStorePath(cfg.session?.store);
@@ -33,10 +37,13 @@ export function extractDeliveryInfo(sessionKey: string | undefined): {
       entry = store[baseSessionKey];
     }
     if (entry?.deliveryContext) {
+      const resolvedThreadId =
+        entry.deliveryContext.threadId ?? entry.lastThreadId ?? entry.origin?.threadId;
       deliveryContext = {
         channel: entry.deliveryContext.channel,
         to: entry.deliveryContext.to,
         accountId: entry.deliveryContext.accountId,
+        threadId: resolvedThreadId != null ? String(resolvedThreadId) : undefined,
       };
     }
   } catch {

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -84,6 +84,24 @@ describe("resolveCronDeliveryPlan", () => {
     expect(plan.to).toBe("123");
     expect(plan.accountId).toBe("bot-a");
   });
+
+  it("threads delivery.threadId when explicitly configured", () => {
+    const plan = resolveCronDeliveryPlan(
+      makeJob({
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "-1001234567890",
+          threadId: "99",
+        },
+      }),
+    );
+    expect(plan.mode).toBe("announce");
+    expect(plan.requested).toBe(true);
+    expect(plan.channel).toBe("telegram");
+    expect(plan.to).toBe("-1001234567890");
+    expect(plan.threadId).toBe("99");
+  });
 });
 
 describe("resolveFailureDestination", () => {

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -14,6 +14,7 @@ export type CronDeliveryPlan = {
   mode: CronDeliveryMode;
   channel?: CronMessageChannel;
   to?: string;
+  threadId?: string | number;
   /** Explicit channel account id from the delivery config, if set. */
   accountId?: string;
   source: "delivery" | "payload";
@@ -47,6 +48,17 @@ function normalizeAccountId(value: unknown): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function normalizeThreadId(value: unknown): string | number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
   const payload = job.payload.kind === "agentTurn" ? job.payload : null;
   const delivery = job.delivery;
@@ -70,6 +82,9 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
     (delivery as { channel?: unknown } | undefined)?.channel,
   );
   const deliveryTo = normalizeTo((delivery as { to?: unknown } | undefined)?.to);
+  const deliveryThreadId = normalizeThreadId(
+    (delivery as { threadId?: unknown } | undefined)?.threadId,
+  );
   const channel = deliveryChannel ?? payloadChannel ?? "last";
   const to = deliveryTo ?? payloadTo;
   const deliveryAccountId = normalizeAccountId(
@@ -81,6 +96,7 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
       mode: resolvedMode,
       channel: resolvedMode === "announce" ? channel : undefined,
       to,
+      threadId: resolvedMode === "announce" ? deliveryThreadId : undefined,
       accountId: deliveryAccountId,
       source: "delivery",
       requested: resolvedMode === "announce",
@@ -96,6 +112,7 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
     mode: requested ? "announce" : "none",
     channel,
     to,
+    threadId: undefined,
     source: "payload",
     requested,
   };

--- a/src/cron/isolated-agent.delivery-target-thread-session.test.ts
+++ b/src/cron/isolated-agent.delivery-target-thread-session.test.ts
@@ -161,4 +161,18 @@ describe("resolveDeliveryTarget thread session lookup", () => {
     expect(result.to).toBe("63448508");
     expect(result.threadId).toBe(1008013);
   });
+
+  it("preserves explicit delivery.threadId on first run without topic syntax", async () => {
+    mockStore["/mock/store.json"] = {};
+
+    const result = await resolveDeliveryTarget(cfg, "main", {
+      channel: "telegram",
+      to: "63448508",
+      threadId: "1008013",
+    });
+
+    expect(result.to).toBe("63448508");
+    expect(result.threadId).toBe("1008013");
+    expect(result.channel).toBe("telegram");
+  });
 });

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -43,6 +43,7 @@ export async function resolveDeliveryTarget(
   jobPayload: {
     channel?: "last" | ChannelId;
     to?: string;
+    threadId?: string | number;
     /** Explicit accountId from job.delivery — overrides session-derived and binding-derived values. */
     accountId?: string;
     sessionKey?: string;
@@ -67,6 +68,7 @@ export async function resolveDeliveryTarget(
     entry: main,
     requestedChannel,
     explicitTo,
+    explicitThreadId: jobPayload.threadId,
     allowMismatchedLastTo,
   });
 
@@ -93,6 +95,7 @@ export async function resolveDeliveryTarget(
         entry: main,
         requestedChannel,
         explicitTo,
+        explicitThreadId: jobPayload.threadId,
         fallbackChannel,
         allowMismatchedLastTo,
         mode: preliminary.mode,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -144,6 +144,7 @@ async function resolveCronDeliveryContext(params: {
   const resolvedDelivery = await resolveDeliveryTarget(params.cfg, params.agentId, {
     channel: deliveryPlan.channel ?? "last",
     to: deliveryPlan.to,
+    threadId: deliveryPlan.threadId,
     accountId: deliveryPlan.accountId,
     sessionKey: params.job.sessionKey,
   });

--- a/src/cron/legacy-delivery.test.ts
+++ b/src/cron/legacy-delivery.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDeliveryFromLegacyPayload,
+  buildDeliveryPatchFromLegacyPayload,
+  hasLegacyDeliveryHints,
+  mergeLegacyDeliveryInto,
+  normalizeLegacyDeliveryInput,
+} from "./legacy-delivery.js";
+
+describe("legacy delivery threadId support", () => {
+  it("treats threadId as a legacy delivery hint", () => {
+    expect(hasLegacyDeliveryHints({ threadId: "42" })).toBe(true);
+    expect(hasLegacyDeliveryHints({ threadId: 42 })).toBe(true);
+  });
+
+  it("hydrates threadId into new delivery payloads", () => {
+    expect(
+      buildDeliveryFromLegacyPayload({
+        channel: "telegram",
+        to: "-100123:topic:42",
+        threadId: 42,
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "-100123:topic:42",
+      threadId: "42",
+    });
+  });
+
+  it("patches and merges threadId into existing deliveries", () => {
+    expect(buildDeliveryPatchFromLegacyPayload({ threadId: "77" })).toEqual({
+      mode: "announce",
+      threadId: "77",
+    });
+
+    expect(
+      mergeLegacyDeliveryInto(
+        { mode: "announce", channel: "telegram", to: "-100123", threadId: "1" },
+        { threadId: 77 },
+      ),
+    ).toEqual({
+      delivery: { mode: "announce", channel: "telegram", to: "-100123", threadId: "77" },
+      mutated: true,
+    });
+  });
+
+  it("strips threadId from legacy payloads after normalization", () => {
+    const payload: Record<string, unknown> = {
+      channel: "telegram",
+      to: "-100123:topic:42",
+      threadId: 42,
+    };
+
+    expect(normalizeLegacyDeliveryInput({ payload })).toEqual({
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "-100123:topic:42",
+        threadId: "42",
+      },
+      mutated: true,
+    });
+    expect(payload.threadId).toBeUndefined();
+  });
+});

--- a/src/cron/legacy-delivery.ts
+++ b/src/cron/legacy-delivery.ts
@@ -14,6 +14,12 @@ export function hasLegacyDeliveryHints(payload: Record<string, unknown>) {
   if (typeof payload.to === "string" && payload.to.trim()) {
     return true;
   }
+  if (typeof payload.threadId === "string" && payload.threadId.trim()) {
+    return true;
+  }
+  if (typeof payload.threadId === "number" && Number.isFinite(payload.threadId)) {
+    return true;
+  }
   return false;
 }
 
@@ -29,12 +35,21 @@ export function buildDeliveryFromLegacyPayload(
         ? payload.provider.trim().toLowerCase()
         : "";
   const toRaw = typeof payload.to === "string" ? payload.to.trim() : "";
+  const threadIdRaw =
+    typeof payload.threadId === "string"
+      ? payload.threadId.trim()
+      : typeof payload.threadId === "number" && Number.isFinite(payload.threadId)
+        ? String(payload.threadId)
+        : "";
   const next: Record<string, unknown> = { mode };
   if (channelRaw) {
     next.channel = channelRaw;
   }
   if (toRaw) {
     next.to = toRaw;
+  }
+  if (threadIdRaw) {
+    next.threadId = threadIdRaw;
   }
   if (typeof payload.bestEffortDeliver === "boolean") {
     next.bestEffort = payload.bestEffortDeliver;
@@ -51,6 +66,12 @@ export function buildDeliveryPatchFromLegacyPayload(payload: Record<string, unkn
         ? payload.provider.trim().toLowerCase()
         : "";
   const toRaw = typeof payload.to === "string" ? payload.to.trim() : "";
+  const threadIdRaw =
+    typeof payload.threadId === "string"
+      ? payload.threadId.trim()
+      : typeof payload.threadId === "number" && Number.isFinite(payload.threadId)
+        ? String(payload.threadId)
+        : "";
   const next: Record<string, unknown> = {};
   let hasPatch = false;
 
@@ -61,6 +82,7 @@ export function buildDeliveryPatchFromLegacyPayload(payload: Record<string, unkn
     deliver === true ||
     channelRaw ||
     toRaw ||
+    threadIdRaw ||
     typeof payload.bestEffortDeliver === "boolean"
   ) {
     next.mode = "announce";
@@ -72,6 +94,10 @@ export function buildDeliveryPatchFromLegacyPayload(payload: Record<string, unkn
   }
   if (toRaw) {
     next.to = toRaw;
+    hasPatch = true;
+  }
+  if (threadIdRaw) {
+    next.threadId = threadIdRaw;
     hasPatch = true;
   }
   if (typeof payload.bestEffortDeliver === "boolean") {
@@ -104,6 +130,10 @@ export function mergeLegacyDeliveryInto(
   }
   if ("to" in patch && patch.to !== next.to) {
     next.to = patch.to;
+    mutated = true;
+  }
+  if ("threadId" in patch && patch.threadId !== next.threadId) {
+    next.threadId = patch.threadId;
     mutated = true;
   }
   if ("bestEffort" in patch && patch.bestEffort !== next.bestEffort) {
@@ -150,6 +180,9 @@ export function stripLegacyDeliveryFields(payload: Record<string, unknown>) {
   }
   if ("to" in payload) {
     delete payload.to;
+  }
+  if ("threadId" in payload) {
+    delete payload.threadId;
   }
   if ("bestEffortDeliver" in payload) {
     delete payload.bestEffortDeliver;

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -248,6 +248,32 @@ describe("normalizeCronJobCreate", () => {
     expect(delivery.accountId).toBe("coordinator");
   });
 
+  it("normalizes delivery threadId and preserves numeric values", () => {
+    const stringThread = normalizeIsolatedAgentTurnCreateJob({
+      name: "delivery thread string",
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "-1003816714067",
+        threadId: " 1008013 ",
+      },
+    });
+
+    expect((stringThread.delivery as Record<string, unknown>).threadId).toBe("1008013");
+
+    const numericThread = normalizeIsolatedAgentTurnCreateJob({
+      name: "delivery thread number",
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "-1003816714067",
+        threadId: 1008013,
+      },
+    });
+
+    expect((numericThread.delivery as Record<string, unknown>).threadId).toBe(1008013);
+  });
+
   it("strips empty accountId from delivery", () => {
     const normalized = normalizeIsolatedAgentTurnCreateJob({
       name: "empty account",
@@ -308,6 +334,26 @@ describe("normalizeCronJobCreate", () => {
     const delivery = normalized.delivery as Record<string, unknown>;
     expectAnnounceDeliveryTarget(delivery, { channel: "telegram", to: "7200373102" });
     expect(delivery.bestEffort).toBe(true);
+  });
+
+  it("migrates legacy top-level threadId hints into delivery", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "legacy root thread",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      payload: {
+        kind: "agentTurn",
+        message: "hi",
+      },
+      channel: "telegram",
+      to: "-1001234567890",
+      threadId: " 99 ",
+    }) as unknown as Record<string, unknown>;
+
+    const delivery = normalized.delivery as Record<string, unknown>;
+    expectAnnounceDeliveryTarget(delivery, { channel: "telegram", to: "-1001234567890" });
+    expect(delivery.threadId).toBe("99");
+    expect(normalized.threadId).toBeUndefined();
   });
 
   it("maps legacy deliver=false to delivery none", () => {
@@ -498,5 +544,17 @@ describe("normalizeCronJobPatch", () => {
 
     const schedule = normalized.schedule as Record<string, unknown>;
     expect(schedule.staggerMs).toBe(30_000);
+  });
+
+  it("preserves legacy patch threadId hints for downstream delivery migration", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        kind: "agentTurn",
+        threadId: 77,
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.delivery).toBeUndefined();
+    expect((normalized.payload as Record<string, unknown>).threadId).toBe(77);
   });
 });

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -208,6 +208,18 @@ function coerceDelivery(delivery: UnknownRecord) {
       delete next.to;
     }
   }
+  if (typeof delivery.threadId === "number" && Number.isFinite(delivery.threadId)) {
+    next.threadId = delivery.threadId;
+  } else if (typeof delivery.threadId === "string") {
+    const trimmed = delivery.threadId.trim();
+    if (trimmed) {
+      next.threadId = trimmed;
+    } else {
+      delete next.threadId;
+    }
+  } else if ("threadId" in next) {
+    delete next.threadId;
+  }
   if (typeof delivery.accountId === "string") {
     const trimmed = delivery.accountId.trim();
     if (trimmed) {
@@ -300,6 +312,13 @@ function copyTopLevelLegacyDeliveryFields(next: UnknownRecord, payload: UnknownR
     payload.to = next.to.trim();
   }
   if (
+    !("threadId" in payload) &&
+    ((typeof next.threadId === "number" && Number.isFinite(next.threadId)) ||
+      (typeof next.threadId === "string" && next.threadId.trim()))
+  ) {
+    payload.threadId = typeof next.threadId === "string" ? next.threadId.trim() : next.threadId;
+  }
+  if (
     typeof payload.bestEffortDeliver !== "boolean" &&
     typeof next.bestEffortDeliver === "boolean"
   ) {
@@ -324,6 +343,7 @@ function stripLegacyTopLevelFields(next: UnknownRecord) {
   delete next.deliver;
   delete next.channel;
   delete next.to;
+  delete next.threadId;
   delete next.bestEffortDeliver;
   delete next.provider;
 }

--- a/src/cron/service/jobs.apply-patch.test.ts
+++ b/src/cron/service/jobs.apply-patch.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../types.js";
+import { applyJobPatch } from "./jobs.js";
+
+function makeJob(overrides: Partial<CronJob> = {}): CronJob {
+  const now = Date.now();
+  return {
+    id: "job-1",
+    name: "test",
+    enabled: true,
+    createdAtMs: now,
+    updatedAtMs: now,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "hello" },
+    delivery: { mode: "announce", channel: "telegram", to: "-1001234567890" },
+    state: {},
+    ...overrides,
+  };
+}
+
+describe("applyJobPatch legacy delivery migration", () => {
+  it("threads legacy payload threadId hints into delivery", () => {
+    const job = makeJob();
+    const patch = {
+      payload: {
+        kind: "agentTurn",
+        threadId: "99",
+      },
+    } as unknown as Parameters<typeof applyJobPatch>[1];
+
+    applyJobPatch(job, patch);
+
+    expect(job.delivery).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "-1001234567890",
+      threadId: "99",
+    });
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -712,10 +712,18 @@ function buildLegacyDeliveryPatch(
 ): CronDeliveryPatch | null {
   const deliver = payload.deliver;
   const toRaw = typeof payload.to === "string" ? payload.to.trim() : "";
+  const threadIdValue = (payload as { threadId?: unknown }).threadId;
+  const threadIdRaw =
+    typeof threadIdValue === "number" && Number.isFinite(threadIdValue)
+      ? threadIdValue
+      : typeof threadIdValue === "string" && threadIdValue.trim()
+        ? threadIdValue.trim()
+        : undefined;
   const hasLegacyHints =
     typeof deliver === "boolean" ||
     typeof payload.bestEffortDeliver === "boolean" ||
-    Boolean(toRaw);
+    Boolean(toRaw) ||
+    threadIdRaw != null;
   if (!hasLegacyHints) {
     return null;
   }
@@ -738,6 +746,10 @@ function buildLegacyDeliveryPatch(
   }
   if (typeof payload.to === "string") {
     patch.to = payload.to.trim();
+    hasPatch = true;
+  }
+  if (threadIdRaw != null) {
+    patch.threadId = threadIdRaw;
     hasPatch = true;
   }
   if (typeof payload.bestEffortDeliver === "boolean") {
@@ -780,6 +792,13 @@ function normalizeOptionalTrimmedString(value: unknown): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function normalizeOptionalThreadId(value: unknown): string | number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return normalizeOptionalTrimmedString(value);
+}
+
 function mergeCronDelivery(
   existing: CronDelivery | undefined,
   patch: CronDeliveryPatch,
@@ -788,6 +807,7 @@ function mergeCronDelivery(
     mode: existing?.mode ?? "none",
     channel: existing?.channel,
     to: existing?.to,
+    threadId: existing?.threadId,
     accountId: existing?.accountId,
     bestEffort: existing?.bestEffort,
     failureDestination: existing?.failureDestination,
@@ -801,6 +821,9 @@ function mergeCronDelivery(
   }
   if ("to" in patch) {
     next.to = normalizeOptionalTrimmedString(patch.to);
+  }
+  if ("threadId" in patch) {
+    next.threadId = normalizeOptionalThreadId(patch.threadId);
   }
   if ("accountId" in patch) {
     next.accountId = normalizeOptionalTrimmedString(patch.accountId);

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -25,6 +25,8 @@ export type CronDelivery = {
   mode: CronDeliveryMode;
   channel?: CronMessageChannel;
   to?: string;
+  /** Explicit thread/topic id for channels that support threaded delivery. */
+  threadId?: string | number;
   /** Explicit channel account id for multi-account setups (e.g. multiple Telegram bots). */
   accountId?: string;
   bestEffort?: boolean;


### PR DESCRIPTION
## Summary

Fix Telegram forum topic routing gaps across the upstream send chain so async delivery can reliably return to the correct topic instead of falling back to the group root / General topic.

This patch addresses four linked gaps:

1. Preserve Telegram forum topic `threadId` in subagent announce/completion origin resolution when the stored route and requester target still refer to the same group chat.
2. Persist Telegram forum topic inbound last-route targets as `telegram:<chatId>:topic:<threadId>` instead of only `telegram:<chatId>`.
3. Add `threadId` support to legacy cron delivery payload migration.
4. Include `threadId` when `extractDeliveryInfo()` reconstructs `deliveryContext` from session metadata.

## Why

Before this change, sync replies could still work, but async paths could lose topic routing:

- subagent completion / announce could drop back to General
- cron delivery using legacy payload hints could not carry topic thread information
- restart / recovery paths could reconstruct a delivery context without `threadId`

The provider layer itself was fine; the issue was in upstream route persistence / recovery / merge behavior.

## Changes

### Announce / completion
- tighten `resolveAnnounceOrigin()` so Telegram forum topic routes keep `threadId` for same-chat delivery instead of stripping it unconditionally when requester origin omits an explicit thread id
- still strip stale thread ids when the stored Telegram route points at a different chat

### Telegram inbound route persistence
- when a Telegram forum group message has a resolved thread id, persist `updateLastRoute.to` as:
  - `telegram:<chatId>:topic:<threadId>`
- continue persisting `threadId` itself

### Legacy cron delivery migration
- recognize `threadId` as a legacy delivery hint
- carry it through build / patch / merge / strip helpers

### Session delivery reconstruction
- include `threadId` in `extractDeliveryInfo()` return value
- resolve it from:
  - `deliveryContext.threadId`
  - `lastThreadId`
  - `origin.threadId`

## Tests

Added / updated tests covering the new behavior:

- `src/agents/subagent-announce-delivery.test.ts`
- `src/cron/legacy-delivery.test.ts`
- `src/config/sessions/delivery-info.test.ts`
- `extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts`

Local validation run:

```bash
pnpm vitest run \
  src/config/sessions/delivery-info.test.ts \
  src/cron/legacy-delivery.test.ts \
  src/agents/subagent-announce-delivery.test.ts \
  extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts
```

Result: **4 files / 15 tests passed**

## Notes

This patch was also validated on a live local install with manual Telegram topic checks:
- cron / main systemEvent -> topic delivery passed
- subagent completion -> topic delivery passed
