### PR TITLE
Fix broken StreamWeasels URL in Twitch extension README

### DIFF
--- a/extensions/twitch/README.md
+++ b/extensions/twitch/README.md
@@ -31,7 +31,7 @@ Minimal config (simplified single-account):
       accessToken: "oauth:abc123...", // OAuth Access Token (add oauth: prefix)
       clientId: "xyz789...", // Client ID from Token Generator
       channel: "vevisk", // Channel to join (required)
-      allowFrom: ["123456789"], // (recommended) Your Twitch user ID only (Convert your twitch username to ID at https://www.streamweasels.com/tools/convert-twitch-username-%20to-user-id/)
+      allowFrom: ["123456789"], // (recommended) Your Twitch user ID only (Convert your twitch username to ID at https://www.streamweasels.com/tools/convert-twitch-username-to-user-id/)
     },
   },
 }


### PR DESCRIPTION
## Summary

The StreamWeasels username-to-ID converter link in `extensions/twitch/README.md` contains a stray `%20` (URL-encoded space) that causes a 404:

```diff
- https://www.streamweasels.com/tools/convert-twitch-username-%20to-user-id/
+ https://www.streamweasels.com/tools/convert-twitch-username-to-user-id/
```

## Test plan
- [x] Verified the corrected URL resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)