### PR TITLE
fix(marketplace): canonicalize remote plugin paths

### DIFF
--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -23,6 +23,7 @@ const runCommandWithTimeoutMock = vi.hoisted(() => vi.fn());
 let installPluginFromMarketplace: typeof import("./marketplace.js").installPluginFromMarketplace;
 let listMarketplacePlugins: typeof import("./marketplace.js").listMarketplacePlugins;
 let resolveMarketplaceInstallShortcut: typeof import("./marketplace.js").resolveMarketplaceInstallShortcut;
+const tempOutsideDirs: string[] = [];
 
 vi.mock("./install.js", () => ({
   installPluginFromPath: (...args: unknown[]) => installPluginFromPathMock(...args),
@@ -111,6 +112,27 @@ function mockRemoteMarketplaceClone(params: { manifest: unknown; pluginDir?: str
   });
 }
 
+function mockRemoteMarketplaceCloneWithOutsideSymlink(params: {
+  manifest: unknown;
+  symlinkPath: string;
+}) {
+  runCommandWithTimeoutMock.mockImplementationOnce(async (argv: string[]) => {
+    const repoDir = argv.at(-1);
+    expect(typeof repoDir).toBe("string");
+    await writeRemoteMarketplaceFixture({
+      repoDir: repoDir as string,
+      manifest: params.manifest,
+    });
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-marketplace-outside-"));
+    tempOutsideDirs.push(outsideDir);
+    await fs.mkdir(path.dirname(path.join(repoDir as string, params.symlinkPath)), {
+      recursive: true,
+    });
+    await fs.symlink(outsideDir, path.join(repoDir as string, params.symlinkPath));
+    return { code: 0, stdout: "", stderr: "", killed: false };
+  });
+}
+
 async function expectRemoteMarketplaceError(params: { manifest: unknown; expectedError: string }) {
   mockRemoteMarketplaceClone({ manifest: params.manifest });
 
@@ -183,11 +205,16 @@ function expectLocalMarketplaceInstallResult(params: {
 }
 
 describe("marketplace plugins", () => {
-  afterEach(() => {
+  afterEach(async () => {
     fetchWithSsrFGuardMock.mockClear();
     installPluginFromPathMock.mockReset();
     runCommandWithTimeoutMock.mockReset();
     vi.unstubAllGlobals();
+    await Promise.all(
+      tempOutsideDirs.splice(0, tempOutsideDirs.length).map(async (dir) => {
+        await fs.rm(dir, { recursive: true, force: true });
+      }),
+    );
   });
 
   it("lists plugins from a local marketplace root", async () => {
@@ -342,6 +369,36 @@ describe("marketplace plugins", () => {
 
     expectRemoteMarketplaceInstallResult(result);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects remote marketplace plugin paths that resolve through symlinks outside the cloned repo",
+    async () => {
+      mockRemoteMarketplaceCloneWithOutsideSymlink({
+        symlinkPath: "plugins/evil-link",
+        manifest: {
+          plugins: [
+            {
+              name: "frontend-design",
+              source: "./plugins/evil-link",
+            },
+          ],
+        },
+      });
+
+      const result = await installPluginFromMarketplace({
+        marketplace: "owner/repo",
+        plugin: "frontend-design",
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        error:
+          'invalid marketplace entry "frontend-design" in owner/repo: ' +
+          "plugin source escapes marketplace root: ./plugins/evil-link",
+      });
+      expect(installPluginFromPathMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("returns a structured error for archive downloads with an empty response body", async () => {
     await withTempDir(async (rootDir) => {
@@ -796,4 +853,33 @@ describe("marketplace plugins", () => {
   ] as const)("$name", async ({ manifest, expectedError }) => {
     await expectRemoteMarketplaceError({ manifest, expectedError });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects remote marketplace symlink plugin paths during manifest validation",
+    async () => {
+      mockRemoteMarketplaceCloneWithOutsideSymlink({
+        symlinkPath: "evil-link",
+        manifest: {
+          plugins: [
+            {
+              name: "frontend-design",
+              source: {
+                type: "path",
+                path: "evil-link",
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await listMarketplacePlugins({ marketplace: "owner/repo" });
+
+      expect(result).toEqual({
+        ok: false,
+        error:
+          'invalid marketplace entry "frontend-design" in owner/repo: ' +
+          "plugin source escapes marketplace root: evil-link",
+      });
+    },
+  );
 });

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveOsHomeRelativePath } from "../infra/home-dir.js";
+import { assertCanonicalPathWithinBase } from "../infra/install-safe-path.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { redactSensitiveUrlLikeString } from "../shared/net/redact-sensitive-url.js";
@@ -485,7 +486,7 @@ async function loadMarketplace(params: {
     if (!parsed.ok) {
       return parsed;
     }
-    const validated = validateMarketplaceManifest({
+    const validated = await validateMarketplaceManifest({
       manifest: parsed.manifest,
       sourceLabel: local.manifestPath,
       rootDir: local.rootDir,
@@ -561,7 +562,7 @@ async function loadMarketplace(params: {
     await cloned.cleanup();
     return parsed;
   }
-  const validated = validateMarketplaceManifest({
+  const validated = await validateMarketplaceManifest({
     manifest: parsed.manifest,
     sourceLabel: cloned.label,
     rootDir: cloned.rootDir,
@@ -802,10 +803,10 @@ async function downloadUrlToTempFile(
   }
 }
 
-function ensureInsideMarketplaceRoot(
+async function ensureInsideMarketplaceRoot(
   rootDir: string,
   candidate: string,
-): { ok: true; path: string } | { ok: false; error: string } {
+): Promise<{ ok: true; path: string } | { ok: false; error: string }> {
   const resolved = path.resolve(rootDir, candidate);
   const relative = path.relative(rootDir, resolved);
   if (relative === ".." || relative.startsWith(`..${path.sep}`)) {
@@ -814,15 +815,29 @@ function ensureInsideMarketplaceRoot(
       error: `plugin source escapes marketplace root: ${candidate}`,
     };
   }
+
+  try {
+    await assertCanonicalPathWithinBase({
+      baseDir: rootDir,
+      candidatePath: resolved,
+      boundaryLabel: "marketplace root",
+    });
+  } catch {
+    return {
+      ok: false,
+      error: `plugin source escapes marketplace root: ${candidate}`,
+    };
+  }
+
   return { ok: true, path: resolved };
 }
 
-function validateMarketplaceManifest(params: {
+async function validateMarketplaceManifest(params: {
   manifest: MarketplaceManifest;
   sourceLabel: string;
   rootDir: string;
   origin: MarketplaceManifestOrigin;
-}): { ok: true; manifest: MarketplaceManifest } | { ok: false; error: string } {
+}): Promise<{ ok: true; manifest: MarketplaceManifest } | { ok: false; error: string }> {
   if (params.origin === "local") {
     return { ok: true, manifest: params.manifest };
   }
@@ -846,7 +861,7 @@ function validateMarketplaceManifest(params: {
             "remote marketplaces may only use relative plugin paths",
         };
       }
-      const resolved = ensureInsideMarketplaceRoot(params.rootDir, source.path);
+      const resolved = await ensureInsideMarketplaceRoot(params.rootDir, source.path);
       if (!resolved.ok) {
         return {
           ok: false,
@@ -895,7 +910,7 @@ async function resolveMarketplaceEntryInstallPath(params: {
     }
     const resolved = path.isAbsolute(params.source.path)
       ? { ok: true as const, path: params.source.path }
-      : ensureInsideMarketplaceRoot(params.marketplaceRootDir, params.source.path);
+      : await ensureInsideMarketplaceRoot(params.marketplaceRootDir, params.source.path);
     if (!resolved.ok) {
       return resolved;
     }
@@ -923,7 +938,7 @@ async function resolveMarketplaceEntryInstallPath(params: {
       params.source.kind === "github" || params.source.kind === "git"
         ? params.source.path?.trim() || "."
         : params.source.path.trim();
-    const target = ensureInsideMarketplaceRoot(cloned.rootDir, subPath);
+    const target = await ensureInsideMarketplaceRoot(cloned.rootDir, subPath);
     if (!target.ok) {
       await cloned.cleanup();
       return target;


### PR DESCRIPTION
## Summary
- Tightens remote marketplace path validation before plugin installs
- Rejects remote marketplace entries whose resolved path escapes the cloned repository through symlinks

## Changes
- Updated `src/plugins/marketplace.ts` to validate remote marketplace path entries with canonical path checks after the existing relative-path guard
- Applied the same canonical validation during remote marketplace manifest loading and final install-path resolution
- Added regression coverage in `src/plugins/marketplace.test.ts` for remote marketplace symlink escapes during listing and install

## Validation
- Ran `corepack pnpm test -- src/plugins/marketplace.test.ts`
- Ran `corepack pnpm test -- src/infra/install-safe-path.test.ts`
- Ran `corepack pnpm test -- src/plugins/marketplace.test.ts -t 'rejects remote marketplace symlink plugin paths during manifest validation'`
- Ran `PATH="<tmp pnpm shim>:$PATH" corepack pnpm build`
- Ran local agentic review attempts with `claude -p "/review"` and diff-scoped `claude` review invocations; no actionable findings were produced locally

## Notes
- Scope is limited to remote marketplace path sources; local marketplace behavior is unchanged
- No earlier fix PR was found to incorporate or credit
