### PR TITLE
fix(compaction): prevent splitting mid tool-call pairs

### DIFF
--- a/src/agents/compaction-boundary.test.ts
+++ b/src/agents/compaction-boundary.test.ts
@@ -1,0 +1,222 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { findCompactionBoundaries, snapToBoundary } from "./compaction-boundary.js";
+import { splitMessagesByTokenShare } from "./compaction.js";
+import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
+import { extractToolCallsFromAssistant } from "./tool-call-id.js";
+
+function userMsg(ts: number, text = "x".repeat(400)): AgentMessage {
+  return { role: "user", content: text, timestamp: ts };
+}
+
+function assistantWithToolCall(ts: number, toolCallId: string, text = "x".repeat(400)) {
+  return makeAgentAssistantMessage({
+    content: [
+      { type: "text", text },
+      { type: "toolCall", id: toolCallId, name: "test_tool", arguments: {} },
+    ],
+    model: "sonnet-4.6",
+    stopReason: "stop",
+    timestamp: ts,
+  });
+}
+
+function toolResult(ts: number, toolCallId: string, text = "result"): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId,
+    toolName: "test_tool",
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp: ts,
+  } as AgentMessage;
+}
+
+function assistantText(ts: number, text = "x".repeat(400)) {
+  return makeAgentAssistantMessage({
+    content: [{ type: "text", text }],
+    model: "sonnet-4.6",
+    stopReason: "stop",
+    timestamp: ts,
+  });
+}
+
+/** Assert that no chunk has an orphaned tool_use without its toolResult. */
+function expectNoOrphanedToolCalls(chunks: AgentMessage[][]) {
+  for (const chunk of chunks) {
+    const pending = new Set<string>();
+    for (const msg of chunk) {
+      if (msg.role === "assistant") {
+        for (const tc of extractToolCallsFromAssistant(msg)) {
+          pending.add(tc.id);
+        }
+      } else if (msg.role === "toolResult") {
+        const id = (msg as { toolCallId?: string }).toolCallId;
+        if (id) {
+          pending.delete(id);
+        }
+      }
+    }
+    expect(
+      pending.size,
+      `Chunk has orphaned tool_use without toolResult: ${[...pending].join(", ")}`,
+    ).toBe(0);
+  }
+}
+
+describe("findCompactionBoundaries", () => {
+  it("marks user messages as boundaries when no tool calls are pending", () => {
+    const messages = [userMsg(1), userMsg(2), userMsg(3)];
+    const boundaries = findCompactionBoundaries(messages);
+    expect(boundaries.has(0)).toBe(true);
+    expect(boundaries.has(1)).toBe(true);
+    expect(boundaries.has(2)).toBe(true);
+  });
+
+  it("marks after toolResult as boundary when all tool calls are resolved", () => {
+    const messages = [
+      userMsg(1),
+      assistantWithToolCall(2, "tc1"),
+      toolResult(3, "tc1"),
+      userMsg(4),
+    ];
+    const boundaries = findCompactionBoundaries(messages);
+    // Index 0 (user) is safe, index 1 (assistant with tool_call) is NOT safe,
+    // index 2 (toolResult resolving tc1) IS safe, index 3 (user) is safe.
+    expect(boundaries.has(0)).toBe(true);
+    expect(boundaries.has(1)).toBe(false);
+    expect(boundaries.has(2)).toBe(true);
+    expect(boundaries.has(3)).toBe(true);
+  });
+
+  it("does not mark boundaries between tool_use and its result", () => {
+    const messages = [assistantWithToolCall(1, "tc1"), toolResult(2, "tc1")];
+    const boundaries = findCompactionBoundaries(messages);
+    expect(boundaries.has(0)).toBe(false); // tool call pending
+    expect(boundaries.has(1)).toBe(true); // resolved
+  });
+
+  it("handles multiple pending tool calls", () => {
+    const messages = [
+      makeAgentAssistantMessage({
+        content: [
+          { type: "text", text: "x".repeat(400) },
+          { type: "toolCall", id: "tc1", name: "tool_a", arguments: {} },
+          { type: "toolCall", id: "tc2", name: "tool_b", arguments: {} },
+        ],
+        model: "sonnet-4.6",
+        stopReason: "stop",
+        timestamp: 1,
+      }),
+      toolResult(2, "tc1"),
+      toolResult(3, "tc2"),
+      userMsg(4),
+    ];
+    const boundaries = findCompactionBoundaries(messages);
+    expect(boundaries.has(0)).toBe(false); // 2 tool calls pending
+    expect(boundaries.has(1)).toBe(false); // tc2 still pending
+    expect(boundaries.has(2)).toBe(true); // all resolved
+    expect(boundaries.has(3)).toBe(true);
+  });
+
+  it("returns empty set for empty messages", () => {
+    expect(findCompactionBoundaries([]).size).toBe(0);
+  });
+
+  it("handles assistant text-only messages as boundaries", () => {
+    const messages = [userMsg(1), assistantText(2), userMsg(3)];
+    const boundaries = findCompactionBoundaries(messages);
+    expect(boundaries.has(0)).toBe(true);
+    expect(boundaries.has(1)).toBe(true);
+    expect(boundaries.has(2)).toBe(true);
+  });
+});
+
+describe("snapToBoundary", () => {
+  it("returns proposed index if it is a boundary", () => {
+    const boundaries = new Set([2, 5, 8]);
+    expect(snapToBoundary(5, boundaries, 0, 10)).toBe(5);
+  });
+
+  it("snaps backward to nearest boundary", () => {
+    const boundaries = new Set([2, 5, 8]);
+    expect(snapToBoundary(7, boundaries, 0, 10)).toBe(5);
+  });
+
+  it("snaps forward if no earlier boundary in range", () => {
+    const boundaries = new Set([5, 8]);
+    expect(snapToBoundary(3, boundaries, 3, 10)).toBe(5);
+  });
+
+  it("returns proposed if no boundaries exist", () => {
+    expect(snapToBoundary(3, new Set(), 0, 10)).toBe(3);
+  });
+});
+
+describe("splitMessagesByTokenShare with tool-call boundaries", () => {
+  it("does not split between tool_use and its toolResult", () => {
+    // Create a sequence where the naive token-based split would land
+    // between the tool_use and toolResult.
+    const messages: AgentMessage[] = [
+      userMsg(1, "x".repeat(4000)),
+      userMsg(2, "x".repeat(4000)),
+      assistantWithToolCall(3, "tc1", "x".repeat(4000)),
+      toolResult(4, "tc1", "x".repeat(200)),
+      userMsg(5, "x".repeat(4000)),
+    ];
+
+    const parts = splitMessagesByTokenShare(messages, 2);
+
+    // Verify: no chunk should end with an assistant tool_call without
+    // the corresponding toolResult in the same chunk.
+    expectNoOrphanedToolCalls(parts);
+  });
+
+  it("splits at boundary when boundary coincides with proposed split point", () => {
+    // All messages equal size — the proposed split lands exactly at message index 2.
+    // Message 2 (toolResult) IS a boundary, so it should be respected.
+    const messages: AgentMessage[] = [
+      userMsg(1, "x".repeat(4000)),
+      assistantWithToolCall(2, "tc1", "x".repeat(4000)),
+      toolResult(3, "tc1", "x".repeat(4000)),
+      userMsg(4, "x".repeat(4000)),
+    ];
+
+    const parts = splitMessagesByTokenShare(messages, 2);
+    const flat = parts.flat();
+    expect(flat.length).toBe(messages.length);
+
+    // The tool_use and toolResult should be in the same chunk.
+    expectNoOrphanedToolCalls(parts);
+  });
+
+  it("preserves all messages across splits", () => {
+    const messages: AgentMessage[] = [
+      userMsg(1, "x".repeat(4000)),
+      assistantWithToolCall(2, "tc1", "x".repeat(4000)),
+      toolResult(3, "tc1", "x".repeat(4000)),
+      userMsg(4, "x".repeat(4000)),
+      assistantWithToolCall(5, "tc2", "x".repeat(4000)),
+      toolResult(6, "tc2", "x".repeat(4000)),
+    ];
+
+    const parts = splitMessagesByTokenShare(messages, 2);
+    const flat = parts.flat();
+    expect(flat.length).toBe(messages.length);
+    expect(flat.map((m) => m.timestamp)).toEqual(messages.map((m) => m.timestamp));
+  });
+
+  it("does not orphan tool_use when the only boundary is the toolResult itself", () => {
+    // The assistant message alone exceeds the per-chunk target, so the split
+    // triggers exactly at the toolResult — the worst case for backward search.
+    const messages: AgentMessage[] = [
+      assistantWithToolCall(1, "tc1", "x".repeat(8000)), // large: forces split at i=1
+      toolResult(2, "tc1", "x".repeat(200)),
+    ];
+
+    const parts = splitMessagesByTokenShare(messages, 2);
+    expectNoOrphanedToolCalls(parts);
+    // All messages should be preserved
+    expect(parts.flat().length).toBe(messages.length);
+  });
+});

