### PR TITLE
feat: add agents.defaults.params for global default model params

### DIFF
--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -20,9 +20,18 @@ For Anthropic pricing details, see:
 
 ## Primary knobs
 
-### `cacheRetention` (model and per-agent)
+### `cacheRetention` (global default, model, and per-agent)
 
-Set cache retention on model params:
+Set cache retention as a global default for all models:
+
+```yaml
+agents:
+  defaults:
+    params:
+      cacheRetention: "long" # none | short | long
+```
+
+Override per-model:
 
 ```yaml
 agents:
@@ -45,8 +54,9 @@ agents:
 
 Config merge order:
 
-1. `agents.defaults.models["provider/model"].params`
-2. `agents.list[].params` (matching agent id; overrides by key)
+1. `agents.defaults.params` (global default — applies to all models)
+2. `agents.defaults.models["provider/model"].params` (per-model override)
+3. `agents.list[].params` (matching agent id; overrides by key)
 
 ### Legacy `cacheControlTtl`
 

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -77,6 +77,7 @@ export function resolveExtraParams(params: {
   modelId: string;
   agentId?: string;
 }): Record<string, unknown> | undefined {
+  const defaultParams = params.cfg?.agents?.defaults?.params ?? undefined;
   const modelKey = `${params.provider}/${params.modelId}`;
   const modelConfig = params.cfg?.agents?.defaults?.models?.[modelKey];
   const globalParams = modelConfig?.params ? { ...modelConfig.params } : undefined;
@@ -85,13 +86,13 @@ export function resolveExtraParams(params: {
       ? params.cfg.agents.list.find((agent) => agent.id === params.agentId)?.params
       : undefined;
 
-  if (!globalParams && !agentParams) {
+  if (!defaultParams && !globalParams && !agentParams) {
     return undefined;
   }
 
-  const merged = Object.assign({}, globalParams, agentParams);
+  const merged = Object.assign({}, defaultParams, globalParams, agentParams);
   const resolvedParallelToolCalls = resolveAliasedParamValue(
-    [globalParams, agentParams],
+    [defaultParams, globalParams, agentParams],
     "parallel_tool_calls",
     "parallelToolCalls",
   );

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -118,6 +118,8 @@ export type CliBackendConfig = {
 };
 
 export type AgentDefaultsConfig = {
+  /** Global default provider params applied to all models before per-model and per-agent overrides. */
+  params?: Record<string, unknown>;
   /** Primary model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   model?: AgentModelConfig;
   /** Optional image-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -16,6 +16,8 @@ import {
 
 export const AgentDefaultsSchema = z
   .object({
+    /** Global default provider params applied to all models before per-model and per-agent overrides. */
+    params: z.record(z.string(), z.unknown()).optional(),
     model: AgentModelSchema.optional(),
     imageModel: AgentModelSchema.optional(),
     imageGenerationModel: AgentModelSchema.optional(),


### PR DESCRIPTION
## Summary

- Adds `agents.defaults.params` as a global default params object that applies to all models
- Allows setting `cacheRetention` (or any param) once instead of per-model
- Merge order: `agents.defaults.params` → `agents.defaults.models[model].params` → `agents.list[agent].params`

**Before:**
```json5
{
  agents: {
    defaults: {
      models: {
        "anthropic/claude-opus-4-6": { params: { cacheRetention: "long" } },
        "anthropic/claude-sonnet-4-6": { params: { cacheRetention: "long" } },
        "anthropic/claude-haiku-4-5": { params: { cacheRetention: "long" } },
      }
    }
  }
}
```

**After:**
```json5
{
  agents: {
    defaults: {
      params: { cacheRetention: "long" },
    }
  }
}
```

Per-model and per-agent overrides still take precedence.

## Changes

- `src/agents/pi-embedded-runner/extra-params.ts` — include `agents.defaults.params` in merge chain
- `src/config/zod-schema.agent-defaults.ts` — add `params` to schema
- `src/config/types.agent-defaults.ts` — add `params` to type
- `docs/reference/prompt-caching.md` — document global default and merge order

## Test plan

- [ ] Set `agents.defaults.params.cacheRetention: "long"` with no per-model config — verify all Anthropic models use long cache
- [ ] Set per-model override to `"none"` — verify it takes precedence over global
- [ ] Set per-agent override — verify it takes precedence over both

🤖 Generated with [Claude Code](https://claude.com/claude-code)