### PR TITLE
feat: feishu comment event

### DIFF
--- a/extensions/feishu/src/comment-dispatcher.ts
+++ b/extensions/feishu/src/comment-dispatcher.ts
@@ -1,0 +1,83 @@
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import type { OutboundIdentity } from "../runtime-api.js";
+import {
+  createReplyPrefixContext,
+  type ClawdbotConfig,
+  type RuntimeEnv,
+  type ReplyPayload,
+} from "../runtime-api.js";
+import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
+import { replyComment, type CommentFileType } from "./drive.js";
+import { getFeishuRuntime } from "./runtime.js";
+
+export type CreateFeishuCommentReplyDispatcherParams = {
+  cfg: ClawdbotConfig;
+  agentId: string;
+  runtime: RuntimeEnv;
+  accountId?: string;
+  identity?: OutboundIdentity;
+  fileToken: string;
+  fileType: CommentFileType;
+  commentId: string;
+};
+
+export function createFeishuCommentReplyDispatcher(
+  params: CreateFeishuCommentReplyDispatcherParams,
+) {
+  const core = getFeishuRuntime();
+  const prefixContext = createReplyPrefixContext({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    channel: "feishu",
+    accountId: params.accountId,
+  });
+  const account = resolveFeishuRuntimeAccount({ cfg: params.cfg, accountId: params.accountId });
+  const client = createFeishuClient(account);
+  const textChunkLimit = core.channel.text.resolveTextChunkLimit(
+    params.cfg,
+    "feishu",
+    params.accountId,
+    {
+      fallbackLimit: 4000,
+    },
+  );
+  const chunkMode = core.channel.text.resolveChunkMode(params.cfg, "feishu");
+
+  const { dispatcher, replyOptions, markDispatchIdle } =
+    core.channel.reply.createReplyDispatcherWithTyping({
+      responsePrefix: prefixContext.responsePrefix,
+      responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
+      humanDelay: core.channel.reply.resolveHumanDelayConfig(params.cfg, params.agentId),
+      deliver: async (payload: ReplyPayload, info) => {
+        if (info.kind !== "final") {
+          return;
+        }
+        const reply = resolveSendableOutboundReplyParts(payload);
+        if (!reply.hasText) {
+          if (reply.hasMedia) {
+            params.runtime.log?.(
+              `feishu[${params.accountId ?? "default"}]: comment reply ignored media-only payload for comment=${params.commentId}`,
+            );
+          }
+          return;
+        }
+        const chunks = core.channel.text.chunkTextWithMode(reply.text, textChunkLimit, chunkMode);
+        for (const chunk of chunks) {
+          await replyComment(client, {
+            file_token: params.fileToken,
+            file_type: params.fileType,
+            comment_id: params.commentId,
+            content: chunk,
+          });
+        }
+      },
+      onError: (err, info) => {
+        params.runtime.error?.(
+          `feishu[${params.accountId ?? "default"}]: comment dispatcher failed kind=${info.kind} comment=${params.commentId}: ${String(err)}`,
+        );
+      },
+    });
+
+  return { dispatcher, replyOptions, markDispatchIdle };
+}

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -1,0 +1,238 @@
+import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
+import {
+  createChannelPairingController,
+  resolveAgentOutboundIdentity,
+  type ClawdbotConfig,
+  type RuntimeEnv,
+} from "../runtime-api.js";
+import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { createFeishuCommentReplyDispatcher } from "./comment-dispatcher.js";
+import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
+import {
+  parseFeishuDriveCommentNoticeEventPayload,
+  resolveDriveCommentEventTurn,
+  type FeishuDriveCommentNoticeEvent,
+} from "./monitor.comment.js";
+import { resolveFeishuAllowlistMatch } from "./policy.js";
+import { getFeishuRuntime } from "./runtime.js";
+import type { DynamicAgentCreationConfig } from "./types.js";
+
+type HandleFeishuCommentEventParams = {
+  cfg: ClawdbotConfig;
+  accountId: string;
+  runtime?: RuntimeEnv;
+  event: FeishuDriveCommentNoticeEvent;
+  botOpenId?: string;
+};
+
+type HandleFeishuCommentNoticePayloadParams = Omit<HandleFeishuCommentEventParams, "event"> & {
+  payload: unknown;
+};
+
+function buildCommentSessionKey(params: {
+  core: ReturnType<typeof getFeishuRuntime>;
+  route: ResolvedAgentRoute;
+  fileToken: string;
+  commentId: string;
+}): string {
+  return params.core.channel.routing.buildAgentSessionKey({
+    agentId: params.route.agentId,
+    channel: "feishu",
+    accountId: params.route.accountId,
+    peer: {
+      kind: "direct",
+      id: `comment:${params.fileToken}:${params.commentId}`,
+    },
+    dmScope: "per-account-channel-peer",
+  });
+}
+
+function parseTimestampMs(value: string | undefined): number {
+  const parsed = value ? Number.parseInt(value, 10) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+export async function handleFeishuCommentEvent(
+  params: HandleFeishuCommentEventParams,
+): Promise<void> {
+  const account = resolveFeishuRuntimeAccount({ cfg: params.cfg, accountId: params.accountId });
+  const feishuCfg = account.config;
+  const core = getFeishuRuntime();
+  const log = params.runtime?.log ?? console.log;
+  const error = params.runtime?.error ?? console.error;
+  const runtime = (params.runtime ?? { log, error }) as RuntimeEnv;
+
+  const turn = await resolveDriveCommentEventTurn({
+    cfg: params.cfg,
+    accountId: account.accountId,
+    event: params.event,
+    botOpenId: params.botOpenId,
+    logger: log,
+  });
+  if (!turn) {
+    log(
+      `feishu[${account.accountId}]: drive comment notice skipped ` +
+        `event=${params.event.event_id ?? "unknown"} comment=${params.event.comment_id ?? "unknown"}`,
+    );
+    return;
+  }
+
+  const dmPolicy = feishuCfg?.dmPolicy ?? "pairing";
+  const configAllowFrom = feishuCfg?.allowFrom ?? [];
+  const pairing = createChannelPairingController({
+    core,
+    channel: "feishu",
+    accountId: account.accountId,
+  });
+  const storeAllowFrom =
+    dmPolicy !== "allowlist" && dmPolicy !== "open"
+      ? await pairing.readAllowFromStore().catch(() => [])
+      : [];
+  const effectiveDmAllowFrom = [...configAllowFrom, ...storeAllowFrom];
+  const senderAllowed = resolveFeishuAllowlistMatch({
+    allowFrom: effectiveDmAllowFrom,
+    senderId: turn.senderId,
+  }).allowed;
+  if (dmPolicy !== "open" && !senderAllowed) {
+    log(
+      `feishu[${account.accountId}]: blocked unauthorized comment sender ${turn.senderId} ` +
+        `(dmPolicy=${dmPolicy}, comment=${turn.commentId})`,
+    );
+    return;
+  }
+
+  let effectiveCfg = params.cfg;
+  let route = core.channel.routing.resolveAgentRoute({
+    cfg: params.cfg,
+    channel: "feishu",
+    accountId: account.accountId,
+    peer: {
+      kind: "direct",
+      id: turn.senderId,
+    },
+  });
+  if (route.matchedBy === "default") {
+    const dynamicCfg = feishuCfg?.dynamicAgentCreation as DynamicAgentCreationConfig | undefined;
+    if (dynamicCfg?.enabled) {
+      const dynamicResult = await maybeCreateDynamicAgent({
+        cfg: params.cfg,
+        runtime: core,
+        senderOpenId: turn.senderId,
+        dynamicCfg,
+        log: (message) => log(message),
+      });
+      if (dynamicResult.created) {
+        effectiveCfg = dynamicResult.updatedCfg;
+        route = core.channel.routing.resolveAgentRoute({
+          cfg: dynamicResult.updatedCfg,
+          channel: "feishu",
+          accountId: account.accountId,
+          peer: {
+            kind: "direct",
+            id: turn.senderId,
+          },
+        });
+        log(
+          `feishu[${account.accountId}]: dynamic agent created for comment flow, route=${route.sessionKey}`,
+        );
+      }
+    }
+  }
+
+  const commentSessionKey = buildCommentSessionKey({
+    core,
+    route,
+    fileToken: turn.fileToken,
+    commentId: turn.commentId,
+  });
+  const bodyForAgent = `[message_id: ${turn.messageId}]\n${turn.prompt}`;
+  const ctxPayload = core.channel.reply.finalizeInboundContext({
+    Body: bodyForAgent,
+    BodyForAgent: bodyForAgent,
+    RawBody: turn.targetReplyText ?? turn.rootCommentText ?? turn.prompt,
+    CommandBody: turn.targetReplyText ?? turn.rootCommentText ?? turn.prompt,
+    From: `feishu-comment:${turn.senderId}`,
+    To: `comment:${turn.fileToken}:${turn.commentId}`,
+    SessionKey: commentSessionKey,
+    AccountId: route.accountId,
+    ChatType: "direct",
+    ConversationLabel: turn.documentTitle
+      ? `Feishu comment · ${turn.documentTitle}`
+      : "Feishu comment",
+    SenderName: turn.senderId,
+    SenderId: turn.senderId,
+    Provider: "feishu",
+    Surface: "feishu-comment",
+    MessageSid: turn.messageId,
+    Timestamp: parseTimestampMs(turn.timestamp),
+    WasMentioned: turn.isMentioned,
+    CommandAuthorized: false,
+    OriginatingTo: `comment:${turn.fileToken}:${turn.commentId}`,
+  });
+
+  const storePath = core.channel.session.resolveStorePath(effectiveCfg.session?.store, {
+    agentId: route.agentId,
+  });
+  await core.channel.session.recordInboundSession({
+    storePath,
+    sessionKey: commentSessionKey,
+    ctx: ctxPayload,
+    onRecordError: (err) => {
+      error(
+        `feishu[${account.accountId}]: failed to record comment inbound session ${commentSessionKey}: ${String(err)}`,
+      );
+    },
+  });
+
+  const identity = resolveAgentOutboundIdentity(effectiveCfg, route.agentId);
+  const { dispatcher, replyOptions, markDispatchIdle } = createFeishuCommentReplyDispatcher({
+    cfg: effectiveCfg,
+    agentId: route.agentId,
+    runtime,
+    accountId: account.accountId,
+    identity,
+    fileToken: turn.fileToken,
+    fileType: turn.fileType,
+    commentId: turn.commentId,
+  });
+
+  log(
+    `feishu[${account.accountId}]: dispatching drive comment to agent ` +
+      `(session=${commentSessionKey} comment=${turn.commentId} type=${turn.noticeType})`,
+  );
+  const { queuedFinal, counts } = await core.channel.reply.withReplyDispatcher({
+    dispatcher,
+    onSettled: () => {
+      markDispatchIdle();
+    },
+    run: () =>
+      core.channel.reply.dispatchReplyFromConfig({
+        ctx: ctxPayload,
+        cfg: effectiveCfg,
+        dispatcher,
+        replyOptions,
+      }),
+  });
+  log(
+    `feishu[${account.accountId}]: drive comment dispatch complete ` +
+      `(queuedFinal=${queuedFinal}, replies=${counts.final}, session=${commentSessionKey})`,
+  );
+}
+
+export async function handleFeishuCommentNoticePayload(
+  params: HandleFeishuCommentNoticePayloadParams,
+): Promise<void> {
+  const event = parseFeishuDriveCommentNoticeEventPayload(params.payload);
+  if (!event) {
+    const error = params.runtime?.error ?? console.error;
+    error(`feishu[${params.accountId}]: ignoring malformed drive comment notice payload`);
+    return;
+  }
+  await handleFeishuCommentEvent({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    runtime: params.runtime,
+    event,
+    botOpenId: params.botOpenId,
+  });
+}

--- a/extensions/feishu/src/drive-schema.ts
+++ b/extensions/feishu/src/drive-schema.ts
@@ -11,6 +11,14 @@ const FileType = Type.Union([
   Type.Literal("shortcut"),
 ]);
 
+const CommentFileType = Type.Union([
+  Type.Literal("doc"),
+  Type.Literal("docx"),
+  Type.Literal("sheet"),
+  Type.Literal("file"),
+  Type.Literal("slides"),
+]);
+
 export const FeishuDriveSchema = Type.Union([
   Type.Object({
     action: Type.Literal("list"),
@@ -40,6 +48,40 @@ export const FeishuDriveSchema = Type.Union([
     action: Type.Literal("delete"),
     file_token: Type.String({ description: "File token to delete" }),
     type: FileType,
+  }),
+  Type.Object({
+    action: Type.Literal("list_comments"),
+    file_token: Type.String({ description: "Document token" }),
+    file_type: CommentFileType,
+    page_size: Type.Optional(Type.Integer({ minimum: 1, description: "Page size" })),
+    page_token: Type.Optional(Type.String({ description: "Comment page token" })),
+  }),
+  Type.Object({
+    action: Type.Literal("list_comment_replies"),
+    file_token: Type.String({ description: "Document token" }),
+    file_type: CommentFileType,
+    comment_id: Type.String({ description: "Comment id" }),
+    page_size: Type.Optional(Type.Integer({ minimum: 1, description: "Page size" })),
+    page_token: Type.Optional(Type.String({ description: "Reply page token" })),
+  }),
+  Type.Object({
+    action: Type.Literal("add_comment"),
+    file_token: Type.String({ description: "Document token" }),
+    file_type: Type.Union([Type.Literal("doc"), Type.Literal("docx")]),
+    content: Type.String({ description: "Comment text content" }),
+    block_id: Type.Optional(
+      Type.String({
+        description:
+          "Optional docx block id for a local comment. Omit to create a full-document comment.",
+      }),
+    ),
+  }),
+  Type.Object({
+    action: Type.Literal("reply_comment"),
+    file_token: Type.String({ description: "Document token" }),
+    file_type: CommentFileType,
+    comment_id: Type.String({ description: "Comment id" }),
+    content: Type.String({ description: "Reply text content" }),
   }),
 ]);
 

--- a/extensions/feishu/src/drive.test.ts
+++ b/extensions/feishu/src/drive.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../../test/helpers/plugins/plugin-api.js";
+import { createPluginRuntimeMock } from "../../../test/helpers/plugins/plugin-runtime-mock.js";
+import type { OpenClawPluginApi } from "../runtime-api.js";
+
+const createFeishuToolClientMock = vi.hoisted(() => vi.fn());
+const resolveAnyEnabledFeishuToolsConfigMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./tool-account.js", () => ({
+  createFeishuToolClient: createFeishuToolClientMock,
+  resolveAnyEnabledFeishuToolsConfig: resolveAnyEnabledFeishuToolsConfigMock,
+}));
+
+let registerFeishuDriveTools: typeof import("./drive.js").registerFeishuDriveTools;
+
+function createDriveToolApi(params: {
+  config: OpenClawPluginApi["config"];
+  registerTool: OpenClawPluginApi["registerTool"];
+}): OpenClawPluginApi {
+  return createTestPluginApi({
+    id: "feishu-test",
+    name: "Feishu Test",
+    source: "local",
+    config: params.config,
+    runtime: createPluginRuntimeMock(),
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    registerTool: params.registerTool,
+  });
+}
+
+describe("registerFeishuDriveTools", () => {
+  const requestMock = vi.fn();
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    ({ registerFeishuDriveTools } = await import("./drive.js"));
+    resolveAnyEnabledFeishuToolsConfigMock.mockReturnValue({
+      doc: false,
+      chat: false,
+      wiki: false,
+      drive: true,
+      perm: false,
+      scopes: false,
+    });
+    createFeishuToolClientMock.mockReturnValue({
+      request: requestMock,
+    });
+  });
+
+  it("registers feishu_drive and handles comment actions", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    const tool = registerTool.mock.calls[0]?.[0];
+    expect(tool?.name).toBe("feishu_drive");
+
+    requestMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        has_more: false,
+        page_token: "0",
+        items: [
+          {
+            comment_id: "c1",
+            quote: "quoted text",
+            reply_list: {
+              replies: [
+                {
+                  reply_id: "r1",
+                  user_id: "ou_author",
+                  content: {
+                    elements: [
+                      {
+                        type: "text_run",
+                        text_run: { text: "root comment" },
+                      },
+                    ],
+                  },
+                },
+                {
+                  reply_id: "r2",
+                  user_id: "ou_reply",
+                  content: {
+                    elements: [
+                      {
+                        type: "text_run",
+                        text_run: { text: "reply text" },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    const listResult = await tool.execute("call-1", {
+      action: "list_comments",
+      file_token: "doc_1",
+      file_type: "docx",
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "GET",
+        url: "/open-apis/drive/v1/files/doc_1/comments?file_type=docx&user_id_type=open_id",
+      }),
+    );
+    expect(listResult.details).toEqual(
+      expect.objectContaining({
+        comments: [
+          expect.objectContaining({
+            comment_id: "c1",
+            text: "root comment",
+            quote: "quoted text",
+            replies: [expect.objectContaining({ reply_id: "r2", text: "reply text" })],
+          }),
+        ],
+      }),
+    );
+
+    requestMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        has_more: false,
+        page_token: "0",
+        items: [
+          {
+            reply_id: "r3",
+            user_id: "ou_reply_2",
+            content: {
+              elements: [
+                {
+                  type: "text_run",
+                  text_run: { content: "reply from api" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    const repliesResult = await tool.execute("call-2", {
+      action: "list_comment_replies",
+      file_token: "doc_1",
+      file_type: "docx",
+      comment_id: "c1",
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: "GET",
+        url: "/open-apis/drive/v1/files/doc_1/comments/c1/replies?file_type=docx&user_id_type=open_id",
+      }),
+    );
+    expect(repliesResult.details).toEqual(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ reply_id: "r3", text: "reply from api" })],
+      }),
+    );
+
+    requestMock.mockResolvedValueOnce({
+      code: 0,
+      data: { comment_id: "c2" },
+    });
+    const addCommentResult = await tool.execute("call-3", {
+      action: "add_comment",
+      file_token: "doc_1",
+      file_type: "docx",
+      block_id: "blk_1",
+      content: "please update this section",
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/new_comments",
+        data: {
+          file_type: "docx",
+          reply_elements: [{ type: "text", text: "please update this section" }],
+          anchor: { block_id: "blk_1" },
+        },
+      }),
+    );
+    expect(addCommentResult.details).toEqual(
+      expect.objectContaining({ success: true, comment_id: "c2" }),
+    );
+
+    requestMock
+      .mockResolvedValueOnce({
+        code: 99991663,
+        msg: "invalid request body",
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { reply_id: "r4" },
+      });
+    const replyCommentResult = await tool.execute("call-4", {
+      action: "reply_comment",
+      file_token: "doc_1",
+      file_type: "docx",
+      comment_id: "c1",
+      content: "handled",
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/comments/c1/replies?file_type=docx",
+        data: {
+          content: {
+            elements: [
+              {
+                type: "text_run",
+                text_run: {
+                  text: "handled",
+                },
+              },
+            ],
+          },
+        },
+      }),
+    );
+    expect(requestMock).toHaveBeenNthCalledWith(
+      5,
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/comments/c1/replies?file_type=docx",
+        data: {
+          reply_elements: [{ type: "text", text: "handled" }],
+        },
+      }),
+    );
+    expect(replyCommentResult.details).toEqual(
+      expect.objectContaining({ success: true, reply_id: "r4" }),
+    );
+  });
+
+  it("rejects block-scoped comments for non-docx files", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const tool = registerTool.mock.calls[0]?.[0];
+    const result = await tool.execute("call-5", {
+      action: "add_comment",
+      file_token: "doc_1",
+      file_type: "doc",
+      block_id: "blk_1",
+      content: "invalid",
+    });
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        error: "block_id is only supported for docx comments",
+      }),
+    );
+  });
+});

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -22,10 +22,188 @@ type FeishuExplorerRootFolderMetaResponse = {
 type FeishuDriveInternalClient = Lark.Client & {
   domain?: string;
   httpInstance: Pick<Lark.HttpInstance, "get">;
+  request(params: {
+    method: "GET" | "POST";
+    url: string;
+    data: unknown;
+    timeout?: number;
+  }): Promise<unknown>;
 };
+
+export type CommentFileType = "doc" | "docx" | "file" | "sheet" | "slides";
+
+type FeishuDriveApiResponse<T> = {
+  code: number;
+  msg?: string;
+  data?: T;
+};
+
+type FeishuDriveCommentReply = {
+  reply_id?: string;
+  user_id?: string;
+  create_time?: number;
+  update_time?: number;
+  content?: {
+    elements?: unknown[];
+  };
+};
+
+type FeishuDriveCommentCard = {
+  comment_id?: string;
+  user_id?: string;
+  create_time?: number;
+  update_time?: number;
+  is_solved?: boolean;
+  is_whole?: boolean;
+  has_more?: boolean;
+  page_token?: string;
+  quote?: string;
+  reply_list?: {
+    replies?: FeishuDriveCommentReply[];
+  };
+};
+
+type FeishuDriveListCommentsResponse = FeishuDriveApiResponse<{
+  has_more?: boolean;
+  items?: FeishuDriveCommentCard[];
+  page_token?: string;
+}>;
+
+type FeishuDriveListRepliesResponse = FeishuDriveApiResponse<{
+  has_more?: boolean;
+  items?: FeishuDriveCommentReply[];
+  page_token?: string;
+}>;
+
+const FEISHU_DRIVE_REQUEST_TIMEOUT_MS = 30_000;
 
 function getDriveInternalClient(client: Lark.Client): FeishuDriveInternalClient {
   return client as FeishuDriveInternalClient;
+}
+
+function encodeQuery(params: Record<string, string | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      search.set(key, trimmed);
+    }
+  }
+  const query = search.toString();
+  return query ? `?${query}` : "";
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function extractCommentElementText(element: unknown): string | undefined {
+  if (!isRecord(element)) {
+    return undefined;
+  }
+  const type = readString(element.type)?.trim();
+  if (type === "text_run" && isRecord(element.text_run)) {
+    return (
+      readString(element.text_run.content)?.trim() ||
+      readString(element.text_run.text)?.trim() ||
+      undefined
+    );
+  }
+  if (type === "mention") {
+    const mention = isRecord(element.mention) ? element.mention : undefined;
+    const mentionName =
+      readString(mention?.name)?.trim() ||
+      readString(mention?.display_name)?.trim() ||
+      readString(element.name)?.trim();
+    return mentionName ? `@${mentionName}` : "@mention";
+  }
+  if (type === "docs_link") {
+    const docsLink = isRecord(element.docs_link) ? element.docs_link : undefined;
+    return (
+      readString(docsLink?.text)?.trim() ||
+      readString(docsLink?.url)?.trim() ||
+      readString(element.text)?.trim() ||
+      readString(element.url)?.trim() ||
+      undefined
+    );
+  }
+  return (
+    readString(element.text)?.trim() ||
+    readString(element.content)?.trim() ||
+    readString(element.name)?.trim() ||
+    undefined
+  );
+}
+
+function extractReplyText(reply: FeishuDriveCommentReply | undefined): string | undefined {
+  if (!reply || !isRecord(reply.content)) {
+    return undefined;
+  }
+  const elements = Array.isArray(reply.content.elements) ? reply.content.elements : [];
+  const text = elements
+    .map(extractCommentElementText)
+    .filter((part): part is string => Boolean(part && part.trim()))
+    .join("")
+    .trim();
+  return text || undefined;
+}
+
+function buildReplyElements(content: string) {
+  return [{ type: "text", text: content }];
+}
+
+async function requestDriveApi<T>(params: {
+  client: Lark.Client;
+  method: "GET" | "POST";
+  url: string;
+  data?: unknown;
+}): Promise<T> {
+  const internalClient = getDriveInternalClient(params.client);
+  return (await internalClient.request({
+    method: params.method,
+    url: params.url,
+    data: params.data ?? {},
+    timeout: FEISHU_DRIVE_REQUEST_TIMEOUT_MS,
+  })) as T;
+}
+
+function assertDriveApiSuccess<T extends { code: number; msg?: string }>(response: T): T {
+  if (response.code !== 0) {
+    throw new Error(response.msg ?? "Feishu Drive API request failed");
+  }
+  return response;
+}
+
+function normalizeCommentReply(reply: FeishuDriveCommentReply) {
+  return {
+    reply_id: reply.reply_id,
+    user_id: reply.user_id,
+    create_time: reply.create_time,
+    update_time: reply.update_time,
+    text: extractReplyText(reply),
+  };
+}
+
+function normalizeCommentCard(comment: FeishuDriveCommentCard) {
+  const replies = comment.reply_list?.replies ?? [];
+  const rootReply = replies[0];
+  return {
+    comment_id: comment.comment_id,
+    user_id: comment.user_id,
+    create_time: comment.create_time,
+    update_time: comment.update_time,
+    is_solved: comment.is_solved,
+    is_whole: comment.is_whole,
+    quote: comment.quote,
+    text: extractReplyText(rootReply),
+    has_more_replies: comment.has_more,
+    replies_page_token: comment.page_token,
+    replies: replies.slice(1).map(normalizeCommentReply),
+  };
 }
 
 async function getRootFolderToken(client: Lark.Client): Promise<string> {
@@ -177,6 +355,154 @@ async function deleteFile(client: Lark.Client, fileToken: string, type: string) 
   };
 }
 
