### PR TITLE
docs(whatsapp): clarify remote QR pairing limitations

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -68,6 +68,8 @@ openclaw channels login --channel whatsapp
 openclaw channels login --channel whatsapp --account work
 ```
 
+    Current login is QR-based. If you are pairing from a remote/headless machine, plan for a reliable way to deliver the QR as an image/file to the phone that will scan it.
+
   </Step>
 
   <Step title="Start the gateway">
@@ -93,6 +95,12 @@ openclaw pairing approve whatsapp <CODE>
 <Note>
 OpenClaw recommends running WhatsApp on a separate number when possible. (The channel metadata and setup flow are optimized for that setup, but personal-number setups are also supported.)
 </Note>
+
+<Warning>
+The current WhatsApp login flow is QR-only. In remote/headless setups, relaying a terminal-rendered QR through screenshots, PDFs, or chat attachments can be brittle because the QR may refresh or expire before it is scanned.
+
+If you are not physically near the target machine, prefer a direct QR image handoff path (for example, a saved PNG or an HTTP-served QR image) over manual terminal capture. Phone-number / pairing-code login would be a better fit for these environments, but is not documented as part of the current channel setup flow.
+</Warning>
 
 ## Deployment patterns
 
@@ -134,6 +142,19 @@ OpenClaw recommends running WhatsApp on a separate number when possible. (The ch
     The messaging platform channel is WhatsApp Web-based (`Baileys`) in current OpenClaw channel architecture.
 
     There is no separate Twilio WhatsApp messaging channel in the built-in chat-channel registry.
+
+  </Accordion>
+
+  <Accordion title="Remote/headless pairing caveat">
+    Current setup assumes you can scan a live WhatsApp QR quickly.
+
+    In remote/headless environments, QR delivery itself can become the hard part:
+
+    - terminal-rendered QR output is easy to mangle in SSH / narrow terminals
+    - screenshot/PDF relays can lag behind QR refresh or expiry
+    - messaging the QR to another surface is workable, but still more fragile than a first-class export or pairing-code flow
+
+    If this is your deployment pattern, treat WhatsApp setup as requiring an explicit QR handoff plan.
 
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
Document the practical limitations of the current QR-only WhatsApp login flow in remote/headless setups.

## Why
We hit a real-world failure mode where:
- OpenClaw WhatsApp login was QR-only
- the target machine was not physically nearby
- relaying the QR through screenshots / PDFs / chat attachments was brittle
- the QR refreshed or expired underneath the handoff

This does not add new behavior. It makes the limitation explicit in the channel docs and nudges users toward a direct QR image handoff plan instead of assuming terminal capture will be fine.

## Notes
- This PR does **not** claim phone-number / pairing-code login is available in the current documented flow.
- Related issues:
  - #45652
  - #56797
