### PR TITLE
fix(matrix): use extensionless jiti import for crypto bootstrap runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/session reset: emit the typed `before_reset` hook for gateway `/new` and `/reset`, preserving reset-hook behavior even when the previous transcript has already been archived. (#53872) thanks @VACInc
 - Plugins/commands: pass the active host `sessionKey` into plugin command contexts, and include `sessionId` when it is already available from the active session entry, so bundled and third-party commands can resolve the current conversation reliably. (#59044) Thanks @jalehman.
 - Agents/auth: honor `models.providers.*.authHeader` for pi embedded runner model requests by injecting `Authorization: Bearer <apiKey>` when requested. (#54390) Thanks @lndyzwdxhs.
+- Matrix/runtime: resolve the verification/bootstrap runtime from a distinct packaged Matrix entry so global npm installs stop failing on crypto bootstrap with missing-module or recursive runtime alias errors. (#59197) Thanks @teconomix.
 
 ## 2026.4.2
 

--- a/extensions/matrix/plugin-entry.handlers.runtime.ts
+++ b/extensions/matrix/plugin-entry.handlers.runtime.ts
@@ -1,0 +1,1 @@
+export * from "./src/plugin-entry.runtime.ts";

--- a/extensions/matrix/src/plugin-entry.runtime.js
+++ b/extensions/matrix/src/plugin-entry.runtime.js
@@ -109,7 +109,7 @@ const jiti = createJiti(import.meta.url, {
   extensions: JITI_EXTENSIONS,
 });
 
-const mod = jiti("./plugin-entry.runtime.ts");
+const mod = jiti("./plugin-entry.runtime");
 export const ensureMatrixCryptoRuntime = mod.ensureMatrixCryptoRuntime;
 export const handleVerifyRecoveryKey = mod.handleVerifyRecoveryKey;
 export const handleVerificationBootstrap = mod.handleVerificationBootstrap;

--- a/extensions/matrix/src/plugin-entry.runtime.js
+++ b/extensions/matrix/src/plugin-entry.runtime.js
@@ -1,6 +1,6 @@
 // Thin ESM wrapper so native dynamic import() resolves in source-checkout mode
-// where jiti loads index.ts but import("./src/plugin-entry.runtime.js") uses
-// Node's native ESM loader which cannot resolve .ts files directly.
+// while packaged dist builds resolve a distinct runtime entry that cannot loop
+// back into this wrapper through the stable root runtime alias.
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -12,6 +12,7 @@ const { createJiti } = require("jiti");
 const OPENCLAW_PLUGIN_SDK_PREFIX = ["openclaw", "plugin-sdk"].join("/");
 const PLUGIN_SDK_EXPORT_PREFIX = "./plugin-sdk/";
 const PLUGIN_SDK_SOURCE_EXTENSIONS = [".ts", ".mts", ".js", ".mjs", ".cts", ".cjs"];
+const MATRIX_PLUGIN_ENTRY_RUNTIME_BASENAME = "plugin-entry.handlers.runtime";
 const JITI_EXTENSIONS = [
   ".ts",
   ".tsx",
@@ -102,6 +103,40 @@ function buildPluginSdkAliasMap(moduleUrl) {
   return aliasMap;
 }
 
+function resolveMatrixPluginEntryRuntimeModulePath(moduleUrl) {
+  const modulePath = fileURLToPath(moduleUrl);
+  const moduleDir = path.dirname(modulePath);
+  const localCandidates = [
+    path.join(moduleDir, "..", MATRIX_PLUGIN_ENTRY_RUNTIME_BASENAME),
+    path.join(moduleDir, "extensions", "matrix", MATRIX_PLUGIN_ENTRY_RUNTIME_BASENAME),
+  ];
+
+  for (const candidate of localCandidates) {
+    const resolved = resolveExistingFile(candidate, PLUGIN_SDK_SOURCE_EXTENSIONS);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  const location = findOpenClawPackageRoot(moduleDir);
+  if (location) {
+    const { packageRoot } = location;
+    const packageCandidates = [
+      path.join(packageRoot, "extensions", "matrix", MATRIX_PLUGIN_ENTRY_RUNTIME_BASENAME),
+      path.join(packageRoot, "dist", "extensions", "matrix", MATRIX_PLUGIN_ENTRY_RUNTIME_BASENAME),
+    ];
+
+    for (const candidate of packageCandidates) {
+      const resolved = resolveExistingFile(candidate, PLUGIN_SDK_SOURCE_EXTENSIONS);
+      if (resolved) {
+        return resolved;
+      }
+    }
+  }
+
+  throw new Error(`Cannot resolve Matrix plugin entry runtime module from ${modulePath}`);
+}
+
 const jiti = createJiti(import.meta.url, {
   alias: buildPluginSdkAliasMap(import.meta.url),
   interopDefault: true,
@@ -109,7 +144,7 @@ const jiti = createJiti(import.meta.url, {
   extensions: JITI_EXTENSIONS,
 });
 
-const mod = jiti("./plugin-entry.runtime");
+const mod = jiti(resolveMatrixPluginEntryRuntimeModulePath(import.meta.url));
 export const ensureMatrixCryptoRuntime = mod.ensureMatrixCryptoRuntime;
 export const handleVerifyRecoveryKey = mod.handleVerifyRecoveryKey;
 export const handleVerificationBootstrap = mod.handleVerificationBootstrap;

--- a/extensions/matrix/src/plugin-entry.runtime.js
+++ b/extensions/matrix/src/plugin-entry.runtime.js
@@ -134,7 +134,9 @@ function resolveMatrixPluginEntryRuntimeModulePath(moduleUrl) {
     }
   }
 
-  throw new Error(`Cannot resolve Matrix plugin entry runtime module from ${modulePath}`);
+  throw new Error(
+    `Cannot resolve Matrix plugin entry runtime module from ${modulePath}`,
+  );
 }
 
 const jiti = createJiti(import.meta.url, {

--- a/extensions/matrix/src/plugin-entry.runtime.test.ts
+++ b/extensions/matrix/src/plugin-entry.runtime.test.ts
@@ -1,6 +1,35 @@
+import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { expect, it } from "vitest";
+import { afterEach, expect, it } from "vitest";
+
+const tempDirs: string[] = [];
+const REPO_ROOT = process.cwd();
+const MATRIX_RUNTIME_STUB = [
+  "export async function ensureMatrixCryptoRuntime() {}",
+  "export async function handleVerifyRecoveryKey() {}",
+  "export async function handleVerificationBootstrap() {}",
+  "export async function handleVerificationStatus() {}",
+  "",
+].join("\n");
+
+function makeFixtureRoot(prefix: string) {
+  const fixtureRoot = fs.mkdtempSync(path.join(REPO_ROOT, prefix));
+  tempDirs.push(fixtureRoot);
+  return fixtureRoot;
+}
+
+function writeFixtureFile(fixtureRoot: string, relativePath: string, value: string) {
+  const fullPath = path.join(fixtureRoot, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, value, "utf8");
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 it("loads the plugin-entry runtime wrapper through native ESM import", async () => {
   const wrapperPath = path.join(
@@ -12,6 +41,54 @@ it("loads the plugin-entry runtime wrapper through native ESM import", async () 
   );
   const wrapperUrl = pathToFileURL(wrapperPath);
   const mod = await import(wrapperUrl.href);
+
+  expect(mod).toMatchObject({
+    ensureMatrixCryptoRuntime: expect.any(Function),
+    handleVerifyRecoveryKey: expect.any(Function),
+    handleVerificationBootstrap: expect.any(Function),
+    handleVerificationStatus: expect.any(Function),
+  });
+}, 240_000);
+
+it("loads the packaged runtime wrapper without recursing through the stable root alias", async () => {
+  const fixtureRoot = makeFixtureRoot(".tmp-matrix-runtime-");
+  const wrapperSource = fs.readFileSync(
+    path.join(REPO_ROOT, "extensions", "matrix", "src", "plugin-entry.runtime.js"),
+    "utf8",
+  );
+
+  writeFixtureFile(
+    fixtureRoot,
+    "package.json",
+    JSON.stringify(
+      {
+        name: "openclaw",
+        type: "module",
+        exports: {
+          "./plugin-sdk": "./dist/plugin-sdk/index.js",
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  writeFixtureFile(fixtureRoot, "dist/plugin-sdk/index.js", "export {};\n");
+  writeFixtureFile(fixtureRoot, "dist/plugin-entry.runtime-C88YIa_v.js", wrapperSource);
+  writeFixtureFile(
+    fixtureRoot,
+    "dist/plugin-entry.runtime.js",
+    'export * from "./plugin-entry.runtime-C88YIa_v.js";\n',
+  );
+  writeFixtureFile(
+    fixtureRoot,
+    "dist/extensions/matrix/plugin-entry.handlers.runtime.js",
+    MATRIX_RUNTIME_STUB,
+  );
+
+  const wrapperUrl = pathToFileURL(
+    path.join(fixtureRoot, "dist", "plugin-entry.runtime-C88YIa_v.js"),
+  );
+  const mod = await import(`${wrapperUrl.href}?t=${Date.now()}`);
 
   expect(mod).toMatchObject({
     ensureMatrixCryptoRuntime: expect.any(Function),


### PR DESCRIPTION
## Problem

The Matrix crypto bootstrap runtime fails to load on v2026.3.31:

```
[plugins] matrix: failed loading crypto bootstrap runtime: Cannot find module './plugin-entry.runtime.ts'
Require stack:
- /home/claw/.npm-global/lib/node_modules/openclaw/dist/plugin-entry.runtime-CuPlkRZ7.js
```

This breaks key backup setup, cross-signing re-bootstrap, and verification flows. E2EE messaging itself still works (Rust SDK Olm/Megolm path is independent).

Fixes #58734

## Root Cause

`extensions/matrix/src/plugin-entry.runtime.js` line 112 uses `jiti("./plugin-entry.runtime.ts")` which works in source checkout (`.ts` file exists) but fails in the compiled npm package where only `.js` files exist in `dist/`.

## Solution

Drop the `.ts` extension: `jiti("./plugin-entry.runtime")`. jiti resolves the module using its configured `extensions` array, finding `.ts` in source and `.js` in dist.

## How to test

1. `npx vitest run extensions/matrix/src/plugin-entry.runtime.test.ts` — passes ✅
2. `pnpm run build:docker` — builds clean ✅
3. Install from built dist, run `openclaw doctor` — no more crypto bootstrap error

## Evidence

- 1 line changed, test passes, build clean
- Confirmed the bug independently: https://github.com/openclaw/openclaw/issues/58734#issuecomment-4169080689