### PR TITLE
fix: add type guard for cred.key/cred.token before calling .trim()

### DIFF
--- a/extensions/cloudflare-ai-gateway/index.ts
+++ b/extensions/cloudflare-ai-gateway/index.ts
@@ -37,7 +37,7 @@ function resolveApiKeyFromCredential(
       ? keyRef.id.trim()
       : resolveNonEnvSecretRefApiKeyMarker(keyRef.source);
   }
-  return cred.key?.trim() || undefined;
+  return typeof cred.key === "string" ? cred.key.trim() : undefined;
 }
 
 function resolveMetadataFromCredential(

--- a/src/agents/models-config.providers.secrets.ts
+++ b/src/agents/models-config.providers.secrets.ts
@@ -131,7 +131,7 @@ export function resolveApiKeyFromCredential(
         source: "non-env-ref",
       };
     }
-    if (cred.key?.trim()) {
+    if (typeof cred.key === "string" && cred.key.trim()) {
       return {
         apiKey: cred.key,
         source: "plaintext",
@@ -156,7 +156,7 @@ export function resolveApiKeyFromCredential(
         source: "non-env-ref",
       };
     }
-    if (cred.token?.trim()) {
+    if (typeof cred.token === "string" && cred.token.trim()) {
       return {
         apiKey: cred.token,
         source: "plaintext",


### PR DESCRIPTION
## Problem

When an `api_key` credential uses a SecretRef object (e.g., `{source: "env", provider: "default", id: "MY_API_KEY"}`) instead of a plain string, the gateway crashes on startup with:

```
TypeError: cred.key?.trim is not a function
```

or:

```
TypeError: cred.token?.trim is not a function
```

This happens in `resolveApiKeyFromCredential()` in two files:

- `src/agents/models-config.providers.secrets.ts` (lines 134, 159)
- `extensions/cloudflare-ai-gateway/index.ts` (line 40)

The `.trim()` call assumes `cred.key` / `cred.token` is always a string, but with SecretRef support (introduced in v2026.3.28), these fields can be object references.

The bug is latent — the code has been present since v2026.3.28 but only triggers when credential values are SecretRef objects rather than plain strings.

## Root Cause

`resolveApiKeyFromCredential()` does:

```ts
if (cred.key?.trim()) {   // crashes when cred.key is {source, provider, id}
```

Other files already guard against this (e.g., `pi-model-discovery`, `provider-usage`):

```ts
if (typeof cred.key === "string" && cred.key.trim()) {  // safe
```

The models-config and cloudflare-ai-gateway files were missed in the original SecretRef integration.

## Fix

Add `typeof` guards before `.trim()` calls — 3 lines, 2 files:

**`src/agents/models-config.providers.secrets.ts:134`**
```ts
- if (cred.key?.trim()) {
+ if (typeof cred.key === "string" && cred.key.trim()) {
```

**`src/agents/models-config.providers.secrets.ts:159`**
```ts
- if (cred.token?.trim()) {
+ if (typeof cred.token === "string" && cred.token.trim()) {
```

**`extensions/cloudflare-ai-gateway/index.ts:40`**
```ts
- return cred.key?.trim() || undefined;
+ return typeof cred.key === "string" ? cred.key.trim() : undefined;
```

## Testing

Verified on v2026.3.31 (ARM64/Linux) — gateway starts successfully with SecretRef-formatted `key` and `token` credentials. Greptile AI review: 5/5 confidence, safe to merge.

## Related

- #34335 — normalizeProviders leaks plaintext API keys into models.json for exec-source SecretRefs
