### PR TITLE
fix[Bug]: [skills] Skipping skill path error triggered on officially installed skills via clawhub (WSL Environment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1040,6 +1040,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Codex: stop prompting message-tool-only source turns to finish with `NO_REPLY`, so quiet turns are represented by not calling the visible message tool instead of conflicting final-text instructions. Thanks @pashpashpash.
 - Gateway/config: report failed backup restores as failed in logs and config observe audit records instead of marking them valid. (#70515) Thanks @davidangularme.
 - Compaction: use the active session model fallback chain for implicit summarization failures without persisting fallback model selection, so Azure content-filter 400s can recover. Fixes #64960. (#74470) Thanks @jalehman and @OpenCodeEngineer.
+- Skills: allow managed and personal skill directories installed through symlinks or junctions while keeping workspace, extra, project, and bundled skill roots contained. Fixes #44051. (#59219) Thanks @luoxiao6645.
 - Gateway/config: allow `gateway config.patch` to update documented subagent thinking defaults. Fixes #75764. (#75802) Thanks @kAIborg24.
 - Plugins/CLI: keep git plugin install paths credential-free, preserve existing git checkouts until replacement succeeds, honor duplicate npm install mode, and remove managed git repos on uninstall. Thanks @vincentkoc.
 - Plugins/CLI: redact authenticated git URLs from git install command failure details, so failed clone or checkout output cannot leak credentials during plugin installs. Thanks @vincentkoc.

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -600,7 +600,10 @@ export async function loadCompactHooksHarness(): Promise<{
     };
   });
 
