### PR TITLE
fix(media-understanding): avoid audio upload path leaks and missing-filename crashes

### DIFF
--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { postTranscriptionRequestMock } = vi.hoisted(() => ({
+  postTranscriptionRequestMock: vi.fn(),
+}));
+
+vi.mock("./shared.js", async () => {
+  const actual = await vi.importActual<typeof import("./shared.js")>("./shared.js");
+  return {
+    ...actual,
+    postTranscriptionRequest: postTranscriptionRequestMock,
+  };
+});
+
+import { transcribeOpenAiCompatibleAudio } from "./openai-compatible-audio.js";
+
+function createParams(
+  overrides: Partial<Parameters<typeof transcribeOpenAiCompatibleAudio>[0]> = {},
+): Parameters<typeof transcribeOpenAiCompatibleAudio>[0] {
+  return {
+    buffer: Buffer.from("audio-bytes"),
+    fileName: "clip.wav",
+    apiKey: "test-key",
+    timeoutMs: 1_000,
+    defaultBaseUrl: "https://api.openai.com/v1",
+    defaultModel: "whisper-1",
+    ...overrides,
+  };
+}
+
+function expectPostedAudioFileName(): string {
+  expect(postTranscriptionRequestMock).toHaveBeenCalledTimes(1);
+  const [request] = postTranscriptionRequestMock.mock.calls[0] as [
+    { body: FormData; headers: Headers; url: string },
+  ];
+  expect(request.url).toBe("https://api.openai.com/v1/audio/transcriptions");
+  expect(request.headers.get("authorization")).toBe("Bearer test-key");
+  const uploaded = request.body.get("file");
+  expect(uploaded instanceof File).toBe(true);
+  if (!(uploaded instanceof File)) {
+    expect.unreachable("expected multipart upload file");
+  }
+  return uploaded.name;
+}
+
+describe("transcribeOpenAiCompatibleAudio", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    postTranscriptionRequestMock.mockResolvedValue({
+      response: new Response(JSON.stringify({ text: "hello world" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      release: async () => {},
+    });
+  });
+
+  it("uploads only the basename when fileName contains a host path", async () => {
+    const result = await transcribeOpenAiCompatibleAudio(
+      createParams({ fileName: "/Users/alice/private/note.wav" }),
+    );
+
+    expect(result).toEqual({ text: "hello world", model: "whisper-1" });
+    expect(expectPostedAudioFileName()).toBe("note.wav");
+  });
+
+  it("falls back to a generic filename when fileName is missing at runtime", async () => {
+    const result = await transcribeOpenAiCompatibleAudio(
+      createParams({ fileName: undefined as never }),
+    );
+
+    expect(result).toEqual({ text: "hello world", model: "whisper-1" });
+    expect(expectPostedAudioFileName()).toBe("audio");
+  });
+});

--- a/src/media-understanding/openai-compatible-audio.ts
+++ b/src/media-understanding/openai-compatible-audio.ts
@@ -17,6 +17,16 @@ function resolveModel(model: string | undefined, fallback: string): string {
   return trimmed || fallback;
 }
 
+function resolveUploadFileName(fileName: string | undefined): string {
+  const trimmed = fileName?.trim();
+  if (!trimmed) {
+    return "audio";
+  }
+  // Keep only the terminal segment so multipart uploads never expose host paths.
+  const baseName = path.win32.basename(path.posix.basename(trimmed));
+  return baseName || "audio";
+}
+
 export async function transcribeOpenAiCompatibleAudio(
   params: OpenAiCompatibleAudioParams,
 ): Promise<AudioTranscriptionResult> {
@@ -27,7 +37,7 @@ export async function transcribeOpenAiCompatibleAudio(
 
   const model = resolveModel(params.model, params.defaultModel);
   const form = new FormData();
-  const fileName = params.fileName?.trim() || path.basename(params.fileName) || "audio";
+  const fileName = resolveUploadFileName(params.fileName);
   const bytes = new Uint8Array(params.buffer);
   const blob = new Blob([bytes], {
     type: params.mime ?? "application/octet-stream",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `src/media-understanding/openai-compatible-audio.ts` built the multipart upload filename with `params.fileName?.trim() || path.basename(params.fileName) || "audio"`, so path-shaped inputs leaked full local paths and missing runtime filenames could throw before the request was sent.
- Why it matters: this shared helper is used by OpenAI-compatible audio providers, so a bad filename could either expose host path metadata to third-party APIs or break audio transcription entirely.
- What changed: added a dedicated upload filename resolver that strips both POSIX and Windows path segments and falls back safely to `"audio"`, plus direct unit coverage in `src/media-understanding/openai-compatible-audio.test.ts`.
- What did NOT change (scope boundary): no provider auth/model selection changed, no network endpoints changed, and no broader media-understanding pipeline behavior was refactored.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the helper preferred `params.fileName?.trim()` directly, which preserved full host paths, and then called `path.basename(params.fileName)` in the fallback branch, which throws if `fileName` is missing at runtime.
- Missing detection / guardrail: there was no unit test covering path-shaped filenames or missing runtime filenames for this shared helper.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown; this appears to be a latent bug in the existing helper implementation rather than a provider-specific regression.
- Why this regressed now: not a known recent regression; it is a latent runtime bug that shows up when callers pass path-like values or when runtime data violates the static `fileName: string` contract.
- If unknown, what was ruled out: ruled out provider-specific wrapper issues; OpenAI/Groq/Mistral all go through the same shared helper.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/media-understanding/openai-compatible-audio.test.ts`
- Scenario the test should lock in: path-shaped filenames are reduced to the basename, and missing runtime filenames fall back to `"audio"` without throwing.
- Why this is the smallest reliable guardrail: the bug is entirely in shared request-building logic, so a direct unit test around the helper isolates the failure without needing live provider calls.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Audio transcription requests sent through the shared OpenAI-compatible helper no longer expose local file paths in multipart filenames.
- Audio transcription no longer crashes before request dispatch when the runtime filename is missing.
- When no usable filename is available, uploads use the generic filename `"audio"`.

## Diagram (if applicable)

```text
Before:
[audio attachment] -> [shared OpenAI-compatible helper]
-> [full path kept as multipart filename OR basename(undefined) throws]
-> [path metadata leak OR transcription failure]

After:
[audio attachment] -> [shared OpenAI-compatible helper]
-> [basename-only filename resolver with "audio" fallback]
-> [safe request metadata] -> [transcription proceeds]
