### PR TITLE
fix(cron): add readable nextAt companion field to timer logs

### DIFF
--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -81,6 +81,14 @@ describe("cron service timer seam coverage", () => {
       .filter((delay): delay is number => typeof delay === "number");
     expect(delays.some((delay) => delay > 0)).toBe(true);
 
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextAt: now + 60_000,
+        nextAtReadable: new Date(now + 60_000).toISOString(),
+      }),
+      "cron: timer armed",
+    );
+
     timeoutSpy.mockRestore();
   });
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -642,7 +642,12 @@ export function armTimer(state: CronServiceState) {
     });
   }, clampedDelay);
   state.deps.log.debug(
-    { nextAt, delayMs: clampedDelay, clamped: delay > MAX_TIMER_DELAY_MS },
+    {
+      nextAt,
+      nextAtReadable: new Date(nextAt).toISOString(),
+      delayMs: clampedDelay,
+      clamped: delay > MAX_TIMER_DELAY_MS,
+    },
     "cron: timer armed",
   );
 }


### PR DESCRIPTION
## Summary
- Problem: `cron: timer armed` debug logs expose nextAt only as a Unix ms timestamp.
- Why it matters: operators have to manually convert it when debugging cron scheduling.
- What changed: added nextAtReadable as an ISO-8601 companion field while preserving numeric nextAt.
- What did NOT change: scheduler behavior, persisted state, CLI output, and existing nextAt semantics remain unchanged.

AI-assisted: yes; author reviewed and verified the final code, tests, and PR framing.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #58574
- Related: none
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)
- Root cause: the timer-armed debug payload included only the numeric timestamp.
- Missing detection / guardrail: no seam test asserted a human-readable companion field on that debug log payload.
- Prior context (git blame, prior PR, issue, or refactor if known): N/A
- Why this regressed now: N/A
- If unknown, what was ruled out: persisted cron state and CLI output were inspected and are not part of the issue.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: src/cron/service/timer.test.ts
- Scenario the test should lock in: when the timer is armed, the debug payload includes both numeric nextAt and ISO nextAtReadable.
- Why this is the smallest reliable guardrail: the change is only in the timer-arm logging seam.
- Existing test that already covers this (if any): existing timer seam test already asserted timer arming behavior and logger interaction.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- Debug logs for `cron: timer armed` now include nextAtReadable in ISO-8601 format.

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification
### Environment
- OS: macOS
- Runtime/container: local clean clone
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): cron timer seam tests only

### Steps
1. Run `pnpm test -- src/cron/service/timer.test.ts`
2. Inspect the logger assertion on the timer-armed debug payload.
3. Optionally inspect a live debug log entry after arming a cron timer.

### Expected
- The debug payload contains both numeric nextAt and readable nextAtReadable.

### Actual
- Matches expected after the change.

## Evidence
- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)
What you personally verified (not just CI), and how:
- Verified scenarios: targeted timer seam test passes; logger payload includes both nextAt and nextAtReadable.
- Edge cases checked: machine-readable nextAt remains present.
- What you did **not** verify: full gateway manual log capture in a real cron deployment.

## Review Conversations
- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations
- Risk: consumers might start depending on nextAtReadable once it exists.
  - Mitigation: keep numeric nextAt unchanged and document nextAtReadable as an additive debug field.
- Risk: accidental unrelated worktree noise in PR.
  - Mitigation: verify clean git status before posting and do not include unrelated lockfile changes.
