### PR TITLE
feat(skills): notify agents of available updates via skill preambles

### DIFF
--- a/.agents/skills/openclaw-ghsa-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-ghsa-maintainer/SKILL.md
@@ -3,6 +3,12 @@ name: openclaw-ghsa-maintainer
 description: Maintainer workflow for OpenClaw GitHub Security Advisories (GHSA). Use when Codex needs to inspect, patch, validate, or publish a repo advisory, verify private-fork state, prepare advisory Markdown or JSON payloads safely, handle GHSA API-specific publish constraints, or confirm advisory publish success.
 ---
 
+```bash
+# preamble: check for openclaw updates (reads cached state, no network call)
+_UPD=$(openclaw update hint 2>/dev/null || true)
+[ -n "$_UPD" ] && echo "$_UPD" || true
+```
+
 # OpenClaw GHSA Maintainer
 
 Use this skill for repo security advisory workflow only. Keep general release work in `openclaw-release-maintainer`.

--- a/.agents/skills/openclaw-parallels-smoke/SKILL.md
+++ b/.agents/skills/openclaw-parallels-smoke/SKILL.md
@@ -3,6 +3,12 @@ name: openclaw-parallels-smoke
 description: End-to-end Parallels smoke, upgrade, and rerun workflow for OpenClaw across macOS, Windows, and Linux guests. Use when Codex needs to run, rerun, debug, or interpret VM-based install, onboarding, gateway smoke tests, latest-release-to-main upgrade checks, fresh snapshot retests, or optional Discord roundtrip verification under Parallels.
 ---
 
+```bash
+# preamble: check for openclaw updates (reads cached state, no network call)
+_UPD=$(openclaw update hint 2>/dev/null || true)
+[ -n "$_UPD" ] && echo "$_UPD" || true
+```
+
 # OpenClaw Parallels Smoke
 
 Use this skill for Parallels guest workflows and smoke interpretation. Do not load it for normal repo work.

--- a/.agents/skills/openclaw-pr-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-pr-maintainer/SKILL.md
@@ -3,6 +3,12 @@ name: openclaw-pr-maintainer
 description: Maintainer workflow for reviewing, triaging, preparing, closing, or landing OpenClaw pull requests and related issues. Use when Codex needs to validate bug-fix claims, search for related issues or PRs, apply or recommend close/reason labels, prepare GitHub comments safely, check review-thread follow-up, or perform maintainer-style PR decision making before merge or closure.
 ---
 
+```bash
+# preamble: check for openclaw updates (reads cached state, no network call)
+_UPD=$(openclaw update hint 2>/dev/null || true)
+[ -n "$_UPD" ] && echo "$_UPD" || true
+```
+
 # OpenClaw PR Maintainer
 
 Use this skill for maintainer-facing GitHub workflow, not for ordinary code changes.

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -3,6 +3,12 @@ name: openclaw-release-maintainer
 description: Maintainer workflow for OpenClaw releases, prereleases, changelog release notes, and publish validation. Use when Codex needs to prepare or verify stable or beta release steps, align version naming, assemble release notes, check release auth requirements, or validate publish-time commands and artifacts.
 ---
 
+```bash
+# preamble: check for openclaw updates (reads cached state, no network call)
+_UPD=$(openclaw update hint 2>/dev/null || true)
+[ -n "$_UPD" ] && echo "$_UPD" || true
+```
+
 # OpenClaw Release Maintainer
 
 Use this skill for release and publish-time workflow. Keep ordinary development changes and GHSA-specific advisory work outside this skill.

--- a/.agents/skills/openclaw-test-heap-leaks/SKILL.md
+++ b/.agents/skills/openclaw-test-heap-leaks/SKILL.md
@@ -3,6 +3,12 @@ name: openclaw-test-heap-leaks
 description: Investigate `pnpm test` memory growth, Vitest worker OOMs, and suspicious RSS increases in OpenClaw using the `scripts/test-parallel.mjs` heap snapshot tooling. Use when Codex needs to reproduce test-lane memory growth, collect repeated `.heapsnapshot` files, compare snapshots from the same worker PID, triage likely transformed-module retention versus likely runtime leaks, and fix or reduce the impact by patching cleanup logic or isolating hotspot tests.
 ---
 
