### PR TITLE
fix(cron): propagate timeoutSeconds to LLM idle timeout

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -335,7 +335,31 @@ export async function runCronIsolatedAgentTurn(params: {
       params.job.payload.kind === "agentTurn" ? params.job.payload.timeoutSeconds : undefined,
   });
 
+  // Propagate cron timeoutSeconds to LLM idle timeout if not explicitly configured.
+  // This ensures that long-running cron jobs don't hit the default 60s LLM idle timeout
+  // when the user has configured a longer job timeout.
+  // See: https://github.com/openclaw/openclaw/issues/59403
   const agentPayload = params.job.payload.kind === "agentTurn" ? params.job.payload : null;
+  const effectiveLlmIdleTimeoutSeconds =
+    params.cfg.agents?.defaults?.llm?.idleTimeoutSeconds ?? agentPayload?.timeoutSeconds;
+  if (
+    agentPayload?.timeoutSeconds &&
+    params.cfg.agents?.defaults?.llm?.idleTimeoutSeconds === undefined
+  ) {
+    cfgWithAgentDefaults = {
+      ...cfgWithAgentDefaults,
+      agents: {
+        ...cfgWithAgentDefaults.agents,
+        defaults: {
+          ...cfgWithAgentDefaults.agents?.defaults,
+          llm: {
+            ...cfgWithAgentDefaults.agents?.defaults?.llm,
+            idleTimeoutSeconds: agentPayload.timeoutSeconds,
+          },
+        },
+      },
+    };
+  }
   const { deliveryRequested, resolvedDelivery, toolPolicy } = await resolveCronDeliveryContext({
     cfg: cfgWithAgentDefaults,
     job: params.job,


### PR DESCRIPTION
Fixes #59403

## Summary

When a cron job has `timeoutSeconds` configured (e.g., 900s), the LLM idle timeout was still using the default 60s. This caused jobs to fail prematurely when the LLM took longer than 60s to respond.

## Root Cause

The `timeoutSeconds` cron payload setting only affected the job execution timeout, but the LLM streaming idle timeout (`DEFAULT_LLM_IDLE_TIMEOUT_MS = 60_000`) was independent.

## Solution

If `timeoutSeconds` is set and `llm.idleTimeoutSeconds` is not explicitly configured, the cron `timeoutSeconds` value is now used as the LLM idle timeout.

## Before

- LLM idle timeout always defaulted to 60s
- Long-running LLM calls would timeout even if `timeoutSeconds: 900` was set

## After

- LLM idle timeout respects cron `timeoutSeconds` when not explicitly configured
- Users can still override via `llm.idleTimeoutSeconds` config

## Test Plan

1. Create a cron job with `timeoutSeconds: 300`
2. Ensure the LLM has time to complete long responses
3. Verify no premature timeout at 60s

🤖 Generated with [ClawHub](https://clawhub.ai)