### PR TITLE
fix(memory): prefer --mask over --glob for qmd collection pattern flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Channels/WhatsApp: pass inbound message timestamp to model context so the AI can see when WhatsApp messages were sent. (#58590) Thanks @Maninae
 - Web UI/OpenResponses: preserve rewritten stream snapshots in webchat and keep OpenResponses final streamed text aligned when models rewind earlier output. (#58641) Thanks @neeravmakwana
 - MiniMax/plugins: auto-enable the bundled MiniMax plugin for API-key auth/config so MiniMax image generation and other plugin-owned capabilities load without manual plugin allowlisting. (#57127) Thanks @tars90percent.
+- Memory/QMD: prefer `--mask` over `--glob` when creating QMD collections so default memory collections keep their intended patterns and stop colliding on restart. (#58643) Thanks @GitZhangChi.
 
 ## 2026.3.31
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -749,7 +749,10 @@ describe("QmdMemoryManager", () => {
         const child = createMockChild({ autoClose: false });
         const pathArg = args[2] ?? "";
         const name = args[args.indexOf("--name") + 1] ?? "";
-        const pattern = args[args.indexOf("--glob") + 1] ?? args[args.indexOf("--mask") + 1] ?? "";
+        const globIdx = args.indexOf("--glob");
+        const maskIdx = args.indexOf("--mask");
+        const pattern =
+          (globIdx !== -1 ? args[globIdx + 1] : maskIdx !== -1 ? args[maskIdx + 1] : "") ?? "";
         const hasConflict = [...legacyCollections.entries()].some(
           ([existingName, info]) =>
             existingName !== name && info.path === pathArg && info.pattern === pattern,
@@ -827,7 +830,10 @@ describe("QmdMemoryManager", () => {
         const child = createMockChild({ autoClose: false });
         const pathArg = args[2] ?? "";
         const name = args[args.indexOf("--name") + 1] ?? "";
-        const pattern = args[args.indexOf("--glob") + 1] ?? args[args.indexOf("--mask") + 1] ?? "";
+        const globIdx = args.indexOf("--glob");
+        const maskIdx = args.indexOf("--mask");
+        const pattern =
+          (globIdx !== -1 ? args[globIdx + 1] : maskIdx !== -1 ? args[maskIdx + 1] : "") ?? "";
         const hasConflict = [...listedCollections.entries()].some(
           ([existingName, info]) =>
             existingName !== name && info.path === pathArg && info.pattern === pattern,
@@ -887,7 +893,7 @@ describe("QmdMemoryManager", () => {
     );
   });
 
-  it("falls back to --mask when qmd collection add rejects --glob", async () => {
+  it("prefers --mask for collection add and falls back to --glob when --mask is rejected", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -909,10 +915,10 @@ describe("QmdMemoryManager", () => {
       }
       if (args[0] === "collection" && args[1] === "add") {
         const child = createMockChild({ autoClose: false });
-        const flag = args.includes("--glob") ? "--glob" : args.includes("--mask") ? "--mask" : "";
+        const flag = args.includes("--mask") ? "--mask" : args.includes("--glob") ? "--glob" : "";
         addFlagCalls.push(flag);
-        if (flag === "--glob") {
-          emitAndClose(child, "stderr", "unknown flag: --glob", 1);
+        if (flag === "--mask") {
+          emitAndClose(child, "stderr", "unknown flag: --mask", 1);
           return child;
         }
         queueMicrotask(() => child.closeWith(0));
@@ -924,7 +930,7 @@ describe("QmdMemoryManager", () => {
     const { manager } = await createManager({ mode: "full" });
     await manager.close();
 
-    expect(addFlagCalls).toEqual(["--glob", "--mask", "--mask", "--mask"]);
+    expect(addFlagCalls).toEqual(["--mask", "--glob", "--glob", "--glob"]);
     expect(logWarnMock).toHaveBeenCalledWith(
       expect.stringContaining("retrying with legacy compatibility flag"),
     );

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -274,7 +274,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private attemptedNullByteCollectionRepair = false;
   private attemptedDuplicateDocumentRepair = false;
   private readonly sessionWarm = new Set<string>();
-  private collectionPatternFlag: QmdCollectionPatternFlag | null = null;
+  private collectionPatternFlag: QmdCollectionPatternFlag | null = "--mask";
 
   private constructor(params: {
     cfg: OpenClawConfig;


### PR DESCRIPTION
Fixes #58618
Related #58643

## Summary

- **Problem:** QMD 2.0.1 accepts the `--glob` flag during `collection add`, but silently ignores it and falls back to the default `**/*.md` pattern. This causes strictly scoped collections (e.g., `MEMORY.md`) to be created as full-workspace collections instead.
- **Why it matters:** It breaks multi-agent memory initialization. When OpenClaw tries to add a second collection under the same directory with a different pattern, QMD throws a path+pattern conflict, resulting in `memory-alt-*` registration failures on every gateway restart. It also silently pulls unintended files into the LLM memory context.
- **What changed:** Defaulted `collectionPatternFlag` to `--mask` so OpenClaw uses the working flag first.
- **What did NOT change:** The fallback mechanism is preserved for older environments where `--mask` might not be supported.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Security hardening

## Root Cause

`collectionPatternFlag` initializes as `null`, causing OpenClaw's negotiation logic to try `--glob` first. Because the `qmd` CLI does not exit with an error code when it ignores `--glob`, OpenClaw falsely assumes the flag succeeded and never falls back to `--mask`. Consequently, every collection is effectively created with the catch-all `**/*.md` pattern.

## Evidence & Repro

Observed on gateway startup with QMD enabled. The narrower `memory.md` collection collides with an already-created `memory-root-*` collection:

```text
12:05:19+08:00 [memory] qmd collection add skipped for memory-alt-tg: 
qmd collection add ~/.openclaw/workspace --name memory-alt-tg --glob memory.md failed (code 1): 
A collection already exists for this path and pattern:
Name: memory-root-tg (qmd://memory-root-tg/)
Pattern: **/*.md

Use 'qmd update' to re-index it, or remove it first with 'qmd collection remove memory-root-tg'
```

**Expected:** memory-root-* and memory-alt-* coexist in the same workspace targeting different patterns (**/*.md vs MEMORY.md).
**Actual:** The first collection is forced to **/*.md, blocking the second.

## Testing & Verification

* **Updated Tests:** extensions/memory-core/src/memory/qmd-manager.test.ts
* Added regression coverage to verify addCollection() correctly prefers --mask over --glob while preserving the fallback behavior.

## Verification Steps:

- Clear existing QMD collections (qmd collection remove ...).
- Restart the gateway with multiple agents targeting the same workspace.
- Verify that collections are successfully created without conflict warnings and strictly adhere to their intended patterns.

## Compatibility / Risks

- **Backward compatible?** Yes. If --mask fails, it falls back to --glob.
- **Migration needed?** Users encountering the bug may need to clear their existing conflicting collections (qmd collection remove memory-root-<agent>) so they can be rebuilt correctly.