### PR TITLE
fix(acp): route Telegram follow-ups to bound ACP session

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -475,6 +475,48 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("clarifies inbound-thread binding regression case with acp", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-acp-thread-1",
+      targetSessionKey: "agent:codex-acp:mattermost:channel:CHAN1",
+      targetKind: "session",
+      conversation: {
+        channel: "webchat",
+        accountId: "default",
+        conversationId: "channel:CHAN1",
+      },
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {},
+    } satisfies SessionBindingRecord);
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "webchat",
+      Surface: "webchat",
+      SessionKey: "agent:main:mattermost:channel:CHAN1:thread:post-root",
+      AccountId: "default",
+      MessageThreadId: undefined,
+      OriginatingChannel: "mattermost",
+      OriginatingTo: "channel:CHAN1",
+      To: "channel:CHAN1",
+      ExplicitDeliverRoute: true,
+    });
+
+    const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "mattermost",
+        to: "channel:CHAN1",
+        threadId: "post-root",
+      }),
+    );
+  });
+
   it("does not resurrect a cleared route thread from origin metadata", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -517,6 +517,83 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("dispatches bound conversation messages through the ACP runtime with the bound session key", async () => {
+    setNoAbort();
+    const runtime = createAcpRuntime([{ type: "done" }]);
+    const inboundSessionKey = "agent:main:mattermost:channel:CHAN1:thread:post-root";
+    const boundAcpSessionKey = "agent:codex-acp:session-bound-1";
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-acp-dispatch-1",
+      targetSessionKey: boundAcpSessionKey,
+      targetKind: "session",
+      conversation: {
+        channel: "webchat",
+        accountId: "default",
+        conversationId: "channel:CHAN1",
+      },
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {},
+    } satisfies SessionBindingRecord);
+    acpMocks.readAcpSessionEntry.mockImplementation((...args: unknown[]) => {
+      const params = args[0] as { sessionKey?: string } | undefined;
+      if (params?.sessionKey !== boundAcpSessionKey) {
+        return null;
+      }
+      return {
+        sessionKey: boundAcpSessionKey,
+        storeSessionKey: boundAcpSessionKey,
+        cfg: {},
+        storePath: "/tmp/mock-sessions.json",
+        entry: {},
+        acp: {
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "runtime:bound-1",
+          mode: "persistent",
+          state: "idle",
+          lastActivityAt: Date.now(),
+        },
+      };
+    });
+    acpMocks.requireAcpRuntimeBackend.mockReturnValue({
+      id: "acpx",
+      runtime,
+    });
+
+    const cfg = {
+      acp: {
+        enabled: true,
+        dispatch: { enabled: true },
+      },
+    } as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "webchat",
+      Surface: "webchat",
+      SessionKey: inboundSessionKey,
+      AccountId: "default",
+      BodyForAgent: "hello from bound chat",
+      OriginatingChannel: "mattermost",
+      OriginatingTo: "channel:CHAN1",
+      To: "channel:CHAN1",
+      ExplicitDeliverRoute: true,
+    });
+    const replyResolver = vi.fn(async () => ({ text: "fallback" }) as ReplyPayload);
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(runtime.ensureSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: boundAcpSessionKey,
+        agent: "codex",
+        mode: "persistent",
+      }),
+    );
+    expect(runtime.runTurn).toHaveBeenCalledTimes(1);
+  });
+
   it("does not resurrect a cleared route thread from origin metadata", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -122,7 +122,7 @@ const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
   return AUDIO_HEADER_RE.test(trimmed);
 };
 
