### PR TITLE
fix(memory): preserve retry state and embedding cache across reindex rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -672,6 +672,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: rotate auth profiles before deferred cooldown marking on rate-limit failures, so file-lock contention cannot stall profile failover. Fixes #57281. (#57283) Thanks @jeremyknows.
 - Gateway/sessions: when `session.dmScope: "main"` is configured, route a bare webchat `/new` against the agent's main session (`sessions.create` with `emitCommandHooks=true`) to an in-place reset instead of creating a parallel `dashboard:` child, matching `/new` behavior on Telegram/Discord. Fixes #77434. (#71170) Thanks @statxc.
 - Scripts/UI/Windows: launch `.cmd` and `.bat` UI runners through the shared cmd.exe escaping path with shell mode disabled, avoiding Node.js v24 DEP0190 warnings while preserving argument boundaries. (#62910) Thanks @nandanadileep.
+- Memory/reindex: restore in-memory dirty flags, session dirty files, session deltas, and a new `sessionFullRetryPending` sentinel when a safe or unsafe reindex rolls back, so the next sync retries the rolled-back work instead of silently converging; mirror successful embedding batches into the original index during a safe temp-DB reindex so the cache survives a later batch failure; and check for an existing `embedding_cache` table before seeding, so enabling cache on an older index no longer crashes the reindex. (#59137) Thanks @TSHOGX.
 
 ## 2026.5.3-1
 

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import type { DatabaseSync } from "node:sqlite";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   enforceEmbeddingMaxInputTokens,
@@ -125,24 +126,29 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     if (!max || max <= 0) {
       return;
     }
-    const row = this.db.prepare(`SELECT COUNT(*) as c FROM ${EMBEDDING_CACHE_TABLE}`).get() as
-      | { c: number }
-      | undefined;
-    const count = row?.c ?? 0;
-    if (count <= max) {
-      return;
-    }
-    const excess = count - max;
-    this.db
-      .prepare(
+    const pruneExcess = (db: DatabaseSync) => {
+      const row = db.prepare(`SELECT COUNT(*) as c FROM ${EMBEDDING_CACHE_TABLE}`).get() as
+        | { c: number }
+        | undefined;
+      const count = row?.c ?? 0;
+      if (count <= max) {
+        return;
+      }
+      const excess = count - max;
+      db.prepare(
         `DELETE FROM ${EMBEDDING_CACHE_TABLE}\n` +
           ` WHERE rowid IN (\n` +
           `   SELECT rowid FROM ${EMBEDDING_CACHE_TABLE}\n` +
           `   ORDER BY updated_at ASC\n` +
           `   LIMIT ?\n` +
           ` )`,
-      )
-      .run(excess);
+      ).run(excess);
+    };
+    pruneExcess(this.db);
+    const mirror = this.embeddingCacheMirrorDb;
+    if (mirror && mirror !== this.db) {
+      pruneExcess(mirror);
+    }
   }
 
   private async embedChunksInBatches(chunks: MemoryChunk[]): Promise<number[][]> {
@@ -157,7 +163,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
     const missingChunks = missing.map((m) => m.chunk);
     const batches = buildMemoryEmbeddingBatches(missingChunks, EMBEDDING_BATCH_MAX_TOKENS);
-    const toCache: Array<{ hash: string; embedding: number[] }> = [];
     const provider = this.provider;
     if (!provider) {
       throw new Error("Cannot embed batch in FTS-only mode (no embedding provider)");
@@ -174,25 +179,50 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       const batchEmbeddings = hasStructuredInputs
         ? await this.embedBatchInputsWithRetry(inputs)
         : await this.embedBatchWithRetry(batch.map((chunk) => chunk.text));
+      const batchCache: Array<{ hash: string; embedding: number[] }> = [];
       for (let i = 0; i < batch.length; i += 1) {
         const item = missing[cursor + i];
         const embedding = batchEmbeddings[i] ?? [];
         if (item) {
           embeddings[item.index] = embedding;
-          toCache.push({ hash: item.chunk.hash, embedding });
+          batchCache.push({ hash: item.chunk.hash, embedding });
         }
       }
       cursor += batch.length;
+      // Persist per-batch instead of at the end of the loop so an error in a
+      // later batch still leaves earlier batches durably cached — both in the
+      // live DB the current reindex is writing to, *and* in the mirror DB
+      // (i.e. the original index) when a safe reindex is in progress. Without
+      // the mirror, the temp DB gets thrown away on rollback and we have to
+      // re-pay the provider for work we already completed.
+      this.persistEmbeddingBatchCache(batchCache);
+    }
+    return embeddings;
+  }
+
+  private persistEmbeddingBatchCache(entries: Array<{ hash: string; embedding: number[] }>): void {
+    if (entries.length === 0) {
+      return;
     }
     upsertMemoryEmbeddingCache({
       db: this.db,
       enabled: this.cache.enabled,
       provider: this.provider,
       providerKey: this.providerKey,
-      entries: toCache,
+      entries,
       tableName: EMBEDDING_CACHE_TABLE,
     });
-    return embeddings;
+    const mirror = this.embeddingCacheMirrorDb;
+    if (mirror && mirror !== this.db) {
+      upsertMemoryEmbeddingCache({
+        db: mirror,
+        enabled: this.cache.enabled,
+        provider: this.provider,
+        providerKey: this.providerKey,
+        entries,
+        tableName: EMBEDDING_CACHE_TABLE,
+      });
+    }
   }
 
   protected computeProviderKey(): string {

--- a/extensions/memory-core/src/memory/manager-session-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager-session-reindex.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { shouldSyncSessionsForReindex } from "./manager-session-reindex.js";
+
+describe("shouldSyncSessionsForReindex", () => {
+  const base = {
+    hasSessionSource: true,
+    sessionsDirty: false,
+    dirtySessionFileCount: 0,
+  };
+
+  it("skips when session source is not configured", () => {
+    expect(
+      shouldSyncSessionsForReindex({
+        ...base,
+        hasSessionSource: false,
+        sessionsDirty: true,
+        dirtySessionFileCount: 3,
+        sessionFullRetryPending: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("forces a sync when explicit session files are requested", () => {
+    expect(
+      shouldSyncSessionsForReindex({
+        ...base,
+        sync: { sessionFiles: ["a"] },
+      }),
+    ).toBe(true);
+  });
+
+  it("forces a sync on explicit force", () => {
+    expect(shouldSyncSessionsForReindex({ ...base, sync: { force: true } })).toBe(true);
+  });
+
+  it("forces a sync during a full reindex", () => {
+    expect(shouldSyncSessionsForReindex({ ...base, needsFullReindex: true })).toBe(true);
+  });
+
+  it("forces a sync when the previous full session rebuild is still pending retry", () => {
+    expect(
+      shouldSyncSessionsForReindex({
+        ...base,
+        sessionFullRetryPending: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("skips regular session-start and watch reasons without dirty files", () => {
+    for (const reason of ["session-start", "watch"] as const) {
+      expect(
+        shouldSyncSessionsForReindex({
+          ...base,
+          sessionsDirty: true,
+          sync: { reason },
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("syncs only when both sessionsDirty and a dirty file count are present", () => {
+    expect(shouldSyncSessionsForReindex({ ...base, sessionsDirty: true })).toBe(false);
+    expect(shouldSyncSessionsForReindex({ ...base, dirtySessionFileCount: 1 })).toBe(false);
+    expect(
+      shouldSyncSessionsForReindex({
+        ...base,
+        sessionsDirty: true,
+        dirtySessionFileCount: 1,
+      }),
+    ).toBe(true);
+  });
+});

--- a/extensions/memory-core/src/memory/manager-session-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-session-reindex.ts
@@ -2,6 +2,7 @@ export function shouldSyncSessionsForReindex(params: {
   hasSessionSource: boolean;
   sessionsDirty: boolean;
   dirtySessionFileCount: number;
+  sessionFullRetryPending?: boolean;
   sync?: {
     reason?: string;
     force?: boolean;
@@ -19,6 +20,11 @@ export function shouldSyncSessionsForReindex(params: {
     return true;
   }
   if (params.needsFullReindex) {
+    return true;
+  }
+  // Previous full session rebuild failed: keep forcing full reindex until success,
+  // even if `sessionsDirtyFiles` was cleared (or was empty to begin with).
+  if (params.sessionFullRetryPending) {
     return true;
   }
   const reason = params.sync?.reason;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -58,6 +58,12 @@ import {
   loadMemorySourceFileState,
   resolveMemorySourceExistingHash,
 } from "./manager-source-state.js";
+import {
+  computeRestoredSyncState,
+  restoreRetryStateAfterReindexRollback,
+  snapshotSyncState,
+  type MemorySyncStateSnapshot,
+} from "./manager-sync-recovery.js";
 import { runMemoryTargetedSessionSync } from "./manager-targeted-sync.js";
 
 type MemorySyncProgressState = {
@@ -186,7 +192,9 @@ export abstract class MemoryManagerSyncOps {
     string,
     { lastSize: number; pendingBytes: number; pendingMessages: number }
   >();
+  protected sessionFullRetryPending = false;
   protected vectorDegradedWriteWarningShown = false;
+  protected embeddingCacheMirrorDb: DatabaseSync | null = null;
   private lastMetaSerialized: string | null = null;
 
   protected abstract readonly cache: { enabled: boolean; maxEntries?: number };
@@ -321,6 +329,14 @@ export abstract class MemoryManagerSyncOps {
 
   private async seedEmbeddingCache(sourceDb: DatabaseSync): Promise<void> {
     if (!this.cache.enabled) {
+      return;
+    }
+    // The source DB may pre-date the embedding cache schema — enabling the
+    // cache on an older index must not crash the reindex before we even start.
+    const hasCacheTable = sourceDb
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+      .get(EMBEDDING_CACHE_TABLE);
+    if (!hasCacheTable) {
       return;
     }
     let transactionStarted = false;
@@ -708,8 +724,36 @@ export abstract class MemoryManagerSyncOps {
       hasSessionSource: this.sources.has("sessions"),
       sessionsDirty: this.sessionsDirty,
       dirtySessionFileCount: this.sessionsDirtyFiles.size,
+      sessionFullRetryPending: this.sessionFullRetryPending,
       sync: params,
       needsFullReindex,
+    });
+  }
+
+  private captureSyncStateFields() {
+    return {
+      dirty: this.dirty,
+      sessionsDirty: this.sessionsDirty,
+      sessionsDirtyFiles: this.sessionsDirtyFiles,
+      sessionPendingFiles: this.sessionPendingFiles,
+      sessionDeltas: this.sessionDeltas,
+      sessionFullRetryPending: this.sessionFullRetryPending,
+    };
+  }
+
+  private applyRestoredSyncState(
+    snapshot: MemorySyncStateSnapshot,
+    ranSessionFullRebuild: boolean,
+  ): void {
+    const restored = computeRestoredSyncState(this.captureSyncStateFields(), snapshot);
+    this.dirty = restored.dirty;
+    this.sessionsDirty = restored.sessionsDirty;
+    this.sessionsDirtyFiles = restored.sessionsDirtyFiles;
+    this.sessionPendingFiles = restored.sessionPendingFiles;
+    this.sessionDeltas = restored.sessionDeltas;
+    this.sessionFullRetryPending = restoreRetryStateAfterReindexRollback({
+      previous: restored.sessionFullRetryPending,
+      ranSessionFullRebuild,
     });
   }
 
@@ -1025,7 +1069,9 @@ export abstract class MemoryManagerSyncOps {
       },
     });
     if (targetedSessionSync.handled) {
-      this.sessionsDirty = targetedSessionSync.sessionsDirty;
+      // Preserve `sessionFullRetryPending` — a targeted sync on a subset of
+      // session files must not silence the outstanding full-rebuild requirement.
+      this.sessionsDirty = this.sessionFullRetryPending || targetedSessionSync.sessionsDirty;
       return;
     }
     const needsFullReindex =
@@ -1188,8 +1234,14 @@ export abstract class MemoryManagerSyncOps {
       vectorDegradedWriteWarningShown: this.vectorDegradedWriteWarningShown,
       vectorReady: this.vectorReady,
     };
+    // Snapshot the in-memory sync state *before* we start mutating dirty flags,
+    // so a reindex failure can restore it and the next sync retries the work
+    // that was in flight.
+    const syncSnapshot = snapshotSyncState(this.captureSyncStateFields());
+    let sessionFullRebuildStarted = false;
 
-    const restoreOriginalState = () => {
+    const restoreOriginalState = (options: { restoreVectorDims?: boolean } = {}) => {
+      const { restoreVectorDims = true } = options;
       if (originalDbClosed) {
         this.db = openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled);
       } else {
@@ -1199,7 +1251,9 @@ export abstract class MemoryManagerSyncOps {
       this.fts.loadError = originalState.ftsError;
       this.vector.available = originalDbClosed ? null : originalState.vectorAvailable;
       this.vector.loadError = originalState.vectorLoadError;
-      this.vector.dims = originalState.vectorDims;
+      if (restoreVectorDims) {
+        this.vector.dims = originalState.vectorDims;
+      }
       this.vectorDegradedWriteWarningShown = originalState.vectorDegradedWriteWarningShown;
       this.vectorReady = originalDbClosed ? null : originalState.vectorReady;
     };
@@ -1218,6 +1272,11 @@ export abstract class MemoryManagerSyncOps {
         tempPath: tempDbPath,
         build: async () => {
           await this.seedEmbeddingCache(originalDb);
+          // Mirror every successful embedding batch back to the original DB
+          // while the temp DB is being built, so a later failure (which rolls
+          // back the temp swap) still preserves the work we already paid the
+          // provider for.
+          this.embeddingCacheMirrorDb = originalDb;
           const shouldSyncMemory = this.sources.has("memory");
           const shouldSyncSessions = this.shouldSyncSessions(
             { reason: params.reason, force: params.force },
@@ -1230,13 +1289,15 @@ export abstract class MemoryManagerSyncOps {
           }
 
           if (shouldSyncSessions) {
+            sessionFullRebuildStarted = true;
             await this.syncSessionFiles({ needsFullReindex: true, progress: params.progress });
             this.sessionsDirty = false;
             this.sessionsDirtyFiles.clear();
+            this.sessionFullRetryPending = false;
           } else if (this.sessionsDirtyFiles.size > 0) {
             this.sessionsDirty = true;
           } else {
-            this.sessionsDirty = false;
+            this.sessionsDirty = this.sessionFullRetryPending;
           }
 
           const meta: MemoryIndexMeta = {
@@ -1281,7 +1342,10 @@ export abstract class MemoryManagerSyncOps {
         closeMemoryDatabase(this.db);
       } catch {}
       restoreOriginalState();
+      this.applyRestoredSyncState(syncSnapshot, sessionFullRebuildStarted);
       throw err;
+    } finally {
+      this.embeddingCacheMirrorDb = null;
     }
   }
 
@@ -1292,53 +1356,65 @@ export abstract class MemoryManagerSyncOps {
   }): Promise<void> {
     // Perf: for test runs, skip atomic temp-db swapping. The index is isolated
     // under the per-test HOME anyway, and this cuts substantial fs+sqlite churn.
+    const syncSnapshot = snapshotSyncState(this.captureSyncStateFields());
+    let sessionFullRebuildStarted = false;
     this.resetIndex();
 
-    const shouldSyncMemory = this.sources.has("memory");
-    const shouldSyncSessions = this.shouldSyncSessions(
-      { reason: params.reason, force: params.force },
-      true,
-    );
+    try {
+      const shouldSyncMemory = this.sources.has("memory");
+      const shouldSyncSessions = this.shouldSyncSessions(
+        { reason: params.reason, force: params.force },
+        true,
+      );
 
-    if (shouldSyncMemory) {
-      await this.syncMemoryFiles({ needsFullReindex: true, progress: params.progress });
-      this.dirty = false;
+      if (shouldSyncMemory) {
+        await this.syncMemoryFiles({ needsFullReindex: true, progress: params.progress });
+        this.dirty = false;
+      }
+
+      if (shouldSyncSessions) {
+        sessionFullRebuildStarted = true;
+        await this.syncSessionFiles({ needsFullReindex: true, progress: params.progress });
+        this.sessionsDirty = false;
+        this.sessionsDirtyFiles.clear();
+        this.sessionFullRetryPending = false;
+      } else if (this.sessionsDirtyFiles.size > 0) {
+        this.sessionsDirty = true;
+      } else {
+        this.sessionsDirty = this.sessionFullRetryPending;
+      }
+
+      const nextMeta: MemoryIndexMeta = {
+        model: this.provider?.model ?? "fts-only",
+        provider: this.provider?.id ?? "none",
+        providerKey: this.providerKey!,
+        sources: resolveConfiguredSourcesForMeta(this.sources),
+        scopeHash: resolveConfiguredScopeHash({
+          workspaceDir: this.workspaceDir,
+          extraPaths: this.settings.extraPaths,
+          multimodal: {
+            enabled: this.settings.multimodal.enabled,
+            modalities: this.settings.multimodal.modalities,
+            maxFileBytes: this.settings.multimodal.maxFileBytes,
+          },
+        }),
+        chunkTokens: this.settings.chunking.tokens,
+        chunkOverlap: this.settings.chunking.overlap,
+        ftsTokenizer: this.settings.store.fts.tokenizer,
+      };
+      if (this.vector.available && this.vector.dims) {
+        nextMeta.vectorDims = this.vector.dims;
+      }
+
+      this.writeMeta(nextMeta);
+      this.pruneEmbeddingCacheIfNeeded?.();
+    } catch (err) {
+      // Unsafe path truncated the DB in place, so there is no temp-DB to
+      // discard — but we still need to put the in-memory sync state back so
+      // the next sync retries the files that did not finish.
+      this.applyRestoredSyncState(syncSnapshot, sessionFullRebuildStarted);
+      throw err;
     }
-
-    if (shouldSyncSessions) {
-      await this.syncSessionFiles({ needsFullReindex: true, progress: params.progress });
-      this.sessionsDirty = false;
-      this.sessionsDirtyFiles.clear();
-    } else if (this.sessionsDirtyFiles.size > 0) {
-      this.sessionsDirty = true;
-    } else {
-      this.sessionsDirty = false;
-    }
-
-    const nextMeta: MemoryIndexMeta = {
-      model: this.provider?.model ?? "fts-only",
-      provider: this.provider?.id ?? "none",
-      providerKey: this.providerKey!,
-      sources: resolveConfiguredSourcesForMeta(this.sources),
-      scopeHash: resolveConfiguredScopeHash({
-        workspaceDir: this.workspaceDir,
-        extraPaths: this.settings.extraPaths,
-        multimodal: {
-          enabled: this.settings.multimodal.enabled,
-          modalities: this.settings.multimodal.modalities,
-          maxFileBytes: this.settings.multimodal.maxFileBytes,
-        },
-      }),
-      chunkTokens: this.settings.chunking.tokens,
-      chunkOverlap: this.settings.chunking.overlap,
-      ftsTokenizer: this.settings.store.fts.tokenizer,
-    };
-    if (this.vector.available && this.vector.dims) {
-      nextMeta.vectorDims = this.vector.dims;
-    }
-
-    this.writeMeta(nextMeta);
-    this.pruneEmbeddingCacheIfNeeded?.();
   }
 
   private resetIndex() {

--- a/extensions/memory-core/src/memory/manager-sync-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-recovery.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeRestoredSyncState,
+  mergeSessionDeltas,
+  restoreRetryStateAfterReindexRollback,
+  snapshotSyncState,
+  type SessionDeltaEntry,
+} from "./manager-sync-recovery.js";
+
+function delta(lastSize: number, pendingBytes: number, pendingMessages: number): SessionDeltaEntry {
+  return { lastSize, pendingBytes, pendingMessages };
+}
+
+describe("snapshotSyncState", () => {
+  it("creates deep copies of mutable collections", () => {
+    const state = {
+      dirty: true,
+      sessionsDirty: false,
+      sessionsDirtyFiles: new Set(["a"]),
+      sessionPendingFiles: new Set(["b"]),
+      sessionDeltas: new Map([["session-1", delta(10, 2, 1)]]),
+      sessionFullRetryPending: false,
+    };
+    const snap = snapshotSyncState(state);
+    state.sessionsDirtyFiles.add("mutation");
+    state.sessionPendingFiles.add("mutation");
+    state.sessionDeltas.get("session-1")!.pendingBytes = 999;
+    expect(snap.sessionsDirtyFiles.has("mutation")).toBe(false);
+    expect(snap.sessionPendingFiles.has("mutation")).toBe(false);
+    expect(snap.sessionDeltas.get("session-1")?.pendingBytes).toBe(2);
+  });
+});
+
+describe("computeRestoredSyncState", () => {
+  const emptyState = {
+    dirty: false,
+    sessionsDirty: false,
+    sessionsDirtyFiles: new Set<string>(),
+    sessionPendingFiles: new Set<string>(),
+    sessionDeltas: new Map<string, SessionDeltaEntry>(),
+    sessionFullRetryPending: false,
+  };
+
+  it("treats dirty flags as sticky across snapshot and live", () => {
+    const snapshot = snapshotSyncState({ ...emptyState, dirty: true });
+    const restored = computeRestoredSyncState({ ...emptyState, dirty: false }, snapshot);
+    expect(restored.dirty).toBe(true);
+
+    const snapshot2 = snapshotSyncState({ ...emptyState, dirty: false });
+    const restored2 = computeRestoredSyncState({ ...emptyState, dirty: true }, snapshot2);
+    expect(restored2.dirty).toBe(true);
+  });
+
+  it("unions dirty file sets from snapshot and live", () => {
+    const snapshot = snapshotSyncState({
+      ...emptyState,
+      sessionsDirtyFiles: new Set(["snap-1"]),
+    });
+    const live = {
+      ...emptyState,
+      sessionsDirtyFiles: new Set(["live-1"]),
+    };
+    const restored = computeRestoredSyncState(live, snapshot);
+    expect(Array.from(restored.sessionsDirtyFiles).toSorted()).toEqual(["live-1", "snap-1"]);
+    expect(restored.sessionsDirty).toBe(true);
+  });
+
+  it("propagates sessionFullRetryPending from either side", () => {
+    const snapshot = snapshotSyncState({ ...emptyState, sessionFullRetryPending: true });
+    const restored = computeRestoredSyncState(emptyState, snapshot);
+    expect(restored.sessionFullRetryPending).toBe(true);
+
+    const snapshot2 = snapshotSyncState(emptyState);
+    const restored2 = computeRestoredSyncState(
+      { ...emptyState, sessionFullRetryPending: true },
+      snapshot2,
+    );
+    expect(restored2.sessionFullRetryPending).toBe(true);
+  });
+});
+
+describe("mergeSessionDeltas", () => {
+  it("keeps entries present only in one side untouched", () => {
+    const base = new Map([["only-base", delta(10, 5, 2)]]);
+    const live = new Map([["only-live", delta(20, 7, 3)]]);
+    const merged = mergeSessionDeltas(base, live);
+    expect(merged.get("only-base")).toEqual(delta(10, 5, 2));
+    expect(merged.get("only-live")).toEqual(delta(20, 7, 3));
+  });
+
+  it("takes the newer lastSize and the conservative pending counters when live has advanced", () => {
+    const base = new Map([["s", delta(100, 50, 10)]]);
+    const live = new Map([["s", delta(200, 30, 5)]]);
+    const merged = mergeSessionDeltas(base, live);
+    // lastSize: take max so we do not go backwards in time.
+    expect(merged.get("s")?.lastSize).toBe(200);
+    // pendingBytes / messages: take min so we do not re-count work that the
+    // live indexer has already folded into its tally.
+    expect(merged.get("s")?.pendingBytes).toBe(30);
+    expect(merged.get("s")?.pendingMessages).toBe(5);
+  });
+
+  it("does not lose the snapshot baseline when live is at zero", () => {
+    // Ensures the merge never silently wipes pending work by trusting an empty
+    // live side over a legitimate snapshot.
+    const base = new Map([["s", delta(100, 50, 10)]]);
+    const live = new Map([["s", delta(100, 0, 0)]]);
+    const merged = mergeSessionDeltas(base, live);
+    expect(merged.get("s")?.pendingBytes).toBe(0);
+    expect(merged.get("s")?.pendingMessages).toBe(0);
+  });
+});
+
+describe("restoreRetryStateAfterReindexRollback", () => {
+  it("keeps the sentinel set if it was already set before the rollback", () => {
+    expect(
+      restoreRetryStateAfterReindexRollback({ previous: true, ranSessionFullRebuild: false }),
+    ).toBe(true);
+  });
+  it("sets the sentinel when the failed attempt started a full session rebuild", () => {
+    expect(
+      restoreRetryStateAfterReindexRollback({ previous: false, ranSessionFullRebuild: true }),
+    ).toBe(true);
+  });
+  it("leaves the sentinel cleared otherwise", () => {
+    expect(
+      restoreRetryStateAfterReindexRollback({ previous: false, ranSessionFullRebuild: false }),
+    ).toBe(false);
+  });
+});

--- a/extensions/memory-core/src/memory/manager-sync-recovery.ts
+++ b/extensions/memory-core/src/memory/manager-sync-recovery.ts
@@ -1,0 +1,126 @@
+// Helpers for snapshotting and restoring the in-memory sync state that tracks
+// which files still need to be (re)indexed. Reindex rollback must put these
+// back exactly where they were so the next sync retries the work that failed,
+// instead of silently losing the dirty signal.
+//
+// Helpers accept plain fields rather than `this` so the manager class can keep
+// `dirty` / `sessionsDirty` / etc. declared `protected`; TypeScript refuses to
+// widen a `this` type to a plain structural type when the fields are
+// non-public, so we pass values in and return merged values back.
+
+export type SessionDeltaEntry = {
+  lastSize: number;
+  pendingBytes: number;
+  pendingMessages: number;
+};
+
+export type MemorySyncStateSnapshot = {
+  dirty: boolean;
+  sessionsDirty: boolean;
+  sessionsDirtyFiles: Set<string>;
+  sessionPendingFiles: Set<string>;
+  sessionDeltas: Map<string, SessionDeltaEntry>;
+  sessionFullRetryPending: boolean;
+};
+
+export function snapshotSyncState(state: {
+  dirty: boolean;
+  sessionsDirty: boolean;
+  sessionsDirtyFiles: ReadonlySet<string>;
+  sessionPendingFiles: ReadonlySet<string>;
+  sessionDeltas: ReadonlyMap<string, SessionDeltaEntry>;
+  sessionFullRetryPending: boolean;
+}): MemorySyncStateSnapshot {
+  return {
+    dirty: state.dirty,
+    sessionsDirty: state.sessionsDirty,
+    sessionsDirtyFiles: new Set(state.sessionsDirtyFiles),
+    sessionPendingFiles: new Set(state.sessionPendingFiles),
+    sessionDeltas: new Map(
+      Array.from(state.sessionDeltas.entries()).map(([key, value]) => [key, { ...value }]),
+    ),
+    sessionFullRetryPending: state.sessionFullRetryPending,
+  };
+}
+
+// Compute the restored sync state. Callers apply the fields back to `this`
+// themselves.
+//
+// Semantics:
+//   • `dirty`, `sessionsDirty` are sticky booleans: OR live on top of snapshot.
+//   • `sessionsDirtyFiles`, `sessionPendingFiles` are unions.
+//   • `sessionDeltas` is merged per-entry (see `mergeSessionDeltas`) so we do
+//     not double-count pending bytes/messages that the failed reindex would
+//     have consumed.
+export function computeRestoredSyncState(
+  live: {
+    dirty: boolean;
+    sessionsDirty: boolean;
+    sessionsDirtyFiles: ReadonlySet<string>;
+    sessionPendingFiles: ReadonlySet<string>;
+    sessionDeltas: ReadonlyMap<string, SessionDeltaEntry>;
+    sessionFullRetryPending: boolean;
+  },
+  snapshot: MemorySyncStateSnapshot,
+): MemorySyncStateSnapshot {
+  const sessionsDirtyFiles = new Set(live.sessionsDirtyFiles);
+  for (const file of snapshot.sessionsDirtyFiles) {
+    sessionsDirtyFiles.add(file);
+  }
+  const sessionPendingFiles = new Set(live.sessionPendingFiles);
+  for (const file of snapshot.sessionPendingFiles) {
+    sessionPendingFiles.add(file);
+  }
+  return {
+    dirty: snapshot.dirty || live.dirty,
+    sessionsDirty: snapshot.sessionsDirty || live.sessionsDirty || sessionsDirtyFiles.size > 0,
+    sessionsDirtyFiles,
+    sessionPendingFiles,
+    sessionDeltas: mergeSessionDeltas(snapshot.sessionDeltas, live.sessionDeltas),
+    sessionFullRetryPending: snapshot.sessionFullRetryPending || live.sessionFullRetryPending,
+  };
+}
+
+// Merge two session delta maps. `base` is the pre-reindex snapshot, `live` is
+// whatever has been accumulated concurrently during the failed reindex. When
+// the same session file appears in both, the merge must:
+//   • Take the larger `lastSize` (the file only grows from each indexer's
+//     point of view, and `live` may already have seen newer appends).
+//   • Use `Math.min` of the two `pendingBytes`/`pendingMessages` values so we
+//     do not re-count bytes the live indexer has already folded into its own
+//     tally — `live.pendingBytes` is measured against `live.lastSize`, so
+//     anything older than that has already been handled.
+export function mergeSessionDeltas(
+  base: ReadonlyMap<string, SessionDeltaEntry>,
+  live: ReadonlyMap<string, SessionDeltaEntry>,
+): Map<string, SessionDeltaEntry> {
+  const merged = new Map<string, SessionDeltaEntry>();
+  for (const [key, entry] of base) {
+    merged.set(key, { ...entry });
+  }
+  for (const [key, liveEntry] of live) {
+    const baseEntry = merged.get(key);
+    if (!baseEntry) {
+      merged.set(key, { ...liveEntry });
+      continue;
+    }
+    const indexedSize = Math.max(baseEntry.lastSize, liveEntry.lastSize);
+    merged.set(key, {
+      lastSize: indexedSize,
+      pendingBytes: Math.min(baseEntry.pendingBytes, liveEntry.pendingBytes),
+      pendingMessages: Math.min(baseEntry.pendingMessages, liveEntry.pendingMessages),
+    });
+  }
+  return merged;
+}
+
+// Decide what to set `sessionFullRetryPending` to after a reindex attempt
+// fails. Only failures that actually started the full session rebuild need the
+// sentinel: the goal is to force the next sync to run the full path even if
+// `sessionsDirtyFiles` was cleared earlier in the same run.
+export function restoreRetryStateAfterReindexRollback(params: {
+  previous: boolean;
+  ranSessionFullRebuild: boolean;
+}): boolean {
+  return params.previous || params.ranSessionFullRebuild;
+}

--- a/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
@@ -1,0 +1,246 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MemoryIndexManager } from "./manager.js";
+import "./test-runtime-mocks.js";
+
+// Give the provider mock control over batch behavior per call. The array is
+// swapped wholesale by each test; calls past the end use the default response.
+const embedBatchOverrides: Array<(texts: string[]) => Promise<number[][]> | number[][]> = [];
+let embedBatchCalls = 0;
+
+function resetEmbedBatch(): void {
+  embedBatchOverrides.length = 0;
+  embedBatchCalls = 0;
+}
+
+vi.mock("./embeddings.js", () => ({
+  createEmbeddingProvider: async () => ({
+    requestedProvider: "openai",
+    provider: {
+      id: "mock",
+      model: "mock-embed",
+      embedQuery: async () => [0, 1, 0],
+      embedBatch: async (texts: string[]) => {
+        const handler = embedBatchOverrides[embedBatchCalls];
+        embedBatchCalls += 1;
+        if (handler) {
+          return await handler(texts);
+        }
+        return texts.map((_, index) => [embedBatchCalls, index, 0]);
+      },
+    },
+  }),
+  resolveEmbeddingProviderFallbackModel: () => "mock-embed",
+}));
+
+type MemoryIndexModule = typeof import("./index.js");
+
+describe("memory manager reindex recovery", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+  let workspaceDir = "";
+  let indexPath = "";
+  let manager: MemoryIndexManager | null = null;
+  let getMemorySearchManager: MemoryIndexModule["getMemorySearchManager"];
+  let closeAllMemorySearchManagers: MemoryIndexModule["closeAllMemorySearchManagers"];
+
+  beforeAll(async () => {
+    vi.resetModules();
+    ({ getMemorySearchManager, closeAllMemorySearchManagers } = await import("./index.js"));
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-reindex-recovery-"));
+  });
+
+  beforeEach(async () => {
+    // The reindex recovery tests specifically exercise the safe (temp-DB)
+    // atomic swap path, so we must keep `OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX`
+    // unset for this suite — the cache mirror only runs there.
+    vi.unstubAllEnvs();
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "0");
+    resetEmbedBatch();
+    workspaceDir = path.join(fixtureRoot, `case-${caseId++}`);
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    indexPath = path.join(workspaceDir, "index.sqlite");
+  });
+
+  afterEach(async () => {
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await closeAllMemorySearchManagers();
+    vi.unstubAllEnvs();
+  });
+
+  afterAll(async () => {
+    if (!fixtureRoot) {
+      vi.resetModules();
+      return;
+    }
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  function createCfg(params?: { cacheEnabled?: boolean }): OpenClawConfig {
+    return {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: indexPath, vector: { enabled: false } },
+            cache: { enabled: params?.cacheEnabled ?? false },
+            // Per-chunk size stays at the default 4000 tokens; size of the
+            // seed file is what controls how many chunks (and therefore how
+            // many batches) a single sync produces.
+            chunking: { tokens: 4000, overlap: 0 },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+            query: { minScore: 0, hybrid: { enabled: false } },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as unknown as OpenClawConfig;
+  }
+
+  async function createManager(params?: { cacheEnabled?: boolean }): Promise<MemoryIndexManager> {
+    const result = await getMemorySearchManager({ cfg: createCfg(params), agentId: "main" });
+    if (!result.manager) {
+      throw new Error(result.error ?? "manager missing");
+    }
+    manager = result.manager as unknown as MemoryIndexManager;
+    return manager;
+  }
+
+  function countEmbeddingCacheRows(): number {
+    const db = new DatabaseSync(indexPath);
+    try {
+      const hasTable = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+        .get("embedding_cache") as { name: string } | undefined;
+      if (!hasTable) {
+        return 0;
+      }
+      const row = db.prepare("SELECT COUNT(*) as c FROM embedding_cache").get() as
+        | { c: number }
+        | undefined;
+      return row?.c ?? 0;
+    } finally {
+      db.close();
+    }
+  }
+
+  async function writeMultiBatchMemory(): Promise<void> {
+    // Three ~4200-byte chunks. The batch builder caps each batch at 8000
+    // bytes, so this guarantees at least two batches per memory sync — which
+    // is what we need to prove partial success/failure handling works.
+    const line = "a".repeat(4200);
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), [line, line, line].join("\n\n"));
+  }
+
+  it("preserves successful batch cache writes across a rolled-back safe reindex", async () => {
+    await writeMultiBatchMemory();
+    await createManager({ cacheEnabled: true });
+
+    // First run: succeed so we have a real index and a populated cache table
+    // on disk. The test then clears the cache rows and mocks a mid-reindex
+    // failure to prove that subsequent reruns do not start from zero.
+    await manager!.sync({ force: true });
+    expect(countEmbeddingCacheRows()).toBeGreaterThan(0);
+
+    // Drop only the cache rows (preserving the committed index + schema), so
+    // the next reindex must recompute embeddings from scratch.
+    {
+      const db = new DatabaseSync(indexPath);
+      try {
+        db.exec("DELETE FROM embedding_cache");
+      } finally {
+        db.close();
+      }
+    }
+    expect(countEmbeddingCacheRows()).toBe(0);
+
+    resetEmbedBatch();
+    // Succeed on the first batch, fail on the second. If the cache mirror
+    // works, batch #1's entries land in the *original* DB even though the
+    // temp DB will be thrown away.
+    embedBatchOverrides[0] = async (texts) => texts.map((_, index) => [1, index, 0]);
+    embedBatchOverrides[1] = async () => {
+      throw new Error("mock batch failure");
+    };
+    await expect(manager!.sync({ force: true })).rejects.toThrow("mock batch failure");
+    expect(embedBatchCalls).toBeGreaterThanOrEqual(2);
+
+    // Cache survived rollback → some rows are in the original DB now.
+    expect(countEmbeddingCacheRows()).toBeGreaterThan(0);
+  });
+
+  it("enables cache on an existing index that pre-dates the cache table", async () => {
+    await writeMultiBatchMemory();
+    await createManager({ cacheEnabled: false });
+    await manager!.sync({ force: true });
+    await manager!.close();
+    manager = null;
+
+    // Drop the embedding_cache table to simulate an index created before the
+    // cache feature existed.
+    {
+      const db = new DatabaseSync(indexPath);
+      try {
+        db.exec("DROP TABLE IF EXISTS embedding_cache");
+      } finally {
+        db.close();
+      }
+    }
+
+    resetEmbedBatch();
+    await createManager({ cacheEnabled: true });
+    // With cache on, the seed step used to SELECT * FROM embedding_cache on
+    // the original DB before any schema migration could run — that crashed.
+    // Now it checks sqlite_master first and reindex succeeds cleanly.
+    await expect(manager!.sync({ force: true })).resolves.toBeUndefined();
+    // Cache rows appear in the new index (the safe reindex created the table
+    // in the temp DB, then swapped it in).
+    const db = new DatabaseSync(indexPath);
+    try {
+      const hasTable = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+        .get("embedding_cache") as { name: string } | undefined;
+      expect(hasTable?.name).toBe("embedding_cache");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("restores dirty flag and sessionFullRetryPending after a rolled-back safe reindex", async () => {
+    await writeMultiBatchMemory();
+    await createManager({ cacheEnabled: false });
+
+    // Pre-state: dirty bit is cleared, sessions are clean.
+    await manager!.sync({ force: true });
+    const internal = manager as unknown as {
+      dirty: boolean;
+      sessionsDirty: boolean;
+      sessionFullRetryPending: boolean;
+      sessionsDirtyFiles: Set<string>;
+    };
+    expect(internal.dirty).toBe(false);
+
+    // Mark the index dirty (simulating an edit), then force a reindex that
+    // explodes on the second batch. After rollback, `dirty` must still be true
+    // so the next sync retries the work we just rolled back.
+    internal.dirty = true;
+    resetEmbedBatch();
+    embedBatchOverrides[0] = async (texts) => texts.map((_, index) => [2, index, 0]);
+    embedBatchOverrides[1] = async () => {
+      throw new Error("mock retry-state failure");
+    };
+    await expect(manager!.sync({ force: true })).rejects.toThrow("mock retry-state failure");
+
+    expect(internal.dirty).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: when a safe (temp-DB) or unsafe (in-place) full memory reindex aborts mid-run, the committed index is preserved but the in-memory sync state is not — the next sync can silently converge without retrying the rolled-back work, and any successful embedding batches are thrown away with the temp DB.
- Why it matters: transient provider failures during `memory index --force` should degrade to "retry the same work next sync" and should not waste the embedding batches that already succeeded before the failure. Today they do both.
- What changed: snapshot the sync state (dirty flags, session dirty files, session deltas) before a full reindex and restore the union on rollback; add a `sessionFullRetryPending` sentinel so a failed full session rebuild still forces the next sync onto the full path even if `sessionsDirtyFiles` was cleared; during a safe reindex, mirror every successful embedding cache batch back to the original DB so the cache survives a later-batch rollback; and have `seedEmbeddingCache` check for the `embedding_cache` table on the source DB so enabling cache on an older index no longer crashes the reindex.
- What did NOT change (scope boundary): no new config knobs, no provider API changes, no query behavior changes, no schema migrations. The committed index swap remains atomic and transport-layer retry work stays out of scope (see #44166).

AI-assisted: yes. I used Claude Opus 4.7 to port the original fix onto the current `manager-sync-ops` / `manager-embedding-ops` layout and reviewed the diff and validation output.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: none
- Related: #56901, #56427, #44166, #45981, #56862
- Supersedes: #55497
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: an offline force-reindex that aborts mid-run used to leave `Embedding cache` at `0` on retry, throwing away the embedding work the provider had already returned before the failure.
- Real environment tested: macOS, Node 24.13.0, `pnpm` + OpenClaw checkout; two isolated `$OPENCLAW_HOME` dirs with identical starting DB (`14408 chunks · 0 cache rows`) and identical workspace (45 local markdown files). Remote provider: real SiliconFlow `openai` / `BAAI/bge-m3`, `memorySearch.cache.enabled: true`, `cap = 500000`. Git worktrees at `upstream/main` and `fix/memory-reindex-recovery`.
- Exact steps or command run after this patch:
  1. `sqlite3 $OPENCLAW_HOME/.openclaw/memory/main.sqlite 'DELETE FROM embedding_cache;'` (baseline confirmed: 0 rows).
  2. `OPENCLAW_HOME=... pnpm openclaw memory index --force` (against real provider).
  3. Wi-Fi off ~5 s in (macOS airport disable), mid-reindex.
  4. `OPENCLAW_HOME=... pnpm openclaw memory status`.
  5. `sqlite3 $OPENCLAW_HOME/.openclaw/memory/main.sqlite 'SELECT COUNT(*) FROM embedding_cache;'`.
- Evidence after fix: terminal capture from the isolated `home-fix` run — `Memory index failed (main): fetch failed`, then `openclaw memory status` prints `Embedding cache: enabled (109 entries)`, and `sqlite3 ... 'SELECT COUNT(*) FROM embedding_cache'` prints `109`. Row breakdown `SELECT provider, model, COUNT(*) ...` returns `openai|BAAI/bge-m3|109` with `MIN/MAX(updated_at)` both landing inside the interrupted reindex window (`2026-05-09 10:01:34..10:01:36`). Full A/B terminal transcript is pasted under `## Evidence` below.
- Observed result after fix: on `upstream/main` the same offline force-reindex leaves `embedding_cache` at `0` rows; on `fix/memory-reindex-recovery` the same run preserves `109` rows written through the mirror write, which survive the temp-DB rollback. The committed `chunks` / `files` table counts are unchanged on both sides (`2384 files · 14408 chunks`), confirming the atomic swap is still atomic.
- What was not tested: a live CLI repro for the session `sessionFullRetryPending` state machine (covered by focused manager-level tests instead); multi-process concurrent indexing; running the full pre-fix flow against a remote provider that rate-limits instead of failing DNS.
- Before evidence: on `upstream/main` (64514a6548) the same offline force-reindex emits `Memory index failed (main): getaddrinfo ENOTFOUND api.siliconflow.cn`, then `openclaw memory status` prints `Embedding cache: enabled (0 entries)` and `sqlite3 ... 'SELECT COUNT(*) FROM embedding_cache'` prints `0` — captured in this same evidence window.

## Root Cause (if applicable)

- Root cause: `runSafeReindex` / `runUnsafeReindex` preserved storage/vector state on rollback but did not snapshot or restore the in-memory sync state (`dirty`, `sessionsDirty`, `sessionsDirtyFiles`, `sessionDeltas`). A failed full session rebuild could clear the per-file dirty filter mid-run and leave no sentinel for the next sync to see, so `shouldSyncSessionsForReindex` fell back to `sessionsDirty && dirtySessionFileCount > 0` and silently downgraded to an incremental sync. Separately, `embedChunksInBatches` accumulated cache entries until all batches finished and wrote them only to the temp DB, so a later-batch failure threw away every successful batch along with the temp DB.
- Missing detection / guardrail: existing atomic-reindex coverage asserted that the previous index survives a failed temp reindex, but did not exercise retry-state restoration, post-compaction targeted refresh after a pending full retry, or cache preservation across temp-DB rollback.
- Contributing context: after the memory engine moved into `extensions/memory-core/src/memory/*` with the helper-split layout, the old reliability work in #55497 no longer applied cleanly. This PR replays the narrow fix on top of the current layout.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/memory-core/src/memory/manager-sync-recovery.test.ts` (new)
  - `extensions/memory-core/src/memory/manager-session-reindex.test.ts` (new)
  - `extensions/memory-core/src/memory/manager.reindex-recovery.test.ts` (new)
- Scenario the test should lock in:
  - `snapshotSyncState` / `computeRestoredSyncState` union sticky dirty flags and dirty file sets; `mergeSessionDeltas` takes the later `lastSize` and the conservative `pendingBytes` / `pendingMessages`; `restoreRetryStateAfterReindexRollback` flips the sentinel only when the failed attempt actually began a full session rebuild.
  - `shouldSyncSessionsForReindex` forces a full sync when `sessionFullRetryPending` is set, even with zero dirty files.
  - A real manager where batch #1 succeeds and batch #2 throws: the committed index is preserved, the embedding_cache on the original DB has rows after the failure, a subsequent `sync({ force: true })` succeeds, and enabling cache on an index that was built without the `embedding_cache` table no longer crashes.
- Why this is the smallest reliable guardrail: the invariants live in local SQLite-backed state and per-method sync bookkeeping, so focused unit + seam tests exercise the contract without requiring live providers or gateway E2E.
- Existing test that already covers this (if any): `manager.atomic-reindex.test.ts` covered "previous index survives failed temp reindex" but not retry state or cache preservation.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Full memory reindex continues to keep the previous committed index on failure, and now also keeps enough dirty/retry state for the next sync to finish the rolled-back work.
- A failed full session rebuild sets `sessionFullRetryPending` so the next normal sync still performs a full session retry instead of silently downgrading to an incremental pass.
- Successful embedding batches survive a later safe-reindex rollback via cache mirroring, reducing repeated provider calls on retry.
- Indexes built before the `embedding_cache` table existed can enable cache without failing reindex.

## Diagram (if applicable)

```text
Before:
[force reindex] -> [temp DB builds some state] -> [later batch failure]
               -> [committed DB restored]
               -> [dirty flags lost / full-retry intent lost / temp cache discarded]

After:
[force reindex] -> [snapshot sync state] -> [temp DB builds some state]
               -> [each successful cache batch mirrored to committed DB]
               -> [later batch failure]
               -> [committed DB restored + sync state restored + sessionFullRetryPending set]
               -> [next normal sync rebuilds the rolled-back work]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.2.0)
- Runtime/container: Node 24.13.0 + pnpm + Vitest
- Model/provider: OpenAI-compatible remote embeddings (`provider: openai`, `model: BAAI/bge-m3`) for manual repro; mocked provider in targeted tests
- Integration/channel (if any): CLI / builtin memory index
- Relevant config (redacted):
  - `memorySearch.provider: "openai"`
  - `memorySearch.model: "BAAI/bge-m3"`
  - `memorySearch.cache.enabled: true`

### Steps

1. Start from an existing committed index (14408 chunks, 0 cache rows) in an isolated `$OPENCLAW_HOME`.
2. `sqlite3 $OPENCLAW_HOME/.openclaw/memory/main.sqlite 'DELETE FROM embedding_cache;'`
3. `OPENCLAW_HOME=... pnpm openclaw memory index --force` (real SiliconFlow provider).
4. Turn Wi-Fi off ~5 s into the reindex.
5. Wait for the CLI to fail (on `main`) or cancel once retry backoff has spent the retry budget (on `fix`, see note below).
6. `OPENCLAW_HOME=... pnpm openclaw memory status` and `sqlite3 ... 'SELECT COUNT(*) FROM embedding_cache;'`

Note on fix-side cancellation: the retry classifier treats `fetch failed`-class wrapped errors as retryable, so per-item fallback after a failed batch keeps retrying for a while; on main the error surfaced as raw `getaddrinfo ENOTFOUND` and exited on its own. Early-cancelling the fix run after the retries are all exhausted does not affect the `0` vs `109` evidence — those rows were already mirrored to the original DB before cancellation. Tightening that retry classifier for obviously-permanent network failures is out of scope here (see "Known follow-ups" below).

### Expected

- Force reindex fails with a transport error.
- Committed index is preserved.
- On `main`: `Embedding cache` count stays at 0 (successful batches are in the temp DB that gets thrown away).
- On this branch: `Embedding cache` count > 0 (mirrored to the original DB).

### Actual

- On `upstream/main` (64514a6548): `Memory index failed (main): getaddrinfo ENOTFOUND api.siliconflow.cn`; `memory status` → `Embedding cache: enabled (0 entries)`; `SELECT COUNT(*)` → 0.
- On `fix/memory-reindex-recovery-v2` (0ed55aac0c): `memory status` → `Embedding cache: enabled (109 entries)`; `SELECT COUNT(*)` → 109, all rows `provider=openai / model=BAAI/bge-m3`, `updated_at` inside the reindex window.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

```text
pnpm test extensions/memory-core
  Test Files  56 passed (56)
  Tests  631 passed (631)

pnpm exec oxfmt --check --threads=1 \
  extensions/memory-core/src/memory/manager-sync-ops.ts \
  extensions/memory-core/src/memory/manager-sync-recovery.ts \
  extensions/memory-core/src/memory/manager-sync-recovery.test.ts \
  extensions/memory-core/src/memory/manager-session-reindex.ts \
  extensions/memory-core/src/memory/manager-session-reindex.test.ts \
  extensions/memory-core/src/memory/manager-embedding-ops.ts \
  extensions/memory-core/src/memory/manager.reindex-recovery.test.ts \
  CHANGELOG.md
  All matched files use the correct format.

pnpm tsgo:extensions && pnpm tsgo:test
  (both green)

pnpm check:changed
  EXIT=0 (typecheck all + lint + import cycles + changelog attributions)
```

Manual CLI A/B (same starting DB and workspace in both isolated homes, real SiliconFlow provider, Wi-Fi turned off mid-reindex):

```text
# upstream/main (64514a6548)
$ OPENCLAW_HOME=/.../home-main pnpm openclaw memory index --force
[memory] embeddings rate limited; retrying in 591ms
[memory] embeddings rate limited; retrying in 502ms
[memory] embeddings rate limited; retrying in 524ms
[memory] embeddings rate limited; retrying in 550ms
Memory index failed (main): getaddrinfo ENOTFOUND api.siliconflow.cn

$ OPENCLAW_HOME=/.../home-main pnpm openclaw memory status
  Indexed: 2384/45 files · 14408 chunks
  Embedding cache: enabled (0 entries)       # <- committed index preserved but cache gone

$ sqlite3 .../home-main/.openclaw/memory/main.sqlite 'SELECT COUNT(*) FROM embedding_cache;'
0
```

```text
# fix/memory-reindex-recovery-v2 (0ed55aac0c)
$ OPENCLAW_HOME=/.../home-fix pnpm openclaw memory index --force
[memory] embeddings rate limited; retrying in 540ms
[memory] embeddings rate limited; retrying in 593ms
[memory] embeddings rate limited; retrying in 586ms
^C                                           # <- cancelled after retry loop exhausted

$ OPENCLAW_HOME=/.../home-fix pnpm openclaw memory status
  Indexed: 2384/45 files · 14408 chunks
  Embedding cache: enabled (109 entries)     # <- mirrored to original DB before rollback

$ sqlite3 .../home-fix/.openclaw/memory/main.sqlite \
    "SELECT provider, model, COUNT(*) FROM embedding_cache GROUP BY provider, model;"
openai|BAAI/bge-m3|109
$ sqlite3 .../home-fix/.openclaw/memory/main.sqlite \
    "SELECT datetime(MIN(updated_at)/1000, 'unixepoch', 'localtime'),
            datetime(MAX(updated_at)/1000, 'unixepoch', 'localtime'),
            COUNT(*) FROM embedding_cache;"
2026-05-09 10:01:34|2026-05-09 10:01:36|109   # <- rows written inside the reindex window
```

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/memory-core` — 56 files / 631 tests green, including the three new suites for recovery helpers, `shouldSyncSessionsForReindex`, and the manager-level rollback integration.
  - Traced the current code paths to confirm the three gaps (no sync-state snapshot on rollback, no full-retry sentinel, no mirror write) still exist on `upstream/main` before this PR.
  - Forced a second-batch failure in the manager-level test and asserted the original DB has `embedding_cache` rows after rollback.
  - Dropped `embedding_cache` from an existing index and reopened with cache enabled — reindex completes and the table is re-created.
  - Manual CLI A/B against real SiliconFlow (`BAAI/bge-m3`), Wi-Fi cut mid-reindex: `main` cache stays at 0 after rollback, this branch preserves 109 rows (provider+model+timestamp all from the interrupted reindex window).
- Edge cases checked:
  - Safe reindex rollback after the first batch succeeded and a later batch threw.
  - Cache table absent in the original DB when enabling cache.
  - Targeted post-compaction session refresh preserves `sessionFullRetryPending` (it only clears on a full rebuild success, not on targeted refresh).
  - `mergeSessionDeltas` when one side has `pendingBytes: 0` and the other does not — the conservative `min` still does not silently wipe pending work.
- What you did **not** verify:
  - Live CLI repro for the session `sessionFullRetryPending` state machine (covered by focused manager-level tests).
  - Batch API fallback flows beyond the local regression tests.
  - Multi-process concurrent indexing.

## Known follow-ups (out of scope for this PR)

- `isRetryableMemoryEmbeddingError` classifies any `fetch failed`-wrapped error as retryable, including permanent failures like `getaddrinfo ENOTFOUND`. Combined with per-item fallback after a failed batch, an offline reindex on some Node versions keeps looping for a long time before the process exits — surfaces as an apparent hang. Pre-existing on `main`, unrelated to rollback recovery. A separate narrow PR can add `ENOTFOUND` to the non-retryable set or put a total-elapsed budget on the retry loop.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: `sessionFullRetryPending` adds one bit to the session sync state machine.
  - Mitigation: `shouldSyncSessionsForReindex` is the single point of consumption, unit-tested in isolation; targeted session refresh preserves the flag and only full-rebuild success clears it.
- Risk: cache mirroring during safe reindex writes successful embedding batches into the original DB before the temp DB is committed.
  - Mitigation: the mirror is scoped to `embedding_cache` rows only (reusable work), never the searchable index rows; the committed searchable index swap remains atomic; regression coverage locks in the intended rollback behavior.
- Risk: older indexes may not have `embedding_cache`.
  - Mitigation: `seedEmbeddingCache` probes for the table in `sqlite_master` before reading or mirroring; regression test exercises enabling cache on a pre-cache index.