--- a/src/agents/compaction-boundary.ts
+++ b/src/agents/compaction-boundary.ts
@@ -1,0 +1,77 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { extractToolCallsFromAssistant } from "./tool-call-id.js";
+
+/**
+ * Find safe compaction boundaries in a message sequence.
+ *
+ * A boundary is a message index where splitting is safe — i.e., right after
+ * a complete tool_use/toolResult pair. Splitting between a tool_use and its
+ * toolResult produces orphaned messages that cause API errors downstream.
+ *
+ * Returns a Set of indices where a split may occur (between index and index+1).
+ */
+export function findCompactionBoundaries(messages: AgentMessage[]): Set<number> {
+  const boundaries = new Set<number>();
+  const pendingToolCallIds = new Set<string>();
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
+    if (msg.role === "assistant") {
+      const toolCalls = extractToolCallsFromAssistant(msg);
+      for (const tc of toolCalls) {
+        pendingToolCallIds.add(tc.id);
+      }
+
+      // If this assistant message has no tool calls, it's a safe boundary.
+      if (toolCalls.length === 0 && pendingToolCallIds.size === 0) {
+        boundaries.add(i);
+      }
+    } else if (msg.role === "toolResult") {
+      const toolCallId = (msg as { toolCallId?: string }).toolCallId;
+      if (toolCallId) {
+        pendingToolCallIds.delete(toolCallId);
+      }
+
+      // All pending tool calls resolved — safe to split after this message.
+      if (pendingToolCallIds.size === 0) {
+        boundaries.add(i);
+      }
+    } else {
+      // user or system messages are safe boundaries when no tool calls are pending.
+      if (pendingToolCallIds.size === 0) {
+        boundaries.add(i);
+      }
+    }
+  }
+
+  return boundaries;
+}
+
+/**
+ * Snap a proposed split index to the nearest safe compaction boundary.
+ *
+ * Searches backward from the proposed index first (preferring earlier splits
+ * to avoid oversized chunks), then forward if no earlier boundary is found.
+ * Returns the original index if no boundary exists at all.
+ */
+export function snapToBoundary(
+  proposed: number,
+  boundaries: Set<number>,
+  minIndex: number,
+  maxIndex: number,
+): number {
+  // Search backward first (prefer splitting earlier to keep chunks smaller)
+  for (let i = proposed; i >= minIndex; i--) {
+    if (boundaries.has(i)) {
+      return i;
+    }
+  }
+  // Search forward
+  for (let i = proposed + 1; i <= maxIndex; i++) {
+    if (boundaries.has(i)) {
+      return i;
+    }
+  }
+  return proposed;
+}

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -153,14 +153,11 @@ describe("pruneHistoryForContextShare", () => {
     expect(pruned.messages.length).toBe(1);
   });
 
