### PR TITLE
perf(test): reduce hotspot reload churn [AI-assisted]

### DIFF
--- a/extensions/browser/src/browser/control-service.plugin-disabled.test.ts
+++ b/extensions/browser/src/browser/control-service.plugin-disabled.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   ensureBrowserControlAuth: vi.fn(async () => ({ generatedToken: false })),
@@ -45,12 +45,14 @@ vi.mock("./runtime-lifecycle.js", () => ({
 let startBrowserControlServiceFromConfig: typeof import("../control-service.js").startBrowserControlServiceFromConfig;
 
 describe("startBrowserControlServiceFromConfig", () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
+    ({ startBrowserControlServiceFromConfig } = await import("../control-service.js"));
+  });
+
+  beforeEach(() => {
     mocks.ensureBrowserControlAuth.mockClear();
     mocks.createBrowserRuntimeState.mockClear();
     mocks.loadConfig.mockClear();
-    vi.resetModules();
-    ({ startBrowserControlServiceFromConfig } = await import("../control-service.js"));
   });
 
   it("does not start the default service when the browser plugin is disabled", async () => {

--- a/extensions/browser/src/browser/profiles-service.test.ts
+++ b/extensions/browser/src/browser/profiles-service.test.ts
@@ -58,7 +58,6 @@ async function createWorkProfileWithConfig(params: {
 
 describe("BrowserProfilesService", () => {
   beforeAll(async () => {
-    vi.resetModules();
     ({ resolveBrowserConfig } = await import("./config.js"));
     ({ createBrowserProfilesService } = await import("./profiles-service.js"));
   });

--- a/extensions/browser/src/browser/server-context.existing-session.test.ts
+++ b/extensions/browser/src/browser/server-context.existing-session.test.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserServerState } from "./server-context.js";
 
 vi.mock("./chrome-mcp.js", () => ({
@@ -62,10 +62,13 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-beforeEach(async () => {
-  vi.resetModules();
+beforeAll(async () => {
   ({ createBrowserRouteContext } = await import("./server-context.js"));
   chromeMcp = await import("./chrome-mcp.js");
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
 });
 
 describe("browser server-context existing-session profile", () => {

--- a/extensions/browser/src/browser/server-lifecycle.test.ts
+++ b/extensions/browser/src/browser/server-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { stopOpenClawChromeMock } = vi.hoisted(() => ({
   stopOpenClawChromeMock: vi.fn(async () => {}),
@@ -21,10 +21,12 @@ vi.mock("./server-context.js", () => ({
 let ensureExtensionRelayForProfiles: typeof import("./server-lifecycle.js").ensureExtensionRelayForProfiles;
 let stopKnownBrowserProfiles: typeof import("./server-lifecycle.js").stopKnownBrowserProfiles;
 
-beforeEach(async () => {
-  vi.resetModules();
+beforeAll(async () => {
   ({ ensureExtensionRelayForProfiles, stopKnownBrowserProfiles } =
     await import("./server-lifecycle.js"));
+});
+
+beforeEach(() => {
   createBrowserRouteContextMock.mockClear();
   listKnownProfileNamesMock.mockClear();
   stopOpenClawChromeMock.mockClear();

--- a/extensions/matrix/src/matrix/client-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/client-bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockMatrixClient,
   matrixClientResolverMocks,
@@ -36,10 +36,12 @@ let resolveRuntimeMatrixClientWithReadiness: typeof import("./client-bootstrap.j
 let withResolvedRuntimeMatrixClient: typeof import("./client-bootstrap.js").withResolvedRuntimeMatrixClient;
 
 describe("client bootstrap", () => {
-  beforeEach(async () => {
-    vi.resetModules();
+  beforeAll(async () => {
     ({ resolveRuntimeMatrixClientWithReadiness, withResolvedRuntimeMatrixClient } =
       await import("./client-bootstrap.js"));
+  });
+
+  beforeEach(() => {
     primeMatrixClientResolverMocks({ resolved: {} });
   });
 

--- a/extensions/matrix/src/onboarding.resolve.test.ts
+++ b/extensions/matrix/src/onboarding.resolve.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { installMatrixTestRuntime } from "./test-runtime.js";
 import type { CoreConfig } from "./types.js";
 
@@ -13,9 +13,11 @@ vi.mock("./resolve-targets.js", () => ({
 let runMatrixAddAccountAllowlistConfigure: typeof import("./onboarding.test-harness.js").runMatrixAddAccountAllowlistConfigure;
 
 describe("matrix onboarding account-scoped resolution", () => {
-  beforeEach(async () => {
-    vi.resetModules();
+  beforeAll(async () => {
     ({ runMatrixAddAccountAllowlistConfigure } = await import("./onboarding.test-harness.js"));
+  });
+
+  beforeEach(() => {
     installMatrixTestRuntime();
     resolveMatrixTargetsMock.mockClear();
   });

--- a/scripts/test-planner/planner.mjs
+++ b/scripts/test-planner/planner.mjs
@@ -1325,7 +1325,7 @@ export function buildCIExecutionManifest(scopeInput = {}, options = {}) {
     targetDurationMs: 120_000,
     targetFilesPerShard: 140,
     minShards: 4,
-    maxShards: 5,
+    maxShards: 6,
   });
 
   const checksFastInclude = nodeEligible

--- a/test/scripts/test-planner.test.ts
+++ b/test/scripts/test-planner.test.ts
@@ -653,7 +653,7 @@ describe("test planner", () => {
     expect(manifest.shardCounts.unit).toBe(4);
     expect(manifest.shardCounts.channels).toBe(4);
     expect(manifest.shardCounts.extensionFast).toBeGreaterThanOrEqual(4);
-    expect(manifest.shardCounts.extensionFast).toBeLessThanOrEqual(5);
+    expect(manifest.shardCounts.extensionFast).toBeLessThanOrEqual(6);
     expect(manifest.shardCounts.windows).toBe(6);
     expect(manifest.shardCounts.macosNode).toBe(9);
     expect(manifest.jobs.checks.matrix.include).toHaveLength(8);


### PR DESCRIPTION
## Summary
- stop reloading several browser and matrix hotspot test modules before every case
- let `checks-fast-extensions` expand to 6 shards instead of capping at 5
- keep planner coverage aligned with the new shard ceiling

## Testing
- `pnpm test -- extensions/browser/src/browser/server-lifecycle.test.ts extensions/browser/src/browser/server-context.existing-session.test.ts extensions/browser/src/browser/control-service.plugin-disabled.test.ts extensions/browser/src/browser/profiles-service.test.ts extensions/matrix/src/matrix/client-bootstrap.test.ts extensions/matrix/src/onboarding.resolve.test.ts`
- `pnpm test -- test/scripts/test-planner.test.ts -t "builds a CI manifest with planner-owned shard counts and matrices"`

## Notes
- I started a full timing-manifest refresh for extensions/channels, but aborted it after local VRAM pressure. Those generated timing files are not part of this PR.

## AI
- AI-assisted
- targeted local verification only