### PR TITLE
fix(whatsapp): gate connect-time presence on selfChatMode to preserve phone notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Slack/mrkdwn formatting: add built-in Slack mrkdwn guidance in inbound context so Slack replies stop falling back to generic Markdown patterns that render poorly in Slack. (#59100) Thanks @jadewon.
 - Gateway/exec loopback: restore legacy-role fallback for empty paired-device token maps and allow silent local role upgrades so local exec and node clients stop failing with pairing-required errors after `2026.3.31`. (#59092) Thanks @openperf.
 - WhatsApp/media: add HTML, XML, and CSS to the MIME map and fall back gracefully for unknown media types instead of dropping the attachment. (#51562) Thanks @bobbyt74.
+- WhatsApp/presence: send `unavailable` presence on connect in self-chat mode so personal-phone users stop losing all push notifications while the gateway is running. Thanks @mcaxtr.
 
 ## 2026.4.1-beta.1
 

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -202,6 +202,7 @@ export async function monitorWebChannel(
       accountId: account.accountId,
       authDir: account.authDir,
       mediaMaxMb: account.mediaMaxMb,
+      selfChatMode: account.selfChatMode,
       sendReadReceipts: account.sendReadReceipts,
       debounceMs: inboundDebounceMs,
       shouldDebounce,

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -40,6 +40,8 @@ export async function monitorWebInbox(options: {
   authDir: string;
   onMessage: (msg: WebInboundMessage) => Promise<void>;
   mediaMaxMb?: number;
+  /** Keep the global presence unavailable so self-chat sessions do not mute phone pushes. */
+  selfChatMode?: boolean;
   /** Send read receipts for incoming messages (default true). */
   sendReadReceipts?: boolean;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
@@ -67,14 +69,15 @@ export async function monitorWebInbox(options: {
     onCloseResolve = null;
     resolver(reason);
   };
+  const presence = options.selfChatMode ? "unavailable" : "available";
 
   try {
-    await sock.sendPresenceUpdate("available");
+    await sock.sendPresenceUpdate(presence);
     if (shouldLogVerbose()) {
-      logVerbose("Sent global 'available' presence on connect");
+      logVerbose(`Sent global '${presence}' presence on connect`);
     }
   } catch (err) {
-    logVerbose(`Failed to send 'available' presence on connect: ${String(err)}`);
+    logVerbose(`Failed to send '${presence}' presence on connect: ${String(err)}`);
   }
 
   const self = await readWebSelfIdentity(

--- a/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test.ts
@@ -83,7 +83,7 @@ describe("web monitor inbox", () => {
         fromMe: false,
       },
     ]);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "available");
     await listener.close();
   });
 

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
@@ -94,7 +94,7 @@ describe("web monitor inbox", () => {
     });
 
     const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "available");
     const messageId = nextMessageId("stream");
     const upsert = buildNotifyMessageUpsert({
       id: messageId,
@@ -127,6 +127,16 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
+  it("stays unavailable on connect in self-chat mode", async () => {
+    const { listener, sock } = await startInboxMonitor(vi.fn(async () => {}) as InboxOnMessage, {
+      selfChatMode: true,
+    });
+
+    expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "unavailable");
+
+    await listener.close();
+  });
+
   it("hydrates participating groups once after connect", async () => {
     const { listener, sock } = await startInboxMonitor(vi.fn(async () => {}) as InboxOnMessage);
 
@@ -142,7 +152,7 @@ describe("web monitor inbox", () => {
     const { listener } = await startInboxMonitor(vi.fn(async () => {}) as InboxOnMessage);
 
     expect(sock.groupFetchAllParticipating).toHaveBeenCalledTimes(1);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "available");
 
     await listener.close();
   });

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -157,7 +157,10 @@ export async function waitForMessageCalls(onMessage: ReturnType<typeof vi.fn>, c
   );
 }
 
-export async function startInboxMonitor(onMessage: InboxOnMessage) {
+export async function startInboxMonitor(
+  onMessage: InboxOnMessage,
+  options: { selfChatMode?: boolean } = {},
+) {
   if (!monitorWebInbox) {
     ({ monitorWebInbox } = await import("./inbound.js"));
   }
@@ -166,6 +169,7 @@ export async function startInboxMonitor(onMessage: InboxOnMessage) {
     onMessage,
     accountId: DEFAULT_ACCOUNT_ID,
     authDir: getAuthDir(),
+    selfChatMode: options.selfChatMode,
   });
   return { listener, sock: getSock() };
 }


### PR DESCRIPTION
## Summary

- Problem: WhatsApp inbound monitor sends `sendPresenceUpdate("available")` on connect, overriding `markOnlineOnConnect: false` in `session.ts` and causing WhatsApp to suppress all phone push notifications for the linked number.
- Why it matters: 100% of personal-phone WhatsApp users lose all push notifications while the gateway is running — not just for monitored chats, but for every conversation.
- What changed: the connect-time presence now reads the existing `selfChatMode` flag — sends `"unavailable"` for personal-phone setups and keeps `"available"` for dedicated bot numbers.
- What did NOT change (scope boundary): per-chat `"composing"` presence, read receipt behavior, message processing, reconnect logic, config types, and zod schema are all untouched. No new config fields.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30286
- Related #30608, #58122
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `extensions/whatsapp/src/inbound/monitor.ts:72` called `sendPresenceUpdate("available")` unconditionally on connect, overriding the `markOnlineOnConnect: false` Baileys option in `session.ts:129`.
- Missing detection / guardrail: no test asserted which presence value was sent relative to the account mode.
- Prior context: the `"available"` call was added early in the WhatsApp channel implementation. `markOnlineOnConnect: false` was later set in session.ts with the right intent, but the explicit call was never updated to match.
- Why this regressed now: it was always broken for personal-phone users; the issue was reported after wider adoption.
- If unknown, what was ruled out: N/A — root cause is confirmed via Baileys docs and Beeper comparison.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts`
- Scenario the test should lock in: when `selfChatMode: true`, the first `sendPresenceUpdate` call sends `"unavailable"` instead of `"available"`.
- Why this is the smallest reliable guardrail: directly asserts the presence value at the exact call site that caused the bug.
- Existing test that already covers this (if any): existing tests asserted `sendPresenceUpdate("available")` — they now assert the nth-call pattern and a new test covers the `selfChatMode: true` path.

## User-visible / Behavior Changes

- Personal-phone users (`selfChatMode: true`): phone push notifications are restored. The WhatsApp account shows "last seen at..." instead of permanent "online" status. Per-chat "typing..." indicators remain.
- Dedicated-bot users (`selfChatMode: false` or unset): no change.

## Diagram (if applicable)

```text
Before (selfChatMode: true):
[gateway connects] -> sendPresenceUpdate("available") -> phone notifications suppressed

After (selfChatMode: true):
[gateway connects] -> sendPresenceUpdate("unavailable") -> phone notifications preserved
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — same Baileys `sendPresenceUpdate` call, different argument.
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+
- Integration/channel (if any): WhatsApp (Baileys/WhatsApp Web)

### Steps

1. Configure WhatsApp channel with `selfChatMode: true` (or select "personal phone" during onboarding)
2. Start the gateway
3. Send a message to the linked phone number from another device

### Expected

- Phone receives push notification normally

### Actual (before fix)

- Phone receives no push notification (WhatsApp suppresses them for the "online" linked device)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

All 23 scoped tests pass (14 in streams-inbound-messages, 9 in captures-media-path-image-messages). `pnpm check` clean.

## Human Verification (required)

- Verified scenarios: scoped tests for both default (available) and selfChatMode (unavailable) paths; full lint/format gate.
- Edge cases checked: `selfChatMode` undefined (falls back to `false`, sends `"available"` — no behavior change for existing users).
- What you did **not** verify: live WhatsApp session (requires paired phone).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No — uses the existing `selfChatMode` field.
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: users with `selfChatMode: true` who relied on permanent "online" status.
  - Mitigation: unlikely scenario — `selfChatMode` indicates a personal phone where losing all notifications is almost certainly undesirable. The "online" indicator was a side effect, not a feature.