### PR TITLE
feat(sessions): timezone-aware daily reset + idleGuard AND mode

### DIFF
--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -146,6 +146,7 @@ export function resolveSession(opts: {
     sessionCfg,
     resetType,
     resetOverride: channelReset,
+    userTimezone: opts.cfg.agents?.defaults?.userTimezone,
   });
   const fresh = sessionEntry
     ? evaluateSessionFreshness({ updatedAt: sessionEntry.updatedAt, now, policy: resetPolicy })

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -382,6 +382,7 @@ export async function initSessionState(params: {
     sessionCfg,
     resetType,
     resetOverride: channelReset,
+    userTimezone: cfg.agents?.defaults?.userTimezone,
   });
   // Heartbeat, cron-event, and exec-event runs should NEVER trigger session resets.
   // These are automated system events, not user interactions that should affect

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1188,6 +1188,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Sets local-hour boundary (0-23) for daily reset mode so sessions roll over at predictable times. Use with mode=daily and align to operator timezone expectations for human-readable behavior.",
   "session.reset.idleMinutes":
     "Sets inactivity window before reset for idle mode and can also act as secondary guard with daily mode. Use larger values to preserve continuity or smaller values for fresher short-lived threads.",
+  "session.reset.timezone":
+    'IANA timezone string (e.g. "Asia/Shanghai", "America/New_York") for interpreting the atHour boundary. When omitted, the host machine\'s local timezone is used. Set this when the user is in a different timezone than the server.',
+  "session.reset.idleGuard":
+    "When true and mode is daily, the idleMinutes window acts as an AND guard: the session resets only when BOTH the daily boundary has passed AND the user has been idle for at least idleMinutes. Default false preserves the legacy OR behavior where either condition alone triggers a reset.",
   "session.resetByType":
     "Overrides reset behavior by chat type (direct, group, thread) when defaults are not sufficient. Use this when group/thread traffic needs different reset cadence than direct messages.",
   "session.resetByType.direct":

