### PR TITLE
fix(gateway): scope session kill requests

### DIFF
--- a/src/gateway/session-kill-http.test.ts
+++ b/src/gateway/session-kill-http.test.ts
@@ -5,7 +5,10 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 const TEST_GATEWAY_TOKEN = "test-gateway-token-1234567890";
 
 let cfg: Record<string, unknown> = {};
-const authMock = vi.fn(async () => ({ ok: true }) as { ok: boolean; rateLimited?: boolean });
+const authMock = vi.fn(
+  async () =>
+    ({ ok: true, method: "token" }) as { ok: boolean; method?: string; rateLimited?: boolean },
+);
 const isLocalDirectRequestMock = vi.fn(() => true);
 const loadSessionEntryMock = vi.fn();
 const getLatestSubagentRunByChildSessionKeyMock = vi.fn();
@@ -76,7 +79,7 @@ afterAll(async () => {
 beforeEach(() => {
   cfg = {};
   authMock.mockReset();
-  authMock.mockResolvedValue({ ok: true });
+  authMock.mockResolvedValue({ ok: true, method: "token" });
   isLocalDirectRequestMock.mockReset();
   isLocalDirectRequestMock.mockReturnValue(true);
   loadSessionEntryMock.mockReset();
@@ -169,7 +172,7 @@ describe("POST /sessions/:sessionKey/kill", () => {
 
   it("rejects remote kills without requester ownership or an authorized token", async () => {
     isLocalDirectRequestMock.mockReturnValue(false);
-    authMock.mockResolvedValueOnce({ ok: true });
+    authMock.mockResolvedValueOnce({ ok: true, method: "token" });
     loadSessionEntryMock.mockReturnValue({
       entry: { sessionId: "sess-worker", updatedAt: Date.now() },
       canonicalKey: "agent:main:subagent:worker",
@@ -182,9 +185,33 @@ describe("POST /sessions/:sessionKey/kill", () => {
     expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
   });
 
-  it("uses requester ownership checks when a requester session header is provided without admin bypass", async () => {
+  it("rejects identity-bearing requests that only declare operator.read", async () => {
     isLocalDirectRequestMock.mockReturnValue(false);
-    authMock.mockResolvedValueOnce({ ok: true });
+    authMock.mockResolvedValueOnce({ ok: true, method: "trusted-proxy" });
+    loadSessionEntryMock.mockReturnValue({
+      entry: { sessionId: "sess-worker", updatedAt: Date.now() },
+      canonicalKey: "agent:main:subagent:worker",
+    });
+
+    const response = await post("/sessions/agent%3Amain%3Asubagent%3Aworker/kill", "", {
+      "x-openclaw-requester-session-key": "agent:main:main",
+      "x-openclaw-scopes": "operator.read",
+    });
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: "missing scope: operator.write",
+      },
+    });
+    expect(killControlledSubagentRunMock).not.toHaveBeenCalled();
+    expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
+  });
+
+  it("uses requester ownership checks when operator.write is declared without admin bypass", async () => {
+    isLocalDirectRequestMock.mockReturnValue(false);
+    authMock.mockResolvedValueOnce({ ok: true, method: "trusted-proxy" });
     loadSessionEntryMock.mockReturnValue({
       entry: { sessionId: "sess-worker", updatedAt: Date.now() },
       canonicalKey: "agent:main:subagent:worker",
@@ -197,6 +224,7 @@ describe("POST /sessions/:sessionKey/kill", () => {
 
     const response = await post("/sessions/agent%3Amain%3Asubagent%3Aworker/kill", "", {
       "x-openclaw-requester-session-key": "agent:main:main",
+      "x-openclaw-scopes": "operator.write",
     });
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true, killed: true });
@@ -212,7 +240,7 @@ describe("POST /sessions/:sessionKey/kill", () => {
 
   it("uses the newest child-session row for requester-owned kills when stale rows still exist", async () => {
     isLocalDirectRequestMock.mockReturnValue(false);
-    authMock.mockResolvedValueOnce({ ok: true });
+    authMock.mockResolvedValueOnce({ ok: true, method: "trusted-proxy" });
     loadSessionEntryMock.mockReturnValue({
       entry: { sessionId: "sess-worker", updatedAt: Date.now() },
       canonicalKey: "agent:main:subagent:worker",
@@ -226,6 +254,7 @@ describe("POST /sessions/:sessionKey/kill", () => {
 
     const response = await post("/sessions/agent%3Amain%3Asubagent%3Aworker/kill", "", {
       "x-openclaw-requester-session-key": "agent:main:main",
+      "x-openclaw-scopes": "operator.write",
     });
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true, killed: false });
@@ -239,37 +268,31 @@ describe("POST /sessions/:sessionKey/kill", () => {
     });
   });
 
-  it("keeps bearer-auth requester kills on the requester-owned path", async () => {
+  it("rejects bearer-auth requester kills because shared-secret HTTP scopes are not trusted", async () => {
     isLocalDirectRequestMock.mockReturnValue(false);
     loadSessionEntryMock.mockReturnValue({
       entry: { sessionId: "sess-worker", updatedAt: Date.now() },
       canonicalKey: "agent:main:subagent:worker",
     });
-    getLatestSubagentRunByChildSessionKeyMock.mockReturnValue({
-      runId: "run-1",
-      childSessionKey: "agent:main:subagent:worker",
-    });
-    killControlledSubagentRunMock.mockResolvedValue({ status: "ok" });
 
     const response = await post(
       "/sessions/agent%3Amain%3Asubagent%3Aworker/kill",
       TEST_GATEWAY_TOKEN,
-      { "x-openclaw-requester-session-key": "agent:other:main" },
+      {
+        "x-openclaw-requester-session-key": "agent:other:main",
+        "x-openclaw-scopes": "operator.write",
+      },
     );
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true, killed: true });
-    expect(resolveSubagentControllerMock).toHaveBeenCalledWith({
-      cfg,
-      agentSessionKey: "agent:other:main",
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: "missing scope: operator.write",
+      },
     });
-    expect(killControlledSubagentRunMock).toHaveBeenCalledWith({
-      cfg,
-      controller: { controllerSessionKey: "agent:main:main" },
-      entry: expect.objectContaining({
-        runId: "run-1",
-        childSessionKey: "agent:main:subagent:worker",
-      }),
-    });
+    expect(resolveSubagentControllerMock).not.toHaveBeenCalled();
+    expect(killControlledSubagentRunMock).not.toHaveBeenCalled();
     expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/session-kill-http.ts
+++ b/src/gateway/session-kill-http.ts
@@ -8,8 +8,12 @@ import { getLatestSubagentRunByChildSessionKey } from "../agents/subagent-regist
 import { loadConfig } from "../config/config.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import { isLocalDirectRequest, type ResolvedGatewayAuth } from "./auth.js";
-import { authorizeGatewayBearerRequestOrReply } from "./http-auth-helpers.js";
 import { sendJson, sendMethodNotAllowed } from "./http-common.js";
+import {
+  authorizeGatewayHttpRequestOrReply,
+  resolveTrustedHttpOperatorScopes,
+} from "./http-utils.js";
+import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import { loadSessionEntry } from "./session-utils.js";
 
 const REQUESTER_SESSION_KEY_HEADER = "x-openclaw-requester-session-key";
@@ -49,7 +53,7 @@ export async function handleSessionKillHttpRequest(
     return true;
   }
 
-  const ok = await authorizeGatewayBearerRequestOrReply({
+  const requestAuth = await authorizeGatewayHttpRequestOrReply({
     req,
     res,
     auth: opts.auth,
@@ -57,7 +61,7 @@ export async function handleSessionKillHttpRequest(
     allowRealIpFallback: opts.allowRealIpFallback ?? cfg.gateway?.allowRealIpFallback,
     rateLimiter: opts.rateLimiter,
   });
-  if (!ok) {
+  if (!requestAuth) {
     return true;
   }
 
@@ -77,6 +81,21 @@ export async function handleSessionKillHttpRequest(
   const allowRealIpFallback = opts.allowRealIpFallback ?? cfg.gateway?.allowRealIpFallback;
   const requesterSessionKey = req.headers[REQUESTER_SESSION_KEY_HEADER]?.toString().trim();
   const allowLocalAdminKill = isLocalDirectRequest(req, trustedProxies, allowRealIpFallback);
+
+  if (!allowLocalAdminKill) {
+    const requestedScopes = resolveTrustedHttpOperatorScopes(req, requestAuth);
+    const scopeAuth = authorizeOperatorScopesForMethod("sessions.abort", requestedScopes);
+    if (!scopeAuth.allowed) {
+      sendJson(res, 403, {
+        ok: false,
+        error: {
+          type: "forbidden",
+          message: `missing scope: ${scopeAuth.missingScope}`,
+        },
+      });
+      return true;
+    }
+  }
 
   if (!requesterSessionKey && !allowLocalAdminKill) {
     sendJson(res, 403, {


### PR DESCRIPTION
## Summary
- Applies the standard HTTP operator-scope gate to `POST /sessions/:sessionKey/kill`
- Keeps local admin and requester-owned kill behavior intact for authorized callers

## Changes
- Switched the session kill HTTP route to `authorizeGatewayHttpRequestOrReply(...)`
- Enforced `sessions.abort` scope checks before the requester-owned mutation path runs
- Added regression coverage for `operator.read`, `operator.write`, and shared-secret bearer requests

## Validation
- Ran `corepack pnpm test -- src/gateway/session-kill-http.test.ts`
- Ran `PATH=/app/.local/bin:$PATH corepack pnpm build` and confirmed the branch still hits the existing unrelated duplicate-identifier failure in `extensions/discord/src/components.ts`
- Ran local agentic review via `claude -p "/review"`; it did not produce code feedback and instead requested PR context

## Notes
- Residual follow-up: the route still relies on requester-session ownership headers for the non-local path; this change narrows access by requiring the declared write scope before that path is considered
- Existing unrelated validation blocker: `extensions/discord/src/components.ts` currently fails `pnpm build` on current `main` with duplicate identifier errors