### PR TITLE
fix(browser): block SSRF redirect bypass via real-time route interception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/tools: include value-shape hints in missing-parameter tool errors so dropped, empty-string, and wrong-type write payloads are easier to diagnose from logs. (#55317) Thanks @priyansh19.
+- Plugins/browser: block SSRF redirect bypass by installing a real-time Playwright route handler before `page.goto()` so navigation to private/internal IPs is intercepted and aborted mid-redirect instead of checked post-hoc. (#58771) Thanks @pgondhi987.
 
 ## 2026.4.2-beta.1
 

--- a/extensions/browser/src/browser/errors.test.ts
+++ b/extensions/browser/src/browser/errors.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { BrowserValidationError, toBrowserErrorResponse } from "./errors.js";
+
+describe("browser error mapping", () => {
+  it("maps blocked browser targets to conflict responses", () => {
+    const err = new Error(
+      "Browser target is unavailable after SSRF policy blocked its navigation.",
+    );
+    err.name = "BlockedBrowserTargetError";
+
+    expect(toBrowserErrorResponse(err)).toEqual({
+      status: 409,
+      message: "Browser target is unavailable after SSRF policy blocked its navigation.",
+    });
+  });
+
+  it("preserves BrowserError mappings", () => {
+    expect(toBrowserErrorResponse(new BrowserValidationError("bad input"))).toEqual({
+      status: 400,
+      message: "bad input",
+    });
+  });
+});

--- a/extensions/browser/src/browser/errors.ts
+++ b/extensions/browser/src/browser/errors.ts
@@ -72,6 +72,9 @@ export function toBrowserErrorResponse(err: unknown): {
   if (err instanceof BrowserError) {
     return { status: err.status, message: err.message };
   }
+  if (err instanceof Error && err.name === "BlockedBrowserTargetError") {
+    return { status: 409, message: err.message };
+  }
   if (err instanceof SsrFBlockedError) {
     return { status: 400, message: err.message };
   }

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -255,6 +255,58 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     }
   });
 
+  it("does not quarantine a tab on transient post-navigation check errors", async () => {
+    const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
+    const assertNavigationAllowedSpy = vi.spyOn(
+      navigationGuardModule,
+      "assertBrowserNavigationAllowed",
+    );
+    assertNavigationAllowedSpy.mockImplementation(async (opts: { url: string }) => {
+      if (opts.url === "https://postcheck.example/hop") {
+        throw new Error("getaddrinfo EAI_AGAIN postcheck.example");
+      }
+    });
+    pageGoto.mockImplementationOnce(async () => {
+      const handler = getRouteHandler();
+      if (!handler) {
+        throw new Error("missing route handler");
+      }
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "https://93.184.216.34/start",
+        },
+      );
+      return {
+        request: () => ({
+          url: () => "https://93.184.216.34/final",
+          redirectedFrom: () => ({
+            url: () => "https://postcheck.example/hop",
+            redirectedFrom: () => null,
+          }),
+        }),
+      };
+    });
+
+    try {
+      await expect(
+        createPageViaPlaywright({
+          cdpUrl: "http://127.0.0.1:18792",
+          url: "https://93.184.216.34/start",
+        }),
+      ).rejects.toThrow("getaddrinfo EAI_AGAIN postcheck.example");
+
+      const pages = await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:18792" });
+      expect(pages).toHaveLength(1);
+      expect(pages[0]?.targetId).toBe("TARGET_1");
+      expect(pageClose).not.toHaveBeenCalled();
+    } finally {
+      assertNavigationAllowedSpy.mockRestore();
+    }
+  });
+
   it("keeps blocked tab manageable if close fails", async () => {
     const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
     pageClose.mockRejectedValueOnce(new Error("close failed"));

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -11,6 +11,7 @@ import {
   createPageViaPlaywright,
   forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
+  gotoPageWithNavigationGuard,
   listPagesViaPlaywright,
 } from "./pw-session.js";
 
@@ -607,5 +608,55 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         targetId: "MISSING_TARGET",
       }),
     ).rejects.toBeInstanceOf(BrowserTabNotFoundError);
+  });
+
+  it("quarantines the actual page when blocked navigation receives a stale target id", async () => {
+    const { pageGoto, pageClose, sessionSend, getRouteHandler, mainFrame } = installBrowserMocks();
+    pageClose.mockRejectedValueOnce(new Error("close failed"));
+
+    await createPageViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      url: "about:blank",
+    });
+
+    const page = await getPageForTargetId({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "MISSING_TARGET",
+    });
+
+    pageGoto.mockImplementationOnce(async () => {
+      const handler = getRouteHandler();
+      if (!handler) {
+        throw new Error("missing route handler");
+      }
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "http://127.0.0.1:18080/internal-hop",
+        },
+      );
+      throw new Error("Navigation aborted");
+    });
+
+    // Simulate target-info churn while quarantining so caller target id cannot be trusted.
+    sessionSend.mockRejectedValueOnce(new Error("Target lookup failed"));
+
+    await expect(
+      gotoPageWithNavigationGuard({
+        cdpUrl: "http://127.0.0.1:18792",
+        page,
+        url: "https://93.184.216.34/start",
+        timeoutMs: 1000,
+        targetId: "MISSING_TARGET",
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+
+    await expect(
+      getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:18792",
+      }),
+    ).rejects.toBeInstanceOf(BlockedBrowserTargetError);
   });
 });

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import * as chromeModule from "./chrome.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
+import * as navigationGuardModule from "./navigation-guard.js";
 import {
   closePlaywrightBrowserConnection,
   createPageViaPlaywright,
@@ -202,6 +203,56 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     expect(created.targetId).toBe("TARGET_1");
     expect(pageGoto).toHaveBeenCalledTimes(1);
     expect(pageClose).not.toHaveBeenCalled();
+  });
+
+  it("does not quarantine a tab on transient redirect lookup errors", async () => {
+    const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
+    const assertNavigationAllowedSpy = vi.spyOn(
+      navigationGuardModule,
+      "assertBrowserNavigationAllowed",
+    );
+    assertNavigationAllowedSpy.mockImplementation(async (opts: { url: string }) => {
+      if (opts.url === "http://127.0.0.1:18080/internal-hop") {
+        throw new Error("getaddrinfo EAI_AGAIN internal-hop");
+      }
+    });
+    pageGoto.mockImplementationOnce(async () => {
+      const handler = getRouteHandler();
+      if (!handler) {
+        throw new Error("missing route handler");
+      }
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "https://93.184.216.34/start",
+        },
+      );
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "http://127.0.0.1:18080/internal-hop",
+        },
+      );
+      throw new Error("Navigation aborted");
+    });
+
+    try {
+      const created = await createPageViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://93.184.216.34/start",
+      });
+      const pages = await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:18792" });
+
+      expect(created.targetId).toBe("TARGET_1");
+      expect(pages).toHaveLength(1);
+      expect(pageClose).not.toHaveBeenCalled();
+    } finally {
+      assertNavigationAllowedSpy.mockRestore();
+    }
   });
 
   it("keeps blocked tab manageable if close fails", async () => {

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -334,7 +334,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
           cdpUrl: "http://127.0.0.1:18792",
           url: "https://93.184.216.34/start",
         }),
-      ).rejects.toThrow("getaddrinfo EAI_AGAIN postcheck.example");
+      ).rejects.toThrow(/getaddrinfo .*postcheck\.example/);
 
       const pages = await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:18792" });
       expect(pages).toHaveLength(1);

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -2,6 +2,7 @@ import { chromium } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import * as chromeModule from "./chrome.js";
+import { BrowserTabNotFoundError } from "./errors.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 import * as navigationGuardModule from "./navigation-guard.js";
 import {
@@ -542,5 +543,69 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         cdpUrl: "http://127.0.0.1:18792",
       }),
     ).rejects.toBeInstanceOf(BlockedBrowserTargetError);
