### PR TITLE
fix(security): strip C1 control characters in console sanitization

### DIFF
--- a/src/agents/console-sanitize.test.ts
+++ b/src/agents/console-sanitize.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeForConsole } from "./console-sanitize.js";
+
+describe("sanitizeForConsole", () => {
+  it("returns undefined for empty/whitespace input", () => {
+    expect(sanitizeForConsole(undefined)).toBeUndefined();
+    expect(sanitizeForConsole("")).toBeUndefined();
+    expect(sanitizeForConsole("   ")).toBeUndefined();
+  });
+
+  it("passes through normal text", () => {
+    expect(sanitizeForConsole("hello world")).toBe("hello world");
+  });
+
+  it("strips C0 control characters", () => {
+    expect(sanitizeForConsole("a\x01b\x02c")).toBe("abc");
+    expect(sanitizeForConsole("\x08backspace")).toBe("backspace");
+    expect(sanitizeForConsole("bell\x07ring")).toBe("bellring");
+  });
+
+  it("strips DEL (0x7F)", () => {
+    expect(sanitizeForConsole("before\x7Fafter")).toBe("beforeafter");
+  });
+
+  it("strips C1 control characters (U+0080..U+009F)", () => {
+    // CSI (0x9B) can start terminal escape sequences without a preceding ESC
+    expect(sanitizeForConsole("safe\x9Bunsafe")).toBe("safeunsafe");
+    // OSC (0x9D) can set terminal window titles
+    expect(sanitizeForConsole("title\x9Dinjection")).toBe("titleinjection");
+    // DCS (0x90) is the Device Control String introducer
+    expect(sanitizeForConsole("data\x90control")).toBe("datacontrol");
+    // Full C1 range should be stripped
+    for (let code = 0x80; code <= 0x9f; code++) {
+      const input = `a${String.fromCharCode(code)}b`;
+      expect(sanitizeForConsole(input)).toBe("ab");
+    }
+  });
+
+  it("collapses whitespace and newlines", () => {
+    expect(sanitizeForConsole("foo\n\nbar\tbaz")).toBe("foo bar baz");
+    expect(sanitizeForConsole("a  b   c")).toBe("a b c");
+  });
+
+  it("truncates to maxChars", () => {
+    const long = "x".repeat(300);
+    const result = sanitizeForConsole(long, 200);
+    expect(result).toBe("x".repeat(200) + "…");
+  });
+
+  it("respects custom maxChars", () => {
+    expect(sanitizeForConsole("abcdefgh", 5)).toBe("abcde…");
+  });
+
+  it("does not truncate when at exactly maxChars", () => {
+    expect(sanitizeForConsole("abcde", 5)).toBe("abcde");
+  });
+});

--- a/src/agents/console-sanitize.ts
+++ b/src/agents/console-sanitize.ts
@@ -11,7 +11,11 @@ export function sanitizeForConsole(text: string | undefined, maxChars = 200): st
         code === 0x0b ||
         code === 0x0c ||
         (code >= 0x0e && code <= 0x1f) ||
-        code === 0x7f
+        code === 0x7f ||
+        // C1 control characters (U+0080..U+009F) include terminal escape
+        // sequences such as CSI (0x9B), OSC (0x9D), and DCS (0x90) that can
+        // be used for terminal injection when logged to a TTY.
+        (code >= 0x80 && code <= 0x9f)
       );
     })
     .join("");


### PR DESCRIPTION
## Problem

`sanitizeForConsole` strips C0 control characters (U+0000..U+001F) and DEL (U+007F) but does not filter C1 control characters (U+0080..U+009F). Several bytes in the C1 range are terminal-significant and do not require a leading ESC byte to take effect:

- **CSI** (0x9B): starts control sequences (cursor movement, SGR color changes, line clearing)
- **OSC** (0x9D): sets window title, creates hyperlinks, modifies clipboard
- **DCS** (0x90): device control strings

When attacker-controlled strings containing these bytes pass through `sanitizeForConsole` and are logged to a TTY, they can manipulate terminal state -- moving the cursor, overwriting visible output, or injecting clickable hyperlinks that point to malicious URLs.

The prompt-level sanitizer (`sanitizeForPromptLiteral`) already handles this correctly via the `\p{Cc}` Unicode category, but the console sanitizer has a gap.

## Fix

Extend the character filter to also reject the U+0080..U+009F range:

```ts
(code >= 0x80 && code <= 0x9f)
```

## Testing

Added `console-sanitize.test.ts` covering:
- C0 control character stripping (existing behavior)
- DEL stripping (existing behavior)
- C1 control character stripping for the full 0x80..0x9F range (new)
- Individual checks for CSI, OSC, and DCS specifically
- Whitespace collapsing and truncation behavior

All tests pass locally via `vitest run`.