### PR TITLE
feat(gateway): make chat history max chars configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/webchat: make `chat.history` text truncation configurable with `gateway.webchat.chatHistoryMaxChars` and per-request `maxChars`, while preserving silent-reply filtering and existing default payload limits. (#58900)
 - Agents/compaction: resolve `agents.defaults.compaction.model` consistently for manual `/compact` and other context-engine compaction paths, so engine-owned compaction uses the configured override model across runtime entrypoints. (#56710) Thanks @oliviareid-svg
 - Channels/session routing: move provider-specific session conversation grammar into plugin-owned session-key surfaces, preserving Telegram topic routing and Feishu scoped inheritance across bootstrap, model override, restart, and tool-policy paths.
 - WhatsApp/reactions: add `reactionLevel` guidance for agent reactions. Thanks @mcaxtr.

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -618,11 +618,13 @@ extension GatewayConnection {
     func chatHistory(
         sessionKey: String,
         limit: Int? = nil,
+        maxChars: Int? = nil,
         timeoutMs: Int? = nil) async throws -> OpenClawChatHistoryPayload
     {
         let resolvedKey = self.canonicalizeSessionKey(sessionKey)
         var params: [String: AnyCodable] = ["sessionKey": AnyCodable(resolvedKey)]
         if let limit { params["limit"] = AnyCodable(limit) }
+        if let maxChars { params["maxChars"] = AnyCodable(maxChars) }
         let timeout = timeoutMs.map { Double($0) }
         return try await self.requestDecoded(
             method: .chatHistory,

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -3710,18 +3710,22 @@ public struct DevicePairResolvedEvent: Codable, Sendable {
 public struct ChatHistoryParams: Codable, Sendable {
     public let sessionkey: String
     public let limit: Int?
+    public let maxchars: Int?
 
     public init(
         sessionkey: String,
-        limit: Int?)
+        limit: Int?,
+        maxchars: Int?)
     {
         self.sessionkey = sessionkey
         self.limit = limit
+        self.maxchars = maxchars
     }
 
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case limit
+        case maxchars = "maxChars"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -3710,18 +3710,22 @@ public struct DevicePairResolvedEvent: Codable, Sendable {
 public struct ChatHistoryParams: Codable, Sendable {
     public let sessionkey: String
     public let limit: Int?
+    public let maxchars: Int?
 
     public init(
         sessionkey: String,
-        limit: Int?)
+        limit: Int?,
+        maxchars: Int?)
     {
         self.sessionkey = sessionkey
         self.limit = limit
+        self.maxchars = maxchars
     }
 
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case limit
+        case maxchars = "maxChars"
     }
 }
 

--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -3,6 +3,7 @@ import register from "./index.js";
 
 describe("thread-ownership plugin", () => {
   const hooks: Record<string, Function> = {};
+  const fetchMock = vi.fn() as unknown as typeof globalThis.fetch;
   const api = {
     pluginConfig: {},
     config: {
@@ -18,8 +19,6 @@ describe("thread-ownership plugin", () => {
     }),
   };
 
-  let originalFetch: typeof globalThis.fetch;
-
   beforeEach(() => {
     vi.clearAllMocks();
     for (const key of Object.keys(hooks)) delete hooks[key];
@@ -27,12 +26,11 @@ describe("thread-ownership plugin", () => {
     process.env.SLACK_FORWARDER_URL = "http://localhost:8750";
     process.env.SLACK_BOT_USER_ID = "U999";
 
-    originalFetch = globalThis.fetch;
-    globalThis.fetch = vi.fn() as unknown as typeof globalThis.fetch;
+    vi.stubGlobal("fetch", fetchMock);
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    vi.unstubAllGlobals();
     delete process.env.SLACK_FORWARDER_URL;
     delete process.env.SLACK_BOT_USER_ID;
     vi.restoreAllMocks();

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -19,7 +19,6 @@ import {
   registerZaloWebhookTarget,
 } from "./monitor.js";
 import type { ResolvedZaloAccount } from "./types.js";
-
 const DEFAULT_ACCOUNT: ResolvedZaloAccount = {
   accountId: "default",
   enabled: true,

--- a/package.json
+++ b/package.json
@@ -1079,6 +1079,7 @@
     "postinstall": "node scripts/postinstall-bundled-plugins.mjs",
     "prepack": "node --import tsx scripts/openclaw-prepack.ts",
     "prepare": "command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath git-hooks || exit 0",
+    "prepush:ci": "bash scripts/prepush-ci.sh",
     "protocol:check": "pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
     "protocol:gen": "node --import tsx scripts/protocol-gen.ts",
     "protocol:gen:swift": "node --import tsx scripts/protocol-gen-swift.ts",

--- a/scripts/prepush-ci.sh
+++ b/scripts/prepush-ci.sh
@@ -42,7 +42,12 @@ has_native_swift_changes() {
     fi
   fi
 
-  git diff --name-only --relative -- apps/macos apps/ios apps/shared/OpenClawKit | rg -q .
+  if git rev-parse --verify --quiet HEAD^ >/dev/null; then
+    git diff --name-only --relative HEAD^..HEAD -- apps/macos apps/ios apps/shared/OpenClawKit | rg -q .
+    return $?
+  fi
+
+  git show --name-only --relative --pretty='' HEAD -- apps/macos apps/ios apps/shared/OpenClawKit | rg -q .
 }
 
 run_linux_ci_mirror() {

--- a/scripts/prepush-ci.sh
+++ b/scripts/prepush-ci.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT_DIR"
+
+log_step() {
+  printf '\n==> %s\n' "$*"
+}
+
+run_step() {
+  log_step "$*"
+  "$@"
+}
+
+run_protocol_ci_mirror() {
+  local targets=(
+    "dist/protocol.schema.json"
+    "apps/macos/Sources/OpenClawProtocol/GatewayModels.swift"
+    "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift"
+  )
+  local before after
+  before="$(git diff --no-ext-diff -- "${targets[@]}" || true)"
+
+  run_step pnpm protocol:gen
+  run_step pnpm protocol:gen:swift
+
+  after="$(git diff --no-ext-diff -- "${targets[@]}" || true)"
+  if [[ "$before" != "$after" ]]; then
+    echo "Protocol generation changed tracked outputs beyond the pre-run worktree." >&2
+    echo "Refresh generated protocol files and include the updated outputs before pushing." >&2
+    git --no-pager diff -- "${targets[@]}"
+    return 1
+  fi
+}
+
+has_native_swift_changes() {
+  if git rev-parse --verify --quiet origin/main >/dev/null; then
+    if git diff --name-only --relative origin/main...HEAD -- apps/macos apps/ios apps/shared/OpenClawKit | rg -q .; then
+      return 0
+    fi
+  fi
+
+  git diff --name-only --relative -- apps/macos apps/ios apps/shared/OpenClawKit | rg -q .
+}
+
+run_linux_ci_mirror() {
+  run_step pnpm check
+  run_step pnpm build:strict-smoke
+  run_step pnpm lint:ui:no-raw-window-open
+  run_protocol_ci_mirror
+  run_step pnpm canvas:a2ui:bundle
+  run_step pnpm vitest run --config vitest.extensions.config.ts --maxWorkers=1
+  run_step env CI=true pnpm exec vitest run --config vitest.unit.config.ts --maxWorkers=1
+
+  log_step "OPENCLAW_TEST_WORKERS=${OPENCLAW_TEST_WORKERS:-1} OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB=${OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB:-6144} pnpm test"
+  OPENCLAW_TEST_WORKERS="${OPENCLAW_TEST_WORKERS:-1}" \
+  OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB="${OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB:-6144}" \
+    pnpm test
+}
+
+run_macos_ci_mirror() {
+  if [[ "${OPENCLAW_PREPUSH_SKIP_MACOS:-0}" == "1" ]]; then
+    log_step "Skipping macOS mirror because OPENCLAW_PREPUSH_SKIP_MACOS=1"
+    return 0
+  fi
+
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    log_step "Skipping macOS mirror on non-Darwin host"
+    return 0
+  fi
+
+  if ! has_native_swift_changes; then
+    log_step "Skipping macOS mirror because no native Swift paths changed"
+    return 0
+  fi
+
+  run_step swiftlint --config .swiftlint.yml
+  run_step swiftformat --lint apps/macos/Sources --config .swiftformat
+  run_step swift build --package-path apps/macos --configuration release
+  run_step swift test --package-path apps/macos --parallel
+}
+
+main() {
+  run_linux_ci_mirror
+  run_macos_ci_mirror
+}
+
+main "$@"

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -9927,6 +9927,17 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
             },
             additionalProperties: false,
           },
+          webchat: {
+            type: "object",
+            properties: {
+              chatHistoryMaxChars: {
+                type: "integer",
+                exclusiveMinimum: 0,
+                maximum: 500000,
+              },
+            },
+            additionalProperties: false,
+          },
           channelHealthCheckMinutes: {
             type: "integer",
             minimum: 0,
@@ -12849,6 +12860,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
       label: "Gateway Node Denylist",
       help: "Node command names to block even if present in node claims or default allowlist (exact command-name matching only, e.g. `system.run`; does not inspect shell text inside that command).",
       tags: ["access", "network"],
+    },
+    "gateway.webchat.chatHistoryMaxChars": {
+      label: "WebChat History Max Chars",
+      help: "Max characters per text field in chat.history responses before truncation (default: 12000).",
+      tags: ["network", "performance"],
     },
     "nodeHost.browserProxy": {
       label: "Node Browser Proxy",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -437,6 +437,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Extra node.invoke commands to allow beyond the gateway defaults (array of command strings). Enabling dangerous commands here is a security-sensitive override and is flagged by `openclaw security audit`.",
   "gateway.nodes.denyCommands":
     "Node command names to block even if present in node claims or default allowlist (exact command-name matching only, e.g. `system.run`; does not inspect shell text inside that command).",
+  "gateway.webchat.chatHistoryMaxChars":
+    "Max characters per text field in chat.history responses before truncation (default: 64000).",
   nodeHost:
     "Node host controls for features exposed from this gateway node to other nodes or clients. Keep defaults unless you intentionally proxy local capabilities across your node network.",
   "nodeHost.browserProxy":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -438,7 +438,7 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.nodes.denyCommands":
     "Node command names to block even if present in node claims or default allowlist (exact command-name matching only, e.g. `system.run`; does not inspect shell text inside that command).",
   "gateway.webchat.chatHistoryMaxChars":
-    "Max characters per text field in chat.history responses before truncation (default: 64000).",
+    "Max characters per text field in chat.history responses before truncation (default: 12000).",
   nodeHost:
     "Node host controls for features exposed from this gateway node to other nodes or clients. Keep defaults unless you intentionally proxy local capabilities across your node network.",
   "nodeHost.browserProxy":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -300,6 +300,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.nodes.browser.node": "Gateway Node Browser Pin",
   "gateway.nodes.allowCommands": "Gateway Node Allowlist (Extra Commands)",
   "gateway.nodes.denyCommands": "Gateway Node Denylist",
+  "gateway.webchat.chatHistoryMaxChars": "WebChat History Max Chars",
   nodeHost: "Node Host",
   "nodeHost.browserProxy": "Node Browser Proxy",
   "nodeHost.browserProxy.enabled": "Node Browser Proxy Enabled",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -391,7 +391,7 @@ export type GatewayToolsConfig = {
 };
 
 export type GatewayWebchatConfig = {
-  /** Max characters per text field in chat.history responses before truncation (default: 64000). */
+  /** Max characters per text field in chat.history responses before truncation (default: 12000). */
   chatHistoryMaxChars?: number;
 };
 

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -390,6 +390,11 @@ export type GatewayToolsConfig = {
   allow?: string[];
 };
 
+export type GatewayWebchatConfig = {
+  /** Max characters per text field in chat.history responses before truncation (default: 64000). */
+  chatHistoryMaxChars?: number;
+};
+
 export type GatewayConfig = {
   /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
   port?: number;
@@ -432,6 +437,8 @@ export type GatewayConfig = {
   allowRealIpFallback?: boolean;
   /** Tool access restrictions for HTTP /tools/invoke endpoint. */
   tools?: GatewayToolsConfig;
+  /** WebChat display/history settings. */
+  webchat?: GatewayWebchatConfig;
   /**
    * Channel health monitor interval in minutes.
    * Periodically checks channel health and restarts unhealthy channels.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -729,6 +729,12 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        webchat: z
+          .object({
+            chatHistoryMaxChars: z.number().int().positive().max(500_000).optional(),
+          })
+          .strict()
+          .optional(),
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
         channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),
         channelMaxRestartsPerHour: z.number().int().min(1).optional(),

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -27,6 +27,7 @@ export const ChatHistoryParamsSchema = Type.Object(
   {
     sessionKey: NonEmptyString,
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+    maxChars: Type.Optional(Type.Integer({ minimum: 1, maximum: 500_000 })),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -102,7 +102,7 @@ type ChatAbortRequester = {
   isAdmin: boolean;
 };
 
-const CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
+const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 64_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
 let chatHistoryPlaceholderEmitCount = 0;
@@ -483,17 +483,23 @@ async function rewriteChatSendUserTurnMediaPaths(params: {
   });
 }
 
-function truncateChatHistoryText(text: string): { text: string; truncated: boolean } {
-  if (text.length <= CHAT_HISTORY_TEXT_MAX_CHARS) {
+function truncateChatHistoryText(
+  text: string,
+  maxChars: number,
+): { text: string; truncated: boolean } {
+  if (text.length <= maxChars) {
     return { text, truncated: false };
   }
   return {
-    text: `${text.slice(0, CHAT_HISTORY_TEXT_MAX_CHARS)}\n...(truncated)...`,
+    text: `${text.slice(0, maxChars)}\n...(truncated)...`,
     truncated: true,
   };
 }
 
-function sanitizeChatHistoryContentBlock(block: unknown): { block: unknown; changed: boolean } {
+function sanitizeChatHistoryContentBlock(
+  block: unknown,
+  maxChars: number,
+): { block: unknown; changed: boolean } {
   if (!block || typeof block !== "object") {
     return { block, changed: false };
   }
@@ -501,22 +507,22 @@ function sanitizeChatHistoryContentBlock(block: unknown): { block: unknown; chan
   let changed = false;
   if (typeof entry.text === "string") {
     const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
-    const res = truncateChatHistoryText(stripped.text);
+    const res = truncateChatHistoryText(stripped.text, maxChars);
     entry.text = res.text;
     changed ||= stripped.changed || res.truncated;
   }
   if (typeof entry.partialJson === "string") {
-    const res = truncateChatHistoryText(entry.partialJson);
+    const res = truncateChatHistoryText(entry.partialJson, maxChars);
     entry.partialJson = res.text;
     changed ||= res.truncated;
   }
   if (typeof entry.arguments === "string") {
-    const res = truncateChatHistoryText(entry.arguments);
+    const res = truncateChatHistoryText(entry.arguments, maxChars);
     entry.arguments = res.text;
     changed ||= res.truncated;
   }
   if (typeof entry.thinking === "string") {
-    const res = truncateChatHistoryText(entry.thinking);
+    const res = truncateChatHistoryText(entry.thinking, maxChars);
     entry.thinking = res.text;
     changed ||= res.truncated;
   }
@@ -597,7 +603,10 @@ function sanitizeCost(raw: unknown): { total?: number } | undefined {
   return total !== undefined ? { total } : undefined;
 }
 
-function sanitizeChatHistoryMessage(message: unknown): { message: unknown; changed: boolean } {
+function sanitizeChatHistoryMessage(
+  message: unknown,
+  maxChars: number,
+): { message: unknown; changed: boolean } {
   if (!message || typeof message !== "object") {
     return { message, changed: false };
   }
@@ -644,11 +653,11 @@ function sanitizeChatHistoryMessage(message: unknown): { message: unknown; chang
 
   if (typeof entry.content === "string") {
     const stripped = stripInlineDirectiveTagsForDisplay(entry.content);
-    const res = truncateChatHistoryText(stripped.text);
+    const res = truncateChatHistoryText(stripped.text, maxChars);
     entry.content = res.text;
     changed ||= stripped.changed || res.truncated;
   } else if (Array.isArray(entry.content)) {
-    const updated = entry.content.map((block) => sanitizeChatHistoryContentBlock(block));
+    const updated = entry.content.map((block) => sanitizeChatHistoryContentBlock(block, maxChars));
     if (updated.some((item) => item.changed)) {
       entry.content = updated.map((item) => item.block);
       changed = true;
@@ -657,7 +666,7 @@ function sanitizeChatHistoryMessage(message: unknown): { message: unknown; chang
 
   if (typeof entry.text === "string") {
     const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
-    const res = truncateChatHistoryText(stripped.text);
+    const res = truncateChatHistoryText(stripped.text, maxChars);
     entry.text = res.text;
     changed ||= stripped.changed || res.truncated;
   }
@@ -703,14 +712,14 @@ function extractAssistantTextForSilentCheck(message: unknown): string | undefine
   return texts.length > 0 ? texts.join("\n") : undefined;
 }
 
-function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {
+function sanitizeChatHistoryMessages(messages: unknown[], maxChars: number): unknown[] {
   if (messages.length === 0) {
     return messages;
   }
   let changed = false;
   const next: unknown[] = [];
   for (const message of messages) {
-    const res = sanitizeChatHistoryMessage(message);
+    const res = sanitizeChatHistoryMessage(message, maxChars);
     changed ||= res.changed;
     // Drop assistant messages whose entire visible text is the silent reply token.
     const text = extractAssistantTextForSilentCheck(res.message);
@@ -1205,13 +1214,25 @@ export const chatHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const { sessionKey, limit } = params as {
+    const {
+      sessionKey,
+      limit,
+      maxChars: rpcMaxChars,
+    } = params as {
       sessionKey: string;
       limit?: number;
+      maxChars?: number;
     };
     const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
-    const sessionId = entry?.sessionId;
+    const configMaxChars = cfg.gateway?.webchat?.chatHistoryMaxChars;
+    const effectiveMaxChars =
+      typeof rpcMaxChars === "number"
+        ? rpcMaxChars
+        : typeof configMaxChars === "number"
+          ? configMaxChars
+          : DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
     const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
+    const sessionId = entry?.sessionId;
     const resolvedSessionModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
     const localMessages =
       sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
@@ -1226,7 +1247,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     const max = Math.min(hardMax, requested);
     const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
     const sanitized = stripEnvelopeFromMessages(sliced);
-    const normalized = sanitizeChatHistoryMessages(sanitized);
+    const normalized = sanitizeChatHistoryMessages(sanitized, effectiveMaxChars);
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
     const perMessageHardCap = Math.min(CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES, maxHistoryBytes);
     const replaced = replaceOversizedChatHistoryMessages({

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -102,7 +102,7 @@ type ChatAbortRequester = {
   isAdmin: boolean;
 };
 
-const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 64_000;
+const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
 let chatHistoryPlaceholderEmitCount = 0;
@@ -719,14 +719,14 @@ function sanitizeChatHistoryMessages(messages: unknown[], maxChars: number): unk
   let changed = false;
   const next: unknown[] = [];
   for (const message of messages) {
-    const res = sanitizeChatHistoryMessage(message, maxChars);
-    changed ||= res.changed;
     // Drop assistant messages whose entire visible text is the silent reply token.
-    const text = extractAssistantTextForSilentCheck(res.message);
+    const text = extractAssistantTextForSilentCheck(message);
     if (text !== undefined && isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
       changed = true;
       continue;
     }
+    const res = sanitizeChatHistoryMessage(message, maxChars);
+    changed ||= res.changed;
     next.push(res.message);
   }
   return changed ? next : messages;

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import type { GetReplyOptions } from "../auto-reply/types.js";
+import { clearConfigCache } from "../config/config.js";
 import { __setMaxChatHistoryMessagesBytesForTest } from "./server-constants.js";
 import {
   connectOk,
@@ -54,6 +55,7 @@ async function withGatewayChatHarness(
     await run({ ws, createSessionDir });
   } finally {
     __setMaxChatHistoryMessagesBytesForTest();
+    clearConfigCache();
     testState.sessionStorePath = undefined;
     ws.close();
     await server.close();
@@ -76,6 +78,7 @@ async function writeGatewayConfig(config: Record<string, unknown>) {
   }
   await fs.mkdir(path.dirname(configPath), { recursive: true });
   await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+  clearConfigCache();
 }
 
 async function writeMainSessionTranscript(sessionDir: string, lines: string[]) {
@@ -544,6 +547,24 @@ describe("gateway server chat", () => {
       expect((tooLargeRes.error as { message?: string } | undefined)?.message ?? "").toMatch(
         /invalid chat\.history params/i,
       );
+    });
+  });
+
+  test("chat.history still drops assistant NO_REPLY entries before truncation", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "NO_REPLY" }],
+            timestamp: Date.now(),
+          },
+        }),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws, { maxChars: 3 });
+      expect(messages).toEqual([]);
     });
   });
 

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -69,16 +69,30 @@ async function writeMainSessionStore() {
   });
 }
 
+async function writeGatewayConfig(config: Record<string, unknown>) {
+  const configPath = process.env.OPENCLAW_CONFIG_PATH;
+  if (!configPath) {
+    throw new Error("OPENCLAW_CONFIG_PATH missing in gateway test environment");
+  }
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+}
+
 async function writeMainSessionTranscript(sessionDir: string, lines: string[]) {
   await fs.writeFile(path.join(sessionDir, "sess-main.jsonl"), `${lines.join("\n")}\n`, "utf-8");
 }
 
 async function fetchHistoryMessages(
   ws: Awaited<ReturnType<typeof startServerWithClient>>["ws"],
+  params?: {
+    limit?: number;
+    maxChars?: number;
+  },
 ): Promise<unknown[]> {
   const historyRes = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
     sessionKey: "main",
-    limit: 1000,
+    limit: params?.limit ?? 1000,
+    ...(typeof params?.maxChars === "number" ? { maxChars: params.maxChars } : {}),
   });
   expect(historyRes.ok).toBe(true);
   return historyRes.payload?.messages ?? [];
@@ -454,6 +468,82 @@ describe("gateway server chat", () => {
       expect(second.content?.replace(/\s+/g, " ").trim()).toBe("A B");
       expect(third.text?.replace(/\s+/g, " ").trim()).toBe("C");
       expect(fourth.content?.[0]?.text).toBe("  keep padded  ");
+    });
+  });
+
+  test("chat.history applies gateway.webchat.chatHistoryMaxChars from config", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await writeGatewayConfig({
+        gateway: {
+          webchat: {
+            chatHistoryMaxChars: 5,
+          },
+        },
+      });
+      const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "abcdefghij" }],
+            timestamp: Date.now(),
+          },
+        }),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws);
+      expect(JSON.stringify(messages)).toContain("abcde\\n...(truncated)...");
+    });
+  });
+
+  test("chat.history prefers RPC maxChars over config", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await writeGatewayConfig({
+        gateway: {
+          webchat: {
+            chatHistoryMaxChars: 3,
+          },
+        },
+      });
+      const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "abcdefghij" }],
+            timestamp: Date.now(),
+          },
+        }),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws, { maxChars: 7 });
+      const serialized = JSON.stringify(messages);
+      expect(serialized).toContain("abcdefg\\n...(truncated)...");
+      expect(serialized).not.toContain("abc\\n...(truncated)...");
+    });
+  });
+
+  test("chat.history rejects invalid RPC maxChars values", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await prepareMainHistoryHarness({ ws, createSessionDir });
+
+      const zeroRes = await rpcReq(ws, "chat.history", {
+        sessionKey: "main",
+        maxChars: 0,
+      });
+      expect(zeroRes.ok).toBe(false);
+      expect((zeroRes.error as { message?: string } | undefined)?.message ?? "").toMatch(
+        /invalid chat\.history params/i,
+      );
+
+      const tooLargeRes = await rpcReq(ws, "chat.history", {
+        sessionKey: "main",
+        maxChars: 500_001,
+      });
+      expect(tooLargeRes.ok).toBe(false);
+      expect((tooLargeRes.error as { message?: string } | undefined)?.message ?? "").toMatch(
+        /invalid chat\.history params/i,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- make `chat.history` max text truncation configurable via `gateway.webchat.chatHistoryMaxChars` and per-request `maxChars`
- keep current assistant `usage` / `cost` metadata preservation intact while applying the new truncation limit
- expose the new `maxChars` request parameter in the gateway protocol and macOS Swift client models
- add a local `prepush:ci` mirror script and stabilize a few extension tests needed for local CI signal

## Why

- the old PR for this feature was stale and based on outdated `chat.history` behavior
- current `main` still hardcodes the history text limit, so the feature is still useful, but it needed a fresh implementation on top of current semantics

## Validation

- `pnpm exec vitest run src/gateway/server.chat.gateway-server-chat-b.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/config/schema.help.quality.test.ts`
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/feishu/src/docx.test.ts extensions/thread-ownership/index.test.ts extensions/zalo/src/monitor.webhook.test.ts`
- clean-worktree `bash scripts/prepush-ci.sh` got through `pnpm check`, `pnpm build:strict-smoke`, `pnpm lint:ui:no-raw-window-open`, protocol generation, and bundle

## Notes

- the full clean-worktree mirror is still blocked by an unrelated serial extensions failure on current `main`: `extensions/openshell/src/remote-fs-bridge.test.ts`
