### PR TITLE
fix(slack): add warning log when channel is dropped due to allow:false

### DIFF
--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -9,7 +9,7 @@ import type { DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/config-runtime";
 import { createDedupeCache } from "openclaw/plugin-sdk/core";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
-import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { SlackMessageEvent } from "../types.js";
@@ -349,7 +349,7 @@ export function createSlackMonitorContext(params: {
       // config (matchSource undefined) should be allowed under open policy.
       const hasExplicitConfig = Boolean(channelConfig?.matchSource);
       if (!channelAllowed && (params.groupPolicy !== "open" || hasExplicitConfig)) {
-        logVerbose(`slack: drop channel ${p.channelId} (${channelMatchMeta})`);
+        warn(`slack: drop channel ${p.channelId} (allow=${channelConfig?.allowed}, ${channelMatchMeta})`);
         return false;
       }
       logVerbose(`slack: allow channel ${p.channelId} (${channelMatchMeta})`);


### PR DESCRIPTION
## Summary

When a message resolves to a channel config entry that has `allow:false`, the gateway now logs a warning instead of a verbose log. This makes access denial more visible in production environments.

## Issue

Fixes #58570

## Changes

- Import `warn` from `openclaw/plugin-sdk/runtime-env`
- Change the log level from `logVerbose` to `warn` when a channel is dropped due to `allow:false`
- Include the `allow` value in the log message for clarity

## Test Plan

- [x] Code compiles without errors
- [x] Log message now includes `allow=false` in the output for easy debugging