### PR TITLE
fix(ui): stop persisting derived agents.defaultId

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -35,6 +35,7 @@ import {
   openConfigFile,
   runUpdate,
   saveConfig,
+  setDefaultAgentInConfig,
   updateConfigFormValue,
   removeConfigFormValue,
 } from "./controllers/config.ts";
@@ -1409,7 +1410,7 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  updateConfigFormValue(state, ["agents", "defaultId"], agentId);
+                  setDefaultAgentInConfig(state, agentId);
                 },
               }),
             )

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -6,6 +6,7 @@ import {
   findAgentConfigEntryIndex,
   runUpdate,
   saveConfig,
+  setDefaultAgentInConfig,
   updateConfigFormValue,
   type ConfigState,
 } from "./config.ts";
@@ -124,6 +125,28 @@ describe("applyConfigSnapshot", () => {
 
     expect(state.configFormMode).toBe("form");
     expect(state.configRaw).toBe('{\n  "gateway": {\n    "mode": "local"\n  }\n}\n');
+  });
+
+  it("drops derived agents.defaultId from clean snapshots", () => {
+    const state = createState();
+
+    applyConfigSnapshot(state, {
+      config: {
+        agents: {
+          defaultId: "assistant",
+          list: [{ id: "main" }, { id: "assistant", default: true }],
+        },
+      },
+      valid: true,
+      issues: [],
+      raw: "{\n}\n",
+    });
+
+    expect(state.configForm).toEqual({
+      agents: {
+        list: [{ id: "main" }, { id: "assistant", default: true }],
+      },
+    });
   });
 });
 
@@ -244,6 +267,36 @@ describe("agent config helpers", () => {
       },
     });
   });
