### PR TITLE
fix(agent): treat webchat exec approvals as native UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Channels/plugins: keep bundled channel plugins loadable from legacy `channels.<id>` config even under restrictive plugin allowlists, and make `openclaw doctor` warn only on real plugin blockers instead of misleading setup guidance. (#58873) Thanks @obviyus
 - Auto-reply/commands: strip inbound metadata before slash command detection so wrapped `/model`, `/new`, and `/status` commands are recognized. (#58725) Thanks @Mlightsnow.
 - Gateway/nodes: stop pinning live node commands to the approved node-pair record. Node pairing remains a trust/token flow, while per-node `system.run` policy stays in that node's exec approvals config. Fixes #58824.
+- WebChat/exec approvals: use native approval UI guidance in agent system prompts instead of telling agents to paste manual `/approve` commands in webchat sessions. Thanks @vincentkoc.
 
 ## 2026.3.31
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -177,10 +177,24 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain(
-      "When exec returns approval-pending on Discord, Slack, or Telegram, rely on the native approval card/buttons when they appear",
+      "When exec returns approval-pending on Discord, Slack, Telegram, or WebChat, rely on the native approval card/buttons when they appear",
     );
     expect(prompt).toContain(
       "Only include the concrete /approve command if the tool result says chat approvals are unavailable or only manual approval is possible.",
+    );
+    expect(prompt).not.toContain(
+      "When exec returns approval-pending, include the concrete /approve command from tool output",
+    );
+  });
+
+  it("treats webchat as a native approval surface", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      runtimeInfo: { channel: "webchat" },
+    });
+
+    expect(prompt).toContain(
+      "When exec returns approval-pending on Discord, Slack, Telegram, or WebChat, rely on the native approval card/buttons when they appear",
     );
     expect(prompt).not.toContain(
       "When exec returns approval-pending, include the concrete /approve command from tool output",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -196,6 +196,9 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain(
       "When exec returns approval-pending on Discord, Slack, Telegram, or WebChat, rely on the native approval card/buttons when they appear",
     );
+    expect(prompt).toContain(
+      "Only include the concrete /approve command if the tool result says chat approvals are unavailable or only manual approval is possible.",
+    );
     expect(prompt).not.toContain(
       "When exec returns approval-pending, include the concrete /approve command from tool output",
     );

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -175,8 +175,13 @@ function buildDocsSection(params: { docsPath?: string; isMinimal: boolean; readT
 
 function buildExecApprovalPromptGuidance(params: { runtimeChannel?: string }) {
   const runtimeChannel = params.runtimeChannel?.trim().toLowerCase();
-  if (runtimeChannel === "discord" || runtimeChannel === "slack" || runtimeChannel === "telegram") {
-    return "When exec returns approval-pending on Discord, Slack, or Telegram, rely on the native approval card/buttons when they appear and do not also send plain chat /approve instructions. Only include the concrete /approve command if the tool result says chat approvals are unavailable or only manual approval is possible.";
+  if (
+    runtimeChannel === "discord" ||
+    runtimeChannel === "slack" ||
+    runtimeChannel === "telegram" ||
+    runtimeChannel === "webchat"
+  ) {
+    return "When exec returns approval-pending on Discord, Slack, Telegram, or WebChat, rely on the native approval card/buttons when they appear and do not also send plain chat /approve instructions. Only include the concrete /approve command if the tool result says chat approvals are unavailable or only manual approval is possible.";
   }
   return "When exec returns approval-pending, include the concrete /approve command from tool output (with allow-once|allow-always|deny) as plain chat text for the user, and do not ask for a different or rotated code.";
 }


### PR DESCRIPTION
## Summary
- treat webchat like Discord/Slack/Telegram for exec approval prompt guidance
- stop telling agents to paste manual `/approve` commands when the runtime has native approval UI
- add regression coverage for the webchat path

## Why
This is a narrow residual after #58792 and #58860.

Those changes fixed the exec policy/config cluster and the async continuation path. One UI mismatch remained: webchat/control sessions still got the manual `/approve` system-prompt guidance even though approvals arrive through native UI.

## Testing
- pnpm test -- src/agents/system-prompt.test.ts
- pnpm check

Related #52850
Related #58797
