### PR TITLE
fix(compaction): add circuit breaker for retry loops

### DIFF
--- a/src/agents/compaction-circuit-breaker.test.ts
+++ b/src/agents/compaction-circuit-breaker.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CompactionCircuitBreaker } from "./compaction-circuit-breaker.js";
+
+describe("CompactionCircuitBreaker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts in closed state", () => {
+    const cb = new CompactionCircuitBreaker();
+    expect(cb.state).toBe("closed");
+    expect(cb.canAttempt()).toBe(true);
+  });
+
+  it("stays closed after fewer than maxFailures", () => {
+    const cb = new CompactionCircuitBreaker({ maxFailures: 3 });
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.state).toBe("closed");
+    expect(cb.canAttempt()).toBe(true);
+  });
+
+  it("opens after maxFailures consecutive failures", () => {
+    const cb = new CompactionCircuitBreaker({ maxFailures: 3 });
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.state).toBe("open");
+    expect(cb.canAttempt()).toBe(false);
+  });
+
+  it("transitions to half-open after resetAfterMs", () => {
+    const cb = new CompactionCircuitBreaker({ maxFailures: 2, resetAfterMs: 5000 });
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.state).toBe("open");
+
+    vi.advanceTimersByTime(5000);
+    expect(cb.state).toBe("half-open");
+    expect(cb.canAttempt()).toBe(true);
+  });
+
+  it("resets to closed on success", () => {
+    const cb = new CompactionCircuitBreaker({ maxFailures: 2 });
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.state).toBe("open");
+
+    vi.advanceTimersByTime(60_000);
+    cb.recordSuccess();
+    expect(cb.state).toBe("closed");
+    expect(cb.canAttempt()).toBe(true);
+  });
+
+  it("reopens on failure in half-open state", () => {
+    const cb = new CompactionCircuitBreaker({ maxFailures: 2, resetAfterMs: 5000 });
+    cb.recordFailure();
+    cb.recordFailure();
+    vi.advanceTimersByTime(5000);
+    expect(cb.state).toBe("half-open");
+
+    cb.recordFailure();
+    expect(cb.state).toBe("open");
+    expect(cb.canAttempt()).toBe(false);
+  });
+
+  it("success after some failures resets the counter", () => {
+    const cb = new CompactionCircuitBreaker({ maxFailures: 3 });
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordSuccess();
+    expect(cb.state).toBe("closed");
+
+    // Need 3 new failures to open again
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.state).toBe("closed");
+    cb.recordFailure();
+    expect(cb.state).toBe("open");
+  });
+
+  it("reset() clears all state", () => {
+    const cb = new CompactionCircuitBreaker({ maxFailures: 1 });
+    cb.recordFailure();
+    expect(cb.state).toBe("open");
+
+    cb.reset();
+    expect(cb.state).toBe("closed");
+    expect(cb.canAttempt()).toBe(true);
+  });
+
+  it("uses default config values", () => {
+    const cb = new CompactionCircuitBreaker();
+    // Default maxFailures is 3
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.state).toBe("closed");
+    cb.recordFailure();
+    expect(cb.state).toBe("open");
+
+    // Default resetAfterMs is 60_000
+    vi.advanceTimersByTime(59_999);
+    expect(cb.state).toBe("open");
+    vi.advanceTimersByTime(1);
+    expect(cb.state).toBe("half-open");
+  });
+});

