### PR TITLE
[codex] Docs: add Agent Computer hosting guide

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -4,6 +4,10 @@
     "target": "OpenClaw"
   },
   {
+    "source": "Agent Computer",
+    "target": "Agent Computer"
+  },
+  {
     "source": "Gateway",
     "target": "Gateway 网关"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -941,11 +941,11 @@
               {
                 "group": "Hosting",
                 "pages": [
+                  "install/agentcomputer",
                   "install/azure",
                   "install/digitalocean",
                   "install/docker-vm-runtime",
                   "install/exe-dev",
-                  "install/agentcomputer",
                   "install/fly",
                   "install/gcp",
                   "install/hetzner",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -941,11 +941,11 @@
               {
                 "group": "Hosting",
                 "pages": [
-                  "install/agentcomputer",
                   "install/azure",
                   "install/digitalocean",
                   "install/docker-vm-runtime",
                   "install/exe-dev",
+                  "install/agentcomputer",
                   "install/fly",
                   "install/gcp",
                   "install/hetzner",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -833,12 +833,20 @@
       "destination": "/install/render"
     },
     {
+      "source": "/agentcomputer",
+      "destination": "/install/agentcomputer"
+    },
+    {
       "source": "/gcp",
       "destination": "/install/gcp"
     },
     {
       "source": "/azure",
       "destination": "/install/azure"
+    },
+    {
+      "source": "/platforms/agentcomputer",
+      "destination": "/install/agentcomputer"
     },
     {
       "source": "/platforms/fly",
@@ -933,6 +941,7 @@
               {
                 "group": "Hosting",
                 "pages": [
+                  "install/agentcomputer",
                   "install/azure",
                   "install/digitalocean",
                   "install/docker-vm-runtime",

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -466,7 +466,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   <Accordion title="How do I install OpenClaw on a VPS?">
     Any Linux VPS works. Install on the server, then use SSH/Tailscale to reach the Gateway.
 
-    Guides: [exe.dev](/install/exe-dev), [Hetzner](/install/hetzner), [Fly.io](/install/fly).
+    Guides: [Agent Computer](/install/agentcomputer), [exe.dev](/install/exe-dev), [Fly.io](/install/fly), [Hetzner](/install/hetzner).
     Remote access: [Gateway remote](/gateway/remote).
 
   </Accordion>
@@ -475,9 +475,10 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
     We keep a **hosting hub** with the common providers. Pick one and follow the guide:
 
     - [VPS hosting](/vps) (all providers in one place)
+    - [Agent Computer](/install/agentcomputer)
+    - [exe.dev](/install/exe-dev)
     - [Fly.io](/install/fly)
     - [Hetzner](/install/hetzner)
-    - [exe.dev](/install/exe-dev)
 
     How it works in the cloud: the **Gateway runs on the server**, and you access it
     from your laptop/phone via the Control UI (or Tailscale/SSH). Your state + workspace

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -466,7 +466,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   <Accordion title="How do I install OpenClaw on a VPS?">
     Any Linux VPS works. Install on the server, then use SSH/Tailscale to reach the Gateway.
 
-    Guides: [exe.dev](/install/exe-dev), [Agent Computer](/install/agentcomputer), [Hetzner](/install/hetzner), [Fly.io](/install/fly).
+    Guides: [Agent Computer](/install/agentcomputer), [exe.dev](/install/exe-dev), [Hetzner](/install/hetzner), [Fly.io](/install/fly).
     Remote access: [Gateway remote](/gateway/remote).
 
   </Accordion>
@@ -475,10 +475,10 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
     We keep a **hosting hub** with the common providers. Pick one and follow the guide:
 
     - [VPS hosting](/vps) (all providers in one place)
+    - [Agent Computer](/install/agentcomputer)
     - [Fly.io](/install/fly)
     - [Hetzner](/install/hetzner)
     - [exe.dev](/install/exe-dev)
-    - [Agent Computer](/install/agentcomputer)
 
     How it works in the cloud: the **Gateway runs on the server**, and you access it
     from your laptop/phone via the Control UI (or Tailscale/SSH). Your state + workspace

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -466,7 +466,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   <Accordion title="How do I install OpenClaw on a VPS?">
     Any Linux VPS works. Install on the server, then use SSH/Tailscale to reach the Gateway.
 
-    Guides: [exe.dev](/install/exe-dev), [Hetzner](/install/hetzner), [Fly.io](/install/fly).
+    Guides: [Agent Computer](/install/agentcomputer), [exe.dev](/install/exe-dev), [Hetzner](/install/hetzner), [Fly.io](/install/fly).
     Remote access: [Gateway remote](/gateway/remote).
 
   </Accordion>
@@ -475,9 +475,10 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
     We keep a **hosting hub** with the common providers. Pick one and follow the guide:
 
     - [VPS hosting](/vps) (all providers in one place)
+    - [Agent Computer](/install/agentcomputer)
+    - [exe.dev](/install/exe-dev)
     - [Fly.io](/install/fly)
     - [Hetzner](/install/hetzner)
-    - [exe.dev](/install/exe-dev)
 
     How it works in the cloud: the **Gateway runs on the server**, and you access it
     from your laptop/phone via the Control UI (or Tailscale/SSH). Your state + workspace

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -466,7 +466,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   <Accordion title="How do I install OpenClaw on a VPS?">
     Any Linux VPS works. Install on the server, then use SSH/Tailscale to reach the Gateway.
 
-    Guides: [Agent Computer](/install/agentcomputer), [exe.dev](/install/exe-dev), [Hetzner](/install/hetzner), [Fly.io](/install/fly).
+    Guides: [exe.dev](/install/exe-dev), [Agent Computer](/install/agentcomputer), [Hetzner](/install/hetzner), [Fly.io](/install/fly).
     Remote access: [Gateway remote](/gateway/remote).
 
   </Accordion>
@@ -475,10 +475,10 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
     We keep a **hosting hub** with the common providers. Pick one and follow the guide:
 
     - [VPS hosting](/vps) (all providers in one place)
-    - [Agent Computer](/install/agentcomputer)
-    - [exe.dev](/install/exe-dev)
     - [Fly.io](/install/fly)
     - [Hetzner](/install/hetzner)
+    - [exe.dev](/install/exe-dev)
+    - [Agent Computer](/install/agentcomputer)
 
     How it works in the cloud: the **Gateway runs on the server**, and you access it
     from your laptop/phone via the Control UI (or Tailscale/SSH). Your state + workspace

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -466,7 +466,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   <Accordion title="How do I install OpenClaw on a VPS?">
     Any Linux VPS works. Install on the server, then use SSH/Tailscale to reach the Gateway.
 
-    Guides: [Agent Computer](/install/agentcomputer), [exe.dev](/install/exe-dev), [Fly.io](/install/fly), [Hetzner](/install/hetzner).
+    Guides: [exe.dev](/install/exe-dev), [Hetzner](/install/hetzner), [Fly.io](/install/fly).
     Remote access: [Gateway remote](/gateway/remote).
 
   </Accordion>
@@ -475,10 +475,9 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
     We keep a **hosting hub** with the common providers. Pick one and follow the guide:
 
     - [VPS hosting](/vps) (all providers in one place)
-    - [Agent Computer](/install/agentcomputer)
-    - [exe.dev](/install/exe-dev)
     - [Fly.io](/install/fly)
     - [Hetzner](/install/hetzner)
+    - [exe.dev](/install/exe-dev)
 
     How it works in the cloud: the **Gateway runs on the server**, and you access it
     from your laptop/phone via the Control UI (or Tailscale/SSH). Your state + workspace

--- a/docs/install/agentcomputer.md
+++ b/docs/install/agentcomputer.md
@@ -24,13 +24,14 @@ Either way, the final hosting step is the same: publish port `18789` so the Cont
 2. Sign in and create a machine from the preselected **OpenClaw** template
 3. Let the template finish installing and onboarding OpenClaw in the browser
 4. On your local machine, run `npm install -g aicomputer`
-5. Run `computer ssh <machine-name>` (the next commands run inside the Agent Computer shell)
-6. Run `openclaw doctor --generate-gateway-token`
-7. Run `openclaw config set gateway.bind lan`
-8. Run `openclaw gateway restart`
-9. Run `exit` (return to your local machine)
-10. Run `computer ports publish <machine-name> 18789 --subdomain openclaw --protocol https`
-11. If OpenClaw prompts for auth, run `computer ssh <machine-name>`, then `openclaw config get gateway.auth.token`
+5. Run `computer login`
+6. Run `computer ssh <machine-name>` (the next commands run inside the Agent Computer shell)
+7. Run `openclaw doctor --generate-gateway-token`
+8. Run `openclaw config set gateway.bind lan`
+9. Run `openclaw gateway restart`
+10. Run `exit` (return to your local machine)
+11. Run `computer ports publish <machine-name> 18789 --subdomain openclaw --protocol https`
+12. If OpenClaw prompts for auth, run `computer ssh <machine-name>`, then `openclaw config get gateway.auth.token`
 
 ## What you need
 

--- a/docs/install/agentcomputer.md
+++ b/docs/install/agentcomputer.md
@@ -1,7 +1,8 @@
 ---
-summary: "Run OpenClaw on an Agent Computer managed worker and expose it through a published host"
+summary: "Deploy OpenClaw on Agent Computer with a browser shortcut and published port"
 read_when:
   - You want OpenClaw on Agent Computer
+  - You want a one-click browser setup for OpenClaw on a managed worker
   - You want a cloud Linux machine with SSH, durable home storage, and published web access
 title: "Agent Computer"
 ---
@@ -10,28 +11,44 @@ title: "Agent Computer"
 
 Goal: OpenClaw Gateway running on an Agent Computer managed worker, reachable from your browser through a published host.
 
-This guide uses the Agent Computer CLI to create a managed worker, installs OpenClaw inside it, then publishes port `18789` so the Control UI can be reached remotely.
+This guide supports two paths:
+
+- **Browser shortcut (recommended):** open [https://agentcomputer.ai/openclaw](https://agentcomputer.ai/openclaw) to start from Agent Computer's OpenClaw template
+- **Manual CLI path:** create the managed worker yourself, then install and expose OpenClaw step by step
+
+Either way, the final hosting step is the same: publish port `18789` so the Control UI can be reached remotely.
 
 ## Beginner quick path
 
-1. `npm install -g aicomputer`
-2. `computer login`
-3. `computer create my-openclaw`
-4. `computer ssh my-openclaw` (the next commands run inside the Agent Computer shell)
-5. `curl -fsSL https://openclaw.ai/install.sh | bash`
-6. `openclaw onboard --install-daemon`
-7. `openclaw doctor --generate-gateway-token`
-8. `openclaw config set gateway.bind lan`
-9. `openclaw gateway restart`
-10. `exit` (return to your local machine)
-11. `computer ports publish my-openclaw 18789 --subdomain openclaw --protocol https`
-12. If OpenClaw prompts for auth, run `computer ssh my-openclaw`, then `openclaw config get gateway.auth.token`
+1. Open [https://agentcomputer.ai/openclaw](https://agentcomputer.ai/openclaw)
+2. Sign in and create a machine from the preselected **OpenClaw** template
+3. Let the template finish installing and onboarding OpenClaw in the browser
+4. On your local machine, run `npm install -g aicomputer`
+5. Run `computer ssh <machine-name>` (the next commands run inside the Agent Computer shell)
+6. Run `openclaw doctor --generate-gateway-token`
+7. Run `openclaw config set gateway.bind lan`
+8. Run `openclaw gateway restart`
+9. Run `exit` (return to your local machine)
+10. Run `computer ports publish <machine-name> 18789 --subdomain openclaw --protocol https`
+11. If OpenClaw prompts for auth, run `computer ssh <machine-name>`, then `openclaw config get gateway.auth.token`
 
 ## What you need
 
 - Agent Computer account
 - Node.js on your local machine so you can install `aicomputer`
 - A model provider key or other auth required by your OpenClaw onboarding flow
+
+## Browser shortcut
+
+The shortcut route below opens Agent Computer's **OpenClaw** template directly:
+
+```text
+https://agentcomputer.ai/openclaw
+```
+
+Choose a machine name in the browser, let the template finish the initial install, then continue with the bind/publish steps later in this guide.
+
+## Manual CLI path
 
 ## 1) Install the Agent Computer CLI and sign in
 

--- a/docs/install/agentcomputer.md
+++ b/docs/install/agentcomputer.md
@@ -1,0 +1,143 @@
+---
+summary: "Run OpenClaw on an Agent Computer managed worker and expose it through a published host"
+read_when:
+  - You want OpenClaw on Agent Computer
+  - You want a cloud Linux machine with SSH, durable home storage, and published web access
+title: "Agent Computer"
+---
+
+# Agent Computer
+
+Goal: OpenClaw Gateway running on an Agent Computer managed worker, reachable from your browser through a published host.
+
+This guide uses the Agent Computer CLI to create a managed worker, installs OpenClaw inside it, then publishes port `18789` so the Control UI can be reached remotely.
+
+## Beginner quick path
+
+1. `npm install -g aicomputer`
+2. `computer login`
+3. `computer create my-openclaw`
+4. `computer ssh my-openclaw`
+5. `curl -fsSL https://openclaw.ai/install.sh | bash`
+6. `openclaw onboard --install-daemon`
+7. `openclaw doctor --generate-gateway-token`
+8. `openclaw config set gateway.bind lan`
+9. `openclaw gateway restart`
+10. `computer ports publish my-openclaw 18789 --subdomain openclaw`
+11. Open the published URL and paste the token from `openclaw config get gateway.auth.token`
+
+## What you need
+
+- Agent Computer account
+- Node.js on your local machine so you can install `aicomputer`
+- A model provider key or other auth required by your OpenClaw onboarding flow
+
+## 1) Install the Agent Computer CLI and sign in
+
+On your local machine:
+
+```bash
+npm install -g aicomputer
+computer login
+```
+
+The login flow opens a browser, stores an Agent Computer API key locally, and prepares SSH access for later steps.
+
+## 2) Create the machine
+
+On your local machine:
+
+```bash
+computer create my-openclaw
+computer ssh my-openclaw
+```
+
+Tip: Agent Computer keeps the machine home directory at `/home/node`, so OpenClaw state under `~/.openclaw/` persists across reconnects and power cycles.
+
+## 3) Install OpenClaw
+
+Inside the Agent Computer shell:
+
+```bash
+curl -fsSL https://openclaw.ai/install.sh | bash
+openclaw --version
+```
+
+## 4) Run onboarding
+
+Inside the Agent Computer shell:
+
+```bash
+openclaw onboard --install-daemon
+```
+
+If the machine reports that systemd user services are unavailable, rerun onboarding without the daemon install and keep the gateway running in `tmux` instead:
+
+```bash
+openclaw onboard
+tmux new-session -d -s openclaw 'openclaw gateway run'
+```
+
+## 5) Bind the gateway for published-port access
+
+Agent Computer published ports reach the machine over its service network path, so the default loopback bind is not enough. OpenClaw must listen on a non-loopback interface before you publish port `18789`.
+
+Inside the Agent Computer shell:
+
+```bash
+openclaw doctor --generate-gateway-token
+openclaw config set gateway.bind lan
+openclaw gateway restart
+```
+
+If you are using the `tmux` fallback instead of a service, restart the `tmux` session rather than `openclaw gateway restart`.
+
+## 6) Publish the OpenClaw port
+
+Back on your local machine:
+
+```bash
+computer ports publish my-openclaw 18789 --subdomain openclaw
+```
+
+Agent Computer will print the published host. If you need to retrieve it again later:
+
+```bash
+computer ports ls my-openclaw
+```
+
+## 7) Access OpenClaw and finish pairing
+
+Open the published host from the previous step. If OpenClaw prompts for auth, retrieve the gateway token from the machine:
+
+```bash
+openclaw config get gateway.auth.token
+```
+
+Then approve any pairing requests:
+
+```bash
+openclaw devices list
+openclaw devices approve <requestId>
+```
+
+Agent Computer browser auth and OpenClaw gateway auth are separate. Reaching the published host gets you to the machine; OpenClaw may still require its own token or pairing approval.
+
+## Updating
+
+Inside the Agent Computer shell:
+
+```bash
+npm i -g openclaw@latest
+openclaw doctor
+openclaw gateway restart
+```
+
+If you used the `tmux` fallback, restart the gateway in `tmux` after updating.
+
+## Power and persistence
+
+- `computer power-off my-openclaw` stops the managed worker without deleting its durable home.
+- `computer power-on my-openclaw` recreates the runtime against the same stored home directory.
+- Published hosts only work while the machine is running.
+- If you did not install a daemon, reconnect after power-on and start the gateway again.

--- a/docs/install/agentcomputer.md
+++ b/docs/install/agentcomputer.md
@@ -17,14 +17,15 @@ This guide uses the Agent Computer CLI to create a managed worker, installs Open
 1. `npm install -g aicomputer`
 2. `computer login`
 3. `computer create my-openclaw`
-4. `computer ssh my-openclaw`
+4. `computer ssh my-openclaw` (the next commands run inside the Agent Computer shell)
 5. `curl -fsSL https://openclaw.ai/install.sh | bash`
 6. `openclaw onboard --install-daemon`
 7. `openclaw doctor --generate-gateway-token`
 8. `openclaw config set gateway.bind lan`
 9. `openclaw gateway restart`
-10. `computer ports publish my-openclaw 18789 --subdomain openclaw`
-11. Open the published URL and paste the token from `openclaw config get gateway.auth.token`
+10. `exit` (return to your local machine)
+11. `computer ports publish my-openclaw 18789 --subdomain openclaw --protocol https`
+12. If OpenClaw prompts for auth, run `computer ssh my-openclaw`, then `openclaw config get gateway.auth.token`
 
 ## What you need
 
@@ -97,7 +98,7 @@ If you are using the `tmux` fallback instead of a service, restart the `tmux` se
 Back on your local machine:
 
 ```bash
-computer ports publish my-openclaw 18789 --subdomain openclaw
+computer ports publish my-openclaw 18789 --subdomain openclaw --protocol https
 ```
 
 Agent Computer will print the published host. If you need to retrieve it again later:
@@ -108,9 +109,10 @@ computer ports ls my-openclaw
 
 ## 7) Access OpenClaw and finish pairing
 
-Open the published host from the previous step. If OpenClaw prompts for auth, retrieve the gateway token from the machine:
+Open the published host from the previous step. If OpenClaw prompts for auth, SSH back in and retrieve the gateway token:
 
 ```bash
+computer ssh my-openclaw
 openclaw config get gateway.auth.token
 ```
 
@@ -132,6 +134,8 @@ npm i -g openclaw@latest
 openclaw doctor
 openclaw gateway restart
 ```
+
+If your npm global prefix requires root, rerun the install command with `sudo`.
 
 If you used the `tmux` fallback, restart the gateway in `tmux` after updating.
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -138,7 +138,6 @@ openclaw gateway status # verify the Gateway is running
 Deploy OpenClaw on a cloud server or VPS:
 
 <CardGroup cols={3}>
-  <Card title="Agent Computer" href="/install/agentcomputer">Managed worker + published port</Card>
   <Card title="VPS" href="/vps">Any Linux VPS</Card>
   <Card title="Docker VM" href="/install/docker-vm-runtime">Shared Docker steps</Card>
   <Card title="Kubernetes" href="/install/kubernetes">K8s</Card>
@@ -149,6 +148,7 @@ Deploy OpenClaw on a cloud server or VPS:
   <Card title="Railway" href="/install/railway">Railway</Card>
   <Card title="Render" href="/install/render">Render</Card>
   <Card title="Northflank" href="/install/northflank">Northflank</Card>
+  <Card title="Agent Computer" href="/install/agentcomputer">Managed worker + published port</Card>
 </CardGroup>
 
 ## Update, migrate, or uninstall

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -139,16 +139,16 @@ Deploy OpenClaw on a cloud server or VPS:
 
 <CardGroup cols={3}>
   <Card title="Agent Computer" href="/install/agentcomputer">Managed worker + published port</Card>
-  <Card title="Azure" href="/install/azure">Azure</Card>
+  <Card title="VPS" href="/vps">Any Linux VPS</Card>
   <Card title="Docker VM" href="/install/docker-vm-runtime">Shared Docker steps</Card>
-  <Card title="Fly.io" href="/install/fly">Fly.io</Card>
-  <Card title="GCP" href="/install/gcp">Google Cloud</Card>
-  <Card title="Hetzner" href="/install/hetzner">Hetzner</Card>
   <Card title="Kubernetes" href="/install/kubernetes">K8s</Card>
-  <Card title="Northflank" href="/install/northflank">Northflank</Card>
+  <Card title="Fly.io" href="/install/fly">Fly.io</Card>
+  <Card title="Hetzner" href="/install/hetzner">Hetzner</Card>
+  <Card title="GCP" href="/install/gcp">Google Cloud</Card>
+  <Card title="Azure" href="/install/azure">Azure</Card>
   <Card title="Railway" href="/install/railway">Railway</Card>
   <Card title="Render" href="/install/render">Render</Card>
-  <Card title="VPS" href="/vps">Any Linux VPS</Card>
+  <Card title="Northflank" href="/install/northflank">Northflank</Card>
 </CardGroup>
 
 ## Update, migrate, or uninstall

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -138,6 +138,7 @@ openclaw gateway status # verify the Gateway is running
 Deploy OpenClaw on a cloud server or VPS:
 
 <CardGroup cols={3}>
+  <Card title="Agent Computer" href="/install/agentcomputer">One-click, browser setup</Card>
   <Card title="VPS" href="/vps">Any Linux VPS</Card>
   <Card title="Docker VM" href="/install/docker-vm-runtime">Shared Docker steps</Card>
   <Card title="Kubernetes" href="/install/kubernetes">K8s</Card>
@@ -148,7 +149,6 @@ Deploy OpenClaw on a cloud server or VPS:
   <Card title="Railway" href="/install/railway">Railway</Card>
   <Card title="Render" href="/install/render">Render</Card>
   <Card title="Northflank" href="/install/northflank">Northflank</Card>
-  <Card title="Agent Computer" href="/install/agentcomputer">Managed worker + published port</Card>
 </CardGroup>
 
 ## Update, migrate, or uninstall

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -138,16 +138,17 @@ openclaw gateway status # verify the Gateway is running
 Deploy OpenClaw on a cloud server or VPS:
 
 <CardGroup cols={3}>
-  <Card title="VPS" href="/vps">Any Linux VPS</Card>
-  <Card title="Docker VM" href="/install/docker-vm-runtime">Shared Docker steps</Card>
-  <Card title="Kubernetes" href="/install/kubernetes">K8s</Card>
-  <Card title="Fly.io" href="/install/fly">Fly.io</Card>
-  <Card title="Hetzner" href="/install/hetzner">Hetzner</Card>
-  <Card title="GCP" href="/install/gcp">Google Cloud</Card>
+  <Card title="Agent Computer" href="/install/agentcomputer">Managed worker + published port</Card>
   <Card title="Azure" href="/install/azure">Azure</Card>
+  <Card title="Docker VM" href="/install/docker-vm-runtime">Shared Docker steps</Card>
+  <Card title="Fly.io" href="/install/fly">Fly.io</Card>
+  <Card title="GCP" href="/install/gcp">Google Cloud</Card>
+  <Card title="Hetzner" href="/install/hetzner">Hetzner</Card>
+  <Card title="Kubernetes" href="/install/kubernetes">K8s</Card>
+  <Card title="Northflank" href="/install/northflank">Northflank</Card>
   <Card title="Railway" href="/install/railway">Railway</Card>
   <Card title="Render" href="/install/render">Render</Card>
-  <Card title="Northflank" href="/install/northflank">Northflank</Card>
+  <Card title="VPS" href="/vps">Any Linux VPS</Card>
 </CardGroup>
 
 ## Update, migrate, or uninstall

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -27,11 +27,11 @@ Native companion apps for Windows are also planned; the Gateway is recommended v
 
 - VPS hub: [VPS hosting](/vps)
 - Agent Computer (managed worker + published port): [Agent Computer](/install/agentcomputer)
+- Fly.io: [Fly.io](/install/fly)
+- Hetzner (Docker): [Hetzner](/install/hetzner)
+- GCP (Compute Engine): [GCP](/install/gcp)
 - Azure (Linux VM): [Azure](/install/azure)
 - exe.dev (VM + HTTPS proxy): [exe.dev](/install/exe-dev)
-- Fly.io: [Fly.io](/install/fly)
-- GCP (Compute Engine): [GCP](/install/gcp)
-- Hetzner (Docker): [Hetzner](/install/hetzner)
 
 ## Common links
 

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -26,12 +26,12 @@ Native companion apps for Windows are also planned; the Gateway is recommended v
 ## VPS & hosting
 
 - VPS hub: [VPS hosting](/vps)
+- Agent Computer (one-click, browser setup): [Agent Computer](/install/agentcomputer)
 - Fly.io: [Fly.io](/install/fly)
 - Hetzner (Docker): [Hetzner](/install/hetzner)
 - GCP (Compute Engine): [GCP](/install/gcp)
 - Azure (Linux VM): [Azure](/install/azure)
 - exe.dev (VM + HTTPS proxy): [exe.dev](/install/exe-dev)
-- Agent Computer (managed worker + published port): [Agent Computer](/install/agentcomputer)
 
 ## Common links
 

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -26,11 +26,12 @@ Native companion apps for Windows are also planned; the Gateway is recommended v
 ## VPS & hosting
 
 - VPS hub: [VPS hosting](/vps)
-- Fly.io: [Fly.io](/install/fly)
-- Hetzner (Docker): [Hetzner](/install/hetzner)
-- GCP (Compute Engine): [GCP](/install/gcp)
+- Agent Computer (managed worker + published port): [Agent Computer](/install/agentcomputer)
 - Azure (Linux VM): [Azure](/install/azure)
 - exe.dev (VM + HTTPS proxy): [exe.dev](/install/exe-dev)
+- Fly.io: [Fly.io](/install/fly)
+- GCP (Compute Engine): [GCP](/install/gcp)
+- Hetzner (Docker): [Hetzner](/install/hetzner)
 
 ## Common links
 

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -26,12 +26,12 @@ Native companion apps for Windows are also planned; the Gateway is recommended v
 ## VPS & hosting
 
 - VPS hub: [VPS hosting](/vps)
-- Agent Computer (managed worker + published port): [Agent Computer](/install/agentcomputer)
 - Fly.io: [Fly.io](/install/fly)
 - Hetzner (Docker): [Hetzner](/install/hetzner)
 - GCP (Compute Engine): [GCP](/install/gcp)
 - Azure (Linux VM): [Azure](/install/azure)
 - exe.dev (VM + HTTPS proxy): [exe.dev](/install/exe-dev)
+- Agent Computer (managed worker + published port): [Agent Computer](/install/agentcomputer)
 
 ## Common links
 

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -21,7 +21,7 @@ Native Linux companion apps are planned. Contributions are welcome if you want t
 4. From your laptop: `ssh -N -L 18789:127.0.0.1:18789 <user>@<host>`
 5. Open `http://127.0.0.1:18789/` and paste your token
 
-Full Linux server guide: [Linux Server](/vps). Step-by-step hosting examples: [Agent Computer](/install/agentcomputer), [exe.dev](/install/exe-dev)
+Full Linux server guide: [Linux Server](/vps). Step-by-step VPS example: [exe.dev](/install/exe-dev)
 
 ## Install
 

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -21,7 +21,7 @@ Native Linux companion apps are planned. Contributions are welcome if you want t
 4. From your laptop: `ssh -N -L 18789:127.0.0.1:18789 <user>@<host>`
 5. Open `http://127.0.0.1:18789/` and paste your token
 
-Full Linux server guide: [Linux Server](/vps). Step-by-step VPS example: [exe.dev](/install/exe-dev)
+Full Linux server guide: [Linux Server](/vps). Step-by-step hosting examples: [Agent Computer](/install/agentcomputer), [exe.dev](/install/exe-dev)
 
 ## Install
 

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -18,15 +18,15 @@ tuning that applies everywhere.
 
 <CardGroup cols={2}>
   <Card title="Agent Computer" href="/install/agentcomputer">Managed worker + published port</Card>
-  <Card title="Azure" href="/install/azure">Linux VM</Card>
-  <Card title="DigitalOcean" href="/install/digitalocean">Simple paid VPS</Card>
-  <Card title="exe.dev" href="/install/exe-dev">VM with HTTPS proxy</Card>
-  <Card title="Fly.io" href="/install/fly">Fly Machines</Card>
-  <Card title="GCP" href="/install/gcp">Compute Engine</Card>
-  <Card title="Hetzner" href="/install/hetzner">Docker on Hetzner VPS</Card>
-  <Card title="Northflank" href="/install/northflank">One-click, browser setup</Card>
-  <Card title="Oracle Cloud" href="/install/oracle">Always Free ARM tier</Card>
   <Card title="Railway" href="/install/railway">One-click, browser setup</Card>
+  <Card title="Northflank" href="/install/northflank">One-click, browser setup</Card>
+  <Card title="DigitalOcean" href="/install/digitalocean">Simple paid VPS</Card>
+  <Card title="Oracle Cloud" href="/install/oracle">Always Free ARM tier</Card>
+  <Card title="Fly.io" href="/install/fly">Fly Machines</Card>
+  <Card title="Hetzner" href="/install/hetzner">Docker on Hetzner VPS</Card>
+  <Card title="GCP" href="/install/gcp">Compute Engine</Card>
+  <Card title="Azure" href="/install/azure">Linux VM</Card>
+  <Card title="exe.dev" href="/install/exe-dev">VM with HTTPS proxy</Card>
   <Card title="Raspberry Pi" href="/install/raspberry-pi">ARM self-hosted</Card>
 </CardGroup>
 

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -17,6 +17,7 @@ tuning that applies everywhere.
 ## Pick a provider
 
 <CardGroup cols={2}>
+  <Card title="Agent Computer" href="/install/agentcomputer">One-click, browser setup</Card>
   <Card title="Railway" href="/install/railway">One-click, browser setup</Card>
   <Card title="Northflank" href="/install/northflank">One-click, browser setup</Card>
   <Card title="DigitalOcean" href="/install/digitalocean">Simple paid VPS</Card>
@@ -26,7 +27,6 @@ tuning that applies everywhere.
   <Card title="GCP" href="/install/gcp">Compute Engine</Card>
   <Card title="Azure" href="/install/azure">Linux VM</Card>
   <Card title="exe.dev" href="/install/exe-dev">VM with HTTPS proxy</Card>
-  <Card title="Agent Computer" href="/install/agentcomputer">Managed worker + published port</Card>
   <Card title="Raspberry Pi" href="/install/raspberry-pi">ARM self-hosted</Card>
 </CardGroup>
 

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -17,15 +17,16 @@ tuning that applies everywhere.
 ## Pick a provider
 
 <CardGroup cols={2}>
-  <Card title="Railway" href="/install/railway">One-click, browser setup</Card>
-  <Card title="Northflank" href="/install/northflank">One-click, browser setup</Card>
-  <Card title="DigitalOcean" href="/install/digitalocean">Simple paid VPS</Card>
-  <Card title="Oracle Cloud" href="/install/oracle">Always Free ARM tier</Card>
-  <Card title="Fly.io" href="/install/fly">Fly Machines</Card>
-  <Card title="Hetzner" href="/install/hetzner">Docker on Hetzner VPS</Card>
-  <Card title="GCP" href="/install/gcp">Compute Engine</Card>
+  <Card title="Agent Computer" href="/install/agentcomputer">Managed worker + published port</Card>
   <Card title="Azure" href="/install/azure">Linux VM</Card>
+  <Card title="DigitalOcean" href="/install/digitalocean">Simple paid VPS</Card>
   <Card title="exe.dev" href="/install/exe-dev">VM with HTTPS proxy</Card>
+  <Card title="Fly.io" href="/install/fly">Fly Machines</Card>
+  <Card title="GCP" href="/install/gcp">Compute Engine</Card>
+  <Card title="Hetzner" href="/install/hetzner">Docker on Hetzner VPS</Card>
+  <Card title="Northflank" href="/install/northflank">One-click, browser setup</Card>
+  <Card title="Oracle Cloud" href="/install/oracle">Always Free ARM tier</Card>
+  <Card title="Railway" href="/install/railway">One-click, browser setup</Card>
   <Card title="Raspberry Pi" href="/install/raspberry-pi">ARM self-hosted</Card>
 </CardGroup>
 

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -17,7 +17,6 @@ tuning that applies everywhere.
 ## Pick a provider
 
 <CardGroup cols={2}>
-  <Card title="Agent Computer" href="/install/agentcomputer">Managed worker + published port</Card>
   <Card title="Railway" href="/install/railway">One-click, browser setup</Card>
   <Card title="Northflank" href="/install/northflank">One-click, browser setup</Card>
   <Card title="DigitalOcean" href="/install/digitalocean">Simple paid VPS</Card>
@@ -27,6 +26,7 @@ tuning that applies everywhere.
   <Card title="GCP" href="/install/gcp">Compute Engine</Card>
   <Card title="Azure" href="/install/azure">Linux VM</Card>
   <Card title="exe.dev" href="/install/exe-dev">VM with HTTPS proxy</Card>
+  <Card title="Agent Computer" href="/install/agentcomputer">Managed worker + published port</Card>
   <Card title="Raspberry Pi" href="/install/raspberry-pi">ARM self-hosted</Card>
 </CardGroup>
 


### PR DESCRIPTION
This adds a new OpenClaw hosting guide for Agent Computer and wires that provider into the main OpenClaw docs discovery surfaces.

Agent Computer is Companion's managed-worker platform for browser-accessible cloud machines:
- https://www.agentcomputer.ai

For this integration, the relevant user entrypoint is the OpenClaw shortcut on Agent Computer:
- https://www.agentcomputer.ai/openclaw

Before this change, the OpenClaw hosting docs covered providers such as exe.dev, Fly.io, Hetzner, and Azure, but there was no equivalent page for Agent Computer. That meant reviewers and users had no first-party OpenClaw doc explaining how to run OpenClaw there, even though Agent Computer is now a real browser-first path for creating an OpenClaw machine.

The main product difference versus a VM-first host such as exe.dev is that Agent Computer already owns the machine lifecycle and browser surface. OpenClaw runs inside that managed worker and is exposed through a published port instead of taking over the machine's canonical host. In practice, that means the guide must explicitly switch OpenClaw away from loopback-only binding and publish port 18789 over HTTPS.

This PR adds `docs/install/agentcomputer.md` and updates the primary hosting indexes so Agent Computer appears as a one-click browser setup option near the top of the relevant provider lists. It also adds the Mintlify navigation/redirect entries in `docs/docs.json` and the glossary entry needed for the new page title.

Scope in this PR:
- `docs/install/agentcomputer.md`
- `docs/install/index.md`
- `docs/vps.md`
- `docs/platforms/index.md`
- `docs/help/faq.md`
- `docs/docs.json`
- `docs/.i18n/glossary.zh-CN.json`

Validation for this docs-only change was limited to the documentation gates:
- `pnpm format` passed
- `pnpm docs:check-i18n-glossary` passed
- Open review-thread feedback was addressed and resolved

I also ran `pnpm check` after refreshing dependencies with `pnpm install`; that broader repo gate still failed on unrelated existing TypeScript errors in `extensions/telegram/src/bot.ts` around `AbortSignal` typing, which is outside the scope of this docs PR.
