### PR TITLE
fix(agents): normalize provider errors for better failover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 - Memory/session indexing: keep full reindexes from skipping session transcripts when sync is triggered by `session-start` or `watch`, so restart-driven reindexes preserve session memory (#39732) thanks @upupc
 - Telegram/retries: keep non-idempotent sends on the strict safe-send path, retry wrapped pre-connect failures, and preserve `429` / `retry_after` backoff for safe delivery retries. (#51895) Thanks @chinar-amrutkar
 - Agents/Anthropic: preserve thinking blocks and signatures across replay, cache-control patching, and context pruning so compacted Anthropic sessions continue working instead of failing on later turns. (#58916) Thanks @obviyus
+- Agents/failover: unify structured and raw provider error classification so provider-specific `400`/`422` payloads no longer get forced into generic format failures before retry, billing, or compaction logic can inspect them. (#58856) Thanks @aaron-he-zhu.
 
 ## 2026.3.31
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -204,6 +204,24 @@ describe("failover-error", () => {
     ).toBe("billing");
   });
 
+  it("lets structured HTTP 400 payloads reuse provider-specific message classification", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 400,
+        message: "ThrottlingException: Too many concurrent requests",
+      }),
+    ).toBe("rate_limit");
+  });
+
+  it("does not misclassify structured HTTP 400 context overflow payloads as format", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 400,
+        message: "INVALID_ARGUMENT: input exceeds the maximum number of tokens",
+      }),
+    ).toBeNull();
+  });
+
   it("treats HTTP 422 as format error", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -548,6 +548,24 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
     expect(classifyFailoverReasonFromHttpStatus(400, INSUFFICIENT_QUOTA_PAYLOAD)).toBe("billing");
   });
 
