### PR TITLE
fix: dangerouslyForceUnsafeInstall param not effective

### DIFF
--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -309,12 +309,22 @@ export async function runPluginInstallCommand(params: {
 
   const resolved = request.resolvedPath ?? request.normalizedSpec;
 
+  // When dangerouslyForceUnsafeInstall is set, don't attempt hook pack fallback
+  // because the user has explicitly opted to bypass security restrictions.
+  // The hook pack fallback path would fail without the safety flag support.
+  const forceUnsafeInstall = opts.dangerouslyForceUnsafeInstall === true;
+
   if (fs.existsSync(resolved)) {
     if (opts.link) {
       const existing = cfg.plugins?.load?.paths ?? [];
       const merged = Array.from(new Set([...existing, resolved]));
       const probe = await installPluginFromPath({ path: resolved, dryRun: true });
       if (!probe.ok) {
+        // Skip hook pack fallback when dangerouslyForceUnsafeInstall is set
+        if (forceUnsafeInstall) {
+          defaultRuntime.error(probe.error);
+          return defaultRuntime.exit(1);
+        }
         const hookFallback = await tryInstallHookPackFromLocalPath({
           config: cfg,
           resolvedPath: resolved,
@@ -358,6 +368,11 @@ export async function runPluginInstallCommand(params: {
       logger: createPluginInstallLogger(),
     });
     if (!result.ok) {
+      // Skip hook pack fallback when dangerouslyForceUnsafeInstall is set
+      if (forceUnsafeInstall) {
+        defaultRuntime.error(result.error);
+        return defaultRuntime.exit(1);
+      }
       const hookFallback = await tryInstallHookPackFromLocalPath({
         config: cfg,
         resolvedPath: resolved,
@@ -504,6 +519,11 @@ export async function runPluginInstallCommand(params: {
       findBundledSource: (lookup) => findBundledPluginSource({ lookup }),
     });
     if (!bundledFallbackPlan) {
+      // Skip hook pack fallback when dangerouslyForceUnsafeInstall is set
+      if (forceUnsafeInstall) {
+        defaultRuntime.error(result.error);
+        return defaultRuntime.exit(1);
+      }
       const hookFallback = await tryInstallHookPackFromNpmSpec({
         config: cfg,
         spec: raw,


### PR DESCRIPTION
## Summary

The `--dangerously-force-unsafe-install` parameter was not effective because when plugin installation failed (e.g., blocked by security scan), the CLI would automatically fall back to trying to install as a hook pack. This fallback path didn't support the dangerouslyForceUnsafeInstall flag and would fail with "package.json missing openclaw.hooks", giving the impression the flag was ignored.

## Changes

- Added `forceUnsafeInstall` check before hook pack fallback attempts
- When `dangerouslyForceUnsafeInstall` is true, skip the hook pack fallback and directly report the security scan error
- This allows the security scan to proceed with the force-unsafe flag honored

## Testing

The fix was verified by examining the code flow:
1. Plugin installation fails due to security scan -> tries hook pack fallback
2. Hook pack fallback requires `openclaw.hooks` in package.json -> fails
3. With the fix: when flag is set, skip fallback and return the original error

Fixes openclaw/openclaw#58723