### PR TITLE
feat(doctor): detect volatile filesystem (tmpfs/ramfs/overlay) for state directory

### DIFF
--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -397,6 +397,7 @@ That stages grounded durable candidates into the short-term dreaming store while
     - **State dir permissions**: verifies writability; offers to repair permissions (and emits a `chown` hint when owner/group mismatch is detected).
     - **macOS cloud-synced state dir**: warns when state resolves under iCloud Drive (`~/Library/Mobile Documents/com~apple~CloudDocs/...`) or `~/Library/CloudStorage/...` because sync-backed paths can cause slower I/O and lock/sync races.
     - **Linux SD or eMMC state dir**: warns when state resolves to an `mmcblk*` mount source, because SD or eMMC-backed random I/O can be slower and wear faster under session and credential writes.
+    - **Linux volatile state dir (tmpfs/ramfs)**: warns when state resolves to a `tmpfs` or `ramfs` mount, because memory-backed filesystems lose all sessions, credentials, and config on reboot. Move `OPENCLAW_STATE_DIR` to a persistent filesystem to avoid silent data loss.
     - **Session dirs missing**: `sessions/` and the session store directory are required to persist history and avoid `ENOENT` crashes.
     - **Transcript mismatch**: warns when recent session entries have missing transcript files.
     - **Main session "1-line JSONL"**: flags when the main transcript has only one line (history is not accumulating).

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -371,6 +371,86 @@ export function formatLinuxSdBackedStateDirWarning(
   ].join("\n");
 }
 
