### PR TITLE
fix(openai): preserve Gemini tool call thought signatures

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1517,6 +1517,133 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
+  it("adds OpenRouter attribution headers to stream options", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+
+    applyExtraParamsToAgent(agent, undefined, "openrouter", "openrouter/auto");
+
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "openrouter/auto",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, { headers: { "X-Custom": "1" } });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.headers).toEqual({
+      "HTTP-Referer": "https://openclaw.ai",
+      "X-OpenRouter-Title": "OpenClaw",
+      "X-OpenRouter-Categories": "cli-agent",
+      "X-Custom": "1",
+    });
+  });
+
+  it("injects Gemini 3 tool call thought_signature into OpenAI-compatible payloads", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "custom-openai",
+      applyModelId: "gemini-3.1-pro-preview",
+      model: {
+        api: "openai-completions",
+        provider: "custom-openai",
+        id: "gemini-3.1-pro-preview",
+        baseUrl: "https://proxy.example.com/v1",
+      } as Model<"openai-completions">,
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              {
+                id: "call_read_1",
+                type: "function",
+                function: {
+                  name: "read",
+                  arguments: "{\"path\":\"README.md\"}",
+                },
+              },
+            ],
+            reasoning_details: [
+              {
+                type: "reasoning.encrypted",
+                id: "call_read_1",
+                data: "AQID",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const assistantMessage = (payload.messages as Array<Record<string, unknown>>)[0];
+    const toolCall = (assistantMessage.tool_calls as Array<Record<string, unknown>>)[0] ?? {};
+    expect(toolCall.extra_content).toEqual({
+      google: {
+        thought_signature: "AQID",
+      },
+    });
+    expect(assistantMessage.reasoning_details).toEqual([
+      {
+        type: "reasoning.encrypted",
+        id: "call_read_1",
+        data: "AQID",
+      },
+    ]);
+  });
+
+  it("does not overwrite existing Gemini tool call thought_signature payloads", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "custom-openai",
+      applyModelId: "gemini-3.1-pro-preview",
+      model: {
+        api: "openai-completions",
+        provider: "custom-openai",
+        id: "gemini-3.1-pro-preview",
+        baseUrl: "https://proxy.example.com/v1",
+      } as Model<"openai-completions">,
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              {
+                id: "call_read_1",
+                type: "function",
+                function: {
+                  name: "read",
+                  arguments: "{\"path\":\"README.md\"}",
+                },
+                extra_content: {
+                  google: {
+                    thought_signature: "existing-signature",
+                  },
+                },
+              },
+            ],
+            reasoning_details: [
+              {
+                type: "reasoning.encrypted",
+                id: "call_read_1",
+                data: "AQID",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const assistantMessage = (payload.messages as Array<Record<string, unknown>>)[0];
+    const toolCall = (assistantMessage.tool_calls as Array<Record<string, unknown>>)[0] ?? {};
+    expect(toolCall.extra_content).toEqual({
+      google: {
+        thought_signature: "existing-signature",
+      },
+    });
+  });
+
   it("preserves Gemma 4 thinking off instead of rewriting thinkingBudget=0 to MINIMAL", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
@@ -1581,6 +1708,48 @@ describe("applyExtraParamsToAgent", () => {
         thinkingLevel: "HIGH",
       },
     });
