### PR TITLE
fix(gateway): return default scopes when trusted HTTP request has no scope header

### DIFF
--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -135,7 +135,13 @@ export function resolveTrustedHttpOperatorScopes(
     return [];
   }
 
-  const raw = getHeader(req, "x-openclaw-scopes")?.trim();
+  const headerValue = getHeader(req, "x-openclaw-scopes");
+  if (headerValue === undefined) {
+    // No scope header present — trusted clients without an explicit header
+    // get the default operator scopes (matching pre-#57783 behavior).
+    return [...CLI_DEFAULT_OPERATOR_SCOPES];
+  }
+  const raw = headerValue.trim();
   if (!raw) {
     return [];
   }


### PR DESCRIPTION
lobster-biscuit

Closes #58357

## Problem

HTTP `/v1/chat/completions` returns 403 "missing scope: operator.write" when the gateway is configured with `--auth none`. The OpenAI-compatible API is completely broken for unauthenticated setups.

## Root cause

`src/gateway/http-utils.ts:138-140` — `resolveTrustedHttpOperatorScopes()` returns `[]` when the `x-openclaw-scopes` header is absent, even for trusted requests. PR #57783 (`f0af18672`) replaced the old scope resolution which had an explicit fallback to `CLI_DEFAULT_OPERATOR_SCOPES` when no header was present.

The new function treats absent header (`undefined`) the same as empty header (`""`) — both return `[]` → zero scopes → 403.

## User impact

All `--auth none` HTTP API users get 403 on every request. OpenAI-compatible API completely broken for unauthenticated gateway setups.

## Fix

Distinguish absent header (`undefined` → return `CLI_DEFAULT_OPERATOR_SCOPES`) from empty header (`"" → return []`). Uses existing `CLI_DEFAULT_OPERATOR_SCOPES` from `method-scopes.ts` (already imported at line 20).

1 file, +7/-1.

## How to verify

1. Start gateway with `--auth none`
2. `curl http://localhost:18789/v1/chat/completions -d ...`
3. Before: 403 "missing scope: operator.write". After: 200 OK.

## Tests

The scope resolution is tested via the HTTP auth integration tests. The fix restores pre-#57783 behavior for the absent-header case — the same test expectations apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)