### PR TITLE
otel instrumentation

### DIFF
--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -6,9 +6,10 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/api-logs": "^0.214.0",
-    "@opentelemetry/exporter-logs-otlp-proto": "^0.214.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "^0.214.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.214.0",
+    "@opentelemetry/core": "^2.6.1",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.214.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
     "@opentelemetry/resources": "^2.6.1",
     "@opentelemetry/sdk-logs": "^0.214.0",
     "@opentelemetry/sdk-metrics": "^2.6.1",

--- a/extensions/diagnostics-otel/src/otel-event-handlers.ts
+++ b/extensions/diagnostics-otel/src/otel-event-handlers.ts
@@ -1,0 +1,708 @@
+import {
+  context,
+  isSpanContextValid,
+  trace,
+  SpanKind,
+  SpanStatusCode,
+  type Span,
+  type Tracer,
+} from "@opentelemetry/api";
+import type { DiagnosticEventPayload } from "openclaw/plugin-sdk/diagnostics-otel";
+import type { OtelMetricInstruments } from "./otel-metrics.js";
+import type { ActiveTrace, ResolvedCaptureContent, TraceHeaders } from "./otel-utils.js";
+import { formatTraceparent, mapProviderName } from "./otel-utils.js";
+
+export type AgentInfo = {
+  id: string;
+  name?: string;
+};
+
+export interface OtelHandlerCtx {
+  tracer: Tracer;
+  metrics: OtelMetricInstruments;
+  captureContent: ResolvedCaptureContent;
+  tracesEnabled: boolean;
+  debugExports: boolean;
+  logger: { info(msg: string): void };
+  activeTraces: Map<string, ActiveTrace>;
+  runSpans: Map<string, { span: Span; createdAt: number }>;
+  inferenceSpans: Map<string, { span: Span; createdAt: number }>;
+  activeInferenceSpanByRunId: Map<string, Span>;
+  runProviderByRunId: Map<string, string>;
+  resolveAgentInfo: (sessionKey?: string) => AgentInfo | null;
+  spanWithDuration: (
+    name: string,
+    attributes: Record<string, string | number | string[]>,
+    durationMs?: number,
+    kind?: SpanKind,
+    parentCtx?: ReturnType<typeof context.active>,
+  ) => Span;
+  safeJsonStringify: (v: unknown) => string;
+  redactText: (value: string) => string;
+  createToolSpan: (
+    evt: Extract<DiagnosticEventPayload, { type: "tool.execution" }>,
+    parentCtx?: ReturnType<typeof context.active>,
+  ) => void;
+  ensureRunSpan: (params: {
+    runId?: string;
+    sessionKey?: string;
+    sessionId?: string;
+    channel?: string;
+    startTimeMs?: number;
+    attributes?: Record<string, string | number | string[]>;
+  }) => Span | null;
+  TRACE_ATTRS: {
+    SESSION_ID: string;
+  };
+  getTraceHeadersRegistry: () => Map<string, TraceHeaders>;
+}
+
+export function recordRunCompleted(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "run.completed" }>,
+): void {
+  const attrs = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.provider": evt.provider ?? "unknown",
+    "openclaw.model": evt.model ?? "unknown",
+  };
+
+  const usage = evt.usage;
+  if (usage.input) {
+    hctx.metrics.tokensCounter.add(usage.input, { ...attrs, "openclaw.token": "input" });
+  }
+  if (usage.output) {
+    hctx.metrics.tokensCounter.add(usage.output, { ...attrs, "openclaw.token": "output" });
+  }
+  if (usage.cacheRead) {
+    hctx.metrics.tokensCounter.add(usage.cacheRead, { ...attrs, "openclaw.token": "cache_read" });
+  }
+  if (usage.cacheWrite) {
+    hctx.metrics.tokensCounter.add(usage.cacheWrite, {
+      ...attrs,
+      "openclaw.token": "cache_write",
+    });
+  }
+  if (usage.promptTokens) {
+    hctx.metrics.tokensCounter.add(usage.promptTokens, { ...attrs, "openclaw.token": "prompt" });
+  }
+  if (usage.total) {
+    hctx.metrics.tokensCounter.add(usage.total, { ...attrs, "openclaw.token": "total" });
+  }
+
+  if (evt.costUsd) {
+    hctx.metrics.costCounter.add(evt.costUsd, attrs);
+  }
+  if (evt.durationMs) {
+    hctx.metrics.durationHistogram.record(evt.durationMs, attrs);
+  }
+  if (evt.context?.limit) {
+    hctx.metrics.contextHistogram.record(evt.context.limit, {
+      ...attrs,
+      "openclaw.context": "limit",
+    });
+  }
+  if (evt.context?.used) {
+    hctx.metrics.contextHistogram.record(evt.context.used, {
+      ...attrs,
+      "openclaw.context": "used",
+    });
+  }
+
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+
+  // Only put lightweight envelope attributes on the agent.turn span.
+  // gen_ai.* inference attributes (model, messages, tokens, etc.) belong
+  // exclusively on the child chat spans created by recordModelInference.
+  const turnAttrs: Record<string, string | number | string[]> = {
+    ...attrs,
+    "openclaw.runId": evt.runId,
+    "openclaw.sessionKey": evt.sessionKey ?? "",
+    "openclaw.sessionId": evt.sessionId ?? "",
+    "gen_ai.provider.name": mapProviderName(evt.provider),
+  };
+  if (typeof usage.input === "number") {
+    turnAttrs["openclaw.tokens.input"] = usage.input;
+  }
+  if (typeof usage.output === "number") {
+    turnAttrs["openclaw.tokens.output"] = usage.output;
+  }
+  if (typeof usage.cacheRead === "number") {
+    turnAttrs["openclaw.tokens.cache_read"] = usage.cacheRead;
+  }
+  if (typeof usage.cacheWrite === "number") {
+    turnAttrs["openclaw.tokens.cache_write"] = usage.cacheWrite;
+  }
+  if (typeof usage.total === "number") {
+    turnAttrs["openclaw.tokens.total"] = usage.total;
+  }
+  if (evt.sessionId) {
+    turnAttrs["gen_ai.conversation.id"] = evt.sessionId;
+  }
+  // Some non-embedded paths only emit request/response message bodies on
+  // run.completed. Preserve those content attributes here so request/response
+  // capture still lands in telemetry even when there is no separate
+  // model.inference span for that path.
+  if (hctx.captureContent.inputMessages && evt.inputMessages) {
+    turnAttrs["gen_ai.input.messages"] = hctx.safeJsonStringify(evt.inputMessages);
+  }
+  if (hctx.captureContent.outputMessages && evt.outputMessages) {
+    turnAttrs["gen_ai.output.messages"] = hctx.safeJsonStringify(evt.outputMessages);
+  }
+  const runSpan = hctx.ensureRunSpan({
+    runId: evt.runId,
+    sessionKey: evt.sessionKey,
+    sessionId: evt.sessionId,
+    channel: evt.channel,
+    attributes: turnAttrs,
+    startTimeMs:
+      typeof evt.durationMs === "number" ? Date.now() - Math.max(0, evt.durationMs) : undefined,
+  });
+  if (!runSpan) {
+    // Fallback: add agent identity attrs for the standalone span
+    const agentInfo = hctx.resolveAgentInfo(evt.sessionKey);
+    if (agentInfo) {
+      turnAttrs["gen_ai.agent.id"] = agentInfo.id;
+      if (agentInfo.name) {
+        turnAttrs["gen_ai.agent.name"] = agentInfo.name;
+      }
+    }
+    turnAttrs["gen_ai.operation.name"] = "invoke_agent";
+  }
+  const fallbackSpanName = (() => {
+    const agentInfo = hctx.resolveAgentInfo(evt.sessionKey);
+    return agentInfo?.name ? `invoke_agent ${agentInfo.name}` : "invoke_agent";
+  })();
+  const finalRunSpan =
+    runSpan ??
+    hctx.spanWithDuration(fallbackSpanName, turnAttrs, evt.durationMs, SpanKind.INTERNAL);
+
+  if (evt.error) {
+    finalRunSpan.setStatus({ code: SpanStatusCode.ERROR, message: evt.error });
+    if (evt.errorType) {
+      finalRunSpan.setAttribute("error.type", evt.errorType);
+    }
+    finalRunSpan.setAttribute("openclaw.error", evt.error);
+  }
+
+  finalRunSpan.end();
+  hctx.runSpans.delete(evt.runId);
+  hctx.runProviderByRunId.delete(evt.runId);
+  if (evt.sessionKey) {
+    hctx.getTraceHeadersRegistry().delete(evt.sessionKey);
+  }
+}
+
+export function recordRunStarted(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "run.started" }>,
+): void {
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+  hctx.ensureRunSpan({
+    runId: evt.runId,
+    sessionKey: evt.sessionKey,
+    sessionId: evt.sessionId,
+    channel: evt.channel,
+    startTimeMs: evt.ts,
+  });
+}
+
+export function recordModelInferenceStarted(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "model.inference.started" }>,
+): void {
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+  const opName = evt.operationName ?? "chat";
+
+  const runSpan = hctx.ensureRunSpan({
+    runId: evt.runId,
+    sessionKey: evt.sessionKey,
+    sessionId: evt.sessionId,
+    channel: evt.channel,
+    startTimeMs: evt.ts,
+  });
+  const parentCtx = runSpan ? trace.setSpan(context.active(), runSpan) : context.active();
+
+  const spanAttrs: Record<string, string | number | string[]> = {
+    "gen_ai.operation.name": opName,
+    "gen_ai.provider.name": mapProviderName(evt.provider),
+    "gen_ai.request.model": evt.model ?? "unknown",
+  };
+  if (evt.sessionKey) {
+    spanAttrs["openclaw.sessionKey"] = evt.sessionKey;
+  }
+  if (evt.sessionId) {
+    spanAttrs["openclaw.sessionId"] = evt.sessionId;
+    spanAttrs["gen_ai.conversation.id"] = evt.sessionId;
+  }
+  if (typeof evt.callIndex === "number") {
+    spanAttrs["openclaw.callIndex"] = evt.callIndex;
+  }
+  if (typeof evt.temperature === "number") {
+    spanAttrs["gen_ai.request.temperature"] = evt.temperature;
+  }
+  if (typeof evt.maxOutputTokens === "number") {
+    spanAttrs["gen_ai.request.max_tokens"] = evt.maxOutputTokens;
+  }
+  if (hctx.captureContent.inputMessages && evt.inputMessages) {
+    spanAttrs["gen_ai.input.messages"] = JSON.stringify(evt.inputMessages);
+  }
+  if (hctx.captureContent.systemInstructions && evt.systemInstructions) {
+    spanAttrs["gen_ai.system_instructions"] = JSON.stringify(evt.systemInstructions);
+  }
+  if (hctx.captureContent.toolDefinitions && evt.toolDefinitions) {
+    spanAttrs["gen_ai.tool.definitions"] = JSON.stringify(evt.toolDefinitions);
+  }
+
+  const spanName = `${opName} ${evt.model ?? "unknown"}`;
+  const span = hctx.tracer.startSpan(
+    spanName,
+    { attributes: spanAttrs, startTime: evt.ts, kind: SpanKind.CLIENT },
+    parentCtx,
+  );
+  if (hctx.debugExports) {
+    hctx.logger.info(`diagnostics-otel: span created ${spanName}`);
+  }
+
+  if (evt.runId && typeof evt.callIndex === "number") {
+    hctx.inferenceSpans.set(`${evt.runId}:${evt.callIndex}`, { span, createdAt: Date.now() });
+  }
+  if (evt.runId) {
+    hctx.activeInferenceSpanByRunId.set(evt.runId, span);
+    if (evt.provider) {
+      hctx.runProviderByRunId.set(evt.runId, mapProviderName(evt.provider));
+    }
+  }
+}
+
+export function recordModelInference(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "model.inference" }>,
+): void {
+  const opName = evt.operationName ?? "chat";
+  const usage = evt.usage ?? {};
+
+  // GenAI standard metrics (gen_ai_latest_experimental)
+  const genAiMetricAttrs: Record<string, string> = {
+    "gen_ai.operation.name": opName,
+    "gen_ai.provider.name": mapProviderName(evt.provider),
+    "gen_ai.request.model": evt.model ?? "unknown",
+  };
+  if (evt.responseModel) {
+    genAiMetricAttrs["gen_ai.response.model"] = evt.responseModel;
+  }
+  if (evt.durationMs) {
+    hctx.metrics.genAiOperationDuration.record(evt.durationMs / 1000, genAiMetricAttrs);
+  }
+  if (usage.input) {
+    hctx.metrics.genAiTokenUsage.record(usage.input, {
+      ...genAiMetricAttrs,
+      "gen_ai.token.type": "input",
+    });
+  }
+  if (usage.output) {
+    hctx.metrics.genAiTokenUsage.record(usage.output, {
+      ...genAiMetricAttrs,
+      "gen_ai.token.type": "output",
+    });
+  }
+  if (typeof evt.ttftMs === "number") {
+    hctx.metrics.genAiTtft.record(evt.ttftMs / 1000, genAiMetricAttrs);
+  }
+  if (evt.error && evt.errorType) {
+    hctx.metrics.inferenceErrorCounter.add(1, {
+      ...genAiMetricAttrs,
+      "error.type": evt.errorType,
+    });
+  }
+
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+
+  const spanAttrs: Record<string, string | number | string[]> = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.provider": evt.provider ?? "unknown",
+    "openclaw.model": evt.model ?? "unknown",
+    "openclaw.sessionKey": evt.sessionKey ?? "",
+    "openclaw.sessionId": evt.sessionId ?? "",
+    "gen_ai.operation.name": opName,
+    "gen_ai.provider.name": mapProviderName(evt.provider),
+    "gen_ai.request.model": evt.model ?? "unknown",
+  };
+  if (typeof usage.input === "number") {
+    spanAttrs["openclaw.tokens.input"] = usage.input;
+  }
+  if (typeof usage.output === "number") {
+    spanAttrs["openclaw.tokens.output"] = usage.output;
+    spanAttrs["gen_ai.usage.output_tokens"] = usage.output;
+  }
+  if (typeof usage.cacheRead === "number") {
+    spanAttrs["openclaw.tokens.cache_read"] = usage.cacheRead;
+    spanAttrs["gen_ai.usage.cache_read.input_tokens"] = usage.cacheRead;
+  }
+  if (typeof usage.cacheWrite === "number") {
+    spanAttrs["openclaw.tokens.cache_write"] = usage.cacheWrite;
+    spanAttrs["gen_ai.usage.cache_creation.input_tokens"] = usage.cacheWrite;
+  }
+  if (typeof usage.total === "number") {
+    spanAttrs["openclaw.tokens.total"] = usage.total;
+  }
+  // OTEL GenAI semconv: gen_ai.usage.input_tokens SHOULD include all input
+  // tokens including cached tokens. Compute from components when promptTokens
+  // is unavailable to avoid under-counting.
+  const hasInputComponents =
+    typeof usage.input === "number" ||
+    typeof usage.cacheRead === "number" ||
+    typeof usage.cacheWrite === "number";
+  const inputTokensForOtel =
+    usage.promptTokens ??
+    (hasInputComponents
+      ? (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0)
+      : undefined);
+  if (typeof inputTokensForOtel === "number") {
+    spanAttrs["gen_ai.usage.input_tokens"] = inputTokensForOtel;
+  }
+  if (evt.responseModel) {
+    spanAttrs["gen_ai.response.model"] = evt.responseModel;
+  }
+  if (evt.responseId) {
+    spanAttrs["gen_ai.response.id"] = evt.responseId;
+  }
+  if (evt.finishReasons?.length) {
+    spanAttrs["gen_ai.response.finish_reasons"] = evt.finishReasons;
+  }
+  if (evt.sessionId) {
+    spanAttrs["gen_ai.conversation.id"] = evt.sessionId;
+  }
+  if (typeof evt.temperature === "number") {
+    spanAttrs["gen_ai.request.temperature"] = evt.temperature;
+  }
+  if (typeof evt.maxOutputTokens === "number") {
+    spanAttrs["gen_ai.request.max_tokens"] = evt.maxOutputTokens;
+  }
+  if (typeof evt.ttftMs === "number") {
+    spanAttrs["gen_ai.client.time_to_first_token"] = evt.ttftMs;
+  }
+  if (typeof evt.callIndex === "number") {
+    spanAttrs["openclaw.callIndex"] = evt.callIndex;
+  }
+  if (hctx.captureContent.outputMessages && evt.outputMessages) {
+    spanAttrs["gen_ai.output.messages"] = JSON.stringify(evt.outputMessages);
+  }
+  const span =
+    evt.runId && typeof evt.callIndex === "number"
+      ? hctx.inferenceSpans.get(`${evt.runId}:${evt.callIndex}`)?.span
+      : undefined;
+  const activeSpan = evt.runId ? hctx.activeInferenceSpanByRunId.get(evt.runId) : undefined;
+  const resolved = span ?? activeSpan;
+
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+
+  const spanName = `${opName} ${evt.model ?? "unknown"}`;
+  const runEntry = evt.runId ? hctx.runSpans.get(evt.runId) : undefined;
+  const parentCtx = runEntry ? trace.setSpan(context.active(), runEntry.span) : context.active();
+  const finalSpan =
+    resolved ??
+    hctx.spanWithDuration(spanName, spanAttrs, evt.durationMs, SpanKind.CLIENT, parentCtx);
+
+  for (const [key, value] of Object.entries(spanAttrs)) {
+    finalSpan.setAttribute(key, value);
+  }
+  if (hctx.captureContent.outputMessages && evt.outputMessages) {
+    finalSpan.setAttribute("gen_ai.output.messages", JSON.stringify(evt.outputMessages));
+  }
+  if (evt.error) {
+    finalSpan.setStatus({ code: SpanStatusCode.ERROR, message: evt.error });
+    if (evt.errorType) {
+      finalSpan.setAttribute("error.type", evt.errorType);
+    }
+    finalSpan.setAttribute("openclaw.error", evt.error);
+  }
+  finalSpan.end();
+
+  if (evt.runId) {
+    hctx.activeInferenceSpanByRunId.delete(evt.runId);
+    if (typeof evt.callIndex === "number") {
+      hctx.inferenceSpans.delete(`${evt.runId}:${evt.callIndex}`);
+    }
+  }
+}
+
+export function recordWebhookReceived(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "webhook.received" }>,
+): void {
+  const attrs = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.webhook": evt.updateType ?? "unknown",
+  };
+  hctx.metrics.webhookReceivedCounter.add(1, attrs);
+}
+
+export function recordWebhookProcessed(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "webhook.processed" }>,
+): void {
+  const attrs = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.webhook": evt.updateType ?? "unknown",
+  };
+  if (typeof evt.durationMs === "number") {
+    hctx.metrics.webhookDurationHistogram.record(evt.durationMs, attrs);
+  }
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+  const spanAttrs: Record<string, string | number> = { ...attrs };
+  if (evt.chatId !== undefined) {
+    spanAttrs["openclaw.chatId"] = String(evt.chatId);
+  }
+  const span = hctx.spanWithDuration("openclaw.webhook.processed", spanAttrs, evt.durationMs);
+  if (hctx.debugExports) {
+    hctx.logger.info(`diagnostics-otel: span created openclaw.webhook.processed`);
+  }
+  span.end();
+}
+
+export function recordWebhookError(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "webhook.error" }>,
+): void {
+  const attrs = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.webhook": evt.updateType ?? "unknown",
+  };
+  hctx.metrics.webhookErrorCounter.add(1, attrs);
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+  const spanAttrs: Record<string, string | number> = {
+    ...attrs,
+    "openclaw.error": evt.error,
+  };
+  if (evt.chatId !== undefined) {
+    spanAttrs["openclaw.chatId"] = String(evt.chatId);
+  }
+  const span = hctx.tracer.startSpan("openclaw.webhook.error", {
+    attributes: spanAttrs,
+  });
+  span.setStatus({ code: SpanStatusCode.ERROR, message: evt.error });
+  if (hctx.debugExports) {
+    hctx.logger.info(`diagnostics-otel: span created openclaw.webhook.error`);
+  }
+  span.end();
+}
+
+export function recordMessageQueued(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "message.queued" }>,
+): void {
+  const attrs = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.source": evt.source ?? "unknown",
+  };
+  hctx.metrics.messageQueuedCounter.add(1, attrs);
+  if (typeof evt.queueDepth === "number") {
+    hctx.metrics.queueDepthHistogram.record(evt.queueDepth, attrs);
+  }
+
+  // Create root span for nested trace hierarchy.
+  // The message lifecycle is: message.queued → run.started → model.inference → tools → run.completed → message.processed.
+  // This root span covers the entire lifecycle; agent.turn, LLM calls, and tool executions are nested as children.
+  // message.processed ends this span (it does not create a new child).
+  if (hctx.tracesEnabled && evt.sessionKey) {
+    const agentId = evt.sessionKey.split(":")[1] || "unknown";
+
+    const rootSpan = hctx.tracer.startSpan("openclaw.message", {
+      kind: SpanKind.SERVER,
+      attributes: {
+        "openclaw.sessionKey": evt.sessionKey,
+        "openclaw.channel": evt.channel ?? "unknown",
+        "openclaw.source": evt.source ?? "unknown",
+        ...(typeof evt.queueDepth === "number" ? { "openclaw.queueDepth": evt.queueDepth } : {}),
+        [hctx.TRACE_ATTRS.SESSION_ID]: evt.sessionKey,
+      },
+    });
+
+    const traceContext = trace.setSpan(context.active(), rootSpan);
+
+    hctx.activeTraces.set(evt.sessionKey, {
+      span: rootSpan,
+      context: traceContext,
+      startedAt: Date.now(),
+      sessionKey: evt.sessionKey,
+      channel: evt.channel,
+      agentId,
+    });
+
+    // Store W3C trace headers for propagation
+    const spanContext = rootSpan.spanContext();
+    if (isSpanContextValid(spanContext)) {
+      hctx.getTraceHeadersRegistry().set(evt.sessionKey, {
+        traceparent: formatTraceparent(spanContext),
+        ...(spanContext.traceState && { tracestate: spanContext.traceState.serialize() }),
+      });
+    }
+
+    if (hctx.debugExports) {
+      hctx.logger.info(`diagnostics-otel: created root span for session=${evt.sessionKey}`);
+    }
+  }
+}
+
+export function recordMessageProcessed(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "message.processed" }>,
+): void {
+  const attrs = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.outcome": evt.outcome ?? "unknown",
+  };
+  hctx.metrics.messageProcessedCounter.add(1, attrs);
+  if (typeof evt.durationMs === "number") {
+    hctx.metrics.messageDurationHistogram.record(evt.durationMs, attrs);
+  }
+
+  // End root trace span created by message.queued.
+  // No standalone span here — the root span covers the full message lifecycle.
+  const sessionKey = evt.sessionKey;
+  const activeTrace = sessionKey ? hctx.activeTraces.get(sessionKey) : null;
+  if (activeTrace) {
+    activeTrace.span.setAttribute("openclaw.outcome", evt.outcome ?? "unknown");
+    if (typeof evt.durationMs === "number") {
+      activeTrace.span.setAttribute("openclaw.durationMs", evt.durationMs);
+    }
+    if (evt.messageId != null) {
+      activeTrace.span.setAttribute("openclaw.messageId", String(evt.messageId));
+    }
+    if (evt.outcome === "error" && evt.error) {
+      activeTrace.span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: evt.error,
+      });
+    } else {
+      activeTrace.span.setStatus({ code: SpanStatusCode.OK });
+    }
+    activeTrace.span.end();
+    hctx.activeTraces.delete(sessionKey!);
+    hctx.getTraceHeadersRegistry().delete(sessionKey!);
+    if (hctx.debugExports) {
+      hctx.logger.info(`diagnostics-otel: ended root span for session=${sessionKey}`);
+    }
+  } else if (hctx.debugExports) {
+    hctx.logger.info(
+      `diagnostics-otel: no active root trace for message.processed sessionKey=${sessionKey ?? "undefined"}`,
+    );
+  }
+}
+
+export function recordLaneEnqueue(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "queue.lane.enqueue" }>,
+): void {
+  const attrs = { "openclaw.lane": evt.lane };
+  hctx.metrics.laneEnqueueCounter.add(1, attrs);
+  hctx.metrics.queueDepthHistogram.record(evt.queueSize, attrs);
+}
+
+export function recordLaneDequeue(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "queue.lane.dequeue" }>,
+): void {
+  const attrs = { "openclaw.lane": evt.lane };
+  hctx.metrics.laneDequeueCounter.add(1, attrs);
+  hctx.metrics.queueDepthHistogram.record(evt.queueSize, attrs);
+  if (typeof evt.waitMs === "number") {
+    hctx.metrics.queueWaitHistogram.record(evt.waitMs, attrs);
+  }
+}
+
+export function recordSessionState(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "session.state" }>,
+): void {
+  const attrs: Record<string, string> = { "openclaw.state": evt.state };
+  if (evt.reason) {
+    attrs["openclaw.reason"] = hctx.redactText(evt.reason);
+  }
+  hctx.metrics.sessionStateCounter.add(1, attrs);
+}
+
+export function recordSessionStuck(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "session.stuck" }>,
+): void {
+  const attrs: Record<string, string> = { "openclaw.state": evt.state };
+  hctx.metrics.sessionStuckCounter.add(1, attrs);
+  if (typeof evt.ageMs === "number") {
+    hctx.metrics.sessionStuckAgeHistogram.record(evt.ageMs, attrs);
+  }
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+  const spanAttrs: Record<string, string | number> = { ...attrs };
+  if (evt.sessionKey) {
+    spanAttrs["openclaw.sessionKey"] = evt.sessionKey;
+  }
+  if (evt.sessionId) {
+    spanAttrs["openclaw.sessionId"] = evt.sessionId;
+  }
+  spanAttrs["openclaw.queueDepth"] = evt.queueDepth ?? 0;
+  spanAttrs["openclaw.ageMs"] = evt.ageMs;
+  const span = hctx.tracer.startSpan("openclaw.session.stuck", { attributes: spanAttrs });
+  span.setStatus({ code: SpanStatusCode.ERROR, message: "session stuck" });
+  if (hctx.debugExports) {
+    hctx.logger.info(`diagnostics-otel: span created openclaw.session.stuck`);
+  }
+  span.end();
+}
+
+export function recordRunAttempt(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "run.attempt" }>,
+): void {
+  hctx.metrics.runAttemptCounter.add(1, { "openclaw.attempt": evt.attempt });
+}
+
+export function recordToolExecution(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "tool.execution" }>,
+): void {
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+
+  const runId = evt.runId;
+  const inferenceSpan = runId ? hctx.activeInferenceSpanByRunId.get(runId) : undefined;
+  const runEntry = runId ? hctx.runSpans.get(runId) : undefined;
+  const activeTrace = evt.sessionKey ? hctx.activeTraces.get(evt.sessionKey) : null;
+
+  // Prefer the most specific active parent. Tool spans should attach to the
+  // active inference span when available, then the agent turn span, and only
+  // fall back to the root message span for loosely-correlated events.
+  const parentSpan = inferenceSpan ?? runEntry?.span;
+  const parentCtx = parentSpan ? trace.setSpan(context.active(), parentSpan) : activeTrace?.context;
+  hctx.createToolSpan(evt, parentCtx);
+
+  if (hctx.debugExports && !parentCtx) {
+    hctx.logger.info(
+      `diagnostics-otel: no active trace for tool.execution sessionKey=${evt.sessionKey} tool=${evt.toolName}`,
+    );
+  }
+}
+
+export function recordHeartbeat(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "diagnostic.heartbeat" }>,
+): void {
+  hctx.metrics.queueDepthHistogram.record(evt.queued, { "openclaw.channel": "heartbeat" });
+}

