### PR TITLE
fix(cron): add toolsAllow to API schema + merge handler

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1789,6 +1789,19 @@ export async function runEmbeddedAttempt(
             abortSessionForYield?.();
           },
         });
+          if (params.toolsAllow && params.toolsAllow.length > 0) {
+            const allowSet = new Set(params.toolsAllow);
+            const filtered = allTools.filter((tool) => allowSet.has(tool.name));
+            const missing = params.toolsAllow.filter(
+              (name) => !allTools.some((t) => t.name === name),
+            );
+            if (missing.length > 0) {
+              params.log?.(`[toolsAllow] Unknown tool names ignored: ${missing.join(", ")}`);
+            }
+            return filtered;
+          }
+          return allTools;
+        })();
     const toolsEnabled = supportsModelTools(params.model);
     const tools = sanitizeToolsForGoogle({
       tools: toolsEnabled ? toolsRaw : [],

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -704,6 +704,11 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   if (typeof patch.bestEffortDeliver === "boolean") {
     next.bestEffortDeliver = patch.bestEffortDeliver;
   }
+  if (Array.isArray(patch.toolsAllow)) {
+    next.toolsAllow = patch.toolsAllow.length > 0 ? patch.toolsAllow : undefined;
+  } else if ((patch as Record<string, unknown>).toolsAllow === null) {
+    delete next.toolsAllow;
+  }
   return next;
 }
 

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -12,6 +12,7 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
       timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
       lightContext: Type.Optional(Type.Boolean()),
+      toolsAllow: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()])),
       deliver: Type.Optional(Type.Boolean()),
       channel: Type.Optional(Type.String()),
       to: Type.Optional(Type.String()),


### PR DESCRIPTION
Follow-up to #58504. Fixes three issues from Greptile review:

1. **API schema rejects toolsAllow** — cronAgentTurnPayloadSchema in schema/cron.ts has additionalProperties: false but was missing toolsAllow. Both cron add and cron edit fail with 'unexpected property toolsAllow'.

2. **mergeCronPayload drops toolsAllow on edit** — jobs.ts handles every field in CronAgentTurnPayloadFields except toolsAllow. Added array/null handling.

3. **No warning for unknown tool names** — A typo like --tools exec2 silently produces an empty tool set. Added a log warning when allow-listed names don't match any known tool.