### PR TITLE
feat: add scoped working memory lanes

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -78,3 +78,31 @@ openclaw cron add \
 ```
 
 `--light-context` applies to isolated agent-turn jobs only. For cron runs, lightweight mode keeps bootstrap context empty instead of injecting the full workspace bootstrap set.
+
+If you want a lightweight isolated cron job to keep its own scoped notes without
+loading broader durable memory, give it a scoped working-memory file:
+
+```bash
+openclaw cron add \
+  --name "Nightly improvement loop" \
+  --cron "0 2 * * *" \
+  --session isolated \
+  --message "Complete exactly one high-leverage task." \
+  --light-context \
+  --working-memory ".openclaw/working-memory/cron/nightly-improvements.md" \
+  --announce --channel telegram --to "-1001234567890"
+```
+
+`--working-memory` should point to a workspace-relative markdown file under
+`.openclaw/working-memory/`. In this mode, `/context` will show the file as
+**working memory**, distinct from startup memory (`MEMORY.md`), searchable
+memory (`memory/`), and conversation recall/history.
+
+This isolates what gets preloaded and what memory tools can surface by default;
+it does **not** by itself remove general workspace tools like `read`, `write`,
+or `exec` unless the run's tool policy also filters them.
+
+If you omit `--working-memory`, lightweight isolated cron jobs keep lightweight
+bootstrap behavior but do **not** implicitly enable scoped working memory.
+That memory lane is explicit opt-in so existing jobs do not silently change
+their tool exposure or recall behavior.

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -103,9 +103,16 @@ These are the standard files OpenClaw expects inside the workspace:
   - Daily memory log (one file per day).
   - Recommended to read today + yesterday on session start.
 
+- `memory/topics/*.md`, `memory/projects/*.md` (optional conventions)
+  - Evergreen topic or project notes kept under `memory/`.
+  - Useful for deeper reference material that should be searchable but not
+    always loaded at startup.
+
 - `MEMORY.md` (optional)
   - Curated long-term memory.
   - Only load in the main, private session (not shared/group contexts).
+  - Best kept concise; move detail into topic notes and keep summary pointers
+    here.
 
 See [Memory](/concepts/memory) for the workflow and automatic memory flush.
 

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -28,6 +28,76 @@ If you want your agent to remember something, just ask it: "Remember that I
 prefer TypeScript." It will write it to the appropriate file.
 </Tip>
 
+## Recommended memory taxonomy
+
+As your note history grows, it helps to treat memory as **layers** instead of
+putting everything into `MEMORY.md`.
+
+### 1) Startup memory -- `MEMORY.md`
+
+Use `MEMORY.md` for the small set of things the agent should start with every
+private/main session:
+
+- durable preferences
+- standing rules and boundaries
+- stable facts about people, projects, and infrastructure
+- one-line pointers to deeper notes
+
+Keep this file **curated and concise**. If it starts reading like a journal or
+incident log, move the detail elsewhere and leave a short summary plus pointer.
+
+### 2) Running log -- `memory/YYYY-MM-DD.md`
+
+Use dated daily files for:
+
+- recent events
+- rough observations
+- temporary state
+- things that might matter later, but are not yet durable
+
+Daily notes can be messier. Periodically distill the important parts into
+`MEMORY.md` or a topic note.
+
+### 3) Evergreen topic notes -- `memory/topics/*.md`, `memory/projects/*.md`
+
+When a subject needs more detail than belongs in startup memory, create a
+separate note under `memory/`.
+
+Examples:
+
+- `memory/projects/openclaw-memory.md`
+- `memory/topics/home-assistant.md`
+- `memory/topics/briefgen-outreach.md`
+
+These notes are ideal for:
+
+- project-specific conventions
+- architecture notes
+- research summaries
+- runbooks
+- decision histories
+
+By default, they are **searchable** with `memory_search` but are not meant to
+all be loaded automatically at session start.
+
+### 4) Conversation recall -- transcripts, compaction, and recall tools
+
+Past conversations are a **separate layer** from curated memory. Use transcript
+search, compaction summaries, or recall extensions/plugins when you need to ask
+"what happened?" without promoting everything into `MEMORY.md`.
+
+A good rule of thumb:
+
+- put **preferences / durable facts** in `MEMORY.md`
+- put **recent rough context** in daily notes
+- put **deep reference material** in topic notes
+- use **conversation recall** for historical reconstruction
+
+<Tip>
+A strong pattern is to keep `MEMORY.md` short enough to skim quickly, then move
+project detail into searchable topic files under `memory/`.
+</Tip>
+
 ## Memory tools
 
 The agent has two tools for working with memory:

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -93,10 +93,41 @@ A good rule of thumb:
 - put **deep reference material** in topic notes
 - use **conversation recall** for historical reconstruction
 
+### 5) Scoped working memory -- `.openclaw/working-memory/*.md`
+
+For isolated or durable-memory-sensitive automation runs, OpenClaw can also inject a
+**scoped working-memory file** that is separate from both startup memory and
+searchable durable notes.
+
+Typical examples:
+
+- `.openclaw/working-memory/cron/nightly.md`
+- `.openclaw/working-memory/cron/research-watch.md`
+- `.openclaw/working-memory/heartbeat/private.md`
+
+Use this lane for:
+
+- run-local scratch state
+- scoped continuity for isolated cron/heartbeat flows
+- notes that should **not** become part of general searchable memory by default
+
+Unlike `MEMORY.md` or `memory/**/*.md`, these files are meant to be loaded only
+when a run explicitly opts into them.
+
 <Tip>
 A strong pattern is to keep `MEMORY.md` short enough to skim quickly, then move
 project detail into searchable topic files under `memory/`.
 </Tip>
+
+<Tip>
+When you need continuity for an isolated automation loop but do **not** want to
+load or search the agent's broader durable memory, prefer a scoped file under
+`.openclaw/working-memory/`.
+</Tip>
+
+Scoped working memory is a **context-loading boundary**, not a full filesystem or
+tool isolation boundary by itself. A run can still have general workspace tools
+such as `read`, `write`, or `exec` unless those are separately filtered.
 
 ## Memory tools
 

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -29,6 +29,7 @@ Don't ask permission. Just do it.
 You wake up fresh each session. These files are your continuity:
 
 - **Daily notes:** `memory/YYYY-MM-DD.md` (create `memory/` if needed) — raw logs of what happened
+- **Topic notes:** `memory/topics/*.md` or `memory/projects/*.md` — deeper reference notes that should stay searchable without bloating startup context
 - **Long-term:** `MEMORY.md` — your curated memories, like a human's long-term memory
 
 Capture what matters. Decisions, context, things to remember. Skip the secrets unless asked to keep them.
@@ -41,13 +42,14 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 - You can **read, edit, and update** MEMORY.md freely in main sessions
 - Write significant events, thoughts, decisions, opinions, lessons learned
 - This is your curated memory — the distilled essence, not raw logs
+- Keep it lean; if a section grows long, move the detail into a topic note and leave a short pointer
 - Over time, review your daily files and update MEMORY.md with what's worth keeping
 
 ### 📝 Write It Down - No "Mental Notes"!
 
 - **Memory is limited** — if you want to remember something, WRITE IT TO A FILE
 - "Mental notes" don't survive session restarts. Files do.
-- When someone says "remember this" → update `memory/YYYY-MM-DD.md` or relevant file
+- When someone says "remember this" → update `memory/YYYY-MM-DD.md` or the relevant topic file
 - When you learn a lesson → update AGENTS.md, TOOLS.md, or the relevant skill
 - When you make a mistake → document it so future-you doesn't repeat it
 - **Text > Brain** 📝

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -484,6 +484,7 @@ export async function runEmbeddedPiAgent(
             sessionKey: params.sessionKey,
             trigger: params.trigger,
             memoryFlushWritePath: params.memoryFlushWritePath,
+            workingMemoryPath: params.workingMemoryPath,
             messageChannel: params.messageChannel,
             messageProvider: params.messageProvider,
             agentAccountId: params.agentAccountId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -79,6 +79,12 @@ import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../..
 import { registerProviderStreamForModel } from "../../provider-stream.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
+import {
+  buildScopedWorkingMemoryInjectionStats,
+  DEFAULT_SCOPED_WORKING_MEMORY_MAX_CHARS,
+  fitScopedWorkingMemoryContextFileToBudget,
+  loadScopedWorkingMemoryContextFile,
+} from "../../scoped-working-memory.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
@@ -362,7 +368,7 @@ export async function runEmbeddedAttempt(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
-    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
+    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles: bootstrapContextFiles } =
       await resolveBootstrapContextForRun({
         workspaceDir: effectiveWorkspace,
         config: params.config,
@@ -374,11 +380,40 @@ export async function runEmbeddedAttempt(
       });
     const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
     const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
+    const bootstrapInjectedChars = bootstrapContextFiles.reduce(
+      (sum, file) => sum + file.content.length,
+      0,
+    );
+    const scopedWorkingMemory = params.workingMemoryPath
+      ? await loadScopedWorkingMemoryContextFile({
+          workspaceDir: effectiveWorkspace,
+          relativePath: params.workingMemoryPath,
+        })
+      : null;
+    const budgetedScopedWorkingMemory = scopedWorkingMemory
+      ? fitScopedWorkingMemoryContextFileToBudget({
+          loaded: scopedWorkingMemory,
+          maxChars: DEFAULT_SCOPED_WORKING_MEMORY_MAX_CHARS,
+          totalMaxChars: Math.max(0, bootstrapTotalMaxChars - bootstrapInjectedChars),
+          warn: (message) => log.warn(message),
+        })
+      : null;
+    const contextFiles = [
+      ...bootstrapContextFiles,
+      ...(budgetedScopedWorkingMemory?.contextFile
+        ? [budgetedScopedWorkingMemory.contextFile]
+        : []),
+    ];
     const bootstrapAnalysis = analyzeBootstrapBudget({
-      files: buildBootstrapInjectionStats({
-        bootstrapFiles: hookAdjustedBootstrapFiles,
-        injectedFiles: contextFiles,
-      }),
+      files: [
+        ...buildBootstrapInjectionStats({
+          bootstrapFiles: hookAdjustedBootstrapFiles,
+          injectedFiles: contextFiles,
+        }),
+        ...buildScopedWorkingMemoryInjectionStats(
+          budgetedScopedWorkingMemory ? [budgetedScopedWorkingMemory.file] : [],
+        ),
+      ],
       bootstrapMaxChars,
       bootstrapTotalMaxChars,
     });
@@ -393,7 +428,15 @@ export async function runEmbeddedAttempt(
       (file) => file.name === DEFAULT_BOOTSTRAP_FILENAME && !file.missing,
     )
       ? ["Reminder: commit your changes in this workspace after edits."]
-      : undefined;
+      : [];
+    if (
+      budgetedScopedWorkingMemory?.contextFile &&
+      budgetedScopedWorkingMemory.file.status === "loaded"
+    ) {
+      workspaceNotes.push(
+        `Scoped working memory for this run: ${budgetedScopedWorkingMemory.file.path} (separate from MEMORY.md and searchable durable notes).`,
+      );
+    }
 
     const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
 
@@ -419,64 +462,65 @@ export async function runEmbeddedAttempt(
       ? []
       : (() => {
           const allTools = createOpenClawCodingTools({
-          agentId: sessionAgentId,
-          trigger: params.trigger,
-          memoryFlushWritePath: params.memoryFlushWritePath,
-          exec: {
-            ...params.execOverrides,
-            elevated: params.bashElevated,
-          },
-          sandbox,
-          messageProvider: params.messageChannel ?? params.messageProvider,
-          agentAccountId: params.agentAccountId,
-          messageTo: params.messageTo,
-          messageThreadId: params.messageThreadId,
-          groupId: params.groupId,
-          groupChannel: params.groupChannel,
-          groupSpace: params.groupSpace,
-          spawnedBy: params.spawnedBy,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
-          senderIsOwner: params.senderIsOwner,
-          allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-          sessionKey: sandboxSessionKey,
-          sessionId: params.sessionId,
-          runId: params.runId,
-          agentDir,
-          workspaceDir: effectiveWorkspace,
-          // When sandboxing uses a copied workspace (`ro` or `none`), effectiveWorkspace points
-          // at the sandbox copy. Spawned subagents should inherit the real workspace instead.
-          spawnWorkspaceDir: resolveAttemptSpawnWorkspaceDir({
+            agentId: sessionAgentId,
+            trigger: params.trigger,
+            memoryFlushWritePath: params.memoryFlushWritePath,
+            workingMemoryPath: params.workingMemoryPath,
+            exec: {
+              ...params.execOverrides,
+              elevated: params.bashElevated,
+            },
             sandbox,
-            resolvedWorkspace,
-          }),
-          config: params.config,
-          abortSignal: runAbortController.signal,
-          modelProvider: params.model.provider,
-          modelId: params.modelId,
-          modelCompat: params.model.compat,
-          modelApi: params.model.api,
-          modelContextWindowTokens: params.model.contextWindow,
-          modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
-          currentChannelId: params.currentChannelId,
-          currentThreadTs: params.currentThreadTs,
-          currentMessageId: params.currentMessageId,
-          replyToMode: params.replyToMode,
-          hasRepliedRef: params.hasRepliedRef,
-          modelHasVision,
-          requireExplicitMessageTarget:
-            params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
-          disableMessageTool: params.disableMessageTool,
-          onYield: (message) => {
-            yieldDetected = true;
-            yieldMessage = message;
-            queueYieldInterruptForSession?.();
-            runAbortController.abort("sessions_yield");
-            abortSessionForYield?.();
-          },
-        });
+            messageProvider: params.messageChannel ?? params.messageProvider,
+            agentAccountId: params.agentAccountId,
+            messageTo: params.messageTo,
+            messageThreadId: params.messageThreadId,
+            groupId: params.groupId,
+            groupChannel: params.groupChannel,
+            groupSpace: params.groupSpace,
+            spawnedBy: params.spawnedBy,
+            senderId: params.senderId,
+            senderName: params.senderName,
+            senderUsername: params.senderUsername,
+            senderE164: params.senderE164,
+            senderIsOwner: params.senderIsOwner,
+            allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+            sessionKey: sandboxSessionKey,
+            sessionId: params.sessionId,
+            runId: params.runId,
+            agentDir,
+            workspaceDir: effectiveWorkspace,
+            // When sandboxing uses a copied workspace (`ro` or `none`), effectiveWorkspace points
+            // at the sandbox copy. Spawned subagents should inherit the real workspace instead.
+            spawnWorkspaceDir: resolveAttemptSpawnWorkspaceDir({
+              sandbox,
+              resolvedWorkspace,
+            }),
+            config: params.config,
+            abortSignal: runAbortController.signal,
+            modelProvider: params.model.provider,
+            modelId: params.modelId,
+            modelCompat: params.model.compat,
+            modelApi: params.model.api,
+            modelContextWindowTokens: params.model.contextWindow,
+            modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
+            currentChannelId: params.currentChannelId,
+            currentThreadTs: params.currentThreadTs,
+            currentMessageId: params.currentMessageId,
+            replyToMode: params.replyToMode,
+            hasRepliedRef: params.hasRepliedRef,
+            modelHasVision,
+            requireExplicitMessageTarget:
+              params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
+            disableMessageTool: params.disableMessageTool,
+            onYield: (message) => {
+              yieldDetected = true;
+              yieldMessage = message;
+              queueYieldInterruptForSession?.();
+              runAbortController.abort("sessions_yield");
+              abortSessionForYield?.();
+            },
+          });
           if (params.toolsAllow && params.toolsAllow.length > 0) {
             const allowSet = new Set(params.toolsAllow);
             return allTools.filter((tool) => allowSet.has(tool.name));
@@ -621,7 +665,7 @@ export async function runEmbeddedAttempt(
     const promptMode = resolvePromptModeForSession(params.sessionKey);
 
     // When toolsAllow is set, use minimal prompt and strip skills catalog
-    const effectivePromptMode = params.toolsAllow?.length ? "minimal" as const : promptMode;
+    const effectivePromptMode = params.toolsAllow?.length ? ("minimal" as const) : promptMode;
     const effectiveSkillsPrompt = params.toolsAllow?.length ? undefined : skillsPrompt;
     const docsPath = await resolveOpenClawDocsPath({
       workspaceDir: effectiveWorkspace,
@@ -691,6 +735,9 @@ export async function runEmbeddedAttempt(
       systemPrompt: appendPrompt,
       bootstrapFiles: hookAdjustedBootstrapFiles,
       injectedFiles: contextFiles,
+      workingMemoryFiles: budgetedScopedWorkingMemory
+        ? [budgetedScopedWorkingMemory.file]
+        : undefined,
       skillsPrompt,
       tools: effectiveTools,
     });

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -36,6 +36,8 @@ export type RunEmbeddedPiAgentParams = {
   trigger?: EmbeddedRunTrigger;
   /** Relative workspace path that memory-triggered writes are allowed to append to. */
   memoryFlushWritePath?: string;
