### PR TITLE
fix(ui): keep approval modal actions reachable

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2915,6 +2915,10 @@ td.data-table-key-col {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 20px;
+  display: flex;
+  flex-direction: column;
+  max-height: min(720px, calc(100vh - 48px));
+  overflow: hidden;
   animation: scale-in 0.2s var(--ease-out);
 }
 
@@ -2945,20 +2949,27 @@ td.data-table-key-col {
   padding: 4px 10px;
 }
 
-.exec-approval-command {
+.exec-approval-body {
   margin-top: 12px;
+  display: grid;
+  gap: 12px;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.exec-approval-command {
   padding: 10px 12px;
   background: var(--secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   word-break: break-word;
+  overflow-wrap: anywhere;
   white-space: pre-wrap;
   font-family: var(--mono);
   font-size: 13px;
 }
 
 .exec-approval-meta {
-  margin-top: 12px;
   display: grid;
   gap: 6px;
   font-size: 13px;
@@ -2977,7 +2988,6 @@ td.data-table-key-col {
 }
 
 .exec-approval-error {
-  margin-top: 10px;
   font-size: 13px;
   color: var(--danger);
 }
@@ -2987,6 +2997,7 @@ td.data-table-key-col {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  flex-shrink: 0;
 }
 
 /* ===========================================

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2927,6 +2927,7 @@ td.data-table-key-col {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  flex-shrink: 0;
 }
 
 .exec-approval-title {
@@ -2955,6 +2956,7 @@ td.data-table-key-col {
   gap: 12px;
   min-height: 0;
   overflow-y: auto;
+  padding-bottom: 4px;
 }
 
 .exec-approval-command {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -17,6 +17,8 @@ import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ModelCatalogEntry } from "../types.ts";
 import type { SessionsListResult } from "../types.ts";
 import { renderChat, type ChatProps } from "./chat.ts";
+import { renderExecApprovalPrompt } from "./exec-approval.ts";
+import { renderGatewayUrlConfirmation } from "./gateway-url-confirmation.ts";
 import { renderOverview, type OverviewProps } from "./overview.ts";
 
 function readDeleteConfirmPreference(): string | null {
@@ -1295,5 +1297,75 @@ describe("chat view", () => {
     expect(labels.filter((label) => label === "Deep Chat (alpha) / main")).toHaveLength(1);
     expect(labels).toContain("Deep Chat (alpha) / main · named-main");
     expect(labels).toContain("Coding (beta) / main");
+  });
+});
+
+function createExecApprovalState(overrides: Partial<AppViewState> = {}): AppViewState {
+  const now = Date.now();
+  return {
+    execApprovalQueue: [
+      {
+        id: "req-1",
+        createdAtMs: now - 1_000,
+        expiresAtMs: now + 60_000,
+        request: {
+          command:
+            "python - <<'PY'\nprint('very long command body')\nprint('still going')\nprint('done')\nPY",
+          host: "gateway.local",
+          agentId: "agent:main",
+          sessionKey: "main",
+          cwd: "/workspace",
+          resolvedPath: "/usr/bin/python",
+          security: "allowlist",
+          ask: "on-miss",
+        },
+      },
+    ],
+    execApprovalBusy: false,
+    execApprovalError: "Approval failed",
+    pendingGatewayUrl: "https://example.invalid/ws",
+    handleExecApprovalDecision: vi.fn(),
+    handleGatewayUrlConfirm: vi.fn(),
+    handleGatewayUrlCancel: vi.fn(),
+    ...overrides,
+  } as unknown as AppViewState;
+}
+
+describe("approval modal rendering", () => {
+  it("keeps the exec approval action row outside the scrollable body", () => {
+    const state = createExecApprovalState();
+    const container = document.createElement("div");
+
+    render(renderExecApprovalPrompt(state), container);
+
+    const overlay = container.querySelector(".exec-approval-overlay");
+    const card = container.querySelector(".exec-approval-card");
+    const body = container.querySelector(".exec-approval-body");
+    const actions = container.querySelector(".exec-approval-actions");
+
+    expect(overlay?.getAttribute("aria-modal")).toBe("true");
+    expect(card?.children[1]).toBe(body);
+    expect(card?.lastElementChild).toBe(actions);
+    expect(body?.querySelector(".exec-approval-command")?.textContent).toContain(
+      "very long command body",
+    );
+    expect(body?.querySelector(".exec-approval-error")?.textContent).toContain("Approval failed");
+  });
+
+  it("uses the same scrollable body layout for gateway URL confirmation", () => {
+    const state = createExecApprovalState({ execApprovalQueue: [] });
+    const container = document.createElement("div");
+
+    render(renderGatewayUrlConfirmation(state), container);
+
+    const card = container.querySelector(".exec-approval-card");
+    const body = container.querySelector(".exec-approval-body");
+    const actions = container.querySelector(".exec-approval-actions");
+
+    expect(card?.children[1]).toBe(body);
+    expect(card?.lastElementChild).toBe(actions);
+    expect(body?.querySelector(".exec-approval-command")?.textContent).toContain(
+      "https://example.invalid/ws",
+    );
   });
 });

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -67,7 +67,7 @@ export function renderExecApprovalPrompt(state: AppViewState) {
     ? (active.pluginTitle ?? "Plugin approval needed")
     : "Exec approval needed";
   return html`
-    <div class="exec-approval-overlay" role="dialog" aria-live="polite">
+    <div class="exec-approval-overlay" role="dialog" aria-modal="true" aria-live="polite">
       <div class="exec-approval-card">
         <div class="exec-approval-header">
           <div>
@@ -78,10 +78,12 @@ export function renderExecApprovalPrompt(state: AppViewState) {
             ? html`<div class="exec-approval-queue">${queueCount} pending</div>`
             : nothing}
         </div>
-        ${isPlugin ? renderPluginBody(active) : renderExecBody(request)}
-        ${state.execApprovalError
-          ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
-          : nothing}
+        <div class="exec-approval-body">
+          ${isPlugin ? renderPluginBody(active) : renderExecBody(request)}
+          ${state.execApprovalError
+            ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
+            : nothing}
+        </div>
         <div class="exec-approval-actions">
           <button
             class="btn primary"

--- a/ui/src/ui/views/gateway-url-confirmation.ts
+++ b/ui/src/ui/views/gateway-url-confirmation.ts
@@ -16,9 +16,11 @@ export function renderGatewayUrlConfirmation(state: AppViewState) {
             <div class="exec-approval-sub">This will reconnect to a different gateway server</div>
           </div>
         </div>
-        <div class="exec-approval-command mono">${pendingGatewayUrl}</div>
-        <div class="callout danger" style="margin-top: 12px;">
-          Only confirm if you trust this URL. Malicious URLs can compromise your system.
+        <div class="exec-approval-body">
+          <div class="exec-approval-command mono">${pendingGatewayUrl}</div>
+          <div class="callout danger">
+            Only confirm if you trust this URL. Malicious URLs can compromise your system.
+          </div>
         </div>
         <div class="exec-approval-actions">
           <button class="btn primary" @click=${() => state.handleGatewayUrlConfirm()}>


### PR DESCRIPTION
## Summary

- Problem: long exec and plugin approval payloads can make the shared approval modal taller than the viewport, which pushes the action buttons out of reach in the Web UI.
- Why it matters: users can get stuck on a blocking approval prompt with no reachable way to allow or deny the request.
- What changed: bounded the shared approval card height, moved modal content into a scrollable body, kept the action row outside that scroll region, and applied the same layout to gateway URL confirmation.
- What did NOT change (scope boundary): no approval policy, auth, routing, or channel-side approval behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59195
- Related #50980
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the shared approval modal card in `ui/src/styles/components.css` had no internal scroll region or height bound, so long command/plugin text could push the action buttons below the viewport.
- Missing detection / guardrail: there was no UI render test asserting that the shared approval body stays separate from the action row for long approval payloads.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the issue report in #59195 matches the current shared modal structure used by both exec approvals and gateway URL confirmation.
- Why this regressed now: plugin descriptions and long commands can now easily exceed the available viewport height, but the modal layout still assumed short content.
- If unknown, what was ruled out: this is not specific to Gmail OAuth; the overflow is in the shared Web UI approval surface.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/views/chat.test.ts`
- Scenario the test should lock in: long approval content renders inside a dedicated `.exec-approval-body` while the shared action row remains the last child of the modal card.
- Why this is the smallest reliable guardrail: the bug is a pure view-layout regression in shared Lit templates, so a jsdom render test catches the structural contract without needing a full browser harness.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Long exec approval and plugin approval prompts in the Web UI now keep `Allow once`, `Always allow`, and `Deny` reachable by scrolling the modal body instead of letting the whole card overflow off-screen.
- Gateway URL confirmation now uses the same bounded, scrollable modal layout.

## Diagram (if applicable)

```text
Before:
[long approval content] -> [modal grows past viewport] -> [action buttons fall off-screen]

After:
[long approval content] -> [scrollable modal body] -> [fixed action row remains reachable]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 25.3.0
- Runtime/container: local Node/pnpm dev environment
- Model/provider: N/A
- Integration/channel (if any): Web UI shared approval modal
- Relevant config (redacted): default local config

### Steps

1. Trigger an exec or plugin approval that includes a long command or long multi-line description.
2. Open the approval prompt in the Web UI.
3. Try to reach the decision buttons when the content exceeds the viewport height.

### Expected

- The modal body scrolls and the action buttons remain reachable.

### Actual

- Before this change, the modal could grow past the viewport and leave the action buttons inaccessible.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run locally:
- `pnpm test -- ui/src/ui/views/chat.test.ts`
- `pnpm build`
- `pnpm check`
- `pnpm test` (hit an unrelated failure in `src/tts/status-config.test.ts`)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted jsdom coverage for the shared exec approval modal and gateway URL confirmation modal; local `pnpm build`; local `pnpm check`.
- Edge cases checked: long command content, shared error rendering inside the scrollable body, and gateway URL confirmation reusing the same modal layout.
- What you did **not** verify: a live browser screenshot/recording of the modal before and after.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: modal body sizing could feel tighter on very short viewports.
  - Mitigation: only the body scrolls; the action row and existing mobile button stacking remain unchanged.

## Additional Context

- AI assistance: this PR was prepared with AI assistance.
- Testing degree: targeted test, full build, and full `pnpm check` passed; full `pnpm test` hit an unrelated failure in `src/tts/status-config.test.ts`.

Made with [Cursor](https://cursor.com)