### PR TITLE
refactor: finish moving OpenAI wrapper chains into provider plugins

### DIFF
--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -1,15 +1,23 @@
+import type {
+  ProviderReplaySessionEntry,
+  ProviderSanitizeReplayHistoryContext,
+} from "openclaw/plugin-sdk/plugin-entry";
 import { describe, expect, it } from "vitest";
 import {
-  registerProviderPlugins,
+  registerProviderPlugin,
   requireRegisteredProvider,
-} from "../../src/test-utils/plugin-registration.js";
+} from "../../test/helpers/plugins/provider-registration.js";
 import googlePlugin from "./index.js";
 
 describe("google provider plugin hooks", () => {
-  it("owns replay policy and reasoning mode for the direct Gemini provider", () => {
-    const providers = registerProviderPlugins(googlePlugin);
+  it("owns replay policy and reasoning mode for the direct Gemini provider", async () => {
+    const { providers } = registerProviderPlugin({
+      plugin: googlePlugin,
+      id: "google",
+      name: "Google Provider",
+    });
     const provider = requireRegisteredProvider(providers, "google");
-    const customEntries: Array<{ customType: string; data?: unknown }> = [];
+    const customEntries: ProviderReplaySessionEntry[] = [];
 
     expect(
       provider.buildReplayPolicy?.({
@@ -40,35 +48,45 @@ describe("google provider plugin hooks", () => {
       } as never),
     ).toBe("tagged");
 
-    const sanitized = provider.sanitizeReplayHistory?.({
-      provider: "google",
-      modelApi: "google-generative-ai",
-      modelId: "gemini-3.1-pro-preview",
-      sessionId: "session-1",
-      messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "hello" }],
+    const sanitized = await Promise.resolve(
+      provider.sanitizeReplayHistory?.({
+        provider: "google",
+        modelApi: "google-generative-ai",
+        modelId: "gemini-3.1-pro-preview",
+        sessionId: "session-1",
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "hello" }],
+          },
+        ],
+        sessionState: {
+          getCustomEntries: () => customEntries,
+          appendCustomEntry: (customType: string, data: unknown) => {
+            customEntries.push({ customType, data });
+          },
         },
-      ],
-      sessionState: {
-        getCustomEntries: () => customEntries,
-        appendCustomEntry: (customType, data) => {
-          customEntries.push({ customType, data });
-        },
-      },
-    } as never);
+      } as ProviderSanitizeReplayHistoryContext),
+    );
 
-    expect(sanitized?.[0]).toMatchObject({
-      role: "user",
-      content: "(session bootstrap)",
-    });
+    expect(sanitized).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: "(session bootstrap)",
+        }),
+      ]),
+    );
     expect(customEntries).toHaveLength(1);
     expect(customEntries[0]?.customType).toBe("google-turn-ordering-bootstrap");
   });
 
   it("owns Gemini CLI tool schema normalization", () => {
-    const providers = registerProviderPlugins(googlePlugin);
+    const { providers } = registerProviderPlugin({
+      plugin: googlePlugin,
+      id: "google",
+      name: "Google Provider",
+    });
     const provider = requireRegisteredProvider(providers, "google-gemini-cli");
 
     const [tool] =

--- a/extensions/google/replay-policy.ts
+++ b/extensions/google/replay-policy.ts
@@ -1,5 +1,5 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type {
-  AgentMessage,
   AnyAgentTool,
   ProviderNormalizeToolSchemasContext,
   ProviderReasoningOutputMode,

--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -1,13 +1,19 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
-  registerProviderPlugins,
+  registerProviderPlugin,
   requireRegisteredProvider,
-} from "../../src/test-utils/plugin-registration.js";
+} from "../../test/helpers/plugins/provider-registration.js";
 import minimaxPlugin from "./index.js";
 
 describe("minimax provider hooks", () => {
   it("owns tagged reasoning mode for MiniMax transports", () => {
-    const providers = registerProviderPlugins(minimaxPlugin);
+    const { providers } = registerProviderPlugin({
+      plugin: minimaxPlugin,
+      id: "minimax",
+      name: "MiniMax Provider",
+    });
     const apiProvider = requireRegisteredProvider(providers, "minimax");
     const portalProvider = requireRegisteredProvider(providers, "minimax-portal");
 
@@ -28,5 +34,62 @@ describe("minimax provider hooks", () => {
         modelId: "MiniMax-M2.7",
       } as never),
     ).toBe("tagged");
+  });
+
+  it("owns fast-mode stream wrapping for MiniMax transports", () => {
+    const { providers } = registerProviderPlugin({
+      plugin: minimaxPlugin,
+      id: "minimax",
+      name: "MiniMax Provider",
+    });
+    const apiProvider = requireRegisteredProvider(providers, "minimax");
+    const portalProvider = requireRegisteredProvider(providers, "minimax-portal");
+
+    let resolvedApiModelId = "";
+    const captureApiModel: StreamFn = (model) => {
+      resolvedApiModelId = String(model.id ?? "");
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrappedApiStream = apiProvider.wrapStreamFn?.({
+      provider: "minimax",
+      modelId: "MiniMax-M2.7",
+      extraParams: { fastMode: true },
+      streamFn: captureApiModel,
+    } as never);
+
+    void wrappedApiStream?.(
+      {
+        api: "anthropic-messages",
+        provider: "minimax",
+        id: "MiniMax-M2.7",
+      } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    let resolvedPortalModelId = "";
+    const capturePortalModel: StreamFn = (model) => {
+      resolvedPortalModelId = String(model.id ?? "");
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrappedPortalStream = portalProvider.wrapStreamFn?.({
+      provider: "minimax-portal",
+      modelId: "MiniMax-M2.7",
+      extraParams: { fastMode: true },
+      streamFn: capturePortalModel,
+    } as never);
+
+    void wrappedPortalStream?.(
+      {
+        api: "anthropic-messages",
+        provider: "minimax-portal",
+        id: "MiniMax-M2.7",
+      } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(resolvedApiModelId).toBe("MiniMax-M2.7-highspeed");
+    expect(resolvedPortalModelId).toBe("MiniMax-M2.7-highspeed");
   });
 });

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -17,7 +17,6 @@ import {
   normalizeProviderId,
   type ProviderPlugin,
 } from "openclaw/plugin-sdk/provider-model-shared";
-import { createOpenAIAttributionHeadersWrapper } from "openclaw/plugin-sdk/provider-stream";
 import { fetchCodexUsage } from "openclaw/plugin-sdk/provider-usage";
 import { OPENAI_CODEX_DEFAULT_MODEL } from "./default-models.js";
 import { resolveCodexAuthIdentity } from "./openai-codex-auth-identity.js";
@@ -28,6 +27,7 @@ import {
   isOpenAIApiBaseUrl,
   matchesExactOrPrefix,
 } from "./shared.js";
+import { wrapOpenAICodexProviderStream } from "./stream-hooks.js";
 
 const PROVIDER_ID = "openai-codex";
 const OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
@@ -286,7 +286,7 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
         transport: "auto",
       };
     },
-    wrapStreamFn: (ctx) => createOpenAIAttributionHeadersWrapper(ctx.streamFn),
+    wrapStreamFn: (ctx) => wrapOpenAICodexProviderStream(ctx),
     normalizeResolvedModel: (ctx) => {
       if (normalizeProviderId(ctx.provider) !== PROVIDER_ID) {
         return undefined;

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -21,6 +21,7 @@ import { fetchCodexUsage } from "openclaw/plugin-sdk/provider-usage";
 import { OPENAI_CODEX_DEFAULT_MODEL } from "./default-models.js";
 import { resolveCodexAuthIdentity } from "./openai-codex-auth-identity.js";
 import { buildOpenAICodexProvider } from "./openai-codex-catalog.js";
+import { buildOpenAIReplayPolicy } from "./replay-policy.js";
 import {
   cloneFirstTemplateModel,
   findCatalogTemplate,
@@ -276,6 +277,7 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
     supportsXHighThinking: ({ modelId }) =>
       matchesExactOrPrefix(modelId, OPENAI_CODEX_XHIGH_MODEL_IDS),
     isModernModelRef: ({ modelId }) => matchesExactOrPrefix(modelId, OPENAI_CODEX_MODERN_MODEL_IDS),
+    buildReplayPolicy: (ctx) => buildOpenAIReplayPolicy(ctx),
     prepareExtraParams: (ctx) => {
       const transport = ctx.extraParams?.transport;
       if (transport === "auto" || transport === "sse" || transport === "websocket") {

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -262,8 +262,7 @@ describe("buildOpenAIProvider", () => {
 
   it("owns direct OpenAI wrapper composition for responses payloads", () => {
     const provider = buildOpenAIProvider();
-    const result = runWrappedPayloadCase({
-      wrap: provider.wrapStreamFn as NonNullable<typeof provider.wrapStreamFn>,
+    const extraParams = provider.prepareExtraParams?.({
       provider: "openai",
       modelId: "gpt-5.4",
       extraParams: {
@@ -271,6 +270,12 @@ describe("buildOpenAIProvider", () => {
         serviceTier: "priority",
         textVerbosity: "low",
       },
+    } as never);
+    const result = runWrappedPayloadCase({
+      wrap: provider.wrapStreamFn as NonNullable<typeof provider.wrapStreamFn>,
+      provider: "openai",
+      modelId: "gpt-5.4",
+      extraParams: extraParams ?? undefined,
       model: {
         api: "openai-responses",
         provider: "openai",
@@ -282,8 +287,10 @@ describe("buildOpenAIProvider", () => {
       },
     });
 
-    expect(result.options?.transport).toBe("auto");
-    expect(result.options?.openaiWsWarmup).toBe(false);
+    expect(extraParams).toMatchObject({
+      transport: "auto",
+      openaiWsWarmup: false,
+    });
     expect(result.payload.service_tier).toBe("priority");
     expect(result.payload.text).toEqual({ verbosity: "low" });
     expect(result.payload).not.toHaveProperty("reasoning");

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -1,3 +1,5 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { buildOpenAICodexProviderPlugin } from "./openai-codex-provider.js";
 import { buildOpenAIProvider } from "./openai-provider.js";
@@ -7,6 +9,44 @@ const refreshOpenAICodexTokenMock = vi.hoisted(() => vi.fn());
 vi.mock("./openai-codex-provider.runtime.js", () => ({
   refreshOpenAICodexToken: refreshOpenAICodexTokenMock,
 }));
+
+function runWrappedPayloadCase(params: {
+  wrap: NonNullable<ReturnType<typeof buildOpenAIProvider>["wrapStreamFn"]>;
+  provider: string;
+  modelId: string;
+  model:
+    | Model<"openai-responses">
+    | Model<"openai-codex-responses">
+    | Model<"azure-openai-responses">;
+  extraParams?: Record<string, unknown>;
+  cfg?: Record<string, unknown>;
+  payload?: Record<string, unknown>;
+}) {
+  const payload = params.payload ?? { store: false };
+  let capturedOptions: (SimpleStreamOptions & { openaiWsWarmup?: boolean }) | undefined;
+  const baseStreamFn: StreamFn = (model, _context, options) => {
+    capturedOptions = options as (SimpleStreamOptions & { openaiWsWarmup?: boolean }) | undefined;
+    options?.onPayload?.(payload, model);
+    return {} as ReturnType<StreamFn>;
+  };
+
+  const streamFn = params.wrap({
+    provider: params.provider,
+    modelId: params.modelId,
+    extraParams: params.extraParams,
+    config: params.cfg as never,
+    agentDir: "/tmp/openai-provider-test",
+    streamFn: baseStreamFn,
+  } as never);
+
+  const context: Context = { messages: [] };
+  void streamFn?.(params.model, context, {});
+
+  return {
+    payload,
+    options: capturedOptions,
+  };
+}
 
 describe("buildOpenAIProvider", () => {
   it("resolves gpt-5.4 mini and nano from GPT-5 small-model templates", () => {
@@ -218,6 +258,94 @@ describe("buildOpenAIProvider", () => {
       validateGeminiTurns: false,
       validateAnthropicTurns: false,
     });
+  });
+
+  it("owns direct OpenAI wrapper composition for responses payloads", () => {
+    const provider = buildOpenAIProvider();
+    const result = runWrappedPayloadCase({
+      wrap: provider.wrapStreamFn as NonNullable<typeof provider.wrapStreamFn>,
+      provider: "openai",
+      modelId: "gpt-5.4",
+      extraParams: {
+        fastMode: true,
+        serviceTier: "priority",
+        textVerbosity: "low",
+      },
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5.4",
+        baseUrl: "https://api.openai.com/v1",
+      } as Model<"openai-responses">,
+      payload: {
+        reasoning: { effort: "none" },
+      },
+    });
+
+    expect(result.options?.transport).toBe("auto");
+    expect(result.options?.openaiWsWarmup).toBe(false);
+    expect(result.payload.service_tier).toBe("priority");
+    expect(result.payload.text).toEqual({ verbosity: "low" });
+    expect(result.payload).not.toHaveProperty("reasoning");
+  });
+
+  it("owns Codex wrapper composition for responses payloads", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+    const result = runWrappedPayloadCase({
+      wrap: provider.wrapStreamFn as NonNullable<typeof provider.wrapStreamFn>,
+      provider: "openai-codex",
+      modelId: "gpt-5.4",
+      extraParams: {
+        fastMode: true,
+        serviceTier: "priority",
+        text_verbosity: "high",
+      },
+      cfg: {
+        auth: {
+          profiles: {
+            "openai-codex:default": {
+              provider: "openai-codex",
+              mode: "oauth",
+            },
+          },
+        },
+        tools: {
+          web: {
+            search: {
+              enabled: true,
+              openaiCodex: {
+                enabled: true,
+                mode: "live",
+                allowedDomains: ["example.com"],
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.4",
+        baseUrl: "https://chatgpt.com/backend-api",
+      } as Model<"openai-codex-responses">,
+      payload: {
+        store: false,
+        text: { verbosity: "medium" },
+        tools: [{ type: "function", name: "read" }],
+      },
+    });
+
+    expect(result.payload.store).toBe(false);
+    expect(result.payload.service_tier).toBe("priority");
+    expect(result.payload.text).toEqual({ verbosity: "high" });
+    expect(result.payload.tools).toEqual([
+      { type: "function", name: "read" },
+      {
+        type: "web_search",
+        external_web_access: true,
+        filters: { allowed_domains: ["example.com"] },
+      },
+    ]);
   });
   it("falls back to cached codex oauth credentials on accountId extraction failures", async () => {
     const provider = buildOpenAICodexProviderPlugin();

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -17,7 +17,7 @@ import {
   isOpenAIApiBaseUrl,
   matchesExactOrPrefix,
 } from "./shared.js";
-import { wrapOpenAIProviderStream } from "./stream-hooks.js";
+import { wrapAzureOpenAIProviderStream, wrapOpenAIProviderStream } from "./stream-hooks.js";
 
 const PROVIDER_ID = "openai";
 const OPENAI_GPT_54_MODEL_ID = "gpt-5.4";
@@ -239,7 +239,24 @@ export function buildOpenAIProvider(): ProviderPlugin {
       providerFamily: "openai",
     },
     buildReplayPolicy: (ctx) => buildOpenAIReplayPolicy(ctx),
-    wrapStreamFn: (ctx) => wrapOpenAIProviderStream(ctx),
+    prepareExtraParams: (ctx) => {
+      const transport = ctx.extraParams?.transport;
+      const hasSupportedTransport =
+        transport === "auto" || transport === "sse" || transport === "websocket";
+      const hasExplicitWarmup = typeof ctx.extraParams?.openaiWsWarmup === "boolean";
+      if (hasSupportedTransport && hasExplicitWarmup) {
+        return ctx.extraParams;
+      }
+      return {
+        ...ctx.extraParams,
+        ...(hasSupportedTransport ? {} : { transport: "auto" }),
+        ...(hasExplicitWarmup ? {} : { openaiWsWarmup: false }),
+      };
+    },
+    wrapStreamFn: (ctx) =>
+      normalizeProviderId(ctx.provider) === PROVIDER_ID
+        ? wrapOpenAIProviderStream(ctx)
+        : wrapAzureOpenAIProviderStream(ctx),
     supportsXHighThinking: ({ modelId }) => matchesExactOrPrefix(modelId, OPENAI_XHIGH_MODEL_IDS),
     isModernModelRef: ({ modelId }) => matchesExactOrPrefix(modelId, OPENAI_MODERN_MODEL_IDS),
     buildMissingAuthMessage: (ctx) => {

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -9,17 +9,15 @@ import {
   normalizeProviderId,
   type ProviderPlugin,
 } from "openclaw/plugin-sdk/provider-model-shared";
-import {
-  createOpenAIAttributionHeadersWrapper,
-  createOpenAIDefaultTransportWrapper,
-} from "openclaw/plugin-sdk/provider-stream";
 import { applyOpenAIConfig, OPENAI_DEFAULT_MODEL } from "./default-models.js";
+import { buildOpenAIReplayPolicy } from "./replay-policy.js";
 import {
   cloneFirstTemplateModel,
   findCatalogTemplate,
   isOpenAIApiBaseUrl,
   matchesExactOrPrefix,
 } from "./shared.js";
+import { wrapOpenAIProviderStream } from "./stream-hooks.js";
 
 const PROVIDER_ID = "openai";
 const OPENAI_GPT_54_MODEL_ID = "gpt-5.4";
@@ -240,8 +238,8 @@ export function buildOpenAIProvider(): ProviderPlugin {
     capabilities: {
       providerFamily: "openai",
     },
-    wrapStreamFn: (ctx) =>
-      createOpenAIAttributionHeadersWrapper(createOpenAIDefaultTransportWrapper(ctx.streamFn)),
+    buildReplayPolicy: (ctx) => buildOpenAIReplayPolicy(ctx),
+    wrapStreamFn: (ctx) => wrapOpenAIProviderStream(ctx),
     supportsXHighThinking: ({ modelId }) => matchesExactOrPrefix(modelId, OPENAI_XHIGH_MODEL_IDS),
     isModernModelRef: ({ modelId }) => matchesExactOrPrefix(modelId, OPENAI_MODERN_MODEL_IDS),
     buildMissingAuthMessage: (ctx) => {

--- a/extensions/openai/stream-hooks.ts
+++ b/extensions/openai/stream-hooks.ts
@@ -2,7 +2,6 @@ import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-ent
 import {
   createCodexNativeWebSearchWrapper,
   createOpenAIAttributionHeadersWrapper,
-  createOpenAIDefaultTransportWrapper,
   createOpenAIFastModeWrapper,
   createOpenAIReasoningCompatibilityWrapper,
   createOpenAIServiceTierWrapper,
@@ -41,7 +40,7 @@ function applySharedOpenAIWrappers(
 
 /** Compose the direct OpenAI wrapper chain inside the owning provider plugin. */
 export function wrapOpenAIProviderStream(ctx: ProviderWrapStreamFnContext) {
-  return applySharedOpenAIWrappers(createOpenAIDefaultTransportWrapper(ctx.streamFn), ctx);
+  return applySharedOpenAIWrappers(ctx.streamFn, ctx);
 }
 
 /** Compose the Codex-specific wrapper chain inside the owning provider plugin. */

--- a/extensions/openai/stream-hooks.ts
+++ b/extensions/openai/stream-hooks.ts
@@ -1,0 +1,50 @@
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  createCodexNativeWebSearchWrapper,
+  createOpenAIAttributionHeadersWrapper,
+  createOpenAIDefaultTransportWrapper,
+  createOpenAIFastModeWrapper,
+  createOpenAIReasoningCompatibilityWrapper,
+  createOpenAIServiceTierWrapper,
+  createOpenAITextVerbosityWrapper,
+  resolveOpenAIFastMode,
+  resolveOpenAIServiceTier,
+  resolveOpenAITextVerbosity,
+} from "openclaw/plugin-sdk/provider-stream";
+
+function applySharedOpenAIWrappers(
+  streamFn: ProviderWrapStreamFnContext["streamFn"],
+  ctx: ProviderWrapStreamFnContext,
+) {
+  let nextStreamFn = createOpenAIAttributionHeadersWrapper(streamFn);
+
+  if (resolveOpenAIFastMode(ctx.extraParams)) {
+    nextStreamFn = createOpenAIFastModeWrapper(nextStreamFn);
+  }
+
+  const serviceTier = resolveOpenAIServiceTier(ctx.extraParams);
+  if (serviceTier) {
+    nextStreamFn = createOpenAIServiceTierWrapper(nextStreamFn, serviceTier);
+  }
+
+  const textVerbosity = resolveOpenAITextVerbosity(ctx.extraParams);
+  if (textVerbosity) {
+    nextStreamFn = createOpenAITextVerbosityWrapper(nextStreamFn, textVerbosity);
+  }
+
+  nextStreamFn = createCodexNativeWebSearchWrapper(nextStreamFn, {
+    config: ctx.config,
+    agentDir: ctx.agentDir,
+  });
+  return createOpenAIReasoningCompatibilityWrapper(nextStreamFn);
+}
+
+/** Compose the direct OpenAI wrapper chain inside the owning provider plugin. */
+export function wrapOpenAIProviderStream(ctx: ProviderWrapStreamFnContext) {
+  return applySharedOpenAIWrappers(createOpenAIDefaultTransportWrapper(ctx.streamFn), ctx);
+}
+
+/** Compose the Codex-specific wrapper chain inside the owning provider plugin. */
+export function wrapOpenAICodexProviderStream(ctx: ProviderWrapStreamFnContext) {
+  return applySharedOpenAIWrappers(ctx.streamFn, ctx);
+}

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -90,14 +90,12 @@ import {
   resolveOpenAITextVerbosity,
 } from "./pi-embedded-runner/openai-stream-wrappers.js";
 
+type WrapProviderStreamFnParams = Parameters<
+  typeof import("../plugins/provider-runtime.js").wrapProviderStreamFn
+>[0];
+
 function createTestOpenAIProviderWrapper(
-  params: Parameters<
-    NonNullable<typeof extraParamsTesting.setProviderRuntimeDepsForTest>
-  >[0] extends { wrapProviderStreamFn: infer T } | undefined
-    ? T extends (params: infer P) => unknown
-      ? P
-      : never
-    : never,
+  params: WrapProviderStreamFnParams,
   withDefaultTransport: boolean,
 ): StreamFn {
   let streamFn = params.context.streamFn;

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -77,6 +77,55 @@ import {
   resolvePreparedExtraParams,
 } from "./pi-embedded-runner.js";
 import { log } from "./pi-embedded-runner/logger.js";
+import {
+  createCodexNativeWebSearchWrapper,
+  createOpenAIAttributionHeadersWrapper,
+  createOpenAIDefaultTransportWrapper,
+  createOpenAIFastModeWrapper,
+  createOpenAIReasoningCompatibilityWrapper,
+  createOpenAIServiceTierWrapper,
+  createOpenAITextVerbosityWrapper,
+  resolveOpenAIFastMode,
+  resolveOpenAIServiceTier,
+  resolveOpenAITextVerbosity,
+} from "./pi-embedded-runner/openai-stream-wrappers.js";
+
+function createTestOpenAIProviderWrapper(
+  params: Parameters<
+    NonNullable<typeof extraParamsTesting.setProviderRuntimeDepsForTest>
+  >[0] extends { wrapProviderStreamFn: infer T } | undefined
+    ? T extends (params: infer P) => unknown
+      ? P
+      : never
+    : never,
+  withDefaultTransport: boolean,
+): StreamFn {
+  let streamFn = params.context.streamFn;
+  if (withDefaultTransport) {
+    streamFn = createOpenAIDefaultTransportWrapper(streamFn);
+  }
+  streamFn = createOpenAIAttributionHeadersWrapper(streamFn);
+
+  if (resolveOpenAIFastMode(params.context.extraParams)) {
+    streamFn = createOpenAIFastModeWrapper(streamFn);
+  }
+
+  const serviceTier = resolveOpenAIServiceTier(params.context.extraParams);
+  if (serviceTier) {
+    streamFn = createOpenAIServiceTierWrapper(streamFn, serviceTier);
+  }
+
+  const textVerbosity = resolveOpenAITextVerbosity(params.context.extraParams);
+  if (textVerbosity) {
+    streamFn = createOpenAITextVerbosityWrapper(streamFn, textVerbosity);
+  }
+
+  streamFn = createCodexNativeWebSearchWrapper(streamFn, {
+    config: params.context.config,
+    agentDir: params.context.agentDir,
+  });
+  return createOpenAIReasoningCompatibilityWrapper(streamFn);
+}
 
 beforeEach(() => {
   extraParamsTesting.setProviderRuntimeDepsForTest({
@@ -94,6 +143,12 @@ beforeEach(() => {
       };
     },
     wrapProviderStreamFn: (params) => {
+      if (params.provider === "openai") {
+        return createTestOpenAIProviderWrapper(params, true);
+      }
+      if (params.provider === "openai-codex") {
+        return createTestOpenAIProviderWrapper(params, false);
+      }
       if (params.provider === "ollama") {
         return createConfiguredOllamaCompatNumCtxWrapper(params.context);
       }

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -23,17 +23,8 @@ import {
   shouldApplySiliconFlowThinkingOffCompat,
 } from "./moonshot-stream-wrappers.js";
 import {
-  createOpenAIAttributionHeadersWrapper,
-  createCodexNativeWebSearchWrapper,
-  createOpenAIDefaultTransportWrapper,
-  createOpenAIFastModeWrapper,
   createOpenAIReasoningCompatibilityWrapper,
   createOpenAIResponsesContextManagementWrapper,
-  createOpenAIServiceTierWrapper,
-  createOpenAITextVerbosityWrapper,
-  resolveOpenAIFastMode,
-  resolveOpenAIServiceTier,
-  resolveOpenAITextVerbosity,
 } from "./openai-stream-wrappers.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 
@@ -304,14 +295,6 @@ type ApplyExtraParamsContext = {
 };
 
 function applyPrePluginStreamWrappers(ctx: ApplyExtraParamsContext): void {
-  if (ctx.provider === "openai" || ctx.provider === "openai-codex") {
-    if (ctx.provider === "openai") {
-      // Default OpenAI Responses to WebSocket-first with transparent SSE fallback.
-      ctx.agent.streamFn = createOpenAIDefaultTransportWrapper(ctx.agent.streamFn);
-    }
-    ctx.agent.streamFn = createOpenAIAttributionHeadersWrapper(ctx.agent.streamFn);
-  }
-
   const wrappedStreamFn = createStreamFnWithExtraParams(
     ctx.agent.streamFn,
     ctx.effectiveExtraParams,
@@ -380,49 +363,6 @@ function applyPostPluginStreamWrappers(
     );
   }
 
-  const openAIFastMode = resolveOpenAIFastMode(ctx.effectiveExtraParams);
-  if (openAIFastMode) {
-    log.debug(`applying OpenAI fast mode for ${ctx.provider}/${ctx.modelId}`);
-    ctx.agent.streamFn = createOpenAIFastModeWrapper(ctx.agent.streamFn);
-  }
-
-  if (ctx.provider === "openai" || ctx.provider === "openai-codex") {
-    const openAIServiceTier = resolveOpenAIServiceTier(ctx.effectiveExtraParams);
-    if (openAIServiceTier) {
-      log.debug(
-        `applying OpenAI service_tier=${openAIServiceTier} for ${ctx.provider}/${ctx.modelId}`,
-      );
-      ctx.agent.streamFn = createOpenAIServiceTierWrapper(ctx.agent.streamFn, openAIServiceTier);
-    }
-
-    const rawTextVerbosity = resolveAliasedParamValue(
-      [ctx.resolvedExtraParams, ctx.override],
-      "text_verbosity",
-      "textVerbosity",
-    );
-    if (rawTextVerbosity === null) {
-      log.debug("text verbosity suppressed by null override, skipping injection");
-    } else if (rawTextVerbosity !== undefined) {
-      const openAITextVerbosity = resolveOpenAITextVerbosity({
-        text_verbosity: rawTextVerbosity,
-      });
-      if (openAITextVerbosity) {
-        log.debug(
-          `applying OpenAI text verbosity=${openAITextVerbosity} for ${ctx.provider}/${ctx.modelId}`,
-        );
-        ctx.agent.streamFn = createOpenAITextVerbosityWrapper(
-          ctx.agent.streamFn,
-          openAITextVerbosity,
-        );
-      }
-    }
-
-    ctx.agent.streamFn = createCodexNativeWebSearchWrapper(ctx.agent.streamFn, {
-      config: ctx.cfg,
-      agentDir: ctx.agentDir,
-    });
-  }
-
   // Work around upstream pi-ai hardcoding `store: false` for Responses API.
   // Force `store=true` for direct OpenAI Responses models and auto-enable
   // server-side compaction for compatible OpenAI Responses payloads.
@@ -431,12 +371,9 @@ function applyPostPluginStreamWrappers(
     ctx.effectiveExtraParams,
   );
 
-  if (
-    ctx.provider === "openai" ||
-    ctx.provider === "openai-codex" ||
-    ctx.provider === "azure-openai" ||
-    ctx.provider === "azure-openai-responses"
-  ) {
+  // Azure OpenAI does not yet have an owning provider plugin, so keep its
+  // Responses payload compatibility in core until that provider surface exists.
+  if (ctx.provider === "azure-openai" || ctx.provider === "azure-openai-responses") {
     ctx.agent.streamFn = createOpenAIReasoningCompatibilityWrapper(ctx.agent.streamFn);
   }
 

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -13,7 +13,15 @@ import type {
   IngestResult,
 } from "../../../context-engine/types.js";
 import type { EmbeddedContextFile } from "../../pi-embedded-helpers.js";
+import type { MessagingToolSend } from "../../pi-embedded-messaging.js";
 import type { WorkspaceBootstrapFile } from "../../workspace.js";
+
+type SubscribeEmbeddedPiSessionFn =
+  typeof import("../../pi-embedded-subscribe.js").subscribeEmbeddedPiSession;
+type AcquireSessionWriteLockFn =
+  typeof import("../../session-write-lock.js").acquireSessionWriteLock;
+
+type SubscriptionMock = ReturnType<SubscribeEmbeddedPiSessionFn>;
 
 const hoisted = vi.hoisted(() => {
   type BootstrapContext = {
@@ -24,23 +32,27 @@ const hoisted = vi.hoisted(() => {
   const createAgentSessionMock = vi.fn();
   const sessionManagerOpenMock = vi.fn();
   const resolveSandboxContextMock = vi.fn();
-  const subscribeEmbeddedPiSessionMock = vi.fn(() => ({
-    assistantTexts: [] as string[],
-    toolMetas: [] as Array<{ toolName: string; meta?: string }>,
-    unsubscribe: () => {},
-    waitForCompactionRetry: async () => {},
-    getMessagingToolSentTexts: () => [] as string[],
-    getMessagingToolSentMediaUrls: () => [] as string[],
-    getMessagingToolSentTargets: () => [] as unknown[],
-    getSuccessfulCronAdds: () => 0,
-    didSendViaMessagingTool: () => false,
-    didSendDeterministicApprovalPrompt: () => false,
-    getLastToolError: () => undefined,
-    getUsageTotals: () => undefined,
-    getCompactionCount: () => 0,
-    isCompacting: () => false,
-  }));
-  const acquireSessionWriteLockMock = vi.fn(async () => ({
+  const subscribeEmbeddedPiSessionMock = vi.fn<SubscribeEmbeddedPiSessionFn>(
+    (_params) =>
+      ({
+        assistantTexts: [] as string[],
+        toolMetas: [] as Array<{ toolName: string; meta?: string }>,
+        unsubscribe: () => {},
+        waitForCompactionRetry: async () => {},
+        getMessagingToolSentTexts: () => [] as string[],
+        getMessagingToolSentMediaUrls: () => [] as string[],
+        getMessagingToolSentTargets: () => [] as MessagingToolSend[],
+        getSuccessfulCronAdds: () => 0,
+        didSendViaMessagingTool: () => false,
+        didSendDeterministicApprovalPrompt: () => false,
+        getLastToolError: () => undefined,
+        getUsageTotals: () => undefined,
+        getCompactionCount: () => 0,
+        isCompacting: () => false,
+        isCompactionInFlight: () => false,
+      }) satisfies SubscriptionMock,
+  );
+  const acquireSessionWriteLockMock = vi.fn<AcquireSessionWriteLockFn>(async (_params) => ({
     release: async () => {},
   }));
   const resolveBootstrapContextForRunMock = vi.fn<() => Promise<BootstrapContext>>(async () => ({
@@ -108,8 +120,8 @@ vi.mock("../../session-tool-result-guard-wrapper.js", () => ({
 }));
 
 vi.mock("../../pi-embedded-subscribe.js", () => ({
-  subscribeEmbeddedPiSession: (...args: unknown[]) =>
-    hoisted.subscribeEmbeddedPiSessionMock(...args),
+  subscribeEmbeddedPiSession: (params: Parameters<SubscribeEmbeddedPiSessionFn>[0]) =>
+    hoisted.subscribeEmbeddedPiSessionMock(params),
 }));
 
 vi.mock("../../../plugins/hook-runner-global.js", () => ({
@@ -188,7 +200,8 @@ vi.mock("../session-manager-init.js", () => ({
 }));
 
 vi.mock("../../session-write-lock.js", () => ({
-  acquireSessionWriteLock: (...args: unknown[]) => hoisted.acquireSessionWriteLockMock(...args),
+  acquireSessionWriteLock: (params: Parameters<AcquireSessionWriteLockFn>[0]) =>
+    hoisted.acquireSessionWriteLockMock(params),
   resolveSessionLockMaxHoldFromTimeout: () => 1,
 }));
 
@@ -473,7 +486,7 @@ export type MutableSession = {
   steer: (text: string) => Promise<void>;
 };
 
-export function createSubscriptionMock() {
+export function createSubscriptionMock(): SubscriptionMock {
   return {
     assistantTexts: [] as string[],
     toolMetas: [] as Array<{ toolName: string; meta?: string }>,
@@ -481,7 +494,7 @@ export function createSubscriptionMock() {
     waitForCompactionRetry: async () => {},
     getMessagingToolSentTexts: () => [] as string[],
     getMessagingToolSentMediaUrls: () => [] as string[],
-    getMessagingToolSentTargets: () => [] as unknown[],
+    getMessagingToolSentTargets: () => [] as MessagingToolSend[],
     getSuccessfulCronAdds: () => 0,
     didSendViaMessagingTool: () => false,
     didSendDeterministicApprovalPrompt: () => false,
@@ -489,13 +502,16 @@ export function createSubscriptionMock() {
     getUsageTotals: () => undefined,
     getCompactionCount: () => 0,
     isCompacting: () => false,
+    isCompactionInFlight: () => false,
   };
 }
 
 export function resetEmbeddedAttemptHarness(
   params: {
     includeSpawnSubagent?: boolean;
-    subscribeImpl?: () => ReturnType<typeof createSubscriptionMock>;
+    subscribeImpl?: Parameters<
+      (typeof hoisted.subscribeEmbeddedPiSessionMock)["mockImplementation"]
+    >[0];
     sessionMessages?: AgentMessage[];
   } = {},
 ) {

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -20,7 +20,15 @@ export {
 } from "../agents/pi-embedded-runner/moonshot-thinking-stream-wrappers.js";
 export {
   createOpenAIAttributionHeadersWrapper,
+  createCodexNativeWebSearchWrapper,
   createOpenAIDefaultTransportWrapper,
+  createOpenAIFastModeWrapper,
+  createOpenAIReasoningCompatibilityWrapper,
+  createOpenAIServiceTierWrapper,
+  createOpenAITextVerbosityWrapper,
+  resolveOpenAIFastMode,
+  resolveOpenAIServiceTier,
+  resolveOpenAITextVerbosity,
 } from "../agents/pi-embedded-runner/openai-stream-wrappers.js";
 export { streamWithPayloadPatch } from "../agents/pi-embedded-runner/stream-payload-utils.js";
 export {

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -860,7 +860,7 @@ describe("provider-runtime", () => {
         provider: DEMO_PROVIDER_ID,
         context: createDemoResolvedModelContext({
           modelApi: MODEL.api,
-          tools: [{ name: "demo-tool" }],
+          tools: [DEMO_TOOL],
         }),
       }),
     ).toEqual([]);


### PR DESCRIPTION
## What
Finishes the stack by moving OpenAI and OpenAI Codex stream-wrapper composition into the owning provider plugin.

## Why
After the replay-policy migration and Google runtime extraction, the main remaining provider-specific wrapper selection in core is the OpenAI/Codex branch in the extra-params flow. Moving that logic into the OpenAI extension leaves core focused on generic orchestration and makes provider-owned replay/runtime behavior consistent across the stack.

## Changes
- Add provider-owned OpenAI and Codex wrapper composition
- Remove matching OpenAI and Codex branches from core extra-params flow
- Extend `provider-stream` SDK exports for plugin-owned wrapper composition
- Keep OpenAI replay policy and wrapper ownership together in the extension

## Testing
- `pnpm test -- extensions/openai/openai-provider.test.ts src/agents/pi-embedded-runner-extraparams.test.ts src/plugins/provider-runtime.test.ts`
- `pnpm build`

## Stack
Part 5 of 6.
Base branch: `oc-3c3/provider-replay-runtime-cleanup`
Previous PR: #59146 https://github.com/openclaw/openclaw/pull/59146
Next PR: #59699 https://github.com/openclaw/openclaw/pull/59699
