### PR TITLE
Use better examples in the IRC extension docs and tests

### DIFF
--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -24,14 +24,15 @@ IRC ships as an extension plugin, but it is configured in the main config under 
     irc: {
       enabled: true,
       host: "localhost",
-      port: 6697,
-      tls: true,
+      port: 6667,
       nick: "openclaw-bot",
       channels: ["#openclaw"],
     },
   },
 }
 ```
+
+Note: This configuration does not use TLS. Before attempting to connect with TLS, add `TLS: true` and switch the `port` value to `6697`
 
 3. Start/restart gateway:
 

--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -15,7 +15,7 @@ IRC ships as an extension plugin, but it is configured in the main config under 
 
 1. Enable IRC config in `~/.openclaw/openclaw.json`.
 2. Install docker, if not already installed.
-3. Install and configure the ergo IRCd using docker. Instructions are at https://github.com/ergochat/ergo/blob/stable/docs/MANUAL.md#docker
+3. Install and configure the ergo IRCd using docker, [instructions are available on the ergo github.](https://github.com/ergochat/ergo/blob/stable/docs/MANUAL.md#docker)
 4. Set at least:
 
 ```json5

--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -14,14 +14,16 @@ IRC ships as an extension plugin, but it is configured in the main config under 
 ## Quick start
 
 1. Enable IRC config in `~/.openclaw/openclaw.json`.
-2. Set at least:
+2. Install docker, if not already installed.
+3. Install and configure the ergo IRCd using docker. Instructions are at https://github.com/ergochat/ergo/blob/stable/docs/MANUAL.md#docker
+4. Set at least:
 
 ```json5
 {
   channels: {
     irc: {
       enabled: true,
-      host: "irc.libera.chat",
+      host: "localhost",
       port: 6697,
       tls: true,
       nick: "openclaw-bot",
@@ -179,7 +181,7 @@ Use `toolsBySender` to apply a stricter policy to `"*"` and a looser one to your
 Notes:
 
 - `toolsBySender` keys should use `id:` for IRC sender identity values:
-  `id:eigen` or `id:eigen!~eigen@174.127.248.171` for stronger matching.
+  `id:eigen` or `id:eigen!~eigen@192.0.2.255` for stronger matching.
 - Legacy unprefixed keys are still accepted and matched as `id:` only.
 - The first matching sender policy wins; `"*"` is the wildcard fallback.
 

--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -25,7 +25,7 @@ IRC ships as an extension plugin, but it is configured in the main config under 
       enabled: true,
       host: "localhost",
       port: 6667,
-      tls: false
+      tls: false,
       nick: "openclaw-bot",
       channels: ["#openclaw"],
     },

--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -25,6 +25,7 @@ IRC ships as an extension plugin, but it is configured in the main config under 
       enabled: true,
       host: "localhost",
       port: 6667,
+      tls: false
       nick: "openclaw-bot",
       channels: ["#openclaw"],
     },
@@ -32,7 +33,7 @@ IRC ships as an extension plugin, but it is configured in the main config under 
 }
 ```
 
-Note: This configuration does not use TLS. Before attempting to connect with TLS, add `TLS: true` and switch the `port` value to `6697`
+Note: This configuration does not use TLS. Before attempting to connect with TLS, add `tls: true` and switch the `port` value to `6697`
 
 5. Start/restart gateway:
 

--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -34,7 +34,7 @@ IRC ships as an extension plugin, but it is configured in the main config under 
 
 Note: This configuration does not use TLS. Before attempting to connect with TLS, add `TLS: true` and switch the `port` value to `6697`
 
