### PR TITLE
fix(agents): handle context overflow consistently across providers

### DIFF
--- a/src/agents/pi-embedded-helpers/context-overflow-detection.test.ts
+++ b/src/agents/pi-embedded-helpers/context-overflow-detection.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  isContextOverflowError,
+  isDefiniteContextOverflowError,
+  isLikelyContextOverflowError,
+} from "./errors.js";
+
+describe("isContextOverflowError — provider-specific patterns", () => {
+  describe("AWS Bedrock", () => {
+    it("detects ValidationException with input too long", () => {
+      expect(isContextOverflowError("ValidationException: The input is too long")).toBe(true);
+    });
+
+    it("detects ValidationException with max input token", () => {
+      expect(
+        isContextOverflowError(
+          "ValidationException: Input exceeds the max input token limit of 128000",
+        ),
+      ).toBe(true);
+    });
+
+    it("detects ModelStreamErrorException with input is too long", () => {
+      expect(
+        isContextOverflowError("ModelStreamErrorException: Input is too long for this model"),
+      ).toBe(true);
+    });
+
+    it("detects ModelStreamErrorException with too many input tokens", () => {
+      expect(isContextOverflowError("ModelStreamErrorException: too many input tokens")).toBe(true);
+    });
+
+    it("detects maximum number of input tokens", () => {
+      expect(
+        isContextOverflowError("Exceeded the maximum number of input tokens for the model"),
+      ).toBe(true);
+    });
+  });
+
+  describe("Ollama / local models", () => {
+    it("detects ollama context length error", () => {
+      expect(isContextOverflowError("ollama: context length exceeded for llama3")).toBe(true);
+    });
+  });
+
+  describe("Cohere", () => {
+    it("detects total tokens exceeds model max", () => {
+      expect(isContextOverflowError("total tokens exceeds the model's max of 4096")).toBe(true);
+    });
+
+    it("detects total tokens exceeds limit", () => {
+      expect(isContextOverflowError("total tokens exceeds the limit of 4096")).toBe(true);
+    });
+  });
+
+  describe("generic patterns", () => {
+    it("detects input is too long for model", () => {
+      expect(isContextOverflowError("input is too long for model gpt-5.4")).toBe(true);
+    });
+
+    it("detects input too long for this model", () => {
+      expect(isContextOverflowError("input too long for this model")).toBe(true);
+    });
+  });
+
+  describe("existing patterns still work", () => {
+    it("detects context length exceeded", () => {
+      expect(isContextOverflowError("context length exceeded")).toBe(true);
+    });
+
+    it("detects prompt is too long", () => {
+      expect(isContextOverflowError("prompt is too long: 150000 tokens > 128000 maximum")).toBe(
+        true,
+      );
+    });
+
+    it("detects context_window_exceeded", () => {
+      expect(isContextOverflowError("context_window_exceeded")).toBe(true);
+    });
+  });
+
+  describe("false positives", () => {
+    it("does not match rate limit with TPM hint", () => {
+      expect(isContextOverflowError("413 TPM rate limit exceeded")).toBe(false);
+    });
+
+    it("does not match generic rate limit", () => {
+      expect(isContextOverflowError("rate limit exceeded")).toBe(false);
+    });
+  });
+});
+
+describe("isLikelyContextOverflowError — provider-specific patterns", () => {
+  it("detects Bedrock ValidationException via isContextOverflowError path", () => {
+    expect(isLikelyContextOverflowError("ValidationException: The input is too long")).toBe(true);
+  });
+
+  it("detects Cohere total tokens via isContextOverflowError path", () => {
+    expect(isLikelyContextOverflowError("total tokens exceeds the model's max of 4096")).toBe(true);
+  });
+});
+
+describe("isDefiniteContextOverflowError", () => {
+  it("matches 400 + context length exceeded", () => {
+    expect(isDefiniteContextOverflowError("400 context length exceeded")).toBe(true);
+  });
+
+  it("matches 400 + prompt is too long", () => {
+    expect(isDefiniteContextOverflowError("400 prompt is too long")).toBe(true);
+  });
+
+  it("matches 400 + request_too_large", () => {
+    expect(isDefiniteContextOverflowError("400 request_too_large")).toBe(true);
+  });
+
+  it("does not match without 400 status", () => {
+    expect(isDefiniteContextOverflowError("context length exceeded")).toBe(false);
+  });
+
+  it("does not match 429 + context overflow", () => {
+    expect(isDefiniteContextOverflowError("429 context length exceeded")).toBe(false);
+  });
+
+  it("returns false for empty/undefined", () => {
+    expect(isDefiniteContextOverflowError(undefined)).toBe(false);
+    expect(isDefiniteContextOverflowError("")).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -235,7 +235,37 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     errorMessage.includes("上下文超出") ||
     errorMessage.includes("上下文长度超") ||
     errorMessage.includes("超出最大上下文") ||
-    errorMessage.includes("请压缩上下文")
+    errorMessage.includes("请压缩上下文") ||
+    // AWS Bedrock
+    (lower.includes("validationexception") &&
+      (lower.includes("input is too long") || lower.includes("max input token"))) ||
+    (lower.includes("modelstreamerrorexception") &&
+      (lower.includes("input is too long") || lower.includes("too many input tokens"))) ||
+    // Ollama / local models
+    (lower.includes("ollama") && lower.includes("context length")) ||
+    // Cohere
+    /total tokens?\s+exceeds?\s+(?:the\s+)?(?:model(?:'s)?\s+)?(?:max|limit)/i.test(errorMessage) ||
+    // Generic patterns missed by base checks
+    lower.includes("input is too long for model") ||
+    lower.includes("input too long for this model") ||
+    lower.includes("maximum number of input tokens")
+  );
+}
+
+/**
+ * High-confidence context overflow check for cases where we want to be sure
+ * before triggering compaction. Unlike `isContextOverflowError` which uses
+ * heuristic keyword matching, this only matches explicit, unambiguous patterns
+ * from known provider APIs.
+ */
+export function isDefiniteContextOverflowError(errorMessage?: string): boolean {
+  if (!errorMessage) {
+    return false;
+  }
+  // Only match patterns that are unambiguously context overflow with HTTP 400.
+  // Use [_\s] to match separators (underscores, spaces) between words.
+  return /\b400\b.*(?:context[_\s]length[_\s]exceeded|prompt[_\s]is[_\s]too[_\s]long|request_too_large|context_window_exceeded)/i.test(
+    errorMessage,
   );
 }
 


### PR DESCRIPTION
Fixes #58839

## Summary

`isContextOverflowError()` detects context overflow for Anthropic and OpenAI but misses several other providers. When overflow goes undetected, the agent retries with the same oversized payload instead of triggering compaction, wasting API credits.

- Add Bedrock patterns: `ValidationException` + input too long, `ModelStreamErrorException`
- Add Ollama pattern: context length errors
- Add Cohere pattern: total tokens exceeds model max
- Add generic patterns: "input is too long for model", "maximum number of input tokens"
- Add `isDefiniteContextOverflowError()` for high-confidence detection (HTTP 400 + explicit message)

## Test plan

- [x] Bedrock: ValidationException, ModelStreamErrorException (3 variants)
- [x] Ollama: context length exceeded
- [x] Cohere: total tokens exceeds model max
- [x] Generic: input too long for model, maximum input tokens
- [x] Existing patterns still work (context length exceeded, prompt is too long)
- [x] False positive checks (rate limit, TPM not matched)
- [x] `isDefiniteContextOverflowError`: HTTP 400 requirement verified
- [x] Existing failover tests pass (35 tests)