### PR TITLE
fix(agents): honor cacheRetention for custom anthropic providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Docs: https://docs.openclaw.ai
 - ACPX/runtime: repair `queue owner unavailable` session recovery by replacing dead named sessions and resuming the backend session when ACPX exposes a stable session id, so the first ACP prompt no longer inherits a dead handle. (#58669) Thanks @neeravmakwana
 - ACPX/runtime: retry dead-session queue-owner repair without `--resume-session` when the reported ACPX session id is stale, so recovery still creates a fresh named session instead of failing session init. Thanks @obviyus.
 - Auth/OpenAI Codex: persist plugin-refreshed OAuth credentials to `auth-profiles.json` before returning them, so rotated Codex refresh tokens survive restart and stop falling into `refresh_token_reused` loops. (#53082)
+- Agents/Anthropic: honor explicit `cacheRetention` for custom providers using `anthropic-messages`, so Anthropic-compatible proxy providers can reuse prompt caching when they opt in. (#59049) Thanks @wwerst and @vincentkoc.
 - Discord/gateway: hand reconnect ownership back to Carbon, keep runtime status aligned with close/reconnect state, and force-stop sockets that open without reaching READY so Discord monitors recover promptly instead of waiting on stale health timeouts. (#59019) Thanks @obviyus
 - Config/Telegram: migrate removed `channels.telegram.groupMentionsOnly` into `channels.telegram.groups["*"].requireMention` on load so legacy configs no longer crash at startup. (#55336) thanks @jameslcowan.
 

--- a/src/agents/pi-embedded-runner/anthropic-cache-retention.ts
+++ b/src/agents/pi-embedded-runner/anthropic-cache-retention.ts
@@ -3,13 +3,19 @@ type CacheRetention = "none" | "short" | "long";
 export function resolveCacheRetention(
   extraParams: Record<string, unknown> | undefined,
   provider: string,
+  modelApi?: string,
 ): CacheRetention | undefined {
   const isAnthropicDirect = provider === "anthropic";
-  const hasBedrockOverride =
+  const hasExplicitCacheConfig =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
-  const isAnthropicBedrock = provider === "amazon-bedrock" && hasBedrockOverride;
+  const isAnthropicBedrock = provider === "amazon-bedrock" && hasExplicitCacheConfig;
+  const isCustomAnthropicApi =
+    !isAnthropicDirect &&
+    !isAnthropicBedrock &&
+    modelApi === "anthropic-messages" &&
+    hasExplicitCacheConfig;
 
-  if (!isAnthropicDirect && !isAnthropicBedrock) {
+  if (!isAnthropicDirect && !isAnthropicBedrock && !isCustomAnthropicApi) {
     return undefined;
   }
 

--- a/src/agents/pi-embedded-runner/extra-params.cache-retention-default.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.cache-retention-default.test.ts
@@ -1,11 +1,13 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { describe, expect, it, vi } from "vitest";
 import { applyExtraParamsToAgent } from "../pi-embedded-runner.js";
+import { resolveCacheRetention } from "./anthropic-cache-retention.js";
 
 function applyAndExpectWrapped(params: {
   cfg?: Parameters<typeof applyExtraParamsToAgent>[1];
   extraParamsOverride?: Parameters<typeof applyExtraParamsToAgent>[4];
   modelId: string;
+  model?: Parameters<typeof applyExtraParamsToAgent>[8];
   provider: string;
 }) {
   const agent: { streamFn?: StreamFn } = {};
@@ -16,6 +18,10 @@ function applyAndExpectWrapped(params: {
     params.provider,
     params.modelId,
     params.extraParamsOverride,
+    undefined,
+    undefined,
+    undefined,
+    params.model,
   );
 
   expect(agent.streamFn).toBeDefined();
@@ -142,6 +148,52 @@ describe("cacheRetention default behavior", () => {
       },
       modelId: "claude-3-sonnet",
       provider: "anthropic",
+    });
+  });
+
+  it("respects cacheRetention for custom provider with anthropic-messages API", () => {
+    applyAndExpectWrapped({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "litellm/claude-sonnet-4-6": {
+                params: {
+                  cacheRetention: "long" as const,
+                },
+              },
+            },
+          },
+        },
+      },
+      modelId: "claude-sonnet-4-6",
+      model: { api: "anthropic-messages" } as Parameters<typeof applyExtraParamsToAgent>[8],
+      provider: "litellm",
+    });
+  });
+
+  it("does not default to caching for custom provider without explicit config", () => {
+    expect(resolveCacheRetention(undefined, "litellm", "anthropic-messages")).toBeUndefined();
+  });
+
+  it("respects cacheRetention 'short' for custom anthropic-messages provider", () => {
+    applyAndExpectWrapped({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "litellm/claude-opus-4-6": {
+                params: {
+                  cacheRetention: "short" as const,
+                },
+              },
+            },
+          },
+        },
+      },
+      modelId: "claude-opus-4-6",
+      model: { api: "anthropic-messages" } as Parameters<typeof applyExtraParamsToAgent>[8],
+      provider: "litellm",
     });
   });
 });

