### PR TITLE
Document gateway:watch recovery for invalid package configs

### DIFF
--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -97,6 +97,14 @@ pnpm gateway:watch
 `gateway:watch` runs the gateway in watch mode and reloads on relevant source,
 config, and bundled-plugin metadata changes.
 
+> If `pnpm gateway:watch` fails with `ERR_INVALID_PACKAGE_CONFIG` or points to a file under `node_modules`, one of your local dependency files may be corrupted or truncated. A common recovery path is:
+>
+> ```bash
+> rm -rf node_modules
+> pnpm store prune
+> pnpm install
+> ```
+
 ### 2) Point the macOS app at your running Gateway
 
 In **OpenClaw.app**:


### PR DESCRIPTION
## Summary

Document a common recovery path when `pnpm gateway:watch` fails because a dependency under `node_modules` has an invalid or truncated `package.json`.

## What changed

- Added a troubleshooting note to `docs/start/setup.md`
- Documented the recovery steps for `ERR_INVALID_PACKAGE_CONFIG` in `gateway:watch`

## Why

During local source-based development, `pnpm gateway:watch` can fail very early if a dependency file under `node_modules` is corrupted or truncated. In that case, the most reliable recovery path is often:

- `rm -rf node_modules`
- `pnpm store prune`
- `pnpm install`

This note makes that workflow easier to discover from the setup guide.

## Manual verification

1. Opened `docs/start/setup.md`
2. Added the note under the `pnpm gateway:watch` development workflow section
3. Ran the repo checks during commit
4. Confirmed the docs change stayed scoped to the setup guide