### PR TITLE
fix(whatsapp): default unknown senders to silent dm policy

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -1087,6 +1087,20 @@
       "hasChildren": false
     },
     {
+      "path": "agents.defaults.compaction.notifyUser",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "advanced"
+      ],
+      "label": "Compaction Notify User",
+      "help": "When enabled, sends a brief compaction notice to the user (e.g. '🧹 Compacting context...') when compaction starts. Disabled by default to keep compaction silent and non-intrusive.",
+      "hasChildren": false
+    },
+    {
       "path": "agents.defaults.compaction.postCompactionSections",
       "kind": "core",
       "type": "array",
@@ -2194,16 +2208,6 @@
       "path": "agents.defaults.memorySearch.multimodal.modalities.*",
       "kind": "core",
       "type": "string",
-      "required": false,
-      "deprecated": false,
-      "sensitive": false,
-      "tags": [],
-      "hasChildren": false
-    },
-    {
-      "path": "agents.defaults.memorySearch.notifyUser",
-      "kind": "core",
-      "type": "boolean",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -8984,6 +8988,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -9531,6 +9536,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -10209,10 +10215,7 @@
     {
       "path": "channels.discord.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -10462,10 +10465,7 @@
     {
       "path": "channels.discord.accounts.*.dm.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -10495,10 +10495,7 @@
     {
       "path": "channels.discord.accounts.*.dm.groupChannels.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -10521,6 +10518,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -10547,6 +10545,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -10720,10 +10719,7 @@
     {
       "path": "channels.discord.accounts.*.execApprovals.approvers.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -10947,10 +10943,7 @@
     {
       "path": "channels.discord.accounts.*.guilds.*.channels.*.roles.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -11150,10 +11143,7 @@
     {
       "path": "channels.discord.accounts.*.guilds.*.channels.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -11209,10 +11199,7 @@
     {
       "path": "channels.discord.accounts.*.guilds.*.roles.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -11392,10 +11379,7 @@
     {
       "path": "channels.discord.accounts.*.guilds.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -12635,10 +12619,7 @@
     {
       "path": "channels.discord.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -12946,10 +12927,7 @@
     {
       "path": "channels.discord.dm.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -12979,10 +12957,7 @@
     {
       "path": "channels.discord.dm.groupChannels.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -13005,6 +12980,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -13037,6 +13013,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -13250,10 +13227,7 @@
     {
       "path": "channels.discord.execApprovals.approvers.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -13477,10 +13451,7 @@
     {
       "path": "channels.discord.guilds.*.channels.*.roles.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -13680,10 +13651,7 @@
     {
       "path": "channels.discord.guilds.*.channels.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -13739,10 +13707,7 @@
     {
       "path": "channels.discord.guilds.*.roles.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -13922,10 +13887,7 @@
     {
       "path": "channels.discord.guilds.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -17279,6 +17241,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -17960,6 +17923,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -18612,6 +18576,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -19282,6 +19247,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -19922,6 +19888,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -20654,6 +20621,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -22367,6 +22335,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -22469,6 +22438,16 @@
       "sensitive": false,
       "tags": [],
       "hasChildren": true
+    },
+    {
+      "path": "channels.matrix.groups.*.account",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
     },
     {
       "path": "channels.matrix.groups.*.allow",
@@ -22838,6 +22817,16 @@
       "sensitive": false,
       "tags": [],
       "hasChildren": true
+    },
+    {
+      "path": "channels.matrix.rooms.*.account",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
     },
     {
       "path": "channels.matrix.rooms.*.allow",
@@ -23528,6 +23517,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -24081,6 +24071,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -24510,6 +24501,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -25582,6 +25574,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -26207,6 +26200,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -26624,6 +26618,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -27823,6 +27818,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -28572,6 +28568,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -29891,6 +29888,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -29927,6 +29925,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -31381,6 +31380,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -31423,6 +31423,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -32758,6 +32759,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -33162,6 +33164,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -34920,6 +34923,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -35324,6 +35328,7 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -37713,12 +37718,13 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
         "disabled"
       ],
-      "defaultValue": "pairing",
+      "defaultValue": "silent",
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -38421,12 +38427,13 @@
       "type": "string",
       "required": true,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
         "disabled"
       ],
-      "defaultValue": "pairing",
+      "defaultValue": "silent",
       "deprecated": false,
       "sensitive": false,
       "tags": [
@@ -38435,7 +38442,7 @@
         "network"
       ],
       "label": "WhatsApp DM Policy",
-      "help": "Direct message access control (\"pairing\" recommended). \"open\" requires channels.whatsapp.allowFrom=[\"*\"].",
+      "help": "Direct message access control (\"silent\" default, \"pairing\" opt-in). \"open\" requires channels.whatsapp.allowFrom=[\"*\"].",
       "hasChildren": false
     },
     {
@@ -38984,6 +38991,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -39273,6 +39281,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -39549,6 +39558,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",
@@ -39853,6 +39863,7 @@
       "type": "string",
       "required": false,
       "enumValues": [
+        "silent",
         "pairing",
         "allowlist",
         "open",

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5766}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5768}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -92,6 +92,7 @@
 {"recordType":"path","path":"agents.defaults.compaction.memoryFlush.systemPrompt","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Compaction Memory Flush System Prompt","help":"System-prompt override for the pre-compaction memory flush turn to control extraction style and safety constraints. Use carefully so custom instructions do not reduce memory quality or leak sensitive context.","hasChildren":false}
 {"recordType":"path","path":"agents.defaults.compaction.mode","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Compaction Mode","help":"Compaction strategy mode: \"default\" uses baseline behavior, while \"safeguard\" applies stricter guardrails to preserve recent context. Keep \"default\" unless you observe aggressive history loss near limit boundaries.","hasChildren":false}
 {"recordType":"path","path":"agents.defaults.compaction.model","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["models"],"label":"Compaction Model Override","help":"Optional provider/model override used only for compaction summarization. Set this when you want compaction to run on a different model than the session default, and leave it unset to keep using the primary agent model.","hasChildren":false}
+{"recordType":"path","path":"agents.defaults.compaction.notifyUser","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Compaction Notify User","help":"When enabled, sends a brief compaction notice to the user (e.g. '🧹 Compacting context...') when compaction starts. Disabled by default to keep compaction silent and non-intrusive.","hasChildren":false}
 {"recordType":"path","path":"agents.defaults.compaction.postCompactionSections","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Post-Compaction Context Sections","help":"AGENTS.md H2/H3 section names re-injected after compaction so the agent reruns critical startup guidance. Leave unset to use \"Session Startup\"/\"Red Lines\" with legacy fallback to \"Every Session\"/\"Safety\"; set to [] to disable reinjection entirely.","hasChildren":true}
 {"recordType":"path","path":"agents.defaults.compaction.postCompactionSections.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.defaults.compaction.postIndexSync","kind":"core","type":"string","required":false,"enumValues":["off","async","await"],"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Compaction Post-Index Sync","help":"Controls post-compaction session memory reindex mode: \"off\", \"async\", or \"await\" (default: \"async\"). Use \"await\" for strongest freshness, \"async\" for lower compaction latency, and \"off\" only when session-memory sync is handled elsewhere.","hasChildren":false}
@@ -185,7 +186,6 @@
 {"recordType":"path","path":"agents.defaults.memorySearch.multimodal.maxFileBytes","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":["performance","storage"],"label":"Memory Search Multimodal Max File Bytes","help":"Sets the maximum bytes allowed per multimodal file before it is skipped during memory indexing. Use this to cap upload cost and indexing latency, or raise it for short high-quality audio clips.","hasChildren":false}
 {"recordType":"path","path":"agents.defaults.memorySearch.multimodal.modalities","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Memory Search Multimodal Modalities","help":"Selects which multimodal file types are indexed from extraPaths: \"image\", \"audio\", or \"all\". Keep this narrow to avoid indexing large binary corpora unintentionally.","hasChildren":true}
 {"recordType":"path","path":"agents.defaults.memorySearch.multimodal.modalities.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"agents.defaults.memorySearch.notifyUser","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.defaults.memorySearch.outputDimensionality","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Memory Search Output Dimensionality","help":"Gemini embedding-2 only: chooses the output vector size for memory embeddings. Use 768, 1536, or 3072 (default), and expect a full reindex when you change it because stored vector dimensions must stay consistent.","hasChildren":false}
 {"recordType":"path","path":"agents.defaults.memorySearch.provider","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Memory Search Provider","help":"Selects the embedding backend used to build/query memory vectors: \"openai\", \"gemini\", \"voyage\", \"mistral\", \"ollama\", or \"local\". Keep your most reliable provider here and configure fallback for resilience.","hasChildren":false}
 {"recordType":"path","path":"agents.defaults.memorySearch.qmd","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Memory Search QMD Collections","help":"Use this when one agent should query another agent's transcript collections; QMD-specific extra collections let you opt into cross-agent memory search without flattening everything into one shared namespace.","hasChildren":true}
@@ -783,7 +783,7 @@
 {"recordType":"path","path":"channels.bluebubbles.accounts.*.blockStreaming","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.bluebubbles.accounts.*.chunkMode","kind":"channel","type":"string","required":false,"enumValues":["length","newline"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.bluebubbles.accounts.*.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.bluebubbles.accounts.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.bluebubbles.accounts.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.bluebubbles.accounts.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.bluebubbles.accounts.*.enrichGroupParticipantsFromContacts","kind":"channel","type":"boolean","required":true,"defaultValue":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.bluebubbles.accounts.*.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -833,7 +833,7 @@
 {"recordType":"path","path":"channels.bluebubbles.chunkMode","kind":"channel","type":"string","required":false,"enumValues":["length","newline"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.bluebubbles.defaultAccount","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.bluebubbles.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.bluebubbles.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"BlueBubbles DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.bluebubbles.allowFrom=[\"*\"].","hasChildren":false}
+{"recordType":"path","path":"channels.bluebubbles.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"BlueBubbles DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.bluebubbles.allowFrom=[\"*\"].","hasChildren":false}
 {"recordType":"path","path":"channels.bluebubbles.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.bluebubbles.enrichGroupParticipantsFromContacts","kind":"channel","type":"boolean","required":true,"defaultValue":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.bluebubbles.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -896,7 +896,7 @@
 {"recordType":"path","path":"channels.discord.accounts.*.agentComponents.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.allowBots","kind":"channel","type":["boolean","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.accounts.*.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.allowFrom.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.autoPresence","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.autoPresence.degradedText","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.autoPresence.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -920,14 +920,14 @@
 {"recordType":"path","path":"channels.discord.accounts.*.defaultTo","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.dm","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.dm.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.accounts.*.dm.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.dm.allowFrom.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.dm.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.dm.groupChannels","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.accounts.*.dm.groupChannels.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.dm.groupChannels.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.dm.groupEnabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.discord.accounts.*.dm.policy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.dm.policy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.discord.accounts.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -944,7 +944,7 @@
 {"recordType":"path","path":"channels.discord.accounts.*.execApprovals.agentFilter","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.execApprovals.agentFilter.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.execApprovals.approvers","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.accounts.*.execApprovals.approvers.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.execApprovals.approvers.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.execApprovals.cleanupAfterResolve","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.execApprovals.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.execApprovals.sessionFilter","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -964,7 +964,7 @@
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.includeThreadStarter","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.roles","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.roles.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.roles.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.skills","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.skills.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -984,12 +984,12 @@
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.toolsBySender.*.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.users","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.users.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.users.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.ignoreOtherMentions","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.reactionNotifications","kind":"channel","type":"string","required":false,"enumValues":["off","own","all","allowlist"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.roles","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.accounts.*.guilds.*.roles.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.guilds.*.roles.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.slug","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1007,7 +1007,7 @@
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.toolsBySender.*.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.users","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.accounts.*.guilds.*.users.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.guilds.*.users.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1121,7 +1121,7 @@
 {"recordType":"path","path":"channels.discord.agentComponents.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.allowBots","kind":"channel","type":["boolean","string"],"required":false,"deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Discord Allow Bot Messages","help":"Allow bot-authored messages to trigger Discord replies (default: false). Set \"mentions\" to only accept bot messages that mention the bot.","hasChildren":false}
 {"recordType":"path","path":"channels.discord.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.allowFrom.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.autoPresence","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.autoPresence.degradedText","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Discord Auto Presence Degraded Text","help":"Optional custom status text while runtime/model availability is degraded or unknown (idle).","hasChildren":false}
 {"recordType":"path","path":"channels.discord.autoPresence.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Discord Auto Presence Enabled","help":"Enable automatic Discord bot presence updates based on runtime/model availability signals. When enabled: healthy=>online, degraded/unknown=>idle, exhausted/unavailable=>dnd.","hasChildren":false}
@@ -1146,14 +1146,14 @@
 {"recordType":"path","path":"channels.discord.defaultTo","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.dm","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.dm.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.dm.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.dm.allowFrom.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.dm.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.dm.groupChannels","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.dm.groupChannels.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.dm.groupChannels.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.dm.groupEnabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.discord.dm.policy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Discord DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.discord.allowFrom=[\"*\"] (legacy: channels.discord.dm.allowFrom).","hasChildren":false}
+{"recordType":"path","path":"channels.discord.dm.policy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Discord DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.discord.allowFrom=[\"*\"] (legacy: channels.discord.dm.allowFrom).","hasChildren":false}
 {"recordType":"path","path":"channels.discord.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.discord.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Discord DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.discord.allowFrom=[\"*\"].","hasChildren":false}
+{"recordType":"path","path":"channels.discord.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Discord DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.discord.allowFrom=[\"*\"].","hasChildren":false}
 {"recordType":"path","path":"channels.discord.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1170,7 +1170,7 @@
 {"recordType":"path","path":"channels.discord.execApprovals.agentFilter","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.execApprovals.agentFilter.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.execApprovals.approvers","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.execApprovals.approvers.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.execApprovals.approvers.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.execApprovals.cleanupAfterResolve","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.execApprovals.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.execApprovals.sessionFilter","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1190,7 +1190,7 @@
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.includeThreadStarter","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.roles","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.guilds.*.channels.*.roles.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.guilds.*.channels.*.roles.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.skills","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.skills.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1210,12 +1210,12 @@
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.toolsBySender.*.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.users","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.guilds.*.channels.*.users.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.guilds.*.channels.*.users.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.ignoreOtherMentions","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.reactionNotifications","kind":"channel","type":"string","required":false,"enumValues":["off","own","all","allowlist"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.roles","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.guilds.*.roles.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.guilds.*.roles.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.slug","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.guilds.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1233,7 +1233,7 @@
 {"recordType":"path","path":"channels.discord.guilds.*.toolsBySender.*.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.guilds.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.users","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
-{"recordType":"path","path":"channels.discord.guilds.*.users.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.guilds.*.users.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1523,7 +1523,7 @@
 {"recordType":"path","path":"channels.googlechat.accounts.*.dm.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.accounts.*.dm.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.accounts.*.dm.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.googlechat.accounts.*.dm.policy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.googlechat.accounts.*.dm.policy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.accounts.*.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1586,7 +1586,7 @@
 {"recordType":"path","path":"channels.googlechat.dm.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.dm.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.dm.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.googlechat.dm.policy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.googlechat.dm.policy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1646,7 +1646,7 @@
 {"recordType":"path","path":"channels.imessage.accounts.*.dbPath","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.accounts.*.defaultTo","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.accounts.*.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.imessage.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.imessage.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.imessage.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.imessage.accounts.*.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1709,7 +1709,7 @@
 {"recordType":"path","path":"channels.imessage.defaultAccount","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.defaultTo","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.imessage.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"iMessage DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.imessage.allowFrom=[\"*\"].","hasChildren":false}
+{"recordType":"path","path":"channels.imessage.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"iMessage DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.imessage.allowFrom=[\"*\"].","hasChildren":false}
 {"recordType":"path","path":"channels.imessage.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.imessage.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.imessage.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1769,7 +1769,7 @@
 {"recordType":"path","path":"channels.irc.accounts.*.chunkMode","kind":"channel","type":"string","required":false,"enumValues":["length","newline"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.irc.accounts.*.dangerouslyAllowNameMatching","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.irc.accounts.*.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.irc.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.irc.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.irc.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.irc.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.irc.accounts.*.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1838,7 +1838,7 @@
 {"recordType":"path","path":"channels.irc.dangerouslyAllowNameMatching","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.irc.defaultAccount","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.irc.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.irc.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"IRC DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.irc.allowFrom=[\"*\"].","hasChildren":false}
+{"recordType":"path","path":"channels.irc.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"IRC DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.irc.allowFrom=[\"*\"].","hasChildren":false}
 {"recordType":"path","path":"channels.irc.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.irc.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.irc.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1990,7 +1990,7 @@
 {"recordType":"path","path":"channels.matrix.dm.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.matrix.dm.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.dm.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.matrix.dm.policy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.matrix.dm.policy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.dm.threadReplies","kind":"channel","type":"string","required":false,"enumValues":["off","inbound","always"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.encryption","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1999,6 +1999,7 @@
 {"recordType":"path","path":"channels.matrix.groupPolicy","kind":"channel","type":"string","required":false,"enumValues":["open","disabled","allowlist"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.groups","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.matrix.groups.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.matrix.groups.*.account","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.groups.*.allow","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.groups.*.allowBots","kind":"channel","type":["boolean","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.groups.*.autoReply","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2033,6 +2034,7 @@
 {"recordType":"path","path":"channels.matrix.responsePrefix","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.rooms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.matrix.rooms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.matrix.rooms.*.account","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.rooms.*.allow","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.rooms.*.allowBots","kind":"channel","type":["boolean","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.rooms.*.autoReply","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2096,7 +2098,7 @@
 {"recordType":"path","path":"channels.mattermost.accounts.*.dmChannelRetry.maxDelayMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.accounts.*.dmChannelRetry.maxRetries","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.accounts.*.dmChannelRetry.timeoutMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.mattermost.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.mattermost.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.accounts.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.accounts.*.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.mattermost.accounts.*.groupAllowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2146,7 +2148,7 @@
 {"recordType":"path","path":"channels.mattermost.dmChannelRetry.maxDelayMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.dmChannelRetry.maxRetries","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.dmChannelRetry.timeoutMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.mattermost.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.mattermost.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.mattermost.groupAllowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2184,7 +2186,7 @@
 {"recordType":"path","path":"channels.msteams.dangerouslyAllowNameMatching","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.defaultTo","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.msteams.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.msteams.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.msteams.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.msteams.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2285,7 +2287,7 @@
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.botSecretFile","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":true,"tags":["auth","channels","network","security","storage"],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.chunkMode","kind":"channel","type":"string","required":false,"enumValues":["length","newline"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.nextcloud-talk.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.nextcloud-talk.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2343,7 +2345,7 @@
 {"recordType":"path","path":"channels.nextcloud-talk.chunkMode","kind":"channel","type":"string","required":false,"enumValues":["length","newline"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.defaultAccount","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.nextcloud-talk.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.nextcloud-talk.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nextcloud-talk.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nextcloud-talk.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2382,7 +2384,7 @@
 {"recordType":"path","path":"channels.nostr.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nostr.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nostr.defaultAccount","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.nostr.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.nostr.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nostr.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nostr.markdown","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nostr.markdown.tables","kind":"channel","type":"string","required":false,"enumValues":["off","bullets","code","block"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2492,7 +2494,7 @@
 {"recordType":"path","path":"channels.signal.accounts.*.configWrites","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.accounts.*.defaultTo","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.accounts.*.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.signal.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.signal.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.signal.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.signal.accounts.*.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2562,7 +2564,7 @@
 {"recordType":"path","path":"channels.signal.defaultAccount","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.defaultTo","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.signal.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Signal DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.signal.allowFrom=[\"*\"].","hasChildren":false}
+{"recordType":"path","path":"channels.signal.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Signal DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.signal.allowFrom=[\"*\"].","hasChildren":false}
 {"recordType":"path","path":"channels.signal.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.signal.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.signal.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2685,10 +2687,10 @@
 {"recordType":"path","path":"channels.slack.accounts.*.dm.groupChannels","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.accounts.*.dm.groupChannels.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.accounts.*.dm.groupEnabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.slack.accounts.*.dm.policy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.slack.accounts.*.dm.policy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.accounts.*.dm.replyToMode","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.accounts.*.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.slack.accounts.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.slack.accounts.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.accounts.*.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2819,10 +2821,10 @@
 {"recordType":"path","path":"channels.slack.dm.groupChannels","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.dm.groupChannels.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.dm.groupEnabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.slack.dm.policy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Slack DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.slack.allowFrom=[\"*\"] (legacy: channels.slack.dm.allowFrom).","hasChildren":false}
+{"recordType":"path","path":"channels.slack.dm.policy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Slack DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.slack.allowFrom=[\"*\"] (legacy: channels.slack.dm.allowFrom).","hasChildren":false}
 {"recordType":"path","path":"channels.slack.dm.replyToMode","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.slack.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Slack DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.slack.allowFrom=[\"*\"].","hasChildren":false}
+{"recordType":"path","path":"channels.slack.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Slack DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.slack.allowFrom=[\"*\"].","hasChildren":false}
 {"recordType":"path","path":"channels.slack.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2935,7 +2937,7 @@
 {"recordType":"path","path":"channels.telegram.accounts.*.direct.*.autoTopicLabel","kind":"channel","type":["boolean","object"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.accounts.*.direct.*.autoTopicLabel.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.direct.*.autoTopicLabel.prompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.telegram.accounts.*.direct.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.telegram.accounts.*.direct.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.direct.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.direct.*.errorCooldownMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.direct.*.errorPolicy","kind":"channel","type":"string","required":false,"enumValues":["always","once","silent"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2973,7 +2975,7 @@
 {"recordType":"path","path":"channels.telegram.accounts.*.direct.*.topics.*.skills.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.direct.*.topics.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.telegram.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.telegram.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.accounts.*.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3130,7 +3132,7 @@
 {"recordType":"path","path":"channels.telegram.direct.*.autoTopicLabel","kind":"channel","type":["boolean","object"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.direct.*.autoTopicLabel.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.direct.*.autoTopicLabel.prompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.telegram.direct.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.telegram.direct.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.direct.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.direct.*.errorCooldownMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.direct.*.errorPolicy","kind":"channel","type":"string","required":false,"enumValues":["always","once","silent"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3168,7 +3170,7 @@
 {"recordType":"path","path":"channels.telegram.direct.*.topics.*.skills.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.direct.*.topics.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.telegram.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Telegram DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.telegram.allowFrom=[\"*\"].","hasChildren":false}
+{"recordType":"path","path":"channels.telegram.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"Telegram DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.telegram.allowFrom=[\"*\"].","hasChildren":false}
 {"recordType":"path","path":"channels.telegram.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3380,7 +3382,7 @@
 {"recordType":"path","path":"channels.whatsapp.accounts.*.debounceMs","kind":"channel","type":"integer","required":true,"defaultValue":0,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.defaultTo","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.whatsapp.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"silent","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3446,7 +3448,7 @@
 {"recordType":"path","path":"channels.whatsapp.defaultAccount","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.defaultTo","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.whatsapp.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["pairing","allowlist","open","disabled"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"WhatsApp DM Policy","help":"Direct message access control (\"pairing\" recommended). \"open\" requires channels.whatsapp.allowFrom=[\"*\"].","hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["silent","pairing","allowlist","open","disabled"],"defaultValue":"silent","deprecated":false,"sensitive":false,"tags":["access","channels","network"],"label":"WhatsApp DM Policy","help":"Direct message access control (\"silent\" default, \"pairing\" opt-in). \"open\" requires channels.whatsapp.allowFrom=[\"*\"].","hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3497,7 +3499,7 @@
 {"recordType":"path","path":"channels.zalo.accounts.*.botToken.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalo.accounts.*.botToken.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalo.accounts.*.botToken.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.zalo.accounts.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.zalo.accounts.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalo.accounts.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalo.accounts.*.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.zalo.accounts.*.groupAllowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3522,7 +3524,7 @@
 {"recordType":"path","path":"channels.zalo.botToken.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalo.botToken.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalo.defaultAccount","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.zalo.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.zalo.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalo.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalo.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.zalo.groupAllowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3546,7 +3548,7 @@
 {"recordType":"path","path":"channels.zalouser.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.zalouser.accounts.*.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalouser.accounts.*.dangerouslyAllowNameMatching","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.zalouser.accounts.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.zalouser.accounts.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalouser.accounts.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalouser.accounts.*.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.zalouser.accounts.*.groupAllowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3574,7 +3576,7 @@
 {"recordType":"path","path":"channels.zalouser.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalouser.dangerouslyAllowNameMatching","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalouser.defaultAccount","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.zalouser.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.zalouser.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["silent","pairing","allowlist","open","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalouser.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalouser.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.zalouser.groupAllowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/extensions/discord/src/monitor.test.ts
+++ b/extensions/discord/src/monitor.test.ts
@@ -984,7 +984,7 @@ function makeReactionListenerParams(overrides?: {
   dmEnabled?: boolean;
   groupDmEnabled?: boolean;
   groupDmChannels?: string[];
-  dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
+  dmPolicy?: "open" | "pairing" | "allowlist" | "silent" | "disabled";
   allowFrom?: string[];
   groupPolicy?: "open" | "allowlist" | "disabled";
   allowNameMatching?: boolean;

--- a/extensions/discord/src/monitor/agent-components-helpers.ts
+++ b/extensions/discord/src/monitor/agent-components-helpers.ts
@@ -14,11 +14,11 @@ import { createChannelPairingChallengeIssuer } from "openclaw/plugin-sdk/channel
 import { resolveCommandAuthorizedFromAuthorizers } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-runtime";
-import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
-import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import * as conversationRuntime from "openclaw/plugin-sdk/conversation-runtime";
+import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import * as securityRuntime from "openclaw/plugin-sdk/security-runtime";
 import { logError } from "openclaw/plugin-sdk/text-runtime";
 import {
@@ -73,7 +73,7 @@ export type AgentComponentContext = {
   token?: string;
   guildEntries?: Record<string, DiscordGuildEntryResolved>;
   allowFrom?: string[];
-  dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
+  dmPolicy?: "open" | "pairing" | "allowlist" | "silent" | "disabled";
 };
 
 export type ComponentInteractionContext = NonNullable<

--- a/extensions/discord/src/monitor/dm-command-auth.ts
+++ b/extensions/discord/src/monitor/dm-command-auth.ts
@@ -8,7 +8,7 @@ import { normalizeDiscordAllowList, resolveDiscordAllowListMatch } from "./allow
 
 const DISCORD_ALLOW_LIST_PREFIXES = ["discord:", "user:", "pk:"];
 
-export type DiscordDmPolicy = "open" | "pairing" | "allowlist" | "disabled";
+export type DiscordDmPolicy = "open" | "pairing" | "allowlist" | "silent" | "disabled";
 
 export type DiscordDmCommandAccess = {
   decision: DmGroupAccessDecision;

--- a/extensions/discord/src/monitor/listeners.ts
+++ b/extensions/discord/src/monitor/listeners.ts
@@ -66,7 +66,7 @@ type DiscordReactionRoutingParams = {
   dmEnabled: boolean;
   groupDmEnabled: boolean;
   groupDmChannels: string[];
-  dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
+  dmPolicy: "open" | "pairing" | "allowlist" | "silent" | "disabled";
   allowFrom: string[];
   groupPolicy: "open" | "allowlist" | "disabled";
   allowNameMatching: boolean;
@@ -308,7 +308,7 @@ type DiscordReactionIngressAuthorizationParams = {
   dmEnabled: boolean;
   groupDmEnabled: boolean;
   groupDmChannels: string[];
-  dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
+  dmPolicy: "open" | "pairing" | "allowlist" | "silent" | "disabled";
   allowFrom: string[];
   groupPolicy: "open" | "allowlist" | "disabled";
   allowNameMatching: boolean;

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -397,7 +397,11 @@ export async function handleFeishuMessage(params: {
       })
     : null;
   const groupHistoryKey = isGroup ? (groupSession?.peerId ?? ctx.chatId) : undefined;
-  const dmPolicy = feishuCfg?.dmPolicy ?? "pairing";
+  const dmPolicy = (feishuCfg?.dmPolicy ?? "pairing") as
+    | "open"
+    | "pairing"
+    | "allowlist"
+    | "silent";
   const configAllowFrom = feishuCfg?.allowFrom ?? [];
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
   const rawBroadcastAgents = isGroup ? resolveBroadcastAgents(cfg, ctx.chatId) : null;
@@ -511,6 +515,7 @@ export async function handleFeishuMessage(params: {
     const storeAllowFrom =
       !isGroup &&
       dmPolicy !== "allowlist" &&
+      dmPolicy !== "silent" &&
       (dmPolicy !== "open" || shouldComputeCommandAuthorized)
         ? await pairing.readAllowFromStore().catch(() => [])
         : [];

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -78,7 +78,11 @@ export async function handleFeishuCommentEvent(
     fileToken: turn.fileToken,
     commentId: turn.commentId,
   });
-  const dmPolicy = feishuCfg?.dmPolicy ?? "pairing";
+  const dmPolicy = (feishuCfg?.dmPolicy ?? "pairing") as
+    | "open"
+    | "pairing"
+    | "allowlist"
+    | "silent";
   const configAllowFrom = feishuCfg?.allowFrom ?? [];
   const pairing = createChannelPairingController({
     core,
@@ -86,7 +90,7 @@ export async function handleFeishuCommentEvent(
     accountId: account.accountId,
   });
   const storeAllowFrom =
-    dmPolicy !== "allowlist" && dmPolicy !== "open"
+    dmPolicy !== "allowlist" && dmPolicy !== "silent" && dmPolicy !== "open"
       ? await pairing.readAllowFromStore().catch(() => [])
       : [];
   const effectiveDmAllowFrom = [...configAllowFrom, ...storeAllowFrom];

--- a/extensions/googlechat/src/monitor-access.ts
+++ b/extensions/googlechat/src/monitor-access.ts
@@ -280,7 +280,10 @@ export async function applyGoogleChatInboundAccessPolicy(params: {
         });
   const shouldComputeAuth = core.channel.commands.shouldComputeCommandAuthorized(rawBody, config);
   const storeAllowFrom =
-    !isGroup && dmPolicy !== "allowlist" && (dmPolicy !== "open" || shouldComputeAuth)
+    !isGroup &&
+    dmPolicy !== "allowlist" &&
+    dmPolicy !== "silent" &&
+    (dmPolicy !== "open" || shouldComputeAuth)
       ? await pairing.readAllowFromStore().catch(() => [])
       : [];
   const access = resolveDmGroupAccessWithLists({

--- a/extensions/matrix/src/matrix/monitor/events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/events.test.ts
@@ -427,6 +427,33 @@ describe("registerMatrixMonitorEvents verification routing", () => {
     expect(readStoreAllowFrom).toHaveBeenCalled();
   });
 
+  it("allows verification notices for explicit allowlisted DM senders without store fallback", async () => {
+    const { sendMessage, roomMessageListener, readStoreAllowFrom } = createHarness({
+      dmPolicy: "allowlist",
+      allowFrom: ["@alice:example.org"],
+      storeAllowFrom: ["@not-used:example.org"],
+    });
+    if (!roomMessageListener) {
+      throw new Error("room.message listener was not registered");
+    }
+
+    roomMessageListener("!room:example.org", {
+      event_id: "$req-allowlist-allowed",
+      sender: "@alice:example.org",
+      type: EventType.RoomMessage,
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.key.verification.request",
+        body: "verification request",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    });
+    expect(readStoreAllowFrom).not.toHaveBeenCalled();
+  });
+
   it("does not consult the allow store when dmPolicy is open", async () => {
     const { sendMessage, roomMessageListener, readStoreAllowFrom } = createHarness({
       dmPolicy: "open",

--- a/extensions/matrix/src/matrix/monitor/events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/events.test.ts
@@ -26,7 +26,7 @@ function createHarness(params?: {
   selfUserIdError?: Error;
   allowFrom?: string[];
   dmEnabled?: boolean;
-  dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
+  dmPolicy?: "open" | "pairing" | "allowlist" | "silent" | "disabled";
   storeAllowFrom?: string[];
   accountDataByType?: Record<string, unknown>;
   joinedMembersByRoom?: Record<string, string[]>;

--- a/extensions/matrix/src/matrix/monitor/events.ts
+++ b/extensions/matrix/src/matrix/monitor/events.ts
@@ -36,7 +36,7 @@ export function registerMatrixMonitorEvents(params: {
   auth: MatrixAuth;
   allowFrom: string[];
   dmEnabled: boolean;
-  dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
+  dmPolicy: "open" | "pairing" | "allowlist" | "silent" | "disabled";
   readStoreAllowFrom: () => Promise<string[]>;
   directTracker?: {
     invalidateRoom: (roomId: string) => void;

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -223,6 +223,33 @@ describe("matrix monitor handler pairing account scope", () => {
     });
   });
 
+  it("preserves store-backed command auth for room control commands", async () => {
+    const dispatchReplyFromConfig = vi.fn(async () => ({
+      queuedFinal: false,
+      counts: { final: 0, block: 0, tool: 0 },
+    }));
+    const { handler, readAllowFromStore } = createMatrixHandlerTestHarness({
+      isDirectMessage: false,
+      dmPolicy: "pairing",
+      readAllowFromStore: vi.fn(async () => ["@paired:example.org"]),
+      shouldHandleTextCommands: () => true,
+      hasControlCommand: () => true,
+      dispatchReplyFromConfig,
+    });
+
+    await handler(
+      "!room:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$room-command-paired",
+        sender: "@paired:example.org",
+        body: "/status",
+      }),
+    );
+
+    expect(readAllowFromStore).toHaveBeenCalledTimes(1);
+    expect(dispatchReplyFromConfig).toHaveBeenCalled();
+  });
+
   it("passes accountId into route resolution for inbound dm messages", async () => {
     const resolveAgentRoute = vi.fn(() => ({
       agentId: "ops",

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -461,7 +461,10 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           senderNamePromise ??= getMemberDisplayName(roomId, senderId).catch(() => senderId);
           return await senderNamePromise;
         };
-        const storeAllowFrom = await readStoreAllowFrom();
+        const storeAllowFrom =
+          isDirectMessage && dmPolicy !== "allowlist" && dmPolicy !== "silent"
+            ? await readStoreAllowFrom()
+            : [];
         const roomUsers = roomConfig?.users ?? [];
         const accessState = resolveMatrixMonitorAccessState({
           allowFrom,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -463,19 +463,34 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           senderNamePromise ??= getMemberDisplayName(roomId, senderId).catch(() => senderId);
           return await senderNamePromise;
         };
-        const storeAllowFrom =
+        const accessStoreAllowFrom =
           isDirectMessage && dmPolicy !== "allowlist" && dmPolicy !== "silent"
             ? await readStoreAllowFrom()
             : [];
+        const commandStoreAllowFrom =
+          !isDirectMessage && dmPolicy !== "allowlist" && dmPolicy !== "silent"
+            ? await readStoreAllowFrom()
+            : accessStoreAllowFrom;
         const roomUsers = roomConfig?.users ?? [];
         const accessState = resolveMatrixMonitorAccessState({
           allowFrom,
-          storeAllowFrom,
+          storeAllowFrom: accessStoreAllowFrom,
           groupAllowFrom,
           roomUsers,
           senderId,
           isRoom,
         });
+        const commandAuthorizers =
+          isRoom && commandStoreAllowFrom !== accessStoreAllowFrom
+            ? resolveMatrixMonitorAccessState({
+                allowFrom,
+                storeAllowFrom: commandStoreAllowFrom,
+                groupAllowFrom,
+                roomUsers,
+                senderId,
+                isRoom,
+              }).commandAuthorizers
+            : accessState.commandAuthorizers;
         const {
           effectiveGroupAllowFrom,
           effectiveRoomUsers,
@@ -483,7 +498,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           directAllowMatch,
           roomUserMatch,
           groupAllowMatch,
-          commandAuthorizers,
         } = accessState;
 
         if (isDirectMessage) {

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -85,7 +85,7 @@ export type MatrixMonitorHandlerParams = {
   dmThreadReplies?: "off" | "inbound" | "always";
   streaming: "partial" | "off";
   dmEnabled: boolean;
-  dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
+  dmPolicy: "open" | "pairing" | "allowlist" | "silent" | "disabled";
   textLimit: number;
   mediaMaxBytes: number;
   historyLimit: number;

--- a/extensions/matrix/src/matrix/monitor/verification-events.ts
+++ b/extensions/matrix/src/matrix/monitor/verification-events.ts
@@ -358,6 +358,12 @@ async function isVerificationNoticeAuthorized(params: {
   if (params.dmPolicy === "open") {
     return true;
   }
+  if (params.dmPolicy === "silent" || params.dmPolicy === "allowlist") {
+    params.logVerboseMessage(
+      `matrix: blocked verification sender ${params.senderId} (dmPolicy=${params.dmPolicy})`,
+    );
+    return false;
+  }
   const storeAllowFrom = await params.readStoreAllowFrom();
   const accessState = resolveMatrixMonitorAccessState({
     allowFrom: params.allowFrom,

--- a/extensions/matrix/src/matrix/monitor/verification-events.ts
+++ b/extensions/matrix/src/matrix/monitor/verification-events.ts
@@ -343,7 +343,7 @@ async function isVerificationNoticeAuthorized(params: {
   senderId: string;
   allowFrom: string[];
   dmEnabled: boolean;
-  dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
+  dmPolicy: "open" | "pairing" | "allowlist" | "silent" | "disabled";
   readStoreAllowFrom: () => Promise<string[]>;
   logVerboseMessage: (message: string) => void;
 }): Promise<boolean> {
@@ -382,7 +382,7 @@ export function createMatrixVerificationEventRouter(params: {
   client: MatrixClient;
   allowFrom: string[];
   dmEnabled: boolean;
-  dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
+  dmPolicy: "open" | "pairing" | "allowlist" | "silent" | "disabled";
   readStoreAllowFrom: () => Promise<string[]>;
   logVerboseMessage: (message: string) => void;
 }) {

--- a/extensions/matrix/src/matrix/monitor/verification-events.ts
+++ b/extensions/matrix/src/matrix/monitor/verification-events.ts
@@ -358,13 +358,13 @@ async function isVerificationNoticeAuthorized(params: {
   if (params.dmPolicy === "open") {
     return true;
   }
-  if (params.dmPolicy === "silent" || params.dmPolicy === "allowlist") {
+  if (params.dmPolicy === "silent") {
     params.logVerboseMessage(
       `matrix: blocked verification sender ${params.senderId} (dmPolicy=${params.dmPolicy})`,
     );
     return false;
   }
-  const storeAllowFrom = await params.readStoreAllowFrom();
+  const storeAllowFrom = params.dmPolicy === "pairing" ? await params.readStoreAllowFrom() : [];
   const accessState = resolveMatrixMonitorAccessState({
     allowFrom: params.allowFrom,
     storeAllowFrom,

--- a/extensions/signal/src/monitor/access-policy.ts
+++ b/extensions/signal/src/monitor/access-policy.ts
@@ -6,7 +6,7 @@ import {
 } from "openclaw/plugin-sdk/security-runtime";
 import { isSignalSenderAllowed, type SignalSender } from "../identity.js";
 
-type SignalDmPolicy = "open" | "pairing" | "allowlist" | "disabled";
+type SignalDmPolicy = "open" | "pairing" | "allowlist" | "silent" | "disabled";
 type SignalGroupPolicy = "open" | "allowlist" | "disabled";
 
 export async function resolveSignalAccessState(params: {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -7,8 +7,8 @@ import { formatInboundEnvelope } from "openclaw/plugin-sdk/channel-inbound";
 import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
 import { shouldComputeCommandAuthorized } from "openclaw/plugin-sdk/command-detection";
 import type { loadConfig } from "openclaw/plugin-sdk/config-runtime";
-import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { recordSessionMetaFromInbound } from "openclaw/plugin-sdk/config-runtime";
+import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import {
   buildHistoryContextFromEntries,
@@ -78,7 +78,7 @@ async function resolveWhatsAppCommandAuthorized(params: {
   }
 
   const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.msg.accountId });
-  const dmPolicy = account.dmPolicy ?? "pairing";
+  const dmPolicy = account.dmPolicy ?? "silent";
   const groupPolicy = account.groupPolicy ?? "allowlist";
   const configuredAllowFrom = account.allowFrom ?? [];
   const configuredGroupAllowFrom =

--- a/extensions/whatsapp/src/config-ui-hints.ts
+++ b/extensions/whatsapp/src/config-ui-hints.ts
@@ -7,7 +7,7 @@ export const whatsAppChannelConfigUiHints = {
   },
   dmPolicy: {
     label: "WhatsApp DM Policy",
-    help: 'Direct message access control ("pairing" recommended). "open" requires channels.whatsapp.allowFrom=["*"].',
+    help: 'Direct message access control ("silent" default, "pairing" opt-in). "open" requires channels.whatsapp.allowFrom=["*"].',
   },
   selfChatMode: {
     label: "WhatsApp Self-Phone Mode",

--- a/extensions/whatsapp/src/inbound/access-control.test-harness.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test-harness.ts
@@ -22,7 +22,7 @@ export function setupAccessControlTestHarness(): void {
     config = {
       channels: {
         whatsapp: {
-          dmPolicy: "pairing",
+          dmPolicy: "silent",
           allowFrom: [],
         },
       },

--- a/extensions/whatsapp/src/inbound/access-control.test.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test.ts
@@ -36,6 +36,17 @@ function expectSilentlyBlocked(result: { allowed: boolean }) {
 }
 
 describe("checkInboundAccessControl pairing grace", () => {
+  beforeEach(() => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+        },
+      },
+    });
+  });
+
   async function runPairingGraceCase(messageTimestampMs: number) {
     const connectedAtMs = 1_000_000;
     return await checkInboundAccessControl({
@@ -72,6 +83,41 @@ describe("checkInboundAccessControl pairing grace", () => {
 });
 
 describe("WhatsApp dmPolicy precedence", () => {
+  it("defaults to silent blocking when no policy is set", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          accounts: {
+            work: {
+              allowFrom: ["+15559999999"],
+            },
+          },
+        },
+      },
+    });
+
+    const result = await checkUnauthorizedWorkDmSender();
+    expectSilentlyBlocked(result);
+  });
+
+  it("silently blocks unauthorized senders when dmPolicy is silent", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "silent",
+          accounts: {
+            work: {
+              allowFrom: ["+15559999999"],
+            },
+          },
+        },
+      },
+    });
+
+    const result = await checkUnauthorizedWorkDmSender();
+    expectSilentlyBlocked(result);
+  });
+
   it("uses account-level dmPolicy instead of channel-level (#8736)", async () => {
     // Channel-level says "pairing" but the account-level says "allowlist".
     // The account-level override should take precedence, so an unauthorized
@@ -160,5 +206,32 @@ describe("WhatsApp dmPolicy precedence", () => {
     expect(result.allowed).toBe(true);
     expect(upsertPairingRequestMock).not.toHaveBeenCalled();
     expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit pairing replies but removes the phone number line", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "pairing",
+          accounts: {
+            work: {},
+          },
+        },
+      },
+    });
+    upsertPairingRequestMock.mockResolvedValueOnce({ code: "PAIRCODE", created: true });
+
+    const result = await checkUnauthorizedWorkDmSender();
+
+    expect(result.allowed).toBe(false);
+    expect(upsertPairingRequestMock).toHaveBeenCalledOnce();
+    expect(sendMessageMock).toHaveBeenCalledOnce();
+    const sendMessageCalls = (
+      sendMessageMock as unknown as { mock: { calls: Array<Array<unknown>> } }
+    ).mock.calls;
+    const text = String((sendMessageCalls[0]?.[1] as { text?: string } | undefined)?.text ?? "");
+    expect(text).toContain("pairing approve whatsapp PAIRCODE");
+    expect(text).not.toContain("Your WhatsApp phone number");
+    expect(text).not.toContain("+15550001111");
   });
 });

--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -49,6 +49,7 @@ export async function checkInboundAccessControl(params: {
   messageTimestampMs?: number;
   connectedAtMs?: number;
   pairingGraceMs?: number;
+  suppressPairingReply?: boolean;
   sock: {
     sendMessage: (jid: string, content: { text: string }) => Promise<unknown>;
   };
@@ -59,7 +60,7 @@ export async function checkInboundAccessControl(params: {
     cfg,
     accountId: params.accountId,
   });
-  const dmPolicy = account.dmPolicy ?? "pairing";
+  const dmPolicy = account.dmPolicy ?? "silent";
   const configuredAllowFrom = account.allowFrom ?? [];
   const storeAllowFrom = await readStoreAllowFromForDmPolicy({
     provider: "whatsapp",
@@ -146,7 +147,7 @@ export async function checkInboundAccessControl(params: {
     };
   }
 
-  // DM access control (secure defaults): "pairing" (default) / "allowlist" / "open" / "disabled".
+  // DM access control (secure defaults): "silent" (default) / "pairing" / "allowlist" / "open" / "disabled".
   if (!params.group) {
     if (params.isFromMe && !isSamePhone) {
       logVerbose("Skipping outbound DM (fromMe); no pairing reply needed.");
@@ -168,8 +169,8 @@ export async function checkInboundAccessControl(params: {
     }
     if (access.decision === "pairing" && !isSamePhone) {
       const candidate = params.from;
-      if (suppressPairingReply) {
-        logVerbose(`Skipping pairing reply for historical DM from ${candidate}.`);
+      if (params.suppressPairingReply || suppressPairingReply) {
+        logVerbose(`Skipping pairing reply for suppressed DM from ${candidate}.`);
       } else {
         await createChannelPairingChallengeIssuer({
           channel: "whatsapp",
@@ -182,7 +183,6 @@ export async function checkInboundAccessControl(params: {
             }),
         })({
           senderId: candidate,
-          senderIdLine: `Your WhatsApp phone number: ${candidate}`,
           meta: { name: (params.pushName ?? "").trim() || undefined },
           onCreated: () => {
             logVerbose(

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -207,6 +207,7 @@ export async function monitorWebInbox(options: {
 
   const normalizeInboundMessage = async (
     msg: WAMessage,
+    opts?: { suppressPairingReply?: boolean },
   ): Promise<NormalizedInboundMessage | null> => {
     const id = msg.key?.id ?? undefined;
     const remoteJid = msg.key?.remoteJid;
@@ -271,6 +272,7 @@ export async function monitorWebInbox(options: {
       isFromMe: Boolean(msg.key?.fromMe),
       messageTimestampMs,
       connectedAtMs,
+      suppressPairingReply: opts?.suppressPairingReply,
       sock: { sendMessage: (jid, content) => sendTrackedMessage(jid, content) },
       remoteJid,
     });
@@ -464,20 +466,8 @@ export async function monitorWebInbox(options: {
       return;
     }
     for (const msg of upsert.messages ?? []) {
-      recordChannelActivity({
-        channel: "whatsapp",
-        accountId: options.accountId,
-        direction: "inbound",
-      });
-      const inbound = await normalizeInboundMessage(msg);
-      if (!inbound) {
-        continue;
-      }
-
-      await maybeMarkInboundAsRead(inbound);
-
-      // If this is history/offline catch-up, mark read above but skip auto-reply.
-      if (upsert.type === "append") {
+      const isAppend = upsert.type === "append";
+      if (isAppend) {
         const APPEND_RECENT_GRACE_MS = 60_000;
         const msgTsRaw = msg.messageTimestamp;
         const msgTsNum = msgTsRaw != null ? Number(msgTsRaw) : NaN;
@@ -486,6 +476,17 @@ export async function monitorWebInbox(options: {
           continue;
         }
       }
+      recordChannelActivity({
+        channel: "whatsapp",
+        accountId: options.accountId,
+        direction: "inbound",
+      });
+      const inbound = await normalizeInboundMessage(msg, { suppressPairingReply: isAppend });
+      if (!inbound) {
+        continue;
+      }
+
+      await maybeMarkInboundAsRead(inbound);
 
       const enriched = await enrichInboundMessage(msg);
       if (!enriched) {

--- a/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
@@ -136,12 +136,9 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
-  it("locks down when no config is present (pairing for unknown senders)", async () => {
-    // No config file => locked-down defaults apply (pairing for unknown senders)
+  it("locks down silently when no config is present", async () => {
+    // No config file => locked-down defaults apply (silent block for unknown senders)
     mockLoadConfig.mockReturnValue({});
-    upsertPairingRequestMock
-      .mockResolvedValueOnce({ code: "PAIRCODE", created: true })
-      .mockResolvedValueOnce({ code: "PAIRCODE", created: false });
 
     const { onMessage, listener, sock } = await openInboxMonitor();
 
@@ -154,14 +151,10 @@ describe("web monitor inbox", () => {
     });
 
     sock.ev.emit("messages.upsert", upsertBlocked);
-    await vi.waitFor(
-      () => {
-        expect(sock.sendMessage).toHaveBeenCalledTimes(1);
-      },
-      { timeout: 5_000, interval: 5 },
-    );
+    await settleInboundWork();
     expect(onMessage).not.toHaveBeenCalled();
-    expectPairingPromptSent(sock, "999@s.whatsapp.net", "+999");
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+    expect(sock.sendMessage).not.toHaveBeenCalled();
 
     const upsertBlockedAgain = buildNotifyMessageUpsert({
       id: "no-config-1b",
@@ -173,7 +166,7 @@ describe("web monitor inbox", () => {
     sock.ev.emit("messages.upsert", upsertBlockedAgain);
     await settleInboundWork();
     expect(onMessage).not.toHaveBeenCalled();
-    expect(sock.sendMessage).toHaveBeenCalledTimes(1);
+    expect(sock.sendMessage).not.toHaveBeenCalled();
 
     // Message from self should be allowed
     const upsertSelf = buildNotifyMessageUpsert({
@@ -194,6 +187,39 @@ describe("web monitor inbox", () => {
         to: "+123",
       }),
     );
+
+    await listener.close();
+  });
+
+  it("still sends pairing replies when dmPolicy is explicitly pairing", async () => {
+    mockLoadConfig.mockReturnValue({
+      channels: {
+        whatsapp: {
+          dmPolicy: "pairing",
+        },
+      },
+      messages: DEFAULT_MESSAGES_CFG,
+    });
+    upsertPairingRequestMock.mockResolvedValueOnce({ code: "PAIRCODE", created: true });
+
+    const { onMessage, listener, sock } = await openInboxMonitor();
+    const upsertBlocked = buildNotifyMessageUpsert({
+      id: "pairing-1",
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: nowSeconds(),
+    });
+
+    sock.ev.emit("messages.upsert", upsertBlocked);
+    await vi.waitFor(
+      () => {
+        expect(sock.sendMessage).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 5_000, interval: 5 },
+    );
+
+    expect(onMessage).not.toHaveBeenCalled();
+    expectPairingPromptSent(sock, "999@s.whatsapp.net", "+999");
 
     await listener.close();
   });
@@ -337,7 +363,7 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
-  it("handles append messages by marking them read but skipping auto-reply", async () => {
+  it("skips stale append messages before normalization and auto-reply", async () => {
     const { onMessage, listener, sock } = await openInboxMonitor();
     const staleTs = Math.floor(Date.now() / 1000) - 300;
 
@@ -358,21 +384,9 @@ describe("web monitor inbox", () => {
     };
 
     sock.ev.emit("messages.upsert", upsert);
-    await vi.waitFor(
-      () => {
-        expect(sock.readMessages).toHaveBeenCalledWith([
-          {
-            remoteJid: "999@s.whatsapp.net",
-            id: "history1",
-            participant: undefined,
-            fromMe: false,
-          },
-        ]);
-      },
-      { timeout: 5_000, interval: 5 },
-    );
+    await settleInboundWork();
 
-    // Verify it WAS NOT passed to onMessage
+    expect(sock.readMessages).not.toHaveBeenCalled();
     expect(onMessage).not.toHaveBeenCalled();
 
     await listener.close();

--- a/extensions/whatsapp/src/monitor-inbox.append-upsert.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.append-upsert.test.ts
@@ -1,6 +1,8 @@
 import "./monitor-inbox.test-harness.js";
 import { describe, expect, it, vi } from "vitest";
 import {
+  mockLoadConfig,
+  upsertPairingRequestMock,
   installWebMonitorInboxUnitTestHooks,
   settleInboundWork,
   startInboxMonitor,
@@ -103,6 +105,38 @@ describe("append upsert handling (#20952)", () => {
     await waitForMessageCalls(onMessage, 1);
 
     expect(onMessage).toHaveBeenCalledTimes(1);
+
+    await listener.close();
+  });
+
+  it("does not send pairing replies for recent append DMs", async () => {
+    mockLoadConfig.mockReturnValue({
+      channels: {
+        whatsapp: {
+          dmPolicy: "pairing",
+        },
+      },
+    });
+    const onMessage = vi.fn(async () => {});
+    const { listener, sock } = await startInboxMonitor(onMessage);
+
+    const recentTs = Math.floor(Date.now() / 1000) - 5;
+    sock.ev.emit("messages.upsert", {
+      type: "append",
+      messages: [
+        {
+          key: { id: "append-dm-1", fromMe: false, remoteJid: "999@s.whatsapp.net" },
+          message: { conversation: "hello from history" },
+          messageTimestamp: recentTs,
+          pushName: "HistoryUser",
+        },
+      ],
+    });
+    await settleInboundWork();
+
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+    expect(sock.sendMessage).not.toHaveBeenCalled();
 
     await listener.close();
   });

--- a/extensions/whatsapp/src/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts
@@ -88,6 +88,7 @@ describe("web monitor inbox", () => {
       channels: {
         whatsapp: {
           // Only allow +111
+          dmPolicy: "pairing",
           allowFrom: ["+111"],
         },
       },

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -121,7 +121,7 @@ function expectInboxPairingReplyText(
   text: string,
   params: {
     channel: string;
-    idLine: string;
+    idLine?: string;
     code?: string;
   },
 ): string {
@@ -129,7 +129,9 @@ function expectInboxPairingReplyText(
   expect(code).toBeDefined();
   const resolvedCode = params.code ?? code ?? "";
   expect(text).toContain("OpenClaw: access not configured.");
-  expect(text).toContain(params.idLine);
+  if (params.idLine) {
+    expect(text).toContain(params.idLine);
+  }
   expect(text).toContain("Pairing code:");
   expect(text).toContain(`\n\`\`\`\n${resolvedCode}\n\`\`\`\n`);
   expect(text).toContain(`pairing approve ${params.channel} ${resolvedCode}`);
@@ -200,14 +202,12 @@ export function expectPairingPromptSent(sock: MockSock, jid: string, senderE164:
   expect(sock.sendMessage).toHaveBeenCalledTimes(1);
   const sendCall = sock.sendMessage.mock.calls[0];
   expect(sendCall?.[0]).toBe(jid);
-  expectInboxPairingReplyText(
-    String((sendCall?.[1] as { text?: string } | undefined)?.text ?? ""),
-    {
-      channel: "whatsapp",
-      idLine: `Your WhatsApp phone number: ${senderE164}`,
-      code: "PAIRCODE",
-    },
-  );
+  const text = String((sendCall?.[1] as { text?: string } | undefined)?.text ?? "");
+  expectInboxPairingReplyText(text, {
+    channel: "whatsapp",
+    code: "PAIRCODE",
+  });
+  expect(text).not.toContain(senderE164);
 }
 
 let authDir: string | undefined;

--- a/extensions/whatsapp/src/setup-surface.ts
+++ b/extensions/whatsapp/src/setup-surface.ts
@@ -144,7 +144,7 @@ async function promptWhatsAppDmAccess(params: {
   forceAllowFrom: boolean;
   prompter: Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0]["prompter"];
 }): Promise<OpenClawConfig> {
-  const existingPolicy = params.cfg.channels?.whatsapp?.dmPolicy ?? "pairing";
+  const existingPolicy = params.cfg.channels?.whatsapp?.dmPolicy ?? "silent";
   const existingAllowFrom = params.cfg.channels?.whatsapp?.allowFrom ?? [];
   const existingLabel = existingAllowFrom.length > 0 ? existingAllowFrom.join(", ") : "unset";
 
@@ -161,7 +161,8 @@ async function promptWhatsAppDmAccess(params: {
   await params.prompter.note(
     [
       "WhatsApp direct chats are gated by `channels.whatsapp.dmPolicy` + `channels.whatsapp.allowFrom`.",
-      "- pairing (default): unknown senders get a pairing code; owner approves",
+      "- silent (default): unknown senders are blocked with no reply",
+      "- pairing: unknown senders get a pairing code; owner approves",
       "- allowlist: unknown senders are blocked",
       '- open: public inbound DMs (requires allowFrom to include "*")',
       "- disabled: ignore WhatsApp DMs",
@@ -196,7 +197,8 @@ async function promptWhatsAppDmAccess(params: {
   const policy = (await params.prompter.select({
     message: "WhatsApp DM policy",
     options: [
-      { value: "pairing", label: "Pairing (recommended)" },
+      { value: "silent", label: "Silent (recommended)" },
+      { value: "pairing", label: "Pairing (opt-in)" },
       { value: "allowlist", label: "Allowlist only (block unknown senders)" },
       { value: "open", label: "Open (public inbound DMs)" },
       { value: "disabled", label: "Disabled (ignore WhatsApp DMs)" },

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -363,7 +363,10 @@ async function processMessage(
     config,
   );
   const storeAllowFrom =
-    !isGroup && dmPolicy !== "allowlist" && (dmPolicy !== "open" || shouldComputeCommandAuth)
+    !isGroup &&
+    dmPolicy !== "allowlist" &&
+    dmPolicy !== "silent" &&
+    (dmPolicy !== "open" || shouldComputeCommandAuth)
       ? await pairing.readAllowFromStore().catch(() => [])
       : [];
   const accessDecision = resolveDmGroupAccessWithLists({

--- a/extensions/zalouser/src/types.ts
+++ b/extensions/zalouser/src/types.ts
@@ -99,7 +99,7 @@ type ZalouserSharedConfig = {
   name?: string;
   profile?: string;
   dangerouslyAllowNameMatching?: boolean;
-  dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
+  dmPolicy?: "pairing" | "allowlist" | "open" | "silent" | "disabled";
   allowFrom?: Array<string | number>;
   historyLimit?: number;
   groupAllowFrom?: Array<string | number>;

--- a/src/channels/allow-from.ts
+++ b/src/channels/allow-from.ts
@@ -3,7 +3,10 @@ export function mergeDmAllowFromSources(params: {
   storeAllowFrom?: Array<string | number>;
   dmPolicy?: string;
 }): string[] {
-  const storeEntries = params.dmPolicy === "allowlist" ? [] : (params.storeAllowFrom ?? []);
+  const storeEntries =
+    params.dmPolicy === "allowlist" || params.dmPolicy === "silent"
+      ? []
+      : (params.storeAllowFrom ?? []);
   return [...(params.allowFrom ?? []), ...storeEntries]
     .map((value) => String(value).trim())
     .filter(Boolean);

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -100,7 +100,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         dmPolicy: {
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -308,7 +308,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -879,19 +879,12 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         dmPolicy: {
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
           items: {
-            anyOf: [
-              {
-                type: "string",
-              },
-              {
-                type: "number",
-              },
-            ],
+            type: "string",
           },
         },
         defaultTo: {
@@ -905,19 +898,12 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             },
             policy: {
               type: "string",
-              enum: ["pairing", "allowlist", "open", "disabled"],
+              enum: ["silent", "pairing", "allowlist", "open", "disabled"],
             },
             allowFrom: {
               type: "array",
               items: {
-                anyOf: [
-                  {
-                    type: "string",
-                  },
-                  {
-                    type: "number",
-                  },
-                ],
+                type: "string",
               },
             },
             groupEnabled: {
@@ -926,14 +912,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             groupChannels: {
               type: "array",
               items: {
-                anyOf: [
-                  {
-                    type: "string",
-                  },
-                  {
-                    type: "number",
-                  },
-                ],
+                type: "string",
               },
             },
           },
@@ -1017,27 +996,13 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               users: {
                 type: "array",
                 items: {
-                  anyOf: [
-                    {
-                      type: "string",
-                    },
-                    {
-                      type: "number",
-                    },
-                  ],
+                  type: "string",
                 },
               },
               roles: {
                 type: "array",
                 items: {
-                  anyOf: [
-                    {
-                      type: "string",
-                    },
-                    {
-                      type: "number",
-                    },
-                  ],
+                  type: "string",
                 },
               },
               channels: {
@@ -1123,27 +1088,13 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                     users: {
                       type: "array",
                       items: {
-                        anyOf: [
-                          {
-                            type: "string",
-                          },
-                          {
-                            type: "number",
-                          },
-                        ],
+                        type: "string",
                       },
                     },
                     roles: {
                       type: "array",
                       items: {
-                        anyOf: [
-                          {
-                            type: "string",
-                          },
-                          {
-                            type: "number",
-                          },
-                        ],
+                        type: "string",
                       },
                     },
                     systemPrompt: {
@@ -1224,14 +1175,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             approvers: {
               type: "array",
               items: {
-                anyOf: [
-                  {
-                    type: "string",
-                  },
-                  {
-                    type: "number",
-                  },
-                ],
+                type: "string",
               },
             },
             agentFilter: {
@@ -2087,19 +2031,12 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
                 items: {
-                  anyOf: [
-                    {
-                      type: "string",
-                    },
-                    {
-                      type: "number",
-                    },
-                  ],
+                  type: "string",
                 },
               },
               defaultTo: {
@@ -2113,19 +2050,12 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   },
                   policy: {
                     type: "string",
-                    enum: ["pairing", "allowlist", "open", "disabled"],
+                    enum: ["silent", "pairing", "allowlist", "open", "disabled"],
                   },
                   allowFrom: {
                     type: "array",
                     items: {
-                      anyOf: [
-                        {
-                          type: "string",
-                        },
-                        {
-                          type: "number",
-                        },
-                      ],
+                      type: "string",
                     },
                   },
                   groupEnabled: {
@@ -2134,14 +2064,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   groupChannels: {
                     type: "array",
                     items: {
-                      anyOf: [
-                        {
-                          type: "string",
-                        },
-                        {
-                          type: "number",
-                        },
-                      ],
+                      type: "string",
                     },
                   },
                 },
@@ -2225,27 +2148,13 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                     users: {
                       type: "array",
                       items: {
-                        anyOf: [
-                          {
-                            type: "string",
-                          },
-                          {
-                            type: "number",
-                          },
-                        ],
+                        type: "string",
                       },
                     },
                     roles: {
                       type: "array",
                       items: {
-                        anyOf: [
-                          {
-                            type: "string",
-                          },
-                          {
-                            type: "number",
-                          },
-                        ],
+                        type: "string",
                       },
                     },
                     channels: {
@@ -2331,27 +2240,13 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                           users: {
                             type: "array",
                             items: {
-                              anyOf: [
-                                {
-                                  type: "string",
-                                },
-                                {
-                                  type: "number",
-                                },
-                              ],
+                              type: "string",
                             },
                           },
                           roles: {
                             type: "array",
                             items: {
-                              anyOf: [
-                                {
-                                  type: "string",
-                                },
-                                {
-                                  type: "number",
-                                },
-                              ],
+                              type: "string",
                             },
                           },
                           systemPrompt: {
@@ -2432,14 +2327,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   approvers: {
                     type: "array",
                     items: {
-                      anyOf: [
-                        {
-                          type: "string",
-                        },
-                        {
-                          type: "number",
-                        },
-                      ],
+                      type: "string",
                     },
                   },
                   agentFilter: {
@@ -4592,7 +4480,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             policy: {
               default: "pairing",
               type: "string",
-              enum: ["pairing", "allowlist", "open", "disabled"],
+              enum: ["silent", "pairing", "allowlist", "open", "disabled"],
             },
             allowFrom: {
               type: "array",
@@ -4974,7 +4862,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   policy: {
                     default: "pairing",
                     type: "string",
-                    enum: ["pairing", "allowlist", "open", "disabled"],
+                    enum: ["silent", "pairing", "allowlist", "open", "disabled"],
                   },
                   allowFrom: {
                     type: "array",
@@ -5087,7 +4975,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -5363,7 +5251,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -5677,7 +5565,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -5963,7 +5851,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -6836,7 +6724,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             },
             policy: {
               type: "string",
-              enum: ["pairing", "allowlist", "open", "disabled"],
+              enum: ["silent", "pairing", "allowlist", "open", "disabled"],
             },
             allowFrom: {
               type: "array",
@@ -6864,6 +6752,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           additionalProperties: {
             type: "object",
             properties: {
+              account: {
+                type: "string",
+              },
               enabled: {
                 type: "boolean",
               },
@@ -6943,6 +6834,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           additionalProperties: {
             type: "object",
             properties: {
+              account: {
+                type: "string",
+              },
               enabled: {
                 type: "boolean",
               },
@@ -7169,7 +7063,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -7450,7 +7344,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -7746,7 +7640,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -8237,7 +8131,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         webhookPort: {
           type: "integer",
@@ -8568,7 +8462,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               webhookPort: {
                 type: "integer",
@@ -8843,7 +8737,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         dmPolicy: {
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -9340,7 +9234,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -9652,7 +9546,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -10551,7 +10445,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         dmPolicy: {
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -10577,7 +10471,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             },
             policy: {
               type: "string",
-              enum: ["pairing", "allowlist", "open", "disabled"],
+              enum: ["silent", "pairing", "allowlist", "open", "disabled"],
             },
             allowFrom: {
               type: "array",
@@ -11397,7 +11291,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -11423,7 +11317,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   },
                   policy: {
                     type: "string",
-                    enum: ["pairing", "allowlist", "open", "disabled"],
+                    enum: ["silent", "pairing", "allowlist", "open", "disabled"],
                   },
                   allowFrom: {
                     type: "array",
@@ -11869,7 +11763,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         botToken: {
           anyOf: [
@@ -12203,7 +12097,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             properties: {
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               tools: {
                 type: "object",
@@ -12865,7 +12759,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               botToken: {
                 anyOf: [
@@ -13199,7 +13093,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   properties: {
                     dmPolicy: {
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
+                      enum: ["silent", "pairing", "allowlist", "open", "disabled"],
                     },
                     tools: {
                       type: "object",
@@ -14272,9 +14166,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           type: "string",
         },
         dmPolicy: {
-          default: "pairing",
+          default: "silent",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         selfChatMode: {
           type: "boolean",
@@ -14521,9 +14415,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                 type: "string",
               },
               dmPolicy: {
-                default: "pairing",
+                default: "silent",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               selfChatMode: {
                 type: "boolean",
@@ -14781,7 +14675,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
       },
       dmPolicy: {
         label: "WhatsApp DM Policy",
-        help: 'Direct message access control ("pairing" recommended). "open" requires channels.whatsapp.allowFrom=["*"].',
+        help: 'Direct message access control ("silent" default, "pairing" opt-in). "open" requires channels.whatsapp.allowFrom=["*"].',
       },
       selfChatMode: {
         label: "WhatsApp Self-Phone Mode",
@@ -14965,7 +14859,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         dmPolicy: {
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -15171,7 +15065,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -15256,7 +15150,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         dmPolicy: {
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
+          enum: ["silent", "pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -15373,7 +15267,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
+                enum: ["silent", "pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",

--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -382,7 +382,7 @@ describe("legacy config detection", () => {
       expect(res.ok, provider).toBe(true);
       if (res.ok) {
         const channel = getChannelConfig(res.config, provider);
-        expect(channel?.dmPolicy, provider).toBe("pairing");
+        expect(channel?.dmPolicy, provider).toBe(provider === "whatsapp" ? "silent" : "pairing");
         expect(channel?.groupPolicy, provider).toBe("allowlist");
         if (provider === "telegram") {
           expect(channel?.streaming, provider).toBe("partial");

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -6,7 +6,7 @@ export type SessionScope = "per-sender" | "global";
 export type DmScope = "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
 export type ReplyToMode = "off" | "first" | "all";
 export type GroupPolicy = "open" | "disabled" | "allowlist";
-export type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";
+export type DmPolicy = "silent" | "pairing" | "allowlist" | "open" | "disabled";
 
 export type OutboundRetryConfig = {
   /** Max retry attempts for outbound requests (default: 3). */

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -44,7 +44,7 @@ export type WhatsAppAckReactionConfig = {
 type WhatsAppSharedConfig = {
   /** Whether the WhatsApp channel is enabled. */
   enabled?: boolean;
-  /** Direct message access policy (default: pairing). */
+  /** Direct message access policy (default: silent). */
   dmPolicy?: DmPolicy;
   /** Same-phone setup (bot uses your personal WhatsApp number). */
   selfChatMode?: boolean;

--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -28,7 +28,7 @@ describe("config validation allowed-values metadata", () => {
       expect(issue).toBeDefined();
       expect(issue?.message).toContain("expected one of");
       expect(issue?.message).not.toContain("(allowed:");
-      expect(issue?.allowedValues).toEqual(["pairing", "allowlist", "open", "disabled"]);
+      expect(issue?.allowedValues).toEqual(["silent", "pairing", "allowlist", "open", "disabled"]);
       expect(issue?.allowedValuesHiddenCount).toBe(0);
     }
   });

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -335,7 +335,7 @@ export const TypingModeSchema = z.union([
 //   - .default("allowlist") ensures runtime always resolves to "allowlist" if not provided
 export const GroupPolicySchema = z.enum(["open", "disabled", "allowlist"]);
 
-export const DmPolicySchema = z.enum(["pairing", "allowlist", "open", "disabled"]);
+export const DmPolicySchema = z.enum(["silent", "pairing", "allowlist", "open", "disabled"]);
 
 export const BlockStreamingCoalesceSchema = z
   .object({

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -42,7 +42,7 @@ const WhatsAppSharedSchema = z.object({
   sendReadReceipts: z.boolean().optional(),
   messagePrefix: z.string().optional(),
   responsePrefix: z.string().optional(),
-  dmPolicy: DmPolicySchema.optional().default("pairing"),
+  dmPolicy: DmPolicySchema.optional().default("silent"),
   selfChatMode: z.boolean().optional(),
   allowFrom: z.array(z.string()).optional(),
   defaultTo: z.string().optional(),

--- a/src/pairing/pairing-challenge.ts
+++ b/src/pairing/pairing-challenge.ts
@@ -5,14 +5,14 @@ type PairingMeta = Record<string, string | undefined>;
 export type PairingChallengeParams = {
   channel: string;
   senderId: string;
-  senderIdLine: string;
+  senderIdLine?: string;
   meta?: PairingMeta;
   upsertPairingRequest: (params: {
     id: string;
     meta?: PairingMeta;
   }) => Promise<{ code: string; created: boolean }>;
   sendPairingReply: (text: string) => Promise<void>;
-  buildReplyText?: (params: { code: string; senderIdLine: string }) => string;
+  buildReplyText?: (params: { code: string; senderIdLine?: string }) => string;
   onCreated?: (params: { code: string }) => void;
   onReplyError?: (err: unknown) => void;
 };

--- a/src/pairing/pairing-messages.test.ts
+++ b/src/pairing/pairing-messages.test.ts
@@ -44,7 +44,6 @@ describe("buildPairingReply", () => {
     },
     {
       channel: "whatsapp",
-      idLine: "Your WhatsApp phone number: +15550003333",
       code: "MNO345",
     },
   ] as const;
@@ -64,5 +63,14 @@ describe("buildPairingReply", () => {
 
   it.each(pairingReplyCases)("formats pairing reply for $channel", (testCase) => {
     expectProfileAwarePairingReply(testCase);
+  });
+
+  it("omits the identifier line when it is not provided", () => {
+    const text = buildPairingReply({
+      channel: "whatsapp",
+      code: "MNO345",
+    });
+    expect(text).not.toContain("Your WhatsApp phone number:");
+    expectPairingApproveCommand(text, { channel: "whatsapp", code: "MNO345" });
   });
 });

--- a/src/pairing/pairing-messages.ts
+++ b/src/pairing/pairing-messages.ts
@@ -3,7 +3,7 @@ import type { PairingChannel } from "./pairing-store.js";
 
 export function buildPairingReply(params: {
   channel: PairingChannel;
-  idLine: string;
+  idLine?: string;
   code: string;
 }): string {
   const { channel, idLine, code } = params;
@@ -11,7 +11,7 @@ export function buildPairingReply(params: {
   return [
     "OpenClaw: access not configured.",
     "",
-    idLine,
+    ...(idLine ? [idLine] : []),
     "Pairing code:",
     "```",
     code,

--- a/src/plugin-sdk/channel-pairing.test.ts
+++ b/src/plugin-sdk/channel-pairing.test.ts
@@ -68,7 +68,6 @@ describe("createChannelPairingChallengeIssuer", () => {
 
     await issueChallenge({
       senderId: "user-2",
-      senderIdLine: "Your id: user-2",
       sendPairingReply,
     });
 
@@ -77,5 +76,6 @@ describe("createChannelPairingChallengeIssuer", () => {
       meta: undefined,
     });
     expect(replies[0]).toContain("654321");
+    expect(replies[0]).not.toContain("Your id:");
   });
 });

--- a/src/plugin-sdk/command-auth.test.ts
+++ b/src/plugin-sdk/command-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveSenderCommandAuthorization } from "./command-auth.js";
 
@@ -51,5 +51,28 @@ describe("plugin-sdk/command-auth", () => {
       expect(result.effectiveAllowFrom).toEqual(["dm-owner"]);
       expect(result.effectiveGroupAllowFrom).toEqual(["group-owner"]);
     }
+  });
+
+  it("keeps silent DMs strict without pairing-store fallback", async () => {
+    const readAllowFromStore = vi.fn(async () => ["paired-user"]);
+
+    const result = await resolveSenderCommandAuthorization({
+      cfg: baseCfg,
+      rawBody: "/status",
+      isGroup: false,
+      dmPolicy: "silent",
+      configuredAllowFrom: ["dm-owner"],
+      senderId: "paired-user",
+      isSenderAllowed: (senderId, allowFrom) => allowFrom.includes(senderId),
+      readAllowFromStore,
+      shouldComputeCommandAuthorized: () => true,
+      resolveCommandAuthorizedFromAuthorizers: ({ useAccessGroups, authorizers }) =>
+        useAccessGroups && authorizers.some((entry) => entry.configured && entry.allowed),
+    });
+
+    expect(readAllowFromStore).not.toHaveBeenCalled();
+    expect(result.effectiveAllowFrom).toEqual(["dm-owner"]);
+    expect(result.senderAllowedForCommands).toBe(false);
+    expect(result.commandAuthorized).toBe(false);
   });
 });

--- a/src/plugin-sdk/command-auth.ts
+++ b/src/plugin-sdk/command-auth.ts
@@ -161,6 +161,7 @@ export async function resolveSenderCommandAuthorization(
   const storeAllowFrom =
     !params.isGroup &&
     params.dmPolicy !== "allowlist" &&
+    params.dmPolicy !== "silent" &&
     (params.dmPolicy !== "open" || shouldComputeAuth)
       ? await params.readAllowFromStore().catch(() => [])
       : [];

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -20,7 +20,7 @@ describe("security/dm-policy-shared", () => {
   async function expectStoreReadSkipped(params: {
     provider: string;
     accountId: string;
-    dmPolicy?: "open" | "allowlist" | "pairing" | "disabled";
+    dmPolicy?: "silent" | "open" | "allowlist" | "pairing" | "disabled";
     shouldRead?: boolean;
   }) {
     let called = false;
@@ -90,6 +90,14 @@ describe("security/dm-policy-shared", () => {
         provider: "demo-channel-a",
         accountId: "default",
         dmPolicy: "allowlist" as const,
+      },
+    },
+    {
+      name: "dmPolicy is silent",
+      params: {
+        provider: "demo-channel-c",
+        accountId: "default",
+        dmPolicy: "silent" as const,
       },
     },
     {
@@ -185,6 +193,17 @@ describe("security/dm-policy-shared", () => {
     expect(lists.effectiveGroupAllowFrom).toEqual(["group:abc"]);
   });
 
+  it("excludes storeAllowFrom when dmPolicy is silent", () => {
+    const lists = resolveEffectiveAllowFromLists({
+      allowFrom: ["+1111"],
+      groupAllowFrom: ["group:abc"],
+      storeAllowFrom: ["+2222", "+3333"],
+      dmPolicy: "silent",
+    });
+    expect(lists.effectiveAllowFrom).toEqual(["+1111"]);
+    expect(lists.effectiveGroupAllowFrom).toEqual(["group:abc"]);
+  });
+
   it("keeps group allowlist explicit when dmPolicy is pairing", () => {
     const lists = resolveEffectiveAllowFromLists({
       allowFrom: ["+1111"],
@@ -211,6 +230,22 @@ describe("security/dm-policy-shared", () => {
     expect(resolved.reason).toBe("dmPolicy=pairing (allowlisted)");
     expect(resolved.effectiveAllowFrom).toEqual(["owner", "paired-user"]);
     expect(resolved.effectiveGroupAllowFrom).toEqual(["group:room"]);
+  });
+
+  it("blocks unauthorized silent dms without pairing", () => {
+    const resolved = resolveDmGroupAccessWithLists({
+      isGroup: false,
+      dmPolicy: "silent",
+      groupPolicy: "allowlist",
+      allowFrom: ["owner"],
+      groupAllowFrom: ["group:room"],
+      storeAllowFrom: ["paired-user"],
+      isSenderAllowed: () => false,
+    });
+    expect(resolved.decision).toBe("block");
+    expect(resolved.reasonCode).toBe(DM_GROUP_ACCESS_REASON.DM_POLICY_NOT_ALLOWLISTED);
+    expect(resolved.reason).toBe("dmPolicy=silent (not allowlisted)");
+    expect(resolved.effectiveAllowFrom).toEqual(["owner"]);
   });
 
   it("resolves command gate with dm/group parity for groups", () => {

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -330,7 +330,7 @@ describe("security/dm-policy-shared", () => {
   type ParityCase = {
     name: string;
     isGroup: boolean;
-    dmPolicy: "open" | "allowlist" | "pairing" | "disabled";
+    dmPolicy: "open" | "allowlist" | "pairing" | "disabled" | "silent";
     groupPolicy: "open" | "allowlist" | "disabled";
     allowFrom: string[];
     groupAllowFrom: string[];
@@ -396,6 +396,12 @@ describe("security/dm-policy-shared", () => {
         createParityCase({
           name: "dmPolicy=disabled",
           dmPolicy: "disabled",
+          expectedDecision: "block",
+          expectedReactionAllowed: false,
+        }),
+        createParityCase({
+          name: "dmPolicy=silent",
+          dmPolicy: "silent",
           expectedDecision: "block",
           expectedReactionAllowed: false,
         }),

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -92,7 +92,11 @@ export async function readStoreAllowFromForDmPolicy(params: {
   shouldRead?: boolean | null;
   readStore?: (provider: ChannelId, accountId: string) => Promise<string[]>;
 }): Promise<string[]> {
-  if (params.shouldRead === false || params.dmPolicy === "allowlist") {
+  if (
+    params.shouldRead === false ||
+    params.dmPolicy === "allowlist" ||
+    params.dmPolicy === "silent"
+  ) {
     return [];
   }
   const readStore =

--- a/test/helpers/pairing-reply.ts
+++ b/test/helpers/pairing-reply.ts
@@ -10,13 +10,15 @@ export function expectPairingReplyText(
   text: string,
   params: {
     channel: string;
-    idLine: string;
+    idLine?: string;
     code?: string;
   },
 ): string {
   const code = params.code ?? extractPairingCode(text);
   expect(text).toContain("OpenClaw: access not configured.");
-  expect(text).toContain(params.idLine);
+  if (params.idLine) {
+    expect(text).toContain(params.idLine);
+  }
   expect(text).toContain("Pairing code:");
   expect(text).toContain(`\n\`\`\`\n${code}\n\`\`\`\n`);
   expect(text).toContain(`pairing approve ${params.channel} ${code}`);


### PR DESCRIPTION
## Summary
- stop leaking the bot owner's WhatsApp phone number, pairing code, and approval command to unknown senders by default
- change WhatsApp's default `dmPolicy` from `pairing` to `silent`, while preserving explicit `dmPolicy: "pairing"` behavior
- suppress pairing replies for `append` upserts so reconnect history replays never trigger pairing side effects

## What Changed
- added shared `silent` DM policy support in config validation and DM-policy resolution
- made WhatsApp treat unset `dmPolicy` as `silent` and removed the phone-number line from pairing replies
- moved append upsert history gating ahead of inbound normalization and suppressed pairing replies for append-originated events
- updated WhatsApp setup/help surfaces and config metadata to reflect the new default
- added coverage for silent blocking, explicit pairing opt-in, append upsert suppression, and optional pairing identifier rendering

## Testing
- `pnpm exec vitest run src/security/dm-policy-shared.test.ts src/pairing/pairing-messages.test.ts src/plugin-sdk/channel-pairing.test.ts src/config/validation.allowed-values.test.ts extensions/whatsapp/src/inbound/access-control.test.ts extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts extensions/whatsapp/src/monitor-inbox.append-upsert.test.ts`
- `pnpm tsgo`
- `pnpm config:channels:check`
- `pnpm config:docs:check`
