### PR TITLE
refactor: remove replay-era capability fallbacks

### DIFF
--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -105,6 +105,27 @@ describe("amazon-bedrock provider plugin", () => {
     ).toBeUndefined();
   });
 
+  it("owns Anthropic-style replay policy for Claude Bedrock models", () => {
+    const provider = registerSingleProviderPlugin(amazonBedrockPlugin);
+
+    expect(
+      provider.buildReplayPolicy?.({
+        provider: "amazon-bedrock",
+        modelApi: "bedrock-converse-stream",
+        modelId: ANTHROPIC_MODEL,
+      } as never),
+    ).toEqual({
+      sanitizeMode: "full",
+      sanitizeToolCallIds: true,
+      toolCallIdMode: "strict",
+      preserveSignatures: true,
+      repairToolUseResultPairing: true,
+      validateAnthropicTurns: true,
+      allowSyntheticToolResults: true,
+      dropThinkingBlocks: true,
+    });
+  });
+
   it("disables prompt caching for non-Anthropic Bedrock models", () => {
     const provider = registerSingleProviderPlugin(amazonBedrockPlugin);
     const wrapped = provider.wrapStreamFn?.({

--- a/extensions/amazon-bedrock/index.ts
+++ b/extensions/amazon-bedrock/index.ts
@@ -46,6 +46,19 @@ function createGuardrailWrapStreamFn(
 const PROVIDER_ID = "amazon-bedrock";
 const CLAUDE_46_MODEL_RE = /claude-(?:opus|sonnet)-4(?:\.|-)6(?:$|[-.])/i;
 
+function buildAmazonBedrockReplayPolicy(modelId?: string) {
+  return {
+    sanitizeMode: "full" as const,
+    sanitizeToolCallIds: true,
+    toolCallIdMode: "strict" as const,
+    preserveSignatures: true,
+    repairToolUseResultPairing: true,
+    validateAnthropicTurns: true,
+    allowSyntheticToolResults: true,
+    ...((modelId?.toLowerCase() ?? "").includes("claude") ? { dropThinkingBlocks: true } : {}),
+  };
+}
+
 export default definePluginEntry({
   id: PROVIDER_ID,
   name: "Amazon Bedrock Provider",
@@ -91,6 +104,7 @@ export default definePluginEntry({
         providerFamily: "anthropic",
         dropThinkingBlockModelHints: ["claude"],
       },
+      buildReplayPolicy: ({ modelId }) => buildAmazonBedrockReplayPolicy(modelId),
       wrapStreamFn,
       resolveDefaultThinkingLevel: ({ modelId }) =>
         CLAUDE_46_MODEL_RE.test(modelId.trim()) ? "adaptive" : undefined,

--- a/extensions/anthropic-vertex/index.test.ts
+++ b/extensions/anthropic-vertex/index.test.ts
@@ -56,4 +56,25 @@ describe("anthropic-vertex provider plugin", () => {
       },
     });
   });
+
+  it("owns Anthropic-style replay policy", () => {
+    const provider = registerSingleProviderPlugin(anthropicVertexPlugin);
+
+    expect(
+      provider.buildReplayPolicy?.({
+        provider: "anthropic-vertex",
+        modelApi: "anthropic-messages",
+        modelId: "claude-sonnet-4-6",
+      } as never),
+    ).toEqual({
+      sanitizeMode: "full",
+      sanitizeToolCallIds: true,
+      toolCallIdMode: "strict",
+      preserveSignatures: true,
+      repairToolUseResultPairing: true,
+      validateAnthropicTurns: true,
+      allowSyntheticToolResults: true,
+      dropThinkingBlocks: true,
+    });
+  });
 });

--- a/extensions/anthropic-vertex/index.ts
+++ b/extensions/anthropic-vertex/index.ts
@@ -7,6 +7,19 @@ import {
 
 const PROVIDER_ID = "anthropic-vertex";
 
+function buildAnthropicVertexReplayPolicy(modelId?: string) {
+  return {
+    sanitizeMode: "full" as const,
+    sanitizeToolCallIds: true,
+    toolCallIdMode: "strict" as const,
+    preserveSignatures: true,
+    repairToolUseResultPairing: true,
+    validateAnthropicTurns: true,
+    allowSyntheticToolResults: true,
+    ...((modelId?.toLowerCase() ?? "").includes("claude") ? { dropThinkingBlocks: true } : {}),
+  };
+}
+
 export default definePluginEntry({
   id: PROVIDER_ID,
   name: "Anthropic Vertex Provider",
@@ -39,6 +52,7 @@ export default definePluginEntry({
         providerFamily: "anthropic",
         dropThinkingBlockModelHints: ["claude"],
       },
+      buildReplayPolicy: ({ modelId }) => buildAnthropicVertexReplayPolicy(modelId),
     });
   },
 });

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import anthropicPlugin from "./index.js";
+
+describe("anthropic provider replay hooks", () => {
+  it("owns replay policy for Claude transports", () => {
+    const provider = registerSingleProviderPlugin(anthropicPlugin);
+
+    expect(
+      provider.buildReplayPolicy?.({
+        provider: "anthropic",
+        modelApi: "anthropic-messages",
+        modelId: "claude-sonnet-4-6",
+      } as never),
+    ).toEqual({
+      sanitizeMode: "full",
+      sanitizeToolCallIds: true,
+      toolCallIdMode: "strict",
+      preserveSignatures: true,
+      repairToolUseResultPairing: true,
+      allowSyntheticToolResults: true,
+      dropThinkingBlocks: true,
+    });
+  });
+});

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -18,6 +18,7 @@ describe("anthropic provider replay hooks", () => {
       toolCallIdMode: "strict",
       preserveSignatures: true,
       repairToolUseResultPairing: true,
+      validateAnthropicTurns: true,
       allowSyntheticToolResults: true,
       dropThinkingBlocks: true,
     });

--- a/extensions/anthropic/index.ts
+++ b/extensions/anthropic/index.ts
@@ -30,6 +30,7 @@ import { fetchClaudeUsage } from "openclaw/plugin-sdk/provider-usage";
 import { buildAnthropicCliBackend } from "./cli-backend.js";
 import { buildAnthropicCliMigrationResult, hasClaudeCliAuth } from "./cli-migration.js";
 import { anthropicMediaUnderstandingProvider } from "./media-understanding-provider.js";
+import { buildAnthropicReplayPolicy } from "./replay-policy.js";
 import {
   createAnthropicBetaHeadersWrapper,
   createAnthropicFastModeWrapper,
@@ -450,6 +451,7 @@ export default definePluginEntry({
         providerFamily: "anthropic",
         dropThinkingBlockModelHints: ["claude"],
       },
+      buildReplayPolicy: (ctx) => buildAnthropicReplayPolicy(ctx),
       isModernModelRef: ({ modelId }) => matchesAnthropicModernModel(modelId),
       wrapStreamFn: (ctx) => {
         let streamFn = ctx.streamFn;

--- a/extensions/anthropic/replay-policy.ts
+++ b/extensions/anthropic/replay-policy.ts
@@ -1,0 +1,21 @@
+import type {
+  ProviderReplayPolicy,
+  ProviderReplayPolicyContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+
+/**
+ * Returns the provider-owned replay policy for Anthropic transports.
+ */
+export function buildAnthropicReplayPolicy(ctx: ProviderReplayPolicyContext): ProviderReplayPolicy {
+  const modelId = ctx.modelId?.toLowerCase() ?? "";
+
+  return {
+    sanitizeMode: "full",
+    sanitizeToolCallIds: true,
+    toolCallIdMode: "strict",
+    preserveSignatures: true,
+    repairToolUseResultPairing: true,
+    allowSyntheticToolResults: true,
+    ...(modelId.includes("claude") ? { dropThinkingBlocks: true } : {}),
+  };
+}

--- a/extensions/anthropic/replay-policy.ts
+++ b/extensions/anthropic/replay-policy.ts
@@ -15,6 +15,7 @@ export function buildAnthropicReplayPolicy(ctx: ProviderReplayPolicyContext): Pr
     toolCallIdMode: "strict",
     preserveSignatures: true,
     repairToolUseResultPairing: true,
+    validateAnthropicTurns: true,
     allowSyntheticToolResults: true,
     ...(modelId.includes("claude") ? { dropThinkingBlocks: true } : {}),
   };

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -12,6 +12,14 @@ import { fetchCopilotUsage } from "./usage.js";
 const COPILOT_ENV_VARS = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
 const COPILOT_XHIGH_MODEL_IDS = ["gpt-5.2", "gpt-5.2-codex"] as const;
 
+function buildGithubCopilotReplayPolicy(modelId?: string) {
+  return (modelId?.toLowerCase() ?? "").includes("claude")
+    ? {
+        dropThinkingBlocks: true,
+      }
+    : {};
+}
+
 function resolveFirstGithubToken(params: { agentDir?: string; env: NodeJS.ProcessEnv }): {
   githubToken: string;
   hasProfile: boolean;
@@ -147,6 +155,7 @@ export default definePluginEntry({
       capabilities: {
         dropThinkingBlockModelHints: ["claude"],
       },
+      buildReplayPolicy: ({ modelId }) => buildGithubCopilotReplayPolicy(modelId),
       supportsXHighThinking: ({ modelId }) =>
         COPILOT_XHIGH_MODEL_IDS.includes(modelId.trim().toLowerCase() as never),
       prepareRuntimeAuth: async (ctx) => {

--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  registerProviderPlugins,
+  requireRegisteredProvider,
+} from "../../src/test-utils/plugin-registration.js";
+import googlePlugin from "./index.js";
+
+describe("google provider plugin hooks", () => {
+  it("owns replay policy and reasoning mode for the direct Gemini provider", () => {
+    const providers = registerProviderPlugins(googlePlugin);
+    const provider = requireRegisteredProvider(providers, "google");
+
+    expect(
+      provider.buildReplayPolicy?.({
+        provider: "google",
+        modelApi: "google-generative-ai",
+        modelId: "gemini-3.1-pro-preview",
+      } as never),
+    ).toEqual({
+      sanitizeMode: "full",
+      sanitizeToolCallIds: true,
+      toolCallIdMode: "strict",
+      sanitizeThoughtSignatures: {
+        allowBase64Only: true,
+        includeCamelCase: true,
+      },
+      repairToolUseResultPairing: true,
+      applyAssistantFirstOrderingFix: true,
+      allowSyntheticToolResults: true,
+    });
+
+    expect(
+      provider.resolveReasoningOutputMode?.({
+        provider: "google",
+        modelApi: "google-generative-ai",
+        modelId: "gemini-3.1-pro-preview",
+      } as never),
+    ).toBe("tagged");
+  });
+
+  it("owns Gemini CLI tool schema normalization", () => {
+    const providers = registerProviderPlugins(googlePlugin);
+    const provider = requireRegisteredProvider(providers, "google-gemini-cli");
+
+    const [tool] =
+      provider.normalizeToolSchemas?.({
+        provider: "google-gemini-cli",
+        tools: [
+          {
+            name: "write_file",
+            description: "Write a file",
+            parameters: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                path: { type: "string", pattern: "^src/" },
+              },
+            },
+          },
+        ],
+      } as never) ?? [];
+
+    expect(tool).toMatchObject({
+      name: "write_file",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+        },
+      },
+    });
+    expect(tool?.parameters).not.toHaveProperty("additionalProperties");
+    expect(
+      (tool?.parameters as { properties?: { path?: Record<string, unknown> } })?.properties?.path,
+    ).not.toHaveProperty("pattern");
+  });
+});

--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -26,6 +26,8 @@ describe("google provider plugin hooks", () => {
       },
       repairToolUseResultPairing: true,
       applyAssistantFirstOrderingFix: true,
+      validateGeminiTurns: true,
+      validateAnthropicTurns: false,
       allowSyntheticToolResults: true,
     });
 

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -18,6 +18,11 @@ import {
 } from "./api.js";
 import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
 import { isModernGoogleModel, resolveGoogle31ForwardCompatModel } from "./provider-models.js";
+import {
+  buildGoogleReplayPolicy,
+  normalizeGoogleGeminiCliToolSchemas,
+  resolveGoogleReasoningOutputMode,
+} from "./replay-policy.js";
 import { createGeminiWebSearchProvider } from "./src/gemini-web-search-provider.js";
 
 const GOOGLE_GEMINI_CLI_PROVIDER_ID = "google-gemini-cli";
@@ -140,6 +145,9 @@ function createLazyGoogleGeminiCliProvider(): ProviderPlugin {
     normalizeModelId: ({ modelId }) => normalizeGoogleModelId(modelId),
     resolveDynamicModel: (ctx) =>
       resolveGoogle31ForwardCompatModel({ providerId: GOOGLE_GEMINI_CLI_PROVIDER_ID, ctx }),
+    buildReplayPolicy: () => buildGoogleReplayPolicy(),
+    normalizeToolSchemas: (ctx) => normalizeGoogleGeminiCliToolSchemas(ctx),
+    resolveReasoningOutputMode: () => resolveGoogleReasoningOutputMode(),
     isModernModelRef: ({ modelId }) => isModernGoogleModel(modelId),
     formatApiKey: (cred) => formatGoogleOauthApiKey(cred as GoogleOauthApiKeyCredential),
     resolveUsageAuth: async (ctx) => {
@@ -247,6 +255,8 @@ export default definePluginEntry({
           ctx,
         }),
       wrapStreamFn: (ctx) => createGoogleThinkingPayloadWrapper(ctx.streamFn, ctx.thinkingLevel),
+      buildReplayPolicy: () => buildGoogleReplayPolicy(),
+      resolveReasoningOutputMode: () => resolveGoogleReasoningOutputMode(),
       isModernModelRef: ({ modelId }) => isModernGoogleModel(modelId),
     });
     api.registerCliBackend(buildGoogleGeminiCliBackend());

--- a/extensions/google/replay-policy.ts
+++ b/extensions/google/replay-policy.ts
@@ -1,0 +1,50 @@
+import type {
+  AnyAgentTool,
+  ProviderNormalizeToolSchemasContext,
+  ProviderReasoningOutputMode,
+  ProviderReplayPolicy,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { cleanSchemaForGemini } from "openclaw/plugin-sdk/provider-tools";
+
+/**
+ * Returns the provider-owned replay policy for Google Gemini transports.
+ */
+export function buildGoogleReplayPolicy(): ProviderReplayPolicy {
+  return {
+    sanitizeMode: "full",
+    sanitizeToolCallIds: true,
+    toolCallIdMode: "strict",
+    sanitizeThoughtSignatures: {
+      allowBase64Only: true,
+      includeCamelCase: true,
+    },
+    repairToolUseResultPairing: true,
+    applyAssistantFirstOrderingFix: true,
+    allowSyntheticToolResults: true,
+  };
+}
+
+/**
+ * Returns the provider-owned reasoning output mode for Google Gemini transports.
+ */
+export function resolveGoogleReasoningOutputMode(): ProviderReasoningOutputMode {
+  return "tagged";
+}
+
+/**
+ * Normalizes Gemini CLI tool schemas to the restricted JSON Schema subset
+ * accepted by the Cloud Code Assist transport.
+ */
+export function normalizeGoogleGeminiCliToolSchemas(
+  ctx: ProviderNormalizeToolSchemasContext,
+): AnyAgentTool[] {
+  return ctx.tools.map((tool) => {
+    if (!tool.parameters || typeof tool.parameters !== "object") {
+      return tool;
+    }
+    return {
+      ...tool,
+      parameters: cleanSchemaForGemini(tool.parameters as Record<string, unknown>),
+    };
+  });
+}

--- a/extensions/google/replay-policy.ts
+++ b/extensions/google/replay-policy.ts
@@ -20,6 +20,8 @@ export function buildGoogleReplayPolicy(): ProviderReplayPolicy {
     },
     repairToolUseResultPairing: true,
     applyAssistantFirstOrderingFix: true,
+    validateGeminiTurns: true,
+    validateAnthropicTurns: false,
     allowSyntheticToolResults: true,
   };
 }

--- a/extensions/kilocode/index.ts
+++ b/extensions/kilocode/index.ts
@@ -8,6 +8,19 @@ import { buildKilocodeProviderWithDiscovery } from "./provider-catalog.js";
 
 const PROVIDER_ID = "kilocode";
 
+function buildKilocodeReplayPolicy(modelId?: string) {
+  const normalizedModelId = modelId?.toLowerCase() ?? "";
+  if (!normalizedModelId.includes("gemini")) {
+    return {};
+  }
+  return {
+    sanitizeThoughtSignatures: {
+      allowBase64Only: true,
+      includeCamelCase: true,
+    },
+  };
+}
+
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
   name: "Kilo Gateway Provider",
@@ -35,6 +48,7 @@ export default defineSingleProviderPluginEntry({
       geminiThoughtSignatureSanitization: true,
       geminiThoughtSignatureModelHints: ["gemini"],
     },
+    buildReplayPolicy: ({ modelId }) => buildKilocodeReplayPolicy(modelId),
     wrapStreamFn: (ctx) => {
       const thinkingLevel =
         ctx.modelId === "kilo/auto" || isProxyReasoningUnsupported(ctx.modelId)

--- a/extensions/kimi-coding/index.ts
+++ b/extensions/kimi-coding/index.ts
@@ -10,6 +10,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function buildKimiReplayPolicy() {
+  return {
+    preserveSignatures: false,
+  };
+}
+
 export default definePluginEntry({
   id: PLUGIN_ID,
   name: "Kimi Provider",
@@ -83,6 +89,7 @@ export default definePluginEntry({
         openAiPayloadNormalizationMode: "moonshot-thinking",
         preserveAnthropicThinkingSignatures: false,
       },
+      buildReplayPolicy: () => buildKimiReplayPolicy(),
     });
   },
 });

--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  registerProviderPlugins,
+  requireRegisteredProvider,
+} from "../../src/test-utils/plugin-registration.js";
+import minimaxPlugin from "./index.js";
+
+describe("minimax provider hooks", () => {
+  it("owns tagged reasoning mode for MiniMax transports", () => {
+    const providers = registerProviderPlugins(minimaxPlugin);
+    const apiProvider = requireRegisteredProvider(providers, "minimax");
+    const portalProvider = requireRegisteredProvider(providers, "minimax-portal");
+
+    expect(apiProvider.hookAliases).toContain("minimax-cn");
+    expect(
+      apiProvider.resolveReasoningOutputMode?.({
+        provider: "minimax",
+        modelApi: "anthropic-messages",
+        modelId: "MiniMax-M2.7",
+      } as never),
+    ).toBe("tagged");
+
+    expect(portalProvider.hookAliases).toContain("minimax-portal-cn");
+    expect(
+      portalProvider.resolveReasoningOutputMode?.({
+        provider: "minimax-portal",
+        modelApi: "anthropic-messages",
+        modelId: "MiniMax-M2.7",
+      } as never),
+    ).toBe("tagged");
+  });
+});

--- a/extensions/minimax/index.ts
+++ b/extensions/minimax/index.ts
@@ -32,6 +32,10 @@ const DEFAULT_MODEL = MINIMAX_DEFAULT_MODEL_ID;
 const DEFAULT_BASE_URL_CN = "https://api.minimaxi.com/anthropic";
 const DEFAULT_BASE_URL_GLOBAL = "https://api.minimax.io/anthropic";
 
+function resolveMinimaxReasoningOutputMode(): "tagged" {
+  return "tagged";
+}
+
 function getDefaultBaseUrl(region: MiniMaxRegion): string {
   return region === "cn" ? DEFAULT_BASE_URL_CN : DEFAULT_BASE_URL_GLOBAL;
 }
@@ -165,6 +169,7 @@ export default definePluginEntry({
     api.registerProvider({
       id: API_PROVIDER_ID,
       label: PROVIDER_LABEL,
+      hookAliases: ["minimax-cn"],
       docsPath: "/providers/minimax",
       envVars: ["MINIMAX_API_KEY"],
       auth: [
@@ -227,6 +232,7 @@ export default definePluginEntry({
         });
         return apiKey ? { token: apiKey } : null;
       },
+      resolveReasoningOutputMode: () => resolveMinimaxReasoningOutputMode(),
       isModernModelRef: ({ modelId }) => isMiniMaxModernModelId(modelId),
       fetchUsageSnapshot: async (ctx) =>
         await fetchMinimaxUsage(ctx.token, ctx.timeoutMs, ctx.fetchFn),
@@ -238,6 +244,7 @@ export default definePluginEntry({
     api.registerProvider({
       id: PORTAL_PROVIDER_ID,
       label: PROVIDER_LABEL,
+      hookAliases: ["minimax-portal-cn"],
       docsPath: "/providers/minimax",
       envVars: ["MINIMAX_OAUTH_TOKEN", "MINIMAX_API_KEY"],
       catalog: {
@@ -275,6 +282,7 @@ export default definePluginEntry({
           run: createOAuthHandler("cn"),
         },
       ],
+      resolveReasoningOutputMode: () => resolveMinimaxReasoningOutputMode(),
       isModernModelRef: ({ modelId }) => isMiniMaxModernModelId(modelId),
     });
     api.registerImageGenerationProvider(buildMinimaxImageGenerationProvider());

--- a/extensions/mistral/index.ts
+++ b/extensions/mistral/index.ts
@@ -47,6 +47,13 @@ function shouldContributeMistralCompat(params: {
   return isMistralBaseUrl(params.model.baseUrl) || isMistralModelHint(params.modelId);
 }
 
+function buildMistralReplayPolicy() {
+  return {
+    sanitizeToolCallIds: true,
+    toolCallIdMode: "strict9" as const,
+  };
+}
+
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
   name: "Mistral Provider",
@@ -89,6 +96,7 @@ export default defineSingleProviderPluginEntry({
         "mistralai",
       ],
     },
+    buildReplayPolicy: () => buildMistralReplayPolicy(),
   },
   register(api) {
     api.registerMediaUnderstandingProvider(mistralMediaUnderstandingProvider);

--- a/extensions/openai/replay-policy.ts
+++ b/extensions/openai/replay-policy.ts
@@ -1,0 +1,19 @@
+import type {
+  ProviderReplayPolicy,
+  ProviderReplayPolicyContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+
+/**
+ * Returns the provider-owned replay policy for OpenAI-family transports.
+ */
+export function buildOpenAIReplayPolicy(ctx: ProviderReplayPolicyContext): ProviderReplayPolicy {
+  return {
+    sanitizeMode: "images-only",
+    ...(ctx.modelApi === "openai-completions"
+      ? {
+          sanitizeToolCallIds: true,
+          toolCallIdMode: "strict" as const,
+        }
+      : {}),
+  };
+}

--- a/extensions/openai/replay-policy.ts
+++ b/extensions/openai/replay-policy.ts
@@ -9,11 +9,16 @@ import type {
 export function buildOpenAIReplayPolicy(ctx: ProviderReplayPolicyContext): ProviderReplayPolicy {
   return {
     sanitizeMode: "images-only",
+    applyAssistantFirstOrderingFix: false,
+    validateGeminiTurns: false,
+    validateAnthropicTurns: false,
     ...(ctx.modelApi === "openai-completions"
       ? {
           sanitizeToolCallIds: true,
           toolCallIdMode: "strict" as const,
         }
-      : {}),
+      : {
+          sanitizeToolCallIds: false,
+        }),
   };
 }

--- a/extensions/opencode-go/index.ts
+++ b/extensions/opencode-go/index.ts
@@ -4,6 +4,23 @@ import { applyOpencodeGoConfig, OPENCODE_GO_DEFAULT_MODEL_REF } from "./api.js";
 
 const PROVIDER_ID = "opencode-go";
 
+function buildOpencodeGoReplayPolicy(modelId?: string) {
+  const normalizedModelId = modelId?.toLowerCase() ?? "";
+  return {
+    applyAssistantFirstOrderingFix: false,
+    validateGeminiTurns: false,
+    validateAnthropicTurns: false,
+    ...(normalizedModelId.includes("gemini")
+      ? {
+          sanitizeThoughtSignatures: {
+            allowBase64Only: true,
+            includeCamelCase: true,
+          },
+        }
+      : {}),
+  };
+}
+
 export default definePluginEntry({
   id: PROVIDER_ID,
   name: "OpenCode Go Provider",
@@ -48,6 +65,7 @@ export default definePluginEntry({
         geminiThoughtSignatureSanitization: true,
         geminiThoughtSignatureModelHints: ["gemini"],
       },
+      buildReplayPolicy: ({ modelId }) => buildOpencodeGoReplayPolicy(modelId),
       isModernModelRef: () => true,
     });
   },

--- a/extensions/opencode/index.ts
+++ b/extensions/opencode/index.ts
@@ -14,6 +14,23 @@ function isModernOpencodeModel(modelId: string): boolean {
   return !matchesExactOrPrefix(lower, MINIMAX_MODERN_MODEL_MATCHERS);
 }
 
+function buildOpencodeReplayPolicy(modelId?: string) {
+  const normalizedModelId = modelId?.toLowerCase() ?? "";
+  return {
+    applyAssistantFirstOrderingFix: false,
+    validateGeminiTurns: false,
+    validateAnthropicTurns: false,
+    ...(normalizedModelId.includes("gemini")
+      ? {
+          sanitizeThoughtSignatures: {
+            allowBase64Only: true,
+            includeCamelCase: true,
+          },
+        }
+      : {}),
+  };
+}
+
 export default definePluginEntry({
   id: PROVIDER_ID,
   name: "OpenCode Zen Provider",
@@ -59,6 +76,7 @@ export default definePluginEntry({
         geminiThoughtSignatureSanitization: true,
         geminiThoughtSignatureModelHints: ["gemini"],
       },
+      buildReplayPolicy: ({ modelId }) => buildOpencodeReplayPolicy(modelId),
       isModernModelRef: ({ modelId }) => isModernOpencodeModel(modelId),
     });
   },

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -74,6 +74,23 @@ function isOpenRouterCacheTtlModel(modelId: string): boolean {
   return OPENROUTER_CACHE_TTL_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix));
 }
 
+function buildOpenRouterReplayPolicy(modelId?: string) {
+  const normalizedModelId = modelId?.toLowerCase() ?? "";
+  return {
+    applyAssistantFirstOrderingFix: false,
+    validateGeminiTurns: false,
+    validateAnthropicTurns: false,
+    ...(normalizedModelId.includes("gemini")
+      ? {
+          sanitizeThoughtSignatures: {
+            allowBase64Only: true,
+            includeCamelCase: true,
+          },
+        }
+      : {}),
+  };
+}
+
 export default definePluginEntry({
   id: "openrouter",
   name: "OpenRouter Provider",
@@ -130,6 +147,7 @@ export default definePluginEntry({
         geminiThoughtSignatureSanitization: true,
         geminiThoughtSignatureModelHints: ["gemini"],
       },
+      buildReplayPolicy: ({ modelId }) => buildOpenRouterReplayPolicy(modelId),
       isModernModelRef: () => true,
       wrapStreamFn: (ctx) => {
         let streamFn = ctx.streamFn;

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -312,6 +312,30 @@ describe("sanitizeSessionMessagesImages", () => {
       expect((content?.[1] as { thought_signature?: unknown })?.thought_signature).toBe("AQID");
     });
 
+    it("still strips signatures in images-only mode when replay policy requests it", async () => {
+      const input = castAgentMessages([
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "internal", thought_signature: "msg_abc123" },
+            { type: "text", text: "visible" },
+          ],
+        },
+      ]);
+
+      const out = await sanitizeSessionMessagesImages(input, "test", {
+        sanitizeMode: "images-only",
+        sanitizeThoughtSignatures: {
+          allowBase64Only: true,
+          includeCamelCase: true,
+        },
+      });
+
+      const content = (out[0] as { content?: Array<{ thought_signature?: unknown }> }).content;
+      expect(content).toHaveLength(2);
+      expect(content?.[0]?.thought_signature).toBeUndefined();
+    });
+
     it("preserves interleaved thinking block order when signatures are preserved", async () => {
       const input = castAgentMessages([
         {

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -120,18 +120,18 @@ export async function sanitizeSessionMessagesImages(
       }
       const content = assistantMsg.content;
       if (Array.isArray(content)) {
+        const strippedContent = options?.preserveSignatures
+          ? content // Keep signatures for Antigravity Claude
+          : stripThoughtSignatures(content, options?.sanitizeThoughtSignatures); // Strip for Gemini
         if (!allowNonImageSanitization) {
           const nextContent = (await sanitizeContentBlocksImages(
-            content as unknown as ContentBlock[],
+            strippedContent as unknown as ContentBlock[],
             label,
             imageSanitization,
           )) as unknown as typeof assistantMsg.content;
           out.push({ ...assistantMsg, content: nextContent });
           continue;
         }
-        const strippedContent = options?.preserveSignatures
-          ? content // Keep signatures for Antigravity Claude
-          : stripThoughtSignatures(content, options?.sanitizeThoughtSignatures); // Strip for Gemini
 
         const filteredContent =
           options?.preserveSignatures &&

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -1,99 +1,42 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderCapabilities } from "./provider-capabilities.js";
 
-const resolveProviderCapabilitiesWithPluginMock = vi.fn((params: { provider: string }) => {
-  switch (params.provider) {
-    case "anthropic":
-      return {
-        providerFamily: "anthropic",
-        dropThinkingBlockModelHints: ["claude"],
-      };
-    case "anthropic-vertex":
-      return {
-        providerFamily: "anthropic",
-        dropThinkingBlockModelHints: ["claude"],
-      };
-    case "amazon-bedrock":
-      return {
-        providerFamily: "anthropic",
-        dropThinkingBlockModelHints: ["claude"],
-      };
-    case "openai":
-      return {
-        providerFamily: "openai",
-      };
-    case "openrouter":
-      return {
-        openAiCompatTurnValidation: false,
-        geminiThoughtSignatureSanitization: true,
-        geminiThoughtSignatureModelHints: ["gemini"],
-      };
-    case "opencode":
-      return {
-        openAiCompatTurnValidation: false,
-        geminiThoughtSignatureSanitization: true,
-        geminiThoughtSignatureModelHints: ["gemini"],
-      };
-    case "opencode-go":
-      return {
-        openAiCompatTurnValidation: false,
-        geminiThoughtSignatureSanitization: true,
-        geminiThoughtSignatureModelHints: ["gemini"],
-      };
-    case "openai-codex":
-      return {
-        providerFamily: "openai",
-      };
-    case "github-copilot":
-      return {
-        dropThinkingBlockModelHints: ["claude"],
-      };
-    case "kilocode":
-      return {
-        geminiThoughtSignatureSanitization: true,
-        geminiThoughtSignatureModelHints: ["gemini"],
-      };
-    case "mistral":
-      return {
-        transcriptToolCallIdMode: "strict9",
-        transcriptToolCallIdModelHints: ["mistral"],
-      };
-    case "kimi":
-      return {
-        openAiPayloadNormalizationMode: "moonshot-thinking",
-        preserveAnthropicThinkingSignatures: false,
-      };
-    default:
-      return undefined;
-  }
-});
+const resolveProviderCapabilitiesWithPluginMock = vi.fn(
+  (params: { provider: string; workspaceDir?: string }) => {
+    switch (params.provider) {
+      case "anthropic-proxy":
+        return {
+          anthropicToolSchemaMode: "openai-functions",
+          anthropicToolChoiceMode: "openai-string-modes",
+        } satisfies Partial<ProviderCapabilities>;
+      case "workspace-anthropic-proxy":
+        return params.workspaceDir === "/tmp/workspace-capabilities"
+          ? ({
+              anthropicToolSchemaMode: "openai-functions",
+              anthropicToolChoiceMode: "openai-string-modes",
+            } satisfies Partial<ProviderCapabilities>)
+          : undefined;
+      default:
+        return undefined;
+    }
+  },
+);
 
 vi.mock("../plugins/provider-runtime.js", () => ({
-  resolveProviderCapabilitiesWithPlugin: (params: { provider: string }) =>
+  resolveProviderCapabilitiesWithPlugin: (params: { provider: string; workspaceDir?: string }) =>
     resolveProviderCapabilitiesWithPluginMock(params),
 }));
 
-let isAnthropicProviderFamily: typeof import("./provider-capabilities.js").isAnthropicProviderFamily;
-let isOpenAiProviderFamily: typeof import("./provider-capabilities.js").isOpenAiProviderFamily;
 let requiresOpenAiCompatibleAnthropicToolPayload: typeof import("./provider-capabilities.js").requiresOpenAiCompatibleAnthropicToolPayload;
-let resolveProviderCapabilities: typeof import("./provider-capabilities.js").resolveProviderCapabilities;
-let resolveTranscriptToolCallIdMode: typeof import("./provider-capabilities.js").resolveTranscriptToolCallIdMode;
-let shouldDropThinkingBlocksForModel: typeof import("./provider-capabilities.js").shouldDropThinkingBlocksForModel;
-let shouldSanitizeGeminiThoughtSignaturesForModel: typeof import("./provider-capabilities.js").shouldSanitizeGeminiThoughtSignaturesForModel;
-let supportsOpenAiCompatTurnValidation: typeof import("./provider-capabilities.js").supportsOpenAiCompatTurnValidation;
-let usesMoonshotThinkingPayloadCompat: typeof import("./provider-capabilities.js").usesMoonshotThinkingPayloadCompat;
+let usesOpenAiFunctionAnthropicToolSchema: typeof import("./provider-capabilities.js").usesOpenAiFunctionAnthropicToolSchema;
+let usesOpenAiStringModeAnthropicToolChoice: typeof import("./provider-capabilities.js").usesOpenAiStringModeAnthropicToolChoice;
 
-describe("resolveProviderCapabilities", () => {
+describe("provider-capabilities", () => {
   beforeAll(async () => {
     ({
-      isAnthropicProviderFamily,
-      isOpenAiProviderFamily,
       requiresOpenAiCompatibleAnthropicToolPayload,
-      resolveProviderCapabilities,
-      resolveTranscriptToolCallIdMode,
-      shouldDropThinkingBlocksForModel,
-      shouldSanitizeGeminiThoughtSignaturesForModel,
-      supportsOpenAiCompatTurnValidation,
-      usesMoonshotThinkingPayloadCompat,
+      usesOpenAiFunctionAnthropicToolSchema,
+      usesOpenAiStringModeAnthropicToolChoice,
     } = await import("./provider-capabilities.js"));
   });
 
@@ -101,193 +44,30 @@ describe("resolveProviderCapabilities", () => {
     resolveProviderCapabilitiesWithPluginMock.mockClear();
   });
 
-  it("returns provider-owned anthropic defaults for ordinary providers", () => {
-    expect(resolveProviderCapabilities("anthropic")).toEqual({
-      anthropicToolSchemaMode: "native",
-      anthropicToolChoiceMode: "native",
-      openAiPayloadNormalizationMode: "default",
-      providerFamily: "anthropic",
-      preserveAnthropicThinkingSignatures: true,
-      openAiCompatTurnValidation: true,
-      geminiThoughtSignatureSanitization: false,
-      transcriptToolCallIdMode: "default",
-      transcriptToolCallIdModelHints: [],
-      geminiThoughtSignatureModelHints: [],
-      dropThinkingBlockModelHints: ["claude"],
-    });
-    expect(resolveProviderCapabilities("anthropic-vertex")).toEqual({
-      anthropicToolSchemaMode: "native",
-      anthropicToolChoiceMode: "native",
-      openAiPayloadNormalizationMode: "default",
-      providerFamily: "anthropic",
-      preserveAnthropicThinkingSignatures: true,
-      openAiCompatTurnValidation: true,
-      geminiThoughtSignatureSanitization: false,
-      transcriptToolCallIdMode: "default",
-      transcriptToolCallIdModelHints: [],
-      geminiThoughtSignatureModelHints: [],
-      dropThinkingBlockModelHints: ["claude"],
-    });
-    expect(resolveProviderCapabilities("amazon-bedrock")).toEqual({
-      anthropicToolSchemaMode: "native",
-      anthropicToolChoiceMode: "native",
-      openAiPayloadNormalizationMode: "default",
-      providerFamily: "anthropic",
-      preserveAnthropicThinkingSignatures: true,
-      openAiCompatTurnValidation: true,
-      geminiThoughtSignatureSanitization: false,
-      transcriptToolCallIdMode: "default",
-      transcriptToolCallIdModelHints: [],
-      geminiThoughtSignatureModelHints: [],
-      dropThinkingBlockModelHints: ["claude"],
-    });
-  });
-
-  it("preserves built-in fallback capability hints when plugin overrides are partial", () => {
-    resolveProviderCapabilitiesWithPluginMock.mockImplementationOnce(() => ({
-      providerFamily: "anthropic",
-    }));
-
-    expect(resolveProviderCapabilities("anthropic")).toEqual({
-      anthropicToolSchemaMode: "native",
-      anthropicToolChoiceMode: "native",
-      openAiPayloadNormalizationMode: "default",
-      providerFamily: "anthropic",
-      preserveAnthropicThinkingSignatures: true,
-      openAiCompatTurnValidation: true,
-      geminiThoughtSignatureSanitization: false,
-      transcriptToolCallIdMode: "default",
-      transcriptToolCallIdModelHints: [],
-      geminiThoughtSignatureModelHints: [],
-      dropThinkingBlockModelHints: [],
-    });
-  });
-
-  it("normalizes kimi aliases to the same capability set", () => {
-    expect(resolveProviderCapabilities("kimi")).toEqual(resolveProviderCapabilities("kimi-code"));
-    expect(resolveProviderCapabilities("kimi-code")).toEqual({
-      anthropicToolSchemaMode: "native",
-      anthropicToolChoiceMode: "native",
-      openAiPayloadNormalizationMode: "moonshot-thinking",
-      providerFamily: "default",
-      preserveAnthropicThinkingSignatures: false,
-      openAiCompatTurnValidation: true,
-      geminiThoughtSignatureSanitization: false,
-      transcriptToolCallIdMode: "default",
-      transcriptToolCallIdModelHints: [],
-      geminiThoughtSignatureModelHints: [],
-      dropThinkingBlockModelHints: [],
-    });
-  });
-
-  it("flags providers that opt out of OpenAI-compatible turn validation", () => {
-    expect(supportsOpenAiCompatTurnValidation("openrouter")).toBe(false);
-    expect(supportsOpenAiCompatTurnValidation("opencode")).toBe(false);
-    expect(supportsOpenAiCompatTurnValidation("opencode-go")).toBe(false);
-    expect(supportsOpenAiCompatTurnValidation("moonshot")).toBe(true);
-  });
-
-  it("routes moonshot payload compatibility through the capability registry", () => {
-    expect(usesMoonshotThinkingPayloadCompat("moonshot")).toBe(true);
-    expect(usesMoonshotThinkingPayloadCompat("kimi-coding")).toBe(true);
-    expect(usesMoonshotThinkingPayloadCompat("openai")).toBe(false);
-  });
-
-  it("keeps the normalized kimi fallback aligned when plugin capabilities are unavailable", () => {
-    resolveProviderCapabilitiesWithPluginMock.mockImplementationOnce(() => undefined);
-    expect(usesMoonshotThinkingPayloadCompat("kimi-coding")).toBe(true);
-  });
-
-  it("resolves transcript thought-signature and tool-call quirks through the registry", () => {
-    expect(
-      shouldSanitizeGeminiThoughtSignaturesForModel({
-        provider: "openrouter",
-        modelId: "google/gemini-2.5-pro-preview",
-      }),
-    ).toBe(true);
-    expect(
-      shouldSanitizeGeminiThoughtSignaturesForModel({
-        provider: "kilocode",
-        modelId: "gemini-2.0-flash",
-      }),
-    ).toBe(true);
-    expect(
-      shouldSanitizeGeminiThoughtSignaturesForModel({
-        provider: "opencode-go",
-        modelId: "google/gemini-2.5-pro-preview",
-      }),
-    ).toBe(true);
-    expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
-  });
-
-  it("drops replay-related fallback hints when plugin capabilities are unavailable", () => {
-    resolveProviderCapabilitiesWithPluginMock.mockImplementationOnce(() => undefined);
-    resolveProviderCapabilitiesWithPluginMock.mockImplementationOnce(() => undefined);
-    resolveProviderCapabilitiesWithPluginMock.mockImplementationOnce(() => undefined);
-    resolveProviderCapabilitiesWithPluginMock.mockImplementationOnce(() => undefined);
-
-    expect(isOpenAiProviderFamily("openai")).toBe(false);
-    expect(isAnthropicProviderFamily("anthropic")).toBe(false);
-    expect(supportsOpenAiCompatTurnValidation("openrouter")).toBe(true);
-    expect(
-      shouldSanitizeGeminiThoughtSignaturesForModel({
-        provider: "openrouter",
-        modelId: "google/gemini-2.5-pro-preview",
-      }),
-    ).toBe(false);
-  });
-
-  it("treats kimi aliases as native anthropic tool payload providers", () => {
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi")).toBe(false);
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(false);
+  it("defaults to native anthropic tool payload behavior", () => {
     expect(requiresOpenAiCompatibleAnthropicToolPayload("anthropic")).toBe(false);
+    expect(usesOpenAiFunctionAnthropicToolSchema("anthropic")).toBe(false);
+    expect(usesOpenAiStringModeAnthropicToolChoice("anthropic")).toBe(false);
   });
 
-  it("tracks provider families and model-specific transcript quirks in the registry", () => {
-    expect(isOpenAiProviderFamily("openai")).toBe(true);
-    expect(isAnthropicProviderFamily("anthropic-vertex")).toBe(true);
-    expect(isAnthropicProviderFamily("amazon-bedrock")).toBe(true);
-    expect(
-      shouldDropThinkingBlocksForModel({
-        provider: "anthropic",
-        modelId: "claude-opus-4-6",
-      }),
-    ).toBe(true);
-    expect(
-      shouldDropThinkingBlocksForModel({
-        provider: "anthropic-vertex",
-        modelId: "claude-sonnet-4-6",
-      }),
-    ).toBe(true);
-    expect(
-      shouldDropThinkingBlocksForModel({
-        provider: "amazon-bedrock",
-        modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
-      }),
-    ).toBe(true);
-    expect(
-      shouldDropThinkingBlocksForModel({
-        provider: "github-copilot",
-        modelId: "claude-3.7-sonnet",
-      }),
-    ).toBe(true);
+  it("uses plugin-owned anthropic tool payload overrides", () => {
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("anthropic-proxy")).toBe(true);
+    expect(usesOpenAiFunctionAnthropicToolSchema("anthropic-proxy")).toBe(true);
+    expect(usesOpenAiStringModeAnthropicToolChoice("anthropic-proxy")).toBe(true);
   });
 
-  it("forwards config and workspace context to plugin capability lookup", () => {
-    const config = { plugins: { enabled: true } };
-    const env = { OPENCLAW_HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv;
+  it("passes lookup options through to the provider runtime", () => {
+    expect(
+      requiresOpenAiCompatibleAnthropicToolPayload("workspace-anthropic-proxy", {
+        workspaceDir: "/tmp/workspace-capabilities",
+      }),
+    ).toBe(true);
 
-    resolveProviderCapabilities("anthropic", {
-      config,
-      workspaceDir: "/tmp/workspace",
-      env,
-    });
-
-    expect(resolveProviderCapabilitiesWithPluginMock).toHaveBeenLastCalledWith({
-      provider: "anthropic",
-      config,
-      workspaceDir: "/tmp/workspace",
-      env,
-    });
+    expect(resolveProviderCapabilitiesWithPluginMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "workspace-anthropic-proxy",
+        workspaceDir: "/tmp/workspace-capabilities",
+      }),
+    );
   });
 });

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -27,6 +27,18 @@ const resolveProviderCapabilitiesWithPluginMock = vi.fn((params: { provider: str
         geminiThoughtSignatureSanitization: true,
         geminiThoughtSignatureModelHints: ["gemini"],
       };
+    case "opencode":
+      return {
+        openAiCompatTurnValidation: false,
+        geminiThoughtSignatureSanitization: true,
+        geminiThoughtSignatureModelHints: ["gemini"],
+      };
+    case "opencode-go":
+      return {
+        openAiCompatTurnValidation: false,
+        geminiThoughtSignatureSanitization: true,
+        geminiThoughtSignatureModelHints: ["gemini"],
+      };
     case "openai-codex":
       return {
         providerFamily: "openai",
@@ -39,6 +51,11 @@ const resolveProviderCapabilitiesWithPluginMock = vi.fn((params: { provider: str
       return {
         geminiThoughtSignatureSanitization: true,
         geminiThoughtSignatureModelHints: ["gemini"],
+      };
+    case "mistral":
+      return {
+        transcriptToolCallIdMode: "strict9",
+        transcriptToolCallIdModelHints: ["mistral"],
       };
     case "kimi":
       return {
@@ -142,7 +159,7 @@ describe("resolveProviderCapabilities", () => {
       transcriptToolCallIdMode: "default",
       transcriptToolCallIdModelHints: [],
       geminiThoughtSignatureModelHints: [],
-      dropThinkingBlockModelHints: ["claude"],
+      dropThinkingBlockModelHints: [],
     });
   });
 
@@ -201,6 +218,23 @@ describe("resolveProviderCapabilities", () => {
       }),
     ).toBe(true);
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
+  });
+
+  it("drops replay-related fallback hints when plugin capabilities are unavailable", () => {
+    resolveProviderCapabilitiesWithPluginMock.mockImplementationOnce(() => undefined);
+    resolveProviderCapabilitiesWithPluginMock.mockImplementationOnce(() => undefined);
+    resolveProviderCapabilitiesWithPluginMock.mockImplementationOnce(() => undefined);
+    resolveProviderCapabilitiesWithPluginMock.mockImplementationOnce(() => undefined);
+
+    expect(isOpenAiProviderFamily("openai")).toBe(false);
+    expect(isAnthropicProviderFamily("anthropic")).toBe(false);
+    expect(supportsOpenAiCompatTurnValidation("openrouter")).toBe(true);
+    expect(
+      shouldSanitizeGeminiThoughtSignaturesForModel({
+        provider: "openrouter",
+        modelId: "google/gemini-2.5-pro-preview",
+      }),
+    ).toBe(false);
   });
 
   it("treats kimi aliases as native anthropic tool payload providers", () => {

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -22,27 +22,14 @@ export type ProviderCapabilityLookupOptions = {
   env?: NodeJS.ProcessEnv;
 };
 
-const DEFAULT_PROVIDER_CAPABILITIES: ProviderCapabilities = {
+type AnthropicToolPayloadCapabilities = Pick<
+  ProviderCapabilities,
+  "anthropicToolSchemaMode" | "anthropicToolChoiceMode"
+>;
+
+const DEFAULT_ANTHROPIC_TOOL_PAYLOAD_CAPABILITIES: AnthropicToolPayloadCapabilities = {
   anthropicToolSchemaMode: "native",
   anthropicToolChoiceMode: "native",
-  openAiPayloadNormalizationMode: "default",
-  providerFamily: "default",
-  preserveAnthropicThinkingSignatures: true,
-  openAiCompatTurnValidation: true,
-  geminiThoughtSignatureSanitization: false,
-  transcriptToolCallIdMode: "default",
-  transcriptToolCallIdModelHints: [],
-  geminiThoughtSignatureModelHints: [],
-  dropThinkingBlockModelHints: [],
-};
-
-const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities>> = {
-  moonshot: {
-    openAiPayloadNormalizationMode: "moonshot-thinking",
-  },
-  kimi: {
-    openAiPayloadNormalizationMode: "moonshot-thinking",
-  },
 };
 
 const defaultResolveProviderCapabilitiesWithPlugin = resolveProviderCapabilitiesWithPluginRuntime;
@@ -63,38 +50,43 @@ export const __testing = {
   },
 };
 
-export function resolveProviderCapabilities(
+function resolveAnthropicToolPayloadCapabilities(
   provider?: string | null,
   options?: ProviderCapabilityLookupOptions,
-): ProviderCapabilities {
+): AnthropicToolPayloadCapabilities {
   const normalized = normalizeProviderId(provider ?? "");
-  const pluginCapabilities = normalized
-    ? providerCapabilityDeps.resolveProviderCapabilitiesWithPlugin({
-        provider: normalized,
-        config: options?.config,
-        workspaceDir: options?.workspaceDir,
-        env: options?.env,
-      })
-    : undefined;
-  return {
-    ...DEFAULT_PROVIDER_CAPABILITIES,
-    ...PLUGIN_CAPABILITIES_FALLBACKS[normalized],
-    ...pluginCapabilities,
-  };
-}
+  if (!normalized) {
+    return DEFAULT_ANTHROPIC_TOOL_PAYLOAD_CAPABILITIES;
+  }
 
-export function preservesAnthropicThinkingSignatures(
-  provider?: string | null,
-  options?: ProviderCapabilityLookupOptions,
-): boolean {
-  return resolveProviderCapabilities(provider, options).preserveAnthropicThinkingSignatures;
+  const pluginCapabilities =
+    providerCapabilityDeps.resolveProviderCapabilitiesWithPlugin({
+      provider: normalized,
+      config: options?.config,
+      workspaceDir: options?.workspaceDir,
+      env: options?.env,
+    }) ?? undefined;
+
+  return {
+    ...DEFAULT_ANTHROPIC_TOOL_PAYLOAD_CAPABILITIES,
+    ...(pluginCapabilities
+      ? {
+          anthropicToolSchemaMode:
+            pluginCapabilities.anthropicToolSchemaMode ??
+            DEFAULT_ANTHROPIC_TOOL_PAYLOAD_CAPABILITIES.anthropicToolSchemaMode,
+          anthropicToolChoiceMode:
+            pluginCapabilities.anthropicToolChoiceMode ??
+            DEFAULT_ANTHROPIC_TOOL_PAYLOAD_CAPABILITIES.anthropicToolChoiceMode,
+        }
+      : {}),
+  };
 }
 
 export function requiresOpenAiCompatibleAnthropicToolPayload(
   provider?: string | null,
   options?: ProviderCapabilityLookupOptions,
 ): boolean {
-  const capabilities = resolveProviderCapabilities(provider, options);
+  const capabilities = resolveAnthropicToolPayloadCapabilities(provider, options);
   return (
     capabilities.anthropicToolSchemaMode !== "native" ||
     capabilities.anthropicToolChoiceMode !== "native"
@@ -106,7 +98,8 @@ export function usesOpenAiFunctionAnthropicToolSchema(
   options?: ProviderCapabilityLookupOptions,
 ): boolean {
   return (
-    resolveProviderCapabilities(provider, options).anthropicToolSchemaMode === "openai-functions"
+    resolveAnthropicToolPayloadCapabilities(provider, options).anthropicToolSchemaMode ===
+    "openai-functions"
   );
 }
 
@@ -115,92 +108,7 @@ export function usesOpenAiStringModeAnthropicToolChoice(
   options?: ProviderCapabilityLookupOptions,
 ): boolean {
   return (
-    resolveProviderCapabilities(provider, options).anthropicToolChoiceMode === "openai-string-modes"
+    resolveAnthropicToolPayloadCapabilities(provider, options).anthropicToolChoiceMode ===
+    "openai-string-modes"
   );
-}
-
-export function supportsOpenAiCompatTurnValidation(
-  provider?: string | null,
-  options?: ProviderCapabilityLookupOptions,
-): boolean {
-  return resolveProviderCapabilities(provider, options).openAiCompatTurnValidation;
-}
-
-export function usesMoonshotThinkingPayloadCompat(
-  provider?: string | null,
-  options?: ProviderCapabilityLookupOptions,
-): boolean {
-  return (
-    resolveProviderCapabilities(provider, options).openAiPayloadNormalizationMode ===
-    "moonshot-thinking"
-  );
-}
-
-export function sanitizesGeminiThoughtSignatures(
-  provider?: string | null,
-  options?: ProviderCapabilityLookupOptions,
-): boolean {
-  return resolveProviderCapabilities(provider, options).geminiThoughtSignatureSanitization;
-}
-
-function modelIncludesAnyHint(modelId: string | null | undefined, hints: string[]): boolean {
-  const normalized = (modelId ?? "").toLowerCase();
-  return Boolean(normalized) && hints.some((hint) => normalized.includes(hint));
-}
-
-export function isOpenAiProviderFamily(
-  provider?: string | null,
-  options?: ProviderCapabilityLookupOptions,
-): boolean {
-  return resolveProviderCapabilities(provider, options).providerFamily === "openai";
-}
-
-export function isAnthropicProviderFamily(
-  provider?: string | null,
-  options?: ProviderCapabilityLookupOptions,
-): boolean {
-  return resolveProviderCapabilities(provider, options).providerFamily === "anthropic";
-}
-
-export function shouldDropThinkingBlocksForModel(params: {
-  provider?: string | null;
-  modelId?: string | null;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-}): boolean {
-  return modelIncludesAnyHint(
-    params.modelId,
-    resolveProviderCapabilities(params.provider, params).dropThinkingBlockModelHints,
-  );
-}
-
-export function shouldSanitizeGeminiThoughtSignaturesForModel(params: {
-  provider?: string | null;
-  modelId?: string | null;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-}): boolean {
-  const capabilities = resolveProviderCapabilities(params.provider, params);
-  return (
-    capabilities.geminiThoughtSignatureSanitization &&
-    modelIncludesAnyHint(params.modelId, capabilities.geminiThoughtSignatureModelHints)
-  );
-}
-
-export function resolveTranscriptToolCallIdMode(
-  provider?: string | null,
-  modelId?: string | null,
-  options?: ProviderCapabilityLookupOptions,
-): "strict9" | undefined {
-  const capabilities = resolveProviderCapabilities(provider, options);
-  const mode = capabilities.transcriptToolCallIdMode;
-  if (mode === "strict9") {
-    return mode;
-  }
-  if (modelIncludesAnyHint(modelId, capabilities.transcriptToolCallIdModelHints)) {
-    return "strict9";
-  }
-  return undefined;
 }

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -37,40 +37,11 @@ const DEFAULT_PROVIDER_CAPABILITIES: ProviderCapabilities = {
 };
 
 const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities>> = {
-  anthropic: {
-    providerFamily: "anthropic",
-    dropThinkingBlockModelHints: ["claude"],
-  },
-  mistral: {
-    transcriptToolCallIdMode: "strict9",
-    transcriptToolCallIdModelHints: [
-      "mistral",
-      "mixtral",
-      "codestral",
-      "pixtral",
-      "devstral",
-      "ministral",
-      "mistralai",
-    ],
-  },
   moonshot: {
     openAiPayloadNormalizationMode: "moonshot-thinking",
   },
   kimi: {
     openAiPayloadNormalizationMode: "moonshot-thinking",
-  },
-  opencode: {
-    openAiCompatTurnValidation: false,
-    geminiThoughtSignatureSanitization: true,
-    geminiThoughtSignatureModelHints: ["gemini"],
-  },
-  "opencode-go": {
-    openAiCompatTurnValidation: false,
-    geminiThoughtSignatureSanitization: true,
-    geminiThoughtSignatureModelHints: ["gemini"],
-  },
-  openai: {
-    providerFamily: "openai",
   },
 };
 

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -1,30 +1,93 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../plugins/provider-runtime.js", () => ({
-  resolveProviderCapabilitiesWithPlugin: vi.fn(({ provider }: { provider?: string }) => {
-    switch (provider) {
-      case "kimi":
-      case "kimi-code":
-        return {
-          providerFamily: "anthropic",
-          preserveAnthropicThinkingSignatures: false,
-        };
-      case "openrouter":
-        return {
-          openAiCompatTurnValidation: false,
-          geminiThoughtSignatureSanitization: true,
-          geminiThoughtSignatureModelHints: ["gemini"],
-        };
-      case "kilocode":
-        return {
-          geminiThoughtSignatureSanitization: true,
-          geminiThoughtSignatureModelHints: ["gemini"],
-        };
-      default:
-        return undefined;
-    }
-  }),
-  resolveProviderReplayPolicyWithPlugin: vi.fn(() => undefined),
+  resolveProviderCapabilitiesWithPlugin: vi.fn(() => undefined),
+  resolveProviderReplayPolicyWithPlugin: vi.fn(
+    ({
+      provider,
+      context,
+    }: {
+      provider?: string;
+      context?: { modelId?: string; modelApi?: string };
+    }) => {
+      const modelId = context?.modelId?.toLowerCase() ?? "";
+      switch (provider) {
+        case "anthropic":
+          return {
+            sanitizeMode: "full",
+            sanitizeToolCallIds: true,
+            toolCallIdMode: "strict",
+            preserveSignatures: true,
+            repairToolUseResultPairing: true,
+            validateAnthropicTurns: true,
+            allowSyntheticToolResults: true,
+            ...(modelId.includes("claude") ? { dropThinkingBlocks: true } : {}),
+          };
+        case "google":
+          return {
+            sanitizeMode: "full",
+            sanitizeToolCallIds: true,
+            toolCallIdMode: "strict",
+            sanitizeThoughtSignatures: {
+              allowBase64Only: true,
+              includeCamelCase: true,
+            },
+            repairToolUseResultPairing: true,
+            applyAssistantFirstOrderingFix: true,
+            validateGeminiTurns: true,
+            validateAnthropicTurns: false,
+            allowSyntheticToolResults: true,
+          };
+        case "mistral":
+          return {
+            sanitizeToolCallIds: true,
+            toolCallIdMode: "strict9",
+          };
+        case "openai":
+        case "openai-codex":
+          return {
+            sanitizeMode: "images-only",
+            sanitizeToolCallIds: context?.modelApi === "openai-completions",
+            ...(context?.modelApi === "openai-completions" ? { toolCallIdMode: "strict" } : {}),
+            applyAssistantFirstOrderingFix: false,
+            validateGeminiTurns: false,
+            validateAnthropicTurns: false,
+          };
+        case "kimi":
+        case "kimi-code":
+          return {
+            preserveSignatures: false,
+          };
+        case "openrouter":
+        case "opencode":
+        case "opencode-go":
+          return {
+            applyAssistantFirstOrderingFix: false,
+            validateGeminiTurns: false,
+            validateAnthropicTurns: false,
+            ...(modelId.includes("gemini")
+              ? {
+                  sanitizeThoughtSignatures: {
+                    allowBase64Only: true,
+                    includeCamelCase: true,
+                  },
+                }
+              : {}),
+          };
+        case "kilocode":
+          return modelId.includes("gemini")
+            ? {
+                sanitizeThoughtSignatures: {
+                  allowBase64Only: true,
+                  includeCamelCase: true,
+                },
+              }
+            : undefined;
+        default:
+          return undefined;
+      }
+    },
+  ),
   resetProviderRuntimeHookCacheForTest: vi.fn(),
 }));
 
@@ -79,6 +142,9 @@ describe("resolveTranscriptPolicy", () => {
     });
     expect(policy.sanitizeToolCallIds).toBe(false);
     expect(policy.toolCallIdMode).toBeUndefined();
+    expect(policy.applyGoogleTurnOrdering).toBe(false);
+    expect(policy.validateGeminiTurns).toBe(false);
+    expect(policy.validateAnthropicTurns).toBe(false);
   });
 
   it("enables strict tool call id sanitization for openai-completions APIs", () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -3,15 +3,6 @@ import { resolveProviderReplayPolicyWithPlugin } from "../plugins/provider-runti
 import type { ProviderRuntimeModel } from "../plugins/types.js";
 import { normalizeProviderId } from "./model-selection.js";
 import { isGoogleModelApi } from "./pi-embedded-helpers/google.js";
-import {
-  isAnthropicProviderFamily,
-  isOpenAiProviderFamily,
-  preservesAnthropicThinkingSignatures,
-  resolveTranscriptToolCallIdMode,
-  shouldDropThinkingBlocksForModel,
-  shouldSanitizeGeminiThoughtSignaturesForModel,
-  supportsOpenAiCompatTurnValidation,
-} from "./provider-capabilities.js";
 import type { ToolCallIdMode } from "./tool-call-id.js";
 
 export type TranscriptSanitizeMode = "full" | "images-only";
@@ -34,30 +25,12 @@ export type TranscriptPolicy = {
   allowSyntheticToolResults: boolean;
 };
 
-const OPENAI_MODEL_APIS = new Set([
-  "openai",
-  "openai-completions",
-  "openai-responses",
-  "openai-codex-responses",
-]);
-
-function isOpenAiApi(modelApi?: string | null): boolean {
-  if (!modelApi) {
-    return false;
-  }
-  return OPENAI_MODEL_APIS.has(modelApi);
+function isAnthropicApi(modelApi?: string | null): boolean {
+  return modelApi === "anthropic-messages" || modelApi === "bedrock-converse-stream";
 }
 
-function isOpenAiProvider(provider?: string | null): boolean {
-  return isOpenAiProviderFamily(provider);
-}
-
-function isAnthropicApi(modelApi?: string | null, provider?: string | null): boolean {
-  if (modelApi === "anthropic-messages" || modelApi === "bedrock-converse-stream") {
-    return true;
-  }
-  // MiniMax now uses openai-completions API, not anthropic-messages
-  return isAnthropicProviderFamily(provider);
+function shouldDropAnthropicThinkingBlocks(modelId?: string | null): boolean {
+  return (modelId ?? "").toLowerCase().includes("claude");
 }
 
 export function resolveTranscriptPolicy(params: {
@@ -72,66 +45,35 @@ export function resolveTranscriptPolicy(params: {
   const provider = normalizeProviderId(params.provider ?? "");
   const modelId = params.modelId ?? "";
   const isGoogle = isGoogleModelApi(params.modelApi);
-  const isAnthropic = isAnthropicApi(params.modelApi, provider);
-  const isOpenAi = isOpenAiProvider(provider) || (!provider && isOpenAiApi(params.modelApi));
-  const isStrictOpenAiCompatible =
-    params.modelApi === "openai-completions" &&
-    !isOpenAi &&
-    supportsOpenAiCompatTurnValidation(provider);
-  const providerToolCallIdMode = resolveTranscriptToolCallIdMode(provider, modelId);
-  const isMistral = providerToolCallIdMode === "strict9";
-  const shouldSanitizeGeminiThoughtSignaturesForProvider =
-    shouldSanitizeGeminiThoughtSignaturesForModel({
-      provider,
-      modelId,
-    });
+  const isAnthropic = isAnthropicApi(params.modelApi);
+  const isStrictOpenAiCompatible = params.modelApi === "openai-completions";
   const requiresOpenAiCompatibleToolIdSanitization =
     params.modelApi === "openai-completions" ||
-    (!isOpenAi &&
-      (params.modelApi === "openai-responses" ||
-        params.modelApi === "openai-codex-responses" ||
-        params.modelApi === "azure-openai-responses"));
-
-  // Anthropic Claude endpoints can reject replayed `thinking` blocks unless the
-  // original signatures are preserved byte-for-byte. Drop them at send-time to
-  // keep persisted sessions usable across follow-up turns.
-  const dropThinkingBlocks = shouldDropThinkingBlocksForModel({ provider, modelId });
-
-  const needsNonImageSanitize =
-    isGoogle || isAnthropic || isMistral || shouldSanitizeGeminiThoughtSignaturesForProvider;
-
-  const sanitizeToolCallIds =
-    isGoogle || isMistral || isAnthropic || requiresOpenAiCompatibleToolIdSanitization;
-  const toolCallIdMode: ToolCallIdMode | undefined = providerToolCallIdMode
-    ? providerToolCallIdMode
-    : isMistral
-      ? "strict9"
-      : sanitizeToolCallIds
-        ? "strict"
-        : undefined;
+    params.modelApi === "openai-responses" ||
+    params.modelApi === "openai-codex-responses" ||
+    params.modelApi === "azure-openai-responses";
   // All providers need orphaned tool_result repair after history truncation.
   // OpenAI rejects function_call_output items whose call_id has no matching
   // function_call in the conversation, so the repair must run universally.
   const repairToolUseResultPairing = true;
-  const sanitizeThoughtSignatures =
-    shouldSanitizeGeminiThoughtSignaturesForProvider || isGoogle
-      ? { allowBase64Only: true, includeCamelCase: true }
-      : undefined;
 
   const basePolicy: TranscriptPolicy = {
-    sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
-    sanitizeToolCallIds:
-      (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
-    toolCallIdMode,
+    sanitizeMode: isGoogle || isAnthropic ? "full" : "images-only",
+    sanitizeToolCallIds: isGoogle || isAnthropic || requiresOpenAiCompatibleToolIdSanitization,
+    toolCallIdMode: (isGoogle || isAnthropic || requiresOpenAiCompatibleToolIdSanitization
+      ? "strict"
+      : undefined) as ToolCallIdMode | undefined,
     repairToolUseResultPairing,
-    preserveSignatures: isAnthropic && preservesAnthropicThinkingSignatures(provider),
-    sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
+    preserveSignatures: isAnthropic,
+    sanitizeThoughtSignatures: isGoogle
+      ? { allowBase64Only: true, includeCamelCase: true }
+      : undefined,
     sanitizeThinkingSignatures: false,
-    dropThinkingBlocks,
-    applyGoogleTurnOrdering: !isOpenAi && (isGoogle || isStrictOpenAiCompatible),
-    validateGeminiTurns: !isOpenAi && (isGoogle || isStrictOpenAiCompatible),
-    validateAnthropicTurns: !isOpenAi && (isAnthropic || isStrictOpenAiCompatible),
-    allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
+    dropThinkingBlocks: isAnthropic && shouldDropAnthropicThinkingBlocks(modelId),
+    applyGoogleTurnOrdering: isGoogle || isStrictOpenAiCompatible,
+    validateGeminiTurns: isGoogle || isStrictOpenAiCompatible,
+    validateAnthropicTurns: isAnthropic || isStrictOpenAiCompatible,
+    allowSyntheticToolResults: isGoogle || isAnthropic,
   };
 
   const pluginPolicy = provider
@@ -176,6 +118,12 @@ export function resolveTranscriptPolicy(params: {
       : {}),
     ...(typeof pluginPolicy.applyAssistantFirstOrderingFix === "boolean"
       ? { applyGoogleTurnOrdering: pluginPolicy.applyAssistantFirstOrderingFix }
+      : {}),
+    ...(typeof pluginPolicy.validateGeminiTurns === "boolean"
+      ? { validateGeminiTurns: pluginPolicy.validateGeminiTurns }
+      : {}),
+    ...(typeof pluginPolicy.validateAnthropicTurns === "boolean"
+      ? { validateAnthropicTurns: pluginPolicy.validateAnthropicTurns }
       : {}),
     ...(typeof pluginPolicy.allowSyntheticToolResults === "boolean"
       ? { allowSyntheticToolResults: pluginPolicy.allowSyntheticToolResults }

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -1,4 +1,5 @@
 // Shared provider-tool helpers for plugin-owned schema compatibility rewrites.
+export { cleanSchemaForGemini } from "../agents/schema/clean-for-gemini.js";
 
 export const XAI_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
   "minLength",

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -560,6 +560,8 @@ export type ProviderReplayPolicy = {
   dropThinkingBlocks?: boolean;
   repairToolUseResultPairing?: boolean;
   applyAssistantFirstOrderingFix?: boolean;
+  validateGeminiTurns?: boolean;
+  validateAnthropicTurns?: boolean;
   allowSyntheticToolResults?: boolean;
 };
 

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -39,26 +39,6 @@ export function resolveReasoningOutputMode(params: {
     return pluginMode;
   }
 
-  const normalized = provider.toLowerCase();
-
-  // Check for exact matches or known prefixes/substrings for reasoning providers.
-  // Note: Ollama is intentionally excluded - its OpenAI-compatible endpoint
-  // handles reasoning natively via the `reasoning` field in streaming chunks,
-  // so tag-based enforcement is unnecessary and causes all output to be
-  // discarded as "(no output)" (#2279).
-  if (
-    normalized === "google" ||
-    normalized === "google-gemini-cli" ||
-    normalized === "google-generative-ai"
-  ) {
-    return "tagged";
-  }
-
-  // Handle Minimax (M2.5 is chatty/reasoning-like)
-  if (normalized.includes("minimax")) {
-    return "tagged";
-  }
-
   return "native";
 }
 

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -1,7 +1,34 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseBooleanValue } from "./boolean.js";
-import { isReasoningTagProvider } from "./provider-utils.js";
 import { splitShellArgs } from "./shell-argv.js";
+
+const resolveProviderReasoningOutputModeWithPluginMock = vi.fn((params: { provider: string }) => {
+  switch (params.provider.toLowerCase()) {
+    case "google":
+    case "google-gemini-cli":
+    case "google-generative-ai":
+    case "minimax":
+    case "minimax-cn":
+      return "tagged" as const;
+    default:
+      return undefined;
+  }
+});
+
+vi.mock("../plugins/provider-runtime.js", () => ({
+  resolveProviderReasoningOutputModeWithPlugin: (params: { provider: string }) =>
+    resolveProviderReasoningOutputModeWithPluginMock(params),
+}));
+
+let isReasoningTagProvider: typeof import("./provider-utils.js").isReasoningTagProvider;
+
+beforeAll(async () => {
+  ({ isReasoningTagProvider } = await import("./provider-utils.js"));
+});
+
+beforeEach(() => {
+  resolveProviderReasoningOutputModeWithPluginMock.mockClear();
+});
 
 describe("parseBooleanValue", () => {
   it("handles boolean inputs", () => {
@@ -45,7 +72,7 @@ describe("parseBooleanValue", () => {
 describe("isReasoningTagProvider", () => {
   it.each([
     {
-      name: "returns false for ollama - native reasoning field, no tags needed (#2279)",
+      name: "returns false for ollama when the provider plugin has no tagged override",
       value: "ollama",
       expected: false,
     },
@@ -55,7 +82,7 @@ describe("isReasoningTagProvider", () => {
       expected: false,
     },
     {
-      name: "returns true for google (gemini-api-key auth provider)",
+      name: "returns true for google via provider hook",
       value: "google",
       expected: true,
     },
@@ -64,14 +91,22 @@ describe("isReasoningTagProvider", () => {
       value: "Google",
       expected: true,
     },
-    { name: "returns true for google-gemini-cli", value: "google-gemini-cli", expected: true },
     {
-      name: "returns true for google-generative-ai",
+      name: "returns true for google-gemini-cli via provider hook",
+      value: "google-gemini-cli",
+      expected: true,
+    },
+    {
+      name: "returns true for google-generative-ai via provider hook",
       value: "google-generative-ai",
       expected: true,
     },
-    { name: "returns true for minimax", value: "minimax", expected: true },
-    { name: "returns true for minimax-cn", value: "minimax-cn", expected: true },
+    { name: "returns true for minimax via provider hook", value: "minimax", expected: true },
+    {
+      name: "returns true for minimax-cn via provider hook alias",
+      value: "minimax-cn",
+      expected: true,
+    },
     { name: "returns false for null", value: null, expected: false },
     { name: "returns false for undefined", value: undefined, expected: false },
     { name: "returns false for empty", value: "", expected: false },


### PR DESCRIPTION
## What
Removes the replay-era provider capability fallbacks that were only needed while core still owned replay and reasoning policy. This is the cleanup bridge between the initial provider-ownership move and the later runtime extractions.

## Why
After the first ownership move, core still carried compatibility tables and helper branches that described behavior providers now own directly. Keeping them around obscures the new ownership model and makes it harder to tell which behavior is generic orchestration versus provider-specific policy.

## Changes
- Delete replay-era capability fallback tables
- Remove dead provider capability helpers
- Move remaining reasoning-tag defaults into provider hooks
- Refresh focused capability coverage around the slimmer core path

## Testing
- `pnpm test -- src/agents/provider-capabilities.test.ts src/agents/pi-embedded-runner-extraparams.test.ts src/utils/utils-misc.test.ts extensions/minimax/index.test.ts`
- `pnpm build`

## Stack
Part 3 of 6.
Base branch: `oc-3c3/provider-replay-hooks`
Previous https://github.com/openclaw/openclaw/pull/59144
Next  https://github.com/openclaw/openclaw/pull/59146
