### PR TITLE
fix: skip resolution auto-inference for image edit when provider declares supportsResolution: false (#58870)

### DIFF
--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -619,4 +619,59 @@ describe("createImageGenerateTool", () => {
     ).rejects.toThrow("fal edit does not support aspectRatio overrides");
     expect(generateImage).not.toHaveBeenCalled();
   });
+
+  it("skips resolution auto-inference for edit when provider declares supportsResolution: false (#58870)", async () => {
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      {
+        id: "minimax",
+        defaultModel: "minimax-image-01",
+        models: ["minimax-image-01"],
+        capabilities: {
+          generate: {
+            maxCount: 9,
+            supportsSize: false,
+            supportsAspectRatio: true,
+            supportsResolution: false,
+          },
+          edit: {
+            enabled: true,
+            maxCount: 9,
+            maxInputImages: 1,
+            supportsSize: false,
+            supportsAspectRatio: true,
+            supportsResolution: false,
+          },
+          geometry: {
+            aspectRatios: ["1:1", "16:9", "4:3", "3:4", "9:16"],
+          },
+        },
+        generateImage: vi.fn(async () => {
+          throw new Error("not used");
+        }),
+      },
+    ]);
+    const generateImage = stubEditedImageFlow({ width: 3200, height: 1800 });
+    const tool = createToolWithPrimaryImageModel("minimax/minimax-image-01", {
+      workspaceDir: process.cwd(),
+    });
+
+    await tool.execute("call-minimax-edit", {
+      prompt: "Edit the sky",
+      image: "./fixtures/reference.png",
+    });
+
+    // Resolution must NOT be auto-inferred because MiniMax edit declares
+    // supportsResolution: false — previously this caused a validation error.
+    expect(generateImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resolution: undefined,
+        inputImages: [
+          expect.objectContaining({
+            buffer: Buffer.from("input-image"),
+            mimeType: "image/png",
+          }),
+        ],
+      }),
+    );
+  });
 });

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -560,18 +560,25 @@ export function createImageGenerateTool(options?: {
         sandboxConfig,
       });
       const inputImages = loadedReferenceImages.map((entry) => entry.sourceImage);
-      const resolution =
-        explicitResolution ??
-        (size
-          ? undefined
-          : inputImages.length > 0
-            ? await inferResolutionFromInputImages(inputImages)
-            : undefined);
       const selectedProvider = resolveSelectedImageGenerationProvider({
         config: effectiveCfg,
         imageGenerationModelConfig,
         modelOverride: model,
       });
+      // Only auto-infer resolution from input images when the selected
+      // provider's edit capabilities actually support resolution.  Providers
+      // like MiniMax declare `supportsResolution: false` for edits and
+      // reject auto-inferred values (see #58870).
+      const isEdit = inputImages.length > 0;
+      const editSupportsResolution =
+        !selectedProvider || !isEdit || (selectedProvider.capabilities.edit?.supportsResolution ?? true);
+      const resolution =
+        explicitResolution ??
+        (size
+          ? undefined
+          : isEdit && editSupportsResolution
+            ? await inferResolutionFromInputImages(inputImages)
+            : undefined);
       validateImageGenerationCapabilities({
         provider: selectedProvider,
         count,


### PR DESCRIPTION
## Summary

Fixes #58870.

When a user sends a reference image for image-to-image editing without specifying an explicit resolution, `inferResolutionFromInputImages()` is called unconditionally and always returns a resolution value. However, MiniMax's edit capabilities declare `supportsResolution: false`. The auto-inferred resolution then fails `validateImageGenerationCapabilities` with *"minimax edit does not support resolution overrides"*.

## Root cause

The resolution auto-inference at line 563 ran **before** the provider was selected at line 570, so there was no way to check whether the provider's edit mode actually supports resolution.

## Changes

- **`src/agents/tools/image-generate-tool.ts`**: Move `resolveSelectedImageGenerationProvider()` before the resolution computation. Gate `inferResolutionFromInputImages()` on whether the selected provider's edit capabilities declare `supportsResolution` (defaulting to `true` for backwards compatibility when no provider is resolved or for generate mode).
- **`src/agents/tools/image-generate-tool.test.ts`**: Add regression test with a MiniMax-like provider (`supportsResolution: false` for edit) verifying that `resolution` is passed as `undefined` instead of being auto-inferred.

## Test plan

- `pnpm test -- src/agents/tools/image-generate-tool.test.ts` — 14 tests pass
- `pnpm check` — clean