### PR TITLE
Chat: stream reasoning and split tool rendering

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -9,12 +9,12 @@ export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.state.compactionInFlight = true;
   ctx.ensureCompactionPromise();
   ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId}`);
-  emitAgentEvent({
-    runId: ctx.params.runId,
+  void ctx.params.onAgentEvent?.({
     stream: "compaction",
     data: { phase: "start" },
   });
-  void ctx.params.onAgentEvent?.({
+  emitAgentEvent({
+    runId: ctx.params.runId,
     stream: "compaction",
     data: { phase: "start" },
   });
@@ -71,12 +71,12 @@ export function handleAutoCompactionEnd(
     ctx.maybeResolveCompactionWait();
     clearStaleAssistantUsageOnSessionMessages(ctx);
   }
-  emitAgentEvent({
-    runId: ctx.params.runId,
+  void ctx.params.onAgentEvent?.({
     stream: "compaction",
     data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
   });
-  void ctx.params.onAgentEvent?.({
+  emitAgentEvent({
+    runId: ctx.params.runId,
     stream: "compaction",
     data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
   });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { createInlineCodeState } from "../markdown/code-spans.js";
-import { handleAgentEnd } from "./pi-embedded-subscribe.handlers.lifecycle.js";
+import {
+  handleAgentEnd,
+  handleAgentStart,
+} from "./pi-embedded-subscribe.handlers.lifecycle.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+import { emitAgentEvent } from "../infra/agent-events.js";
 
 vi.mock("../infra/agent-events.js", () => ({
   emitAgentEvent: vi.fn(),
@@ -178,5 +182,31 @@ describe("handleAgentEnd", () => {
     });
     expect(ctx.state.pendingToolMediaUrls).toEqual([]);
     expect(ctx.state.pendingToolAudioAsVoice).toBe(false);
+  });
+});
+
+describe("handleAgentStart", () => {
+  it("notifies local listeners before broadcasting the global lifecycle event", () => {
+    const order: string[] = [];
+    const onAgentEvent = vi.fn(() => {
+      order.push("local");
+    });
+    vi.mocked(emitAgentEvent).mockImplementation(() => {
+      order.push("global");
+    });
+    const ctx = createContext(undefined, { onAgentEvent });
+
+    handleAgentStart(ctx);
+
+    expect(order).toEqual(["local", "global"]);
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: { phase: "start" },
+    });
+    expect(emitAgentEvent).toHaveBeenCalledWith({
+      runId: "run-1",
+      stream: "lifecycle",
+      data: expect.objectContaining({ phase: "start", startedAt: expect.any(Number) }),
+    });
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -20,6 +20,12 @@ export {
 
 export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.log.debug(`embedded run agent start: runId=${ctx.params.runId}`);
+  // Let local consumers (for example webchat run-id linking) observe the
+  // start before the global agent event fan-out sees the first lifecycle tick.
+  void ctx.params.onAgentEvent?.({
+    stream: "lifecycle",
+    data: { phase: "start" },
+  });
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "lifecycle",
@@ -27,10 +33,6 @@ export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
       phase: "start",
       startedAt: Date.now(),
     },
-  });
-  void ctx.params.onAgentEvent?.({
-    stream: "lifecycle",
-    data: { phase: "start" },
   });
 }
 
@@ -68,6 +70,13 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
       ...observedError,
       consoleMessage: `embedded run agent end: runId=${safeRunId} isError=true model=${safeModel} provider=${safeProvider} error=${safeErrorText}${rawErrorConsoleSuffix}`,
     });
+    void ctx.params.onAgentEvent?.({
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        error: safeErrorText,
+      },
+    });
     emitAgentEvent({
       runId: ctx.params.runId,
       stream: "lifecycle",
@@ -77,15 +86,12 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
         endedAt: Date.now(),
       },
     });
-    void ctx.params.onAgentEvent?.({
-      stream: "lifecycle",
-      data: {
-        phase: "error",
-        error: safeErrorText,
-      },
-    });
   } else {
     ctx.log.debug(`embedded run agent end: runId=${ctx.params.runId} isError=${isError}`);
+    void ctx.params.onAgentEvent?.({
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
     emitAgentEvent({
       runId: ctx.params.runId,
       stream: "lifecycle",
@@ -93,10 +99,6 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
         phase: "end",
         endedAt: Date.now(),
       },
-    });
-    void ctx.params.onAgentEvent?.({
-      stream: "lifecycle",
-      data: { phase: "end" },
     });
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -306,12 +306,12 @@ export function handleMessageUpdate(
         delta: deltaText,
         mediaUrls,
       });
-      emitAgentEvent({
-        runId: ctx.params.runId,
+      void ctx.params.onAgentEvent?.({
         stream: "assistant",
         data,
       });
-      void ctx.params.onAgentEvent?.({
+      emitAgentEvent({
+        runId: ctx.params.runId,
         stream: "assistant",
         data,
       });
@@ -402,12 +402,12 @@ export function handleMessageEnd(
       delta: cleanedText,
       mediaUrls,
     });
-    emitAgentEvent({
-      runId: ctx.params.runId,
+    void ctx.params.onAgentEvent?.({
       stream: "assistant",
       data,
     });
-    void ctx.params.onAgentEvent?.({
+    emitAgentEvent({
+      runId: ctx.params.runId,
       stream: "assistant",
       data,
     });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -369,6 +369,11 @@ export async function handleToolExecutionStart(
   );
 
   const shouldEmitToolEvents = ctx.shouldEmitToolResult();
+  // Best-effort typing signal; do not block tool summaries on slow emitters.
+  void ctx.params.onAgentEvent?.({
+    stream: "tool",
+    data: { phase: "start", name: toolName, toolCallId },
+  });
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "tool",
@@ -378,11 +383,6 @@ export async function handleToolExecutionStart(
       toolCallId,
       args: args as Record<string, unknown>,
     },
-  });
-  // Best-effort typing signal; do not block tool summaries on slow emitters.
-  void ctx.params.onAgentEvent?.({
-    stream: "tool",
-    data: { phase: "start", name: toolName, toolCallId },
   });
 
   if (
@@ -430,6 +430,14 @@ export function handleToolExecutionUpdate(
   const toolCallId = String(evt.toolCallId);
   const partial = evt.partialResult;
   const sanitized = sanitizeToolResult(partial);
+  void ctx.params.onAgentEvent?.({
+    stream: "tool",
+    data: {
+      phase: "update",
+      name: toolName,
+      toolCallId,
+    },
+  });
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "tool",
@@ -438,14 +446,6 @@ export function handleToolExecutionUpdate(
       name: toolName,
       toolCallId,
       partialResult: sanitized,
-    },
-  });
-  void ctx.params.onAgentEvent?.({
-    stream: "tool",
-    data: {
-      phase: "update",
-      name: toolName,
-      toolCallId,
     },
   });
 }
@@ -549,6 +549,16 @@ export async function handleToolExecutionEnd(
     ctx.state.successfulCronAdds += 1;
   }
 
+  void ctx.params.onAgentEvent?.({
+    stream: "tool",
+    data: {
+      phase: "result",
+      name: toolName,
+      toolCallId,
+      meta,
+      isError: isToolError,
+    },
+  });
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "tool",
@@ -559,16 +569,6 @@ export async function handleToolExecutionEnd(
       meta,
       isError: isToolError,
       result: sanitizedResult,
-    },
-  });
-  void ctx.params.onAgentEvent?.({
-    stream: "tool",
-    data: {
-      phase: "result",
-      name: toolName,
-      toolCallId,
-      meta,
-      isError: isToolError,
     },
   });
 

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
+import { onAgentEvent } from "../infra/agent-events.js";
 import {
   THINKING_TAG_CASES,
   createStubSessionHarness,
@@ -234,6 +235,44 @@ describe("subscribeEmbeddedPiSession", () => {
       .filter((value): value is string => typeof value === "string");
     expect(streamTexts.at(-1)).toBe("Reasoning:\n_Checking files done_");
     expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits thinking agent events even without an onReasoningStream callback", () => {
+    const { session, emit } = createStubSessionHarness();
+    const agentEvents: Array<{ stream?: string; data?: Record<string, unknown> }> = [];
+    const stop = onAgentEvent((evt) => {
+      agentEvents.push(evt as { stream?: string; data?: Record<string, unknown> });
+    });
+
+    try {
+      subscribeEmbeddedPiSession({
+        session,
+        runId: "run",
+        reasoningMode: "stream",
+      });
+
+      emit({
+        type: "message_update",
+        message: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "Checking files" }],
+        },
+        assistantMessageEvent: {
+          type: "thinking_delta",
+          delta: "Checking files",
+        },
+      });
+
+      const thinkingEvents = agentEvents.filter((evt) => evt?.stream === "thinking");
+
+      expect(thinkingEvents).toHaveLength(1);
+      expect(thinkingEvents[0]?.data).toMatchObject({
+        text: "Reasoning:\n_Checking files_",
+        delta: "Reasoning:\n_Checking files_",
+      });
+    } finally {
+      stop();
+    }
   });
 
   it("emits reasoning end once when native and tagged reasoning end overlap", () => {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -48,7 +48,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     reasoningMode,
     includeReasoning: reasoningMode === "on",
     shouldEmitPartialReplies: !(reasoningMode === "on" && !params.onBlockReply),
-    streamReasoning: reasoningMode === "stream" && typeof params.onReasoningStream === "function",
+    // Stream reasoning agent events whenever the run requests reasoning streaming.
+    // UI callbacks are optional consumers of that stream and should not gate it.
+    streamReasoning: reasoningMode === "stream",
     deltaBuffer: "",
     blockBuffer: "",
     // Track if a streamed chunk opened a <think> block (stateful across chunks).
@@ -573,7 +575,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (params.silentExpected) {
       return;
     }
-    if (!state.streamReasoning || !params.onReasoningStream) {
+    if (!state.streamReasoning) {
       return;
     }
     const formatted = formatReasoningMessage(text);
@@ -599,9 +601,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       },
     });
 
-    void params.onReasoningStream({
-      text: formatted,
-    });
+    if (params.onReasoningStream) {
+      void params.onReasoningStream({
+        text: formatted,
+      });
+    }
   };
 
   const resetForCompactionRetry = () => {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -216,6 +216,34 @@ describe("agent event handler", () => {
     nowSpy?.mockRestore();
   });
 
+  it("emits chat delta for streamed thinking events", () => {
+    const { broadcast, nodeSendToSession, chatRunState, handler, nowSpy } = createHarness({
+      now: 1_000,
+    });
+    chatRunState.registry.add("run-1", { sessionKey: "session-1", clientRunId: "client-1" });
+
+    handler({
+      runId: "run-1",
+      seq: 1,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "Reasoning:\nCheck files" },
+    });
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(1);
+    const payload = chatCalls[0]?.[1] as {
+      state?: string;
+      message?: {
+        content?: Array<{ type?: string; text?: string; thinking?: string }>;
+      };
+    };
+    expect(payload.state).toBe("delta");
+    expect(payload.message?.content).toEqual([{ type: "thinking", thinking: "Reasoning:\nCheck files" }]);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    nowSpy?.mockRestore();
+  });
+
   it("does not emit chat delta for NO_REPLY streaming text", () => {
     const { broadcast, nodeSendToSession, nowSpy } = emitRun1AssistantText(
       createHarness({ now: 1_000 }),

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -584,6 +584,32 @@ export function createAgentEventHandler({
     nodeSendToSession(sessionKey, "chat", payload);
   };
 
+  const emitChatThinkingDelta = (
+    sessionKey: string,
+    clientRunId: string,
+    seq: number,
+    thinking: string,
+  ) => {
+    const cleanedThinking = stripInlineDirectiveTagsForDisplay(thinking).text;
+    if (!cleanedThinking.trim()) {
+      return;
+    }
+    const now = Date.now();
+    const payload = {
+      runId: clientRunId,
+      sessionKey,
+      seq,
+      state: "delta" as const,
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: cleanedThinking }],
+        timestamp: now,
+      },
+    };
+    broadcast("chat", payload, { dropIfSlow: true });
+    nodeSendToSession(sessionKey, "chat", payload);
+  };
+
   const resolveBufferedChatTextState = (clientRunId: string, sourceRunId: string) => {
     const bufferedText = stripInlineDirectiveTagsForDisplay(
       chatRunState.buffers.get(clientRunId) ?? "",
@@ -811,6 +837,8 @@ export function createAgentEventHandler({
       }
       if (!isAborted && evt.stream === "assistant" && typeof evt.data?.text === "string") {
         emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text, evt.data.delta);
+      } else if (!isAborted && evt.stream === "thinking" && typeof evt.data?.text === "string") {
+        emitChatThinkingDelta(sessionKey, clientRunId, evt.seq, evt.data.text);
       } else if (!isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {
         const evtStopReason =
           typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -241,6 +241,7 @@ function createChatContext(): Pick<
   | "chatRunBuffers"
   | "chatDeltaSentAt"
   | "chatAbortedRuns"
+  | "addChatRun"
   | "removeChatRun"
   | "dedupe"
   | "registerToolEventRecipient"
@@ -254,6 +255,7 @@ function createChatContext(): Pick<
     chatRunBuffers: new Map(),
     chatDeltaSentAt: new Map(),
     chatAbortedRuns: new Map(),
+    addChatRun: vi.fn(),
     removeChatRun: vi.fn(),
     dedupe: new Map(),
     registerToolEventRecipient: vi.fn(),
@@ -379,6 +381,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
 
     const register = context.registerToolEventRecipient as unknown as ReturnType<typeof vi.fn>;
+    const addChatRun = context.addChatRun as unknown as ReturnType<typeof vi.fn>;
+    expect(addChatRun).toHaveBeenCalledWith("run-current", {
+      sessionKey: "main",
+      clientRunId: "idem-tool-events-on",
+    });
     expect(register).toHaveBeenCalledWith("run-current", "conn-1");
     expect(register).toHaveBeenCalledWith("run-same-session", "conn-1");
     expect(register).not.toHaveBeenCalledWith("run-other-session", "conn-1");

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1723,6 +1723,10 @@ export const chatHandlers: GatewayRequestHandlers = {
           onAgentRunStart: (runId) => {
             agentRunStarted = true;
             void emitUserTranscriptUpdate();
+            context.addChatRun(runId, {
+              sessionKey,
+              clientRunId,
+            });
             const connId = typeof client?.connId === "string" ? client.connId : undefined;
             const wantsToolEvents = hasGatewayClientCap(
               client?.connect?.caps,

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -19,6 +19,7 @@ export type ChatHost = {
   client: GatewayBrowserClient | null;
   chatMessages: unknown[];
   chatStream: string | null;
+  chatStreamMessage?: unknown | null;
   connected: boolean;
   chatMessage: string;
   chatAttachments: ChatAttachment[];
@@ -343,6 +344,7 @@ async function dispatchSlashCommand(
   if (result.trackRunId) {
     host.chatRunId = result.trackRunId;
     host.chatStream = "";
+    host.chatStreamMessage = null;
     host.chatSending = false;
   }
 
@@ -373,6 +375,7 @@ async function clearChatHistory(host: ChatHost) {
     await host.client.request("sessions.reset", { key: host.sessionKey });
     host.chatMessages = [];
     host.chatStream = null;
+    host.chatStreamMessage = null;
     host.chatRunId = null;
     await loadChatHistory(host as unknown as OpenClawApp);
   } catch (err) {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -235,6 +235,7 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       // Any in-flight run's final event was lost during the disconnect window.
       host.chatRunId = null;
       (host as unknown as { chatStream: string | null }).chatStream = null;
+      (host as unknown as { chatStreamMessage?: unknown | null }).chatStreamMessage = null;
       (host as unknown as { chatStreamStartedAt: number | null }).chatStreamStartedAt = null;
       resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
       if (shutdownHost.resumeChatQueueAfterReconnect) {

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -35,6 +35,7 @@ type LifecycleHost = {
   chatMessages: unknown[];
   chatToolMessages: unknown[];
   chatStream: string | null;
+  chatStreamMessage?: unknown | null;
   logsAutoFollow: boolean;
   logsAtBottom: boolean;
   logsEntries: unknown[];

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -44,6 +44,7 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
   state.sessionKey = sessionKey;
   state.chatMessage = "";
   state.chatStream = null;
+  state.chatStreamMessage = null;
   (state as unknown as OpenClawApp).chatStreamStartedAt = null;
   state.chatRunId = null;
   (state as unknown as OpenClawApp).resetToolStream();
@@ -496,6 +497,7 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   state.sessionKey = nextSessionKey;
   state.chatMessage = "";
   state.chatStream = null;
+  state.chatStreamMessage = null;
   // P1: Clear queued chat items from the previous session
   (state as unknown as { chatQueue: unknown[] }).chatQueue = [];
   (state as unknown as OpenClawApp).chatStreamStartedAt = null;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1412,6 +1412,7 @@ export function renderApp(state: AppViewState) {
                 state.chatMessage = "";
                 state.chatAttachments = [];
                 state.chatStream = null;
+                state.chatStreamMessage = null;
                 state.chatStreamStartedAt = null;
                 state.chatRunId = null;
                 state.chatQueue = [];
@@ -1438,6 +1439,7 @@ export function renderApp(state: AppViewState) {
               toolMessages: state.chatToolMessages,
               streamSegments: state.chatStreamSegments,
               stream: state.chatStream,
+              streamMessage: state.chatStreamMessage,
               streamStartedAt: state.chatStreamStartedAt,
               draft: state.chatMessage,
               queue: state.chatQueue,
@@ -1479,6 +1481,7 @@ export function renderApp(state: AppViewState) {
                   await state.client.request("sessions.reset", { key: state.sessionKey });
                   state.chatMessages = [];
                   state.chatStream = null;
+                  state.chatStreamMessage = null;
                   state.chatRunId = null;
                   await loadChatHistory(state);
                 } catch (err) {
@@ -1491,6 +1494,7 @@ export function renderApp(state: AppViewState) {
                 state.sessionKey = buildAgentMainSessionKey({ agentId });
                 state.chatMessages = [];
                 state.chatStream = null;
+                state.chatStreamMessage = null;
                 state.chatRunId = null;
                 state.applySettings({
                   ...state.settings,

--- a/ui/src/ui/app-tool-stream.node.test.ts
+++ b/ui/src/ui/app-tool-stream.node.test.ts
@@ -14,6 +14,7 @@ function createHost(overrides?: Partial<MutableHost>): MutableHost {
     sessionKey: "main",
     chatRunId: null,
     chatStream: null,
+    chatStreamMessage: null,
     chatStreamStartedAt: null,
     chatStreamSegments: [],
     toolStreamById: new Map<string, ToolStreamEntry>(),
@@ -138,5 +139,47 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     expect(host.fallbackStatus?.phase).toBe("cleared");
     expect(host.fallbackStatus?.previous).toBe("deepinfra/moonshotai/Kimi-K2.5");
     vi.useRealTimers();
+  });
+
+  it("commits the current structured stream segment before rendering a tool card", () => {
+    const host = createHost({
+      chatRunId: "run-1",
+      chatStream:
+        "<thinking>\nInspecting request\n</thinking>\n\nFirst answer chunk",
+      chatStreamMessage: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Inspecting request" },
+          { type: "text", text: "First answer chunk" },
+        ],
+        timestamp: 123,
+      },
+      chatStreamStartedAt: 123,
+    });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 2,
+      stream: "tool",
+      ts: 200,
+      sessionKey: "main",
+      data: {
+        phase: "start",
+        toolCallId: "tool-1",
+        name: "search",
+        args: { q: "openclaw" },
+      },
+    });
+
+    expect(host.chatStream).toBeNull();
+    expect(host.chatStreamMessage).toBeNull();
+    expect(host.chatStreamSegments).toHaveLength(1);
+    expect(host.chatStreamSegments[0]?.message).toMatchObject({
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "Inspecting request" },
+        { type: "text", text: "First answer chunk" },
+      ],
+    });
   });
 });

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -1,4 +1,5 @@
 import { truncateText } from "./format.ts";
+import type { ChatStreamSegment } from "./types/chat-types.ts";
 
 const TOOL_STREAM_LIMIT = 50;
 const TOOL_STREAM_THROTTLE_MS = 80;
@@ -29,8 +30,9 @@ type ToolStreamHost = {
   sessionKey: string;
   chatRunId: string | null;
   chatStream: string | null;
+  chatStreamMessage?: unknown | null;
   chatStreamStartedAt: number | null;
-  chatStreamSegments: Array<{ text: string; ts: number }>;
+  chatStreamSegments: ChatStreamSegment[];
   toolStreamById: Map<string, ToolStreamEntry>;
   toolStreamOrder: string[];
   chatToolMessages: Record<string, unknown>[];
@@ -437,9 +439,18 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   if (!entry) {
     // Commit any in-progress streaming text as a segment so it renders
     // above the tool card instead of below it.
-    if (host.chatStream && host.chatStream.trim().length > 0) {
-      host.chatStreamSegments = [...host.chatStreamSegments, { text: host.chatStream, ts: now }];
+    const streamText = host.chatStream?.trim() ?? "";
+    if (streamText.length > 0 || host.chatStreamMessage) {
+      host.chatStreamSegments = [
+        ...host.chatStreamSegments,
+        {
+          text: host.chatStream,
+          message: host.chatStreamMessage ?? undefined,
+          ts: now,
+        },
+      ];
       host.chatStream = null;
+      host.chatStreamMessage = null;
       host.chatStreamStartedAt = null;
     }
     entry = {

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -1,5 +1,6 @@
 import type { EventLogEntry } from "./app-events.ts";
 import type { CompactionStatus, FallbackStatus } from "./app-tool-stream.ts";
+import type { ChatStreamSegment } from "./types/chat-types.ts";
 import type { CronModelSuggestionsState, CronState } from "./controllers/cron.ts";
 import type { DevicePairingList } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
@@ -64,8 +65,9 @@ export type AppViewState = {
   chatAttachments: ChatAttachment[];
   chatMessages: unknown[];
   chatToolMessages: unknown[];
-  chatStreamSegments: Array<{ text: string; ts: number }>;
+  chatStreamSegments: ChatStreamSegment[];
   chatStream: string | null;
+  chatStreamMessage?: unknown | null;
   chatStreamStartedAt: number | null;
   chatRunId: string | null;
   compactionStatus: CompactionStatus | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -55,6 +55,7 @@ import {
 import type { AppViewState } from "./app-view-state.ts";
 import { normalizeAssistantIdentity } from "./assistant-identity.ts";
 import { exportChatMarkdown } from "./chat/export.ts";
+import type { ChatStreamSegment } from "./types/chat-types.ts";
 import {
   loadToolsEffective as loadToolsEffectiveInternal,
   refreshVisibleToolsEffectiveForCurrentSession as refreshVisibleToolsEffectiveForCurrentSessionInternal,
@@ -157,8 +158,9 @@ export class OpenClawApp extends LitElement {
   @state() chatMessage = "";
   @state() chatMessages: unknown[] = [];
   @state() chatToolMessages: unknown[] = [];
-  @state() chatStreamSegments: Array<{ text: string; ts: number }> = [];
+  @state() chatStreamSegments: ChatStreamSegment[] = [];
   @state() chatStream: string | null = null;
+  @state() chatStreamMessage: unknown | null = null;
   @state() chatStreamStartedAt: number | null = null;
   @state() chatRunId: string | null = null;
   @state() compactionStatus: CompactionStatus | null = null;

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -76,8 +76,9 @@ export function renderReadingIndicatorGroup(assistant?: AssistantIdentity, baseP
 }
 
 export function renderStreamingGroup(
-  text: string,
+  message: unknown,
   startedAt: number,
+  showReasoning: boolean,
   onOpenSidebar?: (content: string) => void,
   assistant?: AssistantIdentity,
   basePath?: string,
@@ -92,13 +93,13 @@ export function renderStreamingGroup(
     <div class="chat-group assistant">
       ${renderAvatar("assistant", assistant, basePath)}
       <div class="chat-group-messages">
-        ${renderGroupedMessage(
-          {
+      ${renderGroupedMessage(
+          message ?? {
             role: "assistant",
-            content: [{ type: "text", text }],
+            content: [],
             timestamp: startedAt,
           },
-          { isStreaming: true, showReasoning: false },
+          { isStreaming: true, showReasoning },
           onOpenSidebar,
         )}
         <div class="chat-group-footer">
@@ -684,14 +685,16 @@ function renderGroupedMessage(
     typeof m.toolCallId === "string" ||
     typeof m.tool_call_id === "string";
 
-  const toolCards = (opts.showToolCalls ?? true) ? extractToolCards(message) : [];
+  const toolCards = extractToolCards(message);
   const hasToolCards = toolCards.length > 0;
   const images = extractImages(message);
   const hasImages = images.length > 0;
 
   const extractedText = extractTextCached(message);
   const extractedThinking =
-    opts.showReasoning && role === "assistant" ? extractThinkingCached(message) : null;
+    opts.showReasoning && (role === "assistant" || normalizedRole === "tool")
+      ? extractThinkingCached(message)
+      : null;
   const markdownBase = extractedText?.trim() ? extractedText : null;
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
   const markdown = markdownBase;
@@ -705,13 +708,14 @@ function renderGroupedMessage(
     .filter(Boolean)
     .join(" ");
 
-  if (!markdown && hasToolCards && isToolResult) {
+  const visibleToolCards = hasToolCards && (opts.showToolCalls ?? true);
+
+  if (!markdown && !reasoningMarkdown && !hasImages && visibleToolCards && isToolResult) {
     return renderCollapsedToolCards(toolCards, onOpenSidebar);
   }
 
   // Suppress empty bubbles when tool cards are the only content and toggle is off
-  const visibleToolCards = hasToolCards && (opts.showToolCalls ?? true);
-  if (!markdown && !visibleToolCards && !hasImages) {
+  if (!markdown && !reasoningMarkdown && !visibleToolCards && !hasImages) {
     return nothing;
   }
 
@@ -736,39 +740,41 @@ function renderGroupedMessage(
         : nothing}
       ${isToolMessage
         ? html`
