### PR TITLE
feat(slack): default allowBots to true

### DIFF
--- a/extensions/slack/src/config-ui-hints.ts
+++ b/extensions/slack/src/config-ui-hints.ts
@@ -27,7 +27,7 @@ export const slackChannelConfigUiHints = {
   },
   allowBots: {
     label: "Slack Allow Bot Messages",
-    help: "Allow bot-authored messages to trigger Slack replies (default: false).",
+    help: "Allow bot-authored messages to trigger Slack replies (default: true). Set to false to ignore all bot messages.",
   },
   botToken: {
     label: "Slack Bot Token",

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -151,7 +151,7 @@ async function resolveSlackConversationContext(params: {
     channelConfig?.allowBots ??
     account.config?.allowBots ??
     cfg.channels?.slack?.allowBots ??
-    false;
+    true;
 
   return {
     channelInfo,


### PR DESCRIPTION
## Summary

Changes the default value of `allowBots` for Slack from `false` to `true`.

## Motivation

Bot-to-bot communication is a common use case for multi-agent setups (e.g. multiple OpenClaw agents in the same Slack workspace tagging each other). The previous default (`false`) required **every agent** to manually add `channels.slack.allowBots: true` to their config before they could receive messages from other bots.

This is a one-line default change that makes multi-agent Slack setups work out of the box.

## Safety

`requireMention: true` (the default for Slack channels) ensures bots only respond when explicitly `@mentioned` — not on every bot message in a channel. So enabling `allowBots` by default does not create a flood risk.

## Changes

- `extensions/slack/src/monitor/message-handler/prepare.ts`: Change fallback from `false` to `true`
- `extensions/slack/src/config-ui-hints.ts`: Update help text to reflect new default

## Opt-out

Users who want the old behavior can explicitly set:
```json
{ "channels": { "slack": { "allowBots": false } } }
```

## Note

The auto-generated `docs/.generated/config-baseline.jsonl` still references the old default text — it should be regenerated as part of the release process.