### PR TITLE
Keep channels list JSON output when usage loading fails

### DIFF
--- a/src/commands/channels.adds-non-default-telegram-account.test.ts
+++ b/src/commands/channels.adds-non-default-telegram-account.test.ts
@@ -13,11 +13,23 @@ const authMocks = vi.hoisted(() => ({
   loadAuthProfileStore: vi.fn(),
 }));
 
+const usageMocks = vi.hoisted(() => ({
+  loadProviderUsageSummary: vi.fn(),
+}));
+
 vi.mock("../agents/auth-profiles.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../agents/auth-profiles.js")>();
   return {
     ...actual,
     loadAuthProfileStore: authMocks.loadAuthProfileStore,
+  };
+});
+
+vi.mock("../infra/provider-usage.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/provider-usage.js")>();
+  return {
+    ...actual,
+    loadProviderUsageSummary: usageMocks.loadProviderUsageSummary,
   };
 });
 
@@ -601,6 +613,26 @@ describe("channels command", () => {
     const ids = payload.auth?.map((entry) => entry.id) ?? [];
     expect(ids).toContain("anthropic:default");
     expect(ids).toContain("openai-codex:default");
+  });
+
+  it("keeps JSON output when usage loading fails", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {},
+    });
+    usageMocks.loadProviderUsageSummary.mockRejectedValue(new Error("usage failed"));
+
+    await channelsListCommand({ json: true }, runtime);
+
+    const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] as string) as {
+      chat?: Record<string, string[]>;
+      auth?: Array<{ id: string }>;
+      usage?: unknown;
+    };
+
+    expect(payload.chat).toBeDefined();
+    expect(payload.auth).toBeDefined();
+    expect(payload.usage).toBeUndefined();
   });
 
   it("stores default account names in accounts when multiple accounts exist", async () => {

--- a/src/commands/channels/list.ts
+++ b/src/commands/channels/list.ts
@@ -120,7 +120,14 @@ export async function channelsListCommand(
     isExternal: false,
   }));
   if (opts.json) {
-    const usage = includeUsage ? await loadProviderUsageSummary() : undefined;
+    let usage: Awaited<ReturnType<typeof loadProviderUsageSummary>> | undefined;
+    if (includeUsage) {
+      try {
+        usage = await loadProviderUsageSummary();
+      } catch {
+        usage = undefined;
+      }
+    }
     const chat: Record<string, string[]> = {};
     for (const plugin of plugins) {
       chat[plugin.id] = plugin.config.listAccountIds(cfg);


### PR DESCRIPTION
## Summary

Keep `channels list --json` machine-readable when provider usage loading fails.

## What changed

- Updated the JSON path in `src/commands/channels/list.ts` to tolerate `loadProviderUsageSummary()` failures
- Kept JSON output flowing when usage loading fails by omitting the `usage` field instead of failing the whole command
- Added a focused regression test covering the usage-failure JSON case
- Added a test mock for `../infra/provider-usage.js` in the channels command test file

## Why

`channels list --json` previously called `loadProviderUsageSummary()` directly and would fail the entire command if provider usage loading threw.

That made the JSON mode less robust than the text mode, which already degrades gracefully when usage loading fails. This change keeps the JSON path machine-readable and tolerant of usage-loading failures.

## Scope boundary

This PR only changes the JSON fallback behavior for usage loading in `channels list`. It does not change the shape of successful usage output, and it does not alter the text-mode usage rendering behavior.

## Manual verification

1. Added a focused test in `src/commands/channels.adds-non-default-telegram-account.test.ts`
2. Verified that `channelsListCommand({ json: true })` still emits JSON when provider usage loading fails
3. Ran:
   - `pnpm vitest run src/commands/channels.adds-non-default-telegram-account.test.ts -t "keeps JSON output when usage loading fails"`
   - `pnpm vitest run src/commands/channels.adds-non-default-telegram-account.test.ts`
4. Ran the repo checks during commit