### PR TITLE
fix(whatsapp): pass Timestamp to finalizeInboundContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/local Bot API: preserve media MIME types for absolute-path downloads so local audio files still trigger transcription and other MIME-based handling. (#54603) Thanks @jzakirov
 - Tasks/gateway: re-check the current task record before maintenance marks runs lost or prunes them, so a task heartbeat or cleanup update that lands during a sweep no longer gets overwritten by stale snapshot state.
 - Tasks/gateway: keep the task registry maintenance sweep from stalling the gateway event loop under synchronous SQLite pressure, so upgraded gateways stop hanging about a minute after startup. (#58670) Thanks @openperf
+- Channels/WhatsApp: pass inbound message timestamp to model context so the AI can see when WhatsApp messages were sent. (#58590) Thanks @Maninae
 
 ## 2026.3.31
 

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
@@ -171,6 +171,7 @@ describe("web processMessage inbound context", () => {
           to: "+15550001111",
           chatType: "group",
           body: "hi",
+          timestamp: 1737158400000,
           senderName: "Alice",
           senderJid: "alice@s.whatsapp.net",
           senderE164: "+15550002222",
@@ -182,7 +183,9 @@ describe("web processMessage inbound context", () => {
 
     expect(capturedCtx).toBeTruthy();
     // oxlint-disable-next-line typescript/no-explicit-any
-    expectInboundContextContract(capturedCtx as any);
+    const ctx = capturedCtx as any;
+    expectInboundContextContract(ctx);
+    expect(ctx.Timestamp).toBe(1737158400000);
   });
 
   it("falls back SenderId to SenderE164 when senderJid is empty", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -324,6 +324,7 @@ export async function processMessage(params: {
     MediaUrl: params.msg.mediaUrl,
     MediaType: params.msg.mediaType,
     ChatType: params.msg.chatType,
+    Timestamp: params.msg.timestamp,
     ConversationLabel: params.msg.chatType === "group" ? conversationId : params.msg.from,
     GroupSubject: params.msg.groupSubject,
     GroupMembers: formatGroupMembers({


### PR DESCRIPTION
## Summary

WhatsApp is the **only** channel that does not pass `Timestamp` to `finalizeInboundContext`, so WhatsApp messages never include timestamps in the "Conversation info" metadata block that reaches the AI model.

This adds `Timestamp: params.msg.timestamp` to the `finalizeInboundContext()` call in `extensions/whatsapp/src/auto-reply/monitor/process-message.ts`.

Closes #50098 (WhatsApp side — the Telegram side was already fixed per @piazzatron's confirmation on March 26).

## Context

All other channels correctly pass `Timestamp`:
- Discord, Telegram, Signal, Slack, LINE, iMessage, TUI/webchat — all pass Timestamp via `direct-dm.ts` line 286
- WhatsApp — did **not** pass Timestamp (fixed here)

The timestamp value was already available as `params.msg.timestamp` (computed from `inbound.messageTimestampMs` in `extensions/whatsapp/src/inbound/monitor.ts:392`), it just was never forwarded to `finalizeInboundContext`.

## Diff

```diff
+    Timestamp: params.msg.timestamp,
     ConversationLabel: params.msg.chatType === "group" ? conversationId : params.msg.from,
```

## Test plan

- [x] Existing WhatsApp `process-message.inbound-context.test.ts` passes (12/12 tests)
- [ ] Verify WhatsApp messages now include timestamp in conversation metadata