### PR TITLE
fix(model-picker): proper model filtering for bundled providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Docs: https://docs.openclaw.ai
 - Agents/exec approvals: let `exec-approvals.json` agent security override stricter gateway tool defaults so approved subagents can use `security: "full"` without falling back to allowlist enforcement again. (#60310) Thanks @lml2468.
 - Tasks/maintenance: reconcile stale cron and chat-backed CLI task rows against live cron-job and agent-run ownership instead of treating any persisted session key as proof that the task is still running. (#60310) Thanks @lml2468.
 - Providers/GitHub Copilot: send IDE identity headers on runtime model requests and GitHub token exchange so IDE-authenticated Copilot runs stop failing with missing `Editor-Version`. (#60641) Thanks @VACInc and @vincentkoc.
+- Model picker/providers: treat bundled BytePlus and Volcengine plan aliases as their native providers during setup, and expose their bundled standard/coding catalogs before auth so setup can suggest the right models. (#58819) Thanks @Luckymingxuan.
 - Prompt caching: route Codex Responses and Anthropic Vertex through boundary-aware cache shaping, and report the actual outbound system prompt in cache traces so cache reuse and misses line up with what providers really receive. Thanks @vincentkoc.
 - MiniMax/pricing: keep bundled MiniMax highspeed pricing distinct in provider catalogs and preserve the lower M2.5 cache-read pricing when onboarding older MiniMax models. (#54214) Thanks @octo-patch.
 

--- a/extensions/byteplus/index.test.ts
+++ b/extensions/byteplus/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import plugin from "./index.js";
+import { BYTEPLUS_CODING_MODEL_CATALOG, BYTEPLUS_MODEL_CATALOG } from "./models.js";
+
+describe("byteplus plugin", () => {
+  it("augments the catalog with bundled standard and plan models", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const entries = await provider.augmentModelCatalog?.({
+      env: process.env,
+      entries: [],
+    } as never);
+
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        provider: "byteplus",
+        id: BYTEPLUS_MODEL_CATALOG[0].id,
+        name: BYTEPLUS_MODEL_CATALOG[0].name,
+        reasoning: BYTEPLUS_MODEL_CATALOG[0].reasoning,
+        input: [...BYTEPLUS_MODEL_CATALOG[0].input],
+        contextWindow: BYTEPLUS_MODEL_CATALOG[0].contextWindow,
+      }),
+    );
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        provider: "byteplus-plan",
+        id: BYTEPLUS_CODING_MODEL_CATALOG[0].id,
+        name: BYTEPLUS_CODING_MODEL_CATALOG[0].name,
+        reasoning: BYTEPLUS_CODING_MODEL_CATALOG[0].reasoning,
+        input: [...BYTEPLUS_CODING_MODEL_CATALOG[0].input],
+        contextWindow: BYTEPLUS_CODING_MODEL_CATALOG[0].contextWindow,
+      }),
+    );
+  });
+});

--- a/extensions/byteplus/index.ts
+++ b/extensions/byteplus/index.ts
@@ -2,6 +2,10 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
 import { ensureModelAllowlistEntry } from "openclaw/plugin-sdk/provider-onboard";
 import { buildBytePlusCodingProvider, buildBytePlusProvider } from "./provider-catalog.js";
+import {
+  BYTEPLUS_CODING_MODEL_CATALOG,
+  BYTEPLUS_MODEL_CATALOG,
+} from "./models.js";
 
 const PROVIDER_ID = "byteplus";
 const BYTEPLUS_DEFAULT_MODEL_REF = "byteplus-plan/ark-code-latest";
@@ -56,6 +60,25 @@ export default definePluginEntry({
             },
           };
         },
+      },
+      augmentModelCatalog: () => {
+        const byteplusModels = BYTEPLUS_MODEL_CATALOG.map((entry) => ({
+          provider: "byteplus",
+          id: entry.id,
+          name: entry.name,
+          reasoning: entry.reasoning,
+          input: [...entry.input],
+          contextWindow: entry.contextWindow,
+        }));
+        const byteplusPlanModels = BYTEPLUS_CODING_MODEL_CATALOG.map((entry) => ({
+          provider: "byteplus-plan",
+          id: entry.id,
+          name: entry.name,
+          reasoning: entry.reasoning,
+          input: [...entry.input],
+          contextWindow: entry.contextWindow,
+        }));
+        return [...byteplusModels, ...byteplusPlanModels];
       },
     });
   },

