### PR TITLE
feat(config): suggest closest config paths on get/unset not-found errors

### DIFF
--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -8,6 +8,7 @@ import { isBlockedObjectKey } from "../config/prototype-keys.js";
 import { redactConfigObject } from "../config/redact-snapshot.js";
 import { readBestEffortRuntimeConfigSchema } from "../config/runtime-schema.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { buildConfigPathSuggestionHint } from "../config/suggest-path.js";
 import {
   coerceSecretRef,
   isValidEnvSecretRefId,
@@ -1660,6 +1661,10 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
     const res = getAtPath(redacted, parsedPath);
     if (!res.found) {
       runtime.error(danger(`Config path not found: ${opts.path}`));
+      const hint = buildConfigPathSuggestionHint(opts.path);
+      if (hint) {
+        runtime.error(info(hint));
+      }
       runtime.exit(1);
       return;
     }
@@ -1694,6 +1699,10 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
     const removed = unsetAtPath(next, parsedPath);
     if (!removed) {
       runtime.error(danger(`Config path not found: ${opts.path}`));
+      const hint = buildConfigPathSuggestionHint(opts.path);
+      if (hint) {
+        runtime.error(info(hint));
+      }
       runtime.exit(1);
       return;
     }

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -14,6 +14,7 @@ import { isBlockedObjectKey } from "../config/prototype-keys.js";
 import { redactConfigObject } from "../config/redact-snapshot.js";
 import { readBestEffortRuntimeConfigSchema } from "../config/runtime-schema.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { buildConfigPathSuggestionHint } from "../config/suggest-path.js";
 import {
   coerceSecretRef,
   isValidEnvSecretRefId,
@@ -2010,6 +2011,10 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
           `Config path not found: ${opts.path}. Run ${formatCliCommand("openclaw config validate")} to inspect config shape.`,
         ),
       );
+      const hint = buildConfigPathSuggestionHint(opts.path);
+      if (hint) {
+        runtime.error(info(hint));
+      }
       runtime.exit(1);
       return;
     }
@@ -2084,6 +2089,10 @@ export async function runConfigUnset(opts: {
           `Config path not found: ${opts.path}. Nothing was changed. Run ${formatCliCommand("openclaw config get <path>")} first if you are unsure of the path.`,
         ),
       );
+      const hint = buildConfigPathSuggestionHint(opts.path);
+      if (hint) {
+        runtime.error(info(hint));
+      }
       runtime.exit(1);
       return;
     }

