### PR TITLE
feat: harden mcp channel bridge startup

### DIFF
--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -30,13 +30,84 @@ type PendingWaiter = {
   timeout: NodeJS.Timeout | null;
 };
 
+type ReadyWaiter = {
+  resolve: (value: boolean) => void;
+  timeout: NodeJS.Timeout | null;
+};
+
 type ServerNotification = {
   method: string;
   params?: Record<string, unknown>;
 };
 
+export type OpenClawChannelBridgeState = "idle" | "connecting" | "ready" | "degraded" | "closed";
+
+export type OpenClawChannelBridgeDiagnostics = {
+  state: OpenClawChannelBridgeState;
+  lastError: {
+    name: string;
+    message: string;
+  } | null;
+  lastConnectAttemptAt: string | null;
+  lastReadyAt: string | null;
+  nextRetryAt: string | null;
+  connectionSource: {
+    gatewayMode?: "local" | "remote";
+    gatewayUrlSource?: string;
+    gatewayProtocol?: string;
+    gatewayHost?: string;
+    hasExplicitToken?: boolean;
+    hasExplicitPassword?: boolean;
+    hasResolvedToken?: boolean;
+    hasResolvedPassword?: boolean;
+  } | null;
+};
+
+export class GatewayUnavailableError extends Error {
+  constructor(
+    readonly diagnostics: OpenClawChannelBridgeDiagnostics,
+    message = "OpenClaw gateway bridge is unavailable",
+  ) {
+    super(message);
+    this.name = "GatewayUnavailableError";
+  }
+}
+
 const CLAUDE_PERMISSION_REPLY_RE = /^(yes|no)\s+([a-km-z]{5})$/i;
 const QUEUE_LIMIT = 1_000;
