### PR TITLE
fix(exec): skip gateway cwd injection for remote node host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,9 @@ Docs: https://docs.openclaw.ai
 - Telegram/exec approvals: rewrite shared `/approve … allow-always` callback payloads to `/approve … always` before Telegram button rendering so plugin approval IDs still fit Telegram's `callback_data` limit and keep the Allow Always action visible. (#59217) Thanks @jameslcowan.
 - Cron/exec timeouts: surface timed-out `exec` and `bash` failures in isolated cron runs even when `verbose: off`, including custom session-target cron jobs, so scheduled runs stop failing silently. (#58247) Thanks @skainguyen1412.
 - Telegram/exec approvals: fall back to the origin session key for async approval followups and keep resume-failure status delivery sanitized so Telegram followups still land without leaking raw exec metadata. (#59351) Thanks @seonang.
+<<<<<<< HEAD
 - Node-host/exec approvals: bind `pnpm dlx` invocations through the approval planner's mutable-script path so the effective runtime command is resolved for approval instead of being left unbound. (#58374)
+- Exec/node hosts: stop forwarding the gateway workspace cwd to remote node exec when no workdir was explicitly requested, so cross-platform node approvals fall back to the node default cwd instead of failing with `SYSTEM_RUN_DENIED`. (#58977) Thanks @Starhappysh.
 
 ## 2026.4.2
 

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -154,7 +154,7 @@ type HostExecApprovalParams = {
   commandArgv?: string[];
   systemRunPlan?: SystemRunApprovalPlan;
   env?: Record<string, string>;
-  workdir: string;
+  workdir: string | undefined;
   host: "gateway" | "node";
   nodeId?: string;
   security: ExecSecurity;
@@ -245,3 +245,4 @@ export async function registerExecApprovalRequestForHostOrThrow(
     throw new Error(`Exec approval registration failed: ${String(err)}`, { cause: err });
   }
 }
+

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -11,7 +11,7 @@ export type RequestExecApprovalDecisionParams = {
   commandArgv?: string[];
   systemRunPlan?: SystemRunApprovalPlan;
   env?: Record<string, string>;
-  cwd: string;
+  cwd: string | undefined;
   nodeId?: string;
   host: "gateway" | "node";
   security: ExecSecurity;

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -121,7 +121,7 @@ export async function executeNodeHostCommand(
   }
   const runArgv = prepared.plan.argv;
   const runRawCommand = prepared.plan.commandText;
-  const runCwd = prepared.plan.cwd ?? params.workdir ?? undefined;
+  const runCwd = prepared.plan.cwd ?? params.workdir;
   const runAgentId = prepared.plan.agentId ?? params.agentId;
   const runSessionKey = prepared.plan.sessionKey ?? params.sessionKey;
 
@@ -453,4 +453,3 @@ export async function executeNodeHostCommand(
     } satisfies ExecToolDetails,
   };
 }
-

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -35,7 +35,7 @@ import { listNodes, resolveNodeIdFromList } from "./tools/nodes-utils.js";
 
 export type ExecuteNodeHostCommandParams = {
   command: string;
-  workdir: string;
+  workdir: string | undefined;
   env: Record<string, string>;
   requestedEnv?: Record<string, string>;
   requestedNode?: string;
@@ -108,7 +108,7 @@ export async function executeNodeHostCommand(
       params: {
         command: argv,
         rawCommand: params.command,
-        cwd: params.workdir,
+        ...(params.workdir != null ? { cwd: params.workdir } : {}),
         agentId: params.agentId,
         sessionKey: params.sessionKey,
       },
@@ -121,7 +121,7 @@ export async function executeNodeHostCommand(
   }
   const runArgv = prepared.plan.argv;
   const runRawCommand = prepared.plan.commandText;
-  const runCwd = prepared.plan.cwd ?? params.workdir;
+  const runCwd = prepared.plan.cwd ?? params.workdir ?? undefined;
   const runAgentId = prepared.plan.agentId ?? params.agentId;
   const runSessionKey = prepared.plan.sessionKey ?? params.sessionKey;
 
@@ -453,3 +453,4 @@ export async function executeNodeHostCommand(
     } satisfies ExecToolDetails,
   };
 }
+

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -403,7 +403,7 @@ export async function sendExecApprovalFollowupResult(
 export function buildExecApprovalPendingToolResult(params: {
   host: "gateway" | "node";
   command: string;
-  cwd: string;
+  cwd: string | undefined;
   warningText: string;
   approvalId: string;
   approvalSlug: string;

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -340,7 +340,7 @@ export function buildApprovalPendingMessage(params: {
   approvalId: string;
   allowedDecisions?: readonly ExecApprovalDecision[];
   command: string;
-  cwd: string;
+  cwd: string | undefined;
   host: "gateway" | "node";
   nodeId?: string;
 }) {
@@ -361,7 +361,7 @@ export function buildApprovalPendingMessage(params: {
   if (params.nodeId) {
     lines.push(`Node: ${params.nodeId}`);
   }
-  lines.push(`CWD: ${params.cwd}`);
+  lines.push(`CWD: ${params.cwd ?? "(node default)"}`);
   lines.push("Command:");
   lines.push(commandBlock);
   lines.push("Mode: foreground (interactive approvals available).");

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -94,6 +94,7 @@ function expectPendingApprovalText(
     nodeId?: string;
     interactive?: boolean;
     allowedDecisions?: string;
+    cwdText?: string;
   },
 ) {
   expect(result.details.status).toBe("approval-pending");
@@ -107,7 +108,7 @@ function expectPendingApprovalText(
   if (options.nodeId) {
     expect(pendingText).toContain(`Node: ${options.nodeId}`);
   }
-  expect(pendingText).toContain(`CWD: ${process.cwd()}`);
+  expect(pendingText).toContain(`CWD: ${options.cwdText ?? process.cwd()}`);
   expect(pendingText).toContain("Command:\n```sh\n");
   expect(pendingText).toContain(options.command);
   if (options.interactive) {
@@ -283,6 +284,7 @@ describe("exec approvals", () => {
       nodeId: "node-1",
       interactive: true,
       allowedDecisions: "allow-once|deny",
+      cwdText: "(node default)",
     });
     const approvalId = details.approvalId;
 
@@ -385,6 +387,43 @@ describe("exec approvals", () => {
 
     expect(result.details.status).toBe("completed");
     expect(prepareCwd).toBe(remoteWorkdir);
+  });
+
+  it("does not forward the gateway default cwd to node exec when workdir is omitted", async () => {
+    const gatewayWorkspace = "/gateway/workspace";
+    let prepareHasCwd = false;
+    let prepareCwd: string | undefined;
+
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      if (method === "node.invoke") {
+        const invoke = params as { command?: string; params?: { cwd?: string } };
+        if (invoke.command === "system.run.prepare") {
+          prepareHasCwd = Object.hasOwn(invoke.params ?? {}, "cwd");
+          prepareCwd = invoke.params?.cwd;
+          return buildPreparedSystemRunPayload(params);
+        }
+        if (invoke.command === "system.run") {
+          return { payload: { success: true, stdout: "ok" } };
+        }
+      }
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "node",
+      ask: "off",
+      security: "full",
+      approvalRunningNoticeMs: 0,
+      cwd: gatewayWorkspace,
+    });
+
+    const result = await tool.execute("call-node-default-cwd", {
+      command: "/bin/pwd",
+    });
+
+    expect(result.details.status).toBe("completed");
+    expect(prepareHasCwd).toBe(false);
+    expect(prepareCwd).toBeUndefined();
   });
 
   it("honors ask=off for elevated gateway exec without prompting", async () => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1343,8 +1343,9 @@ export function createExecTool(
           ].join("\n"),
         );
       }
+      const hasExplicitWorkdir = !!(params.workdir?.trim() || defaults?.cwd);
       const rawWorkdir = params.workdir?.trim() || defaults?.cwd || process.cwd();
-      let workdir = rawWorkdir;
+      let workdir: string | undefined = rawWorkdir;
       let containerWorkdir = sandbox?.containerWorkdir;
       if (sandbox) {
         const resolved = await resolveSandboxWorkdir({
@@ -1354,10 +1355,17 @@ export function createExecTool(
         });
         workdir = resolved.hostWorkdir;
         containerWorkdir = resolved.containerWorkdir;
-      } else if (host !== "node") {
-        // Skip local workdir resolution for remote node execution: the remote node's
-        // filesystem is not visible to the gateway, so resolveWorkdir() would incorrectly
-        // fall back to the gateway's cwd. The node is responsible for validating its own cwd.
+      } else if (host === "node") {
+        // For remote node execution, only forward an explicit cwd provided by the
+        // user or agent config.  When no explicit cwd was given, the gateway's own
+        // process.cwd() is meaningless on the remote node (especially cross-platform,
+        // e.g. Linux gateway + Windows node) and would cause
+        // "SYSTEM_RUN_DENIED: approval requires an existing canonical cwd".
+        // Passing undefined lets the node use its own default working directory.
+        if (!hasExplicitWorkdir) {
+          workdir = undefined;
+        }
+      } else {
         workdir = resolveWorkdir(rawWorkdir, warnings);
       }
       rejectExecApprovalShellCommand(params.command);
@@ -1627,3 +1635,4 @@ export function createExecTool(
 }
 
 export const execTool = createExecTool();
+

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1343,29 +1343,32 @@ export function createExecTool(
           ].join("\n"),
         );
       }
-      const hasExplicitWorkdir = !!(params.workdir?.trim() || defaults?.cwd);
-      const rawWorkdir = params.workdir?.trim() || defaults?.cwd || process.cwd();
-      let workdir: string | undefined = rawWorkdir;
+      const explicitWorkdir = params.workdir?.trim() || undefined;
+      const defaultWorkdir = defaults?.cwd?.trim() || undefined;
+      let workdir: string | undefined;
       let containerWorkdir = sandbox?.containerWorkdir;
       if (sandbox) {
+        const sandboxWorkdir = explicitWorkdir ?? defaultWorkdir ?? process.cwd();
         const resolved = await resolveSandboxWorkdir({
-          workdir: rawWorkdir,
+          workdir: sandboxWorkdir,
           sandbox,
           warnings,
         });
         workdir = resolved.hostWorkdir;
         containerWorkdir = resolved.containerWorkdir;
       } else if (host === "node") {
-        // For remote node execution, only forward an explicit cwd provided by the
-        // user or agent config.  When no explicit cwd was given, the gateway's own
+        // For remote node execution, only forward a cwd that was explicitly
+        // requested on the tool call. The gateway's workspace root is wired in as a
+        // local default, but it is not meaningful on the remote node and would
+        // recreate the cross-platform approval failure this path is fixing.
+        // When no explicit cwd was given, the gateway's own
         // process.cwd() is meaningless on the remote node (especially cross-platform,
         // e.g. Linux gateway + Windows node) and would cause
         // "SYSTEM_RUN_DENIED: approval requires an existing canonical cwd".
         // Passing undefined lets the node use its own default working directory.
-        if (!hasExplicitWorkdir) {
-          workdir = undefined;
-        }
+        workdir = explicitWorkdir;
       } else {
+        const rawWorkdir = explicitWorkdir ?? defaultWorkdir ?? process.cwd();
         workdir = resolveWorkdir(rawWorkdir, warnings);
       }
       rejectExecApprovalShellCommand(params.command);
@@ -1469,15 +1472,14 @@ export function createExecTool(
         });
       }
 
-      // After the node early-return above, workdir is guaranteed to be a string
-      // (it was initialised from rawWorkdir and only set to undefined inside the
-      // node branch which already returned).
-      const resolvedWorkdir: string = workdir ?? rawWorkdir;
+      if (!workdir) {
+        throw new Error("exec internal error: local execution requires a resolved workdir");
+      }
 
       if (host === "gateway" && !bypassApprovals) {
         const gatewayResult = await processGatewayAllowlist({
           command: params.command,
-          workdir: resolvedWorkdir,
+          workdir,
           env,
           requestedEnv: params.env,
           pty: params.pty === true && !sandbox,
@@ -1523,12 +1525,12 @@ export function createExecTool(
 
       // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
       // before we execute and burn tokens in cron loops.
-      await validateScriptFileForShellBleed({ command: params.command, workdir: resolvedWorkdir });
+      await validateScriptFileForShellBleed({ command: params.command, workdir });
 
       const run = await runExecProcess({
         command: params.command,
         execCommand: execCommandOverride,
-        workdir: resolvedWorkdir,
+        workdir,
         env,
         sandbox,
         containerWorkdir,
@@ -1640,4 +1642,3 @@ export function createExecTool(
 }
 
 export const execTool = createExecTool();
-

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1469,10 +1469,15 @@ export function createExecTool(
         });
       }
 
+      // After the node early-return above, workdir is guaranteed to be a string
+      // (it was initialised from rawWorkdir and only set to undefined inside the
+      // node branch which already returned).
+      const resolvedWorkdir: string = workdir ?? rawWorkdir;
+
       if (host === "gateway" && !bypassApprovals) {
         const gatewayResult = await processGatewayAllowlist({
           command: params.command,
-          workdir,
+          workdir: resolvedWorkdir,
           env,
           requestedEnv: params.env,
           pty: params.pty === true && !sandbox,
@@ -1518,12 +1523,12 @@ export function createExecTool(
 
       // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
       // before we execute and burn tokens in cron loops.
-      await validateScriptFileForShellBleed({ command: params.command, workdir });
+      await validateScriptFileForShellBleed({ command: params.command, workdir: resolvedWorkdir });
 
       const run = await runExecProcess({
         command: params.command,
         execCommand: execCommandOverride,
-        workdir,
+        workdir: resolvedWorkdir,
         env,
         sandbox,
         containerWorkdir,

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -1415,7 +1415,11 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
             expect(malicious.runCommand).not.toHaveBeenCalled();
             expectInvokeErrorMessage(malicious.sendInvokeResult, {
-              message: "awk inline program requires explicit approval in strictInlineEval mode",
+              message:
+                process.platform === "win32"
+                  ? "SYSTEM_RUN_DENIED: approval required"
+                  : "awk inline program requires explicit approval in strictInlineEval mode",
+              exact: process.platform === "win32",
             });
           } finally {
             fs.rmSync(tempDir, { recursive: true, force: true });

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -12,6 +12,7 @@ import {
 import { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { createManagedTaskFlow, resetTaskFlowRegistryForTests } from "./task-flow-registry.js";
+import { configureTaskFlowRegistryRuntime } from "./task-flow-registry.store.js";
 import {
   createTaskRecord,
   findLatestTaskForOwnerKey,
@@ -182,6 +183,32 @@ async function withTaskRegistryTempDir<T>(run: (root: string) => Promise<T>): Pr
   });
 }
 
+function configureInMemoryTaskStoresForLinkValidationTests() {
+  configureTaskRegistryRuntime({
+    store: {
+      loadSnapshot: () => ({
+        tasks: new Map(),
+        deliveryStates: new Map(),
+      }),
+      saveSnapshot: () => {},
+      upsertTask: () => {},
+      deleteTask: () => {},
+      close: () => {},
+    },
+  });
+  configureTaskFlowRegistryRuntime({
+    store: {
+      loadSnapshot: () => ({
+        flows: new Map(),
+      }),
+      saveSnapshot: () => {},
+      upsertFlow: () => {},
+      deleteFlow: () => {},
+      close: () => {},
+    },
+  });
+}
+
 describe("task-registry", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -301,8 +328,9 @@ describe("task-registry", () => {
   it("rejects cross-owner parent flow links during task creation", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
-      resetTaskRegistryForTests();
-      resetTaskFlowRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      configureInMemoryTaskStoresForLinkValidationTests();
 
       const flow = createManagedTaskFlow({
         ownerKey: "agent:main:main",
@@ -326,8 +354,9 @@ describe("task-registry", () => {
   it("rejects system-scoped parent flow links during task creation", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
-      resetTaskRegistryForTests();
-      resetTaskFlowRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      configureInMemoryTaskStoresForLinkValidationTests();
 
       const flow = createManagedTaskFlow({
         ownerKey: "agent:main:main",
@@ -352,8 +381,9 @@ describe("task-registry", () => {
   it("rejects cross-owner flow links for existing tasks", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
-      resetTaskRegistryForTests();
-      resetTaskFlowRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      configureInMemoryTaskStoresForLinkValidationTests();
 
       const task = createTaskRecord({
         runtime: "acp",
@@ -384,8 +414,9 @@ describe("task-registry", () => {
   it("rejects parent flow links once cancellation has been requested", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
-      resetTaskRegistryForTests();
-      resetTaskFlowRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      configureInMemoryTaskStoresForLinkValidationTests();
 
       const flow = createManagedTaskFlow({
         ownerKey: "agent:main:main",
@@ -417,8 +448,9 @@ describe("task-registry", () => {
   it("rejects parent flow links for terminal flows", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
-      resetTaskRegistryForTests();
-      resetTaskFlowRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      configureInMemoryTaskStoresForLinkValidationTests();
 
       const flow = createManagedTaskFlow({
         ownerKey: "agent:main:main",


### PR DESCRIPTION
## Summary

When `exec` runs with `host=node` and no explicit `cwd` is provided, the gateway injects its own `process.cwd()` as the default working directory for the remote node. In cross-platform setups (e.g. Linux gateway + Windows node), this Linux path does not exist on Windows, causing:

```
SYSTEM_RUN_DENIED: approval requires an existing canonical cwd
```

PR #50961 fixed explicit-cwd path preservation but did not address the omitted-cwd default behavior.

### Changes

- **`bash-tools.exec.ts`**: Track whether workdir was explicitly provided by the user or agent config. When `host=node` and no explicit workdir exists, pass `undefined` instead of the gateway's `process.cwd()`, allowing the remote node to use its own default working directory.
- **`bash-tools.exec-host-node.ts`**: Accept `workdir` as `string | undefined`. Only send `cwd` to `system.run.prepare` when it is defined.
- **`bash-tools.exec-approval-request.ts`**: Update `HostExecApprovalParams.workdir` type to `string | undefined` for consistency.

Fixes #58934

## Test plan

- [ ] Cross-platform setup: Linux gateway + Windows node, run `exec` with `host=node` without explicit `cwd` -- should succeed using node's default cwd
- [ ] Same setup with explicit `cwd` -- should still forward the explicit cwd to the node
- [ ] Gateway-only exec (no node) -- behavior unchanged, still uses `process.cwd()` default
- [ ] Sandbox exec -- behavior unchanged

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>