### PR TITLE
fix: UI keep chat session select synced to sessionKey

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -156,7 +156,7 @@ export function renderChatSessionSelect(state: AppViewState) {
                   group.options,
                   (entry) => entry.key,
                   (entry) =>
-                    html`<option value=${entry.key} title=${entry.title}>${entry.label}</option>`,
+                    html`<option value=${entry.key} title=${entry.title} ?selected=${entry.key === state.sessionKey}>${entry.label}</option>`,
                 )}
               </optgroup>`,
           )}
@@ -428,7 +428,7 @@ export function renderChatMobileToggle(state: AppViewState) {
                   <optgroup label=${group.label}>
                     ${group.options.map(
                       (opt) => html`
-                        <option value=${opt.key} title=${opt.title}>${opt.label}</option>
+                        <option value=${opt.key} title=${opt.title} ?selected=${opt.key === state.sessionKey}>${opt.label}</option>
                       `,
                     )}
                   </optgroup>


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: On page refresh / cold start, the chat session `<select>` could visually default to the first option (often “A”) even when `state.sessionKey` and loaded chat history were for a different session (often “B”).
- Why it matters: The UI appears “out of sync” with the actual active session, confusing users and making it easy to think the app loaded the wrong conversation.
- What changed: Add explicit `selected` binding on chat session `<option>` entries (desktop + mobile) so the selected option converges to `state.sessionKey` once async session options render.
- What did NOT change (scope boundary): No changes to session routing, URL syncing, session persistence, gateway behavior, or chat history loading logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Session `<option>` entries are rendered from `sessionsResult` asynchronously. During initial render, the `<select>` can receive `.value=${state.sessionKey}` before the matching `<option value="...">` exists, so the browser falls back to selecting the first option. When options later arrive, the UI may remain visually on the first option even though `state.sessionKey` (and loaded data) is different.
- Missing detection / guardrail: No UI test or integration test that asserts the chat session dropdown selection matches `state.sessionKey` after asynchronous session list hydration.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: Unknown (likely exposed by timing changes in session loading / render order).
- If unknown, what was ruled out: Not caused by `optgroup` itself; not caused by `loadChatHistory` requesting the wrong `sessionKey` (data layer was correct).

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/app-render.helpers.ts`
- Scenario the test should lock in: With `state.sessionKey` set to a key not present in the initial options render, once `sessionsResult` is hydrated and the option appears, the dropdown selection reflects `state.sessionKey` (desktop + mobile variants).
- Why this is the smallest reliable guardrail: This is a UI state/render-order issue; asserting DOM selection after async options render is the most direct guardrail.
- Existing test that already covers this (if any): None known.
- If no new test is added, why not: UI test coverage for Lit template hydration timing is currently not in place for this surface.

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Chat session dropdown now stays visually in sync with the active `sessionKey` after refresh / initial load (desktop + mobile UI).

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
Refresh page
-> state.sessionKey = B
-> sessions options render without B (async)
-> browser visually selects first option A
-> chat history loads for B (data is B, UI shows A)

After:
Refresh page
-> state.sessionKey = B
-> sessions options hydrate (async)
-> matching <option value="B"> renders with selected=true
-> UI selection converges to B
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Browser UI (Lit)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `localStorage` key `openclaw.control.settings.v1` contains `sessionKey` and `lastActiveSessionKey` set to a non-first session option (B).

### Steps

1. Ensure `openclaw.control.settings.v1` has `sessionKey` and `lastActiveSessionKey` set to B (a session that is not the first option when sessions list renders).
2. Reload the control UI (hard refresh).
3. Observe the chat session dropdown selection and the loaded chat history.

### Expected

- The chat session dropdown shows B as selected.
- The loaded chat history corresponds to B.

### Actual

- The chat session dropdown could show the first option A as selected while the chat history corresponds to B.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Refresh page with `sessionKey` set to a non-first option; dropdown converges to the active session.
  - Verified both desktop and mobile session dropdown variants.
- Edge cases checked:
  - Sessions list initially empty / not yet loaded.
  - Active session option appears after async load.
- What you did **not** verify:
  - No automated UI test added.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Potential mismatch if both `.value` and `selected` bindings diverge due to future refactors.
  - Mitigation: Keep `selected` derived directly from `state.sessionKey` (single source of truth) and ensure desktop/mobile dropdowns share the same selection logic.

<img width="1901" height="699" alt="ScreenShot_2026-04-01_144344_953" src="https://github.com/user-attachments/assets/69c1113f-0504-44ab-a71c-ab671759bd55" />
