### PR TITLE
fix(sessions): make sessions_send blockers more actionable

### DIFF
--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -141,7 +141,7 @@ describe("createSessionVisibilityGuard", () => {
     sessionsResolutionTesting.setDepsForTest();
   });
 
-  it("blocks cross-agent send when agent-to-agent is disabled", async () => {
+  it("blocks cross-agent send when agent-to-agent is disabled with an actionable message", async () => {
     const guard = await createSessionVisibilityGuard({
       action: "send",
       requesterSessionKey: "agent:main:main",
@@ -153,7 +153,7 @@ describe("createSessionVisibilityGuard", () => {
       allowed: false,
       status: "forbidden",
       error:
-        "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
+        "Blocked: session send is targeting another agent, but agent-to-agent access is disabled. To allow this, set tools.agentToAgent.enabled=true.",
     });
   });
 
@@ -171,6 +171,29 @@ describe("createSessionVisibilityGuard", () => {
       status: "forbidden",
       error:
         "Session history visibility is restricted to the current session (tools.sessions.visibility=self).",
+    });
+  });
+
+  it("explains allowlist-denied cross-agent sends", async () => {
+    const guard = await createSessionVisibilityGuard({
+      action: "send",
+      requesterSessionKey: "agent:main:main",
+      visibility: "all",
+      a2aPolicy: createAgentToAgentPolicy({
+        tools: {
+          agentToAgent: {
+            enabled: true,
+            allow: ["main"],
+          },
+        },
+      } as unknown as OpenClawConfig),
+    });
+
+    expect(guard.check("agent:ops:main")).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error:
+        "Blocked: session send is targeting another agent, but tools.agentToAgent.allow does not permit this agent pair. Add both agent IDs (or a matching pattern) to tools.agentToAgent.allow.",
     });
   });
 });

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -136,43 +136,32 @@ function actionPrefix(action: SessionAccessAction): string {
   return "Session list";
 }
 
