### PR TITLE
test(contracts): avoid heavy plugin-sdk testing imports

### DIFF
--- a/extensions/discord/src/monitor/message-handler.inbound-context.test.ts
+++ b/extensions/discord/src/monitor/message-handler.inbound-context.test.ts
@@ -1,5 +1,5 @@
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
-import { expectChannelInboundContextContract as expectInboundContextContract } from "openclaw/plugin-sdk/testing";
+import { expectChannelInboundContextContract as expectInboundContextContract } from "../../../../src/channels/plugins/contracts/suites.js";
 import { describe, expect, it } from "vitest";
 import { buildDiscordInboundAccessContext } from "./inbound-context.js";
 import { buildFinalizedDiscordDirectInboundContext } from "./inbound-context.test-helpers.js";

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -1,6 +1,6 @@
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import { expectChannelInboundContextContract as expectInboundContextContract } from "../../../../src/channels/plugins/contracts/suites.js";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-let expectInboundContextContract: typeof import("openclaw/plugin-sdk/testing").expectChannelInboundContextContract;
 let createBaseSignalEventHandlerDeps: typeof import("./event-handler.test-harness.js").createBaseSignalEventHandlerDeps;
 let createSignalReceiveEvent: typeof import("./event-handler.test-harness.js").createSignalReceiveEvent;
 
@@ -51,8 +51,6 @@ let createSignalEventHandler: typeof import("./event-handler.js").createSignalEv
 describe("signal createSignalEventHandler inbound context", () => {
   beforeAll(async () => {
     vi.useRealTimers();
-    ({ expectChannelInboundContextContract: expectInboundContextContract } =
-      await import("openclaw/plugin-sdk/testing"));
     ({ createBaseSignalEventHandlerDeps, createSignalReceiveEvent } =
       await import("./event-handler.test-harness.js"));
     ({ createSignalEventHandler } = await import("./event-handler.js"));

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -5,7 +5,7 @@ import type { App } from "@slack/bolt";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
-import { expectChannelInboundContextContract as expectInboundContextContract } from "openclaw/plugin-sdk/testing";
+import { expectChannelInboundContextContract as expectInboundContextContract } from "../../../../../src/channels/plugins/contracts/suites.js";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { ResolvedSlackAccount } from "../../accounts.js";
 import type { SlackMessageEvent } from "../../types.js";

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -4,7 +4,7 @@ import {
   clearPluginInteractiveHandlers,
   registerPluginInteractiveHandler,
 } from "openclaw/plugin-sdk/plugin-runtime";
-import { expectChannelInboundContextContract as expectInboundContextContract } from "openclaw/plugin-sdk/testing";
+import { expectChannelInboundContextContract as expectInboundContextContract } from "../../../src/channels/plugins/contracts/suites.js";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { escapeRegExp, formatEnvelopeTimestamp } from "../../../test/helpers/envelope-timestamp.js";
 const {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { expectChannelInboundContextContract as expectInboundContextContract } from "openclaw/plugin-sdk/testing";
+import { expectChannelInboundContextContract as expectInboundContextContract } from "../../../../../src/channels/plugins/contracts/suites.js";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 let capturedCtx: unknown;

--- a/src/channels/plugins/contracts/suites.ts
+++ b/src/channels/plugins/contracts/suites.ts
@@ -1,5 +1,5 @@
 import { expect, it, vi, type Mock } from "vitest";
-import { slackOutbound } from "../../../../test/channel-outbounds.js";
+import { loadBundledPluginTestApiSync } from "../../../test-utils/bundled-plugin-public-surface.js";
 import type { MsgContext } from "../../../auto-reply/templating.js";
 import type { ReplyPayload } from "../../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../../config/config.js";
@@ -123,6 +123,19 @@ type SlackOutboundPayloadHarness = {
   to: string;
 };
 
+let slackOutboundForTests:
+  | typeof import("../../../../extensions/slack/test-api.js").slackOutbound
+  | undefined;
+
+function getSlackOutboundForTests() {
+  if (!slackOutboundForTests) {
+    ({ slackOutbound: slackOutboundForTests } = loadBundledPluginTestApiSync<{
+      slackOutbound: typeof import("../../../../extensions/slack/test-api.js").slackOutbound;
+    }>("slack"));
+  }
+  return slackOutboundForTests;
+}
+
 export function createSlackOutboundPayloadHarness(params: {
   payload: ReplyPayload;
   sendResults?: Array<{ messageId: string }>;
@@ -143,7 +156,7 @@ export function createSlackOutboundPayloadHarness(params: {
     },
   };
   return {
-    run: async () => await slackOutbound.sendPayload!(ctx),
+    run: async () => await getSlackOutboundForTests().sendPayload!(ctx),
     sendMock: sendSlack,
     to: ctx.to,
   };


### PR DESCRIPTION
## Summary

- stop first-party inbound-context tests from importing `expectChannelInboundContextContract` through `openclaw/plugin-sdk/testing`
- switch those internal tests to the direct contract helper path instead
- lazy-load the Slack outbound harness in `src/channels/plugins/contracts/suites.ts` so inbound-only helpers do not pull extra plugin test surfaces into startup

## Problem

Several first-party test files only needed `expectChannelInboundContextContract(...)`, but they imported it from the broad `openclaw/plugin-sdk/testing` barrel.

That forced Vitest to load a much larger graph than necessary, including heavier test-only plumbing and bundled plugin surface loading, which made focused inbound-context tests look hung during import startup.

## What changed

- internal inbound-context tests now import the contract helper directly from `src/channels/plugins/contracts/suites.ts`
- `createSlackOutboundPayloadHarness(...)` now resolves Slack lazily inside `suites.ts` instead of paying that cost at module load time

## Why this stays narrow

This PR does **not** redesign the public `openclaw/plugin-sdk/testing` surface.
It only removes unnecessary usage of that broad barrel from first-party tests and trims one eager helper load in the contract module.

A broader testing-surface redesign should be handled separately, if at all.

## Verification

Focused runs on the same environment:

- Telegram targeted lane before this slice: import `105.51s`
- Telegram targeted lane after this slice: import `29.12s`

Additional passing lanes:

- `pnpm exec vitest run extensions/telegram/src/bot.test.ts -t 'does not fetch reply media for unauthorized DM replies|defers reply media download until debounce flush' --testTimeout 10000 --hookTimeout 10000`
- `pnpm exec vitest run extensions/discord/src/monitor/message-handler.inbound-context.test.ts extensions/signal/src/monitor/event-handler.inbound-context.test.ts`
- `pnpm exec vitest run extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts`

## Related context

- Adjacent upstream discussion: #56423 (`openclaw/plugin-sdk` minimal stable barrel)
- This PR is narrower and specifically targets first-party test import overhead