+const RETRY_BACKOFF_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function sanitizeGatewayTarget(url: string): Pick<
+  NonNullable<OpenClawChannelBridgeDiagnostics["connectionSource"]>,
+  "gatewayProtocol" | "gatewayHost"
+> {
+  try {
+    const parsed = new URL(url);
+    return {
+      gatewayProtocol: parsed.protocol.replace(/:$/, ""),
+      gatewayHost: parsed.hostname,
+    };
+  } catch {
+    return {};
+  }
+}
+
+function normalizeError(error: unknown): { name: string; message: string } {
+  if (error instanceof Error) {
+    return {
+      name: error.name || "Error",
+      message: error.message || String(error),
+    };
+  }
+  return {
+    name: "Error",
+    message: String(error),
+  };
+}
 
 export class OpenClawChannelBridge {
   private gateway: GatewayClient | null = null;
@@ -44,6 +115,7 @@ export class OpenClawChannelBridge {
   private readonly claudeChannelMode: ClaudeChannelMode;
   private readonly queue: QueueEvent[] = [];
   private readonly pendingWaiters = new Set<PendingWaiter>();
+  private readonly readyWaiters = new Set<ReadyWaiter>();
   private readonly pendingClaudePermissions = new Map<string, ClaudePermissionRequest>();
   private readonly pendingApprovals = new Map<string, PendingApproval>();
   private server: McpServer | null = null;
@@ -51,13 +123,23 @@ export class OpenClawChannelBridge {
   private closed = false;
   private ready = false;
   private started = false;
-  private readonly readyPromise: Promise<void>;
-  private resolveReady!: () => void;
-  private rejectReady!: (error: Error) => void;
+  private state: OpenClawChannelBridgeState = "idle";
+  private lastError: OpenClawChannelBridgeDiagnostics["lastError"] = null;
+  private lastConnectAttemptAt: string | null = null;
+  private lastReadyAt: string | null = null;
+  private nextRetryAt: string | null = null;
+  private connectionSource: OpenClawChannelBridgeDiagnostics["connectionSource"] = null;
+  private retryTimer: NodeJS.Timeout | null = null;
+  private retryAttempt = 0;
+  private bootstrapPromise: Promise<void> | null = null;
+  private resolveReady: () => void = () => {
+    this.ready = true;
+    this.resolveReadyWaiters(true);
+  };
   private readySettled = false;
 
   constructor(
-    private readonly cfg: OpenClawConfig,
+    private readonly configSource: OpenClawConfig | (() => OpenClawConfig),
     private readonly params: {
       gatewayUrl?: string;
       gatewayToken?: string;
@@ -68,10 +150,13 @@ export class OpenClawChannelBridge {
   ) {
     this.verbose = params.verbose;
     this.claudeChannelMode = params.claudeChannelMode;
-    this.readyPromise = new Promise<void>((resolve, reject) => {
-      this.resolveReady = resolve;
-      this.rejectReady = reject;
-    });
+    this.resolveReady = () => {
+      this.ready = true;
+      if (!this.readySettled) {
+        this.readySettled = true;
+      }
+      this.resolveReadyWaiters(true);
+    };
   }
 
   setServer(server: McpServer): void {
@@ -79,66 +164,56 @@ export class OpenClawChannelBridge {
   }
 
   async start(): Promise<void> {
-    if (this.started) {
-      await this.readyPromise;
+    if (this.started || this.closed) {
       return;
     }
     this.started = true;
-    const connection = buildGatewayConnectionDetails({
-      config: this.cfg,
-      url: this.params.gatewayUrl,
-    });
-    const gatewayUrlOverrideSource =
-      connection.urlSource === "cli --url"
-        ? "cli"
-        : connection.urlSource === "env OPENCLAW_GATEWAY_URL"
-          ? "env"
-          : undefined;
-    const creds = await resolveGatewayConnectionAuth({
-      config: this.cfg,
-      explicitAuth: {
-        token: this.params.gatewayToken,
-        password: this.params.gatewayPassword,
-      },
-      env: process.env,
-      urlOverride: gatewayUrlOverrideSource ? connection.url : undefined,
-      urlOverrideSource: gatewayUrlOverrideSource,
-    });
-    if (this.closed) {
-      this.resolveReadyOnce();
-      return;
-    }
-
-    this.gateway = new GatewayClient({
-      url: connection.url,
-      token: creds.token,
-      password: creds.password,
-      clientName: GATEWAY_CLIENT_NAMES.CLI,
-      clientDisplayName: "OpenClaw MCP",
-      clientVersion: VERSION,
-      mode: GATEWAY_CLIENT_MODES.CLI,
-      scopes: [READ_SCOPE, WRITE_SCOPE, APPROVALS_SCOPE],
-      onEvent: (event) => {
-        void this.handleGatewayEvent(event);
-      },
-      onHelloOk: () => {
-        void this.handleHelloOk();
-      },
-      onConnectError: (error) => {
-        this.rejectReadyOnce(error instanceof Error ? error : new Error(String(error)));
-      },
-      onClose: (code, reason) => {
-        if (!this.ready && !this.closed) {
-          this.rejectReadyOnce(new Error(`gateway closed before ready (${code}): ${reason}`));
-        }
-      },
-    });
-    this.gateway.start();
-    await this.readyPromise;
+    this.ensureBootstrap();
   }
 
-  async waitUntilReady(): Promise<void> {
-    await this.readyPromise;
+  async waitUntilReady(timeoutMs = 0): Promise<boolean> {
+    if (this.ready) {
+      return true;
+    }
+    if (this.closed) {
+      return false;
+    }
+    if (timeoutMs <= 0) {
+      return false;
+    }
+    return await new Promise<boolean>((resolve) => {
+      const waiter: ReadyWaiter = {
+        resolve: (value) => {
+          this.readyWaiters.delete(waiter);
+          resolve(value);
+        },
+        timeout: null,
+      };
+      waiter.timeout = setTimeout(() => {
+        waiter.resolve(false);
+      }, timeoutMs);
+      waiter.timeout.unref?.();
+      this.readyWaiters.add(waiter);
+    });
+  }
+
+  async requireReady(timeoutMs = 2_000): Promise<void> {
+    const ready = await this.waitUntilReady(timeoutMs);
+    if (ready) {
+      return;
+    }
+    throw new GatewayUnavailableError(this.getDiagnostics());
+  }
+
+  getDiagnostics(): OpenClawChannelBridgeDiagnostics {
+    return {
+      state: this.state,
+      lastError: this.lastError,
+      lastConnectAttemptAt: this.lastConnectAttemptAt,
+      lastReadyAt: this.lastReadyAt,
+      nextRetryAt: this.nextRetryAt,
+      connectionSource: this.connectionSource,
+    };
   }
 
   async close(): Promise<void> {
@@ -146,7 +221,14 @@ export class OpenClawChannelBridge {
       return;
     }
     this.closed = true;
-    this.resolveReadyOnce();
+    this.state = "closed";
+    this.ready = false;
+    this.nextRetryAt = null;
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+    this.resolveReadyWaiters(false);
     for (const waiter of this.pendingWaiters) {
       if (waiter.timeout) {
         clearTimeout(waiter.timeout);
@@ -166,7 +248,7 @@ export class OpenClawChannelBridge {
     includeDerivedTitles?: boolean;
     includeLastMessage?: boolean;
   }): Promise<ConversationDescriptor[]> {
-    await this.waitUntilReady();
+    await this.requireReady();
     const response = await this.requestGateway<SessionListResult>("sessions.list", {
       limit: params?.limit ?? 50,
       search: params?.search,
@@ -197,7 +279,7 @@ export class OpenClawChannelBridge {
     sessionKey: string,
     limit = 20,
   ): Promise<NonNullable<ChatHistoryResult["messages"]>> {
-    await this.waitUntilReady();
+    await this.requireReady();
     const response = await this.requestGateway<ChatHistoryResult>("chat.history", {
       sessionKey,
       limit,
@@ -209,6 +291,7 @@ export class OpenClawChannelBridge {
     sessionKey: string;
     text: string;
   }): Promise<Record<string, unknown>> {
+    await this.requireReady();
     const conversation = await this.getConversation(params.sessionKey);
     if (!conversation) {
       throw new Error(`Conversation not found for session ${params.sessionKey}`);
@@ -235,6 +318,7 @@ export class OpenClawChannelBridge {
     id: string;
     decision: ApprovalDecision;
   }): Promise<Record<string, unknown>> {
+    await this.requireReady();
     if (params.kind === "exec") {
       return await this.requestGateway("exec.approval.resolve", {
         id: params.id,
@@ -254,6 +338,7 @@ export class OpenClawChannelBridge {
   }
 
   async waitForEvent(filter: WaitFilter, timeoutMs = 30_000): Promise<QueueEvent | null> {
+    await this.requireReady();
     const existing = this.queue.find((event) => matchEventFilter(event, filter));
     if (existing) {
       return existing;
@@ -271,6 +356,7 @@ export class OpenClawChannelBridge {
         waiter.timeout = setTimeout(() => {
           waiter.resolve(null);
         }, timeoutMs);
+        waiter.timeout.unref?.();
       }
       this.pendingWaiters.add(waiter);
     });
@@ -300,12 +386,199 @@ export class OpenClawChannelBridge {
     }
   }
 
+  private ensureBootstrap(): void {
+    if (this.closed || this.bootstrapPromise) {
+      return;
+    }
+    this.bootstrapPromise = this.bootstrap().finally(() => {
+      this.bootstrapPromise = null;
+    });
+  }
+
+  private async bootstrap(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.state = "connecting";
+    this.ready = false;
+    this.lastConnectAttemptAt = nowIso();
+    this.nextRetryAt = null;
+
+    let cfg: OpenClawConfig;
+    try {
+      cfg =
+        typeof this.configSource === "function" ? this.configSource() : (this.configSource ?? {});
+    } catch (error) {
+      this.connectionSource = {
+        hasExplicitToken: Boolean(this.params.gatewayToken),
+        hasExplicitPassword: Boolean(this.params.gatewayPassword),
+      };
+      this.markDegraded(error, { scheduleRetry: true });
+      return;
+    }
+
+    let connection: ReturnType<typeof buildGatewayConnectionDetails>;
+    try {
+      connection = buildGatewayConnectionDetails({
+        config: cfg,
+        url: this.params.gatewayUrl,
+      });
+    } catch (error) {
+      this.connectionSource = {
+        gatewayMode: cfg.gateway?.mode === "remote" ? "remote" : "local",
+        hasExplicitToken: Boolean(this.params.gatewayToken),
+        hasExplicitPassword: Boolean(this.params.gatewayPassword),
+      };
+      this.markDegraded(error, { scheduleRetry: true });
+      return;
+    }
+
+    const gatewayUrlOverrideSource =
+      connection.urlSource === "cli --url"
+        ? "cli"
+        : connection.urlSource === "env OPENCLAW_GATEWAY_URL"
+          ? "env"
+          : undefined;
+
+    this.connectionSource = {
+      gatewayMode: cfg.gateway?.mode === "remote" ? "remote" : "local",
+      gatewayUrlSource: connection.urlSource,
+      hasExplicitToken: Boolean(this.params.gatewayToken),
+      hasExplicitPassword: Boolean(this.params.gatewayPassword),
+      ...sanitizeGatewayTarget(connection.url),
+    };
+
+    let creds: { token?: string; password?: string };
+    try {
+      creds = await resolveGatewayConnectionAuth({
+        config: cfg,
+        explicitAuth: {
+          token: this.params.gatewayToken,
+          password: this.params.gatewayPassword,
+        },
+        env: process.env,
+        urlOverride: gatewayUrlOverrideSource ? connection.url : undefined,
+        urlOverrideSource: gatewayUrlOverrideSource,
+      });
+    } catch (error) {
+      this.connectionSource = {
+        ...this.connectionSource,
+        hasResolvedToken: false,
+        hasResolvedPassword: false,
+      };
+      this.markDegraded(error, { scheduleRetry: true });
+      return;
+    }
+
+    if (this.closed) {
+      return;
+    }
+
+    this.connectionSource = {
+      ...this.connectionSource,
+      hasResolvedToken: Boolean(creds.token),
+      hasResolvedPassword: Boolean(creds.password),
+    };
+
+    const gateway = new GatewayClient({
+      url: connection.url,
+      token: creds.token,
+      password: creds.password,
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      clientDisplayName: "OpenClaw MCP",
+      clientVersion: VERSION,
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      scopes: [READ_SCOPE, WRITE_SCOPE, APPROVALS_SCOPE],
+      onEvent: (event) => {
+        void this.handleGatewayEvent(event);
+      },
+      onHelloOk: () => {
+        void this.handleHelloOk(gateway);
+      },
+      onConnectError: (error) => {
+        this.handleGatewayConnectError(gateway, error);
+      },
+      onClose: (code, reason) => {
+        void this.handleGatewayClose(gateway, code, reason);
+      },
+    });
+    this.gateway = gateway;
+
+    try {
+      gateway.start();
+    } catch (error) {
+      if (this.gateway === gateway) {
+        this.gateway = null;
+      }
+      await gateway.stopAndWait().catch(() => undefined);
+      this.markDegraded(error, { scheduleRetry: true });
+    }
+  }
+
+  private markDegraded(
+    error: unknown,
+    opts: {
+      scheduleRetry: boolean;
+    },
+  ): void {
+    if (this.closed) {
+      return;
+    }
+    this.ready = false;
+    this.state = "degraded";
+    this.lastError = normalizeError(error);
+    if (this.verbose) {
+      process.stderr.write(`openclaw mcp: bridge degraded: ${this.lastError.message}\n`);
+    }
+    if (opts.scheduleRetry) {
+      this.scheduleRetry();
+    }
+  }
+
+  private scheduleRetry(): void {
+    if (this.closed || this.state === "closed" || this.retryTimer) {
+      return;
+    }
+    const delayMs =
+      RETRY_BACKOFF_MS[Math.min(this.retryAttempt, RETRY_BACKOFF_MS.length - 1)] ??
+      RETRY_BACKOFF_MS.at(-1) ??
+      30_000;
+    this.retryAttempt += 1;
+    this.nextRetryAt = new Date(Date.now() + delayMs).toISOString();
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      this.nextRetryAt = null;
+      void this.recycleAndBootstrap();
+    }, delayMs);
+    this.retryTimer.unref?.();
+  }
+
+  private async recycleAndBootstrap(): Promise<void> {
+    if (this.closed || this.state === "ready") {
+      return;
+    }
+    const gateway = this.gateway;
+    this.gateway = null;
+    await gateway?.stopAndWait().catch(() => undefined);
+    this.ensureBootstrap();
+  }
+
+  private resolveReadyWaiters(value: boolean): void {
+    for (const waiter of this.readyWaiters) {
+      if (waiter.timeout) {
+        clearTimeout(waiter.timeout);
+      }
+      waiter.resolve(value);
+    }
+    this.readyWaiters.clear();
+  }
+
   private async requestGateway<T = Record<string, unknown>>(
     method: string,
     params: Record<string, unknown>,
   ): Promise<T> {
-    if (!this.gateway) {
-      throw new Error("Gateway client is not ready");
+    if (!this.gateway || !this.ready) {
+      throw new GatewayUnavailableError(this.getDiagnostics());
     }
     return await this.gateway.request<T>(method, params);
   }
@@ -325,30 +598,46 @@ export class OpenClawChannelBridge {
     }
   }
 
-  private async handleHelloOk(): Promise<void> {
+  private async handleHelloOk(gateway: GatewayClient): Promise<void> {
+    if (this.gateway !== gateway || this.closed) {
+      return;
+    }
     try {
-      await this.requestGateway("sessions.subscribe", {});
+      await gateway.request("sessions.subscribe", {});
+      this.state = "ready";
       this.ready = true;
-      this.resolveReadyOnce();
+      this.lastError = null;
+      this.lastReadyAt = nowIso();
+      this.nextRetryAt = null;
+      this.retryAttempt = 0;
+      this.resolveReady();
     } catch (error) {
-      this.rejectReadyOnce(error instanceof Error ? error : new Error(String(error)));
+      this.markDegraded(error, { scheduleRetry: true });
     }
   }
 
-  private resolveReadyOnce(): void {
-    if (this.readySettled) {
+  private handleGatewayConnectError(gateway: GatewayClient, error: unknown): void {
+    if (this.gateway !== gateway || this.closed) {
       return;
     }
-    this.readySettled = true;
-    this.resolveReady();
+    this.markDegraded(error, { scheduleRetry: true });
   }
 
-  private rejectReadyOnce(error: Error): void {
-    if (this.readySettled) {
+  private async handleGatewayClose(
+    gateway: GatewayClient,
+    code: number,
+    reason: string,
+  ): Promise<void> {
+    if (this.gateway !== gateway || this.closed) {
       return;
     }
-    this.readySettled = true;
-    this.rejectReady(error);
+    this.ready = false;
+    this.state = "degraded";
+    this.lastError = {
+      name: "GatewayClosedError",
+      message: `gateway closed (${code}): ${reason}`,
+    };
+    this.scheduleRetry();
   }
 
   private nextCursor(): number {

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -510,6 +510,29 @@ describe("openclaw channel mcp server", () => {
     test("waits for queued events through the MCP tool", async () => {
       const mcp = await connectMcpWithoutGateway({ claudeChannelMode: "off" });
       try {
+        const gatewayRequest = vi.fn().mockResolvedValue({ ok: true });
+        (
+          mcp.bridge as unknown as {
+            gateway: { request: typeof gatewayRequest; stopAndWait: () => Promise<void> };
+            readySettled: boolean;
+            resolveReady: () => void;
+          }
+        ).gateway = {
+          request: gatewayRequest,
+          stopAndWait: async () => {},
+        };
+        (
+          mcp.bridge as unknown as {
+            readySettled: boolean;
+            resolveReady: () => void;
+          }
+        ).readySettled = true;
+        (
+          mcp.bridge as unknown as {
+            resolveReady: () => void;
+          }
+        ).resolveReady();
+
         await (
           mcp.bridge as unknown as {
             handleSessionMessageEvent: (payload: Record<string, unknown>) => Promise<void>;

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -41,6 +41,65 @@ async function connectMcpWithoutGateway(params?: { claudeChannelMode?: "auto" | 
 
 describe("openclaw channel mcp server", () => {
   describe("gateway-backed flows", () => {
+    test("keeps the MCP server alive when bridge bootstrap degrades", async () => {
+      const serverHarness = await createOpenClawChannelMcpServer({
+        configLoader: () => {
+          throw new Error("missing HOME");
+        },
+        claudeChannelMode: "off",
+        verbose: false,
+      });
+      const client = new Client({ name: "mcp-test-client", version: "1.0.0" });
+      const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+      try {
+        await serverHarness.server.connect(serverTransport);
+        await client.connect(clientTransport);
+        await expect(serverHarness.start()).resolves.toBeUndefined();
+
+        await vi.waitFor(() => {
+          expect(serverHarness.bridge.getDiagnostics().state).toBe("degraded");
+        });
+
+        const status = (await client.callTool({
+          name: "gateway_status",
+          arguments: {},
+        })) as {
+          structuredContent?: {
+            gateway?: {
+              state?: string;
+              lastError?: { message?: string };
+            };
+          };
+        };
+        expect(status.structuredContent?.gateway).toMatchObject({
+          state: "degraded",
+          lastError: { message: "missing HOME" },
+        });
+
+        const listed = (await client.callTool({
+          name: "conversations_list",
+          arguments: {},
+        })) as {
+          isError?: boolean;
+          structuredContent?: {
+            error?: {
+              code?: string;
+              diagnostics?: { state?: string };
+            };
+          };
+        };
+        expect(listed.isError).toBe(true);
+        expect(listed.structuredContent?.error).toMatchObject({
+          code: "gateway_unavailable",
+          diagnostics: { state: "degraded" },
+        });
+      } finally {
+        await client.close();
+        await serverHarness.close();
+      }
+    });
+
     describe("gateway integration", () => {
       test("lists conversations and reads messages", async () => {
         const sessionKey = "agent:main:main";

--- a/src/mcp/channel-server.ts
+++ b/src/mcp/channel-server.ts
@@ -13,6 +13,7 @@ export type OpenClawMcpServeOptions = {
   gatewayToken?: string;
   gatewayPassword?: string;
   config?: OpenClawConfig;
+  configLoader?: () => OpenClawConfig;
   claudeChannelMode?: ClaudeChannelMode;
   verbose?: boolean;
 };
@@ -23,20 +24,22 @@ export async function createOpenClawChannelMcpServer(opts: OpenClawMcpServeOptio
   start: () => Promise<void>;
   close: () => Promise<void>;
 }> {
-  const cfg = opts.config ?? loadConfig();
   const claudeChannelMode = opts.claudeChannelMode ?? "auto";
   const capabilities = getChannelMcpCapabilities(claudeChannelMode);
   const server = new McpServer(
     { name: "openclaw", version: VERSION },
     capabilities ? { capabilities } : undefined,
   );
-  const bridge = new OpenClawChannelBridge(cfg, {
-    gatewayUrl: opts.gatewayUrl,
-    gatewayToken: opts.gatewayToken,
-    gatewayPassword: opts.gatewayPassword,
-    claudeChannelMode,
-    verbose: opts.verbose ?? false,
-  });
+  const bridge = new OpenClawChannelBridge(
+    opts.config ? opts.config : (opts.configLoader ?? loadConfig),
+    {
+      gatewayUrl: opts.gatewayUrl,
+      gatewayToken: opts.gatewayToken,
+      gatewayPassword: opts.gatewayPassword,
+      claudeChannelMode,
+      verbose: opts.verbose ?? false,
+    },
+  );
   bridge.setServer(server);
 
   server.server.setNotificationHandler(ClaudePermissionRequestSchema, async ({ params }) => {
@@ -93,7 +96,9 @@ export async function serveOpenClawChannelMcp(opts: OpenClawMcpServeOptions = {}
 
   try {
     await server.connect(transport);
-    await start();
+    void start().catch((error) => {
+      process.stderr.write(`openclaw mcp: background bridge bootstrap failed: ${String(error)}\n`);
+    });
     await closed;
   } finally {
     shutdown();

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -1,12 +1,51 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { OpenClawChannelBridge } from "./channel-bridge.js";
+import {
+  GatewayUnavailableError,
+  type OpenClawChannelBridge,
+  type OpenClawChannelBridgeDiagnostics,
+} from "./channel-bridge.js";
 import {
   extractAttachmentsFromMessage,
   resolveMessageId,
   summarizeResult,
   toText,
 } from "./channel-shared.js";
+
+const READY_TIMEOUT_MS = 2_000;
+
+function gatewayUnavailableResult(
+  toolName: string,
+  diagnostics: OpenClawChannelBridgeDiagnostics,
+) {
+  return {
+    content: [{ type: "text", text: `gateway unavailable: ${toolName}` }],
+    structuredContent: {
+      error: {
+        code: "gateway_unavailable",
+        tool: toolName,
+        diagnostics,
+      },
+    },
+    isError: true,
+  };
+}
+
+async function withGatewayReadiness<T>(
+  bridge: OpenClawChannelBridge,
+  toolName: string,
+  handler: () => Promise<T>,
+): Promise<T | ReturnType<typeof gatewayUnavailableResult>> {
+  try {
+    await bridge.requireReady(READY_TIMEOUT_MS);
+    return await handler();
+  } catch (error) {
+    if (error instanceof GatewayUnavailableError) {
+      return gatewayUnavailableResult(toolName, error.diagnostics);
+    }
+    throw error;
+  }
+}
 
 export function getChannelMcpCapabilities(claudeChannelMode: "off" | "on" | "auto") {
   if (claudeChannelMode === "off") {
@@ -21,6 +60,14 @@ export function getChannelMcpCapabilities(claudeChannelMode: "off" | "on" | "aut
 }
 
 export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChannelBridge): void {
+  server.tool("gateway_status", "Show OpenClaw MCP gateway bridge diagnostics.", {}, async () => {
+    const gateway = bridge.getDiagnostics();
+    return {
+      content: [{ type: "text", text: `gateway ${gateway.state}` }],
+      structuredContent: { gateway },
+    };
+  });
+
   server.tool(
     "conversations_list",
     "List OpenClaw channel-backed conversations available through session routes.",
@@ -31,20 +78,22 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       includeDerivedTitles: z.boolean().optional(),
       includeLastMessage: z.boolean().optional(),
     },
-    async (args) => {
+    async (args) =>
+      await withGatewayReadiness(bridge, "conversations_list", async () => {
       const conversations = await bridge.listConversations(args);
       return {
         ...summarizeResult("conversations", conversations.length),
         structuredContent: { conversations },
       };
-    },
+      }),
   );
 
   server.tool(
     "conversation_get",
     "Get one OpenClaw conversation by session key.",
     { session_key: z.string().min(1) },
-    async ({ session_key }) => {
+    async ({ session_key }) =>
+      await withGatewayReadiness(bridge, "conversation_get", async () => {
       const conversation = await bridge.getConversation(session_key);
       if (!conversation) {
         return {
@@ -56,7 +105,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
         content: [{ type: "text", text: `conversation ${conversation.sessionKey}` }],
         structuredContent: { conversation },
       };
-    },
+      }),
   );
 
   server.tool(
@@ -66,13 +115,14 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       session_key: z.string().min(1),
       limit: z.number().int().min(1).max(200).optional(),
     },
-    async ({ session_key, limit }) => {
+    async ({ session_key, limit }) =>
+      await withGatewayReadiness(bridge, "messages_read", async () => {
       const messages = await bridge.readMessages(session_key, limit ?? 20);
       return {
         ...summarizeResult("messages", messages.length),
         structuredContent: { messages },
       };
-    },
+      }),
   );
 
   server.tool(
@@ -83,7 +133,8 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       message_id: z.string().min(1),
       limit: z.number().int().min(1).max(200).optional(),
     },
-    async ({ session_key, message_id, limit }) => {
+    async ({ session_key, message_id, limit }) =>
+      await withGatewayReadiness(bridge, "attachments_fetch", async () => {
       const messages = await bridge.readMessages(session_key, limit ?? 100);
       const message = messages.find((entry) => resolveMessageId(entry) === message_id);
       if (!message) {
@@ -97,7 +148,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
         ...summarizeResult("attachments", attachments.length),
         structuredContent: { attachments, message },
       };
-    },
+      }),
   );
 
   server.tool(
@@ -108,7 +159,8 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       session_key: z.string().optional(),
       limit: z.number().int().min(1).max(200).optional(),
     },
-    async ({ after_cursor, session_key, limit }) => {
+    async ({ after_cursor, session_key, limit }) =>
+      await withGatewayReadiness(bridge, "events_poll", async () => {
       const { events, nextCursor } = bridge.pollEvents(
         { afterCursor: after_cursor ?? 0, sessionKey: toText(session_key) },
         limit ?? 20,
@@ -117,7 +169,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
         ...summarizeResult("events", events.length),
         structuredContent: { events, next_cursor: nextCursor },
       };
-    },
+      }),
   );
 
   server.tool(
@@ -128,7 +180,8 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       session_key: z.string().optional(),
       timeout_ms: z.number().int().min(1).max(300_000).optional(),
     },
-    async ({ after_cursor, session_key, timeout_ms }) => {
+    async ({ after_cursor, session_key, timeout_ms }) =>
+      await withGatewayReadiness(bridge, "events_wait", async () => {
       const event = await bridge.waitForEvent(
         { afterCursor: after_cursor ?? 0, sessionKey: toText(session_key) },
         timeout_ms ?? 30_000,
@@ -137,7 +190,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
         content: [{ type: "text", text: event ? `event ${event.cursor}` : "timeout" }],
         structuredContent: { event },
       };
-    },
+      }),
   );
 
   server.tool(
@@ -147,26 +200,28 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       session_key: z.string().min(1),
       text: z.string().min(1),
     },
-    async ({ session_key, text }) => {
+    async ({ session_key, text }) =>
+      await withGatewayReadiness(bridge, "messages_send", async () => {
       const result = await bridge.sendMessage({ sessionKey: session_key, text });
       return {
         content: [{ type: "text", text: "sent" }],
         structuredContent: { result },
       };
-    },
+      }),
   );
 
   server.tool(
     "permissions_list_open",
     "List open OpenClaw exec or plugin approval requests visible through the Gateway.",
     {},
-    async () => {
+    async () =>
+      await withGatewayReadiness(bridge, "permissions_list_open", async () => {
       const approvals = bridge.listPendingApprovals();
       return {
         ...summarizeResult("approvals", approvals.length),
         structuredContent: { approvals },
       };
-    },
+      }),
   );
 
   server.tool(
@@ -177,12 +232,13 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       id: z.string().min(1),
       decision: z.enum(["allow-once", "allow-always", "deny"]),
     },
-    async ({ kind, id, decision }) => {
+    async ({ kind, id, decision }) =>
+      await withGatewayReadiness(bridge, "permissions_respond", async () => {
       const result = await bridge.respondToApproval({ kind, id, decision });
       return {
         content: [{ type: "text", text: "approval resolved" }],
         structuredContent: { result },
       };
-    },
+      }),
   );
 }

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import {
   GatewayUnavailableError,
@@ -17,7 +18,7 @@ const READY_TIMEOUT_MS = 2_000;
 function gatewayUnavailableResult(
   toolName: string,
   diagnostics: OpenClawChannelBridgeDiagnostics,
-) {
+): CallToolResult {
   return {
     content: [{ type: "text", text: `gateway unavailable: ${toolName}` }],
     structuredContent: {
@@ -31,11 +32,11 @@ function gatewayUnavailableResult(
   };
 }
 
-async function withGatewayReadiness<T>(
+async function withGatewayReadiness(
   bridge: OpenClawChannelBridge,
   toolName: string,
-  handler: () => Promise<T>,
-): Promise<T | ReturnType<typeof gatewayUnavailableResult>> {
+  handler: () => Promise<CallToolResult>,
+): Promise<CallToolResult> {
   try {
     await bridge.requireReady(READY_TIMEOUT_MS);
     return await handler();
@@ -80,11 +81,11 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     },
     async (args) =>
       await withGatewayReadiness(bridge, "conversations_list", async () => {
-      const conversations = await bridge.listConversations(args);
-      return {
-        ...summarizeResult("conversations", conversations.length),
-        structuredContent: { conversations },
-      };
+        const conversations = await bridge.listConversations(args);
+        return {
+          ...summarizeResult("conversations", conversations.length),
+          structuredContent: { conversations },
+        };
       }),
   );
 
@@ -94,17 +95,17 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     { session_key: z.string().min(1) },
     async ({ session_key }) =>
       await withGatewayReadiness(bridge, "conversation_get", async () => {
-      const conversation = await bridge.getConversation(session_key);
-      if (!conversation) {
+        const conversation = await bridge.getConversation(session_key);
+        if (!conversation) {
+          return {
+            content: [{ type: "text", text: `conversation not found: ${session_key}` }],
+            isError: true,
+          };
+        }
         return {
-          content: [{ type: "text", text: `conversation not found: ${session_key}` }],
-          isError: true,
+          content: [{ type: "text", text: `conversation ${conversation.sessionKey}` }],
+          structuredContent: { conversation },
         };
-      }
-      return {
-        content: [{ type: "text", text: `conversation ${conversation.sessionKey}` }],
-        structuredContent: { conversation },
-      };
       }),
   );
 
@@ -117,11 +118,11 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     },
     async ({ session_key, limit }) =>
       await withGatewayReadiness(bridge, "messages_read", async () => {
-      const messages = await bridge.readMessages(session_key, limit ?? 20);
-      return {
-        ...summarizeResult("messages", messages.length),
-        structuredContent: { messages },
-      };
+        const messages = await bridge.readMessages(session_key, limit ?? 20);
+        return {
+          ...summarizeResult("messages", messages.length),
+          structuredContent: { messages },
+        };
       }),
   );
 
@@ -135,19 +136,19 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     },
     async ({ session_key, message_id, limit }) =>
       await withGatewayReadiness(bridge, "attachments_fetch", async () => {
-      const messages = await bridge.readMessages(session_key, limit ?? 100);
-      const message = messages.find((entry) => resolveMessageId(entry) === message_id);
-      if (!message) {
+        const messages = await bridge.readMessages(session_key, limit ?? 100);
+        const message = messages.find((entry) => resolveMessageId(entry) === message_id);
+        if (!message) {
+          return {
+            content: [{ type: "text", text: `message not found: ${message_id}` }],
+            isError: true,
+          };
+        }
+        const attachments = extractAttachmentsFromMessage(message);
         return {
-          content: [{ type: "text", text: `message not found: ${message_id}` }],
-          isError: true,
+          ...summarizeResult("attachments", attachments.length),
+          structuredContent: { attachments, message },
         };
-      }
-      const attachments = extractAttachmentsFromMessage(message);
-      return {
-        ...summarizeResult("attachments", attachments.length),
-        structuredContent: { attachments, message },
-      };
       }),
   );
 
@@ -161,14 +162,14 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     },
     async ({ after_cursor, session_key, limit }) =>
       await withGatewayReadiness(bridge, "events_poll", async () => {
-      const { events, nextCursor } = bridge.pollEvents(
-        { afterCursor: after_cursor ?? 0, sessionKey: toText(session_key) },
-        limit ?? 20,
-      );
-      return {
-        ...summarizeResult("events", events.length),
-        structuredContent: { events, next_cursor: nextCursor },
-      };
+        const { events, nextCursor } = bridge.pollEvents(
+          { afterCursor: after_cursor ?? 0, sessionKey: toText(session_key) },
+          limit ?? 20,
+        );
+        return {
+          ...summarizeResult("events", events.length),
+          structuredContent: { events, next_cursor: nextCursor },
+        };
       }),
   );
 
@@ -182,14 +183,14 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     },
     async ({ after_cursor, session_key, timeout_ms }) =>
       await withGatewayReadiness(bridge, "events_wait", async () => {
-      const event = await bridge.waitForEvent(
-        { afterCursor: after_cursor ?? 0, sessionKey: toText(session_key) },
-        timeout_ms ?? 30_000,
-      );
-      return {
-        content: [{ type: "text", text: event ? `event ${event.cursor}` : "timeout" }],
-        structuredContent: { event },
-      };
+        const event = await bridge.waitForEvent(
+          { afterCursor: after_cursor ?? 0, sessionKey: toText(session_key) },
+          timeout_ms ?? 30_000,
+        );
+        return {
+          content: [{ type: "text", text: event ? `event ${event.cursor}` : "timeout" }],
+          structuredContent: { event },
+        };
       }),
   );
 
@@ -202,11 +203,11 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     },
     async ({ session_key, text }) =>
       await withGatewayReadiness(bridge, "messages_send", async () => {
-      const result = await bridge.sendMessage({ sessionKey: session_key, text });
-      return {
-        content: [{ type: "text", text: "sent" }],
-        structuredContent: { result },
-      };
+        const result = await bridge.sendMessage({ sessionKey: session_key, text });
+        return {
+          content: [{ type: "text", text: "sent" }],
+          structuredContent: { result },
+        };
       }),
   );
 
@@ -216,11 +217,11 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     {},
     async () =>
       await withGatewayReadiness(bridge, "permissions_list_open", async () => {
-      const approvals = bridge.listPendingApprovals();
-      return {
-        ...summarizeResult("approvals", approvals.length),
-        structuredContent: { approvals },
-      };
+        const approvals = bridge.listPendingApprovals();
+        return {
+          ...summarizeResult("approvals", approvals.length),
+          structuredContent: { approvals },
+        };
       }),
   );
 
@@ -234,11 +235,11 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     },
     async ({ kind, id, decision }) =>
       await withGatewayReadiness(bridge, "permissions_respond", async () => {
-      const result = await bridge.respondToApproval({ kind, id, decision });
-      return {
-        content: [{ type: "text", text: "approval resolved" }],
-        structuredContent: { result },
-      };
+        const result = await bridge.respondToApproval({ kind, id, decision });
+        return {
+          content: [{ type: "text", text: "approval resolved" }],
+          structuredContent: { result },
+        };
       }),
   );
 }


### PR DESCRIPTION
## Summary

Harden `openclaw mcp serve` so MCP stdio startup no longer depends on immediate gateway readiness, inherited shell env, or successful auth/config resolution.

This changes startup from:

1. bootstrap gateway bridge
2. register tools
3. connect stdio

to:

1. create MCP server and register tools
2. connect stdio transport
3. bootstrap the gateway bridge asynchronously
4. keep the MCP process alive until stdio closes

## Behavior Changes

- adds `gateway_status`
- keeps gateway-backed tools registered even when the gateway is unavailable
- returns structured tool errors instead of killing startup when the bridge is unavailable
- persists bridge diagnostics:
  - state
  - last error
  - last connect attempt time
  - last ready time
  - next retry time
  - sanitized connection source metadata
- adds bounded retry with single-flight connect attempts
- makes sparse or missing env degrade cleanly instead of crashing before MCP initialize

## Validation

Focused tests run:

```bash
pnpm exec vitest run --config vitest.unit.config.ts src/mcp/channel-server.test.ts src/cli/mcp-cli.test.ts
```

Live smoke checks run against the installed binary:

- normal MCP startup exposes `gateway_status`
- sparse-env MCP startup still initializes
- unreachable gateway URL leaves MCP alive and returns structured `gateway_unavailable`

## Files

- `src/mcp/channel-bridge.ts`
- `src/mcp/channel-server.ts`
- `src/mcp/channel-tools.ts`
- `src/mcp/channel-server.test.ts`
- `src/plugin-sdk/approval-renderers.test.ts`

## Notes

Local branch: `zach/mcp-serve-hardening`

Patch file:

- `/Users/pearlassistant/projects/openclaw-mcp-serve-hardening.patch`
