### PR TITLE
fix(kimi-web_search): fix web search and add region/model selection during onboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,11 @@ Docs: https://docs.openclaw.ai
 - QQBot/voice: lazy-load `silk-wasm` in `audio-convert.ts` so qqbot still starts when the optional voice dependency is missing, while voice encode/decode degrades gracefully instead of crashing at module load time. (#58829) Thanks @WideLee.
 - WhatsApp/groups: fix bot waking up on self-number quoted replies in groups with `selfChatMode` enabled. (#60148) Thanks @lurebat
 - Device pairing: require `operator.pairing` or `operator.admin` for internal `/pair` setup-code, QR, and cleanup commands so lower-privilege gateway callers cannot mint or revoke pairing bootstrap material. (#60491) Thanks @eleqtrizit.
+- Agents/failover: unify structured and raw provider error classification so provider-specific `400`/`422` payloads no longer get forced into generic format failures before retry, billing, or compaction logic can inspect them. (#58856) Thanks @aaron-he-zhu.
+- Auth profiles/store: coerce misplaced SecretRef objects out of plaintext `key` and `token` fields during store load so agents without ACP runtime stop crashing on `.trim()` after upgrade. (#58923) Thanks @openperf.
+- ACPX/runtime: repair `queue owner unavailable` session recovery by replacing dead named sessions and resuming the backend session when ACPX exposes a stable session id, so the first ACP prompt no longer inherits a dead handle. (#58669) Thanks @neeravmakwana
+- ACPX/runtime: retry dead-session queue-owner repair without `--resume-session` when the reported ACPX session id is stale, so recovery still creates a fresh named session instead of failing session init. Thanks @obviyus.
+- Tools/web_search (Kimi): replay native Moonshot `$web_search` arguments verbatim, disable thinking for `kimi-k2.5`, and add Moonshot region/model setup prompts so bundled Kimi web search works again. (#59356) Thanks @Innocent-children.
 
 ## 2026.3.31
 

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -6,35 +6,35 @@ const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
 
 describe("kimi web search provider", () => {
   it("uses configured model and base url overrides with sane defaults", () => {
-    expect(__testing.resolveKimiModel()).toBe("moonshot-v1-128k");
+    expect(__testing.resolveKimiModel()).toBe("kimi-k2.5");
     expect(__testing.resolveKimiModel({ model: "kimi-k2" })).toBe("kimi-k2");
     expect(__testing.resolveKimiBaseUrl()).toBe("https://api.moonshot.ai/v1");
     expect(__testing.resolveKimiBaseUrl({ baseUrl: "https://kimi.example/v1" })).toBe(
-        "https://kimi.example/v1",
+      "https://kimi.example/v1",
     );
   });
 
   it("extracts unique citations from search results and tool call arguments", () => {
     expect(
-        __testing.extractKimiCitations({
-          search_results: [{ url: "https://a.test" }, { url: "https://b.test" }],
-          choices: [
-            {
-              message: {
-                tool_calls: [
-                  {
-                    function: {
-                      arguments: JSON.stringify({
-                        url: "https://a.test",
-                        search_results: [{ url: "https://c.test" }],
-                      }),
-                    },
+      __testing.extractKimiCitations({
+        search_results: [{ url: "https://a.test" }, { url: "https://b.test" }],
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  function: {
+                    arguments: JSON.stringify({
+                      url: "https://a.test",
+                      search_results: [{ url: "https://c.test" }],
+                    }),
                   },
-                ],
-              },
+                },
+              ],
             },
-          ],
-        }),
+          },
+        ],
+      }),
     ).toEqual(["https://a.test", "https://b.test", "https://c.test"]);
   });
 
@@ -42,19 +42,19 @@ describe("kimi web search provider", () => {
     const rawArguments = '  {"query":"MacBook Neo","usage":{"total_tokens":123}}  ';
 
     expect(
-        __testing.extractKimiToolResultContent({
-          function: {
-            arguments: rawArguments,
-          },
-        }),
+      __testing.extractKimiToolResultContent({
+        function: {
+          arguments: rawArguments,
+        },
+      }),
     ).toBe(rawArguments);
 
     expect(
-        __testing.extractKimiToolResultContent({
-          function: {
-            arguments: "   ",
-          },
-        }),
+      __testing.extractKimiToolResultContent({
+        function: {
+          arguments: "   ",
+        },
+      }),
     ).toBeUndefined();
   });
 

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -10,32 +10,52 @@ describe("kimi web search provider", () => {
     expect(__testing.resolveKimiModel({ model: "kimi-k2" })).toBe("kimi-k2");
     expect(__testing.resolveKimiBaseUrl()).toBe("https://api.moonshot.ai/v1");
     expect(__testing.resolveKimiBaseUrl({ baseUrl: "https://kimi.example/v1" })).toBe(
-      "https://kimi.example/v1",
+        "https://kimi.example/v1",
     );
   });
 
   it("extracts unique citations from search results and tool call arguments", () => {
     expect(
-      __testing.extractKimiCitations({
-        search_results: [{ url: "https://a.test" }, { url: "https://b.test" }],
-        choices: [
-          {
-            message: {
-              tool_calls: [
-                {
-                  function: {
-                    arguments: JSON.stringify({
-                      url: "https://a.test",
-                      search_results: [{ url: "https://c.test" }],
-                    }),
+        __testing.extractKimiCitations({
+          search_results: [{ url: "https://a.test" }, { url: "https://b.test" }],
+          choices: [
+            {
+              message: {
+                tool_calls: [
+                  {
+                    function: {
+                      arguments: JSON.stringify({
+                        url: "https://a.test",
+                        search_results: [{ url: "https://c.test" }],
+                      }),
+                    },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-        ],
-      }),
+          ],
+        }),
     ).toEqual(["https://a.test", "https://b.test", "https://c.test"]);
+  });
+
+  it("returns original tool arguments as tool content", () => {
+    const rawArguments = '  {"query":"MacBook Neo","usage":{"total_tokens":123}}  ';
+
+    expect(
+        __testing.extractKimiToolResultContent({
+          function: {
+            arguments: rawArguments,
+          },
+        }),
+    ).toBe(rawArguments);
+
+    expect(
+        __testing.extractKimiToolResultContent({
+          function: {
+            arguments: "   ",
+          },
+        }),
+    ).toBeUndefined();
   });
 
   it("uses config apiKey when provided", () => {

--- a/extensions/moonshot/src/kimi-web-search-provider.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.ts
@@ -33,7 +33,6 @@ import {
 } from "../provider-catalog.js";
 
 const DEFAULT_KIMI_BASE_URL = MOONSHOT_BASE_URL;
-const DEFAULT_KIMI_MODEL = "moonshot-v1-128k";
 const DEFAULT_KIMI_SEARCH_MODEL = MOONSHOT_DEFAULT_MODEL_ID;
 /** Models that require explicit thinking disablement for web search.
  * Reasoning variants (kimi-k2-thinking, kimi-k2-thinking-turbo) are excluded
@@ -86,14 +85,14 @@ function resolveKimiConfig(searchConfig?: SearchConfigRecord): KimiConfig {
 
 function resolveKimiApiKey(kimi?: KimiConfig): string | undefined {
   return (
-      readConfiguredSecretString(kimi?.apiKey, "tools.web.search.kimi.apiKey") ??
-      readProviderEnvValue(["KIMI_API_KEY", "MOONSHOT_API_KEY"])
+    readConfiguredSecretString(kimi?.apiKey, "tools.web.search.kimi.apiKey") ??
+    readProviderEnvValue(["KIMI_API_KEY", "MOONSHOT_API_KEY"])
   );
 }
 
 function resolveKimiModel(kimi?: KimiConfig): string {
   const model = typeof kimi?.model === "string" ? kimi.model.trim() : "";
-  return model || DEFAULT_KIMI_MODEL;
+  return model || DEFAULT_KIMI_SEARCH_MODEL;
 }
 
 function resolveKimiBaseUrl(kimi?: KimiConfig): string {
@@ -112,8 +111,8 @@ function extractKimiMessageText(message: KimiMessage | undefined): string | unde
 
 function extractKimiCitations(data: KimiSearchResponse): string[] {
   const citations = (data.search_results ?? [])
-      .map((entry) => entry.url?.trim())
-      .filter((url): url is string => Boolean(url));
+    .map((entry) => entry.url?.trim())
+    .filter((url): url is string => Boolean(url));
 
   for (const toolCall of data.choices?.[0]?.message?.tool_calls ?? []) {
     const rawArguments = toolCall.function?.arguments;
@@ -162,72 +161,72 @@ async function runKimiSearch(params: {
 
   for (let round = 0; round < 3; round += 1) {
     const next = await withTrustedWebSearchEndpoint(
-        {
-          url: endpoint,
-          timeoutSeconds: params.timeoutSeconds,
-          init: {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${params.apiKey}`,
-            },
-            body: JSON.stringify({
-              model: params.model,
-              ...(KIMI_THINKING_MODELS.has(params.model) ? { thinking: { type: "disabled" } } : {}),
-              messages,
-              tools: [KIMI_WEB_SEARCH_TOOL],
-            }),
+      {
+        url: endpoint,
+        timeoutSeconds: params.timeoutSeconds,
+        init: {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${params.apiKey}`,
           },
+          body: JSON.stringify({
+            model: params.model,
+            ...(KIMI_THINKING_MODELS.has(params.model) ? { thinking: { type: "disabled" } } : {}),
+            messages,
+            tools: [KIMI_WEB_SEARCH_TOOL],
+          }),
         },
-        async (
-            res,
-        ): Promise<{ done: true; content: string; citations: string[] } | { done: false }> => {
-          if (!res.ok) {
-            const detail = await res.text();
-            throw new Error(`Kimi API error (${res.status}): ${detail || res.statusText}`);
-          }
+      },
+      async (
+        res,
+      ): Promise<{ done: true; content: string; citations: string[] } | { done: false }> => {
+        if (!res.ok) {
+          const detail = await res.text();
+          throw new Error(`Kimi API error (${res.status}): ${detail || res.statusText}`);
+        }
 
-          const data = (await res.json()) as KimiSearchResponse;
-          for (const citation of extractKimiCitations(data)) {
-            collectedCitations.add(citation);
-          }
-          const choice = data.choices?.[0];
-          const message = choice?.message;
-          const text = extractKimiMessageText(message);
-          const toolCalls = message?.tool_calls ?? [];
+        const data = (await res.json()) as KimiSearchResponse;
+        for (const citation of extractKimiCitations(data)) {
+          collectedCitations.add(citation);
+        }
+        const choice = data.choices?.[0];
+        const message = choice?.message;
+        const text = extractKimiMessageText(message);
+        const toolCalls = message?.tool_calls ?? [];
 
-          if (choice?.finish_reason !== "tool_calls" || toolCalls.length === 0) {
-            return { done: true, content: text ?? "No response", citations: [...collectedCitations] };
-          }
+        if (choice?.finish_reason !== "tool_calls" || toolCalls.length === 0) {
+          return { done: true, content: text ?? "No response", citations: [...collectedCitations] };
+        }
 
+        messages.push({
+          role: "assistant",
+          content: message?.content ?? "",
+          ...(message?.reasoning_content ? { reasoning_content: message.reasoning_content } : {}),
+          tool_calls: toolCalls,
+        });
+
+        let pushed = false;
+        for (const toolCall of toolCalls) {
+          const toolCallId = toolCall.id?.trim();
+          const toolCallName = toolCall.function?.name?.trim();
+          const toolContent = extractKimiToolResultContent(toolCall);
+          if (!toolCallId || !toolCallName || !toolContent) {
+            continue;
+          }
+          pushed = true;
           messages.push({
-            role: "assistant",
-            content: message?.content ?? "",
-            ...(message?.reasoning_content ? { reasoning_content: message.reasoning_content } : {}),
-            tool_calls: toolCalls,
+            role: "tool",
+            tool_call_id: toolCallId,
+            name: toolCallName,
+            content: toolContent,
           });
-
-          let pushed = false;
-          for (const toolCall of toolCalls) {
-            const toolCallId = toolCall.id?.trim();
-            const toolCallName = toolCall.function?.name?.trim();
-            const toolContent = extractKimiToolResultContent(toolCall);
-            if (!toolCallId || !toolCallName || !toolContent) {
-              continue;
-            }
-            pushed = true;
-            messages.push({
-              role: "tool",
-              tool_call_id: toolCallId,
-              name: toolCallName,
-              content: toolContent,
-            });
-          }
-          if (!pushed) {
-            return { done: true, content: text ?? "No response", citations: [...collectedCitations] };
-          }
-          return { done: false };
-        },
+        }
+        if (!pushed) {
+          return { done: true, content: text ?? "No response", citations: [...collectedCitations] };
+        }
+        return { done: false };
+      },
     );
 
     if (next.done) {
@@ -245,11 +244,11 @@ function createKimiSchema() {
   return Type.Object({
     query: Type.String({ description: "Search query string." }),
     count: Type.Optional(
-        Type.Number({
-          description: "Number of results to return (1-10).",
-          minimum: 1,
-          maximum: MAX_SEARCH_COUNT,
-        }),
+      Type.Number({
+        description: "Number of results to return (1-10).",
+        minimum: 1,
+        maximum: MAX_SEARCH_COUNT,
+      }),
     ),
     country: Type.Optional(Type.String({ description: "Not supported by Kimi." })),
     language: Type.Optional(Type.String({ description: "Not supported by Kimi." })),
@@ -260,11 +259,11 @@ function createKimiSchema() {
 }
 
 function createKimiToolDefinition(
-    searchConfig?: SearchConfigRecord,
+  searchConfig?: SearchConfigRecord,
 ): WebSearchProviderToolDefinition {
   return {
     description:
-        "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search.",
+      "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search.",
     parameters: createKimiSchema(),
     execute: async (args) => {
       const params = args as Record<string, unknown>;
@@ -279,16 +278,16 @@ function createKimiToolDefinition(
         return {
           error: "missing_kimi_api_key",
           message:
-              "web_search (kimi) needs a Moonshot API key. Set KIMI_API_KEY or MOONSHOT_API_KEY in the Gateway environment, or configure tools.web.search.kimi.apiKey.",
+            "web_search (kimi) needs a Moonshot API key. Set KIMI_API_KEY or MOONSHOT_API_KEY in the Gateway environment, or configure tools.web.search.kimi.apiKey.",
           docs: "https://docs.openclaw.ai/tools/web",
         };
       }
 
       const query = readStringParam(params, "query", { required: true });
       const count =
-          readNumberParam(params, "count", { integer: true }) ??
-          searchConfig?.maxResults ??
-          undefined;
+        readNumberParam(params, "count", { integer: true }) ??
+        searchConfig?.maxResults ??
+        undefined;
       const model = resolveKimiModel(kimiConfig);
       const baseUrl = resolveKimiBaseUrl(kimiConfig);
       const cacheKey = buildSearchCacheKey([
@@ -332,15 +331,15 @@ function createKimiToolDefinition(
 }
 
 async function runKimiSearchProviderSetup(
-    ctx: WebSearchProviderSetupContext,
+  ctx: WebSearchProviderSetupContext,
 ): Promise<WebSearchProviderSetupContext["config"]> {
   const existingPluginConfig = resolveProviderWebSearchPluginConfig(ctx.config, "moonshot");
   const existingBaseUrl =
-      typeof existingPluginConfig?.baseUrl === "string" ? existingPluginConfig.baseUrl.trim() : "";
+    typeof existingPluginConfig?.baseUrl === "string" ? existingPluginConfig.baseUrl.trim() : "";
   // Normalize trailing slashes so initialValue matches canonical option values.
   const normalizedBaseUrl = existingBaseUrl.replace(/\/+$/, "");
   const existingModel =
-      typeof existingPluginConfig?.model === "string" ? existingPluginConfig.model.trim() : "";
+    typeof existingPluginConfig?.model === "string" ? existingPluginConfig.model.trim() : "";
 
   // Region selection (baseUrl)
   const isCustomBaseUrl = normalizedBaseUrl && !isNativeMoonshotBaseUrl(normalizedBaseUrl);
@@ -353,16 +352,16 @@ async function runKimiSearchProviderSetup(
     });
   }
   regionOptions.push(
-      {
-        value: MOONSHOT_BASE_URL,
-        label: "Moonshot API key (.ai)",
-        hint: "api.moonshot.ai",
-      },
-      {
-        value: MOONSHOT_CN_BASE_URL,
-        label: "Moonshot API key (.cn)",
-        hint: "api.moonshot.cn",
-      },
+    {
+      value: MOONSHOT_BASE_URL,
+      label: "Moonshot API key (.ai)",
+      hint: "api.moonshot.ai",
+    },
+    {
+      value: MOONSHOT_CN_BASE_URL,
+      label: "Moonshot API key (.cn)",
+      hint: "api.moonshot.cn",
+    },
   );
 
   const regionChoice = await ctx.prompter.select<string>({
@@ -374,8 +373,8 @@ async function runKimiSearchProviderSetup(
 
   // Model selection
   const currentModelLabel = existingModel
-      ? `Keep current (moonshot/${existingModel})`
-      : `Use default (moonshot/${DEFAULT_KIMI_SEARCH_MODEL})`;
+    ? `Keep current (moonshot/${existingModel})`
+    : `Use default (moonshot/${DEFAULT_KIMI_SEARCH_MODEL})`;
   const modelChoice = await ctx.prompter.select<string>({
     message: "Kimi web search model",
     options: [
@@ -432,21 +431,21 @@ export function createKimiWebSearchProvider(): WebSearchProviderPlugin {
     inactiveSecretPaths: ["plugins.entries.moonshot.config.webSearch.apiKey"],
     getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, "kimi"),
     setCredentialValue: (searchConfigTarget, value) =>
-        setScopedCredentialValue(searchConfigTarget, "kimi", value),
+      setScopedCredentialValue(searchConfigTarget, "kimi", value),
     getConfiguredCredentialValue: (config) =>
-        resolveProviderWebSearchPluginConfig(config, "moonshot")?.apiKey,
+      resolveProviderWebSearchPluginConfig(config, "moonshot")?.apiKey,
     setConfiguredCredentialValue: (configTarget, value) => {
       setProviderWebSearchPluginConfigValue(configTarget, "moonshot", "apiKey", value);
     },
     runSetup: runKimiSearchProviderSetup,
     createTool: (ctx) =>
-        createKimiToolDefinition(
-            mergeScopedSearchConfig(
-                ctx.searchConfig as SearchConfigRecord | undefined,
-                "kimi",
-                resolveProviderWebSearchPluginConfig(ctx.config, "moonshot"),
-            ) as SearchConfigRecord | undefined,
-        ),
+      createKimiToolDefinition(
+        mergeScopedSearchConfig(
+          ctx.searchConfig as SearchConfigRecord | undefined,
+          "kimi",
+          resolveProviderWebSearchPluginConfig(ctx.config, "moonshot"),
+        ) as SearchConfigRecord | undefined,
+      ),
   };
 }
 

--- a/extensions/moonshot/src/kimi-web-search-provider.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.ts
@@ -19,14 +19,27 @@ import {
   setProviderWebSearchPluginConfigValue,
   type SearchConfigRecord,
   type WebSearchProviderPlugin,
+  type WebSearchProviderSetupContext,
   type WebSearchProviderToolDefinition,
   withTrustedWebSearchEndpoint,
   wrapWebContent,
   writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
+import {
+  isNativeMoonshotBaseUrl,
+  MOONSHOT_BASE_URL,
+  MOONSHOT_CN_BASE_URL,
+  MOONSHOT_DEFAULT_MODEL_ID,
+} from "../provider-catalog.js";
 
-const DEFAULT_KIMI_BASE_URL = "https://api.moonshot.ai/v1";
+const DEFAULT_KIMI_BASE_URL = MOONSHOT_BASE_URL;
 const DEFAULT_KIMI_MODEL = "moonshot-v1-128k";
+const DEFAULT_KIMI_SEARCH_MODEL = MOONSHOT_DEFAULT_MODEL_ID;
+/** Models that require explicit thinking disablement for web search.
+ * Reasoning variants (kimi-k2-thinking, kimi-k2-thinking-turbo) are excluded
+ * because they default to thinking-enabled and disabling it would defeat their
+ * purpose; they are also unlikely to be used for web search. */
+const KIMI_THINKING_MODELS = new Set(["kimi-k2.5"]);
 const KIMI_WEB_SEARCH_TOOL = {
   type: "builtin_function",
   function: { name: "$web_search" },
@@ -73,8 +86,8 @@ function resolveKimiConfig(searchConfig?: SearchConfigRecord): KimiConfig {
 
 function resolveKimiApiKey(kimi?: KimiConfig): string | undefined {
   return (
-    readConfiguredSecretString(kimi?.apiKey, "tools.web.search.kimi.apiKey") ??
-    readProviderEnvValue(["KIMI_API_KEY", "MOONSHOT_API_KEY"])
+      readConfiguredSecretString(kimi?.apiKey, "tools.web.search.kimi.apiKey") ??
+      readProviderEnvValue(["KIMI_API_KEY", "MOONSHOT_API_KEY"])
   );
 }
 
@@ -99,8 +112,8 @@ function extractKimiMessageText(message: KimiMessage | undefined): string | unde
 
 function extractKimiCitations(data: KimiSearchResponse): string[] {
   const citations = (data.search_results ?? [])
-    .map((entry) => entry.url?.trim())
-    .filter((url): url is string => Boolean(url));
+      .map((entry) => entry.url?.trim())
+      .filter((url): url is string => Boolean(url));
 
   for (const toolCall of data.choices?.[0]?.message?.tool_calls ?? []) {
     const rawArguments = toolCall.function?.arguments;
@@ -128,14 +141,12 @@ function extractKimiCitations(data: KimiSearchResponse): string[] {
   return [...new Set(citations)];
 }
 
-function buildKimiToolResultContent(data: KimiSearchResponse): string {
-  return JSON.stringify({
-    search_results: (data.search_results ?? []).map((entry) => ({
-      title: entry.title ?? "",
-      url: entry.url ?? "",
-      content: entry.content ?? "",
-    })),
-  });
+function extractKimiToolResultContent(toolCall: KimiToolCall): string | undefined {
+  const rawArguments = toolCall.function?.arguments;
+  if (typeof rawArguments !== "string" || rawArguments.trim().length === 0) {
+    return undefined;
+  }
+  return rawArguments;
 }
 
 async function runKimiSearch(params: {
@@ -151,65 +162,72 @@ async function runKimiSearch(params: {
 
   for (let round = 0; round < 3; round += 1) {
     const next = await withTrustedWebSearchEndpoint(
-      {
-        url: endpoint,
-        timeoutSeconds: params.timeoutSeconds,
-        init: {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${params.apiKey}`,
+        {
+          url: endpoint,
+          timeoutSeconds: params.timeoutSeconds,
+          init: {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${params.apiKey}`,
+            },
+            body: JSON.stringify({
+              model: params.model,
+              ...(KIMI_THINKING_MODELS.has(params.model) ? { thinking: { type: "disabled" } } : {}),
+              messages,
+              tools: [KIMI_WEB_SEARCH_TOOL],
+            }),
           },
-          body: JSON.stringify({
-            model: params.model,
-            messages,
-            tools: [KIMI_WEB_SEARCH_TOOL],
-          }),
         },
-      },
-      async (
-        res,
-      ): Promise<{ done: true; content: string; citations: string[] } | { done: false }> => {
-        if (!res.ok) {
-          const detail = await res.text();
-          throw new Error(`Kimi API error (${res.status}): ${detail || res.statusText}`);
-        }
-
-        const data = (await res.json()) as KimiSearchResponse;
-        for (const citation of extractKimiCitations(data)) {
-          collectedCitations.add(citation);
-        }
-        const choice = data.choices?.[0];
-        const message = choice?.message;
-        const text = extractKimiMessageText(message);
-        const toolCalls = message?.tool_calls ?? [];
-
-        if (choice?.finish_reason !== "tool_calls" || toolCalls.length === 0) {
-          return { done: true, content: text ?? "No response", citations: [...collectedCitations] };
-        }
-
-        messages.push({
-          role: "assistant",
-          content: message?.content ?? "",
-          ...(message?.reasoning_content ? { reasoning_content: message.reasoning_content } : {}),
-          tool_calls: toolCalls,
-        });
-
-        const toolContent = buildKimiToolResultContent(data);
-        let pushed = false;
-        for (const toolCall of toolCalls) {
-          const toolCallId = toolCall.id?.trim();
-          if (!toolCallId) {
-            continue;
+        async (
+            res,
+        ): Promise<{ done: true; content: string; citations: string[] } | { done: false }> => {
+          if (!res.ok) {
+            const detail = await res.text();
+            throw new Error(`Kimi API error (${res.status}): ${detail || res.statusText}`);
           }
-          pushed = true;
-          messages.push({ role: "tool", tool_call_id: toolCallId, content: toolContent });
-        }
-        if (!pushed) {
-          return { done: true, content: text ?? "No response", citations: [...collectedCitations] };
-        }
-        return { done: false };
-      },
+
+          const data = (await res.json()) as KimiSearchResponse;
+          for (const citation of extractKimiCitations(data)) {
+            collectedCitations.add(citation);
+          }
+          const choice = data.choices?.[0];
+          const message = choice?.message;
+          const text = extractKimiMessageText(message);
+          const toolCalls = message?.tool_calls ?? [];
+
+          if (choice?.finish_reason !== "tool_calls" || toolCalls.length === 0) {
+            return { done: true, content: text ?? "No response", citations: [...collectedCitations] };
+          }
+
+          messages.push({
+            role: "assistant",
+            content: message?.content ?? "",
+            ...(message?.reasoning_content ? { reasoning_content: message.reasoning_content } : {}),
+            tool_calls: toolCalls,
+          });
+
+          let pushed = false;
+          for (const toolCall of toolCalls) {
+            const toolCallId = toolCall.id?.trim();
+            const toolCallName = toolCall.function?.name?.trim();
+            const toolContent = extractKimiToolResultContent(toolCall);
+            if (!toolCallId || !toolCallName || !toolContent) {
+              continue;
+            }
+            pushed = true;
+            messages.push({
+              role: "tool",
+              tool_call_id: toolCallId,
+              name: toolCallName,
+              content: toolContent,
+            });
+          }
+          if (!pushed) {
+            return { done: true, content: text ?? "No response", citations: [...collectedCitations] };
+          }
+          return { done: false };
+        },
     );
 
     if (next.done) {
@@ -227,11 +245,11 @@ function createKimiSchema() {
   return Type.Object({
     query: Type.String({ description: "Search query string." }),
     count: Type.Optional(
-      Type.Number({
-        description: "Number of results to return (1-10).",
-        minimum: 1,
-        maximum: MAX_SEARCH_COUNT,
-      }),
+        Type.Number({
+          description: "Number of results to return (1-10).",
+          minimum: 1,
+          maximum: MAX_SEARCH_COUNT,
+        }),
     ),
     country: Type.Optional(Type.String({ description: "Not supported by Kimi." })),
     language: Type.Optional(Type.String({ description: "Not supported by Kimi." })),
@@ -242,11 +260,11 @@ function createKimiSchema() {
 }
 
 function createKimiToolDefinition(
-  searchConfig?: SearchConfigRecord,
+    searchConfig?: SearchConfigRecord,
 ): WebSearchProviderToolDefinition {
   return {
     description:
-      "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search.",
+        "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search.",
     parameters: createKimiSchema(),
     execute: async (args) => {
       const params = args as Record<string, unknown>;
@@ -261,16 +279,16 @@ function createKimiToolDefinition(
         return {
           error: "missing_kimi_api_key",
           message:
-            "web_search (kimi) needs a Moonshot API key. Set KIMI_API_KEY or MOONSHOT_API_KEY in the Gateway environment, or configure tools.web.search.kimi.apiKey.",
+              "web_search (kimi) needs a Moonshot API key. Set KIMI_API_KEY or MOONSHOT_API_KEY in the Gateway environment, or configure tools.web.search.kimi.apiKey.",
           docs: "https://docs.openclaw.ai/tools/web",
         };
       }
 
       const query = readStringParam(params, "query", { required: true });
       const count =
-        readNumberParam(params, "count", { integer: true }) ??
-        searchConfig?.maxResults ??
-        undefined;
+          readNumberParam(params, "count", { integer: true }) ??
+          searchConfig?.maxResults ??
+          undefined;
       const model = resolveKimiModel(kimiConfig);
       const baseUrl = resolveKimiBaseUrl(kimiConfig);
       const cacheKey = buildSearchCacheKey([
@@ -313,6 +331,91 @@ function createKimiToolDefinition(
   };
 }
 
+async function runKimiSearchProviderSetup(
+    ctx: WebSearchProviderSetupContext,
+): Promise<WebSearchProviderSetupContext["config"]> {
+  const existingPluginConfig = resolveProviderWebSearchPluginConfig(ctx.config, "moonshot");
+  const existingBaseUrl =
+      typeof existingPluginConfig?.baseUrl === "string" ? existingPluginConfig.baseUrl.trim() : "";
+  // Normalize trailing slashes so initialValue matches canonical option values.
+  const normalizedBaseUrl = existingBaseUrl.replace(/\/+$/, "");
+  const existingModel =
+      typeof existingPluginConfig?.model === "string" ? existingPluginConfig.model.trim() : "";
+
+  // Region selection (baseUrl)
+  const isCustomBaseUrl = normalizedBaseUrl && !isNativeMoonshotBaseUrl(normalizedBaseUrl);
+  const regionOptions: Array<{ value: string; label: string; hint?: string }> = [];
+  if (isCustomBaseUrl) {
+    regionOptions.push({
+      value: normalizedBaseUrl,
+      label: `Keep current (${normalizedBaseUrl})`,
+      hint: "custom endpoint",
+    });
+  }
+  regionOptions.push(
+      {
+        value: MOONSHOT_BASE_URL,
+        label: "Moonshot API key (.ai)",
+        hint: "api.moonshot.ai",
+      },
+      {
+        value: MOONSHOT_CN_BASE_URL,
+        label: "Moonshot API key (.cn)",
+        hint: "api.moonshot.cn",
+      },
+  );
+
+  const regionChoice = await ctx.prompter.select<string>({
+    message: "Kimi API region",
+    options: regionOptions,
+    initialValue: normalizedBaseUrl || MOONSHOT_BASE_URL,
+  });
+  const baseUrl = regionChoice;
+
+  // Model selection
+  const currentModelLabel = existingModel
+      ? `Keep current (moonshot/${existingModel})`
+      : `Use default (moonshot/${DEFAULT_KIMI_SEARCH_MODEL})`;
+  const modelChoice = await ctx.prompter.select<string>({
+    message: "Kimi web search model",
+    options: [
+      {
+        value: "__keep__",
+        label: currentModelLabel,
+      },
+      {
+        value: "__custom__",
+        label: "Enter model manually",
+      },
+      {
+        value: DEFAULT_KIMI_SEARCH_MODEL,
+        label: `moonshot/${DEFAULT_KIMI_SEARCH_MODEL}`,
+      },
+    ],
+    initialValue: "__keep__",
+  });
+
+  let model: string;
+  if (modelChoice === "__keep__") {
+    model = existingModel || DEFAULT_KIMI_SEARCH_MODEL;
+  } else if (modelChoice === "__custom__") {
+    const customModel = await ctx.prompter.text({
+      message: "Kimi model name",
+      initialValue: existingModel || DEFAULT_KIMI_SEARCH_MODEL,
+      placeholder: DEFAULT_KIMI_SEARCH_MODEL,
+    });
+    model = customModel?.trim() || DEFAULT_KIMI_SEARCH_MODEL;
+  } else {
+    model = modelChoice;
+  }
+
+  // Write baseUrl and model into plugins.entries.moonshot.config.webSearch
+  const next = { ...ctx.config };
+  setProviderWebSearchPluginConfigValue(next, "moonshot", "baseUrl", baseUrl);
+  setProviderWebSearchPluginConfigValue(next, "moonshot", "model", model);
+  return next;
+}
+
 export function createKimiWebSearchProvider(): WebSearchProviderPlugin {
   return {
     id: "kimi",
@@ -329,20 +432,21 @@ export function createKimiWebSearchProvider(): WebSearchProviderPlugin {
     inactiveSecretPaths: ["plugins.entries.moonshot.config.webSearch.apiKey"],
     getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, "kimi"),
     setCredentialValue: (searchConfigTarget, value) =>
-      setScopedCredentialValue(searchConfigTarget, "kimi", value),
+        setScopedCredentialValue(searchConfigTarget, "kimi", value),
     getConfiguredCredentialValue: (config) =>
-      resolveProviderWebSearchPluginConfig(config, "moonshot")?.apiKey,
+        resolveProviderWebSearchPluginConfig(config, "moonshot")?.apiKey,
     setConfiguredCredentialValue: (configTarget, value) => {
       setProviderWebSearchPluginConfigValue(configTarget, "moonshot", "apiKey", value);
     },
+    runSetup: runKimiSearchProviderSetup,
     createTool: (ctx) =>
-      createKimiToolDefinition(
-        mergeScopedSearchConfig(
-          ctx.searchConfig as SearchConfigRecord | undefined,
-          "kimi",
-          resolveProviderWebSearchPluginConfig(ctx.config, "moonshot"),
-        ) as SearchConfigRecord | undefined,
-      ),
+        createKimiToolDefinition(
+            mergeScopedSearchConfig(
+                ctx.searchConfig as SearchConfigRecord | undefined,
+                "kimi",
+                resolveProviderWebSearchPluginConfig(ctx.config, "moonshot"),
+            ) as SearchConfigRecord | undefined,
+        ),
   };
 }
 
@@ -351,4 +455,5 @@ export const __testing = {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  extractKimiToolResultContent,
 } as const;

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -28,11 +28,16 @@ const SEARCH_PROVIDER_ENV_VARS = [
 let originalSearchProviderEnv: Partial<Record<(typeof SEARCH_PROVIDER_ENV_VARS)[number], string>> =
   {};
 
-function createPrompter(params: { selectValue?: string; textValue?: string }): {
+function createPrompter(params: {
+  selectValue?: string;
+  selectValues?: string[];
+  textValue?: string;
+}): {
   prompter: WizardPrompter;
   notes: Array<{ title?: string; message: string }>;
 } {
   const notes: Array<{ title?: string; message: string }> = [];
+  const remainingSelectValues = [...(params.selectValues ?? [])];
   const prompter: WizardPrompter = {
     intro: vi.fn(async () => {}),
     outro: vi.fn(async () => {}),
@@ -40,7 +45,7 @@ function createPrompter(params: { selectValue?: string; textValue?: string }): {
       notes.push({ title, message });
     }),
     select: vi.fn(
-      async () => params.selectValue ?? "perplexity",
+      async () => remainingSelectValues.shift() ?? params.selectValue ?? "perplexity",
     ) as unknown as WizardPrompter["select"],
     multiselect: vi.fn(async () => []) as unknown as WizardPrompter["multiselect"],
     text: vi.fn(async () => params.textValue ?? ""),
@@ -260,14 +265,22 @@ describe("setupSearch", () => {
   it("sets provider and key for kimi", async () => {
     const cfg: OpenClawConfig = {};
     const { prompter } = createPrompter({
-      selectValue: "kimi",
+      selectValues: ["kimi", "https://api.moonshot.ai/v1", "__keep__"],
       textValue: "sk-moonshot",
     });
     const result = await setupSearch(cfg, runtime, prompter);
+    const kimiWebSearchConfig = result.plugins?.entries?.moonshot?.config?.webSearch as
+      | {
+          baseUrl?: string;
+          model?: string;
+        }
+      | undefined;
     expect(result.tools?.web?.search?.provider).toBe("kimi");
     expect(result.tools?.web?.search?.enabled).toBe(true);
     expect(pluginWebSearchApiKey(result, "moonshot")).toBe("sk-moonshot");
     expect(result.plugins?.entries?.moonshot?.enabled).toBe(true);
+    expect(kimiWebSearchConfig?.baseUrl).toBe("https://api.moonshot.ai/v1");
+    expect(kimiWebSearchConfig?.model).toBe("kimi-k2.5");
   });
 
   it("sets provider and key for tavily and enables the plugin", async () => {


### PR DESCRIPTION
## Summary

- Problem: Kimi web search returned incorrect/empty results because baseUrl and model were not configurable during onboarding, and the search result processing logic did not match the official Kimi API sample.
- Why it matters: Users who selected Kimi as their web search provider during onboarding could not get working search results, making the Kimi web search option effectively broken.
- What changed: Fixed search logic to align with official Kimi API usage; added `runSetup` hook to prompt for API region (.ai/.cn) and model selection after the API key step during onboarding; baseUrl and model are now persisted to `plugins.entries.moonshot.config.webSearch`.
- What did NOT change (scope boundary): The core `search-setup.ts` flow is untouched. Only the moonshot extension's `kimi-web-search-provider.ts` was modified. Existing apiKey handling and credential storage logic remain the same.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The Kimi web search provider had no way to configure baseUrl or model during onboarding. The default search logic and result processing did not match the official Kimi API sample, causing incorrect or empty responses.
- Missing detection / guardrail: No onboarding-level validation that the configured provider actually returns valid results.
- Prior context: The original Kimi web search provider was added with hardcoded defaults and no `runSetup` hook, unlike the xAI/Grok provider which already had one.
- Why this regressed now: It was broken from the start for users who needed a non-default baseUrl or model.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
- [x] Unit test
- [x] Seam / integration test
- [x] End-to-end test
- [x] Existing coverage already sufficient
- Target test or file: `extensions/moonshot/src/kimi-web-search-provider.test.ts`
- Scenario the test should lock in: Kimi search provider resolves correct baseUrl and model from plugin config after onboarding setup.
- Why this is the smallest reliable guardrail: Unit tests on resolve functions confirm config is read correctly; the runSetup flow is covered by the existing onboard-search test pattern.
- Existing test that already covers this (if any): `kimi-web-search-provider.test.ts` covers resolveKimiBaseUrl and resolveKimiModel.
- If no new test is added, why not: Existing unit tests for resolveKimiBaseUrl/resolveKimiModel already validate the config reading path. The onboard-search integration test for kimi confirms provider selection and key storage still work.

## User-visible / Behavior Changes

- During onboarding, after selecting Kimi as web search provider and entering the API key, users are now prompted to choose API region (Moonshot .ai or .cn) and model (keep current, manual entry, or kimi-k2.5).
- Kimi web search now returns correct results by using properly configured baseUrl and model.

## Diagram (if applicable)

```text
Before:
[select kimi] -> [enter apiKey] -> done (broken: no baseUrl/model config)

After:
[select kimi] -> [enter apiKey] -> [choose region .ai/.cn] -> [choose model] -> done (working)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (baseUrl was already used at runtime, now it is user-configurable)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / Bun
- Model/provider: Moonshot (Kimi)
- Integration/channel (if any): Web search
- Relevant config (redacted): `plugins.entries.moonshot.config.webSearch`

### Steps

1. Run `pnpm openclaw onboard --install-daemon`
2. At the web search provider step, select Kimi
3. Enter a Moonshot API key
4. Choose API region (.ai or .cn)
5. Choose model (keep current / manual / kimi-k2.5)
6. Verify config is written and web search returns results

### Expected

- Region and model prompts appear after API key entry
- Config is persisted with correct baseUrl and model
- Web search returns valid results

### Actual

- Before fix: no region/model prompts, search returned incorrect/empty results
- After fix: prompts appear, config is saved, search works correctly

## Evidence

-  Failing test/log before + passing after
-  Trace/log snippets
-  Screenshot/recording
-  Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Ran `pnpm test -- extensions/moonshot/src/kimi-web-search-provider.test.ts` (5 passed), ran `pnpm test -- src/commands/onboard-search.test.ts -t "sets provider and key for kimi"` (passed).
- Edge cases checked: Existing config with pre-set baseUrl/model shows correct initial values in prompts; blank manual model input falls back to default.
- What you did **not** verify: Full end-to-end onboarding flow with a real Moonshot API key; quickstart/secretRef mode paths.

## Review Conversations

-  I replied to or resolved every bot review conversation I addressed in this PR.
-  I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No (new optional fields baseUrl and model in existing config path)
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Users with existing Kimi config who re-run onboarding will be prompted for region/model they did not see before.
- Mitigation: The "Keep current" option is pre-selected as default, so pressing enter preserves existing behavior.