### PR TITLE
fix(telegram): enable update dedup to prevent webhook retries

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -59,6 +59,8 @@ import {
   MEDIA_GROUP_TIMEOUT_MS,
   type MediaGroupEntry,
   type TelegramUpdateKeyContext,
+  createTelegramUpdateDedupe,
+  buildTelegramUpdateKey,
 } from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.js";
 import {
@@ -117,6 +119,7 @@ export const registerTelegramHandlers = ({
   logger,
   telegramDeps = defaultTelegramBotDeps,
 }: RegisterTelegramHandlerParams) => {
+  const updateDedupe = createTelegramUpdateDedupe();
   const DEFAULT_TEXT_FRAGMENT_MAX_GAP_MS = 1500;
   const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = 4000;
   const TELEGRAM_TEXT_FRAGMENT_MAX_GAP_MS =
@@ -1676,9 +1679,16 @@ export const registerTelegramHandlers = ({
     oversizeLogMessage: string;
     errorMessage: string;
   };
-
   const handleInboundMessageLike = async (event: InboundTelegramEvent) => {
     try {
+      // === Telegram inbound deduplication ===
+      const dedupeKey = buildTelegramUpdateKey(event.ctxForDedupe);
+      if (dedupeKey && updateDedupe.check(dedupeKey)) {
+        logVerbose(`[telegram] Duplicate update detected (${dedupeKey}), skipping`);
+        return;
+      }
+      // ======================================
+
       if (shouldSkipUpdate(event.ctxForDedupe)) {
         return;
       }


### PR DESCRIPTION
## Summary
Fix Telegram webhook duplication when gateway is slow to respond by enabling existing update deduplication.

## Problem
When the OpenClaw gateway is slow to respond (e.g., due to LLM rate limits), Telegram retries webhook deliveries using the same `update_id`. The Telegram plugin currently processes each retry as a new update, causing:
- 100–300+ duplicate message ingestions
- Token waste and inflated costs
- Context pollution and confused agent behavior

This matches the “inbound deduplication” scenario described in the docs, but the Telegram plugin did not implement the recommended deduplication.

## Solution
Reuse the existing `createTelegramUpdateDedupe` and `buildTelegramUpdateKey` utilities from `bot-updates.ts`:
- Add dedup check at the entry point of `handleInboundMessageLike`
- Use Telegram `update_id` as dedup key (correct for retry detection)
- In-memory LRU cache with 5 min TTL, no external dependencies

## Changes
- `extensions/telegram/src/bot-handlers.runtime.ts`
  - Import `createTelegramUpdateDedupe`, `buildTelegramUpdateKey`
  - Create `updateDedupe` instance per bot account
  - Early return for duplicate updates with log

Fixes #59113