### PR TITLE
fix(ui): refresh chat avatar when switching agents

### DIFF
--- a/ui/src/ui/app-render.helpers.switch.node.test.ts
+++ b/ui/src/ui/app-render.helpers.switch.node.test.ts
@@ -63,6 +63,7 @@ describe("switchChatSession", () => {
     expect(state.chatMessage).toBe("");
     expect(state.chatMessages).toEqual([]);
     expect(state.chatStream).toBeNull();
+    expect((state as never as { chatStreamStartedAt: unknown }).chatStreamStartedAt).toBeNull();
     expect(state.chatQueue).toEqual([]);
     expect(state.chatRunId).toBeNull();
     expect(resetToolStream).toHaveBeenCalledTimes(1);

--- a/ui/src/ui/app-render.helpers.switch.node.test.ts
+++ b/ui/src/ui/app-render.helpers.switch.node.test.ts
@@ -42,6 +42,7 @@ describe("switchChatSession", () => {
     const state = {
       sessionKey: "agent:alpha:main",
       chatMessage: "draft",
+      chatMessages: [{ role: "assistant", content: "stale" }],
       chatStream: "stream",
       chatQueue: [{ id: "queued" }],
       chatRunId: "run-1",
@@ -60,6 +61,7 @@ describe("switchChatSession", () => {
 
     expect(state.sessionKey).toBe("agent:beta:main");
     expect(state.chatMessage).toBe("");
+    expect(state.chatMessages).toEqual([]);
     expect(state.chatStream).toBeNull();
     expect(state.chatQueue).toEqual([]);
     expect(state.chatRunId).toBeNull();

--- a/ui/src/ui/app-render.helpers.switch.node.test.ts
+++ b/ui/src/ui/app-render.helpers.switch.node.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadChatHistory: vi.fn(),
+  loadSessions: vi.fn(),
+  refreshChatAvatar: vi.fn(),
+  syncUrlWithSessionKey: vi.fn(),
+}));
+
+vi.mock("./app-chat.ts", () => ({
+  refreshChat: vi.fn(),
+  refreshChatAvatar: mocks.refreshChatAvatar,
+}));
+
+vi.mock("./controllers/chat.ts", () => ({
+  loadChatHistory: mocks.loadChatHistory,
+}));
+
+vi.mock("./controllers/sessions.ts", () => ({
+  loadSessions: mocks.loadSessions,
+}));
+
+vi.mock("./app-settings.ts", () => ({
+  syncUrlWithSessionKey: mocks.syncUrlWithSessionKey,
+}));
+
+import { switchChatSession } from "./app-render.helpers.ts";
+
+describe("switchChatSession", () => {
+  beforeEach(() => {
+    mocks.loadChatHistory.mockReset();
+    mocks.loadSessions.mockReset();
+    mocks.refreshChatAvatar.mockReset();
+    mocks.syncUrlWithSessionKey.mockReset();
+  });
+
+  it("refreshes the chat avatar when switching sessions", () => {
+    const applySettings = vi.fn();
+    const loadAssistantIdentity = vi.fn();
+    const resetToolStream = vi.fn();
+    const resetChatScroll = vi.fn();
+    const state = {
+      sessionKey: "agent:alpha:main",
+      chatMessage: "draft",
+      chatStream: "stream",
+      chatQueue: [{ id: "queued" }],
+      chatRunId: "run-1",
+      settings: {
+        sessionKey: "agent:alpha:main",
+        lastActiveSessionKey: "agent:alpha:main",
+      },
+      applySettings,
+      loadAssistantIdentity,
+      resetToolStream,
+      resetChatScroll,
+      chatStreamStartedAt: 123,
+    };
+
+    switchChatSession(state as never, "agent:beta:main");
+
+    expect(state.sessionKey).toBe("agent:beta:main");
+    expect(state.chatMessage).toBe("");
+    expect(state.chatStream).toBeNull();
+    expect(state.chatQueue).toEqual([]);
+    expect(state.chatRunId).toBeNull();
+    expect(resetToolStream).toHaveBeenCalledTimes(1);
+    expect(resetChatScroll).toHaveBeenCalledTimes(1);
+    expect(applySettings).toHaveBeenCalledWith({
+      sessionKey: "agent:beta:main",
+      lastActiveSessionKey: "agent:beta:main",
+    });
+    expect(loadAssistantIdentity).toHaveBeenCalledTimes(1);
+    expect(mocks.refreshChatAvatar).toHaveBeenCalledWith(state);
+    expect(mocks.loadChatHistory).toHaveBeenCalledWith(state);
+    expect(mocks.loadSessions).toHaveBeenCalledWith(state, {
+      activeMinutes: 0,
+      limit: 0,
+      includeGlobal: true,
+      includeUnknown: true,
+    });
+    expect(mocks.syncUrlWithSessionKey).toHaveBeenCalledWith(
+      state,
+      "agent:beta:main",
+      true,
+    );
+  });
+});

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,7 +1,7 @@
 import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { t } from "../i18n/index.ts";
-import { refreshChat } from "./app-chat.ts";
+import { refreshChat, refreshChatAvatar } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { OpenClawApp } from "./app.ts";
@@ -57,6 +57,7 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
     sessionKey,
     lastActiveSessionKey: sessionKey,
   });
+  void refreshChatAvatar(state as unknown as Parameters<typeof refreshChatAvatar>[0]);
 }
 
 export function renderTab(state: AppViewState, tab: Tab, opts?: { collapsed?: boolean }) {
@@ -518,6 +519,7 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
     lastActiveSessionKey: nextSessionKey,
   });
   void state.loadAssistantIdentity();