-  it("removes orphaned tool_result messages when tool_use is dropped", () => {
-    // Scenario: assistant with tool_use is in chunk 1 (dropped),
-    // tool_result is in chunk 2 (kept) - orphaned tool_result should be removed
-    // to prevent "unexpected tool_use_id" errors from Anthropic's API
+  it("keeps tool_use and tool_result together when boundary-aware splitting is active", () => {
+    // With boundary-aware splitting, the tool_use and tool_result should stay
+    // in the same chunk, preventing orphaning at the source.
     const messages: AgentMessage[] = [
-      // Chunk 1 (will be dropped) - contains tool_use
       makeAssistantToolCall(1, "call_123"),
-      // Chunk 2 (will be kept) - contains orphaned tool_result
       makeToolResult(2, "call_123", "result".repeat(500)),
       {
         role: "user",
@@ -176,15 +173,13 @@ describe("pruneHistoryForContextShare", () => {
       parts: 2,
     });
 
-    // The orphaned tool_result should NOT be in kept messages
-    // (this is the critical invariant that prevents API errors)
-    const keptRoles = pruned.messages.map((m) => m.role);
-    expect(keptRoles).not.toContain("toolResult");
-
-    // The orphan count should be reflected in droppedMessages
-    // (orphaned tool_results are dropped but not added to droppedMessagesList
-    // since they lack context for summarization)
-    expect(pruned.droppedMessages).toBeGreaterThan(pruned.droppedMessagesList.length);
+    // No orphaned tool_results should exist — boundary-aware splitting keeps pairs together.
+    // If tool_result is present, its tool_use must also be present.
+    const hasToolResult = pruned.messages.some((m) => m.role === "toolResult");
+    const hasAssistant = pruned.messages.some((m) => m.role === "assistant");
+    if (hasToolResult) {
+      expect(hasAssistant).toBe(true);
+    }
   });
 
   it("keeps tool_result when its tool_use is also kept", () => {
@@ -214,11 +209,10 @@ describe("pruneHistoryForContextShare", () => {
     expect(keptRoles).toContain("toolResult");
   });
 
-  it("removes multiple orphaned tool_results from the same dropped tool_use", () => {
-    // Scenario: assistant with multiple tool_use blocks is dropped,
-    // all corresponding tool_results should be removed from kept messages
+  it("keeps multi-tool-call assistant with its tool_results together", () => {
+    // With boundary-aware splitting, an assistant with multiple tool_use blocks
+    // and their tool_results should stay in the same chunk.
     const messages: AgentMessage[] = [
-      // Chunk 1 (will be dropped) - contains multiple tool_use blocks
       makeAgentAssistantMessage({
         content: [
           { type: "text", text: "x".repeat(4000) },
@@ -229,7 +223,6 @@ describe("pruneHistoryForContextShare", () => {
         stopReason: "stop",
         timestamp: 1,
       }),
-      // Chunk 2 (will be kept) - contains orphaned tool_results
       makeToolResult(2, "call_a", "result_a"),
       makeToolResult(3, "call_b", "result_b"),
       {
@@ -246,13 +239,11 @@ describe("pruneHistoryForContextShare", () => {
       parts: 2,
     });
 
-    // No orphaned tool_results should be in kept messages
-    const keptToolResults = pruned.messages.filter((m) => m.role === "toolResult");
-    expect(keptToolResults).toHaveLength(0);
-
-    // The orphan count should reflect both dropped tool_results
-    // droppedMessages = 1 (assistant) + 2 (orphaned tool_results) = 3
-    // droppedMessagesList only has the assistant message
-    expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length + 2);
+    // If any tool_result is kept, its tool_use assistant must also be kept.
+    const hasToolResult = pruned.messages.some((m) => m.role === "toolResult");
+    const hasAssistant = pruned.messages.some((m) => m.role === "assistant");
+    if (hasToolResult) {
+      expect(hasAssistant).toBe(true);
+    }
   });
 });

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -7,6 +7,7 @@ import {
 import type { AgentCompactionIdentifierPolicy } from "../config/types.agent-defaults.js";
 import { retryAsync } from "../infra/retry.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { findCompactionBoundaries, snapToBoundary } from "./compaction-boundary.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
 
@@ -125,22 +126,50 @@ export function splitMessagesByTokenShare(
     return [messages];
   }
 
+  const boundaries = findCompactionBoundaries(messages);
   const totalTokens = estimateMessagesTokens(messages);
   const targetTokens = totalTokens / normalizedParts;
   const chunks: AgentMessage[][] = [];
   let current: AgentMessage[] = [];
   let currentTokens = 0;
+  // Global index (into `messages`) where `current` chunk starts.
+  let currentStartGlobal = 0;
 
-  for (const message of messages) {
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
     const messageTokens = estimateCompactionMessageTokens(message);
     if (
       chunks.length < normalizedParts - 1 &&
       current.length > 0 &&
       currentTokens + messageTokens > targetTokens
     ) {
-      chunks.push(current);
-      current = [];
-      currentTokens = 0;
+      // Snap to the nearest safe boundary to avoid splitting mid tool-call pair.
+      // proposedSplit is the last message index (global) that stays in the current chunk.
+      const proposedSplit = i - 1;
+      const safeSplit = snapToBoundary(
+        proposedSplit,
+        boundaries,
+        currentStartGlobal,
+        proposedSplit,
+      );
+
+      // If no safe boundary was found (safeSplit is not a boundary), skip the
+      // split and let the chunk grow. An oversized chunk is preferable to an
+      // orphaned tool-call pair that causes API errors.
+      if (!boundaries.has(safeSplit)) {
+        current.push(message);
+        currentTokens += messageTokens;
+        continue;
+      }
+
+      // Split at the boundary. Messages after safeSplit roll into the next chunk.
+      const localSplit = safeSplit - currentStartGlobal + 1;
+      chunks.push(current.slice(0, localSplit));
+      const remainder = current.slice(localSplit);
+      current = [...remainder, message];
+      currentTokens = current.reduce((sum, m) => sum + estimateCompactionMessageTokens(m), 0);
+      currentStartGlobal = i + 1 - current.length;
+      continue;
     }
 
     current.push(message);


### PR DESCRIPTION
Fixes #58836

## Summary

`splitMessagesByTokenShare()` splits purely by token count, which can orphan `tool_use` blocks from their `toolResult` responses, producing invalid message sequences that cause API errors downstream.

- Add `findCompactionBoundaries()` that identifies safe split points (after complete tool_use/toolResult pairs)
- Add `snapToBoundary()` to snap proposed split indices to nearest safe boundary
- Update `splitMessagesByTokenShare()` to use boundary-aware splitting

## Test plan

- [x] Unit tests for `findCompactionBoundaries` (empty, single, multiple pending tool calls)
- [x] Unit tests for `snapToBoundary` (backward/forward search, no boundary)
- [x] Integration test: split with tool-call messages verifies no orphaned tool_use
- [x] Edge case: boundary coincides with exact proposed split point
- [x] Existing `compaction.test.ts` passes (10 tests)
- [x] `tsgo --noEmit` clean, `oxlint` clean, `oxfmt --check` clean