### PR TITLE
plugins: suppress provenance warning for allowlisted local plugins

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3099,7 +3099,7 @@ module.exports = {
     useNoBundledPlugins();
     const scenarios = [
       {
-        label: "warns when loaded non-bundled plugin has no install/load-path provenance",
+        label: "does not warn when loaded non-bundled plugin is in plugins.allow",
         loadRegistry: () => {
           const stateDir = makeTempDir();
           return withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
@@ -3119,6 +3119,35 @@ module.exports = {
               config: {
                 plugins: {
                   allow: ["rogue"],
+                },
+              },
+            });
+
+            return { registry, warnings, pluginId: "rogue", expectWarning: false };
+          });
+        },
+      },
+      {
+        label: "warns when loaded non-bundled plugin has no provenance and no allowlist is set",
+        loadRegistry: () => {
+          const stateDir = makeTempDir();
+          return withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+            const globalDir = path.join(stateDir, "extensions", "rogue");
+            mkdirSafe(globalDir);
+            writePlugin({
+              id: "rogue",
+              body: `module.exports = { id: "rogue", register() {} };`,
+              dir: globalDir,
+              filename: "index.cjs",
+            });
+
+            const warnings: string[] = [];
+            const registry = loadOpenClawPlugins({
+              cache: false,
+              logger: createWarningLogger(warnings),
+              config: {
+                plugins: {
+                  enabled: true,
                 },
               },
             });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -641,11 +641,16 @@ function warnWhenAllowlistIsOpen(params: {
 function warnAboutUntrackedLoadedPlugins(params: {
   registry: PluginRegistry;
   provenance: PluginProvenanceIndex;
+  allowlist: string[];
   logger: PluginLogger;
   env: NodeJS.ProcessEnv;
 }) {
+  const allowSet = new Set(params.allowlist);
   for (const plugin of params.registry.plugins) {
     if (plugin.status !== "loaded" || plugin.origin === "bundled") {
+      continue;
+    }
+    if (allowSet.has(plugin.id)) {
       continue;
     }
     if (
@@ -1293,6 +1298,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   warnAboutUntrackedLoadedPlugins({
     registry,
     provenance,
+    allowlist: normalized.allow,
     logger,
     env,
   });


### PR DESCRIPTION
## Summary
- stop emitting the untracked provenance warning for non-bundled plugins that are explicitly trusted via `plugins.allow`
- keep the warning for non-allowlisted local plugins that still lack install/load-path provenance
- extend loader tests to cover both the allowlisted and non-allowlisted cases

## Why
A local workspace plugin can be explicitly trusted through `plugins.allow`, but the loader still warned that it was "loaded without install/load-path provenance". That warning was correct for untrusted local code, but misleading once the plugin id had already been allowlisted on purpose.

## Testing
- `pnpm vitest run src/plugins/loader.test.ts -t "evaluates load-path provenance warnings"`
- `pnpm vitest run src/plugins/loader.test.ts`
- `pnpm build`