+  /** Relative workspace path for scoped working memory injected into isolated/lightweight runs. */
+  workingMemoryPath?: string;
   /** Delivery target (e.g. telegram:group:123:topic:456) for topic/thread routing. */
   messageTo?: string;
   /** Thread/topic identifier for routing replies to the originating thread. */

--- a/src/agents/pi-tools.scoped-working-memory.test.ts
+++ b/src/agents/pi-tools.scoped-working-memory.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { createOpenClawCodingTools } from "./pi-tools.js";
+
+describe("createOpenClawCodingTools scoped working memory", () => {
+  it("withholds durable-memory and recall tools when scoped working memory is enabled", () => {
+    const names = createOpenClawCodingTools({
+      sessionId: "session-1",
+      runId: "run-1",
+      workspaceDir: "/tmp/openclaw-workspace",
+      workingMemoryPath: ".openclaw/working-memory/cron/nightly.md",
+    }).map((tool) => tool.name);
+
+    expect(names).not.toContain("memory_search");
+    expect(names).not.toContain("memory_get");
+    expect(names.some((name) => name.startsWith("lcm_"))).toBe(false);
+    expect(names).toContain("read");
+    expect(names).toContain("write");
+  });
+});

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -234,6 +234,8 @@ export function createOpenClawCodingTools(options?: {
   trigger?: string;
   /** Relative workspace path that memory-triggered writes may append to. */
   memoryFlushWritePath?: string;
+  /** Relative workspace path for scoped working memory in isolated/lightweight runs. */
+  workingMemoryPath?: string;
   agentDir?: string;
   workspaceDir?: string;
   /**
@@ -305,6 +307,7 @@ export function createOpenClawCodingTools(options?: {
     throw new Error("memoryFlushWritePath required for memory-triggered tool runs");
   }
   const memoryFlushWritePath = isMemoryFlushRun ? options.memoryFlushWritePath : undefined;
+  const scopedWorkingMemoryEnabled = Boolean(options?.workingMemoryPath);
   const {
     agentId,
     globalPolicy,
@@ -594,8 +597,14 @@ export function createOpenClawCodingTools(options?: {
           return [tool];
         })
       : tools;
+  const toolsForScopedWorkingMemory = scopedWorkingMemoryEnabled
+    ? toolsForMemoryFlush.filter(
+        (tool) =>
+          tool.name !== "memory_search" && tool.name !== "memory_get" && !/^lcm_/i.test(tool.name),
+      )
+    : toolsForMemoryFlush;
   const toolsForMessageProvider = applyMessageProviderToolPolicy(
-    toolsForMemoryFlush,
+    toolsForScopedWorkingMemory,
     options?.messageProvider,
   );
   const toolsForModelProvider = applyModelProviderToolPolicy(toolsForMessageProvider, {

--- a/src/agents/scoped-working-memory.test.ts
+++ b/src/agents/scoped-working-memory.test.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildScopedWorkingMemoryInjectionStats,
+  defaultCronWorkingMemoryPath,
+  fitScopedWorkingMemoryContextFileToBudget,
+  loadScopedWorkingMemoryContextFile,
+  normalizeScopedWorkingMemoryPath,
+} from "./scoped-working-memory.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("scoped working memory helpers", () => {
+  it("builds a stable default cron working-memory path", () => {
+    expect(defaultCronWorkingMemoryPath("nightly privacy watch")).toBe(
+      ".openclaw/working-memory/cron/nightly-privacy-watch.md",
+    );
+  });
+
+  it("rejects paths outside the scoped working-memory root", () => {
+    expect(() => normalizeScopedWorkingMemoryPath("MEMORY.md")).toThrow(
+      /must live under .openclaw\/working-memory\//,
+    );
+  });
+
+  it("loads scoped working-memory files from the workspace", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-working-memory-"));
+    tempDirs.push(workspaceDir);
+    const relativePath = ".openclaw/working-memory/cron/nightly.md";
+    const absolutePath = path.join(workspaceDir, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, "Current state\n- keep it scoped\n", "utf8");
+
+    const loaded = await loadScopedWorkingMemoryContextFile({
+      workspaceDir,
+      relativePath,
+    });
+
+    expect(loaded.contextFile).toEqual({
+      path: relativePath,
+      content: "Current state\n- keep it scoped\n",
+    });
+    expect(loaded.file).toEqual({
+      path: relativePath,
+      status: "loaded",
+      rawChars: "Current state\n- keep it scoped\n".length,
+      injectedChars: "Current state\n- keep it scoped\n".length,
+    });
+  });
+
+  it("truncates scoped working memory to fit the configured prompt budget", () => {
+    const fitted = fitScopedWorkingMemoryContextFileToBudget({
+      loaded: {
+        contextFile: {
+          path: ".openclaw/working-memory/cron/nightly.md",
+          content: "abcdefghijklmnopqrstuvwxyz",
+        },
+        file: {
+          path: ".openclaw/working-memory/cron/nightly.md",
+          status: "loaded",
+          rawChars: 26,
+          injectedChars: 26,
+        },
+      },
+      maxChars: 10,
+      totalMaxChars: 1_000,
+    });
+
+    expect(fitted.contextFile).toEqual({
+      path: ".openclaw/working-memory/cron/nightly.md",
+      content: "abcdefghij",
+    });
+    expect(fitted.file).toEqual({
+      path: ".openclaw/working-memory/cron/nightly.md",
+      status: "loaded",
+      rawChars: 26,
+      injectedChars: 10,
+    });
+  });
+
+  it("marks scoped working memory as present-not-injected when prompt budget is exhausted", () => {
+    const fitted = fitScopedWorkingMemoryContextFileToBudget({
+      loaded: {
+        contextFile: {
+          path: ".openclaw/working-memory/cron/nightly.md",
+          content: "abcdefghijklmnopqrstuvwxyz",
+        },
+        file: {
+          path: ".openclaw/working-memory/cron/nightly.md",
+          status: "loaded",
+          rawChars: 26,
+          injectedChars: 26,
+        },
+      },
+      maxChars: 26,
+      totalMaxChars: 100,
+    });
+
+    const stats = buildScopedWorkingMemoryInjectionStats([fitted.file]);
+    expect(fitted.contextFile).toBeUndefined();
+    expect(fitted.file).toEqual({
+      path: ".openclaw/working-memory/cron/nightly.md",
+      status: "present-not-injected",
+      rawChars: 26,
+      injectedChars: 0,
+      reason: "budget",
+    });
+    expect(stats).toEqual([
+      {
+        name: "nightly.md",
+        path: ".openclaw/working-memory/cron/nightly.md",
+        missing: false,
+        rawChars: 26,
+        injectedChars: 0,
+        truncated: true,
+      },
+    ]);
+  });
+});

--- a/src/agents/scoped-working-memory.ts
+++ b/src/agents/scoped-working-memory.ts
@@ -1,0 +1,194 @@
+import syncFs from "node:fs";
+import path from "node:path";
+import { openBoundaryFile } from "../infra/boundary-file-read.js";
+import { resolveUserPath } from "../utils.js";
+import type { BootstrapInjectionStat } from "./bootstrap-budget.js";
+import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
+
+const MAX_SCOPED_WORKING_MEMORY_BYTES = 2 * 1024 * 1024;
+export const DEFAULT_SCOPED_WORKING_MEMORY_MAX_CHARS = 10_000;
+const MIN_SCOPED_WORKING_MEMORY_BUDGET_CHARS = 256;
+const SCOPED_WORKING_MEMORY_ROOT = ".openclaw/working-memory";
+
+export function getScopedWorkingMemoryRoot(): string {
+  return SCOPED_WORKING_MEMORY_ROOT;
+}
+
+export function defaultCronWorkingMemoryPath(jobId: string): string {
+  const safeJobId = jobId.trim().replace(/[^a-zA-Z0-9._-]+/g, "-");
+  return path.posix.join(SCOPED_WORKING_MEMORY_ROOT, "cron", `${safeJobId || "job"}.md`);
+}
+
+export function normalizeScopedWorkingMemoryPath(relativePath: string): string {
+  const trimmed = relativePath.trim();
+  if (!trimmed) {
+    throw new Error("workingMemoryPath must not be empty");
+  }
+  if (/^[a-zA-Z]:[\\/]/.test(trimmed) || trimmed.startsWith("/") || trimmed.startsWith("\\\\")) {
+    throw new Error("workingMemoryPath must be a workspace-relative path");
+  }
+  const normalized = path.posix.normalize(trimmed.replace(/\\/g, "/"));
+  if (normalized === "." || normalized.startsWith("../") || normalized.includes("/../")) {
+    throw new Error("workingMemoryPath must stay inside the workspace");
+  }
+  if (!normalized.toLowerCase().endsWith(".md")) {
+    throw new Error("workingMemoryPath must point to a markdown file");
+  }
+  const scopedRootPrefix = `${SCOPED_WORKING_MEMORY_ROOT}/`;
+  if (normalized !== SCOPED_WORKING_MEMORY_ROOT && !normalized.startsWith(scopedRootPrefix)) {
+    throw new Error(`workingMemoryPath must live under ${SCOPED_WORKING_MEMORY_ROOT}/`);
+  }
+  return normalized;
+}
+
+function isMissingFileError(error: unknown): boolean {
+  const code =
+    typeof error === "object" && error !== null && "code" in error ? String(error.code) : "";
+  return code === "ENOENT" || code === "ENOTDIR" || code === "ELOOP";
+}
+
+function clampToBudget(content: string, maxChars: number): string {
+  if (maxChars <= 0) {
+    return "";
+  }
+  return content.length <= maxChars ? content : content.slice(0, maxChars);
+}
+
+export type ScopedWorkingMemoryStatus = "loaded" | "missing" | "present-not-injected" | "rejected";
+
+export type ScopedWorkingMemoryReason = "path" | "validation" | "io" | "budget";
+
+export type ScopedWorkingMemoryFile = {
+  path: string;
+  status: ScopedWorkingMemoryStatus;
+  rawChars: number;
+  injectedChars: number;
+  reason?: ScopedWorkingMemoryReason;
+};
+
+export async function loadScopedWorkingMemoryContextFile(params: {
+  workspaceDir: string;
+  relativePath: string;
+}): Promise<{
+  contextFile?: EmbeddedContextFile;
+  file: ScopedWorkingMemoryFile;
+}> {
+  const workspaceDir = resolveUserPath(params.workspaceDir);
+  const relativePath = normalizeScopedWorkingMemoryPath(params.relativePath);
+  const absolutePath = path.resolve(workspaceDir, relativePath);
+
+  const opened = await openBoundaryFile({
+    absolutePath,
+    rootPath: workspaceDir,
+    boundaryLabel: "workspace root",
+    maxBytes: MAX_SCOPED_WORKING_MEMORY_BYTES,
+  });
+  if (!opened.ok) {
+    const status =
+      opened.reason === "path" && isMissingFileError(opened.error) ? "missing" : "rejected";
+    return {
+      file: {
+        path: relativePath,
+        status,
+        rawChars: 0,
+        injectedChars: 0,
+        ...(status === "rejected" ? { reason: opened.reason } : {}),
+      },
+    };
+  }
+
+  try {
+    const content = syncFs.readFileSync(opened.fd, "utf-8");
+    return {
+      contextFile: { path: relativePath, content },
+      file: {
+        path: relativePath,
+        status: "loaded",
+        rawChars: content.length,
+        injectedChars: content.length,
+      },
+    };
+  } finally {
+    syncFs.closeSync(opened.fd);
+  }
+}
+
+export function fitScopedWorkingMemoryContextFileToBudget(params: {
+  loaded: {
+    contextFile?: EmbeddedContextFile;
+    file: ScopedWorkingMemoryFile;
+  };
+  maxChars?: number;
+  totalMaxChars?: number;
+  warn?: (message: string) => void;
+}): {
+  contextFile?: EmbeddedContextFile;
+  file: ScopedWorkingMemoryFile;
+} {
+  const contextFile = params.loaded.contextFile;
+  const file = params.loaded.file;
+  if (!contextFile || file.status !== "loaded") {
+    return params.loaded;
+  }
+
+  const requestedMaxChars =
+    typeof params.maxChars === "number" && Number.isFinite(params.maxChars) && params.maxChars > 0
+      ? Math.floor(params.maxChars)
+      : DEFAULT_SCOPED_WORKING_MEMORY_MAX_CHARS;
+  const requestedTotalMaxChars =
+    typeof params.totalMaxChars === "number" && Number.isFinite(params.totalMaxChars)
+      ? Math.max(0, Math.floor(params.totalMaxChars))
+      : requestedMaxChars;
+  const availableChars = Math.min(requestedMaxChars, requestedTotalMaxChars);
+  const rawContent = contextFile.content;
+  const rawChars = rawContent.length;
+
+  if (requestedTotalMaxChars < MIN_SCOPED_WORKING_MEMORY_BUDGET_CHARS) {
+    params.warn?.(
+      `scoped working memory ${file.path} is available but only ${requestedTotalMaxChars} chars of prompt budget remain (<${MIN_SCOPED_WORKING_MEMORY_BUDGET_CHARS}); skipping injection`,
+    );
+    return {
+      file: {
+        path: file.path,
+        status: "present-not-injected",
+        rawChars,
+        injectedChars: 0,
+        reason: "budget",
+      },
+    };
+  }
+
+  const injectedContent = clampToBudget(rawContent, availableChars);
+  if (injectedContent.length < rawChars) {
+    params.warn?.(
+      `scoped working memory ${file.path} is ${rawChars} chars (limit ${availableChars}); truncating in injected context`,
+    );
+  }
+
+  return {
+    contextFile: {
+      path: contextFile.path,
+      content: injectedContent,
+    },
+    file: {
+      path: file.path,
+      status: "loaded",
+      rawChars,
+      injectedChars: injectedContent.length,
+    },
+  };
+}
+
+export function buildScopedWorkingMemoryInjectionStats(
+  files: ScopedWorkingMemoryFile[],
+): BootstrapInjectionStat[] {
+  return files.map((file) => ({
+    name: path.posix.basename(file.path) || file.path,
+    path: file.path,
+    missing: file.status === "missing",
+    rawChars: file.rawChars,
+    injectedChars: file.injectedChars,
+    truncated:
+      file.status !== "missing" && file.status !== "rejected" && file.injectedChars < file.rawChars,
+  }));
+}

--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -193,4 +193,42 @@ describe("buildSystemPromptReport", () => {
       },
     ]);
   });
+
+  it("reports scoped working memory separately from startup/searchable memory", () => {
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [],
+      injectedFiles: [
+        {
+          path: ".openclaw/working-memory/cron/nightly.md",
+          content: "current focus\n- tighten cron privacy",
+        },
+      ],
+      workingMemoryFiles: [
+        {
+          path: ".openclaw/working-memory/cron/nightly.md",
+          status: "loaded",
+          rawChars: 36,
+          injectedChars: 36,
+        },
+      ],
+      skillsPrompt: "",
+      tools: [],
+    });
+
+    expect(report.memory?.working).toEqual({
+      enabled: true,
+      files: [
+        {
+          path: ".openclaw/working-memory/cron/nightly.md",
+          status: "loaded",
+          rawChars: 36,
+          injectedChars: 36,
+        },
+      ],
+    });
+  });
 });

--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -112,4 +112,85 @@ describe("buildSystemPromptReport", () => {
 
     expect(report.injectedWorkspaceFiles[0]?.injectedChars).toBe("trimmed".length);
   });
+
+  it("classifies startup memory separately from searchable memory and recall tools", () => {
+    const memoryFile = makeBootstrapFile({
+      name: "MEMORY.md",
+      path: "/tmp/workspace/MEMORY.md",
+      content: "durable facts",
+    });
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [memoryFile],
+      injectedFiles: [{ path: "/tmp/workspace/MEMORY.md", content: "durable facts" }],
+      skillsPrompt: "",
+      tools: [
+        {
+          name: "memory_search",
+          description: "Search memory",
+          parameters: { type: "object", properties: {} },
+        },
+        {
+          name: "memory_get",
+          description: "Read memory",
+          parameters: { type: "object", properties: {} },
+        },
+        {
+          name: "lcm_expand_query",
+          description: "Recall compacted context",
+          parameters: { type: "object", properties: {} },
+        },
+      ] as never,
+    });
+
+    expect(report.memory?.startup.files).toEqual([
+      {
+        name: "MEMORY.md",
+        path: "/tmp/workspace/MEMORY.md",
+        status: "loaded",
+        rawChars: "durable facts".length,
+        injectedChars: "durable facts".length,
+      },
+    ]);
+    expect(report.memory?.searchable).toEqual({
+      available: true,
+      toolNames: ["memory_search", "memory_get"],
+      noteRoots: ["memory/"],
+    });
+    expect(report.memory?.recall).toEqual({
+      available: true,
+      toolNames: ["lcm_expand_query"],
+    });
+  });
+
+  it("marks startup memory as present-not-injected when scoped sessions omit it", () => {
+    const memoryFile = makeBootstrapFile({
+      name: "MEMORY.md",
+      path: "/tmp/workspace/MEMORY.md",
+      content: "durable facts",
+    });
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [memoryFile],
+      injectedFiles: [],
+      skillsPrompt: "",
+      tools: [],
+    });
+
+    expect(report.memory?.startup.files).toEqual([
+      {
+        name: "MEMORY.md",
+        path: "/tmp/workspace/MEMORY.md",
+        status: "present-not-injected",
+        rawChars: "durable facts".length,
+        injectedChars: 0,
+      },
+    ]);
+  });
 });

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -4,6 +4,13 @@ import { buildBootstrapInjectionStats } from "./bootstrap-budget.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
+const STARTUP_MEMORY_FILE_NAMES = new Set(["MEMORY.md", "memory.md"]);
+const SEARCHABLE_MEMORY_TOOL_NAMES = new Set(["memory_search", "memory_get"]);
+
+function isConversationRecallTool(name: string): boolean {
+  return /^lcm_/i.test(name);
+}
+
 function extractBetween(
   input: string,
   startMarker: string,
@@ -107,6 +114,27 @@ export function buildSystemPromptReport(params: {
   const toolsEntries = buildToolsEntries(params.tools);
   const toolsSchemaChars = toolsEntries.reduce((sum, t) => sum + (t.schemaChars ?? 0), 0);
   const skillsEntries = parseSkillBlocks(params.skillsPrompt);
+  const injectedWorkspaceFiles = buildBootstrapInjectionStats({
+    bootstrapFiles: params.bootstrapFiles,
+    injectedFiles: params.injectedFiles,
+  });
+  const startupMemoryFiles = injectedWorkspaceFiles
+    .filter((file) => STARTUP_MEMORY_FILE_NAMES.has(file.name))
+    .map((file) => ({
+      name: file.name,
+      path: file.path,
+      status: file.missing
+        ? ("missing" as const)
+        : file.injectedChars > 0
+          ? ("loaded" as const)
+          : ("present-not-injected" as const),
+      rawChars: file.rawChars,
+      injectedChars: file.injectedChars,
+    }));
+  const searchableMemoryTools = toolsEntries
+    .map((tool) => tool.name)
+    .filter((name) => SEARCHABLE_MEMORY_TOOL_NAMES.has(name));
+  const recallTools = toolsEntries.map((tool) => tool.name).filter(isConversationRecallTool);
 
   return {
     source: params.source,
@@ -125,10 +153,21 @@ export function buildSystemPromptReport(params: {
       projectContextChars,
       nonProjectContextChars: Math.max(0, systemPrompt.length - projectContextChars),
     },
-    injectedWorkspaceFiles: buildBootstrapInjectionStats({
-      bootstrapFiles: params.bootstrapFiles,
-      injectedFiles: params.injectedFiles,
-    }),
+    memory: {
+      startup: {
+        files: startupMemoryFiles,
+      },
+      searchable: {
+        available: searchableMemoryTools.length > 0,
+        toolNames: searchableMemoryTools,
+        noteRoots: ["memory/"],
+      },
+      recall: {
+        available: recallTools.length > 0,
+        toolNames: recallTools,
+      },
+    },
+    injectedWorkspaceFiles,
     skills: {
       promptChars: params.skillsPrompt.length,
       entries: skillsEntries,

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -2,6 +2,7 @@ import type { AgentTool } from "@mariozechner/pi-agent-core";
 import type { SessionSystemPromptReport } from "../config/sessions/types.js";
 import { buildBootstrapInjectionStats } from "./bootstrap-budget.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
+import type { ScopedWorkingMemoryFile } from "./scoped-working-memory.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
 const STARTUP_MEMORY_FILE_NAMES = new Set(["MEMORY.md", "memory.md"]);
@@ -99,6 +100,7 @@ export function buildSystemPromptReport(params: {
   systemPrompt: string;
   bootstrapFiles: WorkspaceBootstrapFile[];
   injectedFiles: EmbeddedContextFile[];
+  workingMemoryFiles?: ScopedWorkingMemoryFile[];
   skillsPrompt: string;
   tools: AgentTool[];
 }): SessionSystemPromptReport {
@@ -156,6 +158,10 @@ export function buildSystemPromptReport(params: {
     memory: {
       startup: {
         files: startupMemoryFiles,
+      },
+      working: {
+        enabled: (params.workingMemoryFiles?.length ?? 0) > 0,
+        files: params.workingMemoryFiles ?? [],
       },
       searchable: {
         available: searchableMemoryTools.length > 0,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -440,6 +440,7 @@ export async function runAgentTurnWithFallback(params: {
                 })(),
                 suppressToolErrorWarnings: params.opts?.suppressToolErrorWarnings,
                 bootstrapContextMode: params.opts?.bootstrapContextMode,
+                workingMemoryPath: params.opts?.workingMemoryPath,
                 bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
                 images: params.opts?.images,
                 imageOrder: params.opts?.imageOrder,

--- a/src/auto-reply/reply/commands-context-report.test.ts
+++ b/src/auto-reply/reply/commands-context-report.test.ts
@@ -69,6 +69,12 @@ function makeParams(
           projectContextChars: 500,
           nonProjectContextChars: 500,
         },
+        memory: {
+          startup: { files: [] },
+          working: { enabled: false, files: [] },
+          searchable: { available: false, toolNames: [], noteRoots: ["memory/"] },
+          recall: { available: false, toolNames: [] },
+        },
         injectedWorkspaceFiles,
         skills: {
           promptChars: 10,
@@ -93,13 +99,13 @@ describe("buildContextReply", () => {
   it("shows bootstrap truncation warning in list output when context exceeds configured limits", async () => {
     const result = await buildContextReply(makeParams("/context list", true));
     expect(result.text).toContain("Bootstrap max/total: 150,000 chars");
-    expect(result.text).toContain("⚠ Bootstrap context is over configured limits");
+    expect(result.text).toContain("⚠ Injected startup/working context is over configured limits");
     expect(result.text).toContain("Causes: 1 file(s) exceeded max/file.");
   });
 
   it("does not show bootstrap truncation warning when there is no truncation", async () => {
     const result = await buildContextReply(makeParams("/context list", false));
-    expect(result.text).not.toContain("Bootstrap context is over configured limits");
+    expect(result.text).not.toContain("Injected startup/working context is over configured limits");
   });
 
   it("falls back to config defaults when legacy reports are missing bootstrap limits", async () => {
@@ -114,12 +120,13 @@ describe("buildContextReply", () => {
   });
 
   it("synthesizes memory-layer output for legacy cached reports", async () => {
-    const result = await buildContextReply(
-      makeParams("/context list", false, {
-        includeLegacyMemoryFile: true,
-        includeMemoryTools: true,
-      }),
-    );
+    const params = makeParams("/context list", false, {
+      includeLegacyMemoryFile: true,
+      includeMemoryTools: true,
+    });
+    delete params.sessionEntry!.systemPromptReport!.memory;
+
+    const result = await buildContextReply(params);
     expect(result.text).toContain("Startup memory: MEMORY.md (present, not startup-injected)");
     expect(result.text).toContain(
       "Searchable memory: on-demand via memory_search, memory_get (note roots: memory/)",
@@ -127,5 +134,97 @@ describe("buildContextReply", () => {
     expect(result.text).toContain(
       "Conversation recall: separate from durable memory via lcm_expand_query",
     );
+  });
+
+  it("shows scoped working-memory files when present", async () => {
+    const params = makeParams("/context list", false);
+    params.sessionEntry!.systemPromptReport!.memory = {
+      startup: { files: [] },
+      working: {
+        enabled: true,
+        files: [
+          {
+            path: ".openclaw/working-memory/cron/nightly.md",
+            status: "loaded",
+            rawChars: 42,
+            injectedChars: 42,
+          },
+        ],
+      },
+      searchable: { available: false, toolNames: [], noteRoots: ["memory/"] },
+      recall: { available: false, toolNames: [] },
+    };
+
+    const result = await buildContextReply(params);
+    expect(result.text).toContain(
+      "Working memory: .openclaw/working-memory/cron/nightly.md (loaded; raw 42 chars (~11 tok) | injected 42 chars (~11 tok))",
+    );
+  });
+
+  it("deep-backfills partially migrated cached memory reports", async () => {
+    const params = makeParams("/context list", false);
+    params.sessionEntry!.systemPromptReport!.memory = {
+      startup: {
+        files: [
+          {
+            name: "MEMORY.md",
+            path: "/tmp/workspace/MEMORY.md",
+            status: "present-not-injected",
+            rawChars: 500,
+            injectedChars: 0,
+          },
+        ],
+      },
+      searchable: {
+        available: true,
+        toolNames: ["memory_search", "memory_get"],
+        noteRoots: ["memory/", "notes/"],
+      },
+      recall: {
+        available: true,
+        toolNames: ["lcm_expand_query"],
+      },
+    } as NonNullable<
+      NonNullable<HandleCommandsParams["sessionEntry"]>["systemPromptReport"]
+    >["memory"];
+    delete (params.sessionEntry!.systemPromptReport!.memory as { working?: unknown }).working;
+
+    const result = await buildContextReply(params);
+    expect(result.text).toContain("Startup memory: MEMORY.md (present, not startup-injected)");
+    expect(result.text).toContain("Working memory: none configured for this run");
+    expect(result.text).toContain(
+      "Searchable memory: on-demand via memory_search, memory_get (note roots: memory/, notes/)",
+    );
+    expect(result.text).toContain(
+      "Conversation recall: separate from durable memory via lcm_expand_query",
+    );
+  });
+
+  it("counts scoped working memory in truncation warnings", async () => {
+    const params = makeParams("/context list", false);
+    params.sessionEntry!.systemPromptReport!.memory = {
+      startup: { files: [] },
+      working: {
+        enabled: true,
+        files: [
+          {
+            path: ".openclaw/working-memory/cron/nightly.md",
+            status: "loaded",
+            rawChars: 200_000,
+            injectedChars: 10_000,
+          },
+        ],
+      },
+      searchable: { available: false, toolNames: [], noteRoots: ["memory/"] },
+      recall: { available: false, toolNames: [] },
+    };
+
+    const result = await buildContextReply(params);
+    expect(result.text).toContain("⚠ Injected startup/working context is over configured limits");
+    expect(result.text).toContain("nightly.md");
+    expect(result.text).toContain(
+      "Scoped working memory note: this lane has its own max/file cap of 10,000 chars",
+    );
+    expect(result.text).toContain("Raising bootstrap limits alone will not remove that truncation");
   });
 });

--- a/src/auto-reply/reply/commands-context-report.test.ts
+++ b/src/auto-reply/reply/commands-context-report.test.ts
@@ -5,8 +5,40 @@ import type { HandleCommandsParams } from "./commands-types.js";
 function makeParams(
   commandBodyNormalized: string,
   truncated: boolean,
-  options?: { omitBootstrapLimits?: boolean },
+  options?: {
+    omitBootstrapLimits?: boolean;
+    includeLegacyMemoryFile?: boolean;
+    includeMemoryTools?: boolean;
+  },
 ): HandleCommandsParams {
+  const injectedWorkspaceFiles = [
+    {
+      name: "AGENTS.md",
+      path: "/tmp/workspace/AGENTS.md",
+      missing: false,
+      rawChars: truncated ? 200_000 : 10_000,
+      injectedChars: truncated ? 20_000 : 10_000,
+      truncated,
+    },
+  ];
+  if (options?.includeLegacyMemoryFile) {
+    injectedWorkspaceFiles.push({
+      name: "MEMORY.md",
+      path: "/tmp/workspace/MEMORY.md",
+      missing: false,
+      rawChars: 500,
+      injectedChars: 0,
+      truncated: true,
+    });
+  }
+  const toolEntries = [{ name: "read", summaryChars: 10, schemaChars: 20, propertiesCount: 1 }];
+  if (options?.includeMemoryTools) {
+    toolEntries.push(
+      { name: "memory_search", summaryChars: 10, schemaChars: 20, propertiesCount: 1 },
+      { name: "memory_get", summaryChars: 10, schemaChars: 20, propertiesCount: 1 },
+      { name: "lcm_expand_query", summaryChars: 10, schemaChars: 20, propertiesCount: 1 },
+    );
+  }
   return {
     command: {
       commandBodyNormalized,
@@ -37,16 +69,7 @@ function makeParams(
           projectContextChars: 500,
           nonProjectContextChars: 500,
         },
-        injectedWorkspaceFiles: [
-          {
-            name: "AGENTS.md",
-            path: "/tmp/workspace/AGENTS.md",
-            missing: false,
-            rawChars: truncated ? 200_000 : 10_000,
-            injectedChars: truncated ? 20_000 : 10_000,
-            truncated,
-          },
-        ],
+        injectedWorkspaceFiles,
         skills: {
           promptChars: 10,
           entries: [{ name: "checks", blockChars: 10 }],
@@ -54,7 +77,7 @@ function makeParams(
         tools: {
           listChars: 10,
           schemaChars: 20,
-          entries: [{ name: "read", summaryChars: 10, schemaChars: 20, propertiesCount: 1 }],
+          entries: toolEntries,
         },
       },
     },
@@ -88,5 +111,21 @@ describe("buildContextReply", () => {
     expect(result.text).toContain("Bootstrap max/file: 20,000 chars");
     expect(result.text).toContain("Bootstrap max/total: 150,000 chars");
     expect(result.text).not.toContain("Bootstrap max/file: ? chars");
+  });
+
+  it("synthesizes memory-layer output for legacy cached reports", async () => {
+    const result = await buildContextReply(
+      makeParams("/context list", false, {
+        includeLegacyMemoryFile: true,
+        includeMemoryTools: true,
+      }),
+    );
+    expect(result.text).toContain("Startup memory: MEMORY.md (present, not startup-injected)");
+    expect(result.text).toContain(
+      "Searchable memory: on-demand via memory_search, memory_get (note roots: memory/)",
+    );
+    expect(result.text).toContain(
+      "Conversation recall: separate from durable memory via lcm_expand_query",
+    );
   });
 });

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -3,6 +3,7 @@ import {
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
 } from "../../agents/pi-embedded-helpers.js";
+import { DEFAULT_SCOPED_WORKING_MEMORY_MAX_CHARS } from "../../agents/scoped-working-memory.js";
 import { buildSystemPromptReport } from "../../agents/system-prompt-report.js";
 import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
 import { estimateTokensFromChars } from "../../utils/cjk-chars.js";
@@ -15,6 +16,8 @@ const SEARCHABLE_MEMORY_TOOL_NAMES = new Set(["memory_search", "memory_get"]);
 type SessionSystemPromptReportWithMemory = SessionSystemPromptReport & {
   memory: NonNullable<SessionSystemPromptReport["memory"]>;
 };
+
+type SessionMemoryReport = NonNullable<SessionSystemPromptReport["memory"]>;
 
 function isConversationRecallTool(name: string): boolean {
   return /^lcm_/i.test(name);
@@ -39,6 +42,30 @@ function formatStatusLabel(status: "loaded" | "present-not-injected" | "missing"
   }
 }
 
+function formatWorkingMemoryStatusLabel(
+  file: SessionSystemPromptReportWithMemory["memory"]["working"]["files"][number],
+): string {
+  const base = (() => {
+    switch (file.status) {
+      case "loaded":
+        return file.injectedChars < file.rawChars ? "loaded, truncated" : "loaded";
+      case "present-not-injected":
+        return "present, not injected";
+      case "missing":
+        return "missing";
+      case "rejected":
+        return file.reason ? `rejected (${file.reason})` : "rejected";
+    }
+  })();
+  if (file.status === "loaded") {
+    return `${base}; raw ${formatCharsAndTokens(file.rawChars)} | injected ${formatCharsAndTokens(file.injectedChars)}`;
+  }
+  if (file.rawChars > 0 || file.injectedChars > 0) {
+    return `${base}; raw ${formatCharsAndTokens(file.rawChars)} | injected ${formatCharsAndTokens(file.injectedChars)}`;
+  }
+  return base;
+}
+
 function formatMemoryBoundaryLines(report: SessionSystemPromptReportWithMemory): string[] {
   const startupFiles = report.memory.startup.files;
   const startupLine = startupFiles.length
@@ -46,6 +73,12 @@ function formatMemoryBoundaryLines(report: SessionSystemPromptReportWithMemory):
         .map((file) => `${file.name} (${formatStatusLabel(file.status)})`)
         .join(", ")}`
     : "Startup memory: none detected";
+
+  const workingLine = report.memory.working.enabled
+    ? `Working memory: ${report.memory.working.files
+        .map((file) => `${file.path} (${formatWorkingMemoryStatusLabel(file)})`)
+        .join(", ")}`
+    : "Working memory: none configured for this run";
 
   const searchableLine = report.memory.searchable.available
     ? `Searchable memory: on-demand via ${report.memory.searchable.toolNames.join(", ")} (note roots: ${report.memory.searchable.noteRoots.join(", ")})`
@@ -58,10 +91,46 @@ function formatMemoryBoundaryLines(report: SessionSystemPromptReportWithMemory):
   return [
     "Memory layers:",
     startupLine,
+    workingLine,
     searchableLine,
     recallLine,
     "Rule of thumb: startup memory is preloaded, searchable memory is pulled on demand, and recall/history stays separate.",
   ];
+}
+
+function buildScopedWorkingMemoryWarningLines(
+  report: SessionSystemPromptReportWithMemory,
+): string[] {
+  const truncatedWorkingMemoryFiles = report.memory.working.files.filter(
+    (file) => file.status === "loaded" && file.injectedChars < file.rawChars,
+  );
+  if (truncatedWorkingMemoryFiles.length === 0) {
+    return [];
+  }
+
+  const cappedFiles = truncatedWorkingMemoryFiles.filter(
+    (file) => file.rawChars > DEFAULT_SCOPED_WORKING_MEMORY_MAX_CHARS,
+  );
+  const lines = [
+    `Scoped working memory note: this lane has its own max/file cap of ${formatInt(DEFAULT_SCOPED_WORKING_MEMORY_MAX_CHARS)} chars and also shares the remaining bootstrap total budget.`,
+  ];
+  if (cappedFiles.length > 0) {
+    lines.push(
+      `${cappedFiles.length} scoped working-memory file(s) exceeded that dedicated ${formatInt(DEFAULT_SCOPED_WORKING_MEMORY_MAX_CHARS)}-char cap. Raising bootstrap limits alone will not remove that truncation.`,
+    );
+  }
+  if (
+    truncatedWorkingMemoryFiles.some(
+      (file) =>
+        file.injectedChars < file.rawChars &&
+        file.injectedChars < DEFAULT_SCOPED_WORKING_MEMORY_MAX_CHARS,
+    )
+  ) {
+    lines.push(
+      "Some scoped working-memory truncation may also come from the shared bootstrap total budget, so check both limits before increasing anything.",
+    );
+  }
+  return lines;
 }
 
 function parseContextArgs(commandBodyNormalized: string): string {
@@ -88,10 +157,6 @@ function formatListTop(
 function ensureMemoryReport(
   report: SessionSystemPromptReport,
 ): SessionSystemPromptReportWithMemory {
-  if (report.memory) {
-    return report as SessionSystemPromptReportWithMemory;
-  }
-
   const startupFiles = report.injectedWorkspaceFiles
     .filter((file) => STARTUP_MEMORY_FILE_NAMES.has(file.name))
     .map((file) => ({
@@ -106,21 +171,46 @@ function ensureMemoryReport(
       injectedChars: file.injectedChars,
     }));
   const toolNames = report.tools.entries.map((tool) => tool.name);
+  const existingMemory = (report.memory ?? {}) as Partial<SessionMemoryReport>;
+  const workingFiles = Array.isArray(existingMemory.working?.files)
+    ? existingMemory.working.files
+    : [];
 
   return {
     ...report,
     memory: {
       startup: {
-        files: startupFiles,
+        files: Array.isArray(existingMemory.startup?.files)
+          ? existingMemory.startup.files
+          : startupFiles,
+      },
+      working: {
+        enabled:
+          typeof existingMemory.working?.enabled === "boolean"
+            ? existingMemory.working.enabled
+            : workingFiles.length > 0,
+        files: workingFiles,
       },
       searchable: {
-        available: toolNames.some((name) => SEARCHABLE_MEMORY_TOOL_NAMES.has(name)),
-        toolNames: toolNames.filter((name) => SEARCHABLE_MEMORY_TOOL_NAMES.has(name)),
-        noteRoots: ["memory/"],
+        available:
+          typeof existingMemory.searchable?.available === "boolean"
+            ? existingMemory.searchable.available
+            : toolNames.some((name) => SEARCHABLE_MEMORY_TOOL_NAMES.has(name)),
+        toolNames: Array.isArray(existingMemory.searchable?.toolNames)
+          ? existingMemory.searchable.toolNames
+          : toolNames.filter((name) => SEARCHABLE_MEMORY_TOOL_NAMES.has(name)),
+        noteRoots: Array.isArray(existingMemory.searchable?.noteRoots)
+          ? existingMemory.searchable.noteRoots
+          : ["memory/"],
       },
       recall: {
-        available: toolNames.some(isConversationRecallTool),
-        toolNames: toolNames.filter(isConversationRecallTool),
+        available:
+          typeof existingMemory.recall?.available === "boolean"
+            ? existingMemory.recall.available
+            : toolNames.some(isConversationRecallTool),
+        toolNames: Array.isArray(existingMemory.recall?.toolNames)
+          ? existingMemory.recall.toolNames
+          : toolNames.filter(isConversationRecallTool),
       },
     },
   };
@@ -242,7 +332,20 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
   const bootstrapMaxLabel = `${formatInt(bootstrapMaxChars)} chars`;
   const bootstrapTotalLabel = `${formatInt(bootstrapTotalMaxChars)} chars`;
   const bootstrapAnalysis = analyzeBootstrapBudget({
-    files: report.injectedWorkspaceFiles,
+    files: [
+      ...report.injectedWorkspaceFiles,
+      ...report.memory.working.files.map((file) => ({
+        name: file.path.split("/").pop() || file.path,
+        path: file.path,
+        missing: file.status === "missing",
+        rawChars: file.rawChars,
+        injectedChars: file.injectedChars,
+        truncated:
+          file.status !== "missing" &&
+          file.status !== "rejected" &&
+          file.injectedChars < file.rawChars,
+      })),
+    ],
     bootstrapMaxChars,
     bootstrapTotalMaxChars,
   });
@@ -269,11 +372,12 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
   const bootstrapWarningLines =
     truncatedBootstrapFiles.length > 0
       ? [
-          `⚠ Bootstrap context is over configured limits: ${truncatedBootstrapFiles.length} file(s) truncated (${formatInt(bootstrapAnalysis.totals.rawChars)} raw chars -> ${formatInt(bootstrapAnalysis.totals.injectedChars)} injected chars).`,
+          `⚠ Injected startup/working context is over configured limits: ${truncatedBootstrapFiles.length} file(s) truncated (${formatInt(bootstrapAnalysis.totals.rawChars)} raw chars -> ${formatInt(bootstrapAnalysis.totals.injectedChars)} injected chars).`,
           ...(truncationCauseParts.length ? [`Causes: ${truncationCauseParts.join("; ")}.`] : []),
           "Tip: increase `agents.defaults.bootstrapMaxChars` and/or `agents.defaults.bootstrapTotalMaxChars` if this truncation is not intentional.",
         ]
       : [];
+  const scopedWorkingMemoryWarningLines = buildScopedWorkingMemoryWarningLines(report);
 
   const totalsLine =
     session.totalTokens != null
@@ -286,6 +390,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     sandboxLine,
     systemPromptLine,
     ...(bootstrapWarningLines.length ? ["", ...bootstrapWarningLines] : []),
+    ...(scopedWorkingMemoryWarningLines.length ? ["", ...scopedWorkingMemoryWarningLines] : []),
     "",
     "Injected workspace files:",
     ...fileLines,

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -10,12 +10,58 @@ import type { ReplyPayload } from "../types.js";
 import { resolveCommandsSystemPromptBundle } from "./commands-system-prompt.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
+const STARTUP_MEMORY_FILE_NAMES = new Set(["MEMORY.md", "memory.md"]);
+const SEARCHABLE_MEMORY_TOOL_NAMES = new Set(["memory_search", "memory_get"]);
+type SessionSystemPromptReportWithMemory = SessionSystemPromptReport & {
+  memory: NonNullable<SessionSystemPromptReport["memory"]>;
+};
+
+function isConversationRecallTool(name: string): boolean {
+  return /^lcm_/i.test(name);
+}
+
 function formatInt(n: number): string {
   return new Intl.NumberFormat("en-US").format(n);
 }
 
 function formatCharsAndTokens(chars: number): string {
   return `${formatInt(chars)} chars (~${formatInt(estimateTokensFromChars(chars))} tok)`;
+}
+
+function formatStatusLabel(status: "loaded" | "present-not-injected" | "missing"): string {
+  switch (status) {
+    case "loaded":
+      return "loaded";
+    case "present-not-injected":
+      return "present, not startup-injected";
+    case "missing":
+      return "missing";
+  }
+}
+
+function formatMemoryBoundaryLines(report: SessionSystemPromptReportWithMemory): string[] {
+  const startupFiles = report.memory.startup.files;
+  const startupLine = startupFiles.length
+    ? `Startup memory: ${startupFiles
+        .map((file) => `${file.name} (${formatStatusLabel(file.status)})`)
+        .join(", ")}`
+    : "Startup memory: none detected";
+
+  const searchableLine = report.memory.searchable.available
+    ? `Searchable memory: on-demand via ${report.memory.searchable.toolNames.join(", ")} (note roots: ${report.memory.searchable.noteRoots.join(", ")})`
+    : "Searchable memory: no memory_search/memory_get tool exposed in this session";
+
+  const recallLine = report.memory.recall.available
+    ? `Conversation recall: separate from durable memory via ${report.memory.recall.toolNames.join(", ")}`
+    : "Conversation recall: no LCM recall tools exposed in this session";
+
+  return [
+    "Memory layers:",
+    startupLine,
+    searchableLine,
+    recallLine,
+    "Rule of thumb: startup memory is preloaded, searchable memory is pulled on demand, and recall/history stays separate.",
+  ];
 }
 
 function parseContextArgs(commandBodyNormalized: string): string {
@@ -39,12 +85,53 @@ function formatListTop(
   return { lines, omitted };
 }
 
+function ensureMemoryReport(
+  report: SessionSystemPromptReport,
+): SessionSystemPromptReportWithMemory {
+  if (report.memory) {
+    return report as SessionSystemPromptReportWithMemory;
+  }
+
+  const startupFiles = report.injectedWorkspaceFiles
+    .filter((file) => STARTUP_MEMORY_FILE_NAMES.has(file.name))
+    .map((file) => ({
+      name: file.name,
+      path: file.path,
+      status: file.missing
+        ? ("missing" as const)
+        : file.injectedChars > 0
+          ? ("loaded" as const)
+          : ("present-not-injected" as const),
+      rawChars: file.rawChars,
+      injectedChars: file.injectedChars,
+    }));
+  const toolNames = report.tools.entries.map((tool) => tool.name);
+
+  return {
+    ...report,
+    memory: {
+      startup: {
+        files: startupFiles,
+      },
+      searchable: {
+        available: toolNames.some((name) => SEARCHABLE_MEMORY_TOOL_NAMES.has(name)),
+        toolNames: toolNames.filter((name) => SEARCHABLE_MEMORY_TOOL_NAMES.has(name)),
+        noteRoots: ["memory/"],
+      },
+      recall: {
+        available: toolNames.some(isConversationRecallTool),
+        toolNames: toolNames.filter(isConversationRecallTool),
+      },
+    },
+  };
+}
+
 async function resolveContextReport(
   params: HandleCommandsParams,
-): Promise<SessionSystemPromptReport> {
+): Promise<SessionSystemPromptReportWithMemory> {
   const existing = params.sessionEntry?.systemPromptReport;
   if (existing && existing.source === "run") {
-    return existing;
+    return ensureMemoryReport(existing);
   }
 
   const bootstrapMaxChars = resolveBootstrapMaxChars(params.cfg);
@@ -68,7 +155,7 @@ async function resolveContextReport(
     injectedFiles,
     skillsPrompt,
     tools,
-  });
+  }) as SessionSystemPromptReportWithMemory;
 }
 
 export async function buildContextReply(params: HandleCommandsParams): Promise<ReplyPayload> {
@@ -81,6 +168,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
         "🧠 /context",
         "",
         "What counts as context (high-level), plus a breakdown mode.",
+        "Also shows the boundary between startup memory, searchable notes, and conversation recall.",
         "",
         "Try:",
         "- /context list   (short breakdown)",
@@ -201,6 +289,8 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     "",
     "Injected workspace files:",
     ...fileLines,
+    "",
+    ...formatMemoryBoundaryLines(report),
     "",
     skillsLine,
     skillsNamesLine,

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -46,6 +46,8 @@ export type GetReplyOptions = {
   heartbeatModelOverride?: string;
   /** Controls bootstrap workspace context injection (default: full). */
   bootstrapContextMode?: "full" | "lightweight";
+  /** Optional scoped working-memory file injected for this run. */
+  workingMemoryPath?: string;
   /** If true, suppress tool error warning payloads for this run. */
   suppressToolErrorWarnings?: boolean;
   onPartialReply?: (payload: ReplyPayload) => Promise<void> | void;

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -60,6 +60,7 @@ type CronUpdatePatch = {
       model?: string;
       thinking?: string;
       lightContext?: boolean;
+      workingMemoryPath?: string;
     };
     delivery?: {
       mode?: string;
@@ -73,7 +74,12 @@ type CronUpdatePatch = {
 
 type CronAddParams = {
   schedule?: { kind?: string; staggerMs?: number };
-  payload?: { model?: string; thinking?: string; lightContext?: boolean };
+  payload?: {
+    model?: string;
+    thinking?: string;
+    lightContext?: boolean;
+    workingMemoryPath?: string;
+  };
   delivery?: { mode?: string; accountId?: string };
   deleteAfterRun?: boolean;
   agentId?: string;
@@ -417,6 +423,40 @@ describe("cron cli", () => {
     expect(params?.payload?.lightContext).toBe(true);
   });
 
+  it("sets workingMemoryPath on cron add when --working-memory is passed", async () => {
+    const params = await runCronAddAndGetParams([
+      "--name",
+      "Scoped memory",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--working-memory",
+      " .openclaw/working-memory/cron/nightly.md ",
+    ]);
+
+    expect(params?.payload?.workingMemoryPath).toBe(".openclaw/working-memory/cron/nightly.md");
+  });
+
+  it("rejects invalid workingMemoryPath on cron add", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "add",
+      "--name",
+      "Scoped memory",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--working-memory",
+      "../outside.md",
+    ]);
+  });
+
   it.each([
     {
       label: "omits empty model and thinking",
@@ -465,6 +505,37 @@ describe("cron cli", () => {
 
     const clearPatch = await runCronEditAndGetPatch(["--no-light-context", "--message", "hello"]);
     expect(clearPatch?.patch?.payload?.lightContext).toBe(false);
+  });
+
+  it("sets and clears workingMemoryPath on cron edit", async () => {
+    const setPatch = await runCronEditAndGetPatch([
+      "--working-memory",
+      " .openclaw/working-memory/cron/privacy.md ",
+      "--message",
+      "hello",
+    ]);
+    expect(setPatch?.patch?.payload?.workingMemoryPath).toBe(
+      ".openclaw/working-memory/cron/privacy.md",
+    );
+
+    const clearPatch = await runCronEditAndGetPatch([
+      "--clear-working-memory",
+      "--message",
+      "hello",
+    ]);
+    expect(clearPatch?.patch?.payload?.workingMemoryPath).toBe("");
+  });
+
+  it("rejects invalid workingMemoryPath on cron edit", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "edit",
+      "job-1",
+      "--working-memory",
+      "../outside.md",
+      "--message",
+      "hello",
+    ]);
   });
 
   it("updates delivery settings without requiring --message", async () => {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { normalizeScopedWorkingMemoryPath } from "../../agents/scoped-working-memory.js";
 import type { CronJob } from "../../cron/types.js";
 import { sanitizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -89,6 +90,10 @@ export function registerCronAddCommand(cron: Command) {
       .option("--model <model>", "Model override for agent jobs (provider/model or alias)")
       .option("--timeout-seconds <n>", "Timeout seconds for agent jobs")
       .option("--light-context", "Use lightweight bootstrap context for agent jobs", false)
+      .option(
+        "--working-memory <path>",
+        "Workspace-relative scoped working-memory markdown file (e.g. .openclaw/working-memory/cron/nightly.md)",
+      )
       .option("--tools <csv>", "Comma-separated tool allow-list (e.g. exec,read,write)")
       .option("--announce", "Announce summary to a chat (subagent-style)", false)
       .option("--deliver", "Deprecated (use --announce). Announces a summary to a chat.")
@@ -153,6 +158,10 @@ export function registerCronAddCommand(cron: Command) {
               timeoutSeconds:
                 timeoutSeconds && Number.isFinite(timeoutSeconds) ? timeoutSeconds : undefined,
               lightContext: opts.lightContext === true ? true : undefined,
+              workingMemoryPath:
+                typeof opts.workingMemory === "string" && opts.workingMemory.trim()
+                  ? normalizeScopedWorkingMemoryPath(opts.workingMemory)
+                  : undefined,
               toolsAllow:
                 typeof opts.tools === "string" && opts.tools.trim()
                   ? opts.tools

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { normalizeScopedWorkingMemoryPath } from "../../agents/scoped-working-memory.js";
 import type { CronJob } from "../../cron/types.js";
 import { danger } from "../../globals.js";
 import { sanitizeAgentId } from "../../routing/session-key.js";
@@ -55,6 +56,8 @@ export function registerCronEditCommand(cron: Command) {
       .option("--timeout-seconds <n>", "Timeout seconds for agent jobs")
       .option("--light-context", "Enable lightweight bootstrap context for agent jobs")
       .option("--no-light-context", "Disable lightweight bootstrap context for agent jobs")
+      .option("--working-memory <path>", "Workspace-relative scoped working-memory markdown file")
+      .option("--clear-working-memory", "Clear scoped working-memory path", false)
       .option("--tools <csv>", "Comma-separated tool allow-list (e.g. exec,read,write)")
       .option("--clear-tools", "Remove tool allow-list (use all tools)", false)
       .option("--announce", "Announce summary to a chat (subagent-style)")
@@ -189,6 +192,8 @@ export function registerCronEditCommand(cron: Command) {
             Boolean(thinking) ||
             hasTimeoutSeconds ||
             typeof opts.lightContext === "boolean" ||
+            typeof opts.workingMemory === "string" ||
+            opts.clearWorkingMemory ||
             typeof opts.tools === "string" ||
             opts.clearTools ||
             hasDeliveryModeFlag ||
@@ -215,6 +220,11 @@ export function registerCronEditCommand(cron: Command) {
               opts.lightContext,
               typeof opts.lightContext === "boolean",
             );
+            if (opts.clearWorkingMemory) {
+              payload.workingMemoryPath = "";
+            } else if (typeof opts.workingMemory === "string") {
+              payload.workingMemoryPath = normalizeScopedWorkingMemoryPath(opts.workingMemory);
+            }
             if (opts.clearTools) {
               payload.toolsAllow = null;
             } else if (typeof opts.tools === "string" && opts.tools.trim()) {

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -383,6 +383,16 @@ export type SessionSystemPromptReport = {
         injectedChars: number;
       }>;
     };
+    working: {
+      enabled: boolean;
+      files: Array<{
+        path: string;
+        status: "loaded" | "missing" | "present-not-injected" | "rejected";
+        rawChars: number;
+        injectedChars: number;
+        reason?: "path" | "validation" | "io" | "budget";
+      }>;
+    };
     searchable: {
       available: boolean;
       toolNames: string[];

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -373,6 +373,26 @@ export type SessionSystemPromptReport = {
     projectContextChars: number;
     nonProjectContextChars: number;
   };
+  memory?: {
+    startup: {
+      files: Array<{
+        name: string;
+        path: string;
+        status: "loaded" | "present-not-injected" | "missing";
+        rawChars: number;
+        injectedChars: number;
+      }>;
+    };
+    searchable: {
+      available: boolean;
+      toolNames: string[];
+      noteRoots: string[];
+    };
+    recall: {
+      available: boolean;
+      toolNames: string[];
+    };
+  };
   injectedWorkspaceFiles: Array<{
     name: string;
     path: string;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -254,6 +254,8 @@ export type AgentDefaultsConfig = {
     ackMaxChars?: number;
     /** Suppress tool error warning payloads during heartbeat runs. */
     suppressToolErrorWarnings?: boolean;
+    /** Optional scoped working-memory file for lightweight/isolated heartbeat runs. */
+    workingMemoryPath?: string;
     /**
      * If true, run heartbeat turns with lightweight bootstrap context.
      * Lightweight mode keeps only HEARTBEAT.md from workspace bootstrap files.

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { getBlockedNetworkModeReason } from "../agents/sandbox/network-mode.js";
+import { normalizeScopedWorkingMemoryPath } from "../agents/scoped-working-memory.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import { AgentModelSchema } from "./zod-schema.agent-model.js";
 import {
@@ -34,6 +35,7 @@ export const HeartbeatSchema = z
     ackMaxChars: z.number().int().nonnegative().optional(),
     suppressToolErrorWarnings: z.boolean().optional(),
     lightContext: z.boolean().optional(),
+    workingMemoryPath: z.string().optional(),
     isolatedSession: z.boolean().optional(),
   })
   .strict()
@@ -90,6 +92,18 @@ export const HeartbeatSchema = z
 
     validateTime(active.start, { allow24: false }, "start");
     validateTime(active.end, { allow24: true }, "end");
+
+    if (typeof val.workingMemoryPath === "string" && val.workingMemoryPath.trim()) {
+      try {
+        normalizeScopedWorkingMemoryPath(val.workingMemoryPath);
+      } catch (error) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["workingMemoryPath"],
+          message: error instanceof Error ? error.message : "invalid workingMemoryPath",
+        });
+      }
+    }
   })
   .optional();
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -564,6 +564,7 @@ export async function runCronIsolatedAgentTurn(params: {
             timeoutMs,
             bootstrapContextMode: agentPayload?.lightContext ? "lightweight" : undefined,
             bootstrapContextRunKind: "cron",
+            workingMemoryPath: agentPayload?.workingMemoryPath,
             toolsAllow: agentPayload?.toolsAllow,
             runId: cronSession.sessionEntry.sessionId,
             requireExplicitMessageTarget: toolPolicy.requireExplicitMessageTarget,

--- a/src/cron/isolated-agent/run.working-memory.test.ts
+++ b/src/cron/isolated-agent/run.working-memory.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  makeIsolatedAgentTurnJob,
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  runEmbeddedPiAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+function mockSuccessfulModelFallback() {
+  runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => {
+    await run(provider, model);
+    return {
+      result: {
+        payloads: [{ text: "ok" }],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider,
+      model,
+      attempts: [],
+    };
+  });
+}
+
+describe("runCronIsolatedAgentTurn — working memory", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  it("does not implicitly enable scoped working memory for light-context cron jobs", async () => {
+    mockSuccessfulModelFallback();
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          payload: {
+            kind: "agentTurn",
+            message: "test",
+            lightContext: true,
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.bootstrapContextMode).toBe("lightweight");
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.workingMemoryPath).toBeUndefined();
+  });
+
+  it("passes explicit scoped working memory through to the isolated runner", async () => {
+    mockSuccessfulModelFallback();
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          payload: {
+            kind: "agentTurn",
+            message: "test",
+            lightContext: true,
+            workingMemoryPath: ".openclaw/working-memory/cron/nightly.md",
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.workingMemoryPath).toBe(
+      ".openclaw/working-memory/cron/nightly.md",
+    );
+  });
+});

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -191,6 +191,73 @@ describe("applyJobPatch", () => {
     }
   });
 
+  it("persists agentTurn payload.workingMemoryPath updates when editing existing jobs", () => {
+    const job = createIsolatedAgentTurnJob("job-working-memory", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      workingMemoryPath: ".openclaw/working-memory/cron/nightly.md",
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "do it",
+        workingMemoryPath: " .openclaw/working-memory/cron/privacy.md ",
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.workingMemoryPath).toBe(".openclaw/working-memory/cron/privacy.md");
+    }
+  });
+
+  it("clears agentTurn payload.workingMemoryPath when an empty patch value is supplied", () => {
+    const job = createIsolatedAgentTurnJob("job-working-memory-clear", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      workingMemoryPath: ".openclaw/working-memory/cron/nightly.md",
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "do it",
+        workingMemoryPath: "",
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.workingMemoryPath).toBeUndefined();
+    }
+  });
+
+  it("rejects invalid agentTurn payload.workingMemoryPath updates", () => {
+    const job = createIsolatedAgentTurnJob("job-working-memory-invalid", {
+      mode: "announce",
+      channel: "telegram",
+    });
+
+    expect(() =>
+      applyJobPatch(job, {
+        payload: {
+          kind: "agentTurn",
+          message: "do it",
+          workingMemoryPath: "../outside.md",
+        },
+      }),
+    ).toThrow("workingMemoryPath must stay inside the workspace");
+  });
+
   it.each([
     { name: "no delivery update", patch: { enabled: true } satisfies CronJobPatch },
     {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { normalizeScopedWorkingMemoryPath } from "../../agents/scoped-working-memory.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
 import {
@@ -696,6 +697,9 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   if (typeof patch.lightContext === "boolean") {
     next.lightContext = patch.lightContext;
   }
+  if (typeof patch.workingMemoryPath === "string") {
+    next.workingMemoryPath = normalizeOptionalWorkingMemoryPath(patch.workingMemoryPath);
+  }
   if (typeof patch.allowUnsafeExternalContent === "boolean") {
     next.allowUnsafeExternalContent = patch.allowUnsafeExternalContent;
   }
@@ -721,8 +725,14 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     thinking: patch.thinking,
     timeoutSeconds: patch.timeoutSeconds,
     lightContext: patch.lightContext,
+    workingMemoryPath: normalizeOptionalWorkingMemoryPath(patch.workingMemoryPath),
     allowUnsafeExternalContent: patch.allowUnsafeExternalContent,
   };
+}
+
+function normalizeOptionalWorkingMemoryPath(value: unknown): string | undefined {
+  const trimmed = normalizeOptionalTrimmedString(value);
+  return trimmed ? normalizeScopedWorkingMemoryPath(trimmed) : undefined;
 }
 
 function normalizeOptionalTrimmedString(value: unknown): string | undefined {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -98,6 +98,8 @@ type CronAgentTurnPayloadFields = {
   externalContentSource?: HookExternalContentSource;
   /** If true, run with lightweight bootstrap context. */
   lightContext?: boolean;
+  /** Optional scoped working-memory file for isolated/lightweight runs. */
+  workingMemoryPath?: string;
   /** Optional tool allow-list; when set, only these tools are sent to the model. */
   toolsAllow?: string[];
 };

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -12,6 +12,7 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
       timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
       lightContext: Type.Optional(Type.Boolean()),
+      workingMemoryPath: Type.Optional(Type.String()),
     },
     { additionalProperties: false },
   );

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -77,6 +77,7 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
     model?: string;
     suppressToolErrorWarnings?: boolean;
     lightContext?: boolean;
+    workingMemoryPath?: string;
     isolatedSession?: boolean;
   }) {
     return withHeartbeatFixture(async ({ tmpDir, storePath, seedSession }) => {
@@ -90,6 +91,7 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
               model: params.model,
               suppressToolErrorWarnings: params.suppressToolErrorWarnings,
               lightContext: params.lightContext,
+              workingMemoryPath: params.workingMemoryPath,
               isolatedSession: params.isolatedSession,
             },
           },
@@ -136,6 +138,52 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
         bootstrapContextMode: "lightweight",
       }),
     );
+  });
+
+  it("passes workingMemoryPath when configured", async () => {
+    const replyOpts = await runDefaultsHeartbeat({
+      workingMemoryPath: ".openclaw/working-memory/heartbeat/private.md",
+    });
+    expect(replyOpts).toEqual(
+      expect.objectContaining({
+        isHeartbeat: true,
+        workingMemoryPath: ".openclaw/working-memory/heartbeat/private.md",
+      }),
+    );
+  });
+
+  it("rejects invalid workingMemoryPath when configured", async () => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+              workingMemoryPath: "../outside.md",
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await seedSession(sessionKey, { lastChannel: "whatsapp", lastTo: "+1555" });
+
+      await expect(
+        runHeartbeatOnce({
+          cfg,
+          deps: {
+            getQueueSize: () => 0,
+            nowMs: () => 0,
+          },
+        }),
+      ).resolves.toMatchObject({
+        status: "failed",
+        reason: "workingMemoryPath must stay inside the workspace",
+      });
+    });
   });
 
   it("uses isolated session key when isolatedSession is enabled", async () => {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -11,6 +11,7 @@ import {
 } from "../agents/agent-scope.js";
 import { appendCronStyleCurrentTimeLine } from "../agents/current-time.js";
 import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
+import { normalizeScopedWorkingMemoryPath } from "../agents/scoped-working-memory.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 import {
@@ -722,14 +723,19 @@ export async function runHeartbeatOnce(opts: {
     const suppressToolErrorWarnings = heartbeat?.suppressToolErrorWarnings === true;
     const bootstrapContextMode: "lightweight" | undefined =
       heartbeat?.lightContext === true ? "lightweight" : undefined;
+    const workingMemoryPath =
+      typeof heartbeat?.workingMemoryPath === "string" && heartbeat.workingMemoryPath.trim()
+        ? normalizeScopedWorkingMemoryPath(heartbeat.workingMemoryPath)
+        : undefined;
     const replyOpts = heartbeatModelOverride
       ? {
           isHeartbeat: true,
           heartbeatModelOverride,
           suppressToolErrorWarnings,
           bootstrapContextMode,
+          workingMemoryPath,
         }
-      : { isHeartbeat: true, suppressToolErrorWarnings, bootstrapContextMode };
+      : { isHeartbeat: true, suppressToolErrorWarnings, bootstrapContextMode, workingMemoryPath };
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;


### PR DESCRIPTION
## Summary
- add scoped working-memory loading with workspace-contained path validation and prompt-budget fitting
- report startup/searchable/recall/working memory as separate lanes in `/context`
- wire explicit working-memory support through cron/heartbeat plumbing without implicit opt-in for light-context jobs
- hide durable-memory + recall tools when scoped working memory is enabled, and add regression coverage around legacy report shapes and path validation

## Validation
- `pnpm exec vitest run src/cron/isolated-agent/run.working-memory.test.ts src/agents/pi-tools.scoped-working-memory.test.ts src/agents/scoped-working-memory.test.ts src/agents/system-prompt-report.test.ts src/auto-reply/reply/commands-context-report.test.ts src/cli/cron-cli.test.ts src/cron/service.jobs.test.ts src/infra/heartbeat-runner.model-override.test.ts src/agents/tools-effective-inventory.test.ts src/auto-reply/reply/commands-system-prompt.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit -p tsconfig.json --pretty false`
- `python3 /Users/Shared/openclaw-review-gate/review_gate.py check`