+  void refreshChatAvatar(state as unknown as Parameters<typeof refreshChatAvatar>[0]);
   syncUrlWithSessionKey(
     state as unknown as Parameters<typeof syncUrlWithSessionKey>[0],
     nextSessionKey,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -506,6 +506,7 @@ export function renderChatMobileToggle(state: AppViewState) {
 export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   state.sessionKey = nextSessionKey;
   state.chatMessage = "";
+  state.chatMessages = [];
   state.chatStream = null;
   // P1: Clear queued chat items from the previous session
   (state as unknown as { chatQueue: unknown[] }).chatQueue = [];

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1622,17 +1622,7 @@ export function renderApp(state: AppViewState) {
               agentsList: state.agentsList,
               currentAgentId: resolvedAgentId ?? "main",
               onAgentChange: (agentId: string) => {
-                state.sessionKey = buildAgentMainSessionKey({ agentId });
-                state.chatMessages = [];
-                state.chatStream = null;
-                state.chatRunId = null;
-                state.applySettings({
-                  ...state.settings,
-                  sessionKey: state.sessionKey,
-                  lastActiveSessionKey: state.sessionKey,
-                });
-                void loadChatHistory(state);
-                void state.loadAssistantIdentity();
+                switchChatSession(state, buildAgentMainSessionKey({ agentId }));
               },
               onNavigateToAgent: () => {
                 state.agentsSelectedId = resolvedAgentId;

--- a/vitest.unit-paths.mjs
+++ b/vitest.unit-paths.mjs
@@ -14,6 +14,7 @@ export const unitTestIncludePatterns = [
   "ui/src/ui/views/usage-render-details.test.ts",
   "ui/src/ui/controllers/agents.test.ts",
   "ui/src/ui/controllers/chat.test.ts",
+  "ui/src/ui/app-render.helpers*.test.ts",
 ];
 
 export const boundaryTestFiles = [


### PR DESCRIPTION
## Summary
- refresh the chat avatar whenever the active chat session changes
- route agent picker changes through the shared session switch helper so avatar refresh stays consistent
- add node coverage for the shared session-switch path and include those helper tests in Vitest

Closes #59438