+```bash
+# preamble: check for openclaw updates (reads cached state, no network call)
+_UPD=$(openclaw update hint 2>/dev/null || true)
+[ -n "$_UPD" ] && echo "$_UPD" || true
+```
+
 # OpenClaw Test Heap Leaks
 
 Use this skill for test-memory investigations. Do not guess from RSS alone when heap snapshots are available. Treat snapshot-name deltas as triage evidence, not proof, until retainers or dominators support the call.

--- a/.agents/skills/parallels-discord-roundtrip/SKILL.md
+++ b/.agents/skills/parallels-discord-roundtrip/SKILL.md
@@ -3,6 +3,12 @@ name: parallels-discord-roundtrip
 description: Run the macOS Parallels smoke harness with Discord end-to-end roundtrip verification, including guest send, host verification, host reply, and guest readback.
 ---
 
+```bash
+# preamble: check for openclaw updates (reads cached state, no network call)
+_UPD=$(openclaw update hint 2>/dev/null || true)
+[ -n "$_UPD" ] && echo "$_UPD" || true
+```
+
 # Parallels Discord Roundtrip
 
 Use when macOS Parallels smoke must prove Discord two-way delivery end to end.

--- a/.agents/skills/security-triage/SKILL.md
+++ b/.agents/skills/security-triage/SKILL.md
@@ -3,6 +3,12 @@ name: security-triage
 description: Triage GitHub security advisories for OpenClaw with high-confidence close/keep decisions, exact tag and commit verification, trust-model checks, optional hardening notes, and a final reply ready to post and copy to clipboard.
 ---
 
+```bash
+# preamble: check for openclaw updates (reads cached state, no network call)
+_UPD=$(openclaw update hint 2>/dev/null || true)
+[ -n "$_UPD" ] && echo "$_UPD" || true
+```
+
 # Security Triage
 
 Use when reviewing OpenClaw security advisories, drafts, or GHSA reports.

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -4,6 +4,7 @@ import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
 import { inheritOptionFromParent } from "./command-options.js";
 import { formatHelpExamples } from "./help-format.js";
+import { type UpdateHintOptions, updateHintCommand } from "./update-cli/hint.js";
 import {
   type UpdateCommandOptions,
   type UpdateStatusOptions,
@@ -13,8 +14,8 @@ import { updateStatusCommand } from "./update-cli/status.js";
 import { updateCommand } from "./update-cli/update-command.js";
 import { updateWizardCommand } from "./update-cli/wizard.js";
 
-export { updateCommand, updateStatusCommand, updateWizardCommand };
-export type { UpdateCommandOptions, UpdateStatusOptions, UpdateWizardOptions };
+export { updateCommand, updateHintCommand, updateStatusCommand, updateWizardCommand };
+export type { UpdateCommandOptions, UpdateHintOptions, UpdateStatusOptions, UpdateWizardOptions };
 
 function inheritedUpdateJson(command?: Command): boolean {
   return Boolean(inheritOptionFromParent<boolean>(command, "json"));
@@ -152,6 +153,20 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/up
       } catch (err) {
         defaultRuntime.error(String(err));
         defaultRuntime.exit(1);
+      }
+    });
+
+  update
+    .command("hint")
+    .description("Print a one-liner if an update is available (for agent/skill preambles)")
+    .option("--json", "Output result as JSON", false)
+    .action(async (opts, command) => {
+      try {
+        await updateHintCommand({
+          json: Boolean(opts.json) || inheritedUpdateJson(command),
+        });
+      } catch {
+        // Hint is best-effort — never fail loudly in a preamble context.
       }
     });
 }

--- a/src/cli/update-cli/hint.test.ts
+++ b/src/cli/update-cli/hint.test.ts
@@ -119,6 +119,38 @@ describe("updateHintCommand", () => {
     expect(writeJsonSpy.mock.calls[0]?.[0]).toEqual({ updateAvailable: false });
   });
 
