### PR TITLE
fix(status): truncate task title and detail in /status output

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -139,11 +139,16 @@ function formatSessionTaskLine(params: {
       : failed > 0
         ? `${failed} recent failure${failed === 1 ? "" : "s"}`
         : `latest ${latest.status.replaceAll("_", " ")}`;
-  const title = latest.label?.trim() || latest.task.trim();
-  const detail =
+  const rawTitle = latest.label?.trim() || latest.task.trim();
+  const title = rawTitle.length > 80 ? rawTitle.slice(0, 77) + "..." : rawTitle;
+  const rawDetail =
     latest.status === "running" || latest.status === "queued"
       ? latest.progressSummary?.trim()
       : latest.error?.trim() || latest.terminalSummary?.trim();
+  const detail =
+    rawDetail && rawDetail.length > 120
+      ? rawDetail.slice(0, 117) + "..."
+      : rawDetail;
   const parts = [headline, latest.runtime, title, detail].filter(Boolean);
   return parts.length ? `📌 Tasks: ${parts.join(" · ")}` : undefined;
 }

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -65,11 +65,16 @@ function formatSessionTaskLine(sessionKey: string): string | undefined {
     (task) => task.status === "queued" || task.status === "running",
   ).length;
   const headline = `${active} active · ${tasks.length} total`;
-  const title = latest.label?.trim() || latest.task.trim();
-  const detail =
+  const rawTitle = latest.label?.trim() || latest.task.trim();
+  const title = rawTitle.length > 80 ? rawTitle.slice(0, 77) + "..." : rawTitle;
+  const rawDetail =
     latest.status === "running" || latest.status === "queued"
       ? latest.progressSummary?.trim()
       : latest.error?.trim() || latest.terminalSummary?.trim();
+  const detail =
+    rawDetail && rawDetail.length > 120
+      ? rawDetail.slice(0, 117) + "..."
+      : rawDetail;
   const parts = [headline, latest.runtime, title, detail].filter(Boolean);
   return parts.length ? `📌 Tasks: ${parts.join(" · ")}` : undefined;
 }


### PR DESCRIPTION
## Problem

When a task has no `label` set (common for subagent-spawned tasks), `formatSessionTaskLine` falls back to `latest.task.trim()` which is the **full task prompt text**. For subagent tasks, this can be a multi-paragraph prompt containing file paths, detailed instructions, and internal context.

This causes `/status` to output hundreds of lines of raw internal task prompts into the chat channel, which:
1. **Leaks internal details** — file paths, subagent instructions, and sensitive context are exposed
2. **Floods the chat** — a single `/status` can produce walls of text
3. **Persists across session resets** — task registry is SQLite-backed and survives `/new`, so old tasks keep appearing

The same issue exists in the `session_status` tool output (`session-status-tool.ts`).

## Root Cause

In both `src/auto-reply/reply/commands-status.ts` and `src/agents/tools/session-status-tool.ts`:

```ts
const title = latest.label?.trim() || latest.task.trim();
```

When `label` is `undefined` (which is the default for spawned subagents), the entire `task` field — often a multi-paragraph prompt — is used as the display title with no length limit.

## Fix

Truncate `title` to 80 characters and `detail` to 120 characters in both `formatSessionTaskLine` implementations. This keeps the `/status` output concise while still showing enough context to identify the task.

## Testing

Reproduced with a session that accumulated 10+ subagent tasks (kernel module development workflow). Before fix: `/status` output included full multi-paragraph subagent prompts. After fix: titles are cleanly truncated with `...` suffix.