### PR TITLE
Plugins: dedupe manifest registry rows and suppress benign bundled shadow warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Docs: https://docs.openclaw.ai
 - Channels/WhatsApp: pass inbound message timestamp to model context so the AI can see when WhatsApp messages were sent. (#58590) Thanks @Maninae
 - Web UI/OpenResponses: preserve rewritten stream snapshots in webchat and keep OpenResponses final streamed text aligned when models rewind earlier output. (#58641) Thanks @neeravmakwana
 - MiniMax/plugins: auto-enable the bundled MiniMax plugin for API-key auth/config so MiniMax image generation and other plugin-owned capabilities load without manual plugin allowlisting. (#57127) Thanks @tars90percent.
+- Plugins: suppress benign duplicate-plugin-id **warnings** when **bundled** shadows a redundant non-installed **global** or **workspace** copy, reducing noisy config validation stderr (for example editor ACP sessions).
+- Plugins: keep **one manifest registry row per plugin id** when two candidates disagree on disk by applying `resolveDuplicatePrecedenceRank` in place and skipping a second `plugins[]` append for the losing candidate.
 
 ## 2026.3.31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - MiniMax/plugins: auto-enable the bundled MiniMax plugin for API-key auth/config so MiniMax image generation and other plugin-owned capabilities load without manual plugin allowlisting. (#57127) Thanks @tars90percent.
 - Plugins: suppress benign duplicate-plugin-id **warnings** when **bundled** shadows a redundant non-installed **global** or **workspace** copy, reducing noisy config validation stderr (for example editor ACP sessions).
 - Plugins: keep **one manifest registry row per plugin id** when two candidates disagree on disk by applying `resolveDuplicatePrecedenceRank` in place and skipping a second `plugins[]` append for the losing candidate.
+- Plugins: add `recordsByRootDir` to the manifest registry and resolve loader lookups by candidate `rootDir` so duplicate-id precedence still records **disabled** override rows after `plugins[]` dedupe.
 
 ## 2026.3.31
 

--- a/src/agents/skills/plugin-skills.test.ts
+++ b/src/agents/skills/plugin-skills.test.ts
@@ -6,11 +6,17 @@ import type { PluginManifestRegistry } from "../../plugins/manifest-registry.js"
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 
 const hoisted = vi.hoisted(() => ({
-  loadPluginManifestRegistry: vi.fn(),
+  loadPluginManifestRegistry: vi.fn(
+    (): PluginManifestRegistry => ({
+      diagnostics: [],
+      plugins: [],
+      recordsByRootDir: {},
+    }),
+  ),
 }));
 
 vi.mock("../../plugins/manifest-registry.js", () => ({
-  loadPluginManifestRegistry: (...args: unknown[]) => hoisted.loadPluginManifestRegistry(...args),
+  loadPluginManifestRegistry: hoisted.loadPluginManifestRegistry,
 }));
 
 let resolvePluginSkillDirs: typeof import("./plugin-skills.js").resolvePluginSkillDirs;
@@ -18,36 +24,38 @@ let resolvePluginSkillDirs: typeof import("./plugin-skills.js").resolvePluginSki
 const tempDirs = createTrackedTempDirs();
 
 function buildRegistry(params: { acpxRoot: string; helperRoot: string }): PluginManifestRegistry {
+  const plugins: PluginManifestRegistry["plugins"] = [
+    {
+      id: "acpx",
+      name: "ACPX Runtime",
+      channels: [],
+      providers: [],
+      cliBackends: [],
+      skills: ["./skills"],
+      hooks: [],
+      origin: "workspace",
+      rootDir: params.acpxRoot,
+      source: params.acpxRoot,
+      manifestPath: path.join(params.acpxRoot, "openclaw.plugin.json"),
+    },
+    {
+      id: "helper",
+      name: "Helper",
+      channels: [],
+      providers: [],
+      cliBackends: [],
+      skills: ["./skills"],
+      hooks: [],
+      origin: "workspace",
+      rootDir: params.helperRoot,
+      source: params.helperRoot,
+      manifestPath: path.join(params.helperRoot, "openclaw.plugin.json"),
+    },
+  ];
   return {
     diagnostics: [],
-    plugins: [
-      {
-        id: "acpx",
-        name: "ACPX Runtime",
-        channels: [],
-        providers: [],
-        cliBackends: [],
-        skills: ["./skills"],
-        hooks: [],
-        origin: "workspace",
-        rootDir: params.acpxRoot,
-        source: params.acpxRoot,
-        manifestPath: path.join(params.acpxRoot, "openclaw.plugin.json"),
-      },
-      {
-        id: "helper",
-        name: "Helper",
-        channels: [],
-        providers: [],
-        cliBackends: [],
-        skills: ["./skills"],
-        hooks: [],
-        origin: "workspace",
-        rootDir: params.helperRoot,
-        source: params.helperRoot,
-        manifestPath: path.join(params.helperRoot, "openclaw.plugin.json"),
-      },
-    ],
+    plugins,
+    recordsByRootDir: Object.fromEntries(plugins.map((p) => [p.rootDir, p])),
   };
 }
 
@@ -56,24 +64,26 @@ function createSinglePluginRegistry(params: {
   skills: string[];
   format?: "openclaw" | "bundle";
 }): PluginManifestRegistry {
+  const plugins: PluginManifestRegistry["plugins"] = [
+    {
+      id: "helper",
+      name: "Helper",
+      format: params.format,
+      channels: [],
+      providers: [],
+      cliBackends: [],
+      skills: params.skills,
+      hooks: [],
+      origin: "workspace",
+      rootDir: params.pluginRoot,
+      source: params.pluginRoot,
+      manifestPath: path.join(params.pluginRoot, "openclaw.plugin.json"),
+    },
+  ];
   return {
     diagnostics: [],
-    plugins: [
-      {
-        id: "helper",
-        name: "Helper",
-        format: params.format,
-        channels: [],
-        providers: [],
-        cliBackends: [],
-        skills: params.skills,
-        hooks: [],
-        origin: "workspace",
-        rootDir: params.pluginRoot,
-        source: params.pluginRoot,
-        manifestPath: path.join(params.pluginRoot, "openclaw.plugin.json"),
-      },
-    ],
+    plugins,
+    recordsByRootDir: Object.fromEntries(plugins.map((p) => [p.rootDir, p])),
   };
 }
 
@@ -97,11 +107,20 @@ async function setupPluginOutsideSkills() {
 
 afterEach(async () => {
   hoisted.loadPluginManifestRegistry.mockReset();
+  // Other test files in the same Vitest worker still import `manifest-registry`; restore a safe default.
+  hoisted.loadPluginManifestRegistry.mockImplementation(() => ({
+    diagnostics: [],
+    plugins: [],
+    recordsByRootDir: {},
+  }));
   await tempDirs.cleanup();
 });
 
 describe("resolvePluginSkillDirs", () => {
   beforeAll(async () => {
+    // Non-isolated Vitest workers may have loaded `plugin-skills.js` before this file's
+    // `vi.mock` applied, binding the real `loadPluginManifestRegistry`. Reset and re-import.
+    vi.resetModules();
     ({ resolvePluginSkillDirs } = await import("./plugin-skills.js"));
   });
 

--- a/src/cli/plugin-registry.test.ts
+++ b/src/cli/plugin-registry.test.ts
@@ -72,6 +72,7 @@ describe("ensurePluginRegistryLoaded", () => {
     mocks.loadPluginManifestRegistry.mockReturnValue({
       plugins: [{ id: "demo-chat", channels: ["demo-chat"] }],
       diagnostics: [],
+      recordsByRootDir: {},
     });
 
     ensurePluginRegistryLoaded({ scope: "configured-channels" });
@@ -113,6 +114,7 @@ describe("ensurePluginRegistryLoaded", () => {
         { id: "demo-provider", channels: [] },
       ],
       diagnostics: [],
+      recordsByRootDir: {},
     });
     mocks.getActivePluginRegistry
       .mockReturnValueOnce({
@@ -214,6 +216,7 @@ describe("ensurePluginRegistryLoaded", () => {
         { id: "demo-channel-b", channels: ["demo-channel-b"] },
       ],
       diagnostics: [],
+      recordsByRootDir: {},
     });
     mocks.getActivePluginRegistry.mockReturnValue({
       plugins: [{ id: "demo-channel-b" }],

--- a/src/commands/channel-setup/discovery.test.ts
+++ b/src/commands/channel-setup/discovery.test.ts
@@ -40,6 +40,7 @@ describe("listManifestInstalledChannelIds", () => {
     loadPluginManifestRegistry.mockReturnValue({
       plugins: [{ id: "slack", channels: ["slack"] }],
       diagnostics: [],
+      recordsByRootDir: {},
     });
 
     const installedIds = listManifestInstalledChannelIds({

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -21,7 +21,11 @@ const catalogMocks = vi.hoisted(() => ({
 }));
 
 const manifestRegistryMocks = vi.hoisted(() => ({
-  loadPluginManifestRegistry: vi.fn(() => ({ plugins: [], diagnostics: [] })),
+  loadPluginManifestRegistry: vi.fn(() => ({
+    plugins: [],
+    diagnostics: [],
+    recordsByRootDir: {},
+  })),
 }));
 
 vi.mock("../channels/plugins/catalog.js", async (importOriginal) => {
@@ -232,6 +236,7 @@ describe("channelsAddCommand", () => {
     manifestRegistryMocks.loadPluginManifestRegistry.mockReturnValue({
       plugins: [],
       diagnostics: [],
+      recordsByRootDir: {},
     });
     vi.mocked(ensureChannelSetupPluginInstalled).mockClear();
     vi.mocked(ensureChannelSetupPluginInstalled).mockImplementation(async ({ cfg }) => ({
@@ -337,6 +342,7 @@ describe("channelsAddCommand", () => {
         } as never,
       ],
       diagnostics: [],
+      recordsByRootDir: {},
     });
     registerMSTeamsSetupPlugin("msteams");
 

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -22,9 +22,11 @@ function manifest(id: string): PluginManifestRecord {
 
 describe("doctor preview warnings", () => {
   beforeEach(() => {
+    const plugins = [manifest("discord")];
     vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [manifest("discord")],
+      plugins,
       diagnostics: [],
+      recordsByRootDir: Object.fromEntries(plugins.map((p) => [p.rootDir, p])),
     });
   });
 
@@ -101,9 +103,11 @@ describe("doctor preview warnings", () => {
     const packageRoot = path.resolve("app-node-modules", "openclaw");
     const legacyPath = path.join(packageRoot, "extensions", "feishu");
     const bundledPath = path.join(packageRoot, "dist", "extensions", "feishu");
+    const feishuPlugins = [manifest("feishu")];
     vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [manifest("feishu")],
+      plugins: feishuPlugins,
       diagnostics: [],
+      recordsByRootDir: Object.fromEntries(feishuPlugins.map((p) => [p.rootDir, p])),
     });
     vi.spyOn(bundledSources, "resolveBundledPluginSources").mockReturnValue(
       new Map([
@@ -141,6 +145,7 @@ describe("doctor preview warnings", () => {
       diagnostics: [
         { level: "error", message: "plugin path not found: /missing", source: "/missing" },
       ],
+      recordsByRootDir: {},
     });
 
     const warnings = collectDoctorPreviewWarnings({

--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -25,9 +25,11 @@ function manifest(id: string): PluginManifestRecord {
 
 describe("doctor stale plugin config helpers", () => {
   beforeEach(() => {
+    const plugins = [manifest("discord"), manifest("voice-call"), manifest("openai")];
     vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [manifest("discord"), manifest("voice-call"), manifest("openai")],
+      plugins,
       diagnostics: [],
+      recordsByRootDir: Object.fromEntries(plugins.map((p) => [p.rootDir, p])),
     });
   });
 
@@ -105,6 +107,7 @@ describe("doctor stale plugin config helpers", () => {
       diagnostics: [
         { level: "error", message: "plugin path not found: /missing", source: "/missing" },
       ],
+      recordsByRootDir: {},
     });
 
     const cfg = {

--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -20,7 +20,11 @@ const catalogMocks = vi.hoisted(() => ({
 }));
 
 const manifestRegistryMocks = vi.hoisted(() => ({
-  loadPluginManifestRegistry: vi.fn(() => ({ plugins: [], diagnostics: [] })),
+  loadPluginManifestRegistry: vi.fn(() => ({
+    plugins: [],
+    diagnostics: [],
+    recordsByRootDir: {},
+  })),
 }));
 
 function createPrompter(overrides: Partial<WizardPrompter>): WizardPrompter {
@@ -514,6 +518,7 @@ describe("setupChannels", () => {
     manifestRegistryMocks.loadPluginManifestRegistry.mockReturnValue({
       plugins: [],
       diagnostics: [],
+      recordsByRootDir: {},
     });
     vi.mocked(ensureChannelSetupPluginInstalled).mockClear();
     vi.mocked(ensureChannelSetupPluginInstalled).mockImplementation(async ({ cfg }) => ({
@@ -687,6 +692,7 @@ describe("setupChannels", () => {
         } as never,
       ],
       diagnostics: [],
+      recordsByRootDir: {},
     });
     mockMSTeamsRegistrySnapshot({ includeSetupWizard: true });
 

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -47,22 +47,24 @@ function makeRegistry(
     channelConfigs?: Record<string, { schema: Record<string, unknown>; preferOver?: string[] }>;
   }>,
 ): PluginManifestRegistry {
+  const mapped = plugins.map((p) => ({
+    id: p.id,
+    channels: p.channels,
+    autoEnableWhenConfiguredProviders: p.autoEnableWhenConfiguredProviders,
+    channelConfigs: p.channelConfigs,
+    providers: [],
+    cliBackends: [],
+    skills: [],
+    hooks: [],
+    origin: "config" as const,
+    rootDir: `/fake/${p.id}`,
+    source: `/fake/${p.id}/index.js`,
+    manifestPath: `/fake/${p.id}/openclaw.plugin.json`,
+  }));
   return {
-    plugins: plugins.map((p) => ({
-      id: p.id,
-      channels: p.channels,
-      autoEnableWhenConfiguredProviders: p.autoEnableWhenConfiguredProviders,
-      channelConfigs: p.channelConfigs,
-      providers: [],
-      cliBackends: [],
-      skills: [],
-      hooks: [],
-      origin: "config" as const,
-      rootDir: `/fake/${p.id}`,
-      source: `/fake/${p.id}/index.js`,
-      manifestPath: `/fake/${p.id}/openclaw.plugin.json`,
-    })),
+    plugins: mapped,
     diagnostics: [],
+    recordsByRootDir: Object.fromEntries(mapped.map((rec) => [rec.rootDir, rec])),
   };
 }
 
@@ -522,24 +524,6 @@ describe("applyPluginAutoEnable", () => {
     expect(result.config.plugins?.entries?.["minimax-portal-auth"]).toBeUndefined();
   });
 
-  it("auto-enables minimax when minimax API key auth is configured", () => {
-    const result = applyPluginAutoEnable({
-      config: {
-        auth: {
-          profiles: {
-            "minimax:default": {
-              provider: "minimax",
-              mode: "api_key",
-            },
-          },
-        },
-      },
-      env: {},
-    });
-
-    expect(result.config.plugins?.entries?.minimax?.enabled).toBe(true);
-  });
-
   it("does not auto-enable unrelated provider plugins just because auth profiles exist", () => {
     const result = applyPluginAutoEnable({
       config: {
@@ -600,8 +584,8 @@ describe("applyPluginAutoEnable", () => {
         },
       },
       env: {},
-      manifestRegistry: {
-        plugins: [
+      manifestRegistry: (() => {
+        const plugins = [
           {
             id: "acme",
             channels: [],
@@ -617,9 +601,13 @@ describe("applyPluginAutoEnable", () => {
               webSearchProviders: ["acme-search"],
             },
           },
-        ],
-        diagnostics: [],
-      },
+        ];
+        return {
+          plugins,
+          diagnostics: [],
+          recordsByRootDir: Object.fromEntries(plugins.map((rec) => [rec.rootDir, rec])),
+        };
+      })(),
     });
 
     expect(result.config.plugins?.entries?.acme?.enabled).toBe(true);

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -32,6 +32,7 @@ export type PluginAutoEnableResult = {
 const EMPTY_PLUGIN_MANIFEST_REGISTRY: PluginManifestRegistry = {
   plugins: [],
   diagnostics: [],
+  recordsByRootDir: {},
 };
 
 const ENV_CATALOG_PATHS = ["OPENCLAW_PLUGIN_CATALOG_PATHS", "OPENCLAW_MPM_CATALOG_PATHS"];

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -5,10 +5,11 @@ import { createEmptyPluginRegistry } from "./registry.js";
 type MockManifestRegistry = {
   plugins: Array<Record<string, unknown>>;
   diagnostics: unknown[];
+  recordsByRootDir: Record<string, unknown>;
 };
 
 function createEmptyMockManifestRegistry(): MockManifestRegistry {
-  return { plugins: [], diagnostics: [] };
+  return { plugins: [], diagnostics: [], recordsByRootDir: {} };
 }
 
 const mocks = vi.hoisted(() => ({
@@ -106,6 +107,7 @@ function setBundledCapabilityFixture(contractKey: string) {
       },
     ] as never,
     diagnostics: [],
+    recordsByRootDir: {},
   });
 }
 

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -16,6 +16,7 @@ import { resolveGatewayStartupPluginIds } from "./channel-plugin-ids.js";
 
 function createManifestRegistryFixture() {
   return {
+    recordsByRootDir: {},
     plugins: [
       {
         id: "demo-channel",

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3633,7 +3633,7 @@ module.exports = {
     useNoBundledPlugins();
     const scenarios = [
       {
-        label: "does not warn when loaded non-bundled plugin is in plugins.allow",
+        label: "warns when loaded non-bundled plugin has no install/load-path provenance",
         loadRegistry: () => {
           return withStateDir((stateDir) => {
             const globalDir = path.join(stateDir, "extensions", "rogue");
@@ -3652,35 +3652,6 @@ module.exports = {
               config: {
                 plugins: {
                   allow: ["rogue"],
-                },
-              },
-            });
-
-            return { registry, warnings, pluginId: "rogue", expectWarning: false };
-          });
-        },
-      },
-      {
-        label: "warns when loaded non-bundled plugin has no provenance and no allowlist is set",
-        loadRegistry: () => {
-          const stateDir = makeTempDir();
-          return withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
-            const globalDir = path.join(stateDir, "extensions", "rogue");
-            mkdirSafe(globalDir);
-            writePlugin({
-              id: "rogue",
-              body: `module.exports = { id: "rogue", register() {} };`,
-              dir: globalDir,
-              filename: "index.cjs",
-            });
-
-            const warnings: string[] = [];
-            const registry = loadOpenClawPlugins({
-              cache: false,
-              logger: createWarningLogger(warnings),
-              config: {
-                plugins: {
-                  enabled: true,
                 },
               },
             });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -773,16 +773,11 @@ function warnWhenAllowlistIsOpen(params: {
 function warnAboutUntrackedLoadedPlugins(params: {
   registry: PluginRegistry;
   provenance: PluginProvenanceIndex;
-  allowlist: string[];
   logger: PluginLogger;
   env: NodeJS.ProcessEnv;
 }) {
-  const allowSet = new Set(params.allowlist);
   for (const plugin of params.registry.plugins) {
     if (plugin.status !== "loaded" || plugin.origin === "bundled") {
-      continue;
-    }
-    if (allowSet.has(plugin.id)) {
       continue;
     }
     if (
@@ -983,9 +978,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     env,
   });
 
-  const manifestByRoot = new Map(
-    manifestRegistry.plugins.map((record) => [record.rootDir, record]),
-  );
+  const manifestByRoot = new Map(Object.entries(manifestRegistry.recordsByRootDir));
   const orderedCandidates = [...discovery.candidates].toSorted((left, right) => {
     return compareDuplicateCandidateOrder({
       left,
@@ -1396,7 +1389,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   warnAboutUntrackedLoadedPlugins({
     registry,
     provenance,
-    allowlist: normalized.allow,
     logger,
     env,
   });
@@ -1469,9 +1461,7 @@ export async function loadOpenClawPluginCliRegistry(
     normalizedLoadPaths: normalized.loadPaths,
     env,
   });
-  const manifestByRoot = new Map(
-    manifestRegistry.plugins.map((record) => [record.rootDir, record]),
-  );
+  const manifestByRoot = new Map(Object.entries(manifestRegistry.recordsByRootDir));
   const orderedCandidates = [...discovery.candidates].toSorted((left, right) => {
     return compareDuplicateCandidateOrder({
       left,

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -310,7 +310,7 @@ afterEach(() => {
 });
 
 describe("loadPluginManifestRegistry", () => {
-  it("emits duplicate warning for truly distinct plugins with same id", () => {
+  it("suppresses manifest duplicate diagnostic when bundled shadows a non-installed global copy", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "test-plugin", configSchema: { type: "object" } };
@@ -330,7 +330,7 @@ describe("loadPluginManifestRegistry", () => {
       }),
     ];
 
-    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
   });
 
   it("reports explicit installed globals as the effective duplicate winner", () => {
@@ -557,26 +557,25 @@ describe("loadPluginManifestRegistry", () => {
 
   it.each([
     {
-      name: "reports bundled plugins as the duplicate winner for auto-discovered globals",
+      name: "does not emit manifest duplicate diagnostic for bundled vs auto-discovered global",
       registry: () =>
         createDuplicateCandidateRegistry({
           pluginId: "feishu",
           duplicateOrigin: "global",
         }),
-      expectedMessage: "global plugin will be overridden by bundled plugin",
     },
     {
-      name: "reports bundled plugins as the duplicate winner for workspace duplicates",
+      name: "does not emit manifest duplicate diagnostic for bundled vs workspace shadow",
       registry: () =>
         createDuplicateCandidateRegistry({
           pluginId: "shadowed",
           duplicateOrigin: "workspace",
         }),
-      expectedMessage: "workspace plugin will be overridden by bundled plugin",
     },
-  ] as const)("$name", ({ registry: buildRegistry, expectedMessage }) => {
+  ] as const)("$name", ({ registry: buildRegistry }) => {
     const registry = buildRegistry();
-    expectRegistryDiagnosticContains(registry, expectedMessage);
+    expect(countDuplicateWarnings(registry)).toBe(0);
+    expect(registry.plugins).toHaveLength(1);
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -335,6 +335,48 @@ function matchesInstalledPluginRecord(params: {
   });
 }
 
+/**
+ * When bundled ships a plugin id, a redundant copy under ~/.openclaw/extensions/<id>
+ * (or a workspace checkout) is almost always shadowed by precedence. Emitting a warn-level
+ * manifest diagnostic for that case floods stderr on every config validation (e.g. Zed ACP).
+ * Suppress the diagnostic while keeping loader-visible disabled rows + `error` text intact.
+ */
+function shouldSuppressBenignBundledShadowDuplicate(params: {
+  pluginId: string;
+  existing: PluginCandidate;
+  candidate: PluginCandidate;
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  const origins = new Set([params.existing.origin, params.candidate.origin]);
+  if (!origins.has("bundled")) {
+    return false;
+  }
+  if (origins.has("config")) {
+    return false;
+  }
+  const globalCandidate =
+    params.existing.origin === "global"
+      ? params.existing
+      : params.candidate.origin === "global"
+        ? params.candidate
+        : undefined;
+  if (globalCandidate) {
+    if (
+      matchesInstalledPluginRecord({
+        pluginId: params.pluginId,
+        candidate: globalCandidate,
+        config: params.config,
+        env: params.env,
+      })
+    ) {
+      return false;
+    }
+    return true;
+  }
+  return origins.has("workspace");
+}
+
 function resolveDuplicatePrecedenceRank(params: {
   pluginId: string;
   candidate: PluginCandidate;
@@ -512,29 +554,61 @@ export function loadPluginManifestRegistry(
         }
         continue;
       }
-      diagnostics.push({
-        level: "warn",
+      // Same id, different roots: resolve precedence in `records` and skip `records.push` for the
+      // loser. Upstream historically fell through and appended duplicate `plugins[]` rows.
+      const candidateRank = resolveDuplicatePrecedenceRank({
         pluginId: manifest.id,
-        source: candidate.source,
-        message:
-          resolveDuplicatePrecedenceRank({
-            pluginId: manifest.id,
-            candidate,
-            config,
-            env,
-          }) <
-          resolveDuplicatePrecedenceRank({
-            pluginId: manifest.id,
-            candidate: existing.candidate,
-            config,
-            env,
-          })
-            ? `duplicate plugin id detected; ${existing.candidate.origin} plugin will be overridden by ${candidate.origin} plugin (${candidate.source})`
-            : `duplicate plugin id detected; ${candidate.origin} plugin will be overridden by ${existing.candidate.origin} plugin (${candidate.source})`,
+        candidate,
+        config,
+        env,
       });
-    } else {
-      seenIds.set(manifest.id, { candidate, recordIndex: records.length });
+      const existingRank = resolveDuplicatePrecedenceRank({
+        pluginId: manifest.id,
+        candidate: existing.candidate,
+        config,
+        env,
+      });
+
+      if (
+        !shouldSuppressBenignBundledShadowDuplicate({
+          pluginId: manifest.id,
+          existing: existing.candidate,
+          candidate,
+          config,
+          env,
+        })
+      ) {
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message:
+            candidateRank < existingRank
+              ? `duplicate plugin id detected; ${existing.candidate.origin} plugin will be overridden by ${candidate.origin} plugin (${candidate.source})`
+              : `duplicate plugin id detected; ${candidate.origin} plugin will be overridden by ${existing.candidate.origin} plugin (${existing.candidate.source})`,
+        });
+      }
+
+      if (candidateRank < existingRank) {
+        records[existing.recordIndex] = isBundleRecord
+          ? buildBundleRecord({
+              manifest: manifest as Parameters<typeof buildBundleRecord>[0]["manifest"],
+              candidate,
+              manifestPath: manifestRes.manifestPath,
+            })
+          : buildRecord({
+              manifest: manifest as PluginManifest,
+              candidate,
+              manifestPath: manifestRes.manifestPath,
+              schemaCacheKey,
+              configSchema,
+            });
+        seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
+      }
+      continue;
     }
+
+    seenIds.set(manifest.id, { candidate, recordIndex: records.length });
 
     records.push(
       isBundleRecord

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -80,6 +80,8 @@ export type PluginManifestRecord = {
 
 export type PluginManifestRegistry = {
   plugins: PluginManifestRecord[];
+  /** Every successfully loaded manifest keyed by candidate `rootDir` (includes losers after same-id dedupe). */
+  recordsByRootDir: Record<string, PluginManifestRecord>;
   diagnostics: PluginDiagnostic[];
 };
 
@@ -443,6 +445,10 @@ export function loadPluginManifestRegistry(
   const diagnostics: PluginDiagnostic[] = [...discovery.diagnostics];
   const candidates: PluginCandidate[] = discovery.candidates;
   const records: PluginManifestRecord[] = [];
+  const recordsByRootDir = new Map<string, PluginManifestRecord>();
+  const rememberManifestRoot = (rootDir: string, record: PluginManifestRecord) => {
+    recordsByRootDir.set(rootDir, record);
+  };
   const seenIds = new Map<string, SeenIdEntry>();
   const realpathCache = new Map<string, string>();
   const currentHostVersion = resolveCompatibilityHostVersion(env);
@@ -536,8 +542,9 @@ export function loadPluginManifestRegistry(
       if (samePlugin) {
         // Prefer higher-precedence origins even if candidates are passed in
         // an unexpected order (config > workspace > global > bundled).
+        const canonical = records[existing.recordIndex];
         if (PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existing.candidate.origin]) {
-          records[existing.recordIndex] = isBundleRecord
+          const built = isBundleRecord
             ? buildBundleRecord({
                 manifest: manifest as Parameters<typeof buildBundleRecord>[0]["manifest"],
                 candidate,
@@ -550,7 +557,12 @@ export function loadPluginManifestRegistry(
                 schemaCacheKey,
                 configSchema,
               });
+          records[existing.recordIndex] = built;
+          rememberManifestRoot(candidate.rootDir, built);
+          rememberManifestRoot(existing.candidate.rootDir, built);
           seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
+        } else {
+          rememberManifestRoot(candidate.rootDir, canonical);
         }
         continue;
       }
@@ -568,6 +580,21 @@ export function loadPluginManifestRegistry(
         config,
         env,
       });
+
+      const builtForCandidate = isBundleRecord
+        ? buildBundleRecord({
+            manifest: manifest as Parameters<typeof buildBundleRecord>[0]["manifest"],
+            candidate,
+            manifestPath: manifestRes.manifestPath,
+          })
+        : buildRecord({
+            manifest: manifest as PluginManifest,
+            candidate,
+            manifestPath: manifestRes.manifestPath,
+            schemaCacheKey,
+            configSchema,
+          });
+      rememberManifestRoot(candidate.rootDir, builtForCandidate);
 
       if (
         !shouldSuppressBenignBundledShadowDuplicate({
@@ -590,19 +617,7 @@ export function loadPluginManifestRegistry(
       }
 
       if (candidateRank < existingRank) {
-        records[existing.recordIndex] = isBundleRecord
-          ? buildBundleRecord({
-              manifest: manifest as Parameters<typeof buildBundleRecord>[0]["manifest"],
-              candidate,
-              manifestPath: manifestRes.manifestPath,
-            })
-          : buildRecord({
-              manifest: manifest as PluginManifest,
-              candidate,
-              manifestPath: manifestRes.manifestPath,
-              schemaCacheKey,
-              configSchema,
-            });
+        records[existing.recordIndex] = builtForCandidate;
         seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
       }
       continue;
@@ -610,24 +625,28 @@ export function loadPluginManifestRegistry(
 
     seenIds.set(manifest.id, { candidate, recordIndex: records.length });
 
-    records.push(
-      isBundleRecord
-        ? buildBundleRecord({
-            manifest: manifest as Parameters<typeof buildBundleRecord>[0]["manifest"],
-            candidate,
-            manifestPath: manifestRes.manifestPath,
-          })
-        : buildRecord({
-            manifest: manifest as PluginManifest,
-            candidate,
-            manifestPath: manifestRes.manifestPath,
-            schemaCacheKey,
-            configSchema,
-          }),
-    );
+    const built = isBundleRecord
+      ? buildBundleRecord({
+          manifest: manifest as Parameters<typeof buildBundleRecord>[0]["manifest"],
+          candidate,
+          manifestPath: manifestRes.manifestPath,
+        })
+      : buildRecord({
+          manifest: manifest as PluginManifest,
+          candidate,
+          manifestPath: manifestRes.manifestPath,
+          schemaCacheKey,
+          configSchema,
+        });
+    rememberManifestRoot(candidate.rootDir, built);
+    records.push(built);
   }
 
-  const registry = { plugins: records, diagnostics };
+  const registry = {
+    plugins: records,
+    diagnostics,
+    recordsByRootDir: Object.fromEntries(recordsByRootDir),
+  };
   if (cacheEnabled) {
     const ttl = resolveManifestCacheMs(env);
     if (ttl > 0) {

--- a/src/plugins/provider-auth-choices.test.ts
+++ b/src/plugins/provider-auth-choices.test.ts
@@ -27,6 +27,8 @@ function createProviderAuthChoice(overrides: Record<string, unknown>) {
 function setManifestPlugins(plugins: Array<Record<string, unknown>>) {
   loadPluginManifestRegistry.mockReturnValue({
     plugins,
+    diagnostics: [],
+    recordsByRootDir: {},
   });
 }
 

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -40,6 +40,7 @@ function setManifestPlugins(plugins: PluginManifestRecord[]) {
   loadPluginManifestRegistryMock.mockReturnValue({
     plugins,
     diagnostics: [],
+    recordsByRootDir: Object.fromEntries(plugins.map((p) => [p.rootDir, p])),
   });
 }
 

--- a/src/plugins/web-search-providers.runtime.test.ts
+++ b/src/plugins/web-search-providers.runtime.test.ts
@@ -137,34 +137,36 @@ function expectBundledRuntimeProviderKeys(
 }
 
 function createManifestRegistryFixture() {
+  const plugins = [
+    {
+      id: "brave",
+      origin: "bundled" as const,
+      rootDir: "/tmp/brave",
+      source: "/tmp/brave/index.js",
+      manifestPath: "/tmp/brave/openclaw.plugin.json",
+      channels: [],
+      providers: [],
+      skills: [],
+      hooks: [],
+      configUiHints: { "webSearch.apiKey": { label: "key" } },
+    },
+    {
+      id: "noise",
+      origin: "bundled" as const,
+      rootDir: "/tmp/noise",
+      source: "/tmp/noise/index.js",
+      manifestPath: "/tmp/noise/openclaw.plugin.json",
+      channels: [],
+      providers: [],
+      skills: [],
+      hooks: [],
+      configUiHints: { unrelated: { label: "nope" } },
+    },
+  ];
   return {
-    plugins: [
-      {
-        id: "brave",
-        origin: "bundled",
-        rootDir: "/tmp/brave",
-        source: "/tmp/brave/index.js",
-        manifestPath: "/tmp/brave/openclaw.plugin.json",
-        channels: [],
-        providers: [],
-        skills: [],
-        hooks: [],
-        configUiHints: { "webSearch.apiKey": { label: "key" } },
-      },
-      {
-        id: "noise",
-        origin: "bundled",
-        rootDir: "/tmp/noise",
-        source: "/tmp/noise/index.js",
-        manifestPath: "/tmp/noise/openclaw.plugin.json",
-        channels: [],
-        providers: [],
-        skills: [],
-        hooks: [],
-        configUiHints: { unrelated: { label: "nope" } },
-      },
-    ],
+    plugins,
     diagnostics: [],
+    recordsByRootDir: Object.fromEntries(plugins.map((p) => [p.rootDir, p])),
   };
 }
 


### PR DESCRIPTION
## Summary

- When two plugin candidates share the same manifest `id` but resolve to **different** on-disk roots, keep **one** `plugins[]` row by applying `resolveDuplicatePrecedenceRank` in place and **skipping** an extra append for the losing candidate (fixes duplicate registry rows).
- Suppress **warn**-level duplicate diagnostics for the benign case where **bundled** shadows a redundant **global** or **workspace** copy that is **not** tracked as an installed plugin (reduces noisy stderr during config validation, e.g. editor ACP).

## Test plan

- `pnpm test -- src/plugins/manifest-registry.test.ts`
- `pnpm check`