+
+  it("sets the selected agent as default without persisting agents.defaultId", () => {
+    const state = createState();
+    state.configSnapshot = {
+      config: {
+        agents: {
+          defaultId: "main",
+          list: [
+            { id: "main", default: true, model: "openai/gpt-5" },
+            { id: "assistant", name: "Assistant" },
+          ],
+        },
+      },
+      valid: true,
+      issues: [],
+      raw: "{\n}\n",
+    };
+
+    setDefaultAgentInConfig(state, "assistant");
+
+    expect(state.configFormDirty).toBe(true);
+    expect(state.configForm).toEqual({
+      agents: {
+        list: [
+          { id: "main", model: "openai/gpt-5" },
+          { id: "assistant", name: "Assistant", default: true },
+        ],
+      },
+    });
+  });
 });
 
 describe("applyConfig", () => {
@@ -347,6 +400,32 @@ describe("saveConfig", () => {
     expect(parsed.gateway.port).toBe(18789);
     expect(parsed.gateway.enabled).toBe(false);
     expect(params.baseHash).toBe("hash-save-1");
+  });
+
+  it("strips derived agents.defaultId before config.set", async () => {
+    const request = createRequestWithConfigGet();
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormMode = "form";
+    state.configForm = {
+      agents: {
+        defaultId: "assistant",
+        list: [{ id: "main" }, { id: "assistant", default: true }],
+      },
+    };
+    state.configSnapshot = { hash: "hash-save-default" };
+
+    await saveConfig(state);
+
+    expect(request.mock.calls[0]?.[0]).toBe("config.set");
+    const params = request.mock.calls[0]?.[1] as { raw: string; baseHash: string };
+    const parsed = JSON.parse(params.raw) as {
+      agents: { defaultId?: string; list: Array<{ id: string; default?: boolean }> };
+    };
+    expect(parsed.agents.defaultId).toBeUndefined();
+    expect(parsed.agents.list).toEqual([{ id: "main" }, { id: "assistant", default: true }]);
+    expect(params.baseHash).toBe("hash-save-default");
   });
 
   it("skips coercion when schema is not an object", async () => {

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -76,8 +76,31 @@ export function applyConfigSchema(state: ConfigState, res: ConfigSchemaResponse)
   state.configSchemaVersion = res.version ?? null;
 }
 
+function sanitizeDerivedAgentConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const next = cloneConfigObject(config);
+  const agents = (next as { agents?: unknown }).agents;
+  if (!agents || typeof agents !== "object" || Array.isArray(agents)) {
+    return next;
+  }
+  const agentsRecord = agents as Record<string, unknown>;
+  if (Object.prototype.hasOwnProperty.call(agentsRecord, "defaultId")) {
+    delete agentsRecord.defaultId;
+  }
+  return next;
+}
+
+function getEditableConfigBase(state: ConfigState): Record<string, unknown> {
+  return sanitizeDerivedAgentConfig(
+    state.configForm ?? (state.configSnapshot?.config as Record<string, unknown> | null) ?? {},
+  );
+}
+
 export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot) {
   state.configSnapshot = snapshot;
+  const snapshotConfig =
+    snapshot.config && typeof snapshot.config === "object" && !Array.isArray(snapshot.config)
+      ? sanitizeDerivedAgentConfig(snapshot.config)
+      : {};
   const rawAvailable = typeof snapshot.raw === "string";
   if (!rawAvailable && state.configFormMode === "raw") {
     state.configFormMode = "form";
@@ -86,7 +109,7 @@ export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot
     typeof snapshot.raw === "string"
       ? snapshot.raw
       : snapshot.config && typeof snapshot.config === "object"
-        ? serializeConfigForm(snapshot.config)
+        ? serializeConfigForm(snapshotConfig)
         : state.configRaw;
   if (!state.configFormDirty || state.configFormMode === "raw") {
     state.configRaw = rawFromSnapshot;
@@ -99,8 +122,8 @@ export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot
   state.configIssues = Array.isArray(snapshot.issues) ? snapshot.issues : [];
 
   if (!state.configFormDirty) {
-    state.configForm = cloneConfigObject(snapshot.config ?? {});
-    state.configFormOriginal = cloneConfigObject(snapshot.config ?? {});
+    state.configForm = cloneConfigObject(snapshotConfig);
+    state.configFormOriginal = cloneConfigObject(snapshotConfig);
     state.configRawOriginal = rawFromSnapshot;
   }
 }
@@ -128,9 +151,10 @@ function serializeFormForSubmit(state: ConfigState): string {
     return state.configRaw;
   }
   const schema = asJsonSchema(state.configSchema);
+  const sanitizedForm = sanitizeDerivedAgentConfig(state.configForm);
   const form = schema
-    ? (coerceFormValues(state.configForm, schema) as Record<string, unknown>)
-    : state.configForm;
+    ? (coerceFormValues(sanitizedForm, schema) as Record<string, unknown>)
+    : sanitizedForm;
   return serializeConfigForm(form);
 }
 
@@ -214,7 +238,7 @@ export function updateConfigFormValue(
   path: Array<string | number>,
   value: unknown,
 ) {
-  const base = cloneConfigObject(state.configForm ?? state.configSnapshot?.config ?? {});
+  const base = getEditableConfigBase(state);
   setPathValue(base, path, value);
   state.configForm = base;
   state.configFormDirty = true;
@@ -224,7 +248,7 @@ export function updateConfigFormValue(
 }
 
 export function removeConfigFormValue(state: ConfigState, path: Array<string | number>) {
-  const base = cloneConfigObject(state.configForm ?? state.configSnapshot?.config ?? {});
+  const base = getEditableConfigBase(state);
   removePathValue(base, path);
   state.configForm = base;
   state.configFormDirty = true;
@@ -269,6 +293,43 @@ export function ensureAgentConfigEntry(state: ConfigState, agentId: string): num
   const nextIndex = Array.isArray(list) ? list.length : 0;
   updateConfigFormValue(state, ["agents", "list", nextIndex, "id"], normalizedAgentId);
   return nextIndex;
+}
+
+export function setDefaultAgentInConfig(state: ConfigState, agentId: string) {
+  const normalizedAgentId = agentId.trim();
+  if (!normalizedAgentId) {
+    return;
+  }
+  const selectedIndex = ensureAgentConfigEntry(state, normalizedAgentId);
+  if (selectedIndex < 0) {
+    return;
+  }
+  const base = getEditableConfigBase(state);
+  const agentsRecord =
+    (base.agents && typeof base.agents === "object" && !Array.isArray(base.agents)
+      ? (base.agents as Record<string, unknown>)
+      : ((base.agents = {}) as Record<string, unknown>));
+  const currentList = Array.isArray(agentsRecord.list) ? agentsRecord.list : [];
+  const nextList = currentList.map((entry, index) => {
+    const nextEntry =
+      entry && typeof entry === "object" && !Array.isArray(entry)
+        ? ({ ...(entry as Record<string, unknown>) } as Record<string, unknown>)
+        : {};
+    if (index === selectedIndex) {
+      nextEntry.id =
+        typeof nextEntry.id === "string" && nextEntry.id.trim() ? nextEntry.id : normalizedAgentId;
+      nextEntry.default = true;
+      return nextEntry;
+    }
+    delete nextEntry.default;
+    return nextEntry;
+  });
+  agentsRecord.list = nextList;
+  state.configForm = base;
+  state.configFormDirty = true;
+  if (state.configFormMode === "form") {
+    state.configRaw = serializeConfigForm(base);
+  }
 }
 
 export async function openConfigFile(state: ConfigState): Promise<void> {

--- a/vitest.unit-paths.mjs
+++ b/vitest.unit-paths.mjs
@@ -12,6 +12,7 @@ export const unitTestIncludePatterns = [
   "ui/src/ui/views/chat.test.ts",
   "ui/src/ui/views/dreams.test.ts",
   "ui/src/ui/views/usage-render-details.test.ts",
+  "ui/src/ui/controllers/config.test.ts",
   "ui/src/ui/controllers/agents.test.ts",
   "ui/src/ui/controllers/chat.test.ts",
 ];


### PR DESCRIPTION
## Summary
- stop persisting the derived \\gents.defaultId\\ field from the Agents UI form state
- persist default-agent changes via \\gents.list[*].default\\ instead of writing an invalid top-level key
- add regression coverage and include the config controller tests in the default unit test set

## Testing
- pnpm.cmd exec vitest run ui/src/ui/controllers/config.test.ts ui/src/ui/controllers/agents.test.ts
- pnpm.cmd exec oxlint ui/src/ui/controllers/config.ts ui/src/ui/controllers/config.test.ts ui/src/ui/app-render.ts vitest.config.ts vitest.unit-paths.mjs
- pnpm.cmd check
- pnpm.cmd test -- ui/src/ui/controllers/config.test.ts ui/src/ui/controllers/agents.test.ts

Fixes #59070