### PR TITLE
feat(tui): add /upload command for file context

### DIFF
--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -114,6 +114,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
       getArgumentCompletions: activationCompletions,
     },
     { name: "abort", description: "Abort active run" },
+    { name: "upload", description: "Browse and attach files as context" },
     { name: "new", description: "Reset the session" },
     { name: "reset", description: "Reset the session" },
     { name: "settings", description: "Open settings" },
@@ -158,6 +159,7 @@ export function helpText(options: SlashCommandOptions = {}): string {
     "/activation <mention|always>",
     "/new or /reset",
     "/abort",
+    "/upload",
     "/settings",
     "/exit",
   ].join("\n");

--- a/src/tui/components/file-browser-select-list.test.ts
+++ b/src/tui/components/file-browser-select-list.test.ts
@@ -1,0 +1,339 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FileBrowserSelectList, type FileBrowserTheme } from "./file-browser-select-list.js";
+
+// Identity theme so renders are plain text (no ANSI)
+const mockTheme: FileBrowserTheme = {
+  selectedPrefix: (t) => t,
+  selectedText: (t) => t,
+  description: (t) => t,
+  scrollInfo: (t) => t,
+  noMatch: (t) => t,
+  searchPrompt: (t) => t,
+  searchInput: (t) => t,
+  checked: (t) => t,
+  unchecked: (t) => t,
+  dirIcon: (t) => t,
+  fileIcon: (t) => t,
+  breadcrumb: (t) => t,
+};
+
+// Key constants
+const DOWN = "\x1b[B";
+const UP = "\x1b[A";
+const ENTER = "\r";
+const BACKSPACE = "\x7f";
+const ESCAPE = "\x1b";
+const LEFT = "\x1b[D";
+const SPACE = " ";
+
+describe("FileBrowserSelectList", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "fb-test-"));
+    // Create a test directory structure:
+    //   alpha.txt
+    //   beta.ts
+    //   .hidden
+    //   subdir/
+    //     nested.txt
+    writeFileSync(join(tmpDir, "alpha.txt"), "hello");
+    writeFileSync(join(tmpDir, "beta.ts"), "world");
+    writeFileSync(join(tmpDir, ".hidden"), "secret");
+    mkdirSync(join(tmpDir, "subdir"));
+    writeFileSync(join(tmpDir, "subdir", "nested.txt"), "nested content");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("renders directory contents with breadcrumb", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+    const output = fb.render(80);
+    const text = output.join("\n");
+
+    // Breadcrumb should show the current directory
+    expect(text).toContain(tmpDir);
+    // Should show files and directory
+    expect(text).toContain("subdir/");
+    expect(text).toContain("alpha.txt");
+    expect(text).toContain("beta.ts");
+  });
+
+  it("excludes hidden files (dotfiles)", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+    const text = fb.render(80).join("\n");
+
+    expect(text).not.toContain(".hidden");
+  });
+
+  it("lists directories before files, both sorted alphabetically", () => {
+    // Add another directory to confirm ordering
+    mkdirSync(join(tmpDir, "aaa-dir"));
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+    const text = fb.render(80).join("\n");
+
+    const aaaIdx = text.indexOf("aaa-dir/");
+    const subdirIdx = text.indexOf("subdir/");
+    const alphaIdx = text.indexOf("alpha.txt");
+    const betaIdx = text.indexOf("beta.ts");
+
+    // Directories come first, alphabetically
+    expect(aaaIdx).toBeLessThan(subdirIdx);
+    // Files come after directories, alphabetically
+    expect(subdirIdx).toBeLessThan(alphaIdx);
+    expect(alphaIdx).toBeLessThan(betaIdx);
+  });
+
+  it("navigates down and up with arrow keys", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+
+    // Initial selection is the first entry (subdir, since dirs first)
+    let output = fb.render(80).join("\n");
+    // The cursor marker is on subdir
+    expect(output).toContain("→");
+
+    // Move down
+    fb.handleInput(DOWN);
+    output = fb.render(80).join("\n");
+    // Both entries should be visible; just verify no crash and selection moved
+
+    // Move back up
+    fb.handleInput(UP);
+    // Should be back at first entry without error
+    fb.render(80);
+  });
+
+  it("selects and deselects a file with Space", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+
+    // Move to first file (skip the directory). Entries: subdir, alpha.txt, beta.ts
+    fb.handleInput(DOWN); // now on alpha.txt
+
+    // Select
+    fb.handleInput(SPACE);
+    expect(fb.getSelectedPaths()).toEqual([join(tmpDir, "alpha.txt")]);
+
+    // Rendered output should show "1 file selected"
+    let text = fb.render(80).join("\n");
+    expect(text).toContain("1 file selected");
+
+    // Deselect
+    fb.handleInput(SPACE);
+    expect(fb.getSelectedPaths()).toEqual([]);
+    text = fb.render(80).join("\n");
+    expect(text).toContain("No files selected");
+  });
+
+  it("can multi-select files", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+
+    // Select alpha.txt (index 1) and beta.ts (index 2)
+    fb.handleInput(DOWN); // alpha.txt
+    fb.handleInput(SPACE);
+    fb.handleInput(DOWN); // beta.ts
+    fb.handleInput(SPACE);
+
+    const selected = fb.getSelectedPaths();
+    expect(selected).toHaveLength(2);
+    expect(selected).toContain(join(tmpDir, "alpha.txt"));
+    expect(selected).toContain(join(tmpDir, "beta.ts"));
+
+    const text = fb.render(80).join("\n");
+    expect(text).toContain("2 files selected");
+  });
+
+  it("enters a directory with Enter", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+
+    // First entry is subdir (dirs come first)
+    fb.handleInput(ENTER);
+
+    const text = fb.render(80).join("\n");
+    // Breadcrumb should now show the subdir path
+    expect(text).toContain(join(tmpDir, "subdir"));
+    // Should show the nested file
+    expect(text).toContain("nested.txt");
+    // Should not show parent-level files
+    expect(text).not.toContain("alpha.txt");
+  });
+
+  it("Space on a directory navigates into it", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+
+    // First entry is subdir
+    fb.handleInput(SPACE);
+
+    const text = fb.render(80).join("\n");
+    expect(text).toContain(join(tmpDir, "subdir"));
+    expect(text).toContain("nested.txt");
+  });
+
+  it("goes to parent directory with Backspace when filter is empty", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+
+    // Navigate into subdir
+    fb.handleInput(ENTER);
+    let text = fb.render(80).join("\n");
+    expect(text).toContain("nested.txt");
+
+    // Go back with Backspace
+    fb.handleInput(BACKSPACE);
+    text = fb.render(80).join("\n");
+    expect(text).toContain("alpha.txt");
+    expect(text).toContain("subdir/");
+  });
+
+  it("goes to parent directory with Left arrow", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+
+    // Navigate into subdir
+    fb.handleInput(ENTER);
+
+    // Go back with Left arrow
+    fb.handleInput(LEFT);
+    const text = fb.render(80).join("\n");
+    expect(text).toContain("alpha.txt");
+  });
+
+  it("filters entries by typing", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+
+    // Type "alpha" to filter
+    for (const ch of "alpha") {
+      fb.handleInput(ch);
+    }
+
+    const text = fb.render(80).join("\n");
+    expect(text).toContain("alpha.txt");
+    expect(text).not.toContain("beta.ts");
+    expect(text).not.toContain("subdir/");
+  });
+
+  it("shows no files found when filter matches nothing", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+
+    for (const ch of "zzzzz") {
+      fb.handleInput(ch);
+    }
+
+    const text = fb.render(80).join("\n");
+    expect(text).toContain("No files found");
+  });
+
+  it("confirms with Enter and returns selected paths via onConfirm", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+    let confirmed: string[] | undefined;
+    fb.onConfirm = (paths) => {
+      confirmed = paths;
+    };
+
+    // Select alpha.txt then confirm
+    fb.handleInput(DOWN); // alpha.txt
+    fb.handleInput(SPACE);
+    fb.handleInput(ENTER);
+
+    expect(confirmed).toEqual([join(tmpDir, "alpha.txt")]);
+  });
+
+  it("confirms with single file under cursor when nothing is checked", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+    let confirmed: string[] | undefined;
+    fb.onConfirm = (paths) => {
+      confirmed = paths;
+    };
+
+    // Move to alpha.txt (no Space, so nothing checked) then Enter
+    fb.handleInput(DOWN); // alpha.txt
+    fb.handleInput(ENTER);
+
+    expect(confirmed).toEqual([join(tmpDir, "alpha.txt")]);
+  });
+
+  it("does not confirm when cursor is on a directory and nothing checked", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+    let confirmed: string[] | undefined;
+    fb.onConfirm = (paths) => {
+      confirmed = paths;
+    };
+
+    // Cursor is on subdir (first entry), Enter should navigate, not confirm
+    fb.handleInput(ENTER);
+
+    // Should have navigated into subdir, not confirmed
+    expect(confirmed).toBeUndefined();
+    const text = fb.render(80).join("\n");
+    expect(text).toContain("nested.txt");
+  });
+
+  it("calls onCancel when Escape is pressed", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+    let cancelled = false;
+    fb.onCancel = () => {
+      cancelled = true;
+    };
+
+    fb.handleInput(ESCAPE);
+
+    expect(cancelled).toBe(true);
+  });
+
+  it("preserves checked paths across directory navigation", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+
+    // Check alpha.txt
+    fb.handleInput(DOWN); // alpha.txt
+    fb.handleInput(SPACE);
+    expect(fb.getSelectedPaths()).toHaveLength(1);
+
+    // Navigate into subdir and back
+    fb.handleInput(UP); // back to subdir
+    fb.handleInput(ENTER); // enter subdir
+    fb.handleInput(BACKSPACE); // back to parent
+
+    // alpha.txt should still be checked
+    expect(fb.getSelectedPaths()).toEqual([join(tmpDir, "alpha.txt")]);
+  });
+
+  it("resets search input and selected index when navigating into a directory", () => {
+    const fb = new FileBrowserSelectList(tmpDir, 10, mockTheme);
+
+    // Type a filter first
+    fb.handleInput("s");
+    let text = fb.render(80).join("\n");
+    expect(text).toContain("subdir/");
+
+    // Enter subdir
+    fb.handleInput(ENTER);
+    text = fb.render(80).join("\n");
+    // Filter should be cleared in the new directory
+    expect(text).toContain("nested.txt");
+  });
+
+  it("handles empty directory gracefully", () => {
+    const emptyDir = join(tmpDir, "empty");
+    mkdirSync(emptyDir);
+
+    const fb = new FileBrowserSelectList(emptyDir, 10, mockTheme);
+    const text = fb.render(80).join("\n");
+
+    expect(text).toContain("No files found");
+  });
+
+  it("shows scroll info when entries exceed maxVisible", () => {
+    // Create many files
+    for (let i = 0; i < 20; i++) {
+      writeFileSync(join(tmpDir, `file${String(i).padStart(2, "0")}.txt`), "data");
+    }
+
+    const fb = new FileBrowserSelectList(tmpDir, 5, mockTheme);
+    const text = fb.render(80).join("\n");
+
+    // Should show scroll position info (e.g., "1/23")
+    expect(text).toMatch(/\d+\/\d+/);
+  });
+});

