### PR TITLE
Validate nodes CLI timeout values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/nodes timeout parsing: reject non-decimal timeout strings like `123abc` and `1e3` instead of coercing partial values, while preserving valid positive integer millisecond strings. Thanks @roytong9.
 - Plugins/runtime-deps: prune legacy version-scoped plugin runtime-deps roots during bundled dependency repair and cover the path in Package Acceptance's upgrade-survivor matrix, so upgrades from 2026.4.x no longer leave stale per-plugin runtime trees after doctor runs. Thanks @vincentkoc.
 - Plugins/runtime-deps: keep Gateway startup plugin imports and runtime plugin fallback loads verify-only after startup/config repair planning, so packaged installs no longer spawn package-manager repair from hot paths after readiness. Refs #75283 and #75069. Thanks @brokemac79 and @xiaohuaxi.
 - Voice Call/realtime: add default-off fast memory/session context for `openclaw_agent_consult`, giving live calls a bounded answer-or-miss path before the full agent consult. Fixes #71849. Thanks @amzzzzzzz.

--- a/src/cli/nodes-cli/register.invoke.approval-transport-timeout.test.ts
+++ b/src/cli/nodes-cli/register.invoke.approval-transport-timeout.test.ts
@@ -74,7 +74,7 @@ describe("exec approval transport timeout (#12098)", () => {
 
   it("fix: user-specified timeout larger than approval is preserved", async () => {
     const approvalTimeoutMs = DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;
-    const userTimeout = 200_000;
+    const userTimeout = approvalTransportFloorMs + 10_000;
     // Mirror the production code: parseTimeoutMs preserves valid large values
     const transportTimeoutMs = Math.max(
       parseTimeoutMs(String(userTimeout)) ?? 0,

--- a/src/cli/nodes-cli/register.invoke.approval-transport-timeout.test.ts
+++ b/src/cli/nodes-cli/register.invoke.approval-transport-timeout.test.ts
@@ -80,7 +80,7 @@ describe("exec approval transport timeout (#12098)", () => {
       parseTimeoutMs(String(userTimeout)) ?? 0,
       approvalTransportFloorMs,
     );
-    expect(transportTimeoutMs).toBe(approvalTransportFloorMs);
+    expect(transportTimeoutMs).toBe(userTimeout);
 
     await callGatewayCli(
       "exec.approval.request",
@@ -90,7 +90,7 @@ describe("exec approval transport timeout (#12098)", () => {
     );
 
     const callOpts = callGatewaySpy.mock.calls[0][0];
-    expect(callOpts.timeoutMs).toBe(approvalTransportFloorMs);
+    expect(callOpts.timeoutMs).toBe(userTimeout);
   });
 
   it("fix: non-numeric timeout falls back to approval floor", async () => {
@@ -109,5 +109,13 @@ describe("exec approval transport timeout (#12098)", () => {
 
     const callOpts = callGatewaySpy.mock.calls[0][0];
     expect(callOpts.timeoutMs).toBe(approvalTransportFloorMs);
+  });
+
+  it("throws for invalid shared gateway CLI timeout values", async () => {
+    await expect(
+      callGatewayCli("exec.approval.request", { timeout: "0" } as never, {
+        timeoutMs: 120_000,
+      }),
+    ).rejects.toThrow("invalid --timeout: 0");
   });
 });

--- a/src/cli/nodes-cli/rpc.runtime.ts
+++ b/src/cli/nodes-cli/rpc.runtime.ts
@@ -1,5 +1,6 @@
 import { callGateway } from "../../gateway/call.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../gateway/protocol/client-info.js";
+import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
 import { withProgress } from "../progress.js";
 import type { NodesRpcOpts } from "./types.js";
 
@@ -21,7 +22,9 @@ export async function callGatewayCliRuntime(
         token: opts.token,
         method,
         params,
-        timeoutMs: callOpts?.transportTimeoutMs ?? Number(opts.timeout ?? 10_000),
+        timeoutMs:
+          callOpts?.transportTimeoutMs ??
+          parseTimeoutMsWithFallback(opts.timeout, 10_000, { invalidType: "error" }),
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
       }),

--- a/src/cli/parse-timeout.test.ts
+++ b/src/cli/parse-timeout.test.ts
@@ -10,6 +10,8 @@ describe("parseTimeoutMs", () => {
     expect(parseTimeoutMs(undefined)).toBeUndefined();
     expect(parseTimeoutMs("")).toBeUndefined();
     expect(parseTimeoutMs("nope")).toBeUndefined();
+    expect(parseTimeoutMs("123abc")).toBeUndefined();
+    expect(parseTimeoutMs("1e3")).toBeUndefined();
   });
 });
 
@@ -39,5 +41,13 @@ describe("parseTimeoutMsWithFallback", () => {
   it("throws on non-positive parsed values", () => {
     expect(() => parseTimeoutMsWithFallback("0", 3000)).toThrow("invalid --timeout: 0");
     expect(() => parseTimeoutMsWithFallback("-1", 3000)).toThrow("invalid --timeout: -1");
+  });
+
+  it("throws on non-numeric, partial, and scientific notation strings", () => {
+    expect(() => parseTimeoutMsWithFallback("foo", 3000)).toThrow("invalid --timeout: foo");
+    expect(() => parseTimeoutMsWithFallback("123abc", 3000)).toThrow(
+      "invalid --timeout: 123abc",
+    );
+    expect(() => parseTimeoutMsWithFallback("1e3", 3000)).toThrow("invalid --timeout: 1e3");
   });
 });

--- a/src/cli/parse-timeout.ts
+++ b/src/cli/parse-timeout.ts
@@ -12,7 +12,10 @@ export function parseTimeoutMs(raw: unknown): number | undefined {
     if (!trimmed) {
       return undefined;
     }
-    value = Number.parseInt(trimmed, 10);
+    if (!/^\d+$/.test(trimmed)) {
+      return undefined;
+    }
+    value = Number(trimmed);
   }
   return Number.isFinite(value) ? value : undefined;
 }
@@ -46,7 +49,11 @@ export function parseTimeoutMsWithFallback(
     return fallbackMs;
   }
 
-  const parsed = Number.parseInt(value, 10);
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`invalid --timeout: ${value}`);
+  }
+
+  const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     throw new Error(`invalid --timeout: ${value}`);
   }


### PR DESCRIPTION
## Summary

Validate `nodes` CLI timeout values using the shared timeout parsing helper.

## What changed

- Replaced raw `Number(opts.timeout ?? 10_000)` parsing in `src/cli/nodes-cli/rpc.ts`
- Switched the nodes CLI transport timeout path to `parseTimeoutMsWithFallback(..., { invalidType: "error" })`
- Added a focused test covering invalid timeout input

## Why

The nodes CLI RPC path was still parsing `--timeout` with a raw `Number(...)` conversion, unlike other CLI paths that already use the shared timeout parsing helper.

This made invalid values less consistently validated. This change brings the nodes CLI timeout behavior in line with the existing shared timeout parsing rules and makes invalid values like `0` fail clearly.

## Manual verification

1. Added a focused test in `src/cli/nodes-cli/register.invoke.approval-transport-timeout.test.ts`
2. Updated `src/cli/nodes-cli/rpc.ts` to use `parseTimeoutMsWithFallback(..., { invalidType: "error" })`
3. Ran:
   - `pnpm vitest run src/cli/nodes-cli/register.invoke.approval-transport-timeout.test.ts -t "throws for invalid shared gateway CLI timeout values"`
   - `pnpm vitest run src/cli/nodes-cli/register.invoke.approval-transport-timeout.test.ts`
4. Ran the repo checks during commit