### PR TITLE
fix(ui): install devDependencies during ui:build (closes #53027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ Docs: https://docs.openclaw.ai
 - Discord/gateway: hand reconnect ownership back to Carbon, keep runtime status aligned with close/reconnect state, and force-stop sockets that open without reaching READY so Discord monitors recover promptly instead of waiting on stale health timeouts. (#59019) Thanks @obviyus
 - QQBot/voice: lazy-load `silk-wasm` in `audio-convert.ts` so qqbot still starts when the optional voice dependency is missing, while voice encode/decode degrades gracefully instead of crashing at module load time. (#58829) Thanks @WideLee.
 - Config/Telegram: migrate removed `channels.telegram.groupMentionsOnly` into `channels.telegram.groups["*"].requireMention` on load so legacy configs no longer crash at startup. (#55336) thanks @jameslcowan.
+- Control UI/build: stop `pnpm ui:build` from reinstalling the UI with production-only dependencies, so fresh self-healing UI builds keep `vite` available instead of failing before asset generation. (#59267) Thanks @juliabush.
 
 ## 2026.3.31
 

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -184,9 +184,8 @@ export function main(argv = process.argv.slice(2)) {
   }
 
   if (!depsInstalled(action === "test" ? "test" : "build")) {
-    const installEnv =
-      action === "build" ? { ...process.env, NODE_ENV: "production" } : process.env;
-    const installArgs = action === "build" ? ["install", "--prod"] : ["install"];
+    const installEnv = process.env;
+    const installArgs = ["install"];
     runSync(runner.cmd, installArgs, installEnv);
   }
 


### PR DESCRIPTION
## Summary

- Problem: `ui:build` installs production-only dependencies (`--prod` + `NODE_ENV=production`), which strips devDependencies required for Vite/PostCSS.
- Why it matters: Fresh installs fail to build the Control UI, breaking gateway startup unless users manually reinstall dependencies.
- What changed: Removed production-only install logic and always run `pnpm install` with full dependency set.
- What did NOT change (scope boundary): No changes to UI code, build config, or dependency versions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53027
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `scripts/ui.js` conditionally installs dependencies with `--prod` and `NODE_ENV=production` during build, removing required devDependencies.
- Missing detection / guardrail: No check ensuring required UI build tooling (vite, postcss) remains available after install.
- Prior context: Introduced as an optimization to reduce install size, but incompatible with build-time tooling requirements.
- Why this regressed now: UI build depends on devDependencies; production-only install breaks modern Vite pipeline.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
- Target test or file: UI bootstrap / gateway startup flow
- Scenario the test should lock in: Fresh clone → `ui:build` succeeds without manual install
- Why this is the smallest reliable guardrail: Requires full install + build pipeline validation
- Existing test that already covers this (if any): None
- If no new test is added, why not: Out of scope for minimal fix

## User-visible / Behavior Changes

- Fresh installs no longer fail during UI build
- No manual `pnpm install` workaround required

## Diagram (if applicable)

```text
Before:
ui:build -> install --prod -> missing dev deps -> build fails

After:
ui:build -> install -> full deps -> build succeeds
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime/container: local
- Model/provider: N/A
- Integration/channel: CLI
- Relevant config (redacted): default

### Steps

1. Fresh clone repo
2. Run `pnpm ui:build`
3. Observe build

### Expected

- UI builds successfully

### Actual

- Fails due to missing devDependencies

## Evidence

- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios:
  - Fresh install + build succeeds
  - Gateway no longer errors on missing UI assets
- Edge cases checked:
  - Re-running build does not reinstall unnecessarily
- What you did **not** verify:
  - CI environments
  - Windows-specific behavior

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Slightly larger dependency install footprint
  - Mitigation: Required for correct build; aligns with standard Vite workflows