### PR TITLE
perf(gateway): start channels without blocking sidecar init

### DIFF
--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -18,7 +18,7 @@ describe("createGatewayCloseHandler", () => {
       canvasHost: null,
       canvasHostServer: null,
       stopChannel: vi.fn(async () => undefined),
-      pluginServices: null,
+      pluginServicesReady: Promise.resolve(null),
       cron: { stop: vi.fn() },
       heartbeatRunner: { stop: vi.fn() } as never,
       updateCheckStop: null,

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -73,7 +73,10 @@ export function createGatewayCloseHandler(params: {
       for (const plugin of listChannelPlugins()) {
         await params.stopChannel(plugin.id);
       }
-      const pluginServices = await params.pluginServicesReady.catch(() => null);
+      const pluginServices = await Promise.race([
+        params.pluginServicesReady.catch(() => null),
+        new Promise<null>((r) => setTimeout(() => r(null), 10_000)),
+      ]);
       if (pluginServices) {
         await pluginServices.stop().catch(() => {});
       }

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -14,6 +14,7 @@ export function createGatewayCloseHandler(params: {
   releasePluginRouteRegistry?: (() => void) | null;
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
   pluginServicesReady: Promise<PluginServicesHandle | null>;
+  sidecarAbort?: AbortController;
   cron: { stop: () => void };
   heartbeatRunner: HeartbeatRunner;
   updateCheckStop?: (() => void) | null;
@@ -42,6 +43,9 @@ export function createGatewayCloseHandler(params: {
         typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
           ? Math.max(0, Math.floor(opts.restartExpectedMs))
           : null;
+      // Signal background sidecar tasks (channels, plugin services) to stop
+      // before we begin tearing down individual resources.
+      params.sidecarAbort?.abort();
       if (params.bonjourStop) {
         try {
           await params.bonjourStop();

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -13,7 +13,7 @@ export function createGatewayCloseHandler(params: {
   canvasHostServer: CanvasHostServer | null;
   releasePluginRouteRegistry?: (() => void) | null;
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
-  pluginServices: PluginServicesHandle | null;
+  pluginServicesReady: Promise<PluginServicesHandle | null>;
   cron: { stop: () => void };
   heartbeatRunner: HeartbeatRunner;
   updateCheckStop?: (() => void) | null;
@@ -69,8 +69,9 @@ export function createGatewayCloseHandler(params: {
       for (const plugin of listChannelPlugins()) {
         await params.stopChannel(plugin.id);
       }
-      if (params.pluginServices) {
-        await params.pluginServices.stop().catch(() => {});
+      const pluginServices = await params.pluginServicesReady.catch(() => null);
+      if (pluginServices) {
+        await pluginServices.stop().catch(() => {});
       }
       await stopGmailWatcher();
       params.cron.stop();

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -152,15 +152,24 @@ export async function startGatewaySidecars(params: {
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
   if (!skipChannels) {
-    try {
-      await prewarmConfiguredPrimaryModel({
-        cfg: params.cfg,
-        log: params.log,
-      });
-      await params.startChannels();
-    } catch (err) {
-      params.logChannels.error(`channel startup failed: ${String(err)}`);
-    }
+    // Fire channel startup without blocking the rest of the sidecar
+    // initialisation.  Channel plugins (especially WhatsApp/baileys) pull in
+    // large dependency trees whose dynamic imports can block the Node.js event
+    // loop for tens of seconds on constrained hosts (e.g. Android/proot).
+    // By not awaiting here the gateway can start serving WebSocket and HTTP
+    // requests (dashboard UI, health checks) while channels connect in the
+    // background.
+    void (async () => {
+      try {
+        await prewarmConfiguredPrimaryModel({
+          cfg: params.cfg,
+          log: params.log,
+        });
+        await params.startChannels();
+      } catch (err) {
+        params.logChannels.error(`channel startup failed: ${String(err)}`);
+      }
+    })();
   } else {
     params.logChannels.info(
       "skipping channel start (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)",

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -77,6 +77,9 @@ export async function startGatewaySidecars(params: {
     error: (msg: string) => void;
   };
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
+  /** When provided, channel startup is skipped if the signal fires before
+   *  `startChannels` begins or while the model pre-warm is still running. */
+  signal?: AbortSignal;
 }) {
   try {
     const stateDir = resolveStateDir(process.env);
@@ -161,12 +164,21 @@ export async function startGatewaySidecars(params: {
     // background.
     void (async () => {
       try {
+        if (params.signal?.aborted) {
+          return;
+        }
         await prewarmConfiguredPrimaryModel({
           cfg: params.cfg,
           log: params.log,
         });
+        if (params.signal?.aborted) {
+          return;
+        }
         await params.startChannels();
       } catch (err) {
+        if (params.signal?.aborted) {
+          return;
+        }
         params.logChannels.error(`channel startup failed: ${String(err)}`);
       }
     })();

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -199,16 +199,19 @@ export async function startGatewaySidecars(params: {
     }, 250);
   }
 
-  let pluginServices: PluginServicesHandle | null = null;
-  try {
-    pluginServices = await startPluginServices({
-      registry: params.pluginRegistry,
-      config: params.cfg,
-      workspaceDir: params.defaultWorkspaceDir,
-    });
-  } catch (err) {
+  // Start plugin services (notably the browser-control server backed by
+  // Playwright) without blocking the rest of sidecar initialisation.  On
+  // constrained hosts (e.g. Android/proot) the Chromium dependency tree can
+  // block the event loop for over a minute.  The returned promise lets the
+  // shutdown handler await the handle even if startup is still in progress.
+  const pluginServicesReady: Promise<PluginServicesHandle | null> = startPluginServices({
+    registry: params.pluginRegistry,
+    config: params.cfg,
+    workspaceDir: params.defaultWorkspaceDir,
+  }).catch((err): null => {
     params.log.warn(`plugin services failed to start: ${String(err)}`);
-  }
+    return null;
+  });
 
   if (params.cfg.acp?.enabled) {
     void getAcpSessionManager()
@@ -236,7 +239,7 @@ export async function startGatewaySidecars(params: {
     }, 750);
   }
 
-  return { pluginServices };
+  return { pluginServicesReady };
 }
 
 export const __testing = {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -626,7 +626,7 @@ export async function startGatewayServer(
   ) as unknown as Record<ChannelId, RuntimeEnv>;
   const channelMethods = listChannelPlugins().flatMap((plugin) => plugin.gatewayMethods ?? []);
   const gatewayMethods = Array.from(new Set([...baseGatewayMethods, ...channelMethods]));
-  let pluginServices: PluginServicesHandle | null = null;
+  let pluginServicesReady: Promise<PluginServicesHandle | null> = Promise.resolve(null);
   const runtimeConfig = await resolveGatewayRuntimeConfig({
     cfg: cfgAtStart,
     port,
@@ -815,7 +815,7 @@ export async function startGatewayServer(
       canvasHostServer,
       releasePluginRouteRegistry,
       stopChannel,
-      pluginServices,
+      pluginServicesReady,
       cron,
       heartbeatRunner,
       updateCheckStop: stopGatewayUpdateCheck,
@@ -1373,7 +1373,7 @@ export async function startGatewayServer(
           logDiagnostics: false,
         }));
       }
-      ({ pluginServices } = await startGatewaySidecars({
+      ({ pluginServicesReady } = await startGatewaySidecars({
         cfg: gatewayPluginConfigAtStart,
         pluginRegistry,
         defaultWorkspaceDir,
@@ -1489,7 +1489,7 @@ export async function startGatewayServer(
     canvasHostServer,
     releasePluginRouteRegistry,
     stopChannel,
-    pluginServices,
+    pluginServicesReady,
     cron,
     heartbeatRunner,
     updateCheckStop: stopGatewayUpdateCheck,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -793,8 +793,10 @@ export async function startGatewayServer(
   let skillsChangeUnsub = () => {};
   let channelHealthMonitor: ReturnType<typeof startChannelHealthMonitor> | null = null;
   let stopModelPricingRefresh = () => {};
+  const sidecarAbort = new AbortController();
   let configReloader: { stop: () => Promise<void> } = { stop: async () => {} };
   const closeOnStartupFailure = async () => {
+    sidecarAbort.abort();
     if (diagnosticsEnabled) {
       stopDiagnosticHeartbeat();
     }
@@ -816,6 +818,7 @@ export async function startGatewayServer(
       releasePluginRouteRegistry,
       stopChannel,
       pluginServicesReady,
+      sidecarAbort,
       cron,
       heartbeatRunner,
       updateCheckStop: stopGatewayUpdateCheck,
@@ -1382,6 +1385,7 @@ export async function startGatewayServer(
         log,
         logHooks,
         logChannels,
+        signal: sidecarAbort.signal,
       }));
     }
 
@@ -1490,6 +1494,7 @@ export async function startGatewayServer(
     releasePluginRouteRegistry,
     stopChannel,
     pluginServicesReady,
+    sidecarAbort,
     cron,
     heartbeatRunner,
     updateCheckStop: stopGatewayUpdateCheck,


### PR DESCRIPTION
## Summary

- Fire `startChannels()` without `await` in `startGatewaySidecars()` so channel plugin loading no longer blocks the event loop.

### Problem

Channel plugins — particularly WhatsApp (`@whiskeysockets/baileys` 9.1 MB + `jimp` 3.9 MB) — pull in large dependency trees. Their dynamic `import()` chains monopolise the Node.js event loop during module resolution:

```
[hooks] loaded 5 internal hook handlers      ← event loop blocked from here
                                              ← 95 seconds of silence
[whatsapp] [default] starting provider       ← event loop released
```

During this window the gateway cannot serve HTTP or WebSocket requests, so the dashboard UI is completely unresponsive even though the server is already listening.

On constrained hosts (Android/proot where every `stat`/`read` syscall goes through ptrace) this takes **~95 seconds**. Even on macOS it can take 5-8 seconds.

### Fix

Wrap the `prewarmConfiguredPrimaryModel` + `startChannels` sequence in a `void` IIFE so it runs in the background. The gateway can start serving requests (dashboard, health checks, pairing) immediately after hooks are loaded. Errors are still caught and logged.

Nothing downstream in `startGatewaySidecars` depends on channel startup completing — `pluginServices`, hooks, ACP reconciliation, and memory backend all proceed independently.

Refs: #58534

## Test plan

- [x] `pnpm exec vitest run src/gateway/server-startup.test.ts` — 2 tests pass
- [x] Pre-commit hooks (tsgo, lint, conflict markers) pass