--- a/extensions/diagnostics-otel/src/otel-metrics.ts
+++ b/extensions/diagnostics-otel/src/otel-metrics.ts
@@ -1,0 +1,119 @@
+import type { Counter, Histogram, Meter } from "@opentelemetry/api";
+
+export interface OtelMetricInstruments {
+  tokensCounter: Counter;
+  costCounter: Counter;
+  durationHistogram: Histogram;
+  contextHistogram: Histogram;
+  webhookReceivedCounter: Counter;
+  webhookErrorCounter: Counter;
+  webhookDurationHistogram: Histogram;
+  messageQueuedCounter: Counter;
+  messageProcessedCounter: Counter;
+  messageDurationHistogram: Histogram;
+  queueDepthHistogram: Histogram;
+  queueWaitHistogram: Histogram;
+  laneEnqueueCounter: Counter;
+  laneDequeueCounter: Counter;
+  sessionStateCounter: Counter;
+  sessionStuckCounter: Counter;
+  sessionStuckAgeHistogram: Histogram;
+  runAttemptCounter: Counter;
+  genAiOperationDuration: Histogram;
+  genAiTokenUsage: Histogram;
+  genAiTtft: Histogram;
+  inferenceErrorCounter: Counter;
+}
+
+export function createMetricInstruments(meter: Meter): OtelMetricInstruments {
+  return {
+    tokensCounter: meter.createCounter("openclaw.tokens", {
+      unit: "1",
+      description: "Token usage by type",
+    }),
+    costCounter: meter.createCounter("openclaw.cost.usd", {
+      unit: "1",
+      description: "Estimated model cost (USD)",
+    }),
+    durationHistogram: meter.createHistogram("openclaw.run.duration_ms", {
+      unit: "ms",
+      description: "Agent run duration",
+    }),
+    contextHistogram: meter.createHistogram("openclaw.context.tokens", {
+      unit: "1",
+      description: "Context window size and usage",
+    }),
+    webhookReceivedCounter: meter.createCounter("openclaw.webhook.received", {
+      unit: "1",
+      description: "Webhook requests received",
+    }),
+    webhookErrorCounter: meter.createCounter("openclaw.webhook.error", {
+      unit: "1",
+      description: "Webhook processing errors",
+    }),
+    webhookDurationHistogram: meter.createHistogram("openclaw.webhook.duration_ms", {
+      unit: "ms",
+      description: "Webhook processing duration",
+    }),
+    messageQueuedCounter: meter.createCounter("openclaw.message.queued", {
+      unit: "1",
+      description: "Messages queued for processing",
+    }),
+    messageProcessedCounter: meter.createCounter("openclaw.message.processed", {
+      unit: "1",
+      description: "Messages processed by outcome",
+    }),
+    messageDurationHistogram: meter.createHistogram("openclaw.message.duration_ms", {
+      unit: "ms",
+      description: "Message processing duration",
+    }),
+    queueDepthHistogram: meter.createHistogram("openclaw.queue.depth", {
+      unit: "1",
+      description: "Queue depth on enqueue/dequeue",
+    }),
+    queueWaitHistogram: meter.createHistogram("openclaw.queue.wait_ms", {
+      unit: "ms",
+      description: "Queue wait time before execution",
+    }),
+    laneEnqueueCounter: meter.createCounter("openclaw.queue.lane.enqueue", {
+      unit: "1",
+      description: "Command queue lane enqueue events",
+    }),
+    laneDequeueCounter: meter.createCounter("openclaw.queue.lane.dequeue", {
+      unit: "1",
+      description: "Command queue lane dequeue events",
+    }),
+    sessionStateCounter: meter.createCounter("openclaw.session.state", {
+      unit: "1",
+      description: "Session state transitions",
+    }),
+    sessionStuckCounter: meter.createCounter("openclaw.session.stuck", {
+      unit: "1",
+      description: "Sessions stuck in processing",
+    }),
+    sessionStuckAgeHistogram: meter.createHistogram("openclaw.session.stuck_age_ms", {
+      unit: "ms",
+      description: "Age of stuck sessions",
+    }),
+    runAttemptCounter: meter.createCounter("openclaw.run.attempt", {
+      unit: "1",
+      description: "Run attempts",
+    }),
+    genAiOperationDuration: meter.createHistogram("gen_ai.client.operation.duration", {
+      unit: "s",
+      description: "GenAI operation duration",
+    }),
+    genAiTokenUsage: meter.createHistogram("gen_ai.client.token.usage", {
+      unit: "{token}",
+      description: "GenAI token usage",
+    }),
+    genAiTtft: meter.createHistogram("gen_ai.client.time_to_first_token", {
+      unit: "s",
+      description: "Time to first token from the model",
+    }),
+    inferenceErrorCounter: meter.createCounter("openclaw.inference.error", {
+      unit: "1",
+      description: "Model inference errors by type",
+    }),
+  };
+}

--- a/extensions/diagnostics-otel/src/otel-utils.ts
+++ b/extensions/diagnostics-otel/src/otel-utils.ts
@@ -1,0 +1,208 @@
+import fs from "node:fs";
+import type { Span, SpanContext } from "@opentelemetry/api";
+import type { ExportResult } from "@opentelemetry/core";
+import { ExportResultCode, hrTimeToMilliseconds } from "@opentelemetry/core";
+import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
+
+export const DEFAULT_SERVICE_NAME = "openclaw";
+export const OTEL_DEBUG_ENV = "OPENCLAW_OTEL_DEBUG";
+export const OTEL_DUMP_ENV = "OPENCLAW_OTEL_DUMP";
+
+export function normalizeEndpoint(endpoint?: string): string | undefined {
+  const trimmed = endpoint?.trim();
+  return trimmed ? trimmed.replace(/\/+$/, "") : undefined;
+}
+
+export function resolveOtelUrl(endpoint: string | undefined, path: string): string | undefined {
+  if (!endpoint) {
+    return undefined;
+  }
+  if (/\/v1\/(?:traces|metrics|logs)(?:\?.*)?$/i.test(endpoint)) {
+    return endpoint;
+  }
+  return `${endpoint}/${path}`;
+}
+
+export function resolveSampleRate(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  if (value < 0 || value > 1) {
+    return undefined;
+  }
+  return value;
+}
+
+/** Map internal provider names to gen_ai.provider.name enum values. */
+export function mapProviderName(provider?: string): string {
+  if (!provider) {
+    return "unknown";
+  }
+  const p = provider.toLowerCase();
+  if (p.includes("openai") || p === "orq") {
+    return "openai";
+  }
+  if (p.includes("anthropic") || p.includes("claude")) {
+    return "anthropic";
+  }
+  if (p.includes("google") || p.includes("gemini")) {
+    return "gcp.gemini";
+  }
+  if (p.includes("bedrock")) {
+    return "aws.bedrock";
+  }
+  if (p.includes("mistral")) {
+    return "mistral_ai";
+  }
+  if (p.includes("deepseek")) {
+    return "deepseek";
+  }
+  if (p.includes("groq")) {
+    return "groq";
+  }
+  if (p.includes("cohere")) {
+    return "cohere";
+  }
+  if (p.includes("perplexity")) {
+    return "perplexity";
+  }
+  return provider;
+}
+
+export class LoggingTraceExporter implements SpanExporter {
+  #inner: SpanExporter;
+  #log: { info: (msg: string) => void };
+  #dumpPath?: string;
+  #dumpFailed = false;
+
+  constructor(inner: SpanExporter, log: { info: (msg: string) => void }, dumpPath?: string) {
+    this.#inner = inner;
+    this.#log = log;
+    this.#dumpPath = dumpPath;
+  }
+
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void) {
+    const first = spans[0];
+    const details = first ? ` first=${first.name}` : "";
+    this.#log.info(`diagnostics-otel: exporting ${spans.length} spans.${details}`);
+    if (this.#dumpPath && !this.#dumpFailed) {
+      try {
+        for (const span of spans) {
+          const startMs = hrTimeToMilliseconds(span.startTime);
+          const endMs = hrTimeToMilliseconds(span.endTime);
+          const parentCtxField = (span as { parentSpanContext?: { spanId?: string } })
+            .parentSpanContext;
+          const payload = {
+            ts: new Date().toISOString(),
+            name: span.name,
+            traceId: span.spanContext().traceId,
+            spanId: span.spanContext().spanId,
+            parentSpanId: parentCtxField?.spanId,
+            kind: span.kind,
+            status: span.status,
+            attributes: span.attributes,
+            resource: span.resource?.attributes,
+            startTimeMs: startMs,
+            endTimeMs: endMs,
+            durationMs: endMs - startMs,
+          };
+          fs.appendFileSync(
+            this.#dumpPath,
+            `${JSON.stringify(payload, (_key, value) =>
+              typeof value === "bigint" ? Number(value) : value,
+            )}\n`,
+          );
+        }
+      } catch (err) {
+        this.#dumpFailed = true;
+        this.#log.info(`diagnostics-otel: failed to write dump file: ${String(err)}`);
+      }
+    }
+    try {
+      this.#inner.export(spans, (result) => {
+        if (result.code !== ExportResultCode.SUCCESS) {
+          this.#log.info(
+            `diagnostics-otel: export failed code=${result.code} error=${String(result.error)}`,
+          );
+        }
+        resultCallback(result);
+      });
+    } catch (err) {
+      this.#log.info(`diagnostics-otel: export threw: ${String(err)}`);
+      resultCallback({ code: ExportResultCode.FAILED, error: err as Error });
+    }
+  }
+
+  async shutdown() {
+    await this.#inner.shutdown();
+  }
+
+  async forceFlush() {
+    if (this.#inner.forceFlush) {
+      await this.#inner.forceFlush();
+    }
+  }
+}
+
+export type ResolvedCaptureContent = {
+  inputMessages: boolean;
+  outputMessages: boolean;
+  systemInstructions: boolean;
+  toolDefinitions: boolean;
+  toolContent: boolean;
+};
+
+/**
+ * Resolve captureContent config to granular booleans.
+ * - `true` → all enabled
+ * - `false` / `undefined` → all disabled
+ * - object → each field defaults to `true` if omitted (opt-out model)
+ */
+export function resolveCaptureContent(
+  raw: boolean | Record<string, boolean | undefined> | undefined,
+): ResolvedCaptureContent {
+  if (raw === true) {
+    return {
+      inputMessages: true,
+      outputMessages: true,
+      systemInstructions: true,
+      toolDefinitions: true,
+      toolContent: true,
+    };
+  }
+  if (!raw || typeof raw !== "object") {
+    return {
+      inputMessages: false,
+      outputMessages: false,
+      systemInstructions: false,
+      toolDefinitions: false,
+      toolContent: false,
+    };
+  }
+  return {
+    inputMessages: raw.inputMessages !== false,
+    outputMessages: raw.outputMessages !== false,
+    systemInstructions: raw.systemInstructions !== false,
+    toolDefinitions: raw.toolDefinitions !== false,
+    toolContent: raw.toolContent !== false,
+  };
+}
+
+/** Format a W3C Trace Context traceparent header from a SpanContext. */
+export function formatTraceparent(spanContext: SpanContext): string {
+  return `00-${spanContext.traceId}-${spanContext.spanId}-${spanContext.traceFlags.toString(16).padStart(2, "0")}`;
+}
+
+export type TraceHeaders = {
+  traceparent: string;
+  tracestate?: string;
+};
+
+export interface ActiveTrace {
+  span: Span;
+  context: ReturnType<typeof import("@opentelemetry/api").context.active>;
+  startedAt: number;
+  sessionKey?: string;
+  channel?: string;
+  agentId?: string;
+}

--- a/extensions/diagnostics-otel/src/service.metrics.test.ts
+++ b/extensions/diagnostics-otel/src/service.metrics.test.ts
@@ -1,0 +1,563 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const registerLogTransportMock = vi.hoisted(() => vi.fn());
+
+const telemetryState = vi.hoisted(() => {
+  const counters = new Map<string, { add: ReturnType<typeof vi.fn> }>();
+  const histograms = new Map<string, { record: ReturnType<typeof vi.fn> }>();
+  const tracer = {
+    startSpan: vi.fn((_name: string, _opts?: unknown, _parentCtx?: unknown) => ({
+      end: vi.fn(),
+      setStatus: vi.fn(),
+      setAttribute: vi.fn(),
+      _parentCtx: _parentCtx,
+    })),
+  };
+  const meter = {
+    createCounter: vi.fn((name: string) => {
+      const counter = { add: vi.fn() };
+      counters.set(name, counter);
+      return counter;
+    }),
+    createHistogram: vi.fn((name: string) => {
+      const histogram = { record: vi.fn() };
+      histograms.set(name, histogram);
+      return histogram;
+    }),
+  };
+  return { counters, histograms, tracer, meter };
+});
+
+const sdkStart = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const sdkShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const logEmit = vi.hoisted(() => vi.fn());
+const logShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+const mockRootContext = vi.hoisted(() => ({ _type: "root" }));
+
+vi.mock("@opentelemetry/api", () => ({
+  context: {
+    active: () => mockRootContext,
+  },
+  metrics: {
+    getMeter: () => telemetryState.meter,
+  },
+  trace: {
+    getTracer: () => telemetryState.tracer,
+    setSpan: (_ctx: unknown, span: unknown) => ({ _type: "with-parent", _span: span }),
+  },
+  SpanKind: {
+    INTERNAL: 0,
+    SERVER: 1,
+    CLIENT: 2,
+    PRODUCER: 3,
+    CONSUMER: 4,
+  },
+  SpanStatusCode: {
+    UNSET: 0,
+    OK: 1,
+    ERROR: 2,
+  },
+}));
+
+vi.mock("@opentelemetry/sdk-node", () => ({
+  NodeSDK: class {
+    start = sdkStart;
+    shutdown = sdkShutdown;
+  },
+}));
+
+vi.mock("@opentelemetry/exporter-metrics-otlp-http", () => ({
+  OTLPMetricExporter: class {},
+}));
+
+vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
+  OTLPTraceExporter: class {},
+}));
+
+vi.mock("@opentelemetry/exporter-logs-otlp-http", () => ({
+  OTLPLogExporter: class {},
+}));
+
+vi.mock("@opentelemetry/sdk-logs", () => ({
+  BatchLogRecordProcessor: class {},
+  LoggerProvider: class {
+    addLogRecordProcessor = vi.fn();
+    getLogger = vi.fn(() => ({
+      emit: logEmit,
+    }));
+    shutdown = logShutdown;
+  },
+}));
+
+vi.mock("@opentelemetry/sdk-metrics", () => ({
+  PeriodicExportingMetricReader: class {},
+}));
+
+vi.mock("@opentelemetry/sdk-trace-base", () => ({
+  ParentBasedSampler: class {},
+  TraceIdRatioBasedSampler: class {},
+}));
+
+vi.mock("@opentelemetry/resources", () => ({
+  resourceFromAttributes: vi.fn((attrs: Record<string, unknown>) => attrs),
+  Resource: class {
+    // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+    constructor(_value?: unknown) {}
+  },
+}));
+
+vi.mock("@opentelemetry/semantic-conventions", () => ({
+  ATTR_SERVICE_NAME: "service.name",
+}));
+
+vi.mock("openclaw/plugin-sdk/diagnostics-otel", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/diagnostics-otel")>(
+    "openclaw/plugin-sdk/diagnostics-otel",
+  );
+  return {
+    ...actual,
+    registerLogTransport: registerLogTransportMock,
+  };
+});
+
+import { emitDiagnosticEvent } from "openclaw/plugin-sdk/diagnostics-otel";
+import type { OpenClawPluginServiceContext } from "openclaw/plugin-sdk/diagnostics-otel";
+import { createDiagnosticsOtelService } from "./service.js";
+
+const OTEL_TEST_STATE_DIR = "/tmp/openclaw-diagnostics-otel-test";
+
+type MockSpan = {
+  end: ReturnType<typeof vi.fn>;
+  setStatus: ReturnType<typeof vi.fn>;
+  setAttribute: ReturnType<typeof vi.fn>;
+  _parentCtx?: unknown;
+};
+
+type MockSpanStartOptions = {
+  attributes?: Record<string, unknown>;
+};
+
+function getSpanAttributes(call: unknown): Record<string, unknown> {
+  return ((call as [unknown, MockSpanStartOptions?] | undefined)?.[1]?.attributes ?? {}) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe("diagnostics-otel service – metrics & inference", () => {
+  const startedServices: Array<ReturnType<typeof createDiagnosticsOtelService>> = [];
+
+  function createTestCtx(otelOverrides?: {
+    captureContent?: boolean;
+  }): OpenClawPluginServiceContext {
+    return {
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "http://otel-collector:4318",
+            protocol: "http/protobuf" as const,
+            traces: true,
+            metrics: true,
+            logs: false,
+            ...otelOverrides,
+          },
+        },
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      stateDir: OTEL_TEST_STATE_DIR,
+    };
+  }
+
+  async function stopService(
+    service: ReturnType<typeof createDiagnosticsOtelService>,
+    ctx: OpenClawPluginServiceContext = createTestCtx(),
+  ) {
+    await Promise.resolve(service.stop?.(ctx)).catch(() => undefined);
+  }
+
+  afterEach(async () => {
+    for (const service of startedServices.splice(0)) {
+      await stopService(service);
+    }
+  });
+
+  beforeEach(() => {
+    telemetryState.counters.clear();
+    telemetryState.histograms.clear();
+    telemetryState.tracer.startSpan.mockClear();
+    telemetryState.meter.createCounter.mockClear();
+    telemetryState.meter.createHistogram.mockClear();
+    sdkStart.mockClear();
+    sdkShutdown.mockClear();
+    logEmit.mockClear();
+    logShutdown.mockClear();
+    registerLogTransportMock.mockReset();
+  });
+
+  function createService() {
+    const service = createDiagnosticsOtelService();
+    startedServices.push(service);
+    return service;
+  }
+
+  test("records message-flow metrics and spans", async () => {
+    const registeredTransports: Array<(logObj: Record<string, unknown>) => void> = [];
+    const stopTransport = vi.fn();
+    registerLogTransportMock.mockImplementation((transport) => {
+      registeredTransports.push(transport);
+      return stopTransport;
+    });
+
+    const service = createService();
+    await service.start({
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "http://otel-collector:4318",
+            protocol: "http/protobuf",
+            traces: true,
+            metrics: true,
+            logs: true,
+          },
+        },
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      stateDir: OTEL_TEST_STATE_DIR,
+    });
+
+    emitDiagnosticEvent({
+      type: "webhook.received",
+      channel: "telegram",
+      updateType: "telegram-post",
+    });
+    emitDiagnosticEvent({
+      type: "webhook.processed",
+      channel: "telegram",
+      updateType: "telegram-post",
+      durationMs: 120,
+    });
+    emitDiagnosticEvent({
+      type: "message.queued",
+      channel: "telegram",
+      source: "telegram",
+      sessionKey: "telegram:test-agent:123",
+      queueDepth: 2,
+    });
+    emitDiagnosticEvent({
+      type: "message.processed",
+      channel: "telegram",
+      sessionKey: "telegram:test-agent:123",
+      outcome: "completed",
+      durationMs: 55,
+    });
+    emitDiagnosticEvent({
+      type: "queue.lane.dequeue",
+      lane: "main",
+      queueSize: 3,
+      waitMs: 10,
+    });
+    emitDiagnosticEvent({
+      type: "session.stuck",
+      state: "processing",
+      ageMs: 125_000,
+    });
+    emitDiagnosticEvent({
+      type: "run.attempt",
+      runId: "run-1",
+      attempt: 2,
+    });
+
+    expect(telemetryState.counters.get("openclaw.webhook.received")?.add).toHaveBeenCalled();
+    expect(
+      telemetryState.histograms.get("openclaw.webhook.duration_ms")?.record,
+    ).toHaveBeenCalled();
+    expect(telemetryState.counters.get("openclaw.message.queued")?.add).toHaveBeenCalled();
+    expect(telemetryState.counters.get("openclaw.message.processed")?.add).toHaveBeenCalled();
+    expect(
+      telemetryState.histograms.get("openclaw.message.duration_ms")?.record,
+    ).toHaveBeenCalled();
+    expect(telemetryState.histograms.get("openclaw.queue.wait_ms")?.record).toHaveBeenCalled();
+    expect(telemetryState.counters.get("openclaw.session.stuck")?.add).toHaveBeenCalled();
+    expect(
+      telemetryState.histograms.get("openclaw.session.stuck_age_ms")?.record,
+    ).toHaveBeenCalled();
+    expect(telemetryState.counters.get("openclaw.run.attempt")?.add).toHaveBeenCalled();
+
+    const spanNames = telemetryState.tracer.startSpan.mock.calls.map((call) => call[0]);
+    expect(spanNames).toContain("openclaw.webhook.processed");
+    // message.processed no longer creates its own span — it ends the root
+    // trace span started by message.queued (nesting approach).
+    expect(spanNames).toContain("openclaw.message");
+    expect(spanNames).not.toContain("openclaw.message.processed");
+    expect(spanNames).toContain("openclaw.session.stuck");
+
+    expect(registerLogTransportMock).toHaveBeenCalledTimes(1);
+    expect(registeredTransports).toHaveLength(1);
+    registeredTransports[0]?.({
+      0: '{"subsystem":"diagnostic"}',
+      1: "hello",
+      _meta: { logLevelName: "INFO", date: new Date() },
+    });
+    expect(logEmit).toHaveBeenCalled();
+
+    await stopService(service);
+  });
+
+  test("model.inference records gen_ai.client.operation.duration in seconds", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5-20250929",
+      usage: { input: 200, output: 100, total: 300 },
+      durationMs: 3200,
+    });
+
+    const histogram = telemetryState.histograms.get("gen_ai.client.operation.duration");
+    expect(histogram?.record).toHaveBeenCalledWith(
+      3.2,
+      expect.objectContaining({
+        "gen_ai.operation.name": "chat",
+        "gen_ai.provider.name": "anthropic",
+        "gen_ai.request.model": "claude-sonnet-4-5-20250929",
+      }),
+    );
+
+    await stopService(service);
+  });
+
+  test("model.inference records gen_ai.client.token.usage split by input/output", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 500, output: 120, total: 620 },
+    });
+
+    const histogram = telemetryState.histograms.get("gen_ai.client.token.usage");
+    expect(histogram?.record).toHaveBeenCalledWith(
+      500,
+      expect.objectContaining({ "gen_ai.token.type": "input" }),
+    );
+    expect(histogram?.record).toHaveBeenCalledWith(
+      120,
+      expect.objectContaining({ "gen_ai.token.type": "output" }),
+    );
+
+    await stopService(service);
+  });
+
+  test("maps provider names to gen_ai.provider.name enum values", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    const cases = [
+      { input: "orq", expected: "openai" },
+      { input: "anthropic", expected: "anthropic" },
+      { input: "google-gemini", expected: "gcp.gemini" },
+      { input: "aws-bedrock", expected: "aws.bedrock" },
+      { input: "mistral", expected: "mistral_ai" },
+      { input: "some-custom-provider", expected: "some-custom-provider" },
+    ];
+
+    for (const { input, expected } of cases) {
+      telemetryState.tracer.startSpan.mockClear();
+      emitDiagnosticEvent({
+        type: "model.inference",
+        provider: input,
+        model: "test-model",
+        usage: { input: 10, output: 5, total: 15 },
+      });
+      const attrs = getSpanAttributes(telemetryState.tracer.startSpan.mock.calls[0]);
+      expect(attrs?.["gen_ai.provider.name"]).toBe(expected);
+    }
+
+    await stopService(service);
+  });
+
+  test("existing openclaw.* metrics are still emitted alongside gen_ai.*", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "run.completed",
+      runId: "run-metrics-1",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 100, output: 50, total: 150 },
+      durationMs: 2000,
+      costUsd: 0.005,
+    });
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 100, output: 50, total: 150 },
+      durationMs: 2000,
+    });
+
+    // Existing openclaw metrics still work
+    expect(telemetryState.counters.get("openclaw.tokens")?.add).toHaveBeenCalled();
+    expect(telemetryState.counters.get("openclaw.cost.usd")?.add).toHaveBeenCalled();
+    expect(telemetryState.histograms.get("openclaw.run.duration_ms")?.record).toHaveBeenCalled();
+
+    // New gen_ai metrics also emitted
+    expect(
+      telemetryState.histograms.get("gen_ai.client.operation.duration")?.record,
+    ).toHaveBeenCalled();
+    expect(telemetryState.histograms.get("gen_ai.client.token.usage")?.record).toHaveBeenCalled();
+
+    await stopService(service);
+  });
+
+  test("finish_reason length is recorded for truncated responses", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      finishReasons: ["length"],
+      usage: { input: 10000, output: 4096, total: 14096 },
+    });
+
+    const attrs = getSpanAttributes(telemetryState.tracer.startSpan.mock.calls[0]);
+    expect(attrs["gen_ai.response.finish_reasons"]).toEqual(["length"]);
+
+    await stopService(service);
+  });
+
+  test("TTFT histogram is recorded and span attribute is set", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 100, output: 50, total: 150 },
+      durationMs: 2000,
+      ttftMs: 350,
+    });
+
+    const histogram = telemetryState.histograms.get("gen_ai.client.time_to_first_token");
+    expect(histogram?.record).toHaveBeenCalledWith(
+      0.35,
+      expect.objectContaining({
+        "gen_ai.operation.name": "chat",
+        "gen_ai.provider.name": "openai",
+        "gen_ai.request.model": "gpt-5.2",
+      }),
+    );
+
+    const attrs = getSpanAttributes(telemetryState.tracer.startSpan.mock.calls[0]);
+    expect(attrs["gen_ai.client.time_to_first_token"]).toBe(350);
+
+    await stopService(service);
+  });
+
+  test("gen_ai.usage.input_tokens includes cache tokens even without promptTokens", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5-20250929",
+      usage: { input: 12, output: 57, cacheRead: 28976, cacheWrite: 295 },
+      durationMs: 4000,
+    });
+
+    const attrs = getSpanAttributes(telemetryState.tracer.startSpan.mock.calls[0]);
+    // gen_ai.usage.input_tokens should be input + cacheRead + cacheWrite
+    expect(attrs["gen_ai.usage.input_tokens"]).toBe(12 + 28976 + 295);
+    expect(attrs["gen_ai.usage.output_tokens"]).toBe(57);
+    // openclaw.tokens.input stays as raw input
+    expect(attrs["openclaw.tokens.input"]).toBe(12);
+
+    await stopService(service);
+  });
+
+  test("gen_ai.usage.input_tokens uses promptTokens when available", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5-20250929",
+      usage: { input: 12, output: 57, cacheRead: 28976, cacheWrite: 295, promptTokens: 29283 },
+      durationMs: 4000,
+    });
+
+    const attrs = getSpanAttributes(telemetryState.tracer.startSpan.mock.calls[0]);
+    expect(attrs["gen_ai.usage.input_tokens"]).toBe(29283);
+
+    await stopService(service);
+  });
+
+  test("error event creates span with ERROR status and error.type attribute", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {},
+      durationMs: 500,
+      error: "Context window exceeded",
+      errorType: "context_overflow",
+    });
+
+    const span = telemetryState.tracer.startSpan.mock.results[0]?.value as MockSpan | undefined;
+    expect(span).toBeDefined();
+    if (!span) {
+      throw new Error("Expected inference span");
+    }
+    expect(span.setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 2, message: "Context window exceeded" }),
+    );
+
+    // Check span attributes directly from the startSpan call
+    const attrs = getSpanAttributes(telemetryState.tracer.startSpan.mock.calls[0]);
+    expect(attrs).toBeDefined();
+
+    // error attributes are set via setAttribute, not in initial attrs
+    // Verify setAttribute was called (the mock span tracks these calls)
+    expect(span.setStatus).toHaveBeenCalled();
+
+    // Verify error counter metric
+    const errorCounter = telemetryState.counters.get("openclaw.inference.error");
+    expect(errorCounter?.add).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        "error.type": "context_overflow",
+      }),
+    );
+
+    await stopService(service);
+  });
+});

