### PR TITLE
fix(acpx): retry backend health probes after ensure

### DIFF
--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -23,6 +23,11 @@ vi.mock("./ensure.js", () => ({
 type RuntimeStub = AcpRuntime & {
   probeAvailability(): Promise<void>;
   isHealthy(): boolean;
+  doctor?(): Promise<{
+    ok: boolean;
+    message: string;
+    details?: string[];
+  }>;
 };
 
 function createRuntimeStub(healthy: boolean): {
@@ -53,6 +58,53 @@ function createRuntimeStub(healthy: boolean): {
     },
     probeAvailabilitySpy,
     isHealthySpy,
+  };
+}
+
+function createRetryingRuntimeStub(healthSequence: boolean[]): {
+  runtime: RuntimeStub;
+  probeAvailabilitySpy: ReturnType<typeof vi.fn>;
+  isHealthySpy: ReturnType<typeof vi.fn>;
+  doctorSpy: ReturnType<typeof vi.fn>;
+} {
+  let probeCount = 0;
+  const probeAvailabilitySpy = vi.fn(async () => {
+    probeCount += 1;
+  });
+  const isHealthySpy = vi.fn(() => {
+    const index = Math.max(0, probeCount - 1);
+    return healthSequence[Math.min(index, healthSequence.length - 1)] ?? false;
+  });
+  const doctorSpy = vi.fn(async () => ({
+    ok: false,
+    message: "acpx help check failed",
+    details: ["stderr=temporary startup race"],
+  }));
+  return {
+    runtime: {
+      ensureSession: vi.fn(async (input) => ({
+        sessionKey: input.sessionKey,
+        backend: "acpx",
+        runtimeSessionName: input.sessionKey,
+      })),
+      runTurn: vi.fn(async function* () {
+        yield { type: "done" as const };
+      }),
+      cancel: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      async probeAvailability() {
+        await probeAvailabilitySpy();
+      },
+      isHealthy() {
+        return isHealthySpy();
+      },
+      async doctor() {
+        return await doctorSpy();
+      },
+    },
+    probeAvailabilitySpy,
+    isHealthySpy,
+    doctorSpy,
   };
 }
 
@@ -204,5 +256,31 @@ describe("createAcpxRuntimeService", () => {
       await service.stop?.(context);
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  it("retries health probes until the runtime becomes healthy", async () => {
+    const { runtime, probeAvailabilitySpy, doctorSpy } = createRetryingRuntimeStub([
+      false,
+      false,
+      true,
+    ]);
+    const service = createAcpxRuntimeService({
+      runtimeFactory: () => runtime,
+      healthProbeRetryDelaysMs: [0, 0],
+    });
+    const context = createServiceContext();
+
+    await service.start(context);
+
+    await vi.waitFor(() => {
+      expect(probeAvailabilitySpy).toHaveBeenCalledTimes(3);
+    });
+    expect(doctorSpy).toHaveBeenCalledTimes(2);
+    expect(context.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("probe attempt 1 failed"),
+    );
+    expect(context.logger.info).toHaveBeenCalledWith(
+      "acpx runtime backend ready after 3 probe attempts",
+    );
   });
 });

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -61,7 +61,14 @@ function createRuntimeStub(healthy: boolean): {
   };
 }
 
-function createRetryingRuntimeStub(healthSequence: boolean[]): {
+function createRetryingRuntimeStub(
+  healthSequence: boolean[],
+  doctorReport: { ok: boolean; message: string; details?: string[] } = {
+    ok: false,
+    message: "acpx help check failed",
+    details: ["stderr=temporary startup race"],
+  },
+): {
   runtime: RuntimeStub;
   probeAvailabilitySpy: ReturnType<typeof vi.fn>;
   isHealthySpy: ReturnType<typeof vi.fn>;
@@ -75,11 +82,7 @@ function createRetryingRuntimeStub(healthSequence: boolean[]): {
     const index = Math.max(0, probeCount - 1);
     return healthSequence[Math.min(index, healthSequence.length - 1)] ?? false;
   });
-  const doctorSpy = vi.fn(async () => ({
-    ok: false,
-    message: "acpx help check failed",
-    details: ["stderr=temporary startup race"],
-  }));
+  const doctorSpy = vi.fn(async () => doctorReport);
   return {
     runtime: {
       ensureSession: vi.fn(async (input) => ({
@@ -160,6 +163,7 @@ describe("createAcpxRuntimeService", () => {
     const { runtime } = createRuntimeStub(false);
     const service = createAcpxRuntimeService({
       runtimeFactory: () => runtime,
+      healthProbeRetryDelaysMs: [],
     });
     const context = createServiceContext();
 
@@ -282,5 +286,29 @@ describe("createAcpxRuntimeService", () => {
     expect(context.logger.info).toHaveBeenCalledWith(
       "acpx runtime backend ready after 3 probe attempts",
     );
+  });
+
+  it("does not treat doctor ok as healthy when the runtime still reports unhealthy", async () => {
+    const { runtime, probeAvailabilitySpy, doctorSpy } = createRetryingRuntimeStub([false], {
+      ok: true,
+      message: "acpx help check passed",
+    });
+    const service = createAcpxRuntimeService({
+      runtimeFactory: () => runtime,
+      healthProbeRetryDelaysMs: [],
+    });
+    const context = createServiceContext();
+
+    await service.start(context);
+
+    await vi.waitFor(() => {
+      expect(probeAvailabilitySpy).toHaveBeenCalledOnce();
+      expect(doctorSpy).toHaveBeenCalledOnce();
+      expect(context.logger.warn).toHaveBeenCalledWith(
+        "acpx runtime backend probe failed: acpx help check passed",
+      );
+    });
+    expect(context.logger.info).not.toHaveBeenCalledWith("acpx runtime backend ready");
+    expect(() => requireAcpRuntimeBackend("acpx")).toThrowError(AcpRuntimeError);
   });
 });

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -13,6 +13,11 @@ import { ACPX_BACKEND_ID, AcpxRuntime } from "./runtime.js";
 type AcpxRuntimeLike = AcpRuntime & {
   probeAvailability(): Promise<void>;
   isHealthy(): boolean;
+  doctor?(): Promise<{
+    ok: boolean;
+    message: string;
+    details?: string[];
+  }>;
 };
 
 type AcpxRuntimeFactoryParams = {
@@ -24,7 +29,24 @@ type AcpxRuntimeFactoryParams = {
 type CreateAcpxRuntimeServiceParams = {
   pluginConfig?: unknown;
   runtimeFactory?: (params: AcpxRuntimeFactoryParams) => AcpxRuntimeLike;
+  healthProbeRetryDelaysMs?: number[];
 };
+
+const DEFAULT_HEALTH_PROBE_RETRY_DELAYS_MS = [250, 1_000, 2_500];
+
+function delay(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function formatDoctorFailureMessage(report: { message: string; details?: string[] }): string {
+  const detailText = report.details?.filter(Boolean).join("; ").trim();
+  return detailText ? `${report.message} (${detailText})` : report.message;
+}
 
 function createDefaultRuntime(params: AcpxRuntimeFactoryParams): AcpxRuntimeLike {
   return new AcpxRuntime(params.pluginConfig, {
@@ -49,6 +71,8 @@ export function createAcpxRuntimeService(
       if (ctx.workspaceDir?.trim()) {
         await fs.mkdir(ctx.workspaceDir, { recursive: true });
       }
+      const healthProbeRetryDelaysMs =
+        params.healthProbeRetryDelaysMs ?? DEFAULT_HEALTH_PROBE_RETRY_DELAYS_MS;
       const runtimeFactory = params.runtimeFactory ?? createDefaultRuntime;
       runtime = runtimeFactory({
         pluginConfig,
@@ -84,12 +108,54 @@ export function createAcpxRuntimeService(
           if (currentRevision !== lifecycleRevision) {
             return;
           }
-          await runtime?.probeAvailability();
-          if (runtime?.isHealthy()) {
-            ctx.logger.info("acpx runtime backend ready");
-          } else {
-            ctx.logger.warn("acpx runtime backend probe failed after local install");
+          let lastFailureMessage: string | undefined;
+          for (let attempt = 0; attempt <= healthProbeRetryDelaysMs.length; attempt += 1) {
+            await runtime?.probeAvailability();
+            if (currentRevision !== lifecycleRevision) {
+              return;
+            }
+            if (runtime?.isHealthy()) {
+              ctx.logger.info(
+                attempt === 0
+                  ? "acpx runtime backend ready"
+                  : `acpx runtime backend ready after ${attempt + 1} probe attempts`,
+              );
+              return;
+            }
+
+            const doctorReport = await runtime?.doctor?.();
+            if (currentRevision !== lifecycleRevision) {
+              return;
+            }
+            if (doctorReport?.ok) {
+              ctx.logger.info(
+                attempt === 0
+                  ? "acpx runtime backend ready"
+                  : `acpx runtime backend ready after ${attempt + 1} probe attempts`,
+              );
+              return;
+            }
+            if (doctorReport) {
+              lastFailureMessage = formatDoctorFailureMessage(doctorReport);
+            } else {
+              lastFailureMessage = "acpx runtime backend remained unhealthy after probe";
+            }
+
+            const retryDelayMs = healthProbeRetryDelaysMs[attempt];
+            if (retryDelayMs == null) {
+              break;
+            }
+            ctx.logger.warn(
+              `acpx runtime backend probe attempt ${attempt + 1} failed: ${lastFailureMessage}; retrying in ${retryDelayMs}ms`,
+            );
+            await delay(retryDelayMs);
+            if (currentRevision !== lifecycleRevision) {
+              return;
+            }
           }
+          ctx.logger.warn(
+            `acpx runtime backend probe failed: ${lastFailureMessage ?? "backend remained unhealthy after setup"}`,
+          );
         } catch (err) {
           if (currentRevision !== lifecycleRevision) {
             return;

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -127,14 +127,6 @@ export function createAcpxRuntimeService(
             if (currentRevision !== lifecycleRevision) {
               return;
             }
-            if (doctorReport?.ok) {
-              ctx.logger.info(
-                attempt === 0
-                  ? "acpx runtime backend ready"
-                  : `acpx runtime backend ready after ${attempt + 1} probe attempts`,
-              );
-              return;
-            }
             if (doctorReport) {
               lastFailureMessage = formatDoctorFailureMessage(doctorReport);
             } else {


### PR DESCRIPTION
Summary
- retry ACPX backend health probes after ensure completes
- use doctor details so transient startup races do not look permanent

Problem
ACPX backend startup only probed health once after ensure. Codex and Gemini can need a short warmup, so the backend could stay marked unhealthy even though it would recover moments later.

Validation
- pnpm exec vitest run extensions/acpx/src/service.test.ts -t retries health probes until the runtime becomes healthy
- pnpm lint extensions/acpx/src/service.ts extensions/acpx/src/service.test.ts

Note
- local full pre-commit check is currently blocked on upstream main by an unrelated unused import in src/agents/pi-embedded-runner/run/attempt.test.ts