### PR TITLE
fix: show effective session model in dashboard

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -6,8 +6,15 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
-import { lookupContextTokens, resolveContextTokensForModel } from "../agents/context.js";
-import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import {
+  lookupContextTokens,
+  resolveContextTokensForModel,
+} from "../agents/context.js";
+import {
+  DEFAULT_CONTEXT_TOKENS,
+  DEFAULT_MODEL,
+  DEFAULT_PROVIDER,
+} from "../agents/defaults.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import {
   inferUniqueProviderFromConfiguredModels,
@@ -54,7 +61,10 @@ import {
   resolveAvatarMime,
 } from "../shared/avatar-policy.js";
 import { normalizeSessionDeliveryFields } from "../utils/delivery-context.js";
-import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
+import {
+  estimateUsageCost,
+  resolveModelCostConfig,
+} from "../utils/usage-format.js";
 import {
   readLatestSessionUsageFromTranscript,
   readSessionTitleFieldsFromTranscript,
@@ -118,7 +128,8 @@ function resolveIdentityAvatarUrl(
     return undefined;
   }
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  const workspaceRoot = tryResolveExistingPath(workspaceDir) ?? path.resolve(workspaceDir);
+  const workspaceRoot =
+    tryResolveExistingPath(workspaceDir) ?? path.resolve(workspaceDir);
   const resolvedCandidate = path.resolve(workspaceRoot, trimmed);
   if (!isPathWithinRoot(workspaceRoot, resolvedCandidate)) {
     return undefined;
@@ -147,7 +158,10 @@ function resolveIdentityAvatarUrl(
   }
 }
 
-function formatSessionIdPrefix(sessionId: string, updatedAt?: number | null): string {
+function formatSessionIdPrefix(
+  sessionId: string,
+  updatedAt?: number | null,
+): string {
   const prefix = sessionId.slice(0, 8);
   if (updatedAt && updatedAt > 0) {
     const d = new Date(updatedAt);
@@ -198,18 +212,30 @@ export function deriveSessionTitle(
 }
 
 function resolveSessionRuntimeMs(
-  run: { startedAt?: number; endedAt?: number; accumulatedRuntimeMs?: number } | null,
+  run: {
+    startedAt?: number;
+    endedAt?: number;
+    accumulatedRuntimeMs?: number;
+  } | null,
   now: number,
 ) {
   return getSubagentSessionRuntimeMs(run, now);
 }
 
-function resolvePositiveNumber(value: number | null | undefined): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+function resolvePositiveNumber(
+  value: number | null | undefined,
+): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
 }
 
-function resolveNonNegativeNumber(value: number | null | undefined): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+function resolveNonNegativeNumber(
+  value: number | null | undefined,
+): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
 }
 
 function resolveEstimatedSessionCostUsd(params: {
@@ -218,7 +244,11 @@ function resolveEstimatedSessionCostUsd(params: {
   model?: string;
   entry?: Pick<
     SessionEntry,
-    "estimatedCostUsd" | "inputTokens" | "outputTokens" | "cacheRead" | "cacheWrite"
+    | "estimatedCostUsd"
+    | "inputTokens"
+    | "outputTokens"
+    | "cacheRead"
+    | "cacheWrite"
   >;
   explicitCostUsd?: number;
 }): number | undefined {
@@ -270,9 +300,11 @@ function resolveChildSessionKeys(
     if (!childSessionKey) {
       continue;
     }
-    const latest = getSessionDisplaySubagentRunByChildSessionKey(childSessionKey);
+    const latest =
+      getSessionDisplaySubagentRunByChildSessionKey(childSessionKey);
     const latestControllerSessionKey =
-      latest?.controllerSessionKey?.trim() || latest?.requesterSessionKey?.trim();
+      latest?.controllerSessionKey?.trim() ||
+      latest?.requesterSessionKey?.trim();
     if (latestControllerSessionKey !== controllerSessionKey) {
       continue;
     }
@@ -284,13 +316,17 @@ function resolveChildSessionKeys(
     }
     const spawnedBy = entry.spawnedBy?.trim();
     const parentSessionKey = entry.parentSessionKey?.trim();
-    if (spawnedBy !== controllerSessionKey && parentSessionKey !== controllerSessionKey) {
+    if (
+      spawnedBy !== controllerSessionKey &&
+      parentSessionKey !== controllerSessionKey
+    ) {
       continue;
     }
     const latest = getSessionDisplaySubagentRunByChildSessionKey(key);
     if (latest) {
       const latestControllerSessionKey =
-        latest.controllerSessionKey?.trim() || latest.requesterSessionKey?.trim();
+        latest.controllerSessionKey?.trim() ||
+        latest.requesterSessionKey?.trim();
       if (latestControllerSessionKey !== controllerSessionKey) {
         continue;
       }
@@ -379,9 +415,20 @@ export function loadSessionEntry(sessionKey: string) {
     key: sessionKey.trim(),
     store,
   });
-  const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(store, target.storeKeys);
-  const legacyKey = freshestMatch?.key !== canonicalKey ? freshestMatch?.key : undefined;
-  return { cfg, storePath, store, entry: freshestMatch?.entry, canonicalKey, legacyKey };
+  const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(
+    store,
+    target.storeKeys,
+  );
+  const legacyKey =
+    freshestMatch?.key !== canonicalKey ? freshestMatch?.key : undefined;
+  return {
+    cfg,
+    storePath,
+    store,
+    entry: freshestMatch?.entry,
+    canonicalKey,
+    legacyKey,
+  };
 }
 
 export function resolveFreshestSessionStoreMatchFromStoreKeys(
@@ -393,14 +440,19 @@ export function resolveFreshestSessionStoreMatchFromStoreKeys(
       const entry = store[key];
       return entry ? { key, entry } : undefined;
     })
-    .filter((match): match is { key: string; entry: SessionEntry } => match !== undefined);
+    .filter(
+      (match): match is { key: string; entry: SessionEntry } =>
+        match !== undefined,
+    );
   if (matches.length === 0) {
     return undefined;
   }
   if (matches.length === 1) {
     return matches[0];
   }
-  return [...matches].toSorted((a, b) => (b.entry.updatedAt ?? 0) - (a.entry.updatedAt ?? 0))[0];
+  return [...matches].toSorted(
+    (a, b) => (b.entry.updatedAt ?? 0) - (a.entry.updatedAt ?? 0),
+  )[0];
 }
 
 export function resolveFreshestSessionEntryFromStoreKeys(
@@ -503,7 +555,10 @@ export function migrateAndPruneGatewaySessionStoreKey(params: {
   );
   if (freshestMatch) {
     const currentPrimary = params.store[primaryKey];
-    if (!currentPrimary || (freshestMatch.entry.updatedAt ?? 0) > (currentPrimary.updatedAt ?? 0)) {
+    if (
+      !currentPrimary ||
+      (freshestMatch.entry.updatedAt ?? 0) > (currentPrimary.updatedAt ?? 0)
+    ) {
       params.store[primaryKey] = freshestMatch.entry;
     }
   }
@@ -515,7 +570,10 @@ export function migrateAndPruneGatewaySessionStoreKey(params: {
   return { target, primaryKey, entry: params.store[primaryKey] };
 }
 
-export function classifySessionKey(key: string, entry?: SessionEntry): GatewaySessionRow["kind"] {
+export function classifySessionKey(
+  key: string,
+  entry?: SessionEntry,
+): GatewaySessionRow["kind"] {
   if (key === "global") {
     return "global";
   }
@@ -611,7 +669,9 @@ function resolveGatewayAgentModel(
 ): GatewayAgentRow["model"] | undefined {
   const primary = resolveAgentEffectiveModelPrimary(cfg, agentId)?.trim();
   const fallbackOverride = resolveAgentModelFallbacksOverride(cfg, agentId);
-  const defaultFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.model);
+  const defaultFallbacks = resolveAgentModelFallbackValues(
+    cfg.agents?.defaults?.model,
+  );
   const fallbacks = normalizeFallbackList(fallbackOverride ?? defaultFallbacks);
   if (!primary && fallbacks.length === 0) {
     return undefined;
@@ -653,7 +713,10 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
         }
       : undefined;
     configuredById.set(normalizeAgentId(entry.id), {
-      name: typeof entry.name === "string" && entry.name.trim() ? entry.name.trim() : undefined,
+      name:
+        typeof entry.name === "string" && entry.name.trim()
+          ? entry.name.trim()
+          : undefined,
       identity,
     });
   }
@@ -662,11 +725,16 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
       .map((entry) => (entry?.id ? normalizeAgentId(entry.id) : ""))
       .filter(Boolean),
   );
-  const allowedIds = explicitIds.size > 0 ? new Set([...explicitIds, defaultId]) : null;
+  const allowedIds =
+    explicitIds.size > 0 ? new Set([...explicitIds, defaultId]) : null;
   let agentIds = listConfiguredAgentIds(cfg).filter((id) =>
     allowedIds ? allowedIds.has(id) : true,
   );
-  if (mainKey && !agentIds.includes(mainKey) && (!allowedIds || allowedIds.has(mainKey))) {
+  if (
+    mainKey &&
+    !agentIds.includes(mainKey) &&
+    (!allowedIds || allowedIds.has(mainKey))
+  ) {
     agentIds = [...agentIds, mainKey];
   }
   const agents = agentIds.map((id) => {
@@ -735,7 +803,10 @@ export function resolveSessionStoreKey(params: {
   return canonicalizeSessionKeyForAgent(agentId, lowered);
 }
 
-function resolveSessionStoreAgentId(cfg: OpenClawConfig, canonicalKey: string): string {
+function resolveSessionStoreAgentId(
+  cfg: OpenClawConfig,
+  canonicalKey: string,
+): string {
   if (canonicalKey === "global" || canonicalKey === "unknown") {
     return resolveDefaultStoreAgentId(cfg);
   }
@@ -767,8 +838,14 @@ export function canonicalizeSpawnedByForAgent(
   }
   // Resolve main-alias references (e.g. agent:ops:main → configured main key).
   const parsed = parseAgentSessionKey(result);
-  const resolvedAgent = parsed?.agentId ? normalizeAgentId(parsed.agentId) : agentId;
-  return canonicalizeMainSessionAlias({ cfg, agentId: resolvedAgent, sessionKey: result });
+  const resolvedAgent = parsed?.agentId
+    ? normalizeAgentId(parsed.agentId)
+    : agentId;
+  return canonicalizeMainSessionAlias({
+    cfg,
+    agentId: resolvedAgent,
+    sessionKey: result,
+  });
 }
 
 function buildGatewaySessionStoreScanTargets(params: {
@@ -787,7 +864,10 @@ function buildGatewaySessionStoreScanTargets(params: {
   if (params.canonicalKey === "global" || params.canonicalKey === "unknown") {
     return [...targets];
   }
-  const agentMainKey = resolveAgentMainSessionKey({ cfg: params.cfg, agentId: params.agentId });
+  const agentMainKey = resolveAgentMainSessionKey({
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
   if (params.canonicalKey === agentMainKey) {
     targets.add(`agent:${params.agentId}:main`);
   }
@@ -828,15 +908,22 @@ function resolveGatewaySessionStoreLookup(params: {
   match: { entry: SessionEntry; key: string } | undefined;
 } {
   const scanTargets = buildGatewaySessionStoreScanTargets(params);
-  const candidates = resolveGatewaySessionStoreCandidates(params.cfg, params.agentId);
+  const candidates = resolveGatewaySessionStoreCandidates(
+    params.cfg,
+    params.agentId,
+  );
   const fallback = candidates[0] ?? {
     agentId: params.agentId,
-    storePath: resolveStorePath(params.cfg.session?.store, { agentId: params.agentId }),
+    storePath: resolveStorePath(params.cfg.session?.store, {
+      agentId: params.agentId,
+    }),
   };
   let selectedStorePath = fallback.storePath;
-  let selectedStore = params.initialStore ?? loadSessionStore(fallback.storePath);
+  let selectedStore =
+    params.initialStore ?? loadSessionStore(fallback.storePath);
   let selectedMatch = findFreshestStoreMatch(selectedStore, ...scanTargets);
-  let selectedUpdatedAt = selectedMatch?.entry.updatedAt ?? Number.NEGATIVE_INFINITY;
+  let selectedUpdatedAt =
+    selectedMatch?.entry.updatedAt ?? Number.NEGATIVE_INFINITY;
 
   for (let index = 1; index < candidates.length; index += 1) {
     const candidate = candidates[index];
@@ -939,7 +1026,11 @@ function mergeSessionEntryIntoCombined(params: {
     combined[canonicalKey] = {
       ...entry,
       ...existing,
-      spawnedBy: canonicalizeSpawnedByForAgent(cfg, agentId, existing.spawnedBy ?? entry.spawnedBy),
+      spawnedBy: canonicalizeSpawnedByForAgent(
+        cfg,
+        agentId,
+        existing.spawnedBy ?? entry.spawnedBy,
+      ),
     };
   } else {
     combined[canonicalKey] = {
@@ -996,11 +1087,15 @@ export function loadCombinedSessionStoreForGateway(cfg: OpenClawConfig): {
   }
 
   const storePath =
-    typeof storeConfig === "string" && storeConfig.trim() ? storeConfig.trim() : "(multiple)";
+    typeof storeConfig === "string" && storeConfig.trim()
+      ? storeConfig.trim()
+      : "(multiple)";
   return { storePath, store: combined };
 }
 
-export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults {
+export function getSessionDefaults(
+  cfg: OpenClawConfig,
+): GatewaySessionsDefaults {
   const resolved = resolveConfiguredModelRef({
     cfg,
     defaultProvider: DEFAULT_PROVIDER,
@@ -1021,7 +1116,10 @@ export function resolveSessionModelRef(
   cfg: OpenClawConfig,
   entry?:
     | SessionEntry
-    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
+    | Pick<
+        SessionEntry,
+        "model" | "modelProvider" | "modelOverride" | "providerOverride"
+      >,
   agentId?: string,
 ): { provider: string; model: string } {
   const resolved = agentId
@@ -1048,7 +1146,10 @@ export function resolveSessionModelRef(
       // provider the user has no credentials for.
       return { provider: runtimeProvider, model: runtimeModel };
     }
-    const parsedRuntime = parseModelRef(runtimeModel, provider || DEFAULT_PROVIDER);
+    const parsedRuntime = parseModelRef(
+      runtimeModel,
+      provider || DEFAULT_PROVIDER,
+    );
     if (parsedRuntime) {
       provider = parsedRuntime.provider;
       model = parsedRuntime.model;
@@ -1062,7 +1163,8 @@ export function resolveSessionModelRef(
   // then finally to configured defaults.
   const storedModelOverride = entry?.modelOverride?.trim();
   if (storedModelOverride) {
-    const overrideProvider = entry?.providerOverride?.trim() || provider || DEFAULT_PROVIDER;
+    const overrideProvider =
+      entry?.providerOverride?.trim() || provider || DEFAULT_PROVIDER;
     const parsedOverride = parseModelRef(storedModelOverride, overrideProvider);
     if (parsedOverride) {
       provider = parsedOverride.provider;
@@ -1088,7 +1190,8 @@ export async function resolveGatewayModelSupportsImages(params: {
     const catalog = await params.loadGatewayModelCatalog();
     const modelEntry = catalog.find(
       (entry) =>
-        entry.id === params.model && (!params.provider || entry.provider === params.provider),
+        entry.id === params.model &&
+        (!params.provider || entry.provider === params.provider),
     );
     return modelEntry ? (modelEntry.input?.includes("image") ?? false) : false;
   } catch {
@@ -1100,7 +1203,10 @@ export function resolveSessionModelIdentityRef(
   cfg: OpenClawConfig,
   entry?:
     | SessionEntry
-    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
+    | Pick<
+        SessionEntry,
+        "model" | "modelProvider" | "modelOverride" | "providerOverride"
+      >,
   agentId?: string,
   fallbackModelRef?: string,
 ): { provider?: string; model: string } {
@@ -1182,14 +1288,23 @@ export function buildGatewaySessionRow(params: {
     originLabel;
   const deliveryFields = normalizeSessionDeliveryFields(entry);
   const parsedAgent = parseAgentSessionKey(key);
-  const sessionAgentId = normalizeAgentId(parsedAgent?.agentId ?? resolveDefaultAgentId(cfg));
+  const sessionAgentId = normalizeAgentId(
+    parsedAgent?.agentId ?? resolveDefaultAgentId(cfg),
+  );
   const subagentRun = getSessionDisplaySubagentRunByChildSessionKey(key);
   const subagentOwner =
-    subagentRun?.controllerSessionKey?.trim() || subagentRun?.requesterSessionKey?.trim();
-  const subagentStatus = subagentRun ? resolveSubagentSessionStatus(subagentRun) : undefined;
-  const subagentStartedAt = subagentRun ? getSubagentSessionStartedAt(subagentRun) : undefined;
+    subagentRun?.controllerSessionKey?.trim() ||
+    subagentRun?.requesterSessionKey?.trim();
+  const subagentStatus = subagentRun
+    ? resolveSubagentSessionStatus(subagentRun)
+    : undefined;
+  const subagentStartedAt = subagentRun
+    ? getSubagentSessionStartedAt(subagentRun)
+    : undefined;
   const subagentEndedAt = subagentRun ? subagentRun.endedAt : undefined;
-  const subagentRuntimeMs = subagentRun ? resolveSessionRuntimeMs(subagentRun, now) : undefined;
+  const subagentRuntimeMs = subagentRun
+    ? resolveSessionRuntimeMs(subagentRun, now)
+    : undefined;
   const resolvedModel = resolveSessionModelIdentityRef(
     cfg,
     entry,
@@ -1200,7 +1315,8 @@ export function buildGatewaySessionRow(params: {
     Boolean(entry?.model?.trim()) || Boolean(entry?.modelProvider?.trim());
   const needsTranscriptTotalTokens =
     resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) === undefined;
-  const needsTranscriptContextTokens = resolvePositiveNumber(entry?.contextTokens) === undefined;
+  const needsTranscriptContextTokens =
+    resolvePositiveNumber(entry?.contextTokens) === undefined;
   const needsTranscriptEstimatedCostUsd =
     resolveEstimatedSessionCostUsd({
       cfg,
@@ -1209,7 +1325,9 @@ export function buildGatewaySessionRow(params: {
       entry,
     }) === undefined;
   const transcriptUsage =
-    needsTranscriptTotalTokens || needsTranscriptContextTokens || needsTranscriptEstimatedCostUsd
+    needsTranscriptTotalTokens ||
+    needsTranscriptContextTokens ||
+    needsTranscriptEstimatedCostUsd
       ? resolveTranscriptUsageFallback({
           cfg,
           key,
@@ -1229,18 +1347,34 @@ export function buildGatewaySessionRow(params: {
     provider: resolvedModel.provider,
     model: resolvedModel.model ?? DEFAULT_MODEL,
   };
-  const modelIdentity = shouldUseTranscriptModelIdentity
+  const baseModelIdentity = shouldUseTranscriptModelIdentity
     ? {
-        provider: transcriptUsage?.modelProvider ?? resolvedModelIdentity.provider,
+        provider:
+          transcriptUsage?.modelProvider ?? resolvedModelIdentity.provider,
         model: transcriptUsage?.model ?? resolvedModelIdentity.model,
       }
     : resolvedModelIdentity;
+  // When no runtime model or explicit override is recorded but the transcript
+  // contains the actual model used, prefer that over the configured default.
+  const useTranscriptFallback =
+    !runtimeModelPresent &&
+    !entry?.modelOverride?.trim() &&
+    !preferLiveSubagentModelIdentity &&
+    Boolean(transcriptUsage?.model);
+  const modelIdentity = useTranscriptFallback
+    ? {
+        provider: transcriptUsage?.modelProvider ?? baseModelIdentity.provider,
+        model: transcriptUsage?.model ?? baseModelIdentity.model,
+      }
+    : baseModelIdentity;
   const { provider: modelProvider, model } = modelIdentity;
   const totalTokens =
     resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) ??
     resolvePositiveNumber(transcriptUsage?.totalTokens);
   const totalTokensFresh =
-    typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0
+    typeof totalTokens === "number" &&
+    Number.isFinite(totalTokens) &&
+    totalTokens > 0
       ? true
       : transcriptUsage?.totalTokensFresh === true;
   const childSessions = resolveChildSessionKeys(key, store);
@@ -1266,7 +1400,10 @@ export function buildGatewaySessionRow(params: {
 
   let derivedTitle: string | undefined;
   let lastMessagePreview: string | undefined;
-  if (entry?.sessionId && (params.includeDerivedTitles || params.includeLastMessage)) {
+  if (
+    entry?.sessionId &&
+    (params.includeDerivedTitles || params.includeLastMessage)
+  ) {
     const fields = readSessionTitleFieldsFromTranscript(
       entry.sessionId,
       storePath,
@@ -1335,9 +1472,14 @@ export function buildGatewaySessionRow(params: {
 
 export function loadGatewaySessionRow(
   sessionKey: string,
-  options?: { includeDerivedTitles?: boolean; includeLastMessage?: boolean; now?: number },
+  options?: {
+    includeDerivedTitles?: boolean;
+    includeLastMessage?: boolean;
+    now?: number;
+  },
 ): GatewaySessionRow | null {
-  const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(sessionKey);
+  const { cfg, storePath, store, entry, canonicalKey } =
+    loadSessionEntry(sessionKey);
   if (!entry) {
     return null;
   }
@@ -1368,10 +1510,13 @@ export function listSessionsFromStore(params: {
   const includeLastMessage = opts.includeLastMessage === true;
   const spawnedBy = typeof opts.spawnedBy === "string" ? opts.spawnedBy : "";
   const label = typeof opts.label === "string" ? opts.label.trim() : "";
-  const agentId = typeof opts.agentId === "string" ? normalizeAgentId(opts.agentId) : "";
-  const search = typeof opts.search === "string" ? opts.search.trim().toLowerCase() : "";
+  const agentId =
+    typeof opts.agentId === "string" ? normalizeAgentId(opts.agentId) : "";
+  const search =
+    typeof opts.search === "string" ? opts.search.trim().toLowerCase() : "";
   const activeMinutes =
-    typeof opts.activeMinutes === "number" && Number.isFinite(opts.activeMinutes)
+    typeof opts.activeMinutes === "number" &&
+    Number.isFinite(opts.activeMinutes)
       ? Math.max(1, Math.floor(opts.activeMinutes))
       : undefined;
 
@@ -1408,10 +1553,13 @@ export function listSessionsFromStore(params: {
       const latest = getSessionDisplaySubagentRunByChildSessionKey(key);
       if (latest) {
         const latestControllerSessionKey =
-          latest.controllerSessionKey?.trim() || latest.requesterSessionKey?.trim();
+          latest.controllerSessionKey?.trim() ||
+          latest.requesterSessionKey?.trim();
         return latestControllerSessionKey === spawnedBy;
       }
-      return entry?.spawnedBy === spawnedBy || entry?.parentSessionKey === spawnedBy;
+      return (
+        entry?.spawnedBy === spawnedBy || entry?.parentSessionKey === spawnedBy
+      );
     })
     .filter(([, entry]) => {
       if (!label) {
@@ -1436,7 +1584,9 @@ export function listSessionsFromStore(params: {
   if (search) {
     sessions = sessions.filter((s) => {
       const fields = [s.displayName, s.label, s.subject, s.sessionId, s.key];
-      return fields.some((f) => typeof f === "string" && f.toLowerCase().includes(search));
+      return fields.some(
+        (f) => typeof f === "string" && f.toLowerCase().includes(search),
+      );
     });
   }
 

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -27,7 +27,10 @@ export type SessionsProps = {
     includeUnknown: boolean;
   }) => void;
   onSearchChange: (query: string) => void;
-  onSortChange: (column: "key" | "kind" | "updated" | "tokens", dir: "asc" | "desc") => void;
+  onSortChange: (
+    column: "key" | "kind" | "updated" | "tokens",
+    dir: "asc" | "desc",
+  ) => void;
   onPageChange: (page: number) => void;
   onPageSizeChange: (size: number) => void;
   onRefresh: () => void;
@@ -49,7 +52,15 @@ export type SessionsProps = {
   onNavigateToChat?: (sessionKey: string) => void;
 };
 
-const THINK_LEVELS = ["", "off", "minimal", "low", "medium", "high", "xhigh"] as const;
+const THINK_LEVELS = [
+  "",
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
 const BINARY_THINK_LEVELS = ["", "off", "on"] as const;
 const VERBOSE_LEVELS = [
   { value: "", label: "inherit" },
@@ -81,10 +92,15 @@ function isBinaryThinkingProvider(provider?: string | null): boolean {
 }
 
 function resolveThinkLevelOptions(provider?: string | null): readonly string[] {
-  return isBinaryThinkingProvider(provider) ? BINARY_THINK_LEVELS : THINK_LEVELS;
+  return isBinaryThinkingProvider(provider)
+    ? BINARY_THINK_LEVELS
+    : THINK_LEVELS;
 }
 
-function withCurrentOption(options: readonly string[], current: string): string[] {
+function withCurrentOption(
+  options: readonly string[],
+  current: string,
+): string[] {
   if (!current) {
     return [...options];
   }
@@ -107,6 +123,13 @@ function withCurrentLabeledOption(
   return [...options, { value: current, label: `${current} (custom)` }];
 }
 
+function shortModelName(model?: string | null): string {
+  if (!model) {
+    return "";
+  }
+  return model.includes("/") ? model.split("/").pop()! : model;
+}
+
 function resolveThinkLevelDisplay(value: string, isBinary: boolean): string {
   if (!isBinary) {
     return value;
@@ -117,7 +140,10 @@ function resolveThinkLevelDisplay(value: string, isBinary: boolean): string {
   return "on";
 }
 
-function resolveThinkLevelPatchValue(value: string, isBinary: boolean): string | null {
+function resolveThinkLevelPatchValue(
+  value: string,
+  isBinary: boolean,
+): string | null {
   if (!value) {
     return null;
   }
@@ -130,7 +156,10 @@ function resolveThinkLevelPatchValue(value: string, isBinary: boolean): string |
   return value;
 }
 
-function filterRows(rows: GatewaySessionRow[], query: string): GatewaySessionRow[] {
+function filterRows(
+  rows: GatewaySessionRow[],
+  query: string,
+): GatewaySessionRow[] {
   const q = query.trim().toLowerCase();
   if (!q) {
     return rows;
@@ -140,7 +169,12 @@ function filterRows(rows: GatewaySessionRow[], query: string): GatewaySessionRow
     const label = (row.label ?? "").toLowerCase();
     const kind = (row.kind ?? "").toLowerCase();
     const displayName = (row.displayName ?? "").toLowerCase();
-    return key.includes(q) || label.includes(q) || kind.includes(q) || displayName.includes(q);
+    return (
+      key.includes(q) ||
+      label.includes(q) ||
+      kind.includes(q) ||
+      displayName.includes(q)
+    );
   });
 }
 
@@ -196,7 +230,10 @@ export function renderSessions(props: SessionsProps) {
     extraClass = "",
   ) => {
     const isActive = props.sortColumn === col;
-    const nextDir = isActive && props.sortDir === "asc" ? ("desc" as const) : ("asc" as const);
+    const nextDir =
+      isActive && props.sortDir === "asc"
+        ? ("desc" as const)
+        : ("asc" as const);
     return html`
       <th
         class=${extraClass}
@@ -212,7 +249,10 @@ export function renderSessions(props: SessionsProps) {
 
   return html`
     <section class="card">
-      <div class="row" style="justify-content: space-between; margin-bottom: 12px;">
+      <div
+        class="row"
+        style="justify-content: space-between; margin-bottom: 12px;"
+      >
         <div>
           <div class="card-title">Sessions</div>
           <div class="card-sub">
@@ -221,7 +261,11 @@ export function renderSessions(props: SessionsProps) {
               : "Active session keys and per-session overrides."}
           </div>
         </div>
-        <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
+        <button
+          class="btn"
+          ?disabled=${props.loading}
+          @click=${props.onRefresh}
+        >
           ${props.loading ? "Loading…" : "Refresh"}
         </button>
       </div>
@@ -287,7 +331,9 @@ export function renderSessions(props: SessionsProps) {
       </div>
 
       ${props.error
-        ? html`<div class="callout danger" style="margin-bottom: 12px;">${props.error}</div>`
+        ? html`<div class="callout danger" style="margin-bottom: 12px;">
+            ${props.error}
+          </div>`
         : nothing}
 
       <div class="data-table-wrapper">
@@ -297,7 +343,8 @@ export function renderSessions(props: SessionsProps) {
               type="text"
               placeholder="Filter by key, label, kind…"
               .value=${props.searchQuery}
-              @input=${(e: Event) => props.onSearchChange((e.target as HTMLInputElement).value)}
+              @input=${(e: Event) =>
+                props.onSearchChange((e.target as HTMLInputElement).value)}
             />
           </div>
         </div>
@@ -306,7 +353,9 @@ export function renderSessions(props: SessionsProps) {
           ? html`
               <div class="data-table-bulk-bar">
                 <span>${props.selectedKeys.size} selected</span>
-                <button class="btn btn--sm" @click=${props.onDeselectAll}>Unselect</button>
+                <button class="btn btn--sm" @click=${props.onDeselectAll}>
+                  Unselect
+                </button>
                 <button
                   class="btn btn--sm danger"
                   ?disabled=${props.loading}
@@ -328,10 +377,14 @@ export function renderSessions(props: SessionsProps) {
                         type="checkbox"
                         .checked=${paginated.length > 0 &&
                         paginated.every((r) => props.selectedKeys.has(r.key))}
-                        .indeterminate=${paginated.some((r) => props.selectedKeys.has(r.key)) &&
+                        .indeterminate=${paginated.some((r) =>
+                          props.selectedKeys.has(r.key),
+                        ) &&
                         !paginated.every((r) => props.selectedKeys.has(r.key))}
                         @change=${() => {
-                          const allSelected = paginated.every((r) => props.selectedKeys.has(r.key));
+                          const allSelected = paginated.every((r) =>
+                            props.selectedKeys.has(r.key),
+                          );
                           if (allSelected) {
                             props.onDeselectPage(paginated.map((r) => r.key));
                           } else {
@@ -344,8 +397,10 @@ export function renderSessions(props: SessionsProps) {
                 </th>
                 ${sortHeader("key", "Key", "data-table-key-col")}
                 <th>Label</th>
-                ${sortHeader("kind", "Kind")} ${sortHeader("updated", "Updated")}
+                ${sortHeader("kind", "Kind")}
+                ${sortHeader("updated", "Updated")}
                 ${sortHeader("tokens", "Tokens")}
+                <th>Model</th>
                 <th>Thinking</th>
                 <th>Fast</th>
                 <th>Verbose</th>
@@ -357,7 +412,7 @@ export function renderSessions(props: SessionsProps) {
                 ? html`
                     <tr>
                       <td
-                        colspan="10"
+                        colspan="11"
                         style="text-align: center; padding: 48px 16px; color: var(--muted)"
                       >
                         No sessions found.
@@ -383,7 +438,10 @@ export function renderSessions(props: SessionsProps) {
           ? html`
               <div class="data-table-pagination">
                 <div class="data-table-pagination__info">
-                  ${page * props.pageSize + 1}-${Math.min((page + 1) * props.pageSize, totalRows)}
+                  ${page * props.pageSize + 1}-${Math.min(
+                    (page + 1) * props.pageSize,
+                    totalRows,
+                  )}
                   of ${totalRows} row${totalRows === 1 ? "" : "s"}
                 </div>
                 <div class="data-table-pagination__controls">
@@ -391,11 +449,18 @@ export function renderSessions(props: SessionsProps) {
                     style="height: 32px; padding: 0 8px; font-size: 13px; border-radius: var(--radius-md); border: 1px solid var(--border); background: var(--card);"
                     .value=${String(props.pageSize)}
                     @change=${(e: Event) =>
-                      props.onPageSizeChange(Number((e.target as HTMLSelectElement).value))}
+                      props.onPageSizeChange(
+                        Number((e.target as HTMLSelectElement).value),
+                      )}
                   >
-                    ${PAGE_SIZES.map((s) => html`<option value=${s}>${s} per page</option>`)}
+                    ${PAGE_SIZES.map(
+                      (s) => html`<option value=${s}>${s} per page</option>`,
+                    )}
                   </select>
-                  <button ?disabled=${page <= 0} @click=${() => props.onPageChange(page - 1)}>
+                  <button
+                    ?disabled=${page <= 0}
+                    @click=${() => props.onPageChange(page - 1)}
+                  >
                     Previous
                   </button>
                   <button
@@ -422,12 +487,18 @@ function renderRow(
   disabled: boolean,
   onNavigateToChat?: (sessionKey: string) => void,
 ) {
-  const updated = row.updatedAt ? formatRelativeTimestamp(row.updatedAt) : "n/a";
+  const updated = row.updatedAt
+    ? formatRelativeTimestamp(row.updatedAt)
+    : "n/a";
   const rawThinking = row.thinkingLevel ?? "";
   const isBinaryThinking = isBinaryThinkingProvider(row.modelProvider);
   const thinking = resolveThinkLevelDisplay(rawThinking, isBinaryThinking);
-  const thinkLevels = withCurrentOption(resolveThinkLevelOptions(row.modelProvider), thinking);
-  const fastMode = row.fastMode === true ? "on" : row.fastMode === false ? "off" : "";
+  const thinkLevels = withCurrentOption(
+    resolveThinkLevelOptions(row.modelProvider),
+    thinking,
+  );
+  const fastMode =
+    row.fastMode === true ? "on" : row.fastMode === false ? "off" : "";
   const fastLevels = withCurrentLabeledOption(FAST_LEVELS, fastMode);
   const verbose = row.verboseLevel ?? "";
   const verboseLevels = withCurrentLabeledOption(VERBOSE_LEVELS, verbose);
@@ -491,7 +562,9 @@ function renderRow(
               >`
             : row.key}
           ${showDisplayName
-            ? html`<span class="muted session-key-display-name">${displayName}</span>`
+            ? html`<span class="muted session-key-display-name"
+                >${displayName}</span
+              >`
             : nothing}
         </div>
       </td>
@@ -512,6 +585,13 @@ function renderRow(
       </td>
       <td>${updated}</td>
       <td>${formatSessionTokens(row)}</td>
+      <td
+        class="mono"
+        style="font-size: 12px; white-space: nowrap; max-width: 160px; overflow: hidden; text-overflow: ellipsis;"
+        title=${row.model ?? ""}
+      >
+        ${shortModelName(row.model)}
+      </td>
       <td>
         <select
           ?disabled=${disabled}
@@ -519,7 +599,10 @@ function renderRow(
           @change=${(e: Event) => {
             const value = (e.target as HTMLSelectElement).value;
             onPatch(row.key, {
-              thinkingLevel: resolveThinkLevelPatchValue(value, isBinaryThinking),
+              thinkingLevel: resolveThinkLevelPatchValue(
+                value,
+                isBinaryThinking,
+              ),
             });
           }}
         >
@@ -537,12 +620,17 @@ function renderRow(
           style="padding: 6px 10px; font-size: 13px; border: 1px solid var(--border); border-radius: var(--radius-sm); min-width: 90px;"
           @change=${(e: Event) => {
             const value = (e.target as HTMLSelectElement).value;
-            onPatch(row.key, { fastMode: value === "" ? null : value === "on" });
+            onPatch(row.key, {
+              fastMode: value === "" ? null : value === "on",
+            });
           }}
         >
           ${fastLevels.map(
             (level) =>
-              html`<option value=${level.value} ?selected=${fastMode === level.value}>
+              html`<option
+                value=${level.value}
+                ?selected=${fastMode === level.value}
+              >
                 ${level.label}
               </option>`,
           )}
@@ -559,7 +647,10 @@ function renderRow(
         >
           ${verboseLevels.map(
             (level) =>
-              html`<option value=${level.value} ?selected=${verbose === level.value}>
+              html`<option
+                value=${level.value}
+                ?selected=${verbose === level.value}
+              >
                 ${level.label}
               </option>`,
           )}


### PR DESCRIPTION
## Summary

- Add a **Model** column to the sessions table so operators can see the per-session effective model at a glance
- Fix transcript model fallback in `buildGatewaySessionRow`: when no runtime model (`entry.model`) or explicit override (`entry.modelOverride`) is recorded but the transcript contains the actual model used, prefer the transcript model over the configured default (`claude-opus-4-6`)

## Root cause

The dashboard sessions table had no model column, making it impossible to see which model each session was actually using. The overview cards showed `s.model` for the top 5 recent sessions, but the sessions table (the primary session management view) omitted model entirely.

Additionally, `buildGatewaySessionRow` would fall back to `DEFAULT_MODEL` ("claude-opus-4-6") when `entry.model` was not set, even when the transcript contained the actual model used. This caused sessions without persisted runtime model data to misleadingly show as Opus.

## Changes

**`src/gateway/session-utils.ts`** — Added `useTranscriptFallback` after the existing `shouldUseTranscriptModelIdentity` logic. When `!runtimeModelPresent && !entry.modelOverride && transcriptUsage?.model` exists, uses the transcript model instead of the configured default. Respects existing priority: entry.model > modelOverride > transcript > default.

**`ui/src/ui/views/sessions.ts`** — Added `shortModelName()` helper (strips provider prefix), `<th>Model</th>` column header, and a `<td>` cell displaying the shortened model name with tooltip. Updated empty-state colspan.

## Test plan

- [x] All 77 `session-utils.test.ts` tests pass (including override precedence tests)
- [x] All 4 `sessions.test.ts` UI tests pass
- [x] PAL codereview: 0 issues
- [x] PAL secaudit: 0 HIGH/CRITICAL (2 LOW — lit-html escaping mitigates XSS, model metadata exposure acceptable for operator dashboard)