### PR TITLE
Exec approvals: fix policy source attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp/media: add HTML, XML, and CSS to the MIME map and fall back gracefully for unknown media types instead of dropping the attachment. (#51562) Thanks @bobbyt74.
 - WhatsApp/presence: send `unavailable` presence on connect in self-chat mode so personal-phone users stop losing all push notifications while the gateway is running. (#59410) Thanks @mcaxtr.
 - Providers/OpenAI-compatible routing: centralize native-vs-proxy request policy so hidden attribution and related OpenAI-family defaults only apply on verified native endpoints across stream, websocket, and shared audio HTTP paths. (#59433) Thanks @vincentkoc.
+- Exec approvals/doctor: report host policy sources from the real approvals file path and ignore malformed host override values when attributing effective policy conflicts. (#59367) Thanks @gumadeiras.
 
 ## 2026.4.1-beta.1
 

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -46,6 +46,11 @@ function createExecApprovals(): ExecApprovalsResolved {
       askFallback: "full",
       autoAllowSkills: false,
     },
+    agentSources: {
+      security: "defaults.security",
+      ask: "defaults.ask",
+      askFallback: "defaults.askFallback",
+    },
     allowlist: [],
     file: {
       version: 1,

--- a/src/agents/pi-tools.safe-bins.test.ts
+++ b/src/agents/pi-tools.safe-bins.test.ts
@@ -52,6 +52,11 @@ vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
       askFallback: "deny",
       autoAllowSkills: false,
     },
+    agentSources: {
+      security: "defaults.security",
+      ask: "defaults.ask",
+      askFallback: "defaults.askFallback",
+    },
     allowlist: [],
     file: {
       version: 1,

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -236,13 +236,13 @@ describe("exec approvals CLI", () => {
             expect.objectContaining({
               scopeLabel: "agent:runner",
               security: expect.objectContaining({
-                hostSource: "~/.openclaw/exec-approvals.json agents.*.security",
+                hostSource: "/tmp/local-exec-approvals.json agents.*.security",
               }),
               ask: expect.objectContaining({
-                hostSource: "~/.openclaw/exec-approvals.json agents.*.ask",
+                hostSource: "/tmp/local-exec-approvals.json agents.*.ask",
               }),
               askFallback: expect.objectContaining({
-                source: "~/.openclaw/exec-approvals.json agents.*.askFallback",
+                source: "/tmp/local-exec-approvals.json agents.*.askFallback",
               }),
             }),
           ]),
@@ -304,7 +304,7 @@ describe("exec approvals CLI", () => {
               }),
               askFallback: expect.objectContaining({
                 effective: "deny",
-                source: "~/.openclaw/exec-approvals.json defaults.askFallback",
+                source: "/tmp/node-exec-approvals.json defaults.askFallback",
               }),
             }),
           ],

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -184,6 +184,7 @@ function buildEffectivePolicyReport(params: {
   cfg: OpenClawConfig | null;
   source: ApprovalsTargetSource;
   approvals: ExecApprovalsFile;
+  hostPath: string;
 }): EffectivePolicyReport {
   if (params.source === "node") {
     if (!params.cfg) {
@@ -196,6 +197,7 @@ function buildEffectivePolicyReport(params: {
       scopes: collectExecPolicyScopeSnapshots({
         cfg: params.cfg,
         approvals: params.approvals,
+        hostPath: params.hostPath,
       }),
       note: "Effective exec policy is the node host approvals file intersected with gateway tools.exec policy.",
     };
@@ -210,6 +212,7 @@ function buildEffectivePolicyReport(params: {
     scopes: collectExecPolicyScopeSnapshots({
       cfg: params.cfg,
       approvals: params.approvals,
+      hostPath: params.hostPath,
     }),
     note: "Effective exec policy is the host approvals file intersected with requested tools.exec policy.",
   };
@@ -474,6 +477,7 @@ export function registerExecApprovalsCli(program: Command) {
           cfg,
           source,
           approvals: snapshot.file,
+          hostPath: snapshot.path,
         });
         if (opts.json) {
           defaultRuntime.writeJson({ ...snapshot, effectivePolicy }, 0);

--- a/src/commands/doctor-security.test.ts
+++ b/src/commands/doctor-security.test.ts
@@ -343,6 +343,39 @@ describe("noteSecurityWarnings gateway exposure", () => {
     expect(message).toContain('agents.runner.ask="always"');
   });
 
+  it("ignores malformed host policy fields when attributing doctor conflicts", async () => {
+    await withExecApprovalsFile(
+      {
+        version: 1,
+        defaults: {
+          ask: "always",
+        },
+        agents: {
+          runner: {
+            ask: "foo",
+          },
+        },
+      },
+      async () => {
+        await noteSecurityWarnings({
+          tools: {
+            exec: {
+              ask: "off",
+            },
+          },
+          agents: {
+            list: [{ id: "runner" }],
+          },
+        } as OpenClawConfig);
+      },
+    );
+
+    const message = lastMessage();
+    expect(message).toContain("agents.list.runner.tools.exec is broader than the host exec policy");
+    expect(message).toContain('defaults.ask="always"');
+    expect(message).not.toContain('agents.runner.ask="foo"');
+  });
+
   it('does not warn about durable allow-always trust when ask="always" is enforced', async () => {
     await withExecApprovalsFile(
       {

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -207,6 +207,48 @@ describe("exec approvals invalid explicit policy fallback", () => {
       askFallback: "defaults.askFallback",
     });
   });
+
+  it("treats null explicit agent fields as unset and still considers wildcard", () => {
+    const resolved = resolveExecApprovalsFromFile({
+      file: {
+        version: 1,
+        defaults: {
+          security: "full",
+          ask: "off",
+          askFallback: "full",
+        },
+        agents: {
+          "*": {
+            security: "deny",
+            ask: "always",
+            askFallback: "deny",
+          },
+          runner: {
+            security: null as unknown as ExecApprovalsAgent["security"],
+            ask: null as unknown as ExecApprovalsAgent["ask"],
+            askFallback: null as unknown as ExecApprovalsAgent["askFallback"],
+          },
+        },
+      },
+      agentId: "runner",
+      overrides: {
+        security: "full",
+        ask: "off",
+        askFallback: "full",
+      },
+    });
+
+    expect(resolved.agent).toMatchObject({
+      security: "deny",
+      ask: "always",
+      askFallback: "deny",
+    });
+    expect(resolved.agentSources).toEqual({
+      security: "agents.*.security",
+      ask: "agents.*.ask",
+      askFallback: "agents.*.askFallback",
+    });
+  });
 });
 
 describe("normalizeExecApprovals handles string allowlist entries (#9790)", () => {

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -165,6 +165,50 @@ describe("exec approvals default agent migration", () => {
   });
 });
 
+describe("exec approvals invalid explicit policy fallback", () => {
+  it("treats invalid explicit agent fields as masked and falls back to defaults instead of wildcard", () => {
+    const resolved = resolveExecApprovalsFromFile({
+      file: {
+        version: 1,
+        defaults: {
+          security: "deny",
+          ask: "on-miss",
+          askFallback: "deny",
+        },
+        agents: {
+          "*": {
+            security: "full",
+            ask: "always",
+            askFallback: "full",
+          },
+          runner: {
+            security: "foo" as unknown as ExecApprovalsAgent["security"],
+            ask: "Always" as unknown as ExecApprovalsAgent["ask"],
+            askFallback: "bar" as unknown as ExecApprovalsAgent["askFallback"],
+          },
+        },
+      },
+      agentId: "runner",
+      overrides: {
+        security: "full",
+        ask: "off",
+        askFallback: "full",
+      },
+    });
+
+    expect(resolved.agent).toMatchObject({
+      security: "deny",
+      ask: "on-miss",
+      askFallback: "deny",
+    });
+    expect(resolved.agentSources).toEqual({
+      security: "defaults.security",
+      ask: "defaults.ask",
+      askFallback: "defaults.askFallback",
+    });
+  });
+});
+
 describe("normalizeExecApprovals handles string allowlist entries (#9790)", () => {
   function normalizeMainAllowlist(file: ExecApprovalsFile): ExecAllowlistEntry[] | undefined {
     const normalized = normalizeExecApprovals(file);

--- a/src/infra/exec-approvals-effective.ts
+++ b/src/infra/exec-approvals-effective.ts
@@ -2,8 +2,6 @@ import type { OpenClawConfig } from "../config/config.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   DEFAULT_EXEC_APPROVAL_ASK_FALLBACK,
-  normalizeExecAsk,
-  normalizeExecSecurity,
   resolveExecApprovalAllowedDecisions,
   type ExecApprovalDecision,
   maxAsk,
@@ -63,39 +61,6 @@ function formatRequestedSource(params: {
 }
 
 type ExecPolicyField = "security" | "ask" | "askFallback";
-type ExecPolicyFieldEntry = {
-  security?: ExecSecurity;
-  ask?: ExecAsk;
-  askFallback?: ExecSecurity;
-};
-
-function readExecPolicyField(params: {
-  field: ExecPolicyField;
-  entry?: ExecPolicyFieldEntry;
-}): ExecSecurity | ExecAsk | undefined {
-  switch (params.field) {
-    case "security":
-      return params.entry?.security;
-    case "ask":
-      return params.entry?.ask;
-    case "askFallback":
-      return params.entry?.askFallback;
-  }
-}
-
-function readNormalizedExecPolicyField(params: {
-  field: ExecPolicyField;
-  entry?: ExecPolicyFieldEntry;
-}): ExecSecurity | ExecAsk | null {
-  const value = readExecPolicyField({ field: params.field, entry: params.entry });
-  switch (params.field) {
-    case "security":
-    case "askFallback":
-      return normalizeExecSecurity(value);
-    case "ask":
-      return normalizeExecAsk(value);
-  }
-}
 
 function resolveRequestedField<TValue extends ExecSecurity | ExecAsk>(params: {
   field: ExecPolicyRequestedField;
@@ -123,42 +88,13 @@ function resolveRequestedField<TValue extends ExecSecurity | ExecAsk>(params: {
   };
 }
 
-function resolveHostFieldSource(params: {
+function formatHostFieldSource(params: {
   hostPath: string;
-  agentId?: string;
   field: ExecPolicyField;
-  approvals: ExecApprovalsFile;
+  sourceSuffix: string | null;
 }): string {
-  const agentKey = params.agentId ?? DEFAULT_AGENT_ID;
-  const explicitAgentEntry = params.approvals.agents?.[agentKey];
-  const wildcardEntry = params.approvals.agents?.["*"];
-  const candidates = [
-    {
-      value: readNormalizedExecPolicyField({
-        field: params.field,
-        entry: explicitAgentEntry,
-      }),
-      source: `${params.hostPath} agents.${agentKey}.${params.field}`,
-    },
-    {
-      value: readNormalizedExecPolicyField({
-        field: params.field,
-        entry: wildcardEntry,
-      }),
-      source: `${params.hostPath} agents.*.${params.field}`,
-    },
-    {
-      value: readNormalizedExecPolicyField({
-        field: params.field,
-        entry: params.approvals.defaults,
-      }),
-      source: `${params.hostPath} defaults.${params.field}`,
-    },
-  ];
-  for (const candidate of candidates) {
-    if (candidate.value != null) {
-      return candidate.source;
-    }
+  if (params.sourceSuffix) {
+    return `${params.hostPath} ${params.sourceSuffix}`;
   }
   if (params.field === "askFallback") {
     return `OpenClaw default (${DEFAULT_EXEC_APPROVAL_ASK_FALLBACK})`;
@@ -281,11 +217,10 @@ export function resolveExecPolicyScopeSnapshot(params: {
         defaultValue: DEFAULT_REQUESTED_SECURITY,
       }),
       host: resolved.agent.security,
-      hostSource: resolveHostFieldSource({
+      hostSource: formatHostFieldSource({
         hostPath,
-        agentId: params.agentId,
         field: "security",
-        approvals: resolved.file,
+        sourceSuffix: resolved.agentSources.security,
       }),
       effective: effectiveSecurity,
       note:
@@ -302,11 +237,10 @@ export function resolveExecPolicyScopeSnapshot(params: {
         defaultValue: DEFAULT_REQUESTED_ASK,
       }),
       host: resolved.agent.ask,
-      hostSource: resolveHostFieldSource({
+      hostSource: formatHostFieldSource({
         hostPath,
-        agentId: params.agentId,
         field: "ask",
-        approvals: resolved.file,
+        sourceSuffix: resolved.agentSources.ask,
       }),
       effective: effectiveAsk,
       note: resolveAskNote({
@@ -317,11 +251,10 @@ export function resolveExecPolicyScopeSnapshot(params: {
     },
     askFallback: {
       effective: resolved.agent.askFallback,
-      source: resolveHostFieldSource({
+      source: formatHostFieldSource({
         hostPath,
-        agentId: params.agentId,
         field: "askFallback",
-        approvals: resolved.file,
+        sourceSuffix: resolved.agentSources.askFallback,
       }),
     },
     allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: effectiveAsk }),

--- a/src/infra/exec-approvals-effective.ts
+++ b/src/infra/exec-approvals-effective.ts
@@ -2,6 +2,8 @@ import type { OpenClawConfig } from "../config/config.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   DEFAULT_EXEC_APPROVAL_ASK_FALLBACK,
+  normalizeExecAsk,
+  normalizeExecSecurity,
   resolveExecApprovalAllowedDecisions,
   type ExecApprovalDecision,
   maxAsk,
@@ -61,14 +63,15 @@ function formatRequestedSource(params: {
 }
 
 type ExecPolicyField = "security" | "ask" | "askFallback";
+type ExecPolicyFieldEntry = {
+  security?: ExecSecurity;
+  ask?: ExecAsk;
+  askFallback?: ExecSecurity;
+};
 
 function readExecPolicyField(params: {
   field: ExecPolicyField;
-  entry?: {
-    security?: ExecSecurity;
-    ask?: ExecAsk;
-    askFallback?: ExecSecurity;
-  };
+  entry?: ExecPolicyFieldEntry;
 }): ExecSecurity | ExecAsk | undefined {
   switch (params.field) {
     case "security":
@@ -77,6 +80,20 @@ function readExecPolicyField(params: {
       return params.entry?.ask;
     case "askFallback":
       return params.entry?.askFallback;
+  }
+}
+
+function readNormalizedExecPolicyField(params: {
+  field: ExecPolicyField;
+  entry?: ExecPolicyFieldEntry;
+}): ExecSecurity | ExecAsk | null {
+  const value = readExecPolicyField({ field: params.field, entry: params.entry });
+  switch (params.field) {
+    case "security":
+    case "askFallback":
+      return normalizeExecSecurity(value);
+    case "ask":
+      return normalizeExecAsk(value);
   }
 }
 
@@ -89,7 +106,7 @@ function resolveRequestedField<TValue extends ExecSecurity | ExecAsk>(params: {
   if (scopeValue !== undefined) {
     return {
       value: scopeValue as TValue,
-      sourcePath: params.field && "scope",
+      sourcePath: "scope",
     };
   }
   const globalValue = params.globalExecConfig?.[params.field];
@@ -114,20 +131,34 @@ function resolveHostFieldSource(params: {
 }): string {
   const agentKey = params.agentId ?? DEFAULT_AGENT_ID;
   const explicitAgentEntry = params.approvals.agents?.[agentKey];
-  if (readExecPolicyField({ field: params.field, entry: explicitAgentEntry }) !== undefined) {
-    return `${params.hostPath} agents.${agentKey}.${params.field}`;
-  }
   const wildcardEntry = params.approvals.agents?.["*"];
-  if (readExecPolicyField({ field: params.field, entry: wildcardEntry }) !== undefined) {
-    return `${params.hostPath} agents.*.${params.field}`;
-  }
-  if (
-    readExecPolicyField({
-      field: params.field,
-      entry: params.approvals.defaults,
-    }) !== undefined
-  ) {
-    return `${params.hostPath} defaults.${params.field}`;
+  const candidates = [
+    {
+      value: readNormalizedExecPolicyField({
+        field: params.field,
+        entry: explicitAgentEntry,
+      }),
+      source: `${params.hostPath} agents.${agentKey}.${params.field}`,
+    },
+    {
+      value: readNormalizedExecPolicyField({
+        field: params.field,
+        entry: wildcardEntry,
+      }),
+      source: `${params.hostPath} agents.*.${params.field}`,
+    },
+    {
+      value: readNormalizedExecPolicyField({
+        field: params.field,
+        entry: params.approvals.defaults,
+      }),
+      source: `${params.hostPath} defaults.${params.field}`,
+    },
+  ];
+  for (const candidate of candidates) {
+    if (candidate.value != null) {
+      return candidate.source;
+    }
   }
   if (params.field === "askFallback") {
     return `OpenClaw default (${DEFAULT_EXEC_APPROVAL_ASK_FALLBACK})`;
@@ -149,24 +180,17 @@ function resolveAskNote(params: {
   return "more aggressive ask wins";
 }
 
-function formatHostSource(params: {
-  hostPath: string;
-  agentId?: string;
-  field: ExecPolicyField;
-  approvals: ExecApprovalsFile;
-}): string {
-  return resolveHostFieldSource(params);
-}
-
 export function collectExecPolicyScopeSnapshots(params: {
   cfg: OpenClawConfig;
   approvals: ExecApprovalsFile;
+  hostPath?: string;
 }): ExecPolicyScopeSnapshot[] {
   const snapshots = [
     resolveExecPolicyScopeSnapshot({
       approvals: params.approvals,
       scopeExecConfig: params.cfg.tools?.exec,
       configPath: "tools.exec",
+      hostPath: params.hostPath,
       scopeLabel: "tools.exec",
     }),
   ];
@@ -188,6 +212,7 @@ export function collectExecPolicyScopeSnapshots(params: {
         scopeExecConfig: agentConfig?.tools?.exec,
         globalExecConfig,
         configPath: `agents.list.${agentId}.tools.exec`,
+        hostPath: params.hostPath,
         scopeLabel: `agent:${agentId}`,
         agentId,
       }),
@@ -256,11 +281,11 @@ export function resolveExecPolicyScopeSnapshot(params: {
         defaultValue: DEFAULT_REQUESTED_SECURITY,
       }),
       host: resolved.agent.security,
-      hostSource: formatHostSource({
+      hostSource: resolveHostFieldSource({
         hostPath,
         agentId: params.agentId,
         field: "security",
-        approvals: params.approvals,
+        approvals: resolved.file,
       }),
       effective: effectiveSecurity,
       note:
@@ -277,11 +302,11 @@ export function resolveExecPolicyScopeSnapshot(params: {
         defaultValue: DEFAULT_REQUESTED_ASK,
       }),
       host: resolved.agent.ask,
-      hostSource: formatHostSource({
+      hostSource: resolveHostFieldSource({
         hostPath,
         agentId: params.agentId,
         field: "ask",
-        approvals: params.approvals,
+        approvals: resolved.file,
       }),
       effective: effectiveAsk,
       note: resolveAskNote({
@@ -292,11 +317,11 @@ export function resolveExecPolicyScopeSnapshot(params: {
     },
     askFallback: {
       effective: resolved.agent.askFallback,
-      source: formatHostSource({
+      source: resolveHostFieldSource({
         hostPath,
         agentId: params.agentId,
         field: "askFallback",
-        approvals: params.approvals,
+        approvals: resolved.file,
       }),
     },
     allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: effectiveAsk }),

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -316,6 +316,68 @@ describe("exec approvals policy helpers", () => {
     });
   });
 
+  it("ignores malformed non-string host fields when attributing their source", () => {
+    const approvals = {
+      version: 1,
+      defaults: {
+        ask: "always",
+      },
+      agents: {
+        runner: {
+          ask: true,
+        },
+      },
+    } as unknown as ExecApprovalsFile;
+    const summary = resolveExecPolicyScopeSummary({
+      approvals,
+      globalExecConfig: {
+        ask: "off",
+      },
+      configPath: "agents.list.runner.tools.exec",
+      scopeLabel: "agent:runner",
+      agentId: "runner",
+    });
+
+    expect(summary.ask).toMatchObject({
+      requested: "off",
+      host: "always",
+      hostSource: "~/.openclaw/exec-approvals.json defaults.ask",
+      effective: "always",
+      note: "more aggressive ask wins",
+    });
+  });
+
+  it("does not credit mixed-case host fields that resolution ignores", () => {
+    const approvals = {
+      version: 1,
+      defaults: {
+        ask: "always",
+      },
+      agents: {
+        runner: {
+          ask: "Always",
+        },
+      },
+    } as unknown as ExecApprovalsFile;
+    const summary = resolveExecPolicyScopeSummary({
+      approvals,
+      globalExecConfig: {
+        ask: "off",
+      },
+      configPath: "agents.list.runner.tools.exec",
+      scopeLabel: "agent:runner",
+      agentId: "runner",
+    });
+
+    expect(summary.ask).toMatchObject({
+      requested: "off",
+      host: "always",
+      hostSource: "~/.openclaw/exec-approvals.json defaults.ask",
+      effective: "always",
+      note: "more aggressive ask wins",
+    });
+  });
+
   it("attributes host policy to wildcard agent entries before defaults", () => {
     const summary = resolveExecPolicyScopeSummary({
       approvals: {

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -14,6 +14,7 @@ import {
   hasDurableExecApproval,
   maxAsk,
   minSecurity,
+  type ExecApprovalsFile,
   normalizeExecAsk,
   normalizeExecHost,
   normalizeExecTarget,
@@ -234,6 +235,33 @@ describe("exec approvals policy helpers", () => {
     });
   });
 
+  it("uses the actual approvals path when reporting host sources", () => {
+    const summary = resolveExecPolicyScopeSummary({
+      approvals: {
+        version: 1,
+        defaults: {
+          security: "allowlist",
+          ask: "always",
+          askFallback: "deny",
+        },
+      },
+      scopeExecConfig: {
+        security: "full",
+        ask: "off",
+      },
+      configPath: "tools.exec",
+      scopeLabel: "tools.exec",
+      hostPath: "/tmp/node-exec-approvals.json",
+    });
+
+    expect(summary.security.hostSource).toBe("/tmp/node-exec-approvals.json defaults.security");
+    expect(summary.ask.hostSource).toBe("/tmp/node-exec-approvals.json defaults.ask");
+    expect(summary.askFallback).toEqual({
+      effective: "deny",
+      source: "/tmp/node-exec-approvals.json defaults.askFallback",
+    });
+  });
+
   it("explains host ask=off suppression separately from stricter ask", () => {
     const summary = resolveExecPolicyScopeSummary({
       approvals: {
@@ -254,6 +282,37 @@ describe("exec approvals policy helpers", () => {
       host: "off",
       effective: "off",
       note: "host ask=off suppresses prompts",
+    });
+  });
+
+  it("skips malformed host fields when attributing their source", () => {
+    const approvals = {
+      version: 1,
+      defaults: {
+        ask: "always",
+      },
+      agents: {
+        runner: {
+          ask: "foo",
+        },
+      },
+    } as unknown as ExecApprovalsFile;
+    const summary = resolveExecPolicyScopeSummary({
+      approvals,
+      globalExecConfig: {
+        ask: "off",
+      },
+      configPath: "agents.list.runner.tools.exec",
+      scopeLabel: "agent:runner",
+      agentId: "runner",
+    });
+
+    expect(summary.ask).toMatchObject({
+      requested: "off",
+      host: "always",
+      hostSource: "~/.openclaw/exec-approvals.json defaults.ask",
+      effective: "always",
+      note: "more aggressive ask wins",
     });
   });
 

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -445,28 +445,11 @@ type ResolvedExecPolicyField<TValue extends ExecSecurity | ExecAsk> = {
   source: string | null;
 };
 
-function resolveAgentSecurityField(params: {
+function resolveDefaultSecurityField(params: {
   field: "security" | "askFallback";
   defaults: ExecApprovalsDefaults;
-  agent: ExecApprovalsAgent;
-  wildcard: ExecApprovalsAgent;
-  agentKey: string;
   fallback: ExecSecurity;
 }): ResolvedExecPolicyField<ExecSecurity> {
-  const agentValue = params.agent[params.field];
-  if (isExecSecurity(agentValue)) {
-    return {
-      value: agentValue,
-      source: `agents.${params.agentKey}.${params.field}`,
-    };
-  }
-  const wildcardValue = params.wildcard[params.field];
-  if (isExecSecurity(wildcardValue)) {
-    return {
-      value: wildcardValue,
-      source: `agents.*.${params.field}`,
-    };
-  }
   const defaultValue = params.defaults[params.field];
   if (isExecSecurity(defaultValue)) {
     return {
@@ -480,25 +463,10 @@ function resolveAgentSecurityField(params: {
   };
 }
 
-function resolveAgentAskField(params: {
+function resolveDefaultAskField(params: {
   defaults: ExecApprovalsDefaults;
-  agent: ExecApprovalsAgent;
-  wildcard: ExecApprovalsAgent;
-  agentKey: string;
   fallback: ExecAsk;
 }): ResolvedExecPolicyField<ExecAsk> {
-  if (isExecAsk(params.agent.ask)) {
-    return {
-      value: params.agent.ask,
-      source: `agents.${params.agentKey}.ask`,
-    };
-  }
-  if (isExecAsk(params.wildcard.ask)) {
-    return {
-      value: params.wildcard.ask,
-      source: "agents.*.ask",
-    };
-  }
   if (isExecAsk(params.defaults.ask)) {
     return {
       value: params.defaults.ask,
@@ -509,6 +477,74 @@ function resolveAgentAskField(params: {
     value: params.fallback,
     source: null,
   };
+}
+
+function resolveAgentSecurityField(params: {
+  field: "security" | "askFallback";
+  defaults: ExecApprovalsDefaults;
+  agent: ExecApprovalsAgent;
+  wildcard: ExecApprovalsAgent;
+  agentKey: string;
+  fallback: ExecSecurity;
+}): ResolvedExecPolicyField<ExecSecurity> {
+  const fallbackField = resolveDefaultSecurityField({
+    field: params.field,
+    defaults: params.defaults,
+    fallback: params.fallback,
+  });
+  const agentValue = params.agent[params.field];
+  if (agentValue !== undefined) {
+    if (isExecSecurity(agentValue)) {
+      return {
+        value: agentValue,
+        source: `agents.${params.agentKey}.${params.field}`,
+      };
+    }
+    return fallbackField;
+  }
+  const wildcardValue = params.wildcard[params.field];
+  if (wildcardValue !== undefined) {
+    if (isExecSecurity(wildcardValue)) {
+      return {
+        value: wildcardValue,
+        source: `agents.*.${params.field}`,
+      };
+    }
+    return fallbackField;
+  }
+  return fallbackField;
+}
+
+function resolveAgentAskField(params: {
+  defaults: ExecApprovalsDefaults;
+  agent: ExecApprovalsAgent;
+  wildcard: ExecApprovalsAgent;
+  agentKey: string;
+  fallback: ExecAsk;
+}): ResolvedExecPolicyField<ExecAsk> {
+  const fallbackField = resolveDefaultAskField({
+    defaults: params.defaults,
+    fallback: params.fallback,
+  });
+  if (params.agent.ask !== undefined) {
+    if (isExecAsk(params.agent.ask)) {
+      return {
+        value: params.agent.ask,
+        source: `agents.${params.agentKey}.ask`,
+      };
+    }
+    return fallbackField;
+  }
+  if (params.wildcard.ask !== undefined) {
+    if (isExecAsk(params.wildcard.ask)) {
+      return {
+        value: params.wildcard.ask,
+        source: "agents.*.ask",
+      };
+    }
+    return fallbackField;
+  }
+  return fallbackField;
 }
 
 export type ExecApprovalsDefaultOverrides = {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -151,6 +151,11 @@ export type ExecApprovalsResolved = {
   token: string;
   defaults: Required<ExecApprovalsDefaults>;
   agent: Required<ExecApprovalsDefaults>;
+  agentSources: {
+    security: string | null;
+    ask: string | null;
+    askFallback: string | null;
+  };
   allowlist: ExecAllowlistEntry[];
   file: ExecApprovalsFile;
 };
@@ -419,18 +424,91 @@ export function ensureExecApprovals(): ExecApprovalsFile {
   return updated;
 }
 
-function normalizeSecurity(value: ExecSecurity | undefined, fallback: ExecSecurity): ExecSecurity {
-  if (value === "allowlist" || value === "full" || value === "deny") {
-    return value;
-  }
-  return fallback;
+function isExecSecurity(value: unknown): value is ExecSecurity {
+  return value === "allowlist" || value === "full" || value === "deny";
 }
 
-function normalizeAsk(value: ExecAsk | undefined, fallback: ExecAsk): ExecAsk {
-  if (value === "always" || value === "off" || value === "on-miss") {
-    return value;
+function isExecAsk(value: unknown): value is ExecAsk {
+  return value === "always" || value === "off" || value === "on-miss";
+}
+
+function normalizeSecurity(value: unknown, fallback: ExecSecurity): ExecSecurity {
+  return isExecSecurity(value) ? value : fallback;
+}
+
+function normalizeAsk(value: unknown, fallback: ExecAsk): ExecAsk {
+  return isExecAsk(value) ? value : fallback;
+}
+
+type ResolvedExecPolicyField<TValue extends ExecSecurity | ExecAsk> = {
+  value: TValue;
+  source: string | null;
+};
+
+function resolveAgentSecurityField(params: {
+  field: "security" | "askFallback";
+  defaults: ExecApprovalsDefaults;
+  agent: ExecApprovalsAgent;
+  wildcard: ExecApprovalsAgent;
+  agentKey: string;
+  fallback: ExecSecurity;
+}): ResolvedExecPolicyField<ExecSecurity> {
+  const agentValue = params.agent[params.field];
+  if (isExecSecurity(agentValue)) {
+    return {
+      value: agentValue,
+      source: `agents.${params.agentKey}.${params.field}`,
+    };
   }
-  return fallback;
+  const wildcardValue = params.wildcard[params.field];
+  if (isExecSecurity(wildcardValue)) {
+    return {
+      value: wildcardValue,
+      source: `agents.*.${params.field}`,
+    };
+  }
+  const defaultValue = params.defaults[params.field];
+  if (isExecSecurity(defaultValue)) {
+    return {
+      value: defaultValue,
+      source: `defaults.${params.field}`,
+    };
+  }
+  return {
+    value: params.fallback,
+    source: null,
+  };
+}
+
+function resolveAgentAskField(params: {
+  defaults: ExecApprovalsDefaults;
+  agent: ExecApprovalsAgent;
+  wildcard: ExecApprovalsAgent;
+  agentKey: string;
+  fallback: ExecAsk;
+}): ResolvedExecPolicyField<ExecAsk> {
+  if (isExecAsk(params.agent.ask)) {
+    return {
+      value: params.agent.ask,
+      source: `agents.${params.agentKey}.ask`,
+    };
+  }
+  if (isExecAsk(params.wildcard.ask)) {
+    return {
+      value: params.wildcard.ask,
+      source: "agents.*.ask",
+    };
+  }
+  if (isExecAsk(params.defaults.ask)) {
+    return {
+      value: params.defaults.ask,
+      source: "defaults.ask",
+    };
+  }
+  return {
+    value: params.fallback,
+    source: null,
+  };
 }
 
 export type ExecApprovalsDefaultOverrides = {
@@ -481,16 +559,33 @@ export function resolveExecApprovalsFromFile(params: {
     ),
     autoAllowSkills: Boolean(defaults.autoAllowSkills ?? fallbackAutoAllowSkills),
   };
+  const resolvedAgentSecurity = resolveAgentSecurityField({
+    field: "security",
+    defaults,
+    agent,
+    wildcard,
+    agentKey,
+    fallback: resolvedDefaults.security,
+  });
+  const resolvedAgentAsk = resolveAgentAskField({
+    defaults,
+    agent,
+    wildcard,
+    agentKey,
+    fallback: resolvedDefaults.ask,
+  });
+  const resolvedAgentAskFallback = resolveAgentSecurityField({
+    field: "askFallback",
+    defaults,
+    agent,
+    wildcard,
+    agentKey,
+    fallback: resolvedDefaults.askFallback,
+  });
   const resolvedAgent: Required<ExecApprovalsDefaults> = {
-    security: normalizeSecurity(
-      agent.security ?? wildcard.security ?? resolvedDefaults.security,
-      resolvedDefaults.security,
-    ),
-    ask: normalizeAsk(agent.ask ?? wildcard.ask ?? resolvedDefaults.ask, resolvedDefaults.ask),
-    askFallback: normalizeSecurity(
-      agent.askFallback ?? wildcard.askFallback ?? resolvedDefaults.askFallback,
-      resolvedDefaults.askFallback,
-    ),
+    security: resolvedAgentSecurity.value,
+    ask: resolvedAgentAsk.value,
+    askFallback: resolvedAgentAskFallback.value,
     autoAllowSkills: Boolean(
       agent.autoAllowSkills ?? wildcard.autoAllowSkills ?? resolvedDefaults.autoAllowSkills,
     ),
@@ -507,6 +602,11 @@ export function resolveExecApprovalsFromFile(params: {
     token: params.token ?? file.socket?.token ?? "",
     defaults: resolvedDefaults,
     agent: resolvedAgent,
+    agentSources: {
+      security: resolvedAgentSecurity.source,
+      ask: resolvedAgentAsk.source,
+      askFallback: resolvedAgentAskFallback.source,
+    },
     allowlist,
     file,
   };

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -493,7 +493,7 @@ function resolveAgentSecurityField(params: {
     fallback: params.fallback,
   });
   const agentValue = params.agent[params.field];
-  if (agentValue !== undefined) {
+  if (agentValue != null) {
     if (isExecSecurity(agentValue)) {
       return {
         value: agentValue,
@@ -503,7 +503,7 @@ function resolveAgentSecurityField(params: {
     return fallbackField;
   }
   const wildcardValue = params.wildcard[params.field];
-  if (wildcardValue !== undefined) {
+  if (wildcardValue != null) {
     if (isExecSecurity(wildcardValue)) {
       return {
         value: wildcardValue,
@@ -526,7 +526,7 @@ function resolveAgentAskField(params: {
     defaults: params.defaults,
     fallback: params.fallback,
   });
-  if (params.agent.ask !== undefined) {
+  if (params.agent.ask != null) {
     if (isExecAsk(params.agent.ask)) {
       return {
         value: params.agent.ask,
@@ -535,7 +535,7 @@ function resolveAgentAskField(params: {
     }
     return fallbackField;
   }
-  if (params.wildcard.ask !== undefined) {
+  if (params.wildcard.ask != null) {
     if (isExecAsk(params.wildcard.ask)) {
       return {
         value: params.wildcard.ask,


### PR DESCRIPTION
## Summary

- Problem: `openclaw approvals get` and doctor exec-policy warnings attributed host policy fields from raw approvals JSON presence instead of the normalized effective source.
- Why it matters: node/custom-path diagnostics could point at `~/.openclaw/exec-approvals.json` even when the real snapshot came from another path, and malformed values like `ask: "foo"` could be reported as authoritative even though resolution ignored them.
- What changed: thread the real approvals snapshot path into effective-policy reporting, and choose host source attribution from normalized host values after wildcard/default fallback.
- What did NOT change (scope boundary): no exec policy semantics, allowlist matching, or approval enforcement behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: effective-policy source reporting inspected raw approvals entries to choose `hostSource`, while `resolveExecApprovalsFromFile` separately normalized invalid values and applied fallback precedence.
- Missing detection / guardrail: tests covered precedence, but not custom snapshot paths or malformed host values surviving into attribution.
- Prior context (`git blame`, prior PR, issue, or refactor if known): introduced in `ba735d0158` when effective-policy reporting was added.
- Why this regressed now: the new diagnostics reused raw approvals input for provenance instead of the normalized resolved file.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/exec-approvals-policy.test.ts`, `src/cli/exec-approvals-cli.test.ts`, `src/commands/doctor-security.test.ts`
- Scenario the test should lock in: custom node/local approvals paths stay visible in `hostSource`, and malformed host overrides do not claim provenance when defaults/wildcards actually win.
- Why this is the smallest reliable guardrail: the bug is pure resolver/reporting logic with no external dependency.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `openclaw approvals get` now reports host policy sources from the real approvals snapshot path.
- Effective-policy and doctor conflict output stop attributing malformed host override values that were ignored during resolution.

## Diagram (if applicable)

```text
Before:
[node snapshot at /tmp/node-exec-approvals.json] -> effective policy report -> hostSource points at ~/.openclaw/exec-approvals.json
[agents.runner.ask="foo", defaults.ask="always"] -> hostSource points at agents.runner.ask

After:
[node snapshot at /tmp/node-exec-approvals.json] -> effective policy report -> hostSource points at /tmp/node-exec-approvals.json
[agents.runner.ask="foo", defaults.ask="always"] -> hostSource points at defaults.ask -> matches effective host value
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): approvals fixtures in unit tests

### Steps

1. Resolve effective policy for a snapshot loaded from a non-default path.
2. Resolve effective policy where an agent host field is malformed but defaults remain valid.
3. Inspect CLI/doctor output expectations.

### Expected

- Host source path matches the real approvals snapshot path.
- Host source attribution matches the normalized effective host field source.

### Actual

- Fixed by this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: direct resolver repro for custom path and malformed host values; targeted approvals/doctor test suite; repo `pnpm check` gate.
- Edge cases checked: wildcard precedence, default fallback, askFallback attribution.
- What you did **not** verify: live gateway/node manual runs.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: attribution logic now depends on normalized host values, so future policy fields need matching normalization support.
  - Mitigation: normalization is centralized in `readNormalizedExecPolicyField`, and regression tests cover the precedence paths touched here.
