### PR TITLE
fix(gateway): skip restart when config.patch has no actual changes

### DIFF
--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -476,6 +476,28 @@ export const configHandlers: GatewayRequestHandlers = {
     }
     const changedPaths = diffConfigPaths(snapshot.config, validated.config);
     const actor = resolveControlPlaneActor(client);
+
+    // No-op: if the validated config is identical to the current config,
+    // skip the file write and SIGUSR1 restart entirely. This avoids a full
+    // gateway restart (and the resulting connection drop) when a control-plane
+    // client re-sends the same config (e.g. hot-apply with no actual changes).
+    if (changedPaths.length === 0) {
+      context?.logGateway?.info(
+        `config.patch noop ${formatControlPlaneActor(actor)} (no changed paths)`,
+      );
+      respond(
+        true,
+        {
+          ok: true,
+          noop: true,
+          path: createConfigIO().configPath,
+          config: redactConfigObject(validated.config, schemaPatch.uiHints),
+        },
+        undefined,
+      );
+      return;
+    }
+
     context?.logGateway?.info(
       `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.patch`,
     );

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -252,6 +252,30 @@ describe("gateway config methods", () => {
     expect(res.error?.message).toBe("config schema path not found");
   });
 
+  it("returns noop for config.patch when config is unchanged", async () => {
+    const current = await rpcReq<{
+      config?: Record<string, unknown>;
+      hash?: string;
+    }>(requireWs(), "config.get", {});
+    expect(current.ok).toBe(true);
+
+    // Patch with the same config — no actual changes
+    const res = await rpcReq<{
+      ok?: boolean;
+      noop?: boolean;
+      config?: Record<string, unknown>;
+    }>(requireWs(), "config.patch", {
+      raw: JSON.stringify(current.payload?.config ?? {}),
+      baseHash: current.payload?.hash,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.payload?.noop).toBe(true);
+    // Config hash should not change (no file write)
+    const after = await rpcReq<{ hash?: string }>(requireWs(), "config.get", {});
+    expect(after.payload?.hash).toBe(current.payload?.hash);
+  });
+
   it("rejects config.patch when raw is null", async () => {
     const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
       raw: "null",


### PR DESCRIPTION
## Summary

`config.patch` unconditionally writes the config file and sends SIGUSR1 even when `diffConfigPaths` detects zero changed paths. This causes a full gateway restart (~10s downtime, all SSE/WebSocket connections dropped) on every `config.patch` call, even when the config is identical.

**Observed behavior:** A control-plane client calls `config.patch` for a model hot-apply. The gateway logs `changedPaths=<none>` but still triggers `SIGUSR1 → full process restart`, killing all active chat sessions.

```
config.patch write ... changedPaths=<none> restartReason=config.patch
signal SIGUSR1 received
received SIGUSR1; restarting
restart mode: full process restart (supervisor restart)
```

## Fix

When `changedPaths` is empty after diffing the current and patched configs, return early with `{ ok: true, noop: true }` — no file write, no sentinel, no SIGUSR1. The validated and redacted config is still returned so the caller knows the current state.

When there are actual changes, behavior is unchanged: write + SIGUSR1 + restart as before.

## Test plan

- Added test: `returns noop for config.patch when config is unchanged` — patches with the identical config, asserts `noop: true` and hash unchanged
- Existing tests continue to pass (rejection cases, SecretRef validation, etc.)