### PR TITLE
fix(gateway): prefer bootstrap auth over tailscale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Matrix/multi-account: keep room-level `account` scoping, inherited room overrides, and implicit account selection consistent across top-level default auth, named accounts, and cached-credential env setups. (#58449) thanks @Daanvdplas and @gumadeiras.
+- Gateway/pairing: prefer explicit QR bootstrap auth over earlier Tailscale auth classification so iOS `/pair qr` silent bootstrap pairing does not fall through to `pairing required`. (#59232) Thanks @ngutman.
 - Config/Discord: coerce safe integer numeric Discord IDs to strings during config validation, keep unsafe or precision-losing numeric snowflakes rejected, and align `openclaw doctor` repair guidance with the same fail-closed behavior. (#45125) Thanks @moliendocode.
 - Gateway/sessions: scope bare `sessions.create` aliases like `main` to the requested agent while preserving the canonical `global` and `unknown` sentinel keys. (#58207) thanks @jalehman.
 - `/context detail` now compares the tracked prompt estimate with cached context usage and surfaces untracked provider/runtime overhead when present. (#28391) thanks @ImLukeF.

--- a/src/gateway/server/ws-connection/auth-context.test.ts
+++ b/src/gateway/server/ws-connection/auth-context.test.ts
@@ -169,23 +169,58 @@ describe("resolveConnectAuthDecision", () => {
     expect(verifyDeviceToken).not.toHaveBeenCalled();
   });
 
-  it("returns the original decision when device fallback does not apply", async () => {
+  it("prefers a valid bootstrap token over an already successful shared auth path", async () => {
+    const verifyBootstrapToken = vi.fn<VerifyBootstrapTokenFn>(async () => ({ ok: true }));
     const verifyDeviceToken = vi.fn<VerifyDeviceTokenFn>(async () => ({ ok: true }));
     const decision = await resolveConnectAuthDecision({
       state: createBaseState({
-        authResult: { ok: true, method: "token" },
+        authResult: { ok: true, method: "tailscale" },
         authOk: true,
+        authMethod: "tailscale",
+        bootstrapTokenCandidate: "bootstrap-token",
+        deviceTokenCandidate: undefined,
+        deviceTokenCandidateSource: undefined,
       }),
       hasDeviceIdentity: true,
       deviceId: "dev-1",
       publicKey: "pub-1",
-      role: "operator",
+      role: "node",
       scopes: [],
-      verifyBootstrapToken: async () => ({ ok: false, reason: "bootstrap_token_invalid" }),
+      verifyBootstrapToken,
       verifyDeviceToken,
     });
     expect(decision.authOk).toBe(true);
-    expect(decision.authMethod).toBe("token");
+    expect(decision.authMethod).toBe("bootstrap-token");
+    expect(verifyBootstrapToken).toHaveBeenCalledOnce();
+    expect(verifyDeviceToken).not.toHaveBeenCalled();
+  });
+
+  it("keeps the original successful auth path when bootstrap validation fails", async () => {
+    const verifyBootstrapToken = vi.fn<VerifyBootstrapTokenFn>(async () => ({
+      ok: false,
+      reason: "bootstrap_token_invalid",
+    }));
+    const verifyDeviceToken = vi.fn<VerifyDeviceTokenFn>(async () => ({ ok: true }));
+    const decision = await resolveConnectAuthDecision({
+      state: createBaseState({
+        authResult: { ok: true, method: "tailscale" },
+        authOk: true,
+        authMethod: "tailscale",
+        bootstrapTokenCandidate: "bootstrap-token",
+        deviceTokenCandidate: undefined,
+        deviceTokenCandidateSource: undefined,
+      }),
+      hasDeviceIdentity: true,
+      deviceId: "dev-1",
+      publicKey: "pub-1",
+      role: "node",
+      scopes: [],
+      verifyBootstrapToken,
+      verifyDeviceToken,
+    });
+    expect(decision.authOk).toBe(true);
+    expect(decision.authMethod).toBe("tailscale");
+    expect(verifyBootstrapToken).toHaveBeenCalledOnce();
     expect(verifyDeviceToken).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -170,13 +170,7 @@ export async function resolveConnectAuthDecision(params: {
   let authMethod = params.state.authMethod;
 
   const bootstrapTokenCandidate = params.state.bootstrapTokenCandidate;
-  if (
-    params.hasDeviceIdentity &&
-    params.deviceId &&
-    params.publicKey &&
-    !authOk &&
-    bootstrapTokenCandidate
-  ) {
+  if (params.hasDeviceIdentity && params.deviceId && params.publicKey && bootstrapTokenCandidate) {
     const tokenCheck = await params.verifyBootstrapToken({
       deviceId: params.deviceId,
       publicKey: params.publicKey,
@@ -185,9 +179,14 @@ export async function resolveConnectAuthDecision(params: {
       scopes: params.scopes,
     });
     if (tokenCheck.ok) {
+      // Prefer an explicit valid bootstrap token even when another auth path
+      // (for example tailscale serve header auth) already succeeded. QR pairing
+      // relies on the server classifying the handshake as bootstrap-token so the
+      // initial node pairing can be silently auto-approved and the bootstrap
+      // token can be revoked after approval.
       authOk = true;
       authMethod = "bootstrap-token";
-    } else {
+    } else if (!authOk) {
       authResult = { ok: false, reason: tokenCheck.reason ?? "bootstrap_token_invalid" };
     }
   }


### PR DESCRIPTION
## Summary

- Problem: QR pairing on iOS could still fail with `pairing required` when the gateway was exposed through Tailscale Serve because websocket auth succeeded as `tailscale` before bootstrap-token evaluation ran.
- Why it matters: that prevented the existing silent QR bootstrap pairing path from running, so the app stayed stuck waiting for approval even though the scanned QR bootstrap token was valid and present on the client.
- What changed: `resolveConnectAuthDecision` now still evaluates an explicit bootstrap token after prior auth success and prefers `authMethod="bootstrap-token"` when bootstrap validation succeeds; added focused regression tests for the tailscale-precedence case.
- What did NOT change (scope boundary): no iOS QR parsing/storage changes, no manual `/pair approve` scope changes, and no broader auth-mode behavior changes outside bootstrap precedence.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `src/gateway/server/ws-connection/auth-context.ts` only evaluated the bootstrap token when `!authOk`. On Tailscale Serve, the websocket could already be authenticated as `tailscale`, so bootstrap verification never ran and the later silent-pairing path never saw `authMethod === "bootstrap-token"`.
- Missing detection / guardrail: there was no unit test covering a valid bootstrap token arriving alongside an already-successful auth path.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the QR bootstrap flow itself was intact; the failure showed up only when a successful auth path preempted bootstrap classification.
- Why this regressed now: the auth decision logic treated bootstrap as a fallback instead of an explicit pairing signal.
- If unknown, what was ruled out: ruled out iOS QR parsing, bootstrap-token persistence, and client auth selection via on-device diagnostics; the client sent and selected the bootstrap token correctly.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server/ws-connection/auth-context.test.ts`
- Scenario the test should lock in: when a node connect has both a valid bootstrap token and a prior successful auth result (for example `tailscale`), the final method must be `bootstrap-token`; if bootstrap validation fails, keep the existing successful method.
- Why this is the smallest reliable guardrail: the bug is isolated to auth-decision precedence in a single pure decision point.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- QR pairing against a Tailscale Serve gateway now correctly follows the bootstrap-token auto-pair path instead of falling through to `pairing required`.

## Diagram (if applicable)

```text
Before:
QR scan -> websocket auth succeeds as tailscale -> bootstrap token skipped -> pairing required

After:
QR scan -> websocket auth succeeds as tailscale -> bootstrap token validated -> authMethod=bootstrap-token -> silent bootstrap pairing
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (Yes)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: this only changes auth precedence for an already-present explicit bootstrap token. The token is still validated server-side before the method is upgraded to `bootstrap-token`, and an invalid bootstrap token does not override an existing successful auth path.

## Repro + Verification

### Environment

- OS: macOS + physical iPhone repro
- Runtime/container: local OpenClaw gateway via Tailscale Serve
- Model/provider: N/A
- Integration/channel (if any): iOS node pairing via `/pair qr`
- Relevant config (redacted): `gateway.auth.mode=token`, `gateway.tailscale.mode=serve`

### Steps

1. Issue `/pair qr` from the gateway.
2. Scan from iOS and connect through the Tailscale Serve URL.
3. Observe that the iPhone selects `authSource=bootstrap-token` but the gateway still returns `pairing required`.

### Expected

- A valid QR bootstrap token should classify the connection as `bootstrap-token` and trigger silent bootstrap pairing.

### Actual

- The gateway authenticated the connection earlier as `tailscale`, skipped bootstrap evaluation, and the pairing stayed pending.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the failure via iOS diagnostics and gateway bootstrap state inspection; added regression tests for bootstrap-over-tailscale precedence; ran `pnpm test -- src/gateway/server/ws-connection/auth-context.test.ts` and `pnpm check`.
- Edge cases checked: invalid bootstrap token does not override an already-successful auth path.
- What you did **not** verify: did not deploy this branch to the remote Mac mini gateway and re-run the physical-device pairing flow from this PR branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: preferring bootstrap-token classification could mask another successful auth method when both are present.
  - Mitigation: the override only happens after successful bootstrap-token validation; invalid bootstrap tokens leave the existing successful auth method unchanged.
