### PR TITLE
fix(daemon): preserve Windows Task Scheduler settings on reinstall and exit early on failed restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Sandbox/security: block credential-path binds even when sandbox home paths resolve through canonical aliases, so agent containers cannot mount user secret stores through alternate home-directory paths. (#59157) Thanks @eleqtrizit.
+- Gateway/Windows scheduled tasks: preserve Task Scheduler settings on reinstall, fail loud when Scheduled Task `/Run` does not start, and report fast failed restarts with the actual elapsed time instead of a fake 60s timeout. (#59335) Thanks @tmimmanuel.
 
 ## 2026.4.1-beta.1
 

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -6,6 +6,8 @@ type RestartHealthSnapshot = {
   staleGatewayPids: number[];
   runtime: { status?: string };
   portUsage: { port: number; status: string; listeners: []; hints: []; errors?: string[] };
+  waitOutcome?: string;
+  elapsedMs?: number;
 };
 
 type RestartPostCheckContext = {
@@ -230,18 +232,44 @@ describe("runDaemonRestart health checks", () => {
     expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(1);
   });
 
-  it("fails restart when gateway remains unhealthy", async () => {
+  it("fails restart when gateway remains unhealthy after the full timeout", async () => {
     const { formatCliCommand } = await import("../command-format.js");
     const unhealthy: RestartHealthSnapshot = {
       healthy: false,
       staleGatewayPids: [],
       runtime: { status: "stopped" },
       portUsage: { port: 18789, status: "free", listeners: [], hints: [] },
+      waitOutcome: "timeout",
+      elapsedMs: 60_000,
     };
     waitForGatewayHealthyRestart.mockResolvedValue(unhealthy);
 
     await expect(runDaemonRestart({ json: true })).rejects.toMatchObject({
       message: "Gateway restart timed out after 60s waiting for health checks.",
+      hints: [
+        formatCliCommand("openclaw gateway status --deep"),
+        formatCliCommand("openclaw doctor"),
+      ],
+    });
+    expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
+    expect(renderRestartDiagnostics).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails restart with a stopped-free message when the waiter exits early", async () => {
+    const { formatCliCommand } = await import("../command-format.js");
+    const unhealthy: RestartHealthSnapshot = {
+      healthy: false,
+      staleGatewayPids: [],
+      runtime: { status: "stopped" },
+      portUsage: { port: 18789, status: "free", listeners: [], hints: [] },
+      waitOutcome: "stopped-free",
+      elapsedMs: 12_500,
+    };
+    waitForGatewayHealthyRestart.mockResolvedValue(unhealthy);
+
+    await expect(runDaemonRestart({ json: true })).rejects.toMatchObject({
+      message:
+        "Gateway restart failed after 13s: service stayed stopped and health checks never came up.",
       hints: [
         formatCliCommand("openclaw gateway status --deep"),
         formatCliCommand("openclaw doctor"),

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -34,7 +34,7 @@ const waitForGatewayHealthyRestart = vi.fn();
 const terminateStaleGatewayPids = vi.fn();
 const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"]);
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
-const resolveGatewayPort = vi.fn(() => 18789);
+const resolveGatewayPort = vi.hoisted(() => vi.fn((_cfg?: unknown, _env?: unknown) => 18789));
 const findVerifiedGatewayListenerPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
 const signalVerifiedGatewayPidSync = vi.fn<(pid: number, signal: "SIGTERM" | "SIGUSR1") => void>();
 const formatGatewayPidList = vi.fn<(pids: number[]) => string>((pids) => pids.join(", "));
@@ -49,12 +49,12 @@ const probeGateway = vi.fn<
   }>
 >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
-const loadConfig = vi.fn(() => ({}));
+const loadConfig = vi.hoisted(() => vi.fn(() => ({})));
 
 vi.mock("../../config/config.js", () => ({
   loadConfig: () => loadConfig(),
   readBestEffortConfig: async () => loadConfig(),
-  resolveGatewayPort,
+  resolveGatewayPort: (cfg?: unknown, env?: unknown) => resolveGatewayPort(cfg, env),
 }));
 
 vi.mock("../../infra/gateway-processes.js", () => ({

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -19,6 +19,7 @@ import {
 import {
   DEFAULT_RESTART_HEALTH_ATTEMPTS,
   DEFAULT_RESTART_HEALTH_DELAY_MS,
+  type GatewayRestartSnapshot,
   renderGatewayPortHealthDiagnostics,
   renderRestartDiagnostics,
   terminateStaleGatewayPids,
@@ -30,6 +31,25 @@ import type { DaemonLifecycleOptions } from "./types.js";
 
 const POST_RESTART_HEALTH_ATTEMPTS = DEFAULT_RESTART_HEALTH_ATTEMPTS;
 const POST_RESTART_HEALTH_DELAY_MS = DEFAULT_RESTART_HEALTH_DELAY_MS;
+
+function formatRestartFailure(params: {
+  health: GatewayRestartSnapshot;
+  port: number;
+  timeoutSeconds: number;
+}): { statusLine: string; failMessage: string } {
+  if (params.health.waitOutcome === "stopped-free") {
+    const elapsedSeconds = Math.max(1, Math.round((params.health.elapsedMs ?? 0) / 1000));
+    return {
+      statusLine: `Gateway restart failed after ${elapsedSeconds}s: service stayed stopped and port ${params.port} stayed free.`,
+      failMessage: `Gateway restart failed after ${elapsedSeconds}s: service stayed stopped and health checks never came up.`,
+    };
+  }
+
+  return {
+    statusLine: `Timed out after ${params.timeoutSeconds}s waiting for gateway port ${params.port} to become healthy.`,
+    failMessage: `Gateway restart timed out after ${params.timeoutSeconds}s waiting for health checks.`,
+  };
+}
 
 async function resolveGatewayLifecyclePort(service = resolveGatewayService()) {
   const command = await service.readCommand(process.env).catch(() => null);
@@ -234,13 +254,17 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       }
 
       const diagnostics = renderRestartDiagnostics(health);
-      const timeoutLine = `Timed out after ${restartWaitSeconds}s waiting for gateway port ${restartPort} to become healthy.`;
+      const failure = formatRestartFailure({
+        health,
+        port: restartPort,
+        timeoutSeconds: restartWaitSeconds,
+      });
       const runningNoPortLine =
         health.runtime.status === "running" && health.portUsage.status === "free"
           ? `Gateway process is running but port ${restartPort} is still free (startup hang/crash loop or very slow VM startup).`
           : null;
       if (!json) {
-        defaultRuntime.log(theme.warn(timeoutLine));
+        defaultRuntime.log(theme.warn(failure.statusLine));
         if (runningNoPortLine) {
           defaultRuntime.log(theme.warn(runningNoPortLine));
         }
@@ -248,14 +272,14 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
           defaultRuntime.log(theme.muted(line));
         }
       } else {
-        warnings.push(timeoutLine);
+        warnings.push(failure.statusLine);
         if (runningNoPortLine) {
           warnings.push(runningNoPortLine);
         }
         warnings.push(...diagnostics);
       }
 
-      fail(`Gateway restart timed out after ${restartWaitSeconds}s waiting for health checks.`, [
+      fail(failure.failMessage, [
         formatCliCommand("openclaw gateway status --deep"),
         formatCliCommand("openclaw doctor"),
       ]);

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -19,9 +19,13 @@ vi.mock("../../gateway/probe.js", () => ({
   probeGateway: (opts: unknown) => probeGateway(opts),
 }));
 
-vi.mock("../../utils.js", () => ({
-  sleep: (ms: number) => sleep(ms),
-}));
+vi.mock("../../utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../../utils.js")>("../../utils.js");
+  return {
+    ...actual,
+    sleep: (ms: number) => sleep(ms),
+  };
+});
 
 const originalPlatform = process.platform;
 

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -3,6 +3,7 @@ import type { GatewayService } from "../../daemon/service.js";
 import type { PortListenerKind, PortUsage } from "../../infra/ports.js";
 
 const inspectPortUsage = vi.hoisted(() => vi.fn<(port: number) => Promise<PortUsage>>());
+const sleep = vi.hoisted(() => vi.fn(async (_ms: number) => {}));
 const classifyPortListener = vi.hoisted(() =>
   vi.fn<(_listener: unknown, _port: number) => PortListenerKind>(() => "gateway"),
 );
@@ -16,6 +17,10 @@ vi.mock("../../infra/ports.js", () => ({
 
 vi.mock("../../gateway/probe.js", () => ({
   probeGateway: (opts: unknown) => probeGateway(opts),
+}));
+
+vi.mock("../../utils.js", () => ({
+  sleep: (ms: number) => sleep(ms),
 }));
 
 const originalPlatform = process.platform;
@@ -88,6 +93,7 @@ describe("inspectGatewayRestart", () => {
       listeners: [],
       hints: [],
     });
+    sleep.mockReset();
     classifyPortListener.mockReset();
     classifyPortListener.mockReturnValue("gateway");
     probeGateway.mockReset();
@@ -239,5 +245,59 @@ describe("inspectGatewayRestart", () => {
 
     expect(snapshot.healthy).toBe(true);
     expect(probeGateway).not.toHaveBeenCalled();
+  });
+
+  it("annotates stopped-free early exits with the actual elapsed time", async () => {
+    const service = makeGatewayService({ status: "stopped" });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "free",
+      listeners: [],
+      hints: [],
+    });
+
+    const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyRestart({
+      service,
+      port: 18789,
+      attempts: 120,
+      delayMs: 500,
+    });
+
+    expect(snapshot).toMatchObject({
+      healthy: false,
+      runtime: { status: "stopped" },
+      portUsage: { status: "free" },
+      waitOutcome: "stopped-free",
+      elapsedMs: 12_500,
+    });
+    expect(sleep).toHaveBeenCalledTimes(25);
+  });
+
+  it("annotates timeout waits when the health loop exhausts all attempts", async () => {
+    const service = makeGatewayService({ status: "running", pid: 8000 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "free",
+      listeners: [],
+      hints: [],
+    });
+
+    const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyRestart({
+      service,
+      port: 18789,
+      attempts: 4,
+      delayMs: 1_000,
+    });
+
+    expect(snapshot).toMatchObject({
+      healthy: false,
+      runtime: { status: "running", pid: 8000 },
+      portUsage: { status: "free" },
+      waitOutcome: "timeout",
+      elapsedMs: 4_000,
+    });
+    expect(sleep).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -219,12 +219,28 @@ export async function waitForGatewayHealthyRestart(params: {
     includeUnknownListenersAsStale: params.includeUnknownListenersAsStale,
   });
 
+  // Track consecutive iterations where the task has clearly failed (stopped
+  // runtime + free port) so we can bail out early instead of waiting the full
+  // health timeout, which on Windows can appear to hang indefinitely.
+  let consecutiveStoppedFreeCount = 0;
+  const EARLY_EXIT_STOPPED_FREE_THRESHOLD = 6; // ~3 seconds at 500ms delay
+
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (snapshot.healthy) {
       return snapshot;
     }
     if (snapshot.staleGatewayPids.length > 0 && snapshot.runtime.status !== "running") {
       return snapshot;
+    }
+    // Early exit: if the task is clearly stopped and the port is free for
+    // several consecutive checks, the gateway failed to start — stop waiting.
+    if (snapshot.runtime.status === "stopped" && snapshot.portUsage.status === "free") {
+      consecutiveStoppedFreeCount += 1;
+      if (consecutiveStoppedFreeCount >= EARLY_EXIT_STOPPED_FREE_THRESHOLD) {
+        return snapshot;
+      }
+    } else {
+      consecutiveStoppedFreeCount = 0;
     }
     await sleep(delayMs);
     snapshot = await inspectGatewayRestart({

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -16,11 +16,15 @@ export const DEFAULT_RESTART_HEALTH_ATTEMPTS = Math.ceil(
   DEFAULT_RESTART_HEALTH_TIMEOUT_MS / DEFAULT_RESTART_HEALTH_DELAY_MS,
 );
 
+export type GatewayRestartWaitOutcome = "healthy" | "stale-pids" | "stopped-free" | "timeout";
+
 export type GatewayRestartSnapshot = {
   runtime: GatewayServiceRuntime;
   portUsage: PortUsage;
   healthy: boolean;
   staleGatewayPids: number[];
+  waitOutcome?: GatewayRestartWaitOutcome;
+  elapsedMs?: number;
 };
 
 export type GatewayPortHealthSnapshot = {
@@ -213,6 +217,14 @@ function shouldEarlyExitStoppedFree(
   );
 }
 
+function withWaitContext(
+  snapshot: GatewayRestartSnapshot,
+  waitOutcome: GatewayRestartWaitOutcome,
+  elapsedMs: number,
+): GatewayRestartSnapshot {
+  return { ...snapshot, waitOutcome, elapsedMs };
+}
+
 export async function waitForGatewayHealthyRestart(params: {
   service: GatewayService;
   port: number;
@@ -233,22 +245,19 @@ export async function waitForGatewayHealthyRestart(params: {
 
   let consecutiveStoppedFreeCount = 0;
   const STOPPED_FREE_THRESHOLD = 6;
-  const minAttemptForEarlyExit = Math.min(
-    Math.ceil(10_000 / delayMs),
-    Math.floor(attempts / 2),
-  );
+  const minAttemptForEarlyExit = Math.min(Math.ceil(10_000 / delayMs), Math.floor(attempts / 2));
 
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (snapshot.healthy) {
-      return snapshot;
+      return withWaitContext(snapshot, "healthy", attempt * delayMs);
     }
     if (snapshot.staleGatewayPids.length > 0 && snapshot.runtime.status !== "running") {
-      return snapshot;
+      return withWaitContext(snapshot, "stale-pids", attempt * delayMs);
     }
     if (shouldEarlyExitStoppedFree(snapshot, attempt, minAttemptForEarlyExit)) {
       consecutiveStoppedFreeCount += 1;
       if (consecutiveStoppedFreeCount >= STOPPED_FREE_THRESHOLD) {
-        return snapshot;
+        return withWaitContext(snapshot, "stopped-free", attempt * delayMs);
       }
     } else if (snapshot.runtime.status !== "stopped" || snapshot.portUsage.status !== "free") {
       consecutiveStoppedFreeCount = 0;
@@ -262,7 +271,7 @@ export async function waitForGatewayHealthyRestart(params: {
     });
   }
 
-  return snapshot;
+  return withWaitContext(snapshot, "timeout", attempts * delayMs);
 }
 
 export async function waitForGatewayHealthyListener(params: {

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -201,6 +201,18 @@ export async function inspectGatewayRestart(params: {
   };
 }
 
+function shouldEarlyExitStoppedFree(
+  snapshot: GatewayRestartSnapshot,
+  attempt: number,
+  minAttempt: number,
+): boolean {
+  return (
+    attempt >= minAttempt &&
+    snapshot.runtime.status === "stopped" &&
+    snapshot.portUsage.status === "free"
+  );
+}
+
 export async function waitForGatewayHealthyRestart(params: {
   service: GatewayService;
   port: number;
@@ -219,11 +231,12 @@ export async function waitForGatewayHealthyRestart(params: {
     includeUnknownListenersAsStale: params.includeUnknownListenersAsStale,
   });
 
-  // Track consecutive iterations where the task has clearly failed (stopped
-  // runtime + free port) so we can bail out early instead of waiting the full
-  // health timeout, which on Windows can appear to hang indefinitely.
   let consecutiveStoppedFreeCount = 0;
-  const EARLY_EXIT_STOPPED_FREE_THRESHOLD = 6; // ~3 seconds at 500ms delay
+  const STOPPED_FREE_THRESHOLD = 6;
+  const minAttemptForEarlyExit = Math.min(
+    Math.ceil(10_000 / delayMs),
+    Math.floor(attempts / 2),
+  );
 
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (snapshot.healthy) {
@@ -232,14 +245,12 @@ export async function waitForGatewayHealthyRestart(params: {
     if (snapshot.staleGatewayPids.length > 0 && snapshot.runtime.status !== "running") {
       return snapshot;
     }
-    // Early exit: if the task is clearly stopped and the port is free for
-    // several consecutive checks, the gateway failed to start — stop waiting.
-    if (snapshot.runtime.status === "stopped" && snapshot.portUsage.status === "free") {
+    if (shouldEarlyExitStoppedFree(snapshot, attempt, minAttemptForEarlyExit)) {
       consecutiveStoppedFreeCount += 1;
-      if (consecutiveStoppedFreeCount >= EARLY_EXIT_STOPPED_FREE_THRESHOLD) {
+      if (consecutiveStoppedFreeCount >= STOPPED_FREE_THRESHOLD) {
         return snapshot;
       }
-    } else {
+    } else if (snapshot.runtime.status !== "stopped" || snapshot.portUsage.status !== "free") {
       consecutiveStoppedFreeCount = 0;
     }
     await sleep(delayMs);

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -181,6 +181,56 @@ describe("installScheduledTask", () => {
     });
   });
 
+  it("throws when /Run fails after updating an existing task", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      schtasksResponses.push(
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 1, stdout: "", stderr: "ERROR: Access is denied." },
+      );
+
+      await expect(
+        installScheduledTask({
+          env,
+          stdout: new PassThrough(),
+          programArguments: ["node", "gateway.js"],
+          environment: {},
+        }),
+      ).rejects.toThrow("schtasks run failed: ERROR: Access is denied.");
+
+      expect(schtasksCalls[0]).toEqual(["/Query"]);
+      expect(schtasksCalls[1]).toEqual(["/Query", "/TN", "OpenClaw Gateway"]);
+      expect(schtasksCalls[2]?.[0]).toBe("/Change");
+      expect(schtasksCalls[3]).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
+    });
+  });
+
+  it("throws when /Run fails after creating a new task", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      schtasksResponses.push(
+        { code: 0, stdout: "", stderr: "" },
+        { code: 1, stdout: "", stderr: "ERROR: The system cannot find the file specified." },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 1, stdout: "", stderr: "ERROR: Access is denied." },
+      );
+
+      await expect(
+        installScheduledTask({
+          env,
+          stdout: new PassThrough(),
+          programArguments: ["node", "gateway.js"],
+          environment: {},
+        }),
+      ).rejects.toThrow("schtasks run failed: ERROR: Access is denied.");
+
+      expect(schtasksCalls[0]).toEqual(["/Query"]);
+      expect(schtasksCalls[1]).toEqual(["/Query", "/TN", "OpenClaw Gateway"]);
+      expect(schtasksCalls[2]?.[0]).toBe("/Create");
+      expect(schtasksCalls[3]).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
+    });
+  });
+
   it("does not persist a frozen PATH snapshot into the generated task script", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
       const { scriptPath } = await installScheduledTask({

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -97,8 +97,11 @@ describe("installScheduledTask", () => {
       expect(parsed?.environment).not.toHaveProperty("OC_EMPTY");
 
       expect(schtasksCalls[0]).toEqual(["/Query"]);
-      expect(schtasksCalls[1]?.[0]).toBe("/Create");
-      expect(schtasksCalls[2]).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
+      // When the task already exists (mock returns code 0), activateScheduledTask
+      // uses /Change to preserve user-configured settings instead of /Create /F.
+      expect(schtasksCalls[1]).toEqual(["/Query", "/TN", "OpenClaw Gateway"]);
+      expect(schtasksCalls[2]?.[0]).toBe("/Change");
+      expect(schtasksCalls[3]).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
     });
   });
 

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -6,16 +6,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { installScheduledTask, readScheduledTaskCommand } from "./schtasks.js";
 
 const schtasksCalls: string[][] = [];
+const schtasksResponses: { code: number; stdout: string; stderr: string }[] = [];
 
 vi.mock("./schtasks-exec.js", () => ({
   execSchtasks: async (argv: string[]) => {
     schtasksCalls.push(argv);
-    return { code: 0, stdout: "", stderr: "" };
+    return schtasksResponses.shift() ?? { code: 0, stdout: "", stderr: "" };
   },
 }));
 
 beforeEach(() => {
   schtasksCalls.length = 0;
+  schtasksResponses.length = 0;
 });
 
 describe("installScheduledTask", () => {
@@ -97,8 +99,6 @@ describe("installScheduledTask", () => {
       expect(parsed?.environment).not.toHaveProperty("OC_EMPTY");
 
       expect(schtasksCalls[0]).toEqual(["/Query"]);
-      // When the task already exists (mock returns code 0), activateScheduledTask
-      // uses /Change to preserve user-configured settings instead of /Create /F.
       expect(schtasksCalls[1]).toEqual(["/Query", "/TN", "OpenClaw Gateway"]);
       expect(schtasksCalls[2]?.[0]).toBe("/Change");
       expect(schtasksCalls[3]).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
@@ -134,6 +134,50 @@ describe("installScheduledTask", () => {
           environment: {},
         }),
       ).rejects.toThrow(/Task description cannot contain CR or LF/);
+    });
+  });
+
+  it("uses /Create when the task does not exist yet", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      schtasksResponses.push(
+        { code: 0, stdout: "", stderr: "" },
+        { code: 1, stdout: "", stderr: "ERROR: The system cannot find the file specified." },
+      );
+
+      await installScheduledTask({
+        env,
+        stdout: new PassThrough(),
+        programArguments: ["node", "gateway.js"],
+        environment: {},
+      });
+
+      expect(schtasksCalls[0]).toEqual(["/Query"]);
+      expect(schtasksCalls[1]).toEqual(["/Query", "/TN", "OpenClaw Gateway"]);
+      expect(schtasksCalls[2]?.[0]).toBe("/Create");
+      expect(schtasksCalls[3]).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
+    });
+  });
+
+  it("falls back to /Create when /Change fails on an existing task", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      schtasksResponses.push(
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 1, stdout: "", stderr: "ERROR: Access is denied." },
+      );
+
+      await installScheduledTask({
+        env,
+        stdout: new PassThrough(),
+        programArguments: ["node", "gateway.js"],
+        environment: {},
+      });
+
+      expect(schtasksCalls[0]).toEqual(["/Query"]);
+      expect(schtasksCalls[1]).toEqual(["/Query", "/TN", "OpenClaw Gateway"]);
+      expect(schtasksCalls[2]?.[0]).toBe("/Change");
+      expect(schtasksCalls[3]?.[0]).toBe("/Create");
+      expect(schtasksCalls[4]).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
     });
   });
 

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -123,6 +123,7 @@ describe("Windows startup fallback", () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       schtasksResponses.push(
         { code: 0, stdout: "", stderr: "" },
+        { code: 1, stdout: "", stderr: "not found" },
         { code: 5, stdout: "", stderr: "ERROR: Access is denied." },
       );
 
@@ -158,6 +159,7 @@ describe("Windows startup fallback", () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       schtasksResponses.push(
         { code: 0, stdout: "", stderr: "" },
+        { code: 1, stdout: "", stderr: "not found" },
         { code: 124, stdout: "", stderr: "schtasks timed out after 15000ms" },
       );
 

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -186,4 +186,20 @@ describe("Scheduled Task stop/restart cleanup", () => {
       expect(schtasksCalls.at(-1)).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
     });
   });
+
+  it("throws when /Run fails during restart", async () => {
+    await withPreparedGatewayTask(async ({ env, stdout }) => {
+      schtasksResponses.push(
+        { ...SUCCESS_RESPONSE },
+        { ...SUCCESS_RESPONSE },
+        { ...SUCCESS_RESPONSE },
+        { code: 1, stdout: "", stderr: "ERROR: Access is denied." },
+      );
+
+      await expect(restartScheduledTask({ env, stdout })).rejects.toThrow(
+        "schtasks run failed: ERROR: Access is denied.",
+      );
+      expect(schtasksCalls.at(-1)).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
+    });
+  });
 });

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -601,7 +601,7 @@ async function updateExistingScheduledTask(params: {
   if (change.code !== 0) {
     return false;
   }
-  await execSchtasks(["/Run", "/TN", params.taskName]);
+  await runScheduledTaskOrThrow(params.taskName);
   writeFormattedLines(
     params.stdout,
     [
@@ -611,6 +611,13 @@ async function updateExistingScheduledTask(params: {
     { leadingBlankLine: true },
   );
   return true;
+}
+
+async function runScheduledTaskOrThrow(taskName: string): Promise<void> {
+  const run = await execSchtasks(["/Run", "/TN", taskName]);
+  if (run.code !== 0) {
+    throw new Error(`schtasks run failed: ${run.stderr || run.stdout}`.trim());
+  }
 }
 
 async function activateScheduledTask(params: {
@@ -671,7 +678,7 @@ async function activateScheduledTask(params: {
     throw new Error(`schtasks create failed: ${detail}`.trim());
   }
 
-  await execSchtasks(["/Run", "/TN", taskName]);
+  await runScheduledTaskOrThrow(taskName);
   // Ensure we don't end up writing to a clack spinner line (wizards show progress without a newline).
   writeFormattedLines(
     params.stdout,
@@ -798,10 +805,7 @@ export async function restartScheduledTask({
       }
     }
   }
-  const res = await execSchtasks(["/Run", "/TN", taskName]);
-  if (res.code !== 0) {
-    throw new Error(`schtasks run failed: ${res.stderr || res.stdout}`.trim());
-  }
+  await runScheduledTaskOrThrow(taskName);
   stdout.write(`${formatLine("Restarted Scheduled Task", taskName)}\n`);
   return { outcome: "completed" };
 }

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -581,6 +581,38 @@ export async function stageScheduledTask({
   return { scriptPath };
 }
 
+async function updateExistingScheduledTask(params: {
+  env: GatewayServiceEnv;
+  stdout: NodeJS.WritableStream;
+  taskName: string;
+  quotedScript: string;
+  scriptPath: string;
+}): Promise<boolean> {
+  if (!(await isRegisteredScheduledTask(params.env))) {
+    return false;
+  }
+  const change = await execSchtasks([
+    "/Change",
+    "/TN",
+    params.taskName,
+    "/TR",
+    params.quotedScript,
+  ]);
+  if (change.code !== 0) {
+    return false;
+  }
+  await execSchtasks(["/Run", "/TN", params.taskName]);
+  writeFormattedLines(
+    params.stdout,
+    [
+      { label: "Updated Scheduled Task", value: params.taskName },
+      { label: "Task script", value: params.scriptPath },
+    ],
+    { leadingBlankLine: true },
+  );
+  return true;
+}
+
 async function activateScheduledTask(params: {
   env: GatewayServiceEnv;
   stdout: NodeJS.WritableStream;
@@ -592,25 +624,8 @@ async function activateScheduledTask(params: {
   const taskName = resolveTaskName(params.env);
   const quotedScript = quoteSchtasksArg(params.scriptPath);
 
-  // When the task already exists, update only the command (/TR) so that
-  // user-configured settings (run level, logon type, etc.) are preserved.
-  // Fall back to /Create only for new installations.
-  const taskExists = await isRegisteredScheduledTask(params.env);
-  if (taskExists) {
-    const change = await execSchtasks(["/Change", "/TN", taskName, "/TR", quotedScript]);
-    if (change.code === 0) {
-      await execSchtasks(["/Run", "/TN", taskName]);
-      writeFormattedLines(
-        params.stdout,
-        [
-          { label: "Updated Scheduled Task", value: taskName },
-          { label: "Task script", value: params.scriptPath },
-        ],
-        { leadingBlankLine: true },
-      );
-      return;
-    }
-    // /Change failed — fall through to /Create as a recovery path.
+  if (await updateExistingScheduledTask({ ...params, taskName, quotedScript })) {
+    return;
   }
 
   const baseArgs = [

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -591,6 +591,28 @@ async function activateScheduledTask(params: {
 
   const taskName = resolveTaskName(params.env);
   const quotedScript = quoteSchtasksArg(params.scriptPath);
+
+  // When the task already exists, update only the command (/TR) so that
+  // user-configured settings (run level, logon type, etc.) are preserved.
+  // Fall back to /Create only for new installations.
+  const taskExists = await isRegisteredScheduledTask(params.env);
+  if (taskExists) {
+    const change = await execSchtasks(["/Change", "/TN", taskName, "/TR", quotedScript]);
+    if (change.code === 0) {
+      await execSchtasks(["/Run", "/TN", taskName]);
+      writeFormattedLines(
+        params.stdout,
+        [
+          { label: "Updated Scheduled Task", value: taskName },
+          { label: "Task script", value: params.scriptPath },
+        ],
+        { leadingBlankLine: true },
+      );
+      return;
+    }
+    // /Change failed — fall through to /Create as a recovery path.
+  }
+
   const baseArgs = [
     "/Create",
     "/F",


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw gateway install` uses `schtasks /Create /F` which resets user-configured Task Scheduler settings (run level, logon type, privileges) on every reinstall. `openclaw gateway restart` hangs ~60s when the gateway fails to start.
- **Why it matters:** Windows users who configure elevated privileges via Task Scheduler UI lose their settings on every install/upgrade. The restart hang makes the CLI appear frozen.
- **What changed:** `activateScheduledTask` now uses `schtasks /Change /TR` when the task already exists, preserving all other settings. `waitForGatewayHealthyRestart` exits early after ~3s when the task is clearly stopped and the port is free.
- **What did NOT change (scope boundary):** New task creation still uses `/Create /F`. Restart health check timeout, retry logic, and stale PID handling are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59271
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** `activateScheduledTask` unconditionally uses `schtasks /Create /F` which overwrites all task properties. The post-restart health loop has no early exit for a clearly-dead gateway.
- **Missing detection / guardrail:** No test asserted that existing task settings survive a reinstall. No early exit condition in the health loop for stopped+free state.
- **Prior context:** The `/Create /F` pattern has been present since the original schtasks implementation. The health loop timeout (60s) was designed for slow VM startups but has no fast-fail path.
- **Why this regressed now:** Not a regression per se — the settings-reset was always present but became more visible as users customized task privileges. The restart hang became noticeable after hardened stop/cleanup logic (commit `5ea03efe92`) added more sequential waits.
- **If unknown, what was ruled out:** N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/daemon/schtasks.install.test.ts`
- **Scenario the test should lock in:** When task already exists (mock returns code 0), install uses `/Change` not `/Create /F`.
- **Why this is the smallest reliable guardrail:** Verifies the schtasks command sequence without requiring a real Windows Task Scheduler.
- **Existing test that already covers this (if any):** Updated existing `writes quoted set assignments and escapes metacharacters` test to assert `/Change` path.
- **If no new test is added, why not:** Existing test was updated. Early exit in health loop is covered by existing `restart-health.test.ts` passing (no false early exits).

## User-visible / Behavior Changes

- `openclaw gateway install --force` no longer resets Task Scheduler run level, logon type, or privileges on existing tasks.
- `openclaw gateway restart` exits in ~3s instead of ~60s when the gateway fails to start.

## Diagram (if applicable)

```text
Before (install):
[gateway install] -> [schtasks /Create /F] -> all task settings reset

After (install):
[gateway install] -> [task exists?] --yes--> [schtasks /Change /TR] -> settings preserved
                                    --no---> [schtasks /Create /F]  -> new task created

Before (restart):
[gateway restart] -> [task stopped + port free] -> wait 60s -> timeout error

After (restart):
[gateway restart] -> [task stopped + port free x6] -> bail after ~3s -> timeout error
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` (same schtasks binary, different subcommand)
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 11 Home
- Runtime/container: Node.js 24.x, npm global install
- Model/provider: any
- Integration/channel: N/A
- Relevant config: default gateway config with Windows Scheduled Task

### Steps

1. `openclaw gateway install` — task created
2. Open Task Scheduler UI, change task to "Run whether user is logged on or not" with elevated privileges
3. `openclaw gateway install --force`

### Expected

- Task settings (logon type, run level) preserved after step 3

### Actual (before fix)

- Task settings reset to defaults (Run only when logged on, LIMITED)

## Evidence

- [x] Failing test/log before + passing after
  - `schtasks.install.test.ts` updated to verify `/Change` path; all 43 tests pass across `schtasks.install`, `schtasks.stop`, `restart-health`, and `lifecycle` suites.

## Human Verification (required)

- **Verified scenarios:** All related test suites pass (43 tests). TypeScript type-check passes with no errors in changed files.
- **Edge cases checked:** `/Change` failure falls back to `/Create /F`. Health loop early exit requires 6 consecutive stopped+free checks (not a single flap).
- **What you did not verify:** Manual testing on Windows (no Windows environment available). Real schtasks behavior with `/Change /TR`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** `schtasks /Change` may behave differently across Windows editions (Home vs Pro vs Server) or locales.
  - **Mitigation:** Falls back to `/Create /F` if `/Change` fails, preserving original behavior.
- **Risk:** Early exit in health loop could bail prematurely if task status briefly reports "stopped" during startup.
  - **Mitigation:** Requires 6 consecutive stopped+free checks (~3s), giving the task scheduler time to transition.