### PR TITLE
Document gateway:watch recovery in the debugging guide

### DIFF
--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -52,6 +52,14 @@ rebuild `dist` first.
 Add any gateway CLI flags after `gateway:watch` and they will be passed through on
 each restart.
 
+> If `pnpm gateway:watch` fails with `ERR_INVALID_PACKAGE_CONFIG` or points to a file under `node_modules`, one of your local dependency files may be corrupted or truncated. A common recovery path is:
+>
+> ```bash
+> rm -rf node_modules
+> pnpm store prune
+> pnpm install
+> ```
+
 ## Dev profile + dev gateway (--dev)
 
 Use the dev profile to isolate state and spin up a safe, disposable setup for


### PR DESCRIPTION
## Summary

Document a common recovery path for `pnpm gateway:watch` failures in the debugging guide.

## What changed

- Added a troubleshooting note to `docs/help/debugging.md`
- Documented the recovery steps for `ERR_INVALID_PACKAGE_CONFIG` when the error points into `node_modules`

## Why

When `pnpm gateway:watch` fails because a dependency file under `node_modules` is corrupted or truncated, the debugging guide is a natural place to document the recovery path.

This keeps the recovery steps easier to discover during local debugging and development.

## Manual verification

1. Opened `docs/help/debugging.md`
2. Added the recovery note under the `gateway:watch` section
3. Ran the repo checks during commit
4. Confirmed the docs change stayed scoped to the debugging guide