### PR TITLE
fix(discord): polyfill Client.registerListener for carbon >=0.14 compat

### DIFF
--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -745,6 +745,18 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       listenerTimeout: 120_000,
       ...discordCfg.eventQueue,
     };
+    // Polyfill registerListener on Client if missing (carbon >=0.14 removed it,
+    // but VoicePlugin/GatewayPlugin still call it during registerClient).
+    const OrigClient = Client as unknown as { prototype: Record<string, unknown> };
+    if (typeof OrigClient.prototype.registerListener !== "function") {
+      OrigClient.prototype.registerListener = function (
+        this: { listeners: unknown[] },
+        listener: unknown,
+      ) {
+        this.listeners.push(listener);
+      };
+    }
+
     const client = new Client(
       {
         baseUrl: "http://localhost",


### PR DESCRIPTION
## Problem

OpenClaw v2026.3.31 crashes on startup with an infinite restart loop when the Discord provider initializes:

```
TypeError: this.client.registerListener is not a function
    at VoicePlugin.registerClient (provider-*.js)
    at SafeGatewayPlugin.registerClient (provider-*.js)
    at new Client (@buape/carbon/src/classes/Client.ts:223:27)
```

**Impact:** Both Signal and Discord become completely unresponsive. The gateway enters a ~5s crash-restart cycle (I observed 368+ restarts before catching it).

## Root Cause

`@buape/carbon@0.14.0` removed `Client.registerListener()`, replacing internal usage with direct `this.listeners.push()`. However, carbon's own plugins still call `this.client.registerListener()` during their `registerClient()` hooks:

- **VoicePlugin.registerClient** — calls `this.client.registerListener(new GuildDelete())` etc.
- **GatewayPlugin.registerClient** — calls `this.client.registerListener(new InteractionEventListener())` when `autoInteractions` is enabled

The published openclaw package specifies `"@buape/carbon": "^0.14.0"` as a dependency, resolving to the version that lacks this method. The source repo uses `@buape/carbon@0.0.0-beta-20260216184201` which still has it — so this only manifests in the published npm package.

## Fix

Adds a one-time prototype polyfill on `Client` before construction, restoring `registerListener` using the same `listeners.push()` semantics that carbon 0.14.0 uses internally. The polyfill is guarded with a `typeof` check so it's a no-op once carbon restores the method or openclaw pins to a compatible version.

## Workaround (for anyone hitting this now)

Add `registerListener` to the installed carbon Client class:

```js
// In node_modules/@buape/carbon/dist/src/classes/Client.js, before getPlugin():
registerListener(listener) {
    this.listeners.push(listener);
}
```

Or patch `provider-*.js` in the openclaw dist to guard all `registerListener` calls.