### PR TITLE
[codex] Fix Feishu attachment filename decoding

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -608,4 +608,78 @@ describe("downloadMessageResourceFeishu", () => {
       fileName: "clip.mp4",
     });
   });
+
+  it("preserves ASCII filename= metadata unchanged", async () => {
+    messageResourceGetMock.mockResolvedValueOnce({
+      data: Buffer.from("fake-doc-data"),
+      headers: {
+        "content-disposition": `attachment; filename="report-2026.pdf"`,
+      },
+    });
+
+    const result = await downloadMessageResourceFeishu({
+      cfg: emptyConfig,
+      messageId: "om_doc_msg",
+      fileKey: "file_key_doc",
+      type: "file",
+    });
+
+    expect(result.fileName).toBe("report-2026.pdf");
+  });
+
+  it("decodes RFC5987 filename*=UTF-8 metadata", async () => {
+    messageResourceGetMock.mockResolvedValueOnce({
+      data: Buffer.from("fake-doc-data"),
+      headers: {
+        "content-disposition":
+          "attachment; filename*=UTF-8''%E5%85%AD%E5%A4%A7%E7%BB%84%E4%BB%B6%E5%85%A8%E8%A7%A3%E6%9E%90.md",
+      },
+    });
+
+    const result = await downloadMessageResourceFeishu({
+      cfg: emptyConfig,
+      messageId: "om_utf8_msg",
+      fileKey: "file_key_utf8",
+      type: "file",
+    });
+
+    expect(result.fileName).toBe("六大组件全解析.md");
+  });
+
+  it("recovers mojibake filename= metadata back to UTF-8", async () => {
+    const mojibake = Buffer.from("六大组件全解析.md", "utf8").toString("latin1");
+    messageResourceGetMock.mockResolvedValueOnce({
+      data: Buffer.from("fake-doc-data"),
+      headers: {
+        "content-disposition": `attachment; filename="${mojibake}"`,
+      },
+    });
+
+    const result = await downloadMessageResourceFeishu({
+      cfg: emptyConfig,
+      messageId: "om_mojibake_msg",
+      fileKey: "file_key_mojibake",
+      type: "file",
+    });
+
+    expect(result.fileName).toBe("六大组件全解析.md");
+  });
+
+  it("does not corrupt already-correct Unicode filename= metadata", async () => {
+    messageResourceGetMock.mockResolvedValueOnce({
+      data: Buffer.from("fake-doc-data"),
+      headers: {
+        "content-disposition": `attachment; filename="六大组件全解析.md"`,
+      },
+    });
+
+    const result = await downloadMessageResourceFeishu({
+      cfg: emptyConfig,
+      messageId: "om_unicode_msg",
+      fileKey: "file_key_unicode",
+      type: "file",
+    });
+
+    expect(result.fileName).toBe("六大组件全解析.md");
+  });
 });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -124,17 +124,35 @@ function readHeaderValue(
 }
 
 function decodeDispositionFileName(value: string): string | undefined {
+  const normalizeDecodedFileName = (fileName: string): string => {
+    const trimmed = fileName.trim().replace(/^"(.*)"$/, "$1");
+    if (!trimmed) {
+      return trimmed;
+    }
+    // Some Feishu responses put UTF-8 bytes into `filename=` and clients decode
+    // them as Latin-1, producing mojibake like `å­å¤§...`. Recover only when the
+    // input is entirely within Latin-1 and round-trips to valid UTF-8.
+    if (/[^\u0000-\u00FF]/.test(trimmed)) {
+      return trimmed;
+    }
+    const decoded = Buffer.from(trimmed, "latin1").toString("utf8");
+    if (!decoded || decoded === trimmed || decoded.includes("\uFFFD")) {
+      return trimmed;
+    }
+    return /[^\x00-\x7F]/.test(decoded) ? decoded : trimmed;
+  };
+
   const utf8Match = value.match(/filename\*=UTF-8''([^;]+)/i);
   if (utf8Match?.[1]) {
     try {
-      return decodeURIComponent(utf8Match[1].trim().replace(/^"(.*)"$/, "$1"));
+      return normalizeDecodedFileName(decodeURIComponent(utf8Match[1].trim()));
     } catch {
-      return utf8Match[1].trim().replace(/^"(.*)"$/, "$1");
+      return normalizeDecodedFileName(utf8Match[1]);
     }
   }
 
   const plainMatch = value.match(/filename="?([^";]+)"?/i);
-  return plainMatch?.[1]?.trim();
+  return plainMatch?.[1] ? normalizeDecodedFileName(plainMatch[1]) : undefined;
 }
 
 function extractFeishuDownloadMetadata(response: FeishuDownloadResponse): {


### PR DESCRIPTION
## Summary

This fixes Feishu inbound attachment filenames being decoded as Latin-1 mojibake when the server returns UTF-8 bytes through the plain `filename=` path.

## Root Cause

The download metadata path already handled RFC5987-style `filename*=` values, but plain `filename=` values were passed through as-is. When Feishu returned UTF-8 bytes that had already been interpreted as Latin-1, OpenClaw preserved the mojibake instead of recovering the intended UTF-8 filename.

## Changes

- keep `filename*=` as the highest-priority decode path
- add a conservative Latin-1 -> UTF-8 recovery path for plain `filename=` values
- avoid rewriting ASCII names or already-correct Unicode names
- add regression coverage for ASCII, RFC5987, mojibake recovery, and already-correct Unicode filenames

## Validation

- `pnpm exec vitest run extensions/feishu/src/media.test.ts`

Fixes #59409
