### PR TITLE
fix(agents): drop streamTo silently for non-ACP spawn requests

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -239,7 +239,7 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
-  it('rejects streamTo when runtime is not "acp"', async () => {
+  it('ignores streamTo when runtime is explicitly "subagent"', async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
@@ -251,12 +251,41 @@ describe("sessions_spawn tool", () => {
     });
 
     expect(result.details).toMatchObject({
-      status: "error",
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:1",
+      runId: "run-subagent",
     });
-    const details = result.details as { error?: string };
-    expect(details.error).toContain("streamTo is only supported for runtime=acp");
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        streamTo: "parent",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('ignores streamTo when runtime is omitted and defaults to "subagent"', async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    const result = await tool.execute("call-3c", {
+      task: "analyze file",
+      streamTo: "parent",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:1",
+      runId: "run-subagent",
+    });
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        streamTo: "parent",
+      }),
+      expect.any(Object),
+    );
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
   it("keeps attachment content schema unconstrained for llama.cpp grammar safety", () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -92,7 +92,13 @@ const SessionsSpawnToolSchema = Type.Object({
   mode: optionalStringEnum(SUBAGENT_SPAWN_MODES),
   cleanup: optionalStringEnum(["delete", "keep"] as const),
   sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
-  streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS),
+  streamTo: Type.Optional(
+    Type.String({
+      enum: [...SESSIONS_SPAWN_ACP_STREAM_TARGETS],
+      description:
+        'ACP-only output routing hint. Only used for runtime="acp" and currently ignored for subagent spawns.',
+    }),
+  ),
 
   // Inline attachments (snapshot-by-value).
   // NOTE: Attachment contents are redacted from transcript persistence by sanitizeToolCallInputs.
@@ -156,7 +162,10 @@ export function createSessionsSpawnTool(
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const requestedStreamTo = params.streamTo === "parent" ? "parent" : undefined;
+      // Some callers retain ACP-only fields when they fall back to subagent runtime.
+      // Treat streamTo as ACP-only and drop it for subagent requests.
+      const streamTo = runtime === "acp" ? requestedStreamTo : undefined;
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
         typeof params.runTimeoutSeconds === "number"
@@ -177,13 +186,6 @@ export function createSessionsSpawnTool(
             mimeType?: string;
           }>)
         : undefined;
-
-      if (streamTo && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
 
       if (resumeSessionId && runtime !== "acp") {
         return jsonResult({


### PR DESCRIPTION
## Summary

**Problem:** sessions_spawn returned { status: "error" } when streamTo: "parent" was passed with runtime: "subagent" or with runtime omitted (defaults to subagent). Callers that retain the full ACP parameter set after a runtime fallback were rejected.

**Why it matters:** streamTo is an output-routing hint with no effect on subagent spawns. Erroring on a no-op field breaks valid spawn flows for callers that don't strip ACP-only params before calling.

**What changed:** Removed the hard-error guard on streamTo for non-ACP runtime. streamTo is now resolved before the runtime branch and forwarded only when runtime === "acp"; silently dropped otherwise. Schema description updated to document the ACP-only contract.

**What did NOT change (scope boundary):** resumeSessionId still errors for non-ACP. All ACP spawn paths, the streamTo !== "parent" registry-tracking guard, and subagent spawn behavior are unchanged.

---

## Change Type (select all)

- [x] Bug fix

---

## Scope (select all touched areas)

- [x] Skills / tool execution

---

## Linked Issue/PR

- Closes #55483
- Related #56906 

---

## This PR fixes a bug or regression

---

## Root Cause / Regression History (if applicable)

- Root cause: The guard if (streamTo && runtime !== "acp") was intentionally strict but treated a harmless no-op field as a fatal input error rather than ignoring it.
- Missing detection / guardrail: No unit test covered the path where a caller passes streamTo and runtime resolves to subagent; only the ACP forward path was tested.
- Prior context: vincentkoc-code/pr-55483-replacement added the schema description update; this PR completes the fix by removing the error guard and adding direct test coverage.
- Why this regressed now: N/A — the guard was always too strict; it became observable when callers started retaining the full ACP parameter set across runtime fallbacks.
- If unknown, what was ruled out: N/A

---

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test

- Target test or file:
  src/agents/tools/sessions-spawn-tool.test.ts

- Scenario the test should lock in:
  - 'ignores streamTo when runtime is explicitly "subagent"' — streamTo: "parent" + explicit subagent runtime → status: "accepted", spawnSubagentDirect called without streamTo.
  - 'ignores streamTo when runtime is omitted and defaults to "subagent"' — same with runtime omitted.

- Why this is the smallest reliable guardrail:
  Both tests directly exercise the removed error branch and the new silent-drop path with zero infrastructure dependencies.

- Existing test that already covers this (if any):
  Replaced 'rejects streamTo when runtime is not "acp"' (which asserted the old error behavior).

- If no new test is added, why not:
  N/A — two tests added.

---

## User-visible / Behavior Changes

Callers that previously received:
{ status: "error", error: "streamTo is only supported for runtime=acp; got runtime=subagent" }

Will now receive a normal:
{ status: "accepted", ... }

No change for callers that do not pass streamTo, or for ACP callers.

---

## Diagram (if applicable)

N/A

---

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

---

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22, local gateway
- Model/provider: any
- Integration/channel (if any): subagent spawn
- Relevant config (redacted): none

### Steps

1. Call sessions_spawn with { task: "test", runtime: "subagent", streamTo: "parent" }
2. Observe result status

### Expected

{ status: "accepted", childSessionKey: "...", runId: "..." }

### Actual (before fix)

{ status: "error", error: "streamTo is only supported for runtime=acp; got runtime=subagent" }

### Evidence

- Failing test/log before + passing after
  - 'rejects streamTo when runtime is not "acp"'（旧行为）
  - 替换为两个断言 status: "accepted" 且未透传 streamTo 的测试

---

## Human Verification (required)

- Verified scenarios:
  - explicit runtime: "subagent" + streamTo: "parent"
  - omitted runtime + streamTo: "parent"
  - streamTo absent entirely (no regression)
  - resumeSessionId error guard still fires for non-ACP

- Edge cases checked:
  - ACP path with streamTo: "parent" — unaffected, forwarded as before.

- What you did not verify:
  - Live ACP end-to-end session with streamTo: "parent"

---

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

---

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

---

## Risks and Mitigations

- Risk: Callers that intentionally passed streamTo on a subagent spawn expecting an error to signal misuse will no longer receive feedback.

- Mitigation:
  streamTo is documented as an ACP-only output-routing hint in the schema description; it has no observable effect on subagent spawns. Silent drop is the correct semantic. Callers can inspect the updated schema description to understand the contract.