--- a/src/config/sessions/reset.ts
+++ b/src/config/sessions/reset.ts
@@ -10,6 +10,10 @@ export type SessionResetPolicy = {
   mode: SessionResetMode;
   atHour: number;
   idleMinutes?: number;
+  /** IANA timezone for atHour. When set, daily reset boundary is computed in this timezone. */
+  timezone?: string;
+  /** When true with daily mode, idleMinutes becomes an AND guard (both conditions must be met). */
+  idleGuard?: boolean;
 };
 
 export type SessionFreshness = {
@@ -67,20 +71,36 @@ export function resolveThreadFlag(params: {
   return isThreadSessionKey(params.sessionKey);
 }
 
-export function resolveDailyResetAtMs(now: number, atHour: number): number {
+export function resolveDailyResetAtMs(now: number, atHour: number, timezone?: string): number {
   const normalizedAtHour = normalizeResetAtHour(atHour);
-  const resetAt = new Date(now);
-  resetAt.setHours(normalizedAtHour, 0, 0, 0);
-  if (now < resetAt.getTime()) {
-    resetAt.setDate(resetAt.getDate() - 1);
+  if (!timezone) {
+    // Legacy path: use server-local timezone (original behavior).
+    const resetAt = new Date(now);
+    resetAt.setHours(normalizedAtHour, 0, 0, 0);
+    if (now < resetAt.getTime()) {
+      resetAt.setDate(resetAt.getDate() - 1);
+    }
+    return resetAt.getTime();
   }
-  return resetAt.getTime();
+
+  // Timezone-aware path: compute the most recent occurrence of atHour in the
+  // given IANA timezone.
+  const { year, month, day } = getWallClockDate(now, timezone);
+  const candidateToday = wallClockToEpochMs(year, month, day, normalizedAtHour, timezone);
+  if (candidateToday <= now) {
+    return candidateToday;
+  }
+  // atHour hasn't occurred yet today in the target timezone → use yesterday.
+  const { year: y2, month: m2, day: d2 } = getWallClockDate(now - 86_400_000, timezone);
+  return wallClockToEpochMs(y2, m2, d2, normalizedAtHour, timezone);
 }
 
 export function resolveSessionResetPolicy(params: {
   sessionCfg?: SessionConfig;
   resetType: SessionResetType;
   resetOverride?: SessionResetConfig;
+  /** Fallback timezone when reset config doesn't specify one (e.g. agents.defaults.userTimezone). */
+  userTimezone?: string;
 }): SessionResetPolicy {
   const sessionCfg = params.sessionCfg;
   const baseReset = params.resetOverride ?? sessionCfg?.reset;
@@ -112,7 +132,11 @@ export function resolveSessionResetPolicy(params: {
     idleMinutes = DEFAULT_IDLE_MINUTES;
   }
 
-  return { mode, atHour, idleMinutes };
+  const timezone =
+    (typeReset?.timezone ?? baseReset?.timezone ?? params.userTimezone)?.trim() || undefined;
+  const idleGuard = typeReset?.idleGuard ?? baseReset?.idleGuard ?? false;
+
+  return { mode, atHour, idleMinutes, timezone, idleGuard };
 }
 
 export function resolveChannelResetConfig(params: {
@@ -139,7 +163,7 @@ export function evaluateSessionFreshness(params: {
 }): SessionFreshness {
   const dailyResetAt =
     params.policy.mode === "daily"
-      ? resolveDailyResetAtMs(params.now, params.policy.atHour)
+      ? resolveDailyResetAtMs(params.now, params.policy.atHour, params.policy.timezone)
       : undefined;
   const idleExpiresAt =
     params.policy.idleMinutes != null && params.policy.idleMinutes > 0
@@ -147,12 +171,116 @@ export function evaluateSessionFreshness(params: {
       : undefined;
   const staleDaily = dailyResetAt != null && params.updatedAt < dailyResetAt;
   const staleIdle = idleExpiresAt != null && params.now > idleExpiresAt;
+
+  let stale: boolean;
+  if (
+    params.policy.idleGuard &&
+    params.policy.mode === "daily" &&
+    dailyResetAt != null &&
+    idleExpiresAt != null
+  ) {
+    // AND mode: both daily boundary AND idle window must be exceeded.
+    stale = staleDaily && staleIdle;
+  } else {
+    // Default OR mode: either condition triggers reset.
+    stale = staleDaily || staleIdle;
+  }
+
   return {
-    fresh: !(staleDaily || staleIdle),
+    fresh: !stale,
     dailyResetAt,
     idleExpiresAt,
   };
 }
+
+//#region timezone helpers
+
+/** Extract wall-clock date components in a given IANA timezone. */
+function getWallClockDate(
+  epochMs: number,
+  timezone: string,
+): { year: number; month: number; day: number } {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(epochMs));
+  const map: Record<string, string> = {};
+  for (const p of parts) {
+    if (p.type !== "literal") {
+      map[p.type] = p.value;
+    }
+  }
+  return { year: Number(map.year), month: Number(map.month), day: Number(map.day) };
+}
+
+/**
+ * Convert a wall-clock date+hour in an IANA timezone to epoch ms.
+ * Uses an offset-estimation approach with one refinement pass to handle DST edges.
+ */
+function wallClockToEpochMs(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  timezone: string,
+): number {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const iso = `${year}-${pad(month)}-${pad(day)}T${pad(hour)}:00:00`;
+  const utcGuess = Date.parse(iso + "Z");
+
+  // First pass: compute offset at the guess point, then refine.
+  const offset1 = computeTzOffsetMs(utcGuess, timezone);
+  const result1 = utcGuess - offset1;
+  const offset2 = computeTzOffsetMs(result1, timezone);
+  if (offset1 === offset2) {
+    return result1;
+  }
+  // DST edge: re-apply with the refined offset.
+  return utcGuess - offset2;
+}
+
+/**
+ * Compute the UTC offset (in ms) for a timezone at a given epoch.
+ * Positive means ahead of UTC (e.g. +8h for Asia/Shanghai).
+ */
+function computeTzOffsetMs(epochMs: number, timezone: string): number {
+  const d = new Date(epochMs);
+  const utcH = d.getUTCHours();
+  const utcM = d.getUTCMinutes();
+  const utcDay = d.getUTCDate();
+
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hour: "2-digit",
+    minute: "2-digit",
+    day: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(d);
+  const map: Record<string, string> = {};
+  for (const p of parts) {
+    if (p.type !== "literal") {
+      map[p.type] = p.value;
+    }
+  }
+
+  let diffMinutes =
+    (Number(map.day) - utcDay) * 1440 +
+    (Number(map.hour) - utcH) * 60 +
+    (Number(map.minute) - utcM);
+  // Handle month boundary (e.g., tz day=1, utc day=31).
+  if (diffMinutes > 720) {
+    diffMinutes -= 1440;
+  }
+  if (diffMinutes < -720) {
+    diffMinutes += 1440;
+  }
+
+  return diffMinutes * 60_000;
+}
+
+//#endregion
 
 function normalizeResetAtHour(value: number | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -21,7 +21,11 @@ import {
   resolveSessionTranscriptPathInDir,
   validateSessionId,
 } from "./paths.js";
-import { evaluateSessionFreshness, resolveSessionResetPolicy } from "./reset.js";
+import {
+  evaluateSessionFreshness,
+  resolveDailyResetAtMs,
+  resolveSessionResetPolicy,
+} from "./reset.js";
 import { appendAssistantMessageToSessionTranscript } from "./transcript.js";
 import type { SessionEntry } from "./types.js";
 
@@ -175,6 +179,157 @@ describe("resolveSessionResetPolicy", () => {
       dailyResetAt: undefined,
       idleExpiresAt: undefined,
     });
+  });
+});
+
+describe("resolveDailyResetAtMs with timezone", () => {
+  it("computes reset boundary in the specified timezone", () => {
+    // 2026-04-02T03:30:00Z = 2026-04-02T11:30 in Asia/Shanghai (UTC+8)
+    const now = Date.parse("2026-04-02T03:30:00Z");
+    // atHour=4 in Asia/Shanghai: today's 4AM Shanghai = 2026-04-01T20:00Z
+    const resetAt = resolveDailyResetAtMs(now, 4, "Asia/Shanghai");
+    expect(resetAt).toBe(Date.parse("2026-04-01T20:00:00Z"));
+  });
+
+  it("uses yesterday when atHour has not occurred yet today in the timezone", () => {
+    // 2026-04-02T19:30:00Z = 2026-04-03T03:30 in Asia/Shanghai
+    // atHour=4 hasn't happened yet today (3:30 < 4:00)
+    const now = Date.parse("2026-04-02T19:30:00Z");
+    const resetAt = resolveDailyResetAtMs(now, 4, "Asia/Shanghai");
+    // Yesterday's 4:00 Shanghai = 2026-04-01T20:00Z
+    expect(resetAt).toBe(Date.parse("2026-04-01T20:00:00Z"));
+  });
+
+  it("falls back to server-local time when no timezone is provided", () => {
+    const now = Date.now();
+    const withoutTz = resolveDailyResetAtMs(now, 4);
+    const withUndefined = resolveDailyResetAtMs(now, 4, undefined);
+    expect(withoutTz).toBe(withUndefined);
+  });
+});
+
+describe("resolveSessionResetPolicy: timezone and idleGuard", () => {
+  it("picks up timezone from reset config", () => {
+    const policy = resolveSessionResetPolicy({
+      sessionCfg: {
+        reset: { timezone: "America/New_York" },
+      } as unknown as SessionConfig,
+      resetType: "direct",
+    });
+    expect(policy.timezone).toBe("America/New_York");
+  });
+
+  it("falls back to userTimezone when reset config has no timezone", () => {
+    const policy = resolveSessionResetPolicy({
+      sessionCfg: {} as unknown as SessionConfig,
+      resetType: "direct",
+      userTimezone: "Europe/London",
+    });
+    expect(policy.timezone).toBe("Europe/London");
+  });
+
+  it("prefers reset config timezone over userTimezone", () => {
+    const policy = resolveSessionResetPolicy({
+      sessionCfg: {
+        reset: { timezone: "Asia/Tokyo" },
+      } as unknown as SessionConfig,
+      resetType: "direct",
+      userTimezone: "Europe/London",
+    });
+    expect(policy.timezone).toBe("Asia/Tokyo");
+  });
+
+  it("resolves idleGuard from reset config", () => {
+    const policy = resolveSessionResetPolicy({
+      sessionCfg: {
+        reset: { mode: "daily", idleMinutes: 60, idleGuard: true },
+      } as unknown as SessionConfig,
+      resetType: "direct",
+    });
+    expect(policy.idleGuard).toBe(true);
+    expect(policy.idleMinutes).toBe(60);
+  });
+
+  it("defaults idleGuard to false", () => {
+    const policy = resolveSessionResetPolicy({
+      sessionCfg: {} as unknown as SessionConfig,
+      resetType: "direct",
+    });
+    expect(policy.idleGuard).toBe(false);
+  });
+});
+
+describe("evaluateSessionFreshness: idleGuard AND logic", () => {
+  it("resets only when BOTH daily and idle conditions are met (idleGuard=true)", () => {
+    const policy = {
+      mode: "daily" as const,
+      atHour: 4,
+      idleMinutes: 60,
+      idleGuard: true,
+    };
+    // Session updated at 3:00 AM, now is 5:00 AM (daily boundary crossed)
+    // Idle is 2 hours = 120 min > 60 min → both conditions met → stale
+    const updated = Date.parse("2026-04-02T03:00:00");
+    const now = Date.parse("2026-04-02T05:00:00");
+    const result = evaluateSessionFreshness({ updatedAt: updated, now, policy });
+    expect(result.fresh).toBe(false);
+  });
+
+  it("stays fresh when daily crossed but idle NOT exceeded (idleGuard=true)", () => {
+    const policy = {
+      mode: "daily" as const,
+      atHour: 4,
+      idleMinutes: 60,
+      idleGuard: true,
+    };
+    // Session updated at 3:50 AM, now is 4:10 AM → daily crossed, but only 20 min idle
+    const updated = Date.parse("2026-04-02T03:50:00");
+    const now = Date.parse("2026-04-02T04:10:00");
+    const result = evaluateSessionFreshness({ updatedAt: updated, now, policy });
+    expect(result.fresh).toBe(true);
+  });
+
+  it("stays fresh when idle exceeded but daily NOT crossed (idleGuard=true)", () => {
+    const policy = {
+      mode: "daily" as const,
+      atHour: 4,
+      idleMinutes: 60,
+      idleGuard: true,
+    };
+    // Session updated at 1:00 AM, now is 3:00 AM → idle 2h > 60min, but daily (4AM) not crossed
+    const updated = Date.parse("2026-04-02T01:00:00");
+    const now = Date.parse("2026-04-02T03:00:00");
+    const result = evaluateSessionFreshness({ updatedAt: updated, now, policy });
+    expect(result.fresh).toBe(true);
+  });
+
+  it("uses OR logic when idleGuard is false (default behavior)", () => {
+    const policy = {
+      mode: "daily" as const,
+      atHour: 4,
+      idleMinutes: 60,
+      idleGuard: false,
+    };
+    // Session updated at 3:50 AM, now is 5:10 AM → daily crossed, idle 80 min
+    const updated = Date.parse("2026-04-02T03:50:00");
+    const now = Date.parse("2026-04-02T05:10:00");
+    const result = evaluateSessionFreshness({ updatedAt: updated, now, policy });
+    expect(result.fresh).toBe(false);
+  });
+
+  it("uses OR logic when idleGuard is undefined", () => {
+    const policy = {
+      mode: "daily" as const,
+      atHour: 4,
+      idleMinutes: 60,
+    };
+    // Daily crossed alone should trigger reset
+    const updated = Date.parse("2026-04-02T03:50:00");
+    const now = Date.parse("2026-04-02T04:10:00");
+    const result = evaluateSessionFreshness({ updatedAt: updated, now, policy });
+    // Daily is crossed (updatedAt 3:50 < daily boundary 4:00), idle only 20 min < 60 min
+    // With OR: daily alone makes it stale
+    expect(result.fresh).toBe(false);
   });
 });
 

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -75,6 +75,14 @@ export type SessionResetConfig = {
   atHour?: number;
   /** Sliding idle window (minutes). When set with daily mode, whichever expires first wins. */
   idleMinutes?: number;
+  /** IANA timezone for atHour (e.g. "Asia/Shanghai"). Defaults to host timezone. */
+  timezone?: string;
+  /**
+   * When true and mode is "daily", idleMinutes acts as an AND guard:
+   * session resets only when BOTH the daily boundary has passed AND the
+   * idle window has expired.  Default false preserves the OR behavior.
+   */
+  idleGuard?: boolean;
 };
 export type SessionResetByTypeConfig = {
   direct?: SessionResetConfig;

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -18,6 +18,8 @@ const SessionResetConfigSchema = z
     mode: z.union([z.literal("daily"), z.literal("idle")]).optional(),
     atHour: z.number().int().min(0).max(23).optional(),
     idleMinutes: z.number().int().positive().optional(),
+    timezone: z.string().optional(),
+    idleGuard: z.boolean().optional(),
   })
   .strict();
 

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -34,6 +34,7 @@ export function resolveCronSession(params: {
     const resetPolicy = resolveSessionResetPolicy({
       sessionCfg,
       resetType: "direct",
+      userTimezone: params.cfg.agents?.defaults?.userTimezone,
     });
     const freshness = evaluateSessionFreshness({
       updatedAt: entry.updatedAt,


### PR DESCRIPTION
## Summary

Two new optional fields on `SessionResetConfig` for better session reset control:

### 1. `timezone` — User timezone-aware daily reset

**Problem:** `resolveDailyResetAtMs()` uses server-local timezone (`new Date().setHours()`). When the server is in UTC but the user is in Asia/Shanghai, `atHour: 4` resets at UTC 04:00 (noon in Shanghai) instead of the intended 4 AM local time.

**Solution:** New `timezone` field (IANA string, e.g. `"Asia/Shanghai"`) on `SessionResetConfig`. When set, the daily boundary is computed in the user's timezone. Falls back to `agents.defaults.userTimezone`, then to host timezone.

### 2. `idleGuard` — AND mode for daily + idle

**Problem:** When both `mode: "daily"` and `idleMinutes` are set, the session resets when *either* condition is met (OR logic). Users who are actively chatting at 4 AM get their session reset mid-conversation.

**Solution:** New `idleGuard: true` flag. When enabled with `mode: "daily"`, both conditions must be met (AND logic): the daily boundary must have passed **AND** the user must have been idle for at least `idleMinutes`. Default `false` preserves existing OR behavior.

### Example config

```json
{
  "session": {
    "reset": {
      "mode": "daily",
      "atHour": 4,
      "timezone": "Asia/Shanghai",
      "idleMinutes": 60,
      "idleGuard": true
    }
  }
}
```

This resets at 4 AM Shanghai time, but only if the user has been quiet for at least 1 hour.

### Changes

- `src/config/types.base.ts` — Added `timezone` and `idleGuard` to `SessionResetConfig`
- `src/config/sessions/reset.ts` — Timezone-aware `resolveDailyResetAtMs()`, `idleGuard` AND logic in `evaluateSessionFreshness()`, `userTimezone` fallback in `resolveSessionResetPolicy()`
- `src/config/zod-schema.session.ts` — Schema validation for new fields
- `src/config/schema.help.ts` — Help text for `session.reset.timezone` and `session.reset.idleGuard`
- `src/auto-reply/reply/session.ts`, `src/agents/command/session.ts`, `src/cron/isolated-agent/session.ts` — Pass `userTimezone` to policy resolution
- `src/config/sessions/sessions.test.ts` — 12 new tests covering timezone-aware reset, idleGuard AND/OR logic

### Backward compatibility

- All new fields are optional with safe defaults
- No existing behavior changes when fields are omitted
- `idleGuard` defaults to `false` (preserves OR logic)
- `timezone` defaults to host timezone (original behavior)