### PR TITLE
feat(image-generation): support response_format=url for MiniMax provider

### DIFF
--- a/extensions/minimax/image-generation-provider.ts
+++ b/extensions/minimax/image-generation-provider.ts
@@ -18,6 +18,7 @@ const MINIMAX_SUPPORTED_ASPECT_RATIOS = [
 type MinimaxImageApiResponse = {
   data?: {
     image_base64?: string[];
+    image_url?: string[];
   };
   metadata?: {
     success_count?: number;
@@ -84,10 +85,17 @@ function buildMinimaxImageProvider(providerId: string): ImageGenerationProvider 
 
       const baseUrl = resolveMinimaxImageBaseUrl(req.cfg, providerId);
 
+      // Allow response_format to be configured via provider config
+      const responseFormat =
+        (req.cfg?.models?.providers?.[providerId] as Record<string, unknown>)?.response_format as
+        | string
+        | undefined;
+      const resolvedFormat = responseFormat === "url" ? "url" : "base64";
+
       const body: Record<string, unknown> = {
         model: req.model || DEFAULT_MODEL,
         prompt: req.prompt,
-        response_format: "base64",
+        response_format: resolvedFormat,
         n: req.count ?? 1,
       };
 
@@ -137,27 +145,38 @@ function buildMinimaxImageProvider(providerId: string): ImageGenerationProvider 
         throw new Error(`MiniMax image generation API error (${baseResp.status_code}): ${msg}`);
       }
 
+      const useUrl = resolvedFormat === "url";
+      const imageUrls = data.data?.image_url ?? [];
       const base64Images = data.data?.image_base64 ?? [];
       const failedCount = data.metadata?.failed_count ?? 0;
 
-      if (base64Images.length === 0) {
+      if (imageUrls.length === 0 && base64Images.length === 0) {
         const reason =
           failedCount > 0 ? `${failedCount} image(s) failed to generate` : "no images returned";
         throw new Error(`MiniMax image generation returned no images: ${reason}`);
       }
 
-      const images = base64Images
-        .map((b64, index) => {
-          if (!b64) {
-            return null;
-          }
-          return {
-            buffer: Buffer.from(b64, "base64"),
-            mimeType: DEFAULT_OUTPUT_MIME,
-            fileName: `image-${index + 1}.png`,
-          };
-        })
-        .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+      const images = useUrl
+        ? imageUrls
+            .map((url, index) => {
+              if (!url) return null;
+              return {
+                url,
+                mimeType: DEFAULT_OUTPUT_MIME,
+                fileName: `image-${index + 1}.png`,
+              };
+            })
+            .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+        : base64Images
+            .map((b64, index) => {
+              if (!b64) return null;
+              return {
+                buffer: Buffer.from(b64, "base64"),
+                mimeType: DEFAULT_OUTPUT_MIME,
+                fileName: `image-${index + 1}.png`,
+              };
+            })
+            .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
 
       return {
         images,


### PR DESCRIPTION
## Summary

Adds support for MiniMax image generation to return direct URLs instead of base64 data, avoiding an extra CDN round-trip.

### Changes

1. **Type update**: `MinimaxImageApiResponse` now includes `image_url?: string[]`
2. **Config-driven format**: `response_format` is now read from provider config (`models.providers.minimax.response_format`), defaulting to `"base64"` for backward compatibility
3. **Dual response handling**: Handles both `image_base64` (buffer) and `image_url` (URL) responses

### Usage

To use URL mode, add this to your `openclaw.json`:

```json
{
  "providers": {
    "models": {
      "providers": {
        "minimax": {
          "response_format": "url"
        }
      }
    }
  }
}
```

When `response_format` is `"url"`, images are returned as MiniMax OSS URLs directly (publicly accessible), skipping the CDN upload step. This reduces latency and eliminates the need for OpenClaw to re-upload the image.

### Backward Compatibility

- Default (`"base64"`): Works exactly as before
- `"url"` mode: Returns MiniMax OSS URLs directly — works with any channel (Feishu, etc.) that can accept public image URLs