### PR TITLE
feat(acp): add session handback with close-self CLI and auto-detect runtime type from agent profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,7 @@ Docs: https://docs.openclaw.ai
 - ACPX/runtime: repair `queue owner unavailable` session recovery by replacing dead named sessions and resuming the backend session when ACPX exposes a stable session id, so the first ACP prompt no longer inherits a dead handle. (#58669) Thanks @neeravmakwana
 - ACPX/runtime: retry dead-session queue-owner repair without `--resume-session` when the reported ACPX session id is stale, so recovery still creates a fresh named session instead of failing session init. Thanks @obviyus.
 - Tools/web_search (Kimi): replay native Moonshot `$web_search` arguments verbatim, disable thinking for `kimi-k2.5`, and add Moonshot region/model setup prompts so bundled Kimi web search works again. (#59356) Thanks @Innocent-children.
+- Agents/compaction: resolve `agents.defaults.compaction.model` consistently for manual `/compact` and other context-engine compaction paths, so engine-owned compaction uses the configured override model across runtime entrypoints. (#56710) Thanks @oliviareid-svg
 
 ## 2026.3.31
 

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -23,6 +23,8 @@ import {
 } from "../infra/outbound/session-binding-service.js";
 import { resetTaskRegistryForTests } from "../tasks/task-registry.js";
 import * as acpSpawnParentStream from "./acp-spawn-parent-stream.js";
+import * as agentScope from "./agent-scope.js";
+import * as workspace from "./workspace.js";
 
 function createDefaultSpawnConfig(): OpenClawConfig {
   return {
@@ -95,6 +97,8 @@ const resolveAcpSpawnStreamLogPathSpy = vi.spyOn(
   acpSpawnParentStream,
   "resolveAcpSpawnStreamLogPath",
 );
+const loadWorkspaceBootstrapFilesSpy = vi.spyOn(workspace, "loadWorkspaceBootstrapFiles");
+const resolveAgentWorkspaceDirSpy = vi.spyOn(agentScope, "resolveAgentWorkspaceDir");
 
 const { isSpawnAcpAcceptedResult, spawnAcpDirect } = await import("./acp-spawn.js");
 type SpawnRequest = Parameters<typeof spawnAcpDirect>[0];
@@ -487,6 +491,8 @@ describe("spawnAcpDirect", () => {
     areHeartbeatsEnabledSpy
       .mockReset()
       .mockImplementation(() => hoisted.areHeartbeatsEnabledMock());
+    loadWorkspaceBootstrapFilesSpy.mockReset().mockResolvedValue([]);
+    resolveAgentWorkspaceDirSpy.mockReset().mockReturnValue("/tmp/workspace-codex");
   });
 
   afterEach(() => {
@@ -1676,5 +1682,221 @@ describe("spawnAcpDirect", () => {
     expect(expectFailedSpawn(result, "error").error).toContain('streamTo="parent"');
     expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
     expect(hoisted.startAcpSpawnParentStreamRelayMock).not.toHaveBeenCalled();
+  });
+
+  describe("ACP bootstrap injection", () => {
+    it("should prepend workspace bootstrap files to task string", async () => {
+      loadWorkspaceBootstrapFilesSpy.mockResolvedValue([
+        {
+          name: "SOUL.md",
+          path: "/tmp/workspace-codex/SOUL.md",
+          content: "You are a researcher.",
+          missing: false,
+        },
+        {
+          name: "AGENTS.md",
+          path: "/tmp/workspace-codex/AGENTS.md",
+          content: "Follow these rules.",
+          missing: false,
+        },
+      ]);
+
+      const result = await spawnAcpDirect(
+        createSpawnRequest({ task: "Investigate flaky tests" }),
+        createRequesterContext(),
+      );
+      expect(result.status).toBe("accepted");
+
+      const agentCall = findAgentGatewayCall();
+      expect(agentCall).toBeDefined();
+      const message = agentCall!.params!.message as string;
+      expect(message).toContain("[WORKSPACE CONTEXT]");
+      expect(message).toContain("You are a researcher.");
+      expect(message).toContain("Follow these rules.");
+      expect(message).toContain("[/WORKSPACE CONTEXT]");
+      expect(message).toContain("Investigate flaky tests");
+      // Task should come after the context block
+      expect(message.indexOf("[/WORKSPACE CONTEXT]")).toBeLessThan(
+        message.indexOf("Investigate flaky tests"),
+      );
+    });
+
+    it("should skip bootstrap injection on resume sessions", async () => {
+      loadWorkspaceBootstrapFilesSpy.mockResolvedValue([
+        {
+          name: "SOUL.md",
+          path: "/tmp/workspace-codex/SOUL.md",
+          content: "You are a researcher.",
+          missing: false,
+        },
+      ]);
+
+      const result = await spawnAcpDirect(
+        createSpawnRequest({ task: "Continue work", resumeSessionId: "prev-session" }),
+        createRequesterContext(),
+      );
+      expect(result.status).toBe("accepted");
+
+      const agentCall = findAgentGatewayCall();
+      expect(agentCall).toBeDefined();
+      expect(agentCall!.params!.message).toBe("Continue work");
+    });
+
+    it("should skip bootstrap when acp.injectBootstrap is false", async () => {
+      replaceSpawnConfig({
+        ...createDefaultSpawnConfig(),
+        acp: { ...createDefaultSpawnConfig().acp, injectBootstrap: false },
+      });
+      loadWorkspaceBootstrapFilesSpy.mockResolvedValue([
+        {
+          name: "SOUL.md",
+          path: "/tmp/workspace-codex/SOUL.md",
+          content: "You are a researcher.",
+          missing: false,
+        },
+      ]);
+
+      const result = await spawnAcpDirect(
+        createSpawnRequest({ task: "Do something" }),
+        createRequesterContext(),
+      );
+      expect(result.status).toBe("accepted");
+
+      const agentCall = findAgentGatewayCall();
+      expect(agentCall).toBeDefined();
+      expect(agentCall!.params!.message).toBe("Do something");
+    });
+
+    it("should not fail spawn if bootstrap loading errors", async () => {
+      loadWorkspaceBootstrapFilesSpy.mockRejectedValue(new Error("Permission denied"));
+
+      const result = await spawnAcpDirect(
+        createSpawnRequest({ task: "Do something" }),
+        createRequesterContext(),
+      );
+      expect(result.status).toBe("accepted");
+
+      const agentCall = findAgentGatewayCall();
+      expect(agentCall).toBeDefined();
+      expect(agentCall!.params!.message).toBe("Do something");
+    });
+
+    it("should respect MAX_TOTAL_CHARS budget", async () => {
+      const largeContent = "x".repeat(40_000);
+      loadWorkspaceBootstrapFilesSpy.mockResolvedValue([
+        {
+          name: "SOUL.md",
+          path: "/tmp/workspace-codex/SOUL.md",
+          content: largeContent,
+          missing: false,
+        },
+        {
+          name: "AGENTS.md",
+          path: "/tmp/workspace-codex/AGENTS.md",
+          content: largeContent,
+          missing: false,
+        },
+      ]);
+
+      const result = await spawnAcpDirect(
+        createSpawnRequest({ task: "Do something" }),
+        createRequesterContext(),
+      );
+      expect(result.status).toBe("accepted");
+
+      const agentCall = findAgentGatewayCall();
+      const message = agentCall!.params!.message as string;
+      // Should include SOUL.md (40k) but not AGENTS.md (would exceed 50k)
+      expect(message).toContain("## SOUL.md");
+      expect(message).not.toContain("## AGENTS.md");
+    });
+
+    it("should exclude missing and empty bootstrap files", async () => {
+      loadWorkspaceBootstrapFilesSpy.mockResolvedValue([
+        {
+          name: "SOUL.md",
+          path: "/tmp/workspace-codex/SOUL.md",
+          content: "Real content.",
+          missing: false,
+        },
+        {
+          name: "AGENTS.md",
+          path: "/tmp/workspace-codex/AGENTS.md",
+          content: undefined,
+          missing: true,
+        },
+        {
+          name: "IDENTITY.md",
+          path: "/tmp/workspace-codex/IDENTITY.md",
+          content: "   ",
+          missing: false,
+        },
+      ]);
+
+      const result = await spawnAcpDirect(
+        createSpawnRequest({ task: "Do something" }),
+        createRequesterContext(),
+      );
+      expect(result.status).toBe("accepted");
+
+      const agentCall = findAgentGatewayCall();
+      const message = agentCall!.params!.message as string;
+      expect(message).toContain("## SOUL.md");
+      expect(message).not.toContain("## AGENTS.md");
+      expect(message).not.toContain("## IDENTITY.md");
+    });
+
+    it("should exclude HEARTBEAT.md and BOOTSTRAP.md", async () => {
+      loadWorkspaceBootstrapFilesSpy.mockResolvedValue([
+        {
+          name: "SOUL.md",
+          path: "/tmp/workspace-codex/SOUL.md",
+          content: "Identity.",
+          missing: false,
+        },
+        {
+          name: "HEARTBEAT.md",
+          path: "/tmp/workspace-codex/HEARTBEAT.md",
+          content: "heartbeat config",
+          missing: false,
+        },
+        {
+          name: "BOOTSTRAP.md",
+          path: "/tmp/workspace-codex/BOOTSTRAP.md",
+          content: "bootstrap ritual",
+          missing: false,
+        },
+      ]);
+
+      const result = await spawnAcpDirect(
+        createSpawnRequest({ task: "Do something" }),
+        createRequesterContext(),
+      );
+      expect(result.status).toBe("accepted");
+
+      const agentCall = findAgentGatewayCall();
+      const message = agentCall!.params!.message as string;
+      expect(message).toContain("## SOUL.md");
+      expect(message).not.toContain("HEARTBEAT.md");
+      expect(message).not.toContain("BOOTSTRAP.md");
+    });
+
+    it("should use params.cwd over resolveAgentWorkspaceDir when provided", async () => {
+      loadWorkspaceBootstrapFilesSpy.mockResolvedValue([
+        {
+          name: "SOUL.md",
+          path: "/custom/cwd/SOUL.md",
+          content: "Custom workspace.",
+          missing: false,
+        },
+      ]);
+
+      await spawnAcpDirect(
+        createSpawnRequest({ task: "Do something", cwd: "/custom/cwd" }),
+        createRequesterContext(),
+      );
+
+      expect(loadWorkspaceBootstrapFilesSpy).toHaveBeenCalledWith("/custom/cwd");
+    });
   });
 });

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1075,6 +1075,182 @@ describe("spawnAcpDirect", () => {
     expect(expectFailedSpawn(result, "error").error).toContain("set `acp.defaultAgent`");
   });
 
+  it("resolves agent profile alias to underlying ACP harness ID", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        allowedAgents: ["claude"],
+      },
+      agents: {
+        list: [
+          {
+            id: "analyst",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "claude" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Analyze data",
+        agentId: "analyst",
+      },
+      {
+        agentSessionKey: "agent:main:telegram:direct:123",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:123",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    // The session key should contain the resolved harness ID "claude", not the alias "analyst"
+    expect(result.childSessionKey).toMatch(/^agent:claude:acp:/);
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "claude", cwd: undefined }),
+    );
+  });
+
+  it("inherits profile workspace cwd when caller does not specify cwd", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        allowedAgents: ["claude"],
+      },
+      agents: {
+        list: [
+          {
+            id: "analyst",
+            workspace: "/workspace/analysis",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "claude", cwd: "/workspace/analysis" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Analyze data",
+        agentId: "analyst",
+      },
+      {
+        agentSessionKey: "agent:main:telegram:direct:123",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:123",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/workspace/analysis" }),
+    );
+  });
+
+  it("prefers explicit cwd over profile workspace when both are provided", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        allowedAgents: ["claude"],
+      },
+      agents: {
+        list: [
+          {
+            id: "analyst",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "claude", cwd: "/workspace/analysis" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Analyze data",
+        agentId: "analyst",
+        cwd: "/override/workspace",
+      },
+      {
+        agentSessionKey: "agent:main:telegram:direct:123",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:123",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/override/workspace" }),
+    );
+  });
+
+  it("inherits profile cwd from defaultAgent when agentId is omitted", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        defaultAgent: "codex",
+        allowedAgents: ["codex"],
+      },
+      agents: {
+        list: [
+          {
+            id: "codex",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "codex", cwd: "/workspace/default-agent" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/workspace/default-agent" }),
+    );
+  });
+
+  it("passes raw harness ID through when no matching agent profile exists", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+        agentId: "codex",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.childSessionKey).toMatch(/^agent:codex:acp:/);
+  });
+
   it("fails fast when Discord ACP thread spawn is disabled", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1236,6 +1236,44 @@ describe("spawnAcpDirect", () => {
     );
   });
 