-            <details class="chat-tool-msg-collapse">
-              <summary class="chat-tool-msg-summary">
-                <span class="chat-tool-msg-summary__icon">${icons.zap}</span>
-                <span class="chat-tool-msg-summary__label">Tool output</span>
-                ${toolSummaryLabel
-                  ? html`<span class="chat-tool-msg-summary__names">${toolSummaryLabel}</span>`
-                  : toolPreview
-                    ? html`<span class="chat-tool-msg-summary__preview">${toolPreview}</span>`
-                    : nothing}
-              </summary>
-              <div class="chat-tool-msg-body">
-                ${renderMessageImages(images)}
-                ${reasoningMarkdown
-                  ? html`<div class="chat-thinking">
-                      ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
-                    </div>`
-                  : nothing}
-                ${jsonResult
-                  ? html`<details class="chat-json-collapse">
-                      <summary class="chat-json-summary">
-                        <span class="chat-json-badge">JSON</span>
-                        <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
-                      </summary>
-                      <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
-                    </details>`
-                  : markdown
-                    ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
-                        ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
-                      </div>`
-                    : nothing}
-                ${hasToolCards ? renderCollapsedToolCards(toolCards, onOpenSidebar) : nothing}
-              </div>
-            </details>
+            ${renderMessageImages(images)}
+            ${reasoningMarkdown
+              ? html`<div class="chat-thinking">
+                  ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
+                </div>`
+              : nothing}
+            ${visibleToolCards
+              ? html`<details class="chat-tool-msg-collapse">
+                  <summary class="chat-tool-msg-summary">
+                    <span class="chat-tool-msg-summary__icon">${icons.zap}</span>
+                    <span class="chat-tool-msg-summary__label">Tool output</span>
+                    ${toolSummaryLabel
+                      ? html`<span class="chat-tool-msg-summary__names">${toolSummaryLabel}</span>`
+                      : toolPreview
+                        ? html`<span class="chat-tool-msg-summary__preview">${toolPreview}</span>`
+                        : nothing}
+                  </summary>
+                  <div class="chat-tool-msg-body">
+                    ${jsonResult
+                      ? html`<details class="chat-json-collapse">
+                          <summary class="chat-json-summary">
+                            <span class="chat-json-badge">JSON</span>
+                            <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
+                          </summary>
+                          <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
+                        </details>`
+                      : markdown
+                        ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
+                            ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
+                          </div>`
+                        : nothing}
+                    ${renderCollapsedToolCards(toolCards, onOpenSidebar)}
+                  </div>
+                </details>`
+              : nothing}
           `
         : html`
             ${renderMessageImages(images)}
@@ -790,7 +796,7 @@ function renderGroupedMessage(
                     ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
                   </div>`
                 : nothing}
-            ${hasToolCards ? renderCollapsedToolCards(toolCards, onOpenSidebar) : nothing}
+            ${visibleToolCards ? renderCollapsedToolCards(toolCards, onOpenSidebar) : nothing}
           `}
     </div>
   `;

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -4,6 +4,7 @@ import {
   extractTextCached,
   extractThinking,
   extractThinkingCached,
+  formatReasoningMarkdown,
 } from "./message-extract.ts";
 
 describe("extractTextCached", () => {
@@ -60,5 +61,19 @@ describe("extractThinkingCached", () => {
     };
     expect(extractThinkingCached(message)).toBe("Plan A");
     expect(extractThinkingCached(message)).toBe("Plan A");
+  });
+});
+
+describe("formatReasoningMarkdown", () => {
+  it("normalizes streamed reasoning prefix and inline italics before rendering", () => {
+    expect(formatReasoningMarkdown("Reasoning:\n_Check files_\n_Compare output_")).toBe(
+      ["_Reasoning:_", "_Check files_", "_Compare output_"].join("\n"),
+    );
+  });
+
+  it("preserves plain reasoning text while applying the shared display style", () => {
+    expect(formatReasoningMarkdown("Check files\nCompare output")).toBe(
+      ["_Reasoning:_", "_Check files_", "_Compare output_"].join("\n"),
+    );
   });
 });

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -108,8 +108,37 @@ export function extractRawText(message: unknown): string | null {
   return null;
 }
 
+function normalizeReasoningDisplayText(text: string): string {
+  const normalized = text.replace(/\r\n?/g, "\n").trim();
+  if (!normalized) {
+    return "";
+  }
+
+  const lines = normalized.split("\n");
+  const contentLines =
+    lines[0]?.trim().toLowerCase() === "reasoning:" ? lines.slice(1) : lines;
+
+  return contentLines
+    .map((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        return "";
+      }
+      const singleWrappedUnderscore =
+        trimmed.length >= 2 && trimmed.startsWith("_") && trimmed.endsWith("_");
+      const singleWrappedAsterisk =
+        trimmed.length >= 2 && trimmed.startsWith("*") && trimmed.endsWith("*");
+      if (singleWrappedUnderscore || singleWrappedAsterisk) {
+        return trimmed.slice(1, -1).trim();
+      }
+      return trimmed;
+    })
+    .join("\n")
+    .trim();
+}
+
 export function formatReasoningMarkdown(text: string): string {
-  const trimmed = text.trim();
+  const trimmed = normalizeReasoningDisplayText(text);
   if (!trimmed) {
     return "";
   }

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -99,6 +99,125 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Hello");
   });
 
+  it("preserves streamed reasoning during delta updates", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "",
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Check the config" },
+          { type: "text", text: "Applied the change." },
+        ],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatStream).toContain("<thinking>");
+    expect(state.chatStream).toContain("Check the config");
+    expect(state.chatStream).toContain("Applied the change.");
+  });
+
+  it("merges streamed reasoning and text from separate delta updates", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "",
+    });
+
+    const thinkingPayload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "Inspect the failing request" }],
+      },
+    };
+    const textPayload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "I found the mismatch." }],
+      },
+    };
+
+    expect(handleChatEvent(state, thinkingPayload)).toBe("delta");
+    expect(handleChatEvent(state, textPayload)).toBe("delta");
+    expect(state.chatStream).toContain("Inspect the failing request");
+    expect(state.chatStream).toContain("I found the mismatch.");
+  });
+
+  it("preserves interleaved reasoning and text blocks in order", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "",
+    });
+
+    const events: ChatEventPayload[] = [
+      {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "delta",
+        message: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "Inspecting request" }],
+        },
+      },
+      {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "delta",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "First answer chunk" }],
+        },
+      },
+      {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "delta",
+        message: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "Re-checking after tool output" }],
+        },
+      },
+      {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "delta",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Second answer chunk" }],
+        },
+      },
+    ];
+
+    for (const event of events) {
+      expect(handleChatEvent(state, event)).toBe("delta");
+    }
+
+    expect(state.chatStream).toContain("Inspecting request");
+    expect(state.chatStream).toContain("First answer chunk");
+    expect(state.chatStream).toContain("Re-checking after tool output");
+    expect(state.chatStream).toContain("Second answer chunk");
+    expect((state.chatStreamMessage as { content?: Array<{ type?: string }> } | null)?.content).toEqual([
+      expect.objectContaining({ type: "thinking" }),
+      expect.objectContaining({ type: "text" }),
+      expect.objectContaining({ type: "thinking" }),
+      expect.objectContaining({ type: "text" }),
+    ]);
+  });
+
   it("appends final payload from another run without clearing active stream", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1,5 +1,5 @@
 import { resetToolStream } from "../app-tool-stream.ts";
-import { extractText } from "../chat/message-extract.ts";
+import { extractText, extractThinking } from "../chat/message-extract.ts";
 import { formatConnectError } from "../connect-error.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ChatAttachment } from "../ui-types.ts";
@@ -44,6 +44,7 @@ export type ChatState = {
   chatAttachments: ChatAttachment[];
   chatRunId: string | null;
   chatStream: string | null;
+  chatStreamMessage?: unknown | null;
   chatStreamStartedAt: number | null;
   lastError: string | null;
 };
@@ -89,6 +90,7 @@ export async function loadChatHistory(state: ChatState) {
     // inline, so keeping streaming artifacts would cause duplicates.
     maybeResetToolStream(state);
     state.chatStream = null;
+    state.chatStreamMessage = null;
     state.chatStreamStartedAt = null;
   } catch (err) {
     if (isMissingOperatorReadScopeError(err)) {
@@ -160,6 +162,192 @@ function normalizeFinalAssistantMessage(message: unknown): Record<string, unknow
   });
 }
 
+type StreamingAssistantBlock =
+  | { type: "text"; text: string }
+  | { type: "thinking"; thinking: string };
+
+type StreamingAssistantMessage = {
+  role: "assistant";
+  content: StreamingAssistantBlock[];
+  timestamp: number;
+};
+
+function toStreamingAssistantBlocks(message: unknown): StreamingAssistantBlock[] {
+  if (message && typeof message === "object") {
+    const content = (message as Record<string, unknown>).content;
+    if (Array.isArray(content)) {
+      const blocks = content
+        .map((block) => {
+          const item = block as Record<string, unknown>;
+          if (item.type === "thinking" && typeof item.thinking === "string" && item.thinking.trim()) {
+            return { type: "thinking", thinking: item.thinking } as const;
+          }
+          if (item.type === "text" && typeof item.text === "string" && item.text.trim()) {
+            return { type: "text", text: item.text } as const;
+          }
+          return null;
+        })
+        .filter((block): block is StreamingAssistantBlock => block !== null);
+      if (blocks.length > 0) {
+        return blocks;
+      }
+    }
+  }
+
+  const thinking = extractThinking(message)?.trim() ?? "";
+  const explicitText =
+    message &&
+    typeof message === "object" &&
+    typeof (message as Record<string, unknown>).text === "string"
+      ? ((message as Record<string, unknown>).text as string).trim()
+      : "";
+  const text = explicitText || extractText(message)?.trim() || "";
+  const blocks: StreamingAssistantBlock[] = [];
+  if (thinking) {
+    blocks.push({ type: "thinking", thinking });
+  }
+  if (text) {
+    blocks.push({ type: "text", text });
+  }
+  return blocks;
+}
+
+function normalizeStreamingAssistantMessage(
+  message: unknown,
+  fallbackSerialized?: string | null,
+): StreamingAssistantMessage | null {
+  const fallbackMessage =
+    !message && fallbackSerialized?.trim()
+      ? ({ role: "assistant", content: fallbackSerialized } as const)
+      : undefined;
+  const source = message ?? fallbackMessage;
+  if (!source) {
+    return null;
+  }
+  const content = toStreamingAssistantBlocks(source);
+  if (content.length === 0) {
+    return null;
+  }
+  const timestamp =
+    source &&
+    typeof source === "object" &&
+    typeof (source as Record<string, unknown>).timestamp === "number"
+      ? ((source as Record<string, unknown>).timestamp as number)
+      : Date.now();
+  return {
+    role: "assistant",
+    content,
+    timestamp,
+  };
+}
+
+function serializeStreamingAssistantMessage(message: unknown): string {
+  const normalized = normalizeStreamingAssistantMessage(message);
+  if (!normalized) {
+    return "";
+  }
+  return normalized.content
+    .map((block) =>
+      block.type === "thinking"
+        ? `<thinking>\n${block.thinking.trim()}\n</thinking>`
+        : block.text.trim(),
+    )
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function mergeStreamingAssistantMessage(
+  currentMessage: unknown,
+  currentSerialized: string | null,
+  message: unknown,
+): StreamingAssistantMessage | null {
+  const previous = normalizeStreamingAssistantMessage(currentMessage, currentSerialized);
+  const incoming = normalizeStreamingAssistantMessage(message);
+  if (!incoming) {
+    return previous;
+  }
+
+  const incomingText = extractText(incoming)?.trim() ?? "";
+  const incomingThinking = extractThinking(incoming)?.trim() ?? "";
+  if (incomingText && isSilentReplyStream(incomingText) && !incomingThinking) {
+    return previous;
+  }
+
+  if (!previous) {
+    return incoming;
+  }
+
+  const mergedContent = previous.content.map((block) => ({ ...block })) as StreamingAssistantBlock[];
+  for (const block of incoming.content) {
+    const last = mergedContent[mergedContent.length - 1];
+    if (last?.type === block.type) {
+      if (block.type === "thinking") {
+        const previousValue = last.thinking.trim();
+        const nextValue = block.thinking.trim();
+        last.thinking = nextValue.length >= previousValue.length ? block.thinking : last.thinking;
+      } else {
+        const previousValue = last.text.trim();
+        const nextValue = block.text.trim();
+        last.text = nextValue.length >= previousValue.length ? block.text : last.text;
+      }
+      continue;
+    }
+    mergedContent.push({ ...block });
+  }
+
+  return {
+    role: "assistant",
+    content: mergedContent,
+    timestamp: previous.timestamp,
+  };
+}
+
+function mergeTerminalAssistantMessage(
+  currentMessage: unknown,
+  currentSerialized: string | null,
+  message: unknown,
+): StreamingAssistantMessage | null {
+  const terminal = normalizeStreamingAssistantMessage(message);
+  if (!terminal) {
+    return normalizeStreamingAssistantMessage(currentMessage, currentSerialized);
+  }
+  const previous = normalizeStreamingAssistantMessage(currentMessage, currentSerialized);
+  if (!previous) {
+    return terminal;
+  }
+  const terminalHasThinking = terminal.content.some((block) => block.type === "thinking");
+  if (terminalHasThinking) {
+    return terminal;
+  }
+  const previousThinking = previous.content
+    .filter((block): block is Extract<StreamingAssistantBlock, { type: "thinking" }> => block.type === "thinking")
+    .map((block) => ({ ...block }));
+  if (previousThinking.length === 0) {
+    return terminal;
+  }
+  return {
+    role: "assistant",
+    content: [...previousThinking, ...terminal.content.map((block) => ({ ...block }))],
+    timestamp: terminal.timestamp,
+  };
+}
+
+function appendStreamMessageToHistory(state: ChatState, fallbackMessage?: unknown) {
+  const mergedMessage = fallbackMessage
+    ? mergeTerminalAssistantMessage(state.chatStreamMessage ?? null, state.chatStream, fallbackMessage)
+    : normalizeStreamingAssistantMessage(state.chatStreamMessage ?? null, state.chatStream);
+  if (mergedMessage && !isAssistantSilentReply(mergedMessage)) {
+    state.chatMessages = [...state.chatMessages, mergedMessage];
+  }
+}
+
+function clearStreamingAssistantState(state: ChatState) {
+  state.chatStream = null;
+  state.chatStreamMessage = null;
+  state.chatRunId = null;
+  state.chatStreamStartedAt = null;
+}
+
 export async function sendChatMessage(
   state: ChatState,
   message: string,
@@ -205,6 +393,7 @@ export async function sendChatMessage(
   const runId = generateUUID();
   state.chatRunId = runId;
   state.chatStream = "";
+  state.chatStreamMessage = null;
   state.chatStreamStartedAt = now;
 
   // Convert attachments to API format
@@ -237,6 +426,7 @@ export async function sendChatMessage(
     const error = formatConnectError(err);
     state.chatRunId = null;
     state.chatStream = null;
+    state.chatStreamMessage = null;
     state.chatStreamStartedAt = null;
     state.lastError = error;
     state.chatMessages = [
@@ -293,54 +483,40 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   }
 
   if (payload.state === "delta") {
-    const next = extractText(payload.message);
-    if (typeof next === "string" && !isSilentReplyStream(next)) {
-      const current = state.chatStream ?? "";
-      if (!current || next.length >= current.length) {
-        state.chatStream = next;
+    const nextMessage = mergeStreamingAssistantMessage(
+      state.chatStreamMessage ?? null,
+      state.chatStream,
+      payload.message,
+    );
+    if (nextMessage) {
+      const nextSerialized = serializeStreamingAssistantMessage(nextMessage);
+      const currentSerialized = state.chatStream ?? "";
+      state.chatStreamMessage = nextMessage;
+      if (!currentSerialized || nextSerialized.length >= currentSerialized.length) {
+        state.chatStream = nextSerialized;
       }
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
     if (finalMessage && !isAssistantSilentReply(finalMessage)) {
-      state.chatMessages = [...state.chatMessages, finalMessage];
-    } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
-      state.chatMessages = [
-        ...state.chatMessages,
-        {
-          role: "assistant",
-          content: [{ type: "text", text: state.chatStream }],
-          timestamp: Date.now(),
-        },
-      ];
+      appendStreamMessageToHistory(state, finalMessage);
+    } else if (state.chatStream?.trim()) {
+      appendStreamMessageToHistory(state);
     }
-    state.chatStream = null;
-    state.chatRunId = null;
-    state.chatStreamStartedAt = null;
+    clearStreamingAssistantState(state);
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
     if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
-      state.chatMessages = [...state.chatMessages, normalizedMessage];
+      appendStreamMessageToHistory(state, normalizedMessage);
     } else {
-      const streamedText = state.chatStream ?? "";
-      if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
-        state.chatMessages = [
-          ...state.chatMessages,
-          {
-            role: "assistant",
-            content: [{ type: "text", text: streamedText }],
-            timestamp: Date.now(),
-          },
-        ];
+      const streamedText = state.chatStream?.trim() ?? "";
+      if (streamedText && !isSilentReplyStream(streamedText)) {
+        appendStreamMessageToHistory(state);
       }
     }
-    state.chatStream = null;
-    state.chatRunId = null;
-    state.chatStreamStartedAt = null;
+    clearStreamingAssistantState(state);
   } else if (payload.state === "error") {
-    state.chatStream = null;
-    state.chatRunId = null;
-    state.chatStreamStartedAt = null;
+    clearStreamingAssistantState(state);
     state.lastError = payload.errorMessage ?? "chat error";
   }
   return payload.state;

--- a/ui/src/ui/types/chat-types.ts
+++ b/ui/src/ui/types/chat-types.ts
@@ -2,11 +2,17 @@
  * Chat message types for the UI layer.
  */
 
+export type ChatStreamSegment = {
+  ts: number;
+  text?: string | null;
+  message?: unknown;
+};
+
 /** Union type for items in the chat thread */
 export type ChatItem =
   | { kind: "message"; key: string; message: unknown }
   | { kind: "divider"; key: string; label: string; timestamp: number }
-  | { kind: "stream"; key: string; text: string; startedAt: number }
+  | { kind: "stream"; key: string; startedAt: number; text?: string | null; message?: unknown }
   | { kind: "reading-indicator"; key: string };
 
 /** A group of consecutive messages from the same role (Slack-style layout) */

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -433,6 +433,127 @@ describe("chat view", () => {
     expect(logoImage?.getAttribute("src")).toBe("favicon.svg");
   });
 
+  it("shows streamed reasoning when the toggle is enabled", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showThinking: true,
+          sessions: {
+            ts: 0,
+            path: "",
+            count: 1,
+            defaults: {
+              modelProvider: "deepseek",
+              model: "deepseek-reasoner",
+              contextTokens: null,
+            },
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: null,
+                reasoningLevel: "high",
+              },
+            ],
+          },
+          stream: "<thinking>\nCompare the files\n</thinking>\n\nReady to answer.",
+          streamStartedAt: 1,
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-thinking")?.textContent ?? "").toContain(
+      "Compare the files",
+    );
+    expect(container.textContent).toContain("Ready to answer.");
+  });
+
+  it("renders a streaming bubble for reasoning-only deltas before answer text arrives", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showThinking: true,
+          sessions: {
+            ts: 0,
+            path: "",
+            count: 1,
+            defaults: {
+              modelProvider: "deepseek",
+              model: "deepseek-reasoner",
+              contextTokens: null,
+            },
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: null,
+                reasoningLevel: "stream",
+              },
+            ],
+          },
+          stream: "<thinking>\nInspect the traceback\n</thinking>",
+          streamStartedAt: 1,
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-bubble.streaming")).not.toBeNull();
+    expect(container.querySelector(".chat-thinking")?.textContent ?? "").toContain(
+      "Inspect the traceback",
+    );
+  });
+
+  it("keeps reasoning visible when tool output is hidden", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showThinking: true,
+          showToolCalls: false,
+          sessions: {
+            ts: 0,
+            path: "",
+            count: 1,
+            defaults: {
+              modelProvider: "deepseek",
+              model: "deepseek-reasoner",
+              contextTokens: null,
+            },
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: null,
+                reasoningLevel: "stream",
+              },
+            ],
+          },
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                { type: "thinking", thinking: "Inspect the tool output first" },
+                { type: "toolresult", name: "bash", text: "ls -la" },
+              ],
+              timestamp: 1000,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-thinking")?.textContent ?? "").toContain(
+      "Inspect the tool output first",
+    );
+    expect(container.textContent).not.toContain("Tool output");
+    expect(container.textContent).not.toContain("ls -la");
+  });
+
   it("keeps the welcome logo fallback under the mounted base path", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -13,6 +13,7 @@ import {
   renderStreamingGroup,
 } from "../chat/grouped-render.ts";
 import { InputHistory } from "../chat/input-history.ts";
+import { extractThinkingCached } from "../chat/message-extract.ts";
 import { normalizeMessage, normalizeRoleForGrouping } from "../chat/message-normalizer.ts";
 import { PinnedMessages } from "../chat/pinned-messages.ts";
 import { getPinnedMessageSummary } from "../chat/pinned-summary.ts";
@@ -29,7 +30,7 @@ import { isSttSupported, startStt, stopStt } from "../chat/speech.ts";
 import { icons } from "../icons.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../types.ts";
-import type { ChatItem, MessageGroup } from "../types/chat-types.ts";
+import type { ChatItem, ChatStreamSegment, MessageGroup } from "../types/chat-types.ts";
 import type { ChatAttachment, ChatQueueItem } from "../ui-types.ts";
 import { agentLogoUrl, resolveAgentAvatarUrl } from "./agents-utils.ts";
 import { renderMarkdownSidebar } from "./markdown-sidebar.ts";
@@ -64,8 +65,9 @@ export type ChatProps = {
   fallbackStatus?: FallbackIndicatorStatus | null;
   messages: unknown[];
   toolMessages: unknown[];
-  streamSegments: Array<{ text: string; ts: number }>;
+  streamSegments: ChatStreamSegment[];
   stream: string | null;
+  streamMessage?: unknown | null;
   streamStartedAt: number | null;
   assistantAvatarUrl?: string | null;
   draft: string;
@@ -183,6 +185,13 @@ export function resetChatViewState() {
 }
 
 export const cleanupChatModuleState = resetChatViewState;
+
+function shouldKeepToolResultMessageWhenToolsHidden(message: unknown, showThinking: boolean): boolean {
+  if (!showThinking) {
+    return false;
+  }
+  return Boolean(extractThinkingCached(message)?.trim());
+}
 
 function adjustTextareaHeight(el: HTMLTextAreaElement) {
   el.style.height = "auto";
@@ -1005,8 +1014,16 @@ export function renderChat(props: ChatProps) {
             }
             if (item.kind === "stream") {
               return renderStreamingGroup(
-                item.text,
+                item.message ??
+                  (typeof item.text === "string"
+                    ? {
+                        role: "assistant",
+                        content: [{ type: "text", text: item.text }],
+                        timestamp: item.startedAt,
+                      }
+                    : null),
                 item.startedAt,
+                showReasoning,
                 props.onOpenSidebar,
                 assistantIdentity,
                 props.basePath,
@@ -1487,7 +1504,11 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
       continue;
     }
 
-    if (!props.showToolCalls && normalized.role.toLowerCase() === "toolresult") {
+    if (
+      !props.showToolCalls &&
+      normalized.role.toLowerCase() === "toolresult" &&
+      !shouldKeepToolResultMessageWhenToolsHidden(msg, props.showThinking)
+    ) {
       continue;
     }
 
@@ -1508,12 +1529,15 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   const segments = props.streamSegments ?? [];
   const maxLen = Math.max(segments.length, tools.length);
   for (let i = 0; i < maxLen; i++) {
-    if (i < segments.length && segments[i].text.trim().length > 0) {
+    const segment = segments[i];
+    const segmentText = segment?.text?.trim() ?? "";
+    if (segment && (segment.message || segmentText.length > 0)) {
       items.push({
         kind: "stream" as const,
         key: `stream-seg:${props.sessionKey}:${i}`,
-        text: segments[i].text,
-        startedAt: segments[i].ts,
+        text: segment.text,
+        message: segment.message,
+        startedAt: segment.ts,
       });
     }
     if (i < tools.length && props.showToolCalls) {
@@ -1525,13 +1549,14 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
     }
   }
 
-  if (props.stream !== null) {
+  if (props.stream !== null || props.streamMessage) {
     const key = `stream:${props.sessionKey}:${props.streamStartedAt ?? "live"}`;
-    if (props.stream.trim().length > 0) {
+    if ((props.stream?.trim().length ?? 0) > 0 || props.streamMessage) {
       items.push({
         kind: "stream",
         key,
         text: props.stream,
+        message: props.streamMessage ?? undefined,
         startedAt: props.streamStartedAt ?? Date.now(),
       });
     } else {


### PR DESCRIPTION
## Summary
- stream assistant reasoning deltas through gateway chat events and preserve client run mapping/order
- render structured think/text/tool streaming in the control UI so interleaved blocks stay in order
- align streamed reasoning styling with final reasoning and keep reasoning visible when tool cards are hidden

## Testing
- pnpm.cmd test -- src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts src/gateway/server-chat.agent-events.test.ts
- pnpm.cmd test -- ui/src/ui/controllers/chat.test.ts ui/src/ui/views/chat.test.ts ui/src/ui/chat/message-extract.test.ts
- pnpm.cmd ui:build