--- a/src/tui/components/file-browser-select-list.ts
+++ b/src/tui/components/file-browser-select-list.ts
@@ -1,0 +1,274 @@
+import { readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import {
+  type Component,
+  Input,
+  Key,
+  isKeyRelease,
+  matchesKey,
+  truncateToWidth,
+} from "@mariozechner/pi-tui";
+import { visibleWidth } from "../../terminal/ansi.js";
+
+export interface FileBrowserTheme {
+  selectedPrefix: (text: string) => string;
+  selectedText: (text: string) => string;
+  description: (text: string) => string;
+  scrollInfo: (text: string) => string;
+  noMatch: (text: string) => string;
+  searchPrompt: (text: string) => string;
+  searchInput: (text: string) => string;
+  checked: (text: string) => string;
+  unchecked: (text: string) => string;
+  dirIcon: (text: string) => string;
+  fileIcon: (text: string) => string;
+  breadcrumb: (text: string) => string;
+}
+
+export interface FileEntry {
+  name: string;
+  fullPath: string;
+  isDirectory: boolean;
+}
+
+/**
+ * A file browser with multi-select checkboxes for picking files to upload as context.
+ *
+ * Controls:
+ *   Up/Down  – navigate
+ *   Space    – toggle file selection
+ *   Enter    – open directory / confirm selection
+ *   Backspace or Left – go to parent directory
+ *   Esc      – cancel
+ */
+export class FileBrowserSelectList implements Component {
+  private currentDir: string;
+  private entries: FileEntry[] = [];
+  private filteredEntries: FileEntry[] = [];
+  private selectedIndex = 0;
+  private maxVisible: number;
+  private theme: FileBrowserTheme;
+  private checkedPaths = new Set<string>();
+  private searchInput: Input;
+
+  onConfirm?: (paths: string[]) => void;
+  onCancel?: () => void;
+
+  constructor(initialDir: string, maxVisible: number, theme: FileBrowserTheme) {
+    this.currentDir = resolve(initialDir);
+    this.maxVisible = maxVisible;
+    this.theme = theme;
+    this.searchInput = new Input();
+    this.loadEntries();
+  }
+
+  private loadEntries() {
+    try {
+      const names = readdirSync(this.currentDir);
+      const dirs: FileEntry[] = [];
+      const files: FileEntry[] = [];
+      for (const name of names) {
+        if (name.startsWith(".")) {
+          continue;
+        }
+        const fullPath = join(this.currentDir, name);
+        try {
+          const stat = statSync(fullPath);
+          const entry: FileEntry = { name, fullPath, isDirectory: stat.isDirectory() };
+          if (stat.isDirectory()) {
+            dirs.push(entry);
+          } else {
+            files.push(entry);
+          }
+        } catch {
+          // Skip entries we can't stat (permissions, broken symlinks, etc.)
+        }
+      }
+      dirs.sort((a, b) => a.name.localeCompare(b.name));
+      files.sort((a, b) => a.name.localeCompare(b.name));
+      this.entries = [...dirs, ...files];
+    } catch {
+      this.entries = [];
+    }
+    this.applyFilter();
+    this.selectedIndex = 0;
+  }
+
+  private applyFilter() {
+    const query = this.searchInput.getValue().trim().toLowerCase();
+    if (!query) {
+      this.filteredEntries = this.entries;
+    } else {
+      this.filteredEntries = this.entries.filter((e) => e.name.toLowerCase().includes(query));
+    }
+  }
+
+  private navigateTo(dir: string) {
+    this.currentDir = resolve(dir);
+    this.searchInput = new Input();
+    this.loadEntries();
+  }
+
+  invalidate() {
+    this.searchInput.invalidate();
+  }
+
+  render(width: number): string[] {
+    const lines: string[] = [];
+
+    // Breadcrumb showing current directory
+    const dirLabel = this.currentDir;
+    const truncatedDir = truncateToWidth(dirLabel, Math.max(1, width - 4), "");
+    lines.push(this.theme.breadcrumb(truncatedDir));
+
+    // Selected count
+    const count = this.checkedPaths.size;
+    const countLabel =
+      count > 0 ? `${count} file${count > 1 ? "s" : ""} selected` : "No files selected";
+    lines.push(
+      this.theme.description(
+        `  ${countLabel}  (space: toggle, enter: open dir/confirm, esc: cancel)`,
+      ),
+    );
+    lines.push("");
+
+    // Search input
+    const promptText = "filter: ";
+    const prompt = this.theme.searchPrompt(promptText);
+    const inputWidth = Math.max(1, width - visibleWidth(prompt));
+    const inputLines = this.searchInput.render(inputWidth);
+    lines.push(`${prompt}${this.theme.searchInput(inputLines[0] ?? "")}`);
+    lines.push("");
+
+    if (this.filteredEntries.length === 0) {
+      lines.push(this.theme.noMatch("  No files found"));
+      return lines;
+    }
+
+    // Calculate visible range with scrolling
+    const startIndex = Math.max(
+      0,
+      Math.min(
+        this.selectedIndex - Math.floor(this.maxVisible / 2),
+        this.filteredEntries.length - this.maxVisible,
+      ),
+    );
+    const endIndex = Math.min(startIndex + this.maxVisible, this.filteredEntries.length);
+
+    for (let i = startIndex; i < endIndex; i++) {
+      const entry = this.filteredEntries[i];
+      if (!entry) {
+        continue;
+      }
+      const isSelected = i === this.selectedIndex;
+      lines.push(this.renderEntry(entry, isSelected, width));
+    }
+
+    if (this.filteredEntries.length > this.maxVisible) {
+      const scrollInfo = `${this.selectedIndex + 1}/${this.filteredEntries.length}`;
+      lines.push(this.theme.scrollInfo(`  ${scrollInfo}`));
+    }
+
+    return lines;
+  }
+
+  private renderEntry(entry: FileEntry, isSelected: boolean, width: number): string {
+    const cursor = isSelected ? "→ " : "  ";
+    const checkbox = entry.isDirectory
+      ? "  "
+      : this.checkedPaths.has(entry.fullPath)
+        ? this.theme.checked("[x] ")
+        : this.theme.unchecked("[ ] ");
+    const icon = entry.isDirectory ? this.theme.dirIcon("📁 ") : this.theme.fileIcon("  ");
+    const suffix = entry.isDirectory ? "/" : "";
+    const maxNameWidth = Math.max(
+      1,
+      width - visibleWidth(cursor) - visibleWidth(checkbox) - visibleWidth(icon) - 2,
+    );
+    const name = truncateToWidth(`${entry.name}${suffix}`, maxNameWidth, "");
+    const line = `${cursor}${checkbox}${icon}${name}`;
+    return isSelected ? this.theme.selectedText(line) : line;
+  }
+
+  handleInput(keyData: string): void {
+    if (isKeyRelease(keyData)) {
+      return;
+    }
+
+    // Navigation
+    if (matchesKey(keyData, "up") || matchesKey(keyData, "ctrl+p")) {
+      this.selectedIndex = Math.max(0, this.selectedIndex - 1);
+      return;
+    }
+    if (matchesKey(keyData, "down") || matchesKey(keyData, "ctrl+n")) {
+      this.selectedIndex = Math.min(this.filteredEntries.length - 1, this.selectedIndex + 1);
+      return;
+    }
+
+    // Space: toggle file selection
+    if (keyData === " ") {
+      const entry = this.filteredEntries[this.selectedIndex];
+      if (entry && !entry.isDirectory) {
+        if (this.checkedPaths.has(entry.fullPath)) {
+          this.checkedPaths.delete(entry.fullPath);
+        } else {
+          this.checkedPaths.add(entry.fullPath);
+        }
+      }
+      // If it's a directory, space navigates into it
+      if (entry?.isDirectory) {
+        this.navigateTo(entry.fullPath);
+      }
+      return;
+    }
+
+    // Enter: open directory or confirm selection
+    if (matchesKey(keyData, "enter")) {
+      const entry = this.filteredEntries[this.selectedIndex];
+      if (entry?.isDirectory) {
+        this.navigateTo(entry.fullPath);
+        return;
+      }
+      // Confirm selection
+      if (this.checkedPaths.size > 0) {
+        this.onConfirm?.([...this.checkedPaths]);
+      } else {
+        // If no files checked but cursor is on a file, select that one
+        if (entry && !entry.isDirectory) {
+          this.onConfirm?.([entry.fullPath]);
+        }
+      }
+      return;
+    }
+
+    // Backspace when filter is empty, or Left arrow: go to parent
+    if (
+      matchesKey(keyData, "left") ||
+      (matchesKey(keyData, "backspace") && !this.searchInput.getValue())
+    ) {
+      const parent = resolve(this.currentDir, "..");
+      if (parent !== this.currentDir) {
+        this.navigateTo(parent);
+      }
+      return;
+    }
+
+    // Escape: cancel
+    if (matchesKey(keyData, Key.escape) || matchesKey(keyData, Key.ctrl("c"))) {
+      this.onCancel?.();
+      return;
+    }
+
+    // Pass other keys to search/filter input
+    const prevValue = this.searchInput.getValue();
+    this.searchInput.handleInput(keyData);
+    if (prevValue !== this.searchInput.getValue()) {
+      this.applyFilter();
+      this.selectedIndex = 0;
+    }
+  }
+
+  getSelectedPaths(): string[] {
+    return [...this.checkedPaths];
+  }
+}

--- a/src/tui/components/selectors.ts
+++ b/src/tui/components/selectors.ts
@@ -1,10 +1,12 @@
 import { type SelectItem, SelectList, type SettingItem, SettingsList } from "@mariozechner/pi-tui";
 import {
+  fileBrowserTheme,
   filterableSelectListTheme,
   searchableSelectListTheme,
   selectListTheme,
   settingsListTheme,
 } from "../theme/theme.js";
+import { FileBrowserSelectList } from "./file-browser-select-list.js";
 import { FilterableSelectList, type FilterableSelectItem } from "./filterable-select-list.js";
 import { SearchableSelectList } from "./searchable-select-list.js";
 
@@ -18,6 +20,10 @@ export function createSearchableSelectList(items: SelectItem[], maxVisible = 7) 
 
 export function createFilterableSelectList(items: FilterableSelectItem[], maxVisible = 7) {
   return new FilterableSelectList(items, maxVisible, filterableSelectListTheme);
+}
+
+export function createFileBrowserSelectList(initialDir: string, maxVisible = 12) {
+  return new FileBrowserSelectList(initialDir, maxVisible, fileBrowserTheme);
 }
 
 export function createSettingsList(

--- a/src/tui/theme/theme.ts
+++ b/src/tui/theme/theme.ts
@@ -6,6 +6,7 @@ import type {
 } from "@mariozechner/pi-tui";
 import chalk from "chalk";
 import { highlight, supportsLanguage } from "cli-highlight";
+import type { FileBrowserTheme } from "../components/file-browser-select-list.js";
 import type { SearchableSelectListTheme } from "../components/searchable-select-list.js";
 import { createSyntaxTheme } from "./syntax-theme.js";
 
@@ -228,4 +229,15 @@ export const searchableSelectListTheme: SearchableSelectListTheme = {
   searchPrompt: (text) => fg(palette.accentSoft)(text),
   searchInput: (text) => fg(palette.text)(text),
   matchHighlight: (text) => chalk.bold(fg(palette.accent)(text)),
+};
+
+export const fileBrowserTheme: FileBrowserTheme = {
+  ...baseSelectListTheme,
+  searchPrompt: (text) => fg(palette.accentSoft)(text),
+  searchInput: (text) => fg(palette.text)(text),
+  checked: (text) => fg(palette.success)(text),
+  unchecked: (text) => fg(palette.dim)(text),
+  dirIcon: (text) => fg(palette.accentSoft)(text),
+  fileIcon: (text) => fg(palette.dim)(text),
+  breadcrumb: (text) => chalk.bold(fg(palette.accent)(text)),
 };

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { basename, relative } from "node:path";
 import type { Component, SelectItem, TUI } from "@mariozechner/pi-tui";
 import { normalizeGroupActivation } from "../auto-reply/group-activation.js";
 import {
@@ -12,6 +14,7 @@ import { normalizeAgentId } from "../routing/session-key.js";
 import { helpText, parseCommand } from "./commands.js";
 import type { ChatLog } from "./components/chat-log.js";
 import {
+  createFileBrowserSelectList,
   createFilterableSelectList,
   createSearchableSelectList,
   createSettingsList,
@@ -82,6 +85,8 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     state.currentAgentId = normalizeAgentId(id);
     await setSession("");
   };
+
+  let pendingFileContext: string | null = null;
 
   const closeOverlayAndRender = () => {
     closeOverlay();
@@ -238,6 +243,47 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       },
     );
     openOverlay(settings);
+    tui.requestRender();
+  };
+
+  const openFileBrowser = () => {
+    const browser = createFileBrowserSelectList(process.cwd(), 12);
+    browser.onConfirm = (paths: string[]) => {
+      closeOverlay();
+      const blocks: string[] = [];
+      for (const filePath of paths) {
+        try {
+          const raw = readFileSync(filePath);
+          // Detect binary files: if >10% of the first 8KB are non-text bytes, skip
+          const sample = raw.subarray(0, 8192);
+          let nonText = 0;
+          for (const byte of sample) {
+            if (byte === 0 || (byte < 8 && byte !== 0)) {
+              nonText++;
+            }
+          }
+          if (sample.length > 0 && nonText / sample.length > 0.1) {
+            const relPath = relative(process.cwd(), filePath) || basename(filePath);
+            chatLog.addSystem(`skipped binary file: ${relPath}`);
+            continue;
+          }
+          const content = raw.toString("utf-8").split("\x00").join("");
+          const relPath = relative(process.cwd(), filePath) || basename(filePath);
+          blocks.push(`--- ${relPath} ---\n${content}\n--- end ${relPath} ---`);
+        } catch (err) {
+          chatLog.addSystem(`failed to read ${filePath}: ${String(err)}`);
+        }
+      }
+      if (blocks.length > 0) {
+        pendingFileContext = blocks.join("\n\n");
+        const names = paths.map((p) => relative(process.cwd(), p) || basename(p));
+        chatLog.addSystem(`${names.length} file(s) attached: ${names.join(", ")}`);
+        chatLog.addSystem("files will be included with your next message");
+      }
+      tui.requestRender();
+    };
+    browser.onCancel = closeOverlayAndRender;
+    openOverlay(browser as Component);
     tui.requestRender();
   };
 
@@ -490,6 +536,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           chatLog.addSystem(`reset failed: ${sanitizeRenderableText(String(err))}`);
         }
         break;
