### PR TITLE
feat(doctor): add Node.js runtime info health contribution

### DIFF
--- a/src/commands/doctor-node-runtime.test.ts
+++ b/src/commands/doctor-node-runtime.test.ts
@@ -203,6 +203,14 @@ describe("buildNodeRuntimeWarnings", () => {
     // No schedule entry for Node 26, and 26 >= RECOMMENDED_NODE_MAJOR (24)
     expect(warnings).toEqual([]);
   });
+
+  it("does not label unknown non-LTS majors as supported (e.g. Node 23)", () => {
+    const diag = makeDiag({ version: "23.0.0", major: 23 });
+    const warnings = buildNodeRuntimeWarnings(diag, new Date("2025-06-01"));
+    // Node 23 is not in NODE_RELEASE_SCHEDULE and is not an LTS line,
+    // so Doctor should not emit "Node 23 is supported" nudge.
+    expect(warnings).toEqual([]);
+  });
 });
 
 // ─── buildNodeRuntimeSummary ────────────────────────────────────
@@ -261,5 +269,26 @@ describe("buildNodeRuntimeSummary", () => {
     // Should have exactly 2 " · " separators (3 parts)
     const separatorCount = (summary.match(/ · /g) || []).length;
     expect(separatorCount).toBe(2);
+  });
+
+  it("does not shorten path when home dir is a prefix of sibling directory", () => {
+    // Regression test for P1: HOME=/home/alice must not match /home/alice2/...
+    const diag = makeDiag({
+      version: "24.14.0",
+      execPath: "/home/alice2/.nvm/versions/node/v24.14.0/bin/node",
+      versionManaged: true,
+      versionManagerHint: "nvm",
+    });
+    // Temporarily override HOME for this test
+    const originalHome = process.env.HOME;
+    process.env.HOME = "/home/alice";
+    try {
+      const summary = buildNodeRuntimeSummary(diag);
+      // Path should NOT be shortened — /home/alice2 is not under /home/alice
+      expect(summary).toContain("/home/alice2/.nvm/versions/node/v24.14.0/bin/node");
+      expect(summary).not.toContain("~2/");
+    } finally {
+      process.env.HOME = originalHome;
+    }
   });
 });

--- a/src/commands/doctor-node-runtime.test.ts
+++ b/src/commands/doctor-node-runtime.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for doctor-node-runtime.ts — Node.js runtime diagnostics
+ * for the `openclaw doctor` health contribution.
+ *
+ * Test groups:
+ *   - detectVersionManagerName: version manager path detection
+ *   - collectNodeRuntimeDiagnostics: data collection with injected deps
+ *   - buildNodeRuntimeWarnings: warning generation for various scenarios
+ *   - buildNodeRuntimeSummary: summary line formatting
+ */
+
+import { describe, expect, it } from "vitest";
+import type { RuntimeDetails } from "../infra/runtime-guard.js";
+import {
+  buildNodeRuntimeSummary,
+  buildNodeRuntimeWarnings,
+  collectNodeRuntimeDiagnostics,
+  detectVersionManagerName,
+  type NodeRuntimeDiagnostics,
+} from "./doctor-node-runtime.js";
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/** Build a minimal RuntimeDetails for testing. */
+function makeRuntimeDetails(overrides: Partial<RuntimeDetails> = {}): RuntimeDetails {
+  return {
+    kind: "node",
+    version: "24.14.0",
+    execPath: "/usr/local/bin/node",
+    pathEnv: "/usr/local/bin:/usr/bin",
+    ...overrides,
+  };
+}
+
+/** Build a minimal NodeRuntimeDiagnostics for testing. */
+function makeDiag(overrides: Partial<NodeRuntimeDiagnostics> = {}): NodeRuntimeDiagnostics {
+  return {
+    version: "24.14.0",
+    major: 24,
+    execPath: "/usr/local/bin/node",
+    versionManaged: false,
+    versionManagerHint: null,
+    satisfiesMinimum: true,
+    runtimeDetails: makeRuntimeDetails(),
+    ...overrides,
+  };
+}
+
+// ─── detectVersionManagerName ───────────────────────────────────
+
+describe("detectVersionManagerName", () => {
+  it("returns null for null execPath", () => {
+    expect(detectVersionManagerName(null)).toBeNull();
+  });
+
+  it("returns null for system install path", () => {
+    expect(detectVersionManagerName("/usr/local/bin/node")).toBeNull();
+  });
+
+  it("detects nvm", () => {
+    expect(detectVersionManagerName("/home/user/.nvm/versions/node/v24.14.0/bin/node")).toBe("nvm");
+  });
+
+  it("detects fnm", () => {
+    expect(detectVersionManagerName("/home/user/.fnm/node-versions/v24.14.0/bin/node")).toBe("fnm");
+  });
+
+  it("detects volta", () => {
+    expect(detectVersionManagerName("/home/user/.volta/tools/image/node/24.14.0/bin/node")).toBe(
+      "volta",
+    );
+  });
+
+  it("detects asdf", () => {
+    expect(detectVersionManagerName("/home/user/.asdf/installs/nodejs/24.14.0/bin/node")).toBe(
+      "asdf",
+    );
+  });
+
+  it("detects n", () => {
+    expect(detectVersionManagerName("/home/user/.n/bin/node")).toBe("n");
+  });
+
+  it("detects nodenv", () => {
+    expect(detectVersionManagerName("/home/user/.nodenv/versions/24.14.0/bin/node")).toBe("nodenv");
+  });
+
+  it("detects nodebrew", () => {
+    expect(detectVersionManagerName("/home/user/.nodebrew/current/bin/node")).toBe("nodebrew");
+  });
+
+  it("detects nvs", () => {
+    expect(detectVersionManagerName("/home/user/nvs/node/24.14.0/bin/node")).toBe("nvs");
+  });
+
+  it("handles Windows-style backslash paths", () => {
+    expect(
+      detectVersionManagerName("C:\\Users\\james\\.nvm\\versions\\node\\v24.14.0\\node.exe"),
+    ).toBe("nvm");
+  });
+});
+
+// ─── collectNodeRuntimeDiagnostics ──────────────────────────────
+
+describe("collectNodeRuntimeDiagnostics", () => {
+  it("collects diagnostics from injected runtime details", () => {
+    const details = makeRuntimeDetails({
+      version: "24.14.0",
+      execPath: "/home/user/.nvm/versions/node/v24.14.0/bin/node",
+    });
+    const diag = collectNodeRuntimeDiagnostics({ runtimeDetails: details });
+    expect(diag.version).toBe("24.14.0");
+    expect(diag.major).toBe(24);
+    expect(diag.satisfiesMinimum).toBe(true);
+    expect(diag.versionManaged).toBe(true);
+    expect(diag.versionManagerHint).toBe("nvm");
+  });
+
+  it("handles unknown runtime version", () => {
+    const details = makeRuntimeDetails({ version: null, kind: "unknown" });
+    const diag = collectNodeRuntimeDiagnostics({ runtimeDetails: details });
+    expect(diag.version).toBeNull();
+    expect(diag.major).toBeNull();
+    expect(diag.satisfiesMinimum).toBe(false);
+  });
+
+  it("handles system install path", () => {
+    const details = makeRuntimeDetails({
+      version: "24.14.0",
+      execPath: "/usr/local/bin/node",
+    });
+    const diag = collectNodeRuntimeDiagnostics({ runtimeDetails: details });
+    expect(diag.versionManaged).toBe(false);
+    expect(diag.versionManagerHint).toBeNull();
+  });
+});
+
+// ─── buildNodeRuntimeWarnings ───────────────────────────────────
+
+describe("buildNodeRuntimeWarnings", () => {
+  it("returns empty array for recommended version", () => {
+    const diag = makeDiag({ version: "24.14.0", major: 24 });
+    expect(buildNodeRuntimeWarnings(diag)).toEqual([]);
+  });
+
+  it("warns when Node version is below minimum", () => {
+    const diag = makeDiag({
+      version: "20.0.0",
+      major: 20,
+      satisfiesMinimum: false,
+    });
+    const warnings = buildNodeRuntimeWarnings(diag);
+    expect(warnings.length).toBe(2);
+    expect(warnings[0]).toContain("does not meet the minimum");
+    expect(warnings[1]).toContain("nodejs.org");
+  });
+
+  it("warns when Node version is past EOL", () => {
+    const diag = makeDiag({ version: "22.14.0", major: 22 });
+    // Simulate a date after Node 22 EOL (2027-04-30)
+    const futureDate = new Date("2027-06-01");
+    const warnings = buildNodeRuntimeWarnings(diag, futureDate);
+    expect(warnings.length).toBe(2);
+    expect(warnings[0]).toContain("end-of-life");
+    expect(warnings[1]).toContain("Upgrade to Node 24");
+  });
+
+  it("warns when Node version is in maintenance phase", () => {
+    const diag = makeDiag({ version: "22.14.0", major: 22 });
+    // Simulate a date during Node 22 maintenance (after 2025-10-21, before 2027-04-30)
+    const maintenanceDate = new Date("2026-06-01");
+    const warnings = buildNodeRuntimeWarnings(diag, maintenanceDate);
+    expect(warnings.length).toBe(2);
+    expect(warnings[0]).toContain("maintenance mode");
+    expect(warnings[0]).toContain("months remaining");
+    expect(warnings[1]).toContain("upgrading to Node 24");
+  });
+
+  it("nudges upgrade when running older-than-recommended LTS (pre-maintenance)", () => {
+    const diag = makeDiag({ version: "22.14.0", major: 22 });
+    // Before maintenance starts (2025-10-21)
+    const earlyDate = new Date("2025-06-01");
+    const warnings = buildNodeRuntimeWarnings(diag, earlyDate);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("Node 24 is recommended");
+  });
+
+  it("shows no warnings for current recommended version", () => {
+    const diag = makeDiag({ version: "24.14.0", major: 24 });
+    const warnings = buildNodeRuntimeWarnings(diag, new Date("2026-04-02"));
+    expect(warnings).toEqual([]);
+  });
+
+  it("handles null major version gracefully", () => {
+    const diag = makeDiag({ version: "unknown", major: null, satisfiesMinimum: true });
+    const warnings = buildNodeRuntimeWarnings(diag);
+    expect(warnings).toEqual([]);
+  });
+
+  it("handles future Node major with no schedule entry", () => {
+    const diag = makeDiag({ version: "26.0.0", major: 26 });
+    const warnings = buildNodeRuntimeWarnings(diag);
+    // No schedule entry for Node 26, and 26 >= RECOMMENDED_NODE_MAJOR (24)
+    expect(warnings).toEqual([]);
+  });
+});
+
+// ─── buildNodeRuntimeSummary ────────────────────────────────────
+
+describe("buildNodeRuntimeSummary", () => {
+  it("formats basic system install summary", () => {
+    const diag = makeDiag({
+      version: "24.14.0",
+      execPath: "/usr/local/bin/node",
+      versionManaged: false,
+      versionManagerHint: null,
+    });
+    const summary = buildNodeRuntimeSummary(diag);
+    expect(summary).toContain("Node 24.14.0");
+    expect(summary).toContain("/usr/local/bin/node");
+    expect(summary).toContain("system install");
+  });
+
+  it("formats version manager summary with name", () => {
+    const diag = makeDiag({
+      version: "24.14.0",
+      execPath: "/home/user/.nvm/versions/node/v24.14.0/bin/node",
+      versionManaged: true,
+      versionManagerHint: "nvm",
+    });
+    const summary = buildNodeRuntimeSummary(diag);
+    expect(summary).toContain("Node 24.14.0");
+    expect(summary).toContain("via nvm");
+  });
+
+  it("formats version managed but unknown manager", () => {
+    const diag = makeDiag({
+      version: "24.14.0",
+      execPath: "/some/custom/manager/bin/node",
+      versionManaged: true,
+      versionManagerHint: null,
+    });
+    const summary = buildNodeRuntimeSummary(diag);
+    expect(summary).toContain("via version manager");
+  });
+
+  it("handles null version", () => {
+    const diag = makeDiag({ version: null, execPath: null });
+    const summary = buildNodeRuntimeSummary(diag);
+    expect(summary).toContain("Node unknown");
+  });
+
+  it("uses dot separator between parts", () => {
+    const diag = makeDiag({
+      version: "24.14.0",
+      execPath: "/usr/bin/node",
+      versionManagerHint: null,
+      versionManaged: false,
+    });
+    const summary = buildNodeRuntimeSummary(diag);
+    // Should have exactly 2 " · " separators (3 parts)
+    const separatorCount = (summary.match(/ · /g) || []).length;
+    expect(separatorCount).toBe(2);
+  });
+});

