### PR TITLE
feat(discord): expose sender client status in conversation metadata

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -50,6 +50,7 @@ import {
   resolveForwardedMediaList,
   resolveMediaList,
 } from "./message-utils.js";
+import { getPresence } from "./presence-cache.js";
 import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-context.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
 import { resolveDiscordAutoThreadReplyPlan, resolveDiscordThreadStarter } from "./threading.js";
@@ -248,6 +249,17 @@ export async function processDiscordMessage(
     ? (sender.tag ?? sender.name ?? author.username)
     : author.username;
   const senderTag = sender.tag;
+  // Resolve sender's Discord client status from the presence cache.
+  // Requires GuildPresences intent to be enabled (channels.discord.intents.presence: true).
+  const senderPresence = getPresence(accountId, sender.id);
+  const senderClientStatus = senderPresence?.client_status
+    ? {
+        desktop: senderPresence.client_status.desktop ?? undefined,
+        mobile: senderPresence.client_status.mobile ?? undefined,
+        web: senderPresence.client_status.web ?? undefined,
+      }
+    : undefined;
+
   const { groupSystemPrompt, ownerAllowFrom, untrustedContext } = buildDiscordInboundAccessContext({
     channelConfig,
     guildInfo,
@@ -395,6 +407,7 @@ export async function processDiscordMessage(
     SenderId: sender.id,
     SenderUsername: senderUsername,
     SenderTag: senderTag,
+    SenderClientStatus: senderClientStatus,
     GroupSubject: groupSubject,
     GroupChannel: groupChannel,
     UntrustedContext: untrustedContext,

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -117,6 +117,7 @@ export function buildInboundUserContextPrefix(
       Array.isArray(ctx.InboundHistory) && ctx.InboundHistory.length > 0
         ? ctx.InboundHistory.length
         : undefined,
+    sender_client_status: ctx.SenderClientStatus ?? undefined,
   };
   if (Object.values(conversationInfo).some((v) => v !== undefined)) {
     blocks.push(

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -137,6 +137,15 @@ export type MsgContext = {
   SenderId?: string;
   SenderUsername?: string;
   SenderTag?: string;
+  /**
+   * Discord client status of the sender (desktop/mobile/web).
+   * Populated from the Discord presence cache when the GuildPresences intent is enabled.
+   */
+  SenderClientStatus?: {
+    desktop?: string;
+    mobile?: string;
+    web?: string;
+  };
   SenderE164?: string;
   Timestamp?: number;
   /** Provider label (e.g. whatsapp, telegram). */


### PR DESCRIPTION
## Summary

- Reads the sender's Discord presence from the existing presence cache (`getPresence()`) during inbound message processing
- Adds `SenderClientStatus` field to `MsgContext` with `desktop`, `mobile`, and `web` status values
- Includes `sender_client_status` in the conversation info (user-role) metadata block, keeping the system-prompt `inbound_meta` cache-stable
- Requires `GuildPresences` intent (`channels.discord.intents.presence: true`); gracefully omits the field when presence data is unavailable

## Motivation

Agents currently have no way to know whether a Discord user is messaging from desktop, mobile, or web. This makes it impossible to adapt response format — for example, opening a file in VS Code when the user is at their desktop vs. pasting content inline when they're on their phone.

The presence cache and `GuildPresences` intent support already exist in the Discord extension. This PR simply wires the cached `client_status` into the inbound context so agents can see it.

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/templating.ts` | Add `SenderClientStatus` to `MsgContext` type |
| `src/auto-reply/reply/inbound-meta.ts` | Include `sender_client_status` in conversation info block |
| `extensions/discord/src/monitor/message-handler.process.ts` | Import `getPresence`, resolve client status, pass to `ctxPayload` |

## Example output

When presence data is available, the conversation info block will include:

```json
{
  "sender_client_status": {
    "desktop": "online",
    "mobile": "offline"
  }
}
```

## Test plan

- [ ] Enable `channels.discord.intents.presence: true` in config
- [ ] Send a message from Discord desktop — verify `sender_client_status.desktop` is `"online"`
- [ ] Send from Discord mobile — verify `sender_client_status.mobile` is `"online"`
- [ ] Disable presence intent — verify field is omitted (no errors)
- [ ] Verify no change to `inbound_meta` system prompt (cache stability)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)