+async function listComments(
+  client: Lark.Client,
+  params: {
+    file_token: string;
+    file_type: CommentFileType;
+    page_size?: number;
+    page_token?: string;
+  },
+) {
+  const response = assertDriveApiSuccess(
+    await requestDriveApi<FeishuDriveListCommentsResponse>({
+      client,
+      method: "GET",
+      url:
+        `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/comments` +
+        encodeQuery({
+          file_type: params.file_type,
+          page_size:
+            typeof params.page_size === "number" && Number.isFinite(params.page_size)
+              ? String(params.page_size)
+              : undefined,
+          page_token: params.page_token,
+          user_id_type: "open_id",
+        }),
+    }),
+  );
+  return {
+    has_more: response.data?.has_more ?? false,
+    page_token: response.data?.page_token,
+    comments: (response.data?.items ?? []).map(normalizeCommentCard),
+  };
+}
+
+async function listCommentReplies(
+  client: Lark.Client,
+  params: {
+    file_token: string;
+    file_type: CommentFileType;
+    comment_id: string;
+    page_size?: number;
+    page_token?: string;
+  },
+) {
+  const response = assertDriveApiSuccess(
+    await requestDriveApi<FeishuDriveListRepliesResponse>({
+      client,
+      method: "GET",
+      url:
+        `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/comments/${encodeURIComponent(
+          params.comment_id,
+        )}/replies` +
+        encodeQuery({
+          file_type: params.file_type,
+          page_size:
+            typeof params.page_size === "number" && Number.isFinite(params.page_size)
+              ? String(params.page_size)
+              : undefined,
+          page_token: params.page_token,
+          user_id_type: "open_id",
+        }),
+    }),
+  );
+  return {
+    has_more: response.data?.has_more ?? false,
+    page_token: response.data?.page_token,
+    replies: (response.data?.items ?? []).map(normalizeCommentReply),
+  };
+}
+
+async function addComment(
+  client: Lark.Client,
+  params: {
+    file_token: string;
+    file_type: "doc" | "docx";
+    content: string;
+    block_id?: string;
+  },
+) {
+  if (params.block_id?.trim() && params.file_type !== "docx") {
+    throw new Error("block_id is only supported for docx comments");
+  }
+  const response = assertDriveApiSuccess(
+    await requestDriveApi<FeishuDriveApiResponse<Record<string, unknown>>>({
+      client,
+      method: "POST",
+      url: `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/new_comments`,
+      data: {
+        file_type: params.file_type,
+        reply_elements: buildReplyElements(params.content),
+        ...(params.block_id?.trim() ? { anchor: { block_id: params.block_id.trim() } } : {}),
+      },
+    }),
+  );
+  return {
+    success: true,
+    ...response.data,
+  };
+}
+
+export async function replyComment(
+  client: Lark.Client,
+  params: {
+    file_token: string;
+    file_type: CommentFileType;
+    comment_id: string;
+    content: string;
+  },
+) {
+  const url =
+    `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/comments/${encodeURIComponent(
+      params.comment_id,
+    )}/replies` + encodeQuery({ file_type: params.file_type });
+  const attempts: unknown[] = [
+    {
+      content: {
+        elements: [
+          {
+            type: "text_run",
+            text_run: {
+              text: params.content,
+            },
+          },
+        ],
+      },
+    },
+    {
+      reply_elements: buildReplyElements(params.content),
+    },
+  ];
+  let lastMessage = "Feishu Drive reply comment failed";
+  for (const data of attempts) {
+    const response = (await requestDriveApi<FeishuDriveApiResponse<Record<string, unknown>>>({
+      client,
+      method: "POST",
+      url,
+      data,
+    })) as FeishuDriveApiResponse<Record<string, unknown>>;
+    if (response.code === 0) {
+      return {
+        success: true,
+        ...response.data,
+      };
+    }
+    lastMessage = response.msg ?? lastMessage;
+  }
+  throw new Error(lastMessage);
+}
+
 // ============ Tool Registration ============
 
 export function registerFeishuDriveTools(api: OpenClawPluginApi) {
@@ -206,7 +532,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
         name: "feishu_drive",
         label: "Feishu Drive",
         description:
-          "Feishu cloud storage operations. Actions: list, info, create_folder, move, delete",
+          "Feishu cloud storage operations. Actions: list, info, create_folder, move, delete, list_comments, list_comment_replies, add_comment, reply_comment",
         parameters: FeishuDriveSchema,
         async execute(_toolCallId, params) {
           const p = params as FeishuDriveExecuteParams;
@@ -227,6 +553,46 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
                 return jsonToolResult(await moveFile(client, p.file_token, p.type, p.folder_token));
               case "delete":
                 return jsonToolResult(await deleteFile(client, p.file_token, p.type));
+              case "list_comments": {
+                api.logger.info?.(
+                  `feishu_drive: list_comments file=${p.file_type}:${p.file_token} page_token=${p.page_token ?? "none"}`,
+                );
+                const result = await listComments(client, p);
+                api.logger.info?.(
+                  `feishu_drive: list_comments resolved count=${result.comments.length} has_more=${result.has_more ? "yes" : "no"}`,
+                );
+                return jsonToolResult(result);
+              }
+              case "list_comment_replies": {
+                api.logger.info?.(
+                  `feishu_drive: list_comment_replies file=${p.file_type}:${p.file_token} comment=${p.comment_id} page_token=${p.page_token ?? "none"}`,
+                );
+                const result = await listCommentReplies(client, p);
+                api.logger.info?.(
+                  `feishu_drive: list_comment_replies resolved count=${result.replies.length} has_more=${result.has_more ? "yes" : "no"}`,
+                );
+                return jsonToolResult(result);
+              }
+              case "add_comment": {
+                api.logger.info?.(
+                  `feishu_drive: add_comment file=${p.file_type}:${p.file_token} block=${p.block_id ?? "whole"} chars=${p.content.length}`,
+                );
+                const result = await addComment(client, p);
+                api.logger.info?.(
+                  `feishu_drive: add_comment success comment=${String((result as { comment_id?: unknown }).comment_id ?? "unknown")}`,
+                );
+                return jsonToolResult(result);
+              }
+              case "reply_comment": {
+                api.logger.info?.(
+                  `feishu_drive: reply_comment file=${p.file_type}:${p.file_token} comment=${p.comment_id} chars=${p.content.length}`,
+                );
+                const result = await replyComment(client, p);
+                api.logger.info?.(
+                  `feishu_drive: reply_comment success reply=${String((result as { reply_id?: unknown }).reply_id ?? "unknown")}`,
+                );
+                return jsonToolResult(result);
+              }
               default:
                 return unknownToolActionResult((p as { action?: unknown }).action);
             }

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -12,6 +12,7 @@ import {
 import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
 import { maybeHandleFeishuQuickActionMenu } from "./card-ux-launcher.js";
 import { createEventDispatcher } from "./client.js";
+import { handleFeishuCommentEvent } from "./comment-handler.js";
 import {
   hasProcessedFeishuMessage,
   recordProcessedFeishuMessage,
@@ -21,6 +22,7 @@ import {
 } from "./dedup.js";
 import { isMentionForwardRequest } from "./mention.js";
 import { applyBotIdentityState, startBotIdentityRecovery } from "./monitor.bot-identity.js";
+import { parseFeishuDriveCommentNoticeEventPayload } from "./monitor.comment.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
@@ -597,6 +599,38 @@ function registerEventHandlers(
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot removed event: ${String(err)}`);
       }
+    },
+    "drive.notice.comment_add_v1": async (data: unknown) => {
+      await runFeishuHandler({
+        errorMessage: `feishu[${accountId}]: error handling drive comment notice`,
+        task: async () => {
+          log(
+            `feishu[${accountId}]: received drive comment raw payload ` + `${JSON.stringify(data)}`,
+          );
+          const event = parseFeishuDriveCommentNoticeEventPayload(data);
+          if (!event) {
+            error(`feishu[${accountId}]: ignoring malformed drive comment notice payload`);
+            return;
+          }
+          log(
+            `feishu[${accountId}]: received drive comment notice ` +
+              `event=${event.event_id ?? "unknown"} ` +
+              `type=${event.notice_meta?.notice_type ?? "unknown"} ` +
+              `file=${event.notice_meta?.file_type ?? "unknown"}:${event.notice_meta?.file_token ?? "unknown"} ` +
+              `comment=${event.comment_id ?? "unknown"} ` +
+              `reply=${event.reply_id ?? "none"} ` +
+              `from=${event.notice_meta?.from_user_id?.open_id ?? "unknown"} ` +
+              `mentioned=${event.is_mentioned === true ? "yes" : "no"}`,
+          );
+          await handleFeishuCommentEvent({
+            cfg,
+            accountId,
+            event,
+            botOpenId: botOpenIds.get(accountId),
+            runtime,
+          });
+        },
+      });
     },
     "im.message.reaction.created_v1": async (data) => {
       await runFeishuHandler({

--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -1,0 +1,373 @@
+import { hasControlCommand } from "openclaw/plugin-sdk/command-auth";
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "openclaw/plugin-sdk/reply-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPluginRuntimeMock } from "../../../test/helpers/plugins/plugin-runtime-mock.js";
+import { createNonExitingTypedRuntimeEnv } from "../../../test/helpers/plugins/runtime-env.js";
+import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
+import type { FeishuMessageEvent } from "./bot.js";
+import { monitorSingleAccount } from "./monitor.account.js";
+import {
+  resolveDriveCommentSyntheticEvent,
+  type FeishuDriveCommentNoticeEvent,
+} from "./monitor.comment.js";
+import { setFeishuRuntime } from "./runtime.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+
+const handleFeishuCommentEventMock = vi.hoisted(() => vi.fn(async () => {}));
+const createEventDispatcherMock = vi.hoisted(() => vi.fn());
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const monitorWebSocketMock = vi.hoisted(() => vi.fn(async () => {}));
+const monitorWebhookMock = vi.hoisted(() => vi.fn(async () => {}));
+const createFeishuThreadBindingManagerMock = vi.hoisted(() => vi.fn(() => ({ stop: vi.fn() })));
+
+let handlers: Record<string, (data: unknown) => Promise<void>> = {};
+
+vi.mock("./client.js", () => ({
+  createEventDispatcher: createEventDispatcherMock,
+  createFeishuClient: createFeishuClientMock,
+}));
+
+vi.mock("./comment-handler.js", () => ({
+  handleFeishuCommentEvent: handleFeishuCommentEventMock,
+}));
+
+vi.mock("./monitor.transport.js", () => ({
+  monitorWebSocket: monitorWebSocketMock,
+  monitorWebhook: monitorWebhookMock,
+}));
+
+vi.mock("./thread-bindings.js", () => ({
+  createFeishuThreadBindingManager: createFeishuThreadBindingManagerMock,
+}));
+
+function buildMonitorConfig(): ClawdbotConfig {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+      },
+    },
+  } as ClawdbotConfig;
+}
+
+function buildMonitorAccount(): ResolvedFeishuAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    appId: "cli_test",
+    appSecret: "secret_test", // pragma: allowlist secret
+    domain: "feishu",
+    config: {
+      enabled: true,
+      connectionMode: "websocket",
+    },
+  } as ResolvedFeishuAccount;
+}
+
+function makeDriveCommentEvent(
+  overrides: Partial<FeishuDriveCommentNoticeEvent> = {},
+): FeishuDriveCommentNoticeEvent {
+  return {
+    comment_id: "7623358762119646411",
+    event_id: "10d9d60b990db39f96a4c2fd357fb877",
+    is_mentioned: true,
+    notice_meta: {
+      file_token: "GS9sdtIlOonqKSx2PtrcRqgCnBe",
+      file_type: "docx",
+      from_user_id: {
+        open_id: "ou_509d4d7ace4a9addec2312676ffcba9b",
+      },
+      notice_type: "add_comment",
+      to_user_id: {
+        open_id: "ou_bot",
+      },
+    },
+    reply_id: "7623358762136374451",
+    timestamp: "1774951528000",
+    type: "drive.notice.comment_add_v1",
+    ...overrides,
+  };
+}
+
+function makeOpenApiClient(params: {
+  documentTitle?: string;
+  documentUrl?: string;
+  quoteText?: string;
+  rootReplyText?: string;
+  targetReplyText?: string;
+  includeTargetReplyInBatch?: boolean;
+}) {
+  return {
+    request: vi.fn(async (request: { method: "GET" | "POST"; url: string; data: unknown }) => {
+      if (request.url === "/open-apis/drive/v1/metas/batch_query") {
+        return {
+          code: 0,
+          data: {
+            metas: [
+              {
+                doc_token: "GS9sdtIlOonqKSx2PtrcRqgCnBe",
+                title: params.documentTitle ?? "评论事件处理需求",
+                url:
+                  params.documentUrl ??
+                  "https://bytedance.larkoffice.com/docx/ZE56dawdDoGb0xxxVcbcmpfinZc",
+              },
+            ],
+          },
+        };
+      }
+      if (request.url.includes("/comments/batch_query")) {
+        return {
+          code: 0,
+          data: {
+            items: [
+              {
+                comment_id: "7623358762119646411",
+                quote: params.quoteText ?? "im.message.receive_v1 消息触发实现",
+                reply_list: {
+                  replies: [
+                    {
+                      reply_id: "7623358762136374451",
+                      content: {
+                        elements: [
+                          {
+                            type: "text_run",
+                            text_run: {
+                              content: params.rootReplyText ?? "收到评论事件后，也发送给agent",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                    ...(params.includeTargetReplyInBatch
+                      ? [
+                          {
+                            reply_id: "7623359125036043462",
+                            content: {
+                              elements: [
+                                {
+                                  type: "text_run",
+                                  text_run: {
+                                    content: params.targetReplyText ?? "跟进处理一下这个评论",
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        ]
+                      : []),
+                  ],
+                },
+              },
+            ],
+          },
+        };
+      }
+      if (request.url.includes("/replies")) {
+        return {
+          code: 0,
+          data: {
+            has_more: false,
+            items: [
+              {
+                reply_id: "7623358762136374451",
+                content: {
+                  elements: [
+                    {
+                      type: "text_run",
+                      text_run: {
+                        content: params.rootReplyText ?? "收到评论事件后，也发送给agent",
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                reply_id: "7623359125036043462",
+                content: {
+                  elements: [
+                    {
+                      type: "text_run",
+                      text_run: {
+                        content: params.targetReplyText ?? "跟进处理一下这个评论",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        };
+      }
+      throw new Error(`unexpected request: ${request.method} ${request.url}`);
+    }),
+  };
+}
+
+async function setupCommentMonitorHandler(): Promise<(data: unknown) => Promise<void>> {
+  const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
+    handlers = registered;
+  });
+  createEventDispatcherMock.mockReturnValue({ register });
+
+  await monitorSingleAccount({
+    cfg: buildMonitorConfig(),
+    account: buildMonitorAccount(),
+    runtime: createNonExitingTypedRuntimeEnv<RuntimeEnv>(),
+    botOpenIdSource: {
+      kind: "prefetched",
+      botOpenId: "ou_bot",
+    },
+  });
+
+  const handler = handlers["drive.notice.comment_add_v1"];
+  if (!handler) {
+    throw new Error("missing drive.notice.comment_add_v1 handler");
+  }
+  return handler;
+}
+
+function extractSyntheticText(event: FeishuMessageEvent): string {
+  const content = JSON.parse(event.message.content) as { text?: string };
+  return content.text ?? "";
+}
+
+describe("resolveDriveCommentSyntheticEvent", () => {
+  it("builds a synthetic Feishu message for add_comment notices", async () => {
+    const client = makeOpenApiClient({ includeTargetReplyInBatch: true });
+
+    const synthetic = await resolveDriveCommentSyntheticEvent({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent(),
+      botOpenId: "ou_bot",
+      createClient: () => client as never,
+    });
+
+    expect(synthetic).not.toBeNull();
+    expect(synthetic?.sender.sender_id.open_id).toBe("ou_509d4d7ace4a9addec2312676ffcba9b");
+    expect(synthetic?.message.message_id).toBe("drive-comment:10d9d60b990db39f96a4c2fd357fb877");
+    expect(synthetic?.message.chat_id).toBe("p2p:ou_509d4d7ace4a9addec2312676ffcba9b");
+    expect(synthetic?.message.chat_type).toBe("p2p");
+    expect(synthetic?.message.create_time).toBe("1774951528000");
+
+    const text = extractSyntheticText(synthetic as FeishuMessageEvent);
+    expect(text).toContain(
+      'I added a comment in "评论事件处理需求": 收到评论事件后，也发送给agent',
+    );
+    expect(text).toContain("收到评论事件后，也发送给agent");
+    expect(text).toContain("Quoted content: im.message.receive_v1 消息触发实现");
+    expect(text).toContain("This comment mentioned you.");
+    expect(text).toContain(
+      "This is a Feishu document comment event, not a normal instant-message conversation.",
+    );
+    expect(text).toContain("feishu_drive.reply_comment");
+    expect(text).toContain(
+      "reply with the answer in that comment thread via feishu_drive.reply_comment",
+    );
+    expect(text).toContain(
+      "after finishing also use feishu_drive.reply_comment in that comment thread to tell the user the update is complete",
+    );
+    expect(text).toContain(
+      "keep it in the same language as the user's original comment or reply unless they explicitly ask for another language",
+    );
+    expect(text).toContain("output only NO_REPLY at the end");
+  });
+
+  it("falls back to the replies API to resolve add_reply text", async () => {
+    const client = makeOpenApiClient({
+      includeTargetReplyInBatch: false,
+      targetReplyText: "跟进处理一下这个评论",
+    });
+
+    const synthetic = await resolveDriveCommentSyntheticEvent({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent({
+        notice_meta: {
+          ...makeDriveCommentEvent().notice_meta,
+          notice_type: "add_reply",
+        },
+        reply_id: "7623359125036043462",
+      }),
+      botOpenId: "ou_bot",
+      createClient: () => client as never,
+    });
+
+    const text = extractSyntheticText(synthetic as FeishuMessageEvent);
+    expect(text).toContain('I added a reply in "评论事件处理需求": 跟进处理一下这个评论');
+    expect(text).toContain("Original comment: 收到评论事件后，也发送给agent");
+    expect(text).toContain("file_token: GS9sdtIlOonqKSx2PtrcRqgCnBe");
+    expect(text).toContain("Event type: add_reply");
+    expect(text).toContain(
+      "keep it in the same language as the user's original comment or reply unless they explicitly ask for another language",
+    );
+  });
+
+  it("ignores self-authored comment notices", async () => {
+    const synthetic = await resolveDriveCommentSyntheticEvent({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent({
+        notice_meta: {
+          ...makeDriveCommentEvent().notice_meta,
+          from_user_id: { open_id: "ou_bot" },
+        },
+      }),
+      botOpenId: "ou_bot",
+      createClient: () => makeOpenApiClient({}) as never,
+    });
+
+    expect(synthetic).toBeNull();
+  });
+});
+
+describe("drive.notice.comment_add_v1 monitor handler", () => {
+  beforeEach(() => {
+    handlers = {};
+    handleFeishuCommentEventMock.mockClear();
+    createEventDispatcherMock.mockReset();
+    createFeishuClientMock.mockReset().mockReturnValue(makeOpenApiClient({}) as never);
+    createFeishuThreadBindingManagerMock.mockReset().mockImplementation(() => ({
+      stop: vi.fn(),
+    }));
+    setFeishuRuntime(
+      createPluginRuntimeMock({
+        channel: {
+          debounce: {
+            resolveInboundDebounceMs,
+            createInboundDebouncer,
+          },
+          text: {
+            hasControlCommand,
+          },
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches comment notices through handleFeishuCommentEvent", async () => {
+    const onComment = await setupCommentMonitorHandler();
+
+    await onComment(makeDriveCommentEvent());
+
+    expect(handleFeishuCommentEventMock).toHaveBeenCalledTimes(1);
+    expect(handleFeishuCommentEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        botOpenId: "ou_bot",
+        event: expect.objectContaining({
+          event_id: "10d9d60b990db39f96a4c2fd357fb877",
+          comment_id: "7623358762119646411",
+        }),
+      }),
+    );
+  });
+});

--- a/extensions/feishu/src/monitor.comment.ts
+++ b/extensions/feishu/src/monitor.comment.ts
@@ -1,0 +1,761 @@
+import type { ClawdbotConfig } from "../runtime-api.js";
+import { resolveFeishuAccount } from "./accounts.js";
+import { raceWithTimeoutAndAbort } from "./async.js";
+import type { FeishuMessageEvent } from "./bot.js";
+import { createFeishuClient } from "./client.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+
+const FEISHU_COMMENT_VERIFY_TIMEOUT_MS = 3_000;
+const FEISHU_COMMENT_REPLY_PAGE_SIZE = 200;
+const FEISHU_COMMENT_REPLY_PAGE_LIMIT = 5;
+
+type FeishuDriveCommentUserId = {
+  open_id?: string;
+  user_id?: string;
+  union_id?: string;
+};
+
+export type FeishuDriveCommentNoticeEvent = {
+  comment_id?: string;
+  event_id?: string;
+  is_mentioned?: boolean;
+  notice_meta?: {
+    file_token?: string;
+    file_type?: string;
+    from_user_id?: FeishuDriveCommentUserId;
+    notice_type?: string;
+    to_user_id?: FeishuDriveCommentUserId;
+  };
+  reply_id?: string;
+  timestamp?: string;
+  type?: string;
+};
+
+type ResolveDriveCommentSyntheticEventParams = {
+  cfg: ClawdbotConfig;
+  accountId: string;
+  event: FeishuDriveCommentNoticeEvent;
+  botOpenId?: string;
+  createClient?: (account: ResolvedFeishuAccount) => FeishuRequestClient;
+  verificationTimeoutMs?: number;
+  logger?: (message: string) => void;
+};
+
+export type ResolvedDriveCommentEventTurn = {
+  eventId: string;
+  messageId: string;
+  commentId: string;
+  replyId?: string;
+  noticeType: "add_comment" | "add_reply";
+  fileToken: string;
+  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  senderId: string;
+  timestamp?: string;
+  isMentioned?: boolean;
+  documentTitle?: string;
+  documentUrl?: string;
+  quoteText?: string;
+  rootCommentText?: string;
+  targetReplyText?: string;
+  prompt: string;
+  preview: string;
+};
+
+type FeishuRequestClient = ReturnType<typeof createFeishuClient> & {
+  request(params: {
+    method: "GET" | "POST";
+    url: string;
+    data: unknown;
+    timeout: number;
+  }): Promise<unknown>;
+};
+
+type FeishuOpenApiResponse<T> = {
+  code?: number;
+  msg?: string;
+  data?: T;
+};
+
+type FeishuDriveMetaBatchQueryResponse = FeishuOpenApiResponse<{
+  metas?: Array<{
+    doc_token?: string;
+    title?: string;
+    url?: string;
+  }>;
+}>;
+
+type FeishuDriveCommentReply = {
+  reply_id?: string;
+  content?: {
+    elements?: unknown[];
+  };
+};
+
+type FeishuDriveCommentCard = {
+  comment_id?: string;
+  has_more?: boolean;
+  quote?: string;
+  reply_list?: {
+    replies?: FeishuDriveCommentReply[];
+  };
+};
+
+type FeishuDriveCommentBatchQueryResponse = FeishuOpenApiResponse<{
+  items?: FeishuDriveCommentCard[];
+}>;
+
+type FeishuDriveCommentRepliesListResponse = FeishuOpenApiResponse<{
+  has_more?: boolean;
+  items?: FeishuDriveCommentReply[];
+  page_token?: string;
+}>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function normalizeDriveCommentFileType(
+  value: unknown,
+): "doc" | "docx" | "file" | "sheet" | "slides" | undefined {
+  return value === "doc" ||
+    value === "docx" ||
+    value === "file" ||
+    value === "sheet" ||
+    value === "slides"
+    ? value
+    : undefined;
+}
+
+function encodeQuery(params: Record<string, string | undefined>): string {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      query.set(key, trimmed);
+    }
+  }
+  const queryString = query.toString();
+  return queryString ? `?${queryString}` : "";
+}
+
+function buildDriveCommentTargetUrl(params: {
+  fileToken: string;
+  commentId: string;
+  fileType: string;
+}): string {
+  return (
+    `/open-apis/drive/v1/files/${encodeURIComponent(params.fileToken)}/comments/batch_query` +
+    encodeQuery({
+      file_type: params.fileType,
+      user_id_type: "open_id",
+    })
+  );
+}
+
+function buildDriveCommentRepliesUrl(params: {
+  fileToken: string;
+  commentId: string;
+  fileType: string;
+  pageToken?: string;
+}): string {
+  return (
+    `/open-apis/drive/v1/files/${encodeURIComponent(params.fileToken)}/comments/${encodeURIComponent(
+      params.commentId,
+    )}/replies` +
+    encodeQuery({
+      file_type: params.fileType,
+      page_token: params.pageToken,
+      page_size: String(FEISHU_COMMENT_REPLY_PAGE_SIZE),
+      user_id_type: "open_id",
+    })
+  );
+}
+
+async function requestFeishuOpenApi<T>(params: {
+  client: FeishuRequestClient;
+  method: "GET" | "POST";
+  url: string;
+  data?: unknown;
+  timeoutMs: number;
+  logger?: (message: string) => void;
+  errorLabel: string;
+}): Promise<T | null> {
+  const result = await raceWithTimeoutAndAbort(
+    params.client.request({
+      method: params.method,
+      url: params.url,
+      data: params.data ?? {},
+      timeout: params.timeoutMs,
+    }) as Promise<T>,
+    { timeoutMs: params.timeoutMs },
+  )
+    .then((resolved) => (resolved.status === "resolved" ? resolved.value : null))
+    .catch((error) => {
+      params.logger?.(`${params.errorLabel}: ${String(error)}`);
+      return null;
+    });
+  if (!result) {
+    params.logger?.(`${params.errorLabel}: request timed out or returned no data`);
+  }
+  return result;
+}
+
+function extractCommentElementText(element: unknown): string | undefined {
+  if (!isRecord(element)) {
+    return undefined;
+  }
+  const type = readString(element.type)?.trim();
+  if (type === "text_run" && isRecord(element.text_run)) {
+    return (
+      readString(element.text_run.content)?.trim() ||
+      readString(element.text_run.text)?.trim() ||
+      undefined
+    );
+  }
+  if (type === "mention") {
+    const mention = isRecord(element.mention) ? element.mention : undefined;
+    const mentionName =
+      readString(mention?.name)?.trim() ||
+      readString(mention?.display_name)?.trim() ||
+      readString(element.name)?.trim();
+    return mentionName ? `@${mentionName}` : "@mention";
+  }
+  if (type === "docs_link") {
+    const docsLink = isRecord(element.docs_link) ? element.docs_link : undefined;
+    return (
+      readString(docsLink?.text)?.trim() ||
+      readString(docsLink?.url)?.trim() ||
+      readString(element.text)?.trim() ||
+      readString(element.url)?.trim() ||
+      undefined
+    );
+  }
+  return (
+    readString(element.text)?.trim() ||
+    readString(element.content)?.trim() ||
+    readString(element.name)?.trim() ||
+    undefined
+  );
+}
+
+function extractReplyText(reply: FeishuDriveCommentReply | undefined): string | undefined {
+  if (!reply || !isRecord(reply.content)) {
+    return undefined;
+  }
+  const elements = Array.isArray(reply.content.elements) ? reply.content.elements : [];
+  const parts = elements
+    .map(extractCommentElementText)
+    .filter((part): part is string => Boolean(part && part.trim()));
+  const text = parts.join("").trim();
+  return text || undefined;
+}
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    return JSON.stringify({
+      error: `stringify_failed:${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+}
+
+function summarizeReplyForLog(reply: FeishuDriveCommentReply | undefined) {
+  return {
+    reply_id: reply?.reply_id,
+    text: extractReplyText(reply),
+  };
+}
+
+async function fetchDriveCommentReplies(params: {
+  client: FeishuRequestClient;
+  fileToken: string;
+  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  commentId: string;
+  timeoutMs: number;
+  logger?: (message: string) => void;
+  accountId: string;
+}): Promise<FeishuDriveCommentReply[]> {
+  const replies: FeishuDriveCommentReply[] = [];
+  let pageToken: string | undefined;
+  for (let page = 0; page < FEISHU_COMMENT_REPLY_PAGE_LIMIT; page += 1) {
+    const response = await requestFeishuOpenApi<FeishuDriveCommentRepliesListResponse>({
+      client: params.client,
+      method: "GET",
+      url: buildDriveCommentRepliesUrl({
+        fileToken: params.fileToken,
+        commentId: params.commentId,
+        fileType: params.fileType,
+        pageToken,
+      }),
+      timeoutMs: params.timeoutMs,
+      logger: params.logger,
+      errorLabel: `feishu[${params.accountId}]: failed to fetch comment replies for ${params.commentId}`,
+    });
+    if (response?.code !== 0) {
+      if (response) {
+        params.logger?.(
+          `feishu[${params.accountId}]: failed to fetch comment replies for ${params.commentId}: ${response.msg ?? "unknown error"}`,
+        );
+      }
+      break;
+    }
+    params.logger?.(
+      `feishu[${params.accountId}]: fetched comment replies page=${page + 1} ` +
+        `comment=${params.commentId} raw=${safeJsonStringify(response?.data?.items ?? [])}`,
+    );
+    replies.push(...(response.data?.items ?? []));
+    if (response.data?.has_more !== true || !response.data.page_token?.trim()) {
+      break;
+    }
+    pageToken = response.data.page_token.trim();
+  }
+  return replies;
+}
+
+async function fetchDriveCommentContext(params: {
+  client: FeishuRequestClient;
+  fileToken: string;
+  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  commentId: string;
+  replyId?: string;
+  timeoutMs: number;
+  logger?: (message: string) => void;
+  accountId: string;
+}): Promise<{
+  documentTitle?: string;
+  documentUrl?: string;
+  quoteText?: string;
+  rootCommentText?: string;
+  targetReplyText?: string;
+}> {
+  const [metaResponse, commentResponse] = await Promise.all([
+    requestFeishuOpenApi<FeishuDriveMetaBatchQueryResponse>({
+      client: params.client,
+      method: "POST",
+      url: "/open-apis/drive/v1/metas/batch_query",
+      data: {
+        request_docs: [{ doc_token: params.fileToken, doc_type: params.fileType }],
+        with_url: true,
+      },
+      timeoutMs: params.timeoutMs,
+      logger: params.logger,
+      errorLabel: `feishu[${params.accountId}]: failed to fetch drive metadata for ${params.fileToken}`,
+    }),
+    requestFeishuOpenApi<FeishuDriveCommentBatchQueryResponse>({
+      client: params.client,
+      method: "POST",
+      url: buildDriveCommentTargetUrl({
+        fileToken: params.fileToken,
+        commentId: params.commentId,
+        fileType: params.fileType,
+      }),
+      data: {
+        comment_ids: [params.commentId],
+      },
+      timeoutMs: params.timeoutMs,
+      logger: params.logger,
+      errorLabel: `feishu[${params.accountId}]: failed to fetch drive comment ${params.commentId}`,
+    }),
+  ]);
+
+  const commentCard =
+    commentResponse?.code === 0
+      ? ((commentResponse.data?.items ?? []).find(
+          (item) => item.comment_id?.trim() === params.commentId,
+        ) ?? commentResponse.data?.items?.[0])
+      : undefined;
+  const embeddedReplies = commentCard?.reply_list?.replies ?? [];
+  params.logger?.(
+    `feishu[${params.accountId}]: embedded comment replies comment=${params.commentId} ` +
+      `raw=${safeJsonStringify(embeddedReplies)}`,
+  );
+  const embeddedTargetReply = params.replyId
+    ? embeddedReplies.find((reply) => reply.reply_id?.trim() === params.replyId?.trim())
+    : embeddedReplies.at(-1);
+
+  let replies = embeddedReplies;
+  if (!embeddedTargetReply || replies.length === 0) {
+    const fetchedReplies = await fetchDriveCommentReplies(params);
+    if (fetchedReplies.length > 0) {
+      replies = fetchedReplies;
+    }
+  }
+
+  const rootReply = replies[0] ?? embeddedReplies[0];
+  const fetchedMatchedReply = params.replyId
+    ? replies.find((reply) => reply.reply_id?.trim() === params.replyId?.trim())
+    : undefined;
+  const targetReply = params.replyId
+    ? (embeddedTargetReply ?? fetchedMatchedReply ?? undefined)
+    : ((replies.at(-1) ?? embeddedTargetReply ?? rootReply) as FeishuDriveCommentReply | undefined);
+  const matchSource = params.replyId
+    ? embeddedTargetReply
+      ? "embedded"
+      : fetchedMatchedReply
+        ? "fetched"
+        : "miss"
+    : targetReply === rootReply
+      ? "fallback_root"
+      : targetReply === embeddedTargetReply
+        ? "embedded_latest"
+        : "fetched_latest";
+  params.logger?.(
+    `feishu[${params.accountId}]: comment reply resolution comment=${params.commentId} ` +
+      `requested_reply=${params.replyId ?? "none"} match_source=${matchSource} ` +
+      `root=${safeJsonStringify(summarizeReplyForLog(rootReply))} ` +
+      `target=${safeJsonStringify(summarizeReplyForLog(targetReply))}`,
+  );
+  const meta = metaResponse?.code === 0 ? metaResponse.data?.metas?.[0] : undefined;
+
+  return {
+    documentTitle: meta?.title?.trim() || undefined,
+    documentUrl: meta?.url?.trim() || undefined,
+    quoteText: commentCard?.quote?.trim() || undefined,
+    rootCommentText: extractReplyText(rootReply),
+    targetReplyText: extractReplyText(targetReply),
+  };
+}
+
+function buildDriveCommentPrompt(params: {
+  noticeType: "add_comment" | "add_reply";
+  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  fileToken: string;
+  isMentioned?: boolean;
+  documentTitle?: string;
+  documentUrl?: string;
+  quoteText?: string;
+  rootCommentText?: string;
+  targetReplyText?: string;
+}): string {
+  const documentLabel = params.documentTitle
+    ? `"${params.documentTitle}"`
+    : `${params.fileType} document ${params.fileToken}`;
+  const actionLabel = params.noticeType === "add_reply" ? "reply" : "comment";
+  const firstLine = params.targetReplyText
+    ? `I added a ${actionLabel} in ${documentLabel}: ${params.targetReplyText}`
+    : `I added a ${actionLabel} in ${documentLabel}.`;
+  const lines = [firstLine];
+  if (
+    params.noticeType === "add_reply" &&
+    params.rootCommentText &&
+    params.rootCommentText !== params.targetReplyText
+  ) {
+    lines.push(`Original comment: ${params.rootCommentText}`);
+  }
+  if (params.quoteText) {
+    lines.push(`Quoted content: ${params.quoteText}`);
+  }
+  if (params.isMentioned === true) {
+    lines.push("This comment mentioned you.");
+  }
+  if (params.documentUrl) {
+    lines.push(`Document link: ${params.documentUrl}`);
+  }
+  lines.push(
+    `Event type: ${params.noticeType}`,
+    `file_token: ${params.fileToken}`,
+    `file_type: ${params.fileType}`,
+    "This is a Feishu document comment event, not a normal instant-message conversation. Do not reply directly in the current Feishu chat, and do not treat this event as something that requires sending an IM text reply.",
+    "If you need to inspect or handle the comment thread, prefer the feishu_drive tools: use list_comments / list_comment_replies to inspect comments, add_comment to add a new comment, and reply_comment to reply in the thread.",
+    "If the user asks a question in the comment, reply with the answer in that comment thread via feishu_drive.reply_comment.",
+    "If you modify the document, after finishing also use feishu_drive.reply_comment in that comment thread to tell the user the update is complete.",
+    "If you decide to add a new comment in the document, use feishu_drive.add_comment; if you decide to reply in the current comment thread, use feishu_drive.reply_comment.",
+    "When you produce a user-visible reply, keep it in the same language as the user's original comment or reply unless they explicitly ask for another language.",
+    "After comment-related tool calls have completed the user-visible action, output only NO_REPLY at the end to avoid sending an extra instant message; do not output the final answer directly as a normal chat reply.",
+  );
+  lines.push(`Decide what to do next based on this document ${actionLabel} event.`);
+  return lines.join("\n");
+}
+
+function buildDriveCommentSurfacePrompt(params: {
+  noticeType: "add_comment" | "add_reply";
+  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  fileToken: string;
+  commentId: string;
+  replyId?: string;
+  isMentioned?: boolean;
+  documentTitle?: string;
+  documentUrl?: string;
+  quoteText?: string;
+  rootCommentText?: string;
+  targetReplyText?: string;
+}): string {
+  const documentLabel = params.documentTitle
+    ? `"${params.documentTitle}"`
+    : `${params.fileType} document ${params.fileToken}`;
+  const actionLabel = params.noticeType === "add_reply" ? "reply" : "comment";
+  const firstLine = params.targetReplyText
+    ? `The user added a ${actionLabel} in ${documentLabel}: ${params.targetReplyText}`
+    : `The user added a ${actionLabel} in ${documentLabel}.`;
+  const lines = [firstLine];
+  if (
+    params.noticeType === "add_reply" &&
+    params.rootCommentText &&
+    params.rootCommentText !== params.targetReplyText
+  ) {
+    lines.push(`Original comment: ${params.rootCommentText}`);
+  }
+  if (params.quoteText) {
+    lines.push(`Quoted content: ${params.quoteText}`);
+  }
+  if (params.isMentioned === true) {
+    lines.push("This comment mentioned you.");
+  }
+  if (params.documentUrl) {
+    lines.push(`Document link: ${params.documentUrl}`);
+  }
+  lines.push(
+    `Event type: ${params.noticeType}`,
+    `file_token: ${params.fileToken}`,
+    `file_type: ${params.fileType}`,
+    `comment_id: ${params.commentId}`,
+  );
+  if (params.replyId?.trim()) {
+    lines.push(`reply_id: ${params.replyId.trim()}`);
+  }
+  lines.push(
+    "This is a Feishu document comment-thread event, not a Feishu IM conversation. Your final text reply will be posted automatically to the current comment thread and will not be sent as an instant message.",
+    "If you need to inspect or handle the comment thread, prefer the feishu_drive tools: use list_comments / list_comment_replies to inspect comments, and use reply_comment/add_comment to notify the user after modifying the document.",
+    'If the comment asks you to modify document content, such as adding, inserting, replacing, or deleting text, tables, or headings, you must first use feishu_doc to actually modify the document. Do not reply with only "done", "I\'ll handle it", or a restated plan without calling tools.',
+    'If the comment quotes document content, that quoted text is usually the edit anchor. For requests like "insert xxx below this content", first locate the position around the quoted content, then use feishu_doc to make the change.',
+    'If the comment asks you to summarize, explain, rewrite, translate, refine, continue, or review the document content "below", "above", "this paragraph", "this section", or the quoted content, you must also treat the quoted content as the primary target anchor instead of defaulting to the whole document.',
+    'For requests like "summarize the content below", "explain this section", or "continue writing from here", first locate the relevant document fragment based on the comment\'s quoted content. If the quote is not sufficient to support the answer, then use feishu_doc.read or feishu_doc.list_blocks to read nearby context.',
+    "Do not guess document content based only on the comment text, and do not output a vague summary before reading enough context. Unless the user explicitly asks to summarize the entire document, default to handling only the local scope related to the quoted content.",
+    "When document edits are involved, first use feishu_doc.read or feishu_doc.list_blocks to confirm the context, then use feishu_doc writing or updating capabilities to complete the change. After the edit succeeds, notify the user through feishu_drive.reply_comment.",
+    "If the document edit fails or you cannot locate the anchor, do not pretend it succeeded. Reply clearly in the comment thread with the reason for failure or the missing information.",
+    "If this is a reading-comprehension task, such as summarization, explanation, or extraction, you may directly output the final answer text after confirming the context. The system will automatically reply with that answer in the current comment thread.",
+    "When you produce a user-visible reply, keep it in the same language as the user's original comment or reply unless they explicitly ask for another language.",
+    "If you have already completed the user-visible action through feishu_drive.reply_comment or feishu_drive.add_comment, output NO_REPLY at the end to avoid duplicate sending.",
+    "If the user directly asks a question in the comment and a plain text answer is sufficient, output the answer text directly. The system will automatically reply with your final answer in the current comment thread.",
+    "If you determine that the current comment does not require any user-visible action, output NO_REPLY at the end.",
+  );
+  lines.push(`Decide what to do next based on this document ${actionLabel} event.`);
+  return lines.join("\n");
+}
+
+async function resolveDriveCommentEventCore(
+  params: ResolveDriveCommentSyntheticEventParams,
+): Promise<{
+  eventId: string;
+  commentId: string;
+  replyId?: string;
+  noticeType: "add_comment" | "add_reply";
+  fileToken: string;
+  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  senderId: string;
+  timestamp?: string;
+  isMentioned?: boolean;
+  context: {
+    documentTitle?: string;
+    documentUrl?: string;
+    quoteText?: string;
+    rootCommentText?: string;
+    targetReplyText?: string;
+  };
+} | null> {
+  const {
+    cfg,
+    accountId,
+    event,
+    botOpenId,
+    createClient = (account) => createFeishuClient(account) as FeishuRequestClient,
+    verificationTimeoutMs = FEISHU_COMMENT_VERIFY_TIMEOUT_MS,
+    logger,
+  } = params;
+  const eventId = event.event_id?.trim();
+  const commentId = event.comment_id?.trim();
+  const replyId = event.reply_id?.trim();
+  const noticeType = event.notice_meta?.notice_type?.trim();
+  const fileToken = event.notice_meta?.file_token?.trim();
+  const fileType = normalizeDriveCommentFileType(event.notice_meta?.file_type);
+  const senderId = event.notice_meta?.from_user_id?.open_id?.trim();
+  if (!eventId || !commentId || !noticeType || !fileToken || !fileType || !senderId) {
+    logger?.(
+      `feishu[${accountId}]: drive comment notice missing required fields ` +
+        `event=${eventId ?? "unknown"} comment=${commentId ?? "unknown"}`,
+    );
+    return null;
+  }
+  if (noticeType !== "add_comment" && noticeType !== "add_reply") {
+    logger?.(
+      `feishu[${accountId}]: unsupported drive comment notice type ${noticeType} ` +
+        `for event ${eventId}`,
+    );
+    return null;
+  }
+  if (senderId === botOpenId) {
+    logger?.(
+      `feishu[${accountId}]: ignoring self-authored drive comment notice ` +
+        `event=${eventId} sender=${senderId}`,
+    );
+    return null;
+  }
+
+  const account = resolveFeishuAccount({ cfg, accountId });
+  const client = createClient(account);
+  logger?.(
+    `feishu[${accountId}]: fetching drive comment context ` +
+      `event=${eventId} type=${noticeType} file=${fileType}:${fileToken} comment=${commentId} reply=${replyId ?? "none"}`,
+  );
+  const context = await fetchDriveCommentContext({
+    client,
+    fileToken,
+    fileType,
+    commentId,
+    replyId,
+    timeoutMs: verificationTimeoutMs,
+    logger,
+    accountId,
+  });
+  logger?.(
+    `feishu[${accountId}]: drive comment context resolved ` +
+      `event=${eventId} title=${context.documentTitle ?? "unknown"} ` +
+      `quote=${context.quoteText ? "yes" : "no"} root=${context.rootCommentText ? "yes" : "no"} ` +
+      `target=${context.targetReplyText ? "yes" : "no"}`,
+  );
+  return {
+    eventId,
+    commentId,
+    replyId,
+    noticeType,
+    fileToken,
+    fileType,
+    senderId,
+    timestamp: event.timestamp,
+    isMentioned: event.is_mentioned,
+    context,
+  };
+}
+
+export function parseFeishuDriveCommentNoticeEventPayload(
+  value: unknown,
+): FeishuDriveCommentNoticeEvent | null {
+  if (!isRecord(value) || !isRecord(value.notice_meta)) {
+    return null;
+  }
+  const noticeMeta = value.notice_meta;
+  const fromUserId = isRecord(noticeMeta.from_user_id) ? noticeMeta.from_user_id : undefined;
+  const toUserId = isRecord(noticeMeta.to_user_id) ? noticeMeta.to_user_id : undefined;
+  return {
+    comment_id: readString(value.comment_id),
+    event_id: readString(value.event_id),
+    is_mentioned: readBoolean(value.is_mentioned),
+    notice_meta: {
+      file_token: readString(noticeMeta.file_token),
+      file_type: readString(noticeMeta.file_type),
+      from_user_id: fromUserId
+        ? {
+            open_id: readString(fromUserId.open_id),
+            user_id: readString(fromUserId.user_id),
+            union_id: readString(fromUserId.union_id),
+          }
+        : undefined,
+      notice_type: readString(noticeMeta.notice_type),
+      to_user_id: toUserId
+        ? {
+            open_id: readString(toUserId.open_id),
+            user_id: readString(toUserId.user_id),
+            union_id: readString(toUserId.union_id),
+          }
+        : undefined,
+    },
+    reply_id: readString(value.reply_id),
+    timestamp: readString(value.timestamp),
+    type: readString(value.type),
+  };
+}
+
+export async function resolveDriveCommentEventTurn(
+  params: ResolveDriveCommentSyntheticEventParams,
+): Promise<ResolvedDriveCommentEventTurn | null> {
+  const resolved = await resolveDriveCommentEventCore(params);
+  if (!resolved) {
+    return null;
+  }
+  const prompt = buildDriveCommentSurfacePrompt({
+    noticeType: resolved.noticeType,
+    fileType: resolved.fileType,
+    fileToken: resolved.fileToken,
+    commentId: resolved.commentId,
+    replyId: resolved.replyId,
+    isMentioned: resolved.isMentioned,
+    documentTitle: resolved.context.documentTitle,
+    documentUrl: resolved.context.documentUrl,
+    quoteText: resolved.context.quoteText,
+    rootCommentText: resolved.context.rootCommentText,
+    targetReplyText: resolved.context.targetReplyText,
+  });
+  const preview = prompt.replace(/\s+/g, " ").slice(0, 160);
+  params.logger?.(
+    `feishu[${params.accountId}]: built drive comment prompt ` +
+      `event=${resolved.eventId} preview=${preview}`,
+  );
+  return {
+    eventId: resolved.eventId,
+    messageId: `drive-comment:${resolved.eventId}`,
+    commentId: resolved.commentId,
+    replyId: resolved.replyId,
+    noticeType: resolved.noticeType,
+    fileToken: resolved.fileToken,
+    fileType: resolved.fileType,
+    senderId: resolved.senderId,
+    timestamp: resolved.timestamp,
+    isMentioned: resolved.isMentioned,
+    documentTitle: resolved.context.documentTitle,
+    documentUrl: resolved.context.documentUrl,
+    quoteText: resolved.context.quoteText,
+    rootCommentText: resolved.context.rootCommentText,
+    targetReplyText: resolved.context.targetReplyText,
+    prompt,
+    preview,
+  };
+}
+
+export async function resolveDriveCommentSyntheticEvent(
+  params: ResolveDriveCommentSyntheticEventParams,
+): Promise<FeishuMessageEvent | null> {
+  const resolved = await resolveDriveCommentEventCore(params);
+  if (!resolved) {
+    return null;
+  }
+  const prompt = buildDriveCommentPrompt({
+    noticeType: resolved.noticeType,
+    fileType: resolved.fileType,
+    fileToken: resolved.fileToken,
+    isMentioned: resolved.isMentioned,
+    documentTitle: resolved.context.documentTitle,
+    documentUrl: resolved.context.documentUrl,
+    quoteText: resolved.context.quoteText,
+    rootCommentText: resolved.context.rootCommentText,
+    targetReplyText: resolved.context.targetReplyText,
+  });
+  const preview = prompt.replace(/\s+/g, " ").slice(0, 160);
+  params.logger?.(
+    `feishu[${params.accountId}]: built drive comment synthetic prompt ` +
+      `event=${resolved.eventId} preview=${preview}`,
+  );
+
+  return {
+    sender: {
+      sender_id: { open_id: resolved.senderId },
+      sender_type: "user",
+    },
+    message: {
+      message_id: `drive-comment:${resolved.eventId}`,
+      chat_id: `p2p:${resolved.senderId}`,
+      chat_type: "p2p",
+      message_type: "text",
+      content: JSON.stringify({ text: prompt }),
+      create_time: resolved.timestamp,
+    },
+  };
+}


### PR DESCRIPTION
  ## Summary

  Describe the problem and fix in 2–5 bullets:

  If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs,
  so the title is the PR-side signal for maintainers and automation.

  - Problem: Feishu document comments and replies were not handled as a first-class event surface, so OpenClaw could not resolve comment-thread context or reply back into the Drive comment thread.
  - Why it matters: document review and collaboration requests in Feishu comments could not trigger the expected agent workflow, which forced manual follow-up outside the comment thread.
  - What changed: added `drive.notice.comment_add_v1` handling, resolved document/comment/reply context into a dedicated comment-event prompt, added a Feishu comment reply dispatcher, extended `feishu_drive` with comment list/add/
  reply actions, and added targeted tests for the comment-event flow and prompt generation.
  - What did NOT change (scope boundary): no generic Feishu IM reply dispatcher changes, no auth/token model changes, no docs changes, and no non-Feishu channel behavior changes.

  ## Change Type (select all)

  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [x] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [x] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related #
  - [ ] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)

  For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

  - Root cause: N/A
  - Missing detection / guardrail: N/A
  - Prior context (`git blame`, prior PR, issue, or refactor if known): N/A
  - Why this regressed now: N/A
  - If unknown, what was ruled out: N/A

  ## Regression Test Plan (if applicable)

  For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

  - Coverage level that should have caught this: N/A
  - Target test or file: N/A
  - Scenario the test should lock in: N/A
  - Why this is the smallest reliable guardrail: N/A
  - Existing test that already covers this (if any): N/A
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  List user-visible changes (including defaults/config).
  If none, write `None`.

  - Feishu document comment and reply events can now enter a dedicated comment-event handling flow.
  - Agents can inspect Feishu Drive comment threads and reply or add comments through `feishu_drive`.
  - Comment-event prompts now instruct the agent to keep user-visible replies in the same language as the original comment or reply unless the user explicitly asks for another language.

  ## Diagram (if applicable)

  For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

  ```text
  Before:
  [Feishu document comment/reply]
    -> [generic channel flow / no dedicated comment-thread handling]
    -> [no structured comment context]
    -> [no direct reply into Drive comment thread]

  After:
  [Feishu document comment/reply]
    -> [drive.notice.comment_add_v1 handler]
    -> [resolve document/comment/reply context]
    -> [dedicated comment-event prompt + routing]
    -> [feishu_drive.reply_comment / add_comment]
    -> [reply posted back into the comment thread]

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No): Yes
  - Secrets/tokens handling changed? (Yes/No): No
  - New/changed network calls? (Yes/No): Yes
  - Command/tool execution surface changed? (Yes/No): Yes
  - Data access scope changed? (Yes/No): Yes
  - If any Yes, explain risk + mitigation: this PR adds Feishu Drive comment read/reply/add capabilities on top of existing Feishu account credentials. The new calls are limited to comment metadata, reply listing, comment
    creation, and reply creation for the Feishu Drive integration. Self-authored comment events are filtered, and the new behavior is scoped to the Feishu comment-event path plus explicit feishu_drive actions.

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Node 22 / pnpm
  - Model/provider: N/A
  - Integration/channel (if any): Feishu
  - Relevant config (redacted): Feishu channel enabled, default Feishu account configured, Drive tool enabled, websocket mode

  ### Steps

  1. Create or reply to a comment in a Feishu document.
  2. Let the gateway receive drive.notice.comment_add_v1.
  3. Let the agent resolve the comment context and reply through feishu_drive.reply_comment or feishu_drive.add_comment.

  ### Expected

  - The comment event is handled through a dedicated Feishu comment-event flow.
  - The agent can inspect the comment-thread context and reply in the Drive comment thread.
  - User-visible replies stay in the same language as the original comment or reply unless the user explicitly asks for another language.

  ### Actual

  - Before this PR, Feishu document comments and replies did not have a dedicated event surface for structured context resolution and in-thread Drive comment replies.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: ran pnpm check; ran pnpm test -- extensions/feishu/src/monitor.comment.test.ts; reviewed the drive.notice.comment_add_v1 -> comment context resolution -> comment reply flow in code.
  - Edge cases checked: add-comment vs add-reply prompt generation; self-authored comment events are ignored; prompt guidance preserves reply language with the original comment/reply unless explicitly overridden.
  - What you did not verify: live Feishu tenant end-to-end comment delivery; live Feishu Drive write operations against real APIs.

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No): Yes
  - Config/env changes? (Yes/No): No
  - Migration needed? (Yes/No): No
  - If yes, exact upgrade steps: N/A

  ## Risks and Mitigations

  List only real risks for this PR. Add/remove entries as needed. If none, write None.

  - Risk: prompt wording changes could change how agents respond inside Feishu comment threads.
      - Mitigation: added and updated targeted comment prompt tests in extensions/feishu/src/monitor.comment.test.ts.
  - Risk: new feishu_drive comment actions expand the Feishu Drive tool surface.
      - Mitigation: the new actions are limited to comment inspection/add/reply flows and use existing Feishu account auth and channel scoping.