--- a/src/commands/doctor-node-runtime.test.ts
+++ b/src/commands/doctor-node-runtime.test.ts
@@ -1,0 +1,250 @@
+// Tests for the Node.js runtime Doctor health contribution.
+//
+// Redaction scenarios (POSIX/Windows home boundaries, case-insensitivity)
+// are intentionally NOT tested here: path redaction moved to the shared
+// shortenHomePath helper (#121455) which carries its own regression tests.
+// This file covers version-manager detection, diagnostics collection,
+// lifecycle warnings, and the two summary forms (default without the
+// executable path, verbose-style with it).
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildNodeRuntimeSummary,
+  buildNodeRuntimeWarnings,
+  collectNodeRuntimeDiagnostics,
+  detectVersionManagerName,
+  type NodeRuntimeDiagnostics,
+} from "./doctor-node-runtime.js";
+
+/** Convenience factory for diagnostics fixtures. */
+function makeDiag(overrides: Partial<NodeRuntimeDiagnostics> = {}): NodeRuntimeDiagnostics {
+  return {
+    version: "24.14.0",
+    major: 24,
+    execPath: "/usr/bin/node",
+    versionManaged: false,
+    versionManagerHint: null,
+    ...overrides,
+  };
+}
+
+describe("detectVersionManagerName", () => {
+  it("returns null for empty environment and null path", () => {
+    expect(detectVersionManagerName({}, null)).toBe(null);
+  });
+
+  it("returns null for a plain system install path", () => {
+    expect(detectVersionManagerName({}, "/usr/bin/node")).toBe(null);
+  });
+
+  it("detects nvm via NVM_DIR", () => {
+    expect(detectVersionManagerName({ NVM_DIR: "/home/test/.nvm" }, "/usr/bin/node")).toBe("nvm");
+  });
+
+  it("detects nvm via execPath", () => {
+    expect(
+      detectVersionManagerName({}, "/home/test/.nvm/versions/node/v24.14.0/bin/node"),
+    ).toBe("nvm");
+  });
+
+  it("detects fnm via execPath", () => {
+    expect(
+      detectVersionManagerName(
+        {},
+        "/home/test/.local/share/fnm/node-versions/v24.14.0/installation/bin/node",
+      ),
+    ).toBe("fnm");
+  });
+
+  it("detects volta via execPath", () => {
+    expect(
+      detectVersionManagerName({}, "/home/test/.volta/tools/image/node/24.14.0/bin/node"),
+    ).toBe("volta");
+  });
+
+  it("detects asdf via execPath", () => {
+    expect(
+      detectVersionManagerName({}, "/home/test/.asdf/installs/nodejs/24.14.0/bin/node"),
+    ).toBe("asdf");
+  });
+
+  it("detects n via execPath", () => {
+    expect(detectVersionManagerName({}, "/usr/local/n/versions/node/24.14.0/bin/node")).toBe("n");
+  });
+
+  it("detects nodenv via execPath", () => {
+    expect(detectVersionManagerName({}, "/home/test/.nodenv/versions/24.14.0/bin/node")).toBe(
+      "nodenv",
+    );
+  });
+
+  it("detects nodebrew via execPath", () => {
+    expect(detectVersionManagerName({}, "/home/test/.nodebrew/node/v24.14.0/bin/node")).toBe(
+      "nodebrew",
+    );
+  });
+
+  it("detects nvs via execPath", () => {
+    expect(detectVersionManagerName({}, "/home/test/.nvs/node/24.14.0/x64/bin/node")).toBe("nvs");
+  });
+
+  it("detects managers on Windows-style backslash paths regardless of casing", () => {
+    expect(
+      detectVersionManagerName({}, "C:\\Users\\Test\\.NVM\\versions\\node\\v24.14.0\\node.exe"),
+    ).toBe("nvm");
+    expect(
+      detectVersionManagerName(
+        {},
+        "c:\\users\\test\\.volta\\tools\\image\\node\\24.14.0\\node.exe",
+      ),
+    ).toBe("volta");
+  });
+});
+
+describe("collectNodeRuntimeDiagnostics", () => {
+  it("collects an nvm-managed runtime", () => {
+    const diag = collectNodeRuntimeDiagnostics(
+      {},
+      "/home/test/.nvm/versions/node/v24.14.0/bin/node",
+      "v24.14.0",
+    );
+    expect(diag.version).toBe("24.14.0");
+    expect(diag.major).toBe(24);
+    expect(diag.versionManaged).toBe(true);
+    expect(diag.versionManagerHint).toBe("nvm");
+  });
+
+  it("degrades gracefully for an unknown runtime shape", () => {
+    const diag = collectNodeRuntimeDiagnostics({}, null, null);
+    expect(diag.version).toBe(null);
+    expect(diag.major).toBe(null);
+    expect(diag.execPath).toBe(null);
+    expect(diag.versionManaged).toBe(false);
+    expect(diag.versionManagerHint).toBe(null);
+  });
+
+  it("collects a system install runtime", () => {
+    const diag = collectNodeRuntimeDiagnostics({}, "/usr/bin/node", "v24.14.0");
+    expect(diag.versionManaged).toBe(false);
+    expect(diag.versionManagerHint).toBe(null);
+    expect(diag.execPath).toBe("/usr/bin/node");
+  });
+});
+
+describe("buildNodeRuntimeWarnings", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Fixed reference date: Node 24 is current and not yet in maintenance;
+    // Node 22 is in maintenance; Node 20 and Node 25 are past EOL.
+    vi.setSystemTime(new Date("2026-08-10T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns no warnings for the recommended current version", () => {
+    expect(buildNodeRuntimeWarnings(makeDiag({ version: "24.14.0", major: 24 }))).toEqual([]);
+  });
+
+  it("warns when the version is below the minimum requirement", () => {
+    const warnings = buildNodeRuntimeWarnings(makeDiag({ version: "20.18.0", major: 20 }));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("does not meet the minimum requirement");
+    expect(warnings[0]).toContain(">=22.19.0");
+  });
+
+  it("warns when the release is past end-of-life", () => {
+    // Node 25 (odd, non-LTS) reached EOL 2026-06-01 and satisfies the minimum.
+    const warnings = buildNodeRuntimeWarnings(makeDiag({ version: "25.6.1", major: 25 }));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("end-of-life");
+    expect(warnings[0]).toContain("Node 24");
+  });
+
+  it("warns when the release is in maintenance mode", () => {
+    const warnings = buildNodeRuntimeWarnings(makeDiag({ version: "22.19.0", major: 22 }));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("maintenance mode");
+    expect(warnings[0]).toContain("EOL 2027-04-30");
+  });
+
+  it("nudges toward the recommended LTS for supported majors not yet in maintenance", () => {
+    // At an earlier reference date Node 22 has not entered maintenance yet
+    // (maintenanceStart 2025-10-21), is LTS, and is older than the
+    // recommended major, so the gentle nudge fires.
+    vi.setSystemTime(new Date("2025-09-01T00:00:00Z"));
+    const warnings = buildNodeRuntimeWarnings(makeDiag({ version: "22.19.0", major: 22 }));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("older than the recommended LTS");
+    expect(warnings[0]).toContain("Node 24");
+  });
+
+  it("returns no warnings when the version is missing", () => {
+    expect(buildNodeRuntimeWarnings(makeDiag({ version: null, major: null }))).toEqual([]);
+  });
+
+  it("returns no warnings for an unknown future major", () => {
+    expect(buildNodeRuntimeWarnings(makeDiag({ version: "99.0.0", major: 99 }))).toEqual([]);
+  });
+
+  it("prioritizes the below-minimum warning over lifecycle warnings", () => {
+    // Node 20 is both below minimum and past EOL; only the minimum warning
+    // should surface (it already forces an upgrade).
+    const warnings = buildNodeRuntimeWarnings(makeDiag({ version: "20.18.0", major: 20 }));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("minimum requirement");
+    expect(warnings[0]).not.toContain("end-of-life");
+  });
+});
+
+describe("buildNodeRuntimeSummary", () => {
+  it("renders version and channel only by default (no executable path)", () => {
+    const summary = buildNodeRuntimeSummary(
+      makeDiag({
+        execPath: "/home/test/.nvm/versions/node/v24.14.0/bin/node",
+        versionManaged: true,
+        versionManagerHint: "nvm",
+      }),
+    );
+    expect(summary).toBe("Node 24.14.0 \u00b7 via nvm");
+    expect(summary).not.toContain("/home/test");
+    expect(summary).not.toContain(".nvm");
+  });
+
+  it("renders a system install without a path by default", () => {
+    expect(buildNodeRuntimeSummary(makeDiag())).toBe("Node 24.14.0 \u00b7 system install");
+  });
+
+  it("includes the executable path when includeExecPath is set", () => {
+    const summary = buildNodeRuntimeSummary(
+      makeDiag({
+        execPath: "/opt/node/bin/node",
+        versionManaged: true,
+        versionManagerHint: "volta",
+      }),
+      { includeExecPath: true },
+    );
+    expect(summary).toContain("/opt/node/bin/node");
+    expect(summary).toContain("via volta");
+  });
+
+  it("labels a version-managed runtime without a hint generically", () => {
+    const summary = buildNodeRuntimeSummary(
+      makeDiag({ versionManaged: true, versionManagerHint: null }),
+    );
+    expect(summary).toBe("Node 24.14.0 \u00b7 version-managed");
+  });
+
+  it("degrades gracefully when the version is unknown", () => {
+    const summary = buildNodeRuntimeSummary(makeDiag({ version: null }));
+    expect(summary).toBe("Node (version unknown) \u00b7 system install");
+  });
+
+  it("uses the interpunct separator between segments", () => {
+    const summary = buildNodeRuntimeSummary(makeDiag(), { includeExecPath: true });
+    const segments = summary.split(" \u00b7 ");
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toBe("Node 24.14.0");
+    expect(segments[2]).toBe("system install");
+  });
+});

