### PR TITLE
fix(approvals): fall back to session mode for invalid exec mode values

### DIFF
--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -591,3 +591,26 @@ describe("exec approval forwarder", () => {
     expect(deliver).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("invalid mode fallback", () => {
+  it("falls back to session routing when mode is an invalid string", async () => {
+    vi.useFakeTimers();
+    setActivePluginRegistry(emptyRegistry);
+    const cfg = {
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "foobar" as "session",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { deliver, forwarder } = createForwarder({
+      cfg,
+      resolveSessionTarget: () => ({ channel: "slack", to: "U1" }),
+    });
+
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -118,9 +118,14 @@ export type ExecApprovalForwarderDeps = {
 };
 
 const DEFAULT_MODE = "session" as const;
+const VALID_MODES = new Set<string>(["session", "targets", "both"]);
 const SYNTHETIC_APPROVAL_REQUEST_ID = "__approval-routing__";
 
 function normalizeMode(mode?: ExecApprovalForwardingConfig["mode"]) {
+  if (mode != null && !VALID_MODES.has(mode)) {
+    log.warn(`Invalid approvals.exec.mode "${mode}", falling back to "${DEFAULT_MODE}"`);
+    return DEFAULT_MODE;
+  }
   return mode ?? DEFAULT_MODE;
 }
 

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -123,7 +123,7 @@ const SYNTHETIC_APPROVAL_REQUEST_ID = "__approval-routing__";
 
 function normalizeMode(mode?: ExecApprovalForwardingConfig["mode"]) {
   if (mode != null && !VALID_MODES.has(mode)) {
-    log.warn(`Invalid approvals.exec.mode "${mode}", falling back to "${DEFAULT_MODE}"`);
+    log.warn(`Invalid approval forwarding mode "${mode}", falling back to "${DEFAULT_MODE}"`);
     return DEFAULT_MODE;
   }
   return mode ?? DEFAULT_MODE;


### PR DESCRIPTION
## Summary
- Validate `approvals.exec.mode` at the consumption point in the approval forwarder
- Invalid values (anything other than `"session"`, `"targets"`, `"both"`) now log a warning and fall back to `"session"` instead of silently producing an empty target list

## Why
The zod schema correctly constrains `approvals.exec.mode` to `"session" | "targets" | "both"`, but `openclaw config set` in default (non-JSON) mode skips schema validation for speed. Users who set an invalid mode via `config set` or manual JSON editing end up with a value that passes through `normalizeMode` unchanged, never matches any routing branch, and silently drops all approval forwarding.

Fixes #59125

## Testing
```
pnpm test -- src/infra/exec-approval-forwarder.test.ts
```

Added test: "falls back to session routing when mode is an invalid string"