### PR TITLE
feat: add built-in command aliases (/c, /ctx, /s, /n, /m, /ms, /h, /f, /u)

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -119,7 +119,8 @@ Text + native (when enabled):
 - `/reasoning on|off|stream` (alias: `/reason`; when on, sends a separate message prefixed `Reasoning:`; `stream` = Telegram draft only)
 - `/elevated on|off|ask|full` (alias: `/elev`; `full` skips exec approvals)
 - `/exec host=<auto|sandbox|gateway|node> security=<deny|allowlist|full> ask=<off|on-miss|always> node=<id>` (send `/exec` to show current)
-- `/model <name>` (aliases: `/m`, `/models`, `/ms`; or `/<alias>` from `agents.defaults.models.*.alias`)
+- `/model <name>` (alias: `/m`; show or set the model; or `/<alias>` from `agents.defaults.models.*.alias`)
+- `/models` (alias: `/ms`; list model providers or provider models)
 - `/queue <mode>` (plus options like `debounce:2s cap:25 drop:summarize`; send `/queue` to see current settings)
 - `/bash <command>` (host-only; alias for `! <command>`; requires `commands.bash: true` + `tools.elevated` allowlists)
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -73,15 +73,15 @@ They run immediately, are stripped before the model sees the message, and the re
 
 Text + native (when enabled):
 
-- `/help`
+- `/help` (alias: `/h`)
 - `/commands`
 - `/tools [compact|verbose]` (show what the current agent can use right now; `verbose` adds descriptions)
 - `/skill <name> [input]` (run a skill by name)
-- `/status` (show current status; includes provider usage/quota for the current model provider when available)
+- `/status` (alias: `/s`; show current status; includes provider usage/quota for the current model provider when available)
 - `/tasks` (list background tasks for the current session; shows active and recent task details with agent-local fallback counts)
 - `/allowlist` (list/add/remove allowlist entries)
 - `/approve <id> <decision>` (resolve exec approval prompts; use the pending approval message for the available decisions)
-- `/context [list|detail|json]` (explain “context”; `detail` shows per-file + per-tool + per-skill + system prompt size)
+- `/context [list|detail|json]` (alias: `/ctx`; explain “context”; `detail` shows per-file + per-tool + per-skill + system prompt size)
 - `/btw <question>` (ask an ephemeral side question about the current session without changing future session context; see [/tools/btw](/tools/btw))
 - `/export-session [path]` (alias: `/export`) (export current session to HTML with full system prompt)
 - `/whoami` (show your sender id; alias: `/id`)
@@ -102,7 +102,7 @@ Text + native (when enabled):
   - `/plugin install <spec>` accepts the same plugin specs as `openclaw plugins install`: local path/archive, npm package, or `clawhub:<pkg>`.
   - Enable/disable writes still reply with a restart hint. On a watched foreground gateway, OpenClaw may perform that restart automatically right after the write.
 - `/debug show|set|unset|reset` (runtime overrides, owner-only; requires `commands.debug: true`)
-- `/usage off|tokens|full|cost` (per-response usage footer or local cost summary)
+- `/usage off|tokens|full|cost` (alias: `/u`; per-response usage footer or local cost summary)
 - `/tts off|always|inbound|tagged|status|provider|limit|summary|audio` (control TTS; see [/tts](/tools/tts))
   - Discord: native command is `/voice` (Discord reserves `/tts`); text `/tts` still works.
 - `/stop`
@@ -112,20 +112,20 @@ Text + native (when enabled):
 - `/dock-slack` (alias: `/dock_slack`) (switch replies to Slack)
 - `/activation mention|always` (groups only)
 - `/send on|off|inherit` (owner-only)
-- `/reset` or `/new [model]` (optional model hint; remainder is passed through)
+- `/reset` or `/new [model]` (alias: `/n`; optional model hint; remainder is passed through)
 - `/think <off|minimal|low|medium|high|xhigh>` (dynamic choices by model/provider; aliases: `/thinking`, `/t`)
-- `/fast status|on|off` (omitting the arg shows the current effective fast-mode state)
+- `/fast status|on|off` (alias: `/f`; omitting the arg shows the current effective fast-mode state)
 - `/verbose on|full|off` (alias: `/v`)
 - `/reasoning on|off|stream` (alias: `/reason`; when on, sends a separate message prefixed `Reasoning:`; `stream` = Telegram draft only)
 - `/elevated on|off|ask|full` (alias: `/elev`; `full` skips exec approvals)
 - `/exec host=<auto|sandbox|gateway|node> security=<deny|allowlist|full> ask=<off|on-miss|always> node=<id>` (send `/exec` to show current)
-- `/model <name>` (alias: `/models`; or `/<alias>` from `agents.defaults.models.*.alias`)
+- `/model <name>` (aliases: `/m`, `/models`, `/ms`; or `/<alias>` from `agents.defaults.models.*.alias`)
 - `/queue <mode>` (plus options like `debounce:2s cap:25 drop:summarize`; send `/queue` to see current settings)
 - `/bash <command>` (host-only; alias for `! <command>`; requires `commands.bash: true` + `tools.elevated` allowlists)
 
 Text-only:
 
