### PR TITLE
Improve env URL override credential guidance

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -764,7 +764,9 @@ describe("callGateway url override auth requirements", () => {
       },
     });
 
-    await expect(callGateway({ method: "health" })).rejects.toThrow("explicit credentials");
+    await expect(callGateway({ method: "health" })).rejects.toThrow(
+      "Fix: set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD.",
+    );
   });
 });
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -884,7 +884,10 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     urlOverrideSource: context.urlOverrideSource,
     explicitAuth: context.explicitAuth,
     resolvedAuth: resolvedCredentials,
-    errorHint: "Fix: pass --token or --password (or gatewayToken in tools).",
+    errorHint:
+      context.urlOverrideSource === "env"
+        ? "Fix: set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD."
+        : "Fix: pass --token or --password (or gatewayToken in tools).",
     configPath: context.configPath,
   });
   ensureRemoteModeUrlConfigured(context);


### PR DESCRIPTION
## Summary

Make the env URL override credential error more actionable by telling users which environment variables to set.

## What changed

- Updated the env URL override guidance to mention `OPENCLAW_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_PASSWORD`
- Added a focused test covering the env URL override error message

## Why

When `OPENCLAW_GATEWAY_URL` is set without matching env credentials, the existing error says that explicit credentials are required, but the most helpful recovery path in this case is to point users to the env vars they actually need to set.

This change keeps the CLI URL override guidance and the env URL override guidance distinct and more actionable.

## Manual verification

1. Located the env URL override credential error path in `src/gateway/call.ts`
2. Updated the env-specific guidance message
3. Updated the focused test in `src/gateway/call.test.ts`
4. Ran the targeted Vitest case for the env URL override assertion
5. Ran the repo checks during commit