### PR TITLE
feat(memory): add heading-aware chunking option for improved search

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -230,6 +230,7 @@ function mergeConfig(
   const chunking = {
     tokens: overrides?.chunking?.tokens ?? defaults?.chunking?.tokens ?? DEFAULT_CHUNK_TOKENS,
     overlap: overrides?.chunking?.overlap ?? defaults?.chunking?.overlap ?? DEFAULT_CHUNK_OVERLAP,
+    headingAware: overrides?.chunking?.headingAware ?? defaults?.chunking?.headingAware ?? false,
   };
   const sync = {
     onSessionStart: overrides?.sync?.onSessionStart ?? defaults?.sync?.onSessionStart ?? true,
@@ -336,7 +337,11 @@ function mergeConfig(
     outputDimensionality,
     local,
     store,
-    chunking: { tokens: Math.max(1, chunking.tokens), overlap },
+    chunking: {
+      tokens: Math.max(1, chunking.tokens),
+      overlap,
+      headingAware: chunking.headingAware,
+    },
     sync: {
       ...sync,
       sessions: {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -834,6 +834,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Chunk size in tokens used when splitting memory sources before embedding/indexing. Increase for broader context per chunk, or lower to improve precision on pinpoint lookups.",
   "agents.defaults.memorySearch.chunking.overlap":
     "Token overlap between adjacent memory chunks to preserve context continuity near split boundaries. Use modest overlap to reduce boundary misses without inflating index size too aggressively.",
+  "agents.defaults.memorySearch.chunking.headingAware":
+    "When enabled, the chunker splits on markdown heading boundaries first before sub-chunking within sections. This keeps heading context together and improves search relevance for structured documents.",
   "agents.defaults.memorySearch.query.maxResults":
     "Maximum number of memory hits returned from search before downstream reranking and prompt injection. Raise for broader recall, or lower for tighter prompts and faster responses.",
   "agents.defaults.memorySearch.query.minScore":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -835,7 +835,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.chunking.overlap":
     "Token overlap between adjacent memory chunks to preserve context continuity near split boundaries. Use modest overlap to reduce boundary misses without inflating index size too aggressively.",
   "agents.defaults.memorySearch.chunking.headingAware":
-    "When enabled, the chunker splits on markdown heading boundaries first before sub-chunking within sections. This keeps heading context together and improves search relevance for structured documents.",
+    "When enabled, the chunker splits on level-2 and level-3 markdown headings (##, ###) before falling back to token-based splitting. This keeps heading-delimited sections as discrete chunks, improving retrieval precision for structured memory files (e.g., per-contact headings in people.md). Files without headings behave exactly as today.",
   "agents.defaults.memorySearch.query.maxResults":
     "Maximum number of memory hits returned from search before downstream reranking and prompt injection. Raise for broader recall, or lower for tighter prompts and faster responses.",
   "agents.defaults.memorySearch.query.minScore":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -343,6 +343,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.store.vector.extensionPath": "Memory Search Vector Extension Path",
   "agents.defaults.memorySearch.chunking.tokens": "Memory Chunk Tokens",
   "agents.defaults.memorySearch.chunking.overlap": "Memory Chunk Overlap Tokens",
+  "agents.defaults.memorySearch.chunking.headingAware": "Memory Heading-Aware Chunking",
   "agents.defaults.memorySearch.sync.onSessionStart": "Index on Session Start",
   "agents.defaults.memorySearch.sync.onSearch": "Index on Search (Lazy)",
   "agents.defaults.memorySearch.sync.watch": "Watch Memory Files",

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -671,6 +671,7 @@ export const MemorySearchSchema = z
       .object({
         tokens: z.number().int().positive().optional(),
         overlap: z.number().int().nonnegative().optional(),
+        headingAware: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -333,7 +333,7 @@ export async function buildMultimodalChunkForIndexing(
 
 export function chunkMarkdown(
   content: string,
-  chunking: { tokens: number; overlap: number },
+  chunking: { tokens: number; overlap: number; headingAware?: boolean },
 ): MemoryChunk[] {
   const lines = content.split("\n");
   if (lines.length === 0) {
@@ -342,6 +342,12 @@ export function chunkMarkdown(
   const maxChars = Math.max(32, chunking.tokens * 4);
   const overlapChars = Math.max(0, chunking.overlap * 4);
   const chunks: MemoryChunk[] = [];
+  const headingAware = chunking.headingAware ?? false;
+
+  // Helper to detect markdown headings
+  const isHeading = (line: string): boolean => {
+    return /^#{1,6}\s+/.test(line.trim());
+  };
 
   let current: Array<{ line: string; lineNo: number }> = [];
   let currentChars = 0;
@@ -393,6 +399,13 @@ export function chunkMarkdown(
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? "";
     const lineNo = i + 1;
+
+    // Heading-aware: flush on heading (unless it's the first heading)
+    if (headingAware && isHeading(line) && current.length > 0) {
+      flush();
+      carryOverlap();
+    }
+
     const segments: string[] = [];
     if (line.length === 0) {
       segments.push("");

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -344,9 +344,9 @@ export function chunkMarkdown(
   const chunks: MemoryChunk[] = [];
   const headingAware = chunking.headingAware ?? false;
 
-  // Helper to detect markdown headings
+  // Helper to detect markdown section headings (## and ### level)
   const isHeading = (line: string): boolean => {
-    return /^#{1,6}\s+/.test(line.trim());
+    return /^#{2,3}\s+/.test(line.trim());
   };
 
   let current: Array<{ line: string; lineNo: number }> = [];

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -59,6 +59,7 @@ type MemoryIndexMeta = {
   scopeHash?: string;
   chunkTokens: number;
   chunkOverlap: number;
+  chunkHeadingAware?: boolean;
   vectorDims?: number;
 };
 
@@ -1002,6 +1003,7 @@ export abstract class MemoryManagerSyncOps {
       meta.scopeHash !== configuredScopeHash ||
       meta.chunkTokens !== this.settings.chunking.tokens ||
       meta.chunkOverlap !== this.settings.chunking.overlap ||
+      meta.chunkHeadingAware !== this.settings.chunking.headingAware ||
       (vectorReady && !meta?.vectorDims);
     try {
       if (needsFullReindex) {
@@ -1221,6 +1223,7 @@ export abstract class MemoryManagerSyncOps {
         scopeHash: this.resolveConfiguredScopeHash(),
         chunkTokens: this.settings.chunking.tokens,
         chunkOverlap: this.settings.chunking.overlap,
+        chunkHeadingAware: this.settings.chunking.headingAware ?? false,
       };
       if (!nextMeta) {
         throw new Error("Failed to compute memory index metadata for reindexing.");
@@ -1293,6 +1296,7 @@ export abstract class MemoryManagerSyncOps {
       scopeHash: this.resolveConfiguredScopeHash(),
       chunkTokens: this.settings.chunking.tokens,
       chunkOverlap: this.settings.chunking.overlap,
+      chunkHeadingAware: this.settings.chunking.headingAware ?? false,
     };
     if (this.vector.available && this.vector.dims) {
       nextMeta.vectorDims = this.vector.dims;


### PR DESCRIPTION
Introduces a `headingAware` config option in memory search chunking that preserves markdown heading structure during text chunking. Instead of splitting purely by token count, the chunker splits on heading boundaries first, then sub-chunks within sections.

- Add `headingAware` boolean to chunking config schema and merge logic
- `chunkMarkdown()` flushes current chunk on heading lines when enabled
- Track `chunkHeadingAware` in `MemoryIndexMeta` for reindex detection
- Add config label and help text for the new option

Closes #45545