### PR TITLE
fix(approvals): use canonical decision values in interactive button payloads

### DIFF
--- a/extensions/telegram/src/exec-approvals-handler.test.ts
+++ b/extensions/telegram/src/exec-approvals-handler.test.ts
@@ -100,7 +100,7 @@ describe("TelegramExecApprovalHandler", () => {
             },
             {
               text: "Allow Always",
-              callback_data: "/approve 9f1c7d5d-b1fb-46ef-ac45-662723b65bb7 always",
+              callback_data: "/approve 9f1c7d5d-b1fb-46ef-ac45-662723b65bb7 allow-always",
               style: "primary",
             },
             {

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -95,7 +95,7 @@ function buildTelegramExecApprovalPendingPayloadForTest(params: {
             },
             {
               label: "Allow Always",
-              value: `/approve ${params.request.id} always`,
+              value: `/approve ${params.request.id} allow-always`,
               style: "primary",
             },
             {
@@ -115,7 +115,7 @@ function buildTelegramExecApprovalPendingPayloadForTest(params: {
         buttons: [
           [
             { text: "Allow Once", callback_data: `/approve ${params.request.id} allow-once` },
-            { text: "Allow Always", callback_data: `/approve ${params.request.id} always` },
+            { text: "Allow Always", callback_data: `/approve ${params.request.id} allow-always` },
           ],
           [{ text: "Deny", callback_data: `/approve ${params.request.id} deny` }],
         ],
@@ -465,7 +465,7 @@ describe("exec approval forwarder", () => {
                     },
                     {
                       label: "Allow Always",
-                      value: "/approve req-1 always",
+                      value: "/approve req-1 allow-always",
                       style: "primary",
                     },
                     {

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -119,7 +119,7 @@ describe("exec approval reply helpers", () => {
             },
             {
               label: "Allow Always",
-              value: "/approve req-1 always",
+              value: "/approve req-1 allow-always",
               style: "primary",
             },
             {
@@ -194,7 +194,7 @@ describe("exec approval reply helpers", () => {
         decision: "allow-always",
         label: "Allow Always",
         style: "primary",
-        command: "/approve req-1 always",
+        command: "/approve req-1 allow-always",
       },
       {
         decision: "deny",
@@ -214,7 +214,7 @@ describe("exec approval reply helpers", () => {
           type: "buttons",
           buttons: [
             { label: "Allow Once", value: "/approve req-1 allow-once", style: "success" },
-            { label: "Allow Always", value: "/approve req-1 always", style: "primary" },
+            { label: "Allow Always", value: "/approve req-1 allow-always", style: "primary" },
             { label: "Deny", value: "/approve req-1 deny", style: "danger" },
           ],
         },
@@ -228,7 +228,7 @@ describe("exec approval reply helpers", () => {
         approvalCommandId: "req-1",
         decision: "allow-always",
       }),
-    ).toBe("/approve req-1 always");
+    ).toBe("/approve req-1 allow-always");
 
     expect(parseExecApprovalCommandText("/approve req-1 deny")).toEqual({
       approvalId: "req-1",

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -47,7 +47,7 @@ export function buildExecApprovalCommandText(params: {
   approvalCommandId: string;
   decision: ExecApprovalReplyDecision;
 }): string {
-  return `/approve ${params.approvalCommandId} ${params.decision === "allow-always" ? "always" : params.decision}`;
+  return `/approve ${params.approvalCommandId} ${params.decision}`;
 }
 
 export function buildExecApprovalActionDescriptors(params: {

--- a/src/infra/plugin-approval-forwarder.test.ts
+++ b/src/infra/plugin-approval-forwarder.test.ts
@@ -106,7 +106,7 @@ describe("plugin approval forwarding", () => {
               },
               {
                 label: "Allow Always",
-                value: "/approve plugin-req-1 always",
+                value: "/approve plugin-req-1 allow-always",
                 style: "primary",
               },
               {

--- a/src/plugin-sdk/approval-renderers.test.ts
+++ b/src/plugin-sdk/approval-renderers.test.ts
@@ -28,7 +28,7 @@ describe("plugin-sdk/approval-renderers", () => {
               },
               {
                 label: "Allow Always",
-                value: "/approve plugin:approval-123 always",
+                value: "/approve plugin:approval-123 allow-always",
                 style: "primary",
               },
               {
@@ -75,7 +75,7 @@ describe("plugin-sdk/approval-renderers", () => {
               },
               {
                 label: "Allow Always",
-                value: "/approve plugin-approval-123 always",
+                value: "/approve plugin-approval-123 allow-always",
                 style: "primary",
               },
               {


### PR DESCRIPTION
## Summary

- `buildExecApprovalCommandText` was converting `allow-always` to the shorter alias `always` in button payloads. On Slack, interactive button values bypass the text command parser's `DECISION_ALIASES` mapping, so the raw `always` value reaches the approval resolver instead of the expected `allow-always`. This causes approvals not to persist and leads to repeated prompts.
- The fix uses canonical decision values (`allow-always`) directly in button payloads, eliminating the alias indirection. The text command parser still accepts both `always` and `allow-always`, so text-based approvals remain backward compatible.
- Note: Telegram's standalone `buildTelegramExecApprovalButtons` in `approval-buttons.ts` intentionally retains the shorter `always` alias to stay within Telegram's 64-byte callback_data limit. Telegram's parser handles the alias translation correctly.

Closes #59091

## Test plan

- [x] `exec-approval-reply.test.ts` (8 tests pass)
- [x] `exec-approval-forwarder.test.ts` (updated button value expectations)
- [x] `plugin-approval-forwarder.test.ts` (updated button value expectations)
- [x] `approval-renderers.test.ts` (updated button value expectations)
- [x] `exec-approvals-handler.test.ts` (Telegram handler, updated expectations)
- [x] `inline-buttons.test.ts` (Telegram standalone buttons, unchanged -- intentionally uses alias)