### PR TITLE
fix: require explicit approval before silent local pairing grants operator scopes

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -434,6 +434,8 @@ describe("GatewayClient connect auth payload", () => {
     return JSON.parse(raw ?? "{}") as {
       id?: string;
       params?: {
+        role?: string;
+        scopes?: string[];
         auth?: {
           token?: string;
           deviceToken?: string;
@@ -583,6 +585,36 @@ describe("GatewayClient connect auth payload", () => {
     });
     expect(connectFrameFrom(ws).token).toBeUndefined();
     expect(connectFrameFrom(ws).deviceToken).toBeUndefined();
+    client.stop();
+  });
+
+  it("defaults operator connect scopes to operator.admin", () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      role: "operator",
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+    emitConnectChallenge(ws);
+
+    expect(connectRequestFrom(ws).params?.scopes).toEqual(["operator.admin"]);
+    client.stop();
+  });
+
+  it("defaults non-operator connect scopes to an empty scope list", () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      role: "node",
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+    emitConnectChallenge(ws);
+
+    expect(connectRequestFrom(ws).params?.scopes).toEqual([]);
     client.stop();
   });
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -152,6 +152,10 @@ type PendingStop = {
   resolve: () => void;
 };
 
+function resolveDefaultScopesForRole(role: string): string[] {
+  return role === "operator" ? ["operator.admin"] : [];
+}
+
 export class GatewayClient {
   private ws: WebSocket | null = null;
   private opts: GatewayClientOptions;
@@ -431,7 +435,7 @@ export class GatewayClient {
           }
         : undefined;
     const signedAtMs = Date.now();
-    const scopes = this.opts.scopes ?? ["operator.admin"];
+    const scopes = this.opts.scopes ?? resolveDefaultScopesForRole(role);
     const platform = this.opts.platform ?? process.platform;
     const device = (() => {
       if (!this.opts.deviceIdentity) {

--- a/src/gateway/server.silent-local-not-paired-admin.poc.test.ts
+++ b/src/gateway/server.silent-local-not-paired-admin.poc.test.ts
@@ -33,7 +33,7 @@ describe("gateway silent local not-paired admin", () => {
       const firstConnect = await connectReq(freshWs, {
         token: "secret",
         deviceIdentityPath: loaded.identityPath,
-        scopes: ["operator.admin"],
+        scopes: [" operator.admin "],
       });
 
       expect(firstConnect.ok).toBe(false);
@@ -41,6 +41,7 @@ describe("gateway silent local not-paired admin", () => {
 
       const pending = await devicePairingModule.listDevicePairing();
       expect(pending.pending).toHaveLength(1);
+      expect(pending.pending[0]?.silent).toBe(false);
       expect(
         (firstConnect.error?.details as { requestId?: unknown; code?: string } | undefined)
           ?.requestId,

--- a/src/gateway/server.silent-local-not-paired-admin.poc.test.ts
+++ b/src/gateway/server.silent-local-not-paired-admin.poc.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import { WebSocket } from "ws";
+import * as devicePairingModule from "../infra/device-pairing.js";
+import { getPairedDevice } from "../infra/device-pairing.js";
+import { loadDeviceIdentity, openTrackedWs } from "./device-authz.test-helpers.js";
+import {
+  connectOk,
+  connectReq,
+  installGatewayTestHooks,
+  onceMessage,
+  startServerWithClient,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+describe("gateway silent local not-paired admin", () => {
+  test("requires explicit approval before a fresh shared-auth device can request operator.admin", async () => {
+    const started = await startServerWithClient("secret");
+    const loaded = loadDeviceIdentity("silent-local-not-paired-admin");
+
+    let watcherWs: WebSocket | undefined;
+    let freshWs: WebSocket | undefined;
+
+    try {
+      watcherWs = await openTrackedWs(started.port);
+      await connectOk(watcherWs, { scopes: ["operator.admin"] });
+      const requestedEvent = onceMessage(
+        watcherWs,
+        (obj) => obj.type === "event" && obj.event === "device.pair.requested",
+      );
+
+      freshWs = await openTrackedWs(started.port);
+      const firstConnect = await connectReq(freshWs, {
+        token: "secret",
+        deviceIdentityPath: loaded.identityPath,
+        scopes: ["operator.admin"],
+      });
+
+      expect(firstConnect.ok).toBe(false);
+      expect(firstConnect.error?.message).toBe("pairing required");
+
+      const pending = await devicePairingModule.listDevicePairing();
+      expect(pending.pending).toHaveLength(1);
+      expect(
+        (firstConnect.error?.details as { requestId?: unknown; code?: string } | undefined)
+          ?.requestId,
+      ).toBe(pending.pending[0]?.requestId);
+
+      const requested = (await requestedEvent) as {
+        payload?: { requestId?: string; deviceId?: string; scopes?: string[] };
+      };
+      expect(requested.payload?.requestId).toBe(pending.pending[0]?.requestId);
+      expect(requested.payload?.deviceId).toBe(loaded.identity.deviceId);
+      expect(requested.payload?.scopes).toEqual(["operator.admin"]);
+
+      const paired = await getPairedDevice(loaded.identity.deviceId);
+      expect(paired).toBeNull();
+    } finally {
+      watcherWs?.close();
+      freshWs?.close();
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+});

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -369,4 +369,22 @@ describe("ws connect policy", () => {
       }),
     ).toBe(true);
   });
+
+  test("clears trusted-proxy scopes before trusted-proxy auth succeeds when device identity is missing", () => {
+    const nonControlUi = resolveControlUiAuthPolicy({
+      isControlUi: false,
+      controlUiConfig: undefined,
+      deviceRaw: null,
+    });
+
+    expect(
+      shouldClearUnboundScopesForMissingDeviceIdentity({
+        decision: { kind: "allow" },
+        controlUiAuthPolicy: nonControlUi,
+        preserveInsecureLocalControlUiScopes: false,
+        authMethod: "trusted-proxy",
+        trustedProxyAuthOk: false,
+      }),
+    ).toBe(true);
+  });
 });

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -94,6 +94,9 @@ export function shouldClearUnboundScopesForMissingDeviceIdentity(params: {
       !params.preserveInsecureLocalControlUiScopes &&
       // trusted-proxy auth can bypass pairing for some clients, but those
       // self-declared scopes are still unbound without device identity.
+      // Clear them as soon as the client declares trusted-proxy auth, even if
+      // that auth later fails, so missing-device sessions never keep scopes
+      // that were not bound to a verified device identity.
       (params.authMethod === "token" ||
         params.authMethod === "password" ||
         params.authMethod === "trusted-proxy" ||

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -65,13 +65,14 @@ describe("handshake auth helpers", () => {
     });
   });
 
-  it("allows silent local pairing only for not-paired and scope upgrades", () => {
+  it("allows silent local pairing only when a fresh local request has no operator scopes", () => {
     expect(
       shouldAllowSilentLocalPairing({
         isLocalClient: true,
         hasBrowserOriginHeader: false,
         isControlUi: false,
         isWebchat: false,
+        hasRequestedOperatorScopes: false,
         reason: "not-paired",
       }),
     ).toBe(true);
@@ -81,6 +82,17 @@ describe("handshake auth helpers", () => {
         hasBrowserOriginHeader: false,
         isControlUi: false,
         isWebchat: false,
+        hasRequestedOperatorScopes: true,
+        reason: "not-paired",
+      }),
+    ).toBe(false);
+    expect(
+      shouldAllowSilentLocalPairing({
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        isControlUi: false,
+        isWebchat: false,
+        hasRequestedOperatorScopes: false,
         reason: "metadata-upgrade",
       }),
     ).toBe(false);

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -65,7 +65,7 @@ describe("handshake auth helpers", () => {
     });
   });
 
-  it("allows silent local pairing only when a fresh local request has no operator scopes", () => {
+  it("allows silent local pairing only for not-paired or scope-upgrade requests without operator scopes", () => {
     expect(
       shouldAllowSilentLocalPairing({
         isLocalClient: true,
@@ -84,6 +84,26 @@ describe("handshake auth helpers", () => {
         isWebchat: false,
         hasRequestedOperatorScopes: true,
         reason: "not-paired",
+      }),
+    ).toBe(false);
+    expect(
+      shouldAllowSilentLocalPairing({
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        isControlUi: false,
+        isWebchat: false,
+        hasRequestedOperatorScopes: false,
+        reason: "scope-upgrade",
+      }),
+    ).toBe(true);
+    expect(
+      shouldAllowSilentLocalPairing({
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        isControlUi: false,
+        isWebchat: false,
+        hasRequestedOperatorScopes: true,
+        reason: "scope-upgrade",
       }),
     ).toBe(false);
     expect(

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -50,12 +50,14 @@ export function shouldAllowSilentLocalPairing(params: {
   hasBrowserOriginHeader: boolean;
   isControlUi: boolean;
   isWebchat: boolean;
+  hasRequestedOperatorScopes: boolean;
   reason: "not-paired" | "role-upgrade" | "scope-upgrade" | "metadata-upgrade";
 }): boolean {
   return (
     params.isLocalClient &&
     (!params.hasBrowserOriginHeader || params.isControlUi || params.isWebchat) &&
-    (params.reason === "not-paired" || params.reason === "scope-upgrade")
+    ((params.reason === "not-paired" && !params.hasRequestedOperatorScopes) ||
+      params.reason === "scope-upgrade")
   );
 }
 

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -56,8 +56,8 @@ export function shouldAllowSilentLocalPairing(params: {
   return (
     params.isLocalClient &&
     (!params.hasBrowserOriginHeader || params.isControlUi || params.isWebchat) &&
-    ((params.reason === "not-paired" && !params.hasRequestedOperatorScopes) ||
-      params.reason === "scope-upgrade")
+    (params.reason === "not-paired" || params.reason === "scope-upgrade") &&
+    !params.hasRequestedOperatorScopes
   );
 }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -788,6 +788,7 @@ export function attachGatewayWsMessageHandler(params: {
               hasBrowserOriginHeader,
               isControlUi,
               isWebchat,
+              hasRequestedOperatorScopes: scopes.some((scope) => scope.startsWith("operator.")),
               reason,
             });
             // QR bootstrap onboarding is node-only and single-use. When a fresh device presents
@@ -828,7 +829,7 @@ export function attachGatewayWsMessageHandler(params: {
             };
             if (pairing.request.silent === true) {
               approved = await approveDevicePairing(pairing.request.requestId, {
-                callerScopes: scopes,
+                callerScopes: [],
               });
               if (approved?.status === "approved") {
                 if (allowSilentBootstrapPairing && bootstrapTokenCandidate) {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -31,6 +31,7 @@ import { upsertPresence } from "../../../infra/system-presence.js";
 import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
 import { rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
+import { normalizeDeviceAuthScopes } from "../../../shared/device-auth.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import {
   isBrowserOperatorUiClient,
@@ -757,6 +758,9 @@ export function attachGatewayWsMessageHandler(params: {
             reason: "not-paired" | "role-upgrade" | "scope-upgrade" | "metadata-upgrade",
             existingPairedDevice: Awaited<ReturnType<typeof getPairedDevice>> | null = null,
           ) => {
+            const hasRequestedOperatorScopes = normalizeDeviceAuthScopes(scopes).some((scope) =>
+              scope.startsWith("operator."),
+            );
             const pairingStateAllowsRequestedAccess = (
               pairedCandidate: Awaited<ReturnType<typeof getPairedDevice>>,
             ): boolean => {
@@ -788,7 +792,7 @@ export function attachGatewayWsMessageHandler(params: {
               hasBrowserOriginHeader,
               isControlUi,
               isWebchat,
-              hasRequestedOperatorScopes: scopes.some((scope) => scope.startsWith("operator.")),
+              hasRequestedOperatorScopes,
               reason,
             });
             // QR bootstrap onboarding is node-only and single-use. When a fresh device presents

--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -48,6 +48,7 @@ export async function connectGatewayClient(params: {
   timeoutMessage?: string;
 }) {
   const role = params.role ?? "operator";
+  const scopes = params.scopes ?? (role === "operator" ? ["operator.admin"] : []);
   const platform = params.platform ?? process.platform;
   const identityRoot = process.env.OPENCLAW_STATE_DIR ?? process.env.HOME ?? os.tmpdir();
   const deviceIdentity =
@@ -86,7 +87,7 @@ export async function connectGatewayClient(params: {
       deviceFamily: params.deviceFamily,
       mode: params.mode ?? GATEWAY_CLIENT_MODES.TEST,
       role,
-      scopes: params.scopes,
+      scopes,
       caps: params.caps,
       commands: params.commands,
       instanceId: params.instanceId,

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -327,6 +327,26 @@ describe("device pairing tokens", () => {
     await expect(getPairedDevice("device-1", baseDir)).resolves.toBeNull();
   });
 
+  test("rejects silent operator-scope approvals even when pending role is missing", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const request = await requestDevicePairing(
+      {
+        deviceId: "device-1",
+        publicKey: "public-key-1",
+        scopes: ["operator.admin"],
+        silent: true,
+      },
+      baseDir,
+    );
+
+    await expect(approveDevicePairing(request.request.requestId, baseDir)).resolves.toEqual({
+      status: "forbidden",
+      missingScope: "operator.admin",
+    });
+
+    await expect(getPairedDevice("device-1", baseDir)).resolves.toBeNull();
+  });
+
   test("generates base64url device tokens with 256-bit entropy output length", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -298,6 +298,35 @@ describe("device pairing tokens", () => {
     );
   });
 
+  test("rejects silent operator-scope approvals even when caller scopes match the request", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const request = await requestDevicePairing(
+      {
+        deviceId: "device-1",
+        publicKey: "public-key-1",
+        role: "operator",
+        scopes: ["operator.admin"],
+        silent: true,
+      },
+      baseDir,
+    );
+
+    await expect(
+      approveDevicePairing(
+        request.request.requestId,
+        {
+          callerScopes: ["operator.admin"],
+        },
+        baseDir,
+      ),
+    ).resolves.toEqual({
+      status: "forbidden",
+      missingScope: "operator.admin",
+    });
+
+    await expect(getPairedDevice("device-1", baseDir)).resolves.toBeNull();
+  });
+
   test("generates base64url device tokens with 256-bit entropy output length", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -503,6 +503,12 @@ export async function approveDevicePairing(
       const requestedOperatorScopes = normalizeDeviceAuthScopes(pending.scopes).filter((scope) =>
         scope.startsWith(OPERATOR_SCOPE_PREFIX),
       );
+      if (pending.silent === true && requestedOperatorScopes.length > 0) {
+        return {
+          status: "forbidden",
+          missingScope: requestedOperatorScopes[0],
+        };
+      }
       if (!options?.callerScopes) {
         return {
           status: "forbidden",

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -498,17 +498,17 @@ export async function approveDevicePairing(
     if (!pending) {
       return null;
     }
+    const requestedOperatorScopes = normalizeDeviceAuthScopes(pending.scopes).filter((scope) =>
+      scope.startsWith(OPERATOR_SCOPE_PREFIX),
+    );
+    if (pending.silent === true && requestedOperatorScopes.length > 0) {
+      return {
+        status: "forbidden",
+        missingScope: requestedOperatorScopes[0],
+      };
+    }
     const approvalRole = resolvePendingApprovalRole(pending);
     if (approvalRole) {
-      const requestedOperatorScopes = normalizeDeviceAuthScopes(pending.scopes).filter((scope) =>
-        scope.startsWith(OPERATOR_SCOPE_PREFIX),
-      );
-      if (pending.silent === true && requestedOperatorScopes.length > 0) {
-        return {
-          status: "forbidden",
-          missingScope: requestedOperatorScopes[0],
-        };
-      }
       if (!options?.callerScopes) {
         return {
           status: "forbidden",


### PR DESCRIPTION
## Summary

- **Problem:** A fresh local client authenticating with a shared gateway token could request `operator.admin` (or any operator scope) and be silently auto-paired without explicit approval, granting elevated privileges without user consent.
- **Why it matters:** Silent local pairing is intended for non-privileged device registration (node role, no scopes). Allowing it for operator scopes bypasses the pairing approval gate and constitutes a local privilege escalation path.
- **What changed:** Three-layer defense applied — (1) `shouldAllowSilentLocalPairing` now blocks silent pairing when any `operator.*` scope is requested; (2) `approveDevicePairing` rejects silent pairing requests that include operator scopes as defense-in-depth; (3) the silent auto-approval path passes `callerScopes: []` instead of the device's self-declared scopes, preventing self-granted elevation. Additional hardening: roles are now derived from active (non-revoked) tokens rather than sticky historical fields; node devices must complete explicit pairing before commands are dispatched; `mergeScopes` correctly preserves explicit empty scope baselines; `shouldClearUnboundScopesForMissingDeviceIdentity` now explicitly covers `trusted-proxy` auth method.
- **What did NOT change:** Silent local pairing for non-operator local clients (node role, no scopes, no browser origin header) continues to work as before, including the QR bootstrap-token path for iOS onboarding.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `shouldAllowSilentLocalPairing` did not check the requested scope set. For `reason === "not-paired"`, it returned `true` for any local client regardless of which scopes were being requested. The silent auto-approval then passed `callerScopes: scopes` (the device's own declared scopes), which satisfied `approveDevicePairing`'s scope delegation check, resulting in an operator-scoped device token being issued without any human approval step.
- Missing detection / guardrail: No guard existed at the `shouldAllowSilentLocalPairing` call site checking whether the requested scopes included privileged operator scopes. No guard existed in `approveDevicePairing` rejecting silent requests for operator scopes.
- Prior context: The silent local pairing path was introduced for zero-friction node and control-UI registration on loopback. The operator scope check was not added at that time.
- Why this regressed now: N/A — this was a missing guard from the initial implementation.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server/ws-connection/handshake-auth-helpers.test.ts` — `shouldAllowSilentLocalPairing` with `hasRequestedOperatorScopes: true` returns `false`
  - `src/infra/device-pairing.test.ts` — `approveDevicePairing` rejects silent requests with operator scopes even when `callerScopes` matches
  - `src/gateway/server.silent-local-not-paired-admin.poc.test.ts` — end-to-end integration: fresh shared-auth device requesting `operator.admin` receives pairing-required, not approval
  - `src/gateway/server/ws-connection/connect-policy.test.ts` — `shouldClearUnboundScopesForMissingDeviceIdentity` covers trusted-proxy with failed auth
- Scenario the test should lock in: Silent auto-pairing must never grant operator scopes; any attempt must return `pairing required` and leave a pending approval request.
- Why this is the smallest reliable guardrail: Unit tests lock each individual guard; the integration test proves all three layers compose correctly end-to-end.
- Existing test that already covers this (if any): None — all tests are new in this PR.

## User-visible / Behavior Changes

- Local devices requesting operator scopes on first connect will now receive `pairing required` and must be explicitly approved, exactly as remote devices do. No change for node-role or zero-scope local pairings.
- Node devices must now have an approved node pairing record before gateway commands are dispatched to them. Previously, nodes without a pairing record received all allowlisted commands unconditionally.

## Diagram (if applicable)

```text
Before:
[local device, token auth, operator.admin] -> shouldAllowSilentLocalPairing=true -> silent approval (callerScopes=["operator.admin"]) -> APPROVED

After (layer 1):
[local device, token auth, operator.admin] -> shouldAllowSilentLocalPairing=false (hasRequestedOperatorScopes) -> explicit pairing required

After (layer 2, defense-in-depth):
[silent pairing request, operator.admin scopes] -> approveDevicePairing -> forbidden (silent+operator blocked)

After (layer 3):
[silent auto-approve] -> callerScopes=[] -> scope delegation check fails for any operator scope
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — silent auto-approval no longer passes device-declared scopes as caller scopes; bootstrap token is revoked immediately after auto-approved node pairing
- New/changed network calls? No
- Command/tool execution surface changed? Yes — node commands are now gated on an approved pairing record
- Data access scope changed? No
- Risk: Tightens silent pairing; any local integration that relied on silent auto-approval for operator scopes will now receive `pairing required`. Mitigation: This was never a supported or documented flow; the explicit approval UI handles it correctly.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / Bun
- Model/provider: N/A
- Integration/channel (if any): Gateway WebSocket
- Relevant config (redacted): `gateway.mode=local`, shared token set

### Steps

1. Start gateway with a shared token
2. Connect a fresh local WebSocket client with `auth.token` + `scopes: ["operator.admin"]`
3. Observe response

### Expected

- `{ ok: false, error: { message: "pairing required", details: { requestId: "..." } } }`
- One entry in `listDevicePairing().pending`
- `getPairedDevice(deviceId)` returns `null`

### Actual (before fix)

- `{ ok: true }` with operator.admin token issued silently

## Evidence

- [x] Failing test/log before + passing after — `src/gateway/server.silent-local-not-paired-admin.poc.test.ts` encodes the exact pre-fix failure scenario and passes post-fix

## Human Verification (required)

- Verified scenarios: AI-generated fix; code reviewed across all three defense layers, test coverage reviewed for completeness
- Edge cases checked: Bootstrap-token node path (still works), control-UI scope-upgrade path (still requires explicit approval via `silent: false`), trusted-proxy with missing device identity
- What you did **not** verify: Live gateway roundtrip on a real device

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? No — local clients relying on silent operator-scope pairing must now go through the explicit approval flow
- Config/env changes? No
- Migration needed? No — the pairing UI already handles this flow correctly

## Risks and Mitigations

- Risk: Existing local integrations that silently paired with operator scopes will break
  - Mitigation: This was never a documented or supported path; the explicit approval UI is the correct flow and already works

---

> 🤖 AI-assisted PR (generated by OpenAI Codex, reviewed by Claude). Lightly tested — unit + seam integration tests added; no live gateway roundtrip verified by a human. Prompts/session available on request.