### PR TITLE
Document gateway:watch recovery in the Chinese setup guide

### DIFF
--- a/docs/zh-CN/start/setup.md
+++ b/docs/zh-CN/start/setup.md
@@ -92,6 +92,14 @@ pnpm gateway:watch
 
 `gateway:watch` 以监视模式运行 Gateway 网关，并在 TypeScript 更改时重新加载。
 
+> 如果 `pnpm gateway:watch` 因 `ERR_INVALID_PACKAGE_CONFIG` 失败，或者错误指向 `node_modules` 下的某个文件，说明你的本地依赖文件可能已损坏或被截断。常见的恢复方式是：
+>
+> ```bash
+> rm -rf node_modules
+> pnpm store prune
+> pnpm install
+> ```
+
 ### 2) 将 macOS 应用指向你正在运行的 Gateway 网关
 
 在 **OpenClaw.app** 中：


### PR DESCRIPTION
## Summary

Document a common recovery path for `pnpm gateway:watch` failures in the Chinese setup guide.

## What changed

- Added a troubleshooting note to `docs/zh-CN/start/setup.md`
- Documented the recovery steps for `ERR_INVALID_PACKAGE_CONFIG` when the error points into `node_modules`

## Why

The English setup guide now documents a common recovery flow when local dependency files under `node_modules` are corrupted or truncated.

This PR keeps the Chinese setup guide aligned by adding the same recovery guidance.

## Manual verification

1. Opened `docs/zh-CN/start/setup.md`
2. Added the recovery note under the `pnpm gateway:watch` development workflow section
3. Ran the repo checks during commit
4. Confirmed the docs change stayed scoped to the Chinese setup guide