### PR TITLE
fix(matrix): restore guided setup flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Matrix/onboarding: restore guided setup in `openclaw channels add` and `openclaw configure --section channels`, while keeping custom plugin wizards on the shared `setupWizard` seam. Thanks @gumadeiras.
 - Slack/mrkdwn formatting: add built-in Slack mrkdwn guidance in inbound context so Slack replies stop falling back to generic Markdown patterns that render poorly in Slack. (#59100) Thanks @jadewon.
 - Gateway/exec loopback: restore legacy-role fallback for empty paired-device token maps and allow silent local role upgrades so local exec and node clients stop failing with pairing-required errors after `2026.3.31`. (#59092) Thanks @openperf.
 - WhatsApp/media: add HTML, XML, and CSS to the MIME map and fall back gracefully for unknown media types instead of dropping the attachment. (#51562) Thanks @bobbyt74.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Matrix/onboarding: restore guided setup in `openclaw channels add` and `openclaw configure --section channels`, while keeping custom plugin wizards on the shared `setupWizard` seam. (#59462) Thanks @gumadeiras.
 - Slack/mrkdwn formatting: add built-in Slack mrkdwn guidance in inbound context so Slack replies stop falling back to generic Markdown patterns that render poorly in Slack. (#59100) Thanks @jadewon.
 - Gateway/exec loopback: restore legacy-role fallback for empty paired-device token maps and allow silent local role upgrades so local exec and node clients stop failing with pairing-required errors after `2026.3.31`. (#59092) Thanks @openperf.
 - WhatsApp/media: add HTML, XML, and CSS to the MIME map and fall back gracefully for unknown media types instead of dropping the attachment. (#51562) Thanks @bobbyt74.
@@ -22,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp/presence: send `unavailable` presence on connect in self-chat mode so personal-phone users stop losing all push notifications while the gateway is running. (#59410) Thanks @mcaxtr.
 - Providers/OpenAI-compatible routing: centralize native-vs-proxy request policy so hidden attribution and related OpenAI-family defaults only apply on verified native endpoints across stream, websocket, and shared audio HTTP paths. (#59433) Thanks @vincentkoc.
 - Exec approvals/doctor: report host policy sources from the real approvals file path and ignore malformed host override values when attributing effective policy conflicts. (#59367) Thanks @gumadeiras.
+- Matrix/onboarding: restore guided setup in `openclaw channels add` and `openclaw configure --section channels`, while keeping custom plugin wizards on the shared `setupWizard` seam. (#59462) Thanks @gumadeiras.
 
 ## 2026.4.1-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Matrix/onboarding: restore guided setup in `openclaw channels add` and `openclaw configure --section channels`, while keeping custom plugin wizards on the shared `setupWizard` seam. Thanks @gumadeiras.
+- Matrix/onboarding: restore guided setup in `openclaw channels add` and `openclaw configure --section channels`, while keeping custom plugin wizards on the shared `setupWizard` seam. (#59462) Thanks @gumadeiras.
 - Slack/mrkdwn formatting: add built-in Slack mrkdwn guidance in inbound context so Slack replies stop falling back to generic Markdown patterns that render poorly in Slack. (#59100) Thanks @jadewon.
 - Gateway/exec loopback: restore legacy-role fallback for empty paired-device token maps and allow silent local role upgrades so local exec and node clients stop failing with pairing-required errors after `2026.3.31`. (#59092) Thanks @openperf.
 - WhatsApp/media: add HTML, XML, and CSS to the MIME map and fall back gracefully for unknown media types instead of dropping the attachment. (#51562) Thanks @bobbyt74.

--- a/extensions/matrix/src/channel.setup.test.ts
+++ b/extensions/matrix/src/channel.setup.test.ts
@@ -11,6 +11,7 @@ vi.mock("./matrix/actions/verification.js", () => ({
 
 import { matrixPlugin } from "./channel.js";
 import { matrixSetupAdapter } from "./setup-core.js";
+import { matrixSetupWizard } from "./setup-surface.js";
 import { installMatrixTestRuntime } from "./test-runtime.js";
 import type { CoreConfig } from "./types.js";
 
@@ -133,6 +134,11 @@ describe("matrix setup post-write bootstrap", () => {
     error.mockClear();
     exit.mockClear();
     installMatrixTestRuntime();
+  });
+
+  it("registers the Matrix guided setup wizard on the channel plugin", () => {
+    expect(matrixPlugin.setupWizard).toBe(matrixSetupWizard);
+    expect(matrixPlugin.setupWizard?.channel).toBe("matrix");
   });
 
   it("bootstraps verification for newly added encrypted accounts", async () => {

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -62,6 +62,7 @@ import {
 import { getMatrixRuntime } from "./runtime.js";
 import { resolveMatrixOutboundSessionRoute } from "./session-route.js";
 import { matrixSetupAdapter } from "./setup-core.js";
+import { matrixSetupWizard } from "./setup-surface.js";
 import type { CoreConfig } from "./types.js";
 
 // Mutex for serializing account startup (workaround for concurrent dynamic import race condition)
@@ -289,6 +290,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
     base: {
       id: "matrix",
       meta,
+      setupWizard: matrixSetupWizard,
       capabilities: {
         chatTypes: ["direct", "group", "thread"],
         polls: true,

--- a/extensions/matrix/src/onboarding.test-harness.ts
+++ b/extensions/matrix/src/onboarding.test-harness.ts
@@ -1,7 +1,12 @@
 import type { OutputRuntimeEnv } from "openclaw/plugin-sdk/runtime";
+import type { ChannelSetupWizardAdapter } from "openclaw/plugin-sdk/setup";
 import { afterEach, vi } from "vitest";
 import type { RuntimeEnv, WizardPrompter } from "../runtime-api.js";
 import type { CoreConfig } from "./types.js";
+
+type MatrixInteractiveOptions = Parameters<
+  NonNullable<ChannelSetupWizardAdapter["configureInteractive"]>
+>[0]["options"];
 
 const MATRIX_ENV_KEYS = [
   "MATRIX_HOMESERVER",
@@ -88,7 +93,7 @@ export function createMatrixWizardPrompter(params: {
 export async function runMatrixInteractiveConfigure(params: {
   cfg: CoreConfig;
   prompter: WizardPrompter;
-  options?: unknown;
+  options?: MatrixInteractiveOptions;
   accountOverrides?: Record<string, string>;
   shouldPromptAccountIds?: boolean;
   forceAllowFrom?: boolean;

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -1,5 +1,8 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
-import { type ChannelSetupDmPolicy } from "openclaw/plugin-sdk/setup";
+import {
+  type ChannelSetupDmPolicy,
+  type ChannelSetupWizardAdapter,
+} from "openclaw/plugin-sdk/setup";
 import { requiresExplicitMatrixDefaultAccount } from "./account-selection.js";
 import { listMatrixDirectoryGroupsLive } from "./directory-live.js";
 import {
@@ -37,54 +40,6 @@ import {
 import type { CoreConfig } from "./types.js";
 
 const channel = "matrix" as const;
-
-type MatrixOnboardingStatus = {
-  channel: typeof channel;
-  configured: boolean;
-  statusLines: string[];
-  selectionHint?: string;
-  quickstartScore?: number;
-};
-
-type MatrixAccountOverrides = Partial<Record<typeof channel, string>>;
-
-type MatrixOnboardingConfigureContext = {
-  cfg: CoreConfig;
-  runtime: RuntimeEnv;
-  prompter: WizardPrompter;
-  options?: unknown;
-  forceAllowFrom: boolean;
-  accountOverrides: MatrixAccountOverrides;
-  shouldPromptAccountIds: boolean;
-};
-
-type MatrixOnboardingInteractiveContext = MatrixOnboardingConfigureContext & {
-  configured: boolean;
-  label?: string;
-};
-
-type MatrixOnboardingAdapter = {
-  channel: typeof channel;
-  getStatus: (ctx: {
-    cfg: CoreConfig;
-    options?: unknown;
-    accountOverrides: MatrixAccountOverrides;
-  }) => Promise<MatrixOnboardingStatus>;
-  configure: (
-    ctx: MatrixOnboardingConfigureContext,
-  ) => Promise<{ cfg: CoreConfig; accountId?: string }>;
-  configureInteractive?: (
-    ctx: MatrixOnboardingInteractiveContext,
-  ) => Promise<{ cfg: CoreConfig; accountId?: string } | "skip">;
-  afterConfigWritten?: (ctx: {
-    previousCfg: CoreConfig;
-    cfg: CoreConfig;
-    accountId: string;
-    runtime: RuntimeEnv;
-  }) => Promise<void> | void;
-  dmPolicy?: ChannelSetupDmPolicy;
-  disable?: (cfg: CoreConfig) => CoreConfig;
-};
 
 function resolveMatrixOnboardingAccountId(cfg: CoreConfig, accountId?: string): string {
   return normalizeAccountId(
@@ -556,7 +511,7 @@ async function runMatrixConfigure(params: {
   return { cfg: next, accountId };
 }
 
-export const matrixOnboardingAdapter: MatrixOnboardingAdapter = {
+export const matrixOnboardingAdapter: ChannelSetupWizardAdapter = {
   channel,
   getStatus: async ({ cfg, accountOverrides }) => {
     const resolvedCfg = cfg as CoreConfig;

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -6,7 +6,10 @@ import {
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import { createAllowlistProviderRouteAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
 import { createChannelPluginBase } from "openclaw/plugin-sdk/core";
-import { createDelegatedSetupWizardProxy } from "openclaw/plugin-sdk/setup";
+import {
+  createDelegatedSetupWizardProxy,
+  type ChannelSetupWizard,
+} from "openclaw/plugin-sdk/setup";
 import {
   listWhatsAppAccountIds,
   resolveDefaultWhatsAppAccountId,
@@ -55,8 +58,8 @@ const whatsappResolveDmPolicy = createScopedDmSecurityResolver<ResolvedWhatsAppA
 });
 
 export function createWhatsAppSetupWizardProxy(
-  loadWizard: () => Promise<NonNullable<ChannelPlugin<ResolvedWhatsAppAccount>["setupWizard"]>>,
-): NonNullable<ChannelPlugin<ResolvedWhatsAppAccount>["setupWizard"]> {
+  loadWizard: () => Promise<ChannelSetupWizard>,
+): ChannelSetupWizard {
   return createDelegatedSetupWizardProxy({
     channel: WHATSAPP_CHANNEL,
     loadWizard,

--- a/src/channels/plugins/types.plugin.ts
+++ b/src/channels/plugins/types.plugin.ts
@@ -1,3 +1,4 @@
+import type { ChannelSetupWizardAdapter } from "./setup-wizard-types.js";
 import type { ChannelSetupWizard } from "./setup-wizard.js";
 import type {
   ChannelApprovalAdapter,
@@ -74,6 +75,8 @@ export type ChannelConfigSchema = {
 };
 
 /** Full capability contract for a native channel plugin. */
+type ChannelPluginSetupWizard = ChannelSetupWizard | ChannelSetupWizardAdapter;
+
 // oxlint-disable-next-line typescript/no-explicit-any
 export type ChannelPlugin<ResolvedAccount = any, Probe = unknown, Audit = unknown> = {
   id: ChannelId;
@@ -85,7 +88,7 @@ export type ChannelPlugin<ResolvedAccount = any, Probe = unknown, Audit = unknow
     };
   };
   reload?: { configPrefixes: string[]; noopPrefixes?: string[] };
-  setupWizard?: ChannelSetupWizard;
+  setupWizard?: ChannelPluginSetupWizard;
   config: ChannelConfigAdapter<ResolvedAccount>;
   configSchema?: ChannelConfigSchema;
   setup?: ChannelSetupAdapter;

--- a/src/commands/channel-setup/registry.test.ts
+++ b/src/commands/channel-setup/registry.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { ChannelSetupPlugin } from "../../channels/plugins/setup-wizard-types.js";
+import type { ChannelSetupWizard } from "../../channels/plugins/setup-wizard.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
+import { resolveChannelSetupWizardAdapterForPlugin } from "./registry.js";
+
+function createSetupPlugin(params: {
+  setupWizard: ChannelSetupPlugin["setupWizard"];
+}): ChannelSetupPlugin {
+  return {
+    ...createChannelTestPluginBase({
+      id: "demo",
+      label: "Demo",
+    }),
+    setup: {
+      applyAccountConfig: ({ cfg }: { cfg: OpenClawConfig }) => cfg,
+    },
+    setupWizard: params.setupWizard,
+  };
+}
+
+describe("resolveChannelSetupWizardAdapterForPlugin", () => {
+  it("builds and caches adapters from the plugin setupWizard surface", () => {
+    const setupWizard: ChannelSetupWizard = {
+      channel: "demo",
+      status: {
+        configuredLabel: "Configured",
+        unconfiguredLabel: "Not configured",
+        resolveConfigured: () => false,
+      },
+      credentials: [],
+    };
+    const plugin = createSetupPlugin({ setupWizard });
+
+    const adapter = resolveChannelSetupWizardAdapterForPlugin(plugin);
+
+    expect(adapter?.channel).toBe("demo");
+    expect(typeof adapter?.getStatus).toBe("function");
+    expect(typeof adapter?.configure).toBe("function");
+    expect(resolveChannelSetupWizardAdapterForPlugin(plugin)).toBe(adapter);
+  });
+
+  it("passes through adapter-shaped setupWizard surfaces", async () => {
+    const setupWizard = {
+      channel: "demo",
+      getStatus: async () => ({
+        channel: "demo",
+        configured: false,
+        statusLines: [],
+      }),
+      configure: async ({ cfg }: { cfg: OpenClawConfig }) => ({ cfg }),
+    };
+    const plugin = createSetupPlugin({ setupWizard });
+
+    expect(resolveChannelSetupWizardAdapterForPlugin(plugin)).toBe(setupWizard);
+  });
+});

--- a/src/commands/channel-setup/registry.test.ts
+++ b/src/commands/channel-setup/registry.test.ts
@@ -41,7 +41,7 @@ describe("resolveChannelSetupWizardAdapterForPlugin", () => {
     expect(resolveChannelSetupWizardAdapterForPlugin(plugin)).toBe(adapter);
   });
 
-  it("passes through adapter-shaped setupWizard surfaces", async () => {
+  it("passes through adapter-shaped setupWizard surfaces", () => {
     const setupWizard = {
       channel: "demo",
       getStatus: async () => ({

--- a/src/commands/channel-setup/registry.ts
+++ b/src/commands/channel-setup/registry.ts
@@ -1,22 +1,54 @@
 import { listChannelSetupPlugins } from "../../channels/plugins/setup-registry.js";
 import { buildChannelSetupWizardAdapterFromSetupWizard } from "../../channels/plugins/setup-wizard.js";
+import type { ChannelSetupWizard } from "../../channels/plugins/setup-wizard.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
 import type { ChannelChoice } from "../onboard-types.js";
 import type { ChannelSetupWizardAdapter } from "./types.js";
 
 const setupWizardAdapters = new WeakMap<object, ChannelSetupWizardAdapter>();
 
+function isChannelSetupWizardAdapter(
+  setupWizard: ChannelPlugin["setupWizard"],
+): setupWizard is ChannelSetupWizardAdapter {
+  return Boolean(
+    setupWizard &&
+    typeof setupWizard === "object" &&
+    "getStatus" in setupWizard &&
+    typeof setupWizard.getStatus === "function" &&
+    "configure" in setupWizard &&
+    typeof setupWizard.configure === "function",
+  );
+}
+
+function isDeclarativeChannelSetupWizard(
+  setupWizard: ChannelPlugin["setupWizard"],
+): setupWizard is ChannelSetupWizard {
+  return Boolean(
+    setupWizard &&
+    typeof setupWizard === "object" &&
+    "status" in setupWizard &&
+    "credentials" in setupWizard,
+  );
+}
+
 export function resolveChannelSetupWizardAdapterForPlugin(
   plugin?: ChannelPlugin,
 ): ChannelSetupWizardAdapter | undefined {
-  if (plugin?.setupWizard) {
+  if (!plugin) {
+    return undefined;
+  }
+  const { setupWizard } = plugin;
+  if (isChannelSetupWizardAdapter(setupWizard)) {
+    return setupWizard;
+  }
+  if (isDeclarativeChannelSetupWizard(setupWizard)) {
     const cached = setupWizardAdapters.get(plugin);
     if (cached) {
       return cached;
     }
     const adapter = buildChannelSetupWizardAdapterFromSetupWizard({
       plugin,
-      wizard: plugin.setupWizard,
+      wizard: setupWizard,
     });
     setupWizardAdapters.set(plugin, adapter);
     return adapter;

--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { matrixSetupAdapter, matrixSetupWizard } from "../../test/helpers/plugins/matrix-setup.js";
 import type { ChannelPluginCatalogEntry } from "../channels/plugins/catalog.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
@@ -113,7 +114,6 @@ function createMSTeamsCatalogEntry(): ChannelPluginCatalogEntry {
 }
 
 async function setMatrixOnboardingRegistryForTests(): Promise<void> {
-  const { matrixSetupAdapter, matrixSetupWizard } = await import("../../extensions/matrix/api.ts");
   setActivePluginRegistry(
     createTestRegistry([
       {

--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -112,6 +112,115 @@ function createMSTeamsCatalogEntry(): ChannelPluginCatalogEntry {
   };
 }
 
+async function setMatrixOnboardingRegistryForTests(): Promise<void> {
+  const { matrixSetupAdapter, matrixSetupWizard } = await import("../../extensions/matrix/api.ts");
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "matrix",
+        source: "test",
+        plugin: {
+          ...createChannelTestPluginBase({
+            id: "matrix",
+            label: "Matrix",
+            capabilities: { chatTypes: ["direct", "group", "thread"] },
+          }),
+          meta: {
+            id: "matrix",
+            label: "Matrix",
+            selectionLabel: "Matrix (plugin)",
+            docsPath: "/channels/matrix",
+            blurb: "open protocol; configure a homeserver + access token.",
+          },
+          setup: matrixSetupAdapter,
+          setupWizard: matrixSetupWizard,
+        },
+      },
+    ]),
+  );
+}
+
+async function withClearedMatrixSetupEnv<T>(run: () => Promise<T>): Promise<T> {
+  const previousEnv = {
+    MATRIX_HOMESERVER: process.env.MATRIX_HOMESERVER,
+    MATRIX_USER_ID: process.env.MATRIX_USER_ID,
+    MATRIX_ACCESS_TOKEN: process.env.MATRIX_ACCESS_TOKEN,
+    MATRIX_PASSWORD: process.env.MATRIX_PASSWORD,
+    MATRIX_DEVICE_ID: process.env.MATRIX_DEVICE_ID,
+    MATRIX_DEVICE_NAME: process.env.MATRIX_DEVICE_NAME,
+  };
+  delete process.env.MATRIX_HOMESERVER;
+  delete process.env.MATRIX_USER_ID;
+  delete process.env.MATRIX_ACCESS_TOKEN;
+  delete process.env.MATRIX_PASSWORD;
+  delete process.env.MATRIX_DEVICE_ID;
+  delete process.env.MATRIX_DEVICE_NAME;
+
+  try {
+    return await run();
+  } finally {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function createMatrixQuickstartPrompter(notes: string[]): WizardPrompter {
+  const select = vi.fn(async ({ message }: { message: string }) => {
+    if (message === "Select channel (QuickStart)") {
+      return "matrix";
+    }
+    if (message === "Matrix auth method") {
+      return "token";
+    }
+    throw new Error(`unexpected select prompt: ${message}`);
+  });
+  const multiselect = vi.fn(async () => {
+    throw new Error("unexpected multiselect");
+  });
+  const text = vi.fn(async ({ message }: { message: string }) => {
+    if (message === "Matrix homeserver URL") {
+      return "https://matrix.example.org";
+    }
+    if (message === "Matrix access token") {
+      return "matrix-token";
+    }
+    if (message === "Matrix device name (optional)") {
+      return "OpenClaw Gateway";
+    }
+    throw new Error(`unexpected text prompt: ${message}`);
+  });
+  const confirm = vi.fn(async ({ message }: { message: string }) => {
+    if (message === "Enable end-to-end encryption (E2EE)?") {
+      return false;
+    }
+    if (message === "Configure Matrix rooms access?") {
+      return false;
+    }
+    if (message === "Configure DM access policies now? (default: pairing)") {
+      return false;
+    }
+    if (message.startsWith("Matrix env vars detected")) {
+      return false;
+    }
+    throw new Error(`unexpected confirm prompt: ${message}`);
+  });
+
+  return createPrompter({
+    select: select as unknown as WizardPrompter["select"],
+    multiselect,
+    text: text as unknown as WizardPrompter["text"],
+    confirm: confirm as unknown as WizardPrompter["confirm"],
+    note: vi.fn(async (message: unknown) => {
+      notes.push(String(message));
+    }),
+  });
+}
+
 function setMinimalOnboardingRegistryForTests(): void {
   setActivePluginRegistry(
     createTestRegistry([
@@ -488,6 +597,11 @@ vi.mock("../plugins/manifest-registry.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../../extensions/matrix/src/matrix/deps.js", () => ({
+  ensureMatrixSdkInstalled: vi.fn(async () => {}),
+  isMatrixSdkAvailable: vi.fn(() => true),
+}));
+
 vi.mock("./onboard-helpers.js", () => ({
   detectBinary: vi.fn(async () => false),
 }));
@@ -557,6 +671,27 @@ describe("setupChannels", () => {
 
   it("renders the QuickStart channel picker without requiring the LINE runtime", async () => {
     await expectQuickstartPickerSkipsWithoutRuntime();
+  });
+
+  it("runs Matrix guided setup through setupChannels without falling back", async () => {
+    await withClearedMatrixSetupEnv(async () => {
+      await setMatrixOnboardingRegistryForTests();
+
+      const notes: string[] = [];
+      const prompter = createMatrixQuickstartPrompter(notes);
+      const cfg = await runSetupChannels({} as OpenClawConfig, prompter, {
+        quickstartDefaults: true,
+      });
+
+      expect(cfg.channels?.matrix).toMatchObject({
+        enabled: true,
+        homeserver: "https://matrix.example.org",
+        accessToken: "matrix-token",
+        deviceName: "OpenClaw Gateway",
+        encryption: false,
+      });
+      expect(notes.join("\n")).not.toContain("matrix does not support guided setup yet.");
+    });
   });
 
   it("renders the QuickStart channel picker without requiring the Matrix runtime", async () => {

--- a/test/helpers/plugins/matrix-setup.ts
+++ b/test/helpers/plugins/matrix-setup.ts
@@ -1,0 +1,1 @@
+export { matrixSetupAdapter, matrixSetupWizard } from "../../../extensions/matrix/api.js";

--- a/test/helpers/plugins/setup-wizard.ts
+++ b/test/helpers/plugins/setup-wizard.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 import { buildChannelSetupWizardAdapterFromSetupWizard } from "../../../src/channels/plugins/setup-wizard.js";
+import type { ChannelPlugin } from "../../../src/channels/plugins/types.js";
 import type { WizardPrompter } from "../../../src/wizard/prompts.js";
 import { createRuntimeEnv } from "./runtime-env.js";
 
@@ -77,6 +78,30 @@ type SetupWizardPlugin = SetupWizardAdapterParams["plugin"];
 type SetupWizard = NonNullable<SetupWizardAdapterParams["wizard"]>;
 type SetupWizardCredentialValues = Record<string, string>;
 
+function isDeclarativeSetupWizard(
+  setupWizard: ChannelPlugin["setupWizard"],
+): setupWizard is SetupWizard {
+  return Boolean(
+    setupWizard &&
+    typeof setupWizard === "object" &&
+    "status" in setupWizard &&
+    "credentials" in setupWizard,
+  );
+}
+
+function requireDeclarativeSetupWizard(
+  plugin: SetupWizardPlugin & Pick<ChannelPlugin, "setupWizard">,
+): SetupWizard {
+  const { setupWizard } = plugin;
+  if (!setupWizard) {
+    throw new Error(`${plugin.id} is missing setupWizard`);
+  }
+  if (!isDeclarativeSetupWizard(setupWizard)) {
+    throw new Error(`${plugin.id} setupWizard is adapter-shaped; test helper expects a wizard`);
+  }
+  return setupWizard;
+}
+
 function resolveSetupWizardAccountContext<TCfg>(params: {
   cfg?: TCfg;
   accountId?: string;
@@ -111,12 +136,9 @@ export function createSetupWizardAdapter(params: SetupWizardAdapterParams) {
 }
 
 export function createPluginSetupWizardAdapter<
-  TPlugin extends SetupWizardPlugin & { setupWizard?: SetupWizard },
+  TPlugin extends SetupWizardPlugin & Pick<ChannelPlugin, "setupWizard">,
 >(plugin: TPlugin) {
-  const wizard = plugin.setupWizard;
-  if (!wizard) {
-    throw new Error(`${plugin.id} is missing setupWizard`);
-  }
+  const wizard = requireDeclarativeSetupWizard(plugin);
   return createSetupWizardAdapter({
     plugin,
     wizard,
@@ -124,13 +146,13 @@ export function createPluginSetupWizardAdapter<
 }
 
 export function createPluginSetupWizardConfigure<
-  TPlugin extends SetupWizardPlugin & { setupWizard?: SetupWizard },
+  TPlugin extends SetupWizardPlugin & Pick<ChannelPlugin, "setupWizard">,
 >(plugin: TPlugin) {
   return createPluginSetupWizardAdapter(plugin).configure;
 }
 
 export function createPluginSetupWizardStatus<
-  TPlugin extends SetupWizardPlugin & { setupWizard?: SetupWizard },
+  TPlugin extends SetupWizardPlugin & Pick<ChannelPlugin, "setupWizard">,
 >(plugin: TPlugin) {
   return createPluginSetupWizardAdapter(plugin).getStatus;
 }


### PR DESCRIPTION
## Summary

- Problem: `openclaw channels add` and `openclaw configure --section channels` fell back to `matrix does not support guided setup yet.` even though Matrix still had guided onboarding logic.
- Why it matters: Matrix users lost the interactive setup path and could not complete onboarding from the shared channel setup flow.
- What changed: restored Matrix on the canonical `setupWizard` seam, taught the setup registry to accept either declarative or adapter-shaped `setupWizard`, and added registry + end-to-end regression coverage.
- What did NOT change (scope boundary): no new public `setupWizardAdapter` field, no changes to Matrix setup behavior outside the broken guided path.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59415
- Related #59425
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the interactive channel setup flow resolves guided onboarding from `plugin.setupWizard`, but Matrix no longer exposed its existing guided adapter there.
- Missing detection / guardrail: we had no setup-registry or `setupChannels` regression test proving Matrix still resolved a guided setup adapter.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Matrix onboarding logic still existed; the break was registration drift after refactor work around the setup surfaces.
- Why this regressed now: Matrix kept `setup` but lost the guided setup registration that the interactive flow actually uses.
- If unknown, what was ruled out: ruled out missing onboarding implementation; the prompts/bootstrap logic was still present.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/channel-setup/registry.test.ts`, `src/commands/onboard-channels.e2e.test.ts`, `extensions/matrix/src/channel.setup.test.ts`
- Scenario the test should lock in: Matrix resolves a guided setup adapter through the shared registry and `setupChannels` runs the guided flow without hitting the fallback error.
- Why this is the smallest reliable guardrail: the bug lived at the seam between plugin registration and the shared interactive flow, not inside Matrix prompt logic itself.
- Existing test that already covers this (if any): Matrix plugin-local setup tests covered pieces of setup but not registry resolution.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Matrix guided setup works again in the shared interactive onboarding flow.
- Custom adapter-shaped plugin wizards continue to work through the same `setupWizard` property.

## Diagram (if applicable)

```text
Before:
[user selects Matrix in setupChannels] -> [registry finds no guided adapter] -> [fallback error]

After:
[user selects Matrix in setupChannels] -> [registry resolves Matrix setupWizard] -> [guided prompts run] -> [config written]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Matrix
- Relevant config (redacted): interactive channel setup with Matrix selected

### Steps

1. Start interactive channel setup.
2. Select Matrix.
3. Continue through the guided prompts.

### Expected

- Matrix guided prompts run and write config.

### Actual

- Before fix: setup fell back to `matrix does not support guided setup yet.`
- After fix: Matrix resolves through the shared guided setup registry and completes setup.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Matrix plugin exposes guided setup; registry resolves both declarative and adapter-shaped `setupWizard`; `setupChannels` Matrix quickstart path no longer falls back.
- Edge cases checked: adapter-shaped `setupWizard` passthrough in registry helper; declarative wizard caching still works.
- What you did **not** verify: full manual TTY run of `openclaw channels add`; full repo `pnpm check` is currently blocked by unrelated local Telegram worktree errors.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: `setupWizard` now explicitly accepts both declarative and adapter-shaped guided setup surfaces.
  - Mitigation: registry tests cover both shapes, and the interactive Matrix e2e covers the real broken path.