--- a/extensions/diagnostics-otel/src/service.spans.test.ts
+++ b/extensions/diagnostics-otel/src/service.spans.test.ts
@@ -1,0 +1,768 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const registerLogTransportMock = vi.hoisted(() => vi.fn());
+
+const telemetryState = vi.hoisted(() => {
+  const counters = new Map<string, { add: ReturnType<typeof vi.fn> }>();
+  const histograms = new Map<string, { record: ReturnType<typeof vi.fn> }>();
+  const tracer = {
+    startSpan: vi.fn((_name: string, _opts?: unknown, _parentCtx?: unknown) => ({
+      end: vi.fn(),
+      setStatus: vi.fn(),
+      setAttribute: vi.fn(),
+      _parentCtx: _parentCtx,
+    })),
+  };
+  const meter = {
+    createCounter: vi.fn((name: string) => {
+      const counter = { add: vi.fn() };
+      counters.set(name, counter);
+      return counter;
+    }),
+    createHistogram: vi.fn((name: string) => {
+      const histogram = { record: vi.fn() };
+      histograms.set(name, histogram);
+      return histogram;
+    }),
+  };
+  return { counters, histograms, tracer, meter };
+});
+
+const sdkStart = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const sdkShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const logEmit = vi.hoisted(() => vi.fn());
+const logShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+const mockRootContext = vi.hoisted(() => ({ _type: "root" }));
+
+vi.mock("@opentelemetry/api", () => ({
+  context: {
+    active: () => mockRootContext,
+  },
+  metrics: {
+    getMeter: () => telemetryState.meter,
+  },
+  trace: {
+    getTracer: () => telemetryState.tracer,
+    setSpan: (_ctx: unknown, span: unknown) => ({ _type: "with-parent", _span: span }),
+  },
+  SpanKind: {
+    INTERNAL: 0,
+    SERVER: 1,
+    CLIENT: 2,
+    PRODUCER: 3,
+    CONSUMER: 4,
+  },
+  SpanStatusCode: {
+    UNSET: 0,
+    OK: 1,
+    ERROR: 2,
+  },
+}));
+
+vi.mock("@opentelemetry/sdk-node", () => ({
+  NodeSDK: class {
+    start = sdkStart;
+    shutdown = sdkShutdown;
+  },
+}));
+
+vi.mock("@opentelemetry/exporter-metrics-otlp-http", () => ({
+  OTLPMetricExporter: class {},
+}));
+
+vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
+  OTLPTraceExporter: class {},
+}));
+
+vi.mock("@opentelemetry/exporter-logs-otlp-http", () => ({
+  OTLPLogExporter: class {},
+}));
+
+vi.mock("@opentelemetry/sdk-logs", () => ({
+  BatchLogRecordProcessor: class {},
+  LoggerProvider: class {
+    addLogRecordProcessor = vi.fn();
+    getLogger = vi.fn(() => ({
+      emit: logEmit,
+    }));
+    shutdown = logShutdown;
+  },
+}));
+
+vi.mock("@opentelemetry/sdk-metrics", () => ({
+  PeriodicExportingMetricReader: class {},
+}));
+
+vi.mock("@opentelemetry/sdk-trace-base", () => ({
+  ParentBasedSampler: class {},
+  TraceIdRatioBasedSampler: class {},
+}));
+
+vi.mock("@opentelemetry/resources", () => ({
+  resourceFromAttributes: vi.fn((attrs: Record<string, unknown>) => attrs),
+  Resource: class {
+    // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+    constructor(_value?: unknown) {}
+  },
+}));
+
+vi.mock("@opentelemetry/semantic-conventions", () => ({
+  ATTR_SERVICE_NAME: "service.name",
+}));
+
+vi.mock("openclaw/plugin-sdk/diagnostics-otel", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/diagnostics-otel")>(
+    "openclaw/plugin-sdk/diagnostics-otel",
+  );
+  return {
+    ...actual,
+    registerLogTransport: registerLogTransportMock,
+  };
+});
+
+import { emitDiagnosticEvent } from "openclaw/plugin-sdk/diagnostics-otel";
+import type { OpenClawPluginServiceContext } from "openclaw/plugin-sdk/diagnostics-otel";
+import { createDiagnosticsOtelService } from "./service.js";
+
+const OTEL_TEST_STATE_DIR = "/tmp/openclaw-diagnostics-otel-test";
+const OTEL_TEST_ENDPOINT = "http://otel-collector:4318";
+
+type MockSpan = {
+  end: ReturnType<typeof vi.fn>;
+  setStatus: ReturnType<typeof vi.fn>;
+  setAttribute: ReturnType<typeof vi.fn>;
+  _parentCtx?: unknown;
+};
+
+type MockSpanStartOptions = {
+  attributes?: Record<string, unknown>;
+  kind?: number;
+};
+
+function getSpanAttributes(call: unknown): Record<string, unknown> {
+  return ((call as [unknown, MockSpanStartOptions?] | undefined)?.[1]?.attributes ?? {}) as Record<
+    string,
+    unknown
+  >;
+}
+
+function getSpanKind(call: unknown): number | undefined {
+  return (call as [unknown, MockSpanStartOptions?] | undefined)?.[1]?.kind;
+}
+
+describe("diagnostics-otel service – span hierarchy", () => {
+  const startedServices: Array<ReturnType<typeof createDiagnosticsOtelService>> = [];
+
+  function createTestCtx(otelOverrides?: {
+    captureContent?: boolean;
+  }): OpenClawPluginServiceContext {
+    return {
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: OTEL_TEST_ENDPOINT,
+            protocol: "http/protobuf" as const,
+            traces: true,
+            metrics: true,
+            logs: false,
+            ...otelOverrides,
+          },
+        },
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      stateDir: OTEL_TEST_STATE_DIR,
+    };
+  }
+
+  async function stopService(
+    service: ReturnType<typeof createDiagnosticsOtelService>,
+    ctx: OpenClawPluginServiceContext = createTestCtx(),
+  ) {
+    await Promise.resolve(service.stop?.(ctx)).catch(() => undefined);
+  }
+
+  afterEach(async () => {
+    for (const service of startedServices.splice(0)) {
+      await stopService(service);
+    }
+  });
+
+  beforeEach(() => {
+    telemetryState.counters.clear();
+    telemetryState.histograms.clear();
+    telemetryState.tracer.startSpan.mockClear();
+    telemetryState.meter.createCounter.mockClear();
+    telemetryState.meter.createHistogram.mockClear();
+    sdkStart.mockClear();
+    sdkShutdown.mockClear();
+    logEmit.mockClear();
+    logShutdown.mockClear();
+    registerLogTransportMock.mockReset();
+  });
+
+  function createService() {
+    const service = createDiagnosticsOtelService();
+    startedServices.push(service);
+    return service;
+  }
+
+  test("run.completed emits gen_ai.* span attributes alongside openclaw.*", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "run.completed",
+      runId: "run-usage-1",
+      channel: "webchat",
+      provider: "openai",
+      model: "gpt-5.2",
+      operationName: "chat",
+      responseId: "chatcmpl-abc123",
+      responseModel: "gpt-5.2-2025-06-01",
+      finishReasons: ["stop"],
+      sessionKey: "agent:main:main",
+      sessionId: "sess-001",
+      usage: {
+        input: 100,
+        output: 50,
+        cacheRead: 80,
+        cacheWrite: 0,
+        promptTokens: 180,
+        total: 230,
+      },
+      durationMs: 1500,
+    });
+
+    const spanCall = telemetryState.tracer.startSpan.mock.calls[0];
+    expect(spanCall[0]).toBe("invoke_agent");
+
+    const attrs = getSpanAttributes(spanCall);
+    // gen_ai.* inference attributes should NOT be on the turn span —
+    // they belong on child chat spans only.
+    // gen_ai.operation.name IS set on the turn span (as "invoke_agent" per agent spec).
+    expect(attrs["gen_ai.operation.name"]).toBe("invoke_agent");
+    expect(attrs["gen_ai.provider.name"]).toBe("openai");
+    expect(attrs["gen_ai.request.model"]).toBeUndefined();
+    expect(attrs["gen_ai.response.id"]).toBeUndefined();
+    expect(attrs["gen_ai.response.model"]).toBeUndefined();
+    expect(attrs["gen_ai.response.finish_reasons"]).toBeUndefined();
+    // conversation.id is kept as it's a session-level attribute
+    expect(attrs["gen_ai.conversation.id"]).toBe("sess-001");
+
+    // gen_ai.agent.* identity attributes
+    expect(attrs["gen_ai.agent.id"]).toBe("main");
+    expect(attrs["gen_ai.agent.name"]).toBeUndefined(); // no identity configured
+
+    // openclaw.* envelope attributes preserved
+    expect(attrs["openclaw.channel"]).toBe("webchat");
+    expect(attrs["openclaw.provider"]).toBe("openai");
+    expect(attrs["openclaw.model"]).toBe("gpt-5.2");
+    expect(attrs["openclaw.tokens.input"]).toBe(100);
+    expect(attrs["openclaw.tokens.output"]).toBe(50);
+    expect(attrs["openclaw.tokens.cache_read"]).toBe(80);
+    // gen_ai.usage.* token attributes should NOT be on the turn span
+    expect(attrs["gen_ai.usage.cache_read.input_tokens"]).toBeUndefined();
+    expect(attrs["gen_ai.usage.cache_creation.input_tokens"]).toBeUndefined();
+    expect(attrs["gen_ai.usage.input_tokens"]).toBeUndefined();
+    expect(attrs["gen_ai.usage.output_tokens"]).toBeUndefined();
+
+    await stopService(service);
+  });
+
+  test("model.inference spans are children of run.started span when runId is present", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-1",
+      sessionId: "sess-1",
+    });
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      runId: "run-1",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 20, output: 10, total: 30 },
+      durationMs: 100,
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    expect(calls[0]?.[0]).toBe("invoke_agent");
+    expect(calls[1]?.[0]).toBe("chat gpt-5.2");
+    expect(calls[1]?.[2]).toEqual(expect.objectContaining({ _type: "with-parent" }));
+
+    await stopService(service);
+  });
+
+  test("inference spans use SpanKind.CLIENT, tool spans use SpanKind.INTERNAL", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 10, output: 5, total: 15 },
+    });
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      toolName: "web_search",
+      durationMs: 200,
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    // SpanKind.CLIENT = 2, SpanKind.INTERNAL = 0
+    expect(getSpanKind(calls[0])).toBe(2);
+    expect(getSpanKind(calls[1])).toBe(0);
+
+    await stopService(service);
+  });
+
+  test("tool spans with matching runId are children of the run span", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-parent-child",
+      sessionId: "sess-1",
+    });
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      runId: "run-parent-child",
+      toolName: "web_search",
+      toolType: "function",
+      toolCallId: "call-1",
+      durationMs: 200,
+    });
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      runId: "run-parent-child",
+      toolName: "read",
+      toolType: "function",
+      toolCallId: "call-2",
+      durationMs: 50,
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    // 3 spans: 1 run parent + 2 child tool spans
+    expect(calls).toHaveLength(3);
+
+    // First call is the run span
+    expect(calls[0][0]).toBe("invoke_agent");
+    const parentSpan = telemetryState.tracer.startSpan.mock.results[0]?.value as
+      | MockSpan
+      | undefined;
+    expect(parentSpan).toBeDefined();
+    if (!parentSpan) {
+      throw new Error("Expected parent run span");
+    }
+
+    // Tool spans should have been created with a parent context derived from the run span
+    expect(calls[1][0]).toBe("execute_tool web_search");
+    const toolParentCtx1 = calls[1][2] as { _type: string; _span: unknown };
+    expect(toolParentCtx1._type).toBe("with-parent");
+    expect(toolParentCtx1._span).toBe(parentSpan);
+
+    expect(calls[2][0]).toBe("execute_tool read");
+    const toolParentCtx2 = calls[2][2] as { _type: string; _span: unknown };
+    expect(toolParentCtx2._type).toBe("with-parent");
+    expect(toolParentCtx2._span).toBe(parentSpan);
+
+    // Tool spans end immediately; the run span stays open until run.completed.
+    expect(parentSpan.end).not.toHaveBeenCalled();
+    expect(telemetryState.tracer.startSpan.mock.results[1]?.value.end).toHaveBeenCalled();
+    expect(telemetryState.tracer.startSpan.mock.results[2]?.value.end).toHaveBeenCalled();
+
+    await stopService(service);
+  });
+
+  test("tool spans with matching runId are children of the active inference span when present", async () => {
+    const service = createService();
+    await service.start(createTestCtx({ captureContent: true }));
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-tool-parent-1",
+      sessionId: "sess-1",
+    });
+
+    emitDiagnosticEvent({
+      type: "model.inference.started",
+      runId: "run-tool-parent-1",
+      callIndex: 0,
+      provider: "openai",
+      model: "gpt-5.2",
+      inputMessages: [{ role: "user" as const, parts: [{ type: "text" as const, content: "hi" }] }],
+    });
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      runId: "run-tool-parent-1",
+      toolName: "web_search",
+      toolType: "function",
+      toolCallId: "call-1",
+      durationMs: 200,
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    const inferenceSpan = telemetryState.tracer.startSpan.mock.results.find(
+      (r, idx) => calls[idx]?.[0] === "chat gpt-5.2",
+    )?.value;
+    expect(inferenceSpan).toBeDefined();
+
+    const toolCall = calls.find((c) => c[0] === "execute_tool web_search");
+    expect(toolCall).toBeDefined();
+    const toolParentCtx = toolCall?.[2] as { _type: string; _span: unknown };
+    expect(toolParentCtx._type).toBe("with-parent");
+    expect(toolParentCtx._span).toBe(inferenceSpan);
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      runId: "run-tool-parent-1",
+      callIndex: 0,
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 10, output: 5, total: 15 },
+      outputMessages: [
+        { role: "assistant" as const, parts: [{ type: "text" as const, content: "ok" }] },
+      ],
+    });
+
+    await stopService(service);
+  });
+
+  test("tool spans prefer the run span over the root message span when both are active", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "message.queued",
+      channel: "telegram",
+      source: "telegram",
+      sessionKey: "telegram:agent:tool-parent",
+      queueDepth: 1,
+    });
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-tool-parent-root-1",
+      sessionKey: "telegram:agent:tool-parent",
+      sessionId: "sess-tool-parent-root-1",
+      channel: "telegram",
+    });
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      runId: "run-tool-parent-root-1",
+      sessionKey: "telegram:agent:tool-parent",
+      toolName: "read",
+      toolType: "function",
+      toolCallId: "call-root-1",
+      durationMs: 50,
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    expect(calls[0]?.[0]).toBe("openclaw.message");
+    expect(calls[1]?.[0]).toBe("invoke_agent");
+    expect(calls[2]?.[0]).toBe("execute_tool read");
+
+    const runSpan = telemetryState.tracer.startSpan.mock.results[1]?.value as MockSpan | undefined;
+    expect(runSpan).toBeDefined();
+    if (!runSpan) {
+      throw new Error("Expected run span");
+    }
+
+    const toolParentCtx = calls[2]?.[2] as { _type: string; _span: unknown };
+    expect(toolParentCtx._type).toBe("with-parent");
+    expect(toolParentCtx._span).toBe(runSpan);
+
+    await stopService(service);
+  });
+
+  test("tool spans prefer the active inference span over the root message span when both are active", async () => {
+    const service = createService();
+    await service.start(createTestCtx({ captureContent: true }));
+
+    emitDiagnosticEvent({
+      type: "message.queued",
+      channel: "telegram",
+      source: "telegram",
+      sessionKey: "telegram:agent:tool-parent-inference",
+      queueDepth: 1,
+    });
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-tool-parent-root-2",
+      sessionKey: "telegram:agent:tool-parent-inference",
+      sessionId: "sess-tool-parent-root-2",
+      channel: "telegram",
+    });
+
+    emitDiagnosticEvent({
+      type: "model.inference.started",
+      runId: "run-tool-parent-root-2",
+      sessionKey: "telegram:agent:tool-parent-inference",
+      sessionId: "sess-tool-parent-root-2",
+      channel: "telegram",
+      callIndex: 0,
+      provider: "openai",
+      model: "gpt-5.2",
+      inputMessages: [{ role: "user" as const, parts: [{ type: "text" as const, content: "hi" }] }],
+    });
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      runId: "run-tool-parent-root-2",
+      sessionKey: "telegram:agent:tool-parent-inference",
+      toolName: "web_search",
+      toolType: "function",
+      toolCallId: "call-root-2",
+      durationMs: 50,
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    const inferenceSpan = telemetryState.tracer.startSpan.mock.results.find(
+      (r, idx) => calls[idx]?.[0] === "chat gpt-5.2",
+    )?.value;
+    expect(inferenceSpan).toBeDefined();
+
+    const toolCall = calls.find((c) => c[0] === "execute_tool web_search");
+    expect(toolCall).toBeDefined();
+    const toolParentCtx = toolCall?.[2] as { _type: string; _span: unknown };
+    expect(toolParentCtx._type).toBe("with-parent");
+    expect(toolParentCtx._span).toBe(inferenceSpan);
+
+    await stopService(service);
+  });
+
+  test("tool events without runId create standalone spans (backward compat)", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      toolName: "exec",
+      toolType: "function",
+      toolCallId: "call-no-run",
+      durationMs: 100,
+    });
+
+    // Span should be created immediately (no buffering)
+    expect(telemetryState.tracer.startSpan).toHaveBeenCalledTimes(1);
+    expect(telemetryState.tracer.startSpan.mock.calls[0][0]).toBe("execute_tool exec");
+    // No parent context
+    expect(telemetryState.tracer.startSpan.mock.calls[0][2]).toBeUndefined();
+
+    await stopService(service);
+  });
+
+  test("tool events with runId but without run.started are standalone spans", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      runId: "run-orphaned",
+      toolName: "web_search",
+      durationMs: 200,
+    });
+
+    // Tool span should be created immediately without a parent
+    expect(telemetryState.tracer.startSpan).toHaveBeenCalledTimes(1);
+    expect(telemetryState.tracer.startSpan.mock.calls[0][0]).toBe("execute_tool web_search");
+    expect(telemetryState.tracer.startSpan.mock.calls[0][2]).toBeUndefined();
+
+    await stopService(service);
+  });
+
+  test("agent.turn spans are nested under openclaw.message root span", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "message.queued",
+      channel: "telegram",
+      source: "telegram",
+      sessionKey: "telegram:agent:123",
+      queueDepth: 1,
+    });
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-nested-1",
+      sessionId: "sess-nested-1",
+      sessionKey: "telegram:agent:123",
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    expect(calls[0]?.[0]).toBe("openclaw.message");
+    expect(calls[1]?.[0]).toBe("invoke_agent");
+    // agent.turn should have a parent context pointing to the root span
+    expect(calls[1]?.[2]).toEqual(expect.objectContaining({ _type: "with-parent" }));
+
+    await stopService(service);
+  });
+
+  test("agent span includes gen_ai.agent.name when identity is configured", async () => {
+    const service = createService();
+    await service.start({
+      ...createTestCtx(),
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "http://otel-collector:4318",
+            protocol: "http/protobuf" as const,
+            traces: true,
+            metrics: true,
+          },
+        },
+        agents: {
+          list: [{ id: "main", workspace: "/tmp", identity: { name: "Samantha" } }],
+        },
+      },
+    });
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-identity-1",
+      sessionKey: "agent:main:telegram:group:123",
+      sessionId: "sess-identity",
+      channel: "telegram",
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    expect(calls[0]?.[0]).toBe("invoke_agent Samantha");
+    const attrs = getSpanAttributes(calls[0]);
+    expect(attrs["gen_ai.agent.id"]).toBe("main");
+    expect(attrs["gen_ai.agent.name"]).toBe("Samantha");
+    expect(attrs["gen_ai.operation.name"]).toBe("invoke_agent");
+
+    await stopService(service);
+  });
+
+  test("agent span uses agentId from subagent sessionKey", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-sub-1",
+      sessionKey: "agent:helper:subagent:550e8400-e29b-41d4-a716-446655440000",
+      sessionId: "sess-sub",
+      channel: "telegram",
+    });
+
+    const attrs = getSpanAttributes(telemetryState.tracer.startSpan.mock.calls[0]);
+    expect(attrs["gen_ai.agent.id"]).toBe("helper");
+    expect(attrs["gen_ai.operation.name"]).toBe("invoke_agent");
+
+    await stopService(service);
+  });
+
+  test("message.processed ends the root span and sets attributes", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "message.queued",
+      channel: "telegram",
+      source: "telegram",
+      sessionKey: "telegram:agent:456",
+      queueDepth: 1,
+    });
+
+    const rootSpan = telemetryState.tracer.startSpan.mock.results[0]?.value as MockSpan | undefined;
+    expect(rootSpan).toBeDefined();
+    if (!rootSpan) {
+      throw new Error("Expected root message span");
+    }
+    expect(rootSpan).toBeDefined();
+
+    emitDiagnosticEvent({
+      type: "message.processed",
+      channel: "telegram",
+      sessionKey: "telegram:agent:456",
+      outcome: "completed",
+      durationMs: 250,
+      messageId: "msg-001",
+    });
+
+    expect(rootSpan.setAttribute).toHaveBeenCalledWith("openclaw.outcome", "completed");
+    expect(rootSpan.setAttribute).toHaveBeenCalledWith("openclaw.durationMs", 250);
+    expect(rootSpan.setAttribute).toHaveBeenCalledWith("openclaw.messageId", "msg-001");
+    expect(rootSpan.setStatus).toHaveBeenCalledWith({ code: 1 }); // SpanStatusCode.OK
+    expect(rootSpan.end).toHaveBeenCalled();
+
+    await stopService(service);
+  });
+
+  test("message.processed sets ERROR status on error outcome", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "message.queued",
+      channel: "telegram",
+      source: "telegram",
+      sessionKey: "telegram:agent:789",
+      queueDepth: 1,
+    });
+
+    const rootSpan = telemetryState.tracer.startSpan.mock.results[0]?.value as MockSpan | undefined;
+    expect(rootSpan).toBeDefined();
+    if (!rootSpan) {
+      throw new Error("Expected root message span");
+    }
+
+    emitDiagnosticEvent({
+      type: "message.processed",
+      channel: "telegram",
+      sessionKey: "telegram:agent:789",
+      outcome: "error",
+      error: "Model timeout",
+    });
+
+    expect(rootSpan.setStatus).toHaveBeenCalledWith({
+      code: 2, // SpanStatusCode.ERROR
+      message: "Model timeout",
+    });
+    expect(rootSpan.end).toHaveBeenCalled();
+
+    await stopService(service);
+  });
+
+  test("message.processed without matching message.queued does not crash", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    // No message.queued emitted — should not throw
+    emitDiagnosticEvent({
+      type: "message.processed",
+      channel: "telegram",
+      sessionKey: "telegram:agent:unknown",
+      outcome: "completed",
+    });
+
+    // Only metrics should be recorded, no span created
+    expect(telemetryState.counters.get("openclaw.message.processed")?.add).toHaveBeenCalled();
+    expect(telemetryState.tracer.startSpan).not.toHaveBeenCalled();
+
+    await stopService(service);
+  });
+});

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const registerLogTransportMock = vi.hoisted(() => vi.fn());
 
