### PR TITLE
fix: differentiate overloaded vs rate-limit user-facing error messages

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -827,9 +827,12 @@ export async function runAgentTurnWithFallback(params: {
         errorCandidate &&
         (isRateLimitErrorMessage(errorCandidate) || isOverloadedErrorMessage(errorCandidate))
       ) {
+        const isOverloaded = isOverloadedErrorMessage(errorCandidate);
         runResult.payloads = [
           {
-            text: "⚠️ API rate limit reached — the model couldn't generate a response. Please try again in a moment.",
+            text: isOverloaded
+              ? "⚠️ The AI service is temporarily overloaded. Please try again in a moment."
+              : "⚠️ API rate limit reached — the model couldn't generate a response. Please try again in a moment.",
             isError: true,
           },
         ];


### PR DESCRIPTION
## Summary

- Fixes #58561
- When Anthropic returns 529 (overloaded), users now see "The AI service is temporarily overloaded" instead of the misleading "API rate limit reached" message
- The existing 429 rate-limit message is unchanged

## Changes

Single file change in `src/auto-reply/reply/agent-runner-execution.ts`: the shared error handler now calls `isOverloadedErrorMessage()` to pick the correct user-facing string.

## Test plan

- [x] Existing test "surfaces a final error when only reasoning preceded a mid-turn rate limit" passes (verifies 429 path unchanged)
- [ ] Manual: trigger a 529 overloaded response and verify the new message appears