### PR TITLE
fix: call onBlockReply synchronously to prevent pre-tool text block loss (#58337)

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -464,8 +464,8 @@ export function handleMessageEnd(
     try {
       const result = onBlockReply(payload);
       // If the callback returns a promise, catch async errors without blocking.
-      if (result && typeof (result as Promise<void>).catch === "function") {
-        (result as Promise<void>).catch((err) => {
+      if (result && typeof result.catch === "function") {
+        result.catch((err) => {
           ctx.log.warn(`block reply callback failed: ${String(err)}`);
         });
       }

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -461,11 +461,17 @@ export function handleMessageEnd(
     if (!onBlockReply) {
       return;
     }
-    void Promise.resolve()
-      .then(() => onBlockReply(payload))
-      .catch((err) => {
-        ctx.log.warn(`block reply callback failed: ${String(err)}`);
-      });
+    try {
+      const result = onBlockReply(payload);
+      // If the callback returns a promise, catch async errors without blocking.
+      if (result && typeof (result as Promise<void>).catch === "function") {
+        (result as Promise<void>).catch((err) => {
+          ctx.log.warn(`block reply callback failed: ${String(err)}`);
+        });
+      }
+    } catch (err) {
+      ctx.log.warn(`block reply callback failed: ${String(err)}`);
+    }
   };
   const shouldEmitReasoning = Boolean(
     !ctx.params.silentExpected &&

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -117,8 +117,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     try {
       const result = params.onBlockReply(payload);
       // If the callback returns a promise, catch async errors without blocking.
-      if (result && typeof (result as Promise<void>).catch === "function") {
-        (result as Promise<void>).catch((err) => {
+      if (result && typeof result.catch === "function") {
+        result.catch((err) => {
           log.warn(`block reply callback failed: ${String(err)}`);
         });
       }

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -114,11 +114,17 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!params.onBlockReply) {
       return;
     }
-    void Promise.resolve()
-      .then(() => params.onBlockReply?.(payload))
-      .catch((err) => {
-        log.warn(`block reply callback failed: ${String(err)}`);
-      });
+    try {
+      const result = params.onBlockReply(payload);
+      // If the callback returns a promise, catch async errors without blocking.
+      if (result && typeof (result as Promise<void>).catch === "function") {
+        (result as Promise<void>).catch((err) => {
+          log.warn(`block reply callback failed: ${String(err)}`);
+        });
+      }
+    } catch (err) {
+      log.warn(`block reply callback failed: ${String(err)}`);
+    }
   };
   const emitBlockReply = (payload: BlockReplyPayload) => {
     emitBlockReplySafely(consumePendingToolMediaIntoReply(state, payload));


### PR DESCRIPTION
## Summary

Fixes #58337 — MiniMax toolCall pre-text block completely dropped on Telegram. The user never sees assistant text output before a tool call.

## Root Cause

`emitBlockReplySafely` used a fire-and-forget microtask pattern (`void Promise.resolve().then(...)`) that deferred `onBlockReply` calls. When `handleToolExecutionStart` ran `flushBlockReplyBuffer()` followed by `onBlockReplyFlush()`, the pending block reply microtask had not yet executed. This caused pre-tool text blocks to be enqueued **after** the flush and effectively dropped on delivery.

Two copies of this pattern existed:
- `src/agents/pi-embedded-subscribe.ts:111-122` (main subscription)
- `src/agents/pi-embedded-subscribe.handlers.messages.ts:429-438` (message end handler)

## Changes

- **`src/agents/pi-embedded-subscribe.ts`**: Replace microtask pattern with synchronous `try/catch` invocation of `onBlockReply`. Async callback errors are still caught via `.catch()` without blocking.
- **`src/agents/pi-embedded-subscribe.handlers.messages.ts`**: Same fix applied to the duplicate `emitBlockReplySafely` in `handleMessageEnd`.

## Test Evidence

The **pre-existing failing test** `"flushes buffered block chunks before tool execution"` now passes. All 30 test files in the `pi-embedded-subscribe` suite pass (163/164 tests — the 1 failure is a pre-existing issue in `reopens-fenced-blocks-splitting-inside-them.test.ts` also present on `main`).