### PR TITLE
feat: feishu comment event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: resolve `agents.defaults.compaction.model` consistently for manual `/compact` and other context-engine compaction paths, so engine-owned compaction uses the configured override model across runtime entrypoints. (#56710) Thanks @oliviareid-svg
 - Channels/session routing: move provider-specific session conversation grammar into plugin-owned session-key surfaces, preserving Telegram topic routing and Feishu scoped inheritance across bootstrap, model override, restart, and tool-policy paths.
 - WhatsApp/reactions: add `reactionLevel` guidance for agent reactions. Thanks @mcaxtr.
+- Feishu/comments: add a dedicated Drive comment-event flow with comment-thread context resolution, in-thread replies, and `feishu_drive` comment actions for document collaboration workflows. (#58497) thanks @wittam-01.
 
 ### Fixes
 

--- a/extensions/feishu/src/comment-dispatcher.ts
+++ b/extensions/feishu/src/comment-dispatcher.ts
@@ -2,12 +2,13 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import {
   createReplyPrefixContext,
   type ClawdbotConfig,
-  type RuntimeEnv,
   type ReplyPayload,
+  type RuntimeEnv,
 } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
-import { replyComment, type CommentFileType } from "./drive.js";
+import type { CommentFileType } from "./comment-target.js";
+import { replyComment } from "./drive.js";
 import { getFeishuRuntime } from "./runtime.js";
 
 export type CreateFeishuCommentReplyDispatcherParams = {

--- a/extensions/feishu/src/comment-dispatcher.ts
+++ b/extensions/feishu/src/comment-dispatcher.ts
@@ -1,0 +1,81 @@
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import {
+  createReplyPrefixContext,
+  type ClawdbotConfig,
+  type RuntimeEnv,
+  type ReplyPayload,
+} from "../runtime-api.js";
+import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
+import { replyComment, type CommentFileType } from "./drive.js";
+import { getFeishuRuntime } from "./runtime.js";
+
+export type CreateFeishuCommentReplyDispatcherParams = {
+  cfg: ClawdbotConfig;
+  agentId: string;
+  runtime: RuntimeEnv;
+  accountId?: string;
+  fileToken: string;
+  fileType: CommentFileType;
+  commentId: string;
+};
+
+export function createFeishuCommentReplyDispatcher(
+  params: CreateFeishuCommentReplyDispatcherParams,
+) {
+  const core = getFeishuRuntime();
+  const prefixContext = createReplyPrefixContext({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    channel: "feishu",
+    accountId: params.accountId,
+  });
+  const account = resolveFeishuRuntimeAccount({ cfg: params.cfg, accountId: params.accountId });
+  const client = createFeishuClient(account);
+  const textChunkLimit = core.channel.text.resolveTextChunkLimit(
+    params.cfg,
+    "feishu",
+    params.accountId,
+    {
+      fallbackLimit: 4000,
+    },
+  );
+  const chunkMode = core.channel.text.resolveChunkMode(params.cfg, "feishu");
+
+  const { dispatcher, replyOptions, markDispatchIdle } =
+    core.channel.reply.createReplyDispatcherWithTyping({
+      responsePrefix: prefixContext.responsePrefix,
+      responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
+      humanDelay: core.channel.reply.resolveHumanDelayConfig(params.cfg, params.agentId),
+      deliver: async (payload: ReplyPayload, info) => {
+        if (info.kind !== "final") {
+          return;
+        }
+        const reply = resolveSendableOutboundReplyParts(payload);
+        if (!reply.hasText) {
+          if (reply.hasMedia) {
+            params.runtime.log?.(
+              `feishu[${params.accountId ?? "default"}]: comment reply ignored media-only payload for comment=${params.commentId}`,
+            );
+          }
+          return;
+        }
+        const chunks = core.channel.text.chunkTextWithMode(reply.text, textChunkLimit, chunkMode);
+        for (const chunk of chunks) {
+          await replyComment(client, {
+            file_token: params.fileToken,
+            file_type: params.fileType,
+            comment_id: params.commentId,
+            content: chunk,
+          });
+        }
+      },
+      onError: (err, info) => {
+        params.runtime.error?.(
+          `feishu[${params.accountId ?? "default"}]: comment dispatcher failed kind=${info.kind} comment=${params.commentId}: ${String(err)}`,
+        );
+      },
+    });
+
+  return { dispatcher, replyOptions, markDispatchIdle };
+}

--- a/extensions/feishu/src/comment-handler.test.ts
+++ b/extensions/feishu/src/comment-handler.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPluginRuntimeMock } from "../../../test/helpers/plugins/plugin-runtime-mock.js";
+import type { ClawdbotConfig } from "../runtime-api.js";
+import { handleFeishuCommentEvent } from "./comment-handler.js";
+import { setFeishuRuntime } from "./runtime.js";
+
+const resolveDriveCommentEventTurnMock = vi.hoisted(() => vi.fn());
+const createFeishuCommentReplyDispatcherMock = vi.hoisted(() => vi.fn());
+const maybeCreateDynamicAgentMock = vi.hoisted(() => vi.fn());
+const createFeishuClientMock = vi.hoisted(() => vi.fn(() => ({ request: vi.fn() })));
+const replyCommentMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./monitor.comment.js", () => ({
+  resolveDriveCommentEventTurn: resolveDriveCommentEventTurnMock,
+}));
+
+vi.mock("./comment-dispatcher.js", () => ({
+  createFeishuCommentReplyDispatcher: createFeishuCommentReplyDispatcherMock,
+}));
+
+vi.mock("./dynamic-agent.js", () => ({
+  maybeCreateDynamicAgent: maybeCreateDynamicAgentMock,
+}));
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+vi.mock("./drive.js", () => ({
+  replyComment: replyCommentMock,
+}));
+
+function buildConfig(overrides?: Partial<ClawdbotConfig>): ClawdbotConfig {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+        dmPolicy: "open",
+      },
+    },
+    ...overrides,
+  } as ClawdbotConfig;
+}
+
+function buildResolvedRoute(matchedBy: "binding.channel" | "default" = "binding.channel") {
+  return {
+    agentId: "main",
+    channel: "feishu",
+    accountId: "default",
+    sessionKey: "agent:main:feishu:direct:ou_sender",
+    mainSessionKey: "agent:main:feishu",
+    lastRoutePolicy: "session" as const,
+    matchedBy,
+  };
+}
+
+describe("handleFeishuCommentEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    maybeCreateDynamicAgentMock.mockResolvedValue({ created: false });
+    resolveDriveCommentEventTurnMock.mockResolvedValue({
+      eventId: "evt_1",
+      messageId: "drive-comment:evt_1",
+      commentId: "comment_1",
+      replyId: "reply_1",
+      noticeType: "add_comment",
+      fileToken: "doc_token_1",
+      fileType: "docx",
+      senderId: "ou_sender",
+      timestamp: "1774951528000",
+      isMentioned: true,
+      documentTitle: "Project review",
+      prompt: "prompt body",
+      preview: "prompt body",
+      rootCommentText: "root comment",
+      targetReplyText: "latest reply",
+    });
+    replyCommentMock.mockResolvedValue({ reply_id: "r1" });
+
+    const runtime = createPluginRuntimeMock({
+      channel: {
+        routing: {
+          resolveAgentRoute: vi.fn(() => buildResolvedRoute()),
+        },
+        reply: {
+          dispatchReplyFromConfig: vi.fn(async () => ({
+            queuedFinal: true,
+            counts: { tool: 0, block: 0, final: 1 },
+          })),
+          withReplyDispatcher: vi.fn(async ({ run, onSettled }) => {
+            try {
+              return await run();
+            } finally {
+              await onSettled?.();
+            }
+          }),
+        },
+      },
+    });
+    setFeishuRuntime(runtime);
+
+    createFeishuCommentReplyDispatcherMock.mockReturnValue({
+      dispatcher: {
+        markComplete: vi.fn(),
+        waitForIdle: vi.fn(async () => {}),
+      },
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+    });
+  });
+
+  it("records a comment-thread inbound context with a routable Feishu origin", async () => {
+    await handleFeishuCommentEvent({
+      cfg: buildConfig(),
+      accountId: "default",
+      event: { event_id: "evt_1" },
+      botOpenId: "ou_bot",
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+
+    const runtime = (await import("./runtime.js")).getFeishuRuntime();
+    const finalizeInboundContext = runtime.channel.reply.finalizeInboundContext as ReturnType<
+      typeof vi.fn
+    >;
+    const recordInboundSession = runtime.channel.session.recordInboundSession as ReturnType<
+      typeof vi.fn
+    >;
+    const dispatchReplyFromConfig = runtime.channel.reply.dispatchReplyFromConfig as ReturnType<
+      typeof vi.fn
+    >;
+
+    expect(finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        From: "feishu:ou_sender",
+        To: "comment:docx:doc_token_1:comment_1",
+        Surface: "feishu-comment",
+        OriginatingChannel: "feishu",
+        OriginatingTo: "comment:docx:doc_token_1:comment_1",
+        MessageSid: "drive-comment:evt_1",
+      }),
+    );
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("issues a pairing challenge in the comment thread when dmPolicy=pairing", async () => {
+    const runtime = createPluginRuntimeMock({
+      channel: {
+        pairing: {
+          readAllowFromStore: vi.fn(async () => []),
+          upsertPairingRequest: vi.fn(async () => ({ code: "TESTCODE", created: true })),
+        },
+        routing: {
+          resolveAgentRoute: vi.fn(() => buildResolvedRoute()),
+        },
+      },
+    });
+    setFeishuRuntime(runtime);
+
+    await handleFeishuCommentEvent({
+      cfg: buildConfig({
+        channels: {
+          feishu: {
+            enabled: true,
+            dmPolicy: "pairing",
+            allowFrom: [],
+          },
+        },
+      }),
+      accountId: "default",
+      event: { event_id: "evt_1" },
+      botOpenId: "ou_bot",
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+
+    expect(replyCommentMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        file_token: "doc_token_1",
+        file_type: "docx",
+        comment_id: "comment_1",
+      }),
+    );
+    const dispatchReplyFromConfig = runtime.channel.reply.dispatchReplyFromConfig as ReturnType<
+      typeof vi.fn
+    >;
+    expect(dispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/comment-handler.test.ts
+++ b/extensions/feishu/src/comment-handler.test.ts
@@ -67,6 +67,7 @@ describe("handleFeishuCommentEvent", () => {
       fileToken: "doc_token_1",
       fileType: "docx",
       senderId: "ou_sender",
+      senderUserId: "on_sender_user",
       timestamp: "1774951528000",
       isMentioned: true,
       documentTitle: "Project review",
@@ -144,6 +145,58 @@ describe("handleFeishuCommentEvent", () => {
     );
     expect(recordInboundSession).toHaveBeenCalledTimes(1);
     expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows comment senders matched by user_id allowlist entries", async () => {
+    const runtime = createPluginRuntimeMock({
+      channel: {
+        pairing: {
+          readAllowFromStore: vi.fn(async () => []),
+        },
+        routing: {
+          resolveAgentRoute: vi.fn(() => buildResolvedRoute()),
+        },
+        reply: {
+          dispatchReplyFromConfig: vi.fn(async () => ({
+            queuedFinal: true,
+            counts: { tool: 0, block: 0, final: 1 },
+          })),
+          withReplyDispatcher: vi.fn(async ({ run, onSettled }) => {
+            try {
+              return await run();
+            } finally {
+              await onSettled?.();
+            }
+          }),
+        },
+      },
+    });
+    setFeishuRuntime(runtime);
+
+    await handleFeishuCommentEvent({
+      cfg: buildConfig({
+        channels: {
+          feishu: {
+            enabled: true,
+            dmPolicy: "allowlist",
+            allowFrom: ["on_sender_user"],
+          },
+        },
+      }),
+      accountId: "default",
+      event: { event_id: "evt_1" },
+      botOpenId: "ou_bot",
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+
+    const dispatchReplyFromConfig = runtime.channel.reply.dispatchReplyFromConfig as ReturnType<
+      typeof vi.fn
+    >;
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(replyCommentMock).not.toHaveBeenCalled();
   });
 
   it("issues a pairing challenge in the comment thread when dmPolicy=pairing", async () => {

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -1,0 +1,213 @@
+import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
+import {
+  createChannelPairingController,
+  type ClawdbotConfig,
+  type RuntimeEnv,
+} from "../runtime-api.js";
+import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { createFeishuCommentReplyDispatcher } from "./comment-dispatcher.js";
+import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
+import {
+  parseFeishuDriveCommentNoticeEventPayload,
+  resolveDriveCommentEventTurn,
+  type FeishuDriveCommentNoticeEvent,
+} from "./monitor.comment.js";
+import { resolveFeishuAllowlistMatch } from "./policy.js";
+import { getFeishuRuntime } from "./runtime.js";
+import type { DynamicAgentCreationConfig } from "./types.js";
+
+type HandleFeishuCommentEventParams = {
+  cfg: ClawdbotConfig;
+  accountId: string;
+  runtime?: RuntimeEnv;
+  event: FeishuDriveCommentNoticeEvent;
+  botOpenId?: string;
+};
+
+function buildCommentSessionKey(params: {
+  core: ReturnType<typeof getFeishuRuntime>;
+  route: ResolvedAgentRoute;
+  fileToken: string;
+  commentId: string;
+}): string {
+  return params.core.channel.routing.buildAgentSessionKey({
+    agentId: params.route.agentId,
+    channel: "feishu",
+    accountId: params.route.accountId,
+    peer: {
+      kind: "direct",
+      id: `comment:${params.fileToken}:${params.commentId}`,
+    },
+    dmScope: "per-account-channel-peer",
+  });
+}
+
+function parseTimestampMs(value: string | undefined): number {
+  const parsed = value ? Number.parseInt(value, 10) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+export async function handleFeishuCommentEvent(
+  params: HandleFeishuCommentEventParams,
+): Promise<void> {
+  const account = resolveFeishuRuntimeAccount({ cfg: params.cfg, accountId: params.accountId });
+  const feishuCfg = account.config;
+  const core = getFeishuRuntime();
+  const log = params.runtime?.log ?? console.log;
+  const error = params.runtime?.error ?? console.error;
+  const runtime = (params.runtime ?? { log, error }) as RuntimeEnv;
+
+  const turn = await resolveDriveCommentEventTurn({
+    cfg: params.cfg,
+    accountId: account.accountId,
+    event: params.event,
+    botOpenId: params.botOpenId,
+    logger: log,
+  });
+  if (!turn) {
+    log(
+      `feishu[${account.accountId}]: drive comment notice skipped ` +
+        `event=${params.event.event_id ?? "unknown"} comment=${params.event.comment_id ?? "unknown"}`,
+    );
+    return;
+  }
+
+  const dmPolicy = feishuCfg?.dmPolicy ?? "pairing";
+  const configAllowFrom = feishuCfg?.allowFrom ?? [];
+  const pairing = createChannelPairingController({
+    core,
+    channel: "feishu",
+    accountId: account.accountId,
+  });
+  const storeAllowFrom =
+    dmPolicy !== "allowlist" && dmPolicy !== "open"
+      ? await pairing.readAllowFromStore().catch(() => [])
+      : [];
+  const effectiveDmAllowFrom = [...configAllowFrom, ...storeAllowFrom];
+  const senderAllowed = resolveFeishuAllowlistMatch({
+    allowFrom: effectiveDmAllowFrom,
+    senderId: turn.senderId,
+  }).allowed;
+  if (dmPolicy !== "open" && !senderAllowed) {
+    log(
+      `feishu[${account.accountId}]: blocked unauthorized comment sender ${turn.senderId} ` +
+        `(dmPolicy=${dmPolicy}, comment=${turn.commentId})`,
+    );
+    return;
+  }
+
+  let effectiveCfg = params.cfg;
+  let route = core.channel.routing.resolveAgentRoute({
+    cfg: params.cfg,
+    channel: "feishu",
+    accountId: account.accountId,
+    peer: {
+      kind: "direct",
+      id: turn.senderId,
+    },
+  });
+  if (route.matchedBy === "default") {
+    const dynamicCfg = feishuCfg?.dynamicAgentCreation as DynamicAgentCreationConfig | undefined;
+    if (dynamicCfg?.enabled) {
+      const dynamicResult = await maybeCreateDynamicAgent({
+        cfg: params.cfg,
+        runtime: core,
+        senderOpenId: turn.senderId,
+        dynamicCfg,
+        log: (message) => log(message),
+      });
+      if (dynamicResult.created) {
+        effectiveCfg = dynamicResult.updatedCfg;
+        route = core.channel.routing.resolveAgentRoute({
+          cfg: dynamicResult.updatedCfg,
+          channel: "feishu",
+          accountId: account.accountId,
+          peer: {
+            kind: "direct",
+            id: turn.senderId,
+          },
+        });
+        log(
+          `feishu[${account.accountId}]: dynamic agent created for comment flow, route=${route.sessionKey}`,
+        );
+      }
+    }
+  }
+
+  const commentSessionKey = buildCommentSessionKey({
+    core,
+    route,
+    fileToken: turn.fileToken,
+    commentId: turn.commentId,
+  });
+  const bodyForAgent = `[message_id: ${turn.messageId}]\n${turn.prompt}`;
+  const ctxPayload = core.channel.reply.finalizeInboundContext({
+    Body: bodyForAgent,
+    BodyForAgent: bodyForAgent,
+    RawBody: turn.targetReplyText ?? turn.rootCommentText ?? turn.prompt,
+    CommandBody: turn.targetReplyText ?? turn.rootCommentText ?? turn.prompt,
+    From: `feishu-comment:${turn.senderId}`,
+    To: `comment:${turn.fileToken}:${turn.commentId}`,
+    SessionKey: commentSessionKey,
+    AccountId: route.accountId,
+    ChatType: "direct",
+    ConversationLabel: turn.documentTitle
+      ? `Feishu comment · ${turn.documentTitle}`
+      : "Feishu comment",
+    SenderName: turn.senderId,
+    SenderId: turn.senderId,
+    Provider: "feishu",
+    Surface: "feishu-comment",
+    MessageSid: turn.messageId,
+    Timestamp: parseTimestampMs(turn.timestamp),
+    WasMentioned: turn.isMentioned,
+    CommandAuthorized: false,
+    OriginatingTo: `comment:${turn.fileToken}:${turn.commentId}`,
+  });
+
+  const storePath = core.channel.session.resolveStorePath(effectiveCfg.session?.store, {
+    agentId: route.agentId,
+  });
+  await core.channel.session.recordInboundSession({
+    storePath,
+    sessionKey: commentSessionKey,
+    ctx: ctxPayload,
+    onRecordError: (err) => {
+      error(
+        `feishu[${account.accountId}]: failed to record comment inbound session ${commentSessionKey}: ${String(err)}`,
+      );
+    },
+  });
+
+  const { dispatcher, replyOptions, markDispatchIdle } = createFeishuCommentReplyDispatcher({
+    cfg: effectiveCfg,
+    agentId: route.agentId,
+    runtime,
+    accountId: account.accountId,
+    fileToken: turn.fileToken,
+    fileType: turn.fileType,
+    commentId: turn.commentId,
+  });
+
+  log(
+    `feishu[${account.accountId}]: dispatching drive comment to agent ` +
+      `(session=${commentSessionKey} comment=${turn.commentId} type=${turn.noticeType})`,
+  );
+  const { queuedFinal, counts } = await core.channel.reply.withReplyDispatcher({
+    dispatcher,
+    onSettled: () => {
+      markDispatchIdle();
+    },
+    run: () =>
+      core.channel.reply.dispatchReplyFromConfig({
+        ctx: ctxPayload,
+        cfg: effectiveCfg,
+        dispatcher,
+        replyOptions,
+      }),
+  });
+  log(
+    `feishu[${account.accountId}]: drive comment dispatch complete ` +
+      `(queuedFinal=${queuedFinal}, replies=${counts.final}, session=${commentSessionKey})`,
+  );
+}

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -5,10 +5,12 @@ import {
   type RuntimeEnv,
 } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
 import { createFeishuCommentReplyDispatcher } from "./comment-dispatcher.js";
+import { buildFeishuCommentTarget } from "./comment-target.js";
+import { replyComment } from "./drive.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
 import {
-  parseFeishuDriveCommentNoticeEventPayload,
   resolveDriveCommentEventTurn,
   type FeishuDriveCommentNoticeEvent,
 } from "./monitor.comment.js";
@@ -27,8 +29,7 @@ type HandleFeishuCommentEventParams = {
 function buildCommentSessionKey(params: {
   core: ReturnType<typeof getFeishuRuntime>;
   route: ResolvedAgentRoute;
-  fileToken: string;
-  commentId: string;
+  commentTarget: string;
 }): string {
   return params.core.channel.routing.buildAgentSessionKey({
     agentId: params.route.agentId,
@@ -36,7 +37,7 @@ function buildCommentSessionKey(params: {
     accountId: params.route.accountId,
     peer: {
       kind: "direct",
-      id: `comment:${params.fileToken}:${params.commentId}`,
+      id: params.commentTarget,
     },
     dmScope: "per-account-channel-peer",
   });
@@ -72,6 +73,11 @@ export async function handleFeishuCommentEvent(
     return;
   }
 
+  const commentTarget = buildFeishuCommentTarget({
+    fileType: turn.fileType,
+    fileToken: turn.fileToken,
+    commentId: turn.commentId,
+  });
   const dmPolicy = feishuCfg?.dmPolicy ?? "pairing";
   const configAllowFrom = feishuCfg?.allowFrom ?? [];
   const pairing = createChannelPairingController({
@@ -89,10 +95,37 @@ export async function handleFeishuCommentEvent(
     senderId: turn.senderId,
   }).allowed;
   if (dmPolicy !== "open" && !senderAllowed) {
-    log(
-      `feishu[${account.accountId}]: blocked unauthorized comment sender ${turn.senderId} ` +
-        `(dmPolicy=${dmPolicy}, comment=${turn.commentId})`,
-    );
+    if (dmPolicy === "pairing") {
+      const client = createFeishuClient(account);
+      await pairing.issueChallenge({
+        senderId: turn.senderId,
+        senderIdLine: `Your Feishu user id: ${turn.senderId}`,
+        meta: { name: turn.senderId },
+        onCreated: ({ code }) => {
+          log(
+            `feishu[${account.accountId}]: comment pairing request sender=${turn.senderId} code=${code}`,
+          );
+        },
+        sendPairingReply: async (text) => {
+          await replyComment(client, {
+            file_token: turn.fileToken,
+            file_type: turn.fileType,
+            comment_id: turn.commentId,
+            content: text,
+          });
+        },
+        onReplyError: (err) => {
+          log(
+            `feishu[${account.accountId}]: comment pairing reply failed for ${turn.senderId}: ${String(err)}`,
+          );
+        },
+      });
+    } else {
+      log(
+        `feishu[${account.accountId}]: blocked unauthorized comment sender ${turn.senderId} ` +
+          `(dmPolicy=${dmPolicy}, comment=${turn.commentId})`,
+      );
+    }
     return;
   }
 
@@ -137,8 +170,7 @@ export async function handleFeishuCommentEvent(
   const commentSessionKey = buildCommentSessionKey({
     core,
     route,
-    fileToken: turn.fileToken,
-    commentId: turn.commentId,
+    commentTarget,
   });
   const bodyForAgent = `[message_id: ${turn.messageId}]\n${turn.prompt}`;
   const ctxPayload = core.channel.reply.finalizeInboundContext({
@@ -146,8 +178,8 @@ export async function handleFeishuCommentEvent(
     BodyForAgent: bodyForAgent,
     RawBody: turn.targetReplyText ?? turn.rootCommentText ?? turn.prompt,
     CommandBody: turn.targetReplyText ?? turn.rootCommentText ?? turn.prompt,
-    From: `feishu-comment:${turn.senderId}`,
-    To: `comment:${turn.fileToken}:${turn.commentId}`,
+    From: `feishu:${turn.senderId}`,
+    To: commentTarget,
     SessionKey: commentSessionKey,
     AccountId: route.accountId,
     ChatType: "direct",
@@ -162,7 +194,8 @@ export async function handleFeishuCommentEvent(
     Timestamp: parseTimestampMs(turn.timestamp),
     WasMentioned: turn.isMentioned,
     CommandAuthorized: false,
-    OriginatingTo: `comment:${turn.fileToken}:${turn.commentId}`,
+    OriginatingChannel: "feishu",
+    OriginatingTo: commentTarget,
   });
 
   const storePath = core.channel.session.resolveStorePath(effectiveCfg.session?.store, {

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -93,6 +93,7 @@ export async function handleFeishuCommentEvent(
   const senderAllowed = resolveFeishuAllowlistMatch({
     allowFrom: effectiveDmAllowFrom,
     senderId: turn.senderId,
+    senderIds: [turn.senderUserId],
   }).allowed;
   if (dmPolicy !== "open" && !senderAllowed) {
     if (dmPolicy === "pairing") {

--- a/extensions/feishu/src/comment-target.ts
+++ b/extensions/feishu/src/comment-target.ts
@@ -1,0 +1,44 @@
+export const FEISHU_COMMENT_FILE_TYPES = ["doc", "docx", "file", "sheet", "slides"] as const;
+
+export type CommentFileType = (typeof FEISHU_COMMENT_FILE_TYPES)[number];
+
+export function normalizeCommentFileType(value: unknown): CommentFileType | undefined {
+  return typeof value === "string" &&
+    (FEISHU_COMMENT_FILE_TYPES as readonly string[]).includes(value)
+    ? (value as CommentFileType)
+    : undefined;
+}
+
+export type FeishuCommentTarget = {
+  fileType: CommentFileType;
+  fileToken: string;
+  commentId: string;
+};
+
+export function buildFeishuCommentTarget(params: FeishuCommentTarget): string {
+  return `comment:${params.fileType}:${params.fileToken}:${params.commentId}`;
+}
+
+export function parseFeishuCommentTarget(
+  raw: string | undefined | null,
+): FeishuCommentTarget | null {
+  const trimmed = raw?.trim();
+  if (!trimmed?.startsWith("comment:")) {
+    return null;
+  }
+  const parts = trimmed.split(":");
+  if (parts.length !== 4) {
+    return null;
+  }
+  const fileType = normalizeCommentFileType(parts[1]);
+  const fileToken = parts[2]?.trim();
+  const commentId = parts[3]?.trim();
+  if (!fileType || !fileToken || !commentId) {
+    return null;
+  }
+  return {
+    fileType,
+    fileToken,
+    commentId,
+  };
+}

--- a/extensions/feishu/src/drive-schema.ts
+++ b/extensions/feishu/src/drive-schema.ts
@@ -11,6 +11,14 @@ const FileType = Type.Union([
   Type.Literal("shortcut"),
 ]);
 
+const CommentFileType = Type.Union([
+  Type.Literal("doc"),
+  Type.Literal("docx"),
+  Type.Literal("sheet"),
+  Type.Literal("file"),
+  Type.Literal("slides"),
+]);
+
 export const FeishuDriveSchema = Type.Union([
   Type.Object({
     action: Type.Literal("list"),
@@ -40,6 +48,40 @@ export const FeishuDriveSchema = Type.Union([
     action: Type.Literal("delete"),
     file_token: Type.String({ description: "File token to delete" }),
     type: FileType,
+  }),
+  Type.Object({
+    action: Type.Literal("list_comments"),
+    file_token: Type.String({ description: "Document token" }),
+    file_type: CommentFileType,
+    page_size: Type.Optional(Type.Integer({ minimum: 1, description: "Page size" })),
+    page_token: Type.Optional(Type.String({ description: "Comment page token" })),
+  }),
+  Type.Object({
+    action: Type.Literal("list_comment_replies"),
+    file_token: Type.String({ description: "Document token" }),
+    file_type: CommentFileType,
+    comment_id: Type.String({ description: "Comment id" }),
+    page_size: Type.Optional(Type.Integer({ minimum: 1, description: "Page size" })),
+    page_token: Type.Optional(Type.String({ description: "Reply page token" })),
+  }),
+  Type.Object({
+    action: Type.Literal("add_comment"),
+    file_token: Type.String({ description: "Document token" }),
+    file_type: Type.Union([Type.Literal("doc"), Type.Literal("docx")]),
+    content: Type.String({ description: "Comment text content" }),
+    block_id: Type.Optional(
+      Type.String({
+        description:
+          "Optional docx block id for a local comment. Omit to create a full-document comment.",
+      }),
+    ),
+  }),
+  Type.Object({
+    action: Type.Literal("reply_comment"),
+    file_token: Type.String({ description: "Document token" }),
+    file_type: CommentFileType,
+    comment_id: Type.String({ description: "Comment id" }),
+    content: Type.String({ description: "Reply text content" }),
   }),
 ]);
 

--- a/extensions/feishu/src/drive.test.ts
+++ b/extensions/feishu/src/drive.test.ts
@@ -67,7 +67,8 @@ describe("registerFeishuDriveTools", () => {
     );
 
     expect(registerTool).toHaveBeenCalledTimes(1);
-    const tool = registerTool.mock.calls[0]?.[0];
+    const toolFactory = registerTool.mock.calls[0]?.[0];
+    const tool = toolFactory?.({ agentAccountId: undefined });
     expect(tool?.name).toBe("feishu_drive");
 
     requestMock.mockResolvedValueOnce({
@@ -271,7 +272,8 @@ describe("registerFeishuDriveTools", () => {
       }),
     );
 
-    const tool = registerTool.mock.calls[0]?.[0];
+    const toolFactory = registerTool.mock.calls[0]?.[0];
+    const tool = toolFactory?.({ agentAccountId: undefined });
     const result = await tool.execute("call-5", {
       action: "add_comment",
       file_token: "doc_1",

--- a/extensions/feishu/src/drive.test.ts
+++ b/extensions/feishu/src/drive.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../../test/helpers/plugins/plugin-api.js";
+import { createPluginRuntimeMock } from "../../../test/helpers/plugins/plugin-runtime-mock.js";
+import type { OpenClawPluginApi } from "../runtime-api.js";
+
+const createFeishuToolClientMock = vi.hoisted(() => vi.fn());
+const resolveAnyEnabledFeishuToolsConfigMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./tool-account.js", () => ({
+  createFeishuToolClient: createFeishuToolClientMock,
+  resolveAnyEnabledFeishuToolsConfig: resolveAnyEnabledFeishuToolsConfigMock,
+}));
+
+let registerFeishuDriveTools: typeof import("./drive.js").registerFeishuDriveTools;
+
+function createDriveToolApi(params: {
+  config: OpenClawPluginApi["config"];
+  registerTool: OpenClawPluginApi["registerTool"];
+}): OpenClawPluginApi {
+  return createTestPluginApi({
+    id: "feishu-test",
+    name: "Feishu Test",
+    source: "local",
+    config: params.config,
+    runtime: createPluginRuntimeMock(),
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    registerTool: params.registerTool,
+  });
+}
+
+describe("registerFeishuDriveTools", () => {
+  const requestMock = vi.fn();
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    ({ registerFeishuDriveTools } = await import("./drive.js"));
+    resolveAnyEnabledFeishuToolsConfigMock.mockReturnValue({
+      doc: false,
+      chat: false,
+      wiki: false,
+      drive: true,
+      perm: false,
+      scopes: false,
+    });
+    createFeishuToolClientMock.mockReturnValue({
+      request: requestMock,
+    });
+  });
+
+  it("registers feishu_drive and handles comment actions", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    const tool = registerTool.mock.calls[0]?.[0];
+    expect(tool?.name).toBe("feishu_drive");
+
+    requestMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        has_more: false,
+        page_token: "0",
+        items: [
+          {
+            comment_id: "c1",
+            quote: "quoted text",
+            reply_list: {
+              replies: [
+                {
+                  reply_id: "r1",
+                  user_id: "ou_author",
+                  content: {
+                    elements: [
+                      {
+                        type: "text_run",
+                        text_run: { text: "root comment" },
+                      },
+                    ],
+                  },
+                },
+                {
+                  reply_id: "r2",
+                  user_id: "ou_reply",
+                  content: {
+                    elements: [
+                      {
+                        type: "text_run",
+                        text_run: { text: "reply text" },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    const listResult = await tool.execute("call-1", {
+      action: "list_comments",
+      file_token: "doc_1",
+      file_type: "docx",
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "GET",
+        url: "/open-apis/drive/v1/files/doc_1/comments?file_type=docx&user_id_type=open_id",
+      }),
+    );
+    expect(listResult.details).toEqual(
+      expect.objectContaining({
+        comments: [
+          expect.objectContaining({
+            comment_id: "c1",
+            text: "root comment",
+            quote: "quoted text",
+            replies: [expect.objectContaining({ reply_id: "r2", text: "reply text" })],
+          }),
+        ],
+      }),
+    );
+
+    requestMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        has_more: false,
+        page_token: "0",
+        items: [
+          {
+            reply_id: "r3",
+            user_id: "ou_reply_2",
+            content: {
+              elements: [
+                {
+                  type: "text_run",
+                  text_run: { content: "reply from api" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    const repliesResult = await tool.execute("call-2", {
+      action: "list_comment_replies",
+      file_token: "doc_1",
+      file_type: "docx",
+      comment_id: "c1",
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: "GET",
+        url: "/open-apis/drive/v1/files/doc_1/comments/c1/replies?file_type=docx&user_id_type=open_id",
+      }),
+    );
+    expect(repliesResult.details).toEqual(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ reply_id: "r3", text: "reply from api" })],
+      }),
+    );
+
+    requestMock.mockResolvedValueOnce({
+      code: 0,
+      data: { comment_id: "c2" },
+    });
+    const addCommentResult = await tool.execute("call-3", {
+      action: "add_comment",
+      file_token: "doc_1",
+      file_type: "docx",
+      block_id: "blk_1",
+      content: "please update this section",
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/new_comments",
+        data: {
+          file_type: "docx",
+          reply_elements: [{ type: "text", text: "please update this section" }],
+          anchor: { block_id: "blk_1" },
+        },
+      }),
+    );
+    expect(addCommentResult.details).toEqual(
+      expect.objectContaining({ success: true, comment_id: "c2" }),
+    );
+
+    requestMock
+      .mockResolvedValueOnce({
+        code: 99991663,
+        msg: "invalid request body",
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { reply_id: "r4" },
+      });
+    const replyCommentResult = await tool.execute("call-4", {
+      action: "reply_comment",
+      file_token: "doc_1",
+      file_type: "docx",
+      comment_id: "c1",
+      content: "handled",
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/comments/c1/replies?file_type=docx",
+        data: {
+          content: {
+            elements: [
+              {
+                type: "text_run",
+                text_run: {
+                  text: "handled",
+                },
+              },
+            ],
+          },
+        },
+      }),
+    );
+    expect(requestMock).toHaveBeenNthCalledWith(
+      5,
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/comments/c1/replies?file_type=docx",
+        data: {
+          reply_elements: [{ type: "text", text: "handled" }],
+        },
+      }),
+    );
+    expect(replyCommentResult.details).toEqual(
+      expect.objectContaining({ success: true, reply_id: "r4" }),
+    );
+  });
+
+  it("rejects block-scoped comments for non-docx files", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const tool = registerTool.mock.calls[0]?.[0];
+    const result = await tool.execute("call-5", {
+      action: "add_comment",
+      file_token: "doc_1",
+      file_type: "doc",
+      block_id: "blk_1",
+      content: "invalid",
+    });
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        error: "block_id is only supported for docx comments",
+      }),
+    );
+  });
+});

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -1,6 +1,7 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
+import { type CommentFileType } from "./comment-target.js";
 import { FeishuDriveSchema, type FeishuDriveParams } from "./drive-schema.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import {
@@ -29,8 +30,6 @@ type FeishuDriveInternalClient = Lark.Client & {
     timeout?: number;
   }): Promise<unknown>;
 };
-
-export type CommentFileType = "doc" | "docx" | "file" | "sheet" | "slides";
 
 type FeishuDriveApiResponse<T> = {
   code: number;
@@ -462,7 +461,7 @@ export async function replyComment(
     comment_id: string;
     content: string;
   },
-) {
+): Promise<{ success: true; reply_id?: string } & Record<string, unknown>> {
   const url =
     `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/comments/${encodeURIComponent(
       params.comment_id,
@@ -553,46 +552,14 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
                 return jsonToolResult(await moveFile(client, p.file_token, p.type, p.folder_token));
               case "delete":
                 return jsonToolResult(await deleteFile(client, p.file_token, p.type));
-              case "list_comments": {
-                api.logger.info?.(
-                  `feishu_drive: list_comments file=${p.file_type}:${p.file_token} page_token=${p.page_token ?? "none"}`,
-                );
-                const result = await listComments(client, p);
-                api.logger.info?.(
-                  `feishu_drive: list_comments resolved count=${result.comments.length} has_more=${result.has_more ? "yes" : "no"}`,
-                );
-                return jsonToolResult(result);
-              }
-              case "list_comment_replies": {
-                api.logger.info?.(
-                  `feishu_drive: list_comment_replies file=${p.file_type}:${p.file_token} comment=${p.comment_id} page_token=${p.page_token ?? "none"}`,
-                );
-                const result = await listCommentReplies(client, p);
-                api.logger.info?.(
-                  `feishu_drive: list_comment_replies resolved count=${result.replies.length} has_more=${result.has_more ? "yes" : "no"}`,
-                );
-                return jsonToolResult(result);
-              }
-              case "add_comment": {
-                api.logger.info?.(
-                  `feishu_drive: add_comment file=${p.file_type}:${p.file_token} block=${p.block_id ?? "whole"} chars=${p.content.length}`,
-                );
-                const result = await addComment(client, p);
-                api.logger.info?.(
-                  `feishu_drive: add_comment success comment=${String((result as { comment_id?: unknown }).comment_id ?? "unknown")}`,
-                );
-                return jsonToolResult(result);
-              }
-              case "reply_comment": {
-                api.logger.info?.(
-                  `feishu_drive: reply_comment file=${p.file_type}:${p.file_token} comment=${p.comment_id} chars=${p.content.length}`,
-                );
-                const result = await replyComment(client, p);
-                api.logger.info?.(
-                  `feishu_drive: reply_comment success reply=${String((result as { reply_id?: unknown }).reply_id ?? "unknown")}`,
-                );
-                return jsonToolResult(result);
-              }
+              case "list_comments":
+                return jsonToolResult(await listComments(client, p));
+              case "list_comment_replies":
+                return jsonToolResult(await listCommentReplies(client, p));
+              case "add_comment":
+                return jsonToolResult(await addComment(client, p));
+              case "reply_comment":
+                return jsonToolResult(await replyComment(client, p));
               default:
                 return unknownToolActionResult((p as { action?: unknown }).action);
             }

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -22,10 +22,188 @@ type FeishuExplorerRootFolderMetaResponse = {
 type FeishuDriveInternalClient = Lark.Client & {
   domain?: string;
   httpInstance: Pick<Lark.HttpInstance, "get">;
+  request(params: {
+    method: "GET" | "POST";
+    url: string;
+    data: unknown;
+    timeout?: number;
+  }): Promise<unknown>;
 };
+
+export type CommentFileType = "doc" | "docx" | "file" | "sheet" | "slides";
+
+type FeishuDriveApiResponse<T> = {
+  code: number;
+  msg?: string;
+  data?: T;
+};
+
+type FeishuDriveCommentReply = {
+  reply_id?: string;
+  user_id?: string;
+  create_time?: number;
+  update_time?: number;
+  content?: {
+    elements?: unknown[];
+  };
+};
+
+type FeishuDriveCommentCard = {
+  comment_id?: string;
+  user_id?: string;
+  create_time?: number;
+  update_time?: number;
+  is_solved?: boolean;
+  is_whole?: boolean;
+  has_more?: boolean;
+  page_token?: string;
+  quote?: string;
+  reply_list?: {
+    replies?: FeishuDriveCommentReply[];
+  };
+};
+
+type FeishuDriveListCommentsResponse = FeishuDriveApiResponse<{
+  has_more?: boolean;
+  items?: FeishuDriveCommentCard[];
+  page_token?: string;
+}>;
+
+type FeishuDriveListRepliesResponse = FeishuDriveApiResponse<{
+  has_more?: boolean;
+  items?: FeishuDriveCommentReply[];
+  page_token?: string;
+}>;
+
+const FEISHU_DRIVE_REQUEST_TIMEOUT_MS = 30_000;
 
 function getDriveInternalClient(client: Lark.Client): FeishuDriveInternalClient {
   return client as FeishuDriveInternalClient;
+}
+
+function encodeQuery(params: Record<string, string | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      search.set(key, trimmed);
+    }
+  }
+  const query = search.toString();
+  return query ? `?${query}` : "";
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function extractCommentElementText(element: unknown): string | undefined {
+  if (!isRecord(element)) {
+    return undefined;
+  }
+  const type = readString(element.type)?.trim();
+  if (type === "text_run" && isRecord(element.text_run)) {
+    return (
+      readString(element.text_run.content)?.trim() ||
+      readString(element.text_run.text)?.trim() ||
+      undefined
+    );
+  }
+  if (type === "mention") {
+    const mention = isRecord(element.mention) ? element.mention : undefined;
+    const mentionName =
+      readString(mention?.name)?.trim() ||
+      readString(mention?.display_name)?.trim() ||
+      readString(element.name)?.trim();
+    return mentionName ? `@${mentionName}` : "@mention";
+  }
+  if (type === "docs_link") {
+    const docsLink = isRecord(element.docs_link) ? element.docs_link : undefined;
+    return (
+      readString(docsLink?.text)?.trim() ||
+      readString(docsLink?.url)?.trim() ||
+      readString(element.text)?.trim() ||
+      readString(element.url)?.trim() ||
+      undefined
+    );
+  }
+  return (
+    readString(element.text)?.trim() ||
+    readString(element.content)?.trim() ||
+    readString(element.name)?.trim() ||
+    undefined
+  );
+}
+
+function extractReplyText(reply: FeishuDriveCommentReply | undefined): string | undefined {
+  if (!reply || !isRecord(reply.content)) {
+    return undefined;
+  }
+  const elements = Array.isArray(reply.content.elements) ? reply.content.elements : [];
+  const text = elements
+    .map(extractCommentElementText)
+    .filter((part): part is string => Boolean(part && part.trim()))
+    .join("")
+    .trim();
+  return text || undefined;
+}
+
+function buildReplyElements(content: string) {
+  return [{ type: "text", text: content }];
+}
+
+async function requestDriveApi<T>(params: {
+  client: Lark.Client;
+  method: "GET" | "POST";
+  url: string;
+  data?: unknown;
+}): Promise<T> {
+  const internalClient = getDriveInternalClient(params.client);
+  return (await internalClient.request({
+    method: params.method,
+    url: params.url,
+    data: params.data ?? {},
+    timeout: FEISHU_DRIVE_REQUEST_TIMEOUT_MS,
+  })) as T;
+}
+
+function assertDriveApiSuccess<T extends { code: number; msg?: string }>(response: T): T {
+  if (response.code !== 0) {
+    throw new Error(response.msg ?? "Feishu Drive API request failed");
+  }
+  return response;
+}
+
+function normalizeCommentReply(reply: FeishuDriveCommentReply) {
+  return {
+    reply_id: reply.reply_id,
+    user_id: reply.user_id,
+    create_time: reply.create_time,
+    update_time: reply.update_time,
+    text: extractReplyText(reply),
+  };
+}
+
+function normalizeCommentCard(comment: FeishuDriveCommentCard) {
+  const replies = comment.reply_list?.replies ?? [];
+  const rootReply = replies[0];
+  return {
+    comment_id: comment.comment_id,
+    user_id: comment.user_id,
+    create_time: comment.create_time,
+    update_time: comment.update_time,
+    is_solved: comment.is_solved,
+    is_whole: comment.is_whole,
+    quote: comment.quote,
+    text: extractReplyText(rootReply),
+    has_more_replies: comment.has_more,
+    replies_page_token: comment.page_token,
+    replies: replies.slice(1).map(normalizeCommentReply),
+  };
 }
 
 async function getRootFolderToken(client: Lark.Client): Promise<string> {
@@ -177,6 +355,154 @@ async function deleteFile(client: Lark.Client, fileToken: string, type: string) 
   };
 }
 
+async function listComments(
+  client: Lark.Client,
+  params: {
+    file_token: string;
+    file_type: CommentFileType;
+    page_size?: number;
+    page_token?: string;
+  },
+) {
+  const response = assertDriveApiSuccess(
+    await requestDriveApi<FeishuDriveListCommentsResponse>({
+      client,
+      method: "GET",
+      url:
+        `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/comments` +
+        encodeQuery({
+          file_type: params.file_type,
+          page_size:
+            typeof params.page_size === "number" && Number.isFinite(params.page_size)
+              ? String(params.page_size)
+              : undefined,
+          page_token: params.page_token,
+          user_id_type: "open_id",
+        }),
+    }),
+  );
+  return {
+    has_more: response.data?.has_more ?? false,
+    page_token: response.data?.page_token,
+    comments: (response.data?.items ?? []).map(normalizeCommentCard),
+  };
+}
+
+async function listCommentReplies(
+  client: Lark.Client,
+  params: {
+    file_token: string;
+    file_type: CommentFileType;
+    comment_id: string;
+    page_size?: number;
+    page_token?: string;
+  },
+) {
+  const response = assertDriveApiSuccess(
+    await requestDriveApi<FeishuDriveListRepliesResponse>({
+      client,
+      method: "GET",
+      url:
+        `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/comments/${encodeURIComponent(
+          params.comment_id,
+        )}/replies` +
+        encodeQuery({
+          file_type: params.file_type,
+          page_size:
+            typeof params.page_size === "number" && Number.isFinite(params.page_size)
+              ? String(params.page_size)
+              : undefined,
+          page_token: params.page_token,
+          user_id_type: "open_id",
+        }),
+    }),
+  );
+  return {
+    has_more: response.data?.has_more ?? false,
+    page_token: response.data?.page_token,
+    replies: (response.data?.items ?? []).map(normalizeCommentReply),
+  };
+}
+
+async function addComment(
+  client: Lark.Client,
+  params: {
+    file_token: string;
+    file_type: "doc" | "docx";
+    content: string;
+    block_id?: string;
+  },
+) {
+  if (params.block_id?.trim() && params.file_type !== "docx") {
+    throw new Error("block_id is only supported for docx comments");
+  }
+  const response = assertDriveApiSuccess(
+    await requestDriveApi<FeishuDriveApiResponse<Record<string, unknown>>>({
+      client,
+      method: "POST",
+      url: `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/new_comments`,
+      data: {
+        file_type: params.file_type,
+        reply_elements: buildReplyElements(params.content),
+        ...(params.block_id?.trim() ? { anchor: { block_id: params.block_id.trim() } } : {}),
+      },
+    }),
+  );
+  return {
+    success: true,
+    ...response.data,
+  };
+}
+
+export async function replyComment(
+  client: Lark.Client,
+  params: {
+    file_token: string;
+    file_type: CommentFileType;
+    comment_id: string;
+    content: string;
+  },
+) {
+  const url =
+    `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/comments/${encodeURIComponent(
+      params.comment_id,
+    )}/replies` + encodeQuery({ file_type: params.file_type });
+  const attempts: unknown[] = [
+    {
+      content: {
+        elements: [
+          {
+            type: "text_run",
+            text_run: {
+              text: params.content,
+            },
+          },
+        ],
+      },
+    },
+    {
+      reply_elements: buildReplyElements(params.content),
+    },
+  ];
+  let lastMessage = "Feishu Drive reply comment failed";
+  for (const data of attempts) {
+    const response = (await requestDriveApi<FeishuDriveApiResponse<Record<string, unknown>>>({
+      client,
+      method: "POST",
+      url,
+      data,
+    })) as FeishuDriveApiResponse<Record<string, unknown>>;
+    if (response.code === 0) {
+      return {
+        success: true,
+        ...response.data,
+      };
+    }
+    lastMessage = response.msg ?? lastMessage;
+  }
+  throw new Error(lastMessage);
+}
+
 // ============ Tool Registration ============
 
 export function registerFeishuDriveTools(api: OpenClawPluginApi) {
@@ -206,7 +532,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
         name: "feishu_drive",
         label: "Feishu Drive",
         description:
-          "Feishu cloud storage operations. Actions: list, info, create_folder, move, delete",
+          "Feishu cloud storage operations. Actions: list, info, create_folder, move, delete, list_comments, list_comment_replies, add_comment, reply_comment",
         parameters: FeishuDriveSchema,
         async execute(_toolCallId, params) {
           const p = params as FeishuDriveExecuteParams;
@@ -227,6 +553,46 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
                 return jsonToolResult(await moveFile(client, p.file_token, p.type, p.folder_token));
               case "delete":
                 return jsonToolResult(await deleteFile(client, p.file_token, p.type));
+              case "list_comments": {
+                api.logger.info?.(
+                  `feishu_drive: list_comments file=${p.file_type}:${p.file_token} page_token=${p.page_token ?? "none"}`,
+                );
+                const result = await listComments(client, p);
+                api.logger.info?.(
+                  `feishu_drive: list_comments resolved count=${result.comments.length} has_more=${result.has_more ? "yes" : "no"}`,
+                );
+                return jsonToolResult(result);
+              }
+              case "list_comment_replies": {
+                api.logger.info?.(
+                  `feishu_drive: list_comment_replies file=${p.file_type}:${p.file_token} comment=${p.comment_id} page_token=${p.page_token ?? "none"}`,
+                );
+                const result = await listCommentReplies(client, p);
+                api.logger.info?.(
+                  `feishu_drive: list_comment_replies resolved count=${result.replies.length} has_more=${result.has_more ? "yes" : "no"}`,
+                );
+                return jsonToolResult(result);
+              }
+              case "add_comment": {
+                api.logger.info?.(
+                  `feishu_drive: add_comment file=${p.file_type}:${p.file_token} block=${p.block_id ?? "whole"} chars=${p.content.length}`,
+                );
+                const result = await addComment(client, p);
+                api.logger.info?.(
+                  `feishu_drive: add_comment success comment=${String((result as { comment_id?: unknown }).comment_id ?? "unknown")}`,
+                );
+                return jsonToolResult(result);
+              }
+              case "reply_comment": {
+                api.logger.info?.(
+                  `feishu_drive: reply_comment file=${p.file_type}:${p.file_token} comment=${p.comment_id} chars=${p.content.length}`,
+                );
+                const result = await replyComment(client, p);
+                api.logger.info?.(
+                  `feishu_drive: reply_comment success reply=${String((result as { reply_id?: unknown }).reply_id ?? "unknown")}`,
+                );
+                return jsonToolResult(result);
+              }
               default:
                 return unknownToolActionResult((p as { action?: unknown }).action);
             }

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -12,6 +12,7 @@ import {
 import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
 import { maybeHandleFeishuQuickActionMenu } from "./card-ux-launcher.js";
 import { createEventDispatcher } from "./client.js";
+import { handleFeishuCommentEvent } from "./comment-handler.js";
 import {
   hasProcessedFeishuMessage,
   recordProcessedFeishuMessage,
@@ -21,6 +22,7 @@ import {
 } from "./dedup.js";
 import { isMentionForwardRequest } from "./mention.js";
 import { applyBotIdentityState, startBotIdentityRecovery } from "./monitor.bot-identity.js";
+import { parseFeishuDriveCommentNoticeEventPayload } from "./monitor.comment.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
@@ -597,6 +599,60 @@ function registerEventHandlers(
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot removed event: ${String(err)}`);
       }
+    },
+    "drive.notice.comment_add_v1": async (data: unknown) => {
+      await runFeishuHandler({
+        errorMessage: `feishu[${accountId}]: error handling drive comment notice`,
+        task: async () => {
+          const event = parseFeishuDriveCommentNoticeEventPayload(data);
+          if (!event) {
+            error(`feishu[${accountId}]: ignoring malformed drive comment notice payload`);
+            return;
+          }
+          const eventId = event.event_id?.trim();
+          const syntheticMessageId = eventId ? `drive-comment:${eventId}` : undefined;
+          if (
+            syntheticMessageId &&
+            (await hasProcessedFeishuMessage(syntheticMessageId, accountId, log))
+          ) {
+            log(`feishu[${accountId}]: dropping duplicate comment event ${syntheticMessageId}`);
+            return;
+          }
+          if (
+            syntheticMessageId &&
+            !tryBeginFeishuMessageProcessing(syntheticMessageId, accountId)
+          ) {
+            log(`feishu[${accountId}]: dropping in-flight comment event ${syntheticMessageId}`);
+            return;
+          }
+          log(
+            `feishu[${accountId}]: received drive comment notice ` +
+              `event=${event.event_id ?? "unknown"} ` +
+              `type=${event.notice_meta?.notice_type ?? "unknown"} ` +
+              `file=${event.notice_meta?.file_type ?? "unknown"}:${event.notice_meta?.file_token ?? "unknown"} ` +
+              `comment=${event.comment_id ?? "unknown"} ` +
+              `reply=${event.reply_id ?? "none"} ` +
+              `from=${event.notice_meta?.from_user_id?.open_id ?? "unknown"} ` +
+              `mentioned=${event.is_mentioned === true ? "yes" : "no"}`,
+          );
+          try {
+            await handleFeishuCommentEvent({
+              cfg,
+              accountId,
+              event,
+              botOpenId: botOpenIds.get(accountId),
+              runtime,
+            });
+            if (syntheticMessageId) {
+              await recordProcessedFeishuMessage(syntheticMessageId, accountId, log);
+            }
+          } finally {
+            if (syntheticMessageId) {
+              releaseFeishuMessageProcessing(syntheticMessageId, accountId);
+            }
+          }
+        },
+      });
     },
     "im.message.reaction.created_v1": async (data) => {
       await runFeishuHandler({

--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -308,6 +308,18 @@ describe("resolveDriveCommentEventTurn", () => {
 
     expect(turn).toBeNull();
   });
+
+  it("skips comment notices when bot open_id is unavailable", async () => {
+    const synthetic = await resolveDriveCommentSyntheticEvent({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent(),
+      botOpenId: undefined,
+      createClient: () => makeOpenApiClient({}) as never,
+    });
+
+    expect(synthetic).toBeNull();
+  });
 });
 
 describe("drive.notice.comment_add_v1 monitor handler", () => {

--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -262,6 +262,29 @@ describe("resolveDriveCommentEventTurn", () => {
     expect(turn?.prompt).toContain("The system will automatically reply with your final answer");
   });
 
+  it("preserves sender user_id for downstream allowlist checks", async () => {
+    const client = makeOpenApiClient({ includeTargetReplyInBatch: true });
+
+    const turn = await resolveDriveCommentEventTurn({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent({
+        notice_meta: {
+          ...makeDriveCommentEvent().notice_meta,
+          from_user_id: {
+            open_id: "ou_509d4d7ace4a9addec2312676ffcba9b",
+            user_id: "on_comment_user_1",
+          },
+        },
+      }),
+      botOpenId: "ou_bot",
+      createClient: () => client as never,
+    });
+
+    expect(turn?.senderId).toBe("ou_509d4d7ace4a9addec2312676ffcba9b");
+    expect(turn?.senderUserId).toBe("on_comment_user_1");
+  });
+
   it("falls back to the replies API to resolve add_reply text", async () => {
     const client = makeOpenApiClient({
       includeTargetReplyInBatch: false,

--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -7,11 +7,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPluginRuntimeMock } from "../../../test/helpers/plugins/plugin-runtime-mock.js";
 import { createNonExitingTypedRuntimeEnv } from "../../../test/helpers/plugins/runtime-env.js";
 import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
-import type { FeishuMessageEvent } from "./bot.js";
 import * as dedup from "./dedup.js";
 import { monitorSingleAccount } from "./monitor.account.js";
 import {
-  resolveDriveCommentSyntheticEvent,
+  resolveDriveCommentEventTurn,
   type FeishuDriveCommentNoticeEvent,
 } from "./monitor.comment.js";
 import { setFeishuRuntime } from "./runtime.js";
@@ -235,16 +234,11 @@ async function setupCommentMonitorHandler(): Promise<(data: unknown) => Promise<
   return handler;
 }
 
-function extractSyntheticText(event: FeishuMessageEvent): string {
-  const content = JSON.parse(event.message.content) as { text?: string };
-  return content.text ?? "";
-}
-
-describe("resolveDriveCommentSyntheticEvent", () => {
-  it("builds a synthetic Feishu message for add_comment notices", async () => {
+describe("resolveDriveCommentEventTurn", () => {
+  it("builds a real comment-turn prompt for add_comment notices", async () => {
     const client = makeOpenApiClient({ includeTargetReplyInBatch: true });
 
-    const synthetic = await resolveDriveCommentSyntheticEvent({
+    const turn = await resolveDriveCommentEventTurn({
       cfg: buildMonitorConfig(),
       accountId: "default",
       event: makeDriveCommentEvent(),
@@ -252,34 +246,20 @@ describe("resolveDriveCommentSyntheticEvent", () => {
       createClient: () => client as never,
     });
 
-    expect(synthetic).not.toBeNull();
-    expect(synthetic?.sender.sender_id.open_id).toBe("ou_509d4d7ace4a9addec2312676ffcba9b");
-    expect(synthetic?.message.message_id).toBe("drive-comment:10d9d60b990db39f96a4c2fd357fb877");
-    expect(synthetic?.message.chat_id).toBe("p2p:ou_509d4d7ace4a9addec2312676ffcba9b");
-    expect(synthetic?.message.chat_type).toBe("p2p");
-    expect(synthetic?.message.create_time).toBe("1774951528000");
-
-    const text = extractSyntheticText(synthetic as FeishuMessageEvent);
-    expect(text).toContain(
-      'I added a comment in "Comment event handling request": Also send it to the agent after receiving the comment event',
+    expect(turn).not.toBeNull();
+    expect(turn?.senderId).toBe("ou_509d4d7ace4a9addec2312676ffcba9b");
+    expect(turn?.messageId).toBe("drive-comment:10d9d60b990db39f96a4c2fd357fb877");
+    expect(turn?.fileType).toBe("docx");
+    expect(turn?.fileToken).toBe(TEST_DOC_TOKEN);
+    expect(turn?.prompt).toContain(
+      'The user added a comment in "Comment event handling request": Also send it to the agent after receiving the comment event',
     );
-    expect(text).toContain("Also send it to the agent after receiving the comment event");
-    expect(text).toContain("Quoted content: im.message.receive_v1 message trigger implementation");
-    expect(text).toContain("This comment mentioned you.");
-    expect(text).toContain(
-      "This is a Feishu document comment event, not a normal instant-message conversation.",
+    expect(turn?.prompt).toContain(
+      "This is a Feishu document comment-thread event, not a Feishu IM conversation.",
     );
-    expect(text).toContain("feishu_drive.reply_comment");
-    expect(text).toContain(
-      "reply with the answer in that comment thread via feishu_drive.reply_comment",
-    );
-    expect(text).toContain(
-      "after finishing also use feishu_drive.reply_comment in that comment thread to tell the user the update is complete",
-    );
-    expect(text).toContain(
-      "keep it in the same language as the user's original comment or reply unless they explicitly ask for another language",
-    );
-    expect(text).toContain("output only NO_REPLY at the end");
+    expect(turn?.prompt).toContain("comment_id: 7623358762119646411");
+    expect(turn?.prompt).toContain("reply_id: 7623358762136374451");
+    expect(turn?.prompt).toContain("The system will automatically reply with your final answer");
   });
 
   it("falls back to the replies API to resolve add_reply text", async () => {
@@ -288,7 +268,7 @@ describe("resolveDriveCommentSyntheticEvent", () => {
       targetReplyText: "Please follow up on this comment",
     });
 
-    const synthetic = await resolveDriveCommentSyntheticEvent({
+    const turn = await resolveDriveCommentEventTurn({
       cfg: buildMonitorConfig(),
       accountId: "default",
       event: makeDriveCommentEvent({
@@ -302,22 +282,18 @@ describe("resolveDriveCommentSyntheticEvent", () => {
       createClient: () => client as never,
     });
 
-    const text = extractSyntheticText(synthetic as FeishuMessageEvent);
-    expect(text).toContain(
-      'I added a reply in "Comment event handling request": Please follow up on this comment',
+    expect(turn?.prompt).toContain(
+      'The user added a reply in "Comment event handling request": Please follow up on this comment',
     );
-    expect(text).toContain(
+    expect(turn?.prompt).toContain(
       "Original comment: Also send it to the agent after receiving the comment event",
     );
-    expect(text).toContain(`file_token: ${TEST_DOC_TOKEN}`);
-    expect(text).toContain("Event type: add_reply");
-    expect(text).toContain(
-      "keep it in the same language as the user's original comment or reply unless they explicitly ask for another language",
-    );
+    expect(turn?.prompt).toContain(`file_token: ${TEST_DOC_TOKEN}`);
+    expect(turn?.prompt).toContain("Event type: add_reply");
   });
 
   it("ignores self-authored comment notices", async () => {
-    const synthetic = await resolveDriveCommentSyntheticEvent({
+    const turn = await resolveDriveCommentEventTurn({
       cfg: buildMonitorConfig(),
       accountId: "default",
       event: makeDriveCommentEvent({
@@ -330,7 +306,7 @@ describe("resolveDriveCommentSyntheticEvent", () => {
       createClient: () => makeOpenApiClient({}) as never,
     });
 
-    expect(synthetic).toBeNull();
+    expect(turn).toBeNull();
   });
 });
 

--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -1,0 +1,394 @@
+import { hasControlCommand } from "openclaw/plugin-sdk/command-auth";
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "openclaw/plugin-sdk/reply-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPluginRuntimeMock } from "../../../test/helpers/plugins/plugin-runtime-mock.js";
+import { createNonExitingTypedRuntimeEnv } from "../../../test/helpers/plugins/runtime-env.js";
+import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
+import type { FeishuMessageEvent } from "./bot.js";
+import * as dedup from "./dedup.js";
+import { monitorSingleAccount } from "./monitor.account.js";
+import {
+  resolveDriveCommentSyntheticEvent,
+  type FeishuDriveCommentNoticeEvent,
+} from "./monitor.comment.js";
+import { setFeishuRuntime } from "./runtime.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+
+const handleFeishuCommentEventMock = vi.hoisted(() => vi.fn(async () => {}));
+const createEventDispatcherMock = vi.hoisted(() => vi.fn());
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const monitorWebSocketMock = vi.hoisted(() => vi.fn(async () => {}));
+const monitorWebhookMock = vi.hoisted(() => vi.fn(async () => {}));
+const createFeishuThreadBindingManagerMock = vi.hoisted(() => vi.fn(() => ({ stop: vi.fn() })));
+
+let handlers: Record<string, (data: unknown) => Promise<void>> = {};
+const TEST_DOC_TOKEN = "doxxxxxxx";
+
+vi.mock("./client.js", () => ({
+  createEventDispatcher: createEventDispatcherMock,
+  createFeishuClient: createFeishuClientMock,
+}));
+
+vi.mock("./comment-handler.js", () => ({
+  handleFeishuCommentEvent: handleFeishuCommentEventMock,
+}));
+
+vi.mock("./monitor.transport.js", () => ({
+  monitorWebSocket: monitorWebSocketMock,
+  monitorWebhook: monitorWebhookMock,
+}));
+
+vi.mock("./thread-bindings.js", () => ({
+  createFeishuThreadBindingManager: createFeishuThreadBindingManagerMock,
+}));
+
+function buildMonitorConfig(): ClawdbotConfig {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+      },
+    },
+  } as ClawdbotConfig;
+}
+
+function buildMonitorAccount(): ResolvedFeishuAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    appId: "cli_test",
+    appSecret: "secret_test", // pragma: allowlist secret
+    domain: "feishu",
+    config: {
+      enabled: true,
+      connectionMode: "websocket",
+    },
+  } as ResolvedFeishuAccount;
+}
+
+function makeDriveCommentEvent(
+  overrides: Partial<FeishuDriveCommentNoticeEvent> = {},
+): FeishuDriveCommentNoticeEvent {
+  return {
+    comment_id: "7623358762119646411",
+    event_id: "10d9d60b990db39f96a4c2fd357fb877",
+    is_mentioned: true,
+    notice_meta: {
+      file_token: TEST_DOC_TOKEN,
+      file_type: "docx",
+      from_user_id: {
+        open_id: "ou_509d4d7ace4a9addec2312676ffcba9b",
+      },
+      notice_type: "add_comment",
+      to_user_id: {
+        open_id: "ou_bot",
+      },
+    },
+    reply_id: "7623358762136374451",
+    timestamp: "1774951528000",
+    type: "drive.notice.comment_add_v1",
+    ...overrides,
+  };
+}
+
+function makeOpenApiClient(params: {
+  documentTitle?: string;
+  documentUrl?: string;
+  quoteText?: string;
+  rootReplyText?: string;
+  targetReplyText?: string;
+  includeTargetReplyInBatch?: boolean;
+}) {
+  return {
+    request: vi.fn(async (request: { method: "GET" | "POST"; url: string; data: unknown }) => {
+      if (request.url === "/open-apis/drive/v1/metas/batch_query") {
+        return {
+          code: 0,
+          data: {
+            metas: [
+              {
+                doc_token: TEST_DOC_TOKEN,
+                title: params.documentTitle ?? "Comment event handling request",
+                url: params.documentUrl ?? `https://www.larksuite.com/docx/${TEST_DOC_TOKEN}`,
+              },
+            ],
+          },
+        };
+      }
+      if (request.url.includes("/comments/batch_query")) {
+        return {
+          code: 0,
+          data: {
+            items: [
+              {
+                comment_id: "7623358762119646411",
+                quote: params.quoteText ?? "im.message.receive_v1 message trigger implementation",
+                reply_list: {
+                  replies: [
+                    {
+                      reply_id: "7623358762136374451",
+                      content: {
+                        elements: [
+                          {
+                            type: "text_run",
+                            text_run: {
+                              content:
+                                params.rootReplyText ??
+                                "Also send it to the agent after receiving the comment event",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                    ...(params.includeTargetReplyInBatch
+                      ? [
+                          {
+                            reply_id: "7623359125036043462",
+                            content: {
+                              elements: [
+                                {
+                                  type: "text_run",
+                                  text_run: {
+                                    content:
+                                      params.targetReplyText ?? "Please follow up on this comment",
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        ]
+                      : []),
+                  ],
+                },
+              },
+            ],
+          },
+        };
+      }
+      if (request.url.includes("/replies")) {
+        return {
+          code: 0,
+          data: {
+            has_more: false,
+            items: [
+              {
+                reply_id: "7623358762136374451",
+                content: {
+                  elements: [
+                    {
+                      type: "text_run",
+                      text_run: {
+                        content:
+                          params.rootReplyText ??
+                          "Also send it to the agent after receiving the comment event",
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                reply_id: "7623359125036043462",
+                content: {
+                  elements: [
+                    {
+                      type: "text_run",
+                      text_run: {
+                        content: params.targetReplyText ?? "Please follow up on this comment",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        };
+      }
+      throw new Error(`unexpected request: ${request.method} ${request.url}`);
+    }),
+  };
+}
+
+async function setupCommentMonitorHandler(): Promise<(data: unknown) => Promise<void>> {
+  const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
+    handlers = registered;
+  });
+  createEventDispatcherMock.mockReturnValue({ register });
+
+  await monitorSingleAccount({
+    cfg: buildMonitorConfig(),
+    account: buildMonitorAccount(),
+    runtime: createNonExitingTypedRuntimeEnv<RuntimeEnv>(),
+    botOpenIdSource: {
+      kind: "prefetched",
+      botOpenId: "ou_bot",
+    },
+  });
+
+  const handler = handlers["drive.notice.comment_add_v1"];
+  if (!handler) {
+    throw new Error("missing drive.notice.comment_add_v1 handler");
+  }
+  return handler;
+}
+
+function extractSyntheticText(event: FeishuMessageEvent): string {
+  const content = JSON.parse(event.message.content) as { text?: string };
+  return content.text ?? "";
+}
+
+describe("resolveDriveCommentSyntheticEvent", () => {
+  it("builds a synthetic Feishu message for add_comment notices", async () => {
+    const client = makeOpenApiClient({ includeTargetReplyInBatch: true });
+
+    const synthetic = await resolveDriveCommentSyntheticEvent({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent(),
+      botOpenId: "ou_bot",
+      createClient: () => client as never,
+    });
+
+    expect(synthetic).not.toBeNull();
+    expect(synthetic?.sender.sender_id.open_id).toBe("ou_509d4d7ace4a9addec2312676ffcba9b");
+    expect(synthetic?.message.message_id).toBe("drive-comment:10d9d60b990db39f96a4c2fd357fb877");
+    expect(synthetic?.message.chat_id).toBe("p2p:ou_509d4d7ace4a9addec2312676ffcba9b");
+    expect(synthetic?.message.chat_type).toBe("p2p");
+    expect(synthetic?.message.create_time).toBe("1774951528000");
+
+    const text = extractSyntheticText(synthetic as FeishuMessageEvent);
+    expect(text).toContain(
+      'I added a comment in "Comment event handling request": Also send it to the agent after receiving the comment event',
+    );
+    expect(text).toContain("Also send it to the agent after receiving the comment event");
+    expect(text).toContain("Quoted content: im.message.receive_v1 message trigger implementation");
+    expect(text).toContain("This comment mentioned you.");
+    expect(text).toContain(
+      "This is a Feishu document comment event, not a normal instant-message conversation.",
+    );
+    expect(text).toContain("feishu_drive.reply_comment");
+    expect(text).toContain(
+      "reply with the answer in that comment thread via feishu_drive.reply_comment",
+    );
+    expect(text).toContain(
+      "after finishing also use feishu_drive.reply_comment in that comment thread to tell the user the update is complete",
+    );
+    expect(text).toContain(
+      "keep it in the same language as the user's original comment or reply unless they explicitly ask for another language",
+    );
+    expect(text).toContain("output only NO_REPLY at the end");
+  });
+
+  it("falls back to the replies API to resolve add_reply text", async () => {
+    const client = makeOpenApiClient({
+      includeTargetReplyInBatch: false,
+      targetReplyText: "Please follow up on this comment",
+    });
+
+    const synthetic = await resolveDriveCommentSyntheticEvent({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent({
+        notice_meta: {
+          ...makeDriveCommentEvent().notice_meta,
+          notice_type: "add_reply",
+        },
+        reply_id: "7623359125036043462",
+      }),
+      botOpenId: "ou_bot",
+      createClient: () => client as never,
+    });
+
+    const text = extractSyntheticText(synthetic as FeishuMessageEvent);
+    expect(text).toContain(
+      'I added a reply in "Comment event handling request": Please follow up on this comment',
+    );
+    expect(text).toContain(
+      "Original comment: Also send it to the agent after receiving the comment event",
+    );
+    expect(text).toContain(`file_token: ${TEST_DOC_TOKEN}`);
+    expect(text).toContain("Event type: add_reply");
+    expect(text).toContain(
+      "keep it in the same language as the user's original comment or reply unless they explicitly ask for another language",
+    );
+  });
+
+  it("ignores self-authored comment notices", async () => {
+    const synthetic = await resolveDriveCommentSyntheticEvent({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent({
+        notice_meta: {
+          ...makeDriveCommentEvent().notice_meta,
+          from_user_id: { open_id: "ou_bot" },
+        },
+      }),
+      botOpenId: "ou_bot",
+      createClient: () => makeOpenApiClient({}) as never,
+    });
+
+    expect(synthetic).toBeNull();
+  });
+});
+
+describe("drive.notice.comment_add_v1 monitor handler", () => {
+  beforeEach(() => {
+    handlers = {};
+    handleFeishuCommentEventMock.mockClear();
+    createEventDispatcherMock.mockReset();
+    createFeishuClientMock.mockReset().mockReturnValue(makeOpenApiClient({}) as never);
+    createFeishuThreadBindingManagerMock.mockReset().mockImplementation(() => ({
+      stop: vi.fn(),
+    }));
+    vi.spyOn(dedup, "tryBeginFeishuMessageProcessing").mockReturnValue(true);
+    vi.spyOn(dedup, "recordProcessedFeishuMessage").mockResolvedValue(true);
+    vi.spyOn(dedup, "hasProcessedFeishuMessage").mockResolvedValue(false);
+    setFeishuRuntime(
+      createPluginRuntimeMock({
+        channel: {
+          debounce: {
+            resolveInboundDebounceMs,
+            createInboundDebouncer,
+          },
+          text: {
+            hasControlCommand,
+          },
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches comment notices through handleFeishuCommentEvent", async () => {
+    const onComment = await setupCommentMonitorHandler();
+
+    await onComment(makeDriveCommentEvent());
+
+    expect(handleFeishuCommentEventMock).toHaveBeenCalledTimes(1);
+    expect(handleFeishuCommentEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        botOpenId: "ou_bot",
+        event: expect.objectContaining({
+          event_id: "10d9d60b990db39f96a4c2fd357fb877",
+          comment_id: "7623358762119646411",
+        }),
+      }),
+    );
+  });
+
+  it("drops duplicate comment events before dispatch", async () => {
+    vi.spyOn(dedup, "hasProcessedFeishuMessage").mockResolvedValue(true);
+    const onComment = await setupCommentMonitorHandler();
+
+    await onComment(makeDriveCommentEvent());
+
+    expect(handleFeishuCommentEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -310,7 +310,7 @@ describe("resolveDriveCommentEventTurn", () => {
   });
 
   it("skips comment notices when bot open_id is unavailable", async () => {
-    const synthetic = await resolveDriveCommentSyntheticEvent({
+    const turn = await resolveDriveCommentEventTurn({
       cfg: buildMonitorConfig(),
       accountId: "default",
       event: makeDriveCommentEvent(),
@@ -318,7 +318,7 @@ describe("resolveDriveCommentEventTurn", () => {
       createClient: () => makeOpenApiClient({}) as never,
     });
 
-    expect(synthetic).toBeNull();
+    expect(turn).toBeNull();
   });
 });
 

--- a/extensions/feishu/src/monitor.comment.ts
+++ b/extensions/feishu/src/monitor.comment.ts
@@ -1,0 +1,761 @@
+import type { ClawdbotConfig } from "../runtime-api.js";
+import { resolveFeishuAccount } from "./accounts.js";
+import { raceWithTimeoutAndAbort } from "./async.js";
+import type { FeishuMessageEvent } from "./bot.js";
+import { createFeishuClient } from "./client.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+
+const FEISHU_COMMENT_VERIFY_TIMEOUT_MS = 3_000;
+const FEISHU_COMMENT_REPLY_PAGE_SIZE = 200;
+const FEISHU_COMMENT_REPLY_PAGE_LIMIT = 5;
+
+type FeishuDriveCommentUserId = {
+  open_id?: string;
+  user_id?: string;
+  union_id?: string;
+};
+
+export type FeishuDriveCommentNoticeEvent = {
+  comment_id?: string;
+  event_id?: string;
+  is_mentioned?: boolean;
+  notice_meta?: {
+    file_token?: string;
+    file_type?: string;
+    from_user_id?: FeishuDriveCommentUserId;
+    notice_type?: string;
+    to_user_id?: FeishuDriveCommentUserId;
+  };
+  reply_id?: string;
+  timestamp?: string;
+  type?: string;
+};
+
+type ResolveDriveCommentSyntheticEventParams = {
+  cfg: ClawdbotConfig;
+  accountId: string;
+  event: FeishuDriveCommentNoticeEvent;
+  botOpenId?: string;
+  createClient?: (account: ResolvedFeishuAccount) => FeishuRequestClient;
+  verificationTimeoutMs?: number;
+  logger?: (message: string) => void;
+};
+
+export type ResolvedDriveCommentEventTurn = {
+  eventId: string;
+  messageId: string;
+  commentId: string;
+  replyId?: string;
+  noticeType: "add_comment" | "add_reply";
+  fileToken: string;
+  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  senderId: string;
+  timestamp?: string;
+  isMentioned?: boolean;
+  documentTitle?: string;
+  documentUrl?: string;
+  quoteText?: string;
+  rootCommentText?: string;
+  targetReplyText?: string;
+  prompt: string;
+  preview: string;
+};
+
+type FeishuRequestClient = ReturnType<typeof createFeishuClient> & {
+  request(params: {
+    method: "GET" | "POST";
+    url: string;
+    data: unknown;
+    timeout: number;
+  }): Promise<unknown>;
+};
+
+type FeishuOpenApiResponse<T> = {
+  code?: number;
+  msg?: string;
+  data?: T;
+};
+
+type FeishuDriveMetaBatchQueryResponse = FeishuOpenApiResponse<{
+  metas?: Array<{
+    doc_token?: string;
+    title?: string;
+    url?: string;
+  }>;
+}>;
+
+type FeishuDriveCommentReply = {
+  reply_id?: string;
+  content?: {
+    elements?: unknown[];
+  };
+};
+
+type FeishuDriveCommentCard = {
+  comment_id?: string;
+  has_more?: boolean;
+  quote?: string;
+  reply_list?: {
+    replies?: FeishuDriveCommentReply[];
+  };
+};
+
+type FeishuDriveCommentBatchQueryResponse = FeishuOpenApiResponse<{
+  items?: FeishuDriveCommentCard[];
+}>;
+
+type FeishuDriveCommentRepliesListResponse = FeishuOpenApiResponse<{
+  has_more?: boolean;
+  items?: FeishuDriveCommentReply[];
+  page_token?: string;
+}>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function normalizeDriveCommentFileType(
+  value: unknown,
+): "doc" | "docx" | "file" | "sheet" | "slides" | undefined {
+  return value === "doc" ||
+    value === "docx" ||
+    value === "file" ||
+    value === "sheet" ||
+    value === "slides"
+    ? value
+    : undefined;
+}
+
+function encodeQuery(params: Record<string, string | undefined>): string {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      query.set(key, trimmed);
+    }
+  }
+  const queryString = query.toString();
+  return queryString ? `?${queryString}` : "";
+}
+
+function buildDriveCommentTargetUrl(params: {
+  fileToken: string;
+  commentId: string;
+  fileType: string;
+}): string {
+  return (
+    `/open-apis/drive/v1/files/${encodeURIComponent(params.fileToken)}/comments/batch_query` +
+    encodeQuery({
+      file_type: params.fileType,
+      user_id_type: "open_id",
+    })
+  );
+}
+
+function buildDriveCommentRepliesUrl(params: {
+  fileToken: string;
+  commentId: string;
+  fileType: string;
+  pageToken?: string;
+}): string {
+  return (
+    `/open-apis/drive/v1/files/${encodeURIComponent(params.fileToken)}/comments/${encodeURIComponent(
+      params.commentId,
+    )}/replies` +
+    encodeQuery({
+      file_type: params.fileType,
+      page_token: params.pageToken,
+      page_size: String(FEISHU_COMMENT_REPLY_PAGE_SIZE),
+      user_id_type: "open_id",
+    })
+  );
+}
+
+async function requestFeishuOpenApi<T>(params: {
+  client: FeishuRequestClient;
+  method: "GET" | "POST";
+  url: string;
+  data?: unknown;
+  timeoutMs: number;
+  logger?: (message: string) => void;
+  errorLabel: string;
+}): Promise<T | null> {
+  const result = await raceWithTimeoutAndAbort(
+    params.client.request({
+      method: params.method,
+      url: params.url,
+      data: params.data ?? {},
+      timeout: params.timeoutMs,
+    }) as Promise<T>,
+    { timeoutMs: params.timeoutMs },
+  )
+    .then((resolved) => (resolved.status === "resolved" ? resolved.value : null))
+    .catch((error) => {
+      params.logger?.(`${params.errorLabel}: ${String(error)}`);
+      return null;
+    });
+  if (!result) {
+    params.logger?.(`${params.errorLabel}: request timed out or returned no data`);
+  }
+  return result;
+}
+
+function extractCommentElementText(element: unknown): string | undefined {
+  if (!isRecord(element)) {
+    return undefined;
+  }
+  const type = readString(element.type)?.trim();
+  if (type === "text_run" && isRecord(element.text_run)) {
+    return (
+      readString(element.text_run.content)?.trim() ||
+      readString(element.text_run.text)?.trim() ||
+      undefined
+    );
+  }
+  if (type === "mention") {
+    const mention = isRecord(element.mention) ? element.mention : undefined;
+    const mentionName =
+      readString(mention?.name)?.trim() ||
+      readString(mention?.display_name)?.trim() ||
+      readString(element.name)?.trim();
+    return mentionName ? `@${mentionName}` : "@mention";
+  }
+  if (type === "docs_link") {
+    const docsLink = isRecord(element.docs_link) ? element.docs_link : undefined;
+    return (
+      readString(docsLink?.text)?.trim() ||
+      readString(docsLink?.url)?.trim() ||
+      readString(element.text)?.trim() ||
+      readString(element.url)?.trim() ||
+      undefined
+    );
+  }
+  return (
+    readString(element.text)?.trim() ||
+    readString(element.content)?.trim() ||
+    readString(element.name)?.trim() ||
+    undefined
+  );
+}
+
+function extractReplyText(reply: FeishuDriveCommentReply | undefined): string | undefined {
+  if (!reply || !isRecord(reply.content)) {
+    return undefined;
+  }
+  const elements = Array.isArray(reply.content.elements) ? reply.content.elements : [];
+  const parts = elements
+    .map(extractCommentElementText)
+    .filter((part): part is string => Boolean(part && part.trim()));
+  const text = parts.join("").trim();
+  return text || undefined;
+}
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    return JSON.stringify({
+      error: `stringify_failed:${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+}
+
+function summarizeReplyForLog(reply: FeishuDriveCommentReply | undefined) {
+  return {
+    reply_id: reply?.reply_id,
+    text: extractReplyText(reply),
+  };
+}
+
+async function fetchDriveCommentReplies(params: {
+  client: FeishuRequestClient;
+  fileToken: string;
+  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  commentId: string;
+  timeoutMs: number;
+  logger?: (message: string) => void;
+  accountId: string;
+}): Promise<FeishuDriveCommentReply[]> {
+  const replies: FeishuDriveCommentReply[] = [];
+  let pageToken: string | undefined;
+  for (let page = 0; page < FEISHU_COMMENT_REPLY_PAGE_LIMIT; page += 1) {
+    const response = await requestFeishuOpenApi<FeishuDriveCommentRepliesListResponse>({
+      client: params.client,
+      method: "GET",
+      url: buildDriveCommentRepliesUrl({
+        fileToken: params.fileToken,
+        commentId: params.commentId,
+        fileType: params.fileType,
+        pageToken,
+      }),
+      timeoutMs: params.timeoutMs,
+      logger: params.logger,
+      errorLabel: `feishu[${params.accountId}]: failed to fetch comment replies for ${params.commentId}`,
+    });
+    if (response?.code !== 0) {
+      if (response) {
+        params.logger?.(
+          `feishu[${params.accountId}]: failed to fetch comment replies for ${params.commentId}: ${response.msg ?? "unknown error"}`,
+        );
+      }
+      break;
+    }
+    params.logger?.(
+      `feishu[${params.accountId}]: fetched comment replies page=${page + 1} ` +
+        `comment=${params.commentId} raw=${safeJsonStringify(response?.data?.items ?? [])}`,
+    );
+    replies.push(...(response.data?.items ?? []));
+    if (response.data?.has_more !== true || !response.data.page_token?.trim()) {
+      break;
+    }
+    pageToken = response.data.page_token.trim();
+  }
+  return replies;
+}
+
+async function fetchDriveCommentContext(params: {
+  client: FeishuRequestClient;
+  fileToken: string;
+  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  commentId: string;
+  replyId?: string;
+  timeoutMs: number;
+  logger?: (message: string) => void;
+  accountId: string;
+}): Promise<{
+  documentTitle?: string;
+  documentUrl?: string;
+  quoteText?: string;
+  rootCommentText?: string;
+  targetReplyText?: string;
+}> {
+  const [metaResponse, commentResponse] = await Promise.all([
+    requestFeishuOpenApi<FeishuDriveMetaBatchQueryResponse>({
+      client: params.client,
+      method: "POST",
+      url: "/open-apis/drive/v1/metas/batch_query",
+      data: {
+        request_docs: [{ doc_token: params.fileToken, doc_type: params.fileType }],
+        with_url: true,
+      },
+      timeoutMs: params.timeoutMs,
+      logger: params.logger,
+      errorLabel: `feishu[${params.accountId}]: failed to fetch drive metadata for ${params.fileToken}`,
+    }),
+    requestFeishuOpenApi<FeishuDriveCommentBatchQueryResponse>({
+      client: params.client,
+      method: "POST",
+      url: buildDriveCommentTargetUrl({
+        fileToken: params.fileToken,
+        commentId: params.commentId,
+        fileType: params.fileType,
+      }),
+      data: {
+        comment_ids: [params.commentId],
+      },
+      timeoutMs: params.timeoutMs,
+      logger: params.logger,
+      errorLabel: `feishu[${params.accountId}]: failed to fetch drive comment ${params.commentId}`,
+    }),
+  ]);
+
+  const commentCard =
+    commentResponse?.code === 0
+      ? ((commentResponse.data?.items ?? []).find(
+          (item) => item.comment_id?.trim() === params.commentId,
+        ) ?? commentResponse.data?.items?.[0])
+      : undefined;
+  const embeddedReplies = commentCard?.reply_list?.replies ?? [];
+  params.logger?.(
+    `feishu[${params.accountId}]: embedded comment replies comment=${params.commentId} ` +
+      `raw=${safeJsonStringify(embeddedReplies)}`,
+  );
+  const embeddedTargetReply = params.replyId
+    ? embeddedReplies.find((reply) => reply.reply_id?.trim() === params.replyId?.trim())
+    : embeddedReplies.at(-1);
+
+  let replies = embeddedReplies;
+  if (!embeddedTargetReply || replies.length === 0) {
+    const fetchedReplies = await fetchDriveCommentReplies(params);
+    if (fetchedReplies.length > 0) {
+      replies = fetchedReplies;
+    }
+  }
+
+  const rootReply = replies[0] ?? embeddedReplies[0];
+  const fetchedMatchedReply = params.replyId
+    ? replies.find((reply) => reply.reply_id?.trim() === params.replyId?.trim())
+    : undefined;
+  const targetReply = params.replyId
+    ? (embeddedTargetReply ?? fetchedMatchedReply ?? undefined)
+    : ((replies.at(-1) ?? embeddedTargetReply ?? rootReply) as FeishuDriveCommentReply | undefined);
+  const matchSource = params.replyId
+    ? embeddedTargetReply
+      ? "embedded"
+      : fetchedMatchedReply
+        ? "fetched"
+        : "miss"
+    : targetReply === rootReply
+      ? "fallback_root"
+      : targetReply === embeddedTargetReply
+        ? "embedded_latest"
+        : "fetched_latest";
+  params.logger?.(
+    `feishu[${params.accountId}]: comment reply resolution comment=${params.commentId} ` +
+      `requested_reply=${params.replyId ?? "none"} match_source=${matchSource} ` +
+      `root=${safeJsonStringify(summarizeReplyForLog(rootReply))} ` +
+      `target=${safeJsonStringify(summarizeReplyForLog(targetReply))}`,
+  );
+  const meta = metaResponse?.code === 0 ? metaResponse.data?.metas?.[0] : undefined;
+
+  return {
+    documentTitle: meta?.title?.trim() || undefined,
+    documentUrl: meta?.url?.trim() || undefined,
+    quoteText: commentCard?.quote?.trim() || undefined,
+    rootCommentText: extractReplyText(rootReply),
+    targetReplyText: extractReplyText(targetReply),
+  };
+}
+
+function buildDriveCommentPrompt(params: {
+  noticeType: "add_comment" | "add_reply";
+  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  fileToken: string;
+  isMentioned?: boolean;
+  documentTitle?: string;
+  documentUrl?: string;
+  quoteText?: string;
+  rootCommentText?: string;
+  targetReplyText?: string;
+}): string {
+  const documentLabel = params.documentTitle
+    ? `"${params.documentTitle}"`
+    : `${params.fileType} document ${params.fileToken}`;
+  const actionLabel = params.noticeType === "add_reply" ? "reply" : "comment";
+  const firstLine = params.targetReplyText
+    ? `I added a ${actionLabel} in ${documentLabel}: ${params.targetReplyText}`
+    : `I added a ${actionLabel} in ${documentLabel}.`;
+  const lines = [firstLine];
+  if (
+    params.noticeType === "add_reply" &&
+    params.rootCommentText &&
+    params.rootCommentText !== params.targetReplyText
+  ) {
+    lines.push(`Original comment: ${params.rootCommentText}`);
+  }
+  if (params.quoteText) {
+    lines.push(`Quoted content: ${params.quoteText}`);
+  }
+  if (params.isMentioned === true) {
+    lines.push("This comment mentioned you.");
+  }
+  if (params.documentUrl) {
+    lines.push(`Document link: ${params.documentUrl}`);
+  }
+  lines.push(
+    `Event type: ${params.noticeType}`,
+    `file_token: ${params.fileToken}`,
+    `file_type: ${params.fileType}`,
+    "This is a Feishu document comment event, not a normal instant-message conversation. Do not reply directly in the current Feishu chat, and do not treat this event as something that requires sending an IM text reply.",
+    "If you need to inspect or handle the comment thread, prefer the feishu_drive tools: use list_comments / list_comment_replies to inspect comments, add_comment to add a new comment, and reply_comment to reply in the thread.",
+    "If the user asks a question in the comment, reply with the answer in that comment thread via feishu_drive.reply_comment.",
+    "If you modify the document, after finishing also use feishu_drive.reply_comment in that comment thread to tell the user the update is complete.",
+    "If you decide to add a new comment in the document, use feishu_drive.add_comment; if you decide to reply in the current comment thread, use feishu_drive.reply_comment.",
+    "When you produce a user-visible reply, keep it in the same language as the user's original comment or reply unless they explicitly ask for another language.",
+    "After comment-related tool calls have completed the user-visible action, output only NO_REPLY at the end to avoid sending an extra instant message; do not output the final answer directly as a normal chat reply.",
+  );
+  lines.push(`Decide what to do next based on this document ${actionLabel} event.`);
+  return lines.join("\n");
+}
+
+function buildDriveCommentSurfacePrompt(params: {
+  noticeType: "add_comment" | "add_reply";
+  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  fileToken: string;
+  commentId: string;
+  replyId?: string;
+  isMentioned?: boolean;
+  documentTitle?: string;
+  documentUrl?: string;
+  quoteText?: string;
+  rootCommentText?: string;
+  targetReplyText?: string;
+}): string {
+  const documentLabel = params.documentTitle
+    ? `"${params.documentTitle}"`
+    : `${params.fileType} document ${params.fileToken}`;
+  const actionLabel = params.noticeType === "add_reply" ? "reply" : "comment";
+  const firstLine = params.targetReplyText
+    ? `The user added a ${actionLabel} in ${documentLabel}: ${params.targetReplyText}`
+    : `The user added a ${actionLabel} in ${documentLabel}.`;
+  const lines = [firstLine];
+  if (
+    params.noticeType === "add_reply" &&
+    params.rootCommentText &&
+    params.rootCommentText !== params.targetReplyText
+  ) {
+    lines.push(`Original comment: ${params.rootCommentText}`);
+  }
+  if (params.quoteText) {
+    lines.push(`Quoted content: ${params.quoteText}`);
+  }
+  if (params.isMentioned === true) {
+    lines.push("This comment mentioned you.");
+  }
+  if (params.documentUrl) {
+    lines.push(`Document link: ${params.documentUrl}`);
+  }
+  lines.push(
+    `Event type: ${params.noticeType}`,
+    `file_token: ${params.fileToken}`,
+    `file_type: ${params.fileType}`,
+    `comment_id: ${params.commentId}`,
+  );
+  if (params.replyId?.trim()) {
+    lines.push(`reply_id: ${params.replyId.trim()}`);
+  }
+  lines.push(
+    "This is a Feishu document comment-thread event, not a Feishu IM conversation. Your final text reply will be posted automatically to the current comment thread and will not be sent as an instant message.",
+    "If you need to inspect or handle the comment thread, prefer the feishu_drive tools: use list_comments / list_comment_replies to inspect comments, and use reply_comment/add_comment to notify the user after modifying the document.",
+    'If the comment asks you to modify document content, such as adding, inserting, replacing, or deleting text, tables, or headings, you must first use feishu_doc to actually modify the document. Do not reply with only "done", "I\'ll handle it", or a restated plan without calling tools.',
+    'If the comment quotes document content, that quoted text is usually the edit anchor. For requests like "insert xxx below this content", first locate the position around the quoted content, then use feishu_doc to make the change.',
+    'If the comment asks you to summarize, explain, rewrite, translate, refine, continue, or review the document content "below", "above", "this paragraph", "this section", or the quoted content, you must also treat the quoted content as the primary target anchor instead of defaulting to the whole document.',
+    'For requests like "summarize the content below", "explain this section", or "continue writing from here", first locate the relevant document fragment based on the comment\'s quoted content. If the quote is not sufficient to support the answer, then use feishu_doc.read or feishu_doc.list_blocks to read nearby context.',
+    "Do not guess document content based only on the comment text, and do not output a vague summary before reading enough context. Unless the user explicitly asks to summarize the entire document, default to handling only the local scope related to the quoted content.",
+    "When document edits are involved, first use feishu_doc.read or feishu_doc.list_blocks to confirm the context, then use feishu_doc writing or updating capabilities to complete the change. After the edit succeeds, notify the user through feishu_drive.reply_comment.",
+    "If the document edit fails or you cannot locate the anchor, do not pretend it succeeded. Reply clearly in the comment thread with the reason for failure or the missing information.",
+    "If this is a reading-comprehension task, such as summarization, explanation, or extraction, you may directly output the final answer text after confirming the context. The system will automatically reply with that answer in the current comment thread.",
+    "When you produce a user-visible reply, keep it in the same language as the user's original comment or reply unless they explicitly ask for another language.",
+    "If you have already completed the user-visible action through feishu_drive.reply_comment or feishu_drive.add_comment, output NO_REPLY at the end to avoid duplicate sending.",
+    "If the user directly asks a question in the comment and a plain text answer is sufficient, output the answer text directly. The system will automatically reply with your final answer in the current comment thread.",
+    "If you determine that the current comment does not require any user-visible action, output NO_REPLY at the end.",
+  );
+  lines.push(`Decide what to do next based on this document ${actionLabel} event.`);
+  return lines.join("\n");
+}
+
+async function resolveDriveCommentEventCore(
+  params: ResolveDriveCommentSyntheticEventParams,
+): Promise<{
+  eventId: string;
+  commentId: string;
+  replyId?: string;
+  noticeType: "add_comment" | "add_reply";
+  fileToken: string;
+  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  senderId: string;
+  timestamp?: string;
+  isMentioned?: boolean;
+  context: {
+    documentTitle?: string;
+    documentUrl?: string;
+    quoteText?: string;
+    rootCommentText?: string;
+    targetReplyText?: string;
+  };
+} | null> {
+  const {
+    cfg,
+    accountId,
+    event,
+    botOpenId,
+    createClient = (account) => createFeishuClient(account) as FeishuRequestClient,
+    verificationTimeoutMs = FEISHU_COMMENT_VERIFY_TIMEOUT_MS,
+    logger,
+  } = params;
+  const eventId = event.event_id?.trim();
+  const commentId = event.comment_id?.trim();
+  const replyId = event.reply_id?.trim();
+  const noticeType = event.notice_meta?.notice_type?.trim();
+  const fileToken = event.notice_meta?.file_token?.trim();
+  const fileType = normalizeDriveCommentFileType(event.notice_meta?.file_type);
+  const senderId = event.notice_meta?.from_user_id?.open_id?.trim();
+  if (!eventId || !commentId || !noticeType || !fileToken || !fileType || !senderId) {
+    logger?.(
+      `feishu[${accountId}]: drive comment notice missing required fields ` +
+        `event=${eventId ?? "unknown"} comment=${commentId ?? "unknown"}`,
+    );
+    return null;
+  }
+  if (noticeType !== "add_comment" && noticeType !== "add_reply") {
+    logger?.(
+      `feishu[${accountId}]: unsupported drive comment notice type ${noticeType} ` +
+        `for event ${eventId}`,
+    );
+    return null;
+  }
+  if (senderId === botOpenId) {
+    logger?.(
+      `feishu[${accountId}]: ignoring self-authored drive comment notice ` +
+        `event=${eventId} sender=${senderId}`,
+    );
+    return null;
+  }
+
+  const account = resolveFeishuAccount({ cfg, accountId });
+  const client = createClient(account);
+  logger?.(
+    `feishu[${accountId}]: fetching drive comment context ` +
+      `event=${eventId} type=${noticeType} file=${fileType}:${fileToken} comment=${commentId} reply=${replyId ?? "none"}`,
+  );
+  const context = await fetchDriveCommentContext({
+    client,
+    fileToken,
+    fileType,
+    commentId,
+    replyId,
+    timeoutMs: verificationTimeoutMs,
+    logger,
+    accountId,
+  });
+  logger?.(
+    `feishu[${accountId}]: drive comment context resolved ` +
+      `event=${eventId} title=${context.documentTitle ?? "unknown"} ` +
+      `quote=${context.quoteText ? "yes" : "no"} root=${context.rootCommentText ? "yes" : "no"} ` +
+      `target=${context.targetReplyText ? "yes" : "no"}`,
+  );
+  return {
+    eventId,
+    commentId,
+    replyId,
+    noticeType,
+    fileToken,
+    fileType,
+    senderId,
+    timestamp: event.timestamp,
+    isMentioned: event.is_mentioned,
+    context,
+  };
+}
+
+export function parseFeishuDriveCommentNoticeEventPayload(
+  value: unknown,
+): FeishuDriveCommentNoticeEvent | null {
+  if (!isRecord(value) || !isRecord(value.notice_meta)) {
+    return null;
+  }
+  const noticeMeta = value.notice_meta;
+  const fromUserId = isRecord(noticeMeta.from_user_id) ? noticeMeta.from_user_id : undefined;
+  const toUserId = isRecord(noticeMeta.to_user_id) ? noticeMeta.to_user_id : undefined;
+  return {
+    comment_id: readString(value.comment_id),
+    event_id: readString(value.event_id),
+    is_mentioned: readBoolean(value.is_mentioned),
+    notice_meta: {
+      file_token: readString(noticeMeta.file_token),
+      file_type: readString(noticeMeta.file_type),
+      from_user_id: fromUserId
+        ? {
+            open_id: readString(fromUserId.open_id),
+            user_id: readString(fromUserId.user_id),
+            union_id: readString(fromUserId.union_id),
+          }
+        : undefined,
+      notice_type: readString(noticeMeta.notice_type),
+      to_user_id: toUserId
+        ? {
+            open_id: readString(toUserId.open_id),
+            user_id: readString(toUserId.user_id),
+            union_id: readString(toUserId.union_id),
+          }
+        : undefined,
+    },
+    reply_id: readString(value.reply_id),
+    timestamp: readString(value.timestamp),
+    type: readString(value.type),
+  };
+}
+
+export async function resolveDriveCommentEventTurn(
+  params: ResolveDriveCommentSyntheticEventParams,
+): Promise<ResolvedDriveCommentEventTurn | null> {
+  const resolved = await resolveDriveCommentEventCore(params);
+  if (!resolved) {
+    return null;
+  }
+  const prompt = buildDriveCommentSurfacePrompt({
+    noticeType: resolved.noticeType,
+    fileType: resolved.fileType,
+    fileToken: resolved.fileToken,
+    commentId: resolved.commentId,
+    replyId: resolved.replyId,
+    isMentioned: resolved.isMentioned,
+    documentTitle: resolved.context.documentTitle,
+    documentUrl: resolved.context.documentUrl,
+    quoteText: resolved.context.quoteText,
+    rootCommentText: resolved.context.rootCommentText,
+    targetReplyText: resolved.context.targetReplyText,
+  });
+  const preview = prompt.replace(/\s+/g, " ").slice(0, 160);
+  params.logger?.(
+    `feishu[${params.accountId}]: built drive comment prompt ` +
+      `event=${resolved.eventId} preview=${preview}`,
+  );
+  return {
+    eventId: resolved.eventId,
+    messageId: `drive-comment:${resolved.eventId}`,
+    commentId: resolved.commentId,
+    replyId: resolved.replyId,
+    noticeType: resolved.noticeType,
+    fileToken: resolved.fileToken,
+    fileType: resolved.fileType,
+    senderId: resolved.senderId,
+    timestamp: resolved.timestamp,
+    isMentioned: resolved.isMentioned,
+    documentTitle: resolved.context.documentTitle,
+    documentUrl: resolved.context.documentUrl,
+    quoteText: resolved.context.quoteText,
+    rootCommentText: resolved.context.rootCommentText,
+    targetReplyText: resolved.context.targetReplyText,
+    prompt,
+    preview,
+  };
+}
+
+export async function resolveDriveCommentSyntheticEvent(
+  params: ResolveDriveCommentSyntheticEventParams,
+): Promise<FeishuMessageEvent | null> {
+  const resolved = await resolveDriveCommentEventCore(params);
+  if (!resolved) {
+    return null;
+  }
+  const prompt = buildDriveCommentPrompt({
+    noticeType: resolved.noticeType,
+    fileType: resolved.fileType,
+    fileToken: resolved.fileToken,
+    isMentioned: resolved.isMentioned,
+    documentTitle: resolved.context.documentTitle,
+    documentUrl: resolved.context.documentUrl,
+    quoteText: resolved.context.quoteText,
+    rootCommentText: resolved.context.rootCommentText,
+    targetReplyText: resolved.context.targetReplyText,
+  });
+  const preview = prompt.replace(/\s+/g, " ").slice(0, 160);
+  params.logger?.(
+    `feishu[${params.accountId}]: built drive comment synthetic prompt ` +
+      `event=${resolved.eventId} preview=${preview}`,
+  );
+
+  return {
+    sender: {
+      sender_id: { open_id: resolved.senderId },
+      sender_type: "user",
+    },
+    message: {
+      message_id: `drive-comment:${resolved.eventId}`,
+      chat_id: `p2p:${resolved.senderId}`,
+      chat_type: "p2p",
+      message_type: "text",
+      content: JSON.stringify({ text: prompt }),
+      create_time: resolved.timestamp,
+    },
+  };
+}

--- a/extensions/feishu/src/monitor.comment.ts
+++ b/extensions/feishu/src/monitor.comment.ts
@@ -1,8 +1,8 @@
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";
-import type { FeishuMessageEvent } from "./bot.js";
 import { createFeishuClient } from "./client.js";
+import { normalizeCommentFileType, type CommentFileType } from "./comment-target.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 const FEISHU_COMMENT_VERIFY_TIMEOUT_MS = 3_000;
@@ -31,7 +31,7 @@ export type FeishuDriveCommentNoticeEvent = {
   type?: string;
 };
 
-type ResolveDriveCommentSyntheticEventParams = {
+type ResolveDriveCommentEventParams = {
   cfg: ClawdbotConfig;
   accountId: string;
   event: FeishuDriveCommentNoticeEvent;
@@ -48,7 +48,7 @@ export type ResolvedDriveCommentEventTurn = {
   replyId?: string;
   noticeType: "add_comment" | "add_reply";
   fileToken: string;
-  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  fileType: CommentFileType;
   senderId: string;
   timestamp?: string;
   isMentioned?: boolean;
@@ -93,7 +93,6 @@ type FeishuDriveCommentReply = {
 
 type FeishuDriveCommentCard = {
   comment_id?: string;
-  has_more?: boolean;
   quote?: string;
   reply_list?: {
     replies?: FeishuDriveCommentReply[];
@@ -122,18 +121,6 @@ function readBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
 }
 
-function normalizeDriveCommentFileType(
-  value: unknown,
-): "doc" | "docx" | "file" | "sheet" | "slides" | undefined {
-  return value === "doc" ||
-    value === "docx" ||
-    value === "file" ||
-    value === "sheet" ||
-    value === "slides"
-    ? value
-    : undefined;
-}
-
 function encodeQuery(params: Record<string, string | undefined>): string {
   const query = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
@@ -148,8 +135,7 @@ function encodeQuery(params: Record<string, string | undefined>): string {
 
 function buildDriveCommentTargetUrl(params: {
   fileToken: string;
-  commentId: string;
-  fileType: string;
+  fileType: CommentFileType;
 }): string {
   return (
     `/open-apis/drive/v1/files/${encodeURIComponent(params.fileToken)}/comments/batch_query` +
@@ -163,7 +149,7 @@ function buildDriveCommentTargetUrl(params: {
 function buildDriveCommentRepliesUrl(params: {
   fileToken: string;
   commentId: string;
-  fileType: string;
+  fileType: CommentFileType;
   pageToken?: string;
 }): string {
   return (
@@ -251,34 +237,18 @@ function extractReplyText(reply: FeishuDriveCommentReply | undefined): string | 
     return undefined;
   }
   const elements = Array.isArray(reply.content.elements) ? reply.content.elements : [];
-  const parts = elements
+  const text = elements
     .map(extractCommentElementText)
-    .filter((part): part is string => Boolean(part && part.trim()));
-  const text = parts.join("").trim();
+    .filter((part): part is string => Boolean(part && part.trim()))
+    .join("")
+    .trim();
   return text || undefined;
-}
-
-function safeJsonStringify(value: unknown): string {
-  try {
-    return JSON.stringify(value);
-  } catch (error) {
-    return JSON.stringify({
-      error: `stringify_failed:${error instanceof Error ? error.message : String(error)}`,
-    });
-  }
-}
-
-function summarizeReplyForLog(reply: FeishuDriveCommentReply | undefined) {
-  return {
-    reply_id: reply?.reply_id,
-    text: extractReplyText(reply),
-  };
 }
 
 async function fetchDriveCommentReplies(params: {
   client: FeishuRequestClient;
   fileToken: string;
-  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  fileType: CommentFileType;
   commentId: string;
   timeoutMs: number;
   logger?: (message: string) => void;
@@ -308,10 +278,6 @@ async function fetchDriveCommentReplies(params: {
       }
       break;
     }
-    params.logger?.(
-      `feishu[${params.accountId}]: fetched comment replies page=${page + 1} ` +
-        `comment=${params.commentId} raw=${safeJsonStringify(response?.data?.items ?? [])}`,
-    );
     replies.push(...(response.data?.items ?? []));
     if (response.data?.has_more !== true || !response.data.page_token?.trim()) {
       break;
@@ -324,7 +290,7 @@ async function fetchDriveCommentReplies(params: {
 async function fetchDriveCommentContext(params: {
   client: FeishuRequestClient;
   fileToken: string;
-  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  fileType: CommentFileType;
   commentId: string;
   replyId?: string;
   timeoutMs: number;
@@ -355,7 +321,6 @@ async function fetchDriveCommentContext(params: {
       method: "POST",
       url: buildDriveCommentTargetUrl({
         fileToken: params.fileToken,
-        commentId: params.commentId,
         fileType: params.fileType,
       }),
       data: {
@@ -374,10 +339,6 @@ async function fetchDriveCommentContext(params: {
         ) ?? commentResponse.data?.items?.[0])
       : undefined;
   const embeddedReplies = commentCard?.reply_list?.replies ?? [];
-  params.logger?.(
-    `feishu[${params.accountId}]: embedded comment replies comment=${params.commentId} ` +
-      `raw=${safeJsonStringify(embeddedReplies)}`,
-  );
   const embeddedTargetReply = params.replyId
     ? embeddedReplies.find((reply) => reply.reply_id?.trim() === params.replyId?.trim())
     : embeddedReplies.at(-1);
@@ -396,24 +357,7 @@ async function fetchDriveCommentContext(params: {
     : undefined;
   const targetReply = params.replyId
     ? (embeddedTargetReply ?? fetchedMatchedReply ?? undefined)
-    : ((replies.at(-1) ?? embeddedTargetReply ?? rootReply) as FeishuDriveCommentReply | undefined);
-  const matchSource = params.replyId
-    ? embeddedTargetReply
-      ? "embedded"
-      : fetchedMatchedReply
-        ? "fetched"
-        : "miss"
-    : targetReply === rootReply
-      ? "fallback_root"
-      : targetReply === embeddedTargetReply
-        ? "embedded_latest"
-        : "fetched_latest";
-  params.logger?.(
-    `feishu[${params.accountId}]: comment reply resolution comment=${params.commentId} ` +
-      `requested_reply=${params.replyId ?? "none"} match_source=${matchSource} ` +
-      `root=${safeJsonStringify(summarizeReplyForLog(rootReply))} ` +
-      `target=${safeJsonStringify(summarizeReplyForLog(targetReply))}`,
-  );
+    : (replies.at(-1) ?? embeddedTargetReply ?? rootReply);
   const meta = metaResponse?.code === 0 ? metaResponse.data?.metas?.[0] : undefined;
 
   return {
@@ -425,60 +369,9 @@ async function fetchDriveCommentContext(params: {
   };
 }
 
-function buildDriveCommentPrompt(params: {
-  noticeType: "add_comment" | "add_reply";
-  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
-  fileToken: string;
-  isMentioned?: boolean;
-  documentTitle?: string;
-  documentUrl?: string;
-  quoteText?: string;
-  rootCommentText?: string;
-  targetReplyText?: string;
-}): string {
-  const documentLabel = params.documentTitle
-    ? `"${params.documentTitle}"`
-    : `${params.fileType} document ${params.fileToken}`;
-  const actionLabel = params.noticeType === "add_reply" ? "reply" : "comment";
-  const firstLine = params.targetReplyText
-    ? `I added a ${actionLabel} in ${documentLabel}: ${params.targetReplyText}`
-    : `I added a ${actionLabel} in ${documentLabel}.`;
-  const lines = [firstLine];
-  if (
-    params.noticeType === "add_reply" &&
-    params.rootCommentText &&
-    params.rootCommentText !== params.targetReplyText
-  ) {
-    lines.push(`Original comment: ${params.rootCommentText}`);
-  }
-  if (params.quoteText) {
-    lines.push(`Quoted content: ${params.quoteText}`);
-  }
-  if (params.isMentioned === true) {
-    lines.push("This comment mentioned you.");
-  }
-  if (params.documentUrl) {
-    lines.push(`Document link: ${params.documentUrl}`);
-  }
-  lines.push(
-    `Event type: ${params.noticeType}`,
-    `file_token: ${params.fileToken}`,
-    `file_type: ${params.fileType}`,
-    "This is a Feishu document comment event, not a normal instant-message conversation. Do not reply directly in the current Feishu chat, and do not treat this event as something that requires sending an IM text reply.",
-    "If you need to inspect or handle the comment thread, prefer the feishu_drive tools: use list_comments / list_comment_replies to inspect comments, add_comment to add a new comment, and reply_comment to reply in the thread.",
-    "If the user asks a question in the comment, reply with the answer in that comment thread via feishu_drive.reply_comment.",
-    "If you modify the document, after finishing also use feishu_drive.reply_comment in that comment thread to tell the user the update is complete.",
-    "If you decide to add a new comment in the document, use feishu_drive.add_comment; if you decide to reply in the current comment thread, use feishu_drive.reply_comment.",
-    "When you produce a user-visible reply, keep it in the same language as the user's original comment or reply unless they explicitly ask for another language.",
-    "After comment-related tool calls have completed the user-visible action, output only NO_REPLY at the end to avoid sending an extra instant message; do not output the final answer directly as a normal chat reply.",
-  );
-  lines.push(`Decide what to do next based on this document ${actionLabel} event.`);
-  return lines.join("\n");
-}
-
 function buildDriveCommentSurfacePrompt(params: {
   noticeType: "add_comment" | "add_reply";
-  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  fileType: CommentFileType;
   fileToken: string;
   commentId: string;
   replyId?: string;
@@ -542,15 +435,13 @@ function buildDriveCommentSurfacePrompt(params: {
   return lines.join("\n");
 }
 
-async function resolveDriveCommentEventCore(
-  params: ResolveDriveCommentSyntheticEventParams,
-): Promise<{
+async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventParams): Promise<{
   eventId: string;
   commentId: string;
   replyId?: string;
   noticeType: "add_comment" | "add_reply";
   fileToken: string;
-  fileType: "doc" | "docx" | "file" | "sheet" | "slides";
+  fileType: CommentFileType;
   senderId: string;
   timestamp?: string;
   isMentioned?: boolean;
@@ -576,36 +467,27 @@ async function resolveDriveCommentEventCore(
   const replyId = event.reply_id?.trim();
   const noticeType = event.notice_meta?.notice_type?.trim();
   const fileToken = event.notice_meta?.file_token?.trim();
-  const fileType = normalizeDriveCommentFileType(event.notice_meta?.file_type);
+  const fileType = normalizeCommentFileType(event.notice_meta?.file_type);
   const senderId = event.notice_meta?.from_user_id?.open_id?.trim();
   if (!eventId || !commentId || !noticeType || !fileToken || !fileType || !senderId) {
     logger?.(
-      `feishu[${accountId}]: drive comment notice missing required fields ` +
-        `event=${eventId ?? "unknown"} comment=${commentId ?? "unknown"}`,
+      `feishu[${accountId}]: drive comment notice missing required fields event=${eventId ?? "unknown"} comment=${commentId ?? "unknown"}`,
     );
     return null;
   }
   if (noticeType !== "add_comment" && noticeType !== "add_reply") {
-    logger?.(
-      `feishu[${accountId}]: unsupported drive comment notice type ${noticeType} ` +
-        `for event ${eventId}`,
-    );
+    logger?.(`feishu[${accountId}]: unsupported drive comment notice type ${noticeType}`);
     return null;
   }
   if (senderId === botOpenId) {
     logger?.(
-      `feishu[${accountId}]: ignoring self-authored drive comment notice ` +
-        `event=${eventId} sender=${senderId}`,
+      `feishu[${accountId}]: ignoring self-authored drive comment notice event=${eventId} sender=${senderId}`,
     );
     return null;
   }
 
   const account = resolveFeishuAccount({ cfg, accountId });
   const client = createClient(account);
-  logger?.(
-    `feishu[${accountId}]: fetching drive comment context ` +
-      `event=${eventId} type=${noticeType} file=${fileType}:${fileToken} comment=${commentId} reply=${replyId ?? "none"}`,
-  );
   const context = await fetchDriveCommentContext({
     client,
     fileToken,
@@ -616,12 +498,6 @@ async function resolveDriveCommentEventCore(
     logger,
     accountId,
   });
-  logger?.(
-    `feishu[${accountId}]: drive comment context resolved ` +
-      `event=${eventId} title=${context.documentTitle ?? "unknown"} ` +
-      `quote=${context.quoteText ? "yes" : "no"} root=${context.rootCommentText ? "yes" : "no"} ` +
-      `target=${context.targetReplyText ? "yes" : "no"}`,
-  );
   return {
     eventId,
     commentId,
@@ -675,7 +551,7 @@ export function parseFeishuDriveCommentNoticeEventPayload(
 }
 
 export async function resolveDriveCommentEventTurn(
-  params: ResolveDriveCommentSyntheticEventParams,
+  params: ResolveDriveCommentEventParams,
 ): Promise<ResolvedDriveCommentEventTurn | null> {
   const resolved = await resolveDriveCommentEventCore(params);
   if (!resolved) {
@@ -695,10 +571,6 @@ export async function resolveDriveCommentEventTurn(
     targetReplyText: resolved.context.targetReplyText,
   });
   const preview = prompt.replace(/\s+/g, " ").slice(0, 160);
-  params.logger?.(
-    `feishu[${params.accountId}]: built drive comment prompt ` +
-      `event=${resolved.eventId} preview=${preview}`,
-  );
   return {
     eventId: resolved.eventId,
     messageId: `drive-comment:${resolved.eventId}`,
@@ -717,45 +589,5 @@ export async function resolveDriveCommentEventTurn(
     targetReplyText: resolved.context.targetReplyText,
     prompt,
     preview,
-  };
-}
-
-export async function resolveDriveCommentSyntheticEvent(
-  params: ResolveDriveCommentSyntheticEventParams,
-): Promise<FeishuMessageEvent | null> {
-  const resolved = await resolveDriveCommentEventCore(params);
-  if (!resolved) {
-    return null;
-  }
-  const prompt = buildDriveCommentPrompt({
-    noticeType: resolved.noticeType,
-    fileType: resolved.fileType,
-    fileToken: resolved.fileToken,
-    isMentioned: resolved.isMentioned,
-    documentTitle: resolved.context.documentTitle,
-    documentUrl: resolved.context.documentUrl,
-    quoteText: resolved.context.quoteText,
-    rootCommentText: resolved.context.rootCommentText,
-    targetReplyText: resolved.context.targetReplyText,
-  });
-  const preview = prompt.replace(/\s+/g, " ").slice(0, 160);
-  params.logger?.(
-    `feishu[${params.accountId}]: built drive comment synthetic prompt ` +
-      `event=${resolved.eventId} preview=${preview}`,
-  );
-
-  return {
-    sender: {
-      sender_id: { open_id: resolved.senderId },
-      sender_type: "user",
-    },
-    message: {
-      message_id: `drive-comment:${resolved.eventId}`,
-      chat_id: `p2p:${resolved.senderId}`,
-      chat_type: "p2p",
-      message_type: "text",
-      content: JSON.stringify({ text: prompt }),
-      create_time: resolved.timestamp,
-    },
   };
 }

--- a/extensions/feishu/src/monitor.comment.ts
+++ b/extensions/feishu/src/monitor.comment.ts
@@ -479,6 +479,13 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
     logger?.(`feishu[${accountId}]: unsupported drive comment notice type ${noticeType}`);
     return null;
   }
+  if (!botOpenId) {
+    logger?.(
+      `feishu[${accountId}]: skipping drive comment notice because bot open_id is unavailable ` +
+        `event=${eventId}`,
+    );
+    return null;
+  }
   if (senderId === botOpenId) {
     logger?.(
       `feishu[${accountId}]: ignoring self-authored drive comment notice event=${eventId} sender=${senderId}`,

--- a/extensions/feishu/src/monitor.comment.ts
+++ b/extensions/feishu/src/monitor.comment.ts
@@ -50,6 +50,7 @@ export type ResolvedDriveCommentEventTurn = {
   fileToken: string;
   fileType: CommentFileType;
   senderId: string;
+  senderUserId?: string;
   timestamp?: string;
   isMentioned?: boolean;
   documentTitle?: string;
@@ -443,6 +444,7 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
   fileToken: string;
   fileType: CommentFileType;
   senderId: string;
+  senderUserId?: string;
   timestamp?: string;
   isMentioned?: boolean;
   context: {
@@ -469,6 +471,7 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
   const fileToken = event.notice_meta?.file_token?.trim();
   const fileType = normalizeCommentFileType(event.notice_meta?.file_type);
   const senderId = event.notice_meta?.from_user_id?.open_id?.trim();
+  const senderUserId = event.notice_meta?.from_user_id?.user_id?.trim() || undefined;
   if (!eventId || !commentId || !noticeType || !fileToken || !fileType || !senderId) {
     logger?.(
       `feishu[${accountId}]: drive comment notice missing required fields event=${eventId ?? "unknown"} comment=${commentId ?? "unknown"}`,
@@ -513,6 +516,7 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
     fileToken,
     fileType,
     senderId,
+    senderUserId,
     timestamp: event.timestamp,
     isMentioned: event.is_mentioned,
     context,
@@ -587,6 +591,7 @@ export async function resolveDriveCommentEventTurn(
     fileToken: resolved.fileToken,
     fileType: resolved.fileType,
     senderId: resolved.senderId,
+    senderUserId: resolved.senderUserId,
     timestamp: resolved.timestamp,
     isMentioned: resolved.isMentioned,
     documentTitle: resolved.context.documentTitle,

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -235,6 +235,50 @@ describe("feishuOutbound comment-thread routing", () => {
     expect(result).toEqual(expect.objectContaining({ channel: "feishu", messageId: "reply_msg" }));
   });
 
+  it("routes comment-thread code-block replies through replyComment instead of IM cards", async () => {
+    const result = await sendText({
+      cfg: emptyConfig,
+      to: "comment:docx:doxcn123:7623358762119646411",
+      text: "```ts\nconst x = 1\n```",
+      accountId: "main",
+    });
+
+    expect(replyCommentMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        file_token: "doxcn123",
+        file_type: "docx",
+        comment_id: "7623358762119646411",
+        content: "```ts\nconst x = 1\n```",
+      }),
+    );
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({ channel: "feishu", messageId: "reply_msg" }));
+  });
+
+  it("routes comment-thread replies through replyComment even when renderMode=card", async () => {
+    const result = await sendText({
+      cfg: cardRenderConfig,
+      to: "comment:docx:doxcn123:7623358762119646411",
+      text: "handled in thread",
+      accountId: "main",
+    });
+
+    expect(replyCommentMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        file_token: "doxcn123",
+        file_type: "docx",
+        comment_id: "7623358762119646411",
+        content: "handled in thread",
+      }),
+    );
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({ channel: "feishu", messageId: "reply_msg" }));
+  });
+
   it("falls back to a text-only comment reply for media payloads", async () => {
     const result = await feishuOutbound.sendMedia?.({
       cfg: emptyConfig,

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -8,6 +8,7 @@ const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
 const sendMarkdownCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendStructuredCardFeishuMock = vi.hoisted(() => vi.fn());
+const replyCommentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./media.js", () => ({
   sendMediaFeishu: sendMediaFeishuMock,
@@ -29,6 +30,14 @@ vi.mock("./runtime.js", () => ({
   }),
 }));
 
+vi.mock("./client.js", () => ({
+  createFeishuClient: vi.fn(() => ({ request: vi.fn() })),
+}));
+
+vi.mock("./drive.js", () => ({
+  replyComment: replyCommentMock,
+}));
+
 import { feishuOutbound } from "./outbound.js";
 const sendText = feishuOutbound.sendText!;
 const emptyConfig: ClawdbotConfig = {};
@@ -46,6 +55,7 @@ function resetOutboundMocks() {
   sendMarkdownCardFeishuMock.mockResolvedValue({ messageId: "card_msg" });
   sendStructuredCardFeishuMock.mockResolvedValue({ messageId: "card_msg" });
   sendMediaFeishuMock.mockResolvedValue({ messageId: "media_msg" });
+  replyCommentMock.mockResolvedValue({ reply_id: "reply_msg" });
 }
 
 describe("feishuOutbound.sendText local-image auto-convert", () => {
@@ -196,6 +206,52 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
         accountId: "main",
       }),
     );
+  });
+});
+
+describe("feishuOutbound comment-thread routing", () => {
+  beforeEach(() => {
+    resetOutboundMocks();
+  });
+
+  it("routes comment-thread text through replyComment", async () => {
+    const result = await sendText({
+      cfg: emptyConfig,
+      to: "comment:docx:doxcn123:7623358762119646411",
+      text: "handled in thread",
+      accountId: "main",
+    });
+
+    expect(replyCommentMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        file_token: "doxcn123",
+        file_type: "docx",
+        comment_id: "7623358762119646411",
+        content: "handled in thread",
+      }),
+    );
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({ channel: "feishu", messageId: "reply_msg" }));
+  });
+
+  it("falls back to a text-only comment reply for media payloads", async () => {
+    const result = await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "comment:docx:doxcn123:7623358762119646411",
+      text: "see attachment",
+      mediaUrl: "https://example.com/file.png",
+      accountId: "main",
+    });
+
+    expect(replyCommentMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        content: "see attachment\n\nhttps://example.com/file.png",
+      }),
+    );
+    expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({ channel: "feishu", messageId: "reply_msg" }));
   });
 });
 

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -3,6 +3,9 @@ import path from "path";
 import { createAttachedChannelResultAdapter } from "openclaw/plugin-sdk/channel-send-result";
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
+import { parseFeishuCommentTarget } from "./comment-target.js";
+import { replyComment } from "./drive.js";
 import { sendMediaFeishu } from "./media.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMarkdownCardFeishu, sendMessageFeishu, sendStructuredCardFeishu } from "./send.js";
@@ -59,6 +62,31 @@ function resolveReplyToMessageId(params: {
   return trimmed || undefined;
 }
 
+async function sendCommentThreadReply(params: {
+  cfg: Parameters<typeof sendMessageFeishu>[0]["cfg"];
+  to: string;
+  text: string;
+  accountId?: string;
+}) {
+  const target = parseFeishuCommentTarget(params.to);
+  if (!target) {
+    return null;
+  }
+  const account = resolveFeishuAccount({ cfg: params.cfg, accountId: params.accountId });
+  const client = createFeishuClient(account);
+  const result = await replyComment(client, {
+    file_token: target.fileToken,
+    file_type: target.fileType,
+    comment_id: target.commentId,
+    content: params.text,
+  });
+  return {
+    messageId: typeof result.reply_id === "string" ? result.reply_id : "",
+    chatId: target.commentId,
+    result,
+  };
+}
+
 async function sendOutboundText(params: {
   cfg: Parameters<typeof sendMessageFeishu>[0]["cfg"];
   to: string;
@@ -67,6 +95,16 @@ async function sendOutboundText(params: {
   accountId?: string;
 }) {
   const { cfg, to, text, accountId, replyToMessageId } = params;
+  const commentResult = await sendCommentThreadReply({
+    cfg,
+    to,
+    text,
+    accountId,
+  });
+  if (commentResult) {
+    return commentResult;
+  }
+
   const account = resolveFeishuAccount({ cfg, accountId });
   const renderMode = account.config?.renderMode ?? "auto";
 
@@ -156,6 +194,18 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       threadId,
     }) => {
       const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
+      const commentTarget = parseFeishuCommentTarget(to);
+      if (commentTarget) {
+        const commentText = [text?.trim(), mediaUrl?.trim()].filter(Boolean).join("\n\n");
+        return await sendOutboundText({
+          cfg,
+          to,
+          text: commentText || mediaUrl || text || "",
+          accountId: accountId ?? undefined,
+          replyToMessageId,
+        });
+      }
+
       // Send text first if provided
       if (text?.trim()) {
         await sendOutboundText({

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -153,6 +153,16 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         }
       }
 
+      if (parseFeishuCommentTarget(to)) {
+        return await sendOutboundText({
+          cfg,
+          to,
+          text,
+          accountId: accountId ?? undefined,
+          replyToMessageId,
+        });
+      }
+
       const account = resolveFeishuAccount({ cfg, accountId: accountId ?? undefined });
       const renderMode = account.config?.renderMode ?? "auto";
       const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));


### PR DESCRIPTION
  ## Summary

  Describe the problem and fix in 2–5 bullets:

  If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs,
  so the title is the PR-side signal for maintainers and automation.

  - Problem: Feishu document comments and replies were not handled as a first-class event surface, so OpenClaw could not resolve comment-thread context or reply back into the Drive comment thread.
  - Why it matters: document review and collaboration requests in Feishu comments could not trigger the expected agent workflow, which forced manual follow-up outside the comment thread.
  - What changed: added `drive.notice.comment_add_v1` handling, resolved document/comment/reply context into a dedicated comment-event prompt, added a Feishu comment reply dispatcher, extended `feishu_drive` with comment list/add/
  reply actions, and added targeted tests for the comment-event flow and prompt generation.
  - What did NOT change (scope boundary): no generic Feishu IM reply dispatcher changes, no auth/token model changes, no docs changes, and no non-Feishu channel behavior changes.

  ## Change Type (select all)

  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [x] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [x] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related #
  - [ ] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)

  For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

  - Root cause: N/A
  - Missing detection / guardrail: N/A
  - Prior context (`git blame`, prior PR, issue, or refactor if known): N/A
  - Why this regressed now: N/A
  - If unknown, what was ruled out: N/A

  ## Regression Test Plan (if applicable)

  For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

  - Coverage level that should have caught this: N/A
  - Target test or file: N/A
  - Scenario the test should lock in: N/A
  - Why this is the smallest reliable guardrail: N/A
  - Existing test that already covers this (if any): N/A
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  List user-visible changes (including defaults/config).
  If none, write `None`.

  - Feishu document comment and reply events can now enter a dedicated comment-event handling flow.
  - Agents can inspect Feishu Drive comment threads and reply or add comments through `feishu_drive`.
  - Comment-event prompts now instruct the agent to keep user-visible replies in the same language as the original comment or reply unless the user explicitly asks for another language.

  ## Diagram (if applicable)

  For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

  ```text
  Before:
  [Feishu document comment/reply]
    -> [generic channel flow / no dedicated comment-thread handling]
    -> [no structured comment context]
    -> [no direct reply into Drive comment thread]

  After:
  [Feishu document comment/reply]
    -> [drive.notice.comment_add_v1 handler]
    -> [resolve document/comment/reply context]
    -> [dedicated comment-event prompt + routing]
    -> [feishu_drive.reply_comment / add_comment]
    -> [reply posted back into the comment thread]

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No): Yes
  - Secrets/tokens handling changed? (Yes/No): No
  - New/changed network calls? (Yes/No): Yes
  - Command/tool execution surface changed? (Yes/No): Yes
  - Data access scope changed? (Yes/No): Yes
  - If any Yes, explain risk + mitigation: this PR adds Feishu Drive comment read/reply/add capabilities on top of existing Feishu account credentials. The new calls are limited to comment metadata, reply listing, comment
    creation, and reply creation for the Feishu Drive integration. Self-authored comment events are filtered, and the new behavior is scoped to the Feishu comment-event path plus explicit feishu_drive actions.

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Node 22 / pnpm
  - Model/provider: N/A
  - Integration/channel (if any): Feishu
  - Relevant config (redacted): Feishu channel enabled, default Feishu account configured, Drive tool enabled, websocket mode

  ### Steps

  1. Create or reply to a comment in a Feishu document.
  2. Let the gateway receive drive.notice.comment_add_v1.
  3. Let the agent resolve the comment context and reply through feishu_drive.reply_comment or feishu_drive.add_comment.

  ### Expected

  - The comment event is handled through a dedicated Feishu comment-event flow.
  - The agent can inspect the comment-thread context and reply in the Drive comment thread.
  - User-visible replies stay in the same language as the original comment or reply unless the user explicitly asks for another language.

  ### Actual

  - Before this PR, Feishu document comments and replies did not have a dedicated event surface for structured context resolution and in-thread Drive comment replies.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: ran pnpm check; ran pnpm test -- extensions/feishu/src/monitor.comment.test.ts; reviewed the drive.notice.comment_add_v1 -> comment context resolution -> comment reply flow in code.
  - Edge cases checked: add-comment vs add-reply prompt generation; self-authored comment events are ignored; prompt guidance preserves reply language with the original comment/reply unless explicitly overridden.
  - What you did not verify: live Feishu tenant end-to-end comment delivery; live Feishu Drive write operations against real APIs.

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No): Yes
  - Config/env changes? (Yes/No): No
  - Migration needed? (Yes/No): No
  - If yes, exact upgrade steps: N/A

  ## Risks and Mitigations

  List only real risks for this PR. Add/remove entries as needed. If none, write None.

  - Risk: prompt wording changes could change how agents respond inside Feishu comment threads.
      - Mitigation: added and updated targeted comment prompt tests in extensions/feishu/src/monitor.comment.test.ts.
  - Risk: new feishu_drive comment actions expand the Feishu Drive tool surface.
      - Mitigation: the new actions are limited to comment inspection/add/reply flows and use existing Feishu account auth and channel scoping.