+  it("resolves defaultAgent alias to harness ID when agentId is omitted", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        defaultAgent: "analyst",
+        allowedAgents: ["claude"],
+      },
+      agents: {
+        list: [
+          {
+            id: "analyst",
+            runtime: {
+              type: "acp" as const,
+              acp: { agent: "claude", cwd: "/workspace/analysis" },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.childSessionKey).toMatch(/^agent:claude:acp:/);
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "claude", cwd: "/workspace/analysis" }),
+    );
+  });
+
   it("passes raw harness ID through when no matching agent profile exists", async () => {
     const result = await spawnAcpDirect(
       {

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1764,7 +1764,9 @@ describe("spawnAcpDirect", () => {
 
       const agentCall = findAgentGatewayCall();
       expect(agentCall).toBeDefined();
-      expect(agentCall!.params!.message).toBe("Do something");
+      const message = agentCall!.params!.message as string;
+      expect(message).not.toContain("[WORKSPACE CONTEXT]");
+      expect(message).toContain("Do something");
     });
 
     it("should not fail spawn if bootstrap loading errors", async () => {
@@ -1778,7 +1780,9 @@ describe("spawnAcpDirect", () => {
 
       const agentCall = findAgentGatewayCall();
       expect(agentCall).toBeDefined();
-      expect(agentCall!.params!.message).toBe("Do something");
+      const message = agentCall!.params!.message as string;
+      expect(message).not.toContain("[WORKSPACE CONTEXT]");
+      expect(message).toContain("Do something");
     });
 
     it("should respect MAX_TOTAL_CHARS budget", async () => {
@@ -1897,6 +1901,53 @@ describe("spawnAcpDirect", () => {
       );
 
       expect(loadWorkspaceBootstrapFilesSpy).toHaveBeenCalledWith("/custom/cwd");
+    });
+  });
+
+  describe("ACP session handback injection", () => {
+    it("should append session control block with session key", async () => {
+      const result = await spawnAcpDirect(
+        createSpawnRequest({ task: "Analyze this" }),
+        createRequesterContext(),
+      );
+      expect(result.status).toBe("accepted");
+
+      const agentCall = findAgentGatewayCall();
+      const message = agentCall!.params!.message as string;
+      expect(message).toContain("[ACP SESSION CONTROL]");
+      expect(message).toContain("openclaw acp close-self --session-key");
+      expect(message).toContain("[/ACP SESSION CONTROL]");
+      // Session control should come after the task
+      expect(message).toContain("Analyze this");
+    });
+
+    it("should skip handback injection on resume sessions", async () => {
+      const result = await spawnAcpDirect(
+        createSpawnRequest({ task: "Continue", resumeSessionId: "prev" }),
+        createRequesterContext(),
+      );
+      expect(result.status).toBe("accepted");
+
+      const agentCall = findAgentGatewayCall();
+      const message = agentCall!.params!.message as string;
+      expect(message).not.toContain("[ACP SESSION CONTROL]");
+    });
+
+    it("should skip handback injection when sessionHandback is false", async () => {
+      replaceSpawnConfig({
+        ...createDefaultSpawnConfig(),
+        acp: { ...createDefaultSpawnConfig().acp, sessionHandback: false },
+      });
+
+      const result = await spawnAcpDirect(
+        createSpawnRequest({ task: "Do something" }),
+        createRequesterContext(),
+      );
+      expect(result.status).toBe("accepted");
+
+      const agentCall = findAgentGatewayCall();
+      const message = agentCall!.params!.message as string;
+      expect(message).not.toContain("[ACP SESSION CONTROL]");
     });
   });
 });

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1198,10 +1198,14 @@ export async function spawnAcpDirect(
       `Session key: ${sessionKey}`,
       "",
       "You can hand control back to the main agent by running this shell command:",
-      `  openclaw acp close-self --session-key "${sessionKey}"`,
+      `  openclaw acp close-self --session-key "${sessionKey}" --message "your summary here"`,
       "",
-      "Do this ONLY when the user asks about something clearly unrelated to your assigned task.",
-      "Do NOT hand back for follow-ups, clarifications, or when completing your task (summarize first).",
+      "Use close-self in these situations:",
+      "- The user explicitly asks you to hand back or delegate to the main agent.",
+      "- You have fully completed your assigned task — summarize results in --message, then close.",
+      "- The user asks about something clearly unrelated to your assigned task.",
+      "",
+      "Do NOT close-self for follow-up questions, clarifications, or while still working on the task.",
       "[/ACP SESSION CONTROL]",
     ].join("\n");
     effectiveTask = `${effectiveTask}\n\n${handbackBlock}`;

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -67,6 +67,16 @@ import { resolveSpawnedWorkspaceInheritance } from "./spawned-context.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 import { loadWorkspaceBootstrapFiles } from "./workspace.js";
 
+const ACP_BOOTSTRAP_INCLUDE = new Set([
+  "AGENTS.md",
+  "SOUL.md",
+  "IDENTITY.md",
+  "USER.md",
+  "TOOLS.md",
+  "MEMORY.md",
+  "memory.md",
+]);
+
 const log = createSubsystemLogger("agents/acp-spawn");
 
 export const ACP_SPAWN_MODES = ["run", "session"] as const;
@@ -1007,15 +1017,6 @@ export async function spawnAcpDirect(
     if (bootstrapWorkspace && cfg.acp?.injectBootstrap !== false) {
       try {
         const bootstrapFiles = await loadWorkspaceBootstrapFiles(bootstrapWorkspace);
-        const ACP_BOOTSTRAP_INCLUDE = new Set([
-          "AGENTS.md",
-          "SOUL.md",
-          "IDENTITY.md",
-          "USER.md",
-          "TOOLS.md",
-          "MEMORY.md",
-          "memory.md",
-        ]);
         const includedFiles = bootstrapFiles.filter(
           (f) => !f.missing && f.content?.trim() && ACP_BOOTSTRAP_INCLUDE.has(f.name),
         );

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -405,11 +405,16 @@ function resolveTargetAcpAgentId(params: {
     const defaultProfile = listAgentEntries(params.cfg).find(
       (a) => normalizeAgentId(a.id) === configuredDefault,
     );
+    let defaultAgentId = configuredDefault;
     const defaultProfileCwd =
       defaultProfile?.runtime?.type === "acp"
         ? defaultProfile.runtime.acp?.cwd || defaultProfile.workspace
         : defaultProfile?.workspace;
-    return { ok: true, agentId: configuredDefault, profileCwd: defaultProfileCwd };
+    if (defaultProfile?.runtime?.type === "acp" && defaultProfile.runtime.acp?.agent) {
+      defaultAgentId =
+        normalizeOptionalAgentId(defaultProfile.runtime.acp.agent) || configuredDefault;
+    }
+    return { ok: true, agentId: defaultAgentId, profileCwd: defaultProfileCwd };
   }
 
   return {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -58,6 +58,7 @@ import {
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
 import {
+  listAgentEntries,
   resolveAgentConfig,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
@@ -379,15 +380,36 @@ function hasSessionLocalHeartbeatRelayRoute(params: {
 function resolveTargetAcpAgentId(params: {
   requestedAgentId?: string;
   cfg: OpenClawConfig;
-}): { ok: true; agentId: string } | { ok: false; error: string } {
+}): { ok: true; agentId: string; profileCwd?: string } | { ok: false; error: string } {
   const requested = normalizeOptionalAgentId(params.requestedAgentId);
   if (requested) {
-    return { ok: true, agentId: requested };
+    // Check if the requested ID is an agent profile alias that maps to
+    // a different underlying ACP harness ID (e.g. "analyst" → "claude").
+    const profile = listAgentEntries(params.cfg).find((a) => normalizeAgentId(a.id) === requested);
+
+    let targetAgentId = requested;
+    let profileCwd: string | undefined;
+
+    if (profile?.runtime?.type === "acp" && profile.runtime.acp?.agent) {
+      targetAgentId = normalizeOptionalAgentId(profile.runtime.acp.agent) || requested;
+      profileCwd = profile.runtime.acp.cwd || profile.workspace;
+    } else if (profile?.workspace) {
+      profileCwd = profile.workspace;
+    }
+
+    return { ok: true, agentId: targetAgentId, profileCwd };
   }
 
   const configuredDefault = normalizeOptionalAgentId(params.cfg.acp?.defaultAgent);
   if (configuredDefault) {
-    return { ok: true, agentId: configuredDefault };
+    const defaultProfile = listAgentEntries(params.cfg).find(
+      (a) => normalizeAgentId(a.id) === configuredDefault,
+    );
+    const defaultProfileCwd =
+      defaultProfile?.runtime?.type === "acp"
+        ? defaultProfile.runtime.acp?.cwd || defaultProfile.workspace
+        : defaultProfile?.workspace;
+    return { ok: true, agentId: configuredDefault, profileCwd: defaultProfileCwd };
   }
 
   return {
@@ -1051,7 +1073,7 @@ export async function spawnAcpDirect(
     config: cfg,
     targetAgentId,
     requesterSessionKey: ctx.agentSessionKey,
-    explicitWorkspaceDir: params.cwd,
+    explicitWorkspaceDir: params.cwd || targetAgentResult.profileCwd,
   });
   let runtimeCwd: string | undefined;
   try {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -57,10 +57,15 @@ import {
   resolveAcpSpawnStreamLogPath,
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
-import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "./agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { resolveSpawnedWorkspaceInheritance } from "./spawned-context.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
+import { loadWorkspaceBootstrapFiles } from "./workspace.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
 
@@ -995,6 +1000,50 @@ export async function spawnAcpDirect(
     });
   }
 
+  // --- ACP bootstrap injection ---
+  let effectiveTask = params.task;
+  if (!params.resumeSessionId) {
+    const bootstrapWorkspace = params.cwd || resolveAgentWorkspaceDir(cfg, targetAgentId);
+    if (bootstrapWorkspace && cfg.acp?.injectBootstrap !== false) {
+      try {
+        const bootstrapFiles = await loadWorkspaceBootstrapFiles(bootstrapWorkspace);
+        const ACP_BOOTSTRAP_INCLUDE = new Set([
+          "AGENTS.md",
+          "SOUL.md",
+          "IDENTITY.md",
+          "USER.md",
+          "TOOLS.md",
+          "MEMORY.md",
+          "memory.md",
+        ]);
+        const includedFiles = bootstrapFiles.filter(
+          (f) => !f.missing && f.content?.trim() && ACP_BOOTSTRAP_INCLUDE.has(f.name),
+        );
+        if (includedFiles.length > 0) {
+          const MAX_TOTAL_CHARS = 50_000;
+          let totalChars = 0;
+          const sections: string[] = [];
+          for (const file of includedFiles) {
+            const content = file.content!.trim();
+            if (totalChars + content.length > MAX_TOTAL_CHARS) {
+              break;
+            }
+            sections.push(`## ${file.name}\n\n${content}`);
+            totalChars += content.length;
+          }
+          if (sections.length > 0) {
+            const bootstrapBlock = sections.join("\n\n---\n\n");
+            effectiveTask = `[WORKSPACE CONTEXT]\nThe following files define your identity, operating instructions, and memory for this workspace. Follow them.\n\n${bootstrapBlock}\n\n[/WORKSPACE CONTEXT]\n\n${params.task}`;
+          }
+        }
+      } catch (err) {
+        log.warn(
+          `ACP bootstrap injection failed for workspace ${bootstrapWorkspace}: ${summarizeError(err)}`,
+        );
+      }
+    }
+  }
+
   const sessionKey = `agent:${targetAgentId}:acp:${crypto.randomUUID()}`;
   const runtimeMode = resolveAcpSessionMode(spawnMode);
   const resolvedCwd = resolveSpawnedWorkspaceInheritance({
@@ -1118,7 +1167,7 @@ export async function spawnAcpDirect(
     const response = await callGateway<{ runId?: string }>({
       method: "agent",
       params: {
-        message: params.task,
+        message: effectiveTask,
         sessionKey,
         channel: deliveryPlan.channel,
         to: deliveryPlan.to,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1164,6 +1164,22 @@ export async function spawnAcpDirect(
       emitStartNotice: false,
     });
   }
+  // --- ACP session handback control injection ---
+  if (cfg.acp?.sessionHandback !== false && !params.resumeSessionId) {
+    const handbackBlock = [
+      "[ACP SESSION CONTROL]",
+      `Session key: ${sessionKey}`,
+      "",
+      "You can hand control back to the main agent by running this shell command:",
+      `  openclaw acp close-self --session-key "${sessionKey}"`,
+      "",
+      "Do this ONLY when the user asks about something clearly unrelated to your assigned task.",
+      "Do NOT hand back for follow-ups, clarifications, or when completing your task (summarize first).",
+      "[/ACP SESSION CONTROL]",
+    ].join("\n");
+    effectiveTask = `${effectiveTask}\n\n${handbackBlock}`;
+  }
+
   try {
     const response = await callGateway<{ runId?: string }>({
       method: "agent",

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -2,7 +2,6 @@ import { streamSimple } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import {
   isOllamaCompatProvider,
-  resolveOllamaBaseUrlForRun,
   resolveOllamaCompatNumCtxEnabled,
   shouldInjectOllamaCompatNumCtx,
   wrapOllamaCompatNumCtx,

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -2,6 +2,7 @@ import { streamSimple } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import {
   isOllamaCompatProvider,
+  resolveOllamaBaseUrlForRun,
   resolveOllamaCompatNumCtxEnabled,
   shouldInjectOllamaCompatNumCtx,
   wrapOllamaCompatNumCtx,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -151,8 +151,7 @@ export function createSessionsSpawnTool(
 
       // Auto-detect runtime from agent profile config when not explicitly specified.
       // If the target agent has runtime.type: "acp", use ACP automatically.
-      let runtime: "acp" | "subagent" =
-        params.runtime === "acp" ? "acp" : params.runtime === "subagent" ? "subagent" : "subagent";
+      let runtime: "acp" | "subagent" = params.runtime === "acp" ? "acp" : "subagent";
       if (!params.runtime && requestedAgentId) {
         const cfg = loadConfig();
         const normalizedId = requestedAgentId.toLowerCase().trim();

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -4,6 +4,7 @@ import { callGateway } from "../../gateway/call.js";
 import { normalizeDeliveryContext } from "../../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import { isSpawnAcpAcceptedResult, spawnAcpDirect } from "../acp-spawn.js";
+import { listAgentEntries } from "../agent-scope.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import type { SpawnedToolContext } from "../spawned-context.js";
 import { registerSubagentRun } from "../subagent-registry.js";
@@ -146,8 +147,22 @@ export function createSessionsSpawnTool(
       }
       const task = readStringParam(params, "task", { required: true });
       const label = typeof params.label === "string" ? params.label.trim() : "";
-      const runtime = params.runtime === "acp" ? "acp" : "subagent";
       const requestedAgentId = readStringParam(params, "agentId");
+
+      // Auto-detect runtime from agent profile config when not explicitly specified.
+      // If the target agent has runtime.type: "acp", use ACP automatically.
+      let runtime: "acp" | "subagent" =
+        params.runtime === "acp" ? "acp" : params.runtime === "subagent" ? "subagent" : "subagent";
+      if (!params.runtime && requestedAgentId) {
+        const cfg = loadConfig();
+        const normalizedId = requestedAgentId.toLowerCase().trim();
+        const agentEntry = listAgentEntries(cfg).find(
+          (e) => e.id?.toLowerCase().trim() === normalizedId,
+        );
+        if (agentEntry?.runtime?.type === "acp") {
+          runtime = "acp";
+        }
+      }
       const resumeSessionId = readStringParam(params, "resumeSessionId");
       const modelOverride = readStringParam(params, "model");
       const thinkingOverrideRaw = readStringParam(params, "thinking");

--- a/src/cli/acp-cli.ts
+++ b/src/cli/acp-cli.ts
@@ -119,4 +119,30 @@ export function registerAcpCli(program: Command) {
         defaultRuntime.exit(1);
       }
     });
+
+  acp
+    .command("close-self")
+    .description(
+      "Close the current ACP session and hand control back to the main agent. Designed for ACP agents to call when the user goes off-topic.",
+    )
+    .option("--session-key <key>", "ACP session key (auto-discovered from cwd if omitted)")
+    .option("--reason <text>", "Why handing back (included in session metadata)")
+    .option("--message <text>", "Final message delivered to the conversation before unbinding")
+    .action(async (opts) => {
+      try {
+        const { handleAcpCloseSelf } = await import("../commands/acp-close-self.js");
+        const result = await handleAcpCloseSelf({
+          sessionKey: opts.sessionKey as string | undefined,
+          reason: opts.reason as string | undefined,
+          message: opts.message as string | undefined,
+        });
+        if (!result.ok) {
+          defaultRuntime.error(result.error || "ACP close-self failed.");
+          defaultRuntime.exit(1);
+        }
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
 }

--- a/src/cli/acp-cli.ts
+++ b/src/cli/acp-cli.ts
@@ -125,15 +125,13 @@ export function registerAcpCli(program: Command) {
     .description(
       "Close the current ACP session and hand control back to the main agent. Designed for ACP agents to call when the user goes off-topic.",
     )
-    .option("--session-key <key>", "ACP session key (auto-discovered from cwd if omitted)")
-    .option("--reason <text>", "Why handing back (included in session metadata)")
+    .option("--session-key <key>", "ACP session key (from the [ACP SESSION CONTROL] block)")
     .option("--message <text>", "Final message delivered to the conversation before unbinding")
     .action(async (opts) => {
       try {
         const { handleAcpCloseSelf } = await import("../commands/acp-close-self.js");
         const result = await handleAcpCloseSelf({
           sessionKey: opts.sessionKey as string | undefined,
-          reason: opts.reason as string | undefined,
           message: opts.message as string | undefined,
         });
         if (!result.ok) {

--- a/src/commands/acp-close-self.ts
+++ b/src/commands/acp-close-self.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import { loadConfig } from "../config/config.js";
 import { callGateway } from "../gateway/call.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
@@ -7,27 +6,21 @@ const log = createSubsystemLogger("commands/acp-close-self");
 
 export async function handleAcpCloseSelf(opts: {
   sessionKey?: string;
-  reason?: string;
   message?: string;
 }): Promise<{ ok: boolean; error?: string }> {
-  const cfg = loadConfig();
-
-  // Resolve session key: explicit flag, or auto-discover from cwd
-  let sessionKey = opts.sessionKey?.trim();
-  if (!sessionKey) {
-    sessionKey = await discoverOwnAcpSessionKey(cfg);
-  }
+  const sessionKey = opts.sessionKey?.trim();
   if (!sessionKey) {
     return {
       ok: false,
       error:
-        "Could not determine ACP session key. Pass --session-key explicitly or ensure this process runs inside an ACP session.",
+        "Missing --session-key. The [ACP SESSION CONTROL] block in your task contains the key.",
     };
   }
 
-  // Deliver handoff message to the conversation before unbinding
+  // Deliver handoff message and wait for it to land before closing.
   if (opts.message?.trim()) {
     try {
+      const idempotencyKey = crypto.randomUUID();
       await callGateway({
         method: "agent",
         params: {
@@ -35,9 +28,17 @@ export async function handleAcpCloseSelf(opts: {
           sessionKey,
           deliver: true,
           label: "handback",
-          idempotencyKey: crypto.randomUUID(),
+          idempotencyKey,
         },
         timeoutMs: 10_000,
+      });
+      // Wait briefly for the message to be processed before deleting the session.
+      await callGateway({
+        method: "agent.wait",
+        params: { idempotencyKey },
+        timeoutMs: 15_000,
+      }).catch(() => {
+        // Best-effort: if wait times out the message may still land.
       });
     } catch (err) {
       log.warn(`Failed to deliver handoff message for ${sessionKey}: ${String(err)}`);
@@ -45,8 +46,8 @@ export async function handleAcpCloseSelf(opts: {
     }
   }
 
-  // Delete the session (closes ACP runtime + unbinds)
-  // The transcript is preserved so the main agent can reference it.
+  // Delete the session (closes ACP runtime + unbinds).
+  // Transcript is preserved so the main agent can reference it.
   try {
     await callGateway<{ ok: boolean; deleted: boolean }>({
       method: "sessions.delete",
@@ -64,38 +65,4 @@ export async function handleAcpCloseSelf(opts: {
   }
 
   return { ok: true };
-}
-
-/**
- * Discover the current ACP session key by matching the cwd against active sessions.
- */
-async function discoverOwnAcpSessionKey(
-  _cfg: ReturnType<typeof loadConfig>,
-): Promise<string | undefined> {
-  const cwd = process.cwd();
-  try {
-    const sessions = await callGateway<{
-      sessions?: Array<{ key: string; acp?: { cwd?: string; state?: string } }>;
-    }>({
-      method: "sessions.list",
-      params: {},
-      timeoutMs: 10_000,
-    });
-
-    if (!sessions?.sessions) {
-      return undefined;
-    }
-
-    // Find an ACP session whose cwd matches ours
-    const match = sessions.sessions.find(
-      (s) => s.acp?.cwd && normalizePath(s.acp.cwd) === normalizePath(cwd),
-    );
-    return match?.key;
-  } catch {
-    return undefined;
-  }
-}
-
-function normalizePath(p: string): string {
-  return p.replace(/\/+$/, "");
 }

--- a/src/commands/acp-close-self.ts
+++ b/src/commands/acp-close-self.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { loadConfig } from "../config/config.js";
 import { callGateway } from "../gateway/call.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -34,6 +35,7 @@ export async function handleAcpCloseSelf(opts: {
           sessionKey,
           deliver: true,
           label: "handback",
+          idempotencyKey: crypto.randomUUID(),
         },
         timeoutMs: 10_000,
       });

--- a/src/commands/acp-close-self.ts
+++ b/src/commands/acp-close-self.ts
@@ -1,0 +1,99 @@
+import { loadConfig } from "../config/config.js";
+import { callGateway } from "../gateway/call.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("commands/acp-close-self");
+
+export async function handleAcpCloseSelf(opts: {
+  sessionKey?: string;
+  reason?: string;
+  message?: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  const cfg = loadConfig();
+
+  // Resolve session key: explicit flag, or auto-discover from cwd
+  let sessionKey = opts.sessionKey?.trim();
+  if (!sessionKey) {
+    sessionKey = await discoverOwnAcpSessionKey(cfg);
+  }
+  if (!sessionKey) {
+    return {
+      ok: false,
+      error:
+        "Could not determine ACP session key. Pass --session-key explicitly or ensure this process runs inside an ACP session.",
+    };
+  }
+
+  // Deliver handoff message to the conversation before unbinding
+  if (opts.message?.trim()) {
+    try {
+      await callGateway({
+        method: "agent",
+        params: {
+          message: opts.message.trim(),
+          sessionKey,
+          deliver: true,
+          label: "handback",
+        },
+        timeoutMs: 10_000,
+      });
+    } catch (err) {
+      log.warn(`Failed to deliver handoff message for ${sessionKey}: ${String(err)}`);
+      // Non-fatal: proceed with close
+    }
+  }
+
+  // Delete the session (closes ACP runtime + unbinds)
+  // The transcript is preserved so the main agent can reference it.
+  try {
+    await callGateway<{ ok: boolean; deleted: boolean }>({
+      method: "sessions.delete",
+      params: {
+        key: sessionKey,
+        deleteTranscript: false,
+      },
+      timeoutMs: 10_000,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Failed to close session ${sessionKey}: ${String(err)}`,
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Discover the current ACP session key by matching the cwd against active sessions.
+ */
+async function discoverOwnAcpSessionKey(
+  _cfg: ReturnType<typeof loadConfig>,
+): Promise<string | undefined> {
+  const cwd = process.cwd();
+  try {
+    const sessions = await callGateway<{
+      sessions?: Array<{ key: string; acp?: { cwd?: string; state?: string } }>;
+    }>({
+      method: "sessions.list",
+      params: {},
+      timeoutMs: 10_000,
+    });
+
+    if (!sessions?.sessions) {
+      return undefined;
+    }
+
+    // Find an ACP session whose cwd matches ours
+    const match = sessions.sessions.find(
+      (s) => s.acp?.cwd && normalizePath(s.acp.cwd) === normalizePath(cwd),
+    );
+    return match?.key;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizePath(p: string): string {
+  return p.replace(/\/+$/, "");
+}

--- a/src/config/types.acp.ts
+++ b/src/config/types.acp.ts
@@ -47,4 +47,6 @@ export type AcpConfig = {
   runtime?: AcpRuntimeConfig;
   /** Inject workspace bootstrap files (SOUL.md, AGENTS.md, etc.) into the ACP task string. Default: true. */
   injectBootstrap?: boolean;
+  /** Inject session handback instructions so ACP agents can hand control back to the main agent. Default: true. */
+  sessionHandback?: boolean;
 };

--- a/src/config/types.acp.ts
+++ b/src/config/types.acp.ts
@@ -45,4 +45,6 @@ export type AcpConfig = {
   maxConcurrentSessions?: number;
   stream?: AcpStreamConfig;
   runtime?: AcpRuntimeConfig;
+  /** Inject workspace bootstrap files (SOUL.md, AGENTS.md, etc.) into the ACP task string. Default: true. */
+  injectBootstrap?: boolean;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -496,6 +496,7 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         injectBootstrap: z.boolean().optional(),
+        sessionHandback: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -495,6 +495,7 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        injectBootstrap: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

- Problem: ACP agents can't hand control back to main, and `sessions_spawn` requires explicit `runtime="acp"` even when the target agent is configured as ACP
- Why it matters: natural language delegation requires automatic routing and specialist handback
- What changed: (1) new `openclaw acp close-self` CLI, (2) auto-injected `[ACP SESSION CONTROL]` block with session key, (3) `sessions_spawn` auto-detects ACP runtime from agent config
- What did NOT change: existing `/acp close`, ACP protocol, native tool registry

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution

## Linked Issue/PR

- Depends on #59230
- Related #57732
- Related #57910

## User-visible / Behavior Changes

- ACP task strings include `[ACP SESSION CONTROL]` block with session key and close-self instructions (automatic, no config needed)
- New CLI: `openclaw acp close-self --session-key <key> --reason <text> --message <text>`
- `sessions_spawn(agentId="analyst")` auto-routes through ACP when agent config has `runtime.type: "acp"`
- New config: `acp.sessionHandback` (default: `true`, set `false` to disable)

## Security Impact (required)

- New permissions/capabilities? Yes — `close-self` can close/unbind sessions
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — CLI connects to gateway WebSocket
- Command/tool execution surface changed? Yes — new CLI subcommand
- Data access scope changed? No
- Mitigation: requires gateway auth token from config. Session transcripts preserved on close.

## Human Verification (required)

- Verified: auto-runtime detection — main agent delegated to researcher without explicit `runtime="acp"`, routed through ACP automatically
- Verified: `[ACP SESSION CONTROL]` block injected with correct session key
- Verified: `openclaw acp close-self` CLI registered and functional (tested with real and nonexistent session keys)
- Verified: multi-turn ACP conversation in Telegram DM with workspace persona
- Verified: `acp.sessionHandback: false` disables injection (unit test)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? New optional `acp.sessionHandback` (default: true)
- Migration needed? No

## Risks and Mitigations

- Risk: auto-runtime detection changes routing for agents with `runtime.type: "acp"` that were previously spawned as subagents
  - Mitigation: only activates when `runtime` param is not explicitly set; `runtime="subagent"` override still works