+export type LinuxVolatileStateDir = {
+  path: string;
+  mountPoint: string;
+  fsType: string;
+};
+
+/** Filesystem types that do not survive a reboot. */
+const VOLATILE_FS_TYPES = new Set(["tmpfs", "ramfs", "overlay"]);
+
+/**
+ * Detect whether the state directory resides on a volatile (non-persistent)
+ * filesystem such as tmpfs, ramfs, or an overlay root.  These filesystems
+ * lose all data on reboot, which means sessions, credentials, and config
+ * are silently destroyed.
+ *
+ * Reuses the same /proc/self/mountinfo parsing and mount-point matching
+ * infrastructure as detectLinuxSdBackedStateDir.
+ */
+export function detectLinuxVolatileStateDir(
+  stateDir: string,
+  deps?: {
+    platform?: NodeJS.Platform;
+    mountInfo?: string;
+    resolveRealPath?: (targetPath: string) => string | null;
+  },
+): LinuxVolatileStateDir | null {
+  const platform = deps?.platform ?? process.platform;
+  if (platform !== "linux") {
+    return null;
+  }
+  const linuxPath = path.posix;
+
+  const resolveRealPath = deps?.resolveRealPath ?? tryResolveRealPath;
+  const resolvedStatePath = resolveRealPath(stateDir) ?? linuxPath.resolve(stateDir);
+  const mountInfo = deps?.mountInfo ?? tryReadLinuxMountInfo();
+  if (!mountInfo) {
+    return null;
+  }
+
+  const mountEntry = findLinuxMountInfoEntryForPath(
+    resolvedStatePath,
+    parseLinuxMountInfo(mountInfo),
+    linuxPath,
+  );
+  if (!mountEntry) {
+    return null;
+  }
+
+  if (!VOLATILE_FS_TYPES.has(mountEntry.fsType)) {
+    return null;
+  }
+
+  return {
+    path: linuxPath.resolve(resolvedStatePath),
+    mountPoint: linuxPath.resolve(mountEntry.mountPoint),
+    fsType: mountEntry.fsType,
+  };
+}
+
+/**
+ * Build a human-readable warning string for a volatile-filesystem state
+ * directory detection, following the same format conventions as
+ * formatLinuxSdBackedStateDirWarning.
+ */
+export function formatLinuxVolatileStateDirWarning(
+  displayStateDir: string,
+  volatileDir: LinuxVolatileStateDir,
+): string {
+  const safeFsType = escapeControlCharsForTerminal(volatileDir.fsType);
+  const safeMountPoint =
+    volatileDir.mountPoint === "/"
+      ? "/"
+      : escapeControlCharsForTerminal(shortenHomePath(volatileDir.mountPoint));
+  return [
+    `- State directory is on a volatile filesystem (${displayStateDir}; fs ${safeFsType}, mount ${safeMountPoint}).`,
+    "- Sessions, credentials, and config will be lost on reboot.",
+    "- Move OPENCLAW_STATE_DIR to a persistent filesystem to avoid data loss.",
+  ].join("\n");
+}
+
 export function detectMacCloudSyncedStateDir(
   stateDir: string,
   deps?: {
@@ -508,6 +588,7 @@ export async function noteStateIntegrity(
   const requireOAuthDir = shouldRequireOAuthDir(cfg, env);
   const cloudSyncedStateDir = detectMacCloudSyncedStateDir(stateDir);
   const linuxSdBackedStateDir = detectLinuxSdBackedStateDir(stateDir);
+  const linuxVolatileStateDir = detectLinuxVolatileStateDir(stateDir);
   const suppressOrphanTranscriptWarning = shouldSuppressOrphanTranscriptWarning(cfg, agentId);
 
   if (cloudSyncedStateDir) {
@@ -522,6 +603,9 @@ export async function noteStateIntegrity(
   }
   if (linuxSdBackedStateDir) {
     warnings.push(formatLinuxSdBackedStateDirWarning(displayStateDir, linuxSdBackedStateDir));
+  }
+  if (linuxVolatileStateDir) {
+    warnings.push(formatLinuxVolatileStateDirWarning(displayStateDir, linuxVolatileStateDir));
   }
 
   let stateDirExists = existsDir(stateDir);

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -378,11 +378,11 @@ export type LinuxVolatileStateDir = {
 };
 
 /** Filesystem types that do not survive a reboot. */
-const VOLATILE_FS_TYPES = new Set(["tmpfs", "ramfs", "overlay"]);
+const VOLATILE_FS_TYPES = new Set(["tmpfs", "ramfs"]);
 
 /**
  * Detect whether the state directory resides on a volatile (non-persistent)
- * filesystem such as tmpfs, ramfs, or an overlay root.  These filesystems
+ * filesystem such as tmpfs or ramfs.  These filesystems
  * lose all data on reboot, which means sessions, credentials, and config
  * are silently destroyed.
  *

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -495,11 +495,11 @@ export type LinuxVolatileStateDir = {
 };
 
 /** Filesystem types that do not survive a reboot. */
-const VOLATILE_FS_TYPES = new Set(["tmpfs", "ramfs", "overlay"]);
+const VOLATILE_FS_TYPES = new Set(["tmpfs", "ramfs"]);
 
 /**
  * Detect whether the state directory resides on a volatile (non-persistent)
- * filesystem such as tmpfs, ramfs, or an overlay root.  These filesystems
+ * filesystem such as tmpfs or ramfs.  These filesystems
  * lose all data on reboot, which means sessions, credentials, and config
  * are silently destroyed.
  *

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -488,6 +488,86 @@ export function formatLinuxSdBackedStateDirWarning(
   ].join("\n");
 }
 
+export type LinuxVolatileStateDir = {
+  path: string;
+  mountPoint: string;
+  fsType: string;
+};
+
+/** Filesystem types that do not survive a reboot. */
+const VOLATILE_FS_TYPES = new Set(["tmpfs", "ramfs", "overlay"]);
+
+/**
+ * Detect whether the state directory resides on a volatile (non-persistent)
+ * filesystem such as tmpfs, ramfs, or an overlay root.  These filesystems
+ * lose all data on reboot, which means sessions, credentials, and config
+ * are silently destroyed.
+ *
+ * Reuses the same /proc/self/mountinfo parsing and mount-point matching
+ * infrastructure as detectLinuxSdBackedStateDir.
+ */
+export function detectLinuxVolatileStateDir(
+  stateDir: string,
+  deps?: {
+    platform?: NodeJS.Platform;
+    mountInfo?: string;
+    resolveRealPath?: (targetPath: string) => string | null;
+  },
+): LinuxVolatileStateDir | null {
+  const platform = deps?.platform ?? process.platform;
+  if (platform !== "linux") {
+    return null;
+  }
+  const linuxPath = path.posix;
+
+  const resolveRealPath = deps?.resolveRealPath ?? tryResolveRealPath;
+  const resolvedStatePath = resolveRealPath(stateDir) ?? linuxPath.resolve(stateDir);
+  const mountInfo = deps?.mountInfo ?? tryReadLinuxMountInfo();
+  if (!mountInfo) {
+    return null;
+  }
+
+  const mountEntry = findLinuxMountInfoEntryForPath(
+    resolvedStatePath,
+    parseLinuxMountInfo(mountInfo),
+    linuxPath,
+  );
+  if (!mountEntry) {
+    return null;
+  }
+
+  if (!VOLATILE_FS_TYPES.has(mountEntry.fsType)) {
+    return null;
+  }
+
+  return {
+    path: linuxPath.resolve(resolvedStatePath),
+    mountPoint: linuxPath.resolve(mountEntry.mountPoint),
+    fsType: mountEntry.fsType,
+  };
+}
+
+/**
+ * Build a human-readable warning string for a volatile-filesystem state
+ * directory detection, following the same format conventions as
+ * formatLinuxSdBackedStateDirWarning.
+ */
+export function formatLinuxVolatileStateDirWarning(
+  displayStateDir: string,
+  volatileDir: LinuxVolatileStateDir,
+): string {
+  const safeFsType = escapeControlCharsForTerminal(volatileDir.fsType);
+  const safeMountPoint =
+    volatileDir.mountPoint === "/"
+      ? "/"
+      : escapeControlCharsForTerminal(shortenHomePath(volatileDir.mountPoint));
+  return [
+    `- State directory is on a volatile filesystem (${displayStateDir}; fs ${safeFsType}, mount ${safeMountPoint}).`,
+    "- Sessions, credentials, and config will be lost on reboot.",
+    "- Move OPENCLAW_STATE_DIR to a persistent filesystem to avoid data loss.",
+  ].join("\n");
+}
+
 export function detectMacCloudSyncedStateDir(
   stateDir: string,
   deps?: {
@@ -637,6 +717,7 @@ export async function noteStateIntegrity(
   const requireOAuthDir = shouldRequireOAuthDir(cfg, env);
   const cloudSyncedStateDir = detectMacCloudSyncedStateDir(stateDir);
   const linuxSdBackedStateDir = detectLinuxSdBackedStateDir(stateDir);
+  const linuxVolatileStateDir = detectLinuxVolatileStateDir(stateDir);
   const suppressOrphanTranscriptWarning = shouldSuppressOrphanTranscriptWarning(cfg, agentId);
 
   if (cloudSyncedStateDir) {
@@ -651,6 +732,9 @@ export async function noteStateIntegrity(
   }
   if (linuxSdBackedStateDir) {
     warnings.push(formatLinuxSdBackedStateDirWarning(displayStateDir, linuxSdBackedStateDir));
+  }
+  if (linuxVolatileStateDir) {
+    warnings.push(formatLinuxVolatileStateDirWarning(displayStateDir, linuxVolatileStateDir));
   }
 
   let stateDirExists = existsDir(stateDir);

--- a/src/commands/doctor-volatile-fs.test.ts
+++ b/src/commands/doctor-volatile-fs.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectLinuxVolatileStateDir,
+  formatLinuxVolatileStateDirWarning,
+} from "./doctor-state-integrity.js";
+
+describe("detectLinuxVolatileStateDir", () => {
+  const TMPFS_MOUNT_INFO = [
+    "22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw",
+    "30 22 0:30 / /tmp rw,nosuid,nodev - tmpfs tmpfs rw",
+    "35 22 0:35 / /home/user/.openclaw rw - tmpfs tmpfs rw,size=1048576k",
+  ].join("\n");
+
+  const RAMFS_MOUNT_INFO = [
+    "22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw",
+    "35 22 0:35 / /home/user/.openclaw rw - ramfs ramfs rw",
+  ].join("\n");
+
+  const OVERLAY_MOUNT_INFO = [
+    "22 1 0:21 / / rw,relatime - overlay overlay rw,lowerdir=/lower,upperdir=/upper",
+  ].join("\n");
+
+  const EXT4_MOUNT_INFO = ["22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw"].join("\n");
+
+  it("detects tmpfs state directory", () => {
+    const result = detectLinuxVolatileStateDir("/home/user/.openclaw", {
+      platform: "linux",
+      mountInfo: TMPFS_MOUNT_INFO,
+      resolveRealPath: (p) => p,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.fsType).toBe("tmpfs");
+    expect(result!.mountPoint).toBe("/home/user/.openclaw");
+  });
+
+  it("detects ramfs state directory", () => {
+    const result = detectLinuxVolatileStateDir("/home/user/.openclaw", {
+      platform: "linux",
+      mountInfo: RAMFS_MOUNT_INFO,
+      resolveRealPath: (p) => p,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.fsType).toBe("ramfs");
+  });
+
+  it("detects overlay root filesystem", () => {
+    const result = detectLinuxVolatileStateDir("/home/user/.openclaw", {
+      platform: "linux",
+      mountInfo: OVERLAY_MOUNT_INFO,
+      resolveRealPath: (p) => p,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.fsType).toBe("overlay");
+  });
+
+  it("returns null for ext4 filesystem", () => {
+    const result = detectLinuxVolatileStateDir("/home/user/.openclaw", {
+      platform: "linux",
+      mountInfo: EXT4_MOUNT_INFO,
+      resolveRealPath: (p) => p,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null on non-linux platforms", () => {
+    const result = detectLinuxVolatileStateDir("/home/user/.openclaw", {
+      platform: "darwin",
+      mountInfo: TMPFS_MOUNT_INFO,
+      resolveRealPath: (p) => p,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when mountInfo is unavailable", () => {
+    const result = detectLinuxVolatileStateDir("/home/user/.openclaw", {
+      platform: "linux",
+      mountInfo: undefined as unknown as string,
+      resolveRealPath: (p) => p,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("picks most specific mount point", () => {
+    const mountInfo = [
+      "22 1 0:21 / / rw - ext4 /dev/sda1 rw",
+      "30 22 0:30 / /home rw - ext4 /dev/sda2 rw",
+      "35 30 0:35 / /home/user/.openclaw rw - tmpfs tmpfs rw",
+    ].join("\n");
+    const result = detectLinuxVolatileStateDir("/home/user/.openclaw", {
+      platform: "linux",
+      mountInfo,
+      resolveRealPath: (p) => p,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.fsType).toBe("tmpfs");
+    expect(result!.mountPoint).toBe("/home/user/.openclaw");
+  });
+
+  it("does not flag tmpfs /tmp when state dir is on ext4", () => {
+    const mountInfo = [
+      "22 1 0:21 / / rw - ext4 /dev/sda1 rw",
+      "30 22 0:30 / /tmp rw - tmpfs tmpfs rw",
+    ].join("\n");
+    const result = detectLinuxVolatileStateDir("/home/user/.openclaw", {
+      platform: "linux",
+      mountInfo,
+      resolveRealPath: (p) => p,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("formatLinuxVolatileStateDirWarning", () => {
+  it("formats warning with fsType and mount point", () => {
+    const warning = formatLinuxVolatileStateDirWarning("~/.openclaw", {
+      path: "/home/user/.openclaw",
+      mountPoint: "/home/user/.openclaw",
+      fsType: "tmpfs",
+    });
+    expect(warning).toContain("volatile filesystem");
+    expect(warning).toContain("tmpfs");
+    expect(warning).toContain("lost on reboot");
+    expect(warning).toContain("OPENCLAW_STATE_DIR");
+  });
+
+  it("formats overlay warning", () => {
+    const warning = formatLinuxVolatileStateDirWarning("~/.openclaw", {
+      path: "/home/user/.openclaw",
+      mountPoint: "/",
+      fsType: "overlay",
+    });
+    expect(warning).toContain("overlay");
+    expect(warning).toContain("volatile filesystem");
+  });
+});

--- a/src/commands/doctor-volatile-fs.test.ts
+++ b/src/commands/doctor-volatile-fs.test.ts
@@ -16,11 +16,11 @@ describe("detectLinuxVolatileStateDir", () => {
     "35 22 0:35 / /home/user/.openclaw rw - ramfs ramfs rw",
   ].join("\n");
 
+  const EXT4_MOUNT_INFO = ["22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw"].join("\n");
+
   const OVERLAY_MOUNT_INFO = [
     "22 1 0:21 / / rw,relatime - overlay overlay rw,lowerdir=/lower,upperdir=/upper",
   ].join("\n");
-
-  const EXT4_MOUNT_INFO = ["22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw"].join("\n");
 
   it("detects tmpfs state directory", () => {
     const result = detectLinuxVolatileStateDir("/home/user/.openclaw", {
@@ -43,14 +43,13 @@ describe("detectLinuxVolatileStateDir", () => {
     expect(result!.fsType).toBe("ramfs");
   });
 
-  it("detects overlay root filesystem", () => {
+  it("does not flag overlay filesystem (Docker overlay2 survives host reboot)", () => {
     const result = detectLinuxVolatileStateDir("/home/user/.openclaw", {
       platform: "linux",
       mountInfo: OVERLAY_MOUNT_INFO,
       resolveRealPath: (p) => p,
     });
-    expect(result).not.toBeNull();
-    expect(result!.fsType).toBe("overlay");
+    expect(result).toBeNull();
   });
 
   it("returns null for ext4 filesystem", () => {
@@ -74,7 +73,7 @@ describe("detectLinuxVolatileStateDir", () => {
   it("returns null when mountInfo is unavailable", () => {
     const result = detectLinuxVolatileStateDir("/home/user/.openclaw", {
       platform: "linux",
-      mountInfo: undefined as unknown as string,
+      mountInfo: "",
       resolveRealPath: (p) => p,
     });
     expect(result).toBeNull();
@@ -123,13 +122,13 @@ describe("formatLinuxVolatileStateDirWarning", () => {
     expect(warning).toContain("OPENCLAW_STATE_DIR");
   });
 
-  it("formats overlay warning", () => {
+  it("formats ramfs warning", () => {
     const warning = formatLinuxVolatileStateDirWarning("~/.openclaw", {
       path: "/home/user/.openclaw",
-      mountPoint: "/",
-      fsType: "overlay",
+      mountPoint: "/home/user/.openclaw",
+      fsType: "ramfs",
     });
-    expect(warning).toContain("overlay");
+    expect(warning).toContain("ramfs");
     expect(warning).toContain("volatile filesystem");
   });
 });


### PR DESCRIPTION
## Summary

Add detection for state directories on volatile filesystems (tmpfs, ramfs, overlay) that lose all data on reboot. This complements the existing SD/eMMC storage and iCloud cloud-sync detection in `doctor-state-integrity`.

## Problem

Container deployments (Docker, LXC) and certain Linux configurations may place the state directory on tmpfs, ramfs, or an overlay root filesystem. When this happens, sessions, credentials, and config are silently destroyed on every reboot. Doctor currently checks for cloud-synced dirs (macOS) and SD/eMMC media (Linux) but has no detection for volatile filesystems.

## Solution

Reuse the existing `/proc/self/mountinfo` parsing infrastructure (`parseLinuxMountInfo` + `findLinuxMountInfoEntryForPath`) to check whether the state directory's filesystem type is in the volatile set (`tmpfs`, `ramfs`, `overlay`).

### Modified: `src/commands/doctor-state-integrity.ts`
- `LinuxVolatileStateDir` type — mirrors `LinuxSdBackedStateDir` structure
- `VOLATILE_FS_TYPES` — `Set` of volatile filesystem type strings
- `detectLinuxVolatileStateDir()` — reuses mountinfo parsing, checks fsType against volatile set
- `formatLinuxVolatileStateDirWarning()` — follows existing warning format conventions
- `noteStateIntegrity()` — register volatile-fs warning between SD/eMMC and state-dir-exists checks

### New: `src/commands/doctor-volatile-fs.test.ts` (10 tests)
- tmpfs / ramfs / overlay detection
- ext4 non-detection (no false positive)
- Non-linux platform skip
- Null mountInfo handling
- Most-specific mount point selection
- No false positive when `/tmp` is tmpfs but state dir is on ext4
- Warning format validation

## Design decisions

1. **Reuse existing infrastructure** — `parseLinuxMountInfo` and `findLinuxMountInfoEntryForPath` already solve mount-point matching. No new parsing code needed.
2. **Same dependency injection pattern** — `deps?` parameter with `platform`, `mountInfo`, `resolveRealPath` for testability, consistent with `detectLinuxSdBackedStateDir`.
3. **overlay included** — Docker's default storage driver uses overlay2/overlay. A state directory on an overlay root without a volume mount will lose data.
4. **Warning placement** — after SD/eMMC check, before state-dir-exists check, so volatile-fs warning appears alongside other storage-quality warnings.

## Verification

- `pnpm check`: 0 errors
- `pnpm vitest run src/commands/doctor-volatile-fs.test.ts`: 10/10 passed

---


## Real behavior proof

- **Behavior or issue addressed:** OpenClaw doctor had no detection for state directories on volatile filesystems (tmpfs/ramfs). On such mounts, sessions, credentials, and config are silently destroyed on reboot. This patch adds a state-integrity warning for that case.

- **Real environment tested:** Linux (Ubuntu 24.04, WSL2), OpenClaw built from this PR head (`openclaw doctor` run from source). `/run/user/1000` is a real `tmpfs` mount per `/proc/self/mountinfo`.

- **Exact steps or command run after this patch:**
```bash
$ grep '/run/user/1000 ' /proc/self/mountinfo
169 132 0:78 / /run/user/1000 rw,nosuid,nodev,relatime shared:235 - tmpfs tmpfs rw,size=1637856k,...

$ mkdir -p /run/user/1000/openclaw-vol-test
$ OPENCLAW_STATE_DIR=/run/user/1000/openclaw-vol-test openclaw doctor
```

- **Evidence after fix:** Live `openclaw doctor` terminal output, "State integrity" section, when the state dir is on the tmpfs mount:
```
State integrity
  - State directory is on a volatile filesystem
    (/run/user/1000/openclaw-vol-test; fs tmpfs, mount /run/user/1000).
  - Sessions, credentials, and config will be lost on reboot.
  - Move OPENCLAW_STATE_DIR to a persistent filesystem to avoid data loss.
```

- **Observed result after fix:** Running `openclaw doctor` with the state dir on the tmpfs mount emits the volatile-filesystem warning shown above. Running `openclaw doctor` with the default `~/.openclaw` (ext4) emits no such warning, confirming no false positive. The warning fires only for `tmpfs`/`ramfs` mounts.

- **What was not tested:** ramfs was not exercised on a live mount (tmpfs and ramfs share the same code path via the volatile fs-type set); macOS and Windows paths are skipped by design as the check is Linux-only.
