### PR TITLE
diffs: add configurable viewer base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: add `agents.defaults.compaction.notifyUser` so the `🧹 Compacting context...` start notice is opt-in instead of always being shown. (#54251) Thanks @oguricap0327.
 - Plugins/hooks: add `before_agent_reply` so plugins can short-circuit the LLM with synthetic replies after inline actions. (#20067) Thanks @JoshuaLelon
 - Providers/runtime: add provider-owned replay hook surfaces for transcript policy, replay cleanup, and reasoning-mode dispatch. (#59143) Thanks @jalehman.
+- Diffs: add plugin-owned `viewerBaseUrl` so viewer links can use a stable proxy/public origin without passing `baseUrl` on every tool call. Related #59227.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: add `agents.defaults.compaction.notifyUser` so the `🧹 Compacting context...` start notice is opt-in instead of always being shown. (#54251) Thanks @oguricap0327.
 - Plugins/hooks: add `before_agent_reply` so plugins can short-circuit the LLM with synthetic replies after inline actions. (#20067) Thanks @JoshuaLelon
 - Providers/runtime: add provider-owned replay hook surfaces for transcript policy, replay cleanup, and reasoning-mode dispatch. (#59143) Thanks @jalehman.
-- Diffs: add plugin-owned `viewerBaseUrl` so viewer links can use a stable proxy/public origin without passing `baseUrl` on every tool call. Related #59227.
+- Diffs: add plugin-owned `viewerBaseUrl` so viewer links can use a stable proxy/public origin without passing `baseUrl` on every tool call. (#59341) Related #59227.
 
 ### Fixes
 

--- a/docs/install/oracle.md
+++ b/docs/install/oracle.md
@@ -96,6 +96,8 @@ Run a persistent OpenClaw Gateway on Oracle Cloud's **Always Free** ARM tier (up
     systemctl --user restart openclaw-gateway
     ```
 
+    `gateway.trustedProxies=["127.0.0.1"]` is for the local Tailscale Serve proxy. Diff viewer routes keep fail-closed behavior in this setup: raw `127.0.0.1` viewer requests without forwarded proxy headers can return `Diff not found`. Use `mode=file` / `mode=both` for attachments, or intentionally enable remote viewers and set a proxy `baseUrl` if you need shareable viewer links.
+
   </Step>
 
   <Step title="Lock down VCN security">

--- a/docs/install/oracle.md
+++ b/docs/install/oracle.md
@@ -96,7 +96,7 @@ Run a persistent OpenClaw Gateway on Oracle Cloud's **Always Free** ARM tier (up
     systemctl --user restart openclaw-gateway
     ```
 
-    `gateway.trustedProxies=["127.0.0.1"]` is for the local Tailscale Serve proxy. Diff viewer routes keep fail-closed behavior in this setup: raw `127.0.0.1` viewer requests without forwarded proxy headers can return `Diff not found`. Use `mode=file` / `mode=both` for attachments, or intentionally enable remote viewers and set a proxy `baseUrl` if you need shareable viewer links.
+    `gateway.trustedProxies=["127.0.0.1"]` is for the local Tailscale Serve proxy. Diff viewer routes keep fail-closed behavior in this setup: raw `127.0.0.1` viewer requests without forwarded proxy headers can return `Diff not found`. Use `mode=file` / `mode=both` for attachments, or intentionally enable remote viewers and set `plugins.entries.diffs.config.viewerBaseUrl` (or pass a proxy `baseUrl`) if you need shareable viewer links.
 
   </Step>
 

--- a/docs/platforms/oracle.md
+++ b/docs/platforms/oracle.md
@@ -126,7 +126,7 @@ openclaw config set gateway.trustedProxies '["127.0.0.1"]'
 systemctl --user restart openclaw-gateway
 ```
 
-`gateway.trustedProxies=["127.0.0.1"]` is for the local Tailscale Serve proxy. Diff viewer routes keep fail-closed behavior in this setup: raw `127.0.0.1` viewer requests without forwarded proxy headers can return `Diff not found`. Use `mode=file` / `mode=both` for attachments, or intentionally enable remote viewers and set a proxy `baseUrl` if you need shareable viewer links.
+`gateway.trustedProxies=["127.0.0.1"]` is for the local Tailscale Serve proxy. Diff viewer routes keep fail-closed behavior in this setup: raw `127.0.0.1` viewer requests without forwarded proxy headers can return `Diff not found`. Use `mode=file` / `mode=both` for attachments, or intentionally enable remote viewers and set `plugins.entries.diffs.config.viewerBaseUrl` (or pass a proxy `baseUrl`) if you need shareable viewer links.
 
 ## 7) Verify
 

--- a/docs/platforms/oracle.md
+++ b/docs/platforms/oracle.md
@@ -126,6 +126,8 @@ openclaw config set gateway.trustedProxies '["127.0.0.1"]'
 systemctl --user restart openclaw-gateway
 ```
 
+`gateway.trustedProxies=["127.0.0.1"]` is for the local Tailscale Serve proxy. Diff viewer routes keep fail-closed behavior in this setup: raw `127.0.0.1` viewer requests without forwarded proxy headers can return `Diff not found`. Use `mode=file` / `mode=both` for attachments, or intentionally enable remote viewers and set a proxy `baseUrl` if you need shareable viewer links.
+
 ## 7) Verify
 
 ```bash

--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -119,7 +119,7 @@ All fields are optional unless noted:
 - `fileScale` (`number`): device scale override (`1`-`4`).
 - `fileMaxWidth` (`number`): max render width in CSS pixels (`640`-`2400`).
 - `ttlSeconds` (`number`): viewer artifact TTL in seconds. Default 1800, max 21600.
-- `baseUrl` (`string`): viewer URL origin override. Must be `http` or `https`, no query/hash.
+- `baseUrl` (`string`): viewer URL origin override. Overrides plugin `viewerBaseUrl`. Must be `http` or `https`, no query/hash.
 
 Validation and limits:
 
@@ -231,6 +231,12 @@ Supported defaults:
 
 Explicit tool parameters override these defaults.
 
+Persistent viewer URL config:
+
+- `viewerBaseUrl` (`string`, optional)
+  - Plugin-owned fallback for returned viewer links when a tool call does not pass `baseUrl`.
+  - Must be `http` or `https`, no query/hash.
+
 ## Security config
 
 - `security.allowRemoteViewer` (`boolean`, default `false`)
@@ -285,8 +291,9 @@ The viewer document resolves those assets relative to the viewer URL, so an opti
 
 URL construction behavior:
 
-- If `baseUrl` is provided, it is used after strict validation.
-- Without `baseUrl`, viewer URL defaults to loopback `127.0.0.1`.
+- If tool-call `baseUrl` is provided, it is used after strict validation.
+- Else if plugin `viewerBaseUrl` is configured, it is used.
+- Without either override, viewer URL defaults to loopback `127.0.0.1`.
 - If gateway bind mode is `custom` and `gateway.customBindHost` is set, that host is used.
 
 `baseUrl` rules:
@@ -353,12 +360,13 @@ Viewer accessibility issues:
 
 - Viewer URL resolves to `127.0.0.1` by default.
 - For remote access scenarios, either:
+  - set plugin `viewerBaseUrl`, or
   - pass `baseUrl` per tool call, or
   - use `gateway.bind=custom` and `gateway.customBindHost`
 - If `gateway.trustedProxies` includes loopback for a same-host proxy (for example Tailscale Serve), raw loopback viewer requests without forwarded client-IP headers fail closed by design.
 - For that proxy topology:
   - prefer `mode: "file"` or `mode: "both"` when you only need an attachment, or
-  - intentionally enable `security.allowRemoteViewer` and pass a proxy/public `baseUrl` when you need a shareable viewer URL
+  - intentionally enable `security.allowRemoteViewer` and set plugin `viewerBaseUrl` or pass a proxy/public `baseUrl` when you need a shareable viewer URL
 - Enable `security.allowRemoteViewer` only when you intend external viewer access.
 
 Unmodified-lines row has no expand button:

--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -237,6 +237,23 @@ Persistent viewer URL config:
   - Plugin-owned fallback for returned viewer links when a tool call does not pass `baseUrl`.
   - Must be `http` or `https`, no query/hash.
 
+Example:
+
+```json5
+{
+  plugins: {
+    entries: {
+      diffs: {
+        enabled: true,
+        config: {
+          viewerBaseUrl: "https://gateway.example.com/openclaw",
+        },
+      },
+    },
+  },
+}
+```
+
 ## Security config
 
 - `security.allowRemoteViewer` (`boolean`, default `false`)

--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -355,6 +355,10 @@ Viewer accessibility issues:
 - For remote access scenarios, either:
   - pass `baseUrl` per tool call, or
   - use `gateway.bind=custom` and `gateway.customBindHost`
+- If `gateway.trustedProxies` includes loopback for a same-host proxy (for example Tailscale Serve), raw loopback viewer requests without forwarded client-IP headers fail closed by design.
+- For that proxy topology:
+  - prefer `mode: "file"` or `mode: "both"` when you only need an attachment, or
+  - intentionally enable `security.allowRemoteViewer` and pass a proxy/public `baseUrl` when you need a shareable viewer URL
 - Enable `security.allowRemoteViewer` only when you intend external viewer access.
 
 Unmodified-lines row has no expand button:

--- a/extensions/diffs/README.md
+++ b/extensions/diffs/README.md
@@ -63,6 +63,7 @@ Useful options:
 - `title`: explicit viewer title
 - `ttlSeconds`: artifact lifetime
 - `baseUrl`: override the gateway base URL used in the returned viewer link (origin or origin+base path only; no query/hash)
+- `viewerBaseUrl` plugin config: persistent fallback used when a tool call omits `baseUrl`
 
 Input safety limits:
 
@@ -109,6 +110,7 @@ Explicit tool parameters still win over these defaults.
 Security options:
 
 - `security.allowRemoteViewer` (default `false`): allows non-loopback access to `/plugins/diffs/view/...` token URLs
+- `viewerBaseUrl` (optional): persistent viewer-link origin/path fallback for shareable URLs
 
 ## Example Agent Prompts
 
@@ -177,9 +179,9 @@ diff --git a/src/example.ts b/src/example.ts
 
 - The viewer is hosted locally through the gateway under `/plugins/diffs/...`.
 - Artifacts are ephemeral and stored in the plugin temp subfolder (`$TMPDIR/openclaw-diffs`).
-- Default viewer URLs use loopback (`127.0.0.1`) unless you set `baseUrl` (or use `gateway.bind=custom` + `gateway.customBindHost`).
+- Default viewer URLs use loopback (`127.0.0.1`) unless you set plugin `viewerBaseUrl`, pass `baseUrl`, or use `gateway.bind=custom` + `gateway.customBindHost`.
 - If `gateway.trustedProxies` includes loopback for a same-host proxy (for example Tailscale Serve), raw `127.0.0.1` viewer requests without forwarded client-IP headers fail closed by design.
-- In that topology, prefer `mode=file` / `mode=both` for attachments, or intentionally enable remote viewers and pass a proxy/public `baseUrl` when you need a shareable viewer URL.
+- In that topology, prefer `mode=file` / `mode=both` for attachments, or intentionally enable remote viewers and set plugin `viewerBaseUrl` (or pass a proxy/public `baseUrl`) when you need a shareable viewer URL.
 - Remote viewer misses are throttled to reduce token-guess abuse.
 - PNG or PDF rendering requires a Chromium-compatible browser. Set `browser.executablePath` if auto-detection is not enough.
 - If your delivery channel compresses images heavily (for example Telegram or WhatsApp), prefer `fileFormat: "pdf"` to preserve readability.

--- a/extensions/diffs/README.md
+++ b/extensions/diffs/README.md
@@ -112,6 +112,23 @@ Security options:
 - `security.allowRemoteViewer` (default `false`): allows non-loopback access to `/plugins/diffs/view/...` token URLs
 - `viewerBaseUrl` (optional): persistent viewer-link origin/path fallback for shareable URLs
 
+Example:
+
+```json5
+{
+  plugins: {
+    entries: {
+      diffs: {
+        enabled: true,
+        config: {
+          viewerBaseUrl: "https://gateway.example.com/openclaw",
+        },
+      },
+    },
+  },
+}
+```
+
 ## Example Agent Prompts
 
 Open in canvas:

--- a/extensions/diffs/README.md
+++ b/extensions/diffs/README.md
@@ -178,6 +178,8 @@ diff --git a/src/example.ts b/src/example.ts
 - The viewer is hosted locally through the gateway under `/plugins/diffs/...`.
 - Artifacts are ephemeral and stored in the plugin temp subfolder (`$TMPDIR/openclaw-diffs`).
 - Default viewer URLs use loopback (`127.0.0.1`) unless you set `baseUrl` (or use `gateway.bind=custom` + `gateway.customBindHost`).
+- If `gateway.trustedProxies` includes loopback for a same-host proxy (for example Tailscale Serve), raw `127.0.0.1` viewer requests without forwarded client-IP headers fail closed by design.
+- In that topology, prefer `mode=file` / `mode=both` for attachments, or intentionally enable remote viewers and pass a proxy/public `baseUrl` when you need a shareable viewer URL.
 - Remote viewer misses are throttled to reduce token-guess abuse.
 - PNG or PDF rendering requires a Chromium-compatible browser. Set `browser.executablePath` if auto-detection is not enough.
 - If your delivery channel compresses images heavily (for example Telegram or WhatsApp), prefer `fileFormat: "pdf"` to preserve readability.

--- a/extensions/diffs/index.ts
+++ b/extensions/diffs/index.ts
@@ -8,6 +8,7 @@ import {
   diffsPluginConfigSchema,
   resolveDiffsPluginDefaults,
   resolveDiffsPluginSecurity,
+  resolveDiffsPluginViewerBaseUrl,
 } from "./src/config.js";
 import { createDiffsHttpHandler } from "./src/http.js";
 import { DIFFS_AGENT_GUIDANCE } from "./src/prompt-guidance.js";
@@ -22,14 +23,18 @@ export default definePluginEntry({
   register(api: OpenClawPluginApi) {
     const defaults = resolveDiffsPluginDefaults(api.pluginConfig);
     const security = resolveDiffsPluginSecurity(api.pluginConfig);
+    const viewerBaseUrl = resolveDiffsPluginViewerBaseUrl(api.pluginConfig);
     const store = new DiffArtifactStore({
       rootDir: path.join(resolvePreferredOpenClawTmpDir(), "openclaw-diffs"),
       logger: api.logger,
     });
 
-    api.registerTool((ctx) => createDiffsTool({ api, store, defaults, context: ctx }), {
-      name: "diffs",
-    });
+    api.registerTool(
+      (ctx) => createDiffsTool({ api, store, defaults, viewerBaseUrl, context: ctx }),
+      {
+        name: "diffs",
+      },
+    );
     api.registerHttpRoute({
       path: "/plugins/diffs",
       auth: "plugin",

--- a/extensions/diffs/openclaw.plugin.json
+++ b/extensions/diffs/openclaw.plugin.json
@@ -4,6 +4,10 @@
   "description": "Read-only diff viewer and file renderer for agents.",
   "skills": ["./skills"],
   "uiHints": {
+    "viewerBaseUrl": {
+      "label": "Viewer Base URL",
+      "help": "Persistent gateway base URL used for returned viewer links when a tool call does not pass baseUrl."
+    },
     "defaults.fontFamily": {
       "label": "Default Font",
       "help": "Preferred font family name for diff content and headers."
@@ -69,6 +73,9 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+      "viewerBaseUrl": {
+        "type": "string"
+      },
       "defaults": {
         "type": "object",
         "additionalProperties": false,

--- a/extensions/diffs/skills/diffs/SKILL.md
+++ b/extensions/diffs/skills/diffs/SKILL.md
@@ -8,6 +8,7 @@ When you need to show edits as a real diff, prefer the `diffs` tool instead of w
 The `diffs` tool accepts either `before` + `after` text, or a unified `patch` string.
 
 Use `mode=view` when you want an interactive gateway-hosted viewer. After the tool returns, use `details.viewerUrl` with the canvas tool via `canvas present` or `canvas navigate`.
+If the deployment uses a loopback trusted proxy (for example Tailscale Serve with `gateway.trustedProxies` including `127.0.0.1`), raw loopback viewer requests can fail closed without forwarded client-IP headers. In that topology, prefer `mode=file` / `mode=both`, or pass an explicit proxy/public `baseUrl` when you need a shareable viewer URL.
 
 Use `mode=file` when you need a rendered file artifact. Set `fileFormat=png` (default) or `fileFormat=pdf`. The tool result includes `details.filePath`.
 

--- a/extensions/diffs/skills/diffs/SKILL.md
+++ b/extensions/diffs/skills/diffs/SKILL.md
@@ -8,7 +8,7 @@ When you need to show edits as a real diff, prefer the `diffs` tool instead of w
 The `diffs` tool accepts either `before` + `after` text, or a unified `patch` string.
 
 Use `mode=view` when you want an interactive gateway-hosted viewer. After the tool returns, use `details.viewerUrl` with the canvas tool via `canvas present` or `canvas navigate`.
-If the deployment uses a loopback trusted proxy (for example Tailscale Serve with `gateway.trustedProxies` including `127.0.0.1`), raw loopback viewer requests can fail closed without forwarded client-IP headers. In that topology, prefer `mode=file` / `mode=both`, or pass an explicit proxy/public `baseUrl` when you need a shareable viewer URL.
+If the deployment uses a loopback trusted proxy (for example Tailscale Serve with `gateway.trustedProxies` including `127.0.0.1`), raw loopback viewer requests can fail closed without forwarded client-IP headers. In that topology, prefer `mode=file` / `mode=both`, or use a configured `viewerBaseUrl` / explicit proxy/public `baseUrl` when you need a shareable viewer URL.
 
 Use `mode=file` when you need a rendered file artifact. Set `fileFormat=png` (default) or `fileFormat=pdf`. The tool result includes `details.filePath`.
 

--- a/extensions/diffs/src/config.test.ts
+++ b/extensions/diffs/src/config.test.ts
@@ -305,7 +305,7 @@ describe("diffs plugin schema surfaces", () => {
         issues: [
           {
             path: ["viewerBaseUrl"],
-            message: "baseUrl must use http or https: javascript:alert(1)",
+            message: "viewerBaseUrl must use http or https: javascript:alert(1)",
           },
         ],
       },
@@ -380,6 +380,12 @@ describe("diffs viewer URL helpers", () => {
     );
     expect(() => normalizeViewerBaseUrl("https://example.com#frag")).toThrow(
       "baseUrl must not include query/hash",
+    );
+  });
+
+  it("uses the configured field name in viewerBaseUrl validation errors", () => {
+    expect(() => normalizeViewerBaseUrl("https://example.com?a=1", "viewerBaseUrl")).toThrow(
+      "viewerBaseUrl must not include query/hash",
     );
   });
 });

--- a/extensions/diffs/src/config.test.ts
+++ b/extensions/diffs/src/config.test.ts
@@ -14,6 +14,7 @@ import {
   resolveDiffImageRenderOptions,
   resolveDiffsPluginDefaults,
   resolveDiffsPluginSecurity,
+  resolveDiffsPluginViewerBaseUrl,
 } from "./config.js";
 import { renderDiffDocument } from "./render.js";
 import { buildViewerUrl, normalizeViewerBaseUrl } from "./url.js";
@@ -219,10 +220,25 @@ describe("resolveDiffsPluginSecurity", () => {
   });
 });
 
+describe("resolveDiffsPluginViewerBaseUrl", () => {
+  it("defaults to undefined when config is missing", () => {
+    expect(resolveDiffsPluginViewerBaseUrl(undefined)).toBeUndefined();
+  });
+
+  it("normalizes configured viewer base URLs", () => {
+    expect(
+      resolveDiffsPluginViewerBaseUrl({
+        viewerBaseUrl: "https://example.com/openclaw/",
+      }),
+    ).toBe("https://example.com/openclaw");
+  });
+});
+
 describe("diffs plugin schema surfaces", () => {
   it("preserves defaults and security for direct safeParse callers", () => {
     expect(
       diffsPluginConfigSchema.safeParse?.({
+        viewerBaseUrl: "https://example.com/openclaw/",
         defaults: {
           theme: "light",
         },
@@ -233,6 +249,7 @@ describe("diffs plugin schema surfaces", () => {
     ).toMatchObject({
       success: true,
       data: {
+        viewerBaseUrl: "https://example.com/openclaw",
         defaults: {
           fontFamily: "Fira Code",
           fontSize: 15,
@@ -273,6 +290,24 @@ describe("diffs plugin schema surfaces", () => {
           fileScale: 2.5,
           fileMaxWidth: 1200,
         },
+      },
+    });
+  });
+
+  it("rejects invalid viewerBaseUrl config values", () => {
+    expect(
+      diffsPluginConfigSchema.safeParse?.({
+        viewerBaseUrl: "javascript:alert(1)",
+      }),
+    ).toMatchObject({
+      success: false,
+      error: {
+        issues: [
+          {
+            path: ["viewerBaseUrl"],
+            message: "baseUrl must use http or https: javascript:alert(1)",
+          },
+        ],
       },
     });
   });
@@ -324,6 +359,16 @@ describe("diffs viewer URL helpers", () => {
       buildViewerUrl({
         config: {},
         baseUrl: "https://example.com/openclaw",
+        viewerPath: "/plugins/diffs/view/id/token",
+      }),
+    ).toBe("https://example.com/openclaw/plugins/diffs/view/id/token");
+  });
+
+  it("prefers normalized viewerBaseUrl strings too", () => {
+    expect(
+      buildViewerUrl({
+        config: {},
+        baseUrl: "https://example.com/openclaw/",
         viewerPath: "/plugins/diffs/view/id/token",
       }),
     ).toBe("https://example.com/openclaw/plugins/diffs/view/id/token");

--- a/extensions/diffs/src/config.ts
+++ b/extensions/diffs/src/config.ts
@@ -100,7 +100,7 @@ const DiffsPluginJsonSchemaSource = z.strictObject({
     .string()
     .superRefine((value, ctx) => {
       try {
-        normalizeViewerBaseUrl(value);
+        normalizeViewerBaseUrl(value, "viewerBaseUrl");
       } catch (error) {
         ctx.addIssue({
           code: "custom",

--- a/extensions/diffs/src/config.ts
+++ b/extensions/diffs/src/config.ts
@@ -18,8 +18,10 @@ import {
   type DiffTheme,
   type DiffToolDefaults,
 } from "./types.js";
+import { normalizeViewerBaseUrl } from "./url.js";
 
 type DiffsPluginConfig = {
+  viewerBaseUrl?: string;
   defaults?: {
     fontFamily?: string;
     fontSize?: number;
@@ -94,6 +96,19 @@ export const DEFAULT_DIFFS_PLUGIN_SECURITY: DiffsPluginSecurityConfig = {
 };
 
 const DiffsPluginJsonSchemaSource = z.strictObject({
+  viewerBaseUrl: z
+    .string()
+    .superRefine((value, ctx) => {
+      try {
+        normalizeViewerBaseUrl(value);
+      } catch (error) {
+        ctx.addIssue({
+          code: "custom",
+          message: error instanceof Error ? error.message : "Invalid viewerBaseUrl",
+        });
+      }
+    })
+    .optional(),
   defaults: z
     .strictObject({
       fontFamily: z.string().default(DEFAULT_DIFFS_TOOL_DEFAULTS.fontFamily).optional(),
@@ -184,7 +199,9 @@ function resolveConfiguredValue<T>(options: {
 }
 
 function buildDiffsPluginConfigShape(config: DiffsPluginConfig): DiffsPluginConfig {
+  const viewerBaseUrl = resolveDiffsPluginViewerBaseUrl(config);
   return {
+    ...(viewerBaseUrl !== undefined ? { viewerBaseUrl } : {}),
     ...(config.defaults !== undefined ? { defaults: resolveDiffsPluginDefaults(config) } : {}),
     ...(config.security !== undefined ? { security: resolveDiffsPluginSecurity(config) } : {}),
   };
@@ -253,6 +270,20 @@ export function resolveDiffsPluginSecurity(config: unknown): DiffsPluginSecurity
   return {
     allowRemoteViewer: security.allowRemoteViewer === true,
   };
+}
+
+export function resolveDiffsPluginViewerBaseUrl(config: unknown): string | undefined {
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    return undefined;
+  }
+
+  const viewerBaseUrl = (config as DiffsPluginConfig).viewerBaseUrl;
+  if (typeof viewerBaseUrl !== "string") {
+    return undefined;
+  }
+
+  const normalized = viewerBaseUrl.trim();
+  return normalized ? normalizeViewerBaseUrl(normalized) : undefined;
 }
 
 export function toPresentationDefaults(defaults: DiffToolDefaults): DiffPresentationDefaults {

--- a/extensions/diffs/src/http.ts
+++ b/extensions/diffs/src/http.ts
@@ -203,27 +203,20 @@ function resolveViewerAccess(
   localRequest: boolean;
 } {
   const proxyHintsPresent = hasProxyForwardingHints(req);
-  const remoteKey = normalizeRemoteClientKey(req.socket?.remoteAddress);
-  // Keep direct same-host access working even when proxy support is configured.
-  const directLoopbackRequest = !proxyHintsPresent && isLoopbackClientIp(remoteKey);
-  if (directLoopbackRequest) {
-    return { remoteKey, localRequest: true };
-  }
-
   const clientIp =
     proxyHintsPresent || (params.trustedProxies?.length ?? 0) > 0
-      ? // Reuse gateway proxy trust rules for proxied requests and fail closed
-        // when a trusted proxy hop does not provide usable client-origin headers.
+      ? // Reuse gateway proxy trust rules and fail closed when a trusted proxy hop
+        // does not provide usable client-origin headers.
         resolveRequestClientIp(
           req,
           params.trustedProxies ? [...params.trustedProxies] : undefined,
           params.allowRealIpFallback === true,
         )
       : req.socket?.remoteAddress;
-  return {
-    remoteKey: normalizeRemoteClientKey(clientIp ?? req.socket?.remoteAddress),
-    localRequest: false,
-  };
+  const remoteKey = normalizeRemoteClientKey(clientIp ?? req.socket?.remoteAddress);
+  const localRequest =
+    !proxyHintsPresent && typeof clientIp === "string" && isLoopbackClientIp(remoteKey);
+  return { remoteKey, localRequest };
 }
 
 function recordRemoteFailure(

--- a/extensions/diffs/src/http.ts
+++ b/extensions/diffs/src/http.ts
@@ -203,20 +203,27 @@ function resolveViewerAccess(
   localRequest: boolean;
 } {
   const proxyHintsPresent = hasProxyForwardingHints(req);
+  const remoteKey = normalizeRemoteClientKey(req.socket?.remoteAddress);
+  // Keep direct same-host access working even when proxy support is configured.
+  const directLoopbackRequest = !proxyHintsPresent && isLoopbackClientIp(remoteKey);
+  if (directLoopbackRequest) {
+    return { remoteKey, localRequest: true };
+  }
+
   const clientIp =
     proxyHintsPresent || (params.trustedProxies?.length ?? 0) > 0
-      ? // Reuse gateway proxy trust rules and fail closed when a trusted proxy hop
-        // does not provide usable client-origin headers.
+      ? // Reuse gateway proxy trust rules for proxied requests and fail closed
+        // when a trusted proxy hop does not provide usable client-origin headers.
         resolveRequestClientIp(
           req,
           params.trustedProxies ? [...params.trustedProxies] : undefined,
           params.allowRealIpFallback === true,
         )
       : req.socket?.remoteAddress;
-  const remoteKey = normalizeRemoteClientKey(clientIp ?? req.socket?.remoteAddress);
-  const localRequest =
-    !proxyHintsPresent && typeof clientIp === "string" && isLoopbackClientIp(remoteKey);
-  return { remoteKey, localRequest };
+  return {
+    remoteKey: normalizeRemoteClientKey(clientIp ?? req.socket?.remoteAddress),
+    localRequest: false,
+  };
 }
 
 function recordRemoteFailure(

--- a/extensions/diffs/src/store.test.ts
+++ b/extensions/diffs/src/store.test.ts
@@ -334,11 +334,19 @@ describe("createDiffsHttpHandler", () => {
       expectedStatusCode: 404,
     },
     {
-      name: "allows direct loopback viewer access when trusted proxies are configured",
+      name: "blocks trusted-proxy loopback requests without client-origin headers by default",
       request: localReq,
       trustedProxies: ["127.0.0.1"],
       allowRemoteViewer: false,
-      expectedStatusCode: 200,
+      expectedStatusCode: 404,
+    },
+    {
+      name: "blocks proxied loopback requests when trusted proxies are configured",
+      request: localReq,
+      headers: { "x-forwarded-for": "203.0.113.10" },
+      trustedProxies: ["127.0.0.1"],
+      allowRemoteViewer: false,
+      expectedStatusCode: 404,
     },
     {
       name: "allows remote access when allowRemoteViewer is enabled",

--- a/extensions/diffs/src/store.test.ts
+++ b/extensions/diffs/src/store.test.ts
@@ -334,11 +334,11 @@ describe("createDiffsHttpHandler", () => {
       expectedStatusCode: 404,
     },
     {
-      name: "blocks trusted-proxy loopback requests without client-origin headers by default",
+      name: "allows direct loopback viewer access when trusted proxies are configured",
       request: localReq,
       trustedProxies: ["127.0.0.1"],
       allowRemoteViewer: false,
-      expectedStatusCode: 404,
+      expectedStatusCode: 200,
     },
     {
       name: "allows remote access when allowRemoteViewer is enabled",

--- a/extensions/diffs/src/tool.test.ts
+++ b/extensions/diffs/src/tool.test.ts
@@ -41,6 +41,57 @@ describe("diffs tool", () => {
     expect((result?.details as Record<string, unknown>).viewerUrl).toBeDefined();
   });
 
+  it("uses configured viewerBaseUrl when tool input omits baseUrl", async () => {
+    const tool = createDiffsTool({
+      api: createApi({
+        viewerBaseUrl: "https://example.com/openclaw/",
+      }),
+      store,
+      defaults: DEFAULT_DIFFS_TOOL_DEFAULTS,
+      viewerBaseUrl: "https://example.com/openclaw",
+    });
+
+    const result = await tool.execute?.("tool-viewer-config", {
+      before: "one\n",
+      after: "two\n",
+      path: "README.md",
+      mode: "view",
+    });
+
+    expect(readTextContent(result, 0)).toContain(
+      "https://example.com/openclaw/plugins/diffs/view/",
+    );
+    expect((result?.details as Record<string, unknown>).viewerUrl).toEqual(
+      expect.stringContaining("https://example.com/openclaw/plugins/diffs/view/"),
+    );
+  });
+
+  it("prefers per-call baseUrl over configured viewerBaseUrl", async () => {
+    const tool = createDiffsTool({
+      api: createApi({
+        viewerBaseUrl: "https://example.com/openclaw",
+      }),
+      store,
+      defaults: DEFAULT_DIFFS_TOOL_DEFAULTS,
+      viewerBaseUrl: "https://example.com/openclaw",
+    });
+
+    const result = await tool.execute?.("tool-viewer-override", {
+      before: "one\n",
+      after: "two\n",
+      path: "README.md",
+      mode: "view",
+      baseUrl: "https://preview.example.com/review",
+    });
+
+    expect(readTextContent(result, 0)).toContain(
+      "https://preview.example.com/review/plugins/diffs/view/",
+    );
+    expect((result?.details as Record<string, unknown>).viewerUrl).toEqual(
+      expect.stringContaining("https://preview.example.com/review/plugins/diffs/view/"),
+    );
+  });
+
   it("does not expose reserved format in the tool schema", async () => {
     const tool = createDiffsTool({
       api: createApi(),
@@ -420,7 +471,7 @@ describe("diffs tool", () => {
   });
 });
 
-function createApi(): OpenClawPluginApi {
+function createApi(pluginConfig?: Record<string, unknown>): OpenClawPluginApi {
   return createTestPluginApi({
     id: "diffs",
     name: "Diffs",
@@ -432,6 +483,7 @@ function createApi(): OpenClawPluginApi {
         bind: "loopback",
       },
     },
+    pluginConfig,
     runtime: {} as OpenClawPluginApi["runtime"],
   }) as OpenClawPluginApi;
 }

--- a/extensions/diffs/src/tool.ts
+++ b/extensions/diffs/src/tool.ts
@@ -125,7 +125,7 @@ const DiffsToolSchema = Type.Object(
     baseUrl: Type.Optional(
       Type.String({
         description:
-          "Optional gateway base URL override used when building the viewer URL, for example https://gateway.example.com.",
+          "Optional gateway base URL override used when building the viewer URL. Overrides configured viewerBaseUrl, for example https://gateway.example.com.",
       }),
     ),
   },
@@ -142,6 +142,7 @@ export function createDiffsTool(params: {
   api: OpenClawPluginApi;
   store: DiffArtifactStore;
   defaults: DiffToolDefaults;
+  viewerBaseUrl?: string;
   screenshotter?: DiffScreenshotter;
   context?: OpenClawPluginToolContext;
 }): AnyAgentTool {
@@ -237,7 +238,7 @@ export function createDiffsTool(params: {
       const viewerUrl = buildViewerUrl({
         config: params.api.config,
         viewerPath: artifact.viewerPath,
-        baseUrl: normalizeBaseUrl(toolParams.baseUrl),
+        baseUrl: normalizeBaseUrl(toolParams.baseUrl) ?? params.viewerBaseUrl,
       });
 
       const baseDetails = {

--- a/extensions/diffs/src/url.ts
+++ b/extensions/diffs/src/url.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../api.js";
 
 const DEFAULT_GATEWAY_PORT = 18789;
+type ViewerBaseUrlFieldName = "baseUrl" | "viewerBaseUrl";
 
 export function buildViewerUrl(params: {
   config: OpenClawConfig;
@@ -20,18 +21,21 @@ export function buildViewerUrl(params: {
   return parsedBase.toString();
 }
 
-export function normalizeViewerBaseUrl(raw: string): string {
+export function normalizeViewerBaseUrl(
+  raw: string,
+  fieldName: ViewerBaseUrlFieldName = "baseUrl",
+): string {
   let parsed: URL;
   try {
     parsed = new URL(raw);
   } catch {
-    throw new Error(`Invalid baseUrl: ${raw}`);
+    throw new Error(`Invalid ${fieldName}: ${raw}`);
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(`baseUrl must use http or https: ${raw}`);
+    throw new Error(`${fieldName} must use http or https: ${raw}`);
   }
   if (parsed.search || parsed.hash) {
-    throw new Error(`baseUrl must not include query/hash: ${raw}`);
+    throw new Error(`${fieldName} must not include query/hash: ${raw}`);
   }
   parsed.search = "";
   parsed.hash = "";


### PR DESCRIPTION
## Summary

- Problem: diffs viewer URLs defaulted to raw loopback, which breaks in same-host proxy deployments that intentionally treat `127.0.0.1` as a trusted proxy and fail closed without forwarded client-IP headers.
- Why it matters: the earlier localhost fast-path idea fixed one topology by weakening the trusted-proxy invariant, which is the wrong tradeoff.
- What changed:
  - added plugin-owned `viewerBaseUrl` config for persistent viewer-link origin/path control
  - kept per-call `baseUrl` as the highest-precedence override
  - preserved the existing fail-closed viewer access policy
  - added config/tool coverage for normalization and precedence
  - documented the supported Oracle/Tailscale proxy path and added a changelog entry
- What did NOT change:
  - no access-policy widening
  - no `remoteAddress` heuristic bypass
  - no storage or token model changes

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #59227
- Related #58598
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: viewer URL generation assumed raw loopback was the right client origin, while the diffs HTTP gate correctly treated loopback-in-`trustedProxies` as ambiguous proxy traffic that must fail closed without forwarded headers.
- Missing detection / guardrail: there was no explicit viewer-origin seam for this plugin, so callers had to pass `baseUrl` on every tool call or accept the raw loopback fallback.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `fix(diffs): harden viewer proxy access` (`30a1690323`) intentionally preserved the fail-closed guard.
- Why this regressed now: the issue surfaced once raw loopback viewer URLs met a same-host trusted-proxy topology.
- If unknown, what was ruled out: ruled out artifact-registry and disk-persistence issues; requests were being denied before artifact lookup.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/diffs/src/config.test.ts`
  - `extensions/diffs/src/tool.test.ts`
  - `extensions/diffs/src/store.test.ts`
- Scenario the tests now lock in:
  - plugin `viewerBaseUrl` is normalized and used when no per-call `baseUrl` is present
  - per-call `baseUrl` still overrides plugin config
  - trusted-proxy loopback requests without valid provenance headers remain denied by default
- Why this is the smallest reliable guardrail: it fixes the real seam (viewer URL generation) while separately preserving the existing access gate behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Diffs can now be configured with `plugins.entries.diffs.config.viewerBaseUrl`, so viewer links can point at a stable proxy/public origin without passing `baseUrl` on every tool call. Access policy is unchanged: loopback trusted-proxy requests still fail closed unless remote viewers are explicitly enabled.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: local repo runtime
- Model/provider: N/A
- Integration/channel (if any): diffs plugin HTTP viewer route
- Relevant config (redacted): `gateway.trustedProxies=["127.0.0.1"]`

### Steps

1. Configure diffs with a persistent viewer origin or pass `baseUrl` per call.
2. Generate diff viewer URLs in `view` / `both` mode.
3. Re-check loopback trusted-proxy denial behavior.

### Expected

- Viewer URLs can target a stable proxy/public origin without weakening the viewer access gate.
- Trusted-proxy loopback traffic without client-origin headers stays denied by default.

### Actual

- This PR adds the explicit viewer-origin seam and preserves the existing fail-closed HTTP policy.

## Evidence

Attach at least one:

- [x] Passing targeted test coverage
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test -- extensions/diffs/src/config.test.ts extensions/diffs/src/tool.test.ts extensions/diffs/src/store.test.ts`
  - `pnpm build`
  - `pnpm check`
  - `pnpm format`
- Edge cases checked:
  - normalized plugin `viewerBaseUrl`
  - per-call `baseUrl` precedence over plugin config
  - trusted-proxy loopback denial path with and without forwarded headers when remote viewers stay disabled
- What you did **not** verify: full `pnpm test` suite (reviewer explicitly requested targeted-only verification for this prep pass).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Optional new plugin config
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: deployments may still point viewers at unusable origins if neither `viewerBaseUrl` nor per-call `baseUrl` is set.
  - Mitigation: keep the existing raw-loopback fallback, document the proxy topology caveat, and let explicit config override it safely.
