### PR TITLE
feat(telegram): add reactionTrigger config to allow reactions to wake agent

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1,5 +1,6 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
 import { resolveAgentDir, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
+import { requestHeartbeatNow } from "openclaw/plugin-sdk/channel-runtime";
 import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
 import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-helpers";
 import { shouldDebounceTextInbound } from "openclaw/plugin-sdk/channel-inbound";
@@ -884,6 +885,19 @@ export const registerTelegramHandlers = ({
           contextKey: `telegram:reaction:add:${chatId}:${messageId}:${user?.id ?? "anon"}:${emoji}`,
         });
         logVerbose(`telegram: reaction event enqueued: ${text}`);
+      }
+
+      // When reactionTrigger is enabled, wake the agent so the reaction
+      // system events are processed as a standalone turn instead of
+      // waiting for the next inbound message.
+      const reactionTrigger = telegramCfg.reactionTrigger === true;
+      if (reactionTrigger && addedReactions.length > 0) {
+        requestHeartbeatNow({
+          reason: "telegram-reaction",
+          sessionKey,
+          coalesceMs: 500,
+        });
+        logVerbose(`telegram: reaction trigger woke agent for session ${sessionKey}`);
       }
     } catch (err) {
       runtime.error?.(danger(`telegram reaction handler failed: ${String(err)}`));

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -195,6 +195,14 @@ export type TelegramAccountConfig = {
    * - "extensive": agent can react liberally when appropriate
    */
   reactionLevel?: "off" | "ack" | "minimal" | "extensive";
+  /**
+   * When true, incoming user reactions trigger a full agent turn instead of
+   * only queuing a system context event. The agent receives a synthetic
+   * inbound message describing the reaction and can respond normally.
+   * Requires reactionNotifications to be "own" or "all" (not "off").
+   * Default: false.
+   */
+  reactionTrigger?: boolean;
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Channel health monitor overrides for this channel/account. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -307,6 +307,7 @@ export const TelegramAccountSchemaBase = z
       .optional(),
     reactionNotifications: z.enum(["off", "own", "all"]).optional(),
     reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
+    reactionTrigger: z.boolean().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     healthMonitor: ChannelHealthMonitorSchema,
     linkPreview: z.boolean().optional(),

--- a/src/plugin-sdk/channel-runtime.ts
+++ b/src/plugin-sdk/channel-runtime.ts
@@ -26,3 +26,4 @@ export {
   keepHttpServerTaskAlive,
   waitUntilAbort,
 } from "./channel-lifecycle.core.js";
+export { requestHeartbeatNow } from "../infra/heartbeat-wake.js";


### PR DESCRIPTION
## Summary

When `channels.telegram.reactionTrigger` is set to `true`, incoming user reactions trigger a full agent turn via `requestHeartbeatNow` instead of only queuing system context events for the next message.

This allows the agent to respond to reactions (e.g. 👎, 🔥, ❤️, 🤣) in real-time without requiring a follow-up text message.

## Changes

- **`src/config/types.telegram.ts`** — Added `reactionTrigger?: boolean` to `TelegramAccountConfig`
- **`src/config/zod-schema.providers-core.ts`** — Added `reactionTrigger: z.boolean().optional()` to the Telegram account schema
- **`extensions/telegram/src/bot-handlers.runtime.ts`** — After enqueuing reaction system events, calls `requestHeartbeatNow()` with a 500ms coalesce to wake the agent when `reactionTrigger` is enabled
- **`src/plugin-sdk/channel-runtime.ts`** — Exported `requestHeartbeatNow` for use by channel extensions

## Config

```json5
{
  channels: {
    telegram: {
      reactionNotifications: "own",  // or "all"
      reactionTrigger: true,
    },
  },
}
```

## Backward Compatibility

`reactionTrigger` defaults to `false`, so existing behavior is unchanged.

Closes #47677
Closes #30875