+  it("keeps HTTP 400 provider-specific rate limits out of the generic format bucket", () => {
+    expect(
+      classifyFailoverReasonFromHttpStatus(
+        400,
+        "ThrottlingException: Too many concurrent requests",
+      ),
+    ).toBe("rate_limit");
+  });
+
+  it("does not force HTTP 400 context-overflow payloads into format", () => {
+    expect(
+      classifyFailoverReasonFromHttpStatus(
+        400,
+        "INVALID_ARGUMENT: input exceeds the maximum number of tokens",
+      ),
+    ).toBeNull();
+  });
+
   it("treats HTTP 499 as transient for structured errors", () => {
     expect(classifyFailoverReasonFromHttpStatus(499)).toBe("timeout");
     expect(classifyFailoverReasonFromHttpStatus(499, "499 Client Closed Request")).toBe("timeout");
@@ -598,6 +616,17 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("HTTP 410: invalid_api_key")).toBe("auth_permanent");
     expect(classifyFailoverReason("HTTP 410: authentication failed")).toBe("auth");
     expect(classifyFailoverReason("HTTP 410: insufficient credits")).toBe("billing");
+  });
+
+  it("keeps raw HTTP 400 wrappers aligned with structured provider classification", () => {
+    expect(
+      classifyFailoverReason("HTTP 400: ThrottlingException: Too many concurrent requests"),
+    ).toBe("rate_limit");
+    expect(
+      classifyFailoverReason(
+        "HTTP 400: INVALID_ARGUMENT: input exceeds the maximum number of tokens",
+      ),
+    ).toBeNull();
   });
 });
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -483,6 +483,7 @@ export function classifyFailoverReasonFromHttpStatus(
   status: number | undefined,
   message?: string,
 ): FailoverReason | null {
+  const messageReason = message ? classifyFailoverReasonFromMessage(message) : null;
   if (typeof status !== "number" || !Number.isFinite(status)) {
     return null;
   }
@@ -507,28 +508,24 @@ export function classifyFailoverReasonFromHttpStatus(
     // remote session/conversation is gone. Generic 410/no-body responses from
     // OpenAI-compatible proxies are better treated as retryable transport-path
     // failures so we do not clear session state or poison auth-profile health.
-    if (message && isCliSessionExpiredErrorMessage(message)) {
-      return "session_expired";
-    }
-    if (message && isBillingErrorMessage(message)) {
-      return "billing";
-    }
-    if (message && isAuthPermanentErrorMessage(message)) {
-      return "auth_permanent";
-    }
-    if (message && isAuthErrorMessage(message)) {
-      return "auth";
+    if (
+      messageReason === "session_expired" ||
+      messageReason === "billing" ||
+      messageReason === "auth_permanent" ||
+      messageReason === "auth"
+    ) {
+      return messageReason;
     }
     return "timeout";
   }
   if (status === 503) {
-    if (message && isOverloadedErrorMessage(message)) {
+    if (messageReason === "overloaded") {
       return "overloaded";
     }
     return "timeout";
   }
   if (status === 499) {
-    if (message && isOverloadedErrorMessage(message)) {
+    if (messageReason === "overloaded") {
       return "overloaded";
     }
     return "timeout";
@@ -540,12 +537,83 @@ export function classifyFailoverReasonFromHttpStatus(
     return "overloaded";
   }
   if (status === 400 || status === 422) {
-    // Some providers return quota/balance errors under HTTP 400, so do not
-    // let the generic format fallback mask an explicit billing signal.
-    if (message && isBillingErrorMessage(message)) {
-      return "billing";
+    // 400/422 are ambiguous: inspect the payload first so provider-specific
+    // rate limits, auth failures, model-not-found errors, and billing signals
+    // are not collapsed into generic "format" failures.
+    if (messageReason) {
+      return messageReason;
+    }
+    // Context overflow does not map to a FailoverReason. Keep it out of the
+    // generic format bucket so callers can handle compaction/reset separately.
+    if (message && isContextOverflowError(message)) {
+      return null;
     }
     return "format";
+  }
+  return null;
+}
+
+function classifyFailoverReasonFromMessage(raw: string): FailoverReason | null {
+  if (isImageDimensionErrorMessage(raw)) {
+    return null;
+  }
+  if (isImageSizeError(raw)) {
+    return null;
+  }
+  if (isCliSessionExpiredErrorMessage(raw)) {
+    return "session_expired";
+  }
+  if (isModelNotFoundErrorMessage(raw)) {
+    return "model_not_found";
+  }
+  const reasonFrom402Text = classifyFailoverReasonFrom402Text(raw);
+  if (reasonFrom402Text) {
+    return reasonFrom402Text;
+  }
+  if (isPeriodicUsageLimitErrorMessage(raw)) {
+    return isBillingErrorMessage(raw) ? "billing" : "rate_limit";
+  }
+  if (isRateLimitErrorMessage(raw)) {
+    return "rate_limit";
+  }
+  if (isOverloadedErrorMessage(raw)) {
+    return "overloaded";
+  }
+  if (isTransientHttpError(raw)) {
+    const status = extractLeadingHttpStatus(raw.trim());
+    if (status?.code === 529) {
+      return "overloaded";
+    }
+    return "timeout";
+  }
+  // Billing and auth classifiers run before the broad isJsonApiInternalServerError
+  // check so that provider errors like {"type":"api_error","message":"insufficient
+  // balance"} are correctly classified as "billing"/"auth" rather than "timeout".
+  if (isBillingErrorMessage(raw)) {
+    return "billing";
+  }
+  if (isAuthPermanentErrorMessage(raw)) {
+    return "auth_permanent";
+  }
+  if (isAuthErrorMessage(raw)) {
+    return "auth";
+  }
+  if (isServerErrorMessage(raw)) {
+    return "timeout";
+  }
+  if (isJsonApiInternalServerError(raw)) {
+    return "timeout";
+  }
+  if (isCloudCodeAssistFormatError(raw)) {
+    return "format";
+  }
+  if (isTimeoutErrorMessage(raw)) {
+    return "timeout";
+  }
+  // Provider-specific patterns as a final catch (Bedrock, Groq, Together AI, etc.)
+  const providerSpecific = classifyProviderSpecificError(raw);
+  if (providerSpecific) {
+    return providerSpecific;
   }
   return null;
 }
@@ -1033,75 +1101,13 @@ function isCliSessionExpiredErrorMessage(raw: string): boolean {
 }
 
 export function classifyFailoverReason(raw: string): FailoverReason | null {
-  if (isImageDimensionErrorMessage(raw)) {
-    return null;
-  }
-  if (isImageSizeError(raw)) {
-    return null;
-  }
-  if (isCliSessionExpiredErrorMessage(raw)) {
-    return "session_expired";
-  }
-  if (isModelNotFoundErrorMessage(raw)) {
-    return "model_not_found";
-  }
   const trimmed = raw.trim();
   const leadingStatus = extractLeadingHttpStatus(trimmed);
-  if (leadingStatus?.code === 410) {
-    return classifyFailoverReasonFromHttpStatus(leadingStatus.code, leadingStatus.rest);
+  const statusReason = classifyFailoverReasonFromHttpStatus(leadingStatus?.code, raw);
+  if (statusReason) {
+    return statusReason;
   }
-  const reasonFrom402Text = classifyFailoverReasonFrom402Text(raw);
-  if (reasonFrom402Text) {
-    return reasonFrom402Text;
-  }
-  if (isPeriodicUsageLimitErrorMessage(raw)) {
-    return isBillingErrorMessage(raw) ? "billing" : "rate_limit";
-  }
-  if (isRateLimitErrorMessage(raw)) {
-    return "rate_limit";
-  }
-  if (isOverloadedErrorMessage(raw)) {
-    return "overloaded";
-  }
-  if (isTransientHttpError(raw)) {
-    // 529 is always overloaded, even without explicit overload keywords in the body.
-    const status = extractLeadingHttpStatus(trimmed);
-    if (status?.code === 529) {
-      return "overloaded";
-    }
-    // Treat remaining transient 5xx provider failures as retryable transport issues.
-    return "timeout";
-  }
-  // Billing and auth classifiers run before the broad isJsonApiInternalServerError
-  // check so that provider errors like {"type":"api_error","message":"insufficient
-  // balance"} are correctly classified as "billing"/"auth" rather than "timeout".
-  if (isBillingErrorMessage(raw)) {
-    return "billing";
-  }
-  if (isAuthPermanentErrorMessage(raw)) {
-    return "auth_permanent";
-  }
-  if (isAuthErrorMessage(raw)) {
-    return "auth";
-  }
-  if (isServerErrorMessage(raw)) {
-    return "timeout";
-  }
-  if (isJsonApiInternalServerError(raw)) {
-    return "timeout";
-  }
-  if (isCloudCodeAssistFormatError(raw)) {
-    return "format";
-  }
-  if (isTimeoutErrorMessage(raw)) {
-    return "timeout";
-  }
-  // Provider-specific patterns as a final catch (Bedrock, Groq, Together AI, etc.)
-  const providerSpecific = classifyProviderSpecificError(raw);
-  if (providerSpecific) {
-    return providerSpecific;
-  }
-  return null;
+  return classifyFailoverReasonFromMessage(raw);
 }
 
 export function isFailoverErrorMessage(raw: string): boolean {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -27,6 +27,10 @@ import {
   isTimeoutErrorMessage,
   matchesFormatErrorPattern,
 } from "./failover-matches.js";
+import {
+  classifyProviderSpecificError,
+  matchesProviderContextOverflow,
+} from "./provider-error-patterns.js";
 import type { FailoverReason } from "./types.js";
 
 export {
@@ -235,7 +239,9 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     errorMessage.includes("上下文超出") ||
     errorMessage.includes("上下文长度超") ||
     errorMessage.includes("超出最大上下文") ||
-    errorMessage.includes("请压缩上下文")
+    errorMessage.includes("请压缩上下文") ||
+    // Provider-specific patterns (Bedrock, Azure, Ollama, Mistral, Cohere, etc.)
+    matchesProviderContextOverflow(errorMessage)
   );
 }
 
@@ -1089,6 +1095,11 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   }
   if (isTimeoutErrorMessage(raw)) {
     return "timeout";
+  }
+  // Provider-specific patterns as a final catch (Bedrock, Groq, Together AI, etc.)
+  const providerSpecific = classifyProviderSpecificError(raw);
+  if (providerSpecific) {
+    return providerSpecific;
   }
   return null;
 }

--- a/src/agents/pi-embedded-helpers/provider-error-patterns.test.ts
+++ b/src/agents/pi-embedded-helpers/provider-error-patterns.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { classifyFailoverReason, isContextOverflowError } from "./errors.js";
+import {
+  classifyProviderSpecificError,
+  matchesProviderContextOverflow,
+} from "./provider-error-patterns.js";
+
+describe("matchesProviderContextOverflow", () => {
+  it.each([
+    // AWS Bedrock
+    "ValidationException: The input is too long for the model",
+    "ValidationException: Input token count exceeds the maximum number of input tokens",
+    "ModelStreamErrorException: Input is too long for this model",
+
+    // Google Vertex
+    "INVALID_ARGUMENT: input exceeds the maximum number of tokens",
+
+    // Ollama
+    "ollama error: context length exceeded, too many tokens",
+
+    // Mistral
+    "mistral: input is too long for this model",
+
+    // Cohere
+    "total tokens exceeds the model's maximum limit of 4096",
+
+    // Generic
+    "input is too long for model gpt-5.4",
+  ])("matches provider-specific overflow: %s", (msg) => {
+    expect(matchesProviderContextOverflow(msg)).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(matchesProviderContextOverflow("rate limit exceeded")).toBe(false);
+    expect(matchesProviderContextOverflow("invalid api key")).toBe(false);
+    expect(matchesProviderContextOverflow("internal server error")).toBe(false);
+  });
+});
+
+describe("classifyProviderSpecificError", () => {
+  it("classifies Bedrock ThrottlingException as rate_limit", () => {
+    expect(classifyProviderSpecificError("ThrottlingException: Too many requests")).toBe(
+      "rate_limit",
+    );
+  });
+
+  it("classifies Bedrock ModelNotReadyException as overloaded", () => {
+    expect(classifyProviderSpecificError("ModelNotReadyException: model is not ready")).toBe(
+      "overloaded",
+    );
+  });
+
+  it("classifies Groq model_deactivated as model_not_found", () => {
+    expect(classifyProviderSpecificError("model_is_deactivated")).toBe("model_not_found");
+  });
+
+  it("classifies concurrency limit as rate_limit", () => {
+    expect(classifyProviderSpecificError("concurrency limit has been reached")).toBe("rate_limit");
+    expect(classifyProviderSpecificError("concurrency limit reached")).toBe("rate_limit");
+  });
+
+  it("does not match generic 'model is not ready' without Bedrock prefix", () => {
+    expect(classifyProviderSpecificError("model is not ready")).toBeNull();
+  });
+
+  it("returns null for unmatched errors", () => {
+    expect(classifyProviderSpecificError("some random error")).toBeNull();
+  });
+});
+
+describe("isContextOverflowError with provider patterns", () => {
+  it("detects Bedrock ValidationException as context overflow", () => {
+    expect(isContextOverflowError("ValidationException: The input is too long for the model")).toBe(
+      true,
+    );
+  });
+
+  it("detects Ollama context overflow", () => {
+    expect(isContextOverflowError("ollama error: context length exceeded")).toBe(true);
+  });
+
+  it("still detects standard context overflow patterns", () => {
+    expect(isContextOverflowError("context length exceeded")).toBe(true);
+    expect(isContextOverflowError("prompt is too long: 150000 tokens > 128000 maximum")).toBe(true);
+  });
+});
+
+describe("classifyFailoverReason with provider patterns", () => {
+  it("classifies Bedrock ThrottlingException via provider patterns", () => {
+    expect(classifyFailoverReason("ThrottlingException: Too many concurrent requests")).toBe(
+      "rate_limit",
+    );
+  });
+
+  it("classifies Groq model_deactivated via provider patterns", () => {
+    expect(classifyFailoverReason("model_is_deactivated: this model has been deactivated")).toBe(
+      "model_not_found",
+    );
+  });
+});

--- a/src/agents/pi-embedded-helpers/provider-error-patterns.ts
+++ b/src/agents/pi-embedded-helpers/provider-error-patterns.ts
@@ -1,0 +1,111 @@
+/**
+ * Provider-specific error patterns that improve failover classification accuracy.
+ *
+ * Many providers return errors in non-standard formats. Without these patterns,
+ * errors get misclassified (e.g., a context overflow classified as "format"),
+ * causing the failover engine to choose wrong recovery strategies.
+ */
+
+import type { FailoverReason } from "./types.js";
+
+type ProviderErrorPattern = {
+  /** Regex to match against the raw error message. */
+  test: RegExp;
+  /** The failover reason this pattern maps to. */
+  reason: FailoverReason;
+};
+
+/**
+ * Provider-specific context overflow patterns not covered by the generic
+ * `isContextOverflowError()` in errors.ts. Called from `isContextOverflowError()`
+ * to catch provider-specific wording that the generic regex misses.
+ */
+export const PROVIDER_CONTEXT_OVERFLOW_PATTERNS: readonly RegExp[] = [
+  // AWS Bedrock
+  /ValidationException.*(?:input is too long|max input token|input token.*exceed)/i,
+  /ValidationException.*(?:exceeds? the (?:maximum|max) (?:number of )?(?:input )?tokens)/i,
+  /ModelStreamErrorException.*(?:Input is too long|too many input tokens)/i,
+
+  // Azure OpenAI (sometimes wraps OpenAI errors differently)
+  /content_filter.*(?:prompt|input).*(?:too long|exceed)/i,
+
+  // Ollama / local models
+  /\bollama\b.*(?:context length|too many tokens|context window)/i,
+  /\btruncating input\b.*\btoo long\b/i,
+
+  // Mistral
+  /\bmistral\b.*(?:input.*too long|token limit.*exceeded)/i,
+
+  // Cohere
+  /\btotal tokens?.*exceeds? (?:the )?(?:model(?:'s)? )?(?:max|maximum|limit)/i,
+
+  // DeepSeek
+  /\bdeepseek\b.*(?:input.*too long|context.*exceed)/i,
+
+  // Google Vertex / Gemini: INVALID_ARGUMENT with token-related messages is context overflow.
+  /INVALID_ARGUMENT.*(?:exceeds? the (?:maximum|max)|input.*too (?:long|large))/i,
+
+  // Generic "input too long" pattern that isn't covered by existing checks
+  /\binput (?:is )?too long for (?:the )?model\b/i,
+];
+
+/**
+ * Provider-specific patterns that map to specific failover reasons.
+ * These handle cases where the generic classifiers in failover-matches.ts
+ * produce wrong results for specific providers.
+ */
+export const PROVIDER_SPECIFIC_PATTERNS: readonly ProviderErrorPattern[] = [
+  // AWS Bedrock: ThrottlingException is rate limit
+  {
+    test: /ThrottlingException|Too many concurrent requests/i,
+    reason: "rate_limit",
+  },
+
+  // AWS Bedrock: ModelNotReadyException (require class prefix to avoid false positives)
+  {
+    test: /ModelNotReadyException/i,
+    reason: "overloaded",
+  },
+
+  // Azure: content_policy_violation should not trigger failover
+  // (it's a content moderation rejection, not a transient error)
+
+  // Groq: model_deactivated is permanent
+  {
+    test: /model(?:_is)?_deactivated|model has been deactivated/i,
+    reason: "model_not_found",
+  },
+
+  // Together AI / Fireworks: specific rate limit messages
+  {
+    test: /\bconcurrency limit\b.*\breached\b/i,
+    reason: "rate_limit",
+  },
+
+  // Cloudflare Workers AI
+  {
+    test: /\bworkers?_ai\b.*\b(?:rate|limit|quota)\b/i,
+    reason: "rate_limit",
+  },
+];
+
+/**
+ * Check if an error message matches any provider-specific context overflow pattern.
+ * Called from `isContextOverflowError()` to catch provider-specific wording.
+ */
+export function matchesProviderContextOverflow(errorMessage: string): boolean {
+  return PROVIDER_CONTEXT_OVERFLOW_PATTERNS.some((pattern) => pattern.test(errorMessage));
+}
+
+/**
+ * Try to classify an error using provider-specific patterns.
+ * Returns null if no provider-specific pattern matches (fall through to generic classification).
+ */
+export function classifyProviderSpecificError(errorMessage: string): FailoverReason | null {
+  for (const pattern of PROVIDER_SPECIFIC_PATTERNS) {
+    if (pattern.test.test(errorMessage)) {
+      return pattern.reason;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Fixes #58837

Related: #58347 #58305 #58377 #58392 (LiveSessionModelSwitchError cluster)

## Summary

Add provider-specific error patterns for AWS Bedrock, Ollama, Mistral, Cohere, DeepSeek, Together AI, and Cloudflare Workers AI. These providers return errors in non-standard formats that the generic classifiers miss, causing incorrect failover behavior.

- Create `provider-error-patterns.ts` with provider-specific matchers
- `matchesProviderContextOverflow()` catches context overflow patterns the generic regex misses
- `classifyProviderSpecificError()` maps provider errors to `FailoverReason`
- Wire into `isContextOverflowError()` and `classifyFailoverReason()` as catch-all layers

Examples fixed:
| Provider | Error | Was | Now |
|---|---|---|---|
| Bedrock | `ThrottlingException` | unclassified | `rate_limit` |
| Bedrock | `ModelNotReadyException` | unclassified | `overloaded` |
| Groq | `model_is_deactivated` | unclassified | `model_not_found` |
| Together AI | `concurrency limit reached` | unclassified | `rate_limit` |

## Test plan

- [x] Unit tests for `matchesProviderContextOverflow` (8 provider samples + negatives)
- [x] Unit tests for `classifyProviderSpecificError` (5 provider mappings)
- [x] Integration tests with `isContextOverflowError` and `classifyFailoverReason`
- [x] Existing failover tests pass (35 tests)
- [x] `tsgo --noEmit` clean, `oxlint` clean, `oxfmt --check` clean