### PR TITLE
fix(cron): honor payload.model override by bypassing allowlist gate

### DIFF
--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import {
+  buildModelAliasIndex,
   getModelRefStatus,
   normalizeModelSelection,
   resolveAllowedModelRef,
@@ -107,9 +108,14 @@ export async function resolveCronModelSelection(
     // payload.model is set explicitly via --model flag and has highest
     // priority per the docs. Resolve the ref but skip the allowlist gate
     // so the user override is always honored.
+    const aliasIndex = buildModelAliasIndex({
+      cfg: params.cfgWithAgentDefaults,
+      defaultProvider: resolvedDefault.provider,
+    });
     const resolved = resolveModelRefFromString({
       raw: modelOverride,
       defaultProvider: resolvedDefault.provider,
+      aliasIndex,
     });
     if (!resolved) {
       return { ok: false, error: `invalid cron model override: "${modelOverride}"` };

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -6,6 +6,7 @@ import {
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
+  resolveModelRefFromString,
 } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { CronJob } from "../types.js";
@@ -103,26 +104,18 @@ export async function resolveCronModelSelection(
   const modelOverrideRaw = params.payload.kind === "agentTurn" ? params.payload.model : undefined;
   const modelOverride = typeof modelOverrideRaw === "string" ? modelOverrideRaw.trim() : undefined;
   if (modelOverride !== undefined && modelOverride.length > 0) {
-    const resolvedOverride = resolveAllowedModelRef({
-      cfg: params.cfgWithAgentDefaults,
-      catalog: await loadCatalogOnce(),
+    // payload.model is set explicitly via --model flag and has highest
+    // priority per the docs. Resolve the ref but skip the allowlist gate
+    // so the user override is always honored.
+    const resolved = resolveModelRefFromString({
       raw: modelOverride,
       defaultProvider: resolvedDefault.provider,
-      defaultModel: resolvedDefault.model,
     });
-    if ("error" in resolvedOverride) {
-      if (resolvedOverride.error.startsWith("model not allowed:")) {
-        return {
-          ok: true,
-          provider,
-          model,
-          warning: `cron: payload.model '${modelOverride}' not allowed, falling back to agent defaults`,
-        };
-      }
-      return { ok: false, error: resolvedOverride.error };
+    if (!resolved) {
+      return { ok: false, error: `invalid cron model override: "${modelOverride}"` };
     }
-    provider = resolvedOverride.ref.provider;
-    model = resolvedOverride.ref.model;
+    provider = resolved.ref.provider;
+    model = resolved.ref.model;
   }
 
   if (!modelOverride && !hooksGmailModelApplied) {

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -166,20 +166,18 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     expect(preRunSnapshot.systemSent).toBe(true);
   });
 
-  it("returns error without persisting model when payload model is disallowed", async () => {
-    resolveAllowedModelRefMock.mockReturnValueOnce({
-      error: "Model not allowed: anthropic/claude-sonnet-4-6",
-    });
+  it("payload model override bypasses allowlist and is always applied", async () => {
+    // Even when the allowlist would reject the model, the explicit --model
+    // flag on a cron job should take highest priority per the docs.
+    runWithModelFallbackMock.mockResolvedValueOnce(makeSuccessfulRunResult());
 
     const result = await runCronIsolatedAgentTurn(makeParams());
 
-    expect(result.status).toBe("error");
-    expect(result.error).toContain("Model not allowed");
-    // Model should remain undefined — the early return happens before the
-    // pre-run persist block, so neither the session entry nor the store
-    // should be touched with a rejected model.
-    expect(cronSession.sessionEntry.model).toBeUndefined();
-    expect(cronSession.sessionEntry.modelProvider).toBeUndefined();
+    expect(result.status).toBe("ok");
+    // The session entry should reflect the payload model override (Sonnet),
+    // not the agent default (Opus).
+    expect(cronSession.sessionEntry.model).toBe("claude-sonnet-4-6");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
   });
 
   it("persists session-level /model override on session entry before the run", async () => {

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -180,6 +180,37 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
   });
 
+  it("resolves model aliases for payload.model override", async () => {
+    const jobWithAlias = makeJob({
+      payload: { kind: "agentTurn", message: "run digest", model: "sonnet" },
+    });
+
+    const cfgWithAlias = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+          },
+        },
+      },
+    } as never;
+
+    runWithModelFallbackMock.mockResolvedValueOnce(
+      makeSuccessfulRunResult({
+        model: "claude-sonnet-4-6",
+        provider: "anthropic",
+      }),
+    );
+
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({ job: jobWithAlias, cfg: cfgWithAlias }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(cronSession.sessionEntry.model).toBe("claude-sonnet-4-6");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+  });
+
   it("persists session-level /model override on session entry before the run", async () => {
     // No cron payload model — the job has no model field
     const jobWithoutModel = makeJob({

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -186,11 +186,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       await expectPrimaryOverridePreservesDefaults({ primary: "anthropic/claude-sonnet-4-5" });
     });
 
-    it("applies payload.model override when model is allowed", async () => {
-      resolveAllowedModelRefMock.mockReturnValueOnce({
-        ref: { provider: "anthropic", model: "claude-sonnet-4-6" },
-      });
-
+    it("applies payload.model override bypassing allowlist", async () => {
       const result = await runCronIsolatedAgentTurn(
         makeSkillParams({
           job: makeSkillJob({
@@ -207,11 +203,8 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       expect(runParams.model).toBe("claude-sonnet-4-6");
     });
 
-    it("falls back to agent defaults when payload.model is not allowed", async () => {
-      resolveAllowedModelRefMock.mockReturnValueOnce({
-        error: "model not allowed: anthropic/claude-sonnet-4-6",
-      });
-
+    it("payload.model override ignores allowlist restrictions", async () => {
+      // Even with an allowlist configured, --model flag takes highest priority
       await runSkillFilterCase({
         cfg: {
           agents: {
@@ -224,20 +217,14 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
           payload: { kind: "agentTurn", message: "test", model: "anthropic/claude-sonnet-4-6" },
         }),
       });
-      expect(logWarnMock).toHaveBeenCalledWith(
-        "cron: payload.model 'anthropic/claude-sonnet-4-6' not allowed, falling back to agent defaults",
-      );
-      expectDefaultModelCall({
-        primary: "openai-codex/gpt-5.4",
-        fallbacks: defaultFallbacks,
-      });
+      expect(logWarnMock).not.toHaveBeenCalled();
+      expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+      const runParams = runWithModelFallbackMock.mock.calls[0][0];
+      expect(runParams.provider).toBe("anthropic");
+      expect(runParams.model).toBe("claude-sonnet-4-6");
     });
 
     it("returns an error when payload.model is invalid", async () => {
-      resolveAllowedModelRefMock.mockReturnValueOnce({
-        error: "invalid model: openai/",
-      });
-
       const result = await runCronIsolatedAgentTurn(
         makeSkillParams({
           job: makeSkillJob({
@@ -247,7 +234,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       );
 
       expect(result.status).toBe("error");
-      expect(result.error).toBe("invalid model: openai/");
+      expect(result.error).toContain("invalid cron model override");
       expect(logWarnMock).not.toHaveBeenCalled();
       expect(runWithModelFallbackMock).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

- The cron `--model` flag override was being validated against the model allowlist via `resolveAllowedModelRef`. When the override model was not in the allowed set, it silently fell back to agent defaults with only a warning — making it impossible to use non-allowlisted models in cron jobs.
- Per the docs, `payload.model` has the highest priority and should always be honored. Now resolves the model ref directly via `resolveModelRefFromString` without the allowlist check, returning an error only for invalid model ref formats.

## Test plan

- [ ] Run a cron job with `--model` set to a model not in the allowlist
- [ ] Verify the cron job uses the specified model (no fallback)
- [ ] Run `npx vitest run src/cron/isolated-agent/run.cron-model-override.test.ts` — all tests pass
- [ ] Run `npx vitest run src/cron/isolated-agent/run.skill-filter.test.ts` — all tests pass

Fixes #58575

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)