### PR TITLE
fix(agents): resolve compaction wait before channel flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals: route Slack, Discord, and Telegram approvals through the shared channel approval-capability path so native approval auth, delivery, and `/approve` handling stay aligned across channels while preserving Telegram session-key agent filtering. (#58634) thanks @gumadeiras
 - Matrix/runtime: resolve the verification/bootstrap runtime from a distinct packaged Matrix entry so global npm installs stop failing on crypto bootstrap with missing-module or recursive runtime alias errors. (#59249) Thanks @gumadeiras.
 - Matrix/streaming: preserve ordered block flushes before tool, message, and agent boundaries, add explicit `channels.matrix.blockStreaming` opt-in so Matrix `streaming: "off"` stays final-only by default, and move MiniMax plain-text final handling into the MiniMax provider runtime instead of the shared core heuristic. (#59266) thanks @gumadeiras
+- Agents/compaction: resolve compaction wait before final reply/channel flush completion so slow end-of-run delivery drains no longer delay compaction completion. (#59308) thanks @gumadeiras
 
 ## 2026.4.2
 

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -9,7 +9,10 @@ vi.mock("../infra/agent-events.js", () => ({
 
 function createContext(
   lastAssistant: unknown,
-  overrides?: { onAgentEvent?: (event: unknown) => void },
+  overrides?: {
+    onAgentEvent?: (event: unknown) => void;
+    onBlockReplyFlush?: () => void | Promise<void>;
+  },
 ): EmbeddedPiSubscribeContext {
   const onBlockReply = vi.fn();
   return {
@@ -19,6 +22,7 @@ function createContext(
       sessionKey: "agent:main:main",
       onAgentEvent: overrides?.onAgentEvent,
       onBlockReply,
+      onBlockReplyFlush: overrides?.onBlockReplyFlush,
     },
     state: {
       lastAssistant: lastAssistant as EmbeddedPiSubscribeContext["state"]["lastAssistant"],
@@ -178,5 +182,46 @@ describe("handleAgentEnd", () => {
     });
     expect(ctx.state.pendingToolMediaUrls).toEqual([]);
     expect(ctx.state.pendingToolAudioAsVoice).toBe(false);
+  });
+
+  it("resolves compaction wait before awaiting an async block reply flush", async () => {
+    let resolveFlush: (() => void) | undefined;
+    const ctx = createContext(undefined);
+    ctx.flushBlockReplyBuffer = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFlush = resolve;
+          }),
+      )
+      .mockImplementation(() => {});
+
+    const endPromise = handleAgentEnd(ctx);
+
+    expect(ctx.maybeResolveCompactionWait).toHaveBeenCalledTimes(1);
+    expect(ctx.resolveCompactionRetry).not.toHaveBeenCalled();
+
+    resolveFlush?.();
+    await endPromise;
+  });
+
+  it("resolves compaction wait before awaiting an async channel flush", async () => {
+    let resolveChannelFlush: (() => void) | undefined;
+    const onBlockReplyFlush = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveChannelFlush = resolve;
+        }),
+    );
+    const ctx = createContext(undefined, { onBlockReplyFlush });
+
+    const endPromise = handleAgentEnd(ctx);
+
+    expect(ctx.maybeResolveCompactionWait).toHaveBeenCalledTimes(1);
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+
+    resolveChannelFlush?.();
+    await endPromise;
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -136,20 +136,13 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
   };
 
   const flushBlockReplyBufferResult = ctx.flushBlockReplyBuffer();
+  finalizeAgentEnd();
   if (isPromiseLike<void>(flushBlockReplyBufferResult)) {
-    return flushBlockReplyBufferResult
-      .then(() => flushPendingMediaAndChannel())
-      .finally(() => {
-        finalizeAgentEnd();
-      });
+    return flushBlockReplyBufferResult.then(() => flushPendingMediaAndChannel());
   }
 
   const flushPendingMediaAndChannelResult = flushPendingMediaAndChannel();
   if (isPromiseLike<void>(flushPendingMediaAndChannelResult)) {
-    return flushPendingMediaAndChannelResult.finally(() => {
-      finalizeAgentEnd();
-    });
+    return flushPendingMediaAndChannelResult;
   }
-
-  finalizeAgentEnd();
 }


### PR DESCRIPTION
## Summary

- Problem: `handleAgentEnd()` awaited async reply-pipeline/channel flush work before resolving compaction wait.
- Why it matters: slow or backpressured channel delivery could stall post-run compaction completion and trip the aggregate timeout even after compaction itself had finished.
- What changed: resolve compaction wait state immediately after kicking off the final block-buffer flush, while still awaiting the remaining reply/media/channel drain for handler completion.
- What did NOT change (scope boundary): no transport ordering changes, no compaction protocol changes, no Matrix work included.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `handleAgentEnd()` tied `resolveCompactionRetry()` / `maybeResolveCompactionWait()` to the completion of async block-reply flush and `onBlockReplyFlush()`.
- Missing detection / guardrail: no unit test asserted that compaction wait resolves before async end-of-run flush promises settle.
- Prior context (`git blame`, prior PR, issue, or refactor if known): groundwork landed in `7a22b3fa0b` (`feat(agents): flush reply pipeline before compaction wait (#35489)`); the visible regression came from `560ea25294` (`Matrix: restore ordered progress delivery with explicit streaming modes (#59266)`), which started awaiting the flush chain before finalizing agent end.
- Why this regressed now: the March change was fire-and-forget; the April refactor made that flush path awaited, so transport backpressure started blocking compaction completion.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts`
- Scenario the test should lock in: compaction wait resolves before async `flushBlockReplyBuffer()` and async `onBlockReplyFlush()` settle.
- Why this is the smallest reliable guardrail: the bug is local to `handleAgentEnd()` ordering and does not need channel or runner integration to reproduce.
- Existing test that already covers this (if any): `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts` covers the aggregate wait behavior, not this ordering edge.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Compaction completion no longer waits on slow final reply/channel flushes at run end.

## Diagram (if applicable)

```text
Before:
[agent_end] -> [await final reply/channel flush] -> [resolve compaction wait]

After:
[agent_end] -> [kick off final block flush] -> [resolve compaction wait] -> [await remaining reply/channel drain]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25 / pnpm
- Model/provider: N/A
- Integration/channel (if any): embedded agent reply pipeline
- Relevant config (redacted): default local test config

### Steps

1. End a run where compaction wait is active.
2. Make the final `flushBlockReplyBuffer()` or `onBlockReplyFlush()` return a slow promise.
3. Observe whether compaction wait resolves before that transport promise settles.

### Expected

- Compaction wait resolves as soon as agent-end state is finalized; slow transport drain does not block it.

### Actual

- Before this fix, async final flush work delayed compaction resolution until the transport promise settled.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: scoped unit coverage for async block-buffer flush and async channel flush ordering; existing compaction-retry wait tests still pass.
- Edge cases checked: synchronous flush path still finalizes immediately; reply/media drain path still returns its async promise.
- What you did **not** verify: end-to-end channel backpressure reproduction against a live transport.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: resolving compaction wait earlier could let later code assume transport flush already finished.
  - Mitigation: the handler still awaits the reply/media/channel drain before it settles; only compaction-resolution ordering moved.