@@ -6,9 +6,11 @@ const telemetryState = vi.hoisted(() => {
   const counters = new Map<string, { add: ReturnType<typeof vi.fn> }>();
   const histograms = new Map<string, { record: ReturnType<typeof vi.fn> }>();
   const tracer = {
-    startSpan: vi.fn((_name: string, _opts?: unknown) => ({
+    startSpan: vi.fn((_name: string, _opts?: unknown, _parentCtx?: unknown) => ({
       end: vi.fn(),
       setStatus: vi.fn(),
+      setAttribute: vi.fn(),
+      _parentCtx: _parentCtx,
     })),
   };
   const meter = {
@@ -32,14 +34,29 @@ const logEmit = vi.hoisted(() => vi.fn());
 const logShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const traceExporterCtor = vi.hoisted(() => vi.fn());
 
+const mockRootContext = vi.hoisted(() => ({ _type: "root" }));
+
 vi.mock("@opentelemetry/api", () => ({
+  context: {
+    active: () => mockRootContext,
+  },
   metrics: {
     getMeter: () => telemetryState.meter,
   },
   trace: {
     getTracer: () => telemetryState.tracer,
+    setSpan: (_ctx: unknown, span: unknown) => ({ _type: "with-parent", _span: span }),
+  },
+  SpanKind: {
+    INTERNAL: 0,
+    SERVER: 1,
+    CLIENT: 2,
+    PRODUCER: 3,
+    CONSUMER: 4,
   },
   SpanStatusCode: {
+    UNSET: 0,
+    OK: 1,
     ERROR: 2,
   },
 }));
@@ -51,11 +68,11 @@ vi.mock("@opentelemetry/sdk-node", () => ({
   },
 }));
 
-vi.mock("@opentelemetry/exporter-metrics-otlp-proto", () => ({
+vi.mock("@opentelemetry/exporter-metrics-otlp-http", () => ({
   OTLPMetricExporter: class {},
 }));
 
-vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => ({
+vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
   OTLPTraceExporter: class {
     constructor(options?: unknown) {
       traceExporterCtor(options);
@@ -63,7 +80,7 @@ vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => ({
   },
 }));
 
-vi.mock("@opentelemetry/exporter-logs-otlp-proto", () => ({
+vi.mock("@opentelemetry/exporter-logs-otlp-http", () => ({
   OTLPLogExporter: class {},
 }));
 
@@ -98,16 +115,18 @@ vi.mock("@opentelemetry/semantic-conventions", () => ({
   ATTR_SERVICE_NAME: "service.name",
 }));
 
-vi.mock("../api.js", async () => {
-  const actual = await vi.importActual<typeof import("../api.js")>("../api.js");
+vi.mock("openclaw/plugin-sdk/diagnostics-otel", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/diagnostics-otel")>(
+    "openclaw/plugin-sdk/diagnostics-otel",
+  );
   return {
     ...actual,
     registerLogTransport: registerLogTransportMock,
   };
 });
 
-import type { OpenClawPluginServiceContext } from "../api.js";
-import { emitDiagnosticEvent } from "../api.js";
+import type { OpenClawPluginServiceContext } from "openclaw/plugin-sdk/diagnostics-otel";
+import { emitDiagnosticEvent } from "openclaw/plugin-sdk/diagnostics-otel";
 import { createDiagnosticsOtelService } from "./service.js";
 
 const OTEL_TEST_STATE_DIR = "/tmp/openclaw-diagnostics-otel-test";
@@ -166,6 +185,35 @@ function setupRegisteredTransports() {
   return { registeredTransports, stopTransport };
 }
 
+type MockSpan = {
+  end: ReturnType<typeof vi.fn>;
+  setStatus: ReturnType<typeof vi.fn>;
+  setAttribute: ReturnType<typeof vi.fn>;
+  _parentCtx?: unknown;
+};
+
+type MockSpanStartOptions = {
+  attributes?: Record<string, unknown>;
+  kind?: number;
+};
+
+async function stopService(
+  service: ReturnType<typeof createDiagnosticsOtelService>,
+  ctx: OpenClawPluginServiceContext = createOtelContext(OTEL_TEST_ENDPOINT, {
+    traces: true,
+    metrics: true,
+  }),
+) {
+  await Promise.resolve(service.stop?.(ctx)).catch(() => undefined);
+}
+
+function getSpanAttributes(call: unknown): Record<string, unknown> {
+  return ((call as [unknown, MockSpanStartOptions?] | undefined)?.[1]?.attributes ?? {}) as Record<
+    string,
+    unknown
+  >;
+}
+
 async function emitAndCaptureLog(logObj: Record<string, unknown>) {
   const { registeredTransports } = setupRegisteredTransports();
   const service = createDiagnosticsOtelService();
@@ -179,7 +227,15 @@ async function emitAndCaptureLog(logObj: Record<string, unknown>) {
   return emitCall;
 }
 
-describe("diagnostics-otel service", () => {
+describe("diagnostics-otel service – content capture & tools", () => {
+  const startedServices: Array<ReturnType<typeof createDiagnosticsOtelService>> = [];
+
+  afterEach(async () => {
+    for (const service of startedServices.splice(0)) {
+      await stopService(service);
+    }
+  });
+
   beforeEach(() => {
     telemetryState.counters.clear();
     telemetryState.histograms.clear();
@@ -194,84 +250,341 @@ describe("diagnostics-otel service", () => {
     registerLogTransportMock.mockReset();
   });
 
-  test("records message-flow metrics and spans", async () => {
-    const { registeredTransports } = setupRegisteredTransports();
-
+  function createService() {
     const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true, logs: true });
-    await service.start(ctx);
+    startedServices.push(service);
+    return service;
+  }
+
+  function createTestCtx(otelOverrides?: { captureContent?: boolean }) {
+    return {
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "http://otel-collector:4318",
+            protocol: "http/protobuf" as const,
+            traces: true,
+            metrics: true,
+            logs: false,
+            ...otelOverrides,
+          },
+        },
+      },
+      logger: createLogger(),
+      stateDir: "/tmp/openclaw-diagnostics-otel-test",
+    };
+  }
+
+  test("records gen_ai.input.messages when captureContent is enabled", async () => {
+    const service = createService();
+    await service.start(createTestCtx({ captureContent: true }));
+
+    const inputMessages = [
+      {
+        role: "user" as const,
+        parts: [{ type: "text" as const, content: "Hello" }],
+      },
+    ];
+    const outputMessages = [
+      {
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, content: "Hi there!" }],
+        finish_reason: "stop",
+      },
+    ];
 
     emitDiagnosticEvent({
-      type: "webhook.received",
-      channel: "telegram",
-      updateType: "telegram-post",
-    });
-    emitDiagnosticEvent({
-      type: "webhook.processed",
-      channel: "telegram",
-      updateType: "telegram-post",
-      durationMs: 120,
-    });
-    emitDiagnosticEvent({
-      type: "message.queued",
-      channel: "telegram",
-      source: "telegram",
-      queueDepth: 2,
-    });
-    emitDiagnosticEvent({
-      type: "message.processed",
-      channel: "telegram",
-      outcome: "completed",
-      durationMs: 55,
-    });
-    emitDiagnosticEvent({
-      type: "queue.lane.dequeue",
-      lane: "main",
-      queueSize: 3,
-      waitMs: 10,
-    });
-    emitDiagnosticEvent({
-      type: "session.stuck",
-      state: "processing",
-      ageMs: 125_000,
-    });
-    emitDiagnosticEvent({
-      type: "run.attempt",
-      runId: "run-1",
-      attempt: 2,
+      type: "model.inference.started",
+      runId: "run-cap-1",
+      provider: "openai",
+      model: "gpt-5.2",
+      inputMessages,
     });
 
-    expect(telemetryState.counters.get("openclaw.webhook.received")?.add).toHaveBeenCalled();
-    expect(
-      telemetryState.histograms.get("openclaw.webhook.duration_ms")?.record,
-    ).toHaveBeenCalled();
-    expect(telemetryState.counters.get("openclaw.message.queued")?.add).toHaveBeenCalled();
-    expect(telemetryState.counters.get("openclaw.message.processed")?.add).toHaveBeenCalled();
-    expect(
-      telemetryState.histograms.get("openclaw.message.duration_ms")?.record,
-    ).toHaveBeenCalled();
-    expect(telemetryState.histograms.get("openclaw.queue.wait_ms")?.record).toHaveBeenCalled();
-    expect(telemetryState.counters.get("openclaw.session.stuck")?.add).toHaveBeenCalled();
-    expect(
-      telemetryState.histograms.get("openclaw.session.stuck_age_ms")?.record,
-    ).toHaveBeenCalled();
-    expect(telemetryState.counters.get("openclaw.run.attempt")?.add).toHaveBeenCalled();
-
-    const spanNames = telemetryState.tracer.startSpan.mock.calls.map((call) => call[0]);
-    expect(spanNames).toContain("openclaw.webhook.processed");
-    expect(spanNames).toContain("openclaw.message.processed");
-    expect(spanNames).toContain("openclaw.session.stuck");
-
-    expect(registerLogTransportMock).toHaveBeenCalledTimes(1);
-    expect(registeredTransports).toHaveLength(1);
-    registeredTransports[0]?.({
-      0: '{"subsystem":"diagnostic"}',
-      1: "hello",
-      _meta: { logLevelName: "INFO", date: new Date() },
+    emitDiagnosticEvent({
+      type: "model.inference",
+      runId: "run-cap-1",
+      callIndex: 0,
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 10, output: 5, total: 15 },
+      outputMessages,
     });
-    expect(logEmit).toHaveBeenCalled();
 
-    await service.stop?.(ctx);
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    const inferenceCall = calls.find((c) => c[0] === "chat gpt-5.2");
+    expect(inferenceCall).toBeDefined();
+    const attrs = getSpanAttributes(inferenceCall);
+    expect(attrs["gen_ai.input.messages"]).toBe(JSON.stringify(inputMessages));
+
+    const span = telemetryState.tracer.startSpan.mock.results.find(
+      (r, idx) => telemetryState.tracer.startSpan.mock.calls[idx]?.[0] === "chat gpt-5.2",
+    )?.value as MockSpan | undefined;
+    expect(span).toBeDefined();
+    if (!span) {
+      throw new Error("Expected inference span");
+    }
+    expect(span.setAttribute).toHaveBeenCalledWith(
+      "gen_ai.output.messages",
+      JSON.stringify(outputMessages),
+    );
+
+    await stopService(service);
+  });
+
+  test("does NOT record gen_ai.input.messages when captureContent is disabled", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference.started",
+      runId: "run-cap-2",
+      provider: "openai",
+      model: "gpt-5.2",
+      inputMessages: [
+        { role: "user" as const, parts: [{ type: "text" as const, content: "secret" }] },
+      ],
+    });
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      runId: "run-cap-2",
+      callIndex: 0,
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 10, output: 5, total: 15 },
+      outputMessages: [
+        { role: "assistant" as const, parts: [{ type: "text" as const, content: "x" }] },
+      ],
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    const inferenceCall = calls.find((c) => c[0] === "chat gpt-5.2");
+    const attrs = getSpanAttributes(inferenceCall);
+    expect(attrs["gen_ai.input.messages"]).toBeUndefined();
+
+    await stopService(service);
+  });
+
+  test("records request and response content from run.completed when present", async () => {
+    const service = createService();
+    await service.start(createTestCtx({ captureContent: true }));
+
+    const inputMessages = [
+      {
+        role: "user" as const,
+        parts: [{ type: "text" as const, content: "Summarize this" }],
+      },
+    ];
+    const outputMessages = [
+      {
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, content: "Summary output" }],
+        finish_reason: "stop",
+      },
+    ];
+
+    emitDiagnosticEvent({
+      type: "run.completed",
+      runId: "run-completed-cap-1",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 10, output: 5, total: 15 },
+      inputMessages,
+      outputMessages,
+      finishReasons: ["stop"],
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    const runCall = calls.find((c) => c[0] === "invoke_agent");
+    expect(runCall).toBeDefined();
+    const attrs = getSpanAttributes(runCall);
+    expect(attrs["gen_ai.input.messages"]).toBe(JSON.stringify(inputMessages));
+    expect(attrs["gen_ai.output.messages"]).toBe(JSON.stringify(outputMessages));
+
+    await stopService(service);
+  });
+
+  test("input messages with media parts use correct modality and type", async () => {
+    const service = createService();
+    await service.start(createTestCtx({ captureContent: true }));
+
+    const inputMessages = [
+      {
+        role: "user" as const,
+        parts: [
+          { type: "text" as const, content: "What's in this image?" },
+          {
+            type: "uri" as const,
+            modality: "image" as const,
+            mime_type: "image/png",
+            uri: "https://example.com/photo.png",
+          },
+        ],
+      },
+    ];
+
+    emitDiagnosticEvent({
+      type: "model.inference.started",
+      runId: "run-media-1",
+      provider: "openai",
+      model: "gpt-5.2",
+      inputMessages,
+    });
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      runId: "run-media-1",
+      callIndex: 0,
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 500, output: 50, total: 550 },
+      outputMessages: [
+        { role: "assistant" as const, parts: [{ type: "text" as const, content: "x" }] },
+      ],
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    const inferenceCall = calls.find((c) => c[0] === "chat gpt-5.2");
+    const attrs = getSpanAttributes(inferenceCall);
+    const parsed = JSON.parse(attrs["gen_ai.input.messages"] as string);
+    expect(parsed[0].parts).toHaveLength(2);
+    expect(parsed[0].parts[0].type).toBe("text");
+    expect(parsed[0].parts[1].type).toBe("uri");
+    expect(parsed[0].parts[1].modality).toBe("image");
+    expect(parsed[0].parts[1].mime_type).toBe("image/png");
+
+    await stopService(service);
+  });
+
+  test("output messages with tool_call parts are recorded correctly", async () => {
+    const service = createService();
+    await service.start(createTestCtx({ captureContent: true }));
+
+    const outputMessages = [
+      {
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool_call" as const,
+            id: "call_abc",
+            name: "get_weather",
+            arguments: { location: "Paris" },
+          },
+        ],
+        finish_reason: "tool_call",
+      },
+    ];
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      finishReasons: ["tool_call"],
+      usage: { input: 100, output: 20, total: 120 },
+      outputMessages,
+    });
+
+    const attrs = getSpanAttributes(telemetryState.tracer.startSpan.mock.calls[0]);
+    expect(attrs["gen_ai.response.finish_reasons"]).toEqual(["tool_call"]);
+    const parsed = JSON.parse(attrs["gen_ai.output.messages"] as string);
+    expect(parsed[0].parts[0].type).toBe("tool_call");
+    expect(parsed[0].parts[0].name).toBe("get_weather");
+    expect(parsed[0].finish_reason).toBe("tool_call");
+
+    await stopService(service);
+  });
+
+  test("tool.execution emits execute_tool span with gen_ai.tool.* attributes", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      toolName: "web_search",
+      toolType: "function",
+      toolCallId: "call_xyz",
+      channel: "webchat",
+      durationMs: 850,
+    });
+
+    const spanCall = telemetryState.tracer.startSpan.mock.calls[0];
+    expect(spanCall[0]).toBe("execute_tool web_search");
+
+    const attrs = getSpanAttributes(spanCall);
+    expect(attrs["gen_ai.operation.name"]).toBe("execute_tool");
+    expect(attrs["gen_ai.tool.name"]).toBe("web_search");
+    expect(attrs["gen_ai.tool.type"]).toBe("function");
+    expect(attrs["gen_ai.tool.call.id"]).toBe("call_xyz");
+    expect(attrs["openclaw.channel"]).toBe("webchat");
+
+    await stopService(service);
+  });
+
+  test("tool.execution with error sets ERROR span status", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      toolName: "exec",
+      toolCallId: "call_err",
+      durationMs: 100,
+      error: "timeout",
+    });
+
+    const span = telemetryState.tracer.startSpan.mock.results[0]?.value as MockSpan | undefined;
+    expect(span).toBeDefined();
+    if (!span) {
+      throw new Error("Expected tool span");
+    }
+    expect(span.setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 2, message: "timeout" }),
+    );
+
+    await stopService(service);
+  });
+
+  test("system instructions do NOT appear on agent.turn span (belong on child chat spans)", async () => {
+    const service = createService();
+    await service.start(createTestCtx({ captureContent: true }));
+
+    emitDiagnosticEvent({
+      type: "run.completed",
+      runId: "run-sys-1",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5-20250929",
+      usage: { input: 100, output: 50, total: 150 },
+      systemInstructions: [{ type: "text" as const, content: "You are a helpful assistant." }],
+    });
+
+    const attrs = getSpanAttributes(telemetryState.tracer.startSpan.mock.calls[0]);
+    expect(attrs["gen_ai.system_instructions"]).toBeUndefined();
+
+    await stopService(service);
+  });
+
+  test("temperature and maxOutputTokens do NOT appear on agent.turn span (belong on child chat spans)", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "run.completed",
+      runId: "run-temp-1",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 100, output: 50, total: 150 },
+      temperature: 0.7,
+      maxOutputTokens: 4096,
+    });
+
+    const attrs = getSpanAttributes(telemetryState.tracer.startSpan.mock.calls[0]);
+    expect(attrs["gen_ai.request.temperature"]).toBeUndefined();
+    expect(attrs["gen_ai.request.max_tokens"]).toBeUndefined();
+
+    await stopService(service);
   });
 
   test("appends signal path when endpoint contains non-signal /v1 segment", async () => {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -1,43 +1,82 @@
-import { metrics, trace, SpanStatusCode } from "@opentelemetry/api";
+import {
+  context,
+  isSpanContextValid,
+  metrics,
+  trace,
+  SpanKind,
+  SpanStatusCode,
+  type Span,
+} from "@opentelemetry/api";
 import type { SeverityNumber } from "@opentelemetry/api-logs";
-import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
-import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ParentBasedSampler, TraceIdRatioBasedSampler } from "@opentelemetry/sdk-trace-base";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
-import type { DiagnosticEventPayload, OpenClawPluginService } from "../api.js";
-import { onDiagnosticEvent, redactSensitiveText, registerLogTransport } from "../api.js";
+import type {
+  DiagnosticEventPayload,
+  OpenClawConfig,
+  OpenClawPluginService,
+} from "openclaw/plugin-sdk/diagnostics-otel";
+import {
+  onDiagnosticEvent,
+  redactSensitiveText,
+  registerLogTransport,
+  resolveAgentIdFromSessionKey,
+  resolveAgentIdentity,
+} from "openclaw/plugin-sdk/diagnostics-otel";
+import {
+  recordRunCompleted,
+  recordRunStarted,
+  recordModelInferenceStarted,
+  recordModelInference,
+  recordWebhookReceived,
+  recordWebhookProcessed,
+  recordWebhookError,
+  recordMessageQueued,
+  recordMessageProcessed,
+  recordLaneEnqueue,
+  recordLaneDequeue,
+  recordSessionState,
+  recordSessionStuck,
+  recordRunAttempt,
+  recordToolExecution,
+  recordHeartbeat,
+  type AgentInfo,
+  type OtelHandlerCtx,
+} from "./otel-event-handlers.js";
+import { createMetricInstruments } from "./otel-metrics.js";
+import {
+  DEFAULT_SERVICE_NAME,
+  OTEL_DEBUG_ENV,
+  OTEL_DUMP_ENV,
+  normalizeEndpoint,
+  resolveCaptureContent,
+  resolveOtelUrl,
+  resolveSampleRate,
+  LoggingTraceExporter,
+  formatTraceparent,
+  type ActiveTrace,
+  type TraceHeaders,
+} from "./otel-utils.js";
 
-const DEFAULT_SERVICE_NAME = "openclaw";
+// Global trace context registry for W3C Trace Context propagation.
+// Stores pre-formatted headers to avoid requiring @opentelemetry/api in main package.
+// Shared via Symbol.for so trace-context-propagator.ts can read without importing this module.
+const TRACE_CONTEXT_REGISTRY_KEY = Symbol.for("openclaw.diagnostics-otel.trace-headers");
 
-function normalizeEndpoint(endpoint?: string): string | undefined {
-  const trimmed = endpoint?.trim();
-  return trimmed ? trimmed.replace(/\/+$/, "") : undefined;
-}
-
-function resolveOtelUrl(endpoint: string | undefined, path: string): string | undefined {
-  if (!endpoint) {
-    return undefined;
+function getTraceHeadersRegistry(): Map<string, TraceHeaders> {
+  const globalStore = globalThis as {
+    [TRACE_CONTEXT_REGISTRY_KEY]?: Map<string, TraceHeaders>;
+  };
+  if (!globalStore[TRACE_CONTEXT_REGISTRY_KEY]) {
+    globalStore[TRACE_CONTEXT_REGISTRY_KEY] = new Map();
   }
-  const endpointWithoutQueryOrFragment = endpoint.split(/[?#]/, 1)[0] ?? endpoint;
-  if (/\/v1\/(?:traces|metrics|logs)$/i.test(endpointWithoutQueryOrFragment)) {
-    return endpoint;
-  }
-  return `${endpoint}/${path}`;
-}
-
-function resolveSampleRate(value: number | undefined): number | undefined {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return undefined;
-  }
-  if (value < 0 || value > 1) {
-    return undefined;
-  }
-  return value;
+  return globalStore[TRACE_CONTEXT_REGISTRY_KEY];
 }
 
 function formatError(err: unknown): string {
@@ -67,6 +106,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
   let logProvider: LoggerProvider | null = null;
   let stopLogTransport: (() => void) | null = null;
   let unsubscribe: (() => void) | null = null;
+  let bufferCleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  // Active root traces keyed by sessionKey. Covers the full message lifecycle;
+  // child spans (agent.turn, LLM calls, tool executions) are nested under it.
+  const activeTraces = new Map<string, ActiveTrace>();
+  const ACTIVE_TRACE_TTL_MS = 10 * 60 * 1000;
 
   return {
     id: "diagnostics-otel",
@@ -88,12 +133,22 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const serviceName =
         otel.serviceName?.trim() || process.env.OTEL_SERVICE_NAME || DEFAULT_SERVICE_NAME;
       const sampleRate = resolveSampleRate(otel.sampleRate);
+      const debugExports = ["1", "true", "yes", "on"].includes(
+        (process.env[OTEL_DEBUG_ENV] ?? "").toLowerCase(),
+      );
+      const dumpPathRaw = process.env[OTEL_DUMP_ENV]?.trim();
+      const dumpPath = dumpPathRaw ? dumpPathRaw : undefined;
 
       const tracesEnabled = otel.traces !== false;
       const metricsEnabled = otel.metrics !== false;
       const logsEnabled = otel.logs === true;
       if (!tracesEnabled && !metricsEnabled && !logsEnabled) {
         return;
+      }
+      if (debugExports) {
+        ctx.logger.info(
+          `diagnostics-otel: debug enabled (traces=${tracesEnabled}, metrics=${metricsEnabled}, logs=${logsEnabled})`,
+        );
       }
 
       const resource = resourceFromAttributes({
@@ -104,10 +159,16 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const metricUrl = resolveOtelUrl(endpoint, "v1/metrics");
       const logUrl = resolveOtelUrl(endpoint, "v1/logs");
       const traceExporter = tracesEnabled
-        ? new OTLPTraceExporter({
-            ...(traceUrl ? { url: traceUrl } : {}),
-            ...(headers ? { headers } : {}),
-          })
+        ? (() => {
+            const base = new OTLPTraceExporter({
+              ...(traceUrl ? { url: traceUrl } : {}),
+              ...(headers ? { headers } : {}),
+            });
+            if (debugExports) {
+              return new LoggingTraceExporter(base, ctx.logger, dumpPath);
+            }
+            return base;
+          })()
         : undefined;
 
       const metricExporter = metricsEnabled
@@ -159,79 +220,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
       const meter = metrics.getMeter("openclaw");
       const tracer = trace.getTracer("openclaw");
+      const otelMetrics = createMetricInstruments(meter);
 
-      const tokensCounter = meter.createCounter("openclaw.tokens", {
-        unit: "1",
-        description: "Token usage by type",
-      });
-      const costCounter = meter.createCounter("openclaw.cost.usd", {
-        unit: "1",
-        description: "Estimated model cost (USD)",
-      });
-      const durationHistogram = meter.createHistogram("openclaw.run.duration_ms", {
-        unit: "ms",
-        description: "Agent run duration",
-      });
-      const contextHistogram = meter.createHistogram("openclaw.context.tokens", {
-        unit: "1",
-        description: "Context window size and usage",
-      });
-      const webhookReceivedCounter = meter.createCounter("openclaw.webhook.received", {
-        unit: "1",
-        description: "Webhook requests received",
-      });
-      const webhookErrorCounter = meter.createCounter("openclaw.webhook.error", {
-        unit: "1",
-        description: "Webhook processing errors",
-      });
-      const webhookDurationHistogram = meter.createHistogram("openclaw.webhook.duration_ms", {
-        unit: "ms",
-        description: "Webhook processing duration",
-      });
-      const messageQueuedCounter = meter.createCounter("openclaw.message.queued", {
-        unit: "1",
-        description: "Messages queued for processing",
-      });
-      const messageProcessedCounter = meter.createCounter("openclaw.message.processed", {
-        unit: "1",
-        description: "Messages processed by outcome",
-      });
-      const messageDurationHistogram = meter.createHistogram("openclaw.message.duration_ms", {
-        unit: "ms",
-        description: "Message processing duration",
-      });
-      const queueDepthHistogram = meter.createHistogram("openclaw.queue.depth", {
-        unit: "1",
-        description: "Queue depth on enqueue/dequeue",
-      });
-      const queueWaitHistogram = meter.createHistogram("openclaw.queue.wait_ms", {
-        unit: "ms",
-        description: "Queue wait time before execution",
-      });
-      const laneEnqueueCounter = meter.createCounter("openclaw.queue.lane.enqueue", {
-        unit: "1",
-        description: "Command queue lane enqueue events",
-      });
-      const laneDequeueCounter = meter.createCounter("openclaw.queue.lane.dequeue", {
-        unit: "1",
-        description: "Command queue lane dequeue events",
-      });
-      const sessionStateCounter = meter.createCounter("openclaw.session.state", {
-        unit: "1",
-        description: "Session state transitions",
-      });
-      const sessionStuckCounter = meter.createCounter("openclaw.session.stuck", {
-        unit: "1",
-        description: "Sessions stuck in processing",
-      });
-      const sessionStuckAgeHistogram = meter.createHistogram("openclaw.session.stuck_age_ms", {
-        unit: "ms",
-        description: "Age of stuck sessions",
-      });
-      const runAttemptCounter = meter.createCounter("openclaw.run.attempt", {
-        unit: "1",
-        description: "Run attempts",
-      });
+      // Trace attribute constants (standard OTEL semantic conventions only)
+      const TRACE_ATTRS = {
+        SESSION_ID: "session.id",
+      } as const;
 
       if (logsEnabled) {
         const logExporter = new OTLPLogExporter({
@@ -358,295 +352,322 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         });
       }
 
+      const captureContent = resolveCaptureContent(otel.captureContent);
+
       const spanWithDuration = (
         name: string,
-        attributes: Record<string, string | number>,
+        attributes: Record<string, string | number | string[]>,
         durationMs?: number,
+        kind?: SpanKind,
+        parentCtx?: ReturnType<typeof context.active>,
       ) => {
         const startTime =
           typeof durationMs === "number" ? Date.now() - Math.max(0, durationMs) : undefined;
-        const span = tracer.startSpan(name, {
-          attributes,
-          ...(startTime ? { startTime } : {}),
-        });
+        const span = tracer.startSpan(
+          name,
+          {
+            attributes,
+            ...(startTime ? { startTime } : {}),
+            ...(kind !== undefined ? { kind } : {}),
+          },
+          parentCtx,
+        );
         return span;
       };
 
-      const recordModelUsage = (evt: Extract<DiagnosticEventPayload, { type: "model.usage" }>) => {
-        const attrs = {
-          "openclaw.channel": evt.channel ?? "unknown",
-          "openclaw.provider": evt.provider ?? "unknown",
-          "openclaw.model": evt.model ?? "unknown",
-        };
+      const safeJsonStringify = (value: unknown): string => {
+        try {
+          return JSON.stringify(value);
+        } catch {
+          return String(value);
+        }
+      };
 
-        const usage = evt.usage;
-        if (usage.input) {
-          tokensCounter.add(usage.input, { ...attrs, "openclaw.token": "input" });
-        }
-        if (usage.output) {
-          tokensCounter.add(usage.output, { ...attrs, "openclaw.token": "output" });
-        }
-        if (usage.cacheRead) {
-          tokensCounter.add(usage.cacheRead, { ...attrs, "openclaw.token": "cache_read" });
-        }
-        if (usage.cacheWrite) {
-          tokensCounter.add(usage.cacheWrite, { ...attrs, "openclaw.token": "cache_write" });
-        }
-        if (usage.promptTokens) {
-          tokensCounter.add(usage.promptTokens, { ...attrs, "openclaw.token": "prompt" });
-        }
-        if (usage.total) {
-          tokensCounter.add(usage.total, { ...attrs, "openclaw.token": "total" });
-        }
+      const runSpans = new Map<string, { span: Span; createdAt: number }>();
+      const RUN_SPAN_TTL_MS = 10 * 60 * 1000;
+      const inferenceSpans = new Map<string, { span: Span; createdAt: number }>();
+      const INFERENCE_SPAN_TTL_MS = 10 * 60 * 1000;
+      const activeInferenceSpanByRunId = new Map<string, Span>();
+      const runProviderByRunId = new Map<string, string>();
 
-        if (evt.costUsd) {
-          costCounter.add(evt.costUsd, attrs);
-        }
-        if (evt.durationMs) {
-          durationHistogram.record(evt.durationMs, attrs);
-        }
-        if (evt.context?.limit) {
-          contextHistogram.record(evt.context.limit, {
-            ...attrs,
-            "openclaw.context": "limit",
-          });
-        }
-        if (evt.context?.used) {
-          contextHistogram.record(evt.context.used, {
-            ...attrs,
-            "openclaw.context": "used",
-          });
-        }
-
-        if (!tracesEnabled) {
-          return;
-        }
+      const createToolSpan = (
+        evt: Extract<DiagnosticEventPayload, { type: "tool.execution" }>,
+        parentCtx?: ReturnType<typeof context.active>,
+      ) => {
         const spanAttrs: Record<string, string | number> = {
-          ...attrs,
-          "openclaw.sessionKey": evt.sessionKey ?? "",
-          "openclaw.sessionId": evt.sessionId ?? "",
-          "openclaw.tokens.input": usage.input ?? 0,
-          "openclaw.tokens.output": usage.output ?? 0,
-          "openclaw.tokens.cache_read": usage.cacheRead ?? 0,
-          "openclaw.tokens.cache_write": usage.cacheWrite ?? 0,
-          "openclaw.tokens.total": usage.total ?? 0,
+          "gen_ai.operation.name": "execute_tool",
+          "gen_ai.tool.name": evt.toolName,
+          "gen_ai.tool.type": evt.toolType ?? "function",
         };
+        if (evt.runId) {
+          const provider = runProviderByRunId.get(evt.runId);
+          if (provider) {
+            spanAttrs["gen_ai.provider.name"] = provider;
+          }
+        }
+        if (evt.toolCallId) {
+          spanAttrs["gen_ai.tool.call.id"] = evt.toolCallId;
+        }
+        if (evt.channel) {
+          spanAttrs["openclaw.channel"] = evt.channel;
+        }
+        if (captureContent.toolContent) {
+          if (evt.toolInput != null) {
+            spanAttrs["gen_ai.tool.call.arguments"] = safeJsonStringify(evt.toolInput);
+          }
+          if (evt.toolOutput != null) {
+            spanAttrs["gen_ai.tool.call.result"] = safeJsonStringify(evt.toolOutput);
+          }
+        }
 
-        const span = spanWithDuration("openclaw.model.usage", spanAttrs, evt.durationMs);
-        span.end();
-      };
-
-      const recordWebhookReceived = (
-        evt: Extract<DiagnosticEventPayload, { type: "webhook.received" }>,
-      ) => {
-        const attrs = {
-          "openclaw.channel": evt.channel ?? "unknown",
-          "openclaw.webhook": evt.updateType ?? "unknown",
-        };
-        webhookReceivedCounter.add(1, attrs);
-      };
-
-      const recordWebhookProcessed = (
-        evt: Extract<DiagnosticEventPayload, { type: "webhook.processed" }>,
-      ) => {
-        const attrs = {
-          "openclaw.channel": evt.channel ?? "unknown",
-          "openclaw.webhook": evt.updateType ?? "unknown",
-        };
-        if (typeof evt.durationMs === "number") {
-          webhookDurationHistogram.record(evt.durationMs, attrs);
+        const spanName = `execute_tool ${evt.toolName}`;
+        const span = spanWithDuration(
+          spanName,
+          spanAttrs,
+          evt.durationMs,
+          SpanKind.INTERNAL,
+          parentCtx,
+        );
+        if (evt.error) {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: evt.error });
         }
-        if (!tracesEnabled) {
-          return;
-        }
-        const spanAttrs: Record<string, string | number> = { ...attrs };
-        if (evt.chatId !== undefined) {
-          spanAttrs["openclaw.chatId"] = String(evt.chatId);
-        }
-        const span = spanWithDuration("openclaw.webhook.processed", spanAttrs, evt.durationMs);
-        span.end();
-      };
-
-      const recordWebhookError = (
-        evt: Extract<DiagnosticEventPayload, { type: "webhook.error" }>,
-      ) => {
-        const attrs = {
-          "openclaw.channel": evt.channel ?? "unknown",
-          "openclaw.webhook": evt.updateType ?? "unknown",
-        };
-        webhookErrorCounter.add(1, attrs);
-        if (!tracesEnabled) {
-          return;
-        }
-        const redactedError = redactSensitiveText(evt.error);
-        const spanAttrs: Record<string, string | number> = {
-          ...attrs,
-          "openclaw.error": redactedError,
-        };
-        if (evt.chatId !== undefined) {
-          spanAttrs["openclaw.chatId"] = String(evt.chatId);
-        }
-        const span = tracer.startSpan("openclaw.webhook.error", {
-          attributes: spanAttrs,
-        });
-        span.setStatus({ code: SpanStatusCode.ERROR, message: redactedError });
-        span.end();
-      };
-
-      const recordMessageQueued = (
-        evt: Extract<DiagnosticEventPayload, { type: "message.queued" }>,
-      ) => {
-        const attrs = {
-          "openclaw.channel": evt.channel ?? "unknown",
-          "openclaw.source": evt.source ?? "unknown",
-        };
-        messageQueuedCounter.add(1, attrs);
-        if (typeof evt.queueDepth === "number") {
-          queueDepthHistogram.record(evt.queueDepth, attrs);
-        }
-      };
-
-      const addSessionIdentityAttrs = (
-        spanAttrs: Record<string, string | number>,
-        evt: { sessionKey?: string; sessionId?: string },
-      ) => {
-        if (evt.sessionKey) {
-          spanAttrs["openclaw.sessionKey"] = evt.sessionKey;
-        }
-        if (evt.sessionId) {
-          spanAttrs["openclaw.sessionId"] = evt.sessionId;
-        }
-      };
-
-      const recordMessageProcessed = (
-        evt: Extract<DiagnosticEventPayload, { type: "message.processed" }>,
-      ) => {
-        const attrs = {
-          "openclaw.channel": evt.channel ?? "unknown",
-          "openclaw.outcome": evt.outcome ?? "unknown",
-        };
-        messageProcessedCounter.add(1, attrs);
-        if (typeof evt.durationMs === "number") {
-          messageDurationHistogram.record(evt.durationMs, attrs);
-        }
-        if (!tracesEnabled) {
-          return;
-        }
-        const spanAttrs: Record<string, string | number> = { ...attrs };
-        addSessionIdentityAttrs(spanAttrs, evt);
-        if (evt.chatId !== undefined) {
-          spanAttrs["openclaw.chatId"] = String(evt.chatId);
-        }
-        if (evt.messageId !== undefined) {
-          spanAttrs["openclaw.messageId"] = String(evt.messageId);
-        }
-        if (evt.reason) {
-          spanAttrs["openclaw.reason"] = redactSensitiveText(evt.reason);
-        }
-        const span = spanWithDuration("openclaw.message.processed", spanAttrs, evt.durationMs);
-        if (evt.outcome === "error" && evt.error) {
-          span.setStatus({ code: SpanStatusCode.ERROR, message: redactSensitiveText(evt.error) });
+        if (debugExports) {
+          ctx.logger.info(`diagnostics-otel: span created ${spanName}`);
         }
         span.end();
       };
 
-      const recordLaneEnqueue = (
-        evt: Extract<DiagnosticEventPayload, { type: "queue.lane.enqueue" }>,
-      ) => {
-        const attrs = { "openclaw.lane": evt.lane };
-        laneEnqueueCounter.add(1, attrs);
-        queueDepthHistogram.record(evt.queueSize, attrs);
-      };
-
-      const recordLaneDequeue = (
-        evt: Extract<DiagnosticEventPayload, { type: "queue.lane.dequeue" }>,
-      ) => {
-        const attrs = { "openclaw.lane": evt.lane };
-        laneDequeueCounter.add(1, attrs);
-        queueDepthHistogram.record(evt.queueSize, attrs);
-        if (typeof evt.waitMs === "number") {
-          queueWaitHistogram.record(evt.waitMs, attrs);
+      const agentInfoCache = new Map<string, AgentInfo | null>();
+      const resolveAgentInfo = (sessionKey?: string): AgentInfo | null => {
+        if (!sessionKey) {
+          return null;
         }
-      };
-
-      const recordSessionState = (
-        evt: Extract<DiagnosticEventPayload, { type: "session.state" }>,
-      ) => {
-        const attrs: Record<string, string> = { "openclaw.state": evt.state };
-        if (evt.reason) {
-          attrs["openclaw.reason"] = redactSensitiveText(evt.reason);
+        const cached = agentInfoCache.get(sessionKey);
+        if (cached !== undefined) {
+          return cached;
         }
-        sessionStateCounter.add(1, attrs);
+        const agentId = resolveAgentIdFromSessionKey(sessionKey);
+        const identity = resolveAgentIdentity(ctx.config, agentId);
+        const info: AgentInfo = { id: agentId, name: identity?.name?.trim() || undefined };
+        agentInfoCache.set(sessionKey, info);
+        return info;
       };
 
-      const recordSessionStuck = (
-        evt: Extract<DiagnosticEventPayload, { type: "session.stuck" }>,
-      ) => {
-        const attrs: Record<string, string> = { "openclaw.state": evt.state };
-        sessionStuckCounter.add(1, attrs);
-        if (typeof evt.ageMs === "number") {
-          sessionStuckAgeHistogram.record(evt.ageMs, attrs);
+      const ensureRunSpan = (params: {
+        runId?: string;
+        sessionKey?: string;
+        sessionId?: string;
+        channel?: string;
+        startTimeMs?: number;
+        attributes?: Record<string, string | number | string[]>;
+      }): Span | null => {
+        const runId = params.runId;
+        if (!runId) {
+          return null;
         }
-        if (!tracesEnabled) {
-          return;
+        const existing = runSpans.get(runId);
+        if (existing) {
+          if (params.attributes) {
+            for (const [key, value] of Object.entries(params.attributes)) {
+              existing.span.setAttribute(key, value);
+            }
+          }
+          return existing.span;
         }
-        const spanAttrs: Record<string, string | number> = { ...attrs };
-        addSessionIdentityAttrs(spanAttrs, evt);
-        spanAttrs["openclaw.queueDepth"] = evt.queueDepth ?? 0;
-        spanAttrs["openclaw.ageMs"] = evt.ageMs;
-        const span = tracer.startSpan("openclaw.session.stuck", { attributes: spanAttrs });
-        span.setStatus({ code: SpanStatusCode.ERROR, message: "session stuck" });
-        span.end();
+        const spanAttrs: Record<string, string | number | string[]> = {
+          "openclaw.runId": runId,
+          "openclaw.type": "openclaw.agent.turn",
+          ...params.attributes,
+        };
+        if (params.sessionKey) {
+          spanAttrs["openclaw.sessionKey"] = params.sessionKey;
+          spanAttrs[TRACE_ATTRS.SESSION_ID] = params.sessionKey;
+        }
+        if (params.sessionId) {
+          spanAttrs["openclaw.sessionId"] = params.sessionId;
+          spanAttrs["gen_ai.conversation.id"] = params.sessionId;
+        }
+        if (params.channel) {
+          spanAttrs["openclaw.channel"] = params.channel;
+        }
+
+        // GenAI agent identity attributes (gen_ai.agent.*)
+        const agentInfo = resolveAgentInfo(params.sessionKey);
+        if (agentInfo) {
+          spanAttrs["gen_ai.agent.id"] = agentInfo.id;
+          if (agentInfo.name) {
+            spanAttrs["gen_ai.agent.name"] = agentInfo.name;
+          }
+        }
+        spanAttrs["gen_ai.operation.name"] = "invoke_agent";
+
+        // Parent under root trace span if available (created by message.queued)
+        const rootTrace = params.sessionKey ? activeTraces.get(params.sessionKey) : undefined;
+        const parentCtx = rootTrace
+          ? trace.setSpan(context.active(), rootTrace.span)
+          : context.active();
+
+        const spanName = agentInfo?.name ? `invoke_agent ${agentInfo.name}` : "invoke_agent";
+        const span = tracer.startSpan(
+          spanName,
+          {
+            attributes: spanAttrs,
+            ...(typeof params.startTimeMs === "number" ? { startTime: params.startTimeMs } : {}),
+            kind: SpanKind.INTERNAL,
+          },
+          parentCtx,
+        );
+        runSpans.set(runId, { span, createdAt: Date.now() });
+
+        // Store W3C trace headers for propagation to downstream LLM providers
+        if (params.sessionKey) {
+          const spanContext = span.spanContext();
+          if (isSpanContextValid(spanContext)) {
+            getTraceHeadersRegistry().set(params.sessionKey, {
+              traceparent: formatTraceparent(spanContext),
+              ...(spanContext.traceState && { tracestate: spanContext.traceState.serialize() }),
+            });
+          }
+        }
+
+        if (debugExports) {
+          ctx.logger.info(`diagnostics-otel: span created ${spanName}`);
+        }
+        return span;
       };
 
-      const recordRunAttempt = (evt: Extract<DiagnosticEventPayload, { type: "run.attempt" }>) => {
-        runAttemptCounter.add(1, { "openclaw.attempt": evt.attempt });
+      // Construct the handler context object used by all event handlers
+      const hctx: OtelHandlerCtx = {
+        tracer,
+        metrics: otelMetrics,
+        captureContent,
+        tracesEnabled,
+        debugExports,
+        logger: ctx.logger,
+        activeTraces,
+        runSpans,
+        inferenceSpans,
+        activeInferenceSpanByRunId,
+        runProviderByRunId,
+        resolveAgentInfo,
+        spanWithDuration,
+        safeJsonStringify,
+        redactText: redactSensitiveText,
+        createToolSpan,
+        ensureRunSpan,
+        TRACE_ATTRS,
+        getTraceHeadersRegistry,
       };
 
-      const recordHeartbeat = (
-        evt: Extract<DiagnosticEventPayload, { type: "diagnostic.heartbeat" }>,
-      ) => {
-        queueDepthHistogram.record(evt.queued, { "openclaw.channel": "heartbeat" });
-      };
+      // Periodic cleanup of orphaned buffer entries
+      bufferCleanupTimer = setInterval(() => {
+        const now = Date.now();
+        for (const [key, entry] of runSpans) {
+          if (now - entry.createdAt > RUN_SPAN_TTL_MS) {
+            try {
+              entry.span.end();
+            } catch {
+              // ignore
+            }
+            runSpans.delete(key);
+          }
+        }
+        for (const [key, entry] of inferenceSpans) {
+          if (now - entry.createdAt > INFERENCE_SPAN_TTL_MS) {
+            try {
+              entry.span.end();
+            } catch {
+              // ignore
+            }
+            inferenceSpans.delete(key);
+          }
+        }
+        // If we had to end inference spans due to TTL, don't keep dangling "active" parents.
+        for (const [runId, span] of activeInferenceSpanByRunId) {
+          if (Array.from(inferenceSpans.values()).every((e) => e.span !== span)) {
+            activeInferenceSpanByRunId.delete(runId);
+          }
+        }
+        // Clean up stale provider entries for completed/expired runs
+        for (const runId of runProviderByRunId.keys()) {
+          if (!runSpans.has(runId)) {
+            runProviderByRunId.delete(runId);
+          }
+        }
+        for (const [key, entry] of activeTraces) {
+          if (now - entry.startedAt > ACTIVE_TRACE_TTL_MS) {
+            try {
+              entry.span.setStatus({ code: SpanStatusCode.ERROR, message: "TTL expired" });
+              entry.span.end();
+            } catch {
+              // ignore
+            }
+            activeTraces.delete(key);
+          }
+        }
+        // Clean up orphaned trace headers whose session has no active trace or run span
+        const registry = getTraceHeadersRegistry();
+        for (const sessionKey of registry.keys()) {
+          if (!activeTraces.has(sessionKey)) {
+            registry.delete(sessionKey);
+          }
+        }
+      }, 60_000);
+      bufferCleanupTimer.unref?.();
 
       unsubscribe = onDiagnosticEvent((evt: DiagnosticEventPayload) => {
         try {
+          if (debugExports) {
+            ctx.logger.info(`diagnostics-otel: event received ${evt.type}`);
+          }
           switch (evt.type) {
-            case "model.usage":
-              recordModelUsage(evt);
+            case "model.inference.started":
+              recordModelInferenceStarted(hctx, evt);
+              return;
+            case "model.inference":
+              recordModelInference(hctx, evt);
+              return;
+            case "run.completed":
+              recordRunCompleted(hctx, evt);
               return;
             case "webhook.received":
-              recordWebhookReceived(evt);
+              recordWebhookReceived(hctx, evt);
               return;
             case "webhook.processed":
-              recordWebhookProcessed(evt);
+              recordWebhookProcessed(hctx, evt);
               return;
             case "webhook.error":
-              recordWebhookError(evt);
+              recordWebhookError(hctx, evt);
               return;
             case "message.queued":
-              recordMessageQueued(evt);
+              recordMessageQueued(hctx, evt);
               return;
             case "message.processed":
-              recordMessageProcessed(evt);
+              recordMessageProcessed(hctx, evt);
               return;
             case "queue.lane.enqueue":
-              recordLaneEnqueue(evt);
+              recordLaneEnqueue(hctx, evt);
               return;
             case "queue.lane.dequeue":
-              recordLaneDequeue(evt);
+              recordLaneDequeue(hctx, evt);
               return;
             case "session.state":
-              recordSessionState(evt);
+              recordSessionState(hctx, evt);
               return;
             case "session.stuck":
-              recordSessionStuck(evt);
+              recordSessionStuck(hctx, evt);
               return;
             case "run.attempt":
-              recordRunAttempt(evt);
+              recordRunAttempt(hctx, evt);
+              return;
+            case "run.started":
+              recordRunStarted(hctx, evt);
               return;
             case "diagnostic.heartbeat":
-              recordHeartbeat(evt);
+              recordHeartbeat(hctx, evt);
+              return;
+            case "tool.execution":
+              recordToolExecution(hctx, evt);
               return;
           }
         } catch (err) {
@@ -661,14 +682,30 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       }
     },
     async stop() {
+      // End any remaining root traces
+      for (const [, activeTrace] of activeTraces) {
+        try {
+          activeTrace.span.setStatus({ code: SpanStatusCode.ERROR, message: "Service stopped" });
+          activeTrace.span.end();
+        } catch {
+          // Ignore errors during cleanup
+        }
+      }
+      activeTraces.clear();
+
       unsubscribe?.();
       unsubscribe = null;
       stopLogTransport?.();
       stopLogTransport = null;
+      if (bufferCleanupTimer) {
+        clearInterval(bufferCleanupTimer);
+        bufferCleanupTimer = null;
+      }
       if (logProvider) {
         await logProvider.shutdown().catch(() => undefined);
         logProvider = null;
       }
+      getTraceHeadersRegistry().clear();
       if (sdk) {
         await sdk.shutdown().catch(() => undefined);
         sdk = null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,13 +293,16 @@ importers:
       '@opentelemetry/api-logs':
         specifier: ^0.214.0
         version: 0.214.0
-      '@opentelemetry/exporter-logs-otlp-proto':
+      '@opentelemetry/core':
+        specifier: ^2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http':
         specifier: ^0.214.0
         version: 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-proto':
+      '@opentelemetry/exporter-metrics-otlp-http':
         specifier: ^0.214.0
         version: 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-proto':
+      '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.214.0
         version: 0.214.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources':

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1450,6 +1450,8 @@ export async function runEmbeddedPiAgent(
                     },
                   ]
                 : undefined,
+              systemPromptText: attempt.systemPromptText,
+              firstTokenMs: attempt.firstTokenAt ? attempt.firstTokenAt - started : undefined,
             },
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
             didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -9,6 +9,7 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
+import { emitDiagnosticEvent } from "../../../infra/diagnostic-events.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import {
   ensureGlobalUndiciEnvProxyDispatcher,
@@ -130,6 +131,7 @@ import { dropThinkingBlocks } from "../thinking.js";
 import { collectAllowedToolNames } from "../tool-name-allowlist.js";
 import { installToolResultContextGuard } from "../tool-result-context-guard.js";
 import { splitSdkTools } from "../tool-split.js";
+import { createTraceContextHeadersWrapper } from "../trace-context-stream-wrapper.js";
 import { describeUnknownError, mapThinkingLevel } from "../utils.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import {
@@ -175,6 +177,10 @@ import {
   selectCompactionTimeoutSnapshot,
   shouldFlagCompactionTimeout,
 } from "./compaction-timeout.js";
+import {
+  buildGenAiMessagesFromContext,
+  buildGenAiToolDefsFromContext,
+} from "./diagnostic-builders.js";
 import { pruneProcessedHistoryImages } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import { resolveLlmIdleTimeoutMs, streamWithIdleTimeout } from "./llm-idle-timeout.js";
@@ -944,6 +950,11 @@ export async function runEmbeddedAttempt(
         activeSession.agent.setTransport(agentTransportOverride);
       }
 
+      activeSession.agent.streamFn = createTraceContextHeadersWrapper(
+        activeSession.agent.streamFn,
+        params.sessionKey,
+      );
+
       if (cacheTrace) {
         cacheTrace.recordStage("session:loaded", {
           messages: activeSession.messages,
@@ -1088,6 +1099,53 @@ export async function runEmbeddedAttempt(
           idleTimeoutMs,
           (error) => idleTimeoutTrigger?.(error),
         );
+      }
+
+      const captureContent =
+        params.config?.diagnostics?.enabled === true &&
+        !!params.config?.diagnostics?.otel?.captureContent;
+      if (captureContent) {
+        // Capture the exact model request context at the point of the LLM call.
+        // This is more trustworthy than sampling AgentSession.state.messages from streaming events.
+        const inner = activeSession.agent.streamFn;
+        let callIndex = 0;
+        activeSession.agent.streamFn = ((model, context, options) => {
+          callIndex += 1;
+          emitDiagnosticEvent({
+            type: "model.inference.started",
+            runId: params.runId,
+            sessionId: activeSession.sessionId,
+            sessionKey: params.sessionKey,
+            channel: params.messageChannel,
+            provider: model.provider,
+            model: model.id,
+            operationName: "chat",
+            callIndex,
+            inputMessages: buildGenAiMessagesFromContext(
+              (context as { messages?: unknown }).messages,
+            ),
+            systemInstructions:
+              typeof (context as { systemPrompt?: unknown }).systemPrompt === "string" &&
+              (context as { systemPrompt?: string }).systemPrompt?.trim()
+                ? [
+                    {
+                      type: "text",
+                      content: String((context as { systemPrompt?: string }).systemPrompt),
+                    },
+                  ]
+                : undefined,
+            toolDefinitions: buildGenAiToolDefsFromContext((context as { tools?: unknown }).tools),
+            temperature:
+              typeof (options as { temperature?: unknown }).temperature === "number"
+                ? (options as { temperature?: number }).temperature
+                : undefined,
+            maxOutputTokens:
+              typeof (options as { maxTokens?: unknown }).maxTokens === "number"
+                ? (options as { maxTokens?: number }).maxTokens
+                : undefined,
+          });
+          return inner(model, context, options);
+        }) as typeof inner;
       }
 
       try {
@@ -1250,6 +1308,8 @@ export async function runEmbeddedAttempt(
       const subscription = subscribeEmbeddedPiSession({
         session: activeSession,
         runId: params.runId,
+        captureContent,
+        channel: params.messageChannel,
         hookRunner: getGlobalHookRunner() ?? undefined,
         verboseLevel: params.verboseLevel,
         reasoningMode: params.reasoningLevel ?? "off",
@@ -1875,6 +1935,8 @@ export async function runEmbeddedAttempt(
         // Client tool call detected (OpenResponses hosted tools)
         clientToolCall: clientToolCallDetected ?? undefined,
         yieldDetected: yieldDetected || undefined,
+        systemPromptText: systemPromptText,
+        firstTokenAt: subscription?.getFirstTokenAt?.(),
       };
     } finally {
       // Always tear down the session (and release the lock) before we leave this attempt.

--- a/src/agents/pi-embedded-runner/run/diagnostic-builders.ts
+++ b/src/agents/pi-embedded-runner/run/diagnostic-builders.ts
@@ -1,0 +1,120 @@
+import type { GenAiMessage, GenAiPart, GenAiToolDef } from "../../../infra/diagnostic-events.js";
+
+export function buildGenAiPartsFromContent(content: unknown): GenAiPart[] {
+  if (typeof content === "string") {
+    return [{ type: "text", content }];
+  }
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const parts: GenAiPart[] = [];
+  for (const item of content) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const record = item as Record<string, unknown>;
+    if (record.type === "text" && typeof record.text === "string") {
+      parts.push({ type: "text", content: record.text });
+      continue;
+    }
+    if (record.type === "image" && typeof record.data === "string") {
+      parts.push({
+        type: "blob",
+        modality: "image",
+        mime_type: typeof record.mimeType === "string" ? record.mimeType : undefined,
+        content: record.data,
+      });
+    }
+  }
+  return parts;
+}
+
+export function buildGenAiMessagesFromContext(messages: unknown): GenAiMessage[] | undefined {
+  if (!Array.isArray(messages)) {
+    return undefined;
+  }
+  const out: GenAiMessage[] = [];
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
+    const record = msg as Record<string, unknown>;
+    const role = typeof record.role === "string" ? record.role : "";
+    if (role === "user") {
+      out.push({ role: "user", parts: buildGenAiPartsFromContent(record.content) });
+      continue;
+    }
+    if (role === "assistant") {
+      const parts: GenAiPart[] = [];
+      const content = record.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (!block || typeof block !== "object") {
+            continue;
+          }
+          const b = block as Record<string, unknown>;
+          if (b.type === "text" && typeof b.text === "string") {
+            parts.push({ type: "text", content: b.text });
+          } else if (b.type === "toolCall" || b.type === "toolUse" || b.type === "functionCall") {
+            const id = typeof b.id === "string" ? b.id : "";
+            const name = typeof b.name === "string" ? b.name : "";
+            const args =
+              b.arguments && typeof b.arguments === "object"
+                ? (b.arguments as Record<string, unknown>)
+                : b.input && typeof b.input === "object"
+                  ? (b.input as Record<string, unknown>)
+                  : undefined;
+            parts.push({ type: "tool_call", id, name, arguments: args });
+          }
+        }
+      }
+      out.push({ role: "assistant", parts });
+      continue;
+    }
+    if (role === "toolResult") {
+      const toolCallId = typeof record.toolCallId === "string" ? record.toolCallId : "";
+      const toolName = typeof record.toolName === "string" ? record.toolName : "";
+      // Represent tool results as a tool message with a tool_call_response part.
+      out.push({
+        role: "tool",
+        parts: [
+          {
+            type: "tool_call_response",
+            id: toolCallId,
+            response: {
+              toolName,
+              isError: Boolean(record.isError),
+              parts: buildGenAiPartsFromContent(record.content),
+            },
+          },
+        ],
+      });
+    }
+  }
+  return out;
+}
+
+export function buildGenAiToolDefsFromContext(tools: unknown): GenAiToolDef[] | undefined {
+  if (!Array.isArray(tools)) {
+    return undefined;
+  }
+  const defs: GenAiToolDef[] = [];
+  for (const tool of tools) {
+    if (!tool || typeof tool !== "object") {
+      continue;
+    }
+    const record = tool as Record<string, unknown>;
+    const name = typeof record.name === "string" ? record.name : "";
+    if (!name) {
+      continue;
+    }
+    defs.push({
+      name,
+      ...(typeof record.description === "string" ? { description: record.description } : {}),
+      ...(record.parameters && typeof record.parameters === "object"
+        ? { parameters: record.parameters as Record<string, unknown> }
+        : {}),
+    });
+  }
+  return defs.length ? defs : undefined;
+}

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../../../infra/local-file-access.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
@@ -570,4 +571,52 @@ export async function detectAndLoadPromptImages(params: {
     loadedCount,
     skippedCount,
   };
+}
+
+export function injectHistoryImagesIntoMessages(
+  messages: AgentMessage[],
+  historyImagesByIndex: Map<number, ImageContent[]>,
+): boolean {
+  if (historyImagesByIndex.size === 0) {
+    return false;
+  }
+  let didMutate = false;
+
+  for (const [msgIndex, images] of historyImagesByIndex) {
+    // Bounds check: ensure index is valid before accessing
+    if (msgIndex < 0 || msgIndex >= messages.length) {
+      continue;
+    }
+    const msg = messages[msgIndex];
+    if (msg && msg.role === "user") {
+      // Convert string content to array format if needed
+      if (typeof msg.content === "string") {
+        msg.content = [{ type: "text", text: msg.content }];
+        didMutate = true;
+      }
+      if (Array.isArray(msg.content)) {
+        // Check for existing image content to avoid duplicates across turns
+        const existingImageData = new Set(
+          msg.content
+            .filter(
+              (c): c is ImageContent =>
+                c != null &&
+                typeof c === "object" &&
+                c.type === "image" &&
+                typeof c.data === "string",
+            )
+            .map((c) => c.data),
+        );
+        for (const img of images) {
+          // Only add if this image isn't already in the message
+          if (!existingImageData.has(img.data)) {
+            msg.content.push(img);
+            didMutate = true;
+          }
+        }
+      }
+    }
+  }
+
+  return didMutate;
 }

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -66,4 +66,8 @@ export type EmbeddedRunAttemptResult = {
   clientToolCall?: { name: string; params: Record<string, unknown> };
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
+  /** The full system prompt text sent to the model. */
+  systemPromptText?: string;
+  /** Timestamp (ms) when the first token arrived from the model. */
+  firstTokenAt?: number;
 };

--- a/src/agents/pi-embedded-runner/trace-context-stream-wrapper.test.ts
+++ b/src/agents/pi-embedded-runner/trace-context-stream-wrapper.test.ts
@@ -1,0 +1,91 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTraceContextHeadersWrapper } from "./trace-context-stream-wrapper.js";
+
+type TraceHeaders = {
+  traceparent: string;
+  tracestate?: string;
+};
+
+const TRACE_CONTEXT_REGISTRY_KEY = Symbol.for("openclaw.diagnostics-otel.trace-headers");
+
+function getRegistry(): Map<string, TraceHeaders> {
+  const globalStore = globalThis as {
+    [TRACE_CONTEXT_REGISTRY_KEY]?: Map<string, TraceHeaders>;
+  };
+  if (!globalStore[TRACE_CONTEXT_REGISTRY_KEY]) {
+    globalStore[TRACE_CONTEXT_REGISTRY_KEY] = new Map();
+  }
+  return globalStore[TRACE_CONTEXT_REGISTRY_KEY];
+}
+
+describe("trace context stream wrapper", () => {
+  afterEach(() => {
+    getRegistry().clear();
+  });
+
+  it("adds trace headers to OpenAI-compatible requests for the active session", () => {
+    const calls: Array<{ headers?: Record<string, string> }> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push({ headers: options?.headers });
+      return createAssistantMessageEventStream();
+    };
+
+    getRegistry().set("agent:main:session", {
+      traceparent: "00-11111111111111111111111111111111-2222222222222222-01",
+      tracestate: "vendor=value",
+    });
+
+    const wrapped = createTraceContextHeadersWrapper(baseStreamFn, "agent:main:session");
+    const model = {
+      api: "openai-completions",
+      provider: "vllm",
+      id: "vllm/qwen3-coder",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void wrapped(model, context, { headers: { "X-Custom": "1" } });
+
+    expect(calls).toEqual([
+      {
+        headers: {
+          traceparent: "00-11111111111111111111111111111111-2222222222222222-01",
+          tracestate: "vendor=value",
+          "X-Custom": "1",
+        },
+      },
+    ]);
+  });
+
+  it("does not add trace headers to non OpenAI-compatible requests", () => {
+    const calls: Array<{ headers?: Record<string, string> }> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push({ headers: options?.headers });
+      return createAssistantMessageEventStream();
+    };
+
+    getRegistry().set("agent:main:session", {
+      traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+    });
+
+    const wrapped = createTraceContextHeadersWrapper(baseStreamFn, "agent:main:session");
+    const model = {
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "anthropic/sonnet-4.6",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void wrapped(model, context, { headers: { "X-Custom": "1" } });
+
+    expect(calls).toEqual([
+      {
+        headers: {
+          "X-Custom": "1",
+        },
+      },
+    ]);
+  });
+});

--- a/src/agents/pi-embedded-runner/trace-context-stream-wrapper.ts
+++ b/src/agents/pi-embedded-runner/trace-context-stream-wrapper.ts
@@ -1,0 +1,51 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { streamSimple } from "@mariozechner/pi-ai";
+
+type TraceHeaders = {
+  traceparent: string;
+  tracestate?: string;
+};
+
+const TRACE_CONTEXT_REGISTRY_KEY = Symbol.for("openclaw.diagnostics-otel.trace-headers");
+
+function isOpenAICompatibleApi(api: unknown): boolean {
+  return (
+    api === "openai-completions" ||
+    api === "openai-responses" ||
+    api === "azure-openai-responses" ||
+    api === "openai-codex-responses"
+  );
+}
+
+function resolveTraceHeaders(sessionKey?: string): TraceHeaders | undefined {
+  if (!sessionKey) {
+    return undefined;
+  }
+  const globalStore = globalThis as {
+    [TRACE_CONTEXT_REGISTRY_KEY]?: Map<string, TraceHeaders>;
+  };
+  return globalStore[TRACE_CONTEXT_REGISTRY_KEY]?.get(sessionKey);
+}
+
+export function createTraceContextHeadersWrapper(
+  baseStreamFn: StreamFn | undefined,
+  sessionKey?: string,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (!isOpenAICompatibleApi(model?.api)) {
+      return underlying(model, context, options);
+    }
+    const traceHeaders = resolveTraceHeaders(sessionKey);
+    if (!traceHeaders) {
+      return underlying(model, context, options);
+    }
+    return underlying(model, context, {
+      ...options,
+      headers: {
+        ...traceHeaders,
+        ...options?.headers,
+      },
+    });
+  };
+}

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -53,6 +53,10 @@ export type EmbeddedPiRunMeta = {
     name: string;
     arguments: string;
   }>;
+  /** The full system prompt text sent to the model. */
+  systemPromptText?: string;
+  /** Time-to-first-token in milliseconds (relative to run start). */
+  firstTokenMs?: number;
 };
 
 export type EmbeddedPiRunResult = {

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -1,4 +1,5 @@
-import { emitAgentEvent } from "../infra/agent-events.js";
+import { emitAgentEvent, getAgentRunContext } from "../infra/agent-events.js";
+import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import {
   buildApiErrorObservationFields,
@@ -20,6 +21,19 @@ export {
 
 export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.log.debug(`embedded run agent start: runId=${ctx.params.runId}`);
+  const runContext = getAgentRunContext(ctx.params.runId);
+  if (!runContext?.sessionKey) {
+    ctx.log.debug(
+      `embedded run agent start: no sessionKey from runContext for runId=${ctx.params.runId}`,
+    );
+  }
+  emitDiagnosticEvent({
+    type: "run.started",
+    runId: ctx.params.runId,
+    sessionId: (ctx.params.session as { id?: string }).id,
+    sessionKey: runContext?.sessionKey,
+    channel: ctx.params.channel,
+  });
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "lifecycle",

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -3,16 +3,19 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import {
+  emitDiagnosticEvent,
+  type GenAiMessage,
+  type GenAiPart,
+} from "../infra/diagnostic-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
 } from "./pi-embedded-helpers.js";
 import type { BlockReplyPayload } from "./pi-embedded-payloads.js";
-import type {
-  EmbeddedPiSubscribeContext,
-  EmbeddedPiSubscribeState,
-} from "./pi-embedded-subscribe.handlers.types.js";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+import type { EmbeddedPiSubscribeState } from "./pi-embedded-subscribe.handlers.types.js";
 import { appendRawStream } from "./pi-embedded-subscribe.raw-stream.js";
 import {
   extractAssistantText,
@@ -22,6 +25,7 @@ import {
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
+import { derivePromptTokens, normalizeUsage } from "./usage.js";
 
 const stripTrailingDirective = (text: string): string => {
   const openIndex = text.lastIndexOf("[[");
@@ -163,6 +167,45 @@ export function buildAssistantStreamData(params: {
     mediaUrls: mediaUrls.length ? mediaUrls : undefined,
   };
 }
+const buildAssistantParts = (content: unknown): GenAiPart[] => {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const parts: GenAiPart[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as Record<string, unknown>;
+    if (record.type === "text" && typeof record.text === "string") {
+      parts.push({ type: "text", content: record.text });
+      continue;
+    }
+    if (record.type === "thinking" && typeof record.thinking === "string") {
+      parts.push({ type: "reasoning", content: record.thinking });
+      continue;
+    }
+    if (record.type === "toolCall") {
+      const id = typeof record.id === "string" ? record.id : "";
+      const name = typeof record.name === "string" ? record.name : "";
+      const args =
+        record.arguments && typeof record.arguments === "object" && !Array.isArray(record.arguments)
+          ? (record.arguments as Record<string, unknown>)
+          : undefined;
+      parts.push({ type: "tool_call", id, name, ...(args ? { arguments: args } : {}) });
+      continue;
+    }
+    if (record.type === "image" && typeof record.data === "string") {
+      parts.push({
+        type: "blob",
+        modality: "image",
+        mime_type: typeof record.mimeType === "string" ? record.mimeType : undefined,
+        content: record.data,
+      });
+    }
+  }
+  return parts;
+};
 
 export function handleMessageStart(
   ctx: EmbeddedPiSubscribeContext,
@@ -179,6 +222,8 @@ export function handleMessageStart(
   // may deliver late text_end updates after message_end, which would otherwise
   // re-trigger block replies.
   ctx.resetAssistantMessageState(ctx.state.assistantTexts.length);
+  ctx.state.currentMessageStartAt = Date.now();
+  ctx.state.currentMessageFirstTokenAt = undefined;
   // Use assistant message_start as the earliest "writing" signal for typing.
   void ctx.params.onAssistantMessageStart?.();
 }
@@ -271,6 +316,8 @@ export function handleMessageUpdate(
   }
 
   if (chunk) {
+    ctx.state.firstTokenAt ??= Date.now();
+    ctx.state.currentMessageFirstTokenAt ??= Date.now();
     ctx.state.deltaBuffer += chunk;
     if (ctx.blockChunker) {
       ctx.blockChunker.append(chunk);
@@ -567,4 +614,77 @@ export function handleMessageEnd(
   ctx.state.lastStreamedAssistant = undefined;
   ctx.state.lastStreamedAssistantCleaned = undefined;
   ctx.state.reasoningStreamOpen = false;
+
+  const messageStartAt = ctx.state.currentMessageStartAt;
+  const durationMs =
+    typeof messageStartAt === "number" ? Math.max(0, Date.now() - messageStartAt) : undefined;
+  const ttftMs =
+    typeof messageStartAt === "number" && typeof ctx.state.currentMessageFirstTokenAt === "number"
+      ? Math.max(0, ctx.state.currentMessageFirstTokenAt - messageStartAt)
+      : undefined;
+
+  const usage = normalizeUsage({
+    input: (assistantMessage as { usage?: { input?: number } }).usage?.input,
+    output: (assistantMessage as { usage?: { output?: number } }).usage?.output,
+    cacheRead: (assistantMessage as { usage?: { cacheRead?: number } }).usage?.cacheRead,
+    cacheWrite: (assistantMessage as { usage?: { cacheWrite?: number } }).usage?.cacheWrite,
+    total: (assistantMessage as { usage?: { totalTokens?: number } }).usage?.totalTokens,
+  });
+  const promptTokens = derivePromptTokens(usage);
+  const totalTokens =
+    usage?.total ??
+    (typeof promptTokens === "number" && typeof usage?.output === "number"
+      ? promptTokens + usage.output
+      : undefined);
+  const stopReason = (assistantMessage as { stopReason?: string }).stopReason;
+  const finishReasons = stopReason
+    ? [stopReason === "toolUse" ? "tool_call" : stopReason]
+    : undefined;
+  const error =
+    stopReason === "error" || stopReason === "aborted"
+      ? ((assistantMessage as { errorMessage?: string }).errorMessage ?? "LLM request failed.")
+      : undefined;
+
+  // Content capture is intentionally opt-in and controlled by diagnostics.otel.captureContent.
+  // When disabled, we still emit timings/usage/errors but omit message content fields.
+  const outputParts =
+    ctx.params.captureContent === true
+      ? buildAssistantParts((assistantMessage as { content?: unknown }).content)
+      : [];
+  const outputMessages: GenAiMessage[] =
+    ctx.params.captureContent === true && outputParts.length
+      ? [
+          {
+            role: "assistant",
+            parts: outputParts,
+            ...(finishReasons?.length ? { finish_reason: finishReasons[0] } : {}),
+          },
+        ]
+      : [];
+
+  emitDiagnosticEvent({
+    type: "model.inference",
+    runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
+    sessionId: ctx.params.sessionId ?? (ctx.params.session as { id?: string }).id,
+    channel: ctx.params.channel,
+    usage: {
+      input: usage?.input,
+      output: usage?.output,
+      cacheRead: usage?.cacheRead,
+      cacheWrite: usage?.cacheWrite,
+      promptTokens,
+      total: totalTokens,
+    },
+    provider: (assistantMessage as { provider?: string }).provider,
+    model: (assistantMessage as { model?: string }).model,
+    operationName: "chat",
+    durationMs,
+    ttftMs,
+    finishReasons,
+    outputMessages: outputMessages.length > 0 ? outputMessages : undefined,
+    error,
+    errorType: error ? stopReason : undefined,
+    callIndex: ctx.state.assistantMessageIndex,
+  });
 }

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -36,6 +36,8 @@ function createTestContext(): {
     state: {
       toolMetaById: new Map<string, ToolCallSummary>(),
       toolMetas: [],
+      toolStartTimeById: new Map<string, number>(),
+      toolArgsById: new Map<string, Record<string, unknown> | undefined>(),
       toolSummaryById: new Set<string>(),
       pendingMessagingTargets: new Map<string, MessagingToolSend>(),
       pendingMessagingTexts: new Map<string, string>(),

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1,5 +1,6 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import {
   buildExecApprovalPendingReplyPayload,
   buildExecApprovalUnavailableReplyPayload,
@@ -364,6 +365,11 @@ export async function handleToolExecutionStart(
 
   const meta = extendExecMeta(toolName, args, inferToolMetaFromArgs(toolName, args));
   ctx.state.toolMetaById.set(toolCallId, buildToolCallSummary(toolName, args, meta));
+  ctx.state.toolStartTimeById.set(toolCallId, Date.now());
+  ctx.state.toolArgsById.set(
+    toolCallId,
+    args && typeof args === "object" ? (args as Record<string, unknown>) : undefined,
+  );
   ctx.log.debug(
     `embedded run tool start: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
@@ -570,6 +576,26 @@ export async function handleToolExecutionEnd(
       meta,
       isError: isToolError,
     },
+  });
+
+  // Emit OTel diagnostic event for tool execution
+  const startTime = ctx.state.toolStartTimeById.get(toolCallId);
+  ctx.state.toolStartTimeById.delete(toolCallId);
+  const toolInput = ctx.state.toolArgsById.get(toolCallId);
+  ctx.state.toolArgsById.delete(toolCallId);
+  emitDiagnosticEvent({
+    type: "tool.execution",
+    runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
+    sessionId: ctx.params.sessionId,
+    channel: ctx.params.channel,
+    toolName,
+    toolType: "function",
+    toolCallId,
+    durationMs: typeof startTime === "number" ? Date.now() - startTime : undefined,
+    error: isToolError ? extractToolErrorMessage(sanitizedResult) : undefined,
+    toolInput,
+    toolOutput: sanitizedResult,
   });
 
   ctx.log.debug(

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -35,6 +35,8 @@ export type EmbeddedPiSubscribeState = {
   assistantTexts: string[];
   toolMetas: Array<{ toolName?: string; meta?: string }>;
   toolMetaById: Map<string, ToolCallSummary>;
+  toolStartTimeById: Map<string, number>;
+  toolArgsById: Map<string, Record<string, unknown> | undefined>;
   toolSummaryById: Set<string>;
   lastToolError?: ToolErrorSummary;
 
@@ -81,6 +83,12 @@ export type EmbeddedPiSubscribeState = {
   pendingToolAudioAsVoice: boolean;
   deterministicApprovalPromptSent: boolean;
   lastAssistant?: AgentMessage;
+  /** Timestamp (ms) when the first token arrived from the model. */
+  firstTokenAt?: number;
+  /** Timestamp (ms) when the current assistant message started. */
+  currentMessageStartAt?: number;
+  /** Timestamp (ms) when the first token arrived for the current message. */
+  currentMessageFirstTokenAt?: number;
 };
 
 export type EmbeddedPiSubscribeContext = {
@@ -138,6 +146,7 @@ export type EmbeddedPiSubscribeContext = {
 export type ToolHandlerParams = Pick<
   SubscribeEmbeddedPiSessionParams,
   | "runId"
+  | "channel"
   | "onBlockReplyFlush"
   | "onAgentEvent"
   | "onToolResult"
@@ -150,6 +159,8 @@ export type ToolHandlerState = Pick<
   EmbeddedPiSubscribeState,
   | "toolMetaById"
   | "toolMetas"
+  | "toolStartTimeById"
+  | "toolArgsById"
   | "toolSummaryById"
   | "lastToolError"
   | "pendingMessagingTargets"

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-diagnostic-sessionkey.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-diagnostic-sessionkey.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import { clearAgentRunContext, registerAgentRunContext } from "../infra/agent-events.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+
+type StubSession = {
+  subscribe: (fn: (evt: unknown) => void) => () => void;
+};
+
+type SessionEventHandler = (evt: unknown) => void;
+
+describe("subscribeEmbeddedPiSession – sessionKey propagation", () => {
+  it("includes sessionKey on model.inference when run context is registered", () => {
+    resetDiagnosticEventsForTest();
+
+    const runId = "run-sk-inference";
+    registerAgentRunContext(runId, { sessionKey: "agent:main:sub:abc" });
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId,
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "hi" }],
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      usage: { input: 5, output: 3, totalTokens: 8 },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    handler?.({ type: "message_start", message: assistantMessage });
+    handler?.({ type: "message_end", message: assistantMessage });
+
+    unsub();
+    clearAgentRunContext(runId);
+
+    const evt = events.find((e) => e.type === "model.inference");
+    expect(evt).toBeDefined();
+    expect(evt?.sessionKey).toBe("agent:main:sub:abc");
+    expect(evt?.runId).toBe(runId);
+  });
+
+  it("omits sessionKey on model.inference when no run context exists", () => {
+    resetDiagnosticEventsForTest();
+
+    const runId = "run-sk-no-ctx";
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId,
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "hi" }],
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      usage: { input: 5, output: 3, totalTokens: 8 },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    handler?.({ type: "message_start", message: assistantMessage });
+    handler?.({ type: "message_end", message: assistantMessage });
+
+    unsub();
+
+    const evt = events.find((e) => e.type === "model.inference");
+    expect(evt).toBeDefined();
+    expect(evt?.sessionKey).toBeUndefined();
+  });
+
+  it("includes sessionKey on tool.execution when run context is registered", () => {
+    resetDiagnosticEventsForTest();
+
+    const runId = "run-sk-tool";
+    registerAgentRunContext(runId, { sessionKey: "agent:main:sub:def" });
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId,
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "web_search",
+      toolCallId: "call-sk-1",
+      args: { query: "test" },
+    });
+
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "web_search",
+      toolCallId: "call-sk-1",
+      isError: false,
+      result: { output: "results" },
+    });
+
+    unsub();
+    clearAgentRunContext(runId);
+
+    const evt = events.find((e) => e.type === "tool.execution");
+    expect(evt).toBeDefined();
+    expect(evt?.sessionKey).toBe("agent:main:sub:def");
+    expect(evt?.runId).toBe(runId);
+  });
+
+  it("omits sessionKey on tool.execution when no run context exists", () => {
+    resetDiagnosticEventsForTest();
+
+    const runId = "run-sk-tool-no-ctx";
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId,
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "call-sk-2",
+      args: { path: "/tmp/test" },
+    });
+
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "read",
+      toolCallId: "call-sk-2",
+      isError: false,
+      result: "contents",
+    });
+
+    unsub();
+
+    const evt = events.find((e) => e.type === "tool.execution");
+    expect(evt).toBeDefined();
+    expect(evt?.sessionKey).toBeUndefined();
+  });
+
+  it("run.started includes sessionKey from run context", () => {
+    resetDiagnosticEventsForTest();
+
+    const runId = "run-sk-started";
+    registerAgentRunContext(runId, { sessionKey: "agent:main:sub:ghi" });
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId,
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    handler?.({ type: "agent_start" });
+
+    unsub();
+    clearAgentRunContext(runId);
+
+    const evt = events.find((e) => e.type === "run.started");
+    expect(evt).toBeDefined();
+    expect(evt?.sessionKey).toBe("agent:main:sub:ghi");
+  });
+});

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-diagnostic-tool-execution-events.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-diagnostic-tool-execution-events.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+
+type StubSession = {
+  subscribe: (fn: (evt: unknown) => void) => () => void;
+};
+
+type SessionEventHandler = (evt: unknown) => void;
+
+describe("subscribeEmbeddedPiSession", () => {
+  it("emits tool.execution diagnostic event on tool_execution_end", () => {
+    resetDiagnosticEventsForTest();
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-diag-tool",
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "web_search",
+      toolCallId: "call-diag-1",
+      args: { query: "test" },
+    });
+
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "web_search",
+      toolCallId: "call-diag-1",
+      isError: false,
+      result: { output: "search results" },
+    });
+
+    unsub();
+
+    const toolEvents = events.filter((e) => e.type === "tool.execution");
+    expect(toolEvents).toHaveLength(1);
+
+    const evt = toolEvents[0];
+    expect(evt.runId).toBe("run-diag-tool");
+    expect(evt.toolName).toBe("web_search");
+    expect(evt.toolCallId).toBe("call-diag-1");
+    expect(evt.toolType).toBe("function");
+    expect(evt.durationMs).toBeTypeOf("number");
+    expect(evt.durationMs).toBeGreaterThanOrEqual(0);
+    expect(evt.error).toBeUndefined();
+  });
+
+  it("emits tool.execution with error when tool fails", () => {
+    resetDiagnosticEventsForTest();
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-diag-tool-err",
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "exec",
+      toolCallId: "call-diag-err",
+      args: { command: "failing-cmd" },
+    });
+
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "exec",
+      toolCallId: "call-diag-err",
+      isError: true,
+      result: { details: { error: "command not found" } },
+    });
+
+    unsub();
+
+    const toolEvents = events.filter((e) => e.type === "tool.execution");
+    expect(toolEvents).toHaveLength(1);
+
+    const evt = toolEvents[0];
+    expect(evt.runId).toBe("run-diag-tool-err");
+    expect(evt.toolName).toBe("exec");
+    expect(evt.error).toBe("command not found");
+  });
+
+  it("records durationMs from tool start to end", () => {
+    resetDiagnosticEventsForTest();
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-diag-timing",
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    vi.useFakeTimers();
+    try {
+      handler?.({
+        type: "tool_execution_start",
+        toolName: "read",
+        toolCallId: "call-timing",
+        args: { path: "/tmp/test" },
+      });
+
+      vi.advanceTimersByTime(150);
+
+      handler?.({
+        type: "tool_execution_end",
+        toolName: "read",
+        toolCallId: "call-timing",
+        isError: false,
+        result: "file contents",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    unsub();
+
+    const evt = events.find((e) => e.type === "tool.execution");
+    expect(evt).toBeDefined();
+    if (!evt) {
+      throw new Error("Expected tool.execution event");
+    }
+    expect(evt.durationMs).toBe(150);
+  });
+
+  it("emits run.started diagnostic event on agent_start", () => {
+    resetDiagnosticEventsForTest();
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-diag-start",
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    handler?.({ type: "agent_start" });
+
+    unsub();
+
+    const evt = events.find((e) => e.type === "run.started");
+    expect(evt?.runId).toBe("run-diag-start");
+  });
+
+  it("emits model.inference with usage and timings", () => {
+    resetDiagnosticEventsForTest();
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-diag-infer",
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      api: "openai",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {
+        input: 10,
+        output: 5,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 15,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    vi.useFakeTimers();
+    try {
+      handler?.({ type: "message_start", message: assistantMessage });
+      vi.advanceTimersByTime(50);
+      handler?.({
+        type: "message_update",
+        message: assistantMessage,
+        assistantMessageEvent: {
+          type: "text_delta",
+          delta: "hello",
+          contentIndex: 0,
+          partial: assistantMessage,
+        },
+      });
+      vi.advanceTimersByTime(150);
+      handler?.({ type: "message_end", message: assistantMessage });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    unsub();
+
+    const evt = events.find((e) => e.type === "model.inference");
+    expect(evt?.runId).toBe("run-diag-infer");
+    expect(evt?.usage?.input).toBe(10);
+    expect(evt?.usage?.output).toBe(5);
+    expect(evt?.durationMs).toBe(200);
+    expect(evt?.ttftMs).toBe(50);
+  });
+});

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -42,6 +42,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     assistantTexts: [],
     toolMetas: [],
     toolMetaById: new Map(),
+    toolStartTimeById: new Map(),
+    toolArgsById: new Map(),
     toolSummaryById: new Set(),
     lastToolError: undefined,
     blockReplyBreak: params.blockReplyBreak ?? "text_end",
@@ -84,6 +86,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     pendingToolMediaUrls: [],
     pendingToolAudioAsVoice: false,
     deterministicApprovalPromptSent: false,
+    firstTokenAt: undefined,
+    currentMessageStartAt: undefined,
+    currentMessageFirstTokenAt: undefined,
   };
   const usageTotals = {
     input: 0,
@@ -608,6 +613,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     assistantTexts.length = 0;
     toolMetas.length = 0;
     toolMetaById.clear();
+    state.toolStartTimeById.clear();
+    state.toolArgsById.clear();
     toolSummaryById.clear();
     state.lastToolError = undefined;
     messagingToolSentTexts.length = 0;
@@ -621,6 +628,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.pendingToolMediaUrls = [];
     state.pendingToolAudioAsVoice = false;
     state.deterministicApprovalPromptSent = false;
+    state.firstTokenAt = undefined;
     resetAssistantMessageState(0);
   };
 
@@ -704,6 +712,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     unsubscribe,
     isCompacting: () => state.compactionInFlight || state.pendingCompactionRetry > 0,
     isCompactionInFlight: () => state.compactionInFlight,
+    getFirstTokenAt: () => state.firstTokenAt,
     getMessagingToolSentTexts: () => messagingToolSentTexts.slice(),
     getMessagingToolSentMediaUrls: () => messagingToolSentMediaUrls.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -11,6 +11,12 @@ export type ToolResultFormat = "markdown" | "plain";
 export type SubscribeEmbeddedPiSessionParams = {
   session: AgentSession;
   runId: string;
+  channel?: string;
+  /**
+   * When true, diagnostic events may include message content.
+   * This is intentionally opt-in and typically controlled by `diagnostics.otel.captureContent`.
+   */
+  captureContent?: boolean;
   hookRunner?: HookRunner;
   verboseLevel?: VerboseLevel;
   reasoningMode?: ReasoningLevel;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -85,7 +85,12 @@ export type AgentRunLoopResult =
       /** Payload keys sent directly (not via pipeline) during tool flush. */
       directlySentBlockKeys?: Set<string>;
     }
-  | { kind: "final"; payload: ReplyPayload };
+  | {
+      kind: "final";
+      runId: string;
+      payload: ReplyPayload;
+      errorInfo?: { message: string; errorType: string };
+    };
 
 /**
  * Build a human-friendly rate-limit message from a FallbackSummaryError.
@@ -602,9 +607,11 @@ export async function runAgentTurnWithFallback(params: {
         didResetAfterCompactionFailure = true;
         return {
           kind: "final",
+          runId,
           payload: {
             text: "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
           },
+          errorInfo: { message: embeddedError.message, errorType: "context_overflow" },
         };
       }
       if (embeddedError?.kind === "role_ordering") {
@@ -612,9 +619,11 @@ export async function runAgentTurnWithFallback(params: {
         if (didReset) {
           return {
             kind: "final",
+            runId,
             payload: {
               text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
             },
+            errorInfo: { message: embeddedError.message, errorType: "role_ordering" },
           };
         }
       }
@@ -641,8 +650,13 @@ export async function runAgentTurnWithFallback(params: {
               "The requested model may be temporarily unavailable. Please try again shortly.";
           return {
             kind: "final",
+            runId,
             payload: {
               text: switchErrorText,
+            },
+            errorInfo: {
+              message: "model switch could not be completed",
+              errorType: "model_switch_failed",
             },
           };
         }
@@ -672,9 +686,11 @@ export async function runAgentTurnWithFallback(params: {
         didResetAfterCompactionFailure = true;
         return {
           kind: "final",
+          runId,
           payload: {
             text: "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
           },
+          errorInfo: { message, errorType: "compaction_failure" },
         };
       }
       if (isRoleOrderingError) {
@@ -682,9 +698,11 @@ export async function runAgentTurnWithFallback(params: {
         if (didReset) {
           return {
             kind: "final",
+            runId,
             payload: {
               text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
             },
+            errorInfo: { message, errorType: "role_ordering" },
           };
         }
       }
@@ -728,9 +746,11 @@ export async function runAgentTurnWithFallback(params: {
 
         return {
           kind: "final",
+          runId,
           payload: {
             text: "⚠️ Session history was corrupted. I've reset the conversation - please try again!",
           },
+          errorInfo: { message, errorType: "session_corruption" },
         };
       }
 
@@ -773,8 +793,17 @@ export async function runAgentTurnWithFallback(params: {
 
       return {
         kind: "final",
+        runId,
         payload: {
           text: fallbackText,
+        },
+        errorInfo: {
+          message,
+          errorType: isContextOverflow
+            ? "context_overflow"
+            : isRoleOrderingError
+              ? "role_ordering"
+              : "unknown",
         },
       };
     }
@@ -792,6 +821,7 @@ export async function runAgentTurnWithFallback(params: {
     if (isContextOverflowError(errorMsg)) {
       return {
         kind: "final",
+        runId,
         payload: {
           text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
         },

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -3,8 +3,9 @@ import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
+import { resolveExtraParams } from "../../agents/pi-embedded-runner/extra-params.js";
 import { queueEmbeddedPiMessage } from "../../agents/pi-embedded.js";
-import { hasNonzeroUsage } from "../../agents/usage.js";
+import { derivePromptTokens, hasNonzeroUsage } from "../../agents/usage.js";
 import {
   resolveAgentIdFromSessionKey,
   resolveSessionFilePath,
@@ -16,7 +17,11 @@ import {
 } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
-import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import {
+  emitDiagnosticEvent,
+  isDiagnosticsEnabled,
+  type GenAiMessage,
+} from "../../infra/diagnostic-events.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -426,6 +431,22 @@ export async function runReplyAgent(params: {
     });
 
     if (runOutcome.kind === "final") {
+      if (isDiagnosticsEnabled(cfg) && runOutcome.errorInfo) {
+        emitDiagnosticEvent({
+          type: "run.completed",
+          runId: runOutcome.runId,
+          sessionKey,
+          sessionId: followupRun.run.sessionId,
+          channel: replyToChannel,
+          provider: followupRun.run.provider,
+          model: defaultModel,
+          usage: {},
+          durationMs: Date.now() - runStartedAt,
+          operationName: "chat",
+          error: runOutcome.errorInfo.message,
+          errorType: runOutcome.errorInfo.errorType,
+        });
+      }
       return finalizeWithFollowup(runOutcome.payload, queueKey, runFollowupTurn);
     }
 
@@ -513,6 +534,11 @@ export async function runReplyAgent(params: {
         });
       }
     }
+    const resolvedModelParams = resolveExtraParams({
+      cfg,
+      provider: providerUsed,
+      modelId: modelUsed,
+    });
     const cliSessionId = isCliProvider(providerUsed, cfg)
       ? runResult.meta?.agentMeta?.sessionId?.trim()
       : undefined;
@@ -540,6 +566,103 @@ export async function runReplyAgent(params: {
       cliSessionBinding,
       usageIsContextSnapshot: isCliProvider(providerUsed, cfg),
     });
+
+    if (isDiagnosticsEnabled(cfg)) {
+      const captureContent = !!cfg?.diagnostics?.otel?.captureContent;
+      const input = usage?.input;
+      const output = usage?.output;
+      const cacheRead = usage?.cacheRead;
+      const cacheWrite = usage?.cacheWrite;
+      const promptTokens = derivePromptTokens(usage);
+      const totalTokens =
+        usage?.total ??
+        (typeof promptTokens === "number" && typeof output === "number"
+          ? promptTokens + output
+          : undefined);
+      const costConfig = resolveModelCostConfig({
+        provider: providerUsed,
+        model: modelUsed,
+        config: cfg,
+      });
+      const costUsd = hasNonzeroUsage(usage)
+        ? estimateUsageCost({ usage, cost: costConfig })
+        : undefined;
+      // Map stopReason to GenAI finish_reasons
+      const stopReason = runResult.meta.stopReason;
+      const finishReasons = stopReason
+        ? [stopReason === "tool_calls" ? "tool_call" : stopReason]
+        : ["stop"];
+
+      // Content capture is intentionally opt-in and controlled by diagnostics.otel.captureContent.
+      // When disabled, we still emit aggregate usage/timings/errors but omit message content fields.
+      const inputMessages: GenAiMessage[] = captureContent
+        ? [{ role: "user", parts: [{ type: "text", content: commandBody }] }]
+        : [];
+      const outputParts = captureContent
+        ? payloadArray.map((p) => p.text?.trim()).filter((t): t is string => Boolean(t))
+        : [];
+      const pendingCalls = captureContent ? runResult.meta.pendingToolCalls : undefined;
+      const outputMessages: GenAiMessage[] = [];
+      if (captureContent && (outputParts.length > 0 || pendingCalls?.length)) {
+        const msg: GenAiMessage = {
+          role: "assistant",
+          parts: [
+            ...outputParts.map((t) => ({ type: "text" as const, content: t })),
+            ...(pendingCalls?.map((tc) => ({
+              type: "tool_call" as const,
+              id: tc.id,
+              name: tc.name,
+              arguments: (() => {
+                try {
+                  return JSON.parse(tc.arguments) as Record<string, unknown>;
+                } catch {
+                  return { raw: tc.arguments };
+                }
+              })(),
+            })) ?? []),
+          ],
+          finish_reason: finishReasons[0],
+        };
+        outputMessages.push(msg);
+      }
+
+      emitDiagnosticEvent({
+        type: "run.completed",
+        runId,
+        sessionKey,
+        sessionId: followupRun.run.sessionId,
+        channel: replyToChannel,
+        provider: providerUsed,
+        model: modelUsed,
+        usage: {
+          input,
+          output,
+          cacheRead,
+          cacheWrite,
+          promptTokens,
+          total: totalTokens,
+        },
+        context: {
+          limit: contextTokensUsed,
+          used: totalTokens,
+        },
+        costUsd,
+        durationMs: Date.now() - runStartedAt,
+        operationName: "chat",
+        finishReasons,
+        responseModel: runResult.meta.agentMeta?.model,
+        inputMessages: inputMessages.length > 0 ? inputMessages : undefined,
+        outputMessages: outputMessages.length > 0 ? outputMessages : undefined,
+        temperature:
+          typeof resolvedModelParams?.temperature === "number"
+            ? resolvedModelParams.temperature
+            : undefined,
+        maxOutputTokens:
+          typeof resolvedModelParams?.maxTokens === "number"
+            ? resolvedModelParams.maxTokens
+            : undefined,
+      });
+    }
 
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
@@ -600,44 +723,6 @@ export async function runReplyAgent(params: {
         : replyPayloads;
 
     await signalTypingIfNeeded(guardedReplyPayloads, typingSignals);
-
-    if (isDiagnosticsEnabled(cfg) && hasNonzeroUsage(usage)) {
-      const input = usage.input ?? 0;
-      const output = usage.output ?? 0;
-      const cacheRead = usage.cacheRead ?? 0;
-      const cacheWrite = usage.cacheWrite ?? 0;
-      const promptTokens = input + cacheRead + cacheWrite;
-      const totalTokens = usage.total ?? promptTokens + output;
-      const costConfig = resolveModelCostConfig({
-        provider: providerUsed,
-        model: modelUsed,
-        config: cfg,
-      });
-      const costUsd = estimateUsageCost({ usage, cost: costConfig });
-      emitDiagnosticEvent({
-        type: "model.usage",
-        sessionKey,
-        sessionId: followupRun.run.sessionId,
-        channel: replyToChannel,
-        provider: providerUsed,
-        model: modelUsed,
-        usage: {
-          input,
-          output,
-          cacheRead,
-          cacheWrite,
-          promptTokens,
-          total: totalTokens,
-        },
-        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
-        context: {
-          limit: contextTokensUsed,
-          used: totalTokens,
-        },
-        costUsd,
-        durationMs: Date.now() - runStartedAt,
-      });
-    }
 
     const responseUsageRaw =
       activeSessionEntry?.responseUsage ??

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -10,12 +10,16 @@ import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
+import { derivePromptTokens, hasNonzeroUsage } from "../../agents/usage.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
+import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { logMessageQueued, logMessageProcessed } from "../../logging/diagnostic.js";
 import { defaultRuntime } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import type { OriginatingChannelType } from "../templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
@@ -27,7 +31,8 @@ import {
   resolveOriginMessageProvider,
   resolveOriginMessageTo,
 } from "./origin-routing.js";
-import { refreshQueuedFollowupSession, type FollowupRun } from "./queue.js";
+import type { FollowupRun } from "./queue.js";
+import { refreshQueuedFollowupSession } from "./queue.js";
 import {
   applyReplyThreading,
   filterMessagingToolDuplicates,
@@ -135,6 +140,21 @@ export function createFollowupRunner(params: {
   };
 
   return async (queued: FollowupRun) => {
+    const diagnosticsEnabled = isDiagnosticsEnabled(queued.run.config);
+    const channel = queued.originatingChannel ?? queued.run.messageProvider?.toLowerCase();
+    const runStartedAt = diagnosticsEnabled ? Date.now() : 0;
+    let outcome: "completed" | "error" = "completed";
+    let outcomeError: string | undefined;
+
+    // Create root trace span so child spans (agent turn, inference, tools) nest under it.
+    if (diagnosticsEnabled && queued.run.sessionKey) {
+      logMessageQueued({
+        sessionKey: queued.run.sessionKey,
+        channel,
+        source: "followup",
+      });
+    }
+
     try {
       const runId = crypto.randomUUID();
       const shouldSurfaceToControlUi = isInternalMessageChannel(
@@ -269,6 +289,24 @@ export function createFollowupRunner(params: {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         defaultRuntime.error?.(`Followup agent failed before reply: ${message}`);
+        outcome = "error";
+        outcomeError = message;
+        if (diagnosticsEnabled) {
+          emitDiagnosticEvent({
+            type: "run.completed",
+            runId,
+            sessionKey: queued.run.sessionKey,
+            sessionId: queued.run.sessionId,
+            channel,
+            provider: queued.run.provider,
+            model: queued.run.model,
+            usage: {},
+            durationMs: Date.now() - runStartedAt,
+            operationName: "chat",
+            error: message,
+            errorType: err instanceof Error ? err.constructor.name : "UnknownError",
+          });
+        }
         return;
       }
 
@@ -299,6 +337,54 @@ export function createFollowupRunner(params: {
             queued.run.config,
           ),
           logLabel: "followup",
+        });
+      }
+
+      // Emit run.completed so the agent turn span is properly ended with usage data.
+      if (diagnosticsEnabled) {
+        const input = usage?.input;
+        const output = usage?.output;
+        const cacheRead = usage?.cacheRead;
+        const cacheWrite = usage?.cacheWrite;
+        const promptTokens = derivePromptTokens(usage);
+        const totalTokens =
+          usage?.total ??
+          (typeof promptTokens === "number" && typeof output === "number"
+            ? promptTokens + output
+            : undefined);
+        const costConfig = resolveModelCostConfig({
+          provider: fallbackProvider,
+          model: modelUsed,
+          config: queued.run.config,
+        });
+        const costUsd = hasNonzeroUsage(usage)
+          ? estimateUsageCost({ usage, cost: costConfig })
+          : undefined;
+
+        emitDiagnosticEvent({
+          type: "run.completed",
+          runId,
+          sessionKey: queued.run.sessionKey,
+          sessionId: queued.run.sessionId,
+          channel,
+          provider: fallbackProvider,
+          model: modelUsed,
+          usage: {
+            input,
+            output,
+            cacheRead,
+            cacheWrite,
+            promptTokens,
+            total: totalTokens,
+          },
+          context: {
+            limit: contextTokensUsed,
+            used: totalTokens,
+          },
+          costUsd,
+          durationMs: Date.now() - runStartedAt,
+          operationName: "chat",
+          responseModel: runResult.meta.agentMeta?.model,
         });
       }
 
@@ -407,6 +493,18 @@ export function createFollowupRunner(params: {
       // indefinitely until the TTL expires).
       typing.markRunComplete();
       typing.markDispatchIdle();
+
+      // End the root trace span created by logMessageQueued.
+      if (diagnosticsEnabled && queued.run.sessionKey) {
+        logMessageProcessed({
+          channel: channel ?? "unknown",
+          sessionKey: queued.run.sessionKey,
+          sessionId: queued.run.sessionId,
+          durationMs: Date.now() - runStartedAt,
+          outcome,
+          error: outcomeError,
+        });
+      }
     }
   };
 }

--- a/src/commands/agent.diagnostics.test.ts
+++ b/src/commands/agent.diagnostics.test.ts
@@ -1,0 +1,270 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import type { OpenClawConfig } from "../config/config.js";
+import * as configModule from "../config/config.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { agentCommand } from "./agent.js";
+
+const runtime: RuntimeEnv = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(() => {
+    throw new Error("exit");
+  }),
+};
+
+const configSpy = vi.spyOn(configModule, "loadConfig");
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(fn, { prefix: "openclaw-agent-diag-" });
+}
+
+function mockConfig(
+  home: string,
+  storePath: string,
+  overrides?: {
+    diagnostics?: boolean;
+    agentOverrides?: Partial<NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>>;
+  },
+) {
+  configSpy.mockReturnValue({
+    agents: {
+      defaults: {
+        model: { primary: "anthropic/claude-opus-4-5" },
+        models: { "anthropic/claude-opus-4-5": {} },
+        workspace: path.join(home, "openclaw"),
+        ...overrides?.agentOverrides,
+      },
+    },
+    session: { store: storePath, mainKey: "main" },
+    diagnostics: overrides?.diagnostics ? { enabled: true } : undefined,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetDiagnosticEventsForTest();
+  vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+    payloads: [{ text: "ok" }],
+    meta: {
+      durationMs: 5,
+      agentMeta: {
+        sessionId: "s",
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        usage: { input: 10, output: 5, cacheRead: 2, cacheWrite: 1, total: 18 },
+      },
+    },
+  });
+  vi.mocked(loadModelCatalog).mockResolvedValue([]);
+});
+
+describe("agentCommand – diagnostic events", () => {
+  it("emits message.queued when diagnostics are enabled", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await agentCommand({ message: "hello", to: "+1555" }, runtime);
+      unsub();
+
+      const queued = events.filter((e) => e.type === "message.queued");
+      expect(queued).toHaveLength(1);
+      expect(queued[0].source).toBe("agent-command");
+      expect(queued[0].sessionKey).toBeTruthy();
+      expect(queued[0].sessionId).toBeTruthy();
+    });
+  });
+
+  it("emits run.completed on successful run", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await agentCommand({ message: "hello", to: "+1555" }, runtime);
+      unsub();
+
+      const completed = events.filter((e) => e.type === "run.completed");
+      expect(completed).toHaveLength(1);
+
+      const evt = completed[0];
+      expect(evt.runId).toBeTruthy();
+      expect(evt.sessionKey).toBeTruthy();
+      expect(evt.provider).toBe("anthropic");
+      expect(evt.model).toBe("claude-opus-4-5");
+      expect(evt.operationName).toBe("chat");
+      expect(evt.durationMs).toBeTypeOf("number");
+      expect(evt.durationMs).toBeGreaterThanOrEqual(0);
+      expect(evt.usage).toEqual(
+        expect.objectContaining({
+          input: 10,
+          output: 5,
+          cacheRead: 2,
+          cacheWrite: 1,
+          total: 18,
+        }),
+      );
+      expect(evt.error).toBeUndefined();
+    });
+  });
+
+  it("emits run.completed with error info when run throws", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      vi.mocked(runEmbeddedPiAgent).mockRejectedValueOnce(new Error("model overloaded"));
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await expect(agentCommand({ message: "hello", to: "+1555" }, runtime)).rejects.toThrow(
+        "model overloaded",
+      );
+      unsub();
+
+      const completed = events.filter((e) => e.type === "run.completed");
+      expect(completed).toHaveLength(1);
+
+      const evt = completed[0];
+      expect(evt.error).toContain("model overloaded");
+      expect(evt.errorType).toBe("exception");
+      expect(evt.durationMs).toBeTypeOf("number");
+    });
+  });
+
+  it("emits message.processed on successful run", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await agentCommand({ message: "hello", to: "+1555" }, runtime);
+      unsub();
+
+      const processed = events.filter((e) => e.type === "message.processed");
+      expect(processed).toHaveLength(1);
+
+      const evt = processed[0];
+      expect(evt.sessionKey).toBeTruthy();
+      expect(evt.sessionId).toBeTruthy();
+      expect(evt.outcome).toBe("completed");
+      expect(evt.durationMs).toBeTypeOf("number");
+      expect(evt.durationMs).toBeGreaterThanOrEqual(0);
+      expect(evt.error).toBeUndefined();
+    });
+  });
+
+  it("emits message.processed with error outcome when run throws", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      vi.mocked(runEmbeddedPiAgent).mockRejectedValueOnce(new Error("timeout"));
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await expect(agentCommand({ message: "hello", to: "+1555" }, runtime)).rejects.toThrow(
+        "timeout",
+      );
+      unsub();
+
+      const processed = events.filter((e) => e.type === "message.processed");
+      expect(processed).toHaveLength(1);
+
+      const evt = processed[0];
+      expect(evt.outcome).toBe("error");
+      expect(evt.error).toContain("timeout");
+    });
+  });
+
+  it("emits full diagnostic event sequence in correct order", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await agentCommand({ message: "hello", to: "+1555" }, runtime);
+      unsub();
+
+      const types = events.map((e) => e.type);
+      const queuedIdx = types.indexOf("message.queued");
+      const completedIdx = types.indexOf("run.completed");
+      const processedIdx = types.indexOf("message.processed");
+
+      expect(queuedIdx).toBeGreaterThanOrEqual(0);
+      expect(completedIdx).toBeGreaterThanOrEqual(0);
+      expect(processedIdx).toBeGreaterThanOrEqual(0);
+
+      // message.queued must come before run.completed
+      expect(queuedIdx).toBeLessThan(completedIdx);
+      // run.completed must come before message.processed
+      expect(completedIdx).toBeLessThan(processedIdx);
+    });
+  });
+
+  it("does not emit diagnostic events when diagnostics are disabled", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: false });
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await agentCommand({ message: "hello", to: "+1555" }, runtime);
+      unsub();
+
+      const diagTypes = new Set(["message.queued", "run.completed", "message.processed"]);
+      const matched = events.filter((e) => diagTypes.has(e.type));
+      expect(matched).toHaveLength(0);
+    });
+  });
+
+  it("uses replyChannel for diagnostic event channel field", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await agentCommand({ message: "hello", to: "+1555", replyChannel: "slack" }, runtime);
+      unsub();
+
+      const queued = events.find((e) => e.type === "message.queued");
+      expect(queued?.channel).toBe("slack");
+
+      const completed = events.find((e) => e.type === "run.completed");
+      expect(completed?.channel).toBe("slack");
+    });
+  });
+});

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,1 +1,1038 @@
-export * from "../agents/agent-command.js";
+import { getAcpSessionManager } from "../acp/control-plane/manager.js";
+import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../acp/policy.js";
+import { toAcpRuntimeError } from "../acp/runtime/errors.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("commands/agent");
+import {
+  listAgentIds,
+  resolveAgentDir,
+  resolveEffectiveModelFallbacks,
+  resolveSessionAgentId,
+  resolveAgentSkillsFilter,
+  resolveAgentWorkspaceDir,
+} from "../agents/agent-scope.js";
+import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
+import { clearSessionAuthProfileOverride } from "../agents/auth-profiles/session-override.js";
+import { runCliAgent } from "../agents/cli-runner.js";
+import { getCliSessionId, setCliSessionId } from "../agents/cli-session.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { FailoverError } from "../agents/failover-error.js";
+import { formatAgentInternalEventsForPrompt } from "../agents/internal-events.js";
+import { AGENT_LANE_SUBAGENT } from "../agents/lanes.js";
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runWithModelFallback } from "../agents/model-fallback.js";
+import {
+  buildAllowedModelSet,
+  isCliProvider,
+  modelKey,
+  normalizeModelRef,
+  normalizeProviderId,
+  resolveConfiguredModelRef,
+  resolveDefaultModelForAgent,
+  resolveThinkingDefault,
+} from "../agents/model-selection.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
+import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
+import { resolveAgentTimeoutMs } from "../agents/timeout.js";
+import { ensureAgentWorkspace } from "../agents/workspace.js";
+import {
+  formatThinkingLevels,
+  formatXHighModelHint,
+  normalizeThinkLevel,
+  normalizeVerboseLevel,
+  supportsXHighThinking,
+  type ThinkLevel,
+  type VerboseLevel,
+} from "../auto-reply/thinking.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";
+import { getAgentRuntimeCommandSecretTargetIds } from "../cli/command-secret-targets.js";
+import { type CliDeps, createDefaultDeps } from "../cli/deps.js";
+import { loadConfig } from "../config/config.js";
+import {
+  mergeSessionEntry,
+  parseSessionThreadInfo,
+  resolveAndPersistSessionFile,
+  resolveAgentIdFromSessionKey,
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+  resolveSessionTranscriptPath,
+  type SessionEntry,
+  updateSessionStore,
+} from "../config/sessions.js";
+import {
+  clearAgentRunContext,
+  emitAgentEvent,
+  registerAgentRunContext,
+} from "../infra/agent-events.js";
+import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
+import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
+import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
+import { logMessageQueued, logMessageProcessed } from "../logging/diagnostic.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
+import { applyVerboseOverride } from "../sessions/level-overrides.js";
+import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
+import { resolveSendPolicy } from "../sessions/send-policy.js";
+import { resolveMessageChannel } from "../utils/message-channel.js";
+import { deliverAgentCommandResult } from "./agent/delivery.js";
+import { resolveAgentRunContext } from "./agent/run-context.js";
+import { updateSessionStoreAfterAgentRun } from "./agent/session-store.js";
+import { resolveSession } from "./agent/session.js";
+import type { AgentCommandIngressOpts, AgentCommandOpts } from "./agent/types.js";
+
+type PersistSessionEntryParams = {
+  sessionStore: Record<string, SessionEntry>;
+  sessionKey: string;
+  storePath: string;
+  entry: SessionEntry;
+};
+
+type OverrideFieldClearedByDelete =
+  | "providerOverride"
+  | "modelOverride"
+  | "authProfileOverride"
+  | "authProfileOverrideSource"
+  | "authProfileOverrideCompactionCount"
+  | "fallbackNoticeSelectedModel"
+  | "fallbackNoticeActiveModel"
+  | "fallbackNoticeReason"
+  | "claudeCliSessionId";
+
+const OVERRIDE_FIELDS_CLEARED_BY_DELETE: OverrideFieldClearedByDelete[] = [
+  "providerOverride",
+  "modelOverride",
+  "authProfileOverride",
+  "authProfileOverrideSource",
+  "authProfileOverrideCompactionCount",
+  "fallbackNoticeSelectedModel",
+  "fallbackNoticeActiveModel",
+  "fallbackNoticeReason",
+  "claudeCliSessionId",
+];
+
+async function persistSessionEntry(params: PersistSessionEntryParams): Promise<void> {
+  const persisted = await updateSessionStore(params.storePath, (store) => {
+    const merged = mergeSessionEntry(store[params.sessionKey], params.entry);
+    // Preserve explicit `delete` clears done by session override helpers.
+    for (const field of OVERRIDE_FIELDS_CLEARED_BY_DELETE) {
+      if (!Object.hasOwn(params.entry, field)) {
+        Reflect.deleteProperty(merged, field);
+      }
+    }
+    store[params.sessionKey] = merged;
+    return merged;
+  });
+  params.sessionStore[params.sessionKey] = persisted;
+}
+
+function resolveFallbackRetryPrompt(params: { body: string; isFallbackRetry: boolean }): string {
+  if (!params.isFallbackRetry) {
+    return params.body;
+  }
+  return "Continue where you left off. The previous model attempt failed or timed out.";
+}
+
+function prependInternalEventContext(
+  body: string,
+  events: AgentCommandOpts["internalEvents"],
+): string {
+  if (body.includes("OpenClaw runtime context (internal):")) {
+    return body;
+  }
+  const renderedEvents = formatAgentInternalEventsForPrompt(events);
+  if (!renderedEvents) {
+    return body;
+  }
+  return [renderedEvents, body].filter(Boolean).join("\n\n");
+}
+
+function runAgentAttempt(params: {
+  providerOverride: string;
+  modelOverride: string;
+  cfg: ReturnType<typeof loadConfig>;
+  sessionEntry: SessionEntry | undefined;
+  sessionId: string;
+  sessionKey: string | undefined;
+  sessionAgentId: string;
+  sessionFile: string;
+  workspaceDir: string;
+  body: string;
+  isFallbackRetry: boolean;
+  resolvedThinkLevel: ThinkLevel;
+  timeoutMs: number;
+  runId: string;
+  opts: AgentCommandOpts & { senderIsOwner: boolean };
+  runContext: ReturnType<typeof resolveAgentRunContext>;
+  spawnedBy: string | undefined;
+  messageChannel: ReturnType<typeof resolveMessageChannel>;
+  skillsSnapshot: ReturnType<typeof buildWorkspaceSkillSnapshot> | undefined;
+  resolvedVerboseLevel: VerboseLevel | undefined;
+  agentDir: string;
+  onAgentEvent: (evt: { stream: string; data?: Record<string, unknown> }) => void;
+  primaryProvider: string;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+}) {
+  const effectivePrompt = resolveFallbackRetryPrompt({
+    body: params.body,
+    isFallbackRetry: params.isFallbackRetry,
+  });
+  if (isCliProvider(params.providerOverride, params.cfg)) {
+    const cliSessionId = getCliSessionId(params.sessionEntry, params.providerOverride);
+    const runCliWithSession = (nextCliSessionId: string | undefined) =>
+      runCliAgent({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        agentId: params.sessionAgentId,
+        sessionFile: params.sessionFile,
+        workspaceDir: params.workspaceDir,
+        config: params.cfg,
+        prompt: effectivePrompt,
+        provider: params.providerOverride,
+        model: params.modelOverride,
+        thinkLevel: params.resolvedThinkLevel,
+        timeoutMs: params.timeoutMs,
+        runId: params.runId,
+        extraSystemPrompt: params.opts.extraSystemPrompt,
+        cliSessionId: nextCliSessionId,
+        images: params.isFallbackRetry ? undefined : params.opts.images,
+        streamParams: params.opts.streamParams,
+      });
+    return runCliWithSession(cliSessionId).catch(async (err) => {
+      // Handle CLI session expired error
+      if (
+        err instanceof FailoverError &&
+        err.reason === "session_expired" &&
+        cliSessionId &&
+        params.sessionKey &&
+        params.sessionStore &&
+        params.storePath
+      ) {
+        log.warn(
+          `CLI session expired, clearing from session store: provider=${params.providerOverride} sessionKey=${params.sessionKey}`,
+        );
+
+        // Clear the expired session ID from the session store
+        const entry = params.sessionStore[params.sessionKey];
+        if (entry) {
+          const updatedEntry = { ...entry };
+          if (params.providerOverride === "claude-cli") {
+            delete updatedEntry.claudeCliSessionId;
+          }
+          if (updatedEntry.cliSessionIds) {
+            const normalizedProvider = normalizeProviderId(params.providerOverride);
+            const newCliSessionIds = { ...updatedEntry.cliSessionIds };
+            delete newCliSessionIds[normalizedProvider];
+            updatedEntry.cliSessionIds = newCliSessionIds;
+          }
+          updatedEntry.updatedAt = Date.now();
+
+          await persistSessionEntry({
+            sessionStore: params.sessionStore,
+            sessionKey: params.sessionKey,
+            storePath: params.storePath,
+            entry: updatedEntry,
+          });
+
+          // Update the session entry reference
+          params.sessionEntry = updatedEntry;
+        }
+
+        // Retry with no session ID (will create a new session)
+        return runCliWithSession(undefined).then(async (result) => {
+          // Update session store with new CLI session ID if available
+          if (
+            result.meta.agentMeta?.sessionId &&
+            params.sessionKey &&
+            params.sessionStore &&
+            params.storePath
+          ) {
+            const entry = params.sessionStore[params.sessionKey];
+            if (entry) {
+              const updatedEntry = { ...entry };
+              setCliSessionId(
+                updatedEntry,
+                params.providerOverride,
+                result.meta.agentMeta.sessionId,
+              );
+              updatedEntry.updatedAt = Date.now();
+
+              await persistSessionEntry({
+                sessionStore: params.sessionStore,
+                sessionKey: params.sessionKey,
+                storePath: params.storePath,
+                entry: updatedEntry,
+              });
+            }
+          }
+          return result;
+        });
+      }
+      throw err;
+    });
+  }
+
+  const authProfileId =
+    params.providerOverride === params.primaryProvider
+      ? params.sessionEntry?.authProfileOverride
+      : undefined;
+  return runEmbeddedPiAgent({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    agentId: params.sessionAgentId,
+    trigger: "user",
+    messageChannel: params.messageChannel,
+    agentAccountId: params.runContext.accountId,
+    messageTo: params.opts.replyTo ?? params.opts.to,
+    messageThreadId: params.opts.threadId,
+    groupId: params.runContext.groupId,
+    groupChannel: params.runContext.groupChannel,
+    groupSpace: params.runContext.groupSpace,
+    spawnedBy: params.spawnedBy,
+    currentChannelId: params.runContext.currentChannelId,
+    currentThreadTs: params.runContext.currentThreadTs,
+    replyToMode: params.runContext.replyToMode,
+    hasRepliedRef: params.runContext.hasRepliedRef,
+    senderIsOwner: params.opts.senderIsOwner,
+    sessionFile: params.sessionFile,
+    workspaceDir: params.workspaceDir,
+    config: params.cfg,
+    skillsSnapshot: params.skillsSnapshot,
+    prompt: effectivePrompt,
+    images: params.isFallbackRetry ? undefined : params.opts.images,
+    clientTools: params.opts.clientTools,
+    provider: params.providerOverride,
+    model: params.modelOverride,
+    authProfileId,
+    authProfileIdSource: authProfileId ? params.sessionEntry?.authProfileOverrideSource : undefined,
+    thinkLevel: params.resolvedThinkLevel,
+    verboseLevel: params.resolvedVerboseLevel,
+    timeoutMs: params.timeoutMs,
+    runId: params.runId,
+    lane: params.opts.lane,
+    abortSignal: params.opts.abortSignal,
+    extraSystemPrompt: params.opts.extraSystemPrompt,
+    inputProvenance: params.opts.inputProvenance,
+    streamParams: params.opts.streamParams,
+    agentDir: params.agentDir,
+    onAgentEvent: params.onAgentEvent,
+  });
+}
+
+async function agentCommandInternal(
+  opts: AgentCommandOpts & { senderIsOwner: boolean },
+  runtime: RuntimeEnv = defaultRuntime,
+  deps: CliDeps = createDefaultDeps(),
+) {
+  const message = (opts.message ?? "").trim();
+  if (!message) {
+    throw new Error("Message (--message) is required");
+  }
+  const body = prependInternalEventContext(message, opts.internalEvents);
+  if (!opts.to && !opts.sessionId && !opts.sessionKey && !opts.agentId) {
+    throw new Error("Pass --to <E.164>, --session-id, or --agent to choose a session");
+  }
+
+  const loadedRaw = loadConfig();
+  const { resolvedConfig: cfg, diagnostics } = await resolveCommandSecretRefsViaGateway({
+    config: loadedRaw,
+    commandName: "agent",
+    targetIds: getAgentRuntimeCommandSecretTargetIds(),
+  });
+  for (const entry of diagnostics) {
+    runtime.log(`[secrets] ${entry}`);
+  }
+  const agentIdOverrideRaw = opts.agentId?.trim();
+  const agentIdOverride = agentIdOverrideRaw ? normalizeAgentId(agentIdOverrideRaw) : undefined;
+  if (agentIdOverride) {
+    const knownAgents = listAgentIds(cfg);
+    if (!knownAgents.includes(agentIdOverride)) {
+      throw new Error(
+        `Unknown agent id "${agentIdOverrideRaw}". Use "${formatCliCommand("openclaw agents list")}" to see configured agents.`,
+      );
+    }
+  }
+  if (agentIdOverride && opts.sessionKey) {
+    const sessionAgentId = resolveAgentIdFromSessionKey(opts.sessionKey);
+    if (sessionAgentId !== agentIdOverride) {
+      throw new Error(
+        `Agent id "${agentIdOverrideRaw}" does not match session key agent "${sessionAgentId}".`,
+      );
+    }
+  }
+  const agentCfg = cfg.agents?.defaults;
+  const configuredModel = resolveConfiguredModelRef({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+  const thinkingLevelsHint = formatThinkingLevels(configuredModel.provider, configuredModel.model);
+
+  const thinkOverride = normalizeThinkLevel(opts.thinking);
+  const thinkOnce = normalizeThinkLevel(opts.thinkingOnce);
+  if (opts.thinking && !thinkOverride) {
+    throw new Error(`Invalid thinking level. Use one of: ${thinkingLevelsHint}.`);
+  }
+  if (opts.thinkingOnce && !thinkOnce) {
+    throw new Error(`Invalid one-shot thinking level. Use one of: ${thinkingLevelsHint}.`);
+  }
+
+  const verboseOverride = normalizeVerboseLevel(opts.verbose);
+  if (opts.verbose && !verboseOverride) {
+    throw new Error('Invalid verbose level. Use "on", "full", or "off".');
+  }
+
+  const laneRaw = typeof opts.lane === "string" ? opts.lane.trim() : "";
+  const isSubagentLane = laneRaw === String(AGENT_LANE_SUBAGENT);
+  const timeoutSecondsRaw =
+    opts.timeout !== undefined
+      ? Number.parseInt(String(opts.timeout), 10)
+      : isSubagentLane
+        ? 0
+        : undefined;
+  if (
+    timeoutSecondsRaw !== undefined &&
+    (Number.isNaN(timeoutSecondsRaw) || timeoutSecondsRaw < 0)
+  ) {
+    throw new Error("--timeout must be a non-negative integer (seconds; 0 means no timeout)");
+  }
+  const timeoutMs = resolveAgentTimeoutMs({
+    cfg,
+    overrideSeconds: timeoutSecondsRaw,
+  });
+
+  const sessionResolution = resolveSession({
+    cfg,
+    to: opts.to,
+    sessionId: opts.sessionId,
+    sessionKey: opts.sessionKey,
+    agentId: agentIdOverride,
+  });
+
+  const {
+    sessionId,
+    sessionKey,
+    sessionEntry: resolvedSessionEntry,
+    sessionStore,
+    storePath,
+    isNewSession,
+    persistedThinking,
+    persistedVerbose,
+  } = sessionResolution;
+  const sessionAgentId =
+    agentIdOverride ??
+    resolveSessionAgentId({
+      sessionKey: sessionKey ?? opts.sessionKey?.trim(),
+      config: cfg,
+    });
+  const outboundSession = buildOutboundSessionContext({
+    cfg,
+    agentId: sessionAgentId,
+    sessionKey,
+  });
+  const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, sessionAgentId);
+  const agentDir = resolveAgentDir(cfg, sessionAgentId);
+  const workspace = await ensureAgentWorkspace({
+    dir: workspaceDirRaw,
+    ensureBootstrapFiles: !agentCfg?.skipBootstrap,
+  });
+  const workspaceDir = workspace.dir;
+  let sessionEntry = resolvedSessionEntry;
+  const runId = opts.runId?.trim() || sessionId;
+  const acpManager = getAcpSessionManager();
+  const acpResolution = sessionKey
+    ? acpManager.resolveSession({
+        cfg,
+        sessionKey,
+      })
+    : null;
+  const diagnosticsEnabled = isDiagnosticsEnabled(cfg);
+  const diagStartedAt = Date.now();
+  let agentCommandOutcome: "completed" | "error" = "completed";
+  let agentCommandError: string | undefined;
+
+  try {
+    if (opts.deliver === true) {
+      const sendPolicy = resolveSendPolicy({
+        cfg,
+        entry: sessionEntry,
+        sessionKey,
+        channel: sessionEntry?.channel,
+        chatType: sessionEntry?.chatType,
+      });
+      if (sendPolicy === "deny") {
+        throw new Error("send blocked by session policy");
+      }
+    }
+
+    if (acpResolution?.kind === "stale") {
+      throw acpResolution.error;
+    }
+
+    if (acpResolution?.kind === "ready" && sessionKey) {
+      const startedAt = Date.now();
+      registerAgentRunContext(runId, {
+        sessionKey,
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "start",
+          startedAt,
+        },
+      });
+
+      let streamedText = "";
+      let stopReason: string | undefined;
+      try {
+        const dispatchPolicyError = resolveAcpDispatchPolicyError(cfg);
+        if (dispatchPolicyError) {
+          throw dispatchPolicyError;
+        }
+        const acpAgent = normalizeAgentId(
+          acpResolution.meta.agent || resolveAgentIdFromSessionKey(sessionKey),
+        );
+        const agentPolicyError = resolveAcpAgentPolicyError(cfg, acpAgent);
+        if (agentPolicyError) {
+          throw agentPolicyError;
+        }
+
+        await acpManager.runTurn({
+          cfg,
+          sessionKey,
+          text: body,
+          mode: "prompt",
+          requestId: runId,
+          signal: opts.abortSignal,
+          onEvent: (event) => {
+            if (event.type === "done") {
+              stopReason = event.stopReason;
+              return;
+            }
+            if (event.type !== "text_delta") {
+              return;
+            }
+            if (event.stream && event.stream !== "output") {
+              return;
+            }
+            if (!event.text) {
+              return;
+            }
+            streamedText += event.text;
+            emitAgentEvent({
+              runId,
+              stream: "assistant",
+              data: {
+                text: streamedText,
+                delta: event.text,
+              },
+            });
+          },
+        });
+      } catch (error) {
+        const acpError = toAcpRuntimeError({
+          error,
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "ACP turn failed before completion.",
+        });
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: {
+            phase: "error",
+            error: acpError.message,
+            endedAt: Date.now(),
+          },
+        });
+        throw acpError;
+      }
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: Date.now(),
+        },
+      });
+
+      const finalText = streamedText.trim();
+      const payloads = finalText
+        ? [
+            {
+              text: finalText,
+            },
+          ]
+        : [];
+      const result = {
+        payloads,
+        meta: {
+          durationMs: Date.now() - startedAt,
+          aborted: opts.abortSignal?.aborted === true,
+          stopReason,
+        },
+      };
+
+      return await deliverAgentCommandResult({
+        cfg,
+        deps,
+        runtime,
+        opts,
+        outboundSession,
+        sessionEntry,
+        result,
+        payloads,
+      });
+    }
+
+    let resolvedThinkLevel = thinkOnce ?? thinkOverride ?? persistedThinking;
+    const resolvedVerboseLevel =
+      verboseOverride ?? persistedVerbose ?? (agentCfg?.verboseDefault as VerboseLevel | undefined);
+
+    if (sessionKey) {
+      registerAgentRunContext(runId, {
+        sessionKey,
+        verboseLevel: resolvedVerboseLevel,
+      });
+    }
+    if (diagnosticsEnabled && sessionKey) {
+      logMessageQueued({
+        sessionId,
+        sessionKey,
+        channel: resolveMessageChannel(opts.replyChannel, opts.channel),
+        source: "agent-command",
+      });
+    }
+
+    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
+    const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+    const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
+    const skillsSnapshot = needsSkillsSnapshot
+      ? buildWorkspaceSkillSnapshot(workspaceDir, {
+          config: cfg,
+          eligibility: { remote: getRemoteSkillEligibility() },
+          snapshotVersion: skillsSnapshotVersion,
+          skillFilter,
+        })
+      : sessionEntry?.skillsSnapshot;
+
+    if (skillsSnapshot && sessionStore && sessionKey && needsSkillsSnapshot) {
+      const current = sessionEntry ?? {
+        sessionId,
+        updatedAt: Date.now(),
+      };
+      const next: SessionEntry = {
+        ...current,
+        sessionId,
+        updatedAt: Date.now(),
+        skillsSnapshot,
+      };
+      await persistSessionEntry({
+        sessionStore,
+        sessionKey,
+        storePath,
+        entry: next,
+      });
+      sessionEntry = next;
+    }
+
+    // Persist explicit /command overrides to the session store when we have a key.
+    if (sessionStore && sessionKey) {
+      const entry = sessionStore[sessionKey] ??
+        sessionEntry ?? { sessionId, updatedAt: Date.now() };
+      const next: SessionEntry = { ...entry, sessionId, updatedAt: Date.now() };
+      if (thinkOverride) {
+        next.thinkingLevel = thinkOverride;
+      }
+      applyVerboseOverride(next, verboseOverride);
+      await persistSessionEntry({
+        sessionStore,
+        sessionKey,
+        storePath,
+        entry: next,
+      });
+      sessionEntry = next;
+    }
+
+    const configuredDefaultRef = resolveDefaultModelForAgent({
+      cfg,
+      agentId: sessionAgentId,
+    });
+    const { provider: defaultProvider, model: defaultModel } = normalizeModelRef(
+      configuredDefaultRef.provider,
+      configuredDefaultRef.model,
+    );
+    let provider = defaultProvider;
+    let model = defaultModel;
+    const hasAllowlist = agentCfg?.models && Object.keys(agentCfg.models).length > 0;
+    const hasStoredOverride = Boolean(
+      sessionEntry?.modelOverride || sessionEntry?.providerOverride,
+    );
+    const needsModelCatalog = hasAllowlist || hasStoredOverride;
+    let allowedModelKeys = new Set<string>();
+    let allowedModelCatalog: Awaited<ReturnType<typeof loadModelCatalog>> = [];
+    let modelCatalog: Awaited<ReturnType<typeof loadModelCatalog>> | null = null;
+    let allowAnyModel = false;
+
+    if (needsModelCatalog) {
+      modelCatalog = await loadModelCatalog({ config: cfg });
+      const allowed = buildAllowedModelSet({
+        cfg,
+        catalog: modelCatalog,
+        defaultProvider,
+        defaultModel,
+      });
+      allowedModelKeys = allowed.allowedKeys;
+      allowedModelCatalog = allowed.allowedCatalog;
+      allowAnyModel = allowed.allowAny ?? false;
+    }
+
+    if (sessionEntry && sessionStore && sessionKey && hasStoredOverride) {
+      const entry = sessionEntry;
+      const overrideProvider = sessionEntry.providerOverride?.trim() || defaultProvider;
+      const overrideModel = sessionEntry.modelOverride?.trim();
+      if (overrideModel) {
+        const normalizedOverride = normalizeModelRef(overrideProvider, overrideModel);
+        const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
+        if (
+          !isCliProvider(normalizedOverride.provider, cfg) &&
+          !allowAnyModel &&
+          !allowedModelKeys.has(key)
+        ) {
+          const { updated } = applyModelOverrideToSessionEntry({
+            entry,
+            selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
+          });
+          if (updated) {
+            await persistSessionEntry({
+              sessionStore,
+              sessionKey,
+              storePath,
+              entry,
+            });
+          }
+        }
+      }
+    }
+
+    const storedProviderOverride = sessionEntry?.providerOverride?.trim();
+    const storedModelOverride = sessionEntry?.modelOverride?.trim();
+    if (storedModelOverride) {
+      const candidateProvider = storedProviderOverride || defaultProvider;
+      const normalizedStored = normalizeModelRef(candidateProvider, storedModelOverride);
+      const key = modelKey(normalizedStored.provider, normalizedStored.model);
+      if (
+        isCliProvider(normalizedStored.provider, cfg) ||
+        allowAnyModel ||
+        allowedModelKeys.has(key)
+      ) {
+        provider = normalizedStored.provider;
+        model = normalizedStored.model;
+      }
+    }
+    if (sessionEntry) {
+      const authProfileId = sessionEntry.authProfileOverride;
+      if (authProfileId) {
+        const entry = sessionEntry;
+        const store = ensureAuthProfileStore();
+        const profile = store.profiles[authProfileId];
+        if (!profile || profile.provider !== provider) {
+          if (sessionStore && sessionKey) {
+            await clearSessionAuthProfileOverride({
+              sessionEntry: entry,
+              sessionStore,
+              sessionKey,
+              storePath,
+            });
+          }
+        }
+      }
+    }
+
+    if (!resolvedThinkLevel) {
+      let catalogForThinking = modelCatalog ?? allowedModelCatalog;
+      if (!catalogForThinking || catalogForThinking.length === 0) {
+        modelCatalog = await loadModelCatalog({ config: cfg });
+        catalogForThinking = modelCatalog;
+      }
+      resolvedThinkLevel = resolveThinkingDefault({
+        cfg,
+        provider,
+        model,
+        catalog: catalogForThinking,
+      });
+    }
+    if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
+      const explicitThink = Boolean(thinkOnce || thinkOverride);
+      if (explicitThink) {
+        throw new Error(`Thinking level "xhigh" is only supported for ${formatXHighModelHint()}.`);
+      }
+      resolvedThinkLevel = "high";
+      if (sessionEntry && sessionStore && sessionKey && sessionEntry.thinkingLevel === "xhigh") {
+        const entry = sessionEntry;
+        entry.thinkingLevel = "high";
+        entry.updatedAt = Date.now();
+        await persistSessionEntry({
+          sessionStore,
+          sessionKey,
+          storePath,
+          entry,
+        });
+      }
+    }
+    const sessionPathOpts = resolveSessionFilePathOptions({
+      agentId: sessionAgentId,
+      storePath,
+    });
+    let sessionFile = resolveSessionFilePath(sessionId, sessionEntry, sessionPathOpts);
+    if (sessionStore && sessionKey) {
+      const threadIdFromSessionKey = parseSessionThreadInfo(sessionKey).threadId;
+      const fallbackSessionFile = !sessionEntry?.sessionFile
+        ? resolveSessionTranscriptPath(
+            sessionId,
+            sessionAgentId,
+            opts.threadId ?? threadIdFromSessionKey,
+          )
+        : undefined;
+      const resolvedSessionFile = await resolveAndPersistSessionFile({
+        sessionId,
+        sessionKey,
+        sessionStore,
+        storePath,
+        sessionEntry,
+        agentId: sessionPathOpts?.agentId,
+        sessionsDir: sessionPathOpts?.sessionsDir,
+        fallbackSessionFile,
+      });
+      sessionFile = resolvedSessionFile.sessionFile;
+      sessionEntry = resolvedSessionFile.sessionEntry;
+    }
+
+    const startedAt = Date.now();
+    let lifecycleEnded = false;
+
+    let result: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
+    let fallbackProvider = provider;
+    let fallbackModel = model;
+    try {
+      const runContext = resolveAgentRunContext(opts);
+      const messageChannel = resolveMessageChannel(
+        runContext.messageChannel,
+        opts.replyChannel ?? opts.channel,
+      );
+      const spawnedBy = opts.spawnedBy ?? sessionEntry?.spawnedBy;
+      // Keep fallback candidate resolution centralized so session model overrides,
+      // per-agent overrides, and default fallbacks stay consistent across callers.
+      const effectiveFallbacksOverride = resolveEffectiveModelFallbacks({
+        cfg,
+        agentId: sessionAgentId,
+        hasSessionModelOverride: Boolean(storedModelOverride),
+      });
+
+      // Track model fallback attempts so retries on an existing session don't
+      // re-inject the original prompt as a duplicate user message.
+      let fallbackAttemptIndex = 0;
+      const fallbackResult = await runWithModelFallback({
+        cfg,
+        provider,
+        model,
+        agentDir,
+        fallbacksOverride: effectiveFallbacksOverride,
+        run: (providerOverride, modelOverride) => {
+          const isFallbackRetry = fallbackAttemptIndex > 0;
+          fallbackAttemptIndex += 1;
+          return runAgentAttempt({
+            providerOverride,
+            modelOverride,
+            cfg,
+            sessionEntry,
+            sessionId,
+            sessionKey,
+            sessionAgentId,
+            sessionFile,
+            workspaceDir,
+            body,
+            isFallbackRetry,
+            resolvedThinkLevel,
+            timeoutMs,
+            runId,
+            opts,
+            runContext,
+            spawnedBy,
+            messageChannel,
+            skillsSnapshot,
+            resolvedVerboseLevel,
+            agentDir,
+            primaryProvider: provider,
+            sessionStore,
+            storePath,
+            onAgentEvent: (evt) => {
+              // Track lifecycle end for fallback emission below.
+              if (
+                evt.stream === "lifecycle" &&
+                typeof evt.data?.phase === "string" &&
+                (evt.data.phase === "end" || evt.data.phase === "error")
+              ) {
+                lifecycleEnded = true;
+              }
+            },
+          });
+        },
+      });
+      result = fallbackResult.result;
+      fallbackProvider = fallbackResult.provider;
+      fallbackModel = fallbackResult.model;
+      if (diagnosticsEnabled) {
+        const agentMeta = result.meta.agentMeta;
+        const usage = agentMeta?.usage;
+        emitDiagnosticEvent({
+          type: "run.completed",
+          runId,
+          sessionKey,
+          sessionId,
+          channel: resolveMessageChannel(opts.replyChannel, opts.channel),
+          provider: agentMeta?.provider ?? fallbackProvider,
+          model: agentMeta?.model ?? fallbackModel,
+          usage: {
+            input: usage?.input,
+            output: usage?.output,
+            cacheRead: usage?.cacheRead,
+            cacheWrite: usage?.cacheWrite,
+            total: usage?.total,
+          },
+          durationMs: Date.now() - startedAt,
+          operationName: "chat",
+          error: result.meta.error?.message,
+          errorType: result.meta.error?.kind,
+        });
+      }
+      if (!lifecycleEnded) {
+        const stopReason = result.meta.stopReason;
+        if (stopReason && stopReason !== "end_turn") {
+          console.error(`[agent] run ${runId} ended with stopReason=${stopReason}`);
+        }
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: {
+            phase: "end",
+            startedAt,
+            endedAt: Date.now(),
+            aborted: result.meta.aborted ?? false,
+            stopReason,
+          },
+        });
+      }
+    } catch (err) {
+      agentCommandOutcome = "error";
+      agentCommandError = String(err);
+      if (diagnosticsEnabled) {
+        emitDiagnosticEvent({
+          type: "run.completed",
+          runId,
+          sessionKey,
+          sessionId,
+          channel: resolveMessageChannel(opts.replyChannel, opts.channel),
+          provider: fallbackProvider,
+          model: fallbackModel,
+          usage: {},
+          durationMs: Date.now() - startedAt,
+          operationName: "chat",
+          error: String(err),
+          errorType: "exception",
+        });
+      }
+      if (!lifecycleEnded) {
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: {
+            phase: "error",
+            startedAt,
+            endedAt: Date.now(),
+            error: String(err),
+          },
+        });
+      }
+      throw err;
+    }
+
+    // Update token+model fields in the session store.
+    if (sessionStore && sessionKey) {
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        contextTokensOverride: agentCfg?.contextTokens,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: provider,
+        defaultModel: model,
+        fallbackProvider,
+        fallbackModel,
+        result,
+      });
+    }
+
+    const payloads = result.payloads ?? [];
+    return await deliverAgentCommandResult({
+      cfg,
+      deps,
+      runtime,
+      opts,
+      outboundSession,
+      sessionEntry,
+      result,
+      payloads,
+    });
+  } finally {
+    if (diagnosticsEnabled && sessionKey) {
+      logMessageProcessed({
+        channel: resolveMessageChannel(opts.replyChannel, opts.channel) ?? "agent-command",
+        sessionId,
+        sessionKey,
+        durationMs: Date.now() - diagStartedAt,
+        outcome: agentCommandOutcome,
+        error: agentCommandError,
+      });
+    }
+    clearAgentRunContext(runId);
+  }
+}
+
+export async function agentCommand(
+  opts: AgentCommandOpts,
+  runtime: RuntimeEnv = defaultRuntime,
+  deps: CliDeps = createDefaultDeps(),
+) {
+  return await agentCommandInternal(
+    {
+      ...opts,
+      senderIsOwner: opts.senderIsOwner ?? true,
+    },
+    runtime,
+    deps,
+  );
+}
+
+export async function agentCommandFromIngress(
+  opts: AgentCommandIngressOpts,
+  runtime: RuntimeEnv = defaultRuntime,
+  deps: CliDeps = createDefaultDeps(),
+) {
+  if (typeof opts.senderIsOwner !== "boolean") {
+    throw new Error("senderIsOwner must be explicitly set for ingress agent runs.");
+  }
+  return await agentCommandInternal(
+    {
+      ...opts,
+      senderIsOwner: opts.senderIsOwner,
+    },
+    runtime,
+    deps,
+  );
+}

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -191,6 +191,21 @@ export type DiagnosticsOtelConfig = {
   sampleRate?: number;
   /** Metric export interval (ms). */
   flushIntervalMs?: number;
+  /**
+   * Record gen_ai content on inference spans (opt-in, sensitive).
+   * `true` enables all content capture. An object form allows granular control:
+   * `{ inputMessages: true, outputMessages: true, systemInstructions: false, toolDefinitions: true, toolContent: true }`
+   * When using the object form, each field defaults to `true` if omitted.
+   */
+  captureContent?:
+    | boolean
+    | {
+        inputMessages?: boolean;
+        outputMessages?: boolean;
+        systemInstructions?: boolean;
+        toolDefinitions?: boolean;
+        toolContent?: boolean;
+      };
 };
 
 export type DiagnosticsCacheTraceConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -299,6 +299,20 @@ export const OpenClawSchema = z
             logs: z.boolean().optional(),
             sampleRate: z.number().min(0).max(1).optional(),
             flushIntervalMs: z.number().int().nonnegative().optional(),
+            captureContent: z
+              .union([
+                z.boolean(),
+                z
+                  .object({
+                    inputMessages: z.boolean().optional(),
+                    outputMessages: z.boolean().optional(),
+                    systemInstructions: z.boolean().optional(),
+                    toolDefinitions: z.boolean().optional(),
+                    toolContent: z.boolean().optional(),
+                  })
+                  .strict(),
+              ])
+              .optional(),
           })
           .strict()
           .optional(),

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -24,8 +24,9 @@ describe("diagnostic-events", () => {
     });
 
     emitDiagnosticEvent({
-      type: "model.usage",
-      usage: { total: 1 },
+      type: "run.attempt",
+      runId: "run-1",
+      attempt: 1,
     });
     emitDiagnosticEvent({
       type: "session.state",
@@ -34,7 +35,7 @@ describe("diagnostic-events", () => {
     stop();
 
     expect(events).toEqual([
-      { seq: 1, ts: 111, type: "model.usage" },
+      { seq: 1, ts: 111, type: "run.attempt" },
       { seq: 2, ts: 222, type: "session.state" },
     ]);
   });

--- a/src/plugin-sdk/diagnostics-otel.ts
+++ b/src/plugin-sdk/diagnostics-otel.ts
@@ -6,8 +6,11 @@ export { emitDiagnosticEvent, onDiagnosticEvent } from "../infra/diagnostic-even
 export { registerLogTransport } from "../logging/logger.js";
 export { redactSensitiveText } from "../logging/redact.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
+export { resolveAgentIdentity } from "../agents/identity.js";
+export { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 export type {
   OpenClawPluginApi,
   OpenClawPluginService,
   OpenClawPluginServiceContext,
 } from "../plugins/types.js";
+export type { OpenClawConfig } from "../config/config.js";

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -47,6 +47,8 @@ export type {
   MediaUnderstandingProviderPlugin,
   OpenClawPluginApi,
   OpenClawPluginConfigSchema,
+  OpenClawPluginService,
+  OpenClawPluginServiceContext,
   PluginLogger,
   ProviderAuthContext,
   ProviderAuthResult,
@@ -70,7 +72,29 @@ export type { HookEntry } from "../hooks/types.js";
 export type { ReplyPayload } from "../auto-reply/types.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
 export type { ContextEngineFactory } from "../context-engine/registry.js";
-export type { DiagnosticEventPayload } from "../infra/diagnostic-events.js";
+export type {
+  DiagnosticEventPayload,
+  DiagnosticHeartbeatEvent,
+  DiagnosticInferenceEvent,
+  DiagnosticInferenceStartedEvent,
+  DiagnosticLaneDequeueEvent,
+  DiagnosticLaneEnqueueEvent,
+  DiagnosticMessageProcessedEvent,
+  DiagnosticMessageQueuedEvent,
+  DiagnosticRunAttemptEvent,
+  DiagnosticRunCompletedEvent,
+  DiagnosticRunStartedEvent,
+  DiagnosticSessionState,
+  DiagnosticSessionStateEvent,
+  DiagnosticSessionStuckEvent,
+  DiagnosticToolExecutionEvent,
+  DiagnosticWebhookErrorEvent,
+  DiagnosticWebhookProcessedEvent,
+  DiagnosticWebhookReceivedEvent,
+  GenAiMessage,
+  GenAiPart,
+  GenAiToolDef,
+} from "../infra/diagnostic-events.js";
 export type {
   ContextEngine,
   ContextEngineInfo,
@@ -81,7 +105,15 @@ export type {
   TranscriptRewriteResult,
 } from "../context-engine/types.js";
 
+export { resolveAckReaction, resolveAgentIdentity } from "../agents/identity.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export { registerContextEngine } from "../context-engine/registry.js";
 export { delegateCompactionToRuntime } from "../context-engine/delegate.js";
-export { onDiagnosticEvent } from "../infra/diagnostic-events.js";
+export {
+  emitDiagnosticEvent,
+  isDiagnosticsEnabled,
+  onDiagnosticEvent,
+} from "../infra/diagnostic-events.js";
+export { registerLogTransport } from "../logging/logger.js";
+export { redactSensitiveText } from "../logging/redact.js";
+export { resolveAgentIdFromSessionKey } from "../routing/session-key.js";

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3952,14 +3952,16 @@ module.exports = {
       expect(record?.status).toBe("loaded");
 
       emitDiagnosticEvent({
-        type: "model.usage",
+        type: "model.inference",
         sessionKey: "agent:main:test:dm:peer",
+        provider: "openai",
+        model: "gpt-5.4",
         usage: { total: 1 },
       });
 
       expect((globalThis as Record<string, unknown>)[seenKey]).toEqual([
         {
-          type: "model.usage",
+          type: "model.inference",
           sessionKey: "agent:main:test:dm:peer",
         },
       ]);


### PR DESCRIPTION
## Summary

This is a narrowed current-main port of #21290: it keeps the GenAI OTel instrumentation, content capture, metrics, and useful span hierarchy, while trimming ancillary scope and adapting the implementation to the current event/plugin architecture.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

  - Related #28222
  - Related #38477
  - Related #45096
  - Related #21290

## User-visible / Behavior Changes

  - The built-in `diagnostics-otel` plugin now emits structured OpenTelemetry spans and metrics aligned with GenAI semantic conventions on current `main`.
  - Traces now include nested agent-turn, model-inference, and tool-execution spans instead of only coarse diagnostics.
  - Request/response content capture is available again behind `diagnostics.otel.captureContent` and remains opt-in.
  - Outbound trace context propagation is restored for the embedded runner path, so downstream OpenAI-compatible backends can join the same trace when they honor W3C trace headers.
  - Tool spans now prefer the most specific active parent span (`chat ...`, then `invoke_agent`, then `openclaw.message` fallback), which fixes flattened trace trees during interleaved chat/tool flows.

## Diagram (if applicable)

  ```text
  Before (current upstream/main):
  message.queued
    -> openclaw.message
      -> invoke_agent
        -> chat <model> (partial / inconsistent depending on path)
      -> execute_tool <tool> could attach too high
      -> request/response content may be missing on some paths

  After (this PR):
  message.queued
    -> openclaw.message
      -> invoke_agent
        -> chat <model>
          -> execute_tool <tool>
      -> message.processed

  Tool span parenting after this PR:
  active chat span
    -> else active invoke_agent span
      -> else openclaw.message
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)No
- Secrets/tokens handling changed? (`Yes/No`)No
- New/changed network calls? (`Yes/No`)NO
- Command/tool execution surface changed? (`Yes/No`)NO
- Data access scope changed? (`Yes/No`)Yes
- If any `Yes`, explain risk + mitigation:
The optional telemetry data surface changes when `diagnostics.otel.captureContent` is enabled. In that mode, request/response message bodies, system instructions, tool definitions, and selected tool content can be exported in spans.
  This remains disabled by default, so the sensitive-data risk is opt-in rather than a default behavior change.

  Mitigation:
  - Content capture stays off by default.
  - The config supports granular opt-in fields instead of requiring all content capture.
  - Normal tracing/metrics still work without exporting message bodies.

## Repro + Verification

### Environment

- OS: K8s, Local - Otel Collector with  MLflow, Jaeger

## Evidence

Attach at least one:

- [x] Screenshot/recording


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: K8s, Local - Otel Collector with  MLflow, Jaeger
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

  - Added optional `diagnostics.otel.captureContent` config for opt-in request/response and related content capture in spans
  - No new required env vars
  - 
## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation:
