### PR TITLE
Exec approvals: unify effective policy reporting and actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Docs: https://docs.openclaw.ai
 
 - Matrix/multi-account: keep room-level `account` scoping, inherited room overrides, and implicit account selection consistent across top-level default auth, named accounts, and cached-credential env setups. (#58449) thanks @Daanvdplas and @gumadeiras.
 - Gateway/pairing: prefer explicit QR bootstrap auth over earlier Tailscale auth classification so iOS `/pair qr` silent bootstrap pairing does not fall through to `pairing required`. (#59232) Thanks @ngutman.
-- Exec approvals: align approval UX, effective-policy reporting, and `allow-always` availability with the host policy so CLI, doctor, and approval surfaces explain the real host-effective decision path. (#59283) Thanks @gumadeiras.
 - Config/Discord: coerce safe integer numeric Discord IDs to strings during config validation, keep unsafe or precision-losing numeric snowflakes rejected, and align `openclaw doctor` repair guidance with the same fail-closed behavior. (#45125) Thanks @moliendocode.
 - Gateway/sessions: scope bare `sessions.create` aliases like `main` to the requested agent while preserving the canonical `global` and `unknown` sentinel keys. (#58207) thanks @jalehman.
 - `/context detail` now compares the tracked prompt estimate with cached context usage and surfaces untracked provider/runtime overhead when present. (#28391) thanks @ImLukeF.
@@ -29,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/runtime: resolve the verification/bootstrap runtime from a distinct packaged Matrix entry so global npm installs stop failing on crypto bootstrap with missing-module or recursive runtime alias errors. (#59249) Thanks @gumadeiras.
 - Matrix/streaming: preserve ordered block flushes before tool, message, and agent boundaries, add explicit `channels.matrix.blockStreaming` opt-in so Matrix `streaming: "off"` stays final-only by default, and move MiniMax plain-text final handling into the MiniMax provider runtime instead of the shared core heuristic. (#59266) thanks @gumadeiras
 - Agents/compaction: resolve compaction wait before final reply/channel flush completion so slow end-of-run delivery drains no longer delay compaction completion. (#59308) thanks @gumadeiras
+- Exec approvals: align approval UX, effective-policy reporting, and `allow-always` availability with the host policy so CLI, doctor, and approval surfaces explain the real host-effective decision path. (#59283) Thanks @gumadeiras.
 
 ## 2026.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 - Matrix/multi-account: keep room-level `account` scoping, inherited room overrides, and implicit account selection consistent across top-level default auth, named accounts, and cached-credential env setups. (#58449) thanks @Daanvdplas and @gumadeiras.
 - Gateway/pairing: prefer explicit QR bootstrap auth over earlier Tailscale auth classification so iOS `/pair qr` silent bootstrap pairing does not fall through to `pairing required`. (#59232) Thanks @ngutman.
+- Exec approvals: align approval UX, effective-policy reporting, and `allow-always` availability with the host policy so CLI, doctor, and approval surfaces explain the real host-effective decision path. (#59283) Thanks @gumadeiras.
 - Config/Discord: coerce safe integer numeric Discord IDs to strings during config validation, keep unsafe or precision-losing numeric snowflakes rejected, and align `openclaw doctor` repair guidance with the same fail-closed behavior. (#45125) Thanks @moliendocode.
 - Gateway/sessions: scope bare `sessions.create` aliases like `main` to the requested agent while preserving the canonical `global` and `unknown` sentinel keys. (#58207) thanks @jalehman.
 - `/context detail` now compares the tracked prompt estimate with cached context usage and surfaces untracked provider/runtime overhead when present. (#28391) thanks @ImLukeF.

--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -24,7 +24,7 @@ openclaw approvals get --node <id|name|ip>
 openclaw approvals get --gateway
 ```
 
-`openclaw approvals get` now shows the effective exec policy for local and gateway targets:
+`openclaw approvals get` now shows the effective exec policy for local, gateway, and node targets:
 
 - requested `tools.exec` policy
 - host approvals-file policy
@@ -34,7 +34,8 @@ Precedence is intentional:
 
 - the host approvals file is the enforceable source of truth
 - requested `tools.exec` policy can narrow or broaden intent, but the effective result is still derived from the host rules
-- node output stays host-file-only because gateway `tools.exec` policy is applied later at runtime
+- `--node` combines the node host approvals file with gateway `tools.exec` policy, because both still apply at runtime
+- if gateway config is unavailable, the CLI falls back to the node approvals snapshot and notes that the final runtime policy could not be computed
 
 ## Replace approvals from a file
 

--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -24,6 +24,18 @@ openclaw approvals get --node <id|name|ip>
 openclaw approvals get --gateway
 ```
 
+`openclaw approvals get` now shows the effective exec policy for local and gateway targets:
+
+- requested `tools.exec` policy
+- host approvals-file policy
+- effective result after precedence rules are applied
+
+Precedence is intentional:
+
+- the host approvals file is the enforceable source of truth
+- requested `tools.exec` policy can narrow or broaden intent, but the effective result is still derived from the host rules
+- node output stays host-file-only because gateway `tools.exec` policy is applied later at runtime
+
 ## Replace approvals from a file
 
 ```bash

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -17,6 +17,7 @@ Effective policy is the **stricter** of `tools.exec.*` and approvals defaults; i
 Host exec also uses the local approvals state on that machine. A host-local
 `ask: "always"` in `~/.openclaw/exec-approvals.json` keeps prompting even if
 session or config defaults request `ask: "on-miss"`.
+Use `openclaw approvals get` or `openclaw approvals get --gateway` to inspect the requested policy, host policy sources, and the effective result.
 
 If the companion app UI is **not available**, any request that requires a prompt is
 resolved by the **ask fallback** (default: deny).

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -17,7 +17,9 @@ Effective policy is the **stricter** of `tools.exec.*` and approvals defaults; i
 Host exec also uses the local approvals state on that machine. A host-local
 `ask: "always"` in `~/.openclaw/exec-approvals.json` keeps prompting even if
 session or config defaults request `ask: "on-miss"`.
-Use `openclaw approvals get` or `openclaw approvals get --gateway` to inspect the requested policy, host policy sources, and the effective result.
+Use `openclaw approvals get`, `openclaw approvals get --gateway`, or
+`openclaw approvals get --node <id|name|ip>` to inspect the requested policy,
+host policy sources, and the effective result.
 
 If the companion app UI is **not available**, any request that requires a prompt is
 resolved by the **ask fallback** (default: deny).

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -80,7 +80,7 @@ Text + native (when enabled):
 - `/status` (show current status; includes provider usage/quota for the current model provider when available)
 - `/tasks` (list background tasks for the current session; shows active and recent task details with agent-local fallback counts)
 - `/allowlist` (list/add/remove allowlist entries)
-- `/approve <id> allow-once|allow-always|deny` (resolve exec approval prompts)
+- `/approve <id> <decision>` (resolve exec approval prompts; use the pending approval message for the available decisions)
 - `/context [list|detail|json]` (explain “context”; `detail` shows per-file + per-tool + per-skill + system prompt size)
 - `/btw <question>` (ask an ephemeral side question about the current session without changing future session context; see [/tools/btw](/tools/btw))
 - `/export-session [path]` (alias: `/export`) (export current session to HTML with full system prompt)

--- a/extensions/discord/src/monitor/exec-approvals.test.ts
+++ b/extensions/discord/src/monitor/exec-approvals.test.ts
@@ -1090,6 +1090,31 @@ describe("DiscordExecApprovalHandler delivery routing", () => {
       }),
     );
   });
+
+  it("omits allow-always when exec approvals disallow it", async () => {
+    const handler = createHandler({
+      enabled: true,
+      approvers: ["123"],
+      target: "dm",
+    });
+
+    mockSuccessfulDmDelivery({ throwOnUnexpectedRoute: true });
+
+    await handler.handleApprovalRequested(
+      createRequest({
+        ask: "always",
+        allowedDecisions: ["allow-once", "deny"],
+      }),
+    );
+
+    const dmCall = mockRestPost.mock.calls.find(
+      ([route]) => route === Routes.channelMessages("dm-1"),
+    );
+    const payload = JSON.stringify(dmCall?.[1]?.body);
+    expect(payload).toContain("Allow Once");
+    expect(payload).toContain("Deny");
+    expect(payload).not.toContain("Allow Always");
+  });
 });
 
 describe("DiscordExecApprovalHandler resolve routing", () => {

--- a/extensions/discord/src/monitor/exec-approvals.ts
+++ b/extensions/discord/src/monitor/exec-approvals.ts
@@ -190,13 +190,34 @@ class ExecApprovalActionButton extends Button {
 }
 
 class ExecApprovalActionRow extends Row<Button> {
-  constructor(approvalId: string) {
+  constructor(params: {
+    approvalId: string;
+    ask?: string | null;
+    allowedDecisions?: readonly ExecApprovalDecision[];
+  }) {
     super([
-      ...buildExecApprovalActionDescriptors({ approvalCommandId: approvalId }).map(
-        (descriptor) => new ExecApprovalActionButton({ approvalId, descriptor }),
+      ...buildExecApprovalActionDescriptors({
+        approvalCommandId: params.approvalId,
+        ask: params.ask,
+        allowedDecisions: params.allowedDecisions,
+      }).map(
+        (descriptor) => new ExecApprovalActionButton({ approvalId: params.approvalId, descriptor }),
       ),
     ]);
   }
+}
+
+function createApprovalActionRow(request: ApprovalRequest): Row<Button> {
+  if (isPluginApprovalRequest(request)) {
+    return new ExecApprovalActionRow({
+      approvalId: request.id,
+    });
+  }
+  return new ExecApprovalActionRow({
+    approvalId: request.id,
+    ask: request.request.ask,
+    allowedDecisions: request.request.allowedDecisions,
+  });
 }
 
 function buildExecApprovalMetadataLines(request: ExecApprovalRequest): string[] {
@@ -466,7 +487,7 @@ export class DiscordExecApprovalHandler {
       isConfigured: () => Boolean(this.opts.config.enabled && this.getApprovers().length > 0),
       shouldHandle: (request) => this.shouldHandle(request),
       buildPendingContent: ({ request }) => {
-        const actionRow = new ExecApprovalActionRow(request.id);
+        const actionRow = createApprovalActionRow(request);
         const container = isPluginApprovalRequest(request)
           ? createPluginApprovalRequestContainer({
               request,

--- a/extensions/slack/src/monitor/exec-approvals.test.ts
+++ b/extensions/slack/src/monitor/exec-approvals.test.ts
@@ -130,6 +130,37 @@ describe("SlackExecApprovalHandler", () => {
     );
   });
 
+  it("omits allow-always when exec approvals disallow it", async () => {
+    const app = buildApp();
+    const handler = new SlackExecApprovalHandler({
+      app,
+      accountId: "default",
+      config: buildConfig("dm").channels!.slack!.execApprovals!,
+      cfg: buildConfig("dm"),
+    });
+
+    await handler.handleApprovalRequested(
+      buildRequest({
+        ask: "always",
+        allowedDecisions: ["allow-once", "deny"],
+      }),
+    );
+
+    const dmCall = sendMessageSlackMock.mock.calls.find(([to]) => to === "user:U123APPROVER");
+    const blocks = dmCall?.[2]?.blocks as Array<Record<string, unknown>> | undefined;
+    const actionsBlock = blocks?.find((block) => block.type === "actions");
+    const buttons = Array.isArray(actionsBlock?.elements) ? actionsBlock.elements : [];
+    const buttonTexts = buttons.map((button) =>
+      typeof button === "object" && button && typeof button.text === "object" && button.text
+        ? String((button.text as { text?: unknown }).text ?? "")
+        : "",
+    );
+
+    expect(buttonTexts).toContain("Allow Once");
+    expect(buttonTexts).toContain("Deny");
+    expect(buttonTexts).not.toContain("Allow Always");
+  });
+
   it("updates the pending approval card in place after resolution", async () => {
     const app = buildApp();
     const update = app.client.chat.update as ReturnType<typeof vi.fn>;

--- a/extensions/slack/src/monitor/exec-approvals.ts
+++ b/extensions/slack/src/monitor/exec-approvals.ts
@@ -6,6 +6,7 @@ import {
   createChannelNativeApprovalRuntime,
   getExecApprovalApproverDmNoticeText,
   resolveExecApprovalCommandDisplay,
+  resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalChannelRuntime,
   type ExecApprovalDecision,
   type ExecApprovalRequest,
@@ -99,6 +100,8 @@ function buildSlackPendingApprovalBlocks(request: ExecApprovalRequest): SlackBlo
       text: "",
       interactive: buildApprovalInteractiveReply({
         approvalId: request.id,
+        ask: request.request.ask,
+        allowedDecisions: resolveExecApprovalRequestAllowedDecisions(request.request),
       }),
     }) ?? [];
   return [

--- a/extensions/telegram/src/exec-approval-forwarding.ts
+++ b/extensions/telegram/src/exec-approval-forwarding.ts
@@ -1,6 +1,6 @@
 import {
   buildExecApprovalPendingReplyPayload,
-  resolveExecApprovalAllowedDecisions,
+  resolveExecApprovalRequestAllowedDecisions,
   resolveExecApprovalCommandDisplay,
   type ExecApprovalRequest,
 } from "openclaw/plugin-sdk/approval-runtime";
@@ -38,7 +38,7 @@ export function buildTelegramExecApprovalPendingPayload(params: {
     cwd: params.request.request.cwd ?? undefined,
     host: params.request.request.host === "node" ? "node" : "gateway",
     nodeId: params.request.request.nodeId ?? undefined,
-    allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: params.request.request.ask }),
+    allowedDecisions: resolveExecApprovalRequestAllowedDecisions(params.request.request),
     expiresAtMs: params.request.expiresAtMs,
     nowMs: params.nowMs,
   });

--- a/extensions/telegram/src/exec-approval-forwarding.ts
+++ b/extensions/telegram/src/exec-approval-forwarding.ts
@@ -1,5 +1,6 @@
 import {
   buildExecApprovalPendingReplyPayload,
+  resolveExecApprovalAllowedDecisions,
   resolveExecApprovalCommandDisplay,
   type ExecApprovalRequest,
 } from "openclaw/plugin-sdk/approval-runtime";
@@ -37,6 +38,7 @@ export function buildTelegramExecApprovalPendingPayload(params: {
     cwd: params.request.request.cwd ?? undefined,
     host: params.request.request.host === "node" ? "node" : "gateway",
     nodeId: params.request.request.nodeId ?? undefined,
+    allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: params.request.request.ask }),
     expiresAtMs: params.request.expiresAtMs,
     nowMs: params.nowMs,
   });

--- a/extensions/telegram/src/exec-approvals-handler.test.ts
+++ b/extensions/telegram/src/exec-approvals-handler.test.ts
@@ -114,6 +114,50 @@ describe("TelegramExecApprovalHandler", () => {
     );
   });
 
+  it("hides allow-always actions when ask=always", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          execApprovals: {
+            enabled: true,
+            approvers: ["8460800771"],
+            target: "channel",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler, sendMessage } = createHandler(cfg);
+
+    await handler.handleRequested({
+      ...baseRequest,
+      request: {
+        ...baseRequest.request,
+        ask: "always",
+      },
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "-1003841603622",
+      expect.not.stringContaining("allow-always"),
+      expect.objectContaining({
+        buttons: [
+          [
+            {
+              text: "Allow Once",
+              callback_data: "/approve 9f1c7d5d-b1fb-46ef-ac45-662723b65bb7 allow-once",
+              style: "success",
+            },
+            {
+              text: "Deny",
+              callback_data: "/approve 9f1c7d5d-b1fb-46ef-ac45-662723b65bb7 deny",
+              style: "danger",
+            },
+          ],
+        ],
+      }),
+    );
+  });
+
   it("falls back to approver DMs when channel routing is unavailable", async () => {
     const cfg = {
       channels: {

--- a/extensions/telegram/src/exec-approvals-handler.ts
+++ b/extensions/telegram/src/exec-approvals-handler.ts
@@ -2,6 +2,7 @@ import { buildPluginApprovalPendingReplyPayload } from "openclaw/plugin-sdk/appr
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import {
   createChannelNativeApprovalRuntime,
+  resolveExecApprovalAllowedDecisions,
   type ExecApprovalChannelRuntime,
 } from "openclaw/plugin-sdk/infra-runtime";
 import { resolveExecApprovalCommandDisplay } from "openclaw/plugin-sdk/infra-runtime";
@@ -124,6 +125,9 @@ export class TelegramExecApprovalHandler {
                 cwd: (request as ExecApprovalRequest).request.cwd ?? undefined,
                 host: (request as ExecApprovalRequest).request.host === "node" ? "node" : "gateway",
                 nodeId: (request as ExecApprovalRequest).request.nodeId ?? undefined,
+                allowedDecisions: resolveExecApprovalAllowedDecisions({
+                  ask: (request as ExecApprovalRequest).request.ask,
+                }),
                 expiresAtMs: request.expiresAtMs,
                 nowMs,
               } satisfies ExecApprovalPendingReplyParams);

--- a/extensions/telegram/src/exec-approvals-handler.ts
+++ b/extensions/telegram/src/exec-approvals-handler.ts
@@ -2,7 +2,7 @@ import { buildPluginApprovalPendingReplyPayload } from "openclaw/plugin-sdk/appr
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import {
   createChannelNativeApprovalRuntime,
-  resolveExecApprovalAllowedDecisions,
+  resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalChannelRuntime,
 } from "openclaw/plugin-sdk/infra-runtime";
 import { resolveExecApprovalCommandDisplay } from "openclaw/plugin-sdk/infra-runtime";
@@ -125,9 +125,9 @@ export class TelegramExecApprovalHandler {
                 cwd: (request as ExecApprovalRequest).request.cwd ?? undefined,
                 host: (request as ExecApprovalRequest).request.host === "node" ? "node" : "gateway",
                 nodeId: (request as ExecApprovalRequest).request.nodeId ?? undefined,
-                allowedDecisions: resolveExecApprovalAllowedDecisions({
-                  ask: (request as ExecApprovalRequest).request.ask,
-                }),
+                allowedDecisions: resolveExecApprovalRequestAllowedDecisions(
+                  (request as ExecApprovalRequest).request,
+                ),
                 expiresAtMs: request.expiresAtMs,
                 nowMs,
               } satisfies ExecApprovalPendingReplyParams);

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -3,6 +3,7 @@ import {
   addDurableCommandApproval,
   addAllowlistEntry,
   type ExecAsk,
+  resolveExecApprovalAllowedDecisions,
   type ExecSecurity,
   buildEnforcedShellCommand,
   evaluateShellAllowlist,
@@ -410,6 +411,7 @@ export async function processGatewayAllowlist(
         initiatingSurface,
         sentApproverDms,
         unavailableReason,
+        allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: hostAsk }),
       }),
     };
   }

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -7,6 +7,7 @@ import {
   evaluateShellAllowlist,
   hasDurableExecApproval,
   requiresExecApproval,
+  resolveExecApprovalAllowedDecisions,
   resolveExecApprovalsFromFile,
 } from "../infra/exec-approvals.js";
 import {
@@ -415,6 +416,7 @@ export async function executeNodeHostCommand(
         initiatingSurface,
         sentApproverDms,
         unavailableReason,
+        allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: hostAsk }),
         nodeId,
       });
     }

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -10,8 +10,10 @@ import {
 import {
   maxAsk,
   minSecurity,
+  resolveExecApprovalAllowedDecisions,
   resolveExecApprovals,
   type ExecAsk,
+  type ExecApprovalDecision,
   type ExecSecurity,
 } from "../infra/exec-approvals.js";
 import { logWarn } from "../logger.js";
@@ -409,8 +411,10 @@ export function buildExecApprovalPendingToolResult(params: {
   initiatingSurface: ExecApprovalInitiatingSurfaceState;
   sentApproverDms: boolean;
   unavailableReason: ExecApprovalUnavailableReason | null;
+  allowedDecisions?: readonly ExecApprovalDecision[];
   nodeId?: string;
 }): AgentToolResult<ExecToolDetails> {
+  const allowedDecisions = params.allowedDecisions ?? resolveExecApprovalAllowedDecisions();
   return {
     content: [
       {
@@ -427,6 +431,7 @@ export function buildExecApprovalPendingToolResult(params: {
                 warningText: params.warningText,
                 approvalSlug: params.approvalSlug,
                 approvalId: params.approvalId,
+                allowedDecisions,
                 command: params.command,
                 cwd: params.cwd,
                 host: params.host,
@@ -452,6 +457,7 @@ export function buildExecApprovalPendingToolResult(params: {
             approvalId: params.approvalId,
             approvalSlug: params.approvalSlug,
             expiresAtMs: params.expiresAtMs,
+            allowedDecisions,
             host: params.host,
             command: params.command,
             cwd: params.cwd,

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -3,7 +3,9 @@ import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  resolveExecApprovalAllowedDecisions,
   type ExecHost,
+  type ExecApprovalDecision,
   type ExecTarget,
 } from "../infra/exec-approvals.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
@@ -336,6 +338,7 @@ export function buildApprovalPendingMessage(params: {
   warningText?: string;
   approvalSlug: string;
   approvalId: string;
+  allowedDecisions?: readonly ExecApprovalDecision[];
   command: string;
   cwd: string;
   host: "gateway" | "node";
@@ -347,6 +350,8 @@ export function buildApprovalPendingMessage(params: {
   }
   const commandBlock = `${fence}sh\n${params.command}\n${fence}`;
   const lines: string[] = [];
+  const allowedDecisions = params.allowedDecisions ?? resolveExecApprovalAllowedDecisions();
+  const decisionText = allowedDecisions.join("|");
   const warningText = params.warningText?.trim();
   if (warningText) {
     lines.push(warningText, "");
@@ -360,8 +365,15 @@ export function buildApprovalPendingMessage(params: {
   lines.push("Command:");
   lines.push(commandBlock);
   lines.push("Mode: foreground (interactive approvals available).");
-  lines.push("Background mode requires pre-approved policy (allow-always or ask=off).");
-  lines.push(`Reply with: /approve ${params.approvalSlug} allow-once|allow-always|deny`);
+  lines.push(
+    allowedDecisions.includes("allow-always")
+      ? "Background mode requires pre-approved policy (allow-always or ask=off)."
+      : "Background mode requires host policy that allows pre-approval (for example ask=off).",
+  );
+  lines.push(`Reply with: /approve ${params.approvalSlug} ${decisionText}`);
+  if (!allowedDecisions.includes("allow-always")) {
+    lines.push("Host policy requires approval every time, so Allow Always is unavailable.");
+  }
   lines.push("If the short code is ambiguous, use the full id in /approve.");
   return lines.join("\n");
 }

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -368,11 +368,13 @@ export function buildApprovalPendingMessage(params: {
   lines.push(
     allowedDecisions.includes("allow-always")
       ? "Background mode requires pre-approved policy (allow-always or ask=off)."
-      : "Background mode requires host policy that allows pre-approval (for example ask=off).",
+      : "Background mode requires an effective policy that allows pre-approval (for example ask=off).",
   );
   lines.push(`Reply with: /approve ${params.approvalSlug} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
-    lines.push("Host policy requires approval every time, so Allow Always is unavailable.");
+    lines.push(
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+    );
   }
   lines.push("If the short code is ambiguous, use the full id in /approve.");
   return lines.join("\n");

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -1,3 +1,4 @@
+import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
 import type { ExecAsk, ExecHost, ExecSecurity, ExecTarget } from "../infra/exec-approvals.js";
 import type { SafeBinProfileFixture } from "../infra/exec-safe-bin-policy.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -58,6 +59,7 @@ export type ExecToolDetails =
       approvalId: string;
       approvalSlug: string;
       expiresAtMs: number;
+      allowedDecisions?: readonly ExecApprovalDecision[];
       host: ExecHost;
       command: string;
       cwd?: string;

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -93,13 +93,14 @@ function expectPendingApprovalText(
     host: "gateway" | "node";
     nodeId?: string;
     interactive?: boolean;
+    allowedDecisions?: string;
   },
 ) {
   expect(result.details.status).toBe("approval-pending");
   const details = result.details as { approvalId: string; approvalSlug: string };
   const pendingText = getResultText(result);
   expect(pendingText).toContain(
-    `Reply with: /approve ${details.approvalSlug} allow-once|allow-always|deny`,
+    `Reply with: /approve ${details.approvalSlug} ${options.allowedDecisions ?? "allow-once|allow-always|deny"}`,
   );
   expect(pendingText).toContain(`full ${details.approvalId}`);
   expect(pendingText).toContain(`Host: ${options.host}`);
@@ -111,7 +112,11 @@ function expectPendingApprovalText(
   expect(pendingText).toContain(options.command);
   if (options.interactive) {
     expect(pendingText).toContain("Mode: foreground (interactive approvals available).");
-    expect(pendingText).toContain("Background mode requires pre-approved policy");
+    expect(pendingText).toContain(
+      (options.allowedDecisions ?? "").includes("allow-always")
+        ? "Background mode requires pre-approved policy"
+        : "Background mode requires host policy that allows pre-approval",
+    );
   }
   return details;
 }
@@ -277,6 +282,7 @@ describe("exec approvals", () => {
       host: "node",
       nodeId: "node-1",
       interactive: true,
+      allowedDecisions: "allow-once|deny",
     });
     const approvalId = details.approvalId;
 
@@ -460,6 +466,13 @@ describe("exec approvals", () => {
     });
 
     expect(result.details.status).toBe("approval-pending");
+    expect(result.details).toMatchObject({
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    expect(getResultText(result)).toContain("Reply with: /approve ");
+    expect(getResultText(result)).toContain("allow-once|deny");
+    expect(getResultText(result)).not.toContain("allow-once|allow-always|deny");
+    expect(getResultText(result)).toContain("Allow Always is unavailable");
   });
 
   it("keeps ask=always prompts for static allowlist entries without allow-always trust", async () => {
@@ -528,6 +541,9 @@ describe("exec approvals", () => {
     });
 
     expect(result.details.status).toBe("approval-pending");
+    expect(result.details).toMatchObject({
+      allowedDecisions: ["allow-once", "deny"],
+    });
     expect(calls).toContain("exec.approval.request");
   });
 
@@ -1240,6 +1256,7 @@ describe("exec approvals", () => {
     expectPendingApprovalText(result, {
       command: "npm view diver name version description",
       host: "gateway",
+      allowedDecisions: "allow-once|deny",
     });
   });
 
@@ -1278,6 +1295,7 @@ describe("exec approvals", () => {
     const details = expectPendingApprovalText(result, {
       command: "npm view diver name version description",
       host: "gateway",
+      allowedDecisions: "allow-once|deny",
     });
     expect(getResultText(result)).toContain(`/approve ${details.approvalSlug} allow-once`);
     expect(getResultText(result)).not.toContain(getExecApprovalApproverDmNoticeText());

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -281,6 +281,46 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
     expect(ctx.state.deterministicApprovalPromptSent).toBe(true);
   });
 
+  it("preserves filtered approval decisions from tool details", async () => {
+    const { ctx } = createTestContext();
+    const onToolResult = vi.fn();
+    ctx.params.onToolResult = onToolResult;
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-approval-ask-always",
+        isError: false,
+        result: {
+          details: {
+            status: "approval-pending",
+            approvalId: "12345678-1234-1234-1234-123456789012",
+            approvalSlug: "12345678",
+            expiresAtMs: 1_800_000_000_000,
+            allowedDecisions: ["allow-once", "deny"],
+            host: "gateway",
+            command: "npm view diver name version description",
+          },
+        },
+      } as never,
+    );
+
+    expect(onToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.not.stringContaining("allow-always"),
+        channelData: {
+          execApproval: {
+            approvalId: "12345678-1234-1234-1234-123456789012",
+            approvalSlug: "12345678",
+            allowedDecisions: ["allow-once", "deny"],
+          },
+        },
+      }),
+    );
+  });
+
   it("emits a deterministic unavailable payload when the initiating surface cannot approve", async () => {
     const { ctx } = createTestContext();
     const onToolResult = vi.fn();

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -4,6 +4,7 @@ import {
   buildExecApprovalPendingReplyPayload,
   buildExecApprovalUnavailableReplyPayload,
 } from "../infra/exec-approval-reply.js";
+import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
@@ -165,6 +166,7 @@ function readExecApprovalPendingDetails(result: unknown): {
   approvalId: string;
   approvalSlug: string;
   expiresAtMs?: number;
+  allowedDecisions?: readonly ExecApprovalDecision[];
   host: "gateway" | "node";
   command: string;
   cwd?: string;
@@ -193,6 +195,12 @@ function readExecApprovalPendingDetails(result: unknown): {
     approvalId,
     approvalSlug,
     expiresAtMs: typeof details.expiresAtMs === "number" ? details.expiresAtMs : undefined,
+    allowedDecisions: Array.isArray(details.allowedDecisions)
+      ? details.allowedDecisions.filter(
+          (decision): decision is ExecApprovalDecision =>
+            decision === "allow-once" || decision === "allow-always" || decision === "deny",
+        )
+      : undefined,
     host,
     command,
     cwd: typeof details.cwd === "string" ? details.cwd : undefined,
@@ -263,6 +271,7 @@ async function emitToolResultOutput(params: {
         buildExecApprovalPendingReplyPayload({
           approvalId: approvalPending.approvalId,
           approvalSlug: approvalPending.approvalSlug,
+          allowedDecisions: approvalPending.allowedDecisions,
           command: approvalPending.command,
           cwd: approvalPending.cwd,
           host: approvalPending.host,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -168,6 +168,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain(
       "When exec returns approval-pending, include the concrete /approve command from tool output",
     );
+    expect(prompt).not.toContain("allow-once|allow-always|deny");
   });
 
   it("tells native approval channels not to duplicate plain chat /approve instructions", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -183,7 +183,7 @@ function buildExecApprovalPromptGuidance(params: { runtimeChannel?: string }) {
   ) {
     return "When exec returns approval-pending on Discord, Slack, Telegram, or WebChat, rely on the native approval card/buttons when they appear and do not also send plain chat /approve instructions. Only include the concrete /approve command if the tool result says chat approvals are unavailable or only manual approval is possible.";
   }
-  return "When exec returns approval-pending, include the concrete /approve command from tool output (with allow-once|allow-always|deny) as plain chat text for the user, and do not ask for a different or rotated code.";
+  return "When exec returns approval-pending, include the concrete /approve command from tool output as plain chat text for the user, and do not ask for a different or rotated code.";
 }
 
 export function buildAgentSystemPrompt(params: {

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -30,6 +30,9 @@ type ParsedApproveCommand =
   | { ok: true; id: string; decision: "allow-once" | "allow-always" | "deny" }
   | { ok: false; error: string };
 
+const APPROVE_USAGE_TEXT =
+  "Usage: /approve <id> <decision> (see the pending approval message for available decisions)";
+
 function parseApproveCommand(raw: string): ParsedApproveCommand | null {
   const trimmed = raw.trim();
   if (FOREIGN_COMMAND_MENTION_REGEX.test(trimmed)) {
@@ -41,11 +44,11 @@ function parseApproveCommand(raw: string): ParsedApproveCommand | null {
   }
   const rest = trimmed.slice(commandMatch[0].length).trim();
   if (!rest) {
-    return { ok: false, error: "Usage: /approve <id> allow-once|allow-always|deny" };
+    return { ok: false, error: APPROVE_USAGE_TEXT };
   }
   const tokens = rest.split(/\s+/).filter(Boolean);
   if (tokens.length < 2) {
-    return { ok: false, error: "Usage: /approve <id> allow-once|allow-always|deny" };
+    return { ok: false, error: APPROVE_USAGE_TEXT };
   }
 
   const first = tokens[0].toLowerCase();
@@ -65,7 +68,7 @@ function parseApproveCommand(raw: string): ParsedApproveCommand | null {
       id: tokens[0],
     };
   }
-  return { ok: false, error: "Usage: /approve <id> allow-once|allow-always|deny" };
+  return { ok: false, error: APPROVE_USAGE_TEXT };
 }
 
 function buildResolvedByLabel(params: Parameters<CommandHandler>[0]): string {

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -283,6 +283,23 @@ describe("exec approvals CLI", () => {
     expect(runtimeErrors).toHaveLength(0);
   });
 
+  it("keeps local approvals output when config load fails", async () => {
+    readBestEffortConfig.mockRejectedValue(new Error("duplicate agent directories"));
+
+    await runApprovalsCommand(["approvals", "get", "--json"]);
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectivePolicy: {
+          note: "Config unavailable.",
+          scopes: [],
+        },
+      }),
+      0,
+    );
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
   it("reports agent scopes with inherited global requested policy", async () => {
     localSnapshot.file = {
       version: 1,

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -251,6 +251,57 @@ describe("exec approvals CLI", () => {
     );
   });
 
+  it("reports agent scopes with inherited global requested policy", async () => {
+    localSnapshot.file = {
+      version: 1,
+      agents: {
+        runner: {
+          security: "allowlist",
+          ask: "always",
+        },
+      },
+    };
+    readBestEffortConfig.mockResolvedValue({
+      tools: {
+        exec: {
+          security: "full",
+          ask: "off",
+        },
+      },
+      agents: {
+        list: [{ id: "runner" }],
+      },
+    });
+
+    await runApprovalsCommand(["approvals", "get", "--json"]);
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectivePolicy: expect.objectContaining({
+          scopes: expect.arrayContaining([
+            expect.objectContaining({
+              scopeLabel: "agent:runner",
+              security: expect.objectContaining({
+                requested: "full",
+                requestedSource: "tools.exec.security",
+                effective: "allowlist",
+              }),
+              ask: expect.objectContaining({
+                requested: "off",
+                requestedSource: "tools.exec.ask",
+                effective: "always",
+              }),
+              askFallback: expect.objectContaining({
+                source: "OpenClaw default (deny)",
+              }),
+            }),
+          ]),
+        }),
+      }),
+      0,
+    );
+  });
+
   it("defaults allowlist add to wildcard agent", async () => {
     const saveExecApprovals = vi.mocked(execApprovals.saveExecApprovals);
     saveExecApprovals.mockClear();

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -1,11 +1,13 @@
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as execApprovals from "../infra/exec-approvals.js";
+import type { ExecApprovalsFile } from "../infra/exec-approvals.js";
 import { registerExecApprovalsCli } from "./exec-approvals-cli.js";
 
 const mocks = vi.hoisted(() => {
   const runtimeErrors: string[] = [];
   const stringifyArgs = (args: unknown[]) => args.map((value) => String(value)).join(" ");
+  const readBestEffortConfig = vi.fn(async () => ({}));
   const defaultRuntime = {
     log: vi.fn(),
     error: vi.fn((...args: unknown[]) => {
@@ -24,6 +26,18 @@ const mocks = vi.hoisted(() => {
   return {
     callGatewayFromCli: vi.fn(async (method: string, _opts: unknown, params?: unknown) => {
       if (method.endsWith(".get")) {
+        if (method === "config.get") {
+          return {
+            config: {
+              tools: {
+                exec: {
+                  security: "full",
+                  ask: "off",
+                },
+              },
+            },
+          };
+        }
         return {
           path: "/tmp/exec-approvals.json",
           exists: true,
@@ -34,18 +48,19 @@ const mocks = vi.hoisted(() => {
       return { method, params };
     }),
     defaultRuntime,
+    readBestEffortConfig,
     runtimeErrors,
   };
 });
 
-const { callGatewayFromCli, defaultRuntime, runtimeErrors } = mocks;
+const { callGatewayFromCli, defaultRuntime, readBestEffortConfig, runtimeErrors } = mocks;
 
 const localSnapshot = {
   path: "/tmp/local-exec-approvals.json",
   exists: true,
   raw: "{}",
   hash: "hash-local",
-  file: { version: 1, agents: {} },
+  file: { version: 1, agents: {} } as ExecApprovalsFile,
 };
 
 function resetLocalSnapshot() {
@@ -68,6 +83,14 @@ vi.mock("./nodes-cli/rpc.js", async () => {
 vi.mock("../runtime.js", () => ({
   defaultRuntime: mocks.defaultRuntime,
 }));
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return {
+    ...actual,
+    readBestEffortConfig: mocks.readBestEffortConfig,
+  };
+});
 
 vi.mock("../infra/exec-approvals.js", async () => {
   const actual = await vi.importActual<typeof import("../infra/exec-approvals.js")>(
@@ -97,6 +120,7 @@ describe("exec approvals CLI", () => {
     resetLocalSnapshot();
     runtimeErrors.length = 0;
     callGatewayFromCli.mockClear();
+    readBestEffortConfig.mockClear();
     defaultRuntime.log.mockClear();
     defaultRuntime.error.mockClear();
     defaultRuntime.writeStdout.mockClear();
@@ -108,12 +132,19 @@ describe("exec approvals CLI", () => {
     await runApprovalsCommand(["approvals", "get"]);
 
     expect(callGatewayFromCli).not.toHaveBeenCalled();
+    expect(readBestEffortConfig).toHaveBeenCalledTimes(1);
     expect(runtimeErrors).toHaveLength(0);
     callGatewayFromCli.mockClear();
 
     await runApprovalsCommand(["approvals", "get", "--gateway"]);
 
-    expect(callGatewayFromCli).toHaveBeenCalledWith("exec.approvals.get", expect.anything(), {});
+    expect(callGatewayFromCli).toHaveBeenNthCalledWith(
+      1,
+      "exec.approvals.get",
+      expect.anything(),
+      {},
+    );
+    expect(callGatewayFromCli).toHaveBeenNthCalledWith(2, "config.get", expect.anything(), {});
     expect(runtimeErrors).toHaveLength(0);
     callGatewayFromCli.mockClear();
 
@@ -123,6 +154,101 @@ describe("exec approvals CLI", () => {
       nodeId: "node-1",
     });
     expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("adds effective policy to json output", async () => {
+    localSnapshot.file = {
+      version: 1,
+      defaults: { security: "allowlist", ask: "always", askFallback: "deny" },
+      agents: {},
+    };
+    readBestEffortConfig.mockResolvedValue({
+      tools: {
+        exec: {
+          security: "full",
+          ask: "off",
+        },
+      },
+    });
+
+    await runApprovalsCommand(["approvals", "get", "--json"]);
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectivePolicy: {
+          note: "Effective exec policy is the host approvals file intersected with requested tools.exec policy.",
+          scopes: [
+            expect.objectContaining({
+              scopeLabel: "tools.exec",
+              security: expect.objectContaining({
+                requested: "full",
+                host: "allowlist",
+                effective: "allowlist",
+              }),
+              ask: expect.objectContaining({
+                requested: "off",
+                host: "always",
+                effective: "always",
+              }),
+            }),
+          ],
+        },
+      }),
+      0,
+    );
+  });
+
+  it("reports wildcard host policy sources in effective policy output", async () => {
+    localSnapshot.file = {
+      version: 1,
+      defaults: { security: "full", ask: "off", askFallback: "full" },
+      agents: {
+        "*": {
+          security: "allowlist",
+          ask: "always",
+          askFallback: "deny",
+        },
+      },
+    };
+    readBestEffortConfig.mockResolvedValue({
+      agents: {
+        list: [
+          {
+            id: "runner",
+            tools: {
+              exec: {
+                security: "full",
+                ask: "off",
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    await runApprovalsCommand(["approvals", "get", "--json"]);
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectivePolicy: expect.objectContaining({
+          scopes: expect.arrayContaining([
+            expect.objectContaining({
+              scopeLabel: "agent:runner",
+              security: expect.objectContaining({
+                hostSource: "~/.openclaw/exec-approvals.json agents.*.security",
+              }),
+              ask: expect.objectContaining({
+                hostSource: "~/.openclaw/exec-approvals.json agents.*.ask",
+              }),
+              askFallback: expect.objectContaining({
+                source: "~/.openclaw/exec-approvals.json agents.*.askFallback",
+              }),
+            }),
+          ]),
+        }),
+      }),
+      0,
+    );
   });
 
   it("defaults allowlist add to wildcard agent", async () => {

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -153,6 +153,7 @@ describe("exec approvals CLI", () => {
     expect(callGatewayFromCli).toHaveBeenCalledWith("exec.approvals.node.get", expect.anything(), {
       nodeId: "node-1",
     });
+    expect(callGatewayFromCli).toHaveBeenCalledWith("config.get", expect.anything(), {});
     expect(runtimeErrors).toHaveLength(0);
   });
 
@@ -251,6 +252,68 @@ describe("exec approvals CLI", () => {
     );
   });
 
+  it("adds combined node effective policy to json output", async () => {
+    callGatewayFromCli.mockImplementation(
+      async (method: string, _opts: unknown, params?: unknown) => {
+        if (method === "config.get") {
+          return {
+            config: {
+              tools: {
+                exec: {
+                  security: "full",
+                  ask: "off",
+                },
+              },
+            },
+          };
+        }
+        if (method === "exec.approvals.node.get") {
+          return {
+            path: "/tmp/node-exec-approvals.json",
+            exists: true,
+            hash: "hash-node-1",
+            file: {
+              version: 1,
+              defaults: { security: "allowlist", ask: "always", askFallback: "deny" },
+              agents: {},
+            },
+          };
+        }
+        return { method, params };
+      },
+    );
+
+    await runApprovalsCommand(["approvals", "get", "--node", "macbook", "--json"]);
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectivePolicy: {
+          note: "Effective exec policy is the node host approvals file intersected with gateway tools.exec policy.",
+          scopes: [
+            expect.objectContaining({
+              scopeLabel: "tools.exec",
+              security: expect.objectContaining({
+                requested: "full",
+                host: "allowlist",
+                effective: "allowlist",
+              }),
+              ask: expect.objectContaining({
+                requested: "off",
+                host: "always",
+                effective: "always",
+              }),
+              askFallback: expect.objectContaining({
+                effective: "deny",
+                source: "~/.openclaw/exec-approvals.json defaults.askFallback",
+              }),
+            }),
+          ],
+        },
+      }),
+      0,
+    );
+  });
+
   it("keeps gateway approvals output when config.get fails", async () => {
     callGatewayFromCli.mockImplementation(
       async (method: string, _opts: unknown, params?: unknown) => {
@@ -275,6 +338,38 @@ describe("exec approvals CLI", () => {
       expect.objectContaining({
         effectivePolicy: {
           note: "Config unavailable.",
+          scopes: [],
+        },
+      }),
+      0,
+    );
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("keeps node approvals output when gateway config is unavailable", async () => {
+    callGatewayFromCli.mockImplementation(
+      async (method: string, _opts: unknown, params?: unknown) => {
+        if (method === "config.get") {
+          throw new Error("gateway config unavailable");
+        }
+        if (method === "exec.approvals.node.get") {
+          return {
+            path: "/tmp/node-exec-approvals.json",
+            exists: true,
+            hash: "hash-node-1",
+            file: { version: 1, agents: {} },
+          };
+        }
+        return { method, params };
+      },
+    );
+
+    await runApprovalsCommand(["approvals", "get", "--node", "macbook", "--json"]);
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectivePolicy: {
+          note: "Gateway config unavailable. Node output above shows host approvals state only, and final runtime policy still intersects with gateway tools.exec.",
           scopes: [],
         },
       }),

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -251,6 +251,38 @@ describe("exec approvals CLI", () => {
     );
   });
 
+  it("keeps gateway approvals output when config.get fails", async () => {
+    callGatewayFromCli.mockImplementation(
+      async (method: string, _opts: unknown, params?: unknown) => {
+        if (method === "config.get") {
+          throw new Error("gateway config unavailable");
+        }
+        if (method === "exec.approvals.get") {
+          return {
+            path: "/tmp/exec-approvals.json",
+            exists: true,
+            hash: "hash-1",
+            file: { version: 1, agents: {} },
+          };
+        }
+        return { method, params };
+      },
+    );
+
+    await runApprovalsCommand(["approvals", "get", "--gateway", "--json"]);
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectivePolicy: {
+          note: "Config unavailable.",
+          scopes: [],
+        },
+      }),
+      0,
+    );
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
   it("reports agent scopes with inherited global requested policy", async () => {
     localSnapshot.file = {
       version: 1,

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -162,9 +162,6 @@ async function loadConfigForApprovalsTarget(params: {
   opts: ExecApprovalsCliOpts;
   source: ApprovalsTargetSource;
 }): Promise<OpenClawConfig | null> {
-  if (params.source === "node") {
-    return null;
-  }
   try {
     if (params.source === "local") {
       return await readBestEffortConfig();
@@ -217,9 +214,18 @@ function buildEffectivePolicyReport(params: {
   approvals: ExecApprovalsFile;
 }): EffectivePolicyReport {
   if (params.source === "node") {
+    if (!params.cfg) {
+      return {
+        scopes: [],
+        note: "Gateway config unavailable. Node output above shows host approvals state only, and final runtime policy still intersects with gateway tools.exec.",
+      };
+    }
     return {
-      scopes: [],
-      note: "Node output shows host approvals state only. Gateway tools.exec policy still intersects at runtime.",
+      scopes: collectExecPolicySnapshots({
+        cfg: params.cfg,
+        approvals: params.approvals,
+      }),
+      note: "Effective exec policy is the node host approvals file intersected with gateway tools.exec policy.",
     };
   }
   if (!params.cfg) {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -165,10 +165,10 @@ async function loadConfigForApprovalsTarget(params: {
   if (params.source === "node") {
     return null;
   }
-  if (params.source === "local") {
-    return await readBestEffortConfig();
-  }
   try {
+    if (params.source === "local") {
+      return await readBestEffortConfig();
+    }
     const snapshot = (await callGatewayFromCli(
       "config.get",
       params.opts,

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import type { Command } from "commander";
 import JSON5 from "json5";
 import { readBestEffortConfig, type OpenClawConfig } from "../config/config.js";
-import { resolveExecPolicyScopeSummary } from "../infra/exec-approvals-effective.js";
+import { resolveExecPolicyScopeSnapshot } from "../infra/exec-approvals-effective.js";
 import {
   readExecApprovalsSnapshot,
   saveExecApprovals,
@@ -31,7 +31,7 @@ type ConfigSnapshotLike = {
 };
 type ApprovalsTargetSource = "gateway" | "node" | "local";
 type EffectivePolicyReport = {
-  scopes: ReturnType<typeof collectExecPolicySummaries>;
+  scopes: ReturnType<typeof collectExecPolicySnapshots>;
   note?: string;
 };
 
@@ -172,15 +172,16 @@ async function loadConfigForApprovalsTarget(params: {
   return snapshot.config && typeof snapshot.config === "object" ? snapshot.config : null;
 }
 
-function collectExecPolicySummaries(params: { cfg: OpenClawConfig; approvals: ExecApprovalsFile }) {
-  const summaries = [
-    resolveExecPolicyScopeSummary({
+function collectExecPolicySnapshots(params: { cfg: OpenClawConfig; approvals: ExecApprovalsFile }) {
+  const snapshots = [
+    resolveExecPolicyScopeSnapshot({
       approvals: params.approvals,
-      execConfig: params.cfg.tools?.exec,
+      scopeExecConfig: params.cfg.tools?.exec,
       configPath: "tools.exec",
       scopeLabel: "tools.exec",
     }),
   ];
+  const globalExecConfig = params.cfg.tools?.exec;
   const configAgentIds = new Set((params.cfg.agents?.list ?? []).map((agent) => agent.id));
   const approvalAgentIds = Object.keys(params.approvals.agents ?? {}).filter(
     (agentId) => agentId !== "*" && agentId !== "default",
@@ -188,17 +189,18 @@ function collectExecPolicySummaries(params: { cfg: OpenClawConfig; approvals: Ex
   const agentIds = Array.from(new Set([...configAgentIds, ...approvalAgentIds])).toSorted();
   for (const agentId of agentIds) {
     const agentConfig = params.cfg.agents?.list?.find((agent) => agent.id === agentId);
-    summaries.push(
-      resolveExecPolicyScopeSummary({
+    snapshots.push(
+      resolveExecPolicyScopeSnapshot({
         approvals: params.approvals,
-        execConfig: agentConfig?.tools?.exec,
+        scopeExecConfig: agentConfig?.tools?.exec,
+        globalExecConfig,
         configPath: `agents.list.${agentId}.tools.exec`,
         scopeLabel: `agent:${agentId}`,
         agentId,
       }),
     );
   }
-  return summaries;
+  return snapshots;
 }
 
 function buildEffectivePolicyReport(params: {
@@ -219,7 +221,7 @@ function buildEffectivePolicyReport(params: {
     };
   }
   return {
-    scopes: collectExecPolicySummaries({
+    scopes: collectExecPolicySnapshots({
       cfg: params.cfg,
       approvals: params.approvals,
     }),

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -168,8 +168,16 @@ async function loadConfigForApprovalsTarget(params: {
   if (params.source === "local") {
     return await readBestEffortConfig();
   }
-  const snapshot = (await callGatewayFromCli("config.get", params.opts, {})) as ConfigSnapshotLike;
-  return snapshot.config && typeof snapshot.config === "object" ? snapshot.config : null;
+  try {
+    const snapshot = (await callGatewayFromCli(
+      "config.get",
+      params.opts,
+      {},
+    )) as ConfigSnapshotLike;
+    return snapshot.config && typeof snapshot.config === "object" ? snapshot.config : null;
+  } catch {
+    return null;
+  }
 }
 
 function collectExecPolicySnapshots(params: { cfg: OpenClawConfig; approvals: ExecApprovalsFile }) {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import type { Command } from "commander";
 import JSON5 from "json5";
+import { readBestEffortConfig, type OpenClawConfig } from "../config/config.js";
+import { resolveExecPolicyScopeSummary } from "../infra/exec-approvals-effective.js";
 import {
   readExecApprovalsSnapshot,
   saveExecApprovals,
@@ -22,6 +24,15 @@ type ExecApprovalsSnapshot = {
   exists: boolean;
   hash: string;
   file: ExecApprovalsFile;
+};
+
+type ConfigSnapshotLike = {
+  config?: OpenClawConfig;
+};
+type ApprovalsTargetSource = "gateway" | "node" | "local";
+type EffectivePolicyReport = {
+  scopes: ReturnType<typeof collectExecPolicySummaries>;
+  note?: string;
 };
 
 type ExecApprovalsCliOpts = NodesRpcOpts & {
@@ -79,7 +90,7 @@ function saveSnapshotLocal(file: ExecApprovalsFile): ExecApprovalsSnapshot {
 async function loadSnapshotTarget(opts: ExecApprovalsCliOpts): Promise<{
   snapshot: ExecApprovalsSnapshot;
   nodeId: string | null;
-  source: "gateway" | "node" | "local";
+  source: ApprovalsTargetSource;
 }> {
   if (!opts.gateway && !opts.node) {
     return { snapshot: loadSnapshotLocal(), nodeId: null, source: "local" };
@@ -106,7 +117,7 @@ function requireTrimmedNonEmpty(value: string, message: string): string {
 async function loadWritableSnapshotTarget(opts: ExecApprovalsCliOpts): Promise<{
   snapshot: ExecApprovalsSnapshot;
   nodeId: string | null;
-  source: "gateway" | "node" | "local";
+  source: ApprovalsTargetSource;
   targetLabel: string;
   baseHash: string;
 }> {
@@ -124,7 +135,7 @@ async function loadWritableSnapshotTarget(opts: ExecApprovalsCliOpts): Promise<{
 
 async function saveSnapshotTargeted(params: {
   opts: ExecApprovalsCliOpts;
-  source: "gateway" | "node" | "local";
+  source: ApprovalsTargetSource;
   nodeId: string | null;
   file: ExecApprovalsFile;
   baseHash: string;
@@ -145,6 +156,112 @@ async function saveSnapshotTargeted(params: {
 function formatCliError(err: unknown): string {
   const msg = describeUnknownError(err);
   return msg.includes("\n") ? msg.split("\n")[0] : msg;
+}
+
+async function loadConfigForApprovalsTarget(params: {
+  opts: ExecApprovalsCliOpts;
+  source: ApprovalsTargetSource;
+}): Promise<OpenClawConfig | null> {
+  if (params.source === "node") {
+    return null;
+  }
+  if (params.source === "local") {
+    return await readBestEffortConfig();
+  }
+  const snapshot = (await callGatewayFromCli("config.get", params.opts, {})) as ConfigSnapshotLike;
+  return snapshot.config && typeof snapshot.config === "object" ? snapshot.config : null;
+}
+
+function collectExecPolicySummaries(params: { cfg: OpenClawConfig; approvals: ExecApprovalsFile }) {
+  const summaries = [
+    resolveExecPolicyScopeSummary({
+      approvals: params.approvals,
+      execConfig: params.cfg.tools?.exec,
+      configPath: "tools.exec",
+      scopeLabel: "tools.exec",
+    }),
+  ];
+  const configAgentIds = new Set((params.cfg.agents?.list ?? []).map((agent) => agent.id));
+  const approvalAgentIds = Object.keys(params.approvals.agents ?? {}).filter(
+    (agentId) => agentId !== "*" && agentId !== "default",
+  );
+  const agentIds = Array.from(new Set([...configAgentIds, ...approvalAgentIds])).toSorted();
+  for (const agentId of agentIds) {
+    const agentConfig = params.cfg.agents?.list?.find((agent) => agent.id === agentId);
+    summaries.push(
+      resolveExecPolicyScopeSummary({
+        approvals: params.approvals,
+        execConfig: agentConfig?.tools?.exec,
+        configPath: `agents.list.${agentId}.tools.exec`,
+        scopeLabel: `agent:${agentId}`,
+        agentId,
+      }),
+    );
+  }
+  return summaries;
+}
+
+function buildEffectivePolicyReport(params: {
+  cfg: OpenClawConfig | null;
+  source: ApprovalsTargetSource;
+  approvals: ExecApprovalsFile;
+}): EffectivePolicyReport {
+  if (params.source === "node") {
+    return {
+      scopes: [],
+      note: "Node output shows host approvals state only. Gateway tools.exec policy still intersects at runtime.",
+    };
+  }
+  if (!params.cfg) {
+    return {
+      scopes: [],
+      note: "Config unavailable.",
+    };
+  }
+  return {
+    scopes: collectExecPolicySummaries({
+      cfg: params.cfg,
+      approvals: params.approvals,
+    }),
+    note: "Effective exec policy is the host approvals file intersected with requested tools.exec policy.",
+  };
+}
+
+function renderEffectivePolicy(params: { report: EffectivePolicyReport }) {
+  const rich = isRich();
+  const heading = (text: string) => (rich ? theme.heading(text) : text);
+  const muted = (text: string) => (rich ? theme.muted(text) : text);
+  if (params.report.scopes.length === 0 && !params.report.note) {
+    return;
+  }
+  defaultRuntime.log("");
+  defaultRuntime.log(heading("Effective Policy"));
+  if (params.report.scopes.length === 0) {
+    defaultRuntime.log(muted(params.report.note ?? "No effective policy details available."));
+    return;
+  }
+  const rows = params.report.scopes.map((summary) => ({
+    Scope: summary.scopeLabel,
+    Requested: `security=${summary.security.requested} (${summary.security.requestedSource})\nask=${summary.ask.requested} (${summary.ask.requestedSource})`,
+    Host: `security=${summary.security.host} (${summary.security.hostSource})\nask=${summary.ask.host} (${summary.ask.hostSource})\naskFallback=${summary.askFallback.effective} (${summary.askFallback.source})`,
+    Effective: `security=${summary.security.effective}\nask=${summary.ask.effective}`,
+    Notes: `${summary.security.note}; ${summary.ask.note}`,
+  }));
+  defaultRuntime.log(
+    renderTable({
+      width: getTerminalTableWidth(),
+      columns: [
+        { key: "Scope", header: "Scope", minWidth: 12 },
+        { key: "Requested", header: "Requested", minWidth: 24, flex: true },
+        { key: "Host", header: "Host", minWidth: 24, flex: true },
+        { key: "Effective", header: "Effective", minWidth: 16 },
+        { key: "Notes", header: "Notes", minWidth: 20, flex: true },
+      ],
+      rows,
+    }).trimEnd(),
+  );
+  defaultRuntime.log("");
+  defaultRuntime.log(muted(`Precedence: ${params.report.note}`));
 }
 
 function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: string) {
@@ -364,8 +481,14 @@ export function registerExecApprovalsCli(program: Command) {
     .action(async (opts: ExecApprovalsCliOpts) => {
       try {
         const { snapshot, nodeId, source } = await loadSnapshotTarget(opts);
+        const cfg = await loadConfigForApprovalsTarget({ opts, source });
+        const effectivePolicy = buildEffectivePolicyReport({
+          cfg,
+          source,
+          approvals: snapshot.file,
+        });
         if (opts.json) {
-          defaultRuntime.writeJson(snapshot, 0);
+          defaultRuntime.writeJson({ ...snapshot, effectivePolicy }, 0);
           return;
         }
 
@@ -376,6 +499,7 @@ export function registerExecApprovalsCli(program: Command) {
         }
         const targetLabel = source === "local" ? "local" : nodeId ? `node:${nodeId}` : "gateway";
         renderApprovalsSnapshot(snapshot, targetLabel);
+        renderEffectivePolicy({ report: effectivePolicy });
       } catch (err) {
         defaultRuntime.error(formatCliError(err));
         defaultRuntime.exit(1);

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import type { Command } from "commander";
 import JSON5 from "json5";
 import { readBestEffortConfig, type OpenClawConfig } from "../config/config.js";
-import { resolveExecPolicyScopeSnapshot } from "../infra/exec-approvals-effective.js";
+import {
+  collectExecPolicyScopeSnapshots,
+  type ExecPolicyScopeSnapshot,
+} from "../infra/exec-approvals-effective.js";
 import {
   readExecApprovalsSnapshot,
   saveExecApprovals,
@@ -31,7 +34,7 @@ type ConfigSnapshotLike = {
 };
 type ApprovalsTargetSource = "gateway" | "node" | "local";
 type EffectivePolicyReport = {
-  scopes: ReturnType<typeof collectExecPolicySnapshots>;
+  scopes: ExecPolicyScopeSnapshot[];
   note?: string;
 };
 
@@ -177,37 +180,6 @@ async function loadConfigForApprovalsTarget(params: {
   }
 }
 
-function collectExecPolicySnapshots(params: { cfg: OpenClawConfig; approvals: ExecApprovalsFile }) {
-  const snapshots = [
-    resolveExecPolicyScopeSnapshot({
-      approvals: params.approvals,
-      scopeExecConfig: params.cfg.tools?.exec,
-      configPath: "tools.exec",
-      scopeLabel: "tools.exec",
-    }),
-  ];
-  const globalExecConfig = params.cfg.tools?.exec;
-  const configAgentIds = new Set((params.cfg.agents?.list ?? []).map((agent) => agent.id));
-  const approvalAgentIds = Object.keys(params.approvals.agents ?? {}).filter(
-    (agentId) => agentId !== "*" && agentId !== "default",
-  );
-  const agentIds = Array.from(new Set([...configAgentIds, ...approvalAgentIds])).toSorted();
-  for (const agentId of agentIds) {
-    const agentConfig = params.cfg.agents?.list?.find((agent) => agent.id === agentId);
-    snapshots.push(
-      resolveExecPolicyScopeSnapshot({
-        approvals: params.approvals,
-        scopeExecConfig: agentConfig?.tools?.exec,
-        globalExecConfig,
-        configPath: `agents.list.${agentId}.tools.exec`,
-        scopeLabel: `agent:${agentId}`,
-        agentId,
-      }),
-    );
-  }
-  return snapshots;
-}
-
 function buildEffectivePolicyReport(params: {
   cfg: OpenClawConfig | null;
   source: ApprovalsTargetSource;
@@ -221,7 +193,7 @@ function buildEffectivePolicyReport(params: {
       };
     }
     return {
-      scopes: collectExecPolicySnapshots({
+      scopes: collectExecPolicyScopeSnapshots({
         cfg: params.cfg,
         approvals: params.approvals,
       }),
@@ -235,7 +207,7 @@ function buildEffectivePolicyReport(params: {
     };
   }
   return {
-    scopes: collectExecPolicySnapshots({
+    scopes: collectExecPolicyScopeSnapshots({
       cfg: params.cfg,
       approvals: params.approvals,
     }),

--- a/src/commands/doctor-security.test.ts
+++ b/src/commands/doctor-security.test.ts
@@ -309,6 +309,40 @@ describe("noteSecurityWarnings gateway exposure", () => {
     expect(message).toContain('agents.runner.ask="always"');
   });
 
+  it("warns when an agent inherits broader global tools.exec policy than the matching host agent policy", async () => {
+    await withExecApprovalsFile(
+      {
+        version: 1,
+        agents: {
+          runner: {
+            security: "allowlist",
+            ask: "always",
+          },
+        },
+      },
+      async () => {
+        await noteSecurityWarnings({
+          tools: {
+            exec: {
+              security: "full",
+              ask: "off",
+            },
+          },
+          agents: {
+            list: [{ id: "runner" }],
+          },
+        } as OpenClawConfig);
+      },
+    );
+
+    const message = lastMessage();
+    expect(message).toContain("agents.list.runner.tools.exec is broader than the host exec policy");
+    expect(message).toContain('tools.exec.security="full"');
+    expect(message).toContain('tools.exec.ask="off"');
+    expect(message).toContain('agents.runner.security="allowlist"');
+    expect(message).toContain('agents.runner.ask="always"');
+  });
+
   it('does not warn about durable allow-always trust when ask="always" is enforced', async () => {
     await withExecApprovalsFile(
       {

--- a/src/commands/doctor-security.test.ts
+++ b/src/commands/doctor-security.test.ts
@@ -188,6 +188,46 @@ describe("noteSecurityWarnings gateway exposure", () => {
     expect(message).toContain("stricter side wins");
   });
 
+  it("attributes broader host policy warnings to wildcard agent entries", async () => {
+    await withExecApprovalsFile(
+      {
+        version: 1,
+        defaults: {
+          security: "full",
+          ask: "off",
+        },
+        agents: {
+          "*": {
+            security: "allowlist",
+            ask: "always",
+          },
+        },
+      },
+      async () => {
+        await noteSecurityWarnings({
+          agents: {
+            list: [
+              {
+                id: "runner",
+                tools: {
+                  exec: {
+                    security: "full",
+                    ask: "off",
+                  },
+                },
+              },
+            ],
+          },
+        } as OpenClawConfig);
+      },
+    );
+
+    const message = lastMessage();
+    expect(message).toContain("agents.list.runner.tools.exec is broader than the host exec policy");
+    expect(message).toContain('agents.*.security="allowlist"');
+    expect(message).toContain('agents.*.ask="always"');
+  });
+
   it("does not invent a deny host policy when exec-approvals defaults.security is unset", async () => {
     await withExecApprovalsFile(
       {

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -6,15 +6,8 @@ import type { AgentConfig } from "../config/types.agents.js";
 import { hasConfiguredSecretInput } from "../config/types.secrets.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { isLoopbackHost, resolveGatewayBindHost } from "../gateway/net.js";
-import {
-  loadExecApprovals,
-  maxAsk,
-  minSecurity,
-  resolveExecApprovalsFromFile,
-  type ExecApprovalsFile,
-  type ExecAsk,
-  type ExecSecurity,
-} from "../infra/exec-approvals.js";
+import { resolveExecPolicyScopeSummary } from "../infra/exec-approvals-effective.js";
+import { loadExecApprovals, type ExecAsk, type ExecSecurity } from "../infra/exec-approvals.js";
 import { resolveDmAllowState } from "../security/dm-policy-shared.js";
 import { note } from "../terminal/note.js";
 import { resolveDefaultChannelAccountContext } from "./channel-account-context.js";
@@ -79,50 +72,6 @@ function execAskRank(value: ExecAsk): number {
   }
 }
 
-function resolveHostExecPolicy(params: {
-  approvals: ExecApprovalsFile;
-  execConfig: { security?: ExecSecurity; ask?: ExecAsk } | undefined;
-  agentId?: string;
-}): {
-  security: ExecSecurity;
-  ask: ExecAsk;
-  securitySource: string;
-  askSource: string;
-} {
-  const basePath = "~/.openclaw/exec-approvals.json";
-  const agentEntry =
-    params.agentId && params.approvals.agents && params.approvals.agents[params.agentId]
-      ? params.approvals.agents[params.agentId]
-      : undefined;
-  const defaults = params.approvals.defaults;
-  const configuredSecurity = params.execConfig?.security ?? "allowlist";
-  const configuredAsk = params.execConfig?.ask ?? "on-miss";
-  const resolved = resolveExecApprovalsFromFile({
-    file: params.approvals,
-    agentId: params.agentId,
-    overrides: {
-      security: configuredSecurity,
-      ask: configuredAsk,
-    },
-  });
-  const security = minSecurity(configuredSecurity, resolved.agent.security);
-  const ask = resolved.agent.ask === "off" ? "off" : maxAsk(configuredAsk, resolved.agent.ask);
-  return {
-    security,
-    ask,
-    securitySource: agentEntry?.security
-      ? `${basePath} agents.${params.agentId}.security`
-      : defaults?.security
-        ? `${basePath} defaults.security`
-        : "caller tool policy fallback",
-    askSource: agentEntry?.ask
-      ? `${basePath} agents.${params.agentId}.ask`
-      : defaults?.ask
-        ? `${basePath} defaults.ask`
-        : "caller tool policy fallback",
-  };
-}
-
 function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): string[] {
   const warnings: string[] = [];
   const approvals = loadExecApprovals();
@@ -136,16 +85,21 @@ function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): string[] {
     if (!execConfig || (!execConfig.security && !execConfig.ask)) {
       return;
     }
-    const host = resolveHostExecPolicy({
+    const host = resolveExecPolicyScopeSummary({
       approvals,
       execConfig,
+      configPath:
+        params.scopeLabel === "tools.exec"
+          ? "tools.exec"
+          : `agents.list.${params.agentId}.tools.exec`,
+      scopeLabel: params.scopeLabel,
       agentId: params.agentId,
     });
     const securityConflict =
       execConfig.security !== undefined &&
-      execSecurityRank(execConfig.security) > execSecurityRank(host.security);
+      execSecurityRank(execConfig.security) > execSecurityRank(host.security.effective);
     const askConflict =
-      execConfig.ask !== undefined && execAskRank(execConfig.ask) < execAskRank(host.ask);
+      execConfig.ask !== undefined && execAskRank(execConfig.ask) < execAskRank(host.ask.effective);
     if (!securityConflict && !askConflict) {
       return;
     }
@@ -154,11 +108,11 @@ function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): string[] {
     const hostParts: string[] = [];
     if (execConfig.security !== undefined) {
       configParts.push(`security="${execConfig.security}"`);
-      hostParts.push(`${host.securitySource}="${host.security}"`);
+      hostParts.push(`${host.security.hostSource}="${host.security.host}"`);
     }
     if (execConfig.ask !== undefined) {
       configParts.push(`ask="${execConfig.ask}"`);
-      hostParts.push(`${host.askSource}="${host.ask}"`);
+      hostParts.push(`${host.ask.hostSource}="${host.ask.host}"`);
     }
 
     warnings.push(
@@ -166,7 +120,7 @@ function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): string[] {
         `- ${params.scopeLabel} is broader than the host exec policy.`,
         `  Config: ${configParts.join(", ")}`,
         `  Host: ${hostParts.join(", ")}`,
-        `  Effective host exec stays security="${host.security}" ask="${host.ask}" because the stricter side wins.`,
+        `  Effective host exec stays security="${host.security.effective}" ask="${host.ask.effective}" because the stricter side wins.`,
         "  Headless runs like isolated cron cannot answer approval prompts; align both files or enable Web UI, terminal UI, or chat exec approvals.",
         `  Inspect with: ${formatCliCommand("openclaw approvals get --gateway")}`,
       ].join("\n"),

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -6,7 +6,7 @@ import type { AgentConfig } from "../config/types.agents.js";
 import { hasConfiguredSecretInput } from "../config/types.secrets.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { isLoopbackHost, resolveGatewayBindHost } from "../gateway/net.js";
-import { resolveExecPolicyScopeSummary } from "../infra/exec-approvals-effective.js";
+import { resolveExecPolicyScopeSnapshot } from "../infra/exec-approvals-effective.js";
 import { loadExecApprovals, type ExecAsk, type ExecSecurity } from "../infra/exec-approvals.js";
 import { resolveDmAllowState } from "../security/dm-policy-shared.js";
 import { note } from "../terminal/note.js";
@@ -75,19 +75,29 @@ function execAskRank(value: ExecAsk): number {
 function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): string[] {
   const warnings: string[] = [];
   const approvals = loadExecApprovals();
+  const defaultRequestedSecuritySource = "OpenClaw default (allowlist)";
+  const defaultRequestedAskSource = "OpenClaw default (on-miss)";
 
   const maybeWarn = (params: {
     scopeLabel: string;
-    execConfig: { security?: ExecSecurity; ask?: ExecAsk } | undefined;
+    scopeExecConfig: { security?: ExecSecurity; ask?: ExecAsk } | undefined;
+    globalExecConfig?: { security?: ExecSecurity; ask?: ExecAsk } | undefined;
     agentId?: string;
   }) => {
-    const execConfig = params.execConfig;
-    if (!execConfig || (!execConfig.security && !execConfig.ask)) {
+    const scopeExecConfig = params.scopeExecConfig;
+    const globalExecConfig = params.globalExecConfig;
+    if (
+      !scopeExecConfig?.security &&
+      !scopeExecConfig?.ask &&
+      !globalExecConfig?.security &&
+      !globalExecConfig?.ask
+    ) {
       return;
     }
-    const host = resolveExecPolicyScopeSummary({
+    const snapshot = resolveExecPolicyScopeSnapshot({
       approvals,
-      execConfig,
+      scopeExecConfig,
+      globalExecConfig,
       configPath:
         params.scopeLabel === "tools.exec"
           ? "tools.exec"
@@ -95,24 +105,26 @@ function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): string[] {
       scopeLabel: params.scopeLabel,
       agentId: params.agentId,
     });
+    const securityConfigured = snapshot.security.requestedSource !== defaultRequestedSecuritySource;
+    const askConfigured = snapshot.ask.requestedSource !== defaultRequestedAskSource;
     const securityConflict =
-      execConfig.security !== undefined &&
-      execSecurityRank(execConfig.security) > execSecurityRank(host.security.effective);
+      securityConfigured &&
+      execSecurityRank(snapshot.security.requested) > execSecurityRank(snapshot.security.effective);
     const askConflict =
-      execConfig.ask !== undefined && execAskRank(execConfig.ask) < execAskRank(host.ask.effective);
+      askConfigured && execAskRank(snapshot.ask.requested) < execAskRank(snapshot.ask.effective);
     if (!securityConflict && !askConflict) {
       return;
     }
 
     const configParts: string[] = [];
     const hostParts: string[] = [];
-    if (execConfig.security !== undefined) {
-      configParts.push(`security="${execConfig.security}"`);
-      hostParts.push(`${host.security.hostSource}="${host.security.host}"`);
+    if (securityConflict) {
+      configParts.push(`${snapshot.security.requestedSource}="${snapshot.security.requested}"`);
+      hostParts.push(`${snapshot.security.hostSource}="${snapshot.security.host}"`);
     }
-    if (execConfig.ask !== undefined) {
-      configParts.push(`ask="${execConfig.ask}"`);
-      hostParts.push(`${host.ask.hostSource}="${host.ask.host}"`);
+    if (askConflict) {
+      configParts.push(`${snapshot.ask.requestedSource}="${snapshot.ask.requested}"`);
+      hostParts.push(`${snapshot.ask.hostSource}="${snapshot.ask.host}"`);
     }
 
     warnings.push(
@@ -120,7 +132,7 @@ function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): string[] {
         `- ${params.scopeLabel} is broader than the host exec policy.`,
         `  Config: ${configParts.join(", ")}`,
         `  Host: ${hostParts.join(", ")}`,
-        `  Effective host exec stays security="${host.security.effective}" ask="${host.ask.effective}" because the stricter side wins.`,
+        `  Effective host exec stays security="${snapshot.security.effective}" ask="${snapshot.ask.effective}" because the stricter side wins.`,
         "  Headless runs like isolated cron cannot answer approval prompts; align both files or enable Web UI, terminal UI, or chat exec approvals.",
         `  Inspect with: ${formatCliCommand("openclaw approvals get --gateway")}`,
       ].join("\n"),
@@ -129,13 +141,14 @@ function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): string[] {
 
   maybeWarn({
     scopeLabel: "tools.exec",
-    execConfig: cfg.tools?.exec,
+    scopeExecConfig: cfg.tools?.exec,
   });
 
   for (const agent of cfg.agents?.list ?? []) {
     maybeWarn({
       scopeLabel: `agents.list.${agent.id}.tools.exec`,
-      execConfig: agent.tools?.exec,
+      scopeExecConfig: agent.tools?.exec,
+      globalExecConfig: cfg.tools?.exec,
       agentId: agent.id,
     });
   }

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -3,7 +3,8 @@ import { sanitizeExecApprovalDisplayText } from "../../infra/exec-approval-comma
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
-  isExecApprovalDecisionAllowed,
+  resolveExecApprovalAllowedDecisions,
+  resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalDecision,
 } from "../../infra/exec-approvals.js";
 import {
@@ -150,6 +151,7 @@ export function createExecApprovalHandlers(
         host: host || null,
         security: p.security ?? null,
         ask: p.ask ?? null,
+        allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: p.ask ?? null }),
         agentId: effectiveAgentId ?? null,
         resolvedPath: p.resolvedPath ?? null,
         sessionKey: effectiveSessionKey ?? null,
@@ -328,13 +330,8 @@ export function createExecApprovalHandlers(
       }
       const approvalId = resolvedId.id;
       const snapshot = manager.getSnapshot(approvalId);
-      if (
-        snapshot &&
-        !isExecApprovalDecisionAllowed({
-          decision,
-          ask: snapshot.request.ask,
-        })
-      ) {
+      const allowedDecisions = resolveExecApprovalRequestAllowedDecisions(snapshot?.request);
+      if (snapshot && !allowedDecisions.includes(decision)) {
         respond(
           false,
           undefined,

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -337,7 +337,7 @@ export function createExecApprovalHandlers(
           undefined,
           errorShape(
             ErrorCodes.INVALID_REQUEST,
-            "allow-always is unavailable because host policy requires approval every time",
+            "allow-always is unavailable because the effective policy requires approval every time",
           ),
         );
         return;

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -3,6 +3,7 @@ import { sanitizeExecApprovalDisplayText } from "../../infra/exec-approval-comma
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  isExecApprovalDecisionAllowed,
   type ExecApprovalDecision,
 } from "../../infra/exec-approvals.js";
 import {
@@ -327,6 +328,23 @@ export function createExecApprovalHandlers(
       }
       const approvalId = resolvedId.id;
       const snapshot = manager.getSnapshot(approvalId);
+      if (
+        snapshot &&
+        !isExecApprovalDecisionAllowed({
+          decision,
+          ask: snapshot.request.ask,
+        })
+      ) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "allow-always is unavailable because host policy requires approval every time",
+          ),
+        );
+        return;
+      }
       const resolvedBy = client?.connect?.client?.displayName ?? client?.connect?.client?.id;
       const ok = manager.resolve(approvalId, decision, resolvedBy ?? null);
       if (!ok) {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -597,7 +597,8 @@ describe("exec approval handlers", () => {
       false,
       undefined,
       expect.objectContaining({
-        message: "allow-always is unavailable because host policy requires approval every time",
+        message:
+          "allow-always is unavailable because the effective policy requires approval every time",
       }),
     );
 

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -420,11 +420,15 @@ describe("exec approval handlers", () => {
   async function resolveExecApproval(params: {
     handlers: ExecApprovalHandlers;
     id: string;
+    decision?: "allow-once" | "allow-always" | "deny";
     respond: ReturnType<typeof vi.fn>;
     context: { broadcast: (event: string, payload: unknown) => void };
   }) {
     return params.handlers["exec.approval.resolve"]({
-      params: { id: params.id, decision: "allow-once" } as ExecApprovalResolveArgs["params"],
+      params: {
+        id: params.id,
+        decision: params.decision ?? "allow-once",
+      } as ExecApprovalResolveArgs["params"],
       respond: params.respond as unknown as ExecApprovalResolveArgs["respond"],
       context: toExecApprovalResolveContext(params.context),
       client: null,
@@ -564,6 +568,50 @@ describe("exec approval handlers", () => {
       undefined,
     );
     expect(broadcasts.some((entry) => entry.event === "exec.approval.resolved")).toBe(true);
+  });
+
+  it("rejects allow-always when the request ask mode is always", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: { twoPhase: true, ask: "always" },
+    });
+
+    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
+    const id = (requested?.payload as { id?: string })?.id ?? "";
+    expect(id).not.toBe("");
+
+    const resolveRespond = vi.fn();
+    await resolveExecApproval({
+      handlers,
+      id,
+      decision: "allow-always",
+      respond: resolveRespond,
+      context,
+    });
+
+    expect(resolveRespond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: "allow-always is unavailable because host policy requires approval every time",
+      }),
+    );
+
+    const denyRespond = vi.fn();
+    await resolveExecApproval({
+      handlers,
+      id,
+      decision: "deny",
+      respond: denyRespond,
+      context,
+    });
+
+    await requestPromise;
+    expect(denyRespond).toHaveBeenCalledWith(true, { ok: true }, undefined);
   });
 
   it("does not reuse a resolved exact id as a prefix for another pending approval", () => {

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -495,6 +495,25 @@ describe("exec approval forwarder", () => {
     expect(text).toContain("Reply with: /approve <id> allow-once|allow-always|deny");
   });
 
+  it("omits allow-always from forwarded fallback text when ask=always", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+    await expect(
+      forwarder.handleRequested({
+        ...baseRequest,
+        request: {
+          ...baseRequest.request,
+          ask: "always",
+        },
+      }),
+    ).resolves.toBe(true);
+    await Promise.resolve();
+    const text = getFirstDeliveryText(deliver);
+    expect(text).toContain("Reply with: /approve <id> allow-once|deny");
+    expect(text).not.toContain("allow-once|allow-always|deny");
+    expect(text).toContain("Allow Always is unavailable");
+  });
+
   it.each([
     {
       command: "bash safe\u200B.sh",

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -22,7 +22,11 @@ import { matchesApprovalRequestFilters } from "./approval-request-filters.js";
 import { resolveExecApprovalCommandDisplay } from "./exec-approval-command-display.js";
 import { formatExecApprovalExpiresIn } from "./exec-approval-reply.js";
 import { resolveExecApprovalSessionTarget } from "./exec-approval-session-target.js";
-import type { ExecApprovalRequest, ExecApprovalResolved } from "./exec-approvals.js";
+import {
+  resolveExecApprovalAllowedDecisions,
+  type ExecApprovalRequest,
+  type ExecApprovalResolved,
+} from "./exec-approvals.js";
 import { deliverOutboundPayloads } from "./outbound/deliver.js";
 import {
   approvalDecisionLabel,
@@ -196,6 +200,8 @@ function formatApprovalCommand(command: string): { inline: boolean; text: string
 }
 
 function buildRequestMessage(request: ExecApprovalRequest, nowMs: number) {
+  const allowedDecisions = resolveExecApprovalAllowedDecisions({ ask: request.request.ask });
+  const decisionText = allowedDecisions.join("|");
   const lines: string[] = ["🔒 Exec approval required", `ID: ${request.id}`];
   const command = formatApprovalCommand(
     resolveExecApprovalCommandDisplay(request.request).commandText,
@@ -230,9 +236,14 @@ function buildRequestMessage(request: ExecApprovalRequest, nowMs: number) {
   lines.push(`Expires in: ${formatExecApprovalExpiresIn(request.expiresAtMs, nowMs)}`);
   lines.push("Mode: foreground (interactive approvals available in this chat).");
   lines.push(
-    "Background mode note: non-interactive runs cannot wait for chat approvals; use pre-approved policy (allow-always or ask=off).",
+    allowedDecisions.includes("allow-always")
+      ? "Background mode note: non-interactive runs cannot wait for chat approvals; use pre-approved policy (allow-always or ask=off)."
+      : "Background mode note: non-interactive runs cannot wait for chat approvals; host policy still requires per-run approval unless ask=off.",
   );
-  lines.push("Reply with: /approve <id> allow-once|allow-always|deny");
+  lines.push(`Reply with: /approve <id> ${decisionText}`);
+  if (!allowedDecisions.includes("allow-always")) {
+    lines.push("Allow Always is unavailable because host policy requires approval every time.");
+  }
   return lines.join("\n");
 }
 
@@ -338,6 +349,7 @@ function buildExecPendingPayload(params: {
     approvalId: params.request.id,
     approvalSlug: params.request.id.slice(0, 8),
     text: buildRequestMessage(params.request, params.nowMs),
+    allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: params.request.request.ask }),
   });
 }
 

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -238,11 +238,13 @@ function buildRequestMessage(request: ExecApprovalRequest, nowMs: number) {
   lines.push(
     allowedDecisions.includes("allow-always")
       ? "Background mode note: non-interactive runs cannot wait for chat approvals; use pre-approved policy (allow-always or ask=off)."
-      : "Background mode note: non-interactive runs cannot wait for chat approvals; host policy still requires per-run approval unless ask=off.",
+      : "Background mode note: non-interactive runs cannot wait for chat approvals; the effective policy still requires per-run approval unless ask=off.",
   );
   lines.push(`Reply with: /approve <id> ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
-    lines.push("Allow Always is unavailable because host policy requires approval every time.");
+    lines.push(
+      "Allow Always is unavailable because the effective policy requires approval every time.",
+    );
   }
   return lines.join("\n");
 }

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -23,7 +23,7 @@ import { resolveExecApprovalCommandDisplay } from "./exec-approval-command-displ
 import { formatExecApprovalExpiresIn } from "./exec-approval-reply.js";
 import { resolveExecApprovalSessionTarget } from "./exec-approval-session-target.js";
 import {
-  resolveExecApprovalAllowedDecisions,
+  resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
 } from "./exec-approvals.js";
@@ -200,7 +200,7 @@ function formatApprovalCommand(command: string): { inline: boolean; text: string
 }
 
 function buildRequestMessage(request: ExecApprovalRequest, nowMs: number) {
-  const allowedDecisions = resolveExecApprovalAllowedDecisions({ ask: request.request.ask });
+  const allowedDecisions = resolveExecApprovalRequestAllowedDecisions(request.request);
   const decisionText = allowedDecisions.join("|");
   const lines: string[] = ["🔒 Exec approval required", `ID: ${request.id}`];
   const command = formatApprovalCommand(
@@ -349,7 +349,7 @@ function buildExecPendingPayload(params: {
     approvalId: params.request.id,
     approvalSlug: params.request.id.slice(0, 8),
     text: buildRequestMessage(params.request, params.nowMs),
-    allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: params.request.request.ask }),
+    allowedDecisions: resolveExecApprovalRequestAllowedDecisions(params.request.request),
   });
 }
 

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -138,7 +138,7 @@ describe("exec approval reply helpers", () => {
     expect(payload.text).toContain("Full id: `req-1`");
   });
 
-  it("omits allow-always actions when host policy requires approval every time", () => {
+  it("omits allow-always actions when the effective policy requires approval every time", () => {
     const payload = buildExecApprovalPendingReplyPayload({
       approvalId: "req-ask-always",
       approvalSlug: "slug-always",
@@ -156,7 +156,9 @@ describe("exec approval reply helpers", () => {
     });
     expect(payload.text).toContain("```txt\n/approve slug-always allow-once\n```");
     expect(payload.text).not.toContain("allow-always");
-    expect(payload.text).toContain("Allow Always is unavailable");
+    expect(payload.text).toContain(
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+    );
     expect(payload.interactive).toEqual({
       blocks: [
         {

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -138,6 +138,46 @@ describe("exec approval reply helpers", () => {
     expect(payload.text).toContain("Full id: `req-1`");
   });
 
+  it("omits allow-always actions when host policy requires approval every time", () => {
+    const payload = buildExecApprovalPendingReplyPayload({
+      approvalId: "req-ask-always",
+      approvalSlug: "slug-always",
+      ask: "always",
+      command: "echo ok",
+      host: "gateway",
+    });
+
+    expect(payload.channelData).toEqual({
+      execApproval: {
+        approvalId: "req-ask-always",
+        approvalSlug: "slug-always",
+        allowedDecisions: ["allow-once", "deny"],
+      },
+    });
+    expect(payload.text).toContain("```txt\n/approve slug-always allow-once\n```");
+    expect(payload.text).not.toContain("allow-always");
+    expect(payload.text).toContain("Allow Always is unavailable");
+    expect(payload.interactive).toEqual({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            {
+              label: "Allow Once",
+              value: "/approve req-ask-always allow-once",
+              style: "success",
+            },
+            {
+              label: "Deny",
+              value: "/approve req-ask-always deny",
+              style: "danger",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it("uses a longer fence for commands containing triple backticks", () => {
     const payload = buildExecApprovalPendingReplyPayload({
       approvalId: "req-2",

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -267,7 +267,9 @@ export function buildExecApprovalPendingReplyPayload(
     lines.push(secondaryFence);
   }
   if (!allowedDecisions.includes("allow-always")) {
-    lines.push("Host policy requires approval every time, so Allow Always is unavailable.");
+    lines.push(
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+    );
   }
   const info: string[] = [];
   info.push(`Host: ${params.host}`);

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -1,8 +1,12 @@
 import type { ReplyPayload } from "../auto-reply/types.js";
 import type { InteractiveReply, InteractiveReplyButton } from "../interactive/payload.js";
-import type { ExecHost } from "./exec-approvals.js";
+import {
+  resolveExecApprovalAllowedDecisions,
+  type ExecApprovalDecision,
+  type ExecHost,
+} from "./exec-approvals.js";
 
-export type ExecApprovalReplyDecision = "allow-once" | "allow-always" | "deny";
+export type ExecApprovalReplyDecision = ExecApprovalDecision;
 export type ExecApprovalUnavailableReason =
   | "initiating-platform-disabled"
   | "initiating-platform-unsupported"
@@ -26,6 +30,8 @@ export type ExecApprovalPendingReplyParams = {
   approvalId: string;
   approvalSlug: string;
   approvalCommandId?: string;
+  ask?: string | null;
+  allowedDecisions?: readonly ExecApprovalReplyDecision[];
   command: string;
   cwd?: string;
   host: ExecHost;
@@ -41,7 +47,21 @@ export type ExecApprovalUnavailableReplyParams = {
   sentApproverDms?: boolean;
 };
 
-const DEFAULT_ALLOWED_DECISIONS = ["allow-once", "allow-always", "deny"] as const;
+function resolveAllowedDecisions(params: {
+  ask?: string | null;
+  allowedDecisions?: readonly ExecApprovalReplyDecision[];
+}): readonly ExecApprovalReplyDecision[] {
+  return params.allowedDecisions ?? resolveExecApprovalAllowedDecisions({ ask: params.ask });
+}
+
+function buildApprovalCommandFence(
+  descriptors: readonly ExecApprovalActionDescriptor[],
+): string | null {
+  if (descriptors.length === 0) {
+    return null;
+  }
+  return buildFence(descriptors.map((descriptor) => descriptor.command).join("\n"), "txt");
+}
 
 export function buildExecApprovalCommandText(params: {
   approvalCommandId: string;
@@ -52,13 +72,14 @@ export function buildExecApprovalCommandText(params: {
 
 export function buildExecApprovalActionDescriptors(params: {
   approvalCommandId: string;
+  ask?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
 }): ExecApprovalActionDescriptor[] {
   const approvalCommandId = params.approvalCommandId.trim();
   if (!approvalCommandId) {
     return [];
   }
-  const allowedDecisions = params.allowedDecisions ?? DEFAULT_ALLOWED_DECISIONS;
+  const allowedDecisions = resolveAllowedDecisions(params);
   const descriptors: ExecApprovalActionDescriptor[] = [];
   if (allowedDecisions.includes("allow-once")) {
     descriptors.push({
@@ -112,10 +133,11 @@ function buildApprovalInteractiveButtons(
 
 export function buildApprovalInteractiveReply(params: {
   approvalId: string;
+  ask?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
 }): InteractiveReply | undefined {
   const buttons = buildApprovalInteractiveButtons(
-    params.allowedDecisions ?? DEFAULT_ALLOWED_DECISIONS,
+    resolveAllowedDecisions(params),
     params.approvalId,
   );
   return buttons.length > 0 ? { blocks: [{ type: "buttons", buttons }] } : undefined;
@@ -123,10 +145,12 @@ export function buildApprovalInteractiveReply(params: {
 
 export function buildExecApprovalInteractiveReply(params: {
   approvalCommandId: string;
+  ask?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
 }): InteractiveReply | undefined {
   return buildApprovalInteractiveReply({
     approvalId: params.approvalCommandId,
+    ask: params.ask,
     allowedDecisions: params.allowedDecisions,
   });
 }
@@ -218,23 +242,33 @@ export function buildExecApprovalPendingReplyPayload(
   params: ExecApprovalPendingReplyParams,
 ): ReplyPayload {
   const approvalCommandId = params.approvalCommandId?.trim() || params.approvalSlug;
+  const allowedDecisions = resolveAllowedDecisions(params);
+  const descriptors = buildExecApprovalActionDescriptors({
+    approvalCommandId,
+    allowedDecisions,
+  });
+  const primaryAction = descriptors[0] ?? null;
+  const secondaryActions = descriptors.slice(1);
   const lines: string[] = [];
   const warningText = params.warningText?.trim();
   if (warningText) {
     lines.push(warningText);
   }
   lines.push("Approval required.");
-  lines.push("Run:");
-  lines.push(buildFence(`/approve ${approvalCommandId} allow-once`, "txt"));
+  if (primaryAction) {
+    lines.push("Run:");
+    lines.push(buildFence(primaryAction.command, "txt"));
+  }
   lines.push("Pending command:");
   lines.push(buildFence(params.command, "sh"));
-  lines.push("Other options:");
-  lines.push(
-    buildFence(
-      `/approve ${approvalCommandId} allow-always\n/approve ${approvalCommandId} deny`,
-      "txt",
-    ),
-  );
+  const secondaryFence = buildApprovalCommandFence(secondaryActions);
+  if (secondaryFence) {
+    lines.push("Other options:");
+    lines.push(secondaryFence);
+  }
+  if (!allowedDecisions.includes("allow-always")) {
+    lines.push("Host policy requires approval every time, so Allow Always is unavailable.");
+  }
   const info: string[] = [];
   info.push(`Host: ${params.host}`);
   if (params.nodeId) {
@@ -253,12 +287,15 @@ export function buildExecApprovalPendingReplyPayload(
 
   return {
     text: lines.join("\n\n"),
-    interactive: buildApprovalInteractiveReply({ approvalId: params.approvalId }),
+    interactive: buildApprovalInteractiveReply({
+      approvalId: params.approvalId,
+      allowedDecisions,
+    }),
     channelData: {
       execApproval: {
         approvalId: params.approvalId,
         approvalSlug: params.approvalSlug,
-        allowedDecisions: DEFAULT_ALLOWED_DECISIONS,
+        allowedDecisions,
       },
     },
   };

--- a/src/infra/exec-approvals-effective.ts
+++ b/src/infra/exec-approvals-effective.ts
@@ -1,0 +1,196 @@
+import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
+import {
+  maxAsk,
+  minSecurity,
+  resolveExecApprovalsFromFile,
+  type ExecApprovalsFile,
+  type ExecAsk,
+  type ExecSecurity,
+} from "./exec-approvals.js";
+
+const DEFAULT_REQUESTED_SECURITY: ExecSecurity = "allowlist";
+const DEFAULT_REQUESTED_ASK: ExecAsk = "on-miss";
+const DEFAULT_HOST_PATH = "~/.openclaw/exec-approvals.json";
+const REQUESTED_DEFAULT_LABEL = {
+  security: DEFAULT_REQUESTED_SECURITY,
+  ask: DEFAULT_REQUESTED_ASK,
+} as const;
+
+export type ExecPolicyFieldSummary<TValue extends ExecSecurity | ExecAsk> = {
+  requested: TValue;
+  requestedSource: string;
+  host: TValue;
+  hostSource: string;
+  effective: TValue;
+  note: string;
+};
+
+export type ExecPolicyScopeSummary = {
+  scopeLabel: string;
+  configPath: string;
+  agentId?: string;
+  security: ExecPolicyFieldSummary<ExecSecurity>;
+  ask: ExecPolicyFieldSummary<ExecAsk>;
+  askFallback: {
+    effective: ExecSecurity;
+    source: string;
+  };
+};
+
+function formatRequestedSource(params: {
+  path: string;
+  field: "security" | "ask";
+  explicit: boolean;
+}): string {
+  return params.explicit
+    ? `${params.path}.${params.field}`
+    : `OpenClaw default (${REQUESTED_DEFAULT_LABEL[params.field]})`;
+}
+
+type ExecPolicyField = "security" | "ask" | "askFallback";
+
+function readExecPolicyField(params: {
+  field: ExecPolicyField;
+  entry?: {
+    security?: ExecSecurity;
+    ask?: ExecAsk;
+    askFallback?: ExecSecurity;
+  };
+}): ExecSecurity | ExecAsk | undefined {
+  switch (params.field) {
+    case "security":
+      return params.entry?.security;
+    case "ask":
+      return params.entry?.ask;
+    case "askFallback":
+      return params.entry?.askFallback;
+  }
+}
+
+function resolveHostFieldSource(params: {
+  hostPath: string;
+  agentId?: string;
+  field: ExecPolicyField;
+  approvals: ExecApprovalsFile;
+}): string {
+  const agentKey = params.agentId ?? DEFAULT_AGENT_ID;
+  const explicitAgentEntry = params.approvals.agents?.[agentKey];
+  if (readExecPolicyField({ field: params.field, entry: explicitAgentEntry }) !== undefined) {
+    return `${params.hostPath} agents.${agentKey}.${params.field}`;
+  }
+  const wildcardEntry = params.approvals.agents?.["*"];
+  if (readExecPolicyField({ field: params.field, entry: wildcardEntry }) !== undefined) {
+    return `${params.hostPath} agents.*.${params.field}`;
+  }
+  if (
+    readExecPolicyField({
+      field: params.field,
+      entry: params.approvals.defaults,
+    }) !== undefined
+  ) {
+    return `${params.hostPath} defaults.${params.field}`;
+  }
+  return "inherits requested tool policy";
+}
+
+function resolveAskNote(params: {
+  requestedAsk: ExecAsk;
+  hostAsk: ExecAsk;
+  effectiveAsk: ExecAsk;
+}): string {
+  if (params.hostAsk === "off" && params.requestedAsk !== "off") {
+    return "host ask=off suppresses prompts";
+  }
+  if (params.effectiveAsk === params.requestedAsk) {
+    return "requested ask applies";
+  }
+  return "more aggressive ask wins";
+}
+
+function formatHostSource(params: {
+  hostPath: string;
+  agentId?: string;
+  field: ExecPolicyField;
+  approvals: ExecApprovalsFile;
+}): string {
+  return resolveHostFieldSource(params);
+}
+
+export function resolveExecPolicyScopeSummary(params: {
+  approvals: ExecApprovalsFile;
+  execConfig?: { security?: ExecSecurity; ask?: ExecAsk } | undefined;
+  configPath: string;
+  scopeLabel: string;
+  agentId?: string;
+  hostPath?: string;
+}): ExecPolicyScopeSummary {
+  const requestedSecurity = params.execConfig?.security ?? DEFAULT_REQUESTED_SECURITY;
+  const requestedAsk = params.execConfig?.ask ?? DEFAULT_REQUESTED_ASK;
+  const resolved = resolveExecApprovalsFromFile({
+    file: params.approvals,
+    agentId: params.agentId,
+    overrides: {
+      security: requestedSecurity,
+      ask: requestedAsk,
+    },
+  });
+  const hostPath = params.hostPath ?? DEFAULT_HOST_PATH;
+  const effectiveSecurity = minSecurity(requestedSecurity, resolved.agent.security);
+  const effectiveAsk =
+    resolved.agent.ask === "off" ? "off" : maxAsk(requestedAsk, resolved.agent.ask);
+  return {
+    scopeLabel: params.scopeLabel,
+    configPath: params.configPath,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    security: {
+      requested: requestedSecurity,
+      requestedSource: formatRequestedSource({
+        path: params.configPath,
+        field: "security",
+        explicit: params.execConfig?.security !== undefined,
+      }),
+      host: resolved.agent.security,
+      hostSource: formatHostSource({
+        hostPath,
+        agentId: params.agentId,
+        field: "security",
+        approvals: params.approvals,
+      }),
+      effective: effectiveSecurity,
+      note:
+        effectiveSecurity === requestedSecurity
+          ? "requested security applies"
+          : "stricter host security wins",
+    },
+    ask: {
+      requested: requestedAsk,
+      requestedSource: formatRequestedSource({
+        path: params.configPath,
+        field: "ask",
+        explicit: params.execConfig?.ask !== undefined,
+      }),
+      host: resolved.agent.ask,
+      hostSource: formatHostSource({
+        hostPath,
+        agentId: params.agentId,
+        field: "ask",
+        approvals: params.approvals,
+      }),
+      effective: effectiveAsk,
+      note: resolveAskNote({
+        requestedAsk,
+        hostAsk: resolved.agent.ask,
+        effectiveAsk,
+      }),
+    },
+    askFallback: {
+      effective: resolved.agent.askFallback,
+      source: formatHostSource({
+        hostPath,
+        agentId: params.agentId,
+        field: "askFallback",
+        approvals: params.approvals,
+      }),
+    },
+  };
+}

--- a/src/infra/exec-approvals-effective.ts
+++ b/src/infra/exec-approvals-effective.ts
@@ -1,5 +1,8 @@
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
+  DEFAULT_EXEC_APPROVAL_ASK_FALLBACK,
+  resolveExecApprovalAllowedDecisions,
+  type ExecApprovalDecision,
   maxAsk,
   minSecurity,
   resolveExecApprovalsFromFile,
@@ -15,6 +18,10 @@ const REQUESTED_DEFAULT_LABEL = {
   security: DEFAULT_REQUESTED_SECURITY,
   ask: DEFAULT_REQUESTED_ASK,
 } as const;
+type ExecPolicyConfig = {
+  security?: ExecSecurity;
+  ask?: ExecAsk;
+};
 
 export type ExecPolicyFieldSummary<TValue extends ExecSecurity | ExecAsk> = {
   requested: TValue;
@@ -25,7 +32,7 @@ export type ExecPolicyFieldSummary<TValue extends ExecSecurity | ExecAsk> = {
   note: string;
 };
 
-export type ExecPolicyScopeSummary = {
+export type ExecPolicyScopeSnapshot = {
   scopeLabel: string;
   configPath: string;
   agentId?: string;
@@ -35,16 +42,21 @@ export type ExecPolicyScopeSummary = {
     effective: ExecSecurity;
     source: string;
   };
+  allowedDecisions: readonly ExecApprovalDecision[];
 };
 
+export type ExecPolicyScopeSummary = Omit<ExecPolicyScopeSnapshot, "allowedDecisions">;
+
+type ExecPolicyRequestedField = "security" | "ask";
+
 function formatRequestedSource(params: {
-  path: string;
+  sourcePath: string;
   field: "security" | "ask";
-  explicit: boolean;
+  defaultValue: ExecSecurity | ExecAsk;
 }): string {
-  return params.explicit
-    ? `${params.path}.${params.field}`
-    : `OpenClaw default (${REQUESTED_DEFAULT_LABEL[params.field]})`;
+  return params.sourcePath === "__default__"
+    ? `OpenClaw default (${params.defaultValue})`
+    : `${params.sourcePath}.${params.field}`;
 }
 
 type ExecPolicyField = "security" | "ask" | "askFallback";
@@ -65,6 +77,32 @@ function readExecPolicyField(params: {
     case "askFallback":
       return params.entry?.askFallback;
   }
+}
+
+function resolveRequestedField<TValue extends ExecSecurity | ExecAsk>(params: {
+  field: ExecPolicyRequestedField;
+  scopeExecConfig?: ExecPolicyConfig;
+  globalExecConfig?: ExecPolicyConfig;
+}): { value: TValue; sourcePath: string } {
+  const scopeValue = params.scopeExecConfig?.[params.field];
+  if (scopeValue !== undefined) {
+    return {
+      value: scopeValue as TValue,
+      sourcePath: params.field && "scope",
+    };
+  }
+  const globalValue = params.globalExecConfig?.[params.field];
+  if (globalValue !== undefined) {
+    return {
+      value: globalValue as TValue,
+      sourcePath: "tools.exec",
+    };
+  }
+  const defaultValue = REQUESTED_DEFAULT_LABEL[params.field] as TValue;
+  return {
+    value: defaultValue,
+    sourcePath: "__default__",
+  };
 }
 
 function resolveHostFieldSource(params: {
@@ -89,6 +127,9 @@ function resolveHostFieldSource(params: {
     }) !== undefined
   ) {
     return `${params.hostPath} defaults.${params.field}`;
+  }
+  if (params.field === "askFallback") {
+    return `OpenClaw default (${DEFAULT_EXEC_APPROVAL_ASK_FALLBACK})`;
   }
   return "inherits requested tool policy";
 }
@@ -118,36 +159,62 @@ function formatHostSource(params: {
 
 export function resolveExecPolicyScopeSummary(params: {
   approvals: ExecApprovalsFile;
-  execConfig?: { security?: ExecSecurity; ask?: ExecAsk } | undefined;
+  scopeExecConfig?: ExecPolicyConfig | undefined;
+  globalExecConfig?: ExecPolicyConfig | undefined;
   configPath: string;
   scopeLabel: string;
   agentId?: string;
   hostPath?: string;
 }): ExecPolicyScopeSummary {
-  const requestedSecurity = params.execConfig?.security ?? DEFAULT_REQUESTED_SECURITY;
-  const requestedAsk = params.execConfig?.ask ?? DEFAULT_REQUESTED_ASK;
+  const snapshot = resolveExecPolicyScopeSnapshot(params);
+  const { allowedDecisions: _allowedDecisions, ...summary } = snapshot;
+  return summary;
+}
+
+export function resolveExecPolicyScopeSnapshot(params: {
+  approvals: ExecApprovalsFile;
+  scopeExecConfig?: ExecPolicyConfig | undefined;
+  globalExecConfig?: ExecPolicyConfig | undefined;
+  configPath: string;
+  scopeLabel: string;
+  agentId?: string;
+  hostPath?: string;
+}): ExecPolicyScopeSnapshot {
+  const requestedSecurity = resolveRequestedField<ExecSecurity>({
+    field: "security",
+    scopeExecConfig: params.scopeExecConfig,
+    globalExecConfig: params.globalExecConfig,
+  });
+  const requestedAsk = resolveRequestedField<ExecAsk>({
+    field: "ask",
+    scopeExecConfig: params.scopeExecConfig,
+    globalExecConfig: params.globalExecConfig,
+  });
   const resolved = resolveExecApprovalsFromFile({
     file: params.approvals,
     agentId: params.agentId,
     overrides: {
-      security: requestedSecurity,
-      ask: requestedAsk,
+      security: requestedSecurity.value,
+      ask: requestedAsk.value,
     },
   });
   const hostPath = params.hostPath ?? DEFAULT_HOST_PATH;
-  const effectiveSecurity = minSecurity(requestedSecurity, resolved.agent.security);
+  const effectiveSecurity = minSecurity(requestedSecurity.value, resolved.agent.security);
   const effectiveAsk =
-    resolved.agent.ask === "off" ? "off" : maxAsk(requestedAsk, resolved.agent.ask);
+    resolved.agent.ask === "off" ? "off" : maxAsk(requestedAsk.value, resolved.agent.ask);
   return {
     scopeLabel: params.scopeLabel,
     configPath: params.configPath,
     ...(params.agentId ? { agentId: params.agentId } : {}),
     security: {
-      requested: requestedSecurity,
+      requested: requestedSecurity.value,
       requestedSource: formatRequestedSource({
-        path: params.configPath,
+        sourcePath:
+          requestedSecurity.sourcePath === "scope"
+            ? params.configPath
+            : requestedSecurity.sourcePath,
         field: "security",
-        explicit: params.execConfig?.security !== undefined,
+        defaultValue: DEFAULT_REQUESTED_SECURITY,
       }),
       host: resolved.agent.security,
       hostSource: formatHostSource({
@@ -158,16 +225,17 @@ export function resolveExecPolicyScopeSummary(params: {
       }),
       effective: effectiveSecurity,
       note:
-        effectiveSecurity === requestedSecurity
+        effectiveSecurity === requestedSecurity.value
           ? "requested security applies"
           : "stricter host security wins",
     },
     ask: {
-      requested: requestedAsk,
+      requested: requestedAsk.value,
       requestedSource: formatRequestedSource({
-        path: params.configPath,
+        sourcePath:
+          requestedAsk.sourcePath === "scope" ? params.configPath : requestedAsk.sourcePath,
         field: "ask",
-        explicit: params.execConfig?.ask !== undefined,
+        defaultValue: DEFAULT_REQUESTED_ASK,
       }),
       host: resolved.agent.ask,
       hostSource: formatHostSource({
@@ -178,7 +246,7 @@ export function resolveExecPolicyScopeSummary(params: {
       }),
       effective: effectiveAsk,
       note: resolveAskNote({
-        requestedAsk,
+        requestedAsk: requestedAsk.value,
         hostAsk: resolved.agent.ask,
         effectiveAsk,
       }),
@@ -192,5 +260,6 @@ export function resolveExecPolicyScopeSummary(params: {
         approvals: params.approvals,
       }),
     },
+    allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: effectiveAsk }),
   };
 }

--- a/src/infra/exec-approvals-effective.ts
+++ b/src/infra/exec-approvals-effective.ts
@@ -171,9 +171,13 @@ export function collectExecPolicyScopeSnapshots(params: {
     }),
   ];
   const globalExecConfig = params.cfg.tools?.exec;
-  const configAgentIds = new Set((params.cfg.agents?.list ?? []).map((agent) => agent.id));
+  const configAgentIds = new Set(
+    (params.cfg.agents?.list ?? [])
+      .filter((agent) => agent.id !== DEFAULT_AGENT_ID || agent.tools?.exec !== undefined)
+      .map((agent) => agent.id),
+  );
   const approvalAgentIds = Object.keys(params.approvals.agents ?? {}).filter(
-    (agentId) => agentId !== "*" && agentId !== "default",
+    (agentId) => agentId !== "*" && agentId !== "default" && agentId !== DEFAULT_AGENT_ID,
   );
   const agentIds = Array.from(new Set([...configAgentIds, ...approvalAgentIds])).toSorted();
   for (const agentId of agentIds) {

--- a/src/infra/exec-approvals-effective.ts
+++ b/src/infra/exec-approvals-effective.ts
@@ -1,3 +1,4 @@
+import type { OpenClawConfig } from "../config/config.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   DEFAULT_EXEC_APPROVAL_ASK_FALLBACK,
@@ -155,6 +156,40 @@ function formatHostSource(params: {
   approvals: ExecApprovalsFile;
 }): string {
   return resolveHostFieldSource(params);
+}
+
+export function collectExecPolicyScopeSnapshots(params: {
+  cfg: OpenClawConfig;
+  approvals: ExecApprovalsFile;
+}): ExecPolicyScopeSnapshot[] {
+  const snapshots = [
+    resolveExecPolicyScopeSnapshot({
+      approvals: params.approvals,
+      scopeExecConfig: params.cfg.tools?.exec,
+      configPath: "tools.exec",
+      scopeLabel: "tools.exec",
+    }),
+  ];
+  const globalExecConfig = params.cfg.tools?.exec;
+  const configAgentIds = new Set((params.cfg.agents?.list ?? []).map((agent) => agent.id));
+  const approvalAgentIds = Object.keys(params.approvals.agents ?? {}).filter(
+    (agentId) => agentId !== "*" && agentId !== "default",
+  );
+  const agentIds = Array.from(new Set([...configAgentIds, ...approvalAgentIds])).toSorted();
+  for (const agentId of agentIds) {
+    const agentConfig = params.cfg.agents?.list?.find((agent) => agent.id === agentId);
+    snapshots.push(
+      resolveExecPolicyScopeSnapshot({
+        approvals: params.approvals,
+        scopeExecConfig: agentConfig?.tools?.exec,
+        globalExecConfig,
+        configPath: `agents.list.${agentId}.tools.exec`,
+        scopeLabel: `agent:${agentId}`,
+        agentId,
+      }),
+    );
+  }
+  return snapshots;
 }
 
 export function resolveExecPolicyScopeSummary(params: {

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -201,7 +201,7 @@ describe("exec approvals policy helpers", () => {
           askFallback: "deny",
         },
       },
-      execConfig: {
+      scopeExecConfig: {
         security: "full",
         ask: "off",
       },
@@ -237,7 +237,7 @@ describe("exec approvals policy helpers", () => {
           ask: "off",
         },
       },
-      execConfig: {
+      scopeExecConfig: {
         ask: "always",
       },
       configPath: "tools.exec",
@@ -269,7 +269,7 @@ describe("exec approvals policy helpers", () => {
           },
         },
       },
-      execConfig: {
+      scopeExecConfig: {
         security: "full",
         ask: "off",
       },
@@ -289,6 +289,56 @@ describe("exec approvals policy helpers", () => {
     expect(summary.askFallback).toEqual({
       effective: "deny",
       source: "~/.openclaw/exec-approvals.json agents.*.askFallback",
+    });
+  });
+
+  it("inherits requested agent policy from global tools.exec config", () => {
+    const summary = resolveExecPolicyScopeSummary({
+      approvals: {
+        version: 1,
+        agents: {
+          runner: {
+            security: "allowlist",
+            ask: "always",
+          },
+        },
+      },
+      globalExecConfig: {
+        security: "full",
+        ask: "off",
+      },
+      configPath: "agents.list.runner.tools.exec",
+      scopeLabel: "agent:runner",
+      agentId: "runner",
+    });
+
+    expect(summary.security).toMatchObject({
+      requested: "full",
+      requestedSource: "tools.exec.security",
+      host: "allowlist",
+      effective: "allowlist",
+    });
+    expect(summary.ask).toMatchObject({
+      requested: "off",
+      requestedSource: "tools.exec.ask",
+      host: "always",
+      effective: "always",
+    });
+  });
+
+  it("reports askFallback from the OpenClaw default when approvals omit it", () => {
+    const summary = resolveExecPolicyScopeSummary({
+      approvals: {
+        version: 1,
+        agents: {},
+      },
+      configPath: "tools.exec",
+      scopeLabel: "tools.exec",
+    });
+
+    expect(summary.askFallback).toEqual({
+      effective: "deny",
+      source: "OpenClaw default (deny)",
     });
   });
 });

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   collectExecPolicyScopeSnapshots,
   resolveExecPolicyScopeSummary,
@@ -388,6 +389,72 @@ describe("exec approvals policy helpers", () => {
       requestedSource: "tools.exec.security",
       host: "allowlist",
       effective: "allowlist",
+    });
+  });
+
+  it("avoids a duplicate default-agent scope when main only appears in approvals", () => {
+    const snapshots = collectExecPolicyScopeSnapshots({
+      cfg: {
+        tools: {
+          exec: {
+            security: "full",
+            ask: "off",
+          },
+        },
+      } satisfies OpenClawConfig,
+      approvals: {
+        version: 1,
+        agents: {
+          [DEFAULT_AGENT_ID]: {
+            security: "allowlist",
+            ask: "always",
+          },
+        },
+      },
+    });
+
+    expect(snapshots.map((snapshot) => snapshot.scopeLabel)).toEqual(["tools.exec"]);
+    expect(snapshots[0]?.security).toMatchObject({
+      host: "allowlist",
+      hostSource: "~/.openclaw/exec-approvals.json agents.main.security",
+    });
+    expect(snapshots[0]?.ask).toMatchObject({
+      host: "always",
+      hostSource: "~/.openclaw/exec-approvals.json agents.main.ask",
+    });
+  });
+
+  it("keeps the default agent scope when main has an explicit exec override", () => {
+    const snapshots = collectExecPolicyScopeSnapshots({
+      cfg: {
+        tools: {
+          exec: {
+            security: "full",
+            ask: "off",
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: DEFAULT_AGENT_ID,
+              tools: {
+                exec: {
+                  ask: "always",
+                },
+              },
+            },
+          ],
+        },
+      } satisfies OpenClawConfig,
+      approvals: {
+        version: 1,
+      },
+    });
+
+    expect(snapshots.map((snapshot) => snapshot.scopeLabel)).toEqual(["tools.exec", "agent:main"]);
+    expect(snapshots[1]?.ask).toMatchObject({
+      requested: "always",
+      requestedSource: "agents.list.main.tools.exec.ask",
     });
   });
 });

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { resolveExecPolicyScopeSummary } from "./exec-approvals-effective.js";
 import {
   makeMockCommandResolution,
   makeMockExecutableResolution,
@@ -188,5 +189,106 @@ describe("exec approvals policy helpers", () => {
         allowlist: [{ pattern: "/usr/bin/echo", source: "allow-always" }],
       }),
     ).toBe(false);
+  });
+
+  it("explains stricter host security and ask precedence", () => {
+    const summary = resolveExecPolicyScopeSummary({
+      approvals: {
+        version: 1,
+        defaults: {
+          security: "allowlist",
+          ask: "always",
+          askFallback: "deny",
+        },
+      },
+      execConfig: {
+        security: "full",
+        ask: "off",
+      },
+      configPath: "tools.exec",
+      scopeLabel: "tools.exec",
+    });
+
+    expect(summary.security).toMatchObject({
+      requested: "full",
+      host: "allowlist",
+      effective: "allowlist",
+      hostSource: "~/.openclaw/exec-approvals.json defaults.security",
+      note: "stricter host security wins",
+    });
+    expect(summary.ask).toMatchObject({
+      requested: "off",
+      host: "always",
+      effective: "always",
+      hostSource: "~/.openclaw/exec-approvals.json defaults.ask",
+      note: "more aggressive ask wins",
+    });
+    expect(summary.askFallback).toEqual({
+      effective: "deny",
+      source: "~/.openclaw/exec-approvals.json defaults.askFallback",
+    });
+  });
+
+  it("explains host ask=off suppression separately from stricter ask", () => {
+    const summary = resolveExecPolicyScopeSummary({
+      approvals: {
+        version: 1,
+        defaults: {
+          ask: "off",
+        },
+      },
+      execConfig: {
+        ask: "always",
+      },
+      configPath: "tools.exec",
+      scopeLabel: "tools.exec",
+    });
+
+    expect(summary.ask).toMatchObject({
+      requested: "always",
+      host: "off",
+      effective: "off",
+      note: "host ask=off suppresses prompts",
+    });
+  });
+
+  it("attributes host policy to wildcard agent entries before defaults", () => {
+    const summary = resolveExecPolicyScopeSummary({
+      approvals: {
+        version: 1,
+        defaults: {
+          security: "full",
+          ask: "off",
+          askFallback: "full",
+        },
+        agents: {
+          "*": {
+            security: "allowlist",
+            ask: "always",
+            askFallback: "deny",
+          },
+        },
+      },
+      execConfig: {
+        security: "full",
+        ask: "off",
+      },
+      configPath: "agents.list.runner.tools.exec",
+      scopeLabel: "agent:runner",
+      agentId: "runner",
+    });
+
+    expect(summary.security).toMatchObject({
+      host: "allowlist",
+      hostSource: "~/.openclaw/exec-approvals.json agents.*.security",
+    });
+    expect(summary.ask).toMatchObject({
+      host: "always",
+      hostSource: "~/.openclaw/exec-approvals.json agents.*.ask",
+    });
+    expect(summary.askFallback).toEqual({
+      effective: "deny",
+      source: "~/.openclaw/exec-approvals.json agents.*.askFallback",
+    });
   });
 });

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveExecPolicyScopeSummary } from "./exec-approvals-effective.js";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  collectExecPolicyScopeSnapshots,
+  resolveExecPolicyScopeSummary,
+} from "./exec-approvals-effective.js";
 import {
   makeMockCommandResolution,
   makeMockExecutableResolution,
@@ -339,6 +343,51 @@ describe("exec approvals policy helpers", () => {
     expect(summary.askFallback).toEqual({
       effective: "deny",
       source: "OpenClaw default (deny)",
+    });
+  });
+
+  it("collects global, configured-agent, and approvals-only agent scopes", () => {
+    const snapshots = collectExecPolicyScopeSnapshots({
+      cfg: {
+        tools: {
+          exec: {
+            security: "full",
+            ask: "off",
+          },
+        },
+        agents: {
+          list: [{ id: "runner" }],
+        },
+      } satisfies OpenClawConfig,
+      approvals: {
+        version: 1,
+        agents: {
+          runner: {
+            security: "allowlist",
+          },
+          batch: {
+            ask: "always",
+          },
+        },
+      },
+    });
+
+    expect(snapshots.map((snapshot) => snapshot.scopeLabel)).toEqual([
+      "tools.exec",
+      "agent:batch",
+      "agent:runner",
+    ]);
+    expect(snapshots[1]?.ask).toMatchObject({
+      requested: "off",
+      requestedSource: "tools.exec.ask",
+      host: "always",
+      effective: "always",
+    });
+    expect(snapshots[2]?.security).toMatchObject({
+      requested: "full",
+      requestedSource: "tools.exec.security",
+      host: "allowlist",
+      effective: "allowlist",
     });
   });
 });

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -81,6 +81,7 @@ export type ExecApprovalRequestPayload = {
   host?: string | null;
   security?: string | null;
   ask?: string | null;
+  allowedDecisions?: readonly ExecApprovalDecision[];
   agentId?: string | null;
   resolvedPath?: string | null;
   sessionKey?: string | null;
@@ -159,7 +160,7 @@ export const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 1_800_000;
 
 const DEFAULT_SECURITY: ExecSecurity = "deny";
 const DEFAULT_ASK: ExecAsk = "on-miss";
-const DEFAULT_ASK_FALLBACK: ExecSecurity = "deny";
+export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "deny";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
 const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
 const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
@@ -469,7 +470,7 @@ export function resolveExecApprovalsFromFile(params: {
   const wildcard = file.agents?.["*"] ?? {};
   const fallbackSecurity = params.overrides?.security ?? DEFAULT_SECURITY;
   const fallbackAsk = params.overrides?.ask ?? DEFAULT_ASK;
-  const fallbackAskFallback = params.overrides?.askFallback ?? DEFAULT_ASK_FALLBACK;
+  const fallbackAskFallback = params.overrides?.askFallback ?? DEFAULT_EXEC_APPROVAL_ASK_FALLBACK;
   const fallbackAutoAllowSkills = params.overrides?.autoAllowSkills ?? DEFAULT_AUTO_ALLOW_SKILLS;
   const resolvedDefaults: Required<ExecApprovalsDefaults> = {
     security: normalizeSecurity(defaults.security, fallbackSecurity),
@@ -673,6 +674,19 @@ export function resolveExecApprovalAllowedDecisions(params?: {
     return ["allow-once", "deny"];
   }
   return DEFAULT_EXEC_APPROVAL_DECISIONS;
+}
+
+export function resolveExecApprovalRequestAllowedDecisions(params?: {
+  ask?: string | null;
+  allowedDecisions?: readonly ExecApprovalDecision[] | readonly string[] | null;
+}): readonly ExecApprovalDecision[] {
+  const explicit = Array.isArray(params?.allowedDecisions)
+    ? params.allowedDecisions.filter(
+        (decision): decision is ExecApprovalDecision =>
+          decision === "allow-once" || decision === "allow-always" || decision === "deny",
+      )
+    : [];
+  return explicit.length > 0 ? explicit : resolveExecApprovalAllowedDecisions({ ask: params?.ask });
 }
 
 export function isExecApprovalDecisionAllowed(params: {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -659,6 +659,28 @@ export function maxAsk(a: ExecAsk, b: ExecAsk): ExecAsk {
 }
 
 export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
+export const DEFAULT_EXEC_APPROVAL_DECISIONS = [
+  "allow-once",
+  "allow-always",
+  "deny",
+] as const satisfies readonly ExecApprovalDecision[];
+
+export function resolveExecApprovalAllowedDecisions(params?: {
+  ask?: string | null;
+}): readonly ExecApprovalDecision[] {
+  const ask = normalizeExecAsk(params?.ask);
+  if (ask === "always") {
+    return ["allow-once", "deny"];
+  }
+  return DEFAULT_EXEC_APPROVAL_DECISIONS;
+}
+
+export function isExecApprovalDecisionAllowed(params: {
+  decision: ExecApprovalDecision;
+  ask?: string | null;
+}): boolean {
+  return resolveExecApprovalAllowedDecisions({ ask: params.ask }).includes(params.decision);
+}
 
 export async function requestExecApprovalViaSocket(params: {
   socketPath: string;

--- a/src/plugin-sdk/approval-runtime.ts
+++ b/src/plugin-sdk/approval-runtime.ts
@@ -2,6 +2,7 @@
 
 export {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  resolveExecApprovalAllowedDecisions,
   type ExecApprovalDecision,
   type ExecApprovalRequest,
   type ExecApprovalRequestPayload,

--- a/src/plugin-sdk/approval-runtime.ts
+++ b/src/plugin-sdk/approval-runtime.ts
@@ -3,6 +3,7 @@
 export {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
   resolveExecApprovalAllowedDecisions,
+  resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalDecision,
   type ExecApprovalRequest,
   type ExecApprovalRequestPayload,


### PR DESCRIPTION
## Summary
- add a shared effective exec-approval snapshot used by CLI, doctor, and approval UX
- make `openclaw approvals get` report real runtime-effective policy, including combined node host approvals + gateway `tools.exec` when gateway config is available
- align approval copy and action buttons with actual allowed decisions across `/approve`, reply payloads, Discord, Slack, and Telegram
- fix policy-reporting edge cases around inherited global `tools.exec`, `askFallback` attribution, wildcard/default-agent scopes, and config-unavailable fallback handling
- update docs and changelog to match the new approval-policy behavior

## Testing
- pnpm test -- src/infra/exec-approvals-policy.test.ts src/cli/exec-approvals-cli.test.ts src/commands/doctor-security.test.ts
- pnpm test -- src/infra/exec-approval-reply.test.ts src/gateway/server-methods/server-methods.test.ts
- pnpm test -- extensions/discord/src/monitor/exec-approvals.test.ts
- pnpm test -- extensions/slack/src/monitor/exec-approvals.test.ts
- pnpm build
- pnpm check