+      case "upload":
+        openFileBrowser();
+        break;
       case "abort":
         await abortActive();
         break;
@@ -514,6 +563,12 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       tui.requestRender();
       return;
     }
+    // Prepend pending file context if present
+    let messageToSend = text;
+    if (pendingFileContext) {
+      messageToSend = `[Attached files for context]\n\n${pendingFileContext}\n\n[User message]\n${text}`;
+      pendingFileContext = null;
+    }
     const isBtw = isBtwCommand(text);
     const runId = randomUUID();
     try {
@@ -527,7 +582,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       tui.requestRender();
       await client.sendChat({
         sessionKey: state.currentSessionKey,
-        message: text,
+        message: messageToSend,
         thinking: opts.thinking,
         deliver: deliverDefault,
         timeoutMs: opts.timeoutMs,

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -251,6 +251,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     browser.onConfirm = (paths: string[]) => {
       closeOverlay();
       const blocks: string[] = [];
+      const attachedNames: string[] = [];
       for (const filePath of paths) {
         try {
           const raw = readFileSync(filePath);
@@ -258,17 +259,17 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           const sample = raw.subarray(0, 8192);
           let nonText = 0;
           for (const byte of sample) {
-            if (byte === 0 || (byte < 8 && byte !== 0)) {
+            if (byte < 0x20 && byte !== 0x09 && byte !== 0x0a && byte !== 0x0d && byte !== 0x0c) {
               nonText++;
             }
           }
+          const relPath = relative(process.cwd(), filePath) || basename(filePath);
           if (sample.length > 0 && nonText / sample.length > 0.1) {
-            const relPath = relative(process.cwd(), filePath) || basename(filePath);
             chatLog.addSystem(`skipped binary file: ${relPath}`);
             continue;
           }
           const content = raw.toString("utf-8").split("\x00").join("");
-          const relPath = relative(process.cwd(), filePath) || basename(filePath);
+          attachedNames.push(relPath);
           blocks.push(`--- ${relPath} ---\n${content}\n--- end ${relPath} ---`);
         } catch (err) {
           chatLog.addSystem(`failed to read ${filePath}: ${String(err)}`);
@@ -276,8 +277,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       }
       if (blocks.length > 0) {
         pendingFileContext = blocks.join("\n\n");
-        const names = paths.map((p) => relative(process.cwd(), p) || basename(p));
-        chatLog.addSystem(`${names.length} file(s) attached: ${names.join(", ")}`);
+        chatLog.addSystem(`${attachedNames.length} file(s) attached: ${attachedNames.join(", ")}`);
         chatLog.addSystem("files will be included with your next message");
       }
       tui.requestRender();
@@ -504,6 +504,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         }
         break;
       case "new":
+        pendingFileContext = null;
         try {
           // Clear token counts immediately to avoid stale display (#1523)
           state.sessionInfo.inputTokens = null;
@@ -522,6 +523,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         }
         break;
       case "reset":
+        pendingFileContext = null;
         try {
           // Clear token counts immediately to avoid stale display (#1523)
           state.sessionInfo.inputTokens = null;


### PR DESCRIPTION
## Summary

- Problem: No way to interactively browse and attach local files as context in the TUI
- Why it matters: Users often need to provide file content for the AI to reference, but currently must copy-paste file path or reference files manually
- What changed: Added `/upload` slash command with an interactive file browser overlay that supports directory navigation, multi-select, search/filter, and binary file detection
- What did NOT change (scope boundary): No changes to CLI (non-TUI) mode, no changes to message protocol or session handling, no changes to existing commands
<img width="1074" height="673" alt="Screenshot 2026-03-31 180014" src="https://github.com/user-attachments/assets/54b4a1c5-7707-4122-beca-49057a2a5b88" />
<img width="1736" height="1072" alt="Screenshot 2026-03-31 175807" src="https://github.com/user-attachments/assets/58cfa51b-a5a8-469a-812a-b59fd13eb686" />
<img width="1639" height="1036" alt="Screenshot 2026-03-31 175856" src="https://github.com/user-attachments/assets/fe6766cd-143c-4351-9d28-240de5bf0496" />
<img width="1652" height="600" alt="Screenshot 2026-03-31 175918" src="https://github.com/user-attachments/assets/3d437116-d4c6-4478-b70a-f7ddf5b262fd" />


## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- New `/upload` TUI slash command available in help text
- Interactive file browser overlay with keyboard navigation (arrow keys, Enter, Space, Esc, Backspace)
- Multi-select files with checkboxes (Space to toggle)
- Search/filter files by typing
- Binary files are automatically detected and skipped
- Selected file contents are prepended to the next user message with `[Attached files for context]` header

## Diagram (if applicable)

```text
/upload -> [File Browser Overlay] -> Space to select files -> Enter to confirm
  -> Files read & validated (binary skipped)
  -> Content stored as pendingFileContext
  -> Next message sent with file content prepended
```

## Security Impact (required)

- New permissions/capabilities? `No` — reads files already accessible to the user process
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel (if any): TUI
- Relevant config (redacted): Default

### Steps

1. Run `openclaw` to start the TUI
2. Type `/upload` and press Enter
3. Browse directories, select files with Space, press Enter to confirm
4. Type a message — the selected file content is included automatically

### Expected

- File browser overlay appears with current directory listing
- Files can be selected/deselected, directories navigated
- On confirm, files are attached to the next message

### Actual

- Works as expected

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

20 unit tests added in `src/tui/components/file-browser-select-list.test.ts` covering: rendering, navigation, file selection/deselection, directory entry, parent navigation, search/filter, confirm/cancel callbacks, hidden file exclusion, scroll info, and state preservation across navigation.

## Human Verification (required)

- Verified scenarios: basic file selection, multi-select, directory navigation, binary file skipping, search/filter, cancel with Esc, file content correctly prepended to next message
- Edge cases checked: empty directories, permission errors on unreadable files, binary file detection, deeply nested navigation, dotfiles excluded
- What you did **not** verify: behavior on Windows native (tested on WSL2 only), extremely large files (no size cap implemented)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: Large files could cause high memory usage when read with `readFileSync`
  - Mitigation: Users select files explicitly; binary detection prevents accidental large binary reads. A file size limit could be added as a follow-up if maintainers prefer.

---

🤖 This PR was AI-assisted (Claude). The code has been lightly tested locally and verified with `pnpm build`, `pnpm check`, and `pnpm test` (all passing; 20 new unit tests added). The contributor understands what the code does.
