### PR TITLE
fix(matrix): restore guided setup wizard registration

### DIFF
--- a/extensions/matrix/src/channel.setup.test.ts
+++ b/extensions/matrix/src/channel.setup.test.ts
@@ -135,6 +135,11 @@ describe("matrix setup post-write bootstrap", () => {
     installMatrixTestRuntime();
   });
 
+  it("exposes the Matrix guided setup wizard on the channel plugin", () => {
+    expect(matrixPlugin.setupWizard?.channel).toBe("matrix");
+    expect(matrixPlugin.setupWizard?.configureInteractive).toBeTypeOf("function");
+  });
+
   it("bootstraps verification for newly added encrypted accounts", async () => {
     const { previousCfg, nextCfg, accountId, input } = applyDefaultAccountConfig();
     mockBootstrapResult({ success: true, backupVersion: "7" });

--- a/extensions/matrix/src/channel.setup.test.ts
+++ b/extensions/matrix/src/channel.setup.test.ts
@@ -13,6 +13,7 @@ import { matrixPlugin } from "./channel.js";
 import { matrixSetupAdapter } from "./setup-core.js";
 import { installMatrixTestRuntime } from "./test-runtime.js";
 import type { CoreConfig } from "./types.js";
+import { resolveChannelSetupWizardAdapterForPlugin } from "../../../src/commands/channel-setup/registry.js";
 
 let runMatrixSetupBootstrapAfterConfigWrite: typeof import("./setup-bootstrap.js").runMatrixSetupBootstrapAfterConfigWrite;
 
@@ -135,9 +136,10 @@ describe("matrix setup post-write bootstrap", () => {
     installMatrixTestRuntime();
   });
 
-  it("exposes the Matrix guided setup wizard on the channel plugin", () => {
-    expect(matrixPlugin.setupWizard?.channel).toBe("matrix");
-    expect(matrixPlugin.setupWizard?.configureInteractive).toBeTypeOf("function");
+  it("registers the Matrix guided setup adapter for channel setup flows", () => {
+    const adapter = resolveChannelSetupWizardAdapterForPlugin(matrixPlugin);
+    expect(adapter?.channel).toBe("matrix");
+    expect(adapter?.configureInteractive).toBeTypeOf("function");
   });
 
   it("bootstraps verification for newly added encrypted accounts", async () => {

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -41,6 +41,7 @@ import {
   resolveMatrixGroupRequireMention,
   resolveMatrixGroupToolPolicy,
 } from "./group-mentions.js";
+import { matrixOnboardingAdapter } from "./onboarding.js";
 import {
   listMatrixAccountIds,
   resolveMatrixAccountConfig,
@@ -289,6 +290,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
     base: {
       id: "matrix",
       meta,
+      setupWizard: matrixOnboardingAdapter,
       capabilities: {
         chatTypes: ["direct", "group", "thread"],
         polls: true,

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -290,7 +290,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
     base: {
       id: "matrix",
       meta,
-      setupWizard: matrixOnboardingAdapter,
+      setupWizardAdapter: matrixOnboardingAdapter,
       capabilities: {
         chatTypes: ["direct", "group", "thread"],
         polls: true,

--- a/extensions/matrix/src/onboarding.test-harness.ts
+++ b/extensions/matrix/src/onboarding.test-harness.ts
@@ -1,8 +1,8 @@
 import type { OutputRuntimeEnv } from "openclaw/plugin-sdk/runtime";
+import type { SetupChannelsOptions } from "openclaw/plugin-sdk/setup";
 import { afterEach, vi } from "vitest";
 import type { RuntimeEnv, WizardPrompter } from "../runtime-api.js";
 import type { CoreConfig } from "./types.js";
-import type { SetupChannelsOptions } from "../../../src/channels/plugins/setup-wizard-types.js";
 
 const MATRIX_ENV_KEYS = [
   "MATRIX_HOMESERVER",

--- a/extensions/matrix/src/onboarding.test-harness.ts
+++ b/extensions/matrix/src/onboarding.test-harness.ts
@@ -2,6 +2,7 @@ import type { OutputRuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { afterEach, vi } from "vitest";
 import type { RuntimeEnv, WizardPrompter } from "../runtime-api.js";
 import type { CoreConfig } from "./types.js";
+import type { SetupChannelsOptions } from "../../../src/channels/plugins/setup-wizard-types.js";
 
 const MATRIX_ENV_KEYS = [
   "MATRIX_HOMESERVER",
@@ -88,7 +89,7 @@ export function createMatrixWizardPrompter(params: {
 export async function runMatrixInteractiveConfigure(params: {
   cfg: CoreConfig;
   prompter: WizardPrompter;
-  options?: unknown;
+  options?: SetupChannelsOptions;
   accountOverrides?: Record<string, string>;
   shouldPromptAccountIds?: boolean;
   forceAllowFrom?: boolean;

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -1,5 +1,8 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
-import { type ChannelSetupDmPolicy } from "openclaw/plugin-sdk/setup";
+import {
+  type ChannelSetupDmPolicy,
+  type ChannelSetupWizardAdapter,
+} from "openclaw/plugin-sdk/setup";
 import { requiresExplicitMatrixDefaultAccount } from "./account-selection.js";
 import { listMatrixDirectoryGroupsLive } from "./directory-live.js";
 import {
@@ -37,54 +40,6 @@ import {
 import type { CoreConfig } from "./types.js";
 
 const channel = "matrix" as const;
-
-type MatrixOnboardingStatus = {
-  channel: typeof channel;
-  configured: boolean;
-  statusLines: string[];
-  selectionHint?: string;
-  quickstartScore?: number;
-};
-
-type MatrixAccountOverrides = Partial<Record<typeof channel, string>>;
-
-type MatrixOnboardingConfigureContext = {
-  cfg: CoreConfig;
-  runtime: RuntimeEnv;
-  prompter: WizardPrompter;
-  options?: unknown;
-  forceAllowFrom: boolean;
-  accountOverrides: MatrixAccountOverrides;
-  shouldPromptAccountIds: boolean;
-};
-
-type MatrixOnboardingInteractiveContext = MatrixOnboardingConfigureContext & {
-  configured: boolean;
-  label?: string;
-};
-
-type MatrixOnboardingAdapter = {
-  channel: typeof channel;
-  getStatus: (ctx: {
-    cfg: CoreConfig;
-    options?: unknown;
-    accountOverrides: MatrixAccountOverrides;
-  }) => Promise<MatrixOnboardingStatus>;
-  configure: (
-    ctx: MatrixOnboardingConfigureContext,
-  ) => Promise<{ cfg: CoreConfig; accountId?: string }>;
-  configureInteractive?: (
-    ctx: MatrixOnboardingInteractiveContext,
-  ) => Promise<{ cfg: CoreConfig; accountId?: string } | "skip">;
-  afterConfigWritten?: (ctx: {
-    previousCfg: CoreConfig;
-    cfg: CoreConfig;
-    accountId: string;
-    runtime: RuntimeEnv;
-  }) => Promise<void> | void;
-  dmPolicy?: ChannelSetupDmPolicy;
-  disable?: (cfg: CoreConfig) => CoreConfig;
-};
 
 function resolveMatrixOnboardingAccountId(cfg: CoreConfig, accountId?: string): string {
   return normalizeAccountId(
@@ -556,7 +511,7 @@ async function runMatrixConfigure(params: {
   return { cfg: next, accountId };
 }
 
-export const matrixOnboardingAdapter: MatrixOnboardingAdapter = {
+export const matrixOnboardingAdapter: ChannelSetupWizardAdapter = {
   channel,
   getStatus: async ({ cfg, accountOverrides }) => {
     const resolvedCfg = cfg as CoreConfig;

--- a/src/channels/plugins/setup-wizard-types.ts
+++ b/src/channels/plugins/setup-wizard-types.ts
@@ -6,7 +6,7 @@ import type { ChannelId, ChannelPlugin } from "./types.js";
 
 export type ChannelSetupPlugin = Pick<
   ChannelPlugin,
-  "id" | "meta" | "capabilities" | "config" | "setup" | "setupWizard"
+  "id" | "meta" | "capabilities" | "config" | "setup" | "setupWizard" | "setupWizardAdapter"
 >;
 
 export type SetupChannelsOptions = {

--- a/src/channels/plugins/types.plugin.ts
+++ b/src/channels/plugins/types.plugin.ts
@@ -1,4 +1,5 @@
 import type { ChannelSetupWizard } from "./setup-wizard.js";
+import type { ChannelSetupWizardAdapter } from "./setup-wizard-types.js";
 import type {
   ChannelApprovalAdapter,
   ChannelApprovalCapability,
@@ -86,6 +87,7 @@ export type ChannelPlugin<ResolvedAccount = any, Probe = unknown, Audit = unknow
   };
   reload?: { configPrefixes: string[]; noopPrefixes?: string[] };
   setupWizard?: ChannelSetupWizard;
+  setupWizardAdapter?: ChannelSetupWizardAdapter;
   config: ChannelConfigAdapter<ResolvedAccount>;
   configSchema?: ChannelConfigSchema;
   setup?: ChannelSetupAdapter;

--- a/src/commands/channel-setup/registry.ts
+++ b/src/commands/channel-setup/registry.ts
@@ -1,14 +1,17 @@
 import { listChannelSetupPlugins } from "../../channels/plugins/setup-registry.js";
 import { buildChannelSetupWizardAdapterFromSetupWizard } from "../../channels/plugins/setup-wizard.js";
-import type { ChannelPlugin } from "../../channels/plugins/types.js";
+import type { ChannelSetupPlugin } from "../../channels/plugins/setup-wizard-types.js";
 import type { ChannelChoice } from "../onboard-types.js";
 import type { ChannelSetupWizardAdapter } from "./types.js";
 
 const setupWizardAdapters = new WeakMap<object, ChannelSetupWizardAdapter>();
 
 export function resolveChannelSetupWizardAdapterForPlugin(
-  plugin?: ChannelPlugin,
+  plugin?: ChannelSetupPlugin,
 ): ChannelSetupWizardAdapter | undefined {
+  if (plugin?.setupWizardAdapter) {
+    return plugin.setupWizardAdapter;
+  }
   if (plugin?.setupWizard) {
     const cached = setupWizardAdapters.get(plugin);
     if (cached) {

--- a/src/plugin-sdk/setup.ts
+++ b/src/plugin-sdk/setup.ts
@@ -9,6 +9,7 @@ export type { ChannelSetupAdapter } from "../channels/plugins/types.adapters.js"
 export type { ChannelSetupInput } from "../channels/plugins/types.core.js";
 export type {
   ChannelSetupDmPolicy,
+  SetupChannelsOptions,
   ChannelSetupWizardAdapter,
 } from "../channels/plugins/setup-wizard-types.js";
 export type {


### PR DESCRIPTION
## Summary
- register the Matrix onboarding wizard on the channel plugin again so openclaw channels add can drive guided setup
- add a regression test that asserts the Matrix channel still exposes configureInteractive

## Testing
- pnpm.cmd test -- extensions/matrix/src/channel.setup.test.ts
- pnpm.cmd test -- extensions/matrix/src/onboarding.test.ts
- pnpm.cmd test -- extensions/matrix/src/channel.directory.test.ts

Closes #59415