+  });
+
+  it("does not fall back to another tab when explicit target lookup misses", async () => {
+    const { pageGoto, pageClose, sessionSend, getRouteHandler, mainFrame } = installBrowserMocks();
+    pageClose.mockRejectedValueOnce(new Error("close failed"));
+    pageGoto.mockImplementationOnce(async () => {
+      const handler = getRouteHandler();
+      if (!handler) {
+        throw new Error("missing route handler");
+      }
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "https://93.184.216.34/start",
+        },
+      );
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "http://127.0.0.1:18080/internal-hop",
+        },
+      );
+      throw new Error("Navigation aborted");
+    });
+
+    await expect(
+      createPageViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://93.184.216.34/start",
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+
+    sessionSend.mockImplementationOnce(async (method: string) => {
+      if (method === "Target.getTargetInfo") {
+        return { targetInfo: { targetId: "TARGET_2" } };
+      }
+      return {};
+    });
+    await createPageViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      url: "https://example.com",
+    });
+
+    let targetInfoLookups = 0;
+    sessionSend.mockImplementation(async (method: string) => {
+      if (method === "Target.getTargetInfo") {
+        targetInfoLookups += 1;
+        return {
+          targetInfo: { targetId: targetInfoLookups % 2 === 1 ? "TARGET_1" : "TARGET_2" },
+        };
+      }
+      return {};
+    });
+
+    await expect(
+      getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "MISSING_TARGET",
+      }),
+    ).rejects.toBeInstanceOf(BrowserTabNotFoundError);
   });
 });

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -8,6 +8,7 @@ import {
   BlockedBrowserTargetError,
   closePlaywrightBrowserConnection,
   createPageViaPlaywright,
+  forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
   listPagesViaPlaywright,
 } from "./pw-session.js";
@@ -392,5 +393,52 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
       }),
     ).rejects.toBeInstanceOf(BlockedBrowserTargetError);
     expect(pageClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves blocked-target quarantine across forced reconnects", async () => {
+    const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
+    pageClose.mockRejectedValueOnce(new Error("close failed"));
+    pageGoto.mockImplementationOnce(async () => {
+      const handler = getRouteHandler();
+      if (!handler) {
+        throw new Error("missing route handler");
+      }
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "https://93.184.216.34/start",
+        },
+      );
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "http://127.0.0.1:18080/internal-hop",
+        },
+      );
+      throw new Error("Navigation aborted");
+    });
+
+    await expect(
+      createPageViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://93.184.216.34/start",
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+
+    await forceDisconnectPlaywrightForTarget({
+      cdpUrl: "http://127.0.0.1:18792",
+      reason: "test forced reconnect",
+    });
+
+    await expect(
+      getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "TARGET_1",
+      }),
+    ).rejects.toBeInstanceOf(BlockedBrowserTargetError);
   });
 });

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -3,7 +3,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import * as chromeModule from "./chrome.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
-import { closePlaywrightBrowserConnection, createPageViaPlaywright } from "./pw-session.js";
+import {
+  closePlaywrightBrowserConnection,
+  createPageViaPlaywright,
+  listPagesViaPlaywright,
+} from "./pw-session.js";
 
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
 const getChromeWebSocketUrlSpy = vi.spyOn(chromeModule, "getChromeWebSocketUrl");
@@ -27,7 +31,13 @@ function installBrowserMocks() {
   const pageUnroute = vi.fn(async () => {
     routeHandler = null;
   });
-  const pageClose = vi.fn(async () => {});
+  const openPages: import("playwright-core").Page[] = [];
+  const pageClose = vi.fn(async () => {
+    const index = openPages.indexOf(page);
+    if (index >= 0) {
+      openPages.splice(index, 1);
+    }
+  });
   const mainFrame = {};
   const contextOn = vi.fn();
   const browserOn = vi.fn();
@@ -41,9 +51,12 @@ function installBrowserMocks() {
   const sessionDetach = vi.fn(async () => {});
 
   const context = {
-    pages: () => [],
+    pages: () => openPages,
     on: contextOn,
-    newPage: vi.fn(async () => page),
+    newPage: vi.fn(async () => {
+      openPages.push(page);
+      return page;
+    }),
     newCDPSession: vi.fn(async () => ({
       send: sessionSend,
       detach: sessionDetach,
@@ -189,5 +202,45 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     expect(created.targetId).toBe("TARGET_1");
     expect(pageGoto).toHaveBeenCalledTimes(1);
     expect(pageClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps blocked tab manageable if close fails", async () => {
+    const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
+    pageClose.mockRejectedValueOnce(new Error("close failed"));
+    pageGoto.mockImplementationOnce(async () => {
+      const handler = getRouteHandler();
+      if (!handler) {
+        throw new Error("missing route handler");
+      }
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "https://93.184.216.34/start",
+        },
+      );
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "http://127.0.0.1:18080/internal-hop",
+        },
+      );
+      throw new Error("Navigation aborted");
+    });
+
+    await expect(
+      createPageViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://93.184.216.34/start",
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+
+    const pages = await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:18792" });
+    expect(pages).toHaveLength(1);
+    expect(pages[0]?.targetId).toBe("TARGET_1");
+    expect(pageClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -10,11 +10,25 @@ const getChromeWebSocketUrlSpy = vi.spyOn(chromeModule, "getChromeWebSocketUrl")
 
 function installBrowserMocks() {
   const pageOn = vi.fn();
+  let routeHandler:
+    | ((
+        route: { continue: () => Promise<void>; abort: () => Promise<void> },
+        request: unknown,
+      ) => Promise<void>)
+    | null = null;
   const pageGoto = vi.fn<
     (...args: unknown[]) => Promise<null | { request: () => Record<string, unknown> }>
   >(async () => null);
   const pageTitle = vi.fn(async () => "");
   const pageUrl = vi.fn(() => "about:blank");
+  const pageRoute = vi.fn(async (_pattern: string, handler: typeof routeHandler) => {
+    routeHandler = handler;
+  });
+  const pageUnroute = vi.fn(async () => {
+    routeHandler = null;
+  });
+  const pageClose = vi.fn(async () => {});
+  const mainFrame = {};
   const contextOn = vi.fn();
   const browserOn = vi.fn();
   const browserClose = vi.fn(async () => {});
@@ -42,6 +56,10 @@ function installBrowserMocks() {
     goto: pageGoto,
     title: pageTitle,
     url: pageUrl,
+    route: pageRoute,
+    unroute: pageUnroute,
+    close: pageClose,
+    mainFrame: () => mainFrame,
   } as unknown as import("playwright-core").Page;
 
   const browser = {
@@ -53,7 +71,7 @@ function installBrowserMocks() {
   connectOverCdpSpy.mockResolvedValue(browser);
   getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
-  return { pageGoto, browserClose };
+  return { pageGoto, browserClose, pageClose, getRouteHandler: () => routeHandler, mainFrame };
 }
 
 afterEach(async () => {
@@ -89,18 +107,29 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
   });
 
   it("blocks private intermediate redirect hops", async () => {
-    const { pageGoto } = installBrowserMocks();
-    pageGoto.mockResolvedValueOnce({
-      request: () => ({
-        url: () => "https://93.184.216.34/final",
-        redirectedFrom: () => ({
+    const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
+    pageGoto.mockImplementationOnce(async () => {
+      const handler = getRouteHandler();
+      if (!handler) {
+        throw new Error("missing route handler");
+      }
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "https://93.184.216.34/start",
+        },
+      );
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
           url: () => "http://127.0.0.1:18080/internal-hop",
-          redirectedFrom: () => ({
-            url: () => "https://93.184.216.34/start",
-            redirectedFrom: () => null,
-          }),
-        }),
-      }),
+        },
+      );
+      throw new Error("Navigation aborted");
     });
 
     await expect(
@@ -109,5 +138,8 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         url: "https://93.184.216.34/start",
       }),
     ).rejects.toBeInstanceOf(SsrFBlockedError);
+
+    expect(pageGoto).toHaveBeenCalledTimes(1);
+    expect(pageClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -103,6 +103,10 @@ function installBrowserMocks() {
     getBrowserDisconnectedHandler,
     getRouteHandler: () => routeHandler,
     mainFrame,
+    pushOpenPage: () => {
+      openPages.push(page);
+      return page;
+    },
   };
 }
 
@@ -656,6 +660,62 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     await expect(
       getPageForTargetId({
         cdpUrl: "http://127.0.0.1:18792",
+      }),
+    ).rejects.toBeInstanceOf(BlockedBrowserTargetError);
+  });
+
+  it("falls back to caller targetId quarantine when target lookup fails", async () => {
+    const first = installBrowserMocks();
+    first.pageClose.mockRejectedValueOnce(new Error("close failed"));
+
+    await createPageViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      url: "about:blank",
+    });
+    const page = await getPageForTargetId({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "TARGET_1",
+    });
+
+    first.pageGoto.mockImplementationOnce(async () => {
+      const handler = first.getRouteHandler();
+      if (!handler) {
+        throw new Error("missing route handler");
+      }
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => first.mainFrame,
+          url: () => "http://127.0.0.1:18080/internal-hop",
+        },
+      );
+      throw new Error("Navigation aborted");
+    });
+
+    first.sessionSend.mockRejectedValueOnce(new Error("Target lookup failed"));
+    await expect(
+      gotoPageWithNavigationGuard({
+        cdpUrl: "http://127.0.0.1:18792",
+        page,
+        url: "https://93.184.216.34/start",
+        timeoutMs: 1000,
+        targetId: "TARGET_1",
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+
+    await forceDisconnectPlaywrightForTarget({
+      cdpUrl: "http://127.0.0.1:18792",
+      reason: "test reconnect after blocked navigation",
+    });
+
+    const second = installBrowserMocks();
+    second.pushOpenPage();
+
+    await expect(
+      getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "TARGET_1",
       }),
     ).rejects.toBeInstanceOf(BlockedBrowserTargetError);
   });

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -142,4 +142,19 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     expect(pageGoto).toHaveBeenCalledTimes(1);
     expect(pageClose).toHaveBeenCalledTimes(1);
   });
