### PR TITLE
fix: distinguish LLM idle timeout from request timeout in error message (#59133)

### DIFF
--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -177,6 +177,7 @@ const buildAssistant = (overrides: Partial<AssistantMessage>): AssistantMessage 
 const makeAttempt = (overrides: Partial<EmbeddedRunAttemptResult>): EmbeddedRunAttemptResult => ({
   aborted: false,
   timedOut: false,
+  idleTimedOut: false,
   timedOutDuringCompaction: false,
   promptError: null,
   sessionIdUsed: "session:test",

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
@@ -31,6 +31,7 @@ export function makeAttemptResult(
   return {
     aborted: false,
     timedOut: false,
+    idleTimedOut: false,
     timedOutDuringCompaction: false,
     promptError: null,
     sessionIdUsed: "test-session",

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -571,6 +571,7 @@ export async function runEmbeddedPiAgent(
             aborted,
             promptError,
             timedOut,
+            idleTimedOut,
             timedOutDuringCompaction,
             sessionIdUsed,
             lastAssistant,
@@ -1327,12 +1328,15 @@ export async function runEmbeddedPiAgent(
           // Emit an explicit timeout error instead of silently completing, so
           // callers do not lose the turn as an orphaned user message.
           if (timedOut && !timedOutDuringCompaction && payloads.length === 0) {
+            const timeoutHint = idleTimedOut
+              ? "The model took too long to respond. " +
+                "Please try again, or increase `agents.defaults.llm.idleTimeoutSeconds` in your config (set to 0 to disable)."
+              : "Request timed out before a response was generated. " +
+                "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.";
             return {
               payloads: [
                 {
-                  text:
-                    "Request timed out before a response was generated. " +
-                    "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+                  text: timeoutHint,
                   isError: true,
                 },
               ],

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1206,6 +1206,7 @@ export async function runEmbeddedAttempt(
       let aborted = Boolean(params.abortSignal?.aborted);
       let yieldAborted = false;
       let timedOut = false;
+      let idleTimedOut = false;
       let timedOutDuringCompaction = false;
       const getAbortReason = (signal: AbortSignal): unknown =>
         "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
@@ -1255,6 +1256,7 @@ export async function runEmbeddedAttempt(
         void activeSession.abort();
       };
       idleTimeoutTrigger = (error) => {
+        idleTimedOut = true;
         abortRun(true, error);
       };
       const abortable = <T>(promise: Promise<T>): Promise<T> => {
@@ -1885,6 +1887,7 @@ export async function runEmbeddedAttempt(
       return {
         aborted,
         timedOut,
+        idleTimedOut,
         timedOutDuringCompaction,
         promptError,
         sessionIdUsed,

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -35,6 +35,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
 export type EmbeddedRunAttemptResult = {
   aborted: boolean;
   timedOut: boolean;
+  /** True if the timeout was triggered by the LLM idle timeout (no tokens received). */
+  idleTimedOut: boolean;
   /** True if the timeout occurred while compaction was in progress or pending. */
   timedOutDuringCompaction: boolean;
   promptError: unknown;

--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -15,6 +15,7 @@ function makeAttemptResult(
   return {
     aborted: false,
     timedOut: false,
+    idleTimedOut: false,
     timedOutDuringCompaction: false,
     promptError: null,
     sessionIdUsed: "test-session",

--- a/src/agents/test-helpers/pi-embedded-runner-e2e-fixtures.ts
+++ b/src/agents/test-helpers/pi-embedded-runner-e2e-fixtures.ts
@@ -99,6 +99,7 @@ export function makeEmbeddedRunnerAttempt(
   return {
     aborted: false,
     timedOut: false,
+    idleTimedOut: false,
     timedOutDuringCompaction: false,
     promptError: null,
     sessionIdUsed: "session:test",


### PR DESCRIPTION
## Summary

Fixes #59133 — cron timeout appears not to work after upgrading to 2026.3.31.

## Root cause

The new LLM idle timeout feature (added between 3.28 and 3.31) introduces a 60-second default idle timeout that fires if no token is received from the model during streaming. For slow local models (e.g., Ollama running large quantized models), this idle timeout fires before the cron job's configured `timeoutSeconds` (e.g., 120s), aborting the request.

The error message misleadingly tells users to increase `agents.defaults.timeoutSeconds`, but the actual timeout that fired is the LLM idle timeout, which is configured via `agents.defaults.llm.idleTimeoutSeconds`.

## Changes

- Add `idleTimedOut` flag to `EmbeddedRunAttemptResult` to track whether the abort was caused by the LLM idle timeout specifically
- Set the flag in the idle timeout trigger callback in `attempt.ts`
- Update the timeout error message in `run.ts` to suggest the correct config key:
  - Idle timeout → suggests `agents.defaults.llm.idleTimeoutSeconds` (set to 0 to disable)
  - General timeout → suggests `agents.defaults.timeoutSeconds` (existing behavior)
- Update all test fixtures that construct `EmbeddedRunAttemptResult` to include the new field

## Verification

- `pnpm check` passes clean
- `pnpm test -- src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts` — all 14 tests pass