### PR TITLE
Fix: live session model switch no longer blocks failover (Resolves #58466)

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -9,6 +9,7 @@ import type { AuthProfileStore } from "./auth-profiles.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 import { isAnthropicBillingError } from "./live-auth-keys.js";
+import { LiveSessionModelSwitchError } from "./live-model-switch.js";
 import { runWithImageModelFallback, runWithModelFallback } from "./model-fallback.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
@@ -261,6 +262,50 @@ describe("runWithModelFallback", () => {
       }),
     ).rejects.toThrow("something weird");
     expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats LiveSessionModelSwitchError as failover on last candidate (#58466)", async () => {
+    const cfg = makeCfg();
+    const switchError = new LiveSessionModelSwitchError({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    const run = vi.fn().mockRejectedValue(switchError);
+
+    // With no fallbacks, the single candidate is also the last one.
+    // Previously this would re-throw LiveSessionModelSwitchError, causing
+    // the outer retry loop to restart with the overloaded model indefinitely.
+    // Now it should surface as a FailoverError instead.
+    const err = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      run,
+      fallbacksOverride: [],
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    // Should NOT be a LiveSessionModelSwitchError — the outer retry loop must
+    // not restart with the conflicting model.
+    expect(err).not.toBeInstanceOf(LiveSessionModelSwitchError);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues fallback chain past LiveSessionModelSwitchError to next candidate (#58466)", async () => {
+    const cfg = makeCfg();
+    const switchError = new LiveSessionModelSwitchError({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    const run = vi.fn().mockRejectedValueOnce(switchError).mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
   });
 
   it("falls back on auth errors", async () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -15,6 +15,7 @@ import {
 } from "./auth-profiles.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import {
+  FailoverError,
   coerceToFailoverError,
   describeFailoverError,
   isFailoverError,
@@ -25,6 +26,7 @@ import {
   shouldPreserveTransientCooldownProbeSlot,
   shouldUseTransientCooldownProbeSlot,
 } from "./failover-policy.js";
+import { LiveSessionModelSwitchError } from "./live-model-switch.js";
 import { logModelFallbackDecision } from "./model-fallback-observation.js";
 import type { FallbackAttempt, ModelCandidate } from "./model-fallback.types.js";
 import {
@@ -780,6 +782,48 @@ export async function runWithModelFallback<T>(params: {
           provider: candidate.provider,
           model: candidate.model,
         }) ?? err;
+
+      // LiveSessionModelSwitchError during fallback means the session's
+      // persisted model conflicts with this fallback candidate.  Treat it
+      // as a known failover so the chain continues to the next candidate
+      // instead of re-throwing and triggering infinite retry loops in the
+      // outer runner.  (#58466)
+      if (err instanceof LiveSessionModelSwitchError) {
+        const switchMsg = err.message;
+        const switchNormalized = new FailoverError(switchMsg, {
+          reason: "overloaded",
+          provider: candidate.provider,
+          model: candidate.model,
+        });
+        lastError = switchNormalized;
+        const described = describeFailoverError(switchNormalized);
+        attempts.push({
+          provider: candidate.provider,
+          model: candidate.model,
+          error: described.message,
+          reason: described.reason ?? "unknown",
+          status: described.status,
+          code: described.code,
+        });
+        logModelFallbackDecision({
+          decision: "candidate_failed",
+          runId: params.runId,
+          requestedProvider: params.provider,
+          requestedModel: params.model,
+          candidate,
+          attempt: i + 1,
+          total: candidates.length,
+          reason: described.reason,
+          status: described.status,
+          code: described.code,
+          error: described.message,
+          nextCandidate: candidates[i + 1],
+          isPrimary,
+          requestedModelMatched: requestedModel,
+          fallbackConfigured: hasFallbackCandidates,
+        });
+        continue;
+      }
 
       // Even unrecognized errors should not abort the fallback loop when
       // there are remaining candidates.  Only abort/context-overflow errors

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
   isOllamaCompatProvider,
-  resolveOllamaBaseUrlForRun,
   resolveOllamaCompatNumCtxEnabled,
   shouldInjectOllamaCompatNumCtx,
   wrapOllamaCompatNumCtx,

--- a/src/cron/isolated-agent/run.live-session-model-switch.test.ts
+++ b/src/cron/isolated-agent/run.live-session-model-switch.test.ts
@@ -249,6 +249,26 @@ describe("runCronIsolatedAgentTurn — LiveSessionModelSwitchError retry (#57206
     expect(callCount).toBe(2);
   });
 
+  it("aborts after exceeding LiveSessionModelSwitchError retry limit (#58466)", async () => {
+    const switchError = new LiveSessionModelSwitchError({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+
+    let callCount = 0;
+    runWithModelFallbackMock.mockImplementation(async () => {
+      callCount++;
+      throw switchError;
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeParams());
+
+    expect(result.status).toBe("error");
+    // Circuit breaker: max 2 retries → 3 total attempts (initial + 2 retries)
+    expect(callCount).toBe(3);
+    expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("retry limit reached"));
+  });
+
   it("does not retry when the thrown error is not a LiveSessionModelSwitchError", async () => {
     let callCount = 0;
     runWithModelFallbackMock.mockImplementation(async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -591,12 +591,24 @@ export async function runCronIsolatedAgentTurn(params: {
     // in the main agent runner (agent-runner-execution.ts). Without this, cron
     // jobs that specify a model different from the agent primary always fail.
     // See: https://github.com/openclaw/openclaw/issues/57206
+    //
+    // Circuit breaker: cap retries to prevent infinite loops when the live
+    // session model switch guard fires repeatedly during failover (#58466).
+    const MAX_MODEL_SWITCH_RETRIES = 2;
+    let modelSwitchRetries = 0;
     while (true) {
       try {
         await runPrompt(commandBody);
         break;
       } catch (err) {
         if (err instanceof LiveSessionModelSwitchError) {
+          modelSwitchRetries += 1;
+          if (modelSwitchRetries > MAX_MODEL_SWITCH_RETRIES) {
+            logWarn(
+              `[cron:${params.job.id}] LiveSessionModelSwitchError retry limit reached (${MAX_MODEL_SWITCH_RETRIES}); aborting`,
+            );
+            throw err;
+          }
           liveSelection = {
             provider: err.provider,
             model: err.model,


### PR DESCRIPTION
Fixes #58466.

## Problem

When a model returns `overloaded_error` (503), `runWithModelFallback` attempts to switch to a fallback model. However, the "live session model switch" guard inside `runEmbeddedPiAgent` detects the model difference between the fallback candidate and the session store, throwing `LiveSessionModelSwitchError`. When this happens on the **last** fallback candidate, the error is re-thrown by `runWithModelFallback`, causing the outer retry loop (cron/auto-reply) to restart with the original overloaded model — creating an infinite retry loop with no circuit breaker.

## Fix

**Primary fix** (`model-fallback.ts`): Intercept `LiveSessionModelSwitchError` in the fallback loop and convert it to a `FailoverError`. This allows the fallback chain to continue to the next candidate instead of re-throwing the error. When all candidates are exhausted, a proper fallback failure summary is surfaced instead of the raw `LiveSessionModelSwitchError`.

**Circuit breaker** (`cron/isolated-agent/run.ts`): Add a max retry limit (2) for `LiveSessionModelSwitchError` in the cron retry loop, matching the existing guard in the auto-reply path (added in #58348). This prevents infinite loops even if `LiveSessionModelSwitchError` somehow escapes the fallback handler.

## Test plan

- [x] New test: `LiveSessionModelSwitchError` on last candidate surfaces as `FailoverError`, not `LiveSessionModelSwitchError`
- [x] New test: fallback chain continues past `LiveSessionModelSwitchError` to next candidate
- [x] New test: cron retry loop aborts after exceeding retry limit
- [x] Existing model-fallback and cron live-session-model-switch tests pass
- [x] `pnpm check` passes