### PR TITLE
fix(matrix): package verification bootstrap runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles/config: accept `enrichGroupParticipantsFromContacts` in the core strict config schema so gateways no longer fail validation or startup when the BlueBubbles plugin writes that field. (#56889) Thanks @zqchris.
 - Agents/failover: classify AbortError and stream-abort messages as timeout so Ollama NDJSON stream aborts stop showing `reason=unknown` in model fallback logs. (#58324) Thanks @yelog
 - Exec approvals: route Slack, Discord, and Telegram approvals through the shared channel approval-capability path so native approval auth, delivery, and `/approve` handling stay aligned across channels while preserving Telegram session-key agent filtering. (#58634) thanks @gumadeiras
+- Matrix/runtime: resolve the verification/bootstrap runtime from a distinct packaged Matrix entry so global npm installs stop failing on crypto bootstrap with missing-module or recursive runtime alias errors. (#59249) Thanks @gumadeiras.
 
 ## 2026.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: add `agents.defaults.compaction.notifyUser` so the `🧹 Compacting context...` start notice is opt-in instead of always being shown. (#54251) Thanks @oguricap0327.
 - Plugins/hooks: add `before_agent_reply` so plugins can short-circuit the LLM with synthetic replies after inline actions. (#20067) thanks @JoshuaLelon
 - Providers/runtime: add provider-owned replay hook surfaces for transcript policy, replay cleanup, and reasoning-mode dispatch. (#59143) Thanks @jalehman.
+
 ### Fixes
 
 - Matrix/multi-account: keep room-level `account` scoping, inherited room overrides, and implicit account selection consistent across top-level default auth, named accounts, and cached-credential env setups. (#58449) thanks @Daanvdplas and @gumadeiras.

--- a/extensions/matrix/plugin-entry.handlers.runtime.ts
+++ b/extensions/matrix/plugin-entry.handlers.runtime.ts
@@ -1,0 +1,1 @@
+export * from "./src/plugin-entry.runtime.ts";

--- a/extensions/matrix/src/plugin-entry.runtime.js
+++ b/extensions/matrix/src/plugin-entry.runtime.js
@@ -1,6 +1,6 @@
 // Thin ESM wrapper so native dynamic import() resolves in source-checkout mode
-// where jiti loads index.ts but import("./src/plugin-entry.runtime.js") uses
-// Node's native ESM loader which cannot resolve .ts files directly.
+// while packaged dist builds resolve a distinct runtime entry that cannot loop
+// back into this wrapper through the stable root runtime alias.
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -9,9 +9,11 @@ import { fileURLToPath } from "node:url";
 const require = createRequire(import.meta.url);
 const { createJiti } = require("jiti");
 
+const PLUGIN_ID = "matrix";
 const OPENCLAW_PLUGIN_SDK_PREFIX = ["openclaw", "plugin-sdk"].join("/");
 const PLUGIN_SDK_EXPORT_PREFIX = "./plugin-sdk/";
 const PLUGIN_SDK_SOURCE_EXTENSIONS = [".ts", ".mts", ".js", ".mjs", ".cts", ".cjs"];
+const PLUGIN_ENTRY_RUNTIME_BASENAME = "plugin-entry.handlers.runtime";
 const JITI_EXTENSIONS = [
   ".ts",
   ".tsx",
@@ -102,6 +104,42 @@ function buildPluginSdkAliasMap(moduleUrl) {
   return aliasMap;
 }
 
+function resolveBundledPluginRuntimeModulePath(moduleUrl, params) {
+  const modulePath = fileURLToPath(moduleUrl);
+  const moduleDir = path.dirname(modulePath);
+  const localCandidates = [
+    path.join(moduleDir, "..", params.runtimeBasename),
+    path.join(moduleDir, "extensions", params.pluginId, params.runtimeBasename),
+  ];
+
+  for (const candidate of localCandidates) {
+    const resolved = resolveExistingFile(candidate, PLUGIN_SDK_SOURCE_EXTENSIONS);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  const location = findOpenClawPackageRoot(moduleDir);
+  if (location) {
+    const { packageRoot } = location;
+    const packageCandidates = [
+      path.join(packageRoot, "extensions", params.pluginId, params.runtimeBasename),
+      path.join(packageRoot, "dist", "extensions", params.pluginId, params.runtimeBasename),
+    ];
+
+    for (const candidate of packageCandidates) {
+      const resolved = resolveExistingFile(candidate, PLUGIN_SDK_SOURCE_EXTENSIONS);
+      if (resolved) {
+        return resolved;
+      }
+    }
+  }
+
+  throw new Error(
+    `Cannot resolve ${params.pluginId} plugin runtime module ${params.runtimeBasename} from ${modulePath}`,
+  );
+}
+
 const jiti = createJiti(import.meta.url, {
   alias: buildPluginSdkAliasMap(import.meta.url),
   interopDefault: true,
@@ -109,7 +147,12 @@ const jiti = createJiti(import.meta.url, {
   extensions: JITI_EXTENSIONS,
 });
 
-const mod = jiti("./plugin-entry.runtime.ts");
+const mod = jiti(
+  resolveBundledPluginRuntimeModulePath(import.meta.url, {
+    pluginId: PLUGIN_ID,
+    runtimeBasename: PLUGIN_ENTRY_RUNTIME_BASENAME,
+  }),
+);
 export const ensureMatrixCryptoRuntime = mod.ensureMatrixCryptoRuntime;
 export const handleVerifyRecoveryKey = mod.handleVerifyRecoveryKey;
 export const handleVerificationBootstrap = mod.handleVerificationBootstrap;

--- a/extensions/matrix/src/plugin-entry.runtime.test.ts
+++ b/extensions/matrix/src/plugin-entry.runtime.test.ts
@@ -1,10 +1,14 @@
 import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, expect, it } from "vitest";
 
 const tempDirs: string[] = [];
 const REPO_ROOT = process.cwd();
+const require = createRequire(import.meta.url);
+const JITI_ENTRY_PATH = require.resolve("jiti");
 const PACKAGED_RUNTIME_STUB = [
   "export async function ensureMatrixCryptoRuntime() {}",
   "export async function handleVerifyRecoveryKey() {}",
@@ -14,7 +18,7 @@ const PACKAGED_RUNTIME_STUB = [
 ].join("\n");
 
 function makeFixtureRoot(prefix: string) {
-  const fixtureRoot = fs.mkdtempSync(path.join(REPO_ROOT, prefix));
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   tempDirs.push(fixtureRoot);
   return fixtureRoot;
 }
@@ -73,6 +77,11 @@ it("loads the packaged runtime wrapper without recursing through the stable root
     ) + "\n",
   );
   writeFixtureFile(fixtureRoot, "dist/plugin-sdk/index.js", "export {};\n");
+  writeFixtureFile(
+    fixtureRoot,
+    "node_modules/jiti/index.js",
+    `module.exports = require(${JSON.stringify(JITI_ENTRY_PATH)});\n`,
+  );
   writeFixtureFile(fixtureRoot, "dist/plugin-entry.runtime-C88YIa_v.js", wrapperSource);
   writeFixtureFile(
     fixtureRoot,

--- a/extensions/matrix/src/plugin-entry.runtime.test.ts
+++ b/extensions/matrix/src/plugin-entry.runtime.test.ts
@@ -1,6 +1,35 @@
+import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { expect, it } from "vitest";
+import { afterEach, expect, it } from "vitest";
+
+const tempDirs: string[] = [];
+const REPO_ROOT = process.cwd();
+const MATRIX_RUNTIME_STUB = [
+  "export async function ensureMatrixCryptoRuntime() {}",
+  "export async function handleVerifyRecoveryKey() {}",
+  "export async function handleVerificationBootstrap() {}",
+  "export async function handleVerificationStatus() {}",
+  "",
+].join("\n");
+
+function makeFixtureRoot(prefix: string) {
+  const fixtureRoot = fs.mkdtempSync(path.join(REPO_ROOT, prefix));
+  tempDirs.push(fixtureRoot);
+  return fixtureRoot;
+}
+
+function writeFixtureFile(fixtureRoot: string, relativePath: string, value: string) {
+  const fullPath = path.join(fixtureRoot, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, value, "utf8");
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 it("loads the plugin-entry runtime wrapper through native ESM import", async () => {
   const wrapperPath = path.join(
@@ -12,6 +41,54 @@ it("loads the plugin-entry runtime wrapper through native ESM import", async () 
   );
   const wrapperUrl = pathToFileURL(wrapperPath);
   const mod = await import(wrapperUrl.href);
+
+  expect(mod).toMatchObject({
+    ensureMatrixCryptoRuntime: expect.any(Function),
+    handleVerifyRecoveryKey: expect.any(Function),
+    handleVerificationBootstrap: expect.any(Function),
+    handleVerificationStatus: expect.any(Function),
+  });
+}, 240_000);
+
+it("loads the packaged runtime wrapper without recursing through the stable root alias", async () => {
+  const fixtureRoot = makeFixtureRoot(".tmp-matrix-runtime-");
+  const wrapperSource = fs.readFileSync(
+    path.join(REPO_ROOT, "extensions", "matrix", "src", "plugin-entry.runtime.js"),
+    "utf8",
+  );
+
+  writeFixtureFile(
+    fixtureRoot,
+    "package.json",
+    JSON.stringify(
+      {
+        name: "openclaw",
+        type: "module",
+        exports: {
+          "./plugin-sdk": "./dist/plugin-sdk/index.js",
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  writeFixtureFile(fixtureRoot, "dist/plugin-sdk/index.js", "export {};\n");
+  writeFixtureFile(fixtureRoot, "dist/plugin-entry.runtime-C88YIa_v.js", wrapperSource);
+  writeFixtureFile(
+    fixtureRoot,
+    "dist/plugin-entry.runtime.js",
+    'export * from "./plugin-entry.runtime-C88YIa_v.js";\n',
+  );
+  writeFixtureFile(
+    fixtureRoot,
+    "dist/extensions/matrix/plugin-entry.handlers.runtime.js",
+    MATRIX_RUNTIME_STUB,
+  );
+
+  const wrapperUrl = pathToFileURL(
+    path.join(fixtureRoot, "dist", "plugin-entry.runtime-C88YIa_v.js"),
+  );
+  const mod = await import(`${wrapperUrl.href}?t=${Date.now()}`);
 
   expect(mod).toMatchObject({
     ensureMatrixCryptoRuntime: expect.any(Function),

--- a/extensions/matrix/src/plugin-entry.runtime.test.ts
+++ b/extensions/matrix/src/plugin-entry.runtime.test.ts
@@ -5,7 +5,7 @@ import { afterEach, expect, it } from "vitest";
 
 const tempDirs: string[] = [];
 const REPO_ROOT = process.cwd();
-const MATRIX_RUNTIME_STUB = [
+const PACKAGED_RUNTIME_STUB = [
   "export async function ensureMatrixCryptoRuntime() {}",
   "export async function handleVerifyRecoveryKey() {}",
   "export async function handleVerificationBootstrap() {}",
@@ -82,7 +82,7 @@ it("loads the packaged runtime wrapper without recursing through the stable root
   writeFixtureFile(
     fixtureRoot,
     "dist/extensions/matrix/plugin-entry.handlers.runtime.js",
-    MATRIX_RUNTIME_STUB,
+    PACKAGED_RUNTIME_STUB,
   );
 
   const wrapperUrl = pathToFileURL(

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -19,6 +19,15 @@ describe("bundled plugin build entries", () => {
     });
   });
 
+  it("keeps the Matrix packaged runtime shim in bundled plugin build entries", () => {
+    const entries = listBundledPluginBuildEntries();
+
+    expect(entries).toMatchObject({
+      "extensions/matrix/plugin-entry.handlers.runtime":
+        "extensions/matrix/plugin-entry.handlers.runtime.ts",
+    });
+  });
+
   it("packs runtime core support packages without requiring plugin manifests", () => {
     const artifacts = listBundledPluginPackArtifacts();
 
@@ -31,5 +40,11 @@ describe("bundled plugin build entries", () => {
     );
     expect(artifacts).toContain("dist/extensions/speech-core/runtime-api.js");
     expect(artifacts).not.toContain("dist/extensions/speech-core/openclaw.plugin.json");
+  });
+
+  it("packs the Matrix packaged runtime shim", () => {
+    const artifacts = listBundledPluginPackArtifacts();
+
+    expect(artifacts).toContain("dist/extensions/matrix/plugin-entry.handlers.runtime.js");
   });
 });


### PR DESCRIPTION
## Summary

- Problem: packaged installs could load `extensions/matrix/src/plugin-entry.runtime.js`, but the wrapper resolved a same-basename runtime target that did not exist in `dist` and then could recurse through the stable root alias.
- Why it matters: Matrix verification/bootstrap and related runtime helpers failed in global npm installs even though source checkouts still worked.
- What changed: add a distinct packaged Matrix runtime entry, make the wrapper resolve that explicit target in source and dist layouts, and add regression coverage for the built wrapper path.
- What did NOT change (scope boundary): no broader Matrix crypto/bootstrap behavior changes beyond restoring the packaged runtime-loading path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #58734
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the Matrix runtime wrapper loaded `./plugin-entry.runtime(.ts)` through Jiti, but packaged `dist` did not ship a real sibling runtime module for the verification/bootstrap handlers.
- Missing detection / guardrail: coverage only exercised the source-checkout wrapper import, not the packaged `dist/plugin-entry.runtime*.js` path after postbuild alias generation.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `d330782ed18` stopped discovering the runtime helper as a plugin entry, which removed the old explicit packaged target without replacing the wrapper contract.
- Why this regressed now: the wrapper basename collided with the stable root runtime alias in `dist`, so switching to extensionless lookup still pointed back at the wrapper instead of a real handler module.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/matrix/src/plugin-entry.runtime.test.ts`
- Scenario the test should lock in: import the built wrapper shape after postbuild-style aliasing and verify it resolves the packaged Matrix handler runtime without recursion.
- Why this is the smallest reliable guardrail: the bug lives at the source/dist packaging seam, not inside the handler implementations themselves.
- Existing test that already covers this (if any): the native source-checkout wrapper import test remains as partial coverage.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Packaged installs can use Matrix verification/bootstrap runtime helpers again, including the packaged wrapper path used on gateway start and Matrix verification gateway methods.

## Diagram (if applicable)

```text
Before:
[packaged wrapper] -> jiti("./plugin-entry.runtime") -> stable root alias -> wrapper again / missing module

After:
[packaged wrapper] -> explicit plugin-entry.handlers.runtime target -> Matrix verification/bootstrap handlers
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS host; packaged-shape repro via local build output
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Matrix bundled plugin
- Relevant config (redacted): N/A

### Steps

1. Build the repo with `node scripts/tsdown-build.mjs`.
2. Run `node scripts/runtime-postbuild.mjs`.
3. Import `dist/plugin-entry.runtime.js`.

### Expected

- The wrapper resolves Matrix verification/bootstrap runtime exports from a distinct packaged target.

### Actual

- Before this change, packaged imports failed with missing-module or recursive-wrapper behavior.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted wrapper test; build + runtime-postbuild + direct import of built `dist/plugin-entry.runtime.js`.
- Edge cases checked: source-checkout wrapper import still works; packaged wrapper does not recurse through the stable root alias.
- What you did **not** verify: full end-to-end Matrix account restart behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: another bundled plugin could repeat the same wrapper/alias pattern.
  - Mitigation: this wrapper now resolves a distinct plugin-local runtime target, and the new packaged-wrapper regression test locks the Matrix seam in place.