+
+  it("preserves the created tab on ordinary navigation failure", async () => {
+    const { pageGoto, pageClose } = installBrowserMocks();
+    pageGoto.mockRejectedValueOnce(new Error("page.goto: net::ERR_NAME_NOT_RESOLVED"));
+
+    const created = await createPageViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      url: "https://example.invalid",
+    });
+
+    expect(created.targetId).toBe("TARGET_1");
+    expect(created.url).toBe("about:blank");
+    expect(pageGoto).toHaveBeenCalledTimes(1);
+    expect(pageClose).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -165,7 +165,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
 
     const created = await createPageViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
-      url: "https://example.invalid",
+      url: "https://93.184.216.34/start",
     });
 
     expect(created.targetId).toBe("TARGET_1");
@@ -296,15 +296,13 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
 
   it("does not quarantine a tab on transient post-navigation check errors", async () => {
     const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
-    const assertNavigationAllowedSpy = vi.spyOn(
+    const assertRedirectChainAllowedSpy = vi.spyOn(
       navigationGuardModule,
-      "assertBrowserNavigationAllowed",
+      "assertBrowserNavigationRedirectChainAllowed",
     );
-    assertNavigationAllowedSpy.mockImplementation(async (opts: { url: string }) => {
-      if (opts.url === "https://postcheck.example/hop") {
-        throw new Error("getaddrinfo EAI_AGAIN postcheck.example");
-      }
-    });
+    assertRedirectChainAllowedSpy.mockRejectedValueOnce(
+      new Error("getaddrinfo EAI_AGAIN postcheck.example"),
+    );
     pageGoto.mockImplementationOnce(async () => {
       const handler = getRouteHandler();
       if (!handler) {
@@ -342,7 +340,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
       expect(pages[0]?.targetId).toBe("TARGET_1");
       expect(pageClose).not.toHaveBeenCalled();
     } finally {
-      assertNavigationAllowedSpy.mockRestore();
+      assertRedirectChainAllowedSpy.mockRestore();
     }
   });
 

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -5,8 +5,10 @@ import * as chromeModule from "./chrome.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 import * as navigationGuardModule from "./navigation-guard.js";
 import {
+  BlockedBrowserTargetError,
   closePlaywrightBrowserConnection,
   createPageViaPlaywright,
+  getPageForTargetId,
   listPagesViaPlaywright,
 } from "./pw-session.js";
 
@@ -205,6 +207,43 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     expect(pageClose).not.toHaveBeenCalled();
   });
 
+  it("propagates unsupported redirect protocols as navigation errors", async () => {
+    const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
+    pageGoto.mockImplementationOnce(async () => {
+      const handler = getRouteHandler();
+      if (!handler) {
+        throw new Error("missing route handler");
+      }
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "https://93.184.216.34/start",
+        },
+      );
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "file:///etc/passwd",
+        },
+      );
+      throw new Error("Navigation aborted");
+    });
+
+    await expect(
+      createPageViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://93.184.216.34/start",
+      }),
+    ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
+
+    expect(pageGoto).toHaveBeenCalledTimes(1);
+    expect(pageClose).toHaveBeenCalledTimes(1);
+  });
+
   it("does not quarantine a tab on transient redirect lookup errors", async () => {
     const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
     const assertNavigationAllowedSpy = vi.spyOn(
@@ -307,7 +346,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     }
   });
 
-  it("keeps blocked tab manageable if close fails", async () => {
+  it("keeps blocked tab quarantined if close fails", async () => {
     const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
     pageClose.mockRejectedValueOnce(new Error("close failed"));
     pageGoto.mockImplementationOnce(async () => {
@@ -342,8 +381,18 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     ).rejects.toBeInstanceOf(SsrFBlockedError);
 
     const pages = await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:18792" });
-    expect(pages).toHaveLength(1);
-    expect(pages[0]?.targetId).toBe("TARGET_1");
+    expect(pages).toHaveLength(0);
+    await expect(
+      getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "TARGET_1",
+      }),
+    ).rejects.toBeInstanceOf(BlockedBrowserTargetError);
+    await expect(
+      getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:18792",
+      }),
+    ).rejects.toBeInstanceOf(BlockedBrowserTargetError);
     expect(pageClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -157,4 +157,37 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     expect(pageGoto).toHaveBeenCalledTimes(1);
     expect(pageClose).not.toHaveBeenCalled();
   });
+
+  it("does not quarantine a tab when route.continue fails", async () => {
+    const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
+    pageGoto.mockImplementationOnce(async () => {
+      const handler = getRouteHandler();
+      if (!handler) {
+        throw new Error("missing route handler");
+      }
+      await handler(
+        {
+          continue: vi.fn(async () => {
+            throw new Error("page.goto: Frame has been detached");
+          }),
+          abort: vi.fn(async () => {}),
+        },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "https://example.com",
+        },
+      );
+      throw new Error("page.goto: Frame has been detached");
+    });
+
+    const created = await createPageViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      url: "https://example.com",
+    });
+
+    expect(created.targetId).toBe("TARGET_1");
+    expect(pageGoto).toHaveBeenCalledTimes(1);
+    expect(pageClose).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -88,7 +88,20 @@ function installBrowserMocks() {
   connectOverCdpSpy.mockResolvedValue(browser);
   getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
-  return { pageGoto, browserClose, pageClose, getRouteHandler: () => routeHandler, mainFrame };
+  const getBrowserDisconnectedHandler = () =>
+    browserOn.mock.calls.find((call) => call[0] === "disconnected")?.[1] as
+      | (() => void)
+      | undefined;
+
+  return {
+    pageGoto,
+    browserClose,
+    pageClose,
+    sessionSend,
+    getBrowserDisconnectedHandler,
+    getRouteHandler: () => routeHandler,
+    mainFrame,
+  };
 }
 
 afterEach(async () => {
@@ -438,6 +451,95 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
       getPageForTargetId({
         cdpUrl: "http://127.0.0.1:18792",
         targetId: "TARGET_1",
+      }),
+    ).rejects.toBeInstanceOf(BlockedBrowserTargetError);
+  });
+
+  it("preserves blocked-target quarantine across transport disconnects", async () => {
+    const { pageGoto, pageClose, getBrowserDisconnectedHandler, getRouteHandler, mainFrame } =
+      installBrowserMocks();
+    pageClose.mockRejectedValueOnce(new Error("close failed"));
+    pageGoto.mockImplementationOnce(async () => {
+      const handler = getRouteHandler();
+      if (!handler) {
+        throw new Error("missing route handler");
+      }
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "https://93.184.216.34/start",
+        },
+      );
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "http://127.0.0.1:18080/internal-hop",
+        },
+      );
+      throw new Error("Navigation aborted");
+    });
+
+    await expect(
+      createPageViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://93.184.216.34/start",
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+
+    const disconnectedHandler = getBrowserDisconnectedHandler();
+    expect(disconnectedHandler).toBeTypeOf("function");
+    disconnectedHandler?.();
+
+    await expect(
+      getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "TARGET_1",
+      }),
+    ).rejects.toBeInstanceOf(BlockedBrowserTargetError);
+  });
+
+  it("keeps blocked tabs inaccessible when target lookup fails", async () => {
+    const { pageGoto, pageClose, sessionSend, getRouteHandler, mainFrame } = installBrowserMocks();
+    pageClose.mockRejectedValueOnce(new Error("close failed"));
+    pageGoto.mockImplementationOnce(async () => {
+      const handler = getRouteHandler();
+      if (!handler) {
+        throw new Error("missing route handler");
+      }
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "https://93.184.216.34/start",
+        },
+      );
+      await handler(
+        { continue: vi.fn(async () => {}), abort: vi.fn(async () => {}) },
+        {
+          isNavigationRequest: () => true,
+          frame: () => mainFrame,
+          url: () => "http://127.0.0.1:18080/internal-hop",
+        },
+      );
+      throw new Error("Navigation aborted");
+    });
+
+    await expect(
+      createPageViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://93.184.216.34/start",
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+
+    sessionSend.mockRejectedValueOnce(new Error("Target lookup failed"));
+    await expect(
+      getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:18792",
       }),
     ).rejects.toBeInstanceOf(BlockedBrowserTargetError);
   });

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -639,11 +639,12 @@ export async function gotoPageWithNavigationGuard(opts: {
         url: request.url(),
         ...navigationPolicy,
       });