--- a/src/agents/compaction-circuit-breaker.ts
+++ b/src/agents/compaction-circuit-breaker.ts
@@ -1,0 +1,99 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("compaction");
+
+export type CircuitBreakerConfig = {
+  /** Max consecutive failures before opening the circuit. Default: 3. */
+  maxFailures?: number;
+  /** Time in ms before attempting again after circuit opens. Default: 60_000 (1 min). */
+  resetAfterMs?: number;
+};
+
+export type CircuitState = "closed" | "open" | "half-open";
+
+const DEFAULT_MAX_FAILURES = 3;
+const DEFAULT_RESET_AFTER_MS = 60_000;
+
+/**
+ * Circuit breaker for compaction retry loops.
+ *
+ * When compaction fails repeatedly (model errors, timeouts, malformed output),
+ * the retry logic can burn tokens without progress. The circuit breaker stops
+ * attempts after N consecutive failures, resuming only after a cooldown period.
+ *
+ * States:
+ *   closed    → normal operation, compaction allowed
+ *   open      → blocked after N failures, compaction skipped
+ *   half-open → cooldown expired, one attempt allowed to test recovery
+ */
+export class CompactionCircuitBreaker {
+  private consecutiveFailures = 0;
+  private lastFailureTime = 0;
+  private readonly maxFailures: number;
+  private readonly resetAfterMs: number;
+
+  constructor(config?: CircuitBreakerConfig) {
+    this.maxFailures = Math.max(1, config?.maxFailures ?? DEFAULT_MAX_FAILURES);
+    this.resetAfterMs = Math.max(1000, config?.resetAfterMs ?? DEFAULT_RESET_AFTER_MS);
+  }
+
+  get state(): CircuitState {
+    if (this.consecutiveFailures < this.maxFailures) {
+      return "closed";
+    }
+    const elapsed = Date.now() - this.lastFailureTime;
+    if (elapsed >= this.resetAfterMs) {
+      return "half-open";
+    }
+    return "open";
+  }
+
+  /**
+   * Check if a compaction attempt is allowed.
+   * Returns true in closed and half-open states, false when open.
+   */
+  canAttempt(): boolean {
+    const currentState = this.state;
+    if (currentState === "open") {
+      log.debug(
+        `Compaction circuit breaker OPEN — ${this.consecutiveFailures} consecutive failures, ` +
+          `cooldown ${Math.ceil((this.resetAfterMs - (Date.now() - this.lastFailureTime)) / 1000)}s remaining`,
+      );
+      return false;
+    }
+    if (currentState === "half-open") {
+      log.debug("Compaction circuit breaker HALF-OPEN — allowing one test attempt");
+    }
+    return true;
+  }
+
+  /** Record a successful compaction. Resets the circuit to closed. */
+  recordSuccess(): void {
+    if (this.consecutiveFailures > 0) {
+      log.debug(
+        `Compaction circuit breaker reset after ${this.consecutiveFailures} consecutive failures`,
+      );
+    }
+    this.consecutiveFailures = 0;
+    this.lastFailureTime = 0;
+  }
+
+  /** Record a failed compaction. May open the circuit. */
+  recordFailure(): void {
+    this.consecutiveFailures += 1;
+    this.lastFailureTime = Date.now();
+
+    if (this.consecutiveFailures >= this.maxFailures) {
+      log.warn(
+        `Compaction circuit breaker OPENED after ${this.consecutiveFailures} consecutive failures — ` +
+          `pausing compaction for ${Math.ceil(this.resetAfterMs / 1000)}s`,
+      );
+    }
+  }
+
+  /** Reset the circuit breaker to initial state. */
+  reset(): void {
+    this.consecutiveFailures = 0;
+    this.lastFailureTime = 0;
+  }
+}

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -7,6 +7,7 @@ import {
 import type { AgentCompactionIdentifierPolicy } from "../config/types.agent-defaults.js";
 import { retryAsync } from "../infra/retry.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { CompactionCircuitBreaker } from "./compaction-circuit-breaker.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
 
@@ -246,8 +247,15 @@ async function summarizeChunks(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
+  circuitBreaker?: CompactionCircuitBreaker;
 }): Promise<string> {
   if (params.messages.length === 0) {
+    return params.previousSummary ?? DEFAULT_SUMMARY_FALLBACK;
+  }
+
+  const { circuitBreaker } = params;
+  if (circuitBreaker && !circuitBreaker.canAttempt()) {
+    log.warn("Compaction skipped — circuit breaker is open");
     return params.previousSummary ?? DEFAULT_SUMMARY_FALLBACK;
   }
 
@@ -259,28 +267,35 @@ async function summarizeChunks(params: {
     params.customInstructions,
     params.summarizationInstructions,
   );
-  for (const chunk of chunks) {
-    summary = await retryAsync(
-      () =>
-        generateSummary(
-          chunk,
-          params.model,
-          params.reserveTokens,
-          params.apiKey,
-          params.headers,
-          params.signal,
-          effectiveInstructions,
-          summary,
-        ),
-      {
-        attempts: 3,
-        minDelayMs: 500,
-        maxDelayMs: 5000,
-        jitter: 0.2,
-        label: "compaction/generateSummary",
-        shouldRetry: (err) => !(err instanceof Error && err.name === "AbortError"),
-      },
-    );
+
+  try {
+    for (const chunk of chunks) {
+      summary = await retryAsync(
+        () =>
+          generateSummary(
+            chunk,
+            params.model,
+            params.reserveTokens,
+            params.apiKey,
+            params.headers,
+            params.signal,
+            effectiveInstructions,
+            summary,
+          ),
+        {
+          attempts: 3,
+          minDelayMs: 500,
+          maxDelayMs: 5000,
+          jitter: 0.2,
+          label: "compaction/generateSummary",
+          shouldRetry: (err) => !(err instanceof Error && err.name === "AbortError"),
+        },
+      );
+    }
+    circuitBreaker?.recordSuccess();
+  } catch (err) {
+    circuitBreaker?.recordFailure();
+    throw err;
   }
 
   return summary ?? DEFAULT_SUMMARY_FALLBACK;


### PR DESCRIPTION
Fixes #58838

## Summary

When compaction repeatedly fails (model errors, timeouts, malformed output), `retryAsync` burns tokens without progress. Add `CompactionCircuitBreaker` that stops attempts after N consecutive failures and resumes after a cooldown period.

- `CompactionCircuitBreaker` class with closed/open/half-open states
- Default: opens after 3 consecutive failures, resets after 60s cooldown
- Wire into `summarizeChunks()` as optional parameter (backward compatible)
- When circuit is open, falls back to `previousSummary` instead of retrying

## Test plan

- [x] State transitions: closed → open (after N failures)
- [x] State transitions: open → half-open (after cooldown)
- [x] State transitions: half-open → closed (on success) / open (on failure)
- [x] Counter reset on mid-sequence success
- [x] Default config values (3 failures, 60s cooldown)
- [x] `reset()` clears all state
- [x] Fake timers for deterministic time-based tests
- [x] Existing compaction tests pass (10 tests)