### PR TITLE
remove noisy podman output from launch script and update doc

### DIFF
--- a/docs/install/podman.md
+++ b/docs/install/podman.md
@@ -98,72 +98,8 @@ openclaw channels login
 ```
 
 On macOS, Podman machine may make the browser appear non-local to the gateway.
-If the Control UI reports device-auth errors after launch, prefer the SSH
-tunnel flow in [macOS Podman SSH tunnel](#macos-podman-ssh-tunnel). For
-remote HTTPS access, use the Tailscale guidance in
+If the Control UI reports device-auth errors after launch, use the Tailscale guidance in
 [Podman + Tailscale](#podman--tailscale).
-
-## macOS Podman SSH tunnel
-
-On macOS, Podman machine can make the browser appear non-local to the gateway even when the published port is only on `127.0.0.1`.
-
-For local browser access, use an SSH tunnel into the Podman VM and open the tunneled localhost port instead.
-
-Recommended local tunnel port:
-
-- `28889` on the Mac host
-- forwarded to `127.0.0.1:18789` inside the Podman VM
-
-Start the tunnel in a separate terminal:
-
-```bash
-ssh -N \
-  -i ~/.local/share/containers/podman/machine/machine \
-  -p <podman-vm-ssh-port> \
-  -L 28889:127.0.0.1:18789 \
-  core@127.0.0.1
-```
-
-In that command, `<podman-vm-ssh-port>` is the Podman VM's SSH port on the Mac host. Check your current value with:
-
-```bash
-podman system connection list
-```
-
-Allow the tunneled browser origin once. This is required the first time you use the tunnel because the launcher can auto-seed the Podman-published port, but it cannot infer your chosen browser tunnel port:
-
-```bash
-OPENCLAW_CONTAINER=openclaw openclaw config set gateway.controlUi.allowedOrigins \
-  '["http://127.0.0.1:18789","http://localhost:18789","http://127.0.0.1:28889","http://localhost:28889"]' \
-  --strict-json
-podman restart openclaw
-```
-
-That is a one-time step for the default `28889` tunnel.
-
-Then open:
-
-```text
-http://127.0.0.1:28889/
-```
-
-Notes:
-
-- `18789` is usually already occupied on the Mac host by the Podman-published gateway port, so the tunnel uses `28889` as the local browser port.
-- If the UI asks for pairing approval, prefer explicit container-targeted or explicit-URL commands so the host CLI does not fall back to local pairing files:
-
-```bash
-openclaw --container openclaw devices list
-openclaw --container openclaw devices approve --latest
-```
-
-- Equivalent explicit-URL form:
-
-```bash
-openclaw devices list \
-  --url ws://127.0.0.1:28889 \
-  --token "$(sed -n 's/^OPENCLAW_GATEWAY_TOKEN=//p' ~/.openclaw/.env | head -n1)"
-```
 
 <a id="podman--tailscale"></a>
 
@@ -175,7 +111,7 @@ Podman-specific note:
 
 - Keep the Podman publish host at `127.0.0.1`.
 - Prefer host-managed `tailscale serve` over `openclaw gateway --tailscale serve`.
-- For local macOS browser access without HTTPS, prefer the SSH tunnel section above.
+- On macOS, if local browser device-auth context is unreliable, use Tailscale access instead of ad hoc local tunnel workarounds.
 
 See:
 

--- a/scripts/run-openclaw-podman.sh
+++ b/scripts/run-openclaw-podman.sh
@@ -516,7 +516,6 @@ RUN_UID="$(id -u)"
 RUN_GID="$(id -g)"
 if [[ "$PODMAN_USERNS" == "keep-id" ]]; then
   RUN_USER_ARGS=(--user "${RUN_UID}:${RUN_GID}")
-  echo "Starting container as uid=${RUN_UID} gid=${RUN_GID} (must match owner of $CONFIG_DIR)" >&2
 else
   echo "Starting container without --user (OPENCLAW_PODMAN_USERNS=$PODMAN_USERNS), mounts may require ownership fixes." >&2
 fi
@@ -564,22 +563,12 @@ podman run --pull="$PODMAN_PULL" -d --replace \
   -p "${PUBLISH_HOST}:${HOST_GATEWAY_PORT}:18789" \
   -p "${PUBLISH_HOST}:${HOST_BRIDGE_PORT}:18790" \
   "$OPENCLAW_IMAGE" \
-  node dist/index.js gateway --bind "$GATEWAY_BIND" --port 18789
+  node dist/index.js gateway --bind "$GATEWAY_BIND" --port 18789 >/dev/null
 
-echo "Container $CONTAINER_NAME started. Dashboard: http://127.0.0.1:${HOST_GATEWAY_PORT}/"
-echo "Host CLI: openclaw --container $CONTAINER_NAME dashboard --no-open"
-echo "Logs: podman logs -f $CONTAINER_NAME"
-if [[ "$PLATFORM_NAME" == "Darwin" ]]; then
-  echo "macOS Podman note: if Control UI login hits device-auth errors, prefer the SSH-tunnel or Tailscale paths in docs/install/podman.md."
-  echo "Local-safe workaround:"
-  echo "  OPENCLAW_CONTAINER=$CONTAINER_NAME openclaw dashboard --no-open"
-  echo "  One-time setup:"
-  echo "    OPENCLAW_CONTAINER=$CONTAINER_NAME openclaw config set gateway.controlUi.allowedOrigins '[\"http://127.0.0.1:18789\",\"http://localhost:18789\",\"http://127.0.0.1:28889\",\"http://localhost:28889\"]' --strict-json"
-  echo "    podman restart $CONTAINER_NAME"
-  echo "  ssh -N -i ~/.local/share/containers/podman/machine/machine -p <podman-vm-ssh-port> -L 28889:127.0.0.1:18789 core@127.0.0.1"
-  echo "  Then open http://127.0.0.1:28889/"
-  echo "  Note: find <podman-vm-ssh-port> with: podman system connection list"
-fi
+echo "Container $CONTAINER_NAME started: http://127.0.0.1:${HOST_GATEWAY_PORT}/"
+echo "podman exec -it $CONTAINER_NAME openclaw dashboard --no-open"
+echo "podman exec -it $CONTAINER_NAME openclaw devices approve --latest  # if pairing required"
+echo "podman logs -f $CONTAINER_NAME"
 if [[ "$PLATFORM_NAME" == "Linux" ]]; then
   echo "For auto-start/restarts, use: ./scripts/podman/setup.sh --quadlet (Quadlet + systemd user service)."
 fi


### PR DESCRIPTION
## Summary

Podman docs were too noisy, simplifying.
Removed the macOS SSH Tunnel docs, out of scope for basic dev install. 