### PR TITLE
fix(exec): resume agent session after approval completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - LINE/runtime: resolve the packaged runtime contract from the built `dist/plugins/runtime` layout so LINE channels start correctly again after global npm installs on `2026.3.31`. (#58799) Thanks @vincentkoc.
 - Subagents/tasks: keep subagent completion and cleanup from crashing when task-registry writes fail, so a corrupt or missing task row no longer takes down the gateway during lifecycle finalization. Thanks @vincentkoc.
 - Sandbox/browser: compare browser runtime inspection against `agents.defaults.sandbox.browser.image` so `openclaw sandbox list --browser` stops reporting healthy browser containers as image mismatches. (#58759) Thanks @sandpile.
+- Exec/approvals: resume the original agent session after an approved async exec finishes, so external completion followups continue the task instead of waiting for a new user turn. (#58860) Thanks @Nanako0129.
 
 ## 2026.3.31
 

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -36,6 +36,13 @@ describe("exec approval followup", () => {
     expect(prompt).not.toContain("already approved has completed");
   });
 
+  it("tells the agent to continue the task before replying when the command succeeds", () => {
+    const prompt = buildExecApprovalFollowupPrompt("Exec finished (gateway id=req-1, code 0)\nok");
+
+    expect(prompt).toContain("continue from this result before replying to the user");
+    expect(prompt).toContain("Continue the task if needed, then reply to the user");
+  });
+
   it("keeps followups internal when no external route is available", async () => {
     await sendExecApprovalFollowup({
       approvalId: "req-1",
@@ -79,7 +86,7 @@ describe("exec approval followup", () => {
       accountId: "default",
       threadId: "789",
     },
-  ])("uses direct external delivery for $channel followups", async (target) => {
+  ])("uses agent continuation for $channel followups when a session exists", async (target) => {
     await sendExecApprovalFollowup({
       approvalId: `req-${target.channel}`,
       sessionKey: target.sessionKey,
@@ -90,17 +97,42 @@ describe("exec approval followup", () => {
       resultText: "slack exec approval smoke",
     });
 
-    expect(sendMessage).toHaveBeenCalledWith(
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "agent",
+      expect.any(Object),
       expect.objectContaining({
+        sessionKey: target.sessionKey,
+        deliver: true,
+        bestEffortDeliver: true,
         channel: target.channel,
         to: target.to,
         accountId: target.accountId,
         threadId: target.threadId,
-        content: "slack exec approval smoke",
-        mirror: expect.objectContaining({
-          sessionKey: target.sessionKey,
-          idempotencyKey: `exec-approval-followup:req-${target.channel}`,
-        }),
+        idempotencyKey: `exec-approval-followup:req-${target.channel}`,
+      }),
+      { expectFinal: true },
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("falls back to direct external delivery only when no session exists", async () => {
+    await sendExecApprovalFollowup({
+      approvalId: "req-no-session",
+      turnSourceChannel: "discord",
+      turnSourceTo: "123",
+      turnSourceAccountId: "default",
+      turnSourceThreadId: "456",
+      resultText: "discord exec approval smoke",
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        to: "123",
+        accountId: "default",
+        threadId: "456",
+        content: "discord exec approval smoke",
+        idempotencyKey: "exec-approval-followup:req-no-session",
       }),
     );
     expect(callGatewayTool).not.toHaveBeenCalled();

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -1,6 +1,5 @@
 import { resolveExternalBestEffortDeliveryTarget } from "../infra/outbound/best-effort-delivery.js";
 import { sendMessage } from "../infra/outbound/message.js";
-import { parseAgentSessionKey } from "../routing/session-key.js";
 import { isGatewayMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
@@ -38,11 +37,13 @@ export function buildExecApprovalFollowupPrompt(resultText: string): string {
   return [
     "An async command the user already approved has completed.",
     "Do not run the command again.",
+    "If the task requires more steps, continue from this result before replying to the user.",
+    "Only ask the user for help if you are actually blocked.",
     "",
     "Exact completion details:",
     trimmed,
     "",
-    "Reply to the user in a helpful way.",
+    "Continue the task if needed, then reply to the user in a helpful way.",
     "If it succeeded, share the relevant output.",
     "If it failed, explain what went wrong.",
   ].join("\n");
@@ -69,59 +70,50 @@ export async function sendExecApprovalFollowup(
       ? normalizedTurnSourceChannel
       : undefined;
 
+  if (sessionKey) {
+    await callGatewayTool(
+      "agent",
+      { timeoutMs: 60_000 },
+      {
+        sessionKey,
+        message: buildExecApprovalFollowupPrompt(resultText),
+        deliver: deliveryTarget.deliver,
+        ...(deliveryTarget.deliver ? { bestEffortDeliver: true as const } : {}),
+        channel: deliveryTarget.deliver ? deliveryTarget.channel : sessionOnlyOriginChannel,
+        to: deliveryTarget.deliver
+          ? deliveryTarget.to
+          : sessionOnlyOriginChannel
+            ? params.turnSourceTo
+            : undefined,
+        accountId: deliveryTarget.deliver
+          ? deliveryTarget.accountId
+          : sessionOnlyOriginChannel
+            ? params.turnSourceAccountId
+            : undefined,
+        threadId: deliveryTarget.deliver
+          ? deliveryTarget.threadId
+          : sessionOnlyOriginChannel
+            ? params.turnSourceThreadId
+            : undefined,
+        idempotencyKey: `exec-approval-followup:${params.approvalId}`,
+      },
+      { expectFinal: true },
+    );
+    return true;
+  }
+
   if (deliveryTarget.deliver) {
-    const requesterAgentId = sessionKey ? parseAgentSessionKey(sessionKey)?.agentId : undefined;
     await sendMessage({
       channel: deliveryTarget.channel,
       to: deliveryTarget.to ?? "",
       accountId: deliveryTarget.accountId,
       threadId: deliveryTarget.threadId,
       content: resultText,
-      agentId: requesterAgentId,
+      agentId: undefined,
       idempotencyKey: `exec-approval-followup:${params.approvalId}`,
-      mirror: sessionKey
-        ? {
-            sessionKey,
-            agentId: requesterAgentId,
-            idempotencyKey: `exec-approval-followup:${params.approvalId}`,
-          }
-        : undefined,
     });
     return true;
   }
 
-  if (!sessionKey) {
-    throw new Error("Session key or deliverable origin route is required");
-  }
-
-  await callGatewayTool(
-    "agent",
-    { timeoutMs: 60_000 },
-    {
-      sessionKey,
-      message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: deliveryTarget.deliver,
-      ...(deliveryTarget.deliver ? { bestEffortDeliver: true as const } : {}),
-      channel: deliveryTarget.deliver ? deliveryTarget.channel : sessionOnlyOriginChannel,
-      to: deliveryTarget.deliver
-        ? deliveryTarget.to
-        : sessionOnlyOriginChannel
-          ? params.turnSourceTo
-          : undefined,
-      accountId: deliveryTarget.deliver
-        ? deliveryTarget.accountId
-        : sessionOnlyOriginChannel
-          ? params.turnSourceAccountId
-          : undefined,
-      threadId: deliveryTarget.deliver
-        ? deliveryTarget.threadId
-        : sessionOnlyOriginChannel
-          ? params.turnSourceThreadId
-          : undefined,
-      idempotencyKey: `exec-approval-followup:${params.approvalId}`,
-    },
-    { expectFinal: true },
-  );
-
-  return true;
+  throw new Error("Session key or deliverable origin route is required");
 }

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -25,10 +25,15 @@ vi.mock("../infra/exec-obfuscation-detect.js", () => ({
   })),
 }));
 
+vi.mock("../infra/outbound/message.js", () => ({
+  sendMessage: vi.fn(async () => ({ ok: true })),
+}));
+
 let callGatewayTool: typeof import("./tools/gateway.js").callGatewayTool;
 let createExecTool: typeof import("./bash-tools.exec.js").createExecTool;
 let detectCommandObfuscation: typeof import("../infra/exec-obfuscation-detect.js").detectCommandObfuscation;
 let getExecApprovalApproverDmNoticeText: typeof import("../infra/exec-approval-reply.js").getExecApprovalApproverDmNoticeText;
+let sendMessage: typeof import("../infra/outbound/message.js").sendMessage;
 
 async function loadExecApprovalModules() {
   vi.resetModules();
@@ -36,6 +41,7 @@ async function loadExecApprovalModules() {
   ({ createExecTool } = await import("./bash-tools.exec.js"));
   ({ detectCommandObfuscation } = await import("../infra/exec-obfuscation-detect.js"));
   ({ getExecApprovalApproverDmNoticeText } = await import("../infra/exec-approval-reply.js"));
+  ({ sendMessage } = await import("../infra/outbound/message.js"));
 }
 
 function buildPreparedSystemRunPayload(rawInvokeParams: unknown) {
@@ -470,6 +476,55 @@ describe("exec approvals", () => {
     expect(agentCalls[0]?.message).toContain(
       "An async command the user already approved has completed.",
     );
+  });
+
+  it("continues the original agent session after approved gateway exec completes with an external route", async () => {
+    const agentCalls: Array<Record<string, unknown>> = [];
+
+    mockAcceptedApprovalFlow({
+      onAgent: (params) => {
+        agentCalls.push(params);
+      },
+    });
+
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "always",
+      approvalRunningNoticeMs: 0,
+      sessionKey: "agent:main:discord:channel:123",
+      elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
+      messageProvider: "discord",
+      currentChannelId: "123",
+      accountId: "default",
+      currentThreadTs: "456",
+    });
+
+    const result = await tool.execute("call-gw-followup-discord", {
+      command: "echo ok",
+      workdir: process.cwd(),
+      gatewayUrl: undefined,
+      gatewayToken: undefined,
+    });
+
+    expect(result.details.status).toBe("approval-pending");
+    await expect.poll(() => agentCalls.length, { timeout: 3_000, interval: 20 }).toBe(1);
+    expect(agentCalls[0]).toEqual(
+      expect.objectContaining({
+        sessionKey: "agent:main:discord:channel:123",
+        deliver: true,
+        bestEffortDeliver: true,
+        channel: "discord",
+        to: "123",
+        accountId: "default",
+        threadId: "456",
+        idempotencyKey: expect.stringContaining("exec-approval-followup:"),
+      }),
+    );
+    expect(typeof agentCalls[0]?.message).toBe("string");
+    expect(agentCalls[0]?.message).toContain(
+      "If the task requires more steps, continue from this result before replying to the user.",
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("executes approved commands and emits a session-only followup in webchat-only mode", async () => {

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -527,6 +527,98 @@ describe("exec approvals", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("auto-continues the same Discord session after approval resolves without a second user turn", async () => {
+    const agentCalls: Array<Record<string, unknown>> = [];
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-exec-followup-discord-"));
+    const markerPath = path.join(tempDir, "marker.txt");
+    let resolveDecision: ((value: { decision: string }) => void) | undefined;
+    const decisionPromise = new Promise<{ decision: string }>((resolve) => {
+      resolveDecision = resolve;
+    });
+
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      if (method === "exec.approval.request") {
+        return acceptedApprovalResponse(params);
+      }
+      if (method === "exec.approval.waitDecision") {
+        return await decisionPromise;
+      }
+      if (method === "agent") {
+        agentCalls.push(params as Record<string, unknown>);
+        return { status: "ok" };
+      }
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "always",
+      approvalRunningNoticeMs: 0,
+      sessionKey: "agent:main:discord:channel:123",
+      elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
+      messageProvider: "discord",
+      currentChannelId: "123",
+      accountId: "default",
+      currentThreadTs: "456",
+    });
+
+    const result = await tool.execute("call-gw-followup-discord-delayed", {
+      command: "node -e \"require('node:fs').writeFileSync('marker.txt','ok')\"",
+      workdir: tempDir,
+      gatewayUrl: undefined,
+      gatewayToken: undefined,
+    });
+
+    expect(result.details.status).toBe("approval-pending");
+    expect(agentCalls).toHaveLength(0);
+    await expect
+      .poll(
+        async () => {
+          try {
+            await fs.access(markerPath);
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        { timeout: 500, interval: 50 },
+      )
+      .toBe(false);
+
+    resolveDecision?.({ decision: "allow-once" });
+
+    await expect.poll(() => agentCalls.length, { timeout: 3_000, interval: 20 }).toBe(1);
+    expect(agentCalls[0]).toEqual(
+      expect.objectContaining({
+        sessionKey: "agent:main:discord:channel:123",
+        deliver: true,
+        bestEffortDeliver: true,
+        channel: "discord",
+        to: "123",
+        accountId: "default",
+        threadId: "456",
+      }),
+    );
+    expect(typeof agentCalls[0]?.message).toBe("string");
+    expect(agentCalls[0]?.message).toContain(
+      "If the task requires more steps, continue from this result before replying to the user.",
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    await expect
+      .poll(
+        async () => {
+          try {
+            return await fs.readFile(markerPath, "utf8");
+          } catch {
+            return "";
+          }
+        },
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBe("ok");
+  });
+
   it("executes approved commands and emits a session-only followup in webchat-only mode", async () => {
     const agentCalls: Array<Record<string, unknown>> = [];
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-exec-followup-sidefx-"));


### PR DESCRIPTION
## Summary

- resume the original `agent` session when an approved async `exec` finishes and the followup still has a `sessionKey`
- keep direct external `sendMessage(...)` delivery only as the no-session fallback
- add regression coverage for external-route approval completions and continuation-oriented followup prompts

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs
- [ ] Test-only

## Scope

This PR is intentionally narrow.

It only changes exec approval followup routing after an already-approved async exec completes.

It does not change:
- exec approval request registration
- exec allowlist / denylist policy evaluation
- command execution behavior before approval
- node pairing / control UI approval transport
- unrelated skills / provider typing surfaces

## Linked Issue/PR

- Related #39648
- Related #52850
- Related #58797
- Follow-up to merged PR #53702
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

Approved async execs could finish successfully, but channel-backed sessions preferred direct external followup delivery instead of resuming the original `agent` session.

In `sendExecApprovalFollowup()`, the presence of an externally deliverable origin route caused the code path to call `sendMessage(...)` directly, even when the original requester `sessionKey` still existed.

That produced a `delivery-mirror` style followup without waking the original session. In practice, the user could see an `Exec finished ...` message while the task stopped progressing until another user message arrived.

This patch makes the session continuation path authoritative whenever a `sessionKey` exists, while still preserving best-effort external delivery metadata on that resumed `agent` call.

## Behavior Changes

Before:
- approved async exec followups with an external route could bypass `agent` continuation
- the user could receive an external completion message without the original task resuming
- direct external delivery was preferred over session continuation whenever the route was deliverable

After:
- approved async exec followups resume the original `agent` session whenever `sessionKey` exists
- external route metadata is preserved on that continuation path via `deliver`, `bestEffortDeliver`, and route fields
- direct external delivery remains only as the fallback when there is no session to resume

## Regression Test Plan

Updated:
- `src/agents/bash-tools.exec-approval-followup.test.ts`
- `src/agents/bash-tools.exec.approval-id.test.ts`

Coverage:
- followup success prompt tells the resumed agent to continue the task before replying
- channel-backed followups with a live `sessionKey` use `agent` continuation instead of direct `sendMessage(...)`
- no-session followups still fall back to direct external delivery
- gateway exec approval flow with an external route resumes the original session and does not use direct outbound message delivery
- delayed approval on a Discord session key does not trigger followup work before approval resolves, then auto-continues the same session after approval without requiring a second user turn

## Repro + Verification

Observed in local runtime transcripts and gateway logs:
- `exec.approval.waitDecision` resolved successfully
- only an external `Exec finished ...` followup appeared
- the original task did not continue until a new user turn arrived

With this patch:
- focused regression tests pass for the exec-approval followup path
- the new delayed-approval Discord continuation test verifies the real failure mode more directly:
  - the exec stays pending before approval resolves
  - no followup side effect occurs before approval
  - once approval resolves, the same Discord session is resumed automatically
  - no direct `sendMessage(...)` fallback is used while the session exists
- manual validation on the installed runtime reproduced the original Discord approve flow and confirmed the task now continues after approval without needing an extra "好了嗎" message

## Tests

Passed locally:
- `corepack pnpm exec vitest run src/agents/bash-tools.exec-approval-followup.test.ts src/agents/bash-tools.exec.approval-id.test.ts --reporter=verbose`

Additional focused coverage added in this PR:
- `auto-continues the same Discord session after approval resolves without a second user turn`

Did not pass end-to-end repo pre-commit:
- `pnpm check` is currently blocked by unrelated upstream TypeScript issues in:
  - `src/agents/skills.test-helpers.ts`
  - `src/agents/skills/local-loader.ts`

## Risks and Mitigations

Risk:
- channel-backed approval completions now prefer session continuation whenever `sessionKey` exists, so any caller that relied on direct external-only followups in that state will now go through the resumed `agent` path

Mitigation:
- the no-session fallback still uses direct external delivery
- delivery metadata is preserved on the resumed path
- regression coverage now locks the intended continuation behavior in place for both session-backed and no-session cases

## AI assistance

AI-assisted: drafted and implemented with Codex, then locally reviewed and tested by me.