-  vi.doMock("../pi-embedded-helpers.js", () => ({
+  vi.doMock("../pi-embedded-helpers.js", async () => ({
+    ...(await vi.importActual<typeof import("../pi-embedded-helpers.js")>(
+      "../pi-embedded-helpers.js",
+    )),
     ensureSessionHeader: vi.fn(async () => {}),
     pickFallbackThinkingLevel: vi.fn((params: { message?: string; attempted?: Set<string> }) =>
       params.message?.includes("Reasoning is mandatory") && !params.attempted?.has("minimal")

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -185,7 +186,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
 
     expect(ensureRuntimePluginsLoaded).toHaveBeenCalledWith({
       config: undefined,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: path.resolve("/tmp/workspace"),
     });
   });
 
@@ -208,7 +209,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
 
     expect(ensureRuntimePluginsLoaded).toHaveBeenCalledWith({
       config: undefined,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: path.resolve("/tmp/workspace"),
       allowGatewaySubagentBinding: true,
     });
   });
@@ -225,7 +226,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     expect(resolveSandboxContextMock).toHaveBeenCalledWith({
       config: undefined,
       sessionKey: "agent:main:telegram:default:direct:12345",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: path.resolve("/tmp/workspace"),
     });
   });
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -444,7 +444,9 @@ async function compactEmbeddedPiSessionDirectOnce(
   ensureRuntimePluginsLoaded({
     config: params.config,
     workspaceDir: resolvedWorkspace,
-    allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+    ...(params.allowGatewaySubagentBinding === undefined
+      ? {}
+      : { allowGatewaySubagentBinding: params.allowGatewaySubagentBinding }),
   });
   const resolvedCompactionTarget = resolveEmbeddedCompactionTarget({
     config: params.config,

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -466,7 +466,10 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     redactRunIdentifier: vi.fn((value?: string) => value ?? ""),
   }));
 
-  vi.doMock("../pi-embedded-helpers.js", () => ({
+  vi.doMock("../pi-embedded-helpers.js", async () => ({
+    ...(await vi.importActual<typeof import("../pi-embedded-helpers.js")>(
+      "../pi-embedded-helpers.js",
+    )),
     formatBillingErrorMessage: mockedFormatBillingErrorMessage,
     classifyFailoverReason: mockedClassifyFailoverReason,
     extractObservedOverflowTokenCount: mockedExtractObservedOverflowTokenCount,

--- a/src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts
+++ b/src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts
@@ -29,6 +29,10 @@ async function createCaseDir(prefix: string): Promise<string> {
   return dir;
 }
 
+async function symlinkDir(targetDir: string, linkPath: string): Promise<void> {
+  await fs.symlink(targetDir, linkPath, process.platform === "win32" ? "junction" : "dir");
+}
+
 async function syncSourceSkillsToTarget(sourceWorkspace: string, targetWorkspace: string) {
   await syncSkillsToWorkspace({
     sourceWorkspaceDir: sourceWorkspace,
@@ -356,5 +360,33 @@ describe("buildWorkspaceSkillsPrompt", () => {
     expect(await pathExists(path.join(targetWorkspace, "skills", "remote-only", "SKILL.md"))).toBe(
       true,
     );
+  });
+
+  it("dereferences managed symlinked skill directories when syncing into the target workspace", async () => {
+    const sourceWorkspace = await createCaseDir("source");
+    const targetWorkspace = await createCaseDir("target");
+    const outsideRoot = await createCaseDir("outside");
+    const externalSkillDir = path.join(outsideRoot, "managed-symlink-skill");
+    const managedDir = path.join(sourceWorkspace, ".managed");
+
+    await writeSkill({
+      dir: externalSkillDir,
+      name: "managed-symlink-skill",
+      description: "Managed symlink skill",
+    });
+    await fs.mkdir(managedDir, { recursive: true });
+    await symlinkDir(externalSkillDir, path.join(managedDir, "managed-symlink-skill"));
+
+    await syncSourceSkillsToTarget(sourceWorkspace, targetWorkspace);
+
+    const syncedSkillDir = path.join(targetWorkspace, "skills", "managed-symlink-skill");
+    const prompt = buildPrompt(targetWorkspace, {
+      bundledSkillsDir: path.join(targetWorkspace, ".bundled"),
+      managedSkillsDir: path.join(targetWorkspace, ".managed"),
+    });
+
+    expect(prompt).toContain("Managed symlink skill");
+    expect(await pathExists(path.join(syncedSkillDir, "SKILL.md"))).toBe(true);
+    expect((await fs.lstat(syncedSkillDir)).isSymbolicLink()).toBe(false);
   });
 });

--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -58,6 +58,10 @@ async function createTempWorkspaceDir() {
   return workspaceDir;
 }
 
+async function symlinkDir(targetDir: string, linkPath: string) {
+  await fs.symlink(targetDir, linkPath, process.platform === "win32" ? "junction" : "dir");
+}
+
 function captureWarningLogger() {
   setLoggerOverride({ level: "silent", consoleLevel: "warn" });
   const warn = vi.fn();
@@ -361,6 +365,30 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
+  it("skips workspace skill directories that resolve outside the workspace root", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const outsideDir = await createTempWorkspaceDir();
+    const escapedSkillDir = path.join(outsideDir, "outside-skill");
+    await writeSkill({
+      dir: escapedSkillDir,
+      name: "outside-skill",
+      description: "Outside",
+    });
+    await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
+    const requestedPath = path.join(workspaceDir, "skills", "escaped-skill");
+    await symlinkDir(escapedSkillDir, requestedPath);
+    const warn = captureWarningLogger();
+
+    const entries = loadTestWorkspaceSkillEntries(workspaceDir);
+
+    expect(entries.map((entry) => entry.skill.name)).not.toContain("outside-skill");
+    const [line] = warn.mock.calls[0] ?? [];
+    const warningLine = String(line);
+    expect(warningLine).toContain("Skipping escaped skill path outside its configured root:");
+    expect(warningLine).toContain("reason=symlink-escape");
+    expect(warningLine).toContain("source=openclaw-workspace");
+  });
+
   it.runIf(process.platform !== "win32")(
     "calls out bundled symlink escapes with compact home-relative paths",
     async () => {
@@ -401,6 +429,66 @@ describe("loadWorkspaceSkillEntries", () => {
       expect(warningLine).toContain("root=~/workspace/.bundled");
       expect(warningLine).toContain("requested=~/workspace/.bundled/escaped-bundled-skill");
       expect(warningLine).toContain("resolved=~/outside/outside-bundled-skill");
+    },
+  );
+
+  it("allows managed skill directories that resolve outside the managed root", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedDir = path.join(workspaceDir, ".managed");
+    const outsideDir = await createTempWorkspaceDir();
+    const externalSkillDir = path.join(outsideDir, "outside-skill");
+    await writeSkill({
+      dir: externalSkillDir,
+      name: "outside-skill",
+      description: "Outside managed root",
+    });
+    await fs.mkdir(managedDir, { recursive: true });
+    await symlinkDir(externalSkillDir, path.join(managedDir, "outside-skill"));
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+    });
+    const loaded = entries.find((entry) => entry.skill.name === "outside-skill");
+
+    expect(loaded).toBeDefined();
+    expect(loaded?.skill.baseDir).toBe(await fs.realpath(externalSkillDir));
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "skips managed skill files that resolve outside the managed skill root",
+    async () => {
+      const workspaceDir = await createTempWorkspaceDir();
+      const managedDir = path.join(workspaceDir, ".managed");
+      const outsideDir = await createTempWorkspaceDir();
+      const escapedTargetDir = path.join(outsideDir, "outside-file-skill");
+      await writeSkill({
+        dir: escapedTargetDir,
+        name: "outside-file-skill",
+        description: "Outside file",
+      });
+
+      const externalManagedSkillDir = path.join(outsideDir, "managed-skill");
+      await writeSkill({
+        dir: externalManagedSkillDir,
+        name: "managed-skill",
+        description: "Managed skill",
+      });
+      await fs.rm(path.join(externalManagedSkillDir, "SKILL.md"));
+      await fs.symlink(
+        path.join(escapedTargetDir, "SKILL.md"),
+        path.join(externalManagedSkillDir, "SKILL.md"),
+      );
+      await fs.mkdir(managedDir, { recursive: true });
+      await symlinkDir(externalManagedSkillDir, path.join(managedDir, "managed-skill"));
+
+      const entries = loadWorkspaceSkillEntries(workspaceDir, {
+        managedSkillsDir: managedDir,
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      });
+
+      expect(entries.map((entry) => entry.skill.name)).not.toContain("outside-file-skill");
+      expect(entries.map((entry) => entry.skill.name)).not.toContain("managed-skill");
     },
   );
 

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -294,6 +294,18 @@ function warnEscapedSkillPath(params: {
   });
 }
 
+function shouldEnforceContainedSkillPaths(source: string): boolean {
+  // Repo-scoped and explicitly configured external roots are treated as trust
+  // boundaries. Managed/personal roots are user-owned shared roots and may
+  // legitimately expose symlinked skill directories.
+  return (
+    source === "openclaw-bundled" ||
+    source === "openclaw-extra" ||
+    source === "openclaw-workspace" ||
+    source === "agents-skills-project"
+  );
+}
+
 function resolveContainedSkillPath(params: {
   source: string;
   rootDir: string;
@@ -315,6 +327,20 @@ function resolveContainedSkillPath(params: {
     candidateRealPath,
   });
   return null;
+}
+
+function resolveContainedPathWithinSkillRoot(params: {
+  source: string;
+  skillRootDir: string;
+  candidatePath: string;
+}): string | null {
+  const skillRootRealPath = tryRealpath(params.skillRootDir) ?? path.resolve(params.skillRootDir);
+  return resolveContainedSkillPath({
+    source: params.source,
+    rootDir: params.skillRootDir,
+    rootRealPath: skillRootRealPath,
+    candidatePath: params.candidatePath,
+  });
 }
 
 function resolveNestedSkillsRoot(
@@ -371,6 +397,7 @@ function loadContainedSkillRecords(params: {
   skillDir: string;
   source: string;
   maxSkillFileBytes: number;
+  canonicalizePaths?: boolean;
 }): LoadedSkillRecord[] {
   const expectedBaseDir = path.resolve(params.skillDir);
   const loaded = loadSkillsFromDirSafe({
@@ -378,9 +405,35 @@ function loadContainedSkillRecords(params: {
     source: params.source,
     maxBytes: params.maxSkillFileBytes,
   });
-  return unwrapLoadedSkillRecords(loaded).filter(
-    (record) => path.resolve(record.skill.baseDir) === expectedBaseDir,
-  );
+  return unwrapLoadedSkillRecords(loaded)
+    .filter((record) => path.resolve(record.skill.baseDir) === expectedBaseDir)
+    .map((record) =>
+      params.canonicalizePaths
+        ? {
+            ...record,
+            skill: canonicalizeLoadedSkillPath(record.skill),
+          }
+        : record,
+    );
+}
+
+function canonicalizeLoadedSkillPath(skill: Skill): Skill {
+  const baseDir = tryRealpath(skill.baseDir) ?? path.resolve(skill.baseDir);
+  const filePath = tryRealpath(skill.filePath) ?? path.resolve(skill.filePath);
+  return {
+    ...skill,
+    baseDir,
+    filePath,
+    ...(skill.sourceInfo
+      ? {
+          sourceInfo: {
+            ...skill.sourceInfo,
+            path: filePath,
+            ...(skill.sourceInfo.baseDir !== undefined ? { baseDir } : {}),
+          },
+        }
+      : {}),
+  };
 }
 
 function isPathInsideAnyRoot(rootRealPaths: readonly string[], candidateRealPath: string): boolean {
@@ -498,6 +551,7 @@ function loadSkillEntries(
   const limits = resolveSkillsLimits(opts?.config, opts?.agentId);
 
   const loadSkills = (params: { dir: string; source: string }): LoadedSkillRecord[] => {
+    const enforceContainedRealpath = shouldEnforceContainedSkillPaths(params.source);
     const rootDir = path.resolve(params.dir);
     if (!fs.existsSync(rootDir)) {
       return [];
@@ -507,12 +561,14 @@ function loadSkillEntries(
       maxEntriesToScan: limits.maxCandidatesPerRoot,
     });
     const baseDir = resolved.baseDir;
-    const baseDirRealPath = resolveContainedSkillPath({
-      source: params.source,
-      rootDir,
-      rootRealPath,
-      candidatePath: baseDir,
-    });
+    const baseDirRealPath = enforceContainedRealpath
+      ? resolveContainedSkillPath({
+          source: params.source,
+          rootDir,
+          rootRealPath,
+          candidatePath: baseDir,
+        })
+      : (tryRealpath(baseDir) ?? path.resolve(baseDir));
     if (!baseDirRealPath) {
       return [];
     }
@@ -520,10 +576,9 @@ function loadSkillEntries(
     // If the root itself is a skill directory, just load it directly (but enforce size cap).
     const rootSkillMd = path.join(baseDir, "SKILL.md");
     if (fs.existsSync(rootSkillMd)) {
-      const rootSkillRealPath = resolveContainedSkillPath({
+      const rootSkillRealPath = resolveContainedPathWithinSkillRoot({
         source: params.source,
-        rootDir,
-        rootRealPath: baseDirRealPath,
+        skillRootDir: baseDir,
         candidatePath: rootSkillMd,
       });
       if (!rootSkillRealPath) {
@@ -548,6 +603,7 @@ function loadSkillEntries(
         skillDir: baseDir,
         source: params.source,
         maxSkillFileBytes: limits.maxSkillFileBytes,
+        canonicalizePaths: !enforceContainedRealpath,
       });
     }
 
@@ -603,6 +659,7 @@ function loadSkillEntries(
           skillDir,
           source: params.source,
           maxSkillFileBytes: limits.maxSkillFileBytes,
+          canonicalizePaths: !enforceContainedRealpath,
         }),
       );
     };
@@ -612,21 +669,22 @@ function loadSkillEntries(
     // skill directories (e.g. ~/.openclaw/skills/coze/koze-retrieval/SKILL.md).
     for (const name of limitedChildren) {
       const skillDir = path.join(baseDir, name);
-      const skillDirRealPath = resolveContainedSkillPath({
-        source: params.source,
-        rootDir,
-        rootRealPath: baseDirRealPath,
-        candidatePath: skillDir,
-      });
-      if (!skillDirRealPath) {
-        continue;
-      }
-      const skillMd = path.join(skillDir, "SKILL.md");
-      if (fs.existsSync(skillMd)) {
-        const skillMdRealPath = resolveContainedSkillPath({
+      if (enforceContainedRealpath) {
+        const skillDirRealPath = resolveContainedSkillPath({
           source: params.source,
           rootDir,
           rootRealPath: baseDirRealPath,
+          candidatePath: skillDir,
+        });
+        if (!skillDirRealPath) {
+          continue;
+        }
+      }
+      const skillMd = path.join(skillDir, "SKILL.md");
+      if (fs.existsSync(skillMd)) {
+        const skillMdRealPath = resolveContainedPathWithinSkillRoot({
+          source: params.source,
+          skillRootDir: skillDir,
           candidatePath: skillMd,
         });
         if (skillMdRealPath) {
@@ -669,16 +727,17 @@ function loadSkillEntries(
           const nestedDir = path.join(skillDir, nestedName);
           const nestedSkillMd = path.join(nestedDir, "SKILL.md");
           if (fs.existsSync(nestedSkillMd)) {
-            const nestedDirRealPath = resolveContainedSkillPath({
+            const nestedDirRealPath = enforceContainedRealpath
+              ? resolveContainedSkillPath({
+                  source: params.source,
+                  rootDir,
+                  rootRealPath: baseDirRealPath,
+                  candidatePath: nestedDir,
+                })
+              : (tryRealpath(nestedDir) ?? path.resolve(nestedDir));
+            const nestedSkillMdRealPath = resolveContainedPathWithinSkillRoot({
               source: params.source,
-              rootDir,
-              rootRealPath: baseDirRealPath,
-              candidatePath: nestedDir,
-            });
-            const nestedSkillMdRealPath = resolveContainedSkillPath({
-              source: params.source,
-              rootDir,
-              rootRealPath: baseDirRealPath,
+              skillRootDir: nestedDir,
               candidatePath: nestedSkillMd,
             });
             if (nestedDirRealPath && nestedSkillMdRealPath) {

--- a/src/commands/doctor-bootstrap-size.test.ts
+++ b/src/commands/doctor-bootstrap-size.test.ts
@@ -21,7 +21,10 @@ vi.mock("../agents/bootstrap-files.js", () => ({
   resolveBootstrapContextForRun,
 }));
 
-vi.mock("../agents/pi-embedded-helpers.js", () => ({
+vi.mock("../agents/pi-embedded-helpers.js", async () => ({
+  ...(await vi.importActual<typeof import("../agents/pi-embedded-helpers.js")>(
+    "../agents/pi-embedded-helpers.js",
+  )),
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
 }));


### PR DESCRIPTION
 Summary                                                                                                                                                                         
  Fix a managed-skills loading regression introduced by the recent skills realpath boundary hardening.                                                                            
                                                                                                                                                                                  
  The loader started rejecting skill roots and SKILL.md files whose resolved realpath                                                                                             
  escaped the configured source root. That behavior is correct for workspace and                                                                                                  
  extra-dir skills, but it was also being applied to managed skills under                                                                                                         
  `~/.openclaw/skills`.                                                                                                                                                           
                                                                                                                                                                                  
  As a result, managed skills installed via symlink/junction-backed layouts could be                                                                                              
  skipped with:                                                                                                                                                                   
                                                                                                                                                                                  
  `Skipping skill path that resolves outside its configured root.`                                                                                                                
                                                                                                                                                                                  
  This surfaced in WSL reports, but the bug is in source scoping rather than                                                                                                      
  WSL-specific path normalization.                                                                                                                                                
                                                                                                                                                                                  
  Root Cause                                                                                                                                                                      
  The containment check in `src/agents/skills/workspace.ts` was being enforced for                                                                                                
  `openclaw-managed` as well as untrusted roots.                                                                                                                                  
                                                                                                                                                                                  
  That meant a skill path that appeared under `~/.openclaw/skills/` but resolved                                                                                                  
  outside that directory via realpath was rejected, even though managed skill roots are                                                                                           
  user-owned shared roots and were not intended to be subject to the same                                                                                                         
  workspace/extra-dir escape restriction.                                                                                                                                         
                                                                                                                                                                                  
  What Changed                                                                                                                                                                    
  Added `shouldEnforceContainedSkillPaths()` to scope realpath boundary enforcement to:                                                                                           
  - `openclaw-workspace`                                                                                                                                                          
  - `openclaw-extra`                                                                                                                                                              
  - `agents-skills-project`                                                                                                                                                       
  - `openclaw-bundled`                                                                                                                                                            
                                                                                                                                                                                  
  Stopped applying that enforcement to managed/personal roots, while keeping bundled                                                                                              
  roots fail-closed so stray checkout symlinks do not load out-of-root bundled skills.                                                                                            
                                                                                                                                                                                  
  Kept per-skill `SKILL.md` containment checks in place for all sources, so a skill dir                                                                                           
  that is allowed to resolve externally still cannot load a `SKILL.md` that escapes its                                                                                           
  own skill root.                                                                                                                                                                 
                                                                                                                                                                                  
  Canonicalized loaded skill paths for sources exempt from root containment so managed                                                                                            
  symlinked skills carry real paths into workspace sync/copy flows.                                                                                                               
                                                                                                                                                                                  
  Kept size checks and normal loading behavior unchanged for trusted shared roots.                                                                                                
                                                                                                                                                                                  
  Added regression coverage for:                                                                                                                                                  
  - managed skill directories that resolve outside the managed root                                                                                                               
  - managed `SKILL.md` symlinks that escape the skill root and must still be rejected                                                                                             
  - workspace escape cases that must remain fail-closed                                                                                                                           
  - bundled symlink escape warning behavior after merging latest `main`                                                                                                           
                                                                                                                                                                                  
  Re-applied the follow-up fix that restores Claude bundle command loading in                                                                                                     
  `buildWorkspaceSkillCommandSpecs()`.                                                                                                                                            
                                                                                                                                                                                  
  Also fixed the `pi-embedded-helpers.js` partial mock issue that was blocking the                                                                                                
  node test shard.                                                                                                                                                                
                                                                                                                                                                                  
  Files                                                                                                                                                                           
  - `src/agents/skills/workspace.ts`                                                                                                                                              
  - `src/agents/skills.loadworkspaceskillentries.test.ts`                                                                                                                         
  - `src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts`                                                                           
  - `src/commands/doctor-bootstrap-size.test.ts`                                                                                                                                  
  - `src/agents/pi-embedded-runner/compact.hooks.harness.ts`                                                                                                                      
  - `src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts`                                                                                                            
                                                                                                                                                                                  
  Test                                                                                                                                                                            
  Passed:                                                                                                                                                                         
                                                                                                                                                                                  
  `pnpm exec vitest run src/agents/skills.loadworkspaceskillentries.test.ts src/agents/skills.buildworkspaceskillsnapshot.test.ts src/agents/skills.build-workspace-skills-       
  prompt.syncs-merged-skills-into-target-workspace.test.ts src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.test.ts src/agents/skills-     
  status.test.ts
## Real behavior proof

- **Behavior or issue addressed**: Managed skills installed through a symlink/junction-backed ClawHub-style layout were being skipped because the loader enforced the configured managed root realpath as a containment boundary. After the patch, the managed skill directory can resolve outside the managed root while the skill's own `SKILL.md` containment remains enforced.
- **Real environment tested**: Local OpenClaw checkout on Windows 11, Node via the repo toolchain, using the real `loadWorkspaceSkillEntries()` implementation from this branch. This models the WSL/ClawHub failure shape with a managed skills directory entry whose realpath points to an external cache-style skill directory.
- **Exact steps or command run after this patch**: Ran a real Node/OpenClaw loader script from the repo root. The script created a temporary workspace, created a managed skills directory, created an external `clawhub-cache/calendar-skill/SKILL.md`, linked `managed-skills/calendar-skill` to that external directory, then called `loadWorkspaceSkillEntries()` with that managed directory.
- **Evidence after fix**: Terminal output from the real loader run:

```text
platform=win32
workspaceDir=C:\Users\13485\AppData\Local\Temp\openclaw-real-skill-proof-pY0TQq\workspace
managedLink=C:\Users\13485\AppData\Local\Temp\openclaw-real-skill-proof-pY0TQq\managed-skills\calendar-skill
managedLinkRealpath=C:\Users\13485\AppData\Local\Temp\openclaw-real-skill-proof-pY0TQq\clawhub-cache\calendar-skill
loadedSkills=browser-automation,calendar-skill,qqbot-channel,qqbot-media,qqbot-remind
loadedBaseDir=C:\Users\13485\AppData\Local\Temp\openclaw-real-skill-proof-pY0TQq\clawhub-cache\calendar-skill
result=PASS managed symlinked skill loaded
```

- **Observed result after fix**: The real loader returned `calendar-skill` in `loadedSkills`, and `loadedBaseDir` was the external realpath target. This is the behavior users need for ClawHub/managed skill installs that use symlink or junction layouts; the skill was not skipped by the managed-root containment warning path.
- **What was not tested**: I did not run a full WSL distro with the official ClawHub CLI in this session; the real runtime proof exercises the same OpenClaw managed skill loader path and symlink/junction realpath shape locally.
