### PR TITLE
Android: relaunch GatewaySession runLoop when prior job is inactive

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -151,7 +151,8 @@ class GatewaySession(
     pendingDeviceTokenRetry = false
     deviceTokenRetryBudgetUsed = false
     reconnectPausedForAuthFailure = false
-    if (job == null) {
+    val existingJob = job
+    if (existingJob == null || !existingJob.isActive) {
       job = scope.launch(Dispatchers.IO) { runLoop() }
     }
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
@@ -325,6 +326,58 @@ class GatewaySessionInvokeTest {
         "http://127.0.0.1:${server.port}/__openclaw__/cap/new-cap",
         harness.session.currentCanvasHostUrl(),
       )
+    } finally {
+      shutdownHarness(harness, server)
+    }
+  }
+
+  @Test
+  fun disconnect_thenImmediateConnect_reachesOnConnectedAgain() = runBlocking {
+    val json = testJson()
+    val connectCount = AtomicInteger(0)
+    val firstConnected = CompletableDeferred<Unit>()
+    val lastDisconnect = AtomicReference("")
+    val server =
+      startGatewayServer(json) { webSocket, id, method, frame ->
+        when (method) {
+          "connect" -> webSocket.send(connectResponseFrame(id))
+        }
+      }
+
+    val app = RuntimeEnvironment.getApplication()
+    val sessionJob = SupervisorJob()
+    val deviceAuthStore = InMemoryDeviceAuthStore()
+    val session =
+      GatewaySession(
+        scope = CoroutineScope(sessionJob + Dispatchers.Default),
+        identityStore = DeviceIdentityStore(app),
+        deviceAuthStore = deviceAuthStore,
+        onConnected = { _, _, _ ->
+          connectCount.incrementAndGet()
+          if (!firstConnected.isCompleted) {
+            firstConnected.complete(Unit)
+          }
+        },
+        onDisconnected = { message -> lastDisconnect.set(message) },
+        onEvent = { _, _ -> },
+        onInvoke = { GatewaySession.InvokeResult.ok("""{"handled":true}""") },
+      )
+    val harness = NodeHarness(session = session, sessionJob = sessionJob, deviceAuthStore = deviceAuthStore)
+
+    try {
+      connectNodeSession(harness.session, server.port)
+      withTimeout(TEST_TIMEOUT_MS) { firstConnected.await() }
+      assertEquals(1, connectCount.get())
+
+      harness.session.disconnect()
+      connectNodeSession(harness.session, server.port)
+
+      withTimeout(TEST_TIMEOUT_MS) {
+        while (connectCount.get() < 2) {
+          delay(10)
+        }
+      }
+      assertEquals(2, connectCount.get())
     } finally {
       shutdownHarness(harness, server)
     }


### PR DESCRIPTION
## Summary

Fix an Android coroutine race in GatewaySession reconnect flow where connect() could skip relaunching runLoop() due to a stale cached job reference.
Ensure reconnect reliably resumes after disconnect() by relaunching when the current job is missing or inactive.
Add/adjust unit coverage for the immediate disconnect() -> connect() path in GatewaySessionInvokeTest.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## What Changed
Updated GatewaySession.connect() to evaluate a local snapshot of job and start runLoop() when:
job == null, or
job exists but is no longer active.
Kept disconnect() cleanup behavior intact for production (no test-only runtime hook in release code).
Added/updated test coverage in GatewaySessionInvokeTest to validate reconnect behavior when connect() is called immediately after disconnect().

## Why

Previously, disconnect() cleared job asynchronously, which allowed a timing window where connect() observed a non-null but effectively stale job and incorrectly assumed the loop was still running.
In that state, desired could be updated while no active runLoop() existed, causing a stuck reconnect state.
This change makes reconnect logic robust against that stale-reference timing, reducing “wants to connect but no loop is running” failures and improving connection reliability on Android.