### PR TITLE
fix: add Telegram native progress placeholder opt-in for plugin commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/connect: omit admin-scoped config and auth metadata from lower-privilege `hello-ok` snapshots while preserving those fields for admin reconnects. (#58469) Thanks @eleqtrizit.
 - iOS/canvas: restrict A2UI bridge trust to the bundled scaffold and exact capability-backed remote canvas URLs, so generic `canvas.navigate` and `canvas.present` loads no longer gain action-dispatch authority. (#58471) Thanks @eleqtrizit.
 - Agents/tool policy: preserve restrictive plugin-only allowlists instead of silently widening access to core tools, and keep allowlist warnings aligned with the enforced policy. (#58476) Thanks @eleqtrizit.
+- Telegram/native commands: clean up metadata-driven progress placeholders when replies fall back, edits fail, or local exec approval prompts are suppressed. (#59300) Thanks @jalehman.
 
 ## 2026.4.2
 

--- a/extensions/telegram/src/bot-native-commands.delivery.runtime.ts
+++ b/extensions/telegram/src/bot-native-commands.delivery.runtime.ts
@@ -1,4 +1,4 @@
 import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
-import { deliverReplies } from "./bot/delivery.js";
+import { deliverReplies, emitTelegramMessageSentHooks } from "./bot/delivery.js";
 
-export { createChannelReplyPipeline, deliverReplies };
+export { createChannelReplyPipeline, deliverReplies, emitTelegramMessageSentHooks };

--- a/extensions/telegram/src/bot-native-commands.menu-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.menu-test-support.ts
@@ -29,10 +29,12 @@ const skillCommandMocks = vi.hoisted(() => ({
 
 const deliveryMocks = vi.hoisted(() => ({
   deliverReplies: vi.fn(async () => ({ delivered: true })),
+  editMessageTelegram: vi.fn(async () => ({ ok: true as const, messageId: "999", chatId: "100" })),
 }));
 
 export const listSkillCommandsForAgents = skillCommandMocks.listSkillCommandsForAgents;
 export const deliverReplies = deliveryMocks.deliverReplies;
+export const editMessageTelegram = deliveryMocks.editMessageTelegram;
 
 vi.mock("openclaw/plugin-sdk/command-auth", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/command-auth")>();
@@ -64,11 +66,13 @@ export function resetNativeCommandMenuMocks() {
   listSkillCommandsForAgents.mockReturnValue([]);
   deliverReplies.mockClear();
   deliverReplies.mockResolvedValue({ delivered: true });
+  editMessageTelegram.mockClear();
+  editMessageTelegram.mockResolvedValue({ ok: true as const, messageId: "999", chatId: "100" });
 }
 
 export function createCommandBot(): CreateCommandBotResult {
   const commandHandlers = new Map<string, (ctx: unknown) => Promise<void>>();
-  const sendMessage = vi.fn().mockResolvedValue(undefined);
+  const sendMessage = vi.fn().mockResolvedValue({ message_id: 999 });
   const setMyCommands = vi.fn().mockResolvedValue(undefined);
   const bot = {
     api: {
@@ -122,6 +126,7 @@ export function createNativeCommandTestParams(
       return bot.api.setMyCommands(commandsToRegister);
     }) as TelegramBotDeps["syncTelegramMenuCommands"],
     wasSentByBot: vi.fn(() => false) as TelegramBotDeps["wasSentByBot"],
+    editMessageTelegram,
   };
   return createBaseNativeCommandTestParams({
     cfg,

--- a/extensions/telegram/src/bot-native-commands.menu-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.menu-test-support.ts
@@ -18,6 +18,7 @@ type CreateCommandBotResult = {
   bot: RegisterTelegramNativeCommandsParams["bot"];
   commandHandlers: Map<string, (ctx: unknown) => Promise<void>>;
   sendMessage: ReturnType<typeof vi.fn>;
+  deleteMessage: ReturnType<typeof vi.fn>;
   setMyCommands: ReturnType<typeof vi.fn>;
 };
 
@@ -73,17 +74,19 @@ export function resetNativeCommandMenuMocks() {
 export function createCommandBot(): CreateCommandBotResult {
   const commandHandlers = new Map<string, (ctx: unknown) => Promise<void>>();
   const sendMessage = vi.fn().mockResolvedValue({ message_id: 999 });
+  const deleteMessage = vi.fn().mockResolvedValue(true);
   const setMyCommands = vi.fn().mockResolvedValue(undefined);
   const bot = {
     api: {
       setMyCommands,
       sendMessage,
+      deleteMessage,
     },
     command: vi.fn((name: string, cb: (ctx: unknown) => Promise<void>) => {
       commandHandlers.set(name, cb);
     }),
   } as unknown as RegisterTelegramNativeCommandsParams["bot"];
-  return { bot, commandHandlers, sendMessage, setMyCommands };
+  return { bot, commandHandlers, sendMessage, deleteMessage, setMyCommands };
 }
 
 export function createNativeCommandTestParams(

--- a/extensions/telegram/src/bot-native-commands.menu-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.menu-test-support.ts
@@ -31,11 +31,13 @@ const skillCommandMocks = vi.hoisted(() => ({
 const deliveryMocks = vi.hoisted(() => ({
   deliverReplies: vi.fn(async () => ({ delivered: true })),
   editMessageTelegram: vi.fn(async () => ({ ok: true as const, messageId: "999", chatId: "100" })),
+  emitTelegramMessageSentHooks: vi.fn(),
 }));
 
 export const listSkillCommandsForAgents = skillCommandMocks.listSkillCommandsForAgents;
 export const deliverReplies = deliveryMocks.deliverReplies;
 export const editMessageTelegram = deliveryMocks.editMessageTelegram;
+export const emitTelegramMessageSentHooks = deliveryMocks.emitTelegramMessageSentHooks;
 
 vi.mock("openclaw/plugin-sdk/command-auth", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/command-auth")>();
@@ -47,6 +49,7 @@ vi.mock("openclaw/plugin-sdk/command-auth", async (importOriginal) => {
 
 vi.mock("./bot/delivery.js", () => ({
   deliverReplies,
+  emitTelegramMessageSentHooks,
 }));
 
 vi.mock("./bot/delivery.replies.js", () => ({
@@ -69,6 +72,7 @@ export function resetNativeCommandMenuMocks() {
   deliverReplies.mockResolvedValue({ delivered: true });
   editMessageTelegram.mockClear();
   editMessageTelegram.mockResolvedValue({ ok: true as const, messageId: "999", chatId: "100" });
+  emitTelegramMessageSentHooks.mockClear();
 }
 
 export function createCommandBot(): CreateCommandBotResult {

--- a/extensions/telegram/src/bot-native-commands.registry.test.ts
+++ b/extensions/telegram/src/bot-native-commands.registry.test.ts
@@ -8,16 +8,21 @@ let createCommandBot: typeof import("./bot-native-commands.menu-test-support.js"
 let createNativeCommandTestParams: typeof import("./bot-native-commands.menu-test-support.js").createNativeCommandTestParams;
 let createPrivateCommandContext: typeof import("./bot-native-commands.menu-test-support.js").createPrivateCommandContext;
 let deliverReplies: typeof import("./bot-native-commands.menu-test-support.js").deliverReplies;
+let editMessageTelegram: typeof import("./bot-native-commands.menu-test-support.js").editMessageTelegram;
 let resetNativeCommandMenuMocks: typeof import("./bot-native-commands.menu-test-support.js").resetNativeCommandMenuMocks;
 let waitForRegisteredCommands: typeof import("./bot-native-commands.menu-test-support.js").waitForRegisteredCommands;
 
 function registerPairPluginCommand(params?: {
   nativeNames?: { telegram?: string; discord?: string };
+  telegramNativeProgressMessage?: string;
 }) {
   expect(
     registerPluginCommand("demo-plugin", {
       name: "pair",
       ...(params?.nativeNames ? { nativeNames: params.nativeNames } : {}),
+      ...(params?.telegramNativeProgressMessage
+        ? { telegramNativeProgressMessage: params.telegramNativeProgressMessage }
+        : {}),
       description: "Pair device",
       acceptsArgs: true,
       requireAuth: false,
@@ -30,9 +35,13 @@ async function registerPairMenu(params: {
   bot: ReturnType<typeof createCommandBot>["bot"];
   setMyCommands: ReturnType<typeof createCommandBot>["setMyCommands"];
   nativeNames?: { telegram?: string; discord?: string };
+  telegramNativeProgressMessage?: string;
 }) {
   registerPairPluginCommand({
     ...(params.nativeNames ? { nativeNames: params.nativeNames } : {}),
+    ...(params.telegramNativeProgressMessage
+      ? { telegramNativeProgressMessage: params.telegramNativeProgressMessage }
+      : {}),
   });
 
   registerTelegramNativeCommands({
@@ -54,6 +63,7 @@ describe("registerTelegramNativeCommands real plugin registry", () => {
       createNativeCommandTestParams,
       createPrivateCommandContext,
       deliverReplies,
+      editMessageTelegram,
       resetNativeCommandMenuMocks,
       waitForRegisteredCommands,
     } = await import("./bot-native-commands.menu-test-support.js"));
@@ -87,6 +97,35 @@ describe("registerTelegramNativeCommands real plugin registry", () => {
       }),
     );
     expect(sendMessage).not.toHaveBeenCalledWith(123, "Command not found.");
+  });
+
+  it("uses plugin command metadata to send and edit a Telegram progress placeholder", async () => {
+    const { bot, commandHandlers, setMyCommands, sendMessage } = createCommandBot();
+
+    await registerPairMenu({
+      bot,
+      setMyCommands,
+      telegramNativeProgressMessage:
+        "Running pair now...\n\nI'll edit this message with the final result when it's ready.",
+    });
+
+    const handler = commandHandlers.get("pair");
+    expect(handler).toBeTruthy();
+
+    await handler?.(createPrivateCommandContext({ match: "now" }));
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      100,
+      expect.stringContaining("Running pair now"),
+      undefined,
+    );
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      100,
+      999,
+      "paired:now",
+      expect.objectContaining({ accountId: "default" }),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it("round-trips Telegram native aliases through the real plugin registry", async () => {

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -244,7 +244,7 @@ describe("registerTelegramNativeCommands", () => {
   });
 
   it("uses plugin command metadata to send and edit a Telegram progress placeholder", async () => {
-    const { bot, commandHandlers, sendMessage } = createCommandBot();
+    const { bot, commandHandlers, sendMessage, deleteMessage } = createCommandBot();
 
     pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
       {
@@ -290,11 +290,12 @@ describe("registerTelegramNativeCommands", () => {
         accountId: "default",
       }),
     );
+    expect(deleteMessage).not.toHaveBeenCalled();
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it("falls back to a normal reply when a metadata-driven progress result is not editable", async () => {
-    const { bot, commandHandlers, sendMessage } = createCommandBot();
+    const { bot, commandHandlers, sendMessage, deleteMessage } = createCommandBot();
 
     pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
       {
@@ -329,11 +330,107 @@ describe("registerTelegramNativeCommands", () => {
 
     expect(sendMessage).toHaveBeenCalledWith(100, "Working on it...", undefined);
     expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deleteMessage).toHaveBeenCalledWith(100, 999);
     expect(deliverReplies).toHaveBeenCalledWith(
       expect.objectContaining({
         replies: [expect.objectContaining({ mediaUrl: "/tmp/render.png" })],
       }),
     );
+  });
+
+  it("cleans up the progress placeholder before falling back after an edit failure", async () => {
+    const { bot, commandHandlers, sendMessage, deleteMessage } = createCommandBot();
+
+    pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
+      {
+        name: "plug",
+        description: "Plugin command",
+      },
+    ] as never);
+    pluginCommandMocks.matchPluginCommand.mockReturnValue({
+      command: {
+        key: "plug",
+        requireAuth: false,
+        telegramNativeProgressMessage: "Working on it...",
+      },
+      args: "now",
+    } as never);
+    pluginCommandMocks.executePluginCommand.mockResolvedValue({
+      text: "Command completed successfully",
+    } as never);
+    editMessageTelegram.mockRejectedValueOnce(new Error("message to edit not found"));
+
+    registerTelegramNativeCommands({
+      ...createNativeCommandTestParams({}, { bot }),
+    });
+
+    const handler = commandHandlers.get("plug");
+    expect(handler).toBeTruthy();
+    await handler?.(createPrivateCommandContext({ match: "now" }));
+
+    expect(sendMessage).toHaveBeenCalledWith(100, "Working on it...", undefined);
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
+    expect(deleteMessage).toHaveBeenCalledWith(100, 999);
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ text: "Command completed successfully" })],
+      }),
+    );
+  });
+
+  it("cleans up the progress placeholder when Telegram suppresses a local exec approval reply", async () => {
+    const { bot, commandHandlers, sendMessage, deleteMessage } = createCommandBot();
+
+    pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
+      {
+        name: "plug",
+        description: "Plugin command",
+      },
+    ] as never);
+    pluginCommandMocks.matchPluginCommand.mockReturnValue({
+      command: {
+        key: "plug",
+        requireAuth: false,
+        telegramNativeProgressMessage: "Working on it...",
+      },
+      args: "now",
+    } as never);
+    pluginCommandMocks.executePluginCommand.mockResolvedValue({
+      text: "Approval required.\n\n```txt\n/approve 7f423fdc allow-once\n```",
+      channelData: {
+        execApproval: {
+          approvalId: "7f423fdc-1111-2222-3333-444444444444",
+          approvalSlug: "7f423fdc",
+          allowedDecisions: ["allow-once", "allow-always", "deny"],
+        },
+      },
+    } as never);
+
+    registerTelegramNativeCommands({
+      ...createNativeCommandTestParams(
+        {
+          channels: {
+            telegram: {
+              execApprovals: {
+                enabled: true,
+                approvers: ["12345"],
+                target: "dm",
+              },
+            },
+          },
+        },
+        { bot },
+      ),
+    });
+
+    const handler = commandHandlers.get("plug");
+    expect(handler).toBeTruthy();
+    await handler?.(createPrivateCommandContext({ match: "now" }));
+
+    expect(sendMessage).toHaveBeenCalledWith(100, "Working on it...", undefined);
+    expect(deleteMessage).toHaveBeenCalledWith(100, 999);
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it("sends plugin command error replies silently when silentErrorReplies is enabled", async () => {

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -14,6 +14,7 @@ import {
   createPrivateCommandContext,
   deliverReplies,
   editMessageTelegram,
+  emitTelegramMessageSentHooks,
   listSkillCommandsForAgents,
   resetNativeCommandMenuMocks,
   waitForRegisteredCommands,
@@ -288,6 +289,61 @@ describe("registerTelegramNativeCommands", () => {
       expect.stringContaining("Command completed successfully"),
       expect.objectContaining({
         accountId: "default",
+      }),
+    );
+    expect(deleteMessage).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(emitTelegramMessageSentHooks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: "100",
+        content: "Command completed successfully",
+        messageId: 999,
+        success: true,
+      }),
+    );
+  });
+
+  it("preserves Telegram buttons when editing a metadata-driven progress placeholder", async () => {
+    const { bot, commandHandlers, sendMessage, deleteMessage } = createCommandBot();
+
+    pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
+      {
+        name: "plug",
+        description: "Plugin command",
+      },
+    ] as never);
+    pluginCommandMocks.matchPluginCommand.mockReturnValue({
+      command: {
+        key: "plug",
+        requireAuth: false,
+        telegramNativeProgressMessage: "Working on it...",
+      },
+      args: "now",
+    } as never);
+    pluginCommandMocks.executePluginCommand.mockResolvedValue({
+      text: "Choose an option",
+      channelData: {
+        telegram: {
+          buttons: [[{ text: "Approve", callback_data: "approve" }]],
+        },
+      },
+    } as never);
+
+    registerTelegramNativeCommands({
+      ...createNativeCommandTestParams({}, { bot }),
+    });
+
+    const handler = commandHandlers.get("plug");
+    expect(handler).toBeTruthy();
+    await handler?.(createPrivateCommandContext({ match: "now" }));
+
+    expect(sendMessage).toHaveBeenCalledWith(100, "Working on it...", undefined);
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      100,
+      999,
+      "Choose an option",
+      expect.objectContaining({
+        buttons: [[{ text: "Approve", callback_data: "approve" }]],
       }),
     );
     expect(deleteMessage).not.toHaveBeenCalled();

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -13,6 +13,7 @@ import {
   createNativeCommandTestParams,
   createPrivateCommandContext,
   deliverReplies,
+  editMessageTelegram,
   listSkillCommandsForAgents,
   resetNativeCommandMenuMocks,
   waitForRegisteredCommands,
@@ -240,6 +241,96 @@ describe("registerTelegramNativeCommands", () => {
       }),
     );
     expect(sendMessage).not.toHaveBeenCalledWith(123, "Command not found.");
+  });
+
+  it("shows immediate progress feedback for /lossless doctor apply and edits it in place on success", async () => {
+    const { bot, commandHandlers, sendMessage } = createCommandBot();
+
+    pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
+      {
+        name: "lossless",
+        nativeNames: { default: "lossless" },
+        description: "Lossless Claw command",
+      },
+    ] as never);
+    pluginCommandMocks.matchPluginCommand.mockReturnValue({
+      command: { key: "lcm", requireAuth: false },
+      args: "doctor apply",
+    } as never);
+    pluginCommandMocks.executePluginCommand.mockResolvedValue({
+      text: "Lossless Claw Doctor Apply\n\nresult: repaired 8 summary(s) in place",
+    } as never);
+
+    registerTelegramNativeCommands({
+      ...createNativeCommandTestParams({}, { bot }),
+    });
+
+    const handler = commandHandlers.get("lossless");
+    expect(handler).toBeTruthy();
+    await handler?.(
+      createPrivateCommandContext({
+        match: "doctor apply",
+      }),
+    );
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      100,
+      expect.stringContaining("Running `/lossless doctor apply`"),
+      undefined,
+    );
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      100,
+      999,
+      expect.stringContaining("Lossless Claw Doctor Apply"),
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a normal reply when the progress result is not editable", async () => {
+    const { bot, commandHandlers, sendMessage } = createCommandBot();
+
+    pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
+      {
+        name: "lcm",
+        nativeNames: { default: "lcm" },
+        description: "Lossless Claw command",
+      },
+    ] as never);
+    pluginCommandMocks.matchPluginCommand.mockReturnValue({
+      command: { key: "lcm", requireAuth: false },
+      args: "doctor apply",
+    } as never);
+    pluginCommandMocks.executePluginCommand.mockResolvedValue({
+      text: "rich output",
+      mediaUrl: "/tmp/render.png",
+    } as never);
+
+    registerTelegramNativeCommands({
+      ...createNativeCommandTestParams({}, { bot }),
+    });
+
+    const handler = commandHandlers.get("lcm");
+    expect(handler).toBeTruthy();
+    await handler?.(
+      createPrivateCommandContext({
+        match: "doctor apply",
+      }),
+    );
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      100,
+      expect.stringContaining("Running `/lcm doctor apply`"),
+      undefined,
+    );
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ mediaUrl: "/tmp/render.png" })],
+      }),
+    );
   });
 
   it("sends plugin command error replies silently when silentErrorReplies is enabled", async () => {

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -243,45 +243,49 @@ describe("registerTelegramNativeCommands", () => {
     expect(sendMessage).not.toHaveBeenCalledWith(123, "Command not found.");
   });
 
-  it("shows immediate progress feedback for /lossless doctor apply and edits it in place on success", async () => {
+  it("uses plugin command metadata to send and edit a Telegram progress placeholder", async () => {
     const { bot, commandHandlers, sendMessage } = createCommandBot();
 
     pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
       {
-        name: "lossless",
-        nativeNames: { default: "lossless" },
-        description: "Lossless Claw command",
+        name: "plug",
+        description: "Plugin command",
       },
     ] as never);
     pluginCommandMocks.matchPluginCommand.mockReturnValue({
-      command: { key: "lcm", requireAuth: false },
-      args: "doctor apply",
+      command: {
+        key: "plug",
+        requireAuth: false,
+        telegramNativeProgressMessage:
+          "Running this command now...\n\nI'll edit this message with the final result when it's ready.",
+      },
+      args: "now",
     } as never);
     pluginCommandMocks.executePluginCommand.mockResolvedValue({
-      text: "Lossless Claw Doctor Apply\n\nresult: repaired 8 summary(s) in place",
+      text: "Command completed successfully",
     } as never);
 
     registerTelegramNativeCommands({
       ...createNativeCommandTestParams({}, { bot }),
     });
 
-    const handler = commandHandlers.get("lossless");
+    const handler = commandHandlers.get("plug");
     expect(handler).toBeTruthy();
     await handler?.(
       createPrivateCommandContext({
-        match: "doctor apply",
+        match: "now",
       }),
     );
 
     expect(sendMessage).toHaveBeenCalledWith(
       100,
-      expect.stringContaining("Running `/lossless doctor apply`"),
+      expect.stringContaining("Running this command now"),
       undefined,
     );
     expect(editMessageTelegram).toHaveBeenCalledWith(
       100,
       999,
-      expect.stringContaining("Lossless Claw Doctor Apply"),
+      expect.stringContaining("Command completed successfully"),
       expect.objectContaining({
         accountId: "default",
       }),
@@ -289,19 +293,22 @@ describe("registerTelegramNativeCommands", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
-  it("falls back to a normal reply when the progress result is not editable", async () => {
+  it("falls back to a normal reply when a metadata-driven progress result is not editable", async () => {
     const { bot, commandHandlers, sendMessage } = createCommandBot();
 
     pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
       {
-        name: "lcm",
-        nativeNames: { default: "lcm" },
-        description: "Lossless Claw command",
+        name: "plug",
+        description: "Plugin command",
       },
     ] as never);
     pluginCommandMocks.matchPluginCommand.mockReturnValue({
-      command: { key: "lcm", requireAuth: false },
-      args: "doctor apply",
+      command: {
+        key: "plug",
+        requireAuth: false,
+        telegramNativeProgressMessage: "Working on it...",
+      },
+      args: "now",
     } as never);
     pluginCommandMocks.executePluginCommand.mockResolvedValue({
       text: "rich output",
@@ -312,19 +319,15 @@ describe("registerTelegramNativeCommands", () => {
       ...createNativeCommandTestParams({}, { bot }),
     });
 
-    const handler = commandHandlers.get("lcm");
+    const handler = commandHandlers.get("plug");
     expect(handler).toBeTruthy();
     await handler?.(
       createPrivateCommandContext({
-        match: "doctor apply",
+        match: "now",
       }),
     );
 
-    expect(sendMessage).toHaveBeenCalledWith(
-      100,
-      expect.stringContaining("Running `/lcm doctor apply`"),
-      undefined,
-    );
+    expect(sendMessage).toHaveBeenCalledWith(100, "Working on it...", undefined);
     expect(editMessageTelegram).not.toHaveBeenCalled();
     expect(deliverReplies).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -78,6 +78,8 @@ type TelegramNativeCommandContext = Context & { match?: string };
 type TelegramChunkMode = ReturnType<
   typeof import("openclaw/plugin-sdk/reply-dispatch-runtime").resolveChunkMode
 >;
+type TelegramNativeReplyPayload =
+  import("openclaw/plugin-sdk/reply-dispatch-runtime").ReplyPayload;
 
 type TelegramCommandAuthResult = {
   chatId: number;
@@ -108,6 +110,45 @@ let telegramNativeCommandRuntimePromise:
 async function loadTelegramNativeCommandRuntime() {
   telegramNativeCommandRuntimePromise ??= import("./bot-native-commands.runtime.js");
   return await telegramNativeCommandRuntimePromise;
+}
+
+function resolveTelegramProgressPlaceholder(command: {
+  telegramNativeProgressMessage?: string;
+}): string | null {
+  const text = command.telegramNativeProgressMessage?.trim();
+  return text ? text : null;
+}
+
+function isEditableTelegramProgressResult(result: TelegramNativeReplyPayload): boolean {
+  return Boolean(
+    typeof result.text === "string" &&
+    result.text.trim() &&
+    !result.mediaUrl &&
+    (!result.mediaUrls || result.mediaUrls.length === 0) &&
+    !result.interactive &&
+    !result.btw,
+  );
+}
+
+async function cleanupTelegramProgressPlaceholder(params: {
+  bot: Bot;
+  chatId: number;
+  progressMessageId?: number;
+  runtime: RuntimeEnv;
+}): Promise<void> {
+  const progressMessageId = params.progressMessageId;
+  if (progressMessageId == null) {
+    return;
+  }
+  try {
+    await withTelegramApiErrorLogging({
+      operation: "deleteMessage",
+      runtime: params.runtime,
+      fn: () => params.bot.api.deleteMessage(params.chatId, progressMessageId),
+    });
+  } catch {
+    // Best-effort cleanup before fallback or suppression exits.
+  }
 }
 
 export type RegisterTelegramHandlerParams = {
@@ -957,6 +998,29 @@ export const registerTelegramNativeCommands = ({
         const from = isGroup ? buildTelegramGroupFrom(chatId, threadSpec.id) : `telegram:${chatId}`;
         const to = `telegram:${chatId}`;
         const { deliverReplies } = await loadTelegramNativeCommandDeliveryRuntime();
+        let progressMessageId: number | undefined;
+        const progressPlaceholder = resolveTelegramProgressPlaceholder(match.command);
+
+        if (progressPlaceholder) {
+          try {
+            const sent = await withTelegramApiErrorLogging({
+              operation: "sendMessage",
+              runtime,
+              fn: () =>
+                bot.api.sendMessage(
+                  chatId,
+                  progressPlaceholder,
+                  buildTelegramThreadParams(threadSpec),
+                ),
+            });
+            const maybeMessageId = (sent as { message_id?: unknown } | undefined)?.message_id;
+            if (typeof maybeMessageId === "number") {
+              progressMessageId = maybeMessageId;
+            }
+          } catch {
+            // Fall back to the normal final reply path if the placeholder send fails.
+          }
+        }
 
         const result = await nativeCommandRuntime.executePluginCommand({
           command: match.command,
@@ -974,18 +1038,52 @@ export const registerTelegramNativeCommands = ({
         });
 
         if (
-          !shouldSuppressLocalTelegramExecApprovalPrompt({
+          shouldSuppressLocalTelegramExecApprovalPrompt({
             cfg: runtimeCfg,
             accountId: route.accountId,
             payload: result,
           })
         ) {
-          await deliverReplies({
-            replies: [result],
-            ...deliveryBaseOptions,
-            silent: runtimeTelegramCfg.silentErrorReplies === true && result.isError === true,
+          await cleanupTelegramProgressPlaceholder({
+            bot,
+            chatId,
+            progressMessageId,
+            runtime,
           });
+          return;
         }
+
+        const progressResultText =
+          typeof result.text === "string" && result.text.trim().length > 0 ? result.text : null;
+        if (
+          progressMessageId != null &&
+          telegramDeps.editMessageTelegram &&
+          progressResultText &&
+          isEditableTelegramProgressResult(result)
+        ) {
+          try {
+            await telegramDeps.editMessageTelegram(chatId, progressMessageId, progressResultText, {
+              cfg: runtimeCfg,
+              accountId: route.accountId,
+              textMode: "markdown",
+              linkPreview: runtimeTelegramCfg.linkPreview,
+            });
+            return;
+          } catch {
+            // Fall through to cleanup + normal delivered reply if editing fails.
+          }
+        }
+        await cleanupTelegramProgressPlaceholder({
+          bot,
+          chatId,
+          progressMessageId,
+          runtime,
+        });
+        await deliverReplies({
+          replies: [result],
+          ...deliveryBaseOptions,
+          silent: runtimeTelegramCfg.silentErrorReplies === true && result.isError === true,
+        });
       });
     }
   } else if (nativeDisabledExplicit) {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -58,6 +58,7 @@ import {
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
 import type { TelegramContext, TelegramGetChat } from "./bot/types.js";
+import type { TelegramInlineButtons } from "./button-types.js";
 import {
   resolveTelegramConversationBaseSessionKey,
   resolveTelegramConversationRoute,
@@ -70,6 +71,7 @@ import {
 } from "./group-access.js";
 import { resolveTelegramGroupPromptSettings } from "./group-config-helpers.js";
 import { buildInlineKeyboard } from "./send.js";
+import { recordSentMessage } from "./sent-message-cache.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 const TELEGRAM_NATIVE_COMMAND_CALLBACK_PREFIX = "tgcmd:";
@@ -78,8 +80,11 @@ type TelegramNativeCommandContext = Context & { match?: string };
 type TelegramChunkMode = ReturnType<
   typeof import("openclaw/plugin-sdk/reply-dispatch-runtime").resolveChunkMode
 >;
-type TelegramNativeReplyPayload =
-  import("openclaw/plugin-sdk/reply-dispatch-runtime").ReplyPayload;
+type TelegramNativeReplyPayload = import("openclaw/plugin-sdk/reply-dispatch-runtime").ReplyPayload;
+type TelegramNativeReplyChannelData = {
+  buttons?: TelegramInlineButtons;
+  pin?: boolean;
+};
 
 type TelegramCommandAuthResult = {
   chatId: number;
@@ -119,14 +124,22 @@ function resolveTelegramProgressPlaceholder(command: {
   return text ? text : null;
 }
 
+function resolveTelegramNativeReplyChannelData(
+  result: TelegramNativeReplyPayload,
+): TelegramNativeReplyChannelData | undefined {
+  return result.channelData?.telegram as TelegramNativeReplyChannelData | undefined;
+}
+
 function isEditableTelegramProgressResult(result: TelegramNativeReplyPayload): boolean {
+  const telegramData = resolveTelegramNativeReplyChannelData(result);
   return Boolean(
     typeof result.text === "string" &&
     result.text.trim() &&
     !result.mediaUrl &&
     (!result.mediaUrls || result.mediaUrls.length === 0) &&
     !result.interactive &&
-    !result.btw,
+    !result.btw &&
+    telegramData?.pin !== true,
   );
 }
 
@@ -997,7 +1010,8 @@ export const registerTelegramNativeCommands = ({
         });
         const from = isGroup ? buildTelegramGroupFrom(chatId, threadSpec.id) : `telegram:${chatId}`;
         const to = `telegram:${chatId}`;
-        const { deliverReplies } = await loadTelegramNativeCommandDeliveryRuntime();
+        const { deliverReplies, emitTelegramMessageSentHooks } =
+          await loadTelegramNativeCommandDeliveryRuntime();
         let progressMessageId: number | undefined;
         const progressPlaceholder = resolveTelegramProgressPlaceholder(match.command);
 
@@ -1055,6 +1069,7 @@ export const registerTelegramNativeCommands = ({
 
         const progressResultText =
           typeof result.text === "string" && result.text.trim().length > 0 ? result.text : null;
+        const telegramResultData = resolveTelegramNativeReplyChannelData(result);
         if (
           progressMessageId != null &&
           telegramDeps.editMessageTelegram &&
@@ -1067,6 +1082,18 @@ export const registerTelegramNativeCommands = ({
               accountId: route.accountId,
               textMode: "markdown",
               linkPreview: runtimeTelegramCfg.linkPreview,
+              buttons: telegramResultData?.buttons,
+            });
+            recordSentMessage(chatId, progressMessageId);
+            emitTelegramMessageSentHooks({
+              sessionKeyForInternalHooks: route.sessionKey,
+              chatId: String(chatId),
+              accountId: route.accountId,
+              content: progressResultText,
+              success: true,
+              messageId: progressMessageId,
+              isGroup,
+              groupId: isGroup ? String(chatId) : undefined,
             });
             return;
           } catch {

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -570,6 +570,15 @@ function emitMessageSentHooks(
   emitInternalMessageSentHook(params);
 }
 
+export function emitTelegramMessageSentHooks(params: EmitMessageSentHookParams): void {
+  const hookRunner = getGlobalHookRunner();
+  emitMessageSentHooks({
+    ...params,
+    hookRunner,
+    enabled: hookRunner?.hasHooks("message_sent") ?? false,
+  });
+}
+
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
   chatId: string;

--- a/extensions/telegram/src/bot/delivery.ts
+++ b/extensions/telegram/src/bot/delivery.ts
@@ -1,2 +1,6 @@
-export { deliverReplies, emitInternalMessageSentHook } from "./delivery.replies.js";
+export {
+  deliverReplies,
+  emitInternalMessageSentHook,
+  emitTelegramMessageSentHooks,
+} from "./delivery.replies.js";
 export { resolveMedia } from "./delivery.resolve-media.js";

--- a/src/plugins/command-registration.ts
+++ b/src/plugins/command-registration.ts
@@ -112,6 +112,14 @@ export function validatePluginCommandDefinition(
       return `Native command alias "${label}" invalid: ${aliasError}`;
     }
   }
+  if ("telegramNativeProgressMessage" in command) {
+    if (typeof command.telegramNativeProgressMessage !== "string") {
+      return "telegramNativeProgressMessage must be a string";
+    }
+    if (!command.telegramNativeProgressMessage.trim()) {
+      return "telegramNativeProgressMessage cannot be empty";
+    }
+  }
   return null;
 }
 

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -177,6 +177,32 @@ describe("registerPluginCommand", () => {
     ]);
   });
 
+  it("accepts Telegram native progress metadata on plugin commands", () => {
+    const result = registerVoiceCommandForTest({
+      telegramNativeProgressMessage: "Running voice command...",
+      description: "Demo command",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(matchPluginCommand("/voice")).toMatchObject({
+      command: expect.objectContaining({
+        telegramNativeProgressMessage: "Running voice command...",
+      }),
+    });
+  });
+
+  it("rejects empty Telegram native progress metadata", () => {
+    const result = registerVoiceCommandForTest({
+      telegramNativeProgressMessage: "   ",
+      description: "Demo command",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "telegramNativeProgressMessage cannot be empty",
+    });
+  });
+
   it("shares plugin commands across duplicate module instances", async () => {
     const first = await importCommandsModule(`first-${Date.now()}`);
     const second = await importCommandsModule(`second-${Date.now()}`);

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1605,6 +1605,13 @@ export type OpenClawPluginCommandDefinition = {
    * override exists (for example `{ default: "talkvoice", discord: "voice2" }`).
    */
   nativeNames?: Partial<Record<string, string>> & { default?: string };
+  /**
+   * Optional Telegram-native progress placeholder text.
+   * When set, Telegram native/plugin command delivery sends this text
+   * immediately, then edits that same message in place if the final reply
+   * is a simple text-only payload.
+   */
+  telegramNativeProgressMessage?: string;
   /** Description shown in /help and command menus */
   description: string;
   /** Whether this command accepts arguments */


### PR DESCRIPTION
## What
This adds a small plugin-command metadata opt-in for Telegram native/plugin commands. When a plugin command definition sets `telegramNativeProgressMessage`, Telegram sends that placeholder immediately and then edits the same message in place if the final result is a simple text-only reply.

## Why
Some Telegram native/plugin commands are long-running and otherwise appear idle until completion. The original PR hardcoded specific command bodies, which was not a clean OpenClaw seam. This revision moves the behavior behind explicit plugin command metadata so the Telegram UX improvement is generic without coupling the extension to a specific plugin.

## Changes
- Add `telegramNativeProgressMessage` command metadata
- Validate metadata during plugin command registration
- Use metadata in Telegram native command delivery
- Keep fallback for rich or non-editable payloads
- Add focused Telegram and plugin registry tests

## Testing
- `pnpm test -- extensions/telegram/src/bot-native-commands.test.ts`
- `pnpm test -- extensions/telegram/src/bot-native-commands.registry.test.ts`
- `pnpm test -- extensions/telegram/src/bot-native-commands.session-meta.test.ts`
- `pnpm test -- src/plugins/commands.test.ts`