--- a/src/config/suggest-path.test.ts
+++ b/src/config/suggest-path.test.ts
@@ -1,0 +1,135 @@
+/**
+ * suggest-path.test.ts
+ *
+ * Unit tests for the config path suggestion module.
+ * Covers edit-distance computation, path suggestion logic, and hint formatting.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildConfigPathSuggestionHint, editDistance, suggestConfigPaths } from "./suggest-path.js";
+
+// ---------------------------------------------------------------------------
+// editDistance
+// ---------------------------------------------------------------------------
+
+describe("editDistance", () => {
+  it("returns 0 for identical strings", () => {
+    expect(editDistance("abc", "abc")).toBe(0);
+  });
+
+  it("returns length of other string when one is empty", () => {
+    expect(editDistance("", "abc")).toBe(3);
+    expect(editDistance("abc", "")).toBe(3);
+  });
+
+  it("returns 0 for two empty strings", () => {
+    expect(editDistance("", "")).toBe(0);
+  });
+
+  it("computes single substitution distance", () => {
+    expect(editDistance("cat", "bat")).toBe(1);
+  });
+
+  it("computes single insertion distance", () => {
+    expect(editDistance("cat", "cart")).toBe(1);
+  });
+
+  it("computes single deletion distance", () => {
+    expect(editDistance("cart", "cat")).toBe(1);
+  });
+
+  it("computes multi-edit distance", () => {
+    expect(editDistance("kitten", "sitting")).toBe(3);
+  });
+
+  it("handles transposition as two edits", () => {
+    // Levenshtein counts transposition as 2 operations (delete + insert).
+    expect(editDistance("ab", "ba")).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// suggestConfigPaths
+// ---------------------------------------------------------------------------
+
+describe("suggestConfigPaths", () => {
+  it("returns empty array for empty input", () => {
+    expect(suggestConfigPaths("")).toEqual([]);
+  });
+
+  it("returns empty array for completely unrelated input", () => {
+    // A string that is far from any real config key.
+    expect(suggestConfigPaths("xyzzy_totally_unknown_zzz")).toEqual([]);
+  });
+
+  it("suggests a close match for a single-char typo in a known path", () => {
+    // "gateway.prot" is 1 edit away from "gateway.port"
+    const suggestions = suggestConfigPaths("gateway.prot");
+    expect(suggestions.length).toBeGreaterThan(0);
+    expect(suggestions).toContain("gateway.port");
+  });
+
+  it("suggests matches for a typo in the last segment", () => {
+    // "logging.levl" should suggest "logging.level"
+    const suggestions = suggestConfigPaths("logging.levl");
+    expect(suggestions.length).toBeGreaterThan(0);
+    expect(suggestions).toContain("logging.level");
+  });
+
+  it("returns at most 3 suggestions", () => {
+    // Use a short common prefix that could match many paths.
+    const suggestions = suggestConfigPaths("gateway");
+    expect(suggestions.length).toBeLessThanOrEqual(3);
+  });
+
+  it("is case-insensitive", () => {
+    const suggestions = suggestConfigPaths("GATEWAY.PORT");
+    // Should still find gateway.port even though input is uppercase.
+    // May return empty if distance is too large due to case, but should not crash.
+    expect(Array.isArray(suggestions)).toBe(true);
+  });
+
+  it("handles segment-level matching for deep paths", () => {
+    // "diagnostics.cacheTrace" exists; "diagnostics.cachTrace" has a typo.
+    const suggestions = suggestConfigPaths("diagnostics.cachTrace");
+    expect(suggestions.length).toBeGreaterThan(0);
+    // Should find the real path via segment-level matching.
+    expect(suggestions.some((s) => s.startsWith("diagnostics.cacheTrace"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildConfigPathSuggestionHint
+// ---------------------------------------------------------------------------
+
+describe("buildConfigPathSuggestionHint", () => {
+  it("returns null for empty input", () => {
+    expect(buildConfigPathSuggestionHint("")).toBeNull();
+  });
+
+  it("returns null for completely unrelated input", () => {
+    expect(buildConfigPathSuggestionHint("xyzzy_totally_unknown_zzz")).toBeNull();
+  });
+
+  it("returns a 'Did you mean' hint for a close match", () => {
+    const hint = buildConfigPathSuggestionHint("gateway.prot");
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("Did you mean");
+    expect(hint).toContain("gateway.port");
+  });
+
+  it("uses singular form for single suggestion", () => {
+    // Force a path that will likely yield exactly one match.
+    const hint = buildConfigPathSuggestionHint("logging.levl");
+    if (hint && !hint.includes("one of")) {
+      expect(hint).toMatch(/^Did you mean: .+\?$/);
+    }
+  });
+
+  it("uses plural form for multiple suggestions", () => {
+    const hint = buildConfigPathSuggestionHint("gateway");
+    if (hint && hint.includes("one of")) {
+      expect(hint).toMatch(/^Did you mean one of: .+\?$/);
+    }
+  });
+});

--- a/src/config/suggest-path.test.ts
+++ b/src/config/suggest-path.test.ts
@@ -84,9 +84,8 @@ describe("suggestConfigPaths", () => {
 
   it("is case-insensitive", () => {
     const suggestions = suggestConfigPaths("GATEWAY.PORT");
-    // Should still find gateway.port even though input is uppercase.
-    // May return empty if distance is too large due to case, but should not crash.
-    expect(Array.isArray(suggestions)).toBe(true);
+    // Needle is lowercased before matching, so the exact path should always be found.
+    expect(suggestions).toContain("gateway.port");
   });
 
   it("handles segment-level matching for deep paths", () => {

--- a/src/config/suggest-path.ts
+++ b/src/config/suggest-path.ts
@@ -98,7 +98,7 @@ export function suggestConfigPaths(unknownPath: string): string[] {
 
   // --- Phase 1: prefix matches (input is a truncated known path) -----------
   const prefixMatches = knownPaths.filter((known) => known.toLowerCase().startsWith(needle + "."));
-  if (prefixMatches.length > 0 && prefixMatches.length <= MAX_SUGGESTIONS) {
+  if (prefixMatches.length > 0) {
     return prefixMatches.slice(0, MAX_SUGGESTIONS);
   }
 
@@ -128,6 +128,10 @@ export function suggestConfigPaths(unknownPath: string): string[] {
         continue;
       }
       const knownParts = knownLower.split(".");
+      // Restrict to same depth to avoid cross-level false positives (Codex review).
+      if (knownParts.length !== needleParts.length) {
+        continue;
+      }
       const knownTail = knownParts[knownParts.length - 1] ?? "";
       const tailDistance = editDistance(needleTail, knownTail);
       if (tailDistance > 0 && tailDistance <= MAX_DISTANCE) {

--- a/src/config/suggest-path.ts
+++ b/src/config/suggest-path.ts
@@ -1,0 +1,187 @@
+/**
+ * suggest-path.ts
+ *
+ * Provides "Did you mean ...?" suggestions when users enter an invalid
+ * config path in `openclaw config get` or `openclaw config unset`.
+ *
+ * Uses Levenshtein edit-distance to find the closest known paths from
+ * the FIELD_HELP registry (the single source of truth for documented
+ * config keys).
+ */
+
+import { FIELD_HELP } from "./schema.help.js";
+
+// ---------------------------------------------------------------------------
+// Edit-distance (Levenshtein) – single-row DP, O(n·m) time, O(m) space.
+// Intentionally self-contained so this module has no dependency on the
+// security subsystem where a similar helper lives.
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the Levenshtein edit-distance between two strings.
+ */
+export function editDistance(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  if (!a) {
+    return b.length;
+  }
+  if (!b) {
+    return a.length;
+  }
+
+  const dp: number[] = Array.from({ length: b.length + 1 }, (_, j) => j);
+
+  for (let i = 1; i <= a.length; i++) {
+    let prev = dp[0];
+    dp[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const temp = dp[j];
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[j] = Math.min(dp[j] + 1, dp[j - 1] + 1, prev + cost);
+      prev = temp;
+    }
+  }
+
+  return dp[b.length];
+}
+
+// ---------------------------------------------------------------------------
+// Path suggestion
+// ---------------------------------------------------------------------------
+
+/** Maximum edit-distance to consider a path as a valid suggestion. */
+const MAX_DISTANCE = 3;
+
+/** Maximum number of suggestions to return. */
+const MAX_SUGGESTIONS = 3;
+
+/**
+ * Collect all known config paths from the FIELD_HELP registry.
+ *
+ * The result is cached after first call because FIELD_HELP is a static
+ * compile-time constant that never changes at runtime.
+ */
+let cachedKnownPaths: string[] | null = null;
+
+function getKnownConfigPaths(): string[] {
+  if (cachedKnownPaths) {
+    return cachedKnownPaths;
+  }
+  cachedKnownPaths = Object.keys(FIELD_HELP);
+  return cachedKnownPaths;
+}
+
+/**
+ * Find config paths that are similar to the given unknown path.
+ *
+ * Strategy:
+ *  1. Exact prefix match – if the input is a valid prefix of known paths,
+ *     those are returned first (handles truncated paths like "gateway.au").
+ *  2. Edit-distance – for each known path, compute the Levenshtein distance
+ *     to the input. Paths within MAX_DISTANCE are collected and sorted by
+ *     distance ascending, then alphabetically for ties.
+ *  3. Segment-level match – compare the last segment of the input against
+ *     last segments of all known paths to catch cases like
+ *     "channels.telegram.tken" vs "channels.telegram.token".
+ *
+ * Returns an empty array when no close match exists.
+ */
+export function suggestConfigPaths(unknownPath: string): string[] {
+  const needle = unknownPath.trim().toLowerCase();
+  if (!needle) {
+    return [];
+  }
+
+  const knownPaths = getKnownConfigPaths();
+
+  // --- Phase 1: prefix matches (input is a truncated known path) -----------
+  const prefixMatches = knownPaths.filter((known) => known.toLowerCase().startsWith(needle + "."));
+  if (prefixMatches.length > 0 && prefixMatches.length <= MAX_SUGGESTIONS) {
+    return prefixMatches.slice(0, MAX_SUGGESTIONS);
+  }
+
+  // --- Phase 2: full-path edit-distance ------------------------------------
+  type Candidate = { path: string; distance: number };
+  const candidates: Candidate[] = [];
+
+  for (const known of knownPaths) {
+    const distance = editDistance(needle, known.toLowerCase());
+    if (distance <= MAX_DISTANCE) {
+      candidates.push({ path: known, distance });
+    }
+  }
+
+  // --- Phase 3: last-segment edit-distance ---------------------------------
+  // Handles "gateway.auth.tken" → "gateway.auth.token" where the full-path
+  // distance may exceed MAX_DISTANCE but the last segment is very close.
+  const needleParts = needle.split(".");
+  if (needleParts.length >= 2) {
+    const needlePrefix = needleParts.slice(0, -1).join(".");
+    const needleTail = needleParts[needleParts.length - 1] ?? "";
+
+    for (const known of knownPaths) {
+      const knownLower = known.toLowerCase();
+      // Only consider paths that share the same prefix.
+      if (!knownLower.startsWith(needlePrefix + ".")) {
+        continue;
+      }
+      const knownParts = knownLower.split(".");
+      const knownTail = knownParts[knownParts.length - 1] ?? "";
+      const tailDistance = editDistance(needleTail, knownTail);
+      if (tailDistance > 0 && tailDistance <= MAX_DISTANCE) {
+        // Use tail distance as the sort key so segment-level matches
+        // compete fairly with full-path matches.
+        const alreadyPresent = candidates.some((c) => c.path === known);
+        if (!alreadyPresent) {
+          candidates.push({ path: known, distance: tailDistance });
+        }
+      }
+    }
+  }
+
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  // Sort by distance first, then alphabetically for deterministic output.
+  candidates.sort((a, b) => a.distance - b.distance || a.path.localeCompare(b.path));
+
+  // Dedupe (shouldn't be needed but guard against edge cases).
+  const seen = new Set<string>();
+  const results: string[] = [];
+  for (const candidate of candidates) {
+    if (seen.has(candidate.path)) {
+      continue;
+    }
+    seen.add(candidate.path);
+    results.push(candidate.path);
+    if (results.length >= MAX_SUGGESTIONS) {
+      break;
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Build a human-readable hint string for an unknown config path.
+ *
+ * Returns `null` when no suggestion is available, so callers can skip
+ * printing an empty hint.
+ *
+ * Example output:
+ *   'Did you mean: gateway.auth.token?'
+ *   'Did you mean one of: gateway.port, gateway.auth.token, gateway.auth.mode?'
+ */
+export function buildConfigPathSuggestionHint(unknownPath: string): string | null {
+  const suggestions = suggestConfigPaths(unknownPath);
+  if (suggestions.length === 0) {
+    return null;
+  }
+  if (suggestions.length === 1) {
+    return `Did you mean: ${suggestions[0]}?`;
+  }
+  return `Did you mean one of: ${suggestions.join(", ")}?`;
+}

--- a/src/config/suggest-path.ts
+++ b/src/config/suggest-path.ts
@@ -69,7 +69,13 @@ function getKnownConfigPaths(): string[] {
   if (cachedKnownPaths) {
     return cachedKnownPaths;
   }
-  cachedKnownPaths = Object.keys(FIELD_HELP);
+  // Filter out template/wildcard keys (e.g. "plugins.entries.*.apiKey",
+  // "session.sendPolicy.rules[].match.keyPrefix") that are not concrete
+  // CLI paths. Users cannot pass these to config get/unset and parsePath
+  // would reject the "[]" form with an error.
+  cachedKnownPaths = Object.keys(FIELD_HELP).filter(
+    (key) => !key.includes("*") && !key.includes("[]"),
+  );
   return cachedKnownPaths;
 }
 


### PR DESCRIPTION
## Summary
When a user runs `openclaw config get` or `openclaw config unset` with a path that does not exist, the CLI now suggests the closest known config paths using Levenshtein edit-distance matching.

## Problem
Users who mistype config paths get a bare "Config path not found" error with no guidance. This is especially frustrating for paths deep in the config tree (e.g., `channels.telegram.streaming` vs `channels.telegram.streamMode`), where the correct key is not obvious without consulting documentation.

## Real behavior proof

- **Behavior or issue addressed:** `openclaw config get/unset <path>` printed a bare "Config path not found" error with no guidance. This adds a "Did you mean ...?" suggestion built from the FIELD_HELP registry (single source of truth for documented config paths), shown only in the not-found error branch.

- **Real environment tested:** Linux (Ubuntu 24.04, WSL2), Node.js 24.14.0, OpenClaw built from this PR head. Exercised the exported `buildConfigPathSuggestionHint()` against representative mistyped config paths via tsx (the same function config-cli invokes in its not-found branch at config-cli.ts).

- **Exact steps or command run after this patch:** invoked the patched suggestion builder against mistyped paths via tsx:
```bash
$ node --import tsx run-suggest.ts
```

- **Evidence after fix:** Actual output of the patched `buildConfigPathSuggestionHint()` on not-found paths (suggestions drawn from the live FIELD_HELP registry):
```
config path "gateway.prot" -> Did you mean one of: gateway.port, gateway.push?
config path "logging.levl" -> Did you mean: logging.level?
config path "gatway.port"  -> Did you mean: gateway.port?
config path "zzzzzzzzz"    -> (no suggestion)
```

- **Observed result after fix:** Mistyped paths now yield a "Did you mean ...?" hint listing the closest valid config paths (single best match, or up to three when several are equally close), while nonsense input ("zzzzzzzzz") yields no hint (no false suggestion). In config-cli the hint is only emitted inside the `if (!res.found)` branch, so valid paths never trigger it.

- **What was not tested:** The full `openclaw config get` end-to-end CLI invocation was not captured here (it triggers a heavy dist build); the patched suggestion function is exercised directly with the same FIELD_HELP-derived candidate set the CLI uses.

## Solution
A three-phase matching strategy:
1. **Prefix match** — catches truncated paths like `gateway.au` → `gateway.auth.mode`
2. **Full-path edit-distance** — Levenshtein distance ≤ 3 catches typos like `gateway.prot` → `gateway.port`
3. **Last-segment edit-distance** — catches `logging.levl` → `logging.level`

Candidate paths sourced from FIELD_HELP registry (~700 documented config keys). Zero runtime cost.

## Changes
- **New:** `src/config/suggest-path.ts` — self-contained suggestion engine
- **New:** `src/config/suggest-path.test.ts` — 20 unit tests
- **Modified:** `src/cli/config-cli.ts` — added hint output to `runConfigGet` and `runConfigUnset`

## Verification
- 20/20 unit tests pass
- pnpm check: clean
- Greptile: 5/5 Confidence Score
