### PR TITLE
[codex] Hide Windows exec console windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,8 @@ Docs: https://docs.openclaw.ai
 - Plugins/Google: separate OAuth CSRF state from PKCE code verifier during Gemini browser sign-in so state validation and token exchange use independent values. (#59116) Thanks @eleqtrizit.
 - Exec/Windows: reject malformed drive-less rooted executable paths like `:\Users\...` so approval and allowlist candidate resolution no longer treat them as cwd-relative commands. (#58040) Thanks @SnowSky1.
 - Exec/preflight: fail closed on complex interpreter invocations that would otherwise skip script-content validation, and correctly inspect quoted script paths before host execution. Thanks @pgondhi987.
-<<<<<<< HEAD
 - Exec/Windows: include Windows-compatible env override keys like `ProgramFiles(x86)` in system-run approval binding so changed approved values are rejected instead of silently passing unbound. (#59182) Thanks @pgondhi987.
-||||||| parent of 1daac0c7c9 (docs: note windows exec landing (#59466) (thanks @lawrence3699))
-=======
 - Exec/Windows: hide transient console windows for `runExec` and `runCommandWithTimeout` child-process launches, matching other Windows exec paths and stopping visible shell flashes during tool runs. (#59466) Thanks @lawrence3699.
->>>>>>> 1daac0c7c9 (docs: note windows exec landing (#59466) (thanks @lawrence3699))
 
 ## 2026.4.2-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ Docs: https://docs.openclaw.ai
 - Plugins/Google: separate OAuth CSRF state from PKCE code verifier during Gemini browser sign-in so state validation and token exchange use independent values. (#59116) Thanks @eleqtrizit.
 - Exec/Windows: reject malformed drive-less rooted executable paths like `:\Users\...` so approval and allowlist candidate resolution no longer treat them as cwd-relative commands. (#58040) Thanks @SnowSky1.
 - Exec/preflight: fail closed on complex interpreter invocations that would otherwise skip script-content validation, and correctly inspect quoted script paths before host execution. Thanks @pgondhi987.
+<<<<<<< HEAD
 - Exec/Windows: include Windows-compatible env override keys like `ProgramFiles(x86)` in system-run approval binding so changed approved values are rejected instead of silently passing unbound. (#59182) Thanks @pgondhi987.
+||||||| parent of 1daac0c7c9 (docs: note windows exec landing (#59466) (thanks @lawrence3699))
+=======
+- Exec/Windows: hide transient console windows for `runExec` and `runCommandWithTimeout` child-process launches, matching other Windows exec paths and stopping visible shell flashes during tool runs. (#59466) Thanks @lawrence3699.
+>>>>>>> 1daac0c7c9 (docs: note windows exec landing (#59466) (thanks @lawrence3699))
 
 ## 2026.4.2-beta.1
 

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -133,9 +133,9 @@ export async function runExec(
       ? await execFileAsync(
           process.env.ComSpec ?? "cmd.exe",
           ["/d", "/s", "/c", buildCmdExeCommandLine(execCommand, execArgs)],
-          { ...options, windowsVerbatimArguments: true },
+          { ...options, windowsVerbatimArguments: true, windowsHide: true },
         )
-      : await execFileAsync(execCommand, execArgs, options);
+      : await execFileAsync(execCommand, execArgs, { ...options, windowsHide: true });
     if (shouldLogVerbose()) {
       if (stdout.trim()) {
         logDebug(stdout.trim());
@@ -261,6 +261,7 @@ export async function runCommandWithTimeout(
       stdio,
       cwd,
       env: resolvedEnv,
+      windowsHide: true,
       windowsVerbatimArguments: useCmdWrapper ? true : windowsVerbatimArguments,
       ...(shouldSpawnWithShell({ resolvedCommand, platform: process.platform })
         ? { shell: true }

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -79,6 +79,7 @@ function expectCmdWrappedInvocation(params: {
   expect(params.captured[0]).toBe(params.expectedComSpec);
   expect(params.captured[1].slice(0, 3)).toEqual(["/d", "/s", "/c"]);
   expect(params.captured[1][3]).toContain("pnpm.cmd --version");
+  expect(params.captured[2].windowsHide).toBe(true);
   expect(params.captured[2].windowsVerbatimArguments).toBe(true);
 }
 
@@ -145,6 +146,7 @@ describe("windows command wrapper behavior", () => {
         path.join(path.dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js"),
       );
       expect(captured[1][1]).toBe("--version");
+      expect(captured[2].windowsHide).toBe(true);
       expect(captured[2].windowsVerbatimArguments).toBeUndefined();
       expect(captured[2].stdio).toEqual(["inherit", "pipe", "pipe"]);
     } finally {
@@ -172,6 +174,7 @@ describe("windows command wrapper behavior", () => {
       expect(captured[0]).toBe(expectedComSpec);
       expect(captured[1].slice(0, 3)).toEqual(["/d", "/s", "/c"]);
       expect(captured[1][3]).toContain("npm.cmd --version");
+      expect(captured[2].windowsHide).toBe(true);
       expect(captured[2].windowsVerbatimArguments).toBe(true);
       expect(captured[2].stdio).toEqual(["inherit", "pipe", "pipe"]);
     } finally {
@@ -257,6 +260,34 @@ describe("windows command wrapper behavior", () => {
       await runExec("pnpm", ["--version"], 1000);
       const captured = execFileMock.mock.calls[0] as ExecCall | undefined;
       expectCmdWrappedInvocation({ captured, expectedComSpec });
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("sets windowsHide on direct runExec invocations too", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        cb(null, "ok", "");
+      },
+    );
+
+    try {
+      await runExec("node", ["--version"], 1000);
+      const captured = execFileMock.mock.calls[0] as ExecCall | undefined;
+      if (!captured) {
+        throw new Error("expected direct execFile invocation");
+      }
+      expect(captured[0]).toBe("node");
+      expect(captured[1]).toEqual(["--version"]);
+      expect(captured[2].windowsHide).toBe(true);
     } finally {
       platformSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

This hides Windows console windows for the main `exec` code paths used by OpenClaw tools and command runners.

## Root Cause

`runExec` and `runCommandWithTimeout` spawned Windows child processes without `windowsHide: true`. That caused brief visible console windows even though similar process launch sites elsewhere in the codebase were already hidden.

## Changes

- add `windowsHide: true` to both Windows `execFile` paths in `runExec`
- add `windowsHide: true` to the `spawn` path in `runCommandWithTimeout`
- keep the existing `.cmd` wrapping, npm shim resolution, and `windowsVerbatimArguments` behavior unchanged
- add regression tests that assert the hidden-window option across wrapped, shimmed, and direct Windows execution paths

## Validation

- `pnpm exec vitest run src/process/exec.windows.test.ts`

## Notes

- Windows manual verification is still recommended to confirm there is no visible console flash in a real desktop session.

Fixes #58566
