### PR TITLE
fix(gateway): move probe stage ahead of channel stages to prevent plugin load failures from blocking health checks

### DIFF
--- a/src/gateway/server-http.probe.test.ts
+++ b/src/gateway/server-http.probe.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   AUTH_TOKEN,
   AUTH_NONE,
@@ -151,5 +151,54 @@ describe("gateway probe endpoints", () => {
         expect(getBody()).toBe("");
       },
     });
+  });
+
+  it("serves /health even when a later request stage throws", async () => {
+    // Regression test for #58762: when an optional channel dependency is
+    // missing the Slack facade throws on first call.  Before the fix the
+    // gateway-probes stage ran *after* channel stages, so the thrown error
+    // propagated to the catch-all and returned 500 for every endpoint
+    // including health probes.
+    await withGatewayServer({
+      prefix: "probe-stage-throw-health",
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        handleHooksRequest: async () => {
+          throw new Error("simulated optional-dep load failure");
+        },
+      },
+      run: async (server) => {
+        const req = createRequest({ path: "/health" });
+        const { res, getBody } = createResponse();
+        await dispatchRequest(server, req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(JSON.parse(getBody())).toEqual({ ok: true, status: "live" });
+      },
+    });
+  });
+
+  it("serves /healthz even when a later request stage throws", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await withGatewayServer({
+      prefix: "probe-stage-throw-healthz",
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        handleHooksRequest: async () => {
+          throw new Error("simulated optional-dep load failure");
+        },
+      },
+      run: async (server) => {
+        const req = createRequest({ path: "/healthz" });
+        const { res, getBody } = createResponse();
+        await dispatchRequest(server, req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(JSON.parse(getBody())).toEqual({ ok: true, status: "live" });
+      },
+    });
+
+    errorSpy.mockRestore();
   });
 });

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -841,6 +841,19 @@ export function createGatewayHttpServer(opts: {
         : null;
       const requestStages: GatewayHttpRequestStage[] = [
         {
+          name: "gateway-probes",
+          run: () =>
+            handleGatewayProbeRequest(
+              req,
+              res,
+              requestPath,
+              resolvedAuth,
+              trustedProxies,
+              allowRealIpFallback,
+              getReadiness,
+            ),
+        },
+        {
           name: "hooks",
           run: () => handleHooksRequest(req, res),
         },
@@ -1000,20 +1013,6 @@ export function createGatewayHttpServer(opts: {
             }),
         });
       }
-
-      requestStages.push({
-        name: "gateway-probes",
-        run: () =>
-          handleGatewayProbeRequest(
-            req,
-            res,
-            requestPath,
-            resolvedAuth,
-            trustedProxies,
-            allowRealIpFallback,
-            getReadiness,
-          ),
-      });
 
       if (await runGatewayHttpRequestStages(requestStages)) {
         return;


### PR DESCRIPTION
### Summary

- **Problem**: On 2026.3.31, all HTTP endpoints (`/health`, `/healthz`, `/ready`, `/`, `/api/*`, `/__openclaw__/canvas/`) return 500 Internal Server Error when optional channel dependencies (e.g. `@slack/bolt` / `@slack/web-api`) are not installed. The gateway appears healthy over RPC/WebSocket but every HTTP request fails, breaking health probes, the Dashboard, and the REST API.
- **Root Cause**: The `slack` request stage is included unconditionally in the `requestStages` array (`src/gateway/server-http.ts`, line 901 ). When `handleSlackHttpRequest` is first invoked via its facade proxy (`src/plugin-sdk/slack-surface.ts:31`), it calls `loadBundledPluginPublicSurfaceModuleSync`, which synchronously loads the entire Slack plugin bundle (`extensions/slack/api.ts`). That bundle re-exports `src/client.ts`, which performs a **value-level** `import { WebClient } from "@slack/web-api"`. If the package is absent (standard `npm install -g openclaw` does not install optional peer deps), the import throws. Critically, the `gateway-probes` stage — which handles `/health`, `/healthz`, `/ready`, `/readyz` — was positioned **after** all channel stages in the array. Because `runGatewayHttpRequestStages` executes stages sequentially, the thrown error aborts the loop before the probe stage ever runs.
- **Fix**: Moved the `gateway-probes` stage from the end of the `requestStages` array to the very beginning (before `hooks`). Health probes are infrastructure-level endpoints and must never be gated by plugin availability. The probe handler (`handleGatewayProbeRequest`) already returns `false` for non-probe paths, so non-probe requests continue through the remaining stages exactly as before.
- **What changed**:
  - `src/gateway/server-http.ts`: Relocated `gateway-probes` from a trailing `requestStages.push( )` call to the first entry in the `requestStages` array initializer.
  - `src/gateway/server-http.probe.test.ts`: Added two regression tests to the existing probe test suite verifying that `/health` and `/healthz` return 200 even when a later stage throws.
- **What did NOT change (scope boundary )**:
  - The Slack plugin, its facade loading mechanism, and all other channel plugins remain untouched.
  - The `catch` block error logging (already fixed upstream in this commit range) is not modified.
  - No new dependencies are introduced.

### Reproduction

1. `npm install -g openclaw` (standard install, no optional peer deps).
2. Start the gateway: `openclaw start`.
3. `curl http://localhost:18789/health` → 500 Internal Server Error.
4. Check logs → no error output (prior to upstream catch-block fix ).

### Risk / Mitigation

- **Risk**: Moving the probe stage earlier could theoretically let probe requests bypass security headers or authentication that other stages enforce.
- **Mitigation**: `setDefaultSecurityHeaders` is applied unconditionally at the top of `handleRequest` (line 807), before any stage runs. The probe handler itself checks `GATEWAY_PROBE_STATUS_BY_PATH` and only handles the four known probe paths (`/health`, `/healthz`, `/ready`, `/readyz`), returning `false` for everything else. All existing probe tests continue to pass. Three new tests explicitly verify resilience under stage-failure conditions.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Tests

### Linked Issue/PR

Fixes #58762