--- a/src/agents/pi-embedded-runner/extra-params.cache-retention-default.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.cache-retention-default.test.ts
@@ -196,4 +196,22 @@ describe("cacheRetention default behavior", () => {
       provider: "litellm",
     });
   });
+
+  it("resolves 'long' directly for custom anthropic-messages provider", () => {
+    expect(resolveCacheRetention({ cacheRetention: "long" }, "litellm", "anthropic-messages")).toBe(
+      "long",
+    );
+  });
+
+  it("resolves 'short' directly for custom anthropic-messages provider", () => {
+    expect(
+      resolveCacheRetention({ cacheRetention: "short" }, "litellm", "anthropic-messages"),
+    ).toBe("short");
+  });
+
+  it("resolves 'none' directly for custom anthropic-messages provider", () => {
+    expect(resolveCacheRetention({ cacheRetention: "none" }, "litellm", "anthropic-messages")).toBe(
+      "none",
+    );
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -198,6 +198,7 @@ function createStreamFnWithExtraParams(
   baseStreamFn: StreamFn | undefined,
   extraParams: Record<string, unknown> | undefined,
   provider: string,
+  modelApi?: string,
 ): StreamFn | undefined {
   if (!extraParams || Object.keys(extraParams).length === 0) {
     return undefined;
@@ -223,7 +224,7 @@ function createStreamFnWithExtraParams(
   if (typeof extraParams.openaiWsWarmup === "boolean") {
     streamParams.openaiWsWarmup = extraParams.openaiWsWarmup;
   }
-  const cacheRetention = resolveCacheRetention(extraParams, provider);
+  const cacheRetention = resolveCacheRetention(extraParams, provider, modelApi);
   if (cacheRetention) {
     streamParams.cacheRetention = cacheRetention;
   }
@@ -316,6 +317,7 @@ function applyPrePluginStreamWrappers(ctx: ApplyExtraParamsContext): void {
     ctx.agent.streamFn,
     ctx.effectiveExtraParams,
     ctx.provider,
+    ctx.model?.api,
   );
 
   if (wrappedStreamFn) {


### PR DESCRIPTION
## Summary

- Thread `model.api` into cache-retention resolution so custom providers using `anthropic-messages` honor explicit `cacheRetention` config.
- Add direct `resolveCacheRetention` unit tests for all custom-provider retention values (`long`, `short`, `none`) to lock in the gate logic, addressing Greptile review feedback.
- Changelog entry added.

## Context

Builds on #59049 (by @vincentkoc, which itself superseded #58756 by @wwerst). This branch rebases onto current `main`, includes the original production fix, and adds strengthened test assertions per the Greptile review comments on #59049:

1. **Direct positive-case unit tests** for `resolveCacheRetention` with `"long"` and `"short"` — the integration tests via `applyAndExpectWrapped` only check `streamFn` is defined (always true due to unconditional wrappers), so these directly verify the gate logic.
2. **`cacheRetention: "none"` coverage** — ensures the explicit opt-out value passes through for custom `anthropic-messages` providers.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #37325
- Closes #37733
- Related #37418
- Supersedes #59049

## Root Cause / Regression History

- Root cause: `resolveCacheRetention` gated on `provider === "anthropic"` (string equality), not on the model's actual API transport.
- Custom providers with `api: "anthropic-messages"` are fully Anthropic-compatible but use a different provider name, so they never got cache retention.

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `src/agents/pi-embedded-runner/extra-params.cache-retention-default.test.ts`
- Scenarios locked in:
  1. Custom provider + explicit `cacheRetention: "long"` -> resolves to `"long"`
  2. Custom provider + explicit `cacheRetention: "short"` -> resolves to `"short"`
  3. Custom provider + explicit `cacheRetention: "none"` -> resolves to `"none"`
  4. Custom provider + no explicit config -> resolves to `undefined` (no default)
  5. Integration tests through `applyExtraParamsToAgent` for `"long"` and `"short"`

## User-visible / Behavior Changes

Custom providers using `anthropic-messages` now honor explicit `cacheRetention` values. No behavior change for direct Anthropic or Bedrock users.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- 13/13 tests pass in `extra-params.cache-retention-default.test.ts`
- `pnpm check` passes cleanly

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: a custom provider may advertise `anthropic-messages` but reject Anthropic cache fields.
  - Mitigation: custom providers only get retention when explicitly configured; no new implicit default.

Made with [Cursor](https://cursor.com)