### PR TITLE
feat(acp): support streamTo="thread" for ACP spawns

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -304,7 +304,10 @@ Interface details:
 - `cwd` (optional): requested runtime working directory (validated by backend/runtime policy).
 - `label` (optional): operator-facing label used in session/banner text.
 - `resumeSessionId` (optional): resume an existing ACP session instead of creating a new one. The agent replays its conversation history via `session/load`. Requires `runtime: "acp"`.
-- `streamTo` (optional): `"parent"` streams initial ACP run progress summaries back to the requester session as system events.
+- `streamTo` (optional): controls where initial ACP run progress summaries are streamed.
+  - `"parent"` streams progress summaries back to the requester session as system events.
+  - `"thread"` streams progress summaries to the thread-bound ACP session target.
+    - This requires a thread-bound ACP session where OpenClaw can resolve a concrete thread delivery target from the active binding context.
   - When available, accepted responses include `streamLogPath` pointing to a session-scoped JSONL log (`<sessionId>.acp-stream.jsonl`) you can tail for full relay history.
 
 ### Resume an existing session

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -3,6 +3,7 @@ import { mergeMockedModule } from "../test-utils/vitest-module-mocks.js";
 
 const enqueueSystemEventMock = vi.fn();
 const requestHeartbeatNowMock = vi.fn();
+const callGatewayMock = vi.fn();
 const readAcpSessionEntryMock = vi.fn();
 const resolveSessionFilePathMock = vi.fn();
 const resolveSessionFilePathOptionsMock = vi.fn();
@@ -19,6 +20,10 @@ vi.mock("../infra/heartbeat-wake.js", async (importOriginal) => {
     }),
   );
 });
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (...args: unknown[]) => callGatewayMock(...args),
+}));
 
 vi.mock("../acp/runtime/session-meta.js", async (importOriginal) => {
   return await mergeMockedModule(
@@ -69,6 +74,9 @@ async function loadFreshAcpSpawnParentStreamModulesForTest() {
       }),
     );
   });