+  it("handles non-string version field gracefully", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "update-check.json"),
+      JSON.stringify({ lastAvailableVersion: 12345 }),
+    );
+    await updateHintCommand({});
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits JSON false when version field is non-string and --json", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "update-check.json"),
+      JSON.stringify({ lastAvailableVersion: { nested: true } }),
+    );
+    await updateHintCommand({ json: true });
+    expect(writeJsonSpy).toHaveBeenCalledOnce();
+    expect(writeJsonSpy.mock.calls[0]?.[0]).toEqual({ updateAvailable: false });
+  });
+
+  it("handles JSON null root gracefully", async () => {
+    await fs.writeFile(path.join(tmpDir, "update-check.json"), "null");
+    await updateHintCommand({});
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits JSON false when root is not an object and --json", async () => {
+    await fs.writeFile(path.join(tmpDir, "update-check.json"), "42");
+    await updateHintCommand({ json: true });
+    expect(writeJsonSpy).toHaveBeenCalledOnce();
+    expect(writeJsonSpy.mock.calls[0]?.[0]).toEqual({ updateAvailable: false });
+  });
+
   it("emits JSON false when already up to date and --json", async () => {
     await fs.writeFile(
       path.join(tmpDir, "update-check.json"),

--- a/src/cli/update-cli/hint.test.ts
+++ b/src/cli/update-cli/hint.test.ts
@@ -112,4 +112,23 @@ describe("updateHintCommand", () => {
     await updateHintCommand({});
     expect(logSpy).not.toHaveBeenCalled();
   });
+
+  it("emits JSON false when no state file and --json", async () => {
+    await updateHintCommand({ json: true });
+    expect(writeJsonSpy).toHaveBeenCalledOnce();
+    expect(writeJsonSpy.mock.calls[0]?.[0]).toEqual({ updateAvailable: false });
+  });
+
+  it("emits JSON false when already up to date and --json", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "update-check.json"),
+      JSON.stringify({
+        lastAvailableVersion: "2026.3.28",
+        lastAvailableTag: "latest",
+      }),
+    );
+    await updateHintCommand({ json: true });
+    expect(writeJsonSpy).toHaveBeenCalledOnce();
+    expect(writeJsonSpy.mock.calls[0]?.[0]).toEqual({ updateAvailable: false });
+  });
 });

