### PR TITLE
fix(voice-call): clear connection timeout on successful STT connect

### DIFF
--- a/extensions/voice-call/src/providers/stt-openai-realtime.ts
+++ b/extensions/voice-call/src/providers/stt-openai-realtime.ts
@@ -89,6 +89,7 @@ class OpenAIRealtimeSTTSession implements RealtimeSTTSession {
   private ws: WebSocket | null = null;
   private connected = false;
   private closed = false;
+  private connectTimeout: ReturnType<typeof setTimeout> | null = null;
   private reconnectAttempts = 0;
   private pendingTranscript = "";
   private onTranscriptCallback: ((transcript: string) => void) | null = null;
@@ -123,6 +124,10 @@ class OpenAIRealtimeSTTSession implements RealtimeSTTSession {
         console.log("[RealtimeSTT] WebSocket connected");
         this.connected = true;
         this.reconnectAttempts = 0;
+        if (this.connectTimeout) {
+          clearTimeout(this.connectTimeout);
+          this.connectTimeout = null;
+        }
 
         // Configure the transcription session
         this.sendEvent({
@@ -172,7 +177,8 @@ class OpenAIRealtimeSTTSession implements RealtimeSTTSession {
         }
       });
 
-      setTimeout(() => {
+      this.connectTimeout = setTimeout(() => {
+        this.connectTimeout = null;
         if (!this.connected) {
           reject(new Error("Realtime STT connection timeout"));
         }
@@ -298,6 +304,10 @@ class OpenAIRealtimeSTTSession implements RealtimeSTTSession {
 
   close(): void {
     this.closed = true;
+    if (this.connectTimeout) {
+      clearTimeout(this.connectTimeout);
+      this.connectTimeout = null;
+    }
     if (this.ws) {
       this.ws.close();
       this.ws = null;


### PR DESCRIPTION
## Summary

- The 10-second connection timeout in `OpenAIRealtimeSTTSession.doConnect()` was never cleared after a successful WebSocket connection or during `close()` teardown
- This leaks a timer on every connection and accumulates stale timers across reconnect cycles
- Store the timeout handle and clear it in both the `open` handler and `close()`, matching the existing `clearTimeout` pattern already used in `waitForTranscript()`

## What was happening

`doConnect()` sets a 10-second `setTimeout` to reject the connection promise on timeout, but never stores the handle:

```typescript
// Before: fire-and-forget timer
setTimeout(() => {
  if (!this.connected) {
    reject(new Error('Realtime STT connection timeout'));
  }
}, 10000);
```

On success, the timer keeps running. On reconnect cycles (`doConnect` called repeatedly via `attemptReconnect`), stale timers accumulate. On `close()`, the timer isn't cleaned up either.

## Fix

- Add a `connectTimeout` field to track the timer handle
- `clearTimeout` in the `open` handler on successful connection
- `clearTimeout` in `close()` for clean teardown
- Null out the reference in the timeout callback itself

## Test plan

- [ ] Verify voice-call STT connects and transcribes normally
- [ ] Verify timeout still fires correctly when connection fails
- [ ] Verify `close()` during a pending connection does not leave orphaned timers
- [ ] Verify reconnect cycles do not accumulate stale timers

Generated with [Claude Code](https://claude.ai/claude-code)