### PR TITLE
fix(cron): prevent agent default model from overriding payload.model on isolated sessions

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -472,6 +472,10 @@ export async function runCronIsolatedAgentTurn(params: {
     });
     const messageChannel = resolvedDelivery.channel;
     // Per-job payload.fallbacks takes priority over agent-level fallbacks.
+    const hasPayloadModelOverride =
+      params.job.payload.kind === "agentTurn" &&
+      typeof params.job.payload.model === "string" &&
+      params.job.payload.model.trim().length > 0;
     const payloadFallbacks =
       params.job.payload.kind === "agentTurn" && Array.isArray(params.job.payload.fallbacks)
         ? params.job.payload.fallbacks
@@ -488,7 +492,9 @@ export async function runCronIsolatedAgentTurn(params: {
         runId: cronSession.sessionEntry.sessionId,
         agentDir,
         fallbacksOverride:
-          payloadFallbacks ?? resolveAgentModelFallbacksOverride(params.cfg, agentId),
+          payloadFallbacks ??
+          resolveAgentModelFallbacksOverride(params.cfg, agentId) ??
+          (hasPayloadModelOverride ? [] : undefined),
         run: async (providerOverride, modelOverride, runOptions) => {
           if (abortSignal?.aborted) {
             throw new Error(abortReason());


### PR DESCRIPTION
## Summary

- When a cron job specifies `payload.model` (e.g. via `--model` flag) but no explicit `fallbacks`, and the agent has no configured fallback chain, `fallbacksOverride` resolved to `undefined`
- Inside `runWithModelFallback` -> `resolveFallbackCandidates`, when `fallbacksOverride` is `undefined`, the agent's configured primary model is silently appended as a last-resort fallback candidate
- This causes isolated cron sessions to fall back to the agent default model instead of using the payload-specified model
- Fix: when the payload carries an explicit model override and both `payloadFallbacks` and agent-level fallbacks are `undefined`, default `fallbacksOverride` to `[]` (empty array) to prevent the agent primary model injection

Fixes #58575
Related: #58065, #57947

## Test plan

- [ ] Create cron job with `--model anthropic/claude-haiku-4-5 --session isolated`
- [ ] Trigger the job and verify session JSONL shows the specified model, not the agent default
- [ ] Verify cron jobs without explicit model override still use the full fallback chain
- [ ] Verify payload-level `fallbacks` arrays are still respected when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)