### PR TITLE
fix(gateway): allow silent role upgrades for local loopback clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Slack/mrkdwn formatting: add built-in Slack mrkdwn guidance in inbound context so Slack replies stop falling back to generic Markdown patterns that render poorly in Slack. Thanks @jadewon and @vincentkoc.
+- Gateway/exec loopback: restore legacy-role fallback for empty paired-device token maps and allow silent local role upgrades so local exec and node clients stop failing with pairing-required errors after `2026.3.31`. (#59092) Thanks @openperf.
 
 ## 2026.4.1-beta.1
+
 - Plugins/runtime: stop ambient core helper and setup paths from loading non-selected bundled plugins, keep channel-setup snapshot scoping safe for custom channel plugins, and honor env-scoped plugin auth paths. (#59136) Thanks @vincentkoc.
 - Matrix/multi-account: keep room-level `account` scoping, inherited room overrides, and implicit account selection consistent across top-level default auth, named accounts, and cached-credential env setups. (#58449) thanks @Daanvdplas and @gumadeiras.
 - Gateway/pairing: prefer explicit QR bootstrap auth over earlier Tailscale auth classification so iOS `/pair qr` silent bootstrap pairing does not fall through to `pairing required`. (#59232) Thanks @ngutman.

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -65,7 +65,7 @@ describe("handshake auth helpers", () => {
     });
   });
 
-  it("allows silent local pairing only for not-paired and scope upgrades", () => {
+  it("allows silent local pairing for not-paired, scope-upgrade and role-upgrade", () => {
     expect(
       shouldAllowSilentLocalPairing({
         isLocalClient: true,
@@ -81,7 +81,37 @@ describe("handshake auth helpers", () => {
         hasBrowserOriginHeader: false,
         isControlUi: false,
         isWebchat: false,
+        reason: "role-upgrade",
+      }),
+    ).toBe(true);
+    expect(
+      shouldAllowSilentLocalPairing({
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        isControlUi: false,
+        isWebchat: false,
+        reason: "scope-upgrade",
+      }),
+    ).toBe(true);
+    expect(
+      shouldAllowSilentLocalPairing({
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        isControlUi: false,
+        isWebchat: false,
         reason: "metadata-upgrade",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects silent role-upgrade for remote clients", () => {
+    expect(
+      shouldAllowSilentLocalPairing({
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        isControlUi: false,
+        isWebchat: false,
+        reason: "role-upgrade",
       }),
     ).toBe(false);
   });

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -55,7 +55,9 @@ export function shouldAllowSilentLocalPairing(params: {
   return (
     params.isLocalClient &&
     (!params.hasBrowserOriginHeader || params.isControlUi || params.isWebchat) &&
-    (params.reason === "not-paired" || params.reason === "scope-upgrade")
+    (params.reason === "not-paired" ||
+      params.reason === "scope-upgrade" ||
+      params.reason === "role-upgrade")
   );
 }
 

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -593,6 +593,21 @@ describe("device pairing tokens", () => {
     expect(hasEffectivePairedDeviceRole(paired, "node")).toBe(false);
   });
 
+  test("falls back to legacy role fields when tokens map is empty", async () => {
+    const device: PairedDevice = {
+      deviceId: "device-fallback",
+      publicKey: "pk-fallback",
+      role: "node",
+      roles: ["node", "operator"],
+      tokens: {},
+      createdAtMs: Date.now(),
+      approvedAtMs: Date.now(),
+    };
+    expect(listEffectivePairedDeviceRoles(device)).toEqual(["node", "operator"]);
+    expect(hasEffectivePairedDeviceRole(device, "node")).toBe(true);
+    expect(hasEffectivePairedDeviceRole(device, "operator")).toBe(true);
+  });
+
   test("removes paired devices by device id", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
     await setupPairedOperatorDevice(baseDir, ["operator.read"]);

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -170,8 +170,15 @@ export function listEffectivePairedDeviceRoles(
   device: Pick<PairedDevice, "role" | "roles" | "tokens">,
 ): string[] {
   const activeTokenRoles = listActiveTokenRoles(device.tokens);
-  if (device.tokens) {
-    return activeTokenRoles ?? [];
+  if (activeTokenRoles && activeTokenRoles.length > 0) {
+    return activeTokenRoles;
+  }
+  // Only fall back to legacy role fields when the tokens map is absent
+  // or has no entries at all (empty object from a fresh pairing record).
+  // When token entries exist but are all revoked, the revocation is
+  // authoritative — do not re-grant roles from sticky historical fields.
+  if (device.tokens && Object.keys(device.tokens).length > 0) {
+    return [];
   }
   return mergeRoles(device.roles, device.role) ?? [];
 }


### PR DESCRIPTION
### Summary

- **Problem**: v2026.3.31 breaks `exec` tool connections on local loopback setups (Issue #59045). When a local client connects with a new role (e.g., `node` host connecting after an `operator` client), the connection is rejected with a 1008 "pairing required" error, even though the device is already paired.
- **Root Cause**: The issue stems from two interacting changes in v2026.3.31:
  1. `listEffectivePairedDeviceRoles` (in `src/infra/device-pairing.ts`, line 169) incorrectly returns an empty array `[]` when `device.tokens` is an empty object `{}`, failing to fall back to the legacy `device.roles` field. This happens because the original guard `if (device.tokens)` is truthy for `{}`, but `listActiveTokenRoles({})` returns `undefined` (since `Object.values({})` yields no entries), resulting in `undefined ?? []` = `[]`.
  2. When a role upgrade is triggered (because the requested role is not in the effective roles), `shouldAllowSilentLocalPairing` (in `src/gateway/server/ws-connection/handshake-auth-helpers.ts`, line 58) does not support the `role-upgrade` reason. This prevents local loopback clients from automatically approving the role upgrade via silent pairing, causing a 1008 close.
- **Fix**: 
  1. Updated `listEffectivePairedDeviceRoles` to fall back to legacy role fields (`device.roles`, `device.role`) when the `tokens` map is present but has no entries (empty object `{}`). When token entries exist but are all revoked, the function still returns `[]` to preserve the security invariant that revoked tokens permanently remove role access.
  2. Updated `shouldAllowSilentLocalPairing` to explicitly allow the `role-upgrade` reason for local clients, ensuring that loopback connections can seamlessly acquire new roles without manual intervention.
- **What changed**:
  - `src/infra/device-pairing.ts`: Fixed `listEffectivePairedDeviceRoles` fallback logic to distinguish empty tokens map from revoked tokens.
  - `src/infra/device-pairing.test.ts`: Added regression test for the empty tokens map fallback scenario.
  - `src/gateway/server/ws-connection/handshake-auth-helpers.ts`: Added `role-upgrade` to the allowed reasons in `shouldAllowSilentLocalPairing`.
  - `src/gateway/server/ws-connection/handshake-auth-helpers.test.ts`: Updated existing test and added new test for silent role-upgrade boundary (local vs remote).
- **What did NOT change (scope boundary)**:
  - Remote client pairing logic remains unchanged — silent role upgrades are still rejected for non-local clients.
  - The security property that revoked tokens permanently remove role access is preserved — the existing test "derives effective roles from active tokens instead of sticky historical roles" continues to pass unchanged.
  - Scope upgrade logic (`reason === "scope-upgrade"` is force-set to `silent: false` in `requirePairing`) is untouched.
  - General authentication flows, bootstrap token handling, and metadata-upgrade pairing are not affected.

### Reproduction

1. Start a local OpenClaw instance on `main` or `v2026.3.31`.
2. Connect a local client (e.g., CLI) with the `operator` role to establish initial pairing.
3. Attempt to use the `exec` tool or connect a `node` host from the same local loopback address.
4. Observe the connection being rejected with a 1008 "pairing required" error.
5. Apply this patch and repeat steps 1-3; the connection should succeed silently.

### Risk / Mitigation

- **Risk**: Allowing silent role upgrades for local clients could theoretically allow a compromised local process to escalate its privileges to other roles without user interaction.
- **Mitigation**: This risk is mitigated by the existing `isLocalClient` guard, which restricts this behavior strictly to loopback connections (127.0.0.1 / ::1). Remote connections still require explicit approval for role upgrades. Additionally, the fix in `listEffectivePairedDeviceRoles` preserves the security invariant that explicitly revoked tokens cannot be bypassed — only empty token maps (from fresh or legacy pairing records) trigger the fallback. Comprehensive unit tests have been added to verify both the positive path (local role-upgrade succeeds) and the negative boundary (remote role-upgrade is rejected; revoked tokens remain ineffective).

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Infra

### Linked Issue/PR

Fixes #59045