-- `/compact [instructions]` (see [/concepts/compaction](/concepts/compaction))
+- `/compact [instructions]` (alias: `/c`; see [/concepts/compaction](/concepts/compaction))
 - `! <command>` (host-only; one at a time; use `!poll` + `!stop` for long-running jobs)
 - `!poll` (check output / status; accepts optional `sessionId`; `/bash poll` also works)
 - `!stop` (stop the running bash job; accepts optional `sessionId`; `/bash stop` also works)

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -824,6 +824,15 @@ export function buildBuiltinChatCommands(): ChatCommandDefinition[] {
   registerAlias(commands, "reasoning", "/reason");
   registerAlias(commands, "elevated", "/elev");
   registerAlias(commands, "steer", "/tell");
+  registerAlias(commands, "compact", "/c");
+  registerAlias(commands, "context", "/ctx");
+  registerAlias(commands, "status", "/s");
+  registerAlias(commands, "new", "/n");
+  registerAlias(commands, "model", "/m");
+  registerAlias(commands, "models", "/ms");
+  registerAlias(commands, "help", "/h");
+  registerAlias(commands, "fast", "/f");
+  registerAlias(commands, "usage", "/u");
 
   assertCommandRegistry(commands);
   return commands;


### PR DESCRIPTION
Add 9 command aliases to reduce typing for frequently used slash commands:
- /c   → /compact  (session context compaction)
- /ctx → /context  (context diagnostics)
- /s   → /status   (status check)
- /n   → /new      (new session)
- /m   → /model    (model switching)
- /ms  → /models   (model listing)
- /h   → /help     (help)
- /f   → /fast     (fast mode toggle)
- /u   → /usage    (token usage/cost)

Follows the established registerAlias() pattern already used for /t, /v, /id, /reason, /elev, /tell.

Also updates docs/tools/slash-commands.md to document all new aliases (required by slash-commands-doc.test.ts).

## Summary

- **Problem:** Frequently used slash commands (`/compact`, `/status`, `/new`, `/model`, `/fast`, etc.) require typing the full command name, which is slow on mobile messaging surfaces.
- **Why it matters:** Mobile users on Telegram, Feishu, WhatsApp lose time typing long commands repeatedly. Existing aliases like `/t`, `/v`, `/elev` already prove the pattern works.
- **What changed:** Added 9 `registerAlias()` calls in `commands-registry.shared.ts` and documented all new aliases in `docs/tools/slash-commands.md`.
- **What did NOT change (scope boundary):** No schema, config, API, or routing changes. No new commands — only additional text aliases for existing commands.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A (no existing issue; this is a small ergonomic improvement)
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/docs/slash-commands-doc.test.ts`
- Scenario the test should lock in: All registered `textAliases` must appear in `docs/tools/slash-commands.md`
- Why this is the smallest reliable guardrail: The existing test already enforces alias-doc parity; no new test needed
- Existing test that already covers this (if any): `slash-commands-doc.test.ts` — "documents all built-in chat command aliases"
- If no new test is added, why not: Existing `assertCommandRegistry()` catches duplicate aliases at build time; `slash-commands-doc.test.ts` catches undocumented aliases at test time. Both already cover this change.

## User-visible / Behavior Changes

Users can now type shorter aliases for 9 commands:

| Alias | Command |
|-------|---------|
| `/c` | `/compact` |
| `/ctx` | `/context` |
| `/s` | `/status` |
| `/n` | `/new` |
| `/m` | `/model` |
| `/ms` | `/models` |
| `/h` | `/help` |
| `/f` | `/fast` |
| `/u` | `/usage` |

No defaults or config changes. All existing full command names continue to work.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No** — aliases resolve to existing commands with identical authorization checks
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime/container: Node.js via pnpm
- Model/provider: N/A (command routing, not model-specific)
- Integration/channel (if any): All text-based channels
- Relevant config (redacted): Default

### Steps

1. `pnpm install && pnpm build`
2. Send `/c` in any chat channel
3. Observe it resolves to `/compact`

### Expected

- `/c` behaves identically to `/compact`
- All 9 aliases resolve to their target commands with args forwarded

### Actual

- Verified locally: all aliases resolve correctly

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`slash-commands-doc.test.ts` failed before docs update, passes after:
```
✓ src/docs/slash-commands-doc.test.ts (1 test) 4ms
  ✓ documents all built-in chat command aliases 3ms
```

Full test suite: `pnpm build && pnpm check && pnpm test` — all pass locally.

## Human Verification (required)

- Verified scenarios: `pnpm build` succeeds; `pnpm check` reports 0 warnings/errors; `pnpm test` all pass; `assertCommandRegistry()` confirms no duplicate aliases
- Edge cases checked: Verified `/ms` does not conflict with `/m` (prefix matching handled by exact-match-first in `normalizeCommandBody`); verified `/c` does not conflict with `/ctx`, `/config`, `/commands`
- What you did **not** verify: Live gateway testing with actual messaging channels (Telegram/Discord/WhatsApp)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- Risk: A future command could want one of these short names (e.g. `/s` for a new `/search` command)
  - Mitigation: `assertCommandRegistry()` enforces uniqueness at build time — any conflict would be caught immediately. Aliases can be removed or reassigned in a follow-up PR if needed.

---

*AI-assisted (Antigravity / Claude Opus 4.6). Confirmed understanding of all changes.*