--- a/src/commands/doctor-node-runtime.test.ts
+++ b/src/commands/doctor-node-runtime.test.ts
@@ -1,11 +1,13 @@
 // Tests for the Node.js runtime Doctor health contribution.
 //
-// Redaction scenarios (POSIX/Windows home boundaries, case-insensitivity)
-// are intentionally NOT tested here: path redaction moved to the shared
-// shortenHomePath helper (#121455) which carries its own regression tests.
-// This file covers version-manager detection, diagnostics collection,
-// lifecycle warnings, and the two summary forms (default without the
-// executable path, verbose-style with it).
+// Support decisions are delegated to runtime-guard's isSupportedNodeVersion
+// (the canonical engines contract), so these tests exercise the delegation
+// boundary with engines edge versions rather than re-encoding version
+// knowledge. Redaction scenarios are NOT tested here: path redaction moved
+// to the shared shortenHomePath helper (#121455) which carries its own
+// regression tests. This file covers version-manager detection, diagnostics
+// collection, lifecycle advisories, and the two summary forms (default
+// without the executable path, verbose-style with it).
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildNodeRuntimeSummary,
@@ -18,7 +20,7 @@ import {
 /** Convenience factory for diagnostics fixtures. */
 function makeDiag(overrides: Partial<NodeRuntimeDiagnostics> = {}): NodeRuntimeDiagnostics {
   return {
-    version: "24.14.0",
+    version: "24.15.0",
     major: 24,
     execPath: "/usr/bin/node",
     versionManaged: false,
@@ -42,7 +44,7 @@ describe("detectVersionManagerName", () => {
 
   it("detects nvm via execPath", () => {
     expect(
-      detectVersionManagerName({}, "/home/test/.nvm/versions/node/v24.14.0/bin/node"),
+      detectVersionManagerName({}, "/home/test/.nvm/versions/node/v24.15.0/bin/node"),
     ).toBe("nvm");
   });
 
@@ -50,51 +52,51 @@ describe("detectVersionManagerName", () => {
     expect(
       detectVersionManagerName(
         {},
-        "/home/test/.local/share/fnm/node-versions/v24.14.0/installation/bin/node",
+        "/home/test/.local/share/fnm/node-versions/v24.15.0/installation/bin/node",
       ),
     ).toBe("fnm");
   });
 
   it("detects volta via execPath", () => {
     expect(
-      detectVersionManagerName({}, "/home/test/.volta/tools/image/node/24.14.0/bin/node"),
+      detectVersionManagerName({}, "/home/test/.volta/tools/image/node/24.15.0/bin/node"),
     ).toBe("volta");
   });
 
   it("detects asdf via execPath", () => {
     expect(
-      detectVersionManagerName({}, "/home/test/.asdf/installs/nodejs/24.14.0/bin/node"),
+      detectVersionManagerName({}, "/home/test/.asdf/installs/nodejs/24.15.0/bin/node"),
     ).toBe("asdf");
   });
 
   it("detects n via execPath", () => {
-    expect(detectVersionManagerName({}, "/usr/local/n/versions/node/24.14.0/bin/node")).toBe("n");
+    expect(detectVersionManagerName({}, "/usr/local/n/versions/node/24.15.0/bin/node")).toBe("n");
   });
 
   it("detects nodenv via execPath", () => {
-    expect(detectVersionManagerName({}, "/home/test/.nodenv/versions/24.14.0/bin/node")).toBe(
+    expect(detectVersionManagerName({}, "/home/test/.nodenv/versions/24.15.0/bin/node")).toBe(
       "nodenv",
     );
   });
 
   it("detects nodebrew via execPath", () => {
-    expect(detectVersionManagerName({}, "/home/test/.nodebrew/node/v24.14.0/bin/node")).toBe(
+    expect(detectVersionManagerName({}, "/home/test/.nodebrew/node/v24.15.0/bin/node")).toBe(
       "nodebrew",
     );
   });
 
   it("detects nvs via execPath", () => {
-    expect(detectVersionManagerName({}, "/home/test/.nvs/node/24.14.0/x64/bin/node")).toBe("nvs");
+    expect(detectVersionManagerName({}, "/home/test/.nvs/node/24.15.0/x64/bin/node")).toBe("nvs");
   });
 
   it("detects managers on Windows-style backslash paths regardless of casing", () => {
     expect(
-      detectVersionManagerName({}, "C:\\Users\\Test\\.NVM\\versions\\node\\v24.14.0\\node.exe"),
+      detectVersionManagerName({}, "C:\\Users\\Test\\.NVM\\versions\\node\\v24.15.0\\node.exe"),
     ).toBe("nvm");
     expect(
       detectVersionManagerName(
         {},
-        "c:\\users\\test\\.volta\\tools\\image\\node\\24.14.0\\node.exe",
+        "c:\\users\\test\\.volta\\tools\\image\\node\\24.15.0\\node.exe",
       ),
     ).toBe("volta");
   });
@@ -104,10 +106,10 @@ describe("collectNodeRuntimeDiagnostics", () => {
   it("collects an nvm-managed runtime", () => {
     const diag = collectNodeRuntimeDiagnostics(
       {},
-      "/home/test/.nvm/versions/node/v24.14.0/bin/node",
-      "v24.14.0",
+      "/home/test/.nvm/versions/node/v24.15.0/bin/node",
+      "v24.15.0",
     );
-    expect(diag.version).toBe("24.14.0");
+    expect(diag.version).toBe("24.15.0");
     expect(diag.major).toBe(24);
     expect(diag.versionManaged).toBe(true);
     expect(diag.versionManagerHint).toBe("nvm");
@@ -123,7 +125,7 @@ describe("collectNodeRuntimeDiagnostics", () => {
   });
 
   it("collects a system install runtime", () => {
-    const diag = collectNodeRuntimeDiagnostics({}, "/usr/bin/node", "v24.14.0");
+    const diag = collectNodeRuntimeDiagnostics({}, "/usr/bin/node", "v24.15.0");
     expect(diag.versionManaged).toBe(false);
     expect(diag.versionManagerHint).toBe(null);
     expect(diag.execPath).toBe("/usr/bin/node");
@@ -133,8 +135,10 @@ describe("collectNodeRuntimeDiagnostics", () => {
 describe("buildNodeRuntimeWarnings", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    // Fixed reference date: Node 24 is current and not yet in maintenance;
-    // Node 22 is in maintenance; Node 20 and Node 25 are past EOL.
+    // Fixed reference date. Per the upstream schedule encoded in the module:
+    // Node 22 is in maintenance (since 2025-10-21, EOL 2027-04-30);
+    // Node 24 is fully current (maintenance starts 2026-10-20);
+    // Node 25 is supported and not yet in maintenance (starts 2026-10-01).
     vi.setSystemTime(new Date("2026-08-10T00:00:00Z"));
   });
 
@@ -142,58 +146,50 @@ describe("buildNodeRuntimeWarnings", () => {
     vi.useRealTimers();
   });
 
-  it("returns no warnings for the recommended current version", () => {
-    expect(buildNodeRuntimeWarnings(makeDiag({ version: "24.14.0", major: 24 }))).toEqual([]);
+  it("returns no warnings for a fully current supported version", () => {
+    expect(buildNodeRuntimeWarnings(makeDiag({ version: "24.15.0", major: 24 }))).toEqual([]);
   });
 
-  it("warns when the version is below the minimum requirement", () => {
+  it("warns via the engines contract for an unsupported major", () => {
+    // Node 20 is outside the engines range entirely.
     const warnings = buildNodeRuntimeWarnings(makeDiag({ version: "20.18.0", major: 20 }));
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("does not meet the minimum requirement");
-    expect(warnings[0]).toContain(">=22.19.0");
+    expect(warnings[0]).toContain("outside OpenClaw's supported engine range");
+    expect(warnings[0]).toContain("package.json engines");
   });
 
-  it("warns when the release is past end-of-life", () => {
-    // Node 25 (odd, non-LTS) reached EOL 2026-06-01 and satisfies the minimum.
-    const warnings = buildNodeRuntimeWarnings(makeDiag({ version: "25.6.1", major: 25 }));
+  it("warns via the engines contract for a below-floor patch of a supported major", () => {
+    // Node 24.0.0 is below the 24.15.0 engines floor.
+    const warnings = buildNodeRuntimeWarnings(makeDiag({ version: "24.0.0", major: 24 }));
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("end-of-life");
-    expect(warnings[0]).toContain("Node 24");
+    expect(warnings[0]).toContain("outside OpenClaw's supported engine range");
   });
 
-  it("warns when the release is in maintenance mode", () => {
-    const warnings = buildNodeRuntimeWarnings(makeDiag({ version: "22.19.0", major: 22 }));
+  it("notes maintenance mode for a supported release in upstream maintenance", () => {
+    const warnings = buildNodeRuntimeWarnings(makeDiag({ version: "22.22.3", major: 22 }));
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain("maintenance mode");
     expect(warnings[0]).toContain("EOL 2027-04-30");
   });
 
-  it("nudges toward the recommended LTS for supported majors not yet in maintenance", () => {
-    // At an earlier reference date Node 22 has not entered maintenance yet
-    // (maintenanceStart 2025-10-21), is LTS, and is older than the
-    // recommended major, so the gentle nudge fires.
-    vi.setSystemTime(new Date("2025-09-01T00:00:00Z"));
-    const warnings = buildNodeRuntimeWarnings(makeDiag({ version: "22.19.0", major: 22 }));
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("older than the recommended LTS");
-    expect(warnings[0]).toContain("Node 24");
+  it("stays quiet for a supported release not yet in maintenance", () => {
+    // Node 25.9.0 satisfies engines; its maintenance window starts 2026-10-01.
+    expect(buildNodeRuntimeWarnings(makeDiag({ version: "25.9.0", major: 25 }))).toEqual([]);
   });
 
   it("returns no warnings when the version is missing", () => {
     expect(buildNodeRuntimeWarnings(makeDiag({ version: null, major: null }))).toEqual([]);
   });
 
-  it("returns no warnings for an unknown future major", () => {
+  it("returns no lifecycle note for an unknown future major", () => {
     expect(buildNodeRuntimeWarnings(makeDiag({ version: "99.0.0", major: 99 }))).toEqual([]);
   });
 
-  it("prioritizes the below-minimum warning over lifecycle warnings", () => {
-    // Node 20 is both below minimum and past EOL; only the minimum warning
-    // should surface (it already forces an upgrade).
+  it("does not stack lifecycle advice onto the engines warning", () => {
+    // Unsupported versions get exactly one warning: the engines pointer.
     const warnings = buildNodeRuntimeWarnings(makeDiag({ version: "20.18.0", major: 20 }));
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("minimum requirement");
-    expect(warnings[0]).not.toContain("end-of-life");
+    expect(warnings[0]).not.toContain("maintenance");
   });
 });
 
@@ -201,18 +197,18 @@ describe("buildNodeRuntimeSummary", () => {
   it("renders version and channel only by default (no executable path)", () => {
     const summary = buildNodeRuntimeSummary(
       makeDiag({
-        execPath: "/home/test/.nvm/versions/node/v24.14.0/bin/node",
+        execPath: "/home/test/.nvm/versions/node/v24.15.0/bin/node",
         versionManaged: true,
         versionManagerHint: "nvm",
       }),
     );
-    expect(summary).toBe("Node 24.14.0 \u00b7 via nvm");
+    expect(summary).toBe("Node 24.15.0 \u00b7 via nvm");
     expect(summary).not.toContain("/home/test");
     expect(summary).not.toContain(".nvm");
   });
 
   it("renders a system install without a path by default", () => {
-    expect(buildNodeRuntimeSummary(makeDiag())).toBe("Node 24.14.0 \u00b7 system install");
+    expect(buildNodeRuntimeSummary(makeDiag())).toBe("Node 24.15.0 \u00b7 system install");
   });
 
   it("includes the executable path when includeExecPath is set", () => {
@@ -232,7 +228,7 @@ describe("buildNodeRuntimeSummary", () => {
     const summary = buildNodeRuntimeSummary(
       makeDiag({ versionManaged: true, versionManagerHint: null }),
     );
-    expect(summary).toBe("Node 24.14.0 \u00b7 version-managed");
+    expect(summary).toBe("Node 24.15.0 \u00b7 version-managed");
   });
 
   it("degrades gracefully when the version is unknown", () => {
@@ -244,7 +240,7 @@ describe("buildNodeRuntimeSummary", () => {
     const summary = buildNodeRuntimeSummary(makeDiag(), { includeExecPath: true });
     const segments = summary.split(" \u00b7 ");
     expect(segments).toHaveLength(3);
-    expect(segments[0]).toBe("Node 24.14.0");
+    expect(segments[0]).toBe("Node 24.15.0");
     expect(segments[2]).toBe("system install");
   });
 });

--- a/src/commands/doctor-node-runtime.ts
+++ b/src/commands/doctor-node-runtime.ts
@@ -8,8 +8,8 @@
  * Checks performed:
  *   1. Runtime summary — Node version, executable path, version-manager hint
  *   2. Version-manager detection — nvm / fnm / volta / asdf / n / nodenv / nodebrew / nvs
- *   3. EOL proximity warning — Node 22 enters maintenance Oct 2026, EOL Apr 2027
- *   4. Recommended version nudge — suggest Node 24 when running Node 22
+ *   3. EOL proximity warning — Node 22 enters maintenance Oct 2025, EOL Apr 2027
+ *   4. Recommended version nudge — suggest Node 24 when running an older LTS
  *
  * Registered as a Doctor health contribution. Always runs (Node is the
  * only supported runtime), but keeps output to a single informational
@@ -139,6 +139,13 @@ const NODE_RELEASE_SCHEDULE: ReadonlyArray<{
 const RECOMMENDED_NODE_MAJOR = 24;
 
 /**
+ * Set of major versions tracked in NODE_RELEASE_SCHEDULE.
+ * Used to distinguish "known older LTS" from "unknown/non-LTS" majors
+ * when deciding whether to show an upgrade nudge.
+ */
+const KNOWN_RELEASE_MAJORS = new Set(NODE_RELEASE_SCHEDULE.map((s) => s.major));
+
+/**
  * Build user-facing diagnostic notes from Node.js runtime diagnostics.
  * Returns an empty array when everything looks healthy.
  *
@@ -195,9 +202,16 @@ export function buildNodeRuntimeWarnings(
     }
 
     // ── Recommended version nudge ──
-    // Only shown when not already warned about EOL/maintenance,
-    // and only when running an older-than-recommended LTS.
-    if (warnings.length === 0 && diag.major < RECOMMENDED_NODE_MAJOR) {
+    // Only shown when:
+    //   - not already warned about EOL/maintenance above
+    //   - running a known older LTS (tracked in NODE_RELEASE_SCHEDULE)
+    //   - NOT shown for unknown/non-LTS majors (e.g. Node 23) to avoid
+    //     incorrectly labeling them as "supported"
+    if (
+      warnings.length === 0 &&
+      diag.major < RECOMMENDED_NODE_MAJOR &&
+      KNOWN_RELEASE_MAJORS.has(diag.major)
+    ) {
       warnings.push(
         `Node ${diag.major} is supported, but Node ${RECOMMENDED_NODE_MAJOR} is recommended for best performance and longest support window.`,
       );
@@ -210,7 +224,7 @@ export function buildNodeRuntimeWarnings(
 /**
  * Build a one-line Node.js runtime summary for Doctor output.
  *
- * Example: "Node 24.14.0 · /home/user/.nvm/versions/node/v24.14.0/bin/node · nvm"
+ * Example: "Node 24.14.0 · ~/.nvm/versions/node/v24.14.0/bin/node · nvm"
  */
 export function buildNodeRuntimeSummary(diag: NodeRuntimeDiagnostics): string {
   const parts: string[] = [];
@@ -222,7 +236,10 @@ export function buildNodeRuntimeSummary(diag: NodeRuntimeDiagnostics): string {
   if (diag.execPath) {
     const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? "";
     let displayPath = diag.execPath;
-    if (homeDir && displayPath.startsWith(homeDir)) {
+    // Ensure directory-boundary match: homeDir must be an exact prefix
+    // followed by "/" (or be an exact match). Without this guard,
+    // HOME=/home/alice would incorrectly match /home/alice2/...
+    if (homeDir && (displayPath === homeDir || displayPath.startsWith(homeDir + "/"))) {
       displayPath = "~" + displayPath.slice(homeDir.length);
     }
     parts.push(displayPath);

--- a/src/commands/doctor-node-runtime.ts
+++ b/src/commands/doctor-node-runtime.ts
@@ -1,0 +1,268 @@
+/**
+ * Node.js runtime diagnostics for `openclaw doctor`.
+ *
+ * Emits a concise runtime summary note (version, path, version-manager
+ * detection) and warns when the running Node version is approaching
+ * end-of-life or is older than the recommended release line.
+ *
+ * Checks performed:
+ *   1. Runtime summary — Node version, executable path, version-manager hint
+ *   2. Version-manager detection — nvm / fnm / volta / asdf / n / nodenv / nodebrew / nvs
+ *   3. EOL proximity warning — Node 22 enters maintenance Oct 2026, EOL Apr 2027
+ *   4. Recommended version nudge — suggest Node 24 when running Node 22
+ *
+ * Registered as a Doctor health contribution. Always runs (Node is the
+ * only supported runtime), but keeps output to a single informational
+ * note plus optional warnings.
+ *
+ * This contribution reuses infrastructure from:
+ *   - src/infra/runtime-guard.ts  (parseSemver, detectRuntime, MIN_NODE)
+ *   - src/daemon/runtime-paths.ts (isVersionManagedNodePath)
+ */
+
+import process from "node:process";
+import { isVersionManagedNodePath } from "../daemon/runtime-paths.js";
+import {
+  detectRuntime,
+  parseSemver,
+  runtimeSatisfies,
+  type RuntimeDetails,
+} from "../infra/runtime-guard.js";
+import { note } from "../terminal/note.js";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+/** Complete Node.js runtime diagnostics result. */
+export type NodeRuntimeDiagnostics = {
+  /** Node.js version string (e.g. "24.14.0"), or null if unknown. */
+  version: string | null;
+  /** Parsed major version number, or null if unparseable. */
+  major: number | null;
+  /** Absolute path to the Node.js executable. */
+  execPath: string | null;
+  /** Whether the executable lives under a known version manager directory. */
+  versionManaged: boolean;
+  /** Name of the detected version manager, or null. */
+  versionManagerHint: string | null;
+  /** Whether the current version satisfies the minimum requirement. */
+  satisfiesMinimum: boolean;
+  /** The full RuntimeDetails from runtime-guard. */
+  runtimeDetails: RuntimeDetails;
+};
+
+// ─── Version Manager Detection ──────────────────────────────────
+
+/**
+ * Well-known version manager directory markers and their display names.
+ * Order matches VERSION_MANAGER_MARKERS in runtime-paths.ts.
+ */
+const VERSION_MANAGER_NAMES: ReadonlyArray<{ marker: string; name: string }> = [
+  { marker: "/.nvm/", name: "nvm" },
+  { marker: "/.fnm/", name: "fnm" },
+  { marker: "/.volta/", name: "volta" },
+  { marker: "/.asdf/", name: "asdf" },
+  { marker: "/.n/", name: "n" },
+  { marker: "/.nodenv/", name: "nodenv" },
+  { marker: "/.nodebrew/", name: "nodebrew" },
+  { marker: "/nvs/", name: "nvs" },
+];
+
+/**
+ * Detect which version manager (if any) manages the given Node path.
+ * Returns the human-readable name or null.
+ */
+export function detectVersionManagerName(execPath: string | null): string | null {
+  if (!execPath) {
+    return null;
+  }
+  const normalized = execPath.replace(/\\/g, "/");
+  for (const { marker, name } of VERSION_MANAGER_NAMES) {
+    if (normalized.includes(marker)) {
+      return name;
+    }
+  }
+  return null;
+}
+
+// ─── Data Collector ─────────────────────────────────────────────
+
+/**
+ * Collect all Node.js runtime diagnostics.
+ *
+ * Accepts optional deps for testing. Production callers use
+ * the defaults (process.execPath, detectRuntime()).
+ */
+export function collectNodeRuntimeDiagnostics(deps?: {
+  runtimeDetails?: RuntimeDetails;
+}): NodeRuntimeDiagnostics {
+  const details = deps?.runtimeDetails ?? detectRuntime();
+  const parsed = parseSemver(details.version);
+  const execPath = details.execPath ?? process.execPath ?? null;
+
+  return {
+    version: details.version,
+    major: parsed?.major ?? null,
+    execPath,
+    versionManaged: execPath ? isVersionManagedNodePath(execPath) : false,
+    versionManagerHint: detectVersionManagerName(execPath),
+    satisfiesMinimum: runtimeSatisfies(details),
+    runtimeDetails: details,
+  };
+}
+
+// ─── Diagnostic Report ──────────────────────────────────────────
+
+/**
+ * Node.js major release schedule (for EOL/maintenance warnings).
+ *
+ * Source: https://github.com/nodejs/release#release-schedule
+ * Only tracks currently relevant release lines.
+ */
+const NODE_RELEASE_SCHEDULE: ReadonlyArray<{
+  major: number;
+  /** Start of maintenance phase (reduced support). */
+  maintenanceStart: string;
+  /** End of life — no more updates. */
+  eol: string;
+  /** Display label for messaging. */
+  label: string;
+}> = [
+  {
+    major: 22,
+    maintenanceStart: "2025-10-21",
+    eol: "2027-04-30",
+    label: "Node 22 LTS",
+  },
+];
+
+/** The recommended Node.js major version for new installs. */
+const RECOMMENDED_NODE_MAJOR = 24;
+
+/**
+ * Build user-facing diagnostic notes from Node.js runtime diagnostics.
+ * Returns an empty array when everything looks healthy.
+ *
+ * @param diag - collected diagnostics
+ * @param now  - current date (injectable for testing)
+ */
+export function buildNodeRuntimeWarnings(
+  diag: NodeRuntimeDiagnostics,
+  now: Date = new Date(),
+): string[] {
+  const warnings: string[] = [];
+
+  // ── Minimum version check ──
+  // This should rarely trigger (startup gate catches it first),
+  // but guards against edge cases like running doctor via a
+  // different code path.
+  if (!diag.satisfiesMinimum) {
+    warnings.push(
+      `Node ${diag.version ?? "unknown"} does not meet the minimum requirement (>=22.14.0).`,
+    );
+    warnings.push("Upgrade Node: https://nodejs.org/en/download");
+    return warnings;
+  }
+
+  // ── EOL / maintenance proximity warnings ──
+  if (diag.major !== null) {
+    const schedule = NODE_RELEASE_SCHEDULE.find((s) => s.major === diag.major);
+    if (schedule) {
+      const eolDate = new Date(schedule.eol);
+      const maintenanceDate = new Date(schedule.maintenanceStart);
+      const nowMs = now.getTime();
+
+      if (nowMs >= eolDate.getTime()) {
+        // Already past EOL
+        warnings.push(
+          `${schedule.label} reached end-of-life on ${schedule.eol} and no longer receives security updates.`,
+        );
+        warnings.push(
+          `Upgrade to Node ${RECOMMENDED_NODE_MAJOR} (recommended): https://nodejs.org/en/download`,
+        );
+      } else if (nowMs >= maintenanceDate.getTime()) {
+        // In maintenance phase — still supported but winding down
+        const monthsLeft = Math.max(
+          1,
+          Math.round((eolDate.getTime() - nowMs) / (30 * 24 * 60 * 60 * 1000)),
+        );
+        warnings.push(
+          `${schedule.label} is in maintenance mode (EOL ${schedule.eol}, ~${monthsLeft} months remaining).`,
+        );
+        warnings.push(
+          `Consider upgrading to Node ${RECOMMENDED_NODE_MAJOR} for the latest features and longer support.`,
+        );
+      }
+    }
+
+    // ── Recommended version nudge ──
+    // Only shown when not already warned about EOL/maintenance,
+    // and only when running an older-than-recommended LTS.
+    if (warnings.length === 0 && diag.major < RECOMMENDED_NODE_MAJOR) {
+      warnings.push(
+        `Node ${diag.major} is supported, but Node ${RECOMMENDED_NODE_MAJOR} is recommended for best performance and longest support window.`,
+      );
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Build a one-line Node.js runtime summary for Doctor output.
+ *
+ * Example: "Node 24.14.0 · /home/user/.nvm/versions/node/v24.14.0/bin/node · nvm"
+ */
+export function buildNodeRuntimeSummary(diag: NodeRuntimeDiagnostics): string {
+  const parts: string[] = [];
+
+  // Version
+  parts.push(`Node ${diag.version ?? "unknown"}`);
+
+  // Executable path (shortened for readability)
+  if (diag.execPath) {
+    const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? "";
+    let displayPath = diag.execPath;
+    if (homeDir && displayPath.startsWith(homeDir)) {
+      displayPath = "~" + displayPath.slice(homeDir.length);
+    }
+    parts.push(displayPath);
+  }
+
+  // Version manager
+  if (diag.versionManagerHint) {
+    parts.push(`via ${diag.versionManagerHint}`);
+  } else if (diag.versionManaged) {
+    parts.push("via version manager");
+  } else {
+    parts.push("system install");
+  }
+
+  return parts.join(" · ");
+}
+
+// ─── Doctor Contribution Entry Point ────────────────────────────
+
+/**
+ * Doctor health contribution: Node.js runtime information.
+ *
+ * Always runs (Node is the only supported runtime). Emits:
+ *   - A runtime summary note (version, path, manager)
+ *   - Optional warnings for EOL proximity or upgrade suggestions
+ *
+ * This contribution intentionally does not duplicate the startup
+ * version gate (runtime-guard.ts assertSupportedRuntime) — it
+ * provides diagnostic context and forward-looking advice.
+ */
+export async function noteNodeRuntime(): Promise<void> {
+  const diag = collectNodeRuntimeDiagnostics();
+
+  // Always show the runtime summary
+  const summary = buildNodeRuntimeSummary(diag);
+  note(summary, "Node.js runtime");
+
+  // Show warnings when applicable
+  const warnings = buildNodeRuntimeWarnings(diag);
+  if (warnings.length > 0) {
+    note(warnings.join("\n"), "Node.js runtime advisory");
+  }
+}

--- a/src/commands/doctor-node-runtime.ts
+++ b/src/commands/doctor-node-runtime.ts
@@ -1,31 +1,27 @@
 // Doctor health contribution: Node.js runtime diagnostics.
 //
 // Surfaces the Node version, install channel (version manager vs system), and
-// proactive lifecycle guidance (below-minimum, past-EOL, maintenance phase)
-// during `openclaw doctor`. Reuses runtime-guard's semver helpers and the
-// shared shortenHomePath redaction (which handles POSIX and Windows home
-// boundaries case-insensitively, see #121455) rather than local variants.
+// proactive lifecycle guidance during `openclaw doctor`. Version support is
+// delegated entirely to runtime-guard's isSupportedNodeVersion (the canonical
+// engines contract) rather than a local copy, so this note can never disagree
+// with what installs actually enforce. Path redaction reuses the shared
+// shortenHomePath helper (POSIX + Windows home boundaries, case-insensitive,
+// see #121455) rather than local variants.
 //
 // The default summary omits the executable path entirely so ordinary copied
 // Doctor output does not disclose local filesystem layout. Path inclusion is
 // parameterized (includeExecPath) for the verbose gate; the verbose flag
 // itself and its wiring are owned by the maintainer per the #59414 split.
 import { shortenHomePath } from "../utils.js";
-import { parseSemver } from "../infra/runtime-guard.js";
+import { isSupportedNodeVersion, parseSemver } from "../infra/runtime-guard.js";
 import { createDoctorHealthContribution } from "../flows/doctor-health-contribution.js";
 
-/** Minimum supported Node version; keep in sync with runtime-guard. */
-const MINIMUM_NODE_RANGE = ">=22.19.0";
-const MINIMUM_NODE_VERSION = "22.19.0";
-
-/** Recommended (current Active LTS) major used in upgrade guidance. */
-const RECOMMENDED_NODE_MAJOR = 24;
-
 /**
- * Node.js release lifecycle schedule (maintenance entry and end-of-life),
- * sourced from the official Node.js release working group data. Only majors
- * that can plausibly appear in the wild are listed; unknown majors degrade
- * gracefully (no lifecycle warning).
+ * Node.js release lifecycle dates (maintenance entry and end-of-life),
+ * sourced from the official Node.js release working group schedule. Used
+ * only for advisory lifecycle notes about releases the engines contract
+ * already accepts; support decisions themselves come from
+ * isSupportedNodeVersion. Unknown majors degrade gracefully (no note).
  */
 interface NodeReleaseInfo {
   major: number;
@@ -35,10 +31,9 @@ interface NodeReleaseInfo {
 }
 
 const NODE_RELEASE_SCHEDULE: NodeReleaseInfo[] = [
-  { major: 20, maintenanceStart: "2023-10-24", endOfLife: "2026-04-30", isLts: true },
   { major: 22, maintenanceStart: "2025-10-21", endOfLife: "2027-04-30", isLts: true },
   { major: 24, maintenanceStart: "2026-10-20", endOfLife: "2028-04-30", isLts: true },
-  { major: 25, maintenanceStart: "2026-04-01", endOfLife: "2026-06-01", isLts: false },
+  { major: 25, maintenanceStart: "2026-10-01", endOfLife: "2027-06-01", isLts: false },
   { major: 26, maintenanceStart: "2027-10-19", endOfLife: "2029-04-30", isLts: true },
 ];
 
@@ -47,12 +42,10 @@ interface VersionManagerMarker {
   name: string;
   /** Lower-cased path fragments; any match identifies the manager. */
   fragments: string[];
-  /** Optional environment variable that also identifies the manager. */
-  envVar?: string;
 }
 
 const VERSION_MANAGER_MARKERS: VersionManagerMarker[] = [
-  { name: "nvm", fragments: ["/.nvm/", "\\.nvm\\", "/nvm/versions/", "\\nvm\\"], envVar: "NVM_DIR" },
+  { name: "nvm", fragments: ["/.nvm/", "\\.nvm\\", "/nvm/versions/", "\\nvm\\"] },
   { name: "fnm", fragments: ["/.fnm/", "\\.fnm\\", "/fnm/node-versions/", "\\fnm\\node-versions\\"] },
   { name: "volta", fragments: ["/.volta/", "\\.volta\\"] },
   { name: "asdf", fragments: ["/.asdf/", "\\.asdf\\"] },
@@ -128,31 +121,25 @@ function monthsFromDays(days: number): number {
 }
 
 /**
- * Build proactive lifecycle warnings for the detected Node major:
- * below-minimum, past end-of-life, in maintenance, or older-than-recommended.
- * Returns an empty list when the runtime is current and healthy.
+ * Build proactive lifecycle warnings for the detected Node runtime.
+ *
+ * Support decisions delegate to the canonical engines contract
+ * (isSupportedNodeVersion). For unsupported versions the warning points at
+ * the engines requirement. For supported versions, advisory notes surface
+ * upstream lifecycle facts (past EOL / in maintenance) without inventing an
+ * upgrade target the engines contract does not express.
  */
 export function buildNodeRuntimeWarnings(diag: NodeRuntimeDiagnostics): string[] {
   const warnings: string[] = [];
   if (!diag.version || diag.major === null) {
     return warnings;
   }
-  const parsed = parseSemver(diag.version);
-  const minimum = parseSemver(MINIMUM_NODE_VERSION);
-  if (parsed && minimum) {
-    const belowMinimum =
-      parsed.major < minimum.major ||
-      (parsed.major === minimum.major && parsed.minor < minimum.minor) ||
-      (parsed.major === minimum.major &&
-        parsed.minor === minimum.minor &&
-        parsed.patch < minimum.patch);
-    if (belowMinimum) {
-      warnings.push(
-        `Node ${diag.version} does not meet the minimum requirement (${MINIMUM_NODE_RANGE}).\n` +
-          `Upgrade Node: https://nodejs.org/en/download`,
-      );
-      return warnings;
-    }
+  if (!isSupportedNodeVersion(diag.version)) {
+    warnings.push(
+      `Node ${diag.version} is outside OpenClaw's supported engine range (see package.json engines).\n` +
+        `Upgrade Node: https://nodejs.org/en/download`,
+    );
+    return warnings;
   }
   const release = NODE_RELEASE_SCHEDULE.find((entry) => entry.major === diag.major);
   if (!release) {
@@ -163,17 +150,12 @@ export function buildNodeRuntimeWarnings(diag: NodeRuntimeDiagnostics): string[]
   const label = release.isLts ? `Node ${release.major} LTS` : `Node ${release.major}`;
   if (eolDays <= 0) {
     warnings.push(
-      `${label} reached end-of-life on ${release.endOfLife}.\n` +
-        `Upgrade to a current Active LTS release (Node ${RECOMMENDED_NODE_MAJOR}): https://nodejs.org/en/download`,
+      `${label} reached upstream end-of-life on ${release.endOfLife}; it no longer receives security updates.\n` +
+        `Consider a currently maintained release: https://nodejs.org/en/download`,
     );
   } else if (maintenanceDays <= 0) {
     warnings.push(
-      `${label} is in maintenance mode (EOL ${release.endOfLife}, ~${monthsFromDays(eolDays)} months remaining).\n` +
-        `Consider upgrading to Node ${RECOMMENDED_NODE_MAJOR} for the latest features and longer support.`,
-    );
-  } else if (release.isLts && release.major < RECOMMENDED_NODE_MAJOR) {
-    warnings.push(
-      `${label} is supported but older than the recommended LTS (Node ${RECOMMENDED_NODE_MAJOR}).`,
+      `${label} is in upstream maintenance mode (EOL ${release.endOfLife}, ~${monthsFromDays(eolDays)} months remaining).`,
     );
   }
   return warnings;

--- a/src/commands/doctor-node-runtime.ts
+++ b/src/commands/doctor-node-runtime.ts
@@ -1,0 +1,230 @@
+// Doctor health contribution: Node.js runtime diagnostics.
+//
+// Surfaces the Node version, install channel (version manager vs system), and
+// proactive lifecycle guidance (below-minimum, past-EOL, maintenance phase)
+// during `openclaw doctor`. Reuses runtime-guard's semver helpers and the
+// shared shortenHomePath redaction (which handles POSIX and Windows home
+// boundaries case-insensitively, see #121455) rather than local variants.
+//
+// The default summary omits the executable path entirely so ordinary copied
+// Doctor output does not disclose local filesystem layout. Path inclusion is
+// parameterized (includeExecPath) for the verbose gate; the verbose flag
+// itself and its wiring are owned by the maintainer per the #59414 split.
+import { shortenHomePath } from "../utils.js";
+import { parseSemver } from "../infra/runtime-guard.js";
+import { createDoctorHealthContribution } from "../flows/doctor-health-contribution.js";
+
+/** Minimum supported Node version; keep in sync with runtime-guard. */
+const MINIMUM_NODE_RANGE = ">=22.19.0";
+const MINIMUM_NODE_VERSION = "22.19.0";
+
+/** Recommended (current Active LTS) major used in upgrade guidance. */
+const RECOMMENDED_NODE_MAJOR = 24;
+
+/**
+ * Node.js release lifecycle schedule (maintenance entry and end-of-life),
+ * sourced from the official Node.js release working group data. Only majors
+ * that can plausibly appear in the wild are listed; unknown majors degrade
+ * gracefully (no lifecycle warning).
+ */
+interface NodeReleaseInfo {
+  major: number;
+  maintenanceStart: string; // ISO date the release enters maintenance
+  endOfLife: string; // ISO date the release reaches end-of-life
+  isLts: boolean;
+}
+
+const NODE_RELEASE_SCHEDULE: NodeReleaseInfo[] = [
+  { major: 20, maintenanceStart: "2023-10-24", endOfLife: "2026-04-30", isLts: true },
+  { major: 22, maintenanceStart: "2025-10-21", endOfLife: "2027-04-30", isLts: true },
+  { major: 24, maintenanceStart: "2026-10-20", endOfLife: "2028-04-30", isLts: true },
+  { major: 25, maintenanceStart: "2026-04-01", endOfLife: "2026-06-01", isLts: false },
+  { major: 26, maintenanceStart: "2027-10-19", endOfLife: "2029-04-30", isLts: true },
+];
+
+/** Version-manager detection markers, checked against the executable path. */
+interface VersionManagerMarker {
+  name: string;
+  /** Lower-cased path fragments; any match identifies the manager. */
+  fragments: string[];
+  /** Optional environment variable that also identifies the manager. */
+  envVar?: string;
+}
+
+const VERSION_MANAGER_MARKERS: VersionManagerMarker[] = [
+  { name: "nvm", fragments: ["/.nvm/", "\\.nvm\\", "/nvm/versions/", "\\nvm\\"], envVar: "NVM_DIR" },
+  { name: "fnm", fragments: ["/.fnm/", "\\.fnm\\", "/fnm/node-versions/", "\\fnm\\node-versions\\"] },
+  { name: "volta", fragments: ["/.volta/", "\\.volta\\"] },
+  { name: "asdf", fragments: ["/.asdf/", "\\.asdf\\"] },
+  { name: "n", fragments: ["/n/versions/node/"] },
+  { name: "nodenv", fragments: ["/.nodenv/", "\\.nodenv\\"] },
+  { name: "nodebrew", fragments: ["/.nodebrew/", "\\.nodebrew\\"] },
+  { name: "nvs", fragments: ["/.nvs/", "\\.nvs\\"] },
+];
+
+/**
+ * Identify a Node version manager from the executable path (case-insensitive,
+ * both slash styles) or, for nvm, its well-known environment variable.
+ * Returns the manager name or null when the runtime looks system-installed.
+ */
+export function detectVersionManagerName(
+  env: Record<string, string | undefined>,
+  execPath: string | null,
+): string | null {
+  if (env.NVM_DIR && env.NVM_DIR.trim() !== "") {
+    return "nvm";
+  }
+  if (!execPath) {
+    return null;
+  }
+  const lowered = execPath.toLowerCase();
+  for (const marker of VERSION_MANAGER_MARKERS) {
+    if (marker.fragments.some((fragment) => lowered.includes(fragment))) {
+      return marker.name;
+    }
+  }
+  return null;
+}
+
+/** Collected facts about the current Node.js runtime. */
+export interface NodeRuntimeDiagnostics {
+  version: string | null;
+  major: number | null;
+  execPath: string | null;
+  versionManaged: boolean;
+  versionManagerHint: string | null;
+}
+
+/**
+ * Collect Node runtime facts from the live process (or an injected
+ * environment for tests). Never throws; unknown shapes degrade to nulls.
+ */
+export function collectNodeRuntimeDiagnostics(
+  env: Record<string, string | undefined> = process.env,
+  execPath: string | null = process.execPath ?? null,
+  versionRaw: string | null = process.version ?? null,
+): NodeRuntimeDiagnostics {
+  const version = versionRaw ? versionRaw.replace(/^v/, "") : null;
+  const parsed = version ? parseSemver(version) : null;
+  const manager = detectVersionManagerName(env, execPath);
+  return {
+    version,
+    major: parsed ? parsed.major : null,
+    execPath,
+    versionManaged: manager !== null,
+    versionManagerHint: manager,
+  };
+}
+
+/** Days until an ISO date from now; negative when the date has passed. */
+function daysUntil(isoDate: string): number {
+  const target = Date.parse(`${isoDate}T00:00:00Z`);
+  return Math.floor((target - Date.now()) / 86_400_000);
+}
+
+/** Roughly whole months represented by a day count (floored, min 0). */
+function monthsFromDays(days: number): number {
+  return Math.max(0, Math.floor(days / 30));
+}
+
+/**
+ * Build proactive lifecycle warnings for the detected Node major:
+ * below-minimum, past end-of-life, in maintenance, or older-than-recommended.
+ * Returns an empty list when the runtime is current and healthy.
+ */
+export function buildNodeRuntimeWarnings(diag: NodeRuntimeDiagnostics): string[] {
+  const warnings: string[] = [];
+  if (!diag.version || diag.major === null) {
+    return warnings;
+  }
+  const parsed = parseSemver(diag.version);
+  const minimum = parseSemver(MINIMUM_NODE_VERSION);
+  if (parsed && minimum) {
+    const belowMinimum =
+      parsed.major < minimum.major ||
+      (parsed.major === minimum.major && parsed.minor < minimum.minor) ||
+      (parsed.major === minimum.major &&
+        parsed.minor === minimum.minor &&
+        parsed.patch < minimum.patch);
+    if (belowMinimum) {
+      warnings.push(
+        `Node ${diag.version} does not meet the minimum requirement (${MINIMUM_NODE_RANGE}).\n` +
+          `Upgrade Node: https://nodejs.org/en/download`,
+      );
+      return warnings;
+    }
+  }
+  const release = NODE_RELEASE_SCHEDULE.find((entry) => entry.major === diag.major);
+  if (!release) {
+    return warnings;
+  }
+  const eolDays = daysUntil(release.endOfLife);
+  const maintenanceDays = daysUntil(release.maintenanceStart);
+  const label = release.isLts ? `Node ${release.major} LTS` : `Node ${release.major}`;
+  if (eolDays <= 0) {
+    warnings.push(
+      `${label} reached end-of-life on ${release.endOfLife}.\n` +
+        `Upgrade to a current Active LTS release (Node ${RECOMMENDED_NODE_MAJOR}): https://nodejs.org/en/download`,
+    );
+  } else if (maintenanceDays <= 0) {
+    warnings.push(
+      `${label} is in maintenance mode (EOL ${release.endOfLife}, ~${monthsFromDays(eolDays)} months remaining).\n` +
+        `Consider upgrading to Node ${RECOMMENDED_NODE_MAJOR} for the latest features and longer support.`,
+    );
+  } else if (release.isLts && release.major < RECOMMENDED_NODE_MAJOR) {
+    warnings.push(
+      `${label} is supported but older than the recommended LTS (Node ${RECOMMENDED_NODE_MAJOR}).`,
+    );
+  }
+  return warnings;
+}
+
+/**
+ * Render the one-line runtime summary.
+ *
+ * Default form omits the executable path so ordinary copied Doctor output
+ * does not disclose local filesystem layout:
+ *   `Node 24.14.0 · via nvm`  /  `Node 24.14.0 · system install`
+ *
+ * With includeExecPath the path is included, redacted through the shared
+ * shortenHomePath helper (POSIX + Windows home boundaries,
+ * case-insensitive):
+ *   `Node 24.14.0 · ~/.nvm/versions/node/v24.14.0/bin/node · via nvm`
+ */
+export function buildNodeRuntimeSummary(
+  diag: NodeRuntimeDiagnostics,
+  options: { includeExecPath?: boolean } = {},
+): string {
+  const version = diag.version ? `Node ${diag.version}` : "Node (version unknown)";
+  const channel = diag.versionManaged
+    ? diag.versionManagerHint
+      ? `via ${diag.versionManagerHint}`
+      : "version-managed"
+    : "system install";
+  if (options.includeExecPath && diag.execPath) {
+    return `${version} \u00b7 ${shortenHomePath(diag.execPath)} \u00b7 ${channel}`;
+  }
+  return `${version} \u00b7 ${channel}`;
+}
+
+/**
+ * Ready-to-wire Doctor health contribution. Not yet registered in the
+ * initial contribution list: the final contribution-model wiring and the
+ * verbose gate (CLI flag + plumbing) are owned by the maintainer per the
+ * split agreed on #59414. The default render never includes the executable
+ * path; flip includeExecPath from the verbose flag when wiring it up.
+ */
+export const nodeRuntimeHealthContribution = createDoctorHealthContribution({
+  id: "doctor:node-runtime",
+  label: "Node.js runtime",
+  run: async (ctx): Promise<void> => {
+    const diag = collectNodeRuntimeDiagnostics();
+    // includeExecPath stays false until the maintainer-owned verbose gate
+    // lands; ordinary Doctor output must not disclose filesystem layout.
+    const summary = buildNodeRuntimeSummary(diag, { includeExecPath: false });
+    ctx.runtime.log(summary);
+    for (const warning of buildNodeRuntimeWarnings(diag)) {
+      ctx.runtime.log(warning);
+    }
+  },
+});

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -401,6 +401,11 @@ async function runHooksModelHealth(ctx: DoctorHealthFlowContext): Promise<void> 
   }
 }
 
+async function runNodeRuntimeHealth(_ctx: DoctorHealthFlowContext): Promise<void> {
+  const { noteNodeRuntime } = await import("../commands/doctor-node-runtime.js");
+  await noteNodeRuntime();
+}
+
 async function runSystemdLingerHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   if (
     ctx.options.nonInteractive === true ||
@@ -614,6 +619,12 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       id: "doctor:plugin-registry",
       label: "Plugin registry",
       run: runPluginRegistryHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:node-runtime",
+      label: "Node.js runtime",
+      hint: "Node version, path, version manager, EOL status",
+      run: runNodeRuntimeHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:state-integrity",


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor` has no visibility into the Node.js runtime environment. When users share Doctor output in issues, the Node version and installation method are critical diagnostic context that is currently missing — maintainers have to ask for it separately. This PR adds a Doctor health contribution surfacing exactly that: version, install channel (8 version managers detected from the executable path), and upstream lifecycle advisories, with version-support decisions delegated entirely to the canonical engines contract.

## What it does

Default note (what `run()` logs today):

    Node 24.15.0 · via nvm

- **Version-manager detection** — nvm, fnm, volta, asdf, n, nodenv, nodebrew, nvs, from the executable path (case-insensitive, both slash styles).
- **Engines-contract warnings** — unsupported versions point at `package.json` engines via runtime-guard's `isSupportedNodeVersion` (the single authority; no local copy to drift).
- **Lifecycle advisories** — upstream maintenance/EOL facts for supported releases, without inventing upgrade targets the engines contract does not express.

## Current shape (rebuilt head)

- Two new files only (`doctor-node-runtime.ts` + tests); single rebuilt commit chain on current main. The old conversion-plan edit is gone (file removed upstream).
- The local redaction layer was dropped in favor of the shared `shortenHomePath` from #121455 (credit landed separately by @steipete).
- **The default render never includes the executable path.** `buildNodeRuntimeSummary` takes `includeExecPath` so the maintainer-owned verbose gate can flip it on with one line.
- The contribution export (`nodeRuntimeHealthContribution`, id `doctor:node-runtime`) follows `createDoctorHealthContribution` and is intentionally not registered — the final wiring and the verbose gate are owned by @vincentkoc per the split agreed above. (This is also why knip's production pass flags the module as unused and `check-dependencies` is red: it turns green the moment the module is wired.)

## Review findings addressed on this head

- **Canonical Node support contract** — below-range detection now delegates to `isSupportedNodeVersion` (runtime-guard); the hand-copied minimum it replaced had already drifted from engines.
- **Lifecycle advice aligned with engines** — the Node 25 line is supported (engines `>=25.9.0`) and no longer mis-flagged; Node 20 routes through the unsupported-engines warning; no invented "recommended major".

## Test plan

- 29 unit tests (vitest) — detection 12, diagnostics 3, warnings 8, summary 6 — exercising the delegation boundary with engines edge versions (22.22.3 / 24.0.0 / 24.15.0 / 25.9.0).
- tsgo and lint clean on both files.

## Evidence

Real behavior proof. Head: `8085c071107`. Environment: Linux (Ubuntu 24.04, WSL2), Node v22.23.2. Method: direct invocation via tsx of the exact exported functions the contribution's `run()` calls.

**1. Real default render on this machine:**

    summary : Node 22.23.2 · system install
    warning : Node 22 LTS is in upstream maintenance mode (EOL 2027-04-30, ~8 months remaining).

**2. Default render never contains the executable path:**

    input execPath : /home/alice/.nvm/versions/node/v24.15.0/bin/node
    default render : Node 24.15.0 · via nvm
    path leaked?   : NO

**3. includeExecPath preview (verbose-gate hook; path under the real OS home, redacted by shortenHomePath):**

    os home        : /home/<user>
    input execPath : /home/<user>/.nvm/versions/node/v24.15.0/bin/node
    default render : Node 24.15.0 · via nvm
    verbose render : Node 24.15.0 · ~/.nvm/versions/node/v24.15.0/bin/node · via nvm
    home redacted? : YES (~/...)

**4. Engines contract delegation (four edge versions):**

    Node 20.18.0: outside OpenClaw's supported engine range (see package.json engines)
    Node 24.0.0 : outside OpenClaw's supported engine range (below the 24.15.0 floor)
    Node 22.22.3: Node 22 LTS is in upstream maintenance mode (EOL 2027-04-30)
    Node 25.9.0 : (no warnings — supported & current)

**What was not tested:** the registered Doctor command path end-to-end — the contribution is intentionally unwired pending the maintainer-owned integration; an exact-head `openclaw doctor` transcript can follow once the wiring lands.
