### PR TITLE
fix(runner): allow fallback-driven model changes in live sessions

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -619,6 +619,24 @@ export async function runEmbeddedPiAgent(
             );
             throw new LiveSessionModelSwitchError(requestedSelection);
           }
+          const failedOrAbortedAttempt =
+            aborted || Boolean(promptError) || Boolean(assistantErrorText) || timedOut;
+          const persistedSelection =
+            failedOrAbortedAttempt && shouldTrackPersistedLiveSelection
+              ? resolvePersistedLiveSelection()
+              : null;
+          if (
+            failedOrAbortedAttempt &&
+            canRestartForLiveSwitch &&
+            params.authProfileIdSource === "user" &&
+            hasDifferentLiveSessionModelSelection(resolveCurrentLiveSelection(), persistedSelection)
+          ) {
+            log.info(
+              `live session model switch detected after failed attempt for ${params.sessionId}: ${provider}/${modelId} -> ${persistedSelection.provider}/${persistedSelection.model}`,
+            );
+            throw new LiveSessionModelSwitchError(persistedSelection);
+          }
+
           // ── Timeout-triggered compaction ──────────────────────────────────
           // When the LLM times out with high context usage, compact before
           // retrying to break the death spiral of repeated timeouts.


### PR DESCRIPTION
## Summary

Fixes #58600

When a live session's primary provider (e.g., Anthropic) becomes unavailable and the gateway attempts to fall back to an alternate provider (e.g., Google/Gemini), the fallback was being blocked by `LiveSessionModelSwitchError`.

## Root Cause

In `src/agents/pi-embedded-runner/run.ts`, the `persistedSelection` branch (which fires after a failed/aborted attempt) was throwing `LiveSessionModelSwitchError` regardless of whether the current invocation was user-initiated or fallback-driven. It re-reads the session store to detect model changes, but was always blocking if a difference was detected — even when the run itself was triggered by the fallback chain.

## Fix

Gate the `persistedSelection` check on `params.authProfileIdSource === "user"`. When the current invocation is fallback-driven (`authProfileIdSource` is not `"user"`), skip throwing `LiveSessionModelSwitchError` so the fallback can proceed normally.

- If `authProfileIdSource === "user"` → user-initiated session → block mid-turn model changes as before
- Otherwise → fallback-driven invocation → allow the switch

## Testing

- Configure a fallback chain: `anthropic/claude-sonnet-4-6` → `google/gemini-2.5-flash`
- Trigger a session when the primary provider is unavailable
- Confirm fallback succeeds without `LiveSessionModelSwitchError`
- Confirm user-initiated `/model` switches still throw the error mid-turn