+  vi.doMock("../gateway/call.js", () => ({
+    callGateway: (...args: unknown[]) => callGatewayMock(...args),
+  }));
   vi.doMock("../config/sessions/paths.js", async () => {
     return await mergeMockedModule(
       await vi.importActual<typeof import("../config/sessions/paths.js")>(
@@ -100,6 +108,7 @@ describe("startAcpSpawnParentStreamRelay", () => {
   beforeEach(async () => {
     enqueueSystemEventMock.mockClear();
     requestHeartbeatNowMock.mockClear();
+    callGatewayMock.mockClear();
     readAcpSessionEntryMock.mockReset();
     resolveSessionFilePathMock.mockReset();
     resolveSessionFilePathOptionsMock.mockReset();
@@ -305,6 +314,146 @@ describe("startAcpSpawnParentStreamRelay", () => {
 
     const texts = collectedTexts();
     expect(texts.some((text) => text.includes("codex: hello world"))).toBe(true);
+    relay.dispose();
+  });
+
+  it("sends stream updates to a bound thread target through gateway send", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-thread-1",
+      parentSessionKey: "",
+      childSessionKey: "agent:codex:acp:child-thread-1",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+      deliveryTarget: {
+        channel: "discord",
+        to: "channel:123",
+        accountId: "main",
+        threadId: "thread-456",
+      },
+    });
+
+    emitAgentEvent({
+      runId: "run-thread-1",
+      stream: "assistant",
+      data: {
+        delta: "hello from child",
+      },
+    });
+    vi.advanceTimersByTime(15);
+    emitAgentEvent({
+      runId: "run-thread-1",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 1_000,
+        endedAt: 3_100,
+      },
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    expect(callGatewayMock).toHaveBeenCalled();
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "send",
+        params: expect.objectContaining({
+          channel: "discord",
+          to: "channel:123",
+          accountId: "main",
+          threadId: "thread-456",
+          sessionKey: "agent:codex:acp:child-thread-1",
+        }),
+      }),
+    );
+    const sendMessages = callGatewayMock.mock.calls.map((call) => String(call[0]?.params?.message));
+    expect(sendMessages.some((message) => message.includes("Started codex session"))).toBe(true);
+    expect(sendMessages.some((message) => message.includes("codex: hello from child"))).toBe(true);
+    expect(sendMessages.some((message) => message.includes("codex run completed in 2s"))).toBe(
+      true,
+    );
+    relay.dispose();
+  });
+
+  it("keeps no-output and resumed notices in bound-thread delivery mode", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-thread-2",
+      parentSessionKey: "",
+      childSessionKey: "agent:codex:acp:child-thread-2",
+      agentId: "codex",
+      streamFlushMs: 1,
+      noOutputNoticeMs: 1_000,
+      noOutputPollMs: 250,
+      deliveryTarget: {
+        channel: "discord",
+        to: "channel:123",
+      },
+    });
+
+    vi.advanceTimersByTime(1_500);
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(
+      callGatewayMock.mock.calls.some((call) =>
+        String(call[0]?.params?.message).includes("has produced no output for 1s"),
+      ),
+    ).toBe(true);
+
+    emitAgentEvent({
+      runId: "run-thread-2",
+      stream: "assistant",
+      data: {
+        delta: "resumed output",
+      },
+    });
+    vi.advanceTimersByTime(5);
+
+    const sendMessages = callGatewayMock.mock.calls.map((call) => String(call[0]?.params?.message));
+    expect(sendMessages.some((message) => message.includes("resumed output."))).toBe(true);
+    expect(sendMessages.some((message) => message.includes("codex: resumed output"))).toBe(true);
+    relay.dispose();
+  });
+
+  it("treats bound-thread delivery failures as best-effort", async () => {
+    callGatewayMock.mockRejectedValueOnce(new Error("send failed")).mockResolvedValue({});
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-thread-3",
+      parentSessionKey: "",
+      childSessionKey: "agent:codex:acp:child-thread-3",
+      agentId: "codex",
+      streamFlushMs: 1,
+      deliveryTarget: {
+        channel: "slack",
+        to: "channel:C-parent-1",
+        accountId: "default",
+        threadId: "1743525000.123456",
+      },
+    });
+
+    relay.notifyStarted();
+    await Promise.resolve();
+
+    emitAgentEvent({
+      runId: "run-thread-3",
+      stream: "assistant",
+      data: {
+        delta: "still going",
+      },
+    });
+    vi.advanceTimersByTime(5);
+    await Promise.resolve();
+
+    expect(callGatewayMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(callGatewayMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        method: "send",
+        params: expect.objectContaining({
+          channel: "slack",
+          to: "channel:C-parent-1",
+          threadId: "1743525000.123456",
+          sessionKey: "agent:codex:acp:child-thread-3",
+        }),
+      }),
+    );
     relay.dispose();
   });
 

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -121,6 +121,12 @@ describe("startAcpSpawnParentStreamRelay", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.doUnmock("../infra/system-events.js");
+    vi.doUnmock("../infra/heartbeat-wake.js");
+    vi.doUnmock("../gateway/call.js");
+    vi.doUnmock("../acp/runtime/session-meta.js");
+    vi.doUnmock("../config/sessions/paths.js");
+    vi.resetModules();
   });
 
   it("relays assistant progress and completion to the parent session", () => {

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -1,7 +1,9 @@
+import crypto from "node:crypto";
 import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
+import { callGateway } from "../gateway/call.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
@@ -86,10 +88,12 @@ export function startAcpSpawnParentStreamRelay(params: {
   noOutputPollMs?: number;
   maxRelayLifetimeMs?: number;
   emitStartNotice?: boolean;
+  deliveryTarget?: AcpSpawnRelayDeliveryTarget;
 }): AcpSpawnParentRelayHandle {
   const runId = params.runId.trim();
   const parentSessionKey = params.parentSessionKey.trim();
-  if (!runId || !parentSessionKey) {
+  const deliveryTarget = normalizeDeliveryTarget(params.deliveryTarget);
+  if (!runId || (!parentSessionKey && !deliveryTarget)) {
     return {
       dispose: () => {},
       notifyStarted: () => {},
@@ -185,11 +189,36 @@ export function startAcpSpawnParentStreamRelay(params: {
     if (!shouldSurfaceUpdates) {
       return;
     }
+    if (deliveryTarget) {
+      return;
+    }
     requestHeartbeatNow(
       scopedHeartbeatWakeOptions(parentSessionKey, {
         reason: "acp:spawn:stream",
       }),
     );
+  };
+  const sendDirect = (text: string) => {
+    if (!deliveryTarget) {
+      return;
+    }
+    void Promise.resolve(
+      callGateway({
+        method: "send",
+        params: {
+          channel: deliveryTarget.channel,
+          to: deliveryTarget.to,
+          accountId: deliveryTarget.accountId,
+          threadId: deliveryTarget.threadId,
+          agentId: deliveryTarget.agentId,
+          sessionKey: params.childSessionKey,
+          message: text,
+          idempotencyKey: crypto.randomUUID(),
+        },
+      }),
+    ).catch(() => {
+      // Best-effort updates; never break relay flow.
+    });
   };
   const emit = (text: string, contextKey: string) => {
     const cleaned = text.trim();
@@ -198,6 +227,10 @@ export function startAcpSpawnParentStreamRelay(params: {
     }
     logEvent("system_event", { contextKey, text: cleaned });
     if (!shouldSurfaceUpdates) {
+      return;
+    }
+    if (deliveryTarget) {
+      sendDirect(cleaned);
       return;
     }
     enqueueSystemEvent(cleaned, { sessionKey: parentSessionKey, contextKey });
@@ -212,7 +245,7 @@ export function startAcpSpawnParentStreamRelay(params: {
       eventSummary: "Started.",
     });
     emit(
-      `Started ${relayLabel} session ${params.childSessionKey}. Streaming progress updates to parent session.`,
+      `Started ${relayLabel} session ${params.childSessionKey}. Streaming progress updates to ${deliveryTarget ? "bound thread" : "parent session"}.`,
       `${contextPrefix}:start`,
     );
   };
@@ -406,3 +439,34 @@ export type AcpSpawnParentRelayHandle = {
   dispose: () => void;
   notifyStarted: () => void;
 };
+
+export type AcpSpawnRelayDeliveryTarget = {
+  channel: string;
+  to: string;
+  accountId?: string;
+  threadId?: string;
+  agentId?: string;
+};
+
+function normalizeDeliveryTarget(
+  value: AcpSpawnRelayDeliveryTarget | undefined,
+): AcpSpawnRelayDeliveryTarget | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const channel = value.channel.trim();
+  const to = value.to.trim();
+  if (!channel || !to) {
+    return undefined;
+  }
+  const accountId = toTrimmedString(value.accountId);
+  const threadId = toTrimmedString(value.threadId);
+  const agentId = toTrimmedString(value.agentId);
+  return {
+    channel,
+    to,
+    ...(accountId ? { accountId } : {}),
+    ...(threadId ? { threadId } : {}),
+    ...(agentId ? { agentId } : {}),
+  };
+}

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -249,6 +249,22 @@ function enableLineCurrentConversationBindings(): void {
   });
 }
 
+function enableSlackAcpThreadBindings(): void {
+  registerSessionBindingAdapter({
+    channel: "slack",
+    accountId: "default",
+    capabilities: {
+      bindSupported: true,
+      unbindSupported: true,
+      placements: ["current"] satisfies SessionBindingPlacement[],
+    },
+    bind: async (input) => await hoisted.sessionBindingBindMock(input),
+    listBySession: (targetSessionKey) => hoisted.sessionBindingListBySessionMock(targetSessionKey),
+    resolveByConversation: (ref) => hoisted.sessionBindingResolveByConversationMock(ref),
+    unbind: async (input) => await hoisted.sessionBindingUnbindMock(input),
+  });
+}
+
 describe("spawnAcpDirect", () => {
   beforeEach(() => {
     replaceSpawnConfig(createDefaultSpawnConfig());
@@ -435,7 +451,6 @@ describe("spawnAcpDirect", () => {
         agentChannel: "discord",
         agentAccountId: "default",
         agentTo: "channel:parent-channel",
-        agentThreadId: "requester-thread",
       },
     );
 
@@ -942,6 +957,178 @@ describe("spawnAcpDirect", () => {
     expect(firstHandle.dispose).toHaveBeenCalledTimes(1);
     expect(firstHandle.notifyStarted).not.toHaveBeenCalled();
     expect(secondHandle.notifyStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects streamTo="thread" when thread binding is not requested', async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "run",
+        streamTo: "thread",
+      } as SpawnRequest,
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain('streamTo="thread"');
+    expect(result.error).toContain("thread=true");
+    expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
+    expect(hoisted.startAcpSpawnParentStreamRelayMock).not.toHaveBeenCalled();
+  });
+
+  it('derives discord relay delivery target from the bound thread when streamTo="thread"', async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+        streamTo: "thread",
+      } as SpawnRequest,
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.streamLogPath).toBe("/tmp/sess-main.acp-stream.jsonl");
+    const relayCalls = hoisted.startAcpSpawnParentStreamRelayMock.mock.calls.map(
+      (call: unknown[]) =>
+        call[0] as {
+          deliveryTarget?: { channel?: string; to?: string; accountId?: string; threadId?: string };
+        },
+    );
+    expect(relayCalls.length).toBeGreaterThan(0);
+    expect(
+      relayCalls.every(
+        (call) =>
+          call.deliveryTarget?.channel === "discord" &&
+          call.deliveryTarget?.accountId === "default" &&
+          call.deliveryTarget?.to === "channel:child-thread" &&
+          call.deliveryTarget?.threadId === undefined,
+      ),
+    ).toBe(true);
+    expectAgentGatewayCall({
+      deliver: false,
+      channel: undefined,
+      to: undefined,
+      threadId: undefined,
+    });
+  });
+
+  it('derives slack relay delivery target using parent channel + thread id when streamTo="thread"', async () => {
+    enableSlackAcpThreadBindings();
+    hoisted.sessionBindingBindMock.mockImplementationOnce(
+      async (input: {
+        targetSessionKey: string;
+        conversation: { accountId: string };
+        metadata?: Record<string, unknown>;
+      }) =>
+        createSessionBinding({
+          targetSessionKey: input.targetSessionKey,
+          conversation: {
+            channel: "slack",
+            accountId: input.conversation.accountId,
+            conversationId: "1743525000.123456",
+            parentConversationId: "C-parent-1",
+          },
+          metadata: {
+            boundBy:
+              typeof input.metadata?.boundBy === "string" ? input.metadata.boundBy : "system",
+            agentId: "codex",
+          },
+        }),
+    );
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+        streamTo: "thread",
+      } as SpawnRequest,
+      {
+        agentSessionKey: "agent:main:slack:channel:C-parent-1",
+        agentChannel: "slack",
+        agentAccountId: "default",
+        agentTo: "channel:C-parent-1",
+        agentThreadId: "1743525000.123456",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.streamLogPath).toBe("/tmp/sess-main.acp-stream.jsonl");
+    expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: "current",
+        conversation: expect.objectContaining({
+          channel: "slack",
+          accountId: "default",
+          conversationId: "1743525000.123456",
+        }),
+      }),
+    );
+    const relayCalls = hoisted.startAcpSpawnParentStreamRelayMock.mock.calls.map(
+      (call: unknown[]) =>
+        call[0] as {
+          deliveryTarget?: { channel?: string; to?: string; accountId?: string; threadId?: string };
+        },
+    );
+    expect(relayCalls.length).toBeGreaterThan(0);
+    expect(
+      relayCalls.every(
+        (call) =>
+          call.deliveryTarget?.channel === "slack" &&
+          call.deliveryTarget?.accountId === "default" &&
+          call.deliveryTarget?.to === "channel:C-parent-1" &&
+          call.deliveryTarget?.threadId === "1743525000.123456",
+      ),
+    ).toBe(true);
+    expectAgentGatewayCall({
+      deliver: false,
+      channel: undefined,
+      to: undefined,
+      threadId: undefined,
+    });
+  });
+
+  it('starts thread relay without requester session context when streamTo="thread"', async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+        streamTo: "thread",
+      } as SpawnRequest,
+      {
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(
+      hoisted.startAcpSpawnParentStreamRelayMock.mock.calls.some((call: unknown[]) => {
+        const params = call[0] as {
+          parentSessionKey?: string;
+          deliveryTarget?: { channel?: string; to?: string };
+        };
+        return (
+          !params.parentSessionKey &&
+          params.deliveryTarget?.channel === "discord" &&
+          params.deliveryTarget?.to === "channel:child-thread"
+        );
+      }),
+    ).toBe(true);
   });
 
   it("implicitly streams mode=run ACP spawns for subagent requester sessions", async () => {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -18,7 +18,7 @@ import {
 import {
   formatThreadBindingDisabledError,
   formatThreadBindingSpawnDisabledError,
-  requiresNativeThreadContextForThreadHere,
+  resolveThreadBindingPlacementForCurrentContext,
   resolveThreadBindingIdleTimeoutMsForChannel,
   resolveThreadBindingMaxAgeMsForChannel,
   resolveThreadBindingSpawnPolicy,
@@ -53,6 +53,7 @@ import {
 } from "../utils/delivery-context.js";
 import {
   type AcpSpawnParentRelayHandle,
+  type AcpSpawnRelayDeliveryTarget,
   resolveAcpSpawnStreamLogPath,
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
@@ -66,7 +67,7 @@ export const ACP_SPAWN_MODES = ["run", "session"] as const;
 export type SpawnAcpMode = (typeof ACP_SPAWN_MODES)[number];
 export const ACP_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
 export type SpawnAcpSandboxMode = (typeof ACP_SPAWN_SANDBOX_MODES)[number];
-export const ACP_SPAWN_STREAM_TARGETS = ["parent"] as const;
+export const ACP_SPAWN_STREAM_TARGETS = ["parent", "thread"] as const;
 export type SpawnAcpStreamTarget = (typeof ACP_SPAWN_STREAM_TARGETS)[number];
 
 export type SpawnAcpParams = {
@@ -161,6 +162,8 @@ type AcpSpawnRequesterState = {
 type AcpSpawnStreamPlan = {
   implicitStreamToParent: boolean;
   effectiveStreamToParent: boolean;
+  effectiveStreamToThread: boolean;
+  effectiveStreamRelay: boolean;
 };
 
 type AcpSpawnBootstrapDeliveryPlan = {
@@ -476,7 +479,10 @@ function prepareAcpThreadBinding(params: {
       error: `Thread bindings are unavailable for ${policy.channel}.`,
     };
   }
-  const placement = requiresNativeThreadContextForThreadHere(policy.channel) ? "child" : "current";
+  const placement = resolveThreadBindingPlacementForCurrentContext({
+    channel: policy.channel,
+    threadId: params.threadId != null ? String(params.threadId) : undefined,
+  });
   if (!capabilities.bindSupported || !capabilities.placements.includes(placement)) {
     return {
       ok: false,
@@ -558,6 +564,7 @@ function resolveAcpSpawnStreamPlan(params: {
   spawnMode: SpawnAcpMode;
   requestThreadBinding: boolean;
   streamToParentRequested: boolean;
+  streamToThreadRequested: boolean;
   requester: AcpSpawnRequesterState;
 }): AcpSpawnStreamPlan {
   // For mode=run without thread binding, implicitly route output to parent
@@ -577,9 +584,71 @@ function resolveAcpSpawnStreamPlan(params: {
     params.requester.heartbeatEnabled &&
     params.requester.heartbeatRelayRouteUsable;
 
+  const effectiveStreamToParent = params.streamToParentRequested || implicitStreamToParent;
+  const effectiveStreamToThread = params.streamToThreadRequested;
   return {
     implicitStreamToParent,
-    effectiveStreamToParent: params.streamToParentRequested || implicitStreamToParent,
+    effectiveStreamToParent,
+    effectiveStreamToThread,
+    effectiveStreamRelay: effectiveStreamToParent || effectiveStreamToThread,
+  };
+}
+
+function resolveAcpSpawnRelayDeliveryTarget(params: {
+  binding: SessionBindingRecord;
+  targetAgentId: string;
+}): AcpSpawnRelayDeliveryTarget | undefined {
+  const channel = params.binding.conversation.channel.trim().toLowerCase();
+  const accountId = params.binding.conversation.accountId.trim() || "default";
+  const conversationId = params.binding.conversation.conversationId.trim();
+  const parentConversationId =
+    params.binding.conversation.parentConversationId?.trim() || undefined;
+  if (!channel || !conversationId) {
+    return undefined;
+  }
+
+  if (
+    (channel === "slack" || channel === "mattermost") &&
+    parentConversationId &&
+    parentConversationId !== conversationId
+  ) {
+    const parentTarget = formatConversationTarget({
+      channel,
+      conversationId: parentConversationId,
+    });
+    if (!parentTarget) {
+      return undefined;
+    }
+    return {
+      channel,
+      accountId,
+      to: parentTarget,
+      threadId: conversationId,
+      agentId: params.targetAgentId,
+    };
+  }
+
+  const deliveryTarget = resolveConversationDeliveryTarget({
+    channel,
+    conversationId,
+    parentConversationId,
+  });
+  const to =
+    deliveryTarget.to ??
+    formatConversationTarget({
+      channel,
+      conversationId,
+      parentConversationId,
+    });
+  if (!to) {
+    return undefined;
+  }
+  return {
+    channel,
+    accountId,
+    to,
+    ...(deliveryTarget.threadId ? { threadId: deliveryTarget.threadId } : {}),
+    agentId: params.targetAgentId,
   };
 }
 
@@ -710,7 +779,7 @@ async function bindPreparedAcpThread(params: {
 function resolveAcpSpawnBootstrapDeliveryPlan(params: {
   spawnMode: SpawnAcpMode;
   requestThreadBinding: boolean;
-  effectiveStreamToParent: boolean;
+  effectiveStreamRelay: boolean;
   requester: AcpSpawnRequesterState;
   binding: SessionBindingRecord | null;
 }): AcpSpawnBootstrapDeliveryPlan {
@@ -757,7 +826,7 @@ function resolveAcpSpawnBootstrapDeliveryPlan(params: {
   // the parent task lifecycle notifier instead of letting the child ACP
   // session write raw output directly into the originating channel.
   const useInlineDelivery =
-    hasDeliveryTarget && !params.effectiveStreamToParent && params.spawnMode === "session";
+    hasDeliveryTarget && !params.effectiveStreamRelay && params.spawnMode === "session";
 
   return {
     useInlineDelivery,
@@ -784,6 +853,7 @@ export async function spawnAcpDirect(
     };
   }
   const streamToParentRequested = params.streamTo === "parent";
+  const streamToThreadRequested = params.streamTo === "thread";
   const parentSessionKey = ctx.agentSessionKey?.trim();
   if (streamToParentRequested && !parentSessionKey) {
     return {
@@ -793,6 +863,13 @@ export async function spawnAcpDirect(
   }
 
   let requestThreadBinding = params.thread === true;
+  if (streamToThreadRequested && !requestThreadBinding) {
+    return {
+      status: "error",
+      error:
+        'sessions_spawn streamTo="thread" requires thread=true so updates can relay to the bound thread.',
+    };
+  }
   const runtimePolicyError = resolveAcpSpawnRuntimePolicyError({
     cfg,
     requesterSessionKey: ctx.agentSessionKey,
@@ -822,10 +899,11 @@ export async function spawnAcpDirect(
     parentSessionKey,
     ctx,
   });
-  const { effectiveStreamToParent } = resolveAcpSpawnStreamPlan({
+  const { effectiveStreamRelay, effectiveStreamToThread } = resolveAcpSpawnStreamPlan({
     spawnMode,
     requestThreadBinding,
     streamToParentRequested,
+    streamToThreadRequested,
     requester: requesterState,
   });
 
@@ -918,31 +996,53 @@ export async function spawnAcpDirect(
     };
   }
 
+  const relayDeliveryTarget =
+    effectiveStreamToThread && binding
+      ? resolveAcpSpawnRelayDeliveryTarget({
+          binding,
+          targetAgentId,
+        })
+      : undefined;
+  if (effectiveStreamToThread && !relayDeliveryTarget) {
+    await cleanupFailedAcpSpawn({
+      cfg,
+      sessionKey,
+      shouldDeleteSession: true,
+      deleteTranscript: true,
+      runtimeCloseHandle: initializedRuntime,
+    });
+    return {
+      status: "error",
+      error: 'Failed to resolve streamTo="thread" relay target from the bound conversation.',
+      childSessionKey: sessionKey,
+    };
+  }
+
   const deliveryPlan = resolveAcpSpawnBootstrapDeliveryPlan({
     spawnMode,
     requestThreadBinding,
-    effectiveStreamToParent,
+    effectiveStreamRelay,
     requester: requesterState,
     binding,
   });
   const childIdem = crypto.randomUUID();
   let childRunId: string = childIdem;
-  const streamLogPath =
-    effectiveStreamToParent && parentSessionKey
-      ? resolveAcpSpawnStreamLogPath({
-          childSessionKey: sessionKey,
-        })
-      : undefined;
+  const streamLogPath = effectiveStreamRelay
+    ? resolveAcpSpawnStreamLogPath({
+        childSessionKey: sessionKey,
+      })
+    : undefined;
   let parentRelay: AcpSpawnParentRelayHandle | undefined;
-  if (effectiveStreamToParent && parentSessionKey) {
+  if (effectiveStreamRelay && (parentSessionKey || relayDeliveryTarget)) {
     // Register relay before dispatch so fast lifecycle failures are not missed.
     parentRelay = startAcpSpawnParentStreamRelay({
       runId: childIdem,
-      parentSessionKey,
+      parentSessionKey: parentSessionKey ?? "",
       childSessionKey: sessionKey,
       agentId: targetAgentId,
       logPath: streamLogPath,
       emitStartNotice: false,
+      ...(relayDeliveryTarget ? { deliveryTarget: relayDeliveryTarget } : {}),
     });
   }
   try {
@@ -979,17 +1079,18 @@ export async function spawnAcpDirect(
     };
   }
 
-  if (effectiveStreamToParent && parentSessionKey) {
+  if (effectiveStreamRelay && parentRelay) {
     if (parentRelay && childRunId !== childIdem) {
       parentRelay.dispose();
       // Defensive fallback if gateway returns a runId that differs from idempotency key.
       parentRelay = startAcpSpawnParentStreamRelay({
         runId: childRunId,
-        parentSessionKey,
+        parentSessionKey: parentSessionKey ?? "",
         childSessionKey: sessionKey,
         agentId: targetAgentId,
         logPath: streamLogPath,
         emitStartNotice: false,
+        ...(relayDeliveryTarget ? { deliveryTarget: relayDeliveryTarget } : {}),
       });
     }
     parentRelay?.notifyStarted();

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -16,7 +16,7 @@ vi.mock("../subagent-spawn.js", () => ({
 
 vi.mock("../acp-spawn.js", () => ({
   ACP_SPAWN_MODES: ["run", "session"],
-  ACP_SPAWN_STREAM_TARGETS: ["parent"],
+  ACP_SPAWN_STREAM_TARGETS: ["parent", "thread"],
   spawnAcpDirect: (...args: unknown[]) => hoisted.spawnAcpDirectMock(...args),
 }));
 
@@ -30,7 +30,7 @@ async function loadFreshSessionsSpawnToolModuleForTest() {
   }));
   vi.doMock("../acp-spawn.js", () => ({
     ACP_SPAWN_MODES: ["run", "session"],
-    ACP_SPAWN_STREAM_TARGETS: ["parent"],
+    ACP_SPAWN_STREAM_TARGETS: ["parent", "thread"],
     spawnAcpDirect: (...args: unknown[]) => hoisted.spawnAcpDirectMock(...args),
   }));
   ({ createSessionsSpawnTool } = await import("./sessions-spawn-tool.js"));
@@ -145,6 +145,39 @@ describe("sessions_spawn tool", () => {
         thread: true,
         mode: "session",
         streamTo: "parent",
+      }),
+      expect.objectContaining({
+        agentSessionKey: "agent:main:main",
+      }),
+    );
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
+  it('routes to ACP runtime with streamTo "thread"', async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "discord",
+      agentAccountId: "default",
+      agentTo: "channel:123",
+      agentThreadId: "456",
+    });
+
+    await tool.execute("call-2a", {
+      runtime: "acp",
+      task: "continue in bound thread",
+      agentId: "codex",
+      thread: true,
+      mode: "session",
+      streamTo: "thread",
+    });
+
+    expect(hoisted.spawnAcpDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "continue in bound thread",
+        agentId: "codex",
+        thread: true,
+        mode: "session",
+        streamTo: "thread",
       }),
       expect.objectContaining({
         agentSessionKey: "agent:main:main",

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -19,7 +19,7 @@ import {
 const SESSIONS_SPAWN_RUNTIMES = ["subagent", "acp"] as const;
 const SESSIONS_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
 // Keep the schema local to avoid a circular import through acp-spawn/openclaw-tools.
-const SESSIONS_SPAWN_ACP_STREAM_TARGETS = ["parent"] as const;
+const SESSIONS_SPAWN_ACP_STREAM_TARGETS = ["parent", "thread"] as const;
 const UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS = [
   "target",
   "transport",
@@ -156,7 +156,8 @@ export function createSessionsSpawnTool(
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const streamTo =
+        params.streamTo === "parent" || params.streamTo === "thread" ? params.streamTo : undefined;
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
         typeof params.runTimeoutSeconds === "number"

--- a/src/channels/model-overrides.test.ts
+++ b/src/channels/model-overrides.test.ts
@@ -1,5 +1,9 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import type { OpenClawConfig } from "../config/config.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "../config/config.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { createSessionConversationTestRegistry } from "../test-utils/session-conversation-registry.js";
@@ -8,6 +12,10 @@ import { resolveChannelModelOverride } from "./model-overrides.js";
 describe("resolveChannelModelOverride", () => {
   beforeEach(() => {
     setActivePluginRegistry(createSessionConversationTestRegistry());
+  });
+
+  afterEach(() => {
+    clearRuntimeConfigSnapshot();
   });
 
   it.each([
@@ -170,6 +178,15 @@ describe("resolveChannelModelOverride", () => {
 
   it("keeps bundled Feishu parent fallback matching before registry bootstrap", () => {
     resetPluginRuntimeStateForTest();
+    setRuntimeConfigSnapshot({
+      plugins: {
+        entries: {
+          feishu: {
+            enabled: true,
+          },
+        },
+      },
+    });
 
     const resolved = resolveChannelModelOverride({
       cfg: {

--- a/src/plugin-sdk/browser-maintenance.test.ts
+++ b/src/plugin-sdk/browser-maintenance.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const runCommandWithTimeout = vi.hoisted(() => vi.fn());
@@ -58,9 +59,11 @@ describe("browser maintenance", () => {
       termination: "exit",
     });
     access.mockRejectedValue(new Error("missing"));
+    const trashDir = path.join("/home/test", ".Trash");
+    const destination = path.join(trashDir, "demo-123");
 
-    await expect(movePathToTrash("/tmp/demo")).resolves.toBe("/home/test/.Trash/demo-123");
-    expect(mkdir).toHaveBeenCalledWith("/home/test/.Trash", { recursive: true });
-    expect(rename).toHaveBeenCalledWith("/tmp/demo", "/home/test/.Trash/demo-123");
+    await expect(movePathToTrash("/tmp/demo")).resolves.toBe(destination);
+    expect(mkdir).toHaveBeenCalledWith(trashDir, { recursive: true });
+    expect(rename).toHaveBeenCalledWith("/tmp/demo", destination);
   });
 });


### PR DESCRIPTION
## Summary
- add `streamTo="thread"` as an ACP spawn target and require it to be paired with `thread=true`
- relay ACP progress directly to the bound thread delivery target while preserving existing `streamTo="parent"` behavior
- cover Discord and Slack thread delivery in ACP relay tests and document the new ACP spawn option

Closes #55574.

## Test Plan
- `OPENCLAW_TEST_PROFILE=serial OPENCLAW_TEST_SERIAL_GATEWAY=1 corepack pnpm test -- src/agents/tools/sessions-spawn-tool.test.ts`
- `OPENCLAW_TEST_PROFILE=serial OPENCLAW_TEST_SERIAL_GATEWAY=1 corepack pnpm test -- src/agents/acp-spawn-parent-stream.test.ts`
- `OPENCLAW_TEST_PROFILE=serial OPENCLAW_TEST_SERIAL_GATEWAY=1 corepack pnpm test -- src/agents/acp-spawn.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 corepack pnpm exec tsc -p tsconfig.json --noEmit --pretty false`