--- a/extensions/volcengine/index.test.ts
+++ b/extensions/volcengine/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import plugin from "./index.js";
+import { DOUBAO_CODING_MODEL_CATALOG, DOUBAO_MODEL_CATALOG } from "./models.js";
+
+describe("volcengine plugin", () => {
+  it("augments the catalog with bundled standard and plan models", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const entries = await provider.augmentModelCatalog?.({
+      env: process.env,
+      entries: [],
+    } as never);
+
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        provider: "volcengine",
+        id: DOUBAO_MODEL_CATALOG[0].id,
+        name: DOUBAO_MODEL_CATALOG[0].name,
+        reasoning: DOUBAO_MODEL_CATALOG[0].reasoning,
+        input: [...DOUBAO_MODEL_CATALOG[0].input],
+        contextWindow: DOUBAO_MODEL_CATALOG[0].contextWindow,
+      }),
+    );
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        provider: "volcengine-plan",
+        id: DOUBAO_CODING_MODEL_CATALOG[0].id,
+        name: DOUBAO_CODING_MODEL_CATALOG[0].name,
+        reasoning: DOUBAO_CODING_MODEL_CATALOG[0].reasoning,
+        input: [...DOUBAO_CODING_MODEL_CATALOG[0].input],
+        contextWindow: DOUBAO_CODING_MODEL_CATALOG[0].contextWindow,
+      }),
+    );
+  });
+});

--- a/extensions/volcengine/index.ts
+++ b/extensions/volcengine/index.ts
@@ -2,6 +2,10 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
 import { ensureModelAllowlistEntry } from "openclaw/plugin-sdk/provider-onboard";
 import { buildDoubaoCodingProvider, buildDoubaoProvider } from "./provider-catalog.js";
+import {
+  DOUBAO_CODING_MODEL_CATALOG,
+  DOUBAO_MODEL_CATALOG,
+} from "./models.js";
 
 const PROVIDER_ID = "volcengine";
 const VOLCENGINE_DEFAULT_MODEL_REF = "volcengine-plan/ark-code-latest";
@@ -56,6 +60,25 @@ export default definePluginEntry({
             },
           };
         },
