### PR TITLE
feat(doctor): add disk space health check for state directory

### DIFF
--- a/src/commands/doctor-disk-space.test.ts
+++ b/src/commands/doctor-disk-space.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildDiskSpaceWarnings,
+  formatBytes,
+  getAvailableBytes,
+  noteDiskSpace,
+} from "./doctor-disk-space.js";
+
+vi.mock("../terminal/note.js", () => ({
+  note: vi.fn(),
+}));
+
+describe("formatBytes", () => {
+  it("formats zero bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+  });
+
+  it("formats bytes below 1 KB", () => {
+    expect(formatBytes(512)).toBe("512 B");
+  });
+
+  it("formats kilobytes", () => {
+    expect(formatBytes(2048)).toBe("2 KB");
+  });
+
+  it("formats megabytes", () => {
+    expect(formatBytes(50 * 1024 * 1024)).toBe("50 MB");
+  });
+
+  it("formats gigabytes with one decimal", () => {
+    expect(formatBytes(2.5 * 1024 * 1024 * 1024)).toBe("2.5 GB");
+  });
+
+  it("returns unknown for negative values", () => {
+    expect(formatBytes(-1)).toBe("unknown");
+  });
+
+  it("returns unknown for NaN", () => {
+    expect(formatBytes(Number.NaN)).toBe("unknown");
+  });
+
+  it("returns unknown for Infinity", () => {
+    expect(formatBytes(Number.POSITIVE_INFINITY)).toBe("unknown");
+  });
+});
+
+describe("getAvailableBytes", () => {
+  it("returns available bytes from statfsSync", () => {
+    const mockStatfs = vi.fn().mockReturnValue({ bavail: 1000n, bsize: 4096n });
+    const result = getAvailableBytes("/some/path", { statfsSync: mockStatfs });
+    expect(result).toBe(4096000);
+    expect(mockStatfs).toHaveBeenCalledWith("/some/path");
+  });
+
+  it("returns null when statfsSync throws", () => {
+    const mockStatfs = vi.fn().mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const result = getAvailableBytes("/missing/path", { statfsSync: mockStatfs });
+    expect(result).toBeNull();
+  });
+});
+
+describe("buildDiskSpaceWarnings", () => {
+  it("returns empty array when space is sufficient", () => {
+    const warnings = buildDiskSpaceWarnings({
+      availableBytes: 10 * 1024 * 1024 * 1024,
+      displayStateDir: "~/.openclaw",
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns warning lines when space is low (below 500 MB)", () => {
+    const warnings = buildDiskSpaceWarnings({
+      availableBytes: 300 * 1024 * 1024,
+      displayStateDir: "~/.openclaw",
+    });
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain("Low disk space");
+    expect(warnings[0]).toContain("300 MB");
+    expect(warnings[0]).toContain("~/.openclaw");
+  });
+
+  it("returns critical lines when space is very low (below 100 MB)", () => {
+    const warnings = buildDiskSpaceWarnings({
+      availableBytes: 50 * 1024 * 1024,
+      displayStateDir: "~/.openclaw",
+    });
+    expect(warnings).toHaveLength(3);
+    expect(warnings[0]).toContain("CRITICAL");
+    expect(warnings[0]).toContain("50 MB");
+  });
+
+  it("returns critical at exactly 0 bytes", () => {
+    const warnings = buildDiskSpaceWarnings({
+      availableBytes: 0,
+      displayStateDir: "~/.openclaw",
+    });
+    expect(warnings).toHaveLength(3);
+    expect(warnings[0]).toContain("CRITICAL");
+  });
+
+  it("returns empty at exactly 500 MB (boundary)", () => {
+    const warnings = buildDiskSpaceWarnings({
+      availableBytes: 500 * 1024 * 1024,
+      displayStateDir: "~/.openclaw",
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns warning at 499 MB (just below boundary)", () => {
+    const warnings = buildDiskSpaceWarnings({
+      availableBytes: 499 * 1024 * 1024,
+      displayStateDir: "~/.openclaw",
+    });
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain("Low disk space");
+  });
+
+  it("returns critical at exactly 99 MB (just below critical)", () => {
+    const warnings = buildDiskSpaceWarnings({
+      availableBytes: 99 * 1024 * 1024,
+      displayStateDir: "~/.openclaw",
+    });
+    expect(warnings).toHaveLength(3);
+    expect(warnings[0]).toContain("CRITICAL");
+  });
+});
+
+describe("noteDiskSpace", () => {
+  it("calls note when space is below warning threshold", async () => {
+    const { note: mockNote } = await import("../terminal/note.js");
+
+    vi.mocked(mockNote).mockClear();
+
+    const mockStatfs = vi.fn().mockReturnValue({ bavail: 100n, bsize: 1048576n });
+    noteDiskSpace({ gateway: { mode: "local" } } as never, {
+      env: { HOME: "/home/test" },
+      statfsSync: mockStatfs,
+    });
+
+    expect(mockNote).toHaveBeenCalledOnce();
+    const [message, title] = vi.mocked(mockNote).mock.calls[0];
+    expect(title).toBe("Disk space");
+    expect(message).toContain("Low disk space");
+  });
+
+  it("does not call note when space is sufficient", async () => {
+    const { note: mockNote } = await import("../terminal/note.js");
+
+    vi.mocked(mockNote).mockClear();
+
+    const mockStatfs = vi.fn().mockReturnValue({ bavail: 10000n, bsize: 1048576n });
+    noteDiskSpace({ gateway: { mode: "local" } } as never, {
+      env: { HOME: "/home/test" },
+      statfsSync: mockStatfs,
+    });
+
+    expect(mockNote).not.toHaveBeenCalled();
+  });
+
+  it("does not call note when statfsSync fails", async () => {
+    const { note: mockNote } = await import("../terminal/note.js");
+
+    vi.mocked(mockNote).mockClear();
+
+    const mockStatfs = vi.fn().mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    noteDiskSpace({ gateway: { mode: "local" } } as never, {
+      env: { HOME: "/home/test" },
+      statfsSync: mockStatfs,
+    });
+
+    expect(mockNote).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/doctor-disk-space.test.ts
+++ b/src/commands/doctor-disk-space.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   buildDiskSpaceWarnings,
+  findExistingAncestor,
   formatBytes,
   getAvailableBytes,
   noteDiskSpace,
@@ -44,12 +45,33 @@ describe("formatBytes", () => {
   });
 });
 
+describe("findExistingAncestor", () => {
+  it("returns the path itself when it exists", () => {
+    const result = findExistingAncestor("/tmp");
+    expect(result).toBe("/tmp");
+  });
+
+  it("returns parent when child does not exist", () => {
+    const result = findExistingAncestor("/tmp/nonexistent-openclaw-test-dir-12345");
+    expect(result).toBe("/tmp");
+  });
+
+  it("walks up multiple levels", () => {
+    const result = findExistingAncestor("/tmp/nonexistent-a/nonexistent-b/nonexistent-c");
+    expect(result).toBe("/tmp");
+  });
+
+  it("returns root for deeply nonexistent paths", () => {
+    const result = findExistingAncestor("/nonexistent-openclaw-root-test/deep/path");
+    expect(result).toBe("/");
+  });
+});
+
 describe("getAvailableBytes", () => {
   it("returns available bytes from statfsSync", () => {
     const mockStatfs = vi.fn().mockReturnValue({ bavail: 1000n, bsize: 4096n });
     const result = getAvailableBytes("/some/path", { statfsSync: mockStatfs });
     expect(result).toBe(4096000);
-    expect(mockStatfs).toHaveBeenCalledWith("/some/path");
   });
 
   it("returns null when statfsSync throws", () => {
@@ -58,6 +80,16 @@ describe("getAvailableBytes", () => {
     });
     const result = getAvailableBytes("/missing/path", { statfsSync: mockStatfs });
     expect(result).toBeNull();
+  });
+
+  it("probes ancestor when target dir does not exist", () => {
+    const mockStatfs = vi.fn().mockReturnValue({ bavail: 500n, bsize: 4096n });
+    const result = getAvailableBytes("/tmp/nonexistent-openclaw-test-dir-67890", {
+      statfsSync: mockStatfs,
+    });
+    expect(result).toBe(2048000);
+    // Should have been called with /tmp (the existing ancestor), not the nonexistent path
+    expect(mockStatfs).toHaveBeenCalledWith("/tmp");
   });
 });
 

--- a/src/commands/doctor-disk-space.test.ts
+++ b/src/commands/doctor-disk-space.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildDiskSpaceWarnings,
@@ -46,28 +48,37 @@ describe("formatBytes", () => {
 });
 
 describe("findExistingAncestor", () => {
+  const tmpDir = os.tmpdir();
+  const fsRoot = path.parse(tmpDir).root;
+
   it("returns the path itself when it exists", () => {
-    const result = findExistingAncestor("/tmp");
-    expect(result).toBe("/tmp");
+    const result = findExistingAncestor(tmpDir);
+    expect(result).toBe(path.resolve(tmpDir));
   });
 
   it("returns parent when child does not exist", () => {
-    const result = findExistingAncestor("/tmp/nonexistent-openclaw-test-dir-12345");
-    expect(result).toBe("/tmp");
+    const result = findExistingAncestor(path.join(tmpDir, "nonexistent-openclaw-test-dir-12345"));
+    expect(result).toBe(path.resolve(tmpDir));
   });
 
   it("walks up multiple levels", () => {
-    const result = findExistingAncestor("/tmp/nonexistent-a/nonexistent-b/nonexistent-c");
-    expect(result).toBe("/tmp");
+    const result = findExistingAncestor(
+      path.join(tmpDir, "nonexistent-a", "nonexistent-b", "nonexistent-c"),
+    );
+    expect(result).toBe(path.resolve(tmpDir));
   });
 
   it("returns root for deeply nonexistent paths", () => {
-    const result = findExistingAncestor("/nonexistent-openclaw-root-test/deep/path");
-    expect(result).toBe("/");
+    const result = findExistingAncestor(
+      path.join(fsRoot, "nonexistent-openclaw-root-test", "deep", "path"),
+    );
+    expect(result).toBe(path.resolve(fsRoot));
   });
 });
 
 describe("getAvailableBytes", () => {
+  const tmpDir = os.tmpdir();
+
   it("returns available bytes from statfsSync", () => {
     const mockStatfs = vi.fn().mockReturnValue({ bavail: 1000n, bsize: 4096n });
     const result = getAvailableBytes("/some/path", { statfsSync: mockStatfs });
@@ -83,13 +94,11 @@ describe("getAvailableBytes", () => {
   });
 
   it("probes ancestor when target dir does not exist", () => {
+    const nonexistent = path.join(tmpDir, "nonexistent-openclaw-test-dir-67890");
     const mockStatfs = vi.fn().mockReturnValue({ bavail: 500n, bsize: 4096n });
-    const result = getAvailableBytes("/tmp/nonexistent-openclaw-test-dir-67890", {
-      statfsSync: mockStatfs,
-    });
+    const result = getAvailableBytes(nonexistent, { statfsSync: mockStatfs });
     expect(result).toBe(2048000);
-    // Should have been called with /tmp (the existing ancestor), not the nonexistent path
-    expect(mockStatfs).toHaveBeenCalledWith("/tmp");
+    expect(mockStatfs).toHaveBeenCalledWith(path.resolve(tmpDir));
   });
 });
 

--- a/src/commands/doctor-disk-space.test.ts
+++ b/src/commands/doctor-disk-space.test.ts
@@ -1,11 +1,7 @@
-import os from "node:os";
-import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildDiskSpaceWarnings,
-  findExistingAncestor,
   formatBytes,
-  getAvailableBytes,
   noteDiskSpace,
 } from "./doctor-disk-space.js";
 
@@ -30,6 +26,10 @@ describe("formatBytes", () => {
     expect(formatBytes(50 * 1024 * 1024)).toBe("50 MB");
   });
 
+  it("floors megabytes to avoid crossing a threshold (99.6 MB -> 99 MB)", () => {
+    expect(formatBytes(Math.floor(99.6 * 1024 * 1024))).toBe("99 MB");
+  });
+
   it("formats gigabytes with one decimal", () => {
     expect(formatBytes(2.5 * 1024 * 1024 * 1024)).toBe("2.5 GB");
   });
@@ -44,61 +44,6 @@ describe("formatBytes", () => {
 
   it("returns unknown for Infinity", () => {
     expect(formatBytes(Number.POSITIVE_INFINITY)).toBe("unknown");
-  });
-});
-
-describe("findExistingAncestor", () => {
-  const tmpDir = os.tmpdir();
-  const fsRoot = path.parse(tmpDir).root;
-
-  it("returns the path itself when it exists", () => {
-    const result = findExistingAncestor(tmpDir);
-    expect(result).toBe(path.resolve(tmpDir));
-  });
-
-  it("returns parent when child does not exist", () => {
-    const result = findExistingAncestor(path.join(tmpDir, "nonexistent-openclaw-test-dir-12345"));
-    expect(result).toBe(path.resolve(tmpDir));
-  });
-
-  it("walks up multiple levels", () => {
-    const result = findExistingAncestor(
-      path.join(tmpDir, "nonexistent-a", "nonexistent-b", "nonexistent-c"),
-    );
-    expect(result).toBe(path.resolve(tmpDir));
-  });
-
-  it("returns root for deeply nonexistent paths", () => {
-    const result = findExistingAncestor(
-      path.join(fsRoot, "nonexistent-openclaw-root-test", "deep", "path"),
-    );
-    expect(result).toBe(path.resolve(fsRoot));
-  });
-});
-
-describe("getAvailableBytes", () => {
-  const tmpDir = os.tmpdir();
-
-  it("returns available bytes from statfsSync", () => {
-    const mockStatfs = vi.fn().mockReturnValue({ bavail: 1000n, bsize: 4096n });
-    const result = getAvailableBytes("/some/path", { statfsSync: mockStatfs });
-    expect(result).toBe(4096000);
-  });
-
-  it("returns null when statfsSync throws", () => {
-    const mockStatfs = vi.fn().mockImplementation(() => {
-      throw new Error("ENOENT");
-    });
-    const result = getAvailableBytes("/missing/path", { statfsSync: mockStatfs });
-    expect(result).toBeNull();
-  });
-
-  it("probes ancestor when target dir does not exist", () => {
-    const nonexistent = path.join(tmpDir, "nonexistent-openclaw-test-dir-67890");
-    const mockStatfs = vi.fn().mockReturnValue({ bavail: 500n, bsize: 4096n });
-    const result = getAvailableBytes(nonexistent, { statfsSync: mockStatfs });
-    expect(result).toBe(2048000);
-    expect(mockStatfs).toHaveBeenCalledWith(path.resolve(tmpDir));
   });
 });
 
@@ -171,13 +116,11 @@ describe("buildDiskSpaceWarnings", () => {
 describe("noteDiskSpace", () => {
   it("calls note when space is below warning threshold", async () => {
     const { note: mockNote } = await import("../terminal/note.js");
-
     vi.mocked(mockNote).mockClear();
 
-    const mockStatfs = vi.fn().mockReturnValue({ bavail: 100n, bsize: 1048576n });
     noteDiskSpace({ gateway: { mode: "local" } } as never, {
       env: { HOME: "/home/test" },
-      statfsSync: mockStatfs,
+      readDiskSpace: () => ({ availableBytes: 300 * 1024 * 1024 }),
     });
 
     expect(mockNote).toHaveBeenCalledOnce();
@@ -186,31 +129,39 @@ describe("noteDiskSpace", () => {
     expect(message).toContain("Low disk space");
   });
 
-  it("does not call note when space is sufficient", async () => {
+  it("calls note with CRITICAL when space is very low", async () => {
     const { note: mockNote } = await import("../terminal/note.js");
-
     vi.mocked(mockNote).mockClear();
 
-    const mockStatfs = vi.fn().mockReturnValue({ bavail: 10000n, bsize: 1048576n });
     noteDiskSpace({ gateway: { mode: "local" } } as never, {
       env: { HOME: "/home/test" },
-      statfsSync: mockStatfs,
+      readDiskSpace: () => ({ availableBytes: 50 * 1024 * 1024 }),
+    });
+
+    expect(mockNote).toHaveBeenCalledOnce();
+    const [message] = vi.mocked(mockNote).mock.calls[0];
+    expect(message).toContain("CRITICAL");
+  });
+
+  it("does not call note when space is sufficient", async () => {
+    const { note: mockNote } = await import("../terminal/note.js");
+    vi.mocked(mockNote).mockClear();
+
+    noteDiskSpace({ gateway: { mode: "local" } } as never, {
+      env: { HOME: "/home/test" },
+      readDiskSpace: () => ({ availableBytes: 10 * 1024 * 1024 * 1024 }),
     });
 
     expect(mockNote).not.toHaveBeenCalled();
   });
 
-  it("does not call note when statfsSync fails", async () => {
+  it("does not call note when disk space cannot be read", async () => {
     const { note: mockNote } = await import("../terminal/note.js");
-
     vi.mocked(mockNote).mockClear();
 
-    const mockStatfs = vi.fn().mockImplementation(() => {
-      throw new Error("ENOENT");
-    });
     noteDiskSpace({ gateway: { mode: "local" } } as never, {
       env: { HOME: "/home/test" },
-      statfsSync: mockStatfs,
+      readDiskSpace: () => null,
     });
 
     expect(mockNote).not.toHaveBeenCalled();

--- a/src/commands/doctor-disk-space.test.ts
+++ b/src/commands/doctor-disk-space.test.ts
@@ -5,7 +5,7 @@ import {
   noteDiskSpace,
 } from "./doctor-disk-space.js";
 
-vi.mock("../terminal/note.js", () => ({
+vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note: vi.fn(),
 }));
 
@@ -115,7 +115,7 @@ describe("buildDiskSpaceWarnings", () => {
 
 describe("noteDiskSpace", () => {
   it("calls note when space is below warning threshold", async () => {
-    const { note: mockNote } = await import("../terminal/note.js");
+    const { note: mockNote } = await import("../../packages/terminal-core/src/note.js");
     vi.mocked(mockNote).mockClear();
 
     noteDiskSpace({ gateway: { mode: "local" } } as never, {
@@ -130,7 +130,7 @@ describe("noteDiskSpace", () => {
   });
 
   it("calls note with CRITICAL when space is very low", async () => {
-    const { note: mockNote } = await import("../terminal/note.js");
+    const { note: mockNote } = await import("../../packages/terminal-core/src/note.js");
     vi.mocked(mockNote).mockClear();
 
     noteDiskSpace({ gateway: { mode: "local" } } as never, {
@@ -144,7 +144,7 @@ describe("noteDiskSpace", () => {
   });
 
   it("does not call note when space is sufficient", async () => {
-    const { note: mockNote } = await import("../terminal/note.js");
+    const { note: mockNote } = await import("../../packages/terminal-core/src/note.js");
     vi.mocked(mockNote).mockClear();
 
     noteDiskSpace({ gateway: { mode: "local" } } as never, {
@@ -156,7 +156,7 @@ describe("noteDiskSpace", () => {
   });
 
   it("does not call note when disk space cannot be read", async () => {
-    const { note: mockNote } = await import("../terminal/note.js");
+    const { note: mockNote } = await import("../../packages/terminal-core/src/note.js");
     vi.mocked(mockNote).mockClear();
 
     noteDiskSpace({ gateway: { mode: "local" } } as never, {

--- a/src/commands/doctor-disk-space.ts
+++ b/src/commands/doctor-disk-space.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+import os from "node:os";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
+import { resolveRequiredHomeDir } from "../infra/home-dir.js";
+import { note } from "../terminal/note.js";
+import { shortenHomePath } from "../utils.js";
+
+// 100 MB — below this, config writes and session transcripts are likely to
+// fail silently, causing data loss.
+const CRITICAL_BYTES = 100 * 1024 * 1024;
+
+// 500 MB — enough headroom for normal operation but worth a heads-up so
+// operators can free space before it becomes critical.
+const WARNING_BYTES = 500 * 1024 * 1024;
+
+/**
+ * Format a byte count into a human-readable string (B / KB / MB / GB).
+ * Exported for testing.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 0 || !Number.isFinite(bytes)) {
+    return "unknown";
+  }
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(0)} KB`;
+  }
+  return `${bytes} B`;
+}
+
+/**
+ * Read available bytes on the partition that contains `dirPath`.
+ * Returns `null` when the directory does not exist or `statfsSync` fails
+ * (for example on a platform where it is unsupported).
+ */
+export function getAvailableBytes(
+  dirPath: string,
+  deps?: { statfsSync?: (p: string) => fs.StatsFs },
+): number | null {
+  const statfs = deps?.statfsSync ?? fs.statfsSync;
+  try {
+    const stats = statfs(dirPath);
+    // `bavail` is the number of free blocks available to unprivileged users.
+    // Multiply by `bsize` (fundamental block size) to get free bytes.
+    return Number(stats.bavail) * Number(stats.bsize);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build warning lines based on available disk space.
+ * Pure function — exported for testing without FS side effects.
+ */
+export function buildDiskSpaceWarnings(params: {
+  availableBytes: number;
+  displayStateDir: string;
+}): string[] {
+  const { availableBytes, displayStateDir } = params;
+  const displayFreeSpace = formatBytes(availableBytes);
+  const warnings: string[] = [];
+
+  if (availableBytes < CRITICAL_BYTES) {
+    warnings.push(
+      `- CRITICAL: only ${displayFreeSpace} free on the partition containing ${displayStateDir}.`,
+    );
+    warnings.push("- Config writes, session transcripts, and log rotation may fail silently.");
+    warnings.push("- Free up disk space immediately to avoid data loss.");
+  } else if (availableBytes < WARNING_BYTES) {
+    warnings.push(
+      `- Low disk space: ${displayFreeSpace} free on the partition containing ${displayStateDir}.`,
+    );
+    warnings.push("- Consider freeing space to prevent future config/session write failures.");
+  }
+
+  return warnings;
+}
+
+/**
+ * Doctor health contribution: check free disk space on the partition that
+ * holds the state directory and warn when it drops below safe thresholds.
+ *
+ * This catches a common operational failure mode where OpenClaw silently
+ * fails to write config, sessions, or logs because the disk is full.
+ */
+export function noteDiskSpace(
+  cfg: OpenClawConfig,
+  deps?: {
+    env?: NodeJS.ProcessEnv;
+    statfsSync?: (p: string) => fs.StatsFs;
+  },
+): void {
+  const env = deps?.env ?? process.env;
+  const homedir = () => resolveRequiredHomeDir(env, os.homedir);
+  const stateDir = resolveStateDir(env, homedir);
+
+  const availableBytes = getAvailableBytes(stateDir, {
+    statfsSync: deps?.statfsSync,
+  });
+  // If we cannot determine free space (directory missing, unsupported FS,
+  // or permission error), skip silently — other contributions already
+  // handle missing directories.
+  if (availableBytes === null) {
+    return;
+  }
+
+  const displayStateDir = shortenHomePath(stateDir);
+  const warnings = buildDiskSpaceWarnings({ availableBytes, displayStateDir });
+
+  if (warnings.length > 0) {
+    note(warnings.join("\n"), "Disk space");
+  }
+}

--- a/src/commands/doctor-disk-space.ts
+++ b/src/commands/doctor-disk-space.ts
@@ -16,6 +16,8 @@ const WARNING_BYTES = 500 * 1024 * 1024;
 
 /**
  * Format a byte count into a human-readable string (B / KB / MB / GB).
+ * Uses Math.floor for MB values to avoid rounding up past a decision
+ * threshold (e.g. 99.6 MB should display as "99 MB", not "100 MB").
  * Exported for testing.
  */
 export function formatBytes(bytes: number): string {
@@ -26,10 +28,10 @@ export function formatBytes(bytes: number): string {
     return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
   }
   if (bytes >= 1024 * 1024) {
-    return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
+    return `${Math.floor(bytes / (1024 * 1024))} MB`;
   }
   if (bytes >= 1024) {
-    return `${(bytes / 1024).toFixed(0)} KB`;
+    return `${Math.floor(bytes / 1024)} KB`;
   }
   return `${bytes} B`;
 }
@@ -47,7 +49,9 @@ export function getAvailableBytes(
   try {
     const stats = statfs(dirPath);
     // `bavail` is the number of free blocks available to unprivileged users.
-    // Multiply by `bsize` (fundamental block size) to get free bytes.
+    // Multiply by `bsize` (optimal transfer / filesystem block size in Node's
+    // StatsFs, equal to `f_bsize` from the underlying statfs syscall) to get
+    // available bytes.
     return Number(stats.bavail) * Number(stats.bsize);
   } catch {
     return null;
@@ -90,7 +94,7 @@ export function buildDiskSpaceWarnings(params: {
  * fails to write config, sessions, or logs because the disk is full.
  */
 export function noteDiskSpace(
-  cfg: OpenClawConfig,
+  _cfg: OpenClawConfig, // reserved for API consistency with other Doctor contributions
   deps?: {
     env?: NodeJS.ProcessEnv;
     statfsSync?: (p: string) => fs.StatsFs;

--- a/src/commands/doctor-disk-space.ts
+++ b/src/commands/doctor-disk-space.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import os from "node:os";
+import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
@@ -16,7 +17,7 @@ const WARNING_BYTES = 500 * 1024 * 1024;
 
 /**
  * Format a byte count into a human-readable string (B / KB / MB / GB).
- * Uses Math.floor for MB values to avoid rounding up past a decision
+ * Uses Math.floor for MB/KB values to avoid rounding up past a decision
  * threshold (e.g. 99.6 MB should display as "99 MB", not "100 MB").
  * Exported for testing.
  */
@@ -37,8 +38,42 @@ export function formatBytes(bytes: number): string {
 }
 
 /**
+ * Walk up from `dirPath` to find the nearest existing ancestor directory.
+ * Returns the directory itself if it exists, otherwise tries parent
+ * directories up to the filesystem root. Returns `null` only if no
+ * ancestor exists (should not happen in practice).
+ * Exported for testing.
+ */
+export function findExistingAncestor(dirPath: string): string | null {
+  let current = path.resolve(dirPath);
+  // Safety bound: stop after a reasonable depth to avoid infinite loops
+  // on pathological inputs (e.g. circular symlinks resolved to long paths).
+  const maxDepth = 64;
+  for (let i = 0; i < maxDepth; i++) {
+    try {
+      const stat = fs.statSync(current);
+      if (stat.isDirectory()) {
+        return current;
+      }
+    } catch {
+      // directory does not exist — try parent
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      // reached filesystem root
+      return null;
+    }
+    current = parent;
+  }
+  return null;
+}
+
+/**
  * Read available bytes on the partition that contains `dirPath`.
- * Returns `null` when the directory does not exist or `statfsSync` fails
+ * If `dirPath` does not exist, walks up to the nearest existing ancestor
+ * so that disk pressure is still reported even before the state directory
+ * is created (e.g. on first run).
+ * Returns `null` when no ancestor exists or `statfsSync` fails
  * (for example on a platform where it is unsupported).
  */
 export function getAvailableBytes(
@@ -46,8 +81,9 @@ export function getAvailableBytes(
   deps?: { statfsSync?: (p: string) => fs.StatsFs },
 ): number | null {
   const statfs = deps?.statfsSync ?? fs.statfsSync;
+  const probePath = findExistingAncestor(dirPath) ?? dirPath;
   try {
-    const stats = statfs(dirPath);
+    const stats = statfs(probePath);
     // `bavail` is the number of free blocks available to unprivileged users.
     // Multiply by `bsize` (optimal transfer / filesystem block size in Node's
     // StatsFs, equal to `f_bsize` from the underlying statfs syscall) to get
@@ -107,7 +143,7 @@ export function noteDiskSpace(
   const availableBytes = getAvailableBytes(stateDir, {
     statfsSync: deps?.statfsSync,
   });
-  // If we cannot determine free space (directory missing, unsupported FS,
+  // If we cannot determine free space (no existing ancestor, unsupported FS,
   // or permission error), skip silently — other contributions already
   // handle missing directories.
   if (availableBytes === null) {

--- a/src/commands/doctor-disk-space.ts
+++ b/src/commands/doctor-disk-space.ts
@@ -1,9 +1,8 @@
-import fs from "node:fs";
 import os from "node:os";
-import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
+import { tryReadDiskSpace } from "../infra/disk-space.js";
 import { note } from "../terminal/note.js";
 import { shortenHomePath } from "../utils.js";
 
@@ -35,63 +34,6 @@ export function formatBytes(bytes: number): string {
     return `${Math.floor(bytes / 1024)} KB`;
   }
   return `${bytes} B`;
-}
-
-/**
- * Walk up from `dirPath` to find the nearest existing ancestor directory.
- * Returns the directory itself if it exists, otherwise tries parent
- * directories up to the filesystem root. Returns `null` only if no
- * ancestor exists (should not happen in practice).
- * Exported for testing.
- */
-export function findExistingAncestor(dirPath: string): string | null {
-  let current = path.resolve(dirPath);
-  // Safety bound: stop after a reasonable depth to avoid infinite loops
-  // on pathological inputs (e.g. circular symlinks resolved to long paths).
-  const maxDepth = 64;
-  for (let i = 0; i < maxDepth; i++) {
-    try {
-      const stat = fs.statSync(current);
-      if (stat.isDirectory()) {
-        return current;
-      }
-    } catch {
-      // directory does not exist — try parent
-    }
-    const parent = path.dirname(current);
-    if (parent === current) {
-      // reached filesystem root
-      return null;
-    }
-    current = parent;
-  }
-  return null;
-}
-
-/**
- * Read available bytes on the partition that contains `dirPath`.
- * If `dirPath` does not exist, walks up to the nearest existing ancestor
- * so that disk pressure is still reported even before the state directory
- * is created (e.g. on first run).
- * Returns `null` when no ancestor exists or `statfsSync` fails
- * (for example on a platform where it is unsupported).
- */
-export function getAvailableBytes(
-  dirPath: string,
-  deps?: { statfsSync?: (p: string) => fs.StatsFs },
-): number | null {
-  const statfs = deps?.statfsSync ?? fs.statfsSync;
-  const probePath = findExistingAncestor(dirPath) ?? dirPath;
-  try {
-    const stats = statfs(probePath);
-    // `bavail` is the number of free blocks available to unprivileged users.
-    // Multiply by `bsize` (optimal transfer / filesystem block size in Node's
-    // StatsFs, equal to `f_bsize` from the underlying statfs syscall) to get
-    // available bytes.
-    return Number(stats.bavail) * Number(stats.bsize);
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -128,30 +70,38 @@ export function buildDiskSpaceWarnings(params: {
  *
  * This catches a common operational failure mode where OpenClaw silently
  * fails to write config, sessions, or logs because the disk is full.
+ *
+ * Disk-space probing (statfs + nearest-existing-ancestor resolution) is
+ * delegated to the shared src/infra/disk-space.ts helper so this Doctor
+ * check and the install/update diagnostics stay on one implementation.
+ * The two-tier warning/critical thresholds and Doctor-facing formatting
+ * are specific to this health contribution.
  */
 export function noteDiskSpace(
   _cfg: OpenClawConfig, // reserved for API consistency with other Doctor contributions
   deps?: {
     env?: NodeJS.ProcessEnv;
-    statfsSync?: (p: string) => fs.StatsFs;
+    readDiskSpace?: (targetPath: string) => { availableBytes: number } | null;
   },
 ): void {
   const env = deps?.env ?? process.env;
   const homedir = () => resolveRequiredHomeDir(env, os.homedir);
   const stateDir = resolveStateDir(env, homedir);
 
-  const availableBytes = getAvailableBytes(stateDir, {
-    statfsSync: deps?.statfsSync,
-  });
+  const readDiskSpace = deps?.readDiskSpace ?? tryReadDiskSpace;
+  const snapshot = readDiskSpace(stateDir);
   // If we cannot determine free space (no existing ancestor, unsupported FS,
   // or permission error), skip silently — other contributions already
   // handle missing directories.
-  if (availableBytes === null) {
+  if (!snapshot) {
     return;
   }
 
   const displayStateDir = shortenHomePath(stateDir);
-  const warnings = buildDiskSpaceWarnings({ availableBytes, displayStateDir });
+  const warnings = buildDiskSpaceWarnings({
+    availableBytes: snapshot.availableBytes,
+    displayStateDir,
+  });
 
   if (warnings.length > 0) {
     note(warnings.join("\n"), "Disk space");

--- a/src/commands/doctor-disk-space.ts
+++ b/src/commands/doctor-disk-space.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { tryReadDiskSpace } from "../infra/disk-space.js";
-import { note } from "../terminal/note.js";
+import { note } from "../../packages/terminal-core/src/note.js";
 import { shortenHomePath } from "../utils.js";
 
 // 100 MB — below this, config writes and session transcripts are likely to

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -306,6 +306,11 @@ async function runReleaseConfiguredPluginInstallsHealth(
   };
 }
 
+async function runDiskSpaceHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  const { noteDiskSpace } = await import("../commands/doctor-disk-space.js");
+  await noteDiskSpace(ctx.cfg);
+}
+
 async function runStateIntegrityHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { noteStateIntegrity } = await import("../commands/doctor-state-integrity.js");
   await noteStateIntegrity(ctx.cfg, ctx.prompter, ctx.configPath);
@@ -655,6 +660,11 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       id: "doctor:plugin-registry",
       label: "Plugin registry",
       run: runPluginRegistryHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:disk-space",
+      label: "Disk space",
+      run: runDiskSpaceHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:state-integrity",

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -446,6 +446,11 @@ async function runReleaseConfiguredPluginInstallsHealth(
   };
 }
 
+async function runDiskSpaceHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  const { noteDiskSpace } = await import("../commands/doctor-disk-space.js");
+  await noteDiskSpace(ctx.cfg);
+}
+
 async function runStateIntegrityHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { noteStateIntegrity } = await loadDoctorStateIntegrityModule();
   await noteStateIntegrity(ctx.cfg, ctx.prompter, ctx.configPath);
@@ -1063,6 +1068,11 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       id: "doctor:plugin-registry",
       label: "Plugin registry",
       run: runPluginRegistryHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:disk-space",
+      label: "Disk space",
+      run: runDiskSpaceHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:state-integrity",

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -448,7 +448,7 @@ async function runReleaseConfiguredPluginInstallsHealth(
 
 async function runDiskSpaceHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { noteDiskSpace } = await import("../commands/doctor-disk-space.js");
-  await noteDiskSpace(ctx.cfg);
+  noteDiskSpace(ctx.cfg);
 }
 
 async function runStateIntegrityHealth(ctx: DoctorHealthFlowContext): Promise<void> {

--- a/src/flows/doctor-health-conversion-plan.ts
+++ b/src/flows/doctor-health-conversion-plan.ts
@@ -82,6 +82,12 @@ export const doctorHealthConversionRules = [
     rule: "Detect stale plugin registry state and let repair return the next config.",
   },
   {
+    contributionId: "doctor:disk-space",
+    conversion: "terminal-side-effect",
+    target: ["doctor-run/disk-space"],
+    rule: "Currently emits low/critical free-space warnings via note(); convert to a path-scoped read-only finding (no repair) when the disk-space check gains a structured detector.",
+  },
+  {
     contributionId: "doctor:state-integrity",
     conversion: "repair-backed-detect",
     target: ["core/doctor/state-integrity"],


### PR DESCRIPTION
## Summary
Add a new Doctor health contribution that checks free disk space on the partition containing the state directory (~/.openclaw). Warns when available space drops below 500 MB and reports CRITICAL when below 100 MB.

## Problem
When the disk hosting the state directory fills up, OpenClaw silently fails to write config files, session transcripts, and logs. Users see symptoms (missing sessions, corrupted config) but have no way to diagnose the root cause through Doctor.

The existing doctor:state-integrity contribution checks directory existence, permissions, cloud sync, and SD/eMMC storage — but not free space.

The upstream fix in v2026.4.5 (`surface explicit disk-full message when ENOSPC`) confirms this is a recognized problem — this PR adds the proactive diagnostic counterpart.

## Real behavior proof

- **Behavior or issue addressed:** When the disk hosting the state directory fills up, OpenClaw silently fails to write config, session transcripts, and logs. Doctor had no disk-space check, so users only saw downstream symptoms. This adds a `doctor:disk-space` health contribution with two-tier warning (500 MB) / critical (100 MB) thresholds.

- **Real environment tested:** Linux (Ubuntu 24.04, WSL2), Node.js 24.14.0, OpenClaw built from this PR head. Exercised the patched `noteDiskSpace()` and the shared `tryReadDiskSpace()` probe against the real `~/.openclaw` partition and at simulated low-space thresholds.

- **Exact steps or command run after this patch:** invoked the patched functions via tsx against the real state-dir partition and injected low-space readings:
```bash
$ node --import tsx run-disk-check.ts
```

- **Evidence after fix:** Real probe via the shared `tryReadDiskSpace()` helper (now reused instead of a duplicate statfs implementation), plus actual `noteDiskSpace()` terminal output at low-space thresholds:
```
Real probe via shared tryReadDiskSpace
  state dir:    /home/alkor2000/.openclaw
  checked path: /home/alkor2000/.openclaw
  available:    935.1 GB (1004057964544 bytes)
  warnings at real free space: 0  (healthy disk, no warning)

noteDiskSpace at 80 MB (CRITICAL):
  - CRITICAL: only 80 MB free on the partition containing ~/.openclaw.
  - Config writes, session transcripts, and log rotation may fail silently.
  - Free up disk space immediately to avoid data loss.

noteDiskSpace at 400 MB (WARNING):
  - Low disk space: 400 MB free on the partition containing ~/.openclaw.
  - Consider freeing space to prevent future config/session write failures.
```

- **Observed result after fix:** On a healthy disk (935 GB free) no warning is emitted. At 400 MB the WARNING tier fires; at 80 MB the CRITICAL tier fires with data-loss guidance. Disk probing now delegates to the shared `src/infra/disk-space.ts` helper (addressing the duplicate-implementation review note); the two-tier thresholds and formatting remain specific to this Doctor check. 20 unit tests pass.

- **What was not tested:** A literally full partition (real ENOSPC) was not reproduced; low-space readings were injected via the shared probe's return value. Non-Linux platforms rely on the shared helper's platform handling.

## Solution
New doctor:disk-space contribution registered before doctor:state-integrity so the root cause (disk full) appears before downstream symptoms (write failures).

**New file: src/commands/doctor-disk-space.ts**
- `formatBytes()` — human-readable byte formatting (B/KB/MB/GB)
- `getAvailableBytes()` — statfsSync wrapper using bavail * bsize
- `buildDiskSpaceWarnings()` — pure function for threshold logic
- `noteDiskSpace()` — Doctor contribution entry point

**New file: src/commands/doctor-disk-space.test.ts**
- 25 unit tests covering formatting, thresholds, and edge cases

**Modified: src/flows/doctor-health-contributions.ts**
- Register doctor:disk-space contribution

## Design decisions
- **bavail not bfree** — reflects unprivileged user available space
- **Synchronous statfsSync** — Doctor runs serially
- **Dependency injection** — consistent with doctor-state-integrity.ts
- **Silent skip on failure** — other contributions handle missing dirs
- **Thresholds** — 100 MB critical / 500 MB warning

## Verification
- pnpm vitest: 25/25 passed
- pnpm check: clean
