### PR TITLE
Fix/feishu webhook url verification

### DIFF
--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -86,6 +86,36 @@ function isFeishuWebhookSignatureValid(params: {
   return timingSafeEqualString(computedSignature, signature);
 }
 
+function hasFeishuWebhookSignatureHeaders(headers: http.IncomingHttpHeaders): boolean {
+  return !!(
+    headers["x-lark-request-timestamp"] ||
+    headers["x-lark-request-nonce"] ||
+    headers["x-lark-signature"]
+  );
+}
+
+function inspectFeishuWebhookChallenge(
+  payload: Record<string, unknown>,
+  encryptKey?: string,
+):
+  | { isChallenge: true; challenge: { challenge: unknown } }
+  | { isChallenge: false; error?: Error } {
+  try {
+    const { isChallenge, challenge } = Lark.generateChallenge(payload, {
+      encryptKey: encryptKey ?? "",
+    });
+    if (!isChallenge) {
+      return { isChallenge: false };
+    }
+    return { isChallenge: true, challenge: challenge as { challenge: unknown } };
+  } catch (error) {
+    return {
+      isChallenge: false,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+}
+
 function respondText(res: http.ServerResponse, statusCode: number, body: string): void {
   res.statusCode = statusCode;
   res.setHeader("Content-Type", "text/plain; charset=utf-8");
@@ -204,7 +234,21 @@ export async function monitorWebhook({
           return;
         }
 
-        // Reject invalid signatures before any JSON parsing to keep the auth boundary strict.
+        const payload = parseFeishuWebhookPayload(rawBody);
+        const challengeInspection = payload
+          ? inspectFeishuWebhookChallenge(payload, account.encryptKey)
+          : null;
+
+        // Feishu's initial URL verification omits signature headers entirely, so
+        // allow only the challenge handshake to short-circuit the normal auth path.
+        if (challengeInspection?.isChallenge && !hasFeishuWebhookSignatureHeaders(req.headers)) {
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "application/json; charset=utf-8");
+          res.end(JSON.stringify(challengeInspection.challenge));
+          return;
+        }
+
+        // Reject invalid signatures before dispatching ordinary webhook events.
         if (
           !isFeishuWebhookSignatureValid({
             headers: req.headers,
@@ -216,19 +260,19 @@ export async function monitorWebhook({
           return;
         }
 
-        const payload = parseFeishuWebhookPayload(rawBody);
         if (!payload) {
           respondText(res, 400, "Invalid JSON");
           return;
         }
 
-        const { isChallenge, challenge } = Lark.generateChallenge(payload, {
-          encryptKey: account.encryptKey ?? "",
-        });
-        if (isChallenge) {
+        if (challengeInspection && !challengeInspection.isChallenge && challengeInspection.error) {
+          throw challengeInspection.error;
+        }
+
+        if (challengeInspection?.isChallenge) {
           res.statusCode = 200;
           res.setHeader("Content-Type", "application/json; charset=utf-8");
-          res.end(JSON.stringify(challenge));
+          res.end(JSON.stringify(challengeInspection.challenge));
           return;
         }
 

--- a/extensions/feishu/src/monitor.webhook-e2e.test.ts
+++ b/extensions/feishu/src/monitor.webhook-e2e.test.ts
@@ -59,6 +59,14 @@ async function postSignedPayload(url: string, payload: Record<string, unknown>) 
   });
 }
 
+async function postUnsignedPayload(url: string, payload: Record<string, unknown>) {
+  return await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
 afterEach(() => {
   stopFeishuMonitor();
 });
@@ -92,7 +100,7 @@ describe("Feishu webhook signed-request e2e", () => {
     );
   });
 
-  it("rejects missing signature headers with 401", async () => {
+  it("accepts plaintext url_verification challenges without signature headers", async () => {
     probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
 
     await withRunningWebhookMonitor(
@@ -104,14 +112,13 @@ describe("Feishu webhook signed-request e2e", () => {
       },
       monitorFeishuProvider,
       async (url) => {
-        const response = await fetch(url, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ type: "url_verification", challenge: "challenge-token" }),
+        const response = await postUnsignedPayload(url, {
+          type: "url_verification",
+          challenge: "challenge-token",
         });
 
-        expect(response.status).toBe(401);
-        expect(await response.text()).toBe("Invalid signature");
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({ challenge: "challenge-token" });
       },
     );
   });
@@ -242,6 +249,30 @@ describe("Feishu webhook signed-request e2e", () => {
     );
   });
 
+  it("rejects unsigned non-challenge events without signature headers", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+
+    await withRunningWebhookMonitor(
+      {
+        accountId: "unsigned-dispatch",
+        path: "/hook-e2e-unsigned-dispatch",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const response = await postUnsignedPayload(url, {
+          schema: "2.0",
+          header: { event_type: "unknown.event" },
+          event: {},
+        });
+
+        expect(response.status).toBe(401);
+        expect(await response.text()).toBe("Invalid signature");
+      },
+    );
+  });
+
   it("accepts signed encrypted url_verification challenges end-to-end", async () => {
     probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
 
@@ -261,6 +292,33 @@ describe("Feishu webhook signed-request e2e", () => {
           }),
         };
         const response = await postSignedPayload(url, payload);
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({
+          challenge: "encrypted-challenge-token",
+        });
+      },
+    );
+  });
+
+  it("accepts encrypted url_verification challenges without signature headers", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+
+    await withRunningWebhookMonitor(
+      {
+        accountId: "encrypted-challenge-unsigned",
+        path: "/hook-e2e-encrypted-challenge-unsigned",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const response = await postUnsignedPayload(url, {
+          encrypt: encryptFeishuPayload("encrypt_key", {
+            type: "url_verification",
+            challenge: "encrypted-challenge-token",
+          }),
+        });
 
         expect(response.status).toBe(200);
         await expect(response.json()).resolves.toEqual({


### PR DESCRIPTION
Closes #58905

## Summary

- **Problem:** Feishu webhook mode rejects the initial `url_verification` request with `401 Invalid signature` when `encryptKey` is configured.
- **Why it matters:** Users cannot complete webhook URL verification in the Feishu developer console, so webhook mode is effectively blocked during setup.
- **What changed:** Detect and respond to Feishu `url_verification` challenges before ordinary webhook signature auth, and add regression coverage for unsigned challenge requests.
- **What did NOT change:** Signature validation for ordinary non-challenge webhook events is unchanged.

## Root Cause

`extensions/feishu/src/monitor.transport.ts` validated `x-lark-request-timestamp`, `x-lark-request-nonce`, and `x-lark-signature` before checking whether the payload was a Feishu `url_verification` challenge.

When `encryptKey` is configured, `isFeishuWebhookSignatureValid(...)` returns `false` if those headers are missing, so the challenge path was unreachable and the handler always returned `401`.

This diverged from the Lark SDK's challenge-first flow, where `generateChallenge(...)` is handled before normal event dispatch.

## Changes

- `extensions/feishu/src/monitor.transport.ts`
  - Parse the request body first
  - Detect Feishu `url_verification` challenges via `Lark.generateChallenge(...)`
  - Return the challenge response before ordinary webhook signature auth
  - Keep normal signature validation unchanged for non-challenge events

- `extensions/feishu/src/monitor.webhook-e2e.test.ts`
  - Add coverage for unsigned plaintext `url_verification` requests
  - Add coverage for unsigned encrypted `url_verification` requests
  - Add a guard test that unsigned non-challenge events still return `401`

## Evidence & Repro

Before this change:

- unsigned plaintext `url_verification` requests returned `401 Invalid signature`
- unsigned encrypted `url_verification` requests returned `401 Invalid signature`
- signed non-challenge events still worked

Expected:

- `url_verification` returns `{"challenge":"..."}`
- ordinary non-challenge events still require valid signature headers

## Testing & Verification

Updated tests:

- `extensions/feishu/src/monitor.webhook-e2e.test.ts`

Verified locally with:

```bash
pnpm test -- extensions/feishu/src/monitor.webhook-e2e.test.ts extensions/feishu/src/monitor.webhook-security.test.ts
```