### PR TITLE
fix(cron): clear stale model/provider overrides on new isolated sessions

### DIFF
--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -77,12 +77,18 @@ export function resolveCronSession(params: {
     // replies instead of channel top-level messages.
     // deliveryContext must also be cleared because normalizeSessionEntryDelivery
     // repopulates lastThreadId from deliveryContext.threadId on store writes.
+    //
+    // Also clear stale model/provider overrides so the new session starts with
+    // a clean slate and picks up the cron payload model or agent defaults
+    // instead of inheriting a user-set model override from a prior session.
     ...(isNewSession && {
       lastChannel: undefined,
       lastTo: undefined,
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
+      modelOverride: undefined,
+      providerOverride: undefined,
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };


### PR DESCRIPTION
## Summary

- When an isolated cron session rolls to a new `sessionId` (`forceNew=true`), the session entry preserves all fields from the previous entry via object spread (`...entry`)
- This causes `modelOverride` and `providerOverride` from prior sessions to leak into the new session
- These stale overrides can interfere with model resolution in `resolveCronModelSelection`, which checks `sessionEntry.modelOverride` as a fallback when no payload model is specified
- Fix: clear `modelOverride` and `providerOverride` alongside the existing delivery routing state cleanup when starting a fresh session

Fixes #58927
Related: #58575, #58065

## Test plan

- [ ] Create a cron job with `--session isolated` and a specific `--model`
- [ ] Run the job, verify the model is used correctly
- [ ] Set a model override via `/model` on the cron session, then run the job again
- [ ] Verify the new isolated session does NOT inherit the manual model override
- [ ] Verify non-isolated sessions still preserve model overrides as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)