### PR TITLE
fix(acpx): harden codex and gemini ACP runtime flows

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -116,6 +116,36 @@ describe("resolveSpawnCommand", () => {
     });
   });
 
+  it("falls back to node on PATH when execPath is unavailable for a node shebang wrapper", async () => {
+    const dir = await createTempDir();
+    const binDir = path.join(dir, "bin");
+    const scriptPath = path.join(binDir, "acpx");
+    const nodePath = path.join(binDir, "node");
+    await mkdir(binDir, { recursive: true });
+    await writeFile(scriptPath, "#!/usr/bin/env node\nconsole.log('ok')\n", "utf8");
+    await writeFile(nodePath, "#!/bin/sh\nexit 0\n", "utf8");
+    await chmod(scriptPath, 0o755);
+    await chmod(nodePath, 0o755);
+
+    const resolved = resolveSpawnCommand(
+      {
+        command: scriptPath,
+        args: ["--help"],
+      },
+      undefined,
+      {
+        platform: "darwin",
+        env: { PATH: binDir },
+        execPath: "/missing/node",
+      },
+    );
+
+    expect(resolved).toEqual({
+      command: nodePath,
+      args: [scriptPath, "--help"],
+    });
+  });
+
   it("routes .js command execution through node on windows", () => {
     const resolved = resolveSpawnCommand(
       {

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -88,6 +88,13 @@ function resolveExecutableFromPath(command: string, runtime: SpawnRuntime): stri
   return undefined;
 }
 
+function resolveNodeExecPath(runtime: SpawnRuntime): string {
+  if (runtime.execPath && isExecutableFile(runtime.execPath, runtime.platform)) {
+    return runtime.execPath;
+  }
+  return resolveExecutableFromPath("node", runtime) ?? runtime.execPath;
+}
+
 function resolveNodeShebangScriptPath(command: string, runtime: SpawnRuntime): string | undefined {
   const commandPath =
     path.isAbsolute(command) || command.includes(path.sep)
@@ -122,7 +129,7 @@ export function resolveSpawnCommand(
         resolution: "direct",
       });
       return {
-        command: runtime.execPath,
+        command: resolveNodeExecPath(runtime),
         args: [nodeShebangScript, ...params.args],
       };
     }

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -300,6 +300,84 @@ describe("AcpxRuntime", () => {
     });
   });
 
