### PR TITLE
feat(ollama): add bundled web search provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/browser seams: split browser and WhatsApp plugin-sdk seams into narrower browser, approval-auth, and target-helper facades so hot paths and owner tests avoid broader runtime fan-out. (#60376) Thanks @shakkernerd.
 - Tests/runtime: trim local unit-test import/runtime fan-out across browser, WhatsApp, cron, task, and reply flows so owner suites start faster with lower shared-worker overhead while preserving the same focused behavior coverage. (#60249) Thanks @shakkernerd.
 - Tests/secrets runtime: restore split secrets suite cache and env isolation cleanup so broader runs do not leak stale plugin or provider snapshot state. (#60395) Thanks @shakkernerd.
+- Providers/Ollama: add bundled Ollama Web Search provider for key-free web_search via your configured Ollama host and `ollama signin`. (#59318)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/browser seams: split browser and WhatsApp plugin-sdk seams into narrower browser, approval-auth, and target-helper facades so hot paths and owner tests avoid broader runtime fan-out. (#60376) Thanks @shakkernerd.
 - Tests/runtime: trim local unit-test import/runtime fan-out across browser, WhatsApp, cron, task, and reply flows so owner suites start faster with lower shared-worker overhead while preserving the same focused behavior coverage. (#60249) Thanks @shakkernerd.
 - Tests/secrets runtime: restore split secrets suite cache and env isolation cleanup so broader runs do not leak stale plugin or provider snapshot state. (#60395) Thanks @shakkernerd.
-- Providers/Ollama: add bundled Ollama Web Search provider for key-free web_search via your configured Ollama host and `ollama signin`. (#59318)
+- Providers/Ollama: add bundled Ollama Web Search provider for key-free web_search via your configured Ollama host and `ollama signin`. (#59318) Thanks @BruceMacD.
 
 ### Fixes
 

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -216,6 +216,10 @@
     "target": "常见问题"
   },
   {
+    "source": "Ollama Web Search",
+    "target": "Ollama Web 搜索"
+  },
+  {
     "source": "onboarding",
     "target": "新手引导"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1177,6 +1177,7 @@
                       "tools/gemini-search",
                       "tools/grok-search",
                       "tools/kimi-search",
+                      "tools/ollama-search",
                       "tools/perplexity-search",
                       "tools/searxng-search",
                       "tools/tavily"

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1410,16 +1410,24 @@ for usage/billing and raise limits as needed.
   </Accordion>
 
   <Accordion title="How do I enable web search (and web fetch)?">
-    `web_fetch` works without an API key. `web_search` requires a key for your
-    selected provider (Brave, Gemini, Grok, Kimi, or Perplexity).
+    `web_fetch` works without an API key. `web_search` depends on your selected
+    provider:
+
+    - API-backed providers such as Brave, Exa, Firecrawl, Gemini, Grok, Kimi, Perplexity, and Tavily require their normal API key setup.
+    - Ollama Web Search is key-free, but it uses your configured Ollama host and requires `ollama signin`.
+    - DuckDuckGo is key-free, but it is an unofficial HTML-based integration.
+
     **Recommended:** run `openclaw configure --section web` and choose a provider.
     Environment alternatives:
 
     - Brave: `BRAVE_API_KEY`
+    - Exa: `EXA_API_KEY`
+    - Firecrawl: `FIRECRAWL_API_KEY`
     - Gemini: `GEMINI_API_KEY`
     - Grok: `XAI_API_KEY`
     - Kimi: `KIMI_API_KEY` or `MOONSHOT_API_KEY`
     - Perplexity: `PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY`
+    - Tavily: `TAVILY_API_KEY`
 
     ```json5
     {
@@ -2080,13 +2088,13 @@ for usage/billing and raise limits as needed.
 
     1. Install Ollama from `https://ollama.com/download`
     2. Pull a local model such as `ollama pull glm-4.7-flash`
-    3. If you want Ollama Cloud too, run `ollama signin`
+    3. If you want hosted models too, run `ollama signin`
     4. Run `openclaw onboard` and choose `Ollama`
     5. Pick `Local` or `Cloud + Local`
 
     Notes:
 
-    - `Cloud + Local` gives you Ollama Cloud models plus your local Ollama models
+    - `Cloud + Local` gives you hosted models plus your local Ollama models
     - cloud models such as `kimi-k2.5:cloud` do not need a local pull
     - for manual switching, use `openclaw models list` and `openclaw models set ollama/<model>`
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2088,13 +2088,13 @@ for usage/billing and raise limits as needed.
 
     1. Install Ollama from `https://ollama.com/download`
     2. Pull a local model such as `ollama pull glm-4.7-flash`
-    3. If you want hosted models too, run `ollama signin`
+    3. If you want cloud models too, run `ollama signin`
     4. Run `openclaw onboard` and choose `Ollama`
     5. Pick `Local` or `Cloud + Local`
 
     Notes:
 
-    - `Cloud + Local` gives you hosted models plus your local Ollama models
+    - `Cloud + Local` gives you cloud models plus your local Ollama models
     - cloud models such as `kimi-k2.5:cloud` do not need a local pull
     - for manual switching, use `openclaw models list` and `openclaw models set ollama/<model>`
 

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -235,6 +235,33 @@ To use cloud models, select **Cloud + Local** mode during setup. The wizard chec
 
 You can also sign in directly at [ollama.com/signin](https://ollama.com/signin).
 
+## Ollama Web Search
+
+OpenClaw also supports **Ollama Web Search** as a bundled `web_search`
+provider.
+
+- It uses your configured Ollama host (`models.providers.ollama.baseUrl` when
+  set, otherwise `http://127.0.0.1:11434`).
+- It is key-free.
+- It requires Ollama to be running and signed in with `ollama signin`.
+
+Choose **Ollama Web Search** during `openclaw onboard` or
+`openclaw configure --section web`, or set:
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "ollama",
+      },
+    },
+  },
+}
+```
+
+For the full setup and behavior details, see [Ollama Web Search](/tools/ollama-search).
+
 ## Advanced
 
 ### Reasoning models

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -77,13 +77,18 @@ See [Memory](/concepts/memory).
 
 ### 4) Web search tool
 
-`web_search` uses API keys and may incur usage charges depending on your provider:
+`web_search` may incur usage charges depending on your provider:
 
 - **Brave Search API**: `BRAVE_API_KEY` or `plugins.entries.brave.config.webSearch.apiKey`
+- **Exa**: `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`
+- **Firecrawl**: `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey`
 - **Gemini (Google Search)**: `GEMINI_API_KEY` or `plugins.entries.google.config.webSearch.apiKey`
 - **Grok (xAI)**: `XAI_API_KEY` or `plugins.entries.xai.config.webSearch.apiKey`
 - **Kimi (Moonshot)**: `KIMI_API_KEY`, `MOONSHOT_API_KEY`, or `plugins.entries.moonshot.config.webSearch.apiKey`
+- **Ollama Web Search**: key-free, but requires a reachable Ollama host plus `ollama signin`
 - **Perplexity Search API**: `PERPLEXITY_API_KEY`, `OPENROUTER_API_KEY`, or `plugins.entries.perplexity.config.webSearch.apiKey`
+- **Tavily**: `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey`
+- **DuckDuckGo**: key-free fallback (no API billing, but unofficial and HTML-based)
 
 Legacy `tools.web.search.*` provider paths still load through the temporary compatibility shim, but they are no longer the recommended config surface.
 

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -100,8 +100,8 @@ For a high-level overview, see [Onboarding (CLI)](/start/wizard).
     - DM security: default is pairing. First DM sends a code; approve via `openclaw pairing approve <channel> <code>` or use allowlists.
   </Step>
   <Step title="Web search">
-    - Pick a provider: Perplexity, Brave, Gemini, Grok, or Kimi (or skip).
-    - Paste your API key (QuickStart auto-detects keys from env vars or existing config).
+    - Pick a supported provider such as Brave, Firecrawl, Gemini, Grok, Kimi, Ollama Web Search, Perplexity, or Tavily (or skip).
+    - API-backed providers can use env vars or existing config for quick setup; key-free providers use their provider-specific prerequisites instead.
     - Skip with `--skip-search`.
     - Configure later: `openclaw configure --section web`.
   </Step>

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -36,8 +36,9 @@ openclaw agents add <name>
 
 <Tip>
 CLI onboarding includes a web search step where you can pick a provider
-(Perplexity, Brave, Gemini, Grok, or Kimi) and paste your API key so the agent
-can use `web_search`. You can also configure this later with
+such as Brave, Firecrawl, Gemini, Grok, Kimi, Ollama Web Search, Perplexity,
+or Tavily. Some providers require an API key, while others are key-free. You
+can also configure this later with
 `openclaw configure --section web`. Docs: [Web tools](/tools/web).
 </Tip>
 

--- a/docs/tools/ollama-search.md
+++ b/docs/tools/ollama-search.md
@@ -1,0 +1,94 @@
+---
+summary: "Ollama Web Search via your configured Ollama host"
+read_when:
+  - You want to use Ollama for web_search
+  - You want a key-free web_search provider
+  - You need Ollama Web Search setup guidance
+title: "Ollama Web Search"
+---
+
+# Ollama Web Search
+
+OpenClaw supports **Ollama Web Search** as a bundled `web_search` provider.
+It uses Ollama's experimental web-search API and returns structured results
+with titles, URLs, and snippets.
+
+Unlike the Ollama model provider, this setup does not need an API key. It
+does require:
+
+- an Ollama host that is reachable from OpenClaw
+- `ollama signin`
+
+## Setup
+
+<Steps>
+  <Step title="Start Ollama">
+    Make sure Ollama is installed and running.
+  </Step>
+  <Step title="Sign in">
+    Run:
+
+    ```bash
+    ollama signin
+    ```
+
+  </Step>
+  <Step title="Choose Ollama Web Search">
+    Run:
+
+    ```bash
+    openclaw configure --section web
+    ```
+
+    Then select **Ollama Web Search** as the provider.
+
+  </Step>
+</Steps>
+
+If you already use Ollama for models, Ollama Web Search reuses the same
+configured host.
+
+## Config
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "ollama",
+      },
+    },
+  },
+}
+```
+
+Optional Ollama host override:
+
+```json5
+{
+  models: {
+    providers: {
+      ollama: {
+        baseUrl: "http://ollama-host:11434",
+      },
+    },
+  },
+}
+```
+
+If no explicit Ollama base URL is set, OpenClaw uses `http://127.0.0.1:11434`.
+
+## Notes
+
+- No API key field is required for this provider.
+- OpenClaw warns during setup if Ollama is unreachable or not signed in, but
+  it does not block selection.
+- Runtime auto-detect can fall back to Ollama Web Search when no higher-priority
+  credentialed provider is configured.
+- The provider uses Ollama's experimental `/api/experimental/web_search`
+  endpoint.
+
+## Related
+
+- [Web Search overview](/tools/web) -- all providers and auto-detection
+- [Ollama](/providers/ollama) -- Ollama model setup and cloud/local modes

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -27,16 +27,18 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 ## Quick start
 
 <Steps>
-  <Step title="Get an API key">
-    Pick a provider and get an API key. See the provider pages below for
-    sign-up links.
+  <Step title="Choose a provider">
+    Pick a provider and complete any required setup. Some providers are
+    key-free, while others use API keys. See the provider pages below for
+    details.
   </Step>
   <Step title="Configure">
     ```bash
     openclaw configure --section web
     ```
-    This stores the key and sets the provider. You can also set an env var
-    (e.g. `BRAVE_API_KEY`) and skip this step.
+    This stores the provider and any needed credential. You can also set an env
+    var (for example `BRAVE_API_KEY`) and skip this step for API-backed
+    providers.
   </Step>
   <Step title="Use it">
     The agent can now call `web_search`:
@@ -78,6 +80,9 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
   <Card title="Kimi" icon="moon" href="/tools/kimi-search">
     AI-synthesized answers with citations via Moonshot web search.
   </Card>
+  <Card title="Ollama Web Search" icon="globe" href="/tools/ollama-search">
+    Key-free search via your configured Ollama host. Requires `ollama signin`.
+  </Card>
   <Card title="Perplexity" icon="search" href="/tools/perplexity-search">
     Structured results with content extraction controls and domain filtering.
   </Card>
@@ -91,18 +96,19 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 
 ### Provider comparison
 
-| Provider                               | Result style               | Filters                                          | API key                                     |
-| -------------------------------------- | -------------------------- | ------------------------------------------------ | ------------------------------------------- |
-| [Brave](/tools/brave-search)           | Structured snippets        | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                             |
-| [DuckDuckGo](/tools/duckduckgo-search) | Structured snippets        | --                                               | None (key-free)                             |
-| [Exa](/tools/exa-search)               | Structured + extracted     | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                               |
-| [Firecrawl](/tools/firecrawl)          | Structured snippets        | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                         |
-| [Gemini](/tools/gemini-search)         | AI-synthesized + citations | --                                               | `GEMINI_API_KEY`                            |
-| [Grok](/tools/grok-search)             | AI-synthesized + citations | --                                               | `XAI_API_KEY`                               |
-| [Kimi](/tools/kimi-search)             | AI-synthesized + citations | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`         |
-| [Perplexity](/tools/perplexity-search) | Structured snippets        | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` |
-| [SearXNG](/tools/searxng-search)       | Structured snippets        | Categories, language                             | None (self-hosted)                          |
-| [Tavily](/tools/tavily)                | Structured snippets        | Via `tavily_search` tool                         | `TAVILY_API_KEY`                            |
+| Provider                                  | Result style               | Filters                                          | API key                                     |
+| ----------------------------------------- | -------------------------- | ------------------------------------------------ | ------------------------------------------- |
+| [Brave](/tools/brave-search)              | Structured snippets        | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                             |
+| [DuckDuckGo](/tools/duckduckgo-search)    | Structured snippets        | --                                               | None (key-free)                             |
+| [Exa](/tools/exa-search)                  | Structured + extracted     | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                               |
+| [Firecrawl](/tools/firecrawl)             | Structured snippets        | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                         |
+| [Gemini](/tools/gemini-search)            | AI-synthesized + citations | --                                               | `GEMINI_API_KEY`                            |
+| [Grok](/tools/grok-search)                | AI-synthesized + citations | --                                               | `XAI_API_KEY`                               |
+| [Kimi](/tools/kimi-search)                | AI-synthesized + citations | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`         |
+| [Ollama Web Search](/tools/ollama-search) | Structured snippets        | --                                               | None (`ollama signin` required)             |
+| [Perplexity](/tools/perplexity-search)    | Structured snippets        | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` |
+| [SearXNG](/tools/searxng-search)          | Structured snippets        | Categories, language                             | None (self-hosted)                          |
+| [Tavily](/tools/tavily)                   | Structured snippets        | Via `tavily_search` tool                         | `TAVILY_API_KEY`                            |
 
 ## Auto-detection
 
@@ -146,8 +152,8 @@ If native Codex search is enabled but the current model is not Codex-capable, Op
 Provider lists in docs and setup flows are alphabetical. Auto-detection keeps a
 separate precedence order:
 
-If no `provider` is set, OpenClaw checks for API keys in this order and uses
-the first one found:
+If no `provider` is set, OpenClaw checks providers in this order and uses the
+first one that is ready:
 
 1. **Brave** -- `BRAVE_API_KEY` or `plugins.entries.brave.config.webSearch.apiKey`
 2. **Gemini** -- `GEMINI_API_KEY` or `plugins.entries.google.config.webSearch.apiKey`
@@ -155,12 +161,14 @@ the first one found:
 4. **Kimi** -- `KIMI_API_KEY` / `MOONSHOT_API_KEY` or `plugins.entries.moonshot.config.webSearch.apiKey`
 5. **Perplexity** -- `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey`
 6. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey`
-7. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey`
+7. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`
+8. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey`
+9. **Ollama Web Search** -- key-free fallback via your configured Ollama host; requires Ollama to be reachable and signed in with `ollama signin`
+10. **DuckDuckGo** -- key-free HTML fallback with no account or API key
 
 Key-free providers are checked after API-backed providers:
 
-8. **DuckDuckGo** -- no key needed (auto-detect order 100)
-9. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (auto-detect order 200)
+11. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (auto-detect order 200)
 
 If no provider is detected, it falls back to Brave (you will get a missing-key
 error prompting you to configure one).
@@ -376,3 +384,4 @@ If you use tool profiles or allowlists, add `web_search`, `x_search`, or `group:
 - [Web Fetch](/tools/web-fetch) -- fetch a URL and extract readable content
 - [Web Browser](/tools/browser) -- full browser automation for JS-heavy sites
 - [Grok Search](/tools/grok-search) -- Grok as the `web_search` provider
+- [Ollama Web Search](/tools/ollama-search) -- key-free web search through your Ollama host

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -163,8 +163,8 @@ first one that is ready:
 6. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey`
 7. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`
 8. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey`
-9. **Ollama Web Search** -- key-free fallback via your configured Ollama host; requires Ollama to be reachable and signed in with `ollama signin`
-10. **DuckDuckGo** -- key-free HTML fallback with no account or API key
+9. **DuckDuckGo** -- key-free HTML fallback with no account or API key
+10. **Ollama Web Search** -- key-free fallback via your configured Ollama host; requires Ollama to be reachable and signed in with `ollama signin`
 
 Key-free providers are checked after API-backed providers:
 

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -25,6 +25,7 @@ import {
   createConfiguredOllamaCompatStreamWrapper,
   createConfiguredOllamaStreamFn,
 } from "./src/stream.js";
+import { createOllamaWebSearchProvider } from "./src/web-search-provider.js";
 
 const PROVIDER_ID = "ollama";
 const DEFAULT_API_KEY = "ollama-local";
@@ -44,6 +45,7 @@ export default definePluginEntry({
   name: "Ollama Provider",
   description: "Bundled Ollama provider plugin",
   register(api: OpenClawPluginApi) {
+    api.registerWebSearchProvider(createOllamaWebSearchProvider());
     api.registerProvider({
       id: PROVIDER_ID,
       label: "Ollama",

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -17,6 +17,9 @@
       "groupHint": "Cloud and local open models"
     }
   ],
+  "contracts": {
+    "webSearchProviders": ["ollama"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/ollama/plugin-registration.contract.test.ts
+++ b/extensions/ollama/plugin-registration.contract.test.ts
@@ -1,0 +1,7 @@
+import { describePluginRegistrationContract } from "../../test/helpers/plugins/plugin-registration-contract.js";
+
+describePluginRegistrationContract({
+  pluginId: "ollama",
+  providerIds: ["ollama"],
+  webSearchProviderIds: ["ollama"],
+});

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -63,7 +63,7 @@ function formatOllamaPullStatus(status: string): { text: string; hidePercent: bo
   return { text: trimmed, hidePercent: false };
 }
 
-async function checkOllamaCloudAuth(baseUrl: string): Promise<OllamaCloudAuthResult> {
+export async function checkOllamaCloudAuth(baseUrl: string): Promise<OllamaCloudAuthResult> {
   try {
     const apiBase = resolveOllamaApiBase(baseUrl);
     const { response, release } = await fetchWithSsrFGuard({
@@ -344,7 +344,7 @@ export async function promptAndConfigureOllama(params: {
   const mode = (await params.prompter.select({
     message: "Ollama mode",
     options: [
-      { value: "remote", label: "Cloud + Local", hint: "Ollama cloud models + local models" },
+      { value: "remote", label: "Cloud + Local", hint: "Hosted models + local models" },
       { value: "local", label: "Local", hint: "Local models only" },
     ],
   })) as OllamaMode;
@@ -358,27 +358,27 @@ export async function promptAndConfigureOllama(params: {
           await params.openUrl(authResult.signinUrl);
         }
         await params.prompter.note(
-          ["Sign in to Ollama Cloud:", authResult.signinUrl].join("\n"),
-          "Ollama Cloud",
+          ["Run `ollama signin`:", authResult.signinUrl].join("\n"),
+          "Ollama Sign-In",
         );
         const confirmed = await params.prompter.confirm({ message: "Have you signed in?" });
         if (!confirmed) {
-          throw new WizardCancelledError("Ollama cloud sign-in cancelled");
+          throw new WizardCancelledError("Ollama sign-in cancelled");
         }
         if (!(await checkOllamaCloudAuth(baseUrl)).signedIn) {
-          throw new WizardCancelledError("Ollama cloud sign-in required");
+          throw new WizardCancelledError("Ollama sign-in required");
         }
         cloudAuthVerified = true;
       } else {
         await params.prompter.note(
           [
-            "Could not verify Ollama Cloud authentication.",
+            "Could not verify `ollama signin`.",
             "Cloud models may not work until you sign in at https://ollama.com.",
           ].join("\n"),
-          "Ollama Cloud",
+          "Ollama Sign-In",
         );
-        if (!(await params.prompter.confirm({ message: "Continue without cloud auth?" }))) {
-          throw new WizardCancelledError("Ollama cloud auth could not be verified");
+        if (!(await params.prompter.confirm({ message: "Continue without sign-in?" }))) {
+          throw new WizardCancelledError("Ollama sign-in could not be verified");
         }
       }
     } else {

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -344,7 +344,7 @@ export async function promptAndConfigureOllama(params: {
   const mode = (await params.prompter.select({
     message: "Ollama mode",
     options: [
-      { value: "remote", label: "Cloud + Local", hint: "Hosted models + local models" },
+      { value: "remote", label: "Cloud + Local", hint: "Cloud models + local models" },
       { value: "local", label: "Local", hint: "Local models only" },
     ],
   })) as OllamaMode;

--- a/extensions/ollama/src/web-search-provider.test.ts
+++ b/extensions/ollama/src/web-search-provider.test.ts
@@ -185,6 +185,32 @@ describe("ollama web search provider", () => {
     ]);
   });
 
+  it("resolves env var when config apiKey is a marker string", () => {
+    const original = process.env.OLLAMA_API_KEY;
+    try {
+      process.env.OLLAMA_API_KEY = "real-secret-from-env";
+      const key = testing.resolveOllamaWebSearchApiKey({
+        models: {
+          providers: {
+            ollama: {
+              apiKey: "OLLAMA_API_KEY",
+              baseUrl: "http://localhost:11434",
+              api: "ollama",
+              models: [],
+            },
+          },
+        },
+      });
+      expect(key).toBe("real-secret-from-env");
+    } finally {
+      if (original === undefined) {
+        delete process.env.OLLAMA_API_KEY;
+      } else {
+        process.env.OLLAMA_API_KEY = original;
+      }
+    }
+  });
+
   it("warns when ollama signin is missing during setup without cancelling", async () => {
     fetchWithSsrFGuardMock
       .mockResolvedValueOnce({

--- a/extensions/ollama/src/web-search-provider.test.ts
+++ b/extensions/ollama/src/web-search-provider.test.ts
@@ -1,0 +1,239 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import plugin from "../index.js";
+
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+describe("ollama web search provider", () => {
+  let createOllamaWebSearchProvider: typeof import("./web-search-provider.js").createOllamaWebSearchProvider;
+  let runOllamaWebSearch: typeof import("./web-search-provider.js").runOllamaWebSearch;
+  let testing: typeof import("./web-search-provider.js").__testing;
+
+  beforeAll(async () => {
+    ({
+      createOllamaWebSearchProvider,
+      runOllamaWebSearch,
+      __testing: testing,
+    } = await import("./web-search-provider.js"));
+  });
+
+  beforeEach(() => {
+    fetchWithSsrFGuardMock.mockReset();
+  });
+
+  it("registers a keyless web search provider", () => {
+    const webSearchProviders: unknown[] = [];
+
+    plugin.register({
+      registerProvider() {},
+      registerWebSearchProvider(provider: unknown) {
+        webSearchProviders.push(provider);
+      },
+    } as never);
+
+    expect(webSearchProviders).toHaveLength(1);
+    expect(webSearchProviders[0]).toMatchObject({
+      id: "ollama",
+      label: "Ollama Web Search",
+      requiresCredential: false,
+      envVars: [],
+    });
+  });
+
+  it("uses the configured Ollama host and enables the plugin in config", () => {
+    const provider = createOllamaWebSearchProvider();
+    if (!provider.applySelectionConfig) {
+      throw new Error("Expected applySelectionConfig to be defined");
+    }
+
+    const applied = provider.applySelectionConfig({});
+
+    expect(provider.credentialPath).toBe("");
+    expect(applied.plugins?.entries?.ollama?.enabled).toBe(true);
+    expect(
+      testing.resolveOllamaWebSearchBaseUrl({
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "http://ollama.local:11434/v1",
+              api: "ollama",
+              models: [],
+            },
+          },
+        },
+      }),
+    ).toBe("http://ollama.local:11434");
+  });
+
+  it("maps generic search args into the Ollama experimental search endpoint", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        JSON.stringify({
+          results: [
+            {
+              title: "OpenClaw",
+              url: "https://openclaw.ai/docs",
+              content: "Gateway docs and setup details",
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+      release,
+    });
+
+    const provider = createOllamaWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "http://ollama.local:11434/v1",
+              api: "ollama",
+              models: [],
+            },
+          },
+        },
+      },
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    const result = await tool.execute({ query: "openclaw docs", count: 3 });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "http://ollama.local:11434/api/experimental/web_search",
+        auditContext: "ollama-web-search.search",
+      }),
+    );
+    expect(
+      JSON.parse(
+        String(
+          (
+            fetchWithSsrFGuardMock.mock.calls[0]?.[0] as {
+              init?: { body?: string };
+            }
+          ).init?.body,
+        ),
+      ),
+    ).toEqual({
+      query: "openclaw docs",
+      max_results: 3,
+    });
+    expect(result).toMatchObject({
+      query: "openclaw docs",
+      provider: "ollama",
+      count: 1,
+      results: [{ url: "https://openclaw.ai/docs" }],
+    });
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces Ollama signin guidance for 401 responses", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("", { status: 401 }),
+      release: vi.fn(async () => {}),
+    });
+
+    await expect(runOllamaWebSearch({ query: "latest openclaw release" })).rejects.toThrow(
+      "ollama signin",
+    );
+  });
+
+  it("warns when Ollama is not reachable during setup without cancelling", async () => {
+    fetchWithSsrFGuardMock.mockRejectedValueOnce(new Error("connect failed"));
+
+    const notes: Array<{ title?: string; message: string }> = [];
+    const config: OpenClawConfig = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://ollama.local:11434/v1",
+            api: "ollama",
+            models: [],
+          },
+        },
+      },
+    };
+
+    const next = await testing.warnOllamaWebSearchPrereqs({
+      config,
+      prompter: {
+        note: async (message: string, title?: string) => {
+          notes.push({ title, message });
+        },
+      },
+    });
+
+    expect(next).toBe(config);
+    expect(notes).toEqual([
+      expect.objectContaining({
+        title: "Ollama Web Search",
+        message: expect.stringContaining("requires Ollama to be running"),
+      }),
+    ]);
+  });
+
+  it("warns when ollama signin is missing during setup without cancelling", async () => {
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ models: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({ error: "not signed in", signin_url: "https://ollama.com/signin" }),
+          {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      });
+
+    const notes: Array<{ title?: string; message: string }> = [];
+    const config: OpenClawConfig = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://ollama.local:11434/v1",
+            api: "ollama",
+            models: [],
+          },
+        },
+      },
+    };
+
+    const next = await testing.warnOllamaWebSearchPrereqs({
+      config,
+      prompter: {
+        note: async (message: string, title?: string) => {
+          notes.push({ title, message });
+        },
+      },
+    });
+
+    expect(next).toBe(config);
+    expect(notes).toEqual([
+      expect.objectContaining({
+        title: "Ollama Web Search",
+        message: expect.stringContaining("Ollama Web Search requires `ollama signin`."),
+      }),
+    ]);
+    expect(notes[0]?.message).toContain("https://ollama.com/signin");
+  });
+});

--- a/extensions/ollama/src/web-search-provider.ts
+++ b/extensions/ollama/src/web-search-provider.ts
@@ -1,6 +1,9 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { normalizeOptionalSecretInput } from "openclaw/plugin-sdk/provider-auth";
+import {
+  isNonSecretApiKeyMarker,
+  normalizeOptionalSecretInput,
+} from "openclaw/plugin-sdk/provider-auth";
 import { resolveEnvApiKey } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   enablePluginInConfig,
@@ -53,7 +56,7 @@ type OllamaWebSearchResponse = {
 
 function resolveOllamaWebSearchApiKey(config?: OpenClawConfig): string | undefined {
   const providerApiKey = normalizeOptionalSecretInput(config?.models?.providers?.ollama?.apiKey);
-  if (providerApiKey) {
+  if (providerApiKey && !isNonSecretApiKeyMarker(providerApiKey)) {
     return providerApiKey;
   }
   return resolveEnvApiKey("ollama")?.apiKey;

--- a/extensions/ollama/src/web-search-provider.ts
+++ b/extensions/ollama/src/web-search-provider.ts
@@ -1,5 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { normalizeOptionalSecretInput } from "openclaw/plugin-sdk/provider-auth";
+import { resolveEnvApiKey } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   enablePluginInConfig,
   readNumberParam,
@@ -49,6 +51,14 @@ type OllamaWebSearchResponse = {
   results?: OllamaWebSearchResult[];
 };
 
+function resolveOllamaWebSearchApiKey(config?: OpenClawConfig): string | undefined {
+  const providerApiKey = normalizeOptionalSecretInput(config?.models?.providers?.ollama?.apiKey);
+  if (providerApiKey) {
+    return providerApiKey;
+  }
+  return resolveEnvApiKey("ollama")?.apiKey;
+}
+
 function resolveOllamaWebSearchBaseUrl(config?: OpenClawConfig): string {
   const configuredBaseUrl = config?.models?.providers?.ollama?.baseUrl;
   if (typeof configuredBaseUrl === "string" && configuredBaseUrl.trim()) {
@@ -82,13 +92,18 @@ export async function runOllamaWebSearch(params: {
   }
 
   const baseUrl = resolveOllamaWebSearchBaseUrl(params.config);
+  const apiKey = resolveOllamaWebSearchApiKey(params.config);
   const count = resolveSearchCount(params.count, DEFAULT_OLLAMA_WEB_SEARCH_COUNT);
   const startedAt = Date.now();
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
   const { response, release } = await fetchWithSsrFGuard({
     url: `${baseUrl}${OLLAMA_WEB_SEARCH_PATH}`,
     init: {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify({ query, max_results: count }),
       signal: AbortSignal.timeout(DEFAULT_OLLAMA_WEB_SEARCH_TIMEOUT_MS),
     },
@@ -215,6 +230,7 @@ export function createOllamaWebSearchProvider(): WebSearchProviderPlugin {
 
 export const __testing = {
   normalizeOllamaWebSearchResult,
+  resolveOllamaWebSearchApiKey,
   resolveOllamaWebSearchBaseUrl,
   warnOllamaWebSearchPrereqs,
 };

--- a/extensions/ollama/src/web-search-provider.ts
+++ b/extensions/ollama/src/web-search-provider.ts
@@ -189,7 +189,7 @@ export function createOllamaWebSearchProvider(): WebSearchProviderPlugin {
     placeholder: "(run ollama signin)",
     signupUrl: "https://ollama.com/",
     docsUrl: "https://docs.openclaw.ai/tools/web",
-    autoDetectOrder: 80,
+    autoDetectOrder: 110,
     credentialPath: "",
     getCredentialValue: () => undefined,
     setCredentialValue: () => {},

--- a/extensions/ollama/src/web-search-provider.ts
+++ b/extensions/ollama/src/web-search-provider.ts
@@ -1,0 +1,220 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  enablePluginInConfig,
+  readNumberParam,
+  readResponseText,
+  readStringParam,
+  resolveSearchCount,
+  resolveSiteName,
+  truncateText,
+  wrapWebContent,
+  type WebSearchProviderPlugin,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { OLLAMA_DEFAULT_BASE_URL } from "./defaults.js";
+import {
+  buildOllamaBaseUrlSsrFPolicy,
+  fetchOllamaModels,
+  resolveOllamaApiBase,
+} from "./provider-models.js";
+import { checkOllamaCloudAuth } from "./setup.js";
+
+const OLLAMA_WEB_SEARCH_SCHEMA = Type.Object(
+  {
+    query: Type.String({ description: "Search query string." }),
+    count: Type.Optional(
+      Type.Number({
+        description: "Number of results to return (1-10).",
+        minimum: 1,
+        maximum: 10,
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const OLLAMA_WEB_SEARCH_PATH = "/api/experimental/web_search";
+const DEFAULT_OLLAMA_WEB_SEARCH_COUNT = 5;
+const DEFAULT_OLLAMA_WEB_SEARCH_TIMEOUT_MS = 15_000;
+const OLLAMA_WEB_SEARCH_SNIPPET_MAX_CHARS = 300;
+
+type OllamaWebSearchResult = {
+  title?: string;
+  url?: string;
+  content?: string;
+};
+
+type OllamaWebSearchResponse = {
+  results?: OllamaWebSearchResult[];
+};
+
+function resolveOllamaWebSearchBaseUrl(config?: OpenClawConfig): string {
+  const configuredBaseUrl = config?.models?.providers?.ollama?.baseUrl;
+  if (typeof configuredBaseUrl === "string" && configuredBaseUrl.trim()) {
+    return resolveOllamaApiBase(configuredBaseUrl);
+  }
+  return OLLAMA_DEFAULT_BASE_URL;
+}
+
+function normalizeOllamaWebSearchResult(
+  result: OllamaWebSearchResult,
+): { title: string; url: string; content: string } | null {
+  const url = typeof result.url === "string" ? result.url.trim() : "";
+  if (!url) {
+    return null;
+  }
+  return {
+    title: typeof result.title === "string" ? result.title.trim() : "",
+    url,
+    content: typeof result.content === "string" ? result.content.trim() : "",
+  };
+}
+
+export async function runOllamaWebSearch(params: {
+  config?: OpenClawConfig;
+  query: string;
+  count?: number;
+}): Promise<Record<string, unknown>> {
+  const query = params.query.trim();
+  if (!query) {
+    throw new Error("query parameter is required");
+  }
+
+  const baseUrl = resolveOllamaWebSearchBaseUrl(params.config);
+  const count = resolveSearchCount(params.count, DEFAULT_OLLAMA_WEB_SEARCH_COUNT);
+  const startedAt = Date.now();
+  const { response, release } = await fetchWithSsrFGuard({
+    url: `${baseUrl}${OLLAMA_WEB_SEARCH_PATH}`,
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query, max_results: count }),
+      signal: AbortSignal.timeout(DEFAULT_OLLAMA_WEB_SEARCH_TIMEOUT_MS),
+    },
+    policy: buildOllamaBaseUrlSsrFPolicy(baseUrl),
+    auditContext: "ollama-web-search.search",
+  });
+
+  try {
+    if (response.status === 401) {
+      throw new Error("Ollama web search authentication failed. Run `ollama signin`.");
+    }
+    if (response.status === 403) {
+      throw new Error(
+        "Ollama web search is unavailable. Ensure cloud-backed web search is enabled on the Ollama host.",
+      );
+    }
+    if (!response.ok) {
+      const detail = await readResponseText(response, { maxBytes: 64_000 });
+      throw new Error(`Ollama web search failed (${response.status}): ${detail.text || ""}`.trim());
+    }
+
+    const payload = (await response.json()) as OllamaWebSearchResponse;
+    const results = Array.isArray(payload.results)
+      ? payload.results
+          .map(normalizeOllamaWebSearchResult)
+          .filter((result): result is NonNullable<typeof result> => result !== null)
+          .slice(0, count)
+      : [];
+
+    return {
+      query,
+      provider: "ollama",
+      count: results.length,
+      tookMs: Date.now() - startedAt,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: "ollama",
+        wrapped: true,
+      },
+      results: results.map((result) => {
+        const snippet = truncateText(result.content, OLLAMA_WEB_SEARCH_SNIPPET_MAX_CHARS).text;
+        return {
+          title: result.title ? wrapWebContent(result.title, "web_search") : "",
+          url: result.url,
+          snippet: snippet ? wrapWebContent(snippet, "web_search") : "",
+          siteName: resolveSiteName(result.url) || undefined,
+        };
+      }),
+    };
+  } finally {
+    await release();
+  }
+}
+
+async function warnOllamaWebSearchPrereqs(params: {
+  config: OpenClawConfig;
+  prompter: {
+    note: (message: string, title?: string) => Promise<void>;
+  };
+}): Promise<OpenClawConfig> {
+  const baseUrl = resolveOllamaWebSearchBaseUrl(params.config);
+  const { reachable } = await fetchOllamaModels(baseUrl);
+  if (!reachable) {
+    await params.prompter.note(
+      [
+        "Ollama Web Search requires Ollama to be running.",
+        `Expected host: ${baseUrl}`,
+        "Start Ollama before using this provider.",
+      ].join("\n"),
+      "Ollama Web Search",
+    );
+    return params.config;
+  }
+
+  const auth = await checkOllamaCloudAuth(baseUrl);
+  if (!auth.signedIn) {
+    await params.prompter.note(
+      [
+        "Ollama Web Search requires `ollama signin`.",
+        ...(auth.signinUrl ? [auth.signinUrl] : ["Run `ollama signin`."]),
+      ].join("\n"),
+      "Ollama Web Search",
+    );
+  }
+
+  return params.config;
+}
+
+export function createOllamaWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    id: "ollama",
+    label: "Ollama Web Search",
+    hint: "Local Ollama host · requires ollama signin",
+    onboardingScopes: ["text-inference"],
+    requiresCredential: false,
+    envVars: [],
+    placeholder: "(run ollama signin)",
+    signupUrl: "https://ollama.com/",
+    docsUrl: "https://docs.openclaw.ai/tools/web",
+    autoDetectOrder: 80,
+    credentialPath: "",
+    getCredentialValue: () => undefined,
+    setCredentialValue: () => {},
+    applySelectionConfig: (config) => enablePluginInConfig(config, "ollama").config,
+    runSetup: async (ctx) =>
+      await warnOllamaWebSearchPrereqs({
+        config: ctx.config,
+        prompter: ctx.prompter,
+      }),
+    createTool: (ctx) => ({
+      description:
+        "Search the web using Ollama's experimental web search API. Returns titles, URLs, and snippets from the configured Ollama host.",
+      parameters: OLLAMA_WEB_SEARCH_SCHEMA,
+      execute: async (args) =>
+        await runOllamaWebSearch({
+          config: ctx.config,
+          query: readStringParam(args, "query", { required: true }),
+          count: readNumberParam(args, "count", { integer: true }),
+        }),
+    }),
+  };
+}
+
+export const __testing = {
+  normalizeOllamaWebSearchResult,
+  resolveOllamaWebSearchBaseUrl,
+  warnOllamaWebSearchPrereqs,
+};


### PR DESCRIPTION
## Summary

- Problem: OpenClaw did not automatically setup Ollama web search, even though it is a supported provider. Users running Ollama locally had no way to use their Ollama host for web search.
- Why it matters: Ollama users can now get web search without signing up for a third-party API key.
- What changed: Added an Ollama Web Search provider plugin that calls `/api/experimental/web_search` on the configured Ollama host. Registered it in the Ollama plugin manifest, added docs, tests, and onboarding/auto-detect integration.
- What did NOT change (scope boundary): No changes to the core web search orchestration, tool schema, or other provider implementations. The existing Ollama model provider is untouched aside from a terminology cleanup in setup.ts and exporting `checkOllamaCloudAuth` for reuse.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related # (none)
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A -- new feature, not a bug fix. Tests added as part of the feature.

## User-visible / Behavior Changes

- New web search provider "Ollama Web Search" available in `openclaw onboard`, `openclaw configure --section web`, and auto-detection.
- Key-free: requires only a reachable Ollama host and `ollama signin`.
- Onboarding shows informational warnings if Ollama is unreachable or not signed in (does not block selection).
- Setup/config UI labels changed from "Ollama Cloud" to "hosted models" / "Ollama Sign-In".

## Diagram (if applicable)


## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No,  provider is key-free; no new env vars or secret fields
- New/changed network calls? Yes, calls Ollama's `/api/experimental/web_search` endpoint
- Command/tool execution surface changed? No, uses the existing `web_search` tool surface
- Data access scope changed? No
- If any Yes, explain risk + mitigation: The new endpoint call targets the user's own configured Ollama host (default `127.0.0.1:11434`). SSRF policy is enforced via `buildOllamaBaseUrlSsrFPolicy()` and `fetchWithSsrFGuard`. Results are wrapped as untrusted external content, consistent with other web search providers.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / Bun
- Model/provider: Ollama (local or remote host)
- Integration/channel (if any): N/A
- Relevant config (redacted): `tools.web.search.provider: "ollama"` or auto-detect

### Steps

1. Ensure Ollama is running and signed in (`ollama signin`)
2. Run `openclaw onboard` or `openclaw configure --section web` and select "Ollama Web Search"
3. Send a message that triggers web search (e.g., "search for recent news about TypeScript")

### Expected

- Ollama Web Search appears in provider selection with hint "Local Ollama host - requires ollama signin"
- Search returns structured results (title, URL, snippet) from the Ollama endpoint
- If Ollama is unreachable or not signed in, onboarding shows an informational warning but does not block

### Actual

- Works as expected

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test files:
- `extensions/ollama/src/web-search-provider.test.ts` -- test cases covering registration, config, search execution, auth errors, and prerequisite warnings
- `extensions/ollama/plugin-registration.contract.test.ts` -- contract test validating `webSearchProviderIds: ["ollama"]`

## Human Verification (required)

- Verified scenarios: open claw onboarding on Mac and Linux, no Ollama running, Ollama not signed in, used web search without Ollama (OpenRouter provider instead)
- Edge cases checked:
- What you did **not** verify: Windows untested, but previous tested with web search specifically.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No, new provider is additive; no existing config keys change meaning
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Ollama's `/api/experimental/web_search` endpoint is experimental and may change.
  - Mitigation: The endpoint will be backwards compatible moving forwards (I am a maintainer on this part of the codebase in Ollama)
