### PR TITLE
fix(telegram): restore self-authored reply-media guard

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -197,6 +197,13 @@ export const registerTelegramHandlers = ({
         : async () => ({});
     return { message, me: ctx.me, getFile };
   };
+  const isSelfAuthoredTelegramMessage = (
+    ctx: Pick<TelegramContext, "me">,
+    message: Message,
+  ): boolean => {
+    const botId = ctx.me?.id;
+    return typeof botId === "number" && message.from?.id === botId;
+  };
   const inboundDebouncer = createInboundDebouncer<TelegramDebounceEntry>({
     debounceMs,
     resolveDebounceMs: (entry) =>


### PR DESCRIPTION
## Summary

- restore the missing `isSelfAuthoredTelegramMessage(...)` helper in the Telegram runtime
- fix the debounced reply-media path so it no longer throws `ReferenceError` during flush
- keep the existing reply-media behavior intact while restoring the guard used to skip bot-authored replies

## Root cause

`resolveReplyMediaForMessage(...)` still called `isSelfAuthoredTelegramMessage(...)`, but the helper was no longer present in `extensions/telegram/src/bot-handlers.runtime.ts`.

That meant the reply-media debounce flush could fail at runtime with:

`ReferenceError: isSelfAuthoredTelegramMessage is not defined`

The visible symptom in tests was an apparent timeout/hang while waiting for the debounced reply-media path to complete.

## Testing

- `pnpm exec vitest run extensions/telegram/src/bot.test.ts -t 'does not fetch reply media for unauthorized DM replies|defers reply media download until debounce flush' --testTimeout 10000 --hookTimeout 10000`
