### PR TITLE
feat(exec): support `background: false` to force synchronous execution

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -131,7 +131,13 @@ export const execSchema = Type.Object({
       description: "Milliseconds to wait before backgrounding (default 10000)",
     }),
   ),
-  background: Type.Optional(Type.Boolean({ description: "Run in background immediately" })),
+  background: Type.Optional(
+    Type.Boolean({
+      description:
+        "Run in background immediately (true) or force synchronous execution (false). " +
+        "When false, the command runs to completion regardless of yieldMs/backgroundMs.",
+    }),
+  ),
   timeout: Type.Optional(
     Type.Number({
       description: "Timeout in seconds (optional, kills process on expiry)",

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1242,7 +1242,7 @@ function deriveExecShortName(fullPath: string): string {
 export function describeExecTool(params?: { agentId?: string; hasCronTool?: boolean }): string {
   const base = [
     "Execute shell commands with background continuation for work that starts now.",
-    "Use yieldMs/background to continue later via process tool.",
+    "Use yieldMs/background=true to continue later via process tool. Use background=false to force synchronous execution (no auto-backgrounding).",
     "For long-running work started now, rely on automatic completion wake when it is enabled and the command emits output or fails; otherwise use process to confirm completion. Use process whenever you need logs, status, input, or intervention.",
     params?.hasCronTool
       ? "Do not use exec sleep or delay loops for reminders or deferred follow-ups; use cron instead."
@@ -1372,19 +1372,25 @@ export function createExecTool(
       const warnings: string[] = [];
       let execCommandOverride: string | undefined;
       const backgroundRequested = params.background === true;
+      const synchronousRequested = params.background === false;
       const yieldRequested = typeof params.yieldMs === "number";
       if (!allowBackground && (backgroundRequested || yieldRequested)) {
         warnings.push("Warning: background execution is disabled; running synchronously.");
       }
+      if (synchronousRequested && yieldRequested) {
+        warnings.push("Warning: yieldMs is ignored when background=false.");
+      }
       const yieldWindow = allowBackground
-        ? backgroundRequested
-          ? 0
-          : clampWithDefault(
-              params.yieldMs ?? defaultBackgroundMs,
-              defaultBackgroundMs,
-              10,
-              120_000,
-            )
+        ? synchronousRequested
+          ? null
+          : backgroundRequested
+            ? 0
+            : clampWithDefault(
+                params.yieldMs ?? defaultBackgroundMs,
+                defaultBackgroundMs,
+                10,
+                120_000,
+              )
         : null;
       const elevatedDefaults = defaults?.elevated;
       const elevatedAllowed = Boolean(elevatedDefaults?.enabled && elevatedDefaults.allowed);

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -507,6 +507,21 @@ describe("exec tool backgrounding", () => {
     expect(sessions.find((s) => s.sessionId === sessionId)?.name).toBe(COMMAND_ECHO_HELLO);
   });
 
+  it("forces synchronous execution with background=false", async () => {
+    // With a very low backgroundMs, a normal command would be backgrounded.
+    // background=false should override and run synchronously to completion.
+    const tool = createTestExecTool({ backgroundMs: 10 });
+    const result = await executeExecCommand(
+      tool,
+      joinCommands([yieldDelayCmd, shellEcho("sync-done")]),
+      { background: false },
+    );
+
+    // Should complete synchronously, not return status "running"
+    expect(result.details.status).toBe(PROCESS_STATUS_COMPLETED);
+    expect(readTextContent(result.content)).toContain("sync-done");
+  });
+
   it.each<DisallowedElevationCase>(DISALLOWED_ELEVATION_CASES)(
     "$label",
     runDisallowedElevationCase,


### PR DESCRIPTION
## Summary

Rebased revival of #15378 (auto-closed by stale bot).

- Gives `background: false` an explicit meaning: **force synchronous execution**, suppressing the yield timer entirely
- Previously `false` was a no-op (treated the same as omitting the parameter) — no backwards-compatibility impact
- Adds a test verifying synchronous completion even with an aggressive `backgroundMs: 10`

### Semantics after this change

| Value | Behavior |
|---|---|
| `background: true` | Immediate background (unchanged) |
| `background: undefined` | Timer-based auto-background via `yieldMs`/`backgroundMs` (unchanged) |
| `background: false` | **Synchronous — no yield timer, blocks until completion (new)** |

## Motivation

I'm building [agentpass](https://github.com/TorbenWetter/agentpass), a security gateway that mediates AI agent requests to Home Assistant through human approval on Telegram. The `agentpass request` CLI command blocks for up to 15 minutes while waiting for the guardian to approve or deny.

With the current exec tool, the default 10-second yield timer backgrounds these commands prematurely, causing the agent to announce intermediate status messages instead of waiting silently for the result. Neither `yieldMs` (clamped to 120s) nor globally raising `backgroundMs` solve this cleanly — you'd need per-command control.

`background: false` is the natural inverse of `background: true` and gives skills exactly that control.

Related issues where this helps:
- **#16807** — Agent polling a backgrounded `sleep 120` generated 1,535 messages and $150+ in wasted tokens
- **#9875** — Orphaned `tool_use` blocks when backgrounded exec jobs outlive session persistence
- **#8997** — Background `notifyOnExit` messages interrupting active agent turns
- **#14127** — Gateway approval path returning prematurely with Always Allow

## Implementation

When `background: false` is passed, `yieldWindow` is set to `null` — the same value used when `allowBackground` is globally disabled. No `setTimeout` race is created, and the code falls through to the synchronous `run.promise.then(...)` path.

Resolved conflict from original PR: `bash-tools.exec-runtime.ts` was merged into `bash-tools.exec.ts` upstream — schema description update applied there instead.

## Test plan

- [x] New test: `"forces synchronous execution with background=false"` — creates an exec tool with `backgroundMs: 10`, runs a command with `background: false`, asserts `status === "completed"` (not `"running"`)
- [x] All existing tests unaffected