### PR TITLE
fix(agents): keep tool_use and toolResult together when splitting messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Docs: https://docs.openclaw.ai
 - CLI/skills JSON: route `skills list --json`, `skills info --json`, and `skills check --json` output to stdout instead of stderr so machine-readable consumers receive JSON on the expected stream again. (#60914; fixes #57599; landed from contributor PR #57611 by @Aftabbs) Thanks @Aftabbs.
 - Agents/subagents: honor allowlist validation, auth-profile handoff, and session override state when a subagent retries after `LiveSessionModelSwitchError`. (#58178) Thanks @openperf.
 - Agents/exec: restore `host=node` routing for node-pinned and `host=auto` sessions, while still blocking sandboxed `auto` sessions from jumping to gateway. (#60788) Thanks @openperf.
+- Agents/compaction: keep assistant tool calls and displaced tool results in the same compaction chunk so strict summarization providers stop rejecting orphaned tool pairs. (#58849) Thanks @openperf.
 
 ## 2026.4.2
 

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -24,6 +24,7 @@ function makeAssistantToolCall(
   timestamp: number,
   toolCallId: string,
   text = "x".repeat(4000),
+  stopReason: AssistantMessage["stopReason"] = "stop",
 ): AssistantMessage {
   return makeAgentAssistantMessage({
     content: [
@@ -31,7 +32,7 @@ function makeAssistantToolCall(
       { type: "toolCall", id: toolCallId, name: "test_tool", arguments: {} },
     ],
     model: "gpt-5.4",
-    stopReason: "stop",
+    stopReason,
     timestamp,
   });
 }
@@ -167,6 +168,19 @@ describe("splitMessagesByTokenShare", () => {
     const chunk1Roles = parts[0].map((m) => m.role);
     expect(chunk1Roles).toContain("assistant");
     expect(chunk1Roles).toContain("toolResult");
+    expect(parts.flat().length).toBe(messages.length);
+  });
+
+  it("does not block splits after aborted tool-call assistants", () => {
+    const messages: AgentMessage[] = [
+      makeAssistantToolCall(1, "call_abort", "y".repeat(4000), "aborted"),
+      makeMessage(2, 4000),
+      makeMessage(3, 4000),
+    ];
+
+    const parts = splitMessagesByTokenShare(messages, 2);
+
+    expect(parts.length).toBe(2);
     expect(parts.flat().length).toBe(messages.length);
   });
 });

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -76,6 +76,90 @@ describe("splitMessagesByTokenShare", () => {
     const parts = splitMessagesByTokenShare(messages, 3);
     expect(parts.flat().map((msg) => msg.timestamp)).toEqual(messages.map((msg) => msg.timestamp));
   });
+
+  it("keeps tool_use and matching toolResult in the same chunk", () => {
+    // Regression test for #58836: split must not land between
+    // an assistant+tool_use message and its corresponding toolResult.
+    const messages: AgentMessage[] = [
+      makeMessage(1, 4000), // ~1000 tokens
+      makeAssistantToolCall(2, "call_split"), // ~1000 tokens (tool_use)
+      makeToolResult(3, "call_split", "r".repeat(800)), // ~200 tokens (toolResult)
+      makeMessage(4, 4000), // ~1000 tokens
+    ];
+
+    const parts = splitMessagesByTokenShare(messages, 2);
+
+    // Find which chunk contains the assistant tool_use message
+    const chunkWithToolUse = parts.find((chunk) =>
+      chunk.some((m) => m.role === "assistant" && m.timestamp === 2),
+    );
+    // The matching toolResult must be in the same chunk
+    const chunkWithToolResult = parts.find((chunk) =>
+      chunk.some((m) => m.role === "toolResult" && m.timestamp === 3),
+    );
+    expect(chunkWithToolUse).toBeDefined();
+    expect(chunkWithToolResult).toBeDefined();
+    expect(chunkWithToolUse).toBe(chunkWithToolResult);
+
+    // All messages must still be present
+    expect(parts.flat().length).toBe(messages.length);
+  });
+
+  it("keeps multiple toolResults with their assistant in the same chunk", () => {
+    // Assistant with two tool_use blocks; both toolResults must stay together.
+    const assistant = makeAgentAssistantMessage({
+      content: [
+        { type: "text", text: "x".repeat(4000) },
+        { type: "toolCall", id: "call_a", name: "tool_a", arguments: {} },
+        { type: "toolCall", id: "call_b", name: "tool_b", arguments: {} },
+      ],
+      model: "gpt-5.2",
+      stopReason: "stop",
+      timestamp: 2,
+    });
+
+    const messages: AgentMessage[] = [
+      makeMessage(1, 4000),
+      assistant,
+      makeToolResult(3, "call_a", "result_a".repeat(200)),
+      makeToolResult(4, "call_b", "result_b".repeat(200)),
+      makeMessage(5, 4000),
+    ];
+
+    const parts = splitMessagesByTokenShare(messages, 2);
+
+    const chunkWithAssistant = parts.find((chunk) =>
+      chunk.some((m) => m.role === "assistant" && m.timestamp === 2),
+    )!;
+    const resultTimestamps = chunkWithAssistant
+      .filter((m) => m.role === "toolResult")
+      .map((m) => m.timestamp);
+    expect(resultTimestamps).toContain(3);
+    expect(resultTimestamps).toContain(4);
+    expect(parts.flat().length).toBe(messages.length);
+  });
+
+  it("splits after a completed tool_call/result pair when over budget", () => {
+    // Regression: after all toolResults for an assistant are consumed,
+    // the chunk must still be eligible for splitting so that
+    // pruneHistoryForContextShare can produce multiple chunks.
+    const messages: AgentMessage[] = [
+      makeAssistantToolCall(1, "call_x", "y".repeat(4000)), // ~1000 tokens
+      makeToolResult(2, "call_x", "r".repeat(4000)), // ~1000 tokens
+      makeMessage(3, 4000), // ~1000 tokens
+    ];
+
+    const parts = splitMessagesByTokenShare(messages, 2);
+
+    // Must produce 2 chunks, not 1.
+    expect(parts.length).toBe(2);
+    // The tool pair stays together in chunk 1.
+    const chunk1Roles = parts[0].map((m) => m.role);
+    expect(chunk1Roles).toContain("assistant");
+    expect(chunk1Roles).toContain("toolResult");
+    // All messages preserved.
+    expect(parts.flat().length).toBe(messages.length);
+  });
 });
 
 describe("pruneHistoryForContextShare", () => {
@@ -176,15 +260,15 @@ describe("pruneHistoryForContextShare", () => {
       parts: 2,
     });
 
-    // The orphaned tool_result should NOT be in kept messages
-    // (this is the critical invariant that prevents API errors)
+    // With the tool_use/toolResult boundary fix, the assistant+tool_use and
+    // its toolResult now stay in the same chunk. When that chunk is dropped,
+    // both are dropped together — no orphaned toolResult in the kept portion.
     const keptRoles = pruned.messages.map((m) => m.role);
     expect(keptRoles).not.toContain("toolResult");
 
-    // The orphan count should be reflected in droppedMessages
-    // (orphaned tool_results are dropped but not added to droppedMessagesList
-    // since they lack context for summarization)
-    expect(pruned.droppedMessages).toBeGreaterThan(pruned.droppedMessagesList.length);
+    // Both assistant and toolResult are dropped as a unit, so
+    // droppedMessages equals droppedMessagesList.length (no extra orphans).
+    expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
   });
 
   it("keeps tool_result when its tool_use is also kept", () => {
@@ -218,7 +302,8 @@ describe("pruneHistoryForContextShare", () => {
     // Scenario: assistant with multiple tool_use blocks is dropped,
     // all corresponding tool_results should be removed from kept messages
     const messages: AgentMessage[] = [
-      // Chunk 1 (will be dropped) - contains multiple tool_use blocks
+      // With the boundary fix, assistant + both toolResults stay in the same chunk.
+      // When that chunk is dropped, all three are dropped together.
       makeAgentAssistantMessage({
         content: [
           { type: "text", text: "x".repeat(4000) },
@@ -229,7 +314,6 @@ describe("pruneHistoryForContextShare", () => {
         stopReason: "stop",
         timestamp: 1,
       }),
-      // Chunk 2 (will be kept) - contains orphaned tool_results
       makeToolResult(2, "call_a", "result_a"),
       makeToolResult(3, "call_b", "result_b"),
       {
@@ -246,13 +330,12 @@ describe("pruneHistoryForContextShare", () => {
       parts: 2,
     });
 
-    // No orphaned tool_results should be in kept messages
+    // No tool_results should be in kept messages (all dropped with their assistant)
     const keptToolResults = pruned.messages.filter((m) => m.role === "toolResult");
     expect(keptToolResults).toHaveLength(0);
 
-    // The orphan count should reflect both dropped tool_results
-    // droppedMessages = 1 (assistant) + 2 (orphaned tool_results) = 3
-    // droppedMessagesList only has the assistant message
-    expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length + 2);
+    // All three messages (assistant + 2 toolResults) are dropped as a unit,
+    // so droppedMessages equals droppedMessagesList.length (no extra orphans).
+    expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
   });
 });

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -78,35 +78,28 @@ describe("splitMessagesByTokenShare", () => {
   });
 
   it("keeps tool_use and matching toolResult in the same chunk", () => {
-    // Regression test for #58836: split must not land between
-    // an assistant+tool_use message and its corresponding toolResult.
     const messages: AgentMessage[] = [
-      makeMessage(1, 4000), // ~1000 tokens
-      makeAssistantToolCall(2, "call_split"), // ~1000 tokens (tool_use)
-      makeToolResult(3, "call_split", "r".repeat(800)), // ~200 tokens (toolResult)
-      makeMessage(4, 4000), // ~1000 tokens
+      makeMessage(1, 4000),
+      makeAssistantToolCall(2, "call_split"),
+      makeToolResult(3, "call_split", "r".repeat(800)),
+      makeMessage(4, 4000),
     ];
 
     const parts = splitMessagesByTokenShare(messages, 2);
 
-    // Find which chunk contains the assistant tool_use message
     const chunkWithToolUse = parts.find((chunk) =>
       chunk.some((m) => m.role === "assistant" && m.timestamp === 2),
     );
-    // The matching toolResult must be in the same chunk
     const chunkWithToolResult = parts.find((chunk) =>
       chunk.some((m) => m.role === "toolResult" && m.timestamp === 3),
     );
     expect(chunkWithToolUse).toBeDefined();
     expect(chunkWithToolResult).toBeDefined();
     expect(chunkWithToolUse).toBe(chunkWithToolResult);
-
-    // All messages must still be present
     expect(parts.flat().length).toBe(messages.length);
   });
 
   it("keeps multiple toolResults with their assistant in the same chunk", () => {
-    // Assistant with two tool_use blocks; both toolResults must stay together.
     const assistant = makeAgentAssistantMessage({
       content: [
         { type: "text", text: "x".repeat(4000) },
@@ -139,25 +132,41 @@ describe("splitMessagesByTokenShare", () => {
     expect(parts.flat().length).toBe(messages.length);
   });
 
-  it("splits after a completed tool_call/result pair when over budget", () => {
-    // Regression: after all toolResults for an assistant are consumed,
-    // the chunk must still be eligible for splitting so that
-    // pruneHistoryForContextShare can produce multiple chunks.
+  it("keeps displaced toolResults with their assistant chunk", () => {
     const messages: AgentMessage[] = [
-      makeAssistantToolCall(1, "call_x", "y".repeat(4000)), // ~1000 tokens
-      makeToolResult(2, "call_x", "r".repeat(4000)), // ~1000 tokens
-      makeMessage(3, 4000), // ~1000 tokens
+      makeMessage(1, 4000),
+      makeAssistantToolCall(2, "call_split"),
+      makeMessage(3, 800),
+      makeToolResult(4, "call_split", "r".repeat(800)),
+      makeMessage(5, 4000),
     ];
 
     const parts = splitMessagesByTokenShare(messages, 2);
 
-    // Must produce 2 chunks, not 1.
+    const chunkWithToolUse = parts.find((chunk) =>
+      chunk.some((m) => m.role === "assistant" && m.timestamp === 2),
+    );
+    const chunkWithToolResult = parts.find((chunk) =>
+      chunk.some((m) => m.role === "toolResult" && m.timestamp === 4),
+    );
+
+    expect(chunkWithToolUse).toBeDefined();
+    expect(chunkWithToolUse).toBe(chunkWithToolResult);
+  });
+
+  it("splits after a completed tool_call/result pair when over budget", () => {
+    const messages: AgentMessage[] = [
+      makeAssistantToolCall(1, "call_x", "y".repeat(4000)),
+      makeToolResult(2, "call_x", "r".repeat(4000)),
+      makeMessage(3, 4000),
+    ];
+
+    const parts = splitMessagesByTokenShare(messages, 2);
+
     expect(parts.length).toBe(2);
-    // The tool pair stays together in chunk 1.
     const chunk1Roles = parts[0].map((m) => m.role);
     expect(chunk1Roles).toContain("assistant");
     expect(chunk1Roles).toContain("toolResult");
-    // All messages preserved.
     expect(parts.flat().length).toBe(messages.length);
   });
 });
@@ -204,17 +213,11 @@ describe("pruneHistoryForContextShare", () => {
   });
 
   it("returns droppedMessagesList containing dropped messages", () => {
-    // Note: This test uses simple user messages with no tool calls.
-    // When orphaned tool_results exist, droppedMessages may exceed
-    // droppedMessagesList.length since orphans are counted but not
-    // added to the list (they lack context for summarization).
     const { messages, pruned } = pruneLargeSimpleHistory();
 
     expect(pruned.droppedChunks).toBeGreaterThan(0);
-    // Without orphaned tool_results, counts match exactly
     expect(pruned.droppedMessagesList.length).toBe(pruned.droppedMessages);
 
-    // All messages accounted for: kept + dropped = original
     const allIds = [
       ...pruned.droppedMessagesList.map((m) => m.timestamp),
       ...pruned.messages.map((m) => m.timestamp),
@@ -238,13 +241,8 @@ describe("pruneHistoryForContextShare", () => {
   });
 
   it("removes orphaned tool_result messages when tool_use is dropped", () => {
-    // Scenario: assistant with tool_use is in chunk 1 (dropped),
-    // tool_result is in chunk 2 (kept) - orphaned tool_result should be removed
-    // to prevent "unexpected tool_use_id" errors from Anthropic's API
     const messages: AgentMessage[] = [
-      // Chunk 1 (will be dropped) - contains tool_use
       makeAssistantToolCall(1, "call_123"),
-      // Chunk 2 (will be kept) - contains orphaned tool_result
       makeToolResult(2, "call_123", "result".repeat(500)),
       {
         role: "user",
@@ -260,27 +258,18 @@ describe("pruneHistoryForContextShare", () => {
       parts: 2,
     });
 
-    // With the tool_use/toolResult boundary fix, the assistant+tool_use and
-    // its toolResult now stay in the same chunk. When that chunk is dropped,
-    // both are dropped together — no orphaned toolResult in the kept portion.
     const keptRoles = pruned.messages.map((m) => m.role);
     expect(keptRoles).not.toContain("toolResult");
-
-    // Both assistant and toolResult are dropped as a unit, so
-    // droppedMessages equals droppedMessagesList.length (no extra orphans).
     expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
   });
 
   it("keeps tool_result when its tool_use is also kept", () => {
-    // Scenario: both tool_use and tool_result are in the kept portion
     const messages: AgentMessage[] = [
-      // Chunk 1 (will be dropped) - just user content
       {
         role: "user",
         content: "x".repeat(4000),
         timestamp: 1,
       },
-      // Chunk 2 (will be kept) - contains both tool_use and tool_result
       makeAssistantToolCall(2, "call_456", "y".repeat(500)),
       makeToolResult(3, "call_456", "result"),
     ];
@@ -292,18 +281,13 @@ describe("pruneHistoryForContextShare", () => {
       parts: 2,
     });
 
-    // Both assistant and toolResult should be in kept messages
     const keptRoles = pruned.messages.map((m) => m.role);
     expect(keptRoles).toContain("assistant");
     expect(keptRoles).toContain("toolResult");
   });
 
   it("removes multiple orphaned tool_results from the same dropped tool_use", () => {
-    // Scenario: assistant with multiple tool_use blocks is dropped,
-    // all corresponding tool_results should be removed from kept messages
     const messages: AgentMessage[] = [
-      // With the boundary fix, assistant + both toolResults stay in the same chunk.
-      // When that chunk is dropped, all three are dropped together.
       makeAgentAssistantMessage({
         content: [
           { type: "text", text: "x".repeat(4000) },
@@ -330,12 +314,8 @@ describe("pruneHistoryForContextShare", () => {
       parts: 2,
     });
 
-    // No tool_results should be in kept messages (all dropped with their assistant)
     const keptToolResults = pruned.messages.filter((m) => m.role === "toolResult");
     expect(keptToolResults).toHaveLength(0);
-
-    // All three messages (assistant + 2 toolResults) are dropped as a unit,
-    // so droppedMessages equals droppedMessagesList.length (no extra orphans).
     expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
   });
 });

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -132,14 +132,11 @@ export function splitMessagesByTokenShare(
   let current: AgentMessage[] = [];
   let currentTokens = 0;
 
-  // Collect pending tool call IDs from the last assistant message in the current chunk.
-  // When non-empty, the chunk boundary is deferred until all matching toolResults are consumed.
   let pendingToolCallIds = new Set<string>();
 
   for (const message of messages) {
     const messageTokens = estimateCompactionMessageTokens(message);
 
-    // Only consider a split when there are no pending tool calls awaiting results.
     if (
       pendingToolCallIds.size === 0 &&
       chunks.length < normalizedParts - 1 &&
@@ -154,25 +151,16 @@ export function splitMessagesByTokenShare(
     current.push(message);
     currentTokens += messageTokens;
 
-    // Track tool call boundaries: when an assistant message contains tool_use blocks,
-    // record their IDs so subsequent matching toolResult messages stay in the same chunk.
     if (message.role === "assistant") {
       const toolCalls = extractToolCallsFromAssistant(message);
-      if (toolCalls.length > 0) {
-        pendingToolCallIds = new Set(toolCalls.map((t) => t.id));
-      } else {
-        // No tool calls in this assistant turn — clear any stale pending state.
-        pendingToolCallIds = new Set();
-      }
+      pendingToolCallIds = new Set(toolCalls.map((t) => t.id));
     } else if (message.role === "toolResult" && pendingToolCallIds.size > 0) {
       const resultId = extractToolResultId(message);
-      if (resultId) {
+      if (!resultId) {
+        pendingToolCallIds = new Set();
+      } else {
         pendingToolCallIds.delete(resultId);
       }
-      // Once all pending tool results have been consumed, check whether the
-      // current chunk has exceeded the target and should be split now.
-      // Without this, the split opportunity is missed because the gate at the
-      // top of the loop already passed before pending IDs were cleared.
       if (
         pendingToolCallIds.size === 0 &&
         chunks.length < normalizedParts - 1 &&
@@ -182,10 +170,6 @@ export function splitMessagesByTokenShare(
         current = [];
         currentTokens = 0;
       }
-    } else {
-      // Any non-assistant, non-toolResult message clears pending tracking,
-      // since tool results should directly follow their assistant turn.
-      pendingToolCallIds = new Set();
     }
   }
 

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -153,7 +153,11 @@ export function splitMessagesByTokenShare(
 
     if (message.role === "assistant") {
       const toolCalls = extractToolCallsFromAssistant(message);
-      pendingToolCallIds = new Set(toolCalls.map((t) => t.id));
+      const stopReason = (message as { stopReason?: unknown }).stopReason;
+      pendingToolCallIds =
+        stopReason === "aborted" || stopReason === "error"
+          ? new Set()
+          : new Set(toolCalls.map((t) => t.id));
     } else if (message.role === "toolResult" && pendingToolCallIds.size > 0) {
       const resultId = extractToolResultId(message);
       if (!resultId) {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -9,6 +9,7 @@ import { retryAsync } from "../infra/retry.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
+import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
 
 const log = createSubsystemLogger("compaction");
 
@@ -131,9 +132,16 @@ export function splitMessagesByTokenShare(
   let current: AgentMessage[] = [];
   let currentTokens = 0;
 
+  // Collect pending tool call IDs from the last assistant message in the current chunk.
+  // When non-empty, the chunk boundary is deferred until all matching toolResults are consumed.
+  let pendingToolCallIds = new Set<string>();
+
   for (const message of messages) {
     const messageTokens = estimateCompactionMessageTokens(message);
+
+    // Only consider a split when there are no pending tool calls awaiting results.
     if (
+      pendingToolCallIds.size === 0 &&
       chunks.length < normalizedParts - 1 &&
       current.length > 0 &&
       currentTokens + messageTokens > targetTokens
@@ -145,6 +153,40 @@ export function splitMessagesByTokenShare(
 
     current.push(message);
     currentTokens += messageTokens;
+
+    // Track tool call boundaries: when an assistant message contains tool_use blocks,
+    // record their IDs so subsequent matching toolResult messages stay in the same chunk.
+    if (message.role === "assistant") {
+      const toolCalls = extractToolCallsFromAssistant(message);
+      if (toolCalls.length > 0) {
+        pendingToolCallIds = new Set(toolCalls.map((t) => t.id));
+      } else {
+        // No tool calls in this assistant turn — clear any stale pending state.
+        pendingToolCallIds = new Set();
+      }
+    } else if (message.role === "toolResult" && pendingToolCallIds.size > 0) {
+      const resultId = extractToolResultId(message);
+      if (resultId) {
+        pendingToolCallIds.delete(resultId);
+      }
+      // Once all pending tool results have been consumed, check whether the
+      // current chunk has exceeded the target and should be split now.
+      // Without this, the split opportunity is missed because the gate at the
+      // top of the loop already passed before pending IDs were cleared.
+      if (
+        pendingToolCallIds.size === 0 &&
+        chunks.length < normalizedParts - 1 &&
+        currentTokens > targetTokens
+      ) {
+        chunks.push(current);
+        current = [];
+        currentTokens = 0;
+      }
+    } else {
+      // Any non-assistant, non-toolResult message clears pending tracking,
+      // since tool results should directly follow their assistant turn.
+      pendingToolCallIds = new Set();
+    }
   }
 
   if (current.length > 0) {


### PR DESCRIPTION
### Summary

- **Problem**: `splitMessagesByTokenShare` in `src/agents/compaction.ts` splits message arrays purely by token count. This can cause a split to land exactly between an `assistant` message containing a `tool_use` block and its corresponding `toolResult` message. This results in chunks with orphaned tool calls or orphaned tool results, which are rejected by strict APIs (like Anthropic) during `summarizeInStages`.
- **Root Cause**: The split decision (`currentTokens + messageTokens > targetTokens`) did not consider the semantic boundary between tool calls and their results. It blindly cut the array, breaking the invariant that a `toolResult` must immediately follow its matching `assistant` turn.
- **Fix**: Introduced a `pendingToolCallIds` set to track tool call boundaries during the iteration. When an `assistant` message contains tool calls, the split is deferred until all matching `toolResult` messages are consumed. This guarantees that `tool_use` and `toolResult` pairs are never separated into different chunks.
- **What changed**: 
  - `src/agents/compaction.ts`: Added boundary tracking logic in `splitMessagesByTokenShare`.
  - `src/agents/compaction.test.ts`: Added two regression tests to verify that `tool_use` and `toolResult` pairs (including multiple results for a single assistant turn) stay in the same chunk.
- **What did NOT change (scope boundary)**: Did not modify `chunkMessagesByMaxTokens` (which operates on messages that have already had tool result details stripped), and did not change the downstream repair logic in `session-transcript-repair.ts`.

### Reproduction

1. Have a conversation where the agent makes a tool call, and the tool returns a very large result.
2. The context grows large enough to trigger `summarizeInStages`.
3. `splitMessagesByTokenShare` cuts the history into chunks. If the token boundary falls right after the `assistant` tool call but before the `toolResult`, the resulting chunk sent to the LLM for summarization contains an orphaned `tool_use`, causing an API rejection (e.g., "unexpected tool_use_id").

### Risk / Mitigation

- **Risk**: Deferring splits could cause a chunk to exceed its token target if a tool result is massive.
- **Mitigation**: This is acceptable and handled by downstream code. `splitMessagesByTokenShare` is a soft-split for summarization parts. The actual summarization call (`summarizeChunks`) already uses `chunkMessagesByMaxTokens` as a hard limit and strips tool result details before sending to the LLM, so a slightly larger logical chunk here will not cause context window overflows.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents

### Linked Issue/PR

Fixes #58836