### PR TITLE
Fix: gracefully handle Discord WebSocket reconnect exhaustion (Resolves #58764)

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -565,4 +565,98 @@ describe("runDiscordGatewayLifecycle", () => {
       vi.useRealTimers();
     }
   });
+
+  it("gracefully exits lifecycle on reconnect-exhausted during shutdown", async () => {
+    const pendingGatewayEvents: DiscordGatewayEvent[] = [];
+    const abortController = new AbortController();
+
+    const { emitter, gateway } = createGatewayHarness();
+    gateway.isConnected = true;
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const { lifecycleParams, runtimeLog, runtimeError } = createLifecycleHarness({
+      gateway,
+      pendingGatewayEvents,
+    });
+    lifecycleParams.abortSignal = abortController.signal;
+
+    // Start lifecycle; it yields at execApprovalsHandler.start(). We then
+    // queue a reconnect-exhausted event and abort. The lifecycle resumes and
+    // drains the queued event before shutdown teardown flips lifecycleStopping,
+    // so drainPending must treat it as a graceful stop.
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    pendingGatewayEvents.push(
+      createGatewayEvent(
+        "reconnect-exhausted",
+        "Max reconnect attempts (0) reached after code 1005",
+      ),
+    );
+    abortController.abort();
+
+    await expect(lifecyclePromise).resolves.toBeUndefined();
+    expect(runtimeLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
+    );
+    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("Max reconnect attempts"));
+  });
+
+  it("resolves reconnect-exhausted queued before startup when shutdown has not begun", async () => {
+    const pendingGatewayEvents: DiscordGatewayEvent[] = [];
+
+    const emitter = new EventEmitter();
+    const gateway: MockGateway = {
+      isConnected: true,
+      options: { intents: 0, reconnect: { maxAttempts: 50 } } as GatewayPlugin["options"],
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      emitter,
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const { lifecycleParams, runtimeError } = createLifecycleHarness({
+      gateway,
+      pendingGatewayEvents,
+    });
+
+    pendingGatewayEvents.push(
+      createGatewayEvent(
+        "reconnect-exhausted",
+        "Max reconnect attempts (0) reached after code 1005",
+      ),
+    );
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("reconnect attempts exhausted"),
+    );
+  });
+
+  it("does not push connected: true when abortSignal is already aborted", async () => {
+    const emitter = new EventEmitter();
+    const gateway: MockGateway = {
+      isConnected: true,
+      options: { intents: 0, reconnect: { maxAttempts: 3 } } as GatewayPlugin["options"],
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      emitter,
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const statusUpdates: Array<Record<string, unknown>> = [];
+    const statusSink = (patch: Record<string, unknown>) => {
+      statusUpdates.push({ ...patch });
+    };
+
+    const { lifecycleParams } = createLifecycleHarness({ gateway });
+    lifecycleParams.abortSignal = abortController.signal;
+    (lifecycleParams as Record<string, unknown>).statusSink = statusSink;
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+    expect(statusUpdates).not.toContainEqual(expect.objectContaining({ connected: true }));
+  });
 });

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -395,18 +395,20 @@ describe("runDiscordGatewayLifecycle", () => {
     });
   });
 
-  it("throws queued reconnect exhaustion errors", async () => {
-    const { lifecycleParams, start, stop, threadStop, gatewaySupervisor } = createLifecycleHarness({
-      pendingGatewayEvents: [
-        createGatewayEvent(
-          "reconnect-exhausted",
-          "Max reconnect attempts (50) reached after code 1005",
-        ),
-      ],
-    });
+  it("gracefully handles queued reconnect exhaustion errors", async () => {
+    const { lifecycleParams, start, stop, threadStop, gatewaySupervisor, runtimeError } =
+      createLifecycleHarness({
+        pendingGatewayEvents: [
+          createGatewayEvent(
+            "reconnect-exhausted",
+            "Max reconnect attempts (50) reached after code 1005",
+          ),
+        ],
+      });
 
-    await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow(
-      "discord gateway reconnect-exhausted: Error: Max reconnect attempts (50) reached after code 1005",
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("reconnect attempts exhausted"),
     );
 
     expectLifecycleCleanup({
@@ -629,6 +631,11 @@ describe("runDiscordGatewayLifecycle", () => {
     await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
     expect(runtimeError).toHaveBeenCalledWith(
       expect.stringContaining("reconnect attempts exhausted"),
+    );
+    // Only the descriptive catch-block message should be emitted, not the
+    // generic "discord gateway error:" duplicate.
+    expect(runtimeError).not.toHaveBeenCalledWith(
+      expect.stringContaining("discord gateway error:"),
     );
   });
 

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -460,7 +460,19 @@ export async function runDiscordGatewayLifecycle(params: {
       registerForceStop: statusObserver.registerForceStop,
     });
   } catch (err) {
-    if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
+    // Reconnect-exhausted outside of intentional shutdown means the WebSocket
+    // connection was lost and Carbon ran out of retry attempts.  Exit the
+    // lifecycle cleanly so the channel health monitor can restart it instead of
+    // crashing the entire gateway process.
+    const isReconnectExhausted =
+      err instanceof Error && /Max reconnect attempts/i.test(err.message);
+    if (isReconnectExhausted) {
+      params.runtime.error?.(
+        danger(
+          `discord: gateway reconnect attempts exhausted — lifecycle exiting for restart: ${String(err)}`,
+        ),
+      );
+    } else if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
       throw err;
     }
   } finally {

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -405,13 +405,17 @@ export async function runDiscordGatewayLifecycle(params: {
     if (event.shouldStopLifecycle) {
       lifecycleStopping = true;
     }
-    params.runtime.error?.(
-      danger(
-        event.shouldStopLifecycle
-          ? `discord gateway ${event.type}: ${event.message}`
-          : `discord gateway error: ${event.message}`,
-      ),
-    );
+    // Skip the generic log for reconnect-exhausted: the catch block emits a
+    // more descriptive message so we avoid duplicate error entries.
+    if (event.type !== "reconnect-exhausted") {
+      params.runtime.error?.(
+        danger(
+          event.shouldStopLifecycle
+            ? `discord gateway ${event.type}: ${event.message}`
+            : `discord gateway error: ${event.message}`,
+        ),
+      );
+    }
     return event.shouldStopLifecycle ? "stop" : "continue";
   };
   const drainPendingGatewayErrors = (): "continue" | "stop" =>
@@ -465,7 +469,7 @@ export async function runDiscordGatewayLifecycle(params: {
     // lifecycle cleanly so the channel health monitor can restart it instead of
     // crashing the entire gateway process.
     const isReconnectExhausted =
-      err instanceof Error && /Max reconnect attempts/i.test(err.message);
+      err instanceof DiscordGatewayLifecycleError && err.eventType === "reconnect-exhausted";
     if (isReconnectExhausted) {
       params.runtime.error?.(
         danger(


### PR DESCRIPTION
Fixes #58764.

When the Discord WebSocket disconnects with close code 1005 and Carbon's internal reconnect attempts are exhausted, the error propagated as an uncaught exception that crashed the entire gateway process.

**Root cause**: `runDiscordGatewayLifecycle` only caught `disallowedIntents` errors in its catch block, re-throwing everything else. A `reconnect-exhausted` error outside of an intentional shutdown (`lifecycleStopping=false`) would propagate all the way up as an unhandled rejection.

**Fix**: Catch `reconnect-exhausted` errors (matching "Max reconnect attempts" in the error message) and exit the lifecycle cleanly with an error log, allowing the channel health monitor to restart the connection instead of crashing the process.

Updated the existing test that expected rejection to verify the new graceful exit behavior.