### PR TITLE
fix: strip redundant provider prefix from session-stored model names

### DIFF
--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -1,5 +1,5 @@
 import { loadSessionStore, resolveStorePath, type SessionEntry } from "../config/sessions.js";
-import { resolveDefaultModelForAgent } from "./model-selection.js";
+import { resolveDefaultModelForAgent, stripRedundantProviderPrefix } from "./model-selection.js";
 import {
   consumeEmbeddedRunModelSwitch,
   requestEmbeddedRunModelSwitch,
@@ -51,7 +51,8 @@ export function resolveLiveSessionModelSelection(params: {
   const runtimeProvider = entry?.modelProvider?.trim();
   const runtimeModel = entry?.model?.trim();
   const provider = runtimeProvider || entry?.providerOverride?.trim() || defaultModelRef.provider;
-  const model = runtimeModel || entry?.modelOverride?.trim() || defaultModelRef.model;
+  const rawModel = runtimeModel || entry?.modelOverride?.trim() || defaultModelRef.model;
+  const model = stripRedundantProviderPrefix(provider, rawModel);
   const authProfileId = entry?.authProfileOverride?.trim() || undefined;
   return {
     provider,

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -15,6 +15,7 @@ import {
   resolveSubagentConfiguredModelSelection,
   resolveThinkingDefault,
   resolveModelRefFromString,
+  stripRedundantProviderPrefix,
 } from "./model-selection.js";
 
 const EXPLICIT_ALLOWLIST_CONFIG = {
@@ -126,6 +127,41 @@ describe("model-selection", () => {
       expect(normalizeProviderIdForAuth("volcengine-plan")).toBe("volcengine");
       expect(normalizeProviderIdForAuth("byteplus-plan")).toBe("byteplus");
       expect(normalizeProviderIdForAuth("openai")).toBe("openai");
+    });
+  });
+
+  describe("stripRedundantProviderPrefix", () => {
+    it("strips redundant provider prefix from Ollama-style model names", () => {
+      expect(stripRedundantProviderPrefix("ollama-beelink2", "ollama-beelink2/qwen2.5-coder:7b")).toBe(
+        "qwen2.5-coder:7b",
+      );
+    });
+
+    it("preserves OpenRouter vendor-prefixed model names", () => {
+      expect(stripRedundantProviderPrefix("openrouter", "anthropic/claude-haiku-4.5")).toBe(
+        "anthropic/claude-haiku-4.5",
+      );
+    });
+
+    it("preserves OpenRouter self-prefixed canonical model IDs", () => {
+      expect(stripRedundantProviderPrefix("openrouter", "openrouter/auto")).toBe("openrouter/auto");
+    });
+
+    it("handles case-insensitive prefix matching", () => {
+      expect(stripRedundantProviderPrefix("OLLAMA", "ollama/model")).toBe("model");
+    });
+
+    it("does not strip when it would produce an empty string", () => {
+      expect(stripRedundantProviderPrefix("ollama", "ollama/")).toBe("ollama/");
+    });
+
+    it("returns model unchanged for empty provider or model", () => {
+      expect(stripRedundantProviderPrefix("", "some-model")).toBe("some-model");
+      expect(stripRedundantProviderPrefix("ollama", "")).toBe("");
+    });
+
+    it("returns model unchanged when prefix does not match", () => {
+      expect(stripRedundantProviderPrefix("anthropic", "openai/gpt-5.4")).toBe("openai/gpt-5.4");
     });
   });
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -190,13 +190,20 @@ export function normalizeModelRef(
 
 /**
  * Strip a redundant `provider/` prefix from a model name when the provider
- * is already known separately. Safe to call for any provider: for providers
- * like OpenRouter that use vendor-prefixed model names (e.g.
- * "anthropic/claude-haiku-4.5"), the prefix differs from the provider key
- * ("openrouter") and is left intact.
+ * is already known separately.  Skips providers that use self-prefixed model
+ * IDs as canonical names (e.g. OpenRouter normalizes "auto" →
+ * "openrouter/auto"), and preserves vendor-prefixed names where the prefix
+ * differs from the provider key (e.g. "anthropic/claude-haiku-4.5" with
+ * provider "openrouter").
  */
 export function stripRedundantProviderPrefix(provider: string, model: string): string {
   if (!provider || !model) {
+    return model;
+  }
+  // OpenRouter uses `openrouter/<model>` as the canonical form for its
+  // native models (see normalizeProviderModelId). Stripping the prefix
+  // would turn "openrouter/auto" into "auto", which is invalid.
+  if (provider === "openrouter") {
     return model;
   }
   const prefix = `${provider}/`;

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -188,6 +188,27 @@ export function normalizeModelRef(
   return { provider: normalizedProvider, model: normalizedModel };
 }
 
+/**
+ * Strip a redundant `provider/` prefix from a model name when the provider
+ * is already known separately. Safe to call for any provider: for providers
+ * like OpenRouter that use vendor-prefixed model names (e.g.
+ * "anthropic/claude-haiku-4.5"), the prefix differs from the provider key
+ * ("openrouter") and is left intact.
+ */
+export function stripRedundantProviderPrefix(provider: string, model: string): string {
+  if (!provider || !model) {
+    return model;
+  }
+  const prefix = `${provider}/`;
+  if (model.toLowerCase().startsWith(prefix.toLowerCase())) {
+    const stripped = model.slice(prefix.length).trim();
+    if (stripped) {
+      return stripped;
+    }
+  }
+  return model;
+}
+
 type ParseModelRefOptions = ModelRefNormalizeOptions;
 
 export function parseModelRef(

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -14,6 +14,7 @@ import {
   parseModelRef,
   resolveConfiguredModelRef,
   resolveDefaultModelForAgent,
+  stripRedundantProviderPrefix,
 } from "../agents/model-selection.js";
 import {
   getSessionDisplaySubagentRunByChildSessionKey,
@@ -1046,7 +1047,10 @@ export function resolveSessionModelRef(
       // with provider="openrouter") into { provider: "anthropic" }, discarding
       // the stored OpenRouter provider and causing direct API calls to a
       // provider the user has no credentials for.
-      return { provider: runtimeProvider, model: runtimeModel };
+      return {
+        provider: runtimeProvider,
+        model: stripRedundantProviderPrefix(runtimeProvider, runtimeModel),
+      };
     }
     const parsedRuntime = parseModelRef(runtimeModel, provider || DEFAULT_PROVIDER);
     if (parsedRuntime) {


### PR DESCRIPTION
## Summary

- When a session records a model with its provider as a prefix (e.g. `ollama-beelink2/qwen2.5-coder:7b` with `provider=ollama-beelink2`), the downstream API call sends the prefixed string as the model name, causing a 404 from the provider.
- Adds a shared `stripRedundantProviderPrefix` helper in `model-selection.ts` and applies it in `resolveSessionModelRef` and `resolveLiveSessionModelSelection` where session-stored model names are read back.
- OpenRouter vendor-prefixed names (e.g. `anthropic/claude-haiku-4.5` with `provider=openrouter`) are preserved because the vendor prefix differs from the provider key.

## Test plan

- [ ] Configure an Ollama remote with a hyphenated instance name (e.g. `ollama-beelink2`)
- [ ] Start a session using a model from that instance
- [ ] Verify subsequent turns resolve the model without the provider prefix (no 404)
- [ ] Verify OpenRouter models with vendor prefixes still work correctly
- [ ] Run `npx vitest run src/agents/model-selection.test.ts` — all 65 tests pass

Fixes #59122

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)