-const getCurrentSessionKey = (
+const resolveAcpDispatchSessionKey = (
   ctx: FinalizedMsgContext,
   cfg: OpenClawConfig,
 ): string | undefined => {
@@ -158,7 +158,9 @@ const resolveSessionStoreLookup = (
   sessionKey?: string;
   entry?: SessionEntry;
 } => {
-  const sessionKey = getCurrentSessionKey(ctx, cfg);
+  const targetSessionKey =
+    ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey?.trim() : undefined;
+  const sessionKey = (targetSessionKey ?? ctx.SessionKey)?.trim();
   if (!sessionKey) {
     return {};
   }
@@ -251,7 +253,7 @@ export async function dispatchReplyFromConfig(params: {
   }
 
   const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
-  const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
+  const acpDispatchSessionKey = resolveAcpDispatchSessionKey(ctx, cfg) ?? sessionKey;
   // Restore route thread context only from the active turn or the thread-scoped session key.
   // Do not read thread ids from the normalised session store here: `origin.threadId` can be
   // folded back into lastThreadId/deliveryContext during store normalisation and resurrect a

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -253,13 +253,13 @@ export async function dispatchReplyFromConfig(params: {
   }
 
   const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
-  const acpDispatchSessionKey = resolveAcpDispatchSessionKey(ctx, cfg) ?? sessionKey;
+  const routeSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
+  const acpDispatchSessionKey = resolveAcpDispatchSessionKey(ctx, cfg) ?? routeSessionKey;
   // Restore route thread context only from the active turn or the thread-scoped session key.
   // Do not read thread ids from the normalised session store here: `origin.threadId` can be
   // folded back into lastThreadId/deliveryContext during store normalisation and resurrect a
   // stale route after thread delivery was intentionally cleared.
-  const routeThreadId =
-    ctx.MessageThreadId ?? parseSessionThreadInfo(acpDispatchSessionKey).threadId;
+  const routeThreadId = ctx.MessageThreadId ?? parseSessionThreadInfo(routeSessionKey).threadId;
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const hookRunner = getGlobalHookRunner();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -11,6 +11,7 @@ import { parseSessionThreadInfo } from "../../config/sessions/delivery-info.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import { loadSessionStore, resolveSessionStoreEntry } from "../../config/sessions/store.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
+import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
 import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
@@ -192,6 +193,7 @@ const resolveSessionStoreLookupByKey = (
 type AcpDispatchSessionData = {
   sessionKey?: string;
   entry?: SessionEntry;
+  ttsAuto?: TtsAutoMode;
   suppressUserDelivery: boolean;
 };
 
@@ -213,6 +215,7 @@ const resolveAcpDispatchSessionData = (params: {
   return {
     sessionKey,
     entry: sessionStoreEntry.entry,
+    ttsAuto: normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto),
     suppressUserDelivery: isParentOwnedBackgroundAcpSession(sessionStoreEntry.entry),
   };
 };
@@ -673,7 +676,7 @@ export async function dispatchReplyFromConfig(params: {
       sessionKey: acpDispatchSession.sessionKey,
       abortSignal: params.replyOptions?.abortSignal,
       inboundAudio,
-      sessionTtsAuto,
+      sessionTtsAuto: acpDispatchSession.ttsAuto,
       ttsChannel,
       suppressUserDelivery: acpDispatchSession.suppressUserDelivery,
       shouldRouteToOriginating,
@@ -825,7 +828,7 @@ export async function dispatchReplyFromConfig(params: {
         sessionKey: acpDispatchSession.sessionKey,
         abortSignal: params.replyOptions?.abortSignal,
         inboundAudio,
-        sessionTtsAuto,
+        sessionTtsAuto: acpDispatchSession.ttsAuto,
         ttsChannel,
         suppressUserDelivery: acpDispatchSession.suppressUserDelivery,
         shouldRouteToOriginating,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -23,6 +23,7 @@ import {
   toPluginMessageReceivedEvent,
 } from "../../hooks/message-hook-mappers.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import {
   logMessageProcessed,
   logMessageQueued,
@@ -48,6 +49,7 @@ import {
   type GetReplyOptions,
   type ReplyPayload,
 } from "../types.js";
+import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
 import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
 import { resolveReplyRoutingDecision } from "./routing-policy.js";
@@ -120,6 +122,35 @@ const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
   return AUDIO_HEADER_RE.test(trimmed);
 };
 
+const getCurrentSessionKey = (
+  ctx: FinalizedMsgContext,
+  cfg: OpenClawConfig,
+): string | undefined => {
+  const targetSessionKey =
+    ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey?.trim() : undefined;
+  if (targetSessionKey) {
+    return targetSessionKey;
+  }
+  const binding = resolveConversationBindingContextFromMessage({ cfg, ctx });
+  if (!binding) {
+    return ctx.SessionKey?.trim();
+  }
+  const boundSessionKey = getSessionBindingService()
+    .resolveByConversation({
+      channel: binding.channel,
+      accountId: binding.accountId,
+      conversationId: binding.conversationId,
+      ...(binding.parentConversationId
+        ? { parentConversationId: binding.parentConversationId }
+        : {}),
+    })
+    ?.targetSessionKey?.trim();
+  if (boundSessionKey) {
+    return boundSessionKey;
+  }
+  return ctx.SessionKey?.trim();
+};
+
 const resolveSessionStoreLookup = (
   ctx: FinalizedMsgContext,
   cfg: OpenClawConfig,
@@ -127,9 +158,7 @@ const resolveSessionStoreLookup = (
   sessionKey?: string;
   entry?: SessionEntry;
 } => {
-  const targetSessionKey =
-    ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey?.trim() : undefined;
-  const sessionKey = (targetSessionKey ?? ctx.SessionKey)?.trim();
+  const sessionKey = getCurrentSessionKey(ctx, cfg);
   if (!sessionKey) {
     return {};
   }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -160,7 +160,17 @@ const resolveSessionStoreLookup = (
 } => {
   const targetSessionKey =
     ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey?.trim() : undefined;
-  const sessionKey = (targetSessionKey ?? ctx.SessionKey)?.trim();
+  return resolveSessionStoreLookupByKey(targetSessionKey ?? ctx.SessionKey, cfg);
+};
+
+const resolveSessionStoreLookupByKey = (
+  rawSessionKey: string | undefined,
+  cfg: OpenClawConfig,
+): {
+  sessionKey?: string;
+  entry?: SessionEntry;
+} => {
+  const sessionKey = rawSessionKey?.trim();
   if (!sessionKey) {
     return {};
   }
@@ -255,6 +265,10 @@ export async function dispatchReplyFromConfig(params: {
   const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
   const routeSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
   const acpDispatchSessionKey = resolveAcpDispatchSessionKey(ctx, cfg) ?? routeSessionKey;
+  const acpSessionStoreEntry =
+    acpDispatchSessionKey && acpDispatchSessionKey !== routeSessionKey
+      ? resolveSessionStoreLookupByKey(acpDispatchSessionKey, cfg)
+      : sessionStoreEntry;
   // Restore route thread context only from the active turn or the thread-scoped session key.
   // Do not read thread ids from the normalised session store here: `origin.threadId` can be
   // folded back into lastThreadId/deliveryContext during store normalisation and resurrect a
@@ -285,7 +299,9 @@ export async function dispatchReplyFromConfig(params: {
   // flow when the provider handles its own messages.
   //
   // Debug: `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts`
-  const suppressAcpChildUserDelivery = isParentOwnedBackgroundAcpSession(sessionStoreEntry.entry);
+  const suppressAcpChildUserDelivery = isParentOwnedBackgroundAcpSession(
+    acpSessionStoreEntry.entry,
+  );
   const routeReplyRuntime = await loadRouteReplyRuntime();
   const { originatingChannel, currentSurface, shouldRouteToOriginating, shouldSuppressTyping } =
     resolveReplyRoutingDecision({

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -189,6 +189,34 @@ const resolveSessionStoreLookupByKey = (
   }
 };
 
+type AcpDispatchSessionData = {
+  sessionKey?: string;
+  entry?: SessionEntry;
+  suppressUserDelivery: boolean;
+};
+
+const resolveAcpDispatchSessionData = (params: {
+  ctx: FinalizedMsgContext;
+  cfg: OpenClawConfig;
+  routeSessionKey: string | undefined;
+  routeSessionEntry: SessionEntry | undefined;
+}): AcpDispatchSessionData => {
+  const { ctx, cfg, routeSessionKey, routeSessionEntry } = params;
+  const sessionKey = resolveAcpDispatchSessionKey(ctx, cfg) ?? routeSessionKey;
+  const sessionStoreEntry =
+    sessionKey && sessionKey !== routeSessionKey
+      ? resolveSessionStoreLookupByKey(sessionKey, cfg)
+      : {
+          sessionKey: routeSessionKey,
+          entry: routeSessionEntry,
+        };
+  return {
+    sessionKey,
+    entry: sessionStoreEntry.entry,
+    suppressUserDelivery: isParentOwnedBackgroundAcpSession(sessionStoreEntry.entry),
+  };
+};
+
 export type DispatchFromConfigResult = {
   queuedFinal: boolean;
   counts: Record<ReplyDispatchKind, number>;
@@ -264,11 +292,12 @@ export async function dispatchReplyFromConfig(params: {
 
   const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
   const routeSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
-  const acpDispatchSessionKey = resolveAcpDispatchSessionKey(ctx, cfg) ?? routeSessionKey;
-  const acpSessionStoreEntry =
-    acpDispatchSessionKey && acpDispatchSessionKey !== routeSessionKey
-      ? resolveSessionStoreLookupByKey(acpDispatchSessionKey, cfg)
-      : sessionStoreEntry;
+  const acpDispatchSession = resolveAcpDispatchSessionData({
+    ctx,
+    cfg,
+    routeSessionKey,
+    routeSessionEntry: sessionStoreEntry.entry,
+  });
   // Restore route thread context only from the active turn or the thread-scoped session key.
   // Do not read thread ids from the normalised session store here: `origin.threadId` can be
   // folded back into lastThreadId/deliveryContext during store normalisation and resurrect a
@@ -299,9 +328,6 @@ export async function dispatchReplyFromConfig(params: {
   // flow when the provider handles its own messages.
   //
   // Debug: `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts`
-  const suppressAcpChildUserDelivery = isParentOwnedBackgroundAcpSession(
-    acpSessionStoreEntry.entry,
-  );
   const routeReplyRuntime = await loadRouteReplyRuntime();
   const { originatingChannel, currentSurface, shouldRouteToOriginating, shouldSuppressTyping } =
     resolveReplyRoutingDecision({
@@ -310,7 +336,7 @@ export async function dispatchReplyFromConfig(params: {
       explicitDeliverRoute: ctx.ExplicitDeliverRoute,
       originatingChannel: ctx.OriginatingChannel,
       originatingTo: ctx.OriginatingTo,
-      suppressDirectUserDelivery: suppressAcpChildUserDelivery,
+      suppressDirectUserDelivery: acpDispatchSession.suppressUserDelivery,
       isRoutableChannel: routeReplyRuntime.isRoutableChannel,
     });
   const originatingTo = ctx.OriginatingTo;
@@ -538,19 +564,19 @@ export async function dispatchReplyFromConfig(params: {
 
     const sendPolicy = resolveSendPolicy({
       cfg,
-      entry: sessionStoreEntry.entry,
-      sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+      entry: acpDispatchSession.entry,
+      sessionKey: acpDispatchSession.sessionKey,
       channel:
-        sessionStoreEntry.entry?.channel ??
+        acpDispatchSession.entry?.channel ??
         ctx.OriginatingChannel ??
         ctx.Surface ??
         ctx.Provider ??
         undefined,
-      chatType: sessionStoreEntry.entry?.chatType,
+      chatType: acpDispatchSession.entry?.chatType,
     });
     if (sendPolicy === "deny" && !bypassAcpForCommand) {
       logVerbose(
-        `Send blocked by policy for session ${sessionStoreEntry.sessionKey ?? sessionKey ?? "unknown"}`,
+        `Send blocked by policy for session ${acpDispatchSession.sessionKey ?? "unknown"}`,
       );
       const counts = dispatcher.getQueuedCounts();
       recordProcessed("completed", { reason: "send_policy_deny" });
@@ -644,12 +670,12 @@ export async function dispatchReplyFromConfig(params: {
       cfg,
       dispatcher,
       runId: params.replyOptions?.runId,
-      sessionKey: acpDispatchSessionKey,
+      sessionKey: acpDispatchSession.sessionKey,
       abortSignal: params.replyOptions?.abortSignal,
       inboundAudio,
       sessionTtsAuto,
       ttsChannel,
-      suppressUserDelivery: suppressAcpChildUserDelivery,
+      suppressUserDelivery: acpDispatchSession.suppressUserDelivery,
       shouldRouteToOriginating,
       originatingChannel,
       originatingTo,
@@ -796,11 +822,12 @@ export async function dispatchReplyFromConfig(params: {
         cfg,
         dispatcher,
         runId: params.replyOptions?.runId,
-        sessionKey: acpDispatchSessionKey,
+        sessionKey: acpDispatchSession.sessionKey,
         abortSignal: params.replyOptions?.abortSignal,
         inboundAudio,
         sessionTtsAuto,
         ttsChannel,
+        suppressUserDelivery: acpDispatchSession.suppressUserDelivery,
         shouldRouteToOriginating,
         originatingChannel,
         originatingTo,


### PR DESCRIPTION
## Problem
After `/acp spawn <agent> --bind here` in a Telegram chat, a normal follow-up message could miss the ACP session bound to that conversation. Dispatch resolved the session key too early and fell back to the raw Telegram chat session key.

## What it caused
ACP session resolution could return no matching ACP session for the follow-up message, so the reply fell back to the default main model path instead of continuing in the bound ACP session.

## Use case:
A Telegram chat is currently handled by the default ChatGPT-backed session.
Run \/acp spawn codex --bind here in that chat, then send a normal follow-up message in the same conversation.

Expected:
Once the conversation is bound, that follow-up message should be dispatched into the bound ACP Codex session, so the reply comes from Codex rather than the default ChatGPT session.

Actual before this fix:
That follow-up message could still resolve to the default Telegram chat session instead of the bound ACP session, so the conversation kept replying from ChatGPT even after the chat had been bound to Codex.

## Fix
Before dispatch session-key selection preferred:
1. explicit command target session key
2. raw chat session key fallback

After this fix it prefers:
1. explicit command target session key
2. bound conversation target session key (new)
3. raw chat session key fallback

This adds bound conversation target session key resolution to the dispatch path so follow-up Telegram messages use the session bound to the current conversation when one exists.