+  });
+
+  it("does not inject Gemini tool call thought_signature for non-Gemini models", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "custom-openai",
+      applyModelId: "gpt-4.1",
+      model: {
+        api: "openai-completions",
+        provider: "custom-openai",
+        id: "gpt-4.1",
+        baseUrl: "https://proxy.example.com/v1",
+      } as Model<"openai-completions">,
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              {
+                id: "call_read_1",
+                type: "function",
+                function: {
+                  name: "read",
+                  arguments: "{\"path\":\"README.md\"}",
+                },
+              },
+            ],
+            reasoning_details: [
+              {
+                type: "reasoning.encrypted",
+                id: "call_read_1",
+                data: "AQID",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const assistantMessage = (payload.messages as Array<Record<string, unknown>>)[0];
+    const toolCall = (assistantMessage.tool_calls as Array<Record<string, unknown>>)[0] ?? {};
+    expect(toolCall).not.toHaveProperty("extra_content");
   });
   it("passes configured websocket transport through stream options", () => {
     const { calls, agent } = createOptionsCaptureAgent();

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1751,6 +1751,49 @@ describe("applyExtraParamsToAgent", () => {
     const toolCall = (assistantMessage.tool_calls as Array<Record<string, unknown>>)[0] ?? {};
     expect(toolCall).not.toHaveProperty("extra_content");
   });
+
+  it("does not inject Gemini tool call thought_signature for gemini-30 style model ids", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "custom-openai",
+      applyModelId: "gemini-30-pro-preview",
+      model: {
+        api: "openai-completions",
+        provider: "custom-openai",
+        id: "gemini-30-pro-preview",
+        baseUrl: "https://proxy.example.com/v1",
+      } as Model<"openai-completions">,
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              {
+                id: "call_read_1",
+                type: "function",
+                function: {
+                  name: "read",
+                  arguments: "{\"path\":\"README.md\"}",
+                },
+              },
+            ],
+            reasoning_details: [
+              {
+                type: "reasoning.encrypted",
+                id: "call_read_1",
+                data: "AQID",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const assistantMessage = (payload.messages as Array<Record<string, unknown>>)[0];
+    const toolCall = (assistantMessage.tool_calls as Array<Record<string, unknown>>)[0] ?? {};
+    expect(toolCall).not.toHaveProperty("extra_content");
+  });
+
   it("passes configured websocket transport through stream options", () => {
     const { calls, agent } = createOptionsCaptureAgent();
     const cfg = {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1517,29 +1517,6 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
-  it("adds OpenRouter attribution headers to stream options", () => {
-    const { calls, agent } = createOptionsCaptureAgent();
-
-    applyExtraParamsToAgent(agent, undefined, "openrouter", "openrouter/auto");
-
-    const model = {
-      api: "openai-completions",
-      provider: "openrouter",
-      id: "openrouter/auto",
-    } as Model<"openai-completions">;
-    const context: Context = { messages: [] };
-
-    void agent.streamFn?.(model, context, { headers: { "X-Custom": "1" } });
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.headers).toEqual({
-      "HTTP-Referer": "https://openclaw.ai",
-      "X-OpenRouter-Title": "OpenClaw",
-      "X-OpenRouter-Categories": "cli-agent",
-      "X-Custom": "1",
-    });
-  });
-
   it("injects Gemini 3 tool call thought_signature into OpenAI-compatible payloads", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "custom-openai",
@@ -1561,7 +1538,7 @@ describe("applyExtraParamsToAgent", () => {
                 type: "function",
                 function: {
                   name: "read",
-                  arguments: "{\"path\":\"README.md\"}",
+                  arguments: '{"path":"README.md"}',
                 },
               },
             ],
@@ -1614,7 +1591,7 @@ describe("applyExtraParamsToAgent", () => {
                 type: "function",
                 function: {
                   name: "read",
-                  arguments: "{\"path\":\"README.md\"}",
+                  arguments: '{"path":"README.md"}',
                 },
                 extra_content: {
                   google: {
@@ -1731,7 +1708,7 @@ describe("applyExtraParamsToAgent", () => {
                 type: "function",
                 function: {
                   name: "read",
-                  arguments: "{\"path\":\"README.md\"}",
+                  arguments: '{"path":"README.md"}',
                 },
               },
             ],
@@ -1773,7 +1750,7 @@ describe("applyExtraParamsToAgent", () => {
                 type: "function",
                 function: {
                   name: "read",
-                  arguments: "{\"path\":\"README.md\"}",
+                  arguments: '{"path":"README.md"}',
                 },
               },
             ],

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -20,6 +20,7 @@ import {
   shouldApplySiliconFlowThinkingOffCompat,
 } from "./moonshot-stream-wrappers.js";
 import {
+  createGeminiToolCallThoughtSignatureWrapper,
   createOpenAIResponsesContextManagementWrapper,
   createOpenAIStringContentWrapper,
 } from "./openai-stream-wrappers.js";
@@ -538,6 +539,7 @@ function applyPostPluginStreamWrappers(
   }
   ctx.agent.streamFn = createOpenAICompletionsStoreCompatWrapper(ctx.agent.streamFn);
 
+  ctx.agent.streamFn = createGeminiToolCallThoughtSignatureWrapper(ctx.agent.streamFn);
   const rawParallelToolCalls = resolveAliasedParamValue(
     [ctx.effectiveExtraParams, ctx.override],
     "parallel_tool_calls",

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -146,7 +146,11 @@ function patchGeminiToolCallThoughtSignatures(payloadObj: Record<string, unknown
       id?: unknown;
       extra_content?: unknown;
     }>) {
-      if (!toolCallEntry || typeof toolCallEntry !== "object" || typeof toolCallEntry.id !== "string") {
+      if (
+        !toolCallEntry ||
+        typeof toolCallEntry !== "object" ||
+        typeof toolCallEntry.id !== "string"
+      ) {
         continue;
       }
 
@@ -163,7 +167,10 @@ function patchGeminiToolCallThoughtSignatures(payloadObj: Record<string, unknown
         extraContent.google && typeof extraContent.google === "object"
           ? { ...(extraContent.google as Record<string, unknown>) }
           : {};
-      if (typeof googleContent.thought_signature === "string" && googleContent.thought_signature.trim()) {
+      if (
+        typeof googleContent.thought_signature === "string" &&
+        googleContent.thought_signature.trim()
+      ) {
         continue;
       }
       googleContent.thought_signature = thoughtSignature;

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -21,6 +21,7 @@ import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 
 type OpenAIServiceTier = "auto" | "default" | "flex" | "priority";
 export { resolveOpenAITextVerbosity };
+const GEMINI_3_MODEL_ID_PATTERN = /\bgemini-3(?:$|[._-])/i;
 
 function resolveOpenAIRequestCapabilities(model: {
   api?: unknown;
@@ -83,6 +84,93 @@ function shouldFlattenOpenAICompletionMessages(model: {
       ? (model.compat as { requiresStringContent?: unknown })
       : undefined;
   return model.api === "openai-completions" && compat?.requiresStringContent === true;
+}
+
+function shouldApplyGeminiToolCallThoughtSignatureCompat(model: {
+  api?: unknown;
+  id?: unknown;
+}): boolean {
+  if (model.api !== "openai-completions") {
+    return false;
+  }
+  return typeof model.id === "string" && GEMINI_3_MODEL_ID_PATTERN.test(model.id);
+}
+
+function patchGeminiToolCallThoughtSignatures(payloadObj: Record<string, unknown>): void {
+  const messages = payloadObj.messages;
+  if (!Array.isArray(messages)) {
+    return;
+  }
+
+  for (const entry of messages) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+
+    const message = entry as {
+      role?: unknown;
+      tool_calls?: unknown;
+      reasoning_details?: unknown;
+    };
+    if (message.role !== "assistant" || !Array.isArray(message.tool_calls)) {
+      continue;
+    }
+    if (!Array.isArray(message.reasoning_details) || message.reasoning_details.length === 0) {
+      continue;
+    }
+
+    const thoughtSignatures = new Map<string, string>();
+    for (const detail of message.reasoning_details as Array<{
+      type?: unknown;
+      id?: unknown;
+      data?: unknown;
+    }>) {
+      if (
+        detail?.type !== "reasoning.encrypted" ||
+        typeof detail.id !== "string" ||
+        typeof detail.data !== "string"
+      ) {
+        continue;
+      }
+      const thoughtSignature = detail.data.trim();
+      if (thoughtSignature) {
+        thoughtSignatures.set(detail.id, thoughtSignature);
+      }
+    }
+
+    if (thoughtSignatures.size === 0) {
+      continue;
+    }
+
+    for (const toolCallEntry of message.tool_calls as Array<{
+      id?: unknown;
+      extra_content?: unknown;
+    }>) {
+      if (!toolCallEntry || typeof toolCallEntry !== "object" || typeof toolCallEntry.id !== "string") {
+        continue;
+      }
+
+      const thoughtSignature = thoughtSignatures.get(toolCallEntry.id);
+      if (!thoughtSignature) {
+        continue;
+      }
+
+      const extraContent =
+        toolCallEntry.extra_content && typeof toolCallEntry.extra_content === "object"
+          ? { ...(toolCallEntry.extra_content as Record<string, unknown>) }
+          : {};
+      const googleContent =
+        extraContent.google && typeof extraContent.google === "object"
+          ? { ...(extraContent.google as Record<string, unknown>) }
+          : {};
+      if (typeof googleContent.thought_signature === "string" && googleContent.thought_signature.trim()) {
+        continue;
+      }
+      googleContent.thought_signature = thoughtSignature;
+      extraContent.google = googleContent;
+      toolCallEntry.extra_content = extraContent;
+    }
+  }
 }
 
 function normalizeOpenAIServiceTier(value: unknown): OpenAIServiceTier | undefined {
@@ -267,6 +355,20 @@ export function createOpenAIThinkingLevelWrapper(
   };
 }
 
+export function createGeminiToolCallThoughtSignatureWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (!shouldApplyGeminiToolCallThoughtSignatureCompat(model)) {
+      return underlying(model, context, options);
+    }
+    return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
+      patchGeminiToolCallThoughtSignatures(payloadObj);
+    });
+  };
+}
+
 export function createOpenAIFastModeWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
@@ -340,6 +442,7 @@ export function createOpenAITextVerbosityWrapper(
     });
   };
 }
+
 export function createCodexNativeWebSearchWrapper(
   baseStreamFn: StreamFn | undefined,
   params: { config?: OpenClawConfig; agentDir?: string },


### PR DESCRIPTION
## Summary
- restore `tool_calls[*].extra_content.google.thought_signature` for Gemini 3 OpenAI-compatible chat completions payloads
- derive the signature from existing `reasoning_details` entries without overwriting payloads that already include the Google-specific field
- add regression coverage for Gemini payload injection and non-Gemini safety

Fixes #58235

## Testing
- `pnpm.cmd exec vitest run src/agents/pi-embedded-runner-extraparams.test.ts`
