### PR TITLE
fix(msteams): prevent duplicate text when stream exceeds 4000 char limit

### DIFF
--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -5,6 +5,8 @@ const streamInstances = vi.hoisted(
     [] as Array<{
       hasContent: boolean;
       isFinalized: boolean;
+      isFailed: boolean;
+      streamedLength: number;
       sendInformativeUpdate: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
       finalize: ReturnType<typeof vi.fn>;
@@ -15,9 +17,15 @@ vi.mock("./streaming-message.js", () => ({
   TeamsHttpStream: class {
     hasContent = false;
     isFinalized = false;
+    isFailed = false;
+    streamedLength = 0;
     sendInformativeUpdate = vi.fn(async () => {});
-    update = vi.fn(function (this: { hasContent: boolean }) {
+    update = vi.fn(function (
+      this: { hasContent: boolean; streamedLength: number },
+      payloadText?: string,
+    ) {
       this.hasContent = true;
+      this.streamedLength = payloadText?.length ?? 0;
     });
     finalize = vi.fn(async function (this: { isFinalized: boolean }) {
       this.isFinalized = true;
@@ -48,6 +56,34 @@ describe("createTeamsReplyStreamController", () => {
 
     const result = ctrl.preparePayload({ text: "Hello world" });
     expect(result).toBeUndefined();
+  });
+
+  it("when stream fails after partial delivery, fallback sends only remaining text", () => {
+    const ctrl = createController();
+    const fullText = "a".repeat(4000) + "b".repeat(200);
+
+    ctrl.onPartialReply({ text: fullText });
+    streamInstances[0]!.hasContent = false;
+    streamInstances[0]!.isFailed = true;
+    streamInstances[0]!.isFinalized = true;
+    streamInstances[0]!.streamedLength = 4000;
+
+    const result = ctrl.preparePayload({ text: fullText });
+    expect(result).toEqual({ text: "b".repeat(200) });
+  });
+
+  it("when stream fails before sending content, fallback sends full text", () => {
+    const ctrl = createController();
+    const fullText = "Failure at first chunk";
+
+    ctrl.onPartialReply({ text: fullText });
+    streamInstances[0]!.hasContent = false;
+    streamInstances[0]!.isFailed = true;
+    streamInstances[0]!.isFinalized = true;
+    streamInstances[0]!.streamedLength = 0;
+
+    const result = ctrl.preparePayload({ text: fullText });
+    expect(result).toEqual({ text: fullText });
   });
 
   it("allows fallback delivery for second text segment after tool calls", () => {

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -55,17 +55,44 @@ export function createTeamsReplyStreamController(params: {
     },
 
     preparePayload(payload: ReplyPayload): ReplyPayload | undefined {
-      if (!stream || !streamReceivedTokens || !stream.hasContent || stream.isFinalized) {
+      if (!stream || !streamReceivedTokens) {
         return payload;
       }
 
-      // Stream handled this text segment — finalize it and reset so any
+      const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
+
+      // Stream failed after partial delivery (e.g. > 4000 chars). Send only
+      // the unstreamed suffix via block delivery to avoid duplicate text.
+      if (stream.isFailed) {
+        streamReceivedTokens = false;
+
+        if (!payload.text) {
+          return payload;
+        }
+
+        const streamedLength = stream.streamedLength;
+        if (streamedLength <= 0) {
+          return payload;
+        }
+
+        const remainingText = payload.text.slice(streamedLength);
+        if (!remainingText) {
+          return hasMedia ? { ...payload, text: undefined } : undefined;
+        }
+
+        return { ...payload, text: remainingText };
+      }
+
+      if (!stream.hasContent || stream.isFinalized) {
+        return payload;
+      }
+
+      // Stream handled this text segment. Finalize it and reset so any
       // subsequent text segments (after tool calls) use fallback delivery.
       // finalize() is idempotent; the later call in markDispatchIdle is a no-op.
       streamReceivedTokens = false;
       pendingFinalize = stream.finalize();
 
-      const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
       if (!hasMedia) {
         return undefined;
       }

--- a/extensions/msteams/src/streaming-message.ts
+++ b/extensions/msteams/src/streaming-message.ts
@@ -214,6 +214,16 @@ export class TeamsHttpStream {
     return this.accumulatedText.length > 0 && !this.streamFailed;
   }
 
+  /** Whether streaming failed and fallback delivery is needed. */
+  get isFailed(): boolean {
+    return this.streamFailed;
+  }
+
+  /** Number of characters successfully streamed before failure. */
+  get streamedLength(): number {
+    return this.lastStreamedText.length;
+  }
+
   /** Whether the stream has been finalized. */
   get isFinalized(): boolean {
     return this.finalized;


### PR DESCRIPTION
When a streamed response exceeds `TEAMS_MAX_CHARS` (4000), the stream sets `streamFailed = true` and finalizes. However, `hasContent` returns `false` when `streamFailed` is true, which causes `preparePayload` in the reply stream controller to pass through the full payload for block delivery and duplicate already streamed text.

This fix adds stream failure metadata (failed flag and streamed length) and updates fallback payload preparation to trim the already streamed prefix when streaming failed mid delivery. If the streamed prefix covers the full text, fallback delivery is suppressed. If no content was streamed before failure, full block delivery is preserved.

Fixes #58601

---
Test plan:
- Existing normal streaming path unchanged: streamed first segment is suppressed from fallback, later segments after tool calls still use fallback
- Added: stream fails after partial delivery (4000 chars), fallback sends only remaining suffix
- Added: stream fails before sending any content, fallback sends full text
- Existing stream completion behavior remains: no duplicate block delivery for successfully streamed segment