### PR TITLE
utils: add AbortSignal support to runTasksWithConcurrency

### DIFF
--- a/src/utils/run-with-concurrency.test.ts
+++ b/src/utils/run-with-concurrency.test.ts
@@ -101,4 +101,47 @@ describe("runTasksWithConcurrency", () => {
     expect(onTaskError).toHaveBeenNthCalledWith(1, firstErr, 0);
     expect(onTaskError).toHaveBeenNthCalledWith(2, expect.any(Error), 2);
   });
+
+  it("stops picking up new tasks when signal is aborted", async () => {
+    const controller = new AbortController();
+    const seen: number[] = [];
+    const tasks = [0, 1, 2, 3].map((index) => async (): Promise<number> => {
+      seen.push(index);
+      if (index === 1) {
+        controller.abort();
+      }
+      return index;
+    });
+
+    const result = await runTasksWithConcurrency({
+      tasks,
+      limit: 1,
+      signal: controller.signal,
+    });
+    expect(seen).toEqual([0, 1]);
+    expect(result.results[0]).toBe(0);
+    expect(result.results[1]).toBe(1);
+    expect(result.results[2]).toBeUndefined();
+    expect(result.results[3]).toBeUndefined();
+  });
+
+  it("returns immediately when signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const seen: number[] = [];
+    const tasks = [
+      async () => {
+        seen.push(0);
+        return 10;
+      },
+    ];
+
+    const result = await runTasksWithConcurrency({
+      tasks,
+      limit: 1,
+      signal: controller.signal,
+    });
+    expect(seen).toEqual([]);
+    expect(result.hasError).toBe(false);
+  });
 });

--- a/src/utils/run-with-concurrency.ts
+++ b/src/utils/run-with-concurrency.ts
@@ -5,8 +5,10 @@ export async function runTasksWithConcurrency<T>(params: {
   limit: number;
   errorMode?: ConcurrencyErrorMode;
   onTaskError?: (error: unknown, index: number) => void;
+  /** When provided, workers stop picking up new tasks once the signal is aborted. */
+  signal?: AbortSignal;
 }): Promise<{ results: T[]; firstError: unknown; hasError: boolean }> {
-  const { tasks, limit, onTaskError } = params;
+  const { tasks, limit, onTaskError, signal } = params;
   const errorMode = params.errorMode ?? "continue";
   if (tasks.length === 0) {
     return { results: [], firstError: undefined, hasError: false };
@@ -20,6 +22,9 @@ export async function runTasksWithConcurrency<T>(params: {
 
   const workers = Array.from({ length: resolvedLimit }, async () => {
     while (true) {
+      if (signal?.aborted) {
+        return;
+      }
       if (errorMode === "stop" && hasError) {
         return;
       }


### PR DESCRIPTION
## Summary

- Problem: `runTasksWithConcurrency` lacks external cancellation support, making it impossible for callers to abort pending tasks when an operation is no longer needed.
- Why it matters: The codebase already uses `AbortSignal` in `fetch-timeout.ts` and other async utilities; the concurrency helper should follow the same pattern.
- What changed: Added an optional `signal?: AbortSignal` parameter. Workers check `signal.aborted` before picking up new tasks. Already-running tasks complete normally.
- What did NOT change (scope boundary): No changes to existing parameters, return type, or behavior when `signal` is not provided. Fully backward compatible.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] API / contracts

## Linked Issue/PR

- N/A (standalone improvement)

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/utils/run-with-concurrency.test.ts`
- Scenario the test should lock in: abort mid-execution stops new task pickup; pre-aborted signal skips all tasks
- Why this is the smallest reliable guardrail: Unit tests directly exercise the signal check in the worker loop

## User-visible / Behavior Changes

None (new optional parameter only)

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 22.04
- Runtime/container: Node v22.22.2

### Steps

1. Import `runTasksWithConcurrency`
2. Pass an `AbortController.signal` as the `signal` parameter
3. Call `controller.abort()` during task execution

### Expected

- Workers stop picking up new tasks after abort

### Actual

- Confirmed: remaining tasks are skipped, completed tasks retain their results

## Evidence

- [x] Failing test/log before + passing after: 5/5 tests pass including 2 new signal tests

## Human Verification (required)

- Verified scenarios: abort mid-run, pre-aborted signal, existing behavior unchanged
- Edge cases checked: empty task list, limit=1 serialized execution
- What you did **not** verify: multi-worker concurrent abort race (covered by single-threaded JS event loop)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None

Made with [Cursor](https://cursor.com)