+      },
+      augmentModelCatalog: () => {
+        const volcengineModels = DOUBAO_MODEL_CATALOG.map((entry) => ({
+          provider: "volcengine",
+          id: entry.id,
+          name: entry.name,
+          reasoning: entry.reasoning,
+          input: [...entry.input],
+          contextWindow: entry.contextWindow,
+        }));
+        const volcenginePlanModels = DOUBAO_CODING_MODEL_CATALOG.map((entry) => ({
+          provider: "volcengine-plan",
+          id: entry.id,
+          name: entry.name,
+          reasoning: entry.reasoning,
+          input: [...entry.input],
+          contextWindow: entry.contextWindow,
+        }));
+        return [...volcengineModels, ...volcenginePlanModels];
       },
     });
   },

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -88,6 +88,47 @@ beforeEach(() => {
 });
 
 describe("promptDefaultModel", () => {
+  it("treats byteplus plan models as preferred-provider matches", async () => {
+    loadModelCatalog.mockResolvedValue([
+      {
+        provider: "openai",
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+      },
+      {
+        provider: "byteplus-plan",
+        id: "ark-code-latest",
+        name: "Ark Coding Plan",
+      },
+    ]);
+
+    const select = vi.fn(async (params) => params.initialValue as never);
+    const prompter = makePrompter({ select });
+    const config = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.4",
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await promptDefaultModel({
+      config,
+      prompter,
+      allowKeep: true,
+      includeManual: false,
+      ignoreAllowlist: true,
+      preferredProvider: "byteplus",
+    });
+
+    const options = select.mock.calls[0]?.[0]?.options ?? [];
+    const optionValues = options.map((opt: { value: string }) => opt.value);
+    expect(optionValues).toContain("byteplus-plan/ark-code-latest");
+    expect(optionValues[1]).toBe("byteplus-plan/ark-code-latest");
+    expect(select.mock.calls[0]?.[0]?.initialValue).toBe("byteplus-plan/ark-code-latest");
+    expect(result.model).toBe("byteplus-plan/ark-code-latest");
+  });
+
   it("supports configuring vLLM during setup", async () => {
     loadModelCatalog.mockResolvedValue([
       {

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -449,7 +449,7 @@ export async function promptDefaultModel(
     allowKeep &&
     hasPreferredProvider &&
     preferredProvider &&
-    resolved.provider !== preferredProvider
+    !matchesPreferredProvider(resolved.provider, preferredProvider)
   ) {
     const firstModel = filteredModels[0];
     if (firstModel) {

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -231,9 +231,12 @@ async function maybeFilterModelsByProvider(params: {
     }
   }
   if (hasPreferredProvider && params.preferredProvider) {
-    next = next.filter((entry) =>
+    const filtered = next.filter((entry) =>
       matchesPreferredProvider(entry.provider, params.preferredProvider!),
     );
+    if (filtered.length > 0) {
+      next = filtered;
+    }
   }
   return next;
 }

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -215,9 +215,7 @@ async function maybeFilterModelsByProvider(params: {
   const providerIds = Array.from(new Set(params.models.map((entry) => entry.provider))).toSorted(
     (a, b) => a.localeCompare(b),
   );
-  const hasPreferredProvider = params.preferredProvider
-    ? providerIds.includes(params.preferredProvider)
-    : false;
+  const hasPreferredProvider = !!params.preferredProvider;
   const shouldPromptProvider =
     !hasPreferredProvider &&
     providerIds.length > 1 &&

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -295,6 +295,7 @@ export function resolveCatalogHookProviderPluginIds(params: {
           origin: plugin.origin,
           config: normalizedConfig,
           rootConfig: params.config,
+          enabledByDefault: plugin.enabledByDefault,
         }).activated,
     )
     .map((plugin) => plugin.id);


### PR DESCRIPTION
## Summary

Fix model filtering and selection issues in model picker for BytePlus and Volcengine:

- Fix: Model list was not filtered by selected provider (showed all models)
- Fix: "Keep current" failed when using plan variants (e.g. byteplus-plan vs byteplus)
- Improvement: Show model catalog even without API key using static provider catalogs

## Root Cause

- Model catalogs required API key during onboarding and provider matching used strict equality, leading to incorrect model list and selection behavior

## What Changed

- Added `augmentModelCatalog` hooks to expose static model lists
- Updated provider matching logic to support plan variants

## User Impact

- Model picker now correctly filters models by provider
- Models visible even before API key is configured
- "Keep current" selection behaves correctly

## Scope

- Integrations (BytePlus, Volcengine)
- UI (model picker)

## Evidence

### Volcengine (Before vs After)

| Before (bug) | After (fixed) |
|--------------|---------------|
| <img width="320" alt="volcengine-before" src="https://github.com/user-attachments/assets/2cb2d064-c810-416d-a3b8-69a0472f9a99" /> | <img width="320" alt="volcengine-after" src="https://github.com/user-attachments/assets/2808644d-ab60-4c2d-a347-e763356d4ff1" /> |

- Before: shows models from all providers  
- After: correctly filtered to Volcengine + "Keep current" works

---

### BytePlus (Before vs After)

| Before (bug) | After (fixed) |
|--------------|---------------|
| <img width="320" alt="byteplus-before" src="https://github.com/user-attachments/assets/b6574e96-b2cf-467c-ba38-7a5285ece94e" /> | <img width="320" alt="byteplus-after" src="https://github.com/user-attachments/assets/c36b1e6b-1115-4d57-9c42-0647fc94aee5" /> |

- Before: shows models from all providers  
- After: correctly filtered to BytePlus + "Keep current" works

## Risk

- Static catalogs may become outdated (same pattern as other providers; dynamic catalogs still used when API key is configured)