### PR TITLE
Fix: preserve agent display name/avatar on Slack message edits (Resolves #58737)

### DIFF
--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -7,7 +7,8 @@ import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackWebClient, createSlackWriteClient } from "./client.js";
 import { resolveSlackMedia } from "./monitor/media.js";
 import type { SlackMediaResult } from "./monitor/media.js";
-import { sendMessageSlack } from "./send.js";
+import { hasCustomIdentity, isSlackCustomizeScopeError } from "./customize-scope.js";
+import { type SlackSendIdentity, sendMessageSlack } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
 
 export type SlackActionClientOpts = {
@@ -192,17 +193,46 @@ export async function editSlackMessage(
   channelId: string,
   messageId: string,
   content: string,
-  opts: SlackActionClientOpts & { blocks?: (Block | KnownBlock)[] } = {},
+  opts: SlackActionClientOpts & {
+    blocks?: (Block | KnownBlock)[];
+    identity?: SlackSendIdentity;
+  } = {},
 ) {
   const client = await getClient(opts, "write");
   const blocks = opts.blocks == null ? undefined : validateSlackBlocksArray(opts.blocks);
   const trimmedContent = content.trim();
-  await client.chat.update({
+  // Slack's chat.update API supports username/icon_url/icon_emoji (same as
+  // chat.postMessage) but the @slack/web-api types omit them from
+  // ChatUpdateArguments.  Spread identity fields and widen via `as never` so
+  // the runtime payload is correct while keeping the rest type-safe.
+  const identityFields: Record<string, string> = {};
+  if (opts.identity?.username) {
+    identityFields.username = opts.identity.username;
+  }
+  if (opts.identity?.iconUrl) {
+    identityFields.icon_url = opts.identity.iconUrl;
+  } else if (opts.identity?.iconEmoji) {
+    identityFields.icon_emoji = opts.identity.iconEmoji;
+  }
+  const baseArgs = {
     channel: channelId,
     ts: messageId,
     text: trimmedContent || (blocks ? buildSlackBlocksFallbackText(blocks) : " "),
     ...(blocks ? { blocks } : {}),
-  });
+  };
+  if (Object.keys(identityFields).length > 0) {
+    try {
+      await client.chat.update({ ...baseArgs, ...identityFields } as never);
+    } catch (err) {
+      if (!hasCustomIdentity(opts.identity) || !isSlackCustomizeScopeError(err)) {
+        throw err;
+      }
+      logVerbose("slack edit: missing chat:write.customize, retrying without custom identity");
+      await client.chat.update(baseArgs);
+    }
+  } else {
+    await client.chat.update(baseArgs);
+  }
 }
 
 export async function deleteSlackMessage(

--- a/extensions/slack/src/customize-scope.ts
+++ b/extensions/slack/src/customize-scope.ts
@@ -1,0 +1,31 @@
+import type { SlackSendIdentity } from "./send.js";
+
+export function hasCustomIdentity(identity?: SlackSendIdentity): boolean {
+  return Boolean(identity?.username || identity?.iconUrl || identity?.iconEmoji);
+}
+
+export function isSlackCustomizeScopeError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const maybeData = err as Error & {
+    data?: {
+      error?: string;
+      needed?: string;
+      response_metadata?: { scopes?: string[]; acceptedScopes?: string[] };
+    };
+  };
+  const code = maybeData.data?.error?.toLowerCase();
+  if (code !== "missing_scope") {
+    return false;
+  }
+  const needed = maybeData.data?.needed?.toLowerCase();
+  if (needed?.includes("chat:write.customize")) {
+    return true;
+  }
+  const scopes = [
+    ...(maybeData.data?.response_metadata?.scopes ?? []),
+    ...(maybeData.data?.response_metadata?.acceptedScopes ?? []),
+  ].map((scope) => scope.toLowerCase());
+  return scopes.includes("chat:write.customize");
+}

--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -2,7 +2,7 @@ import { createDraftStreamLoop } from "openclaw/plugin-sdk/channel-lifecycle";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { deleteSlackMessage, editSlackMessage } from "./actions.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
-import { sendMessageSlack } from "./send.js";
+import { type SlackSendIdentity, sendMessageSlack } from "./send.js";
 
 const DEFAULT_THROTTLE_MS = 1000;
 
@@ -24,6 +24,7 @@ export function createSlackDraftStream(params: {
   throttleMs?: number;
   resolveThreadTs?: () => string | undefined;
   onMessageSent?: () => void;
+  identity?: SlackSendIdentity;
   log?: (message: string) => void;
   warn?: (message: string) => void;
   send?: typeof sendMessageSlack;
@@ -63,6 +64,7 @@ export function createSlackDraftStream(params: {
         await edit(streamChannelId, streamMessageId, trimmed, {
           token: params.token,
           accountId: params.accountId,
+          identity: params.identity,
         });
         return;
       }
@@ -70,6 +72,7 @@ export function createSlackDraftStream(params: {
         token: params.token,
         accountId: params.accountId,
         threadTs: params.resolveThreadTs?.(),
+        identity: params.identity,
       });
       streamChannelId = sent.channelId || streamChannelId;
       streamMessageId = sent.messageId || streamMessageId;

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -454,6 +454,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             text: normalizeSlackOutboundText(trimmedFinalText),
             ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
             threadTs: usedReplyThreadTs ?? statusThreadTs,
+            ...(slackIdentity ? { identity: slackIdentity } : {}),
           });
           observedReplyDelivery = true;
           return;
@@ -496,6 +497,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         token: ctx.botToken,
         accountId: account.accountId,
         maxChars: Math.min(ctx.textLimit, SLACK_TEXT_LIMIT),
+        identity: slackIdentity,
         resolveThreadTs: () => {
           const ts = replyPlan.nextThreadTs();
           if (ts) {

--- a/extensions/slack/src/monitor/message-handler/preview-finalize.ts
+++ b/extensions/slack/src/monitor/message-handler/preview-finalize.ts
@@ -3,6 +3,7 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { editSlackMessage } from "../../actions.js";
 import { buildSlackBlocksFallbackText } from "../../blocks-fallback.js";
 import { normalizeSlackOutboundText } from "../../format.js";
+import type { SlackSendIdentity } from "../../send.js";
 
 type SlackReadbackMessage = {
   ts?: string;
@@ -104,6 +105,7 @@ export async function finalizeSlackPreviewEdit(params: {
   text: string;
   blocks?: (Block | KnownBlock)[];
   threadTs?: string;
+  identity?: SlackSendIdentity;
 }): Promise<void> {
   try {
     await editSlackMessage(params.channelId, params.messageId, params.text, {
@@ -111,6 +113,7 @@ export async function finalizeSlackPreviewEdit(params: {
       accountId: params.accountId,
       client: params.client,
       ...(params.blocks?.length ? { blocks: params.blocks } : {}),
+      ...(params.identity ? { identity: params.identity } : {}),
     });
     return;
   } catch (err) {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -13,6 +13,7 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { SlackTokenSource } from "./accounts.js";
 import { resolveSlackAccount } from "./accounts.js";
+import { hasCustomIdentity, isSlackCustomizeScopeError } from "./customize-scope.js";
 import { buildSlackBlocksFallbackText } from "./blocks-fallback.js";
 import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackWriteClient } from "./client.js";
@@ -62,36 +63,6 @@ type SlackSendOpts = {
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
 };
-
-function hasCustomIdentity(identity?: SlackSendIdentity): boolean {
-  return Boolean(identity?.username || identity?.iconUrl || identity?.iconEmoji);
-}
-
-function isSlackCustomizeScopeError(err: unknown): boolean {
-  if (!(err instanceof Error)) {
-    return false;
-  }
-  const maybeData = err as Error & {
-    data?: {
-      error?: string;
-      needed?: string;
-      response_metadata?: { scopes?: string[]; acceptedScopes?: string[] };
-    };
-  };
-  const code = maybeData.data?.error?.toLowerCase();
-  if (code !== "missing_scope") {
-    return false;
-  }
-  const needed = maybeData.data?.needed?.toLowerCase();
-  if (needed?.includes("chat:write.customize")) {
-    return true;
-  }
-  const scopes = [
-    ...(maybeData.data?.response_metadata?.scopes ?? []),
-    ...(maybeData.data?.response_metadata?.acceptedScopes ?? []),
-  ].map((scope) => scope.toLowerCase());
-  return scopes.includes("chat:write.customize");
-}
 
 async function postSlackMessageBestEffort(params: {
   client: WebClient;


### PR DESCRIPTION
Fixes #58737.

When OpenClaw edits a Slack message (via `chat.update`), the custom `username`, `icon_url`, and `icon_emoji` fields were not being passed, causing Slack to revert the display name and avatar to the bot's registered defaults.

This change:
- Adds an optional `identity` parameter to `editSlackMessage()` that mirrors the existing `SlackSendIdentity` used by `chat.postMessage`
- Passes the resolved agent identity through the draft stream and message dispatch edit paths
- Works around incomplete `@slack/web-api` types for `ChatUpdateArguments` (which omit authorship fields that the Slack API actually supports)