-3. Start/restart gateway:
+5. Start/restart gateway:
 
 ```bash
 openclaw gateway run

--- a/extensions/irc/src/connect-options.test.ts
+++ b/extensions/irc/src/connect-options.test.ts
@@ -4,7 +4,7 @@ import { buildIrcConnectOptions } from "./connect-options.js";
 describe("buildIrcConnectOptions", () => {
   it("copies resolved account connection fields and NickServ config", () => {
     const account = {
-      host: "irc.libera.chat",
+      host: "localhost",
       port: 6697,
       tls: true,
       nick: "openclaw",
@@ -27,7 +27,7 @@ describe("buildIrcConnectOptions", () => {
         connectTimeoutMs: 1234,
       }),
     ).toEqual({
-      host: "irc.libera.chat",
+      host: "localhost",
       port: 6697,
       tls: true,
       nick: "openclaw",

--- a/extensions/irc/src/probe.test.ts
+++ b/extensions/irc/src/probe.test.ts
@@ -54,12 +54,12 @@ describe("probeIrc", () => {
   it("returns latency and quits the probe client on success", async () => {
     resolveIrcAccountMock.mockReturnValue({
       configured: true,
-      host: "irc.libera.chat",
+      host: "localhost",
       port: 6697,
       tls: true,
       nick: "openclaw",
     });
-    buildIrcConnectOptionsMock.mockReturnValue({ host: "irc.libera.chat" });
+    buildIrcConnectOptionsMock.mockReturnValue({ host: "localhost" });
     const quit = vi.fn();
     connectIrcClientMock.mockResolvedValue({ quit });
     const nowSpy = vi.spyOn(Date, "now").mockReturnValueOnce(100).mockReturnValueOnce(145);
@@ -68,12 +68,12 @@ describe("probeIrc", () => {
       const result = await probeIrc({} as never, { timeoutMs: 5000 });
 
       expect(buildIrcConnectOptionsMock).toHaveBeenCalledWith(
-        expect.objectContaining({ host: "irc.libera.chat" }),
+        expect.objectContaining({ host: "localhost" }),
         { connectTimeoutMs: 5000 },
       );
       expect(result).toEqual({
         ok: true,
-        host: "irc.libera.chat",
+        host: "localhost",
         port: 6697,
         tls: true,
         nick: "openclaw",
@@ -88,17 +88,17 @@ describe("probeIrc", () => {
   it("formats non-Error probe failures into the returned error field", async () => {
     resolveIrcAccountMock.mockReturnValue({
       configured: true,
-      host: "irc.libera.chat",
+      host: "localhost",
       port: 6667,
       tls: false,
       nick: "openclaw",
     });
-    buildIrcConnectOptionsMock.mockReturnValue({ host: "irc.libera.chat" });
+    buildIrcConnectOptionsMock.mockReturnValue({ host: "localhost" });
     connectIrcClientMock.mockRejectedValue({ code: "ECONNREFUSED" });
 
     await expect(probeIrc({} as never)).resolves.toEqual({
       ok: false,
-      host: "irc.libera.chat",
+      host: "localhost",
       port: 6667,
       tls: false,
       nick: "openclaw",

--- a/extensions/irc/src/setup.test.ts
+++ b/extensions/irc/src/setup.test.ts
@@ -135,7 +135,7 @@ describe("irc setup", () => {
 
     expect(
       updateIrcAccountConfig(cfg, "work", {
-        host: "irc.libera.chat",
+        host: "localhost",
         nick: "openclaw-work",
       }),
     ).toMatchObject({
@@ -143,7 +143,7 @@ describe("irc setup", () => {
         irc: {
           accounts: {
             work: {
-              host: "irc.libera.chat",
+              host: "localhost",
               nick: "openclaw-work",
             },
           },
@@ -210,13 +210,13 @@ describe("irc setup", () => {
 
     expect(
       validateInput!({
-        input: { host: "irc.libera.chat", nick: "" },
+        input: { host: "localhost", nick: "" },
       } as never),
     ).toBe("IRC requires nick.");
 
     expect(
       validateInput!({
-        input: { host: "irc.libera.chat", nick: "openclaw" },
+        input: { host: "localhost", nick: "openclaw" },
       } as never),
     ).toBeNull();
 
@@ -226,7 +226,7 @@ describe("irc setup", () => {
         accountId: "default",
         input: {
           name: "Default",
-          host: " irc.libera.chat ",
+          host: " localhost ",
           port: "7000",
           tls: true,
           nick: " openclaw ",
@@ -241,7 +241,7 @@ describe("irc setup", () => {
         irc: {
           enabled: true,
           name: "Default",
-          host: "irc.libera.chat",
+          host: "localhost",
           port: 7000,
           tls: true,
           nick: "openclaw",
@@ -258,7 +258,7 @@ describe("irc setup", () => {
     const prompter = createTestWizardPrompter({
       text: vi.fn(async ({ message }: { message: string }) => {
         if (message === "IRC server host") {
-          return "irc.libera.chat";
+          return "localhost";
         }
         if (message === "IRC server port") {
           return "6697";
@@ -300,7 +300,7 @@ describe("irc setup", () => {
 
     expect(result.accountId).toBe("default");
     expect(result.cfg.channels?.irc?.enabled).toBe(true);
-    expect(result.cfg.channels?.irc?.host).toBe("irc.libera.chat");
+    expect(result.cfg.channels?.irc?.host).toBe("localhost");
     expect(result.cfg.channels?.irc?.nick).toBe("openclaw-bot");
     expect(result.cfg.channels?.irc?.tls).toBe(true);
     expect(result.cfg.channels?.irc?.channels).toEqual(["#openclaw", "#ops"]);
@@ -329,7 +329,7 @@ describe("irc setup", () => {
         irc: {
           accounts: {
             work: {
-              host: "irc.libera.chat",
+              host: "localhost",
               nick: "openclaw-work",
             },
           },

--- a/src/config/config.irc.test.ts
+++ b/src/config/config.irc.test.ts
@@ -22,7 +22,7 @@ describe("config irc", () => {
     const res = validateConfigObject({
       channels: {
         irc: {
-          host: "irc.libera.chat",
+          host: "localhost",
           nick: "openclaw-bot",
           channels: ["#openclaw"],
         },
@@ -30,7 +30,7 @@ describe("config irc", () => {
     });
 
     const config = expectValidConfig(res);
-    expect(config.channels?.irc?.host).toBe("irc.libera.chat");
+    expect(config.channels?.irc?.host).toBe("localhost");
     expect(config.channels?.irc?.nick).toBe("openclaw-bot");
   });
 

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -341,7 +341,7 @@ describe("applyPluginAutoEnable", () => {
     const result = applyPluginAutoEnable({
       config: {},
       env: {
-        IRC_HOST: "irc.libera.chat",
+        IRC_HOST: "localhost",
         IRC_NICK: "openclaw-bot",
       },
     });

--- a/src/config/types.irc.ts
+++ b/src/config/types.irc.ts
@@ -2,7 +2,7 @@ import type { CommonChannelMessagingConfig } from "./types.channel-messaging-com
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
 export type IrcAccountConfig = CommonChannelMessagingConfig & {
-  /** IRC server hostname (example: irc.libera.chat). */
+  /** IRC server hostname (example: localhost). */
   host?: string;
   /** IRC server port (default: 6697 with TLS, otherwise 6667). */
   port?: number;

--- a/src/config/types.irc.ts
+++ b/src/config/types.irc.ts
@@ -2,7 +2,7 @@ import type { CommonChannelMessagingConfig } from "./types.channel-messaging-com
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
 export type IrcAccountConfig = CommonChannelMessagingConfig & {
-  /** IRC server hostname (example: localhost). */
+  /** IRC server hostname (example: irc.example.com). */
   host?: string;
   /** IRC server port (default: 6697 with TLS, otherwise 6667). */
   port?: number;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Update docs and tests to use a localhost IRCd instead of a publicly accessible destination
- Migrate example IP to use a RFC 5737 TEST-NET-1 value instead of a residential allocated IP

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Using public infrastructure and real-world addresses
- Why it matters: Using public destinations for communication backends can lead to information leaks.
- What changed: The default values in docs and test values.
- What did NOT change (scope boundary): Code.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Bad defaults and documentation values.
- Missing detection / guardrail: No CI preventing committing hostnames and IPs without considering consequences.
- Prior context (`git blame`, prior PR, issue, or refactor if known):
- Why this regressed now:
- If unknown, what was ruled out:

## Regression Test Plan (if applicable)

- Check for hostnames and IPs and flag them for human review. Real public hostnames and services should not be in documentation without consent, and certainly not for communication relays that will involve PII and operational configuration values. Non-example IPs should not be in documentation, use RFC 5737 values.

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: Detect IPs and domain names somehow.
- Scenario the test should lock in: Detect IPs and domain names somehow.
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Default config in the docs for IRC extension.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

N/A

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: Removed public hostname from docs. Bots are less likely to be configured to dump private information into specific public IRC channels.

## Repro + Verification

### Environment

- OS: All
- Runtime/container: All
- Model/provider: All
- Integration/channel (if any): IRC
- Relevant config (redacted): Examples.

### Steps

1. Redacted to avoid rubbernecking.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Evidence sent to security address, which requested this PR.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify: Did not run tests. I was asked to submit a PR after contacting the security address. I don't want to install npm with the state of that ecosystem.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation:
