### PR TITLE
fix: re-throw LiveSessionModelSwitchError instead of swallowing in fallback loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/compaction: resolve `agents.defaults.compaction.model` consistently for manual `/compact` and other context-engine compaction paths, so engine-owned compaction uses the configured override model across runtime entrypoints. (#56710) Thanks @oliviareid-svg
 - Channels/session routing: move provider-specific session conversation grammar into plugin-owned session-key surfaces, preserving Telegram topic routing and Feishu scoped inheritance across bootstrap, model override, restart, and tool-policy paths.
+
 - WhatsApp/reactions: add `reactionLevel` guidance for agent reactions. Thanks @mcaxtr.
 
 ### Fixes
@@ -17,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Tasks/gateway: re-check the current task record before maintenance marks runs lost or prunes them, so a task heartbeat or cleanup update that lands during a sweep no longer gets overwritten by stale snapshot state.
 - Tasks/gateway: keep the task registry maintenance sweep from stalling the gateway event loop under synchronous SQLite pressure, so upgraded gateways stop hanging about a minute after startup. (#58670) Thanks @openperf
 - Channels/WhatsApp: pass inbound message timestamp to model context so the AI can see when WhatsApp messages were sent. (#58590) Thanks @Maninae
+- Agents/model fallback: re-throw live-session model switch requests from the fallback loop so `/model` changes restart on the requested model instead of being swallowed as ordinary failover. (#58716) Thanks @aAAaqwq
 
 ## 2026.3.31
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -264,7 +264,7 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
-  it("treats LiveSessionModelSwitchError as failover on last candidate (#58466)", async () => {
+  it("re-throws LiveSessionModelSwitchError immediately (#58700)", async () => {
     const cfg = makeCfg();
     const switchError = new LiveSessionModelSwitchError({
       provider: "anthropic",
@@ -272,10 +272,10 @@ describe("runWithModelFallback", () => {
     });
     const run = vi.fn().mockRejectedValue(switchError);
 
-    // With no fallbacks, the single candidate is also the last one.
-    // Previously this would re-throw LiveSessionModelSwitchError, causing
-    // the outer retry loop to restart with the overloaded model indefinitely.
-    // Now it should surface as a FailoverError instead.
+    // LiveSessionModelSwitchError should be re-thrown immediately so the
+    // outer runner can restart with the new model.  Previously (#58466) it
+    // was caught and converted to a FailoverError, silently losing the
+    // model switch request.  Fixes #58700.
     const err = await runWithModelFallback({
       cfg,
       provider: "anthropic",
@@ -283,14 +283,11 @@ describe("runWithModelFallback", () => {
       run,
       fallbacksOverride: [],
     }).catch((e: unknown) => e);
-    expect(err).toBeInstanceOf(Error);
-    // Should NOT be a LiveSessionModelSwitchError — the outer retry loop must
-    // not restart with the conflicting model.
-    expect(err).not.toBeInstanceOf(LiveSessionModelSwitchError);
+    expect(err).toBeInstanceOf(LiveSessionModelSwitchError);
     expect(run).toHaveBeenCalledTimes(1);
   });
 
-  it("continues fallback chain past LiveSessionModelSwitchError to next candidate (#58466)", async () => {
+  it("re-throws LiveSessionModelSwitchError without trying remaining candidates (#58700)", async () => {
     const cfg = makeCfg();
     const switchError = new LiveSessionModelSwitchError({
       provider: "anthropic",
@@ -298,14 +295,17 @@ describe("runWithModelFallback", () => {
     });
     const run = vi.fn().mockRejectedValueOnce(switchError).mockResolvedValueOnce("ok");
 
-    const result = await runWithModelFallback({
+    // The model switch should abort the fallback loop immediately — no
+    // point trying other candidates when the user explicitly switched models.
+    const err = await runWithModelFallback({
       cfg,
       provider: "openai",
       model: "gpt-4.1-mini",
       run,
-    });
-    expect(result.result).toBe("ok");
-    expect(run).toHaveBeenCalledTimes(2);
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LiveSessionModelSwitchError);
+    // Only called once — the second candidate should never be reached.
+    expect(run).toHaveBeenCalledTimes(1);
   });
 
   it("falls back on auth errors", async () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -15,7 +15,6 @@ import {
 } from "./auth-profiles.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import {
-  FailoverError,
   coerceToFailoverError,
   describeFailoverError,
   isFailoverError,

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -783,46 +783,15 @@ export async function runWithModelFallback<T>(params: {
           model: candidate.model,
         }) ?? err;
 
-      // LiveSessionModelSwitchError during fallback means the session's
-      // persisted model conflicts with this fallback candidate.  Treat it
-      // as a known failover so the chain continues to the next candidate
-      // instead of re-throwing and triggering infinite retry loops in the
-      // outer runner.  (#58466)
+      // LiveSessionModelSwitchError indicates the session's model selection has
+      // changed mid-run (e.g. user ran /model).  Re-throw immediately so the
+      // outer runner can restart with the new model instead of wasting calls on
+      // remaining fallback candidates.  The outer runner already has retry-limit
+      // guards (MAX_LIVE_SWITCH_RETRIES) to prevent infinite loops.
+      // Fixes #58700 — previously this was caught and treated as a candidate
+      // failure, causing the model switch request to be silently lost.
       if (err instanceof LiveSessionModelSwitchError) {
-        const switchMsg = err.message;
-        const switchNormalized = new FailoverError(switchMsg, {
-          reason: "overloaded",
-          provider: candidate.provider,
-          model: candidate.model,
-        });
-        lastError = switchNormalized;
-        const described = describeFailoverError(switchNormalized);
-        attempts.push({
-          provider: candidate.provider,
-          model: candidate.model,
-          error: described.message,
-          reason: described.reason ?? "unknown",
-          status: described.status,
-          code: described.code,
-        });
-        logModelFallbackDecision({
-          decision: "candidate_failed",
-          runId: params.runId,
-          requestedProvider: params.provider,
-          requestedModel: params.model,
-          candidate,
-          attempt: i + 1,
-          total: candidates.length,
-          reason: described.reason,
-          status: described.status,
-          code: described.code,
-          error: described.message,
-          nextCandidate: candidates[i + 1],
-          isPrimary,
-          requestedModelMatched: requestedModel,
-          fallbackConfigured: hasFallbackCandidates,
-        });
-        continue;
+        throw err;
       }
 
       // Even unrecognized errors should not abort the fallback loop when


### PR DESCRIPTION
## Summary

Fixes #58700

`LiveSessionModelSwitchError` was being caught inside `runWithModelFallback` and converted to a `FailoverError` (reason: `"overloaded"`), causing the fallback chain to continue trying remaining candidates. This silently lost the user's model switch request.

## Root Cause

In `src/agents/model-fallback.ts`, the error handling block for `LiveSessionModelSwitchError` (added in #58466) treated it as a candidate failure and called `continue` to try the next fallback model. The outer runner (`agent-runner-execution.ts`) already handles this error correctly — updating provider/model/authProfileId and retrying with `MAX_LIVE_SWITCH_RETRIES` protection — but it never gets the chance because the fallback loop swallows the error.

## Fix

Replace the ~30-line `FailoverError` conversion block with a simple `throw err;`. This lets `LiveSessionModelSwitchError` propagate up to the outer runner, which already knows how to handle it safely.

```typescript
// Before: converted to FailoverError and continued the loop
if (err instanceof LiveSessionModelSwitchError) {
  const switchNormalized = new FailoverError(switchMsg, { reason: "overloaded", ... });
  // ... 20+ lines of logging and metadata ...
  continue;  // ← model switch request lost
}

// After: re-throw immediately
if (err instanceof LiveSessionModelSwitchError) {
  throw err;  // ← outer runner handles this correctly
}
```

## Why This Is Safe

The concern in #58466 was "infinite retry loops in the outer runner." However:

1. The outer runner (`agent-runner-execution.ts` line 624) already has `MAX_LIVE_SWITCH_RETRIES` protection
2. `isExpectedNonErrorLaneFailure` already recognizes `LiveSessionModelSwitchError` as a non-error case
3. The cron runner (`cron/isolated-agent/run.ts` line 605) also handles this with retry limits

The infinite loop scenario was already guarded against at the appropriate layer.

## Impact

- **Before**: User runs `/model` → fallback loop swallows the switch → all fallback candidates tried → run fails with generic error
- **After**: User runs `/model` → fallback loop re-throws → outer runner catches → run restarts with new model ✅

## Test Plan

- [x] Updated existing tests to expect re-throw behavior
- [x] `re-throws LiveSessionModelSwitchError immediately` — verifies single-candidate case
- [x] `re-throws without trying remaining candidates` — verifies multi-candidate case stops immediately