### PR TITLE
revert: sandbox: block sensitive external bind sources

### DIFF
--- a/src/agents/sandbox/validate-sandbox-security.test.ts
+++ b/src/agents/sandbox/validate-sandbox-security.test.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, mkdtempSync, symlinkSync, unlinkSync } from "node:fs";
+import { mkdirSync, mkdtempSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   getBlockedBindReason,
   validateBindMounts,
@@ -16,10 +16,6 @@ function expectBindMountsToThrow(binds: string[], expected: RegExp, label: strin
 }
 
 describe("getBlockedBindReason", () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
   it("blocks common Docker socket directories", () => {
     expect(getBlockedBindReason("/run:/run")).toEqual(expect.objectContaining({ kind: "targets" }));
     expect(getBlockedBindReason("/var/run:/var/run:ro")).toEqual(
@@ -30,61 +26,9 @@ describe("getBlockedBindReason", () => {
   it("does not block /var by default", () => {
     expect(getBlockedBindReason("/var:/var")).toBeNull();
   });
-
-  it("blocks sensitive home subdirectories", () => {
-    vi.stubEnv("HOME", "/home/tester");
-    expect(getBlockedBindReason("/home/tester/.openclaw:/mnt/state:ro")).toEqual(
-      expect.objectContaining({
-        kind: "targets",
-        blockedPath: "/home/tester/.openclaw",
-      }),
-    );
-    expect(getBlockedBindReason("/home/tester/.ssh:/mnt/ssh:ro")).toEqual(
-      expect.objectContaining({
-        kind: "targets",
-        blockedPath: "/home/tester/.ssh",
-      }),
-    );
-  });
-
-  it("blocks sensitive home subdirectories under OPENCLAW_HOME", () => {
-    vi.stubEnv("HOME", "/home/tester");
-    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
-    expect(getBlockedBindReason("/srv/openclaw-home/.ssh:/mnt/ssh:ro")).toEqual(
-      expect.objectContaining({
-        kind: "targets",
-        blockedPath: "/srv/openclaw-home/.ssh",
-      }),
-    );
-  });
-
-  it("still blocks OS-home sensitive paths when OPENCLAW_HOME is overridden", () => {
-    vi.stubEnv("HOME", "/home/tester");
-    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
-    expect(getBlockedBindReason("/home/tester/.aws:/mnt/aws:ro")).toEqual(
-      expect.objectContaining({
-        kind: "targets",
-        blockedPath: "/home/tester/.aws",
-      }),
-    );
-  });
-
-  it("blocks the resolved OpenClaw state directory override", () => {
-    vi.stubEnv("OPENCLAW_STATE_DIR", "/srv/openclaw-state");
-    expect(getBlockedBindReason("/srv/openclaw-state/credentials:/mnt/state:ro")).toEqual(
-      expect.objectContaining({
-        kind: "targets",
-        blockedPath: "/srv/openclaw-state",
-      }),
-    );
-  });
 });
 
 describe("validateBindMounts", () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
   it("allows legitimate project directory mounts", () => {
     expect(() =>
       validateBindMounts([
@@ -176,56 +120,6 @@ describe("validateBindMounts", () => {
     symlinkSync("/etc", link);
     const run = () => validateBindMounts([`${link}/passwd:/mnt/passwd:ro`]);
     expect(run).toThrow(/blocked path/);
-  });
-
-  it("blocks canonicalized sensitive paths derived from OPENCLAW_HOME", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-home-"));
-    const realHome = join(dir, "real-home");
-    const linkedHome = join(dir, "linked-home");
-    mkdirSync(join(realHome, ".ssh"), { recursive: true });
-    symlinkSync(realHome, linkedHome);
-    vi.stubEnv("OPENCLAW_HOME", linkedHome);
-
-    expect(() => validateBindMounts([`${join(realHome, ".ssh")}:/mnt/ssh:ro`])).toThrow(
-      /blocked path/,
-    );
-  });
-
-  it("refreshes canonical blocked aliases when OPENCLAW_HOME symlinks retarget", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-home-"));
-    const firstHome = join(dir, "home-a");
-    const secondHome = join(dir, "home-b");
-    const linkedHome = join(dir, "linked-home");
-    mkdirSync(join(firstHome, ".ssh"), { recursive: true });
-    mkdirSync(join(secondHome, ".ssh"), { recursive: true });
-    symlinkSync(firstHome, linkedHome);
-    vi.stubEnv("OPENCLAW_HOME", linkedHome);
-
-    expect(() => validateBindMounts([`${join(firstHome, ".ssh")}:/mnt/ssh:ro`])).toThrow(
-      /blocked path/,
-    );
-
-    unlinkSync(linkedHome);
-    symlinkSync(secondHome, linkedHome);
-
-    expect(() => validateBindMounts([`${join(secondHome, ".ssh")}:/mnt/ssh:ro`])).toThrow(
-      /blocked path/,
-    );
-  });
-
-  it("blocks OS-home sensitive paths when OPENCLAW_HOME points elsewhere", () => {
-    vi.stubEnv("HOME", "/home/tester");
-    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
-
-    expect(() => validateBindMounts(["/home/tester/.ssh:/mnt/ssh:ro"])).toThrow(/blocked path/);
   });
 
   it("blocks symlink-parent escapes with non-existent leaf outside allowed roots", () => {

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -5,10 +5,6 @@
  * Enforced at runtime when creating sandbox containers.
  */
 
-import os from "node:os";
-import path from "node:path";
-import { resolveStateDir } from "../../config/paths.js";
-import { resolveRequiredHomeDir, resolveRequiredOsHomeDir } from "../../infra/home-dir.js";
 import { splitSandboxBindSpec } from "./bind-spec.js";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
 import {
@@ -17,9 +13,8 @@ import {
 } from "./host-paths.js";
 import { getBlockedNetworkModeReason } from "./network-mode.js";
 
-// Static portion of the targeted denylist: host paths that should never be exposed
-// inside sandbox containers. The full runtime set also includes sensitive home
-// subdirectories and the resolved OpenClaw state directory.
+// Targeted denylist: host paths that should never be exposed inside sandbox containers.
+// Exported for reuse in security audit collectors.
 export const BLOCKED_HOST_PATHS = [
   "/etc",
   "/private/etc",
@@ -35,24 +30,7 @@ export const BLOCKED_HOST_PATHS = [
   "/var/run/docker.sock",
   "/private/var/run/docker.sock",
   "/run/docker.sock",
-  "/var/lib/docker",
-  "/private/var/lib/docker",
-  "/var/log",
-  "/private/var/log",
 ];
-
-const BLOCKED_HOME_SUBPATHS = [".aws", ".config", ".kube", ".openclaw", ".ssh"] as const;
-let cachedBlockedHostPaths:
-  | {
-      key: string;
-      paths: string[];
-    }
-  | undefined;
-
-type BlockedHostPathAlias = {
-  lexical: string;
-  canonical: string;
-};
 
 const BLOCKED_SECCOMP_PROFILES = new Set(["unconfined"]);
 const BLOCKED_APPARMOR_PROFILES = new Set(["unconfined"]);
@@ -129,62 +107,13 @@ export function getBlockedReasonForSourcePath(sourceNormalized: string): Blocked
   if (sourceNormalized === "/") {
     return { kind: "covers", blockedPath: "/" };
   }
-  for (const blocked of getBlockedHostPaths()) {
+  for (const blocked of BLOCKED_HOST_PATHS) {
     if (sourceNormalized === blocked || sourceNormalized.startsWith(blocked + "/")) {
       return { kind: "targets", blockedPath: blocked };
     }
   }
 
   return null;
-}
-
-export function getBlockedHostPaths(): string[] {
-  const effectiveHome = normalizeHostPath(resolveRequiredHomeDir(process.env, os.homedir));
-  const osHome = normalizeHostPath(resolveRequiredOsHomeDir(process.env, os.homedir));
-  const stateDir = normalizeHostPath(resolveStateDir());
-  const aliases: BlockedHostPathAlias[] = [];
-  for (const candidate of BLOCKED_HOST_PATHS) {
-    aliases.push(resolveBlockedHostPathAlias(candidate));
-  }
-  for (const home of new Set([effectiveHome, osHome])) {
-    if (home === "/") {
-      continue;
-    }
-    for (const suffix of BLOCKED_HOME_SUBPATHS) {
-      aliases.push(resolveBlockedHostPathAlias(path.posix.join(home, suffix)));
-    }
-  }
-  aliases.push(resolveBlockedHostPathAlias(stateDir));
-
-  const cacheKey = aliases.flatMap(({ lexical, canonical }) => [lexical, canonical]).join("\u0000");
-  if (cachedBlockedHostPaths?.key === cacheKey) {
-    return cachedBlockedHostPaths.paths;
-  }
-
-  const blocked = new Set<string>();
-  for (const alias of aliases) {
-    addBlockedHostPath(blocked, alias);
-  }
-
-  const paths = [...blocked];
-  cachedBlockedHostPaths = { key: cacheKey, paths };
-  return paths;
-}
-
-function resolveBlockedHostPathAlias(candidate: string): BlockedHostPathAlias {
-  const lexical = normalizeHostPath(candidate);
-  return {
-    lexical,
-    canonical: resolveSandboxHostPathViaExistingAncestor(lexical),
-  };
-}
-
-function addBlockedHostPath(blocked: Set<string>, alias: BlockedHostPathAlias): void {
-  blocked.add(alias.lexical);
-
-  if (alias.canonical !== alias.lexical) {
-    blocked.add(alias.canonical);
-  }
 }
 
 function normalizeAllowedRoots(roots: string[] | undefined): string[] {


### PR DESCRIPTION
## Summary

- Problem: Secops requested a revert of #56024.
- Why it matters: This restores the sandbox bind validation behavior that shipped before #56024 while follow-up review happens separately.
- What changed: Reverted merge commit `8db20c196598b12043886ddc1c3ec0fd7695b9b4` and removed the added blocked external bind-source cases from the sandbox validator and its test.
- What did NOT change (scope boundary): No broader sandbox policy or agent execution changes beyond undoing #56024.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #56024
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Requested revert of #56024.
- Missing detection / guardrail: N/A for a straight revert.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #56024 introduced the additional blocked bind-source coverage.
- Why this regressed now: N/A.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/agents/sandbox/validate-sandbox-security.test.ts`
- Scenario the test should lock in: The sandbox validator should match the pre-#56024 blocked-path behavior.
- Why this is the smallest reliable guardrail: The behavior is isolated in the bind-validation unit and is directly covered there.
- Existing test that already covers this (if any): `src/agents/sandbox/validate-sandbox-security.test.ts`
- If no new test is added, why not: The revert restores the prior implementation and prior test coverage.

## User-visible / Behavior Changes

Sandbox bind validation no longer blocks the additional external bind sources introduced in #56024.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? Yes
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes
- If any `Yes`, explain risk + mitigation: This requested, secops-authorized revert restores the prior sandbox bind-mount allowance surface from before #56024. Review will stay on the security-owned path.

## Repro + Verification

### Environment

- OS: Linux 6.8.0-1052-gcp x86_64 (Ubuntu)
- Runtime/container: Node `v24.14.1`, pnpm `10.32.1`
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Default local dev config

### Steps

1. Revert merge commit `8db20c196598b12043886ddc1c3ec0fd7695b9b4` on top of current `main`.
2. Run `pnpm test -- src/agents/sandbox/validate-sandbox-security.test.ts`.
3. Run `pnpm check`.

### Expected

- The branch cleanly restores pre-#56024 sandbox bind validation behavior.
- Targeted sandbox tests pass.
- Repo local dev gate passes.

### Actual

- Revert applied cleanly.
- `pnpm test -- src/agents/sandbox/validate-sandbox-security.test.ts` passed.
- `pnpm check` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Reviewed the revert diff against #56024, ran the targeted sandbox test file, and ran `pnpm check`.
- Edge cases checked: Confirmed the diff is limited to `src/agents/sandbox/validate-sandbox-security.ts` and `src/agents/sandbox/validate-sandbox-security.test.ts`.
- What you did **not** verify: Full `pnpm test` suite and broader manual sandbox runtime exercises.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Reintroduces the pre-#56024 external bind-source allowance surface.
  - Mitigation: Scope is a straight revert of #56024 only, with secops review expected on the PR.