-      await route.continue();
     } catch (err) {
       blockedError = err;
       await route.abort().catch(() => {});
+      return;
     }
+    await route.continue();
   };
 
   await opts.page.route("**", handler);

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -160,6 +160,14 @@ function markTargetBlocked(cdpUrl: string, targetId?: string): void {
   blockedTargetsByCdpUrl.add(targetKey(cdpUrl, normalizedTargetId));
 }
 
+function clearBlockedTarget(cdpUrl: string, targetId?: string): void {
+  const normalizedTargetId = targetId?.trim() || "";
+  if (!normalizedTargetId) {
+    return;
+  }
+  blockedTargetsByCdpUrl.delete(targetKey(cdpUrl, normalizedTargetId));
+}
+
 function clearBlockedTargetsForCdpUrl(cdpUrl?: string): void {
   if (!cdpUrl) {
     blockedTargetsByCdpUrl.clear();
@@ -399,6 +407,7 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
           const current = cachedByCdpUrl.get(normalized);
           if (current?.browser === browser) {
             cachedByCdpUrl.delete(normalized);
+            clearBlockedTargetsForCdpUrl(normalized);
           }
         };
         const connected: ConnectedBrowser = { browser, cdpUrl: normalized, onDisconnected };
@@ -436,6 +445,23 @@ async function getAllPages(browser: Browser): Promise<Page[]> {
   const contexts = browser.contexts();
   const pages = contexts.flatMap((c) => c.pages());
   return pages;
+}
+
+async function partitionAccessiblePages(opts: {
+  cdpUrl: string;
+  pages: Page[];
+}): Promise<{ accessible: Page[]; blockedCount: number }> {
+  const accessible: Page[] = [];
+  let blockedCount = 0;
+  for (const page of opts.pages) {
+    const targetId = await pageTargetId(page).catch(() => null);
+    if (targetId && isBlockedTarget(opts.cdpUrl, targetId)) {
+      blockedCount += 1;
+      continue;
+    }
+    accessible.push(page);
+  }
+  return { accessible, blockedCount };
 }
 
 async function pageTargetId(page: Page): Promise<string | null> {
@@ -550,19 +576,34 @@ export async function getPageForTargetId(opts: {
   if (!pages.length) {
     throw new Error("No pages available in the connected browser.");
   }
-  const first = pages[0];
+
+  const { accessible, blockedCount } = await partitionAccessiblePages({
+    cdpUrl: opts.cdpUrl,
+    pages,
+  });
+  if (!accessible.length) {
+    if (blockedCount > 0) {
+      throw new BlockedBrowserTargetError();
+    }
+    throw new Error("No pages available in the connected browser.");
+  }
+  const first = accessible[0];
   if (!opts.targetId) {
     return first;
   }
   const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
-  if (!found) {
-    // If Playwright only exposes a single Page, use it as a best-effort fallback.
-    if (pages.length === 1) {
-      return first;
+  if (found) {
+    const foundTargetId = await pageTargetId(found).catch(() => null);
+    if (foundTargetId && isBlockedTarget(opts.cdpUrl, foundTargetId)) {
+      throw new BlockedBrowserTargetError();
     }
-    throw new BrowserTabNotFoundError();
+    return found;
   }
-  return found;
+  // If Playwright only exposes a single Page, use it as a best-effort fallback.
+  if (accessible.length === 1) {
+    return first;
+  }
+  throw new BrowserTabNotFoundError();
 }
 
 function isTopLevelNavigationRequest(page: Page, request: Request): boolean {
@@ -586,13 +627,10 @@ async function closeBlockedNavigationTarget(opts: {
   targetId?: string;
 }): Promise<void> {
   const targetId = opts.targetId?.trim() || (await pageTargetId(opts.page).catch(() => null)) || "";
-  const closed = await opts.page
-    .close()
-    .then(() => true)
-    .catch(() => false);
-  if (closed && targetId) {
+  if (targetId) {
     markTargetBlocked(opts.cdpUrl, targetId);
   }
+  await opts.page.close().catch(() => {});
 }
 
 export async function assertPageNavigationCompletedSafely(opts: {
@@ -860,6 +898,7 @@ export async function forceDisconnectPlaywrightForTarget(opts: {
   if (!cur) {
     return;
   }
+  clearBlockedTargetsForCdpUrl(normalized);
   cachedByCdpUrl.delete(normalized);
   // Also clear the per-url in-flight connect so the next call does a fresh connectOverCDP
   // rather than awaiting a stale promise.
@@ -938,6 +977,7 @@ export async function createPageViaPlaywright(opts: {
   const page = await context.newPage();
   ensurePageState(page);
   const createdTargetId = await pageTargetId(page).catch(() => null);
+  clearBlockedTarget(opts.cdpUrl, createdTargetId ?? undefined);
 
   // Navigate to the URL
   const targetUrl = opts.url.trim() || "about:blank";
@@ -958,7 +998,7 @@ export async function createPageViaPlaywright(opts: {
         targetId: createdTargetId ?? undefined,
       });
     } catch (err) {
-      if (err instanceof SsrFBlockedError || err instanceof BlockedBrowserTargetError) {
+      if (isPolicyDenyNavigationError(err) || err instanceof BlockedBrowserTargetError) {
         throw err;
       }
     }

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -613,11 +613,13 @@ export async function assertPageNavigationCompletedSafely(opts: {
       ...navigationPolicy,
     });
   } catch (err) {
-    await closeBlockedNavigationTarget({
-      cdpUrl: opts.cdpUrl,
-      page: opts.page,
-      targetId: opts.targetId,
-    });
+    if (isPolicyDenyNavigationError(err)) {
+      await closeBlockedNavigationTarget({
+        cdpUrl: opts.cdpUrl,
+        page: opts.page,
+        targetId: opts.targetId,
+      });
+    }
     throw err;
   }
 }

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -9,7 +9,7 @@ import type {
 } from "playwright-core";
 import { chromium } from "playwright-core";
 import { formatErrorMessage } from "../infra/errors.js";
-import type { SsrFPolicy } from "../infra/net/ssrf.js";
+import { SsrFBlockedError, type SsrFPolicy } from "../infra/net/ssrf.js";
 import { withNoProxyForCdpUrl } from "./cdp-proxy-bypass.js";
 import {
   appendCdpPath,
@@ -135,12 +135,12 @@ function findNetworkRequestById(state: PageState, id: string): BrowserNetworkReq
   return undefined;
 }
 
-function roleRefsKey(cdpUrl: string, targetId: string) {
+function targetKey(cdpUrl: string, targetId: string) {
   return `${normalizeCdpUrl(cdpUrl)}::${targetId}`;
 }
 
-function blockedTargetKey(cdpUrl: string, targetId: string) {
-  return `${normalizeCdpUrl(cdpUrl)}::${targetId}`;
+function roleRefsKey(cdpUrl: string, targetId: string) {
+  return targetKey(cdpUrl, targetId);
 }
 
 function isBlockedTarget(cdpUrl: string, targetId?: string): boolean {
@@ -148,7 +148,7 @@ function isBlockedTarget(cdpUrl: string, targetId?: string): boolean {
   if (!normalizedTargetId) {
     return false;
   }
-  return blockedTargetsByCdpUrl.has(blockedTargetKey(cdpUrl, normalizedTargetId));
+  return blockedTargetsByCdpUrl.has(targetKey(cdpUrl, normalizedTargetId));
 }
 
 function markTargetBlocked(cdpUrl: string, targetId?: string): void {
@@ -156,7 +156,7 @@ function markTargetBlocked(cdpUrl: string, targetId?: string): void {
   if (!normalizedTargetId) {
     return;
   }
-  blockedTargetsByCdpUrl.add(blockedTargetKey(cdpUrl, normalizedTargetId));
+  blockedTargetsByCdpUrl.add(targetKey(cdpUrl, normalizedTargetId));
 }
 
 function clearBlockedTargetsForCdpUrl(cdpUrl?: string): void {
@@ -933,14 +933,21 @@ export async function createPageViaPlaywright(opts: {
       url: targetUrl,
       ...navigationPolicy,
     });
-    const response = await gotoPageWithNavigationGuard({
-      cdpUrl: opts.cdpUrl,
-      page,
-      url: targetUrl,
-      timeoutMs: 30_000,
-      ssrfPolicy: opts.ssrfPolicy,
-      targetId: createdTargetId ?? undefined,
-    });
+    let response: Response | null = null;
+    try {
+      response = await gotoPageWithNavigationGuard({
+        cdpUrl: opts.cdpUrl,
+        page,
+        url: targetUrl,
+        timeoutMs: 30_000,
+        ssrfPolicy: opts.ssrfPolicy,
+        targetId: createdTargetId ?? undefined,
+      });
+    } catch (err) {
+      if (err instanceof SsrFBlockedError || err instanceof BlockedBrowserTargetError) {
+        throw err;
+      }
+    }
     await assertPageNavigationCompletedSafely({
       cdpUrl: opts.cdpUrl,
       page,

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -181,6 +181,16 @@ function clearBlockedTargetsForCdpUrl(cdpUrl?: string): void {
   }
 }
 
+function hasBlockedTargetsForCdpUrl(cdpUrl: string): boolean {
+  const prefix = `${normalizeCdpUrl(cdpUrl)}::`;
+  for (const key of blockedTargetsByCdpUrl) {
+    if (key.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export class BlockedBrowserTargetError extends Error {
   constructor() {
     super("Browser target is unavailable after SSRF policy blocked its navigation.");
@@ -407,7 +417,6 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
           const current = cachedByCdpUrl.get(normalized);
           if (current?.browser === browser) {
             cachedByCdpUrl.delete(normalized);
-            clearBlockedTargetsForCdpUrl(normalized);
           }
         };
         const connected: ConnectedBrowser = { browser, cdpUrl: normalized, onDisconnected };
@@ -455,7 +464,17 @@ async function partitionAccessiblePages(opts: {
   let blockedCount = 0;
   for (const page of opts.pages) {
     const targetId = await pageTargetId(page).catch(() => null);
-    if (targetId && isBlockedTarget(opts.cdpUrl, targetId)) {
+    // Fail closed when we cannot resolve a target id while this session has
+    // quarantined targets; otherwise a blocked tab can become selectable.
+    if (!targetId) {
+      if (hasBlockedTargetsForCdpUrl(opts.cdpUrl)) {
+        blockedCount += 1;
+        continue;
+      }
+      accessible.push(page);
+      continue;
+    }
+    if (isBlockedTarget(opts.cdpUrl, targetId)) {
       blockedCount += 1;
       continue;
     }

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -898,7 +898,6 @@ export async function forceDisconnectPlaywrightForTarget(opts: {
   if (!cur) {
     return;
   }
-  clearBlockedTargetsForCdpUrl(normalized);
   cachedByCdpUrl.delete(normalized);
   // Also clear the per-url in-flight connect so the next call does a fresh connectOverCDP
   // rather than awaiting a stale promise.

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -25,6 +25,7 @@ import {
   assertBrowserNavigationAllowed,
   assertBrowserNavigationRedirectChainAllowed,
   assertBrowserNavigationResultAllowed,
+  InvalidBrowserNavigationUrlError,
   withBrowserNavigationPolicy,
 } from "./navigation-guard.js";
 import { withPageScopedCdpClient } from "./pw-session.page-cdp.js";
@@ -575,6 +576,10 @@ function isTopLevelNavigationRequest(page: Page, request: Request): boolean {
   }
 }
 
+function isPolicyDenyNavigationError(err: unknown): boolean {
+  return err instanceof SsrFBlockedError || err instanceof InvalidBrowserNavigationUrlError;
+}
+
 async function closeBlockedNavigationTarget(opts: {
   cdpUrl: string;
   page: Page;
@@ -643,9 +648,12 @@ export async function gotoPageWithNavigationGuard(opts: {
         ...navigationPolicy,
       });
     } catch (err) {
-      blockedError = err;
-      await route.abort().catch(() => {});
-      return;
+      if (isPolicyDenyNavigationError(err)) {
+        blockedError = err;
+        await route.abort().catch(() => {});
+        return;
+      }
+      throw err;
     }
     await route.continue();
   };

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -923,6 +923,7 @@ export async function createPageViaPlaywright(opts: {
 
   const page = await context.newPage();
   ensurePageState(page);
+  const createdTargetId = await pageTargetId(page).catch(() => null);
 
   // Navigate to the URL
   const targetUrl = opts.url.trim() || "about:blank";
@@ -938,17 +939,19 @@ export async function createPageViaPlaywright(opts: {
       url: targetUrl,
       timeoutMs: 30_000,
       ssrfPolicy: opts.ssrfPolicy,
+      targetId: createdTargetId ?? undefined,
     });
     await assertPageNavigationCompletedSafely({
       cdpUrl: opts.cdpUrl,
       page,
       response,
       ssrfPolicy: opts.ssrfPolicy,
+      targetId: createdTargetId ?? undefined,
     });
   }
 
   // Get the targetId for this page
-  const tid = await pageTargetId(page).catch(() => null);
+  const tid = createdTargetId || (await pageTargetId(page).catch(() => null));
   if (!tid) {
     throw new Error("Failed to get targetId for new page");
   }

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -121,6 +121,7 @@ const MAX_NETWORK_REQUESTS = 500;
 const cachedByCdpUrl = new Map<string, ConnectedBrowser>();
 const connectingByCdpUrl = new Map<string, Promise<ConnectedBrowser>>();
 const blockedTargetsByCdpUrl = new Set<string>();
+const blockedPageRefsByCdpUrl = new Map<string, WeakSet<Page>>();
 
 function normalizeCdpUrl(raw: string) {
   return raw.replace(/\/$/, "");
@@ -179,6 +180,37 @@ function clearBlockedTargetsForCdpUrl(cdpUrl?: string): void {
       blockedTargetsByCdpUrl.delete(key);
     }
   }
+}
+
+function blockedPageRefsForCdpUrl(cdpUrl: string): WeakSet<Page> {
+  const normalized = normalizeCdpUrl(cdpUrl);
+  const existing = blockedPageRefsByCdpUrl.get(normalized);
+  if (existing) {
+    return existing;
+  }
+  const created = new WeakSet<Page>();
+  blockedPageRefsByCdpUrl.set(normalized, created);
+  return created;
+}
+
+function isBlockedPageRef(cdpUrl: string, page: Page): boolean {
+  return blockedPageRefsByCdpUrl.get(normalizeCdpUrl(cdpUrl))?.has(page) ?? false;
+}
+
+function markPageRefBlocked(cdpUrl: string, page: Page): void {
+  blockedPageRefsForCdpUrl(cdpUrl).add(page);
+}
+
+function clearBlockedPageRefsForCdpUrl(cdpUrl?: string): void {
+  if (!cdpUrl) {
+    blockedPageRefsByCdpUrl.clear();
+    return;
+  }
+  blockedPageRefsByCdpUrl.delete(normalizeCdpUrl(cdpUrl));
+}
+
+function clearBlockedPageRef(cdpUrl: string, page: Page): void {
+  blockedPageRefsByCdpUrl.get(normalizeCdpUrl(cdpUrl))?.delete(page);
 }
 
 function hasBlockedTargetsForCdpUrl(cdpUrl: string): boolean {
@@ -463,6 +495,10 @@ async function partitionAccessiblePages(opts: {
   const accessible: Page[] = [];
   let blockedCount = 0;
   for (const page of opts.pages) {
+    if (isBlockedPageRef(opts.cdpUrl, page)) {
+      blockedCount += 1;
+      continue;
+    }
     const targetId = await pageTargetId(page).catch(() => null);
     // Fail closed when we cannot resolve a target id while this session has
     // quarantined targets; otherwise a blocked tab can become selectable.
@@ -612,6 +648,9 @@ export async function getPageForTargetId(opts: {
   }
   const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
   if (found) {
+    if (isBlockedPageRef(opts.cdpUrl, found)) {
+      throw new BlockedBrowserTargetError();
+    }
     const foundTargetId = await pageTargetId(found).catch(() => null);
     if (foundTargetId && isBlockedTarget(opts.cdpUrl, foundTargetId)) {
       throw new BlockedBrowserTargetError();
@@ -640,14 +679,12 @@ function isPolicyDenyNavigationError(err: unknown): boolean {
   return err instanceof SsrFBlockedError || err instanceof InvalidBrowserNavigationUrlError;
 }
 
-async function closeBlockedNavigationTarget(opts: {
-  cdpUrl: string;
-  page: Page;
-  targetId?: string;
-}): Promise<void> {
-  const targetId = opts.targetId?.trim() || (await pageTargetId(opts.page).catch(() => null)) || "";
-  if (targetId) {
-    markTargetBlocked(opts.cdpUrl, targetId);
+async function closeBlockedNavigationTarget(opts: { cdpUrl: string; page: Page }): Promise<void> {
+  // Quarantine the concrete page first; caller-provided target ids can be stale.
+  markPageRefBlocked(opts.cdpUrl, opts.page);
+  const resolvedTargetId = await pageTargetId(opts.page).catch(() => null);
+  if (resolvedTargetId) {
+    markTargetBlocked(opts.cdpUrl, resolvedTargetId);
   }
   await opts.page.close().catch(() => {});
 }
@@ -674,7 +711,6 @@ export async function assertPageNavigationCompletedSafely(opts: {
       await closeBlockedNavigationTarget({
         cdpUrl: opts.cdpUrl,
         page: opts.page,
-        targetId: opts.targetId,
       });
     }
     throw err;
@@ -735,7 +771,6 @@ export async function gotoPageWithNavigationGuard(opts: {
       await closeBlockedNavigationTarget({
         cdpUrl: opts.cdpUrl,
         page: opts.page,
-        targetId: opts.targetId,
       });
     }
   }
@@ -785,6 +820,7 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
 
   if (normalized) {
     clearBlockedTargetsForCdpUrl(normalized);
+    clearBlockedPageRefsForCdpUrl(normalized);
     const cur = cachedByCdpUrl.get(normalized);
     cachedByCdpUrl.delete(normalized);
     connectingByCdpUrl.delete(normalized);
@@ -800,6 +836,7 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
 
   const connections = Array.from(cachedByCdpUrl.values());
   clearBlockedTargetsForCdpUrl();
+  clearBlockedPageRefsForCdpUrl();
   cachedByCdpUrl.clear();
   connectingByCdpUrl.clear();
   for (const cur of connections) {
@@ -960,6 +997,9 @@ export async function listPagesViaPlaywright(opts: { cdpUrl: string }): Promise<
   }> = [];
 
   for (const page of pages) {
+    if (isBlockedPageRef(opts.cdpUrl, page)) {
+      continue;
+    }
     const tid = await pageTargetId(page).catch(() => null);
     if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
       results.push({
@@ -994,6 +1034,7 @@ export async function createPageViaPlaywright(opts: {
 
   const page = await context.newPage();
   ensurePageState(page);
+  clearBlockedPageRef(opts.cdpUrl, page);
   const createdTargetId = await pageTargetId(page).catch(() => null);
   clearBlockedTarget(opts.cdpUrl, createdTargetId ?? undefined);
 

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -5,6 +5,7 @@ import type {
   Page,
   Request,
   Response,
+  Route,
 } from "playwright-core";
 import { chromium } from "playwright-core";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -118,6 +119,7 @@ const MAX_NETWORK_REQUESTS = 500;
 
 const cachedByCdpUrl = new Map<string, ConnectedBrowser>();
 const connectingByCdpUrl = new Map<string, Promise<ConnectedBrowser>>();
+const blockedTargetsByCdpUrl = new Set<string>();
 
 function normalizeCdpUrl(raw: string) {
   return raw.replace(/\/$/, "");
@@ -135,6 +137,46 @@ function findNetworkRequestById(state: PageState, id: string): BrowserNetworkReq
 
 function roleRefsKey(cdpUrl: string, targetId: string) {
   return `${normalizeCdpUrl(cdpUrl)}::${targetId}`;
+}
+
+function blockedTargetKey(cdpUrl: string, targetId: string) {
+  return `${normalizeCdpUrl(cdpUrl)}::${targetId}`;
+}
+
+function isBlockedTarget(cdpUrl: string, targetId?: string): boolean {
+  const normalizedTargetId = targetId?.trim() || "";
+  if (!normalizedTargetId) {
+    return false;
+  }
+  return blockedTargetsByCdpUrl.has(blockedTargetKey(cdpUrl, normalizedTargetId));
+}
+
+function markTargetBlocked(cdpUrl: string, targetId?: string): void {
+  const normalizedTargetId = targetId?.trim() || "";
+  if (!normalizedTargetId) {
+    return;
+  }
+  blockedTargetsByCdpUrl.add(blockedTargetKey(cdpUrl, normalizedTargetId));
+}
+
+function clearBlockedTargetsForCdpUrl(cdpUrl?: string): void {
+  if (!cdpUrl) {
+    blockedTargetsByCdpUrl.clear();
+    return;
+  }
+  const prefix = `${normalizeCdpUrl(cdpUrl)}::`;
+  for (const key of blockedTargetsByCdpUrl) {
+    if (key.startsWith(prefix)) {
+      blockedTargetsByCdpUrl.delete(key);
+    }
+  }
+}
+
+export class BlockedBrowserTargetError extends Error {
+  constructor() {
+    super("Browser target is unavailable after SSRF policy blocked its navigation.");
+    this.name = "BlockedBrowserTargetError";
+  }
 }
 
 export function rememberRoleRefsForTarget(opts: {
@@ -484,6 +526,9 @@ async function resolvePageByTargetIdOrThrow(opts: {
   cdpUrl: string;
   targetId: string;
 }): Promise<Page> {
+  if (isBlockedTarget(opts.cdpUrl, opts.targetId)) {
+    throw new BlockedBrowserTargetError();
+  }
   const { browser } = await connectBrowser(opts.cdpUrl);
   const page = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
   if (!page) {
@@ -496,6 +541,9 @@ export async function getPageForTargetId(opts: {
   cdpUrl: string;
   targetId?: string;
 }): Promise<Page> {
+  if (opts.targetId && isBlockedTarget(opts.cdpUrl, opts.targetId)) {
+    throw new BlockedBrowserTargetError();
+  }
   const { browser } = await connectBrowser(opts.cdpUrl);
   const pages = await getAllPages(browser);
   if (!pages.length) {
@@ -514,6 +562,112 @@ export async function getPageForTargetId(opts: {
     throw new BrowserTabNotFoundError();
   }
   return found;
+}
+
+function isTopLevelNavigationRequest(page: Page, request: Request): boolean {
+  if (!request.isNavigationRequest()) {
+    return false;
+  }
+  try {
+    return request.frame() === page.mainFrame();
+  } catch {
+    return true;
+  }
+}
+
+async function closeBlockedNavigationTarget(opts: {
+  cdpUrl: string;
+  page: Page;
+  targetId?: string;
+}): Promise<void> {
+  const targetId = opts.targetId?.trim() || (await pageTargetId(opts.page).catch(() => null)) || "";
+  if (targetId) {
+    markTargetBlocked(opts.cdpUrl, targetId);
+  }
+  await opts.page.close().catch(() => {});
+}
+
+export async function assertPageNavigationCompletedSafely(opts: {
+  cdpUrl: string;
+  page: Page;
+  response: Response | null;
+  ssrfPolicy?: SsrFPolicy;
+  targetId?: string;
+}): Promise<void> {
+  const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy);
+  try {
+    await assertBrowserNavigationRedirectChainAllowed({
+      request: opts.response?.request(),
+      ...navigationPolicy,
+    });
+    await assertBrowserNavigationResultAllowed({
+      url: opts.page.url(),
+      ...navigationPolicy,
+    });
+  } catch (err) {
+    await closeBlockedNavigationTarget({
+      cdpUrl: opts.cdpUrl,
+      page: opts.page,
+      targetId: opts.targetId,
+    });
+    throw err;
+  }
+}
+
+export async function gotoPageWithNavigationGuard(opts: {
+  cdpUrl: string;
+  page: Page;
+  url: string;
+  timeoutMs: number;
+  ssrfPolicy?: SsrFPolicy;
+  targetId?: string;
+}): Promise<Response | null> {
+  const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy);
+  let blockedError: unknown = null;
+
+  const handler = async (route: Route, request: Request) => {
+    if (blockedError) {
+      await route.abort().catch(() => {});
+      return;
+    }
+    if (!isTopLevelNavigationRequest(opts.page, request)) {
+      await route.continue();
+      return;
+    }
+    try {
+      await assertBrowserNavigationAllowed({
+        url: request.url(),
+        ...navigationPolicy,
+      });
+      await route.continue();
+    } catch (err) {
+      blockedError = err;
+      await route.abort().catch(() => {});
+    }
+  };
+
+  await opts.page.route("**", handler);
+  try {
+    const response = await opts.page.goto(opts.url, { timeout: opts.timeoutMs });
+    if (blockedError) {
+      throw blockedError;
+    }
+    return response;
+  } catch (err) {
+    if (blockedError) {
+      throw blockedError;
+    }
+    throw err;
+  } finally {
+    await opts.page.unroute("**", handler).catch(() => {});
+    if (blockedError) {
+      await closeBlockedNavigationTarget({
+        cdpUrl: opts.cdpUrl,
+        page: opts.page,
+        targetId: opts.targetId,
+      });
+    }
+  }
 }
 
 export function refLocator(page: Page, ref: string) {
@@ -559,6 +713,7 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
   const normalized = opts?.cdpUrl ? normalizeCdpUrl(opts.cdpUrl) : null;
 
   if (normalized) {
+    clearBlockedTargetsForCdpUrl(normalized);
     const cur = cachedByCdpUrl.get(normalized);
     cachedByCdpUrl.delete(normalized);
     connectingByCdpUrl.delete(normalized);
@@ -573,6 +728,7 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
   }
 
   const connections = Array.from(cachedByCdpUrl.values());
+  clearBlockedTargetsForCdpUrl();
   cachedByCdpUrl.clear();
   connectingByCdpUrl.clear();
   for (const cur of connections) {
@@ -734,7 +890,7 @@ export async function listPagesViaPlaywright(opts: { cdpUrl: string }): Promise<
 
   for (const page of pages) {
     const tid = await pageTargetId(page).catch(() => null);
-    if (tid) {
+    if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
       results.push({
         targetId: tid,
         title: await page.title().catch(() => ""),
@@ -776,17 +932,18 @@ export async function createPageViaPlaywright(opts: {
       url: targetUrl,
       ...navigationPolicy,
     });
-    const response = await page.goto(targetUrl, { timeout: 30_000 }).catch(() => {
-      // Navigation might fail for some URLs, but page is still created
-      return null;
+    const response = await gotoPageWithNavigationGuard({
+      cdpUrl: opts.cdpUrl,
+      page,
+      url: targetUrl,
+      timeoutMs: 30_000,
+      ssrfPolicy: opts.ssrfPolicy,
     });
-    await assertBrowserNavigationRedirectChainAllowed({
-      request: response?.request(),
-      ...navigationPolicy,
-    });
-    await assertBrowserNavigationResultAllowed({
-      url: page.url(),
-      ...navigationPolicy,
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response,
+      ssrfPolicy: opts.ssrfPolicy,
     });
   }
 

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -679,12 +679,18 @@ function isPolicyDenyNavigationError(err: unknown): boolean {
   return err instanceof SsrFBlockedError || err instanceof InvalidBrowserNavigationUrlError;
 }
 
-async function closeBlockedNavigationTarget(opts: { cdpUrl: string; page: Page }): Promise<void> {
-  // Quarantine the concrete page first; caller-provided target ids can be stale.
+async function closeBlockedNavigationTarget(opts: {
+  cdpUrl: string;
+  page: Page;
+  targetId?: string;
+}): Promise<void> {
+  // Quarantine the concrete page first; then persist by target id when available.
   markPageRefBlocked(opts.cdpUrl, opts.page);
   const resolvedTargetId = await pageTargetId(opts.page).catch(() => null);
-  if (resolvedTargetId) {
-    markTargetBlocked(opts.cdpUrl, resolvedTargetId);
+  const fallbackTargetId = opts.targetId?.trim() || "";
+  const targetIdToBlock = resolvedTargetId || fallbackTargetId;
+  if (targetIdToBlock) {
+    markTargetBlocked(opts.cdpUrl, targetIdToBlock);
   }
   await opts.page.close().catch(() => {});
 }
@@ -711,6 +717,7 @@ export async function assertPageNavigationCompletedSafely(opts: {
       await closeBlockedNavigationTarget({
         cdpUrl: opts.cdpUrl,
         page: opts.page,
+        targetId: opts.targetId,
       });
     }
     throw err;
@@ -771,6 +778,7 @@ export async function gotoPageWithNavigationGuard(opts: {
       await closeBlockedNavigationTarget({
         cdpUrl: opts.cdpUrl,
         page: opts.page,
+        targetId: opts.targetId,
       });
     }
   }

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -581,10 +581,13 @@ async function closeBlockedNavigationTarget(opts: {
   targetId?: string;
 }): Promise<void> {
   const targetId = opts.targetId?.trim() || (await pageTargetId(opts.page).catch(() => null)) || "";
-  if (targetId) {
+  const closed = await opts.page
+    .close()
+    .then(() => true)
+    .catch(() => false);
+  if (closed && targetId) {
     markTargetBlocked(opts.cdpUrl, targetId);
   }
-  await opts.page.close().catch(() => {});
 }
 
 export async function assertPageNavigationCompletedSafely(opts: {

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -618,8 +618,8 @@ export async function getPageForTargetId(opts: {
     }
     return found;
   }
-  // If Playwright only exposes a single Page, use it as a best-effort fallback.
-  if (accessible.length === 1) {
+  // If Playwright only exposes a single Page total, use it as a best-effort fallback.
+  if (pages.length === 1) {
     return first;
   }
   throw new BrowserTabNotFoundError();

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -74,7 +74,7 @@ describe("pw-tools-core.snapshot navigate guard", () => {
     expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
       cdpUrl: "http://127.0.0.1:18792",
       page: expect.anything(),
-      response: undefined,
+      response: null,
       ssrfPolicy: { allowPrivateNetwork: true },
       targetId: undefined,
     });

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -63,6 +63,21 @@ describe("pw-tools-core.snapshot navigate guard", () => {
     });
 
     expect(goto).toHaveBeenCalledWith("https://example.com", { timeout: 1000 });
+    expect(getPwToolsCoreSessionMocks().gotoPageWithNavigationGuard).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page: expect.anything(),
+      ssrfPolicy: { allowPrivateNetwork: true },
+      targetId: undefined,
+      timeoutMs: 1000,
+      url: "https://example.com",
+    });
+    expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page: expect.anything(),
+      response: undefined,
+      ssrfPolicy: { allowPrivateNetwork: true },
+      targetId: undefined,
+    });
     expect(result.url).toBe("https://example.com");
   });
 
@@ -92,7 +107,7 @@ describe("pw-tools-core.snapshot navigate guard", () => {
       targetId: "tab-1",
       reason: "retry navigate after detached frame",
     });
-    expect(goto).toHaveBeenCalledTimes(2);
+    expect(getPwToolsCoreSessionMocks().gotoPageWithNavigationGuard).toHaveBeenCalledTimes(2);
     expect(result.url).toBe("https://example.com/recovered");
   });
 
@@ -113,6 +128,9 @@ describe("pw-tools-core.snapshot navigate guard", () => {
       goto,
       url: vi.fn(() => "https://93.184.216.34/final"),
     });
+    getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely.mockRejectedValueOnce(
+      new SsrFBlockedError("Blocked hostname or private/internal/special-use IP address"),
+    );
 
     await expect(
       mod.navigateViaPlaywright({
@@ -121,6 +139,9 @@ describe("pw-tools-core.snapshot navigate guard", () => {
       }),
     ).rejects.toBeInstanceOf(SsrFBlockedError);
 
-    expect(goto).toHaveBeenCalledTimes(1);
+    expect(getPwToolsCoreSessionMocks().gotoPageWithNavigationGuard).toHaveBeenCalledTimes(1);
+    expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).toHaveBeenCalledTimes(
+      1,
+    );
   });
 });

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -1,11 +1,6 @@
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { type AriaSnapshotNode, formatAriaSnapshot, type RawAXNode } from "./cdp.js";
-import {
-  assertBrowserNavigationAllowed,
-  assertBrowserNavigationRedirectChainAllowed,
-  assertBrowserNavigationResultAllowed,
-  withBrowserNavigationPolicy,
-} from "./navigation-guard.js";
+import { assertBrowserNavigationAllowed, withBrowserNavigationPolicy } from "./navigation-guard.js";
 import {
   buildRoleSnapshotFromAiSnapshot,
   buildRoleSnapshotFromAriaSnapshot,
@@ -14,9 +9,11 @@ import {
   type RoleRefMap,
 } from "./pw-role-snapshot.js";
 import {
+  assertPageNavigationCompletedSafely,
   ensurePageState,
   forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
+  gotoPageWithNavigationGuard,
   storeRoleRefsForTarget,
   type WithSnapshotForAI,
 } from "./pw-session.js";
@@ -197,7 +194,15 @@ export async function navigateViaPlaywright(opts: {
   const timeout = Math.max(1000, Math.min(120_000, opts.timeoutMs ?? 20_000));
   let page = await getPageForTargetId(opts);
   ensurePageState(page);
-  const navigate = async () => await page.goto(url, { timeout });
+  const navigate = async () =>
+    await gotoPageWithNavigationGuard({
+      cdpUrl: opts.cdpUrl,
+      page,
+      url,
+      timeoutMs: timeout,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   let response;
   try {
     response = await navigate();
@@ -216,15 +221,14 @@ export async function navigateViaPlaywright(opts: {
     ensurePageState(page);
     response = await navigate();
   }
-  await assertBrowserNavigationRedirectChainAllowed({
-    request: response?.request(),
-    ...withBrowserNavigationPolicy(opts.ssrfPolicy),
+  await assertPageNavigationCompletedSafely({
+    cdpUrl: opts.cdpUrl,
+    page,
+    response,
+    ssrfPolicy: opts.ssrfPolicy,
+    targetId: opts.targetId,
   });
   const finalUrl = page.url();
-  await assertBrowserNavigationResultAllowed({
-    url: finalUrl,
-    ...withBrowserNavigationPolicy(opts.ssrfPolicy),
-  });
   return { url: finalUrl };
 }
 

--- a/extensions/browser/src/browser/pw-tools-core.test-harness.ts
+++ b/extensions/browser/src/browser/pw-tools-core.test-harness.ts
@@ -15,6 +15,7 @@ let pageState: {
 };
 
 const sessionMocks = vi.hoisted(() => ({
+  assertPageNavigationCompletedSafely: vi.fn(async () => {}),
   getPageForTargetId: vi.fn(async () => {
     if (!currentPage) {
       throw new Error("missing page");
@@ -23,6 +24,13 @@ const sessionMocks = vi.hoisted(() => ({
   }),
   ensurePageState: vi.fn(() => pageState),
   forceDisconnectPlaywrightForTarget: vi.fn(async () => {}),
+  gotoPageWithNavigationGuard: vi.fn(
+    async (opts: {
+      url: string;
+      timeoutMs: number;
+      page: { goto: (url: string, init: { timeout: number }) => Promise<unknown> };
+    }) => await opts.page.goto(opts.url, { timeout: opts.timeoutMs }),
+  ),
   restoreRoleRefsForTarget: vi.fn(() => {}),
   storeRoleRefsForTarget: vi.fn(() => {}),
   refLocator: vi.fn(() => {

--- a/extensions/browser/src/browser/pw-tools-core.test-harness.ts
+++ b/extensions/browser/src/browser/pw-tools-core.test-harness.ts
@@ -29,7 +29,7 @@ const sessionMocks = vi.hoisted(() => ({
       url: string;
       timeoutMs: number;
       page: { goto: (url: string, init: { timeout: number }) => Promise<unknown> };
-    }) => await opts.page.goto(opts.url, { timeout: opts.timeoutMs }),
+    }) => (await opts.page.goto(opts.url, { timeout: opts.timeoutMs })) ?? null,
   ),
   restoreRoleRefsForTarget: vi.fn(() => {}),
   storeRoleRefsForTarget: vi.fn(() => {}),


### PR DESCRIPTION
## Summary

> 🤖 AI-assisted PR (generated by OpenAI Codex, reviewed by Claude)

- **Problem:** The browser extension's navigation guard checked SSRF policy only _after_ `page.goto()` completed, inspecting the redirect chain post-hoc. An attacker-controlled redirect through a private/internal IP could reach the internal host before the check fired.
- **Why it matters:** A specially crafted URL with an intermediate redirect to a private IP could exfiltrate data from internal services via the browser tool before the policy blocked it.
- **What changed:** Navigation is now gated by a Playwright route handler installed _before_ `page.goto()`. Every top-level navigation request is checked in real time via `assertBrowserNavigationAllowed`; blocked requests are aborted immediately, the tab is closed, and the target is marked blocked for all subsequent tool calls (`BlockedBrowserTargetError`). Belt-and-suspenders post-navigation checks (`assertPageNavigationCompletedSafely`) are preserved.
- **What did NOT change:** Sub-frame/resource requests are not intercepted; only top-level navigations are policy-gated. Retry logic for detached-frame errors is unchanged. No changes to the SSRF policy rules themselves.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `page.goto()` follows redirects before Playwright exposes the redirect chain to the caller. Post-hoc inspection of `response.request().redirectedFrom()` is too late — internal HTTP requests have already been sent.
- Missing detection / guardrail: No per-request interception before the HTTP request was dispatched.
- Prior context: Navigation guard was added to check final URLs and redirect chains; the interception-layer approach was not used at the time.
- Why this regressed now: N/A — original guard was never sufficient for mid-redirect blocking.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file: `extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts`
- Scenario the test should lock in: A URL with a private-IP intermediate redirect hop is blocked, `page.close()` is called once, and `SsrFBlockedError` is thrown.
- Why this is the smallest reliable guardrail: Tests the exact route-handler callback path without a live browser.
- Existing test that already covers this (if any): Test existed but only verified post-hoc redirect-chain check; updated to simulate real-time route handler interception.
- If no new test is added, why not: N/A — test was updated.

## User-visible / Behavior Changes

None for safe navigations. For navigations that previously slipped through via redirect, they now fail fast with an error and the tab is permanently closed for that session.

## Diagram (if applicable)

```text
Before:
[goto(url)] -> [redirect to 127.0.0.1] -> [request reaches internal host] -> [post-hoc check blocks]

After:
[route handler installed] -> [goto(url)] -> [redirect to 127.0.0.1 intercepted] -> [abort + close tab] -> [BlockedBrowserTargetError on any future access]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — the fix _prevents_ network calls to blocked destinations
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: Route handler fires synchronously in Playwright's request interception pipeline; aborting the route prevents the HTTP request from completing to the internal host.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / Bun
- Model/provider: N/A
- Integration/channel: Browser extension (Playwright/CDP)

### Steps

1. Configure a URL that redirects through a private IP mid-chain.
2. Invoke `createPageViaPlaywright` or `navigateViaPlaywright` with that URL.
3. Observe `SsrFBlockedError` thrown before any response is received from the internal host.

### Expected

- `SsrFBlockedError` thrown immediately on the blocked redirect hop.
- Tab closed; subsequent tool calls to the same target throw `BlockedBrowserTargetError`.

### Actual (before fix)

- Navigation completed to the final URL; policy check fired after internal request was already sent.

## Evidence

- [x] Failing test/log before + passing after (`pw-session.create-page.navigation-guard.test.ts` updated to simulate route interception; asserts `pageClose` called once)

## Human Verification (required)

- Verified scenarios: Route handler fires for top-level navigations; sub-frame requests pass through; blocked targets are excluded from `listPagesViaPlaywright`.
- Edge cases checked: `request.frame()` throwing returns `true` (conservative); double-close not possible; retry path does not re-attempt SSRF-blocked navigations.
- What you did **not** verify: Live browser round-trip against a real redirect server.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Route handler on `"**"` may intercept sub-frame navigations unexpectedly.
  - Mitigation: `isTopLevelNavigationRequest` gates the policy check to main-frame navigation requests only; all other routes call `route.continue()` unconditionally.
- Risk: `page.unroute` failure in `finally` could leave stale handlers.
  - Mitigation: `unroute` errors are swallowed (`.catch(() => {})`); Playwright cleans up handlers when the page closes.