### PR TITLE
fix(agents): non-default agents inherit agents.defaults.workspace

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -548,4 +548,25 @@ describe("resolveAgentIdsByWorkspacePath", () => {
       "main",
     ]);
   });
+
+  it("returns all agents sharing agents.defaults.workspace when none have explicit workspace", () => {
+    const sharedWorkspace = `/tmp/openclaw-agent-scope-${Date.now()}-shared`;
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: sharedWorkspace },
+        list: [
+          { id: "main", default: true },
+          { id: "agent-a" },
+          { id: "agent-b" },
+        ],
+      },
+    };
+
+    // All agents without explicit workspace resolve to the shared default,
+    // so resolveAgentIdsByWorkspacePath returns all of them.
+    const result = resolveAgentIdsByWorkspacePath(cfg, `${sharedWorkspace}/some/path`);
+    expect(result).toContain("main");
+    expect(result).toContain("agent-a");
+    expect(result).toContain("agent-b");
+  });
 });

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -422,6 +422,34 @@ describe("resolveAgentConfig", () => {
     expect(workspace).toBe(path.join(path.resolve(home), ".openclaw", "workspace"));
   });
 
+  it("non-default agent inherits agents.defaults.workspace when no explicit workspace set", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared/workspace" },
+        list: [
+          { id: "main", default: true },
+          { id: "my-agent" }, // no workspace set
+        ],
+      },
+    };
+    const workspace = resolveAgentWorkspaceDir(cfg, "my-agent");
+    expect(workspace).toBe(path.resolve("/shared/workspace"));
+  });
+
+  it("non-default agent uses explicit workspace over defaults.workspace", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared/workspace" },
+        list: [
+          { id: "main", default: true },
+          { id: "my-agent", workspace: "/custom/workspace" },
+        ],
+      },
+    };
+    const workspace = resolveAgentWorkspaceDir(cfg, "my-agent");
+    expect(workspace).toBe(path.resolve("/custom/workspace"));
+  });
+
   it("uses OPENCLAW_HOME for default agentDir", () => {
     const home = path.join(path.sep, "srv", "openclaw-home");
     vi.stubEnv("OPENCLAW_HOME", home);

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -271,12 +271,17 @@ export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
   if (configured) {
     return stripNullBytes(resolveUserPath(configured));
   }
+  // Check agents.defaults.workspace before falling back to the per-agent
+  // convention (~/.openclaw/workspace-{id}). This allows non-default agents
+  // to inherit the shared workspace when no explicit override is set,
+  // which is essential for multi-agent setups where all agents share
+  // the same persona/context files but operate in different directories.
+  const defaultWorkspace = cfg.agents?.defaults?.workspace?.trim();
+  if (defaultWorkspace) {
+    return stripNullBytes(resolveUserPath(defaultWorkspace));
+  }
   const defaultAgentId = resolveDefaultAgentId(cfg);
   if (id === defaultAgentId) {
-    const fallback = cfg.agents?.defaults?.workspace?.trim();
-    if (fallback) {
-      return stripNullBytes(resolveUserPath(fallback));
-    }
     return stripNullBytes(resolveDefaultAgentWorkspaceDir(process.env));
   }
   const stateDir = resolveStateDir(process.env);


### PR DESCRIPTION
## Problem

When you configure `agents.defaults.workspace` as a shared workspace for all your agents, only the **default** agent actually inherits it. Every other agent silently falls back to `~/.openclaw/workspace-{agentId}` — an auto-generated directory that usually doesn't exist and has no workspace files in it.

This means non-default agents start with **no SOUL.md, no TOOLS.md, no AGENTS.md** — they lose their entire persona and instructions.

### Example

```json
{
  "agents": {
    "defaults": {
      "workspace": "~/.openclaw/workspace"
    },
    "list": [
      { "id": "main", "default": true },
      { "id": "support-bot" },
      { "id": "dev-bot" }
    ]
  }
}
```

**Expected**: All three agents load workspace files from `~/.openclaw/workspace`.

**Actual**: Only `main` uses `~/.openclaw/workspace`. `support-bot` uses `~/.openclaw/workspace-support-bot` (doesn't exist). `dev-bot` uses `~/.openclaw/workspace-dev-bot` (doesn't exist). Both lose their persona.

### Who this affects

Anyone running multiple agents that should share the same identity/persona files. Common setups:
- One agent per Discord channel, all sharing the same TOOLS.md
- Multi-channel bots where agents are distinguished by bindings, not workspaces
- Any config where you expect `agents.defaults` to mean "defaults for all agents"

The workaround today is setting `workspace` explicitly on every agent, which defeats the purpose of having defaults.

## Fix

Move the `agents.defaults.workspace` check **before** the default-agent-specific branch, so it applies to all agents — not just the default one.

**Before** (simplified):
```
if agent has explicit workspace → use it
if agent is default → check defaults.workspace → use it
else → use ~/.openclaw/workspace-{id}   ← bug: ignores defaults
```

**After**:
```
if agent has explicit workspace → use it
if defaults.workspace is set → use it   ← now all agents inherit
if agent is default → use standard default
else → use ~/.openclaw/workspace-{id}
```

Agents with an explicit `workspace` override are completely unaffected. The fallback to `workspace-{id}` still works when no default is configured.

## Tests

- Added test: non-default agent inherits `agents.defaults.workspace`
- Added test: explicit workspace takes priority over defaults
- Added test: `resolveAgentIdsByWorkspacePath` returns all agents sharing the default workspace
- All existing tests pass

Related: #21770