### PR TITLE
superseded by #59353

### DIFF
--- a/src/infra/exec-obfuscation-detect.test.ts
+++ b/src/infra/exec-obfuscation-detect.test.ts
@@ -134,6 +134,24 @@ describe("detectCommandObfuscation", () => {
     });
   });
 
+  describe("inline interpreter encoded execution", () => {
+    it("detects inline python executing a base64-decoded payload", () => {
+      const result = detectCommandObfuscation(
+        `python3 -c "import base64; exec(base64.b64decode('cHJpbnQoJ3B3bmVkJyk='))"`,
+      );
+      expect(result.detected).toBe(true);
+      expect(result.matchedPatterns).toContain("python-exec-encoded");
+    });
+
+    it("does NOT flag benign inline python that only parses JSON fields containing system in a key name", () => {
+      const result = detectCommandObfuscation(
+        `ssh neptune 'curl -s http://localhost:8123/api/ 2>/dev/null | head -5; echo "---"; curl -s http://localhost:8123/api/config 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(\\"Version:\\",d.get(\\"version\\")); print(\\"Location:\\",d.get(\\"location_name\\")); print(\\"Unit:\\",d.get(\\"unit_system\\",{}).get(\\"temperature\\")); print(\\"TZ:\\",d.get(\\"time_zone\\")); print(\\"Components:\\",len(d.get(\\"components\\",[])))" 2>/dev/null || echo "API not accessible without auth"'`,
+      );
+      expect(result.detected).toBe(false);
+      expect(result.matchedPatterns).not.toContain("python-exec-encoded");
+    });
+  });
+
   describe("alternative execution forms", () => {
     it("detects command substitution decode in shell -c", () => {
       const result = detectCommandObfuscation('sh -c "$(base64 -d <<< \\"ZWNobyBoaQ==\\")"');

--- a/src/infra/exec-obfuscation-detect.ts
+++ b/src/infra/exec-obfuscation-detect.ts
@@ -154,7 +154,8 @@ const OBFUSCATION_PATTERNS: ObfuscationPattern[] = [
   {
     id: "python-exec-encoded",
     description: "Python/Perl/Ruby with base64 or encoded execution",
-    regex: /(?:python[23]?|perl|ruby)\s+-[ec]\s+.*(?:base64|b64decode|decode|exec|system|eval)/i,
+    regex:
+      /(?:python[23]?|perl|ruby)\s+-[ec]\s+(?=.*(?:\bbase64\b|\b(?:b64decode|decode_base64)\b))(?=.*(?:\b(?:exec|eval|system)\b|\bsubprocess\.(?:run|Popen|call|check_call|check_output)\b)).*/i,
   },
   {
     id: "curl-pipe-shell",


### PR DESCRIPTION
## Summary

- Problem: `python-exec-encoded` matched any inline interpreter snippet containing `system`, which also matched benign identifiers like `unit_system`.
- Why it matters: harmless JSON parsing commands could be escalated as obfuscated execution and end up blocked behind the stricter approval path.
- What changed: narrowed the inline Python/Perl/Ruby rule so it requires both an encoded-payload marker and an execution sink.
- What did NOT change (scope boundary): other obfuscation heuristics and non-inline interpreter patterns remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the regex treated `system` as a free substring match inside any inline `python -c`/`perl -e`/`ruby -e` command.
- Missing detection / guardrail: there was no regression test covering benign inline scripts with keys or field names containing `system`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this sits in the obfuscation detector added for #8592.
- Why this regressed now: the rule was broad enough to catch both actual execution sinks and ordinary identifiers.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/exec-obfuscation-detect.test.ts`
- Scenario the test should lock in: a benign inline Python JSON parser with `unit_system` should not match `python-exec-encoded`, while `exec(base64.b64decode(...))` still should.
- Why this is the smallest reliable guardrail: the bug is entirely local to one regex in the detector.
- Existing test that already covers this (if any): there was coverage for other obfuscation patterns, but not this false-positive case.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Benign inline Python/Perl/Ruby commands are less likely to be flagged as obfuscated unless they include both an encoded payload marker and an execution sink.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - This slightly narrows one obfuscation heuristic. Mitigation: the rule still requires real encoded-exec characteristics, and the positive encoded-exec case is covered by a unit test.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + Vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `detectCommandObfuscation(...)` on an inline Python command that parses JSON and references `unit_system`.
2. Run `detectCommandObfuscation(...)` on `python3 -c "import base64; exec(base64.b64decode(...))"`.
3. Inspect matched patterns.

### Expected

- The JSON parsing command is not flagged by `python-exec-encoded`.
- The encoded exec command is flagged by `python-exec-encoded`.

### Actual

- With this patch, both expectations hold.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted Vitest run for `src/infra/exec-obfuscation-detect.test.ts`, including the new false-positive regression and the positive encoded-exec case.
- Edge cases checked: benign `base64` encode-only usage and the original Home Assistant-style `unit_system` string no longer trigger the rule.
- What you did **not** verify: full repo test suite and live end-to-end approval flows.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk:
  - Narrowing this heuristic could miss an obfuscated inline interpreter command that relied on a different encoding marker.
- Mitigation:
  - The rule still catches explicit `base64`/`b64decode`/`decode_base64` + execution-sink combinations, and the rest of the detector remains unchanged.
