### PR TITLE
fix(ios/macOS): truncate long session names in chat composer picker

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -138,6 +138,8 @@ struct OpenClawChatComposer: View {
             ForEach(self.viewModel.sessionChoices, id: \.key) { session in
                 Text(session.displayName ?? session.key)
                     .font(.system(.caption, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
                     .tag(session.key)
             }
         }
@@ -145,6 +147,8 @@ struct OpenClawChatComposer: View {
         .pickerStyle(.menu)
         .controlSize(.small)
         .frame(maxWidth: 160, alignment: .leading)
+        .lineLimit(1)
+        .truncationMode(.tail)
         .help("Session")
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -138,8 +138,6 @@ struct OpenClawChatComposer: View {
             ForEach(self.viewModel.sessionChoices, id: \.key) { session in
                 Text(session.displayName ?? session.key)
                     .font(.system(.caption, design: .monospaced))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
                     .tag(session.key)
             }
         }


### PR DESCRIPTION
## Summary

Long session names (e.g. `agent:main:discord:channel:1472178349991264442`) overflow the session picker's 160pt `maxWidth`, pushing the Model and Thinking pickers off-screen in the chat composer toolbar.

## What changed

Added `.lineLimit(1)` and `.truncationMode(.tail)` to:
1. Each `Text` item inside the `ForEach` (dropdown menu items)
2. The `Picker` itself (button label showing current selection)

## Screenshots

TODO: Add before/after screenshots after testing on device.

## Testing

- [ ] Verify on iOS device with long session names
- [ ] Verify on macOS with long session names
- [ ] Verify short session names still display correctly

## AI-assisted

Built with AI assistance (Claude via OpenClaw).