-function a2aDisabledMessage(action: SessionAccessAction): string {
+function actionNoun(action: SessionAccessAction): string {
   if (action === "history") {
-    return "Agent-to-agent history is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent access.";
+    return "session history";
   }
   if (action === "send") {
-    return "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.";
+    return "session send";
   }
   if (action === "status") {
-    return "Agent-to-agent status is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent access.";
+    return "session status";
   }
-  return "Agent-to-agent listing is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent visibility.";
+  return "session list";
+}
+
+function a2aDisabledMessage(action: SessionAccessAction): string {
+  const noun = actionNoun(action);
+  return `Blocked: ${noun} is targeting another agent, but agent-to-agent access is disabled. To allow this, set tools.agentToAgent.enabled=true.`;
 }
 
 function a2aDeniedMessage(action: SessionAccessAction): string {
-  if (action === "history") {
-    return "Agent-to-agent history denied by tools.agentToAgent.allow.";
-  }
-  if (action === "send") {
-    return "Agent-to-agent messaging denied by tools.agentToAgent.allow.";
-  }
-  if (action === "status") {
-    return "Agent-to-agent status denied by tools.agentToAgent.allow.";
-  }
-  return "Agent-to-agent listing denied by tools.agentToAgent.allow.";
+  const noun = actionNoun(action);
+  return `Blocked: ${noun} is targeting another agent, but tools.agentToAgent.allow does not permit this agent pair. Add both agent IDs (or a matching pattern) to tools.agentToAgent.allow.`;
 }
 
 function crossVisibilityMessage(action: SessionAccessAction): string {
-  if (action === "history") {
-    return "Session history visibility is restricted. Set tools.sessions.visibility=all to allow cross-agent access.";
-  }
-  if (action === "send") {
-    return "Session send visibility is restricted. Set tools.sessions.visibility=all to allow cross-agent access.";
-  }
-  if (action === "status") {
-    return "Session status visibility is restricted. Set tools.sessions.visibility=all to allow cross-agent access.";
-  }
-  return "Session list visibility is restricted. Set tools.sessions.visibility=all to allow cross-agent access.";
+  const noun = actionNoun(action);
+  return `Blocked: ${noun} is targeting a session outside the current visibility scope. To allow cross-agent targeting, set tools.sessions.visibility=all. Cross-agent access still requires tools.agentToAgent.enabled=true.`;
 }
 
 function selfVisibilityMessage(action: SessionAccessAction): string {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -135,7 +135,8 @@ export function createSessionsSendTool(opts?: {
           return jsonResult({
             runId: crypto.randomUUID(),
             status: "forbidden",
-            error: "Sandboxed sessions_send label lookup is limited to this agent",
+            error:
+              "Blocked: sandboxed sessions_send label lookup is limited to the current agent. Use a session in this agent, or relax the sandbox/session visibility policy.",
           });
         }
 
@@ -176,7 +177,8 @@ export function createSessionsSendTool(opts?: {
             return jsonResult({
               runId: crypto.randomUUID(),
               status: "forbidden",
-              error: "Session not visible from this sandboxed agent session.",
+              error:
+                "Blocked: this session is outside the current sandboxed session tree. Use a spawned child session from this agent, or relax the sandbox session visibility policy.",
             });
           }
           return jsonResult({
@@ -191,7 +193,8 @@ export function createSessionsSendTool(opts?: {
             return jsonResult({
               runId: crypto.randomUUID(),
               status: "forbidden",
-              error: "Session not visible from this sandboxed agent session.",
+              error:
+                "Blocked: this session is outside the current sandboxed session tree. Use a spawned child session from this agent, or relax the sandbox session visibility policy.",
             });
           }
           return jsonResult({

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -146,14 +146,15 @@ export function createSessionsSendTool(opts?: {
               runId: crypto.randomUUID(),
               status: "forbidden",
               error:
-                "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
+                "Blocked: session send is targeting another agent, but agent-to-agent access is disabled. To allow this, set tools.agentToAgent.enabled=true.",
             });
           }
           if (!a2aPolicy.isAllowed(requesterAgentId, requestedAgentId)) {
             return jsonResult({
               runId: crypto.randomUUID(),
               status: "forbidden",
-              error: "Agent-to-agent messaging denied by tools.agentToAgent.allow.",
+              error:
+                "Blocked: session send is targeting another agent, but tools.agentToAgent.allow does not permit this agent pair. Add both agent IDs (or a matching pattern) to tools.agentToAgent.allow.",
             });
           }
         }

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -529,6 +529,53 @@ describe("sessions_send gating", () => {
     expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ method: "sessions.resolve" });
   });
 
+  it("blocks label + agentId cross-agent sends when agent-to-agent is disabled", async () => {
+    const tool = createMainSessionsSendTool();
+
+    const result = await tool.execute("call-label-a2a-disabled", {
+      label: "alex-main",
+      agentId: "other",
+      message: "hi",
+      timeoutSeconds: 0,
+    });
+
+    expect(result.details).toMatchObject({ status: "forbidden" });
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "targeting another agent, but agent-to-agent access is disabled",
+    );
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "tools.agentToAgent.enabled=true",
+    );
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks label + agentId cross-agent sends when agent-to-agent allowlist denies the pair", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        sessions: { visibility: "all" },
+        agentToAgent: { enabled: true, allow: ["main"] },
+      },
+    });
+    const tool = createMainSessionsSendTool();
+
+    const result = await tool.execute("call-label-a2a-denied", {
+      label: "alex-main",
+      agentId: "other",
+      message: "hi",
+      timeoutSeconds: 0,
+    });
+
+    expect(result.details).toMatchObject({ status: "forbidden" });
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "does not permit this agent pair",
+    );
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "tools.agentToAgent.allow",
+    );
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
   it("blocks cross-agent sends with an actionable visibility message", async () => {
     const tool = createMainSessionsSendTool();
 

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -529,7 +529,7 @@ describe("sessions_send gating", () => {
     expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ method: "sessions.resolve" });
   });
 