+  it("surfaces structured control-command errors from sessions ensure", async () => {
+    const previousEnsureExit = process.env.MOCK_ACPX_ENSURE_EXIT_1;
+    const previousStatusSignal = process.env.MOCK_ACPX_STATUS_SIGNAL;
+    process.env.MOCK_ACPX_ENSURE_EXIT_1 = "1";
+    process.env.MOCK_ACPX_STATUS_SIGNAL = "SIGTERM";
+
+    try {
+      const { runtime } = await createMockRuntimeFixture();
+      await expect(
+        runtime.ensureSession({
+          sessionKey: "agent:codex:acp:ensure-structured-error",
+          agent: "codex",
+          mode: "persistent",
+        }),
+      ).rejects.toMatchObject({
+        code: "ACP_SESSION_INIT_FAILED",
+        message: "-32603: mock ensure failure",
+      });
+    } finally {
+      if (previousEnsureExit === undefined) {
+        delete process.env.MOCK_ACPX_ENSURE_EXIT_1;
+      } else {
+        process.env.MOCK_ACPX_ENSURE_EXIT_1 = previousEnsureExit;
+      }
+      if (previousStatusSignal === undefined) {
+        delete process.env.MOCK_ACPX_STATUS_SIGNAL;
+      } else {
+        process.env.MOCK_ACPX_STATUS_SIGNAL = previousStatusSignal;
+      }
+    }
+  });
+
+  it("appends stderr details when control-command errors are generic", async () => {
+    const previousEnsureExit = process.env.MOCK_ACPX_ENSURE_EXIT_1;
+    const previousEnsureMessage = process.env.MOCK_ACPX_ENSURE_ERROR_MESSAGE;
+    const previousEnsureStderr = process.env.MOCK_ACPX_ENSURE_STDERR;
+    const previousStatusSignal = process.env.MOCK_ACPX_STATUS_SIGNAL;
+    process.env.MOCK_ACPX_ENSURE_EXIT_1 = "1";
+    process.env.MOCK_ACPX_ENSURE_ERROR_MESSAGE = "Internal error";
+    process.env.MOCK_ACPX_ENSURE_STDERR = "usage limit exceeded";
+    process.env.MOCK_ACPX_STATUS_SIGNAL = "SIGTERM";
+
+    try {
+      const { runtime } = await createMockRuntimeFixture();
+      await expect(
+        runtime.ensureSession({
+          sessionKey: "agent:codex:acp:ensure-generic-error",
+          agent: "codex",
+          mode: "persistent",
+        }),
+      ).rejects.toMatchObject({
+        code: "ACP_SESSION_INIT_FAILED",
+        message: "-32603: Internal error | usage limit exceeded",
+      });
+    } finally {
+      if (previousEnsureExit === undefined) {
+        delete process.env.MOCK_ACPX_ENSURE_EXIT_1;
+      } else {
+        process.env.MOCK_ACPX_ENSURE_EXIT_1 = previousEnsureExit;
+      }
+      if (previousEnsureMessage === undefined) {
+        delete process.env.MOCK_ACPX_ENSURE_ERROR_MESSAGE;
+      } else {
+        process.env.MOCK_ACPX_ENSURE_ERROR_MESSAGE = previousEnsureMessage;
+      }
+      if (previousEnsureStderr === undefined) {
+        delete process.env.MOCK_ACPX_ENSURE_STDERR;
+      } else {
+        process.env.MOCK_ACPX_ENSURE_STDERR = previousEnsureStderr;
+      }
+      if (previousStatusSignal === undefined) {
+        delete process.env.MOCK_ACPX_STATUS_SIGNAL;
+      } else {
+        process.env.MOCK_ACPX_STATUS_SIGNAL = previousStatusSignal;
+      }
+    }
+  });
+
   it("serializes text plus image attachments into ACP prompt blocks", async () => {
     const { runtime, logPath } = await createMockRuntimeFixture();
 

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -14,6 +14,7 @@ import type {
 import { AcpRuntimeError } from "../runtime-api.js";
 import { toAcpMcpServers, type ResolvedAcpxPluginConfig } from "./config.js";
 import { checkAcpxVersion, type AcpxVersionCheckResult } from "./ensure.js";
+import { parseControlJsonError } from "./runtime-internals/control-errors.js";
 import {
   parseJsonLines,
   parsePromptEventLine,
@@ -126,6 +127,25 @@ function shouldRetainNamedSessionForDeadStatus(detail: AcpxJsonObject | undefine
   }
   const summary = asTrimmedString(detail?.summary)?.toLowerCase();
   return summary?.includes("queue owner unavailable") ?? false;
+}
+
+function formatAcpxControlErrorMessage(params: {
+  code?: string;
+  message: string;
+  stderr: string;
+}): string {
+  const baseMessage = params.code ? `${params.code}: ${params.message}` : params.message;
+  const stderrSummary = summarizeLogText(params.stderr);
+  if (!stderrSummary) {
+    return baseMessage;
+  }
+  if (
+    /^(?:internal error|acpx reported an error)$/i.test(params.message) &&
+    !baseMessage.includes(stderrSummary)
+  ) {
+    return `${baseMessage} | ${stderrSummary}`;
+  }
+  return baseMessage;
 }
 
 function findSessionIdentifierEvent(events: AcpxJsonObject[]): AcpxJsonObject | undefined {
@@ -1037,14 +1057,21 @@ export class AcpxRuntime implements AcpRuntime {
     }
 
     const events = parseJsonLines(result.stdout);
-    const errorEvent = events.map((event) => toAcpxErrorEvent(event)).find(Boolean) ?? null;
+    const errorEvent =
+      events
+        .map((event) => toAcpxErrorEvent(event) ?? parseControlJsonError(event))
+        .find(Boolean) ?? null;
     if (errorEvent) {
       if (params.ignoreNoSession && errorEvent.code === "NO_SESSION") {
         return events;
       }
       throw new AcpRuntimeError(
         params.fallbackCode,
-        errorEvent.code ? `${errorEvent.code}: ${errorEvent.message}` : errorEvent.message,
+        formatAcpxControlErrorMessage({
+          code: errorEvent.code,
+          message: errorEvent.message,
+          stderr: result.stderr,
+        }),
       );
     }
 

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -23,6 +23,11 @@ vi.mock("./ensure.js", () => ({
 type RuntimeStub = AcpRuntime & {
   probeAvailability(): Promise<void>;
   isHealthy(): boolean;
+  doctor?(): Promise<{
+    ok: boolean;
+    message: string;
+    details?: string[];
+  }>;
 };
 
 function createRuntimeStub(healthy: boolean): {
@@ -53,6 +58,53 @@ function createRuntimeStub(healthy: boolean): {
     },
     probeAvailabilitySpy,
     isHealthySpy,
+  };
+}
+
+function createRetryingRuntimeStub(healthSequence: boolean[]): {
+  runtime: RuntimeStub;
+  probeAvailabilitySpy: ReturnType<typeof vi.fn>;
+  isHealthySpy: ReturnType<typeof vi.fn>;
+  doctorSpy: ReturnType<typeof vi.fn>;
+} {
+  let probeCount = 0;
+  const probeAvailabilitySpy = vi.fn(async () => {
+    probeCount += 1;
+  });
+  const isHealthySpy = vi.fn(() => {
+    const index = Math.max(0, probeCount - 1);
+    return healthSequence[Math.min(index, healthSequence.length - 1)] ?? false;
+  });
+  const doctorSpy = vi.fn(async () => ({
+    ok: false,
+    message: "acpx help check failed",
+    details: ["stderr=temporary startup race"],
+  }));
+  return {
+    runtime: {
+      ensureSession: vi.fn(async (input) => ({
+        sessionKey: input.sessionKey,
+        backend: "acpx",
+        runtimeSessionName: input.sessionKey,
+      })),
+      runTurn: vi.fn(async function* () {
+        yield { type: "done" as const };
+      }),
+      cancel: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      async probeAvailability() {
+        await probeAvailabilitySpy();
+      },
+      isHealthy() {
+        return isHealthySpy();
+      },
+      async doctor() {
+        return await doctorSpy();
+      },
+    },
+    probeAvailabilitySpy,
+    isHealthySpy,
+    doctorSpy,
   };
 }
 
@@ -204,5 +256,31 @@ describe("createAcpxRuntimeService", () => {
       await service.stop?.(context);
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  it("retries health probes until the runtime becomes healthy", async () => {
+    const { runtime, probeAvailabilitySpy, doctorSpy } = createRetryingRuntimeStub([
+      false,
+      false,
+      true,
+    ]);
+    const service = createAcpxRuntimeService({
+      runtimeFactory: () => runtime,
+      healthProbeRetryDelaysMs: [0, 0],
+    });
+    const context = createServiceContext();
+
+    await service.start(context);
+
+    await vi.waitFor(() => {
+      expect(probeAvailabilitySpy).toHaveBeenCalledTimes(3);
+    });
+    expect(doctorSpy).toHaveBeenCalledTimes(2);
+    expect(context.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("probe attempt 1 failed"),
+    );
+    expect(context.logger.info).toHaveBeenCalledWith(
+      "acpx runtime backend ready after 3 probe attempts",
+    );
   });
 });

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -13,6 +13,11 @@ import { ACPX_BACKEND_ID, AcpxRuntime } from "./runtime.js";
 type AcpxRuntimeLike = AcpRuntime & {
   probeAvailability(): Promise<void>;
   isHealthy(): boolean;
+  doctor?(): Promise<{
+    ok: boolean;
+    message: string;
+    details?: string[];
+  }>;
 };
 
 type AcpxRuntimeFactoryParams = {
@@ -24,7 +29,24 @@ type AcpxRuntimeFactoryParams = {
 type CreateAcpxRuntimeServiceParams = {
   pluginConfig?: unknown;
   runtimeFactory?: (params: AcpxRuntimeFactoryParams) => AcpxRuntimeLike;
+  healthProbeRetryDelaysMs?: number[];
 };
+
+const DEFAULT_HEALTH_PROBE_RETRY_DELAYS_MS = [250, 1_000, 2_500];
+
+function delay(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function formatDoctorFailureMessage(report: { message: string; details?: string[] }): string {
+  const detailText = report.details?.filter(Boolean).join("; ").trim();
+  return detailText ? `${report.message} (${detailText})` : report.message;
+}
 
 function createDefaultRuntime(params: AcpxRuntimeFactoryParams): AcpxRuntimeLike {
   return new AcpxRuntime(params.pluginConfig, {
@@ -49,6 +71,8 @@ export function createAcpxRuntimeService(
       if (ctx.workspaceDir?.trim()) {
         await fs.mkdir(ctx.workspaceDir, { recursive: true });
       }
+      const healthProbeRetryDelaysMs =
+        params.healthProbeRetryDelaysMs ?? DEFAULT_HEALTH_PROBE_RETRY_DELAYS_MS;
       const runtimeFactory = params.runtimeFactory ?? createDefaultRuntime;
       runtime = runtimeFactory({
         pluginConfig,
@@ -84,12 +108,54 @@ export function createAcpxRuntimeService(
           if (currentRevision !== lifecycleRevision) {
             return;
           }
-          await runtime?.probeAvailability();
-          if (runtime?.isHealthy()) {
-            ctx.logger.info("acpx runtime backend ready");
-          } else {
-            ctx.logger.warn("acpx runtime backend probe failed after local install");
+          let lastFailureMessage: string | undefined;
+          for (let attempt = 0; attempt <= healthProbeRetryDelaysMs.length; attempt += 1) {
+            await runtime?.probeAvailability();
+            if (currentRevision !== lifecycleRevision) {
+              return;
+            }
+            if (runtime?.isHealthy()) {
+              ctx.logger.info(
+                attempt === 0
+                  ? "acpx runtime backend ready"
+                  : `acpx runtime backend ready after ${attempt + 1} probe attempts`,
+              );
+              return;
+            }
+
+            const doctorReport = await runtime?.doctor?.();
+            if (currentRevision !== lifecycleRevision) {
+              return;
+            }
+            if (doctorReport?.ok) {
+              ctx.logger.info(
+                attempt === 0
+                  ? "acpx runtime backend ready"
+                  : `acpx runtime backend ready after ${attempt + 1} probe attempts`,
+              );
+              return;
+            }
+            if (doctorReport) {
+              lastFailureMessage = formatDoctorFailureMessage(doctorReport);
+            } else {
+              lastFailureMessage = "acpx runtime backend remained unhealthy after probe";
+            }
+
+            const retryDelayMs = healthProbeRetryDelaysMs[attempt];
+            if (retryDelayMs == null) {
+              break;
+            }
+            ctx.logger.warn(
+              `acpx runtime backend probe attempt ${attempt + 1} failed: ${lastFailureMessage}; retrying in ${retryDelayMs}ms`,
+            );
+            await delay(retryDelayMs);
+            if (currentRevision !== lifecycleRevision) {
+              return;
+            }
           }
+          ctx.logger.warn(
+            `acpx runtime backend probe failed: ${lastFailureMessage ?? "backend remained unhealthy after setup"}`,
+          );
         } catch (err) {
           if (currentRevision !== lifecycleRevision) {
             return;

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -84,13 +84,16 @@ const setValue = command === "set" ? String(args[commandIndex + 2] || "") : "";
 
 if (command === "sessions" && args[commandIndex + 1] === "ensure") {
   writeLog({ kind: "ensure", agent, args, sessionName: ensureName });
+  if (process.env.MOCK_ACPX_ENSURE_STDERR) {
+    process.stderr.write(String(process.env.MOCK_ACPX_ENSURE_STDERR) + "\n");
+  }
   if (process.env.MOCK_ACPX_ENSURE_EXIT_1 === "1") {
     return emitJsonAndExit({
       jsonrpc: "2.0",
       id: null,
       error: {
         code: -32603,
-        message: "mock ensure failure",
+        message: process.env.MOCK_ACPX_ENSURE_ERROR_MESSAGE || "mock ensure failure",
       },
     }, 1);
   }
@@ -419,7 +422,9 @@ export async function readMockRuntimeLogEntries(
 export async function cleanupMockRuntimeFixtures(): Promise<void> {
   delete process.env.MOCK_ACPX_LOG;
   delete process.env.MOCK_ACPX_CONFIG_SHOW_AGENTS;
+  delete process.env.MOCK_ACPX_ENSURE_ERROR_MESSAGE;
   delete process.env.MOCK_ACPX_ENSURE_EXIT_1;
+  delete process.env.MOCK_ACPX_ENSURE_STDERR;
   delete process.env.MOCK_ACPX_STATUS_STATUS;
   delete process.env.MOCK_ACPX_STATUS_SUMMARY;
   sharedMockCliScriptPath = null;

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -538,6 +538,49 @@ describe("spawnAcpDirect", () => {
     });
   });
 
+  it("uses the target agent workspace for cross-agent ACP spawns when cwd is omitted", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        ...hoisted.state.cfg.acp,
+        allowedAgents: ["codex", "claude-code"],
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            workspace: "/tmp/workspace-main",
+          },
+          {
+            id: "claude-code",
+            workspace: "/tmp/workspace-claude-code",
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Inspect the queue owner state",
+        agentId: "claude-code",
+        mode: "run",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: expect.stringMatching(/^agent:claude-code:acp:/),
+        agent: "claude-code",
+        cwd: "/tmp/workspace-claude-code",
+      }),
+    );
+  });
+
   it("binds LINE ACP sessions to the current conversation when the channel has no native threads", async () => {
     enableLineCurrentConversationBindings();
     hoisted.sessionBindingBindMock.mockImplementationOnce(

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -58,6 +58,7 @@ import {
 } from "./acp-spawn-parent-stream.js";
 import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
+import { resolveSpawnedWorkspaceInheritance } from "./spawned-context.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
@@ -850,6 +851,12 @@ export async function spawnAcpDirect(
 
   const sessionKey = `agent:${targetAgentId}:acp:${crypto.randomUUID()}`;
   const runtimeMode = resolveAcpSessionMode(spawnMode);
+  const resolvedCwd = resolveSpawnedWorkspaceInheritance({
+    config: cfg,
+    targetAgentId,
+    requesterSessionKey: ctx.agentSessionKey,
+    explicitWorkspaceDir: params.cwd,
+  });
 
   let preparedBinding: PreparedAcpThreadBinding | null = null;
   if (requestThreadBinding) {
@@ -890,7 +897,7 @@ export async function spawnAcpDirect(
       targetAgentId,
       runtimeMode,
       resumeSessionId: params.resumeSessionId,
-      cwd: params.cwd,
+      cwd: resolvedCwd,
     });
     initializedRuntime = initializedSession.runtimeCloseHandle;
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
   isOllamaCompatProvider,
-  resolveOllamaBaseUrlForRun,
   resolveOllamaCompatNumCtxEnabled,
   shouldInjectOllamaCompatNumCtx,
   wrapOllamaCompatNumCtx,


### PR DESCRIPTION
## Summary
- retry acpx backend health probes after ensure() so Codex/Gemini startup races recover automatically
- preserve the target agent workspace for cross-agent ACP spawns when cwd is omitted
- surface structured/stderr control-command failures and fix node shebang wrapper resolution when execPath is stale

## Bugs fixed
- ACP service treated transient acpx startup races as a permanent unhealthy backend after one probe
- cross-agent ACP spawns inherited the requester workspace instead of the target agent workspace
- node-shebang acpx wrappers could fail when process.execPath was unavailable even though node existed on PATH
- generic control-command failures hid stderr context, making Codex/Gemini setup issues hard to diagnose

## Validation
- `pnpm exec vitest run extensions/acpx/src/runtime-internals/process.test.ts extensions/acpx/src/service.test.ts extensions/acpx/src/runtime.test.ts -t "falls back to node on PATH when execPath is unavailable for a node shebang wrapper|retries health probes until the runtime becomes healthy|includes stderr context when ensureSession gets a generic control-command error"`
- `pnpm exec vitest run src/agents/acp-spawn.test.ts -t "uses the target agent workspace for cross-agent ACP spawns when cwd is omitted"`
- `pnpm check`
