### PR TITLE
fix(infra): align env key normalization in approval binding path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Google: separate OAuth CSRF state from PKCE code verifier during Gemini browser sign-in so state validation and token exchange use independent values. (#59116) Thanks @eleqtrizit.
 - Exec/Windows: reject malformed drive-less rooted executable paths like `:\Users\...` so approval and allowlist candidate resolution no longer treat them as cwd-relative commands. (#58040) Thanks @SnowSky1.
 - Exec/preflight: fail closed on complex interpreter invocations that would otherwise skip script-content validation, and correctly inspect quoted script paths before host execution. Thanks @pgondhi987.
+- Exec/Windows: include Windows-compatible env override keys like `ProgramFiles(x86)` in system-run approval binding so changed approved values are rejected instead of silently passing unbound. (#59182) Thanks @pgondhi987.
 
 ## 2026.4.2-beta.1
 

--- a/extensions/discord/src/components.ts
+++ b/extensions/discord/src/components.ts
@@ -24,16 +24,10 @@ import {
 } from "@buape/carbon";
 import { ButtonStyle, MessageFlags, TextInputStyle } from "discord-api-types/v10";
 import {
-  DISCORD_COMPONENT_CUSTOM_ID_KEY,
-  DISCORD_MODAL_CUSTOM_ID_KEY,
   buildDiscordComponentCustomId as buildDiscordComponentCustomIdImpl,
   buildDiscordModalCustomId as buildDiscordModalCustomIdImpl,
-  parseDiscordComponentCustomId,
-  parseDiscordComponentCustomIdForCarbon,
-  parseDiscordModalCustomId,
   parseDiscordModalCustomIdForCarbon as parseDiscordModalCustomIdForCarbonImpl,
 } from "./component-custom-id.js";
-export { buildDiscordComponentCustomId, buildDiscordModalCustomId } from "./component-custom-id.js";
 // Some test-only module graphs partially mock `@buape/carbon` and can drop `Modal`.
 // Keep dynamic form definitions loadable instead of crashing unrelated suites.
 const ModalBase: typeof Modal = (Modal ?? class {}) as typeof Modal;

--- a/extensions/discord/src/components.ts
+++ b/extensions/discord/src/components.ts
@@ -24,8 +24,13 @@ import {
 } from "@buape/carbon";
 import { ButtonStyle, MessageFlags, TextInputStyle } from "discord-api-types/v10";
 import {
+  DISCORD_COMPONENT_CUSTOM_ID_KEY,
+  DISCORD_MODAL_CUSTOM_ID_KEY,
   buildDiscordComponentCustomId as buildDiscordComponentCustomIdImpl,
   buildDiscordModalCustomId as buildDiscordModalCustomIdImpl,
+  parseDiscordComponentCustomId,
+  parseDiscordComponentCustomIdForCarbon,
+  parseDiscordModalCustomId,
   parseDiscordModalCustomIdForCarbon as parseDiscordModalCustomIdForCarbonImpl,
 } from "./component-custom-id.js";
 export { buildDiscordComponentCustomId, buildDiscordModalCustomId } from "./component-custom-id.js";

--- a/extensions/discord/src/components.ts
+++ b/extensions/discord/src/components.ts
@@ -28,6 +28,7 @@ import {
   buildDiscordModalCustomId as buildDiscordModalCustomIdImpl,
   parseDiscordModalCustomIdForCarbon as parseDiscordModalCustomIdForCarbonImpl,
 } from "./component-custom-id.js";
+export { buildDiscordComponentCustomId, buildDiscordModalCustomId } from "./component-custom-id.js";
 // Some test-only module graphs partially mock `@buape/carbon` and can drop `Modal`.
 // Keep dynamic form definitions loadable instead of crashing unrelated suites.
 const ModalBase: typeof Modal = (Modal ?? class {}) as typeof Modal;

--- a/extensions/discord/src/monitor/agent-components.wildcard.test.ts
+++ b/extensions/discord/src/monitor/agent-components.wildcard.test.ts
@@ -1,7 +1,7 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 
-let buildDiscordComponentCustomId: typeof import("../component-custom-id.js").buildDiscordComponentCustomId;
-let buildDiscordModalCustomId: typeof import("../component-custom-id.js").buildDiscordModalCustomId;
+let buildDiscordComponentCustomId: typeof import("../components.js").buildDiscordComponentCustomId;
+let buildDiscordModalCustomId: typeof import("../components.js").buildDiscordModalCustomId;
 let createDiscordComponentButton: typeof import("./agent-components.js").createDiscordComponentButton;
 let createDiscordComponentChannelSelect: typeof import("./agent-components.js").createDiscordComponentChannelSelect;
 let createDiscordComponentMentionableSelect: typeof import("./agent-components.js").createDiscordComponentMentionableSelect;
@@ -11,8 +11,7 @@ let createDiscordComponentStringSelect: typeof import("./agent-components.js").c
 let createDiscordComponentUserSelect: typeof import("./agent-components.js").createDiscordComponentUserSelect;
 
 beforeAll(async () => {
-  ({ buildDiscordComponentCustomId, buildDiscordModalCustomId } =
-    await import("../component-custom-id.js"));
+  ({ buildDiscordComponentCustomId, buildDiscordModalCustomId } = await import("../components.js"));
   ({
     createDiscordComponentButton,
     createDiscordComponentChannelSelect,

--- a/src/gateway/node-invoke-system-run-approval-match.test.ts
+++ b/src/gateway/node-invoke-system-run-approval-match.test.ts
@@ -123,6 +123,32 @@ describe("evaluateSystemRunApprovalMatch", () => {
     expect(result).toEqual({ ok: true });
   });
 
+  test("rejects mismatched Windows-compatible env override values", () => {
+    const result = evaluateSystemRunApprovalMatch({
+      argv: ["cmd.exe", "/c", "echo ok"],
+      request: {
+        host: "node",
+        command: "cmd.exe /c echo ok",
+        systemRunBinding: buildSystemRunApprovalBinding({
+          argv: ["cmd.exe", "/c", "echo ok"],
+          cwd: null,
+          agentId: null,
+          sessionKey: null,
+          env: { "ProgramFiles(x86)": "C:\\Program Files (x86)" },
+        }).binding,
+      },
+      binding: {
+        ...defaultBinding,
+        env: { "ProgramFiles(x86)": "D:\\malicious" },
+      },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("unreachable");
+    }
+    expect(result.code).toBe("APPROVAL_ENV_MISMATCH");
+  });
+
   test("rejects non-node host requests", () => {
     const result = evaluateSystemRunApprovalMatch({
       argv: ["echo", "SAFE"],

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -656,6 +656,37 @@ describe("exec approval handlers", () => {
     );
   });
 
+  it("includes Windows-compatible env keys in approval env bindings", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+    await requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: {
+        timeoutMs: 10,
+        commandArgv: ["cmd.exe", "/c", "echo", "ok"],
+        command: "cmd.exe /c echo ok",
+        env: {
+          "ProgramFiles(x86)": "C:\\Program Files (x86)",
+        },
+      },
+    });
+    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
+    expect(requested).toBeTruthy();
+    const request = (requested?.payload as { request?: Record<string, unknown> })?.request ?? {};
+    const envBinding = buildSystemRunApprovalEnvBinding({
+      "ProgramFiles(x86)": "C:\\Program Files (x86)",
+    });
+    expect(request["envKeys"]).toEqual(envBinding.envKeys);
+    expect(request["systemRunBinding"]).toEqual(
+      buildSystemRunApprovalBinding({
+        argv: ["cmd.exe", "/c", "echo", "ok"],
+        cwd: "/tmp",
+        env: { "ProgramFiles(x86)": "C:\\Program Files (x86)" },
+      }).binding,
+    );
+  });
+
   it("stores sorted env keys for gateway approvals without node-only binding", async () => {
     const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
     await requestExecApproval({

--- a/src/infra/host-env-security.ts
+++ b/src/infra/host-env-security.ts
@@ -68,7 +68,7 @@ export function normalizeEnvVarKey(
   return key;
 }
 
-function normalizeHostOverrideEnvVarKey(rawKey: string): string | null {
+export function normalizeHostOverrideEnvVarKey(rawKey: string): string | null {
   const key = normalizeEnvVarKey(rawKey);
   if (!key) {
     return null;

--- a/src/infra/system-run-approval-binding.test.ts
+++ b/src/infra/system-run-approval-binding.test.ts
@@ -117,6 +117,19 @@ describe("buildSystemRunApprovalEnvBinding", () => {
       envKeys: [],
     });
   });
+
+  it("includes Windows-compatible override keys in env binding", () => {
+    const base = buildSystemRunApprovalEnvBinding({
+      "ProgramFiles(x86)": "C:\\Program Files (x86)",
+    });
+    const changed = buildSystemRunApprovalEnvBinding({
+      "ProgramFiles(x86)": "D:\\SDKs",
+    });
+
+    expect(base.envKeys).toEqual(["ProgramFiles(x86)"]);
+    expect(base.envHash).toBeTypeOf("string");
+    expect(base.envHash).not.toEqual(changed.envHash);
+  });
 });
 
 describe("buildSystemRunApprovalBinding", () => {
@@ -173,6 +186,20 @@ describe("matchSystemRunApprovalEnvHash", () => {
         code: "APPROVAL_ENV_BINDING_MISSING",
         message: "approval id missing env binding for requested env overrides",
         details: { envKeys: ["ALPHA"] },
+      },
+    },
+    {
+      name: "reports missing approval env binding when actual env keys are present without hashes",
+      params: {
+        expectedEnvHash: null,
+        actualEnvHash: null,
+        actualEnvKeys: ["ProgramFiles(x86)"],
+      },
+      expected: {
+        ok: false,
+        code: "APPROVAL_ENV_BINDING_MISSING",
+        message: "approval id missing env binding for requested env overrides",
+        details: { envKeys: ["ProgramFiles(x86)"] },
       },
     },
     {

--- a/src/infra/system-run-approval-binding.ts
+++ b/src/infra/system-run-approval-binding.ts
@@ -4,7 +4,7 @@ import type {
   SystemRunApprovalFileOperand,
   SystemRunApprovalPlan,
 } from "./exec-approvals.js";
-import { normalizeEnvVarKey } from "./host-env-security.js";
+import { normalizeHostOverrideEnvVarKey } from "./host-env-security.js";
 import { normalizeNonEmptyString, normalizeStringArray } from "./system-run-normalize.js";
 
 type NormalizedSystemRunEnvEntry = [key: string, value: string];
@@ -75,7 +75,7 @@ function normalizeSystemRunEnvEntries(env: unknown): NormalizedSystemRunEnvEntry
     if (typeof rawValue !== "string") {
       continue;
     }
-    const key = normalizeEnvVarKey(rawKey, { portable: true });
+    const key = normalizeHostOverrideEnvVarKey(rawKey);
     if (!key) {
       continue;
     }
@@ -162,6 +162,16 @@ export function matchSystemRunApprovalEnvHash(params: {
   actualEnvHash: string | null;
   actualEnvKeys: string[];
 }): SystemRunApprovalMatchResult {
+  // Fail closed if callers provide inconsistent hash/key state. This guards against
+  // normalization drift between approval and execution paths.
+  if (!params.expectedEnvHash && !params.actualEnvHash && params.actualEnvKeys.length > 0) {
+    return {
+      ok: false,
+      code: "APPROVAL_ENV_BINDING_MISSING",
+      message: "approval id missing env binding for requested env overrides",
+      details: { envKeys: params.actualEnvKeys },
+    };
+  }
   if (!params.expectedEnvHash && !params.actualEnvHash) {
     return { ok: true };
   }

--- a/test/fixtures/system-run-approval-binding-contract.json
+++ b/test/fixtures/system-run-approval-binding-contract.json
@@ -49,6 +49,30 @@
       "expected": { "ok": false, "code": "APPROVAL_ENV_MISMATCH" }
     },
     {
+      "name": "binding rejects mismatched Windows-compatible env values",
+      "request": {
+        "host": "node",
+        "command": "cmd.exe /c echo ok",
+        "binding": {
+          "argv": ["cmd.exe", "/c", "echo", "ok"],
+          "cwd": null,
+          "agentId": null,
+          "sessionKey": null,
+          "env": { "ProgramFiles(x86)": "C:\\Program Files (x86)" }
+        }
+      },
+      "invoke": {
+        "argv": ["cmd.exe", "/c", "echo", "ok"],
+        "binding": {
+          "cwd": null,
+          "agentId": null,
+          "sessionKey": null,
+          "env": { "ProgramFiles(x86)": "D:\\malicious" }
+        }
+      },
+      "expected": { "ok": false, "code": "APPROVAL_ENV_MISMATCH" }
+    },
+    {
       "name": "binding rejects unbound env overrides",
       "request": {
         "host": "node",


### PR DESCRIPTION
## Summary

- **Problem:** Environment variable keys using Windows-compatible naming (e.g. `ProgramFiles(x86)`) were silently dropped during approval binding hash computation because the approval path used portable-only normalization, while the execution path accepted these keys.
- **Why it matters:** This created a fail-open condition: an approved env override with a Windows-compatible key would produce `envHash = null`, allowing a different value for that key to pass at execution time undetected.
- **What changed:** `normalizeSystemRunEnvEntries` in `system-run-approval-binding.ts` now uses `normalizeHostOverrideEnvVarKey` (which accepts Windows-compatible keys) instead of `normalizeEnvVarKey(..., { portable: true })`, aligning the approval binding hash with the execution sanitization path. Added a fail-closed guard in `matchSystemRunApprovalEnvHash` for the inconsistent-state case. Exported `normalizeHostOverrideEnvVarKey` from `host-env-security.ts`.
- **What did NOT change:** No changes to the execution path, the allowed key set, the approval UI, or any unrelated normalization logic.

> 🤖 AI-assisted PR

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [x] API / contracts

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** `normalizeSystemRunEnvEntries` used `normalizeEnvVarKey(rawKey, { portable: true })` which applies `PORTABLE_ENV_VAR_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/`, discarding keys with parentheses. Meanwhile `sanitizeHostEnvOverridesWithDiagnostics` (the execution path) already used `normalizeHostOverrideEnvVarKey`, which additionally accepts `WINDOWS_COMPAT_OVERRIDE_ENV_VAR_KEY = /^[A-Za-z_][A-Za-z0-9_()]*$/`.
- **Missing detection / guardrail:** No test covered Windows-compatible env key names in the approval binding roundtrip.
- **Prior context:** The two normalization functions diverged when Windows-compatible key support was added to the execution path without updating the approval binding path.
- **Why this regressed now:** The mismatch was latent; no test exercised keys with parentheses in the approval hash path.
- **If unknown, what was ruled out:** N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `src/infra/system-run-approval-binding.test.ts`, `src/gateway/node-invoke-system-run-approval-match.test.ts`, `src/gateway/server-methods/server-methods.test.ts`
- Scenario the test should lock in: Windows-compatible env keys (`ProgramFiles(x86)`) are included in approval binding hash and mismatch is detected at execution time.
- Why this is the smallest reliable guardrail: Unit tests directly exercise the normalization and matching functions; server-methods test verifies the broadcast payload includes correct env binding.
- Existing test that already covers this (if any): None — new tests added.

## User-visible / Behavior Changes

On Windows, env override approvals that include keys like `ProgramFiles(x86)` are now correctly bound and verified. Previously these keys were silently dropped from the approval hash, allowing undetected value substitution.

## Diagram (if applicable)

```text
Before:
approval path: ProgramFiles(x86) -> dropped -> envHash=null
exec path:     ProgramFiles(x86) -> accepted -> injected into env
match:         null == null -> ok (bypass)

After:
approval path: ProgramFiles(x86) -> accepted -> envHash=<hash>
exec path:     ProgramFiles(x86) -> accepted -> envHash=<hash>
match:         hash == hash -> ok (or mismatch if values differ -> rejected)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — Windows-compatible env keys are now included in the approval binding hash, so mismatched values are rejected rather than silently passed.
- Data access scope changed? No
- **Risk + mitigation:** The change is strictly more restrictive: previously valid bypass is now correctly rejected. No legitimate use case is broken since both approval and execution paths now use the same normalization.

## Repro + Verification

### Environment

- OS: Linux (CI), Windows-targeting code path
- Runtime/container: Node 22 / Bun
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: N/A

### Steps

1. Create env override with key `ProgramFiles(x86)`.
2. Build approval binding — observe key is now included in `envKeys` and `envHash` is non-null.
3. Attempt to match with a different value for `ProgramFiles(x86)` — observe `APPROVAL_ENV_MISMATCH` returned.

### Expected

- `envKeys` contains `ProgramFiles(x86)`
- `envHash` is non-null
- Mismatched value returns `{ ok: false, code: "APPROVAL_ENV_MISMATCH" }`

### Actual

- All three assertions pass with the fix applied.

## Evidence

- [x] Failing test/log before + passing after — new tests in `system-run-approval-binding.test.ts`, `node-invoke-system-run-approval-match.test.ts`, `server-methods.test.ts`, and `system-run-approval-binding-contract.json` cover the before/after behavior.

## Human Verification (required)

- **Verified scenarios:** Normalization alignment across approval and execution paths; fail-closed guard for inconsistent hash/key state; contract fixture updated.
- **Edge cases checked:** Keys with no parentheses unaffected; empty env still produces `envHash = null`.
- **What you did not verify:** Live Windows runtime execution.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — purely more restrictive; no API surface changes.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** Existing approvals with `ProgramFiles(x86)` keys that were previously hashed as null will now produce a non-null hash, requiring re-approval.
  - **Mitigation:** This is the correct behavior. Any prior approval that silently dropped these keys was under-scoped; re-approval is the safe outcome.