### PR TITLE
fix(ollama): prefer real cloud auth over local marker

### DIFF
--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -394,34 +394,36 @@ describe("getApiKeyForModel", () => {
   });
 
   it("prefers explicit configured ollama apiKey over the stored ollama-local profile", async () => {
-    const resolved = await resolveApiKeyForProvider({
-      provider: "ollama",
-      store: {
-        version: 1,
-        profiles: {
-          "ollama:default": {
-            type: "api_key",
-            provider: "ollama",
-            key: "ollama-local",
-          },
-        },
-      },
-      cfg: {
-        models: {
-          providers: {
-            ollama: {
-              baseUrl: "https://ollama.com",
-              api: "ollama",
-              apiKey: "config-ollama-key",
-              models: [],
+    await withEnvAsync({ OLLAMA_API_KEY: undefined }, async () => {
+      const resolved = await resolveApiKeyForProvider({
+        provider: "ollama",
+        store: {
+          version: 1,
+          profiles: {
+            "ollama:default": {
+              type: "api_key",
+              provider: "ollama",
+              key: "ollama-local",
             },
           },
         },
-      },
+        cfg: {
+          models: {
+            providers: {
+              ollama: {
+                baseUrl: "https://ollama.com",
+                api: "ollama",
+                apiKey: "config-ollama-key",
+                models: [],
+              },
+            },
+          },
+        },
+      });
+      expect(resolved.apiKey).toBe("config-ollama-key");
+      expect(resolved.source).toBe("models.json");
+      expect(resolved.profileId).toBeUndefined();
     });
-    expect(resolved.apiKey).toBe("config-ollama-key");
-    expect(resolved.source).toBe("models.json");
-    expect(resolved.profileId).toBeUndefined();
   });
 
   it("falls back to the stored ollama-local profile when no real ollama auth exists", async () => {
@@ -487,6 +489,44 @@ describe("getApiKeyForModel", () => {
       expect(resolved.apiKey).toBe("stored-ollama-key");
       expect(resolved.source).toBe("profile:ollama:default");
       expect(resolved.profileId).toBe("ollama:default");
+    });
+  });
+
+  it("defers every stored ollama-local profile until real auth sources are checked", async () => {
+    await withEnvAsync({ OLLAMA_API_KEY: "env-ollama-key" }, async () => {
+      const resolved = await resolveApiKeyForProvider({
+        provider: "ollama",
+        store: {
+          version: 1,
+          profiles: {
+            "ollama:default": {
+              type: "api_key",
+              provider: "ollama",
+              key: "ollama-local",
+            },
+            "ollama:secondary": {
+              type: "api_key",
+              provider: "ollama",
+              key: "ollama-local",
+            },
+          },
+        },
+        cfg: {
+          models: {
+            providers: {
+              ollama: {
+                baseUrl: "https://ollama.com",
+                api: "ollama",
+                apiKey: "OLLAMA_API_KEY",
+                models: [],
+              },
+            },
+          },
+        },
+      });
+      expect(resolved.apiKey).toBe("env-ollama-key");
+      expect(resolved.source).toContain("OLLAMA_API_KEY");
+      expect(resolved.profileId).toBeUndefined();
     });
   });
 

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -360,6 +360,136 @@ describe("getApiKeyForModel", () => {
     });
   });
 
+  it("prefers explicit OLLAMA_API_KEY over the stored ollama-local profile", async () => {
+    await withEnvAsync({ OLLAMA_API_KEY: "env-ollama-key" }, async () => {
+      const resolved = await resolveApiKeyForProvider({
+        provider: "ollama",
+        store: {
+          version: 1,
+          profiles: {
+            "ollama:default": {
+              type: "api_key",
+              provider: "ollama",
+              key: "ollama-local",
+            },
+          },
+        },
+        cfg: {
+          models: {
+            providers: {
+              ollama: {
+                baseUrl: "https://ollama.com",
+                api: "ollama",
+                apiKey: "OLLAMA_API_KEY",
+                models: [],
+              },
+            },
+          },
+        },
+      });
+      expect(resolved.apiKey).toBe("env-ollama-key");
+      expect(resolved.source).toContain("OLLAMA_API_KEY");
+      expect(resolved.profileId).toBeUndefined();
+    });
+  });
+
+  it("prefers explicit configured ollama apiKey over the stored ollama-local profile", async () => {
+    const resolved = await resolveApiKeyForProvider({
+      provider: "ollama",
+      store: {
+        version: 1,
+        profiles: {
+          "ollama:default": {
+            type: "api_key",
+            provider: "ollama",
+            key: "ollama-local",
+          },
+        },
+      },
+      cfg: {
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "https://ollama.com",
+              api: "ollama",
+              apiKey: "config-ollama-key",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+    expect(resolved.apiKey).toBe("config-ollama-key");
+    expect(resolved.source).toBe("models.json");
+    expect(resolved.profileId).toBeUndefined();
+  });
+
+  it("falls back to the stored ollama-local profile when no real ollama auth exists", async () => {
+    await withEnvAsync({ OLLAMA_API_KEY: undefined }, async () => {
+      const resolved = await resolveApiKeyForProvider({
+        provider: "ollama",
+        store: {
+          version: 1,
+          profiles: {
+            "ollama:default": {
+              type: "api_key",
+              provider: "ollama",
+              key: "ollama-local",
+            },
+          },
+        },
+        cfg: {
+          models: {
+            providers: {
+              ollama: {
+                baseUrl: "https://ollama.com",
+                api: "ollama",
+                apiKey: "OLLAMA_API_KEY",
+                models: [],
+              },
+            },
+          },
+        },
+      });
+      expect(resolved.apiKey).toBe("ollama-local");
+      expect(resolved.source).toBe("profile:ollama:default");
+      expect(resolved.profileId).toBe("ollama:default");
+    });
+  });
+
+  it("keeps a real stored ollama profile ahead of env auth", async () => {
+    await withEnvAsync({ OLLAMA_API_KEY: "env-ollama-key" }, async () => {
+      const resolved = await resolveApiKeyForProvider({
+        provider: "ollama",
+        store: {
+          version: 1,
+          profiles: {
+            "ollama:default": {
+              type: "api_key",
+              provider: "ollama",
+              key: "stored-ollama-key",
+            },
+          },
+        },
+        cfg: {
+          models: {
+            providers: {
+              ollama: {
+                baseUrl: "https://ollama.com",
+                api: "ollama",
+                apiKey: "OLLAMA_API_KEY",
+                models: [],
+              },
+            },
+          },
+        },
+      });
+      expect(resolved.apiKey).toBe("stored-ollama-key");
+      expect(resolved.source).toBe("profile:ollama:default");
+      expect(resolved.profileId).toBe("ollama:default");
+    });
+  });
+
   it("still throws for ollama when no env/profile/config provider is available", async () => {
     await withEnvAsync({ OLLAMA_API_KEY: undefined }, async () => {
       await expect(

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -337,12 +337,26 @@ export async function resolveApiKeyForProvider(params: {
       throw new Error(`No credentials found for profile "${profileId}".`);
     }
     const mode = store.profiles[profileId]?.type;
-    return {
+    const result: ResolvedProviderAuth = {
       apiKey: resolved.apiKey,
       profileId,
       source: `profile:${profileId}`,
       mode: mode === "oauth" ? "oauth" : mode === "token" ? "token" : "api-key",
     };
+    // When the resolved key is the synthetic ollama-local marker, fall through
+    // to env/config resolution so real cloud credentials take precedence.
+    // The auth controller iterates profile candidates and passes each as an
+    // explicit profileId, so we cannot assume explicit === user-chosen.
+    if (
+      shouldDeferSyntheticOllamaProfileAuth({
+        provider,
+        resolvedApiKey: resolved.apiKey,
+      })
+    ) {
+      return resolveApiKeyForProvider({ ...params, profileId: undefined }) //
+        .catch(() => result);
+    }
+    return result;
   }
 
   const authOverride = resolveProviderAuthOverride(cfg, provider);

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -26,6 +26,7 @@ import {
   isKnownEnvApiKeyMarker,
   isNonSecretApiKeyMarker,
   NON_ENV_SECRETREF_MARKER,
+  OLLAMA_LOCAL_AUTH_MARKER,
 } from "./model-auth-markers.js";
 import {
   requireApiKey,
@@ -304,6 +305,16 @@ function resolveAwsSdkAuthInfo(): { mode: "aws-sdk"; source: string } {
   return { mode: "aws-sdk", source: "aws-sdk default chain" };
 }
 
+function shouldDeferSyntheticOllamaProfileAuth(params: {
+  provider: string;
+  resolvedApiKey: string | undefined;
+}): boolean {
+  return (
+    normalizeProviderId(params.provider) === "ollama" &&
+    params.resolvedApiKey?.trim() === OLLAMA_LOCAL_AUTH_MARKER
+  );
+}
+
 export async function resolveApiKeyForProvider(params: {
   provider: string;
   cfg?: OpenClawConfig;
@@ -345,6 +356,7 @@ export async function resolveApiKeyForProvider(params: {
     provider,
     preferredProfile,
   });
+  let deferredAuthProfileResult: ResolvedProviderAuth | null = null;
   for (const candidate of order) {
     try {
       const resolved = await resolveApiKeyForProfile({
@@ -363,6 +375,16 @@ export async function resolveApiKeyForProvider(params: {
           source: `profile:${candidate}`,
           mode: resolvedMode,
         };
+        if (
+          !deferredAuthProfileResult &&
+          shouldDeferSyntheticOllamaProfileAuth({
+            provider,
+            resolvedApiKey: resolved.apiKey,
+          })
+        ) {
+          deferredAuthProfileResult = result;
+          continue;
+        }
         return result;
       }
     } catch (err) {
@@ -387,6 +409,10 @@ export async function resolveApiKeyForProvider(params: {
   if (customKey) {
     const result = { apiKey: customKey.apiKey, source: customKey.source, mode: "api-key" as const };
     return result;
+  }
+
+  if (deferredAuthProfileResult) {
+    return deferredAuthProfileResult;
   }
 
   const syntheticLocalAuth = resolveSyntheticLocalProviderAuth({ cfg, provider });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -376,13 +376,12 @@ export async function resolveApiKeyForProvider(params: {
           mode: resolvedMode,
         };
         if (
-          !deferredAuthProfileResult &&
           shouldDeferSyntheticOllamaProfileAuth({
             provider,
             resolvedApiKey: resolved.apiKey,
           })
         ) {
-          deferredAuthProfileResult = result;
+          deferredAuthProfileResult ??= result;
           continue;
         }
         return result;

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -322,6 +322,9 @@ export async function resolveApiKeyForProvider(params: {
   preferredProfile?: string;
   store?: AuthProfileStore;
   agentDir?: string;
+  /** When true, treat profileId as a user-locked selection that must not be
+   *  silently overridden by env/config credentials (e.g. ollama-local). */
+  lockedProfile?: boolean;
 }): Promise<ResolvedProviderAuth> {
   const { provider, cfg, profileId, preferredProfile } = params;
   const store = params.store ?? ensureAuthProfileStore(params.agentDir);
@@ -343,17 +346,19 @@ export async function resolveApiKeyForProvider(params: {
       source: `profile:${profileId}`,
       mode: mode === "oauth" ? "oauth" : mode === "token" ? "token" : "api-key",
     };
-    // When the resolved key is the synthetic ollama-local marker, fall through
-    // to env/config resolution so real cloud credentials take precedence.
-    // The auth controller iterates profile candidates and passes each as an
-    // explicit profileId, so we cannot assume explicit === user-chosen.
+    // When the resolved key is the synthetic ollama-local marker and the
+    // caller has not locked this profile, fall through to env/config
+    // resolution so real cloud credentials take precedence. The auth
+    // controller iterates profile candidates and passes each as an explicit
+    // profileId, so we cannot assume explicit === user-locked.
     if (
+      !params.lockedProfile &&
       shouldDeferSyntheticOllamaProfileAuth({
         provider,
         resolvedApiKey: resolved.apiKey,
       })
     ) {
-      return resolveApiKeyForProvider({ ...params, profileId: undefined }) //
+      return resolveApiKeyForProvider({ ...params, profileId: undefined, lockedProfile: true }) //
         .catch(() => result);
     }
     return result;
@@ -593,6 +598,7 @@ export async function getApiKeyForModel(params: {
   preferredProfile?: string;
   store?: AuthProfileStore;
   agentDir?: string;
+  lockedProfile?: boolean;
 }): Promise<ResolvedProviderAuth> {
   return resolveApiKeyForProvider({
     provider: params.model.provider,
@@ -601,6 +607,7 @@ export async function getApiKeyForModel(params: {
     preferredProfile: params.preferredProfile,
     store: params.store,
     agentDir: params.agentDir,
+    lockedProfile: params.lockedProfile,
   });
 }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -223,9 +223,22 @@ export function resolveEmbeddedAgentStreamFn(params: {
   sessionId: string;
   signal?: AbortSignal;
   model: EmbeddedRunAttemptParams["model"];
+  authStorage?: { getApiKey(provider: string): Promise<string | undefined> };
 }): StreamFn {
   if (params.providerStreamFn) {
-    return params.providerStreamFn;
+    const inner = params.providerStreamFn;
+    // The default pi-coding-agent streamFn injects apiKey from authStorage
+    // into options via modelRegistry.getApiKeyAndHeaders(). Provider-supplied
+    // stream functions bypass that default, so we replicate the injection here
+    // so the resolved credential reaches the provider's HTTP layer.
+    if (params.authStorage) {
+      const { authStorage, model } = params;
+      return async (m, context, options) => {
+        const apiKey = await authStorage.getApiKey(model.provider);
+        return inner(m, context, { ...options, apiKey: apiKey ?? options?.apiKey });
+      };
+    }
+    return inner;
   }
 
   const currentStreamFn = params.currentStreamFn ?? streamSimple;
@@ -940,6 +953,7 @@ export async function runEmbeddedAttempt(
         sessionId: params.sessionId,
         signal: runAbortController.signal,
         model: params.model,
+        authStorage: params.authStorage,
       });
 
       const { effectiveExtraParams } = applyExtraParamsToAgent(

--- a/src/agents/pi-embedded-runner/run/auth-controller.ts
+++ b/src/agents/pi-embedded-runner/run/auth-controller.ts
@@ -279,6 +279,7 @@ export function createEmbeddedRunAuthController(params: {
       profileId: candidate,
       store: params.authStore,
       agentDir: params.agentDir,
+      lockedProfile: candidate != null && candidate === params.lockedProfileId,
     });
   };
 


### PR DESCRIPTION
## Summary
- defer the synthetic `ollama-local` auth profile until after real Ollama env and configured credentials are checked
- keep local-only Ollama setups working by falling back to the stored local marker when no real credential exists
- add regression coverage for env, configured key, fallback, and real-profile precedence

Closes #59205.
Related: #58384, #58457.

## Test plan
- [x] `pnpm test -- src/agents/model-auth.profiles.test.ts -t "ollama"`
- [x] `pnpm build`
- [ ] `pnpm check` (attempted; currently fails in unrelated `extensions/diffs/src/language-hints.test.ts`)
- [ ] `pnpm test` (attempted; currently fails in unrelated `src/tts/status-config.test.ts`)

## Notes
- Testing level: targeted regression coverage plus build, with broader repo gates attempted and recorded above
- AI-assisted: yes

Made with [Cursor](https://cursor.com)