--- a/src/cli/update-cli/hint.test.ts
+++ b/src/cli/update-cli/hint.test.ts
@@ -1,0 +1,115 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { updateHintCommand } from "./hint.js";
+
+vi.mock("../../config/paths.js", () => ({
+  resolveStateDir: () => tmpDir,
+}));
+
+vi.mock("../../version.js", () => ({
+  VERSION: "2026.3.28",
+}));
+
+const logSpy = vi.fn<(msg: string) => void>();
+const writeJsonSpy = vi.fn<(data: unknown) => void>();
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: (...args: unknown[]) => logSpy(args[0] as string),
+    writeJson: (...args: unknown[]) => writeJsonSpy(args[0]),
+  },
+}));
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(import.meta.dirname ?? "/tmp", "hint-test-"));
+  logSpy.mockClear();
+  writeJsonSpy.mockClear();
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("updateHintCommand", () => {
+  it("prints nothing when no state file exists", async () => {
+    await updateHintCommand({});
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(writeJsonSpy).not.toHaveBeenCalled();
+  });
+
+  it("prints nothing when state file has no available version", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "update-check.json"),
+      JSON.stringify({ lastCheckedAt: "2026-04-01T00:00:00.000Z" }),
+    );
+    await updateHintCommand({});
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("prints nothing when already up to date", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "update-check.json"),
+      JSON.stringify({
+        lastAvailableVersion: "2026.3.28",
+        lastAvailableTag: "latest",
+      }),
+    );
+    await updateHintCommand({});
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("prints upgrade hint when a newer version is available", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "update-check.json"),
+      JSON.stringify({
+        lastAvailableVersion: "2026.4.1",
+        lastAvailableTag: "latest",
+      }),
+    );
+    await updateHintCommand({});
+    expect(logSpy).toHaveBeenCalledOnce();
+    expect(logSpy.mock.calls[0]?.[0]).toMatch(/UPGRADE_AVAILABLE/);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("2026.3.28");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("2026.4.1");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("openclaw update");
+  });
+
+  it("outputs JSON when --json is passed", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "update-check.json"),
+      JSON.stringify({
+        lastAvailableVersion: "2026.4.1",
+        lastAvailableTag: "beta",
+      }),
+    );
+    await updateHintCommand({ json: true });
+    expect(writeJsonSpy).toHaveBeenCalledOnce();
+    expect(writeJsonSpy.mock.calls[0]?.[0]).toEqual({
+      updateAvailable: true,
+      currentVersion: "2026.3.28",
+      latestVersion: "2026.4.1",
+      channel: "beta",
+    });
+  });
+
+  it("prints nothing when local version is newer", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "update-check.json"),
+      JSON.stringify({
+        lastAvailableVersion: "2026.3.1",
+        lastAvailableTag: "latest",
+      }),
+    );
+    await updateHintCommand({});
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("handles corrupt JSON gracefully", async () => {
+    await fs.writeFile(path.join(tmpDir, "update-check.json"), "not json{{{");
+    await updateHintCommand({});
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/update-cli/hint.ts
+++ b/src/cli/update-cli/hint.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { z } from "zod";
 import { resolveStateDir } from "../../config/paths.js";
 import { compareSemverStrings } from "../../infra/update-check.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -9,11 +10,12 @@ export type UpdateHintOptions = {
   json?: boolean;
 };
 
-type UpdateCheckState = {
-  lastCheckedAt?: string;
-  lastAvailableVersion?: string;
-  lastAvailableTag?: string;
-};
+const UpdateCheckStateSchema = z.object({
+  lastCheckedAt: z.string().optional(),
+  lastAvailableVersion: z.string().optional(),
+  lastAvailableTag: z.string().optional(),
+});
+type UpdateCheckState = z.infer<typeof UpdateCheckStateSchema>;
 
 /**
  * Lightweight hint command for agent/skill preambles.
@@ -32,14 +34,14 @@ export async function updateHintCommand(opts: UpdateHintOptions): Promise<void> 
   let state: UpdateCheckState;
   try {
     const raw = await fs.readFile(statePath, "utf-8");
-    const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    const result = UpdateCheckStateSchema.safeParse(JSON.parse(raw));
+    if (!result.success) {
       if (opts.json) {
         defaultRuntime.writeJson({ updateAvailable: false });
       }
       return;
     }
-    state = parsed as UpdateCheckState;
+    state = result.data;
   } catch {
     // No state file or invalid JSON — nothing to report.
     if (opts.json) {
@@ -48,8 +50,7 @@ export async function updateHintCommand(opts: UpdateHintOptions): Promise<void> 
     return;
   }
 
-  const latestVersion =
-    typeof state.lastAvailableVersion === "string" ? state.lastAvailableVersion.trim() : undefined;
+  const latestVersion = state.lastAvailableVersion?.trim();
   if (!latestVersion) {
     if (opts.json) {
       defaultRuntime.writeJson({ updateAvailable: false });
@@ -66,8 +67,7 @@ export async function updateHintCommand(opts: UpdateHintOptions): Promise<void> 
     return;
   }
 
-  const channel =
-    (typeof state.lastAvailableTag === "string" && state.lastAvailableTag.trim()) || "latest";
+  const channel = state.lastAvailableTag?.trim() || "latest";
 
   if (opts.json) {
     defaultRuntime.writeJson({

--- a/src/cli/update-cli/hint.ts
+++ b/src/cli/update-cli/hint.ts
@@ -32,7 +32,14 @@ export async function updateHintCommand(opts: UpdateHintOptions): Promise<void> 
   let state: UpdateCheckState;
   try {
     const raw = await fs.readFile(statePath, "utf-8");
-    state = JSON.parse(raw) as UpdateCheckState;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      if (opts.json) {
+        defaultRuntime.writeJson({ updateAvailable: false });
+      }
+      return;
+    }
+    state = parsed as UpdateCheckState;
   } catch {
     // No state file or invalid JSON — nothing to report.
     if (opts.json) {
@@ -41,7 +48,8 @@ export async function updateHintCommand(opts: UpdateHintOptions): Promise<void> 
     return;
   }
 
-  const latestVersion = state.lastAvailableVersion?.trim();
+  const latestVersion =
+    typeof state.lastAvailableVersion === "string" ? state.lastAvailableVersion.trim() : undefined;
   if (!latestVersion) {
     if (opts.json) {
       defaultRuntime.writeJson({ updateAvailable: false });
@@ -58,7 +66,8 @@ export async function updateHintCommand(opts: UpdateHintOptions): Promise<void> 
     return;
   }
 
-  const channel = state.lastAvailableTag?.trim() || "latest";
+  const channel =
+    (typeof state.lastAvailableTag === "string" && state.lastAvailableTag.trim()) || "latest";
 
   if (opts.json) {
     defaultRuntime.writeJson({

--- a/src/cli/update-cli/hint.ts
+++ b/src/cli/update-cli/hint.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "../../config/paths.js";
+import { compareSemverStrings } from "../../infra/update-check.js";
+import { defaultRuntime } from "../../runtime.js";
+import { VERSION } from "../../version.js";
+
+export type UpdateHintOptions = {
+  json?: boolean;
+};
+
+type UpdateCheckState = {
+  lastCheckedAt?: string;
+  lastAvailableVersion?: string;
+  lastAvailableTag?: string;
+};
+
+/**
+ * Lightweight hint command for agent/skill preambles.
+ *
+ * Reads the cached update-check state from ~/.openclaw/update-check.json
+ * and prints a one-liner if an update is available. No network calls —
+ * the state file is maintained by the gateway's periodic update check.
+ *
+ * Designed to be called from Claude Code skill preambles:
+ *   _UPD=$(openclaw update hint 2>/dev/null || true)
+ *   [ -n "$_UPD" ] && echo "$_UPD" || true
+ */
+export async function updateHintCommand(opts: UpdateHintOptions): Promise<void> {
+  const statePath = path.join(resolveStateDir(), "update-check.json");
+
+  let state: UpdateCheckState;
+  try {
+    const raw = await fs.readFile(statePath, "utf-8");
+    state = JSON.parse(raw) as UpdateCheckState;
+  } catch {
+    // No state file or invalid JSON — nothing to report.
+    return;
+  }
+
+  const latestVersion = state.lastAvailableVersion?.trim();
+  if (!latestVersion) {
+    return;
+  }
+
+  const cmp = compareSemverStrings(VERSION, latestVersion);
+  if (cmp == null || cmp >= 0) {
+    // Already up to date or ahead.
+    return;
+  }
+
+  const channel = state.lastAvailableTag?.trim() || "latest";
+
+  if (opts.json) {
+    defaultRuntime.writeJson({
+      updateAvailable: true,
+      currentVersion: VERSION,
+      latestVersion,
+      channel,
+    });
+    return;
+  }
+
+  defaultRuntime.log(
+    `UPGRADE_AVAILABLE ${VERSION} ${latestVersion} (${channel}). Run: openclaw update`,
+  );
+}

--- a/src/cli/update-cli/hint.ts
+++ b/src/cli/update-cli/hint.ts
@@ -35,17 +35,26 @@ export async function updateHintCommand(opts: UpdateHintOptions): Promise<void> 
     state = JSON.parse(raw) as UpdateCheckState;
   } catch {
     // No state file or invalid JSON — nothing to report.
+    if (opts.json) {
+      defaultRuntime.writeJson({ updateAvailable: false });
+    }
     return;
   }
 
   const latestVersion = state.lastAvailableVersion?.trim();
   if (!latestVersion) {
+    if (opts.json) {
+      defaultRuntime.writeJson({ updateAvailable: false });
+    }
     return;
   }
 
   const cmp = compareSemverStrings(VERSION, latestVersion);
   if (cmp == null || cmp >= 0) {
     // Already up to date or ahead.
+    if (opts.json) {
+      defaultRuntime.writeJson({ updateAvailable: false });
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary

- Problem: No way to know a newer OpenClaw version is available when working inside a Claude Code skill. Users must remember to run `openclaw update` manually.
- Why it matters: Stale versions mean missing bug fixes and features. Seamless upgrade notifications (like [gstack](https://github.com/garrytan/gstack) uses) keep users current without interrupting their workflow.
- What changed: Added `openclaw update hint` subcommand and bash preambles in all 7 `.agents/skills/*/SKILL.md` files. The command reads cached `~/.openclaw/update-check.json` (zero network calls) and prints a one-liner when an update is available.
- What did NOT change (scope boundary): No changes to the gateway update-check logic, no new network calls, no config schema changes. The existing `update-check.json` state file is consumed read-only.

Feature proposal: #59304

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #59304
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A — new feature.

## Regression Test Plan (if applicable)

N/A — new feature. 13 unit tests cover all code paths.

## User-visible / Behavior Changes

- New CLI subcommand: `openclaw update hint` — prints `UPGRADE_AVAILABLE <current> <latest> (<channel>). Run: openclaw update` when a newer version is available, silent otherwise.
- `openclaw update hint --json` — always emits a JSON object (`{ "updateAvailable": false }` or full update details).
- Every skill invocation now runs a 2-line preamble that surfaces the hint to the agent context.

## Diagram (if applicable)

```text
Before:
[skill invocation] -> [skill runs] (no update awareness)

After:
[skill invocation] -> [preamble: openclaw update hint] -> [UPGRADE_AVAILABLE ...] -> [skill runs]
                                                       -> [silent if up-to-date]  -> [skill runs]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (reads local cached file only)
- Command/tool execution surface changed? Yes — new `openclaw update hint` subcommand
- Data access scope changed? No
- The new subcommand reads `~/.openclaw/update-check.json` (already written by the gateway). No secrets, no network, no side effects. The preamble runs with `2>/dev/null || true` to suppress errors.

## Repro + Verification

### Environment

- OS: macOS 15.5 (Darwin 24.5.0)
- Runtime/container: Node 22, pnpm
- Model/provider: N/A
- Integration/channel (if any): Claude Code skills
- Relevant config (redacted): Default

### Steps

1. Run `openclaw update hint` with no `update-check.json` — expect silent (or `{ "updateAvailable": false }` with `--json`)
2. Create `~/.openclaw/update-check.json` with `{ "lastAvailableVersion": "2099.1.1" }` — run `openclaw update hint` — expect `UPGRADE_AVAILABLE` output
3. Invoke any skill (e.g. `$openclaw-pr-maintainer`) in Claude Code — expect the preamble to surface the hint

### Expected

- Silent when up-to-date, one-liner when update available
- `--json` always emits valid JSON on all paths

### Actual

- Matches expected behavior

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

13 unit tests pass covering: no state file, no version field, up-to-date, newer available, local-newer, corrupt JSON, non-string fields, non-object root (`null`, numeric), `--json` on all paths.

## Human Verification (required)

- Verified scenarios: `openclaw update hint` with/without state file, with/without `--json`, with stale and current versions. Invoked skill in Claude Code and confirmed preamble surfaces the hint.
- Edge cases checked: corrupt JSON, `null` root, numeric root, non-string `lastAvailableVersion`, missing fields
- What you did **not** verify: Windows behavior (CI covers this), gateway write path (unchanged)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

### Review feedback addressed

- **Greptile P1 / Codex P2 (`--json` empty output):** all early-return paths now emit `{ "updateAvailable": false }` when `--json` is set (a313ac1)
- **Codex P2 (non-string field shapes):** `lastAvailableVersion` and `lastAvailableTag` guarded with `typeof === "string"` before `.trim()` (6a64813)
- **Codex P2 (non-object root shape):** parsed JSON root validated as a non-null, non-array object before accessing any fields (9ee09ca)
- **Greptile P2 (Zod):** Acknowledged as follow-up — code is already defensive with root-shape validation, typeof guards, optional chaining, and try/catch

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Preamble adds ~50ms latency to skill invocations
  - Mitigation: The command reads a single local file with no network calls. If the file is missing or corrupt, it exits immediately.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>