### PR TITLE
OpenShell: constrain mirror sync roots

### DIFF
--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -26,11 +26,7 @@ import {
   runOpenShellCli,
   type OpenShellExecContext,
 } from "./cli.js";
-import {
-  normalizeOpenShellRemotePath,
-  resolveOpenShellPluginConfig,
-  type ResolvedOpenShellPluginConfig,
-} from "./config.js";
+import { resolveOpenShellPluginConfig, type ResolvedOpenShellPluginConfig } from "./config.js";
 import { createOpenShellFsBridge } from "./fs-bridge.js";
 import {
   DEFAULT_OPEN_SHELL_MIRROR_EXCLUDE_DIRS,
@@ -395,21 +391,14 @@ class OpenShellSandboxBackendImpl {
   }
 
   private async syncWorkspaceToRemote(): Promise<void> {
-    const remoteWorkspaceDir = normalizeOpenShellRemotePath(
-      this.params.remoteWorkspaceDir,
-      this.params.execContext.config.remoteWorkspaceDir,
-      "remoteWorkspaceDir",
-    );
-    const remoteAgentWorkspaceDir = normalizeOpenShellRemotePath(
-      this.params.remoteAgentWorkspaceDir,
-      this.params.execContext.config.remoteAgentWorkspaceDir,
-      "remoteAgentWorkspaceDir",
-    );
     await this.runRemoteShellScriptInternal({
       script: 'mkdir -p -- "$1" && find "$1" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +',
-      args: [remoteWorkspaceDir],
+      args: [this.params.remoteWorkspaceDir],
     });
-    await this.uploadPathToRemote(this.params.createParams.workspaceDir, remoteWorkspaceDir);
+    await this.uploadPathToRemote(
+      this.params.createParams.workspaceDir,
+      this.params.remoteWorkspaceDir,
+    );
 
     if (
       this.params.createParams.cfg.workspaceAccess !== "none" &&
@@ -418,11 +407,11 @@ class OpenShellSandboxBackendImpl {
     ) {
       await this.runRemoteShellScriptInternal({
         script: 'mkdir -p -- "$1" && find "$1" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +',
-        args: [remoteAgentWorkspaceDir],
+        args: [this.params.remoteAgentWorkspaceDir],
       });
       await this.uploadPathToRemote(
         this.params.createParams.agentWorkspaceDir,
-        remoteAgentWorkspaceDir,
+        this.params.remoteAgentWorkspaceDir,
       );
     }
   }

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -26,7 +26,11 @@ import {
   runOpenShellCli,
   type OpenShellExecContext,
 } from "./cli.js";
-import { resolveOpenShellPluginConfig, type ResolvedOpenShellPluginConfig } from "./config.js";
+import {
+  normalizeOpenShellRemotePath,
+  resolveOpenShellPluginConfig,
+  type ResolvedOpenShellPluginConfig,
+} from "./config.js";
 import { createOpenShellFsBridge } from "./fs-bridge.js";
 import {
   DEFAULT_OPEN_SHELL_MIRROR_EXCLUDE_DIRS,
@@ -391,14 +395,21 @@ class OpenShellSandboxBackendImpl {
   }
 
   private async syncWorkspaceToRemote(): Promise<void> {
+    const remoteWorkspaceDir = normalizeOpenShellRemotePath(
+      this.params.remoteWorkspaceDir,
+      this.params.execContext.config.remoteWorkspaceDir,
+      "remoteWorkspaceDir",
+    );
+    const remoteAgentWorkspaceDir = normalizeOpenShellRemotePath(
+      this.params.remoteAgentWorkspaceDir,
+      this.params.execContext.config.remoteAgentWorkspaceDir,
+      "remoteAgentWorkspaceDir",
+    );
     await this.runRemoteShellScriptInternal({
       script: 'mkdir -p -- "$1" && find "$1" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +',
-      args: [this.params.remoteWorkspaceDir],
+      args: [remoteWorkspaceDir],
     });
-    await this.uploadPathToRemote(
-      this.params.createParams.workspaceDir,
-      this.params.remoteWorkspaceDir,
-    );
+    await this.uploadPathToRemote(this.params.createParams.workspaceDir, remoteWorkspaceDir);
 
     if (
       this.params.createParams.cfg.workspaceAccess !== "none" &&
@@ -407,11 +418,11 @@ class OpenShellSandboxBackendImpl {
     ) {
       await this.runRemoteShellScriptInternal({
         script: 'mkdir -p -- "$1" && find "$1" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +',
-        args: [this.params.remoteAgentWorkspaceDir],
+        args: [remoteAgentWorkspaceDir],
       });
       await this.uploadPathToRemote(
         this.params.createParams.agentWorkspaceDir,
-        this.params.remoteAgentWorkspaceDir,
+        remoteAgentWorkspaceDir,
       );
     }
   }

--- a/extensions/openshell/src/config.test.ts
+++ b/extensions/openshell/src/config.test.ts
@@ -1,0 +1,72 @@
+import fsSync from "node:fs";
+import { describe, expect, it } from "vitest";
+import { createOpenShellPluginConfigSchema, resolveOpenShellPluginConfig } from "./config.js";
+
+describe("openshell plugin config", () => {
+  it("applies defaults", () => {
+    expect(resolveOpenShellPluginConfig(undefined)).toEqual({
+      mode: "mirror",
+      command: "openshell",
+      gateway: undefined,
+      gatewayEndpoint: undefined,
+      from: "openclaw",
+      policy: undefined,
+      providers: [],
+      gpu: false,
+      autoProviders: true,
+      remoteWorkspaceDir: "/sandbox",
+      remoteAgentWorkspaceDir: "/agent",
+      timeoutMs: 120_000,
+    });
+  });
+
+  it("accepts remote mode", () => {
+    expect(resolveOpenShellPluginConfig({ mode: "remote" }).mode).toBe("remote");
+  });
+
+  it("rejects relative remote paths", () => {
+    expect(() =>
+      resolveOpenShellPluginConfig({
+        remoteWorkspaceDir: "sandbox",
+      }),
+    ).toThrow("OpenShell remoteWorkspaceDir must be absolute");
+  });
+
+  it("rejects remote paths outside managed sandbox roots", () => {
+    expect(() =>
+      resolveOpenShellPluginConfig({
+        remoteWorkspaceDir: "/tmp/victim",
+      }),
+    ).toThrow("OpenShell remoteWorkspaceDir must stay under /sandbox or /agent");
+  });
+
+  it("normalizes managed sandbox subpaths", () => {
+    expect(
+      resolveOpenShellPluginConfig({
+        remoteWorkspaceDir: "/sandbox/../sandbox/project",
+        remoteAgentWorkspaceDir: "/agent/./session",
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        remoteWorkspaceDir: "/sandbox/project",
+        remoteAgentWorkspaceDir: "/agent/session",
+      }),
+    );
+  });
+
+  it("rejects unknown mode", () => {
+    expect(() =>
+      resolveOpenShellPluginConfig({
+        mode: "bogus",
+      }),
+    ).toThrow("mode must be one of mirror, remote");
+  });
+
+  it("keeps the runtime json schema in sync with the manifest config schema", () => {
+    const manifest = JSON.parse(
+      fsSync.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+    ) as { configSchema?: unknown };
+
+    expect(createOpenShellPluginConfigSchema().jsonSchema).toEqual(manifest.configSchema);
+  });
+});

--- a/extensions/openshell/src/config.ts
+++ b/extensions/openshell/src/config.ts
@@ -38,6 +38,10 @@ const DEFAULT_SOURCE = "openclaw";
 const DEFAULT_REMOTE_WORKSPACE_DIR = "/sandbox";
 const DEFAULT_REMOTE_AGENT_WORKSPACE_DIR = "/agent";
 const DEFAULT_TIMEOUT_MS = 120_000;
+const OPEN_SHELL_MANAGED_REMOTE_ROOTS = [
+  DEFAULT_REMOTE_WORKSPACE_DIR,
+  DEFAULT_REMOTE_AGENT_WORKSPACE_DIR,
+] as const;
 
 function normalizeProviders(value: string[] | undefined): string[] {
   const seen = new Set<string>();
@@ -100,11 +104,26 @@ function formatOpenShellConfigIssue(issue: z.ZodIssue | undefined): string {
   return issue.message;
 }
 
-function normalizeRemotePath(value: string | undefined, fallback: string): string {
+function isManagedOpenShellRemotePath(value: string): boolean {
+  return OPEN_SHELL_MANAGED_REMOTE_ROOTS.some(
+    (root) => value === root || value.startsWith(`${root}/`),
+  );
+}
+
+export function normalizeOpenShellRemotePath(
+  value: string | undefined,
+  fallback: string,
+  fieldName = "remote path",
+): string {
   const candidate = value ?? fallback;
   const normalized = path.posix.normalize(candidate.trim() || fallback);
   if (!normalized.startsWith("/")) {
-    throw new Error(`OpenShell remote path must be absolute: ${candidate}`);
+    throw new Error(`OpenShell ${fieldName} must be absolute: ${candidate}`);
+  }
+  if (!isManagedOpenShellRemotePath(normalized)) {
+    throw new Error(
+      `OpenShell ${fieldName} must stay under ${OPEN_SHELL_MANAGED_REMOTE_ROOTS.join(" or ")}: ${candidate}`,
+    );
   }
   return normalized;
 }
@@ -170,10 +189,15 @@ export function resolveOpenShellPluginConfig(value: unknown): ResolvedOpenShellP
     providers: normalizeProviders(cfg.providers),
     gpu: cfg.gpu ?? false,
     autoProviders: cfg.autoProviders ?? true,
-    remoteWorkspaceDir: normalizeRemotePath(cfg.remoteWorkspaceDir, DEFAULT_REMOTE_WORKSPACE_DIR),
-    remoteAgentWorkspaceDir: normalizeRemotePath(
+    remoteWorkspaceDir: normalizeOpenShellRemotePath(
+      cfg.remoteWorkspaceDir,
+      DEFAULT_REMOTE_WORKSPACE_DIR,
+      "remoteWorkspaceDir",
+    ),
+    remoteAgentWorkspaceDir: normalizeOpenShellRemotePath(
       cfg.remoteAgentWorkspaceDir,
       DEFAULT_REMOTE_AGENT_WORKSPACE_DIR,
+      "remoteAgentWorkspaceDir",
     ),
     timeoutMs:
       typeof cfg.timeoutSeconds === "number"

--- a/extensions/openshell/src/config.ts
+++ b/extensions/openshell/src/config.ts
@@ -156,6 +156,8 @@ export function createOpenShellPluginConfigSchema(): OpenClawPluginConfigSchema 
 
 export function resolveOpenShellPluginConfig(value: unknown): ResolvedOpenShellPluginConfig {
   if (value === undefined) {
+    // The built-in defaults are managed OpenShell roots, so they do not need to
+    // flow back through normalizeOpenShellRemotePath.
     return {
       mode: DEFAULT_MODE,
       command: DEFAULT_COMMAND,

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -1,4 +1,3 @@
-import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -12,60 +11,13 @@ import {
   setBundledOpenShellCommandResolverForTest,
   shellEscape,
 } from "./cli.js";
-import { createOpenShellPluginConfigSchema, resolveOpenShellPluginConfig } from "./config.js";
+import { resolveOpenShellPluginConfig } from "./config.js";
 
 const cliMocks = vi.hoisted(() => ({
   runOpenShellCli: vi.fn(),
 }));
 
 let createOpenShellSandboxBackendManager: typeof import("./backend.js").createOpenShellSandboxBackendManager;
-
-describe("openshell plugin config", () => {
-  it("applies defaults", () => {
-    expect(resolveOpenShellPluginConfig(undefined)).toEqual({
-      mode: "mirror",
-      command: "openshell",
-      gateway: undefined,
-      gatewayEndpoint: undefined,
-      from: "openclaw",
-      policy: undefined,
-      providers: [],
-      gpu: false,
-      autoProviders: true,
-      remoteWorkspaceDir: "/sandbox",
-      remoteAgentWorkspaceDir: "/agent",
-      timeoutMs: 120_000,
-    });
-  });
-
-  it("accepts remote mode", () => {
-    expect(resolveOpenShellPluginConfig({ mode: "remote" }).mode).toBe("remote");
-  });
-
-  it("rejects relative remote paths", () => {
-    expect(() =>
-      resolveOpenShellPluginConfig({
-        remoteWorkspaceDir: "sandbox",
-      }),
-    ).toThrow("OpenShell remote path must be absolute");
-  });
-
-  it("rejects unknown mode", () => {
-    expect(() =>
-      resolveOpenShellPluginConfig({
-        mode: "bogus",
-      }),
-    ).toThrow("mode must be one of mirror, remote");
-  });
-
-  it("keeps the runtime json schema in sync with the manifest config schema", () => {
-    const manifest = JSON.parse(
-      fsSync.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
-    ) as { configSchema?: unknown };
-
-    expect(createOpenShellPluginConfigSchema().jsonSchema).toEqual(manifest.configSchema);
-  });
-});
 
 describe("openshell cli helpers", () => {
   afterEach(() => {


### PR DESCRIPTION
## Summary
- Constrain OpenShell mirror workspace roots to managed sandbox directories
- Fail closed before mirror sync uses an unsafe configured remote path

## Changes
- Added managed-root validation for `remoteWorkspaceDir` and `remoteAgentWorkspaceDir` so they must stay under `/sandbox` or `/agent`
- Reused the same validation in mirror sync before any remote cleanup or upload runs
- Split OpenShell config coverage into a dedicated `config.test.ts` file and added regressions for unsafe and normalized paths

## Validation
- Ran `corepack pnpm test -- extensions/openshell/src/config.test.ts extensions/openshell/src/mirror.test.ts`
- Verified unsafe paths such as `/tmp/victim` are rejected during config resolution before mirror sync can run
- Ran local agentic review with `claude -p "/review"`; it requested a PR number and surfaced no code feedback on the patch itself

## Notes
- Residual risk or follow-up: this change intentionally keeps custom mirror roots limited to managed OpenShell workspace directories