-  it("blocks cross-agent sends when tools.agentToAgent.enabled is false", async () => {
+  it("blocks cross-agent sends with an actionable visibility message", async () => {
     const tool = createMainSessionsSendTool();
 
     const result = await tool.execute("call1", {
@@ -541,6 +541,12 @@ describe("sessions_send gating", () => {
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
     expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ method: "sessions.list" });
     expect(result.details).toMatchObject({ status: "forbidden" });
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "outside the current visibility scope",
+    );
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "tools.sessions.visibility=all",
+    );
   });
 
   it("does not reuse a stale assistant reply when no new reply appears", async () => {


### PR DESCRIPTION
## Summary

- Problem: `sessions_send` failures were technically correct, but the wording made users do too much interpretation — especially for cross-agent visibility, agent-to-agent policy, and sandboxed session-tree restrictions.
- Why it matters: this sits on a user-facing orchestration path, so unclear blocker text makes delegation feel more brittle than the underlying behavior actually is.
- What changed: clarified blocker messages in `sessions-access` and `sessions-send-tool`, and added focused tests for the blocked paths we actually want to lock in.
- What did NOT change (scope boundary): no policy defaults changed, no permissions were broadened, no session-routing behavior changed, and no new orchestration model was introduced.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: blocker text on the `sessions_send` path was written more like internal policy/config output than user-facing recovery guidance.
- Missing detection / guardrail: we had blocked-path coverage, but not assertions that the returned message actually explained the failure clearly enough to recover from it.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: as cross-agent and sandboxed session flows became more common, the existing wording became more obviously insufficient.
- If unknown, what was ruled out: I did not find a behavior bug in the underlying visibility or allowlist logic; this patch only improves the wording around current behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/tools/sessions-access.test.ts`
  - `src/agents/tools/sessions.test.ts`
- Scenario the test should lock in:
  - cross-agent send blocked by visibility explains the visibility scope and points to `tools.sessions.visibility=all`
  - cross-agent send blocked because agent-to-agent is disabled points to `tools.agentToAgent.enabled=true`
  - cross-agent send blocked by allowlist points to `tools.agentToAgent.allow`
  - sandboxed session-tree failures explain the spawned-child/session-tree limitation
- Why this is the smallest reliable guardrail: the issue is the user-visible blocker message on the tool path itself, so tool-level tests are the right place to pin it.
- Existing test that already covers this (if any): existing gating tests covered the blocked path, but not the action-oriented wording.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `sessions_send` now returns more actionable error text when blocked by:
  - session visibility scope
  - agent-to-agent disabled
  - agent-to-agent allowlist denial
  - sandboxed session-tree restrictions
- The tool now tells the user what to change, not just which policy surface they hit.

## Diagram (if applicable)

```text
Before:
[sessions_send blocked] -> generic policy/config error -> user infers the fix

After:
[sessions_send blocked] -> blocker text explains cause + shortest recovery path -> user can act
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local dev workspace
- Model/provider: N/A
- Integration/channel (if any): session tool paths
- Relevant config (redacted): exercised via existing `sessions_send` gating tests

### Steps

1. Attempt `sessions_send` to a cross-agent target when `tools.sessions.visibility` does not allow cross-agent access.
2. Attempt `sessions_send` to a cross-agent target when `tools.agentToAgent.enabled` is false or the allowlist does not permit the pair.
3. Attempt sandboxed label/session resolution outside the current spawned session tree.

### Expected

- The tool should keep the same blocked/error behavior.
- The returned message should explain both the cause and the shortest recovery path.

### Actual

- Before this patch, the tool returned technically correct but less actionable blocker text.
- After this patch, the tool returns clearer blocker text that points users at the relevant config or recovery path.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification command:

    pnpm vitest run src/agents/tools/sessions-access.test.ts src/agents/tools/sessions.test.ts

## Human Verification (required)

- Verified scenarios:
  - cross-agent visibility blocked path
  - agent-to-agent disabled path
  - agent-to-agent allowlist-denied path
  - sandboxed session-tree blocked path
- Edge cases checked:
  - existing tool behavior/status semantics remain intact
  - no policy changes or broader access changes
  - focused tests still pass with the updated wording expectations
- What you did **not** verify:
  - broader end-to-end channel UX outside the focused session tool tests
  - unrelated session tools beyond the shared access helper wording

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: exact-message assertions in downstream tests or tooling could need adjustment.
  - Mitigation: focused tests were updated to pin the new expected wording.
- Risk: maintainers may want the blocker strings shorter or phrased differently.
  - Mitigation: this patch changes wording only, not policy or behavior, so review-driven text adjustments are low risk.
