### PR TITLE
[Fix] Remove spurious plugin id mismatch warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Ollama: prefer real cloud auth credentials over the local-only marker so Ollama instances behind authenticated proxies use the configured API key instead of skipping auth.
 - Plugins/Kimi Coding: parse tagged Kimi tool-call text into structured tool calls on the provider stream path so tools execute instead of echoing raw markup. (#60051) Thanks @obviyus.
 - Channels: emit passive message hooks for mention-skipped Telegram and Signal group messages when `ingest` is enabled, including wildcard/default fallback and per-group override handling. (#60018) Thanks @obviyus.
+- Plugins/manifest registry: stop warning when an explicit manifest `id` intentionally differs from the discovery hint. (#59185) Thanks @samzong.
 
 ## 2026.4.2
 

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -634,32 +634,7 @@ describe("loadPluginManifestRegistry", () => {
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
   });
 
-  it.each([
-    { name: "provider-style", manifestId: "openai", idHint: "openai-provider" },
-    { name: "plugin-style", manifestId: "brave", idHint: "brave-plugin" },
-    { name: "sandbox-style", manifestId: "openshell", idHint: "openshell-sandbox" },
-    { name: "multi-entry-style", manifestId: "matrix", idHint: "matrix/index" },
-    {
-      name: "media-understanding-style",
-      manifestId: "groq",
-      idHint: "groq-media-understanding",
-    },
-  ] as const)("accepts $name id hints without warning", ({ manifestId, idHint }) => {
-    const dir = makeTempDir();
-    writeManifest(dir, { id: manifestId, configSchema: { type: "object" } });
-
-    expect(
-      hasPluginIdMismatchWarning(
-        loadSingleCandidateRegistry({
-          idHint,
-          rootDir: dir,
-          origin: "bundled",
-        }),
-      ),
-    ).toBe(false);
-  });
-
-  it("still warns for unrelated id hint mismatches", () => {
+  it("does not warn for id hint mismatches when manifest id is authoritative", () => {
     const dir = makeTempDir();
     writeManifest(dir, { id: "openai", configSchema: { type: "object" } });
 
@@ -671,13 +646,7 @@ describe("loadPluginManifestRegistry", () => {
       }),
     ]);
 
-    expect(
-      registry.diagnostics.some((diag) =>
-        diag.message.includes(
-          'plugin id mismatch (manifest uses "openai", entry hints "totally-different")',
-        ),
-      ),
-    ).toBe(true);
+    expect(hasPluginIdMismatchWarning(registry)).toBe(false);
   });
 
   it.each([

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -187,26 +187,6 @@ function mergePackageChannelMetaIntoChannelConfigs(params: {
   };
 }
 
-function isCompatiblePluginIdHint(idHint: string | undefined, manifestId: string): boolean {
-  const normalizedHint = idHint?.trim();
-  if (!normalizedHint) {
-    return true;
-  }
-  if (normalizedHint === manifestId) {
-    return true;
-  }
-  // Generated idHint for multi-extension plugins takes the form "id/entryBase".
-  if (normalizedHint.startsWith(`${manifestId}/`)) {
-    return true;
-  }
-  return (
-    normalizedHint === `${manifestId}-provider` ||
-    normalizedHint === `${manifestId}-plugin` ||
-    normalizedHint === `${manifestId}-sandbox` ||
-    normalizedHint === `${manifestId}-media-understanding`
-  );
-}
-
 function buildRecord(params: {
   manifest: PluginManifest;
   candidate: PluginCandidate;
@@ -455,15 +435,6 @@ export function loadPluginManifestRegistry(
               : `plugin requires OpenClaw >=${minHostVersionCheck.requirement.minimumLabel}, but this host is ${minHostVersionCheck.currentVersion}; skipping load`,
       });
       continue;
-    }
-
-    if (!isCompatiblePluginIdHint(candidate.idHint, manifest.id)) {
-      diagnostics.push({
-        level: "warn",
-        pluginId: manifest.id,
-        source: candidate.source,
-        message: `plugin id mismatch (manifest uses "${manifest.id}", entry hints "${candidate.idHint}")`,
-      });
     }
 
     const configSchema = "configSchema" in manifest ? manifest.configSchema : undefined;


### PR DESCRIPTION
## Summary

- Problem: The manifest registry emits a misleading `plugin id mismatch` warning on every gateway startup when a plugin's `openclaw.plugin.json` `id` intentionally differs from the npm package name (e.g. `id: "penfield"` vs package `openclaw-penfield`).
- Why it matters: Third-party plugin authors see spurious warnings they cannot fix without renaming their plugin id to match the npm package name verbatim.
- What changed: Removed the `isCompatiblePluginIdHint()` function and its warning emission site. The manifest `id` is a required field and is authoritative once loaded — comparing it against a bootstrap `idHint` produces no actionable signal.
- What did NOT change (scope boundary): The `idHint` field still exists on `PluginCandidate` and is used as a fallback display name (`manifest-registry.ts:269`). Install-time id resolution (already fixed in `d76742ff88`) is untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45460
- Related #2796, #2834
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `isCompatiblePluginIdHint()` used a hardcoded suffix allowlist (`-provider`, `-plugin`, `-sandbox`, `-media-understanding`) that could not cover all legitimate naming patterns. The manifest `id` field is required and authoritative, making the hint-vs-id comparison structurally non-actionable.
- Missing detection / guardrail: No test asserted that an explicit manifest `id` differing from `idHint` should not warn.
- Prior context: Install-time id resolution was fixed in `d76742ff88`, but the runtime registry warning was not updated.
- Why this regressed now: It did not regress — the warning was always present but only noticed by third-party plugin authors with non-matching names.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/manifest-registry.test.ts`
- Scenario the test should lock in: A plugin with manifest `id: "openai"` and `idHint: "totally-different"` should produce zero `plugin id mismatch` diagnostics.
- Why this is the smallest reliable guardrail: Directly tests the registry loading path with a mismatched hint.
- Existing test that already covers this (if any): The former test asserted `toBe(true)` (warning expected); now asserts `toBe(false)`.
- If no new test is added, why not: Existing test was updated to match new behavior.

## User-visible / Behavior Changes

Gateway startup no longer emits `plugin id mismatch (manifest uses "X", entry hints "Y")` warnings.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.3.0)
- Runtime/container: Node 24, Bun
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Create a plugin with `package.json: "name": "openclaw-penfield"` and `openclaw.plugin.json: "id": "penfield"`
2. Start the gateway
3. Check diagnostics output

### Expected

No mismatch warning.

### Actual

Previously: `plugin id mismatch (manifest uses "penfield", entry hints "openclaw-penfield")` on every startup.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`manifest-registry.test.ts`: 104 tests passed. `bundled-plugin-naming.test.ts` + `loader.test.ts`: all passed.

## Human Verification (required)

- Verified scenarios: All three related test suites pass (manifest-registry, bundled-plugin-naming, loader).
- Edge cases checked: Confirmed `isCompatiblePluginIdHint` had no other callers; confirmed `hasPluginIdMismatchWarning` test helper still has one valid callsite.
- What you did **not** verify: Full `pnpm build` / `pnpm check` (pnpm shim broken in this environment); live gateway startup with a real mismatched plugin.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: A truly accidental id mismatch (e.g. copy-pasted plugin directory with stale manifest) will no longer produce a visible warning.
  - Mitigation: The manifest `id` is authoritative and the registry uses it regardless. The warning was informational only and did not prevent loading. `openclaw doctor` plugin checks and install-time validation (`install.ts:404-410`) still catch real mismatches.
