### PR TITLE
[codex] fix chat reminder cron delivery

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -28,6 +28,11 @@ describe("cron tool", () => {
     return params?.payload?.text ?? "";
   }
 
+  function readCronPayloadMessage(index = 0): string {
+    const params = readGatewayCall(index).params as { payload?: { message?: string } } | undefined;
+    return params?.payload?.message ?? "";
+  }
+
   function expectSingleGatewayCallMethod(method: string) {
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
     const call = readGatewayCall(0);
@@ -223,6 +228,64 @@ describe("cron tool", () => {
     expect(sessionKey).toBe("agent:main:telegram:group:-100123:topic:99");
   });
 
+  it("promotes chat reminders into isolated announce jobs", async () => {
+    const tool = createCronTool({ agentSessionKey: "agent:main:slack:channel:general" });
+    await tool.execute("call-promoted-reminder", {
+      action: "add",
+      job: {
+        name: "rent-reminder",
+        schedule: { at: new Date(123).toISOString() },
+        payload: { kind: "systemEvent", text: "Reminder: pay rent today." },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add") as
+      | {
+          sessionTarget?: string;
+          delivery?: { mode?: string; channel?: string; to?: string };
+          payload?: { kind?: string; message?: string };
+        }
+      | undefined;
+    expect(params?.sessionTarget).toBe("isolated");
+    expect(params?.delivery).toEqual({
+      mode: "announce",
+      channel: "slack",
+      to: "general",
+    });
+    expect(params?.payload?.kind).toBe("agentTurn");
+    expect(params?.payload?.message).toContain(
+      "Reply with the reminder text exactly as written below and nothing else.",
+    );
+    expect(params?.payload?.message).toContain("Reminder: pay rent today.");
+  });
+
+  it("keeps explicit main reminder jobs internal", async () => {
+    const tool = createCronTool({ agentSessionKey: "agent:main:slack:channel:general" });
+    await tool.execute("call-explicit-main-reminder", {
+      action: "add",
+      job: {
+        name: "internal-reminder",
+        schedule: { at: new Date(123).toISOString() },
+        sessionTarget: "main",
+        payload: { kind: "systemEvent", text: "Reminder: update the tracker." },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add") as
+      | {
+          sessionTarget?: string;
+          delivery?: unknown;
+          payload?: { kind?: string; text?: string };
+        }
+      | undefined;
+    expect(params?.sessionTarget).toBe("main");
+    expect(params?.delivery).toBeUndefined();
+    expect(params?.payload).toEqual({
+      kind: "systemEvent",
+      text: "Reminder: update the tracker.",
+    });
+  });
+
   it("adds recent context for systemEvent reminders when contextMessages > 0", async () => {
     callGatewayMock
       .mockResolvedValueOnce({
@@ -250,6 +313,42 @@ describe("cron tool", () => {
     expect(text).toContain("User: Discussed Q2 budget");
     expect(text).toContain("Assistant: We agreed to review on Tuesday.");
     expect(text).toContain("User: Remind me about the thing at 2pm");
+  });
+
+  it("adds recent context to promoted chat reminders as agent-turn instructions", async () => {
+    callGatewayMock
+      .mockResolvedValueOnce({
+        messages: [
+          { role: "user", content: [{ type: "text", text: "Payroll closes today" }] },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "I can remind you in this thread." }],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool({ agentSessionKey: "agent:main:slack:channel:general" });
+    await tool.execute("call-promoted-context", {
+      action: "add",
+      contextMessages: 2,
+      job: {
+        name: "payroll-reminder",
+        schedule: { at: new Date(123).toISOString() },
+        payload: { kind: "systemEvent", text: "Reminder: submit payroll." },
+      },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+    expect(readGatewayCall(0).method).toBe("chat.history");
+    const cronCall = readGatewayCall(1);
+    expect(cronCall.method).toBe("cron.add");
+    const message = readCronPayloadMessage(1);
+    expect(message).toContain("Reminder text:");
+    expect(message).toContain("Reminder: submit payroll.");
+    expect(message).toContain("Recent context:");
+    expect(message).toContain("User: Payroll closes today");
+    expect(message).toContain("Assistant: I can remind you in this thread.");
   });
 
   it("caps contextMessages at 10", async () => {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -26,6 +26,14 @@ const REMINDER_CONTEXT_MESSAGES_MAX = 10;
 const REMINDER_CONTEXT_PER_MESSAGE_MAX = 220;
 const REMINDER_CONTEXT_TOTAL_MAX = 700;
 const REMINDER_CONTEXT_MARKER = "\n\nRecent context:\n";
+const REMINDER_TEXT_PATTERNS = [
+  /\bremind(?:er| me)?\b/i,
+  /\bremember to\b/i,
+  /\bdon'?t forget\b/i,
+  /提醒/u,
+  /记得/u,
+  /别忘/u,
+];
 
 // Flattened schema: runtime validates per-action requirements.
 const CronToolSchema = Type.Object(
@@ -207,6 +215,58 @@ function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | n
   return delivery;
 }
 
+function hasOwn(obj: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function looksLikeReminderText(text: string): boolean {
+  const baseText = stripExistingContext(text);
+  return REMINDER_TEXT_PATTERNS.some((pattern) => pattern.test(baseText));
+}
+
+function shouldPromoteChatReminderJob(params: {
+  rawJob: Record<string, unknown>;
+  job: unknown;
+  inferredDelivery: CronDelivery | null;
+}): params is {
+  rawJob: Record<string, unknown>;
+  job: { payload: { kind: "systemEvent"; text: string } };
+  inferredDelivery: CronDelivery;
+} {
+  if (!params.inferredDelivery) {
+    return false;
+  }
+  if (hasOwn(params.rawJob, "sessionTarget") || hasOwn(params.rawJob, "delivery")) {
+    return false;
+  }
+  if (!isRecord(params.job)) {
+    return false;
+  }
+  const payload = isRecord(params.job.payload) ? params.job.payload : null;
+  if (payload?.kind !== "systemEvent" || typeof payload.text !== "string" || !payload.text.trim()) {
+    return false;
+  }
+  return looksLikeReminderText(payload.text);
+}
+
+function buildChatReminderAgentTurnMessage(params: {
+  reminderText: string;
+  contextLines: string[];
+}): string {
+  const lines = [
+    "This is a scheduled reminder created from an active chat.",
+    "When it runs, send the reminder back to the user in the original chat.",
+    "Reply with the reminder text exactly as written below and nothing else.",
+    "",
+    "Reminder text:",
+    stripExistingContext(params.reminderText),
+  ];
+  if (params.contextLines.length > 0) {
+    lines.push("", "Recent context:", ...params.contextLines);
+  }
+  return lines.join("\n").trim();
+}
+
 export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): AnyAgentTool {
   const callGateway = deps?.callGatewayTool ?? callGatewayTool;
   return {
@@ -245,6 +305,10 @@ DEFAULT BEHAVIOR (unchanged for backward compatibility):
 - payload.kind="systemEvent" → defaults to "main"
 - payload.kind="agentTurn" → defaults to "isolated"
 To use current session binding, explicitly set sessionTarget="current".
+
+CHAT REMINDER DEFAULT:
+- When a reminder is created from an active chat with payload.kind="systemEvent" and no explicit sessionTarget/delivery, the tool promotes it to an isolated announce job so the reminder is delivered back to the originating chat.
+- Set sessionTarget="main" explicitly if you want an internal-only system event instead of a user-visible reminder.
 
 SCHEDULE TYPES (schedule.kind):
 - "at": One-shot at absolute time
@@ -380,6 +444,44 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             }
           }
 
+          const contextMessages =
+            typeof params.contextMessages === "number" && Number.isFinite(params.contextMessages)
+              ? params.contextMessages
+              : 0;
+          const inferredDelivery = inferDeliveryFromSessionKey(opts?.agentSessionKey);
+          const rawJob = isRecord(params.job) ? params.job : null;
+          const promotableReminderJob =
+            rawJob &&
+            shouldPromoteChatReminderJob({
+              rawJob,
+              job,
+              inferredDelivery,
+            })
+              ? (job as {
+                  payload:
+                    | { kind: "systemEvent"; text: string }
+                    | { kind: "agentTurn"; message: string };
+                  sessionTarget?: string;
+                })
+              : null;
+          if (promotableReminderJob?.payload.kind === "systemEvent") {
+            const contextLines = await buildReminderContextLines({
+              agentSessionKey: opts?.agentSessionKey,
+              gatewayOpts,
+              contextMessages,
+              callGatewayTool: callGateway,
+            });
+            const reminderText = promotableReminderJob.payload.text;
+            promotableReminderJob.payload = {
+              kind: "agentTurn",
+              message: buildChatReminderAgentTurnMessage({
+                reminderText,
+                contextLines,
+              }),
+            };
+            promotableReminderJob.sessionTarget = "isolated";
+          }
+
           if (
             opts?.agentSessionKey &&
             job &&
@@ -411,20 +513,14 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               (mode === "" || mode === "announce") &&
               !hasTarget;
             if (shouldInfer) {
-              const inferred = inferDeliveryFromSessionKey(opts.agentSessionKey);
-              if (inferred) {
+              if (inferredDelivery) {
                 (job as { delivery?: unknown }).delivery = {
                   ...delivery,
-                  ...inferred,
+                  ...inferredDelivery,
                 } satisfies CronDelivery;
               }
             }
           }
-
-          const contextMessages =
-            typeof params.contextMessages === "number" && Number.isFinite(params.contextMessages)
-              ? params.contextMessages
-              : 0;
           if (
             job &&
             typeof job === "object" &&


### PR DESCRIPTION
## Summary
- promote reminder-like chat cron jobs without explicit `sessionTarget` or `delivery` into isolated `agentTurn` jobs with inferred announce delivery
- keep explicit `sessionTarget: "main"` reminders internal-only so existing cron semantics stay intact
- add tests covering promotion, explicit main reminders, and promoted reminders with context history

## Root Cause
Cron jobs created as `sessionTarget: "main"` plus `payload.kind: "systemEvent"` only enqueue an internal system event. They do not request outbound delivery, so runs can finish with `deliveryStatus = "not-requested"` even though the reminder never reaches the user.

## Impact
Chat-created reminders now default to a deliverable execution path that sends the reminder back to the originating conversation instead of silently remaining an internal scheduler event.

## Validation
- `pnpm exec vitest run --config vitest.config.ts src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.flat-params.test.ts`
