### PR TITLE
fix: keep ACP prompts alive across gateway reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Feishu/comment threads: harden document comment-thread delivery so whole-document comments fall back to `add_comment`, delayed reply lookups retry more reliably, and user-visible replies avoid reasoning/planning spillover. (#59129) Thanks @wittam-01.
 - Matrix/streaming: keep live partial previews for the current assistant block while preserving completed block updates as separate messages when `channels.matrix.blockStreaming` is enabled. (#59384) thanks @gumadeiras
 - Kimi Coding/tools: normalize Anthropic tool payloads into the OpenAI-compatible function shape Kimi Coding expects so tool calls stop losing required arguments. (#59440) Thanks @obviyus.
+- ACP/gateway reconnects: keep ACP prompts alive across transient websocket drops while still failing boundedly when reconnect recovery does not complete. (#59473) Thanks @obviyus.
 - Exec approvals/config: strip invalid `security`, `ask`, and `askFallback` values from `~/.openclaw/exec-approvals.json` during normalization so malformed policy enums fall back cleanly to the documented defaults instead of corrupting runtime policy resolution. (#59112) Thanks @openperf.
 
 ## 2026.4.1-beta.1

--- a/src/acp/translator.prompt-prefix.test.ts
+++ b/src/acp/translator.prompt-prefix.test.ts
@@ -83,6 +83,7 @@ describe("acp prompt cwd prefix", () => {
       expect.objectContaining({
         message: expect.stringMatching(/\[Working directory: ~[\\/]openclaw-test\]/),
       }),
+      { timeoutMs: null },
     );
   });
 
@@ -93,6 +94,7 @@ describe("acp prompt cwd prefix", () => {
       expect.objectContaining({
         message: expect.stringContaining("[Working directory: ~\\openclaw-test]"),
       }),
+      { timeoutMs: null },
     );
   });
 
@@ -109,6 +111,7 @@ describe("acp prompt cwd prefix", () => {
         },
         systemProvenanceReceipt: undefined,
       }),
+      { timeoutMs: null },
     );
   });
 
@@ -125,24 +128,28 @@ describe("acp prompt cwd prefix", () => {
         },
         systemProvenanceReceipt: expect.stringContaining("[Source Receipt]"),
       }),
+      { timeoutMs: null },
     );
     expect(requestSpy).toHaveBeenCalledWith(
       "chat.send",
       expect.objectContaining({
         systemProvenanceReceipt: expect.stringContaining("bridge=openclaw-acp"),
       }),
+      { timeoutMs: null },
     );
     expect(requestSpy).toHaveBeenCalledWith(
       "chat.send",
       expect.objectContaining({
         systemProvenanceReceipt: expect.stringContaining(`originSessionId=${TEST_SESSION_ID}`),
       }),
+      { timeoutMs: null },
     );
     expect(requestSpy).toHaveBeenCalledWith(
       "chat.send",
       expect.objectContaining({
         systemProvenanceReceipt: expect.stringContaining(`targetSession=${TEST_SESSION_KEY}`),
       }),
+      { timeoutMs: null },
     );
   });
 
@@ -185,6 +192,7 @@ describe("acp prompt cwd prefix", () => {
         },
         systemProvenanceReceipt: expect.stringContaining("[Source Receipt]"),
       }),
+      { timeoutMs: null },
     );
     expect(requestSpy).toHaveBeenNthCalledWith(
       2,
@@ -193,6 +201,7 @@ describe("acp prompt cwd prefix", () => {
         systemInputProvenance: expect.anything(),
         systemProvenanceReceipt: expect.anything(),
       }),
+      { timeoutMs: null },
     );
   });
 });

--- a/src/acp/translator.prompt-prefix.test.ts
+++ b/src/acp/translator.prompt-prefix.test.ts
@@ -83,7 +83,6 @@ describe("acp prompt cwd prefix", () => {
       expect.objectContaining({
         message: expect.stringMatching(/\[Working directory: ~[\\/]openclaw-test\]/),
       }),
-      { expectFinal: true },
     );
   });
 
@@ -94,7 +93,6 @@ describe("acp prompt cwd prefix", () => {
       expect.objectContaining({
         message: expect.stringContaining("[Working directory: ~\\openclaw-test]"),
       }),
-      { expectFinal: true },
     );
   });
 
@@ -111,7 +109,6 @@ describe("acp prompt cwd prefix", () => {
         },
         systemProvenanceReceipt: undefined,
       }),
-      { expectFinal: true },
     );
   });
 
@@ -128,28 +125,24 @@ describe("acp prompt cwd prefix", () => {
         },
         systemProvenanceReceipt: expect.stringContaining("[Source Receipt]"),
       }),
-      { expectFinal: true },
     );
     expect(requestSpy).toHaveBeenCalledWith(
       "chat.send",
       expect.objectContaining({
         systemProvenanceReceipt: expect.stringContaining("bridge=openclaw-acp"),
       }),
-      { expectFinal: true },
     );
     expect(requestSpy).toHaveBeenCalledWith(
       "chat.send",
       expect.objectContaining({
         systemProvenanceReceipt: expect.stringContaining(`originSessionId=${TEST_SESSION_ID}`),
       }),
-      { expectFinal: true },
     );
     expect(requestSpy).toHaveBeenCalledWith(
       "chat.send",
       expect.objectContaining({
         systemProvenanceReceipt: expect.stringContaining(`targetSession=${TEST_SESSION_KEY}`),
       }),
-      { expectFinal: true },
     );
   });
 
@@ -192,7 +185,6 @@ describe("acp prompt cwd prefix", () => {
         },
         systemProvenanceReceipt: expect.stringContaining("[Source Receipt]"),
       }),
-      { expectFinal: true },
     );
     expect(requestSpy).toHaveBeenNthCalledWith(
       2,
@@ -201,7 +193,6 @@ describe("acp prompt cwd prefix", () => {
         systemInputProvenance: expect.anything(),
         systemProvenanceReceipt: expect.anything(),
       }),
-      { expectFinal: true },
     );
   });
 });

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -149,4 +149,47 @@ describe("acp translator stop reason mapping", () => {
       vi.useRealTimers();
     }
   });
+
+  it("keeps pre-ack send disconnects inside the reconnect grace window", async () => {
+    vi.useFakeTimers();
+    try {
+      const sessionStore = createInMemorySessionStore();
+      sessionStore.createSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        cwd: "/tmp",
+      });
+      const request = vi.fn(async (method: string) => {
+        if (method === "chat.send") {
+          throw new Error("gateway closed (1006): connection lost");
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+        sessionStore,
+      });
+      const promptPromise = agent.prompt({
+        sessionId: "session-1",
+        prompt: [{ type: "text", text: "hello" }],
+        _meta: {},
+      } as unknown as PromptRequest);
+      const settleSpy = vi.fn();
+      void promptPromise.then(
+        (value) => settleSpy({ kind: "resolve", value }),
+        (error) => settleSpy({ kind: "reject", error }),
+      );
+
+      await Promise.resolve();
+      expect(settleSpy).not.toHaveBeenCalled();
+
+      agent.handleGatewayDisconnect("1006: connection lost");
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(settleSpy).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -134,4 +134,19 @@ describe("acp translator stop reason mapping", () => {
 
     await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
   });
+
+  it("rejects in-flight prompts when the gateway does not reconnect before the grace window", async () => {
+    vi.useFakeTimers();
+    try {
+      const { agent, promptPromise } = await createPendingPromptHarness();
+      void promptPromise.catch(() => {});
+
+      agent.handleGatewayDisconnect("1006: connection lost");
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -345,4 +345,51 @@ describe("acp translator stop reason mapping", () => {
       vi.useRealTimers();
     }
   });
+
+  it("keeps the disconnect deadline after reconnect when a pre-ack send never started", async () => {
+    vi.useFakeTimers();
+    try {
+      const sessionId = "session-1";
+      const sessionKey = "agent:main:main";
+      const request = vi.fn(async (method: string) => {
+        if (method === "chat.send") {
+          throw new Error("gateway closed (1006): connection lost");
+        }
+        if (method === "agent.wait") {
+          return { status: "timeout" };
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const sessionStore = createInMemorySessionStore();
+      sessionStore.createSession({
+        sessionId,
+        sessionKey,
+        cwd: "/tmp",
+      });
+      const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+        sessionStore,
+      });
+      const promptPromise = agent.prompt({
+        sessionId,
+        prompt: [{ type: "text", text: "hello" }],
+        _meta: {},
+      } as unknown as PromptRequest);
+      void promptPromise.catch(() => {});
+
+      await Promise.resolve();
+      agent.handleGatewayDisconnect("1006: connection lost");
+      agent.handleGatewayReconnect();
+      await Promise.resolve();
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      await expect(Promise.race([promptPromise, Promise.resolve("pending")])).resolves.toBe(
+        "pending",
+      );
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -289,4 +289,60 @@ describe("acp translator stop reason mapping", () => {
       vi.useRealTimers();
     }
   });
+
+  it("does not clear a newer disconnect deadline while reconnect reconciliation is still running", async () => {
+    vi.useFakeTimers();
+    try {
+      const sessionId = "session-1";
+      const sessionKey = "agent:main:main";
+      let resolveAgentWait: ((value: { status: "timeout" }) => void) | undefined;
+      const request = vi.fn(async (method: string) => {
+        if (method === "chat.send") {
+          return {};
+        }
+        if (method === "agent.wait") {
+          return await new Promise<{ status: "timeout" }>((resolve) => {
+            resolveAgentWait = resolve;
+          });
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const sessionStore = createInMemorySessionStore();
+      sessionStore.createSession({
+        sessionId,
+        sessionKey,
+        cwd: "/tmp",
+      });
+      const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+        sessionStore,
+      });
+      const promptPromise = agent.prompt({
+        sessionId,
+        prompt: [{ type: "text", text: "hello" }],
+        _meta: {},
+      } as unknown as PromptRequest);
+      const settleSpy = vi.fn();
+      void promptPromise.then(
+        (value) => settleSpy({ kind: "resolve", value }),
+        (error) => settleSpy({ kind: "reject", error }),
+      );
+
+      await Promise.resolve();
+      agent.handleGatewayDisconnect("1006: first disconnect");
+      agent.handleGatewayReconnect();
+      await Promise.resolve();
+
+      agent.handleGatewayDisconnect("1006: second disconnect");
+      resolveAgentWait?.({ status: "timeout" });
+      await Promise.resolve();
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(settleSpy).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: second disconnect");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -192,4 +192,101 @@ describe("acp translator stop reason mapping", () => {
       vi.useRealTimers();
     }
   });
+
+  it("reconciles a missed final event on reconnect via agent.wait", async () => {
+    const sessionId = "session-1";
+    const sessionKey = "agent:main:main";
+    let runId: string | undefined;
+    const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "chat.send") {
+        runId = params?.idempotencyKey as string | undefined;
+        return {};
+      }
+      if (method === "agent.wait") {
+        return { status: "ok" };
+      }
+      return {};
+    }) as GatewayClient["request"];
+    const sessionStore = createInMemorySessionStore();
+    sessionStore.createSession({
+      sessionId,
+      sessionKey,
+      cwd: "/tmp",
+    });
+    const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+      sessionStore,
+    });
+    const promptPromise = agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "hello" }],
+      _meta: {},
+    } as unknown as PromptRequest);
+
+    await vi.waitFor(() => {
+      expect(runId).toBeDefined();
+    });
+
+    agent.handleGatewayDisconnect("1006: connection lost");
+    agent.handleGatewayReconnect();
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    expect(request).toHaveBeenCalledWith(
+      "agent.wait",
+      {
+        runId,
+        timeoutMs: 0,
+      },
+      { timeoutMs: null },
+    );
+  });
+
+  it("clears the disconnect deadline on reconnect when agent.wait reports the run still active", async () => {
+    vi.useFakeTimers();
+    try {
+      const sessionId = "session-1";
+      const sessionKey = "agent:main:main";
+      const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+        if (method === "chat.send") {
+          return {};
+        }
+        if (method === "agent.wait") {
+          expect(params).toEqual({
+            runId: expect.any(String),
+            timeoutMs: 0,
+          });
+          return { status: "timeout" };
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const sessionStore = createInMemorySessionStore();
+      sessionStore.createSession({
+        sessionId,
+        sessionKey,
+        cwd: "/tmp",
+      });
+      const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+        sessionStore,
+      });
+      const promptPromise = agent.prompt({
+        sessionId,
+        prompt: [{ type: "text", text: "hello" }],
+        _meta: {},
+      } as unknown as PromptRequest);
+      const settleSpy = vi.fn();
+      void promptPromise.then(
+        (value) => settleSpy({ kind: "resolve", value }),
+        (error) => settleSpy({ kind: "reject", error }),
+      );
+
+      await Promise.resolve();
+      agent.handleGatewayDisconnect("1006: connection lost");
+      agent.handleGatewayReconnect();
+      await Promise.resolve();
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(settleSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -108,4 +108,30 @@ describe("acp translator stop reason mapping", () => {
 
     await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
   });
+
+  it("keeps in-flight prompts pending across transient gateway disconnects", async () => {
+    const { agent, promptPromise, runId } = await createPendingPromptHarness();
+    const settleSpy = vi.fn();
+    void promptPromise.then(
+      (value) => settleSpy({ kind: "resolve", value }),
+      (error) => settleSpy({ kind: "reject", error }),
+    );
+
+    agent.handleGatewayDisconnect("1006: connection lost");
+    await Promise.resolve();
+
+    expect(settleSpy).not.toHaveBeenCalled();
+
+    agent.handleGatewayReconnect();
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: "agent:main:main",
+        seq: 1,
+        state: "final",
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+  });
 });

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -330,7 +330,10 @@ describe("acp translator stop reason mapping", () => {
       await Promise.resolve();
       agent.handleGatewayDisconnect("1006: first disconnect");
       agent.handleGatewayReconnect();
-      await Promise.resolve();
+      for (let attempt = 0; attempt < 5 && !resolveAgentWait; attempt += 1) {
+        await Promise.resolve();
+      }
+      expect(resolveAgentWait).toBeDefined();
 
       agent.handleGatewayDisconnect("1006: second disconnect");
       resolveAgentWait?.({ status: "timeout" });
@@ -492,6 +495,66 @@ describe("acp translator stop reason mapping", () => {
       await vi.advanceTimersByTimeAsync(5_000);
 
       await expect(secondPrompt).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects only unrecovered prompts after reconnect reconciliation", async () => {
+    vi.useFakeTimers();
+    try {
+      const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+        if (method === "chat.send") {
+          return params?.sessionKey === "agent:main:second"
+            ? Promise.reject(new Error("gateway closed (1006): connection lost"))
+            : {};
+        }
+        if (method === "agent.wait") {
+          return { status: "timeout" };
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const sessionStore = createInMemorySessionStore();
+      sessionStore.createSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:first",
+        cwd: "/tmp",
+      });
+      sessionStore.createSession({
+        sessionId: "session-2",
+        sessionKey: "agent:main:second",
+        cwd: "/tmp",
+      });
+      const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+        sessionStore,
+      });
+
+      const acceptedPrompt = agent.prompt({
+        sessionId: "session-1",
+        prompt: [{ type: "text", text: "accepted" }],
+        _meta: {},
+      } as unknown as PromptRequest);
+      const preAckPrompt = agent.prompt({
+        sessionId: "session-2",
+        prompt: [{ type: "text", text: "pre-ack" }],
+        _meta: {},
+      } as unknown as PromptRequest);
+      const acceptedSettleSpy = vi.fn();
+      void acceptedPrompt.then(
+        (value) => acceptedSettleSpy({ kind: "resolve", value }),
+        (error) => acceptedSettleSpy({ kind: "reject", error }),
+      );
+      void preAckPrompt.catch(() => {});
+
+      await Promise.resolve();
+
+      agent.handleGatewayDisconnect("1006: connection lost");
+      agent.handleGatewayReconnect();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(acceptedSettleSpy).not.toHaveBeenCalled();
+      await expect(preAckPrompt).rejects.toThrow("Gateway disconnected: 1006: connection lost");
     } finally {
       vi.useRealTimers();
     }

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -433,4 +433,67 @@ describe("acp translator stop reason mapping", () => {
     await expect(firstPrompt).rejects.toThrow("gateway closed (1006): connection lost");
     await expect(Promise.race([secondPrompt, Promise.resolve("pending")])).resolves.toBe("pending");
   });
+
+  it("keeps disconnect deadline when a superseded send resolves late", async () => {
+    vi.useFakeTimers();
+    try {
+      const sessionId = "session-1";
+      const sessionKey = "agent:main:main";
+      let firstSendResolve: (() => void) | undefined;
+      let sendCount = 0;
+      const request = vi.fn(async (method: string) => {
+        if (method === "chat.send") {
+          sendCount += 1;
+          if (sendCount === 1) {
+            return await new Promise<void>((resolve) => {
+              firstSendResolve = resolve;
+            });
+          }
+          throw new Error("gateway closed (1006): connection lost");
+        }
+        if (method === "agent.wait") {
+          return { status: "timeout" };
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const sessionStore = createInMemorySessionStore();
+      sessionStore.createSession({
+        sessionId,
+        sessionKey,
+        cwd: "/tmp",
+      });
+      const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+        sessionStore,
+      });
+
+      const firstPrompt = agent.prompt({
+        sessionId,
+        prompt: [{ type: "text", text: "first" }],
+        _meta: {},
+      } as unknown as PromptRequest);
+      void firstPrompt.catch(() => {});
+      await Promise.resolve();
+      expect(firstSendResolve).toBeDefined();
+
+      const secondPrompt = agent.prompt({
+        sessionId,
+        prompt: [{ type: "text", text: "second" }],
+        _meta: {},
+      } as unknown as PromptRequest);
+      void secondPrompt.catch(() => {});
+      await Promise.resolve();
+      expect(sendCount).toBe(2);
+
+      firstSendResolve?.();
+      await Promise.resolve();
+
+      agent.handleGatewayDisconnect("1006: connection lost");
+      agent.handleGatewayReconnect();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(secondPrompt).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -240,21 +240,23 @@ describe("acp translator stop reason mapping", () => {
     );
   });
 
-  it("clears the disconnect deadline on reconnect when agent.wait reports the run still active", async () => {
+  it("rechecks accepted prompts at the disconnect deadline after reconnect timeout", async () => {
     vi.useFakeTimers();
     try {
       const sessionId = "session-1";
       const sessionKey = "agent:main:main";
+      let waitCount = 0;
       const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
         if (method === "chat.send") {
           return {};
         }
         if (method === "agent.wait") {
+          waitCount += 1;
           expect(params).toEqual({
             runId: expect.any(String),
             timeoutMs: 0,
           });
-          return { status: "timeout" };
+          return waitCount === 1 ? { status: "timeout" } : { status: "ok" };
         }
         return {};
       }) as GatewayClient["request"];
@@ -283,8 +285,11 @@ describe("acp translator stop reason mapping", () => {
       agent.handleGatewayReconnect();
       await Promise.resolve();
 
-      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(4_999);
       expect(settleSpy).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
     } finally {
       vi.useRealTimers();
     }
@@ -296,11 +301,16 @@ describe("acp translator stop reason mapping", () => {
       const sessionId = "session-1";
       const sessionKey = "agent:main:main";
       let resolveAgentWait: ((value: { status: "timeout" }) => void) | undefined;
+      let agentWaitCount = 0;
       const request = vi.fn(async (method: string) => {
         if (method === "chat.send") {
           return {};
         }
         if (method === "agent.wait") {
+          agentWaitCount += 1;
+          if (agentWaitCount > 1) {
+            return { status: "timeout" };
+          }
           return await new Promise<{ status: "timeout" }>((resolve) => {
             resolveAgentWait = resolve;
           });
@@ -503,17 +513,24 @@ describe("acp translator stop reason mapping", () => {
   it("rejects only unrecovered prompts after reconnect reconciliation", async () => {
     vi.useFakeTimers();
     try {
-      const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      let acceptedRunId: string | undefined;
+      let acceptedWaitCount = 0;
+      const requestMock = vi.fn(async (method: string, params?: Record<string, unknown>) => {
         if (method === "chat.send") {
           return params?.sessionKey === "agent:main:second"
             ? Promise.reject(new Error("gateway closed (1006): connection lost"))
             : {};
         }
         if (method === "agent.wait") {
-          return { status: "timeout" };
+          return params?.runId === acceptedRunId && acceptedRunId
+            ? acceptedWaitCount++ === 0
+              ? { status: "timeout" }
+              : { status: "ok" }
+            : { status: "timeout" };
         }
         return {};
-      }) as GatewayClient["request"];
+      });
+      const request = requestMock as GatewayClient["request"];
       const sessionStore = createInMemorySessionStore();
       sessionStore.createSession({
         sessionId: "session-1",
@@ -547,13 +564,17 @@ describe("acp translator stop reason mapping", () => {
       void preAckPrompt.catch(() => {});
 
       await Promise.resolve();
+      acceptedRunId = requestMock.mock.calls.find((call) => {
+        const [method, requestParams] = call;
+        return method === "chat.send" && requestParams?.sessionKey === "agent:main:first";
+      })?.[1]?.idempotencyKey as string | undefined;
 
       agent.handleGatewayDisconnect("1006: connection lost");
       agent.handleGatewayReconnect();
       await Promise.resolve();
       await vi.advanceTimersByTimeAsync(5_000);
 
-      expect(acceptedSettleSpy).not.toHaveBeenCalled();
+      await expect(acceptedPrompt).resolves.toEqual({ stopReason: "end_turn" });
       await expect(preAckPrompt).rejects.toThrow("Gateway disconnected: 1006: connection lost");
     } finally {
       vi.useRealTimers();

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -392,4 +392,45 @@ describe("acp translator stop reason mapping", () => {
       vi.useRealTimers();
     }
   });
+
+  it("rejects a superseded pre-ack prompt when a newer prompt has replaced the session entry", async () => {
+    const sessionId = "session-1";
+    const sessionKey = "agent:main:main";
+    let promptCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method !== "chat.send") {
+        return {};
+      }
+      promptCount += 1;
+      if (promptCount === 1) {
+        throw new Error("gateway closed (1006): connection lost");
+      }
+      return {};
+    }) as GatewayClient["request"];
+    const sessionStore = createInMemorySessionStore();
+    sessionStore.createSession({
+      sessionId,
+      sessionKey,
+      cwd: "/tmp",
+    });
+    const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+      sessionStore,
+    });
+
+    const firstPrompt = agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "first" }],
+      _meta: {},
+    } as unknown as PromptRequest);
+    await Promise.resolve();
+
+    const secondPrompt = agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "second" }],
+      _meta: {},
+    } as unknown as PromptRequest);
+
+    await expect(firstPrompt).rejects.toThrow("gateway closed (1006): connection lost");
+    await expect(Promise.race([secondPrompt, Promise.resolve("pending")])).resolves.toBe("pending");
+  });
 });

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -580,4 +580,62 @@ describe("acp translator stop reason mapping", () => {
       vi.useRealTimers();
     }
   });
+
+  it("does not let a stale disconnect deadline reject a newer prompt on the same session", async () => {
+    vi.useFakeTimers();
+    try {
+      const sessionId = "session-1";
+      const sessionKey = "agent:main:main";
+      let sendCount = 0;
+      const requestMock = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+        if (method === "chat.send") {
+          sendCount += 1;
+          if (sendCount === 1) {
+            throw new Error("gateway closed (1006): connection lost");
+          }
+          return {};
+        }
+        if (method === "agent.wait") {
+          return params?.runId === firstRunId ? { status: "timeout" } : { status: "ok" };
+        }
+        return {};
+      });
+      const request = requestMock as GatewayClient["request"];
+      const sessionStore = createInMemorySessionStore();
+      sessionStore.createSession({
+        sessionId,
+        sessionKey,
+        cwd: "/tmp",
+      });
+      const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+        sessionStore,
+      });
+
+      const firstPrompt = agent.prompt({
+        sessionId,
+        prompt: [{ type: "text", text: "first" }],
+        _meta: {},
+      } as unknown as PromptRequest);
+      void firstPrompt.catch(() => {});
+      await Promise.resolve();
+      const firstRunId = requestMock.mock.calls[0]?.[1]?.idempotencyKey as string;
+
+      agent.handleGatewayDisconnect("1006: connection lost");
+      agent.handleGatewayReconnect();
+      await Promise.resolve();
+
+      const secondPrompt = agent.prompt({
+        sessionId,
+        prompt: [{ type: "text", text: "second" }],
+        _meta: {},
+      } as unknown as PromptRequest);
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(Promise.race([secondPrompt, Promise.resolve("pending")])).resolves.toBe(
+        "pending",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -134,6 +134,10 @@ function isAdminScopeProvenanceRejection(err: unknown): boolean {
   );
 }
 
+function isGatewayCloseError(err: unknown): boolean {
+  return err instanceof Error && err.message.startsWith("gateway closed (");
+}
+
 type SessionSnapshot = SessionPresentation & {
   metadata?: SessionMetadata;
   usage?: SessionUsageSnapshot;
@@ -707,6 +711,9 @@ export class AcpGatewayAgent implements Agent {
       };
 
       void sendWithProvenanceFallback().catch((err) => {
+        if (isGatewayCloseError(err) && this.pendingPrompts.has(params.sessionId)) {
+          return;
+        }
         this.pendingPrompts.delete(params.sessionId);
         this.sessionStore.clearActiveRun(params.sessionId);
         if (this.pendingPrompts.size === 0) {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -685,17 +685,21 @@ export class AcpGatewayAgent implements Agent {
 
       const sendWithProvenanceFallback = async () => {
         try {
-          await this.gateway.request("chat.send", {
-            ...requestParams,
-            systemInputProvenance,
-            systemProvenanceReceipt,
-          });
+          await this.gateway.request(
+            "chat.send",
+            {
+              ...requestParams,
+              systemInputProvenance,
+              systemProvenanceReceipt,
+            },
+            { timeoutMs: null },
+          );
         } catch (err) {
           if (
             (systemInputProvenance || systemProvenanceReceipt) &&
             isAdminScopeProvenanceRejection(err)
           ) {
-            await this.gateway.request("chat.send", requestParams);
+            await this.gateway.request("chat.send", requestParams, { timeoutMs: null });
             return;
           }
           throw err;

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -431,11 +431,6 @@ export class AcpGatewayAgent implements Agent {
 
   handleGatewayDisconnect(reason: string): void {
     this.log(`gateway disconnected: ${reason}`);
-    for (const pending of this.pendingPrompts.values()) {
-      pending.reject(new Error(`Gateway disconnected: ${reason}`));
-      this.sessionStore.clearActiveRun(pending.sessionId);
-    }
-    this.pendingPrompts.clear();
   }
 
   async handleGatewayEvent(evt: EventFrame): Promise<void> {
@@ -678,21 +673,17 @@ export class AcpGatewayAgent implements Agent {
 
       const sendWithProvenanceFallback = async () => {
         try {
-          await this.gateway.request(
-            "chat.send",
-            {
-              ...requestParams,
-              systemInputProvenance,
-              systemProvenanceReceipt,
-            },
-            { expectFinal: true },
-          );
+          await this.gateway.request("chat.send", {
+            ...requestParams,
+            systemInputProvenance,
+            systemProvenanceReceipt,
+          });
         } catch (err) {
           if (
             (systemInputProvenance || systemProvenanceReceipt) &&
             isAdminScopeProvenanceRejection(err)
           ) {
-            await this.gateway.request("chat.send", requestParams, { expectFinal: true });
+            await this.gateway.request("chat.send", requestParams);
             return;
           }
           throw err;

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -409,6 +409,7 @@ export class AcpGatewayAgent implements Agent {
   private sessionCreateRateLimiter: FixedWindowRateLimiter;
   private pendingPrompts = new Map<string, PendingPrompt>();
   private disconnectTimer: NodeJS.Timeout | null = null;
+  private disconnectGeneration = 0;
 
   constructor(
     connection: AgentSideConnection,
@@ -438,7 +439,7 @@ export class AcpGatewayAgent implements Agent {
 
   handleGatewayReconnect(): void {
     this.log("gateway reconnected");
-    void this.reconcilePendingPromptsOnReconnect();
+    void this.reconcilePendingPromptsOnReconnect(this.disconnectGeneration);
   }
 
   handleGatewayDisconnect(reason: string): void {
@@ -446,6 +447,7 @@ export class AcpGatewayAgent implements Agent {
     if (this.pendingPrompts.size === 0) {
       return;
     }
+    this.disconnectGeneration += 1;
     this.clearDisconnectTimer();
     this.disconnectTimer = setTimeout(() => {
       this.disconnectTimer = null;
@@ -1026,9 +1028,13 @@ export class AcpGatewayAgent implements Agent {
     this.pendingPrompts.clear();
   }
 
-  private async reconcilePendingPromptsOnReconnect(): Promise<void> {
+  private async reconcilePendingPromptsOnReconnect(
+    observedDisconnectGeneration: number,
+  ): Promise<void> {
     if (this.pendingPrompts.size === 0) {
-      this.clearDisconnectTimer();
+      if (this.disconnectGeneration === observedDisconnectGeneration) {
+        this.clearDisconnectTimer();
+      }
       return;
     }
 
@@ -1064,7 +1070,9 @@ export class AcpGatewayAgent implements Agent {
       }
     }
 
-    this.clearDisconnectTimer();
+    if (this.disconnectGeneration === observedDisconnectGeneration) {
+      this.clearDisconnectTimer();
+    }
   }
 
   private async sendAvailableCommands(sessionId: string): Promise<void> {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -59,6 +59,7 @@ const ACP_REASONING_LEVEL_CONFIG_ID = "reasoning_level";
 const ACP_RESPONSE_USAGE_CONFIG_ID = "response_usage";
 const ACP_ELEVATED_LEVEL_CONFIG_ID = "elevated_level";
 const ACP_LOAD_SESSION_REPLAY_LIMIT = 1_000_000;
+const ACP_GATEWAY_DISCONNECT_GRACE_MS = 5_000;
 
 type PendingPrompt = {
   sessionId: string;
@@ -398,6 +399,7 @@ export class AcpGatewayAgent implements Agent {
   private sessionStore: AcpSessionStore;
   private sessionCreateRateLimiter: FixedWindowRateLimiter;
   private pendingPrompts = new Map<string, PendingPrompt>();
+  private disconnectTimer: NodeJS.Timeout | null = null;
 
   constructor(
     connection: AgentSideConnection,
@@ -426,11 +428,21 @@ export class AcpGatewayAgent implements Agent {
   }
 
   handleGatewayReconnect(): void {
+    this.clearDisconnectTimer();
     this.log("gateway reconnected");
   }
 
   handleGatewayDisconnect(reason: string): void {
     this.log(`gateway disconnected: ${reason}`);
+    if (this.pendingPrompts.size === 0) {
+      return;
+    }
+    this.clearDisconnectTimer();
+    this.disconnectTimer = setTimeout(() => {
+      this.disconnectTimer = null;
+      this.rejectPendingPrompts(new Error(`Gateway disconnected: ${reason}`));
+    }, ACP_GATEWAY_DISCONNECT_GRACE_MS);
+    this.disconnectTimer.unref?.();
   }
 
   async handleGatewayEvent(evt: EventFrame): Promise<void> {
@@ -693,6 +705,9 @@ export class AcpGatewayAgent implements Agent {
       void sendWithProvenanceFallback().catch((err) => {
         this.pendingPrompts.delete(params.sessionId);
         this.sessionStore.clearActiveRun(params.sessionId);
+        if (this.pendingPrompts.size === 0) {
+          this.clearDisconnectTimer();
+        }
         reject(err instanceof Error ? err : new Error(String(err)));
       });
     });
@@ -724,6 +739,9 @@ export class AcpGatewayAgent implements Agent {
 
     if (pending) {
       this.pendingPrompts.delete(params.sessionId);
+      if (this.pendingPrompts.size === 0) {
+        this.clearDisconnectTimer();
+      }
       pending.resolve({ stopReason: "cancelled" });
     }
   }
@@ -949,6 +967,9 @@ export class AcpGatewayAgent implements Agent {
   ): Promise<void> {
     this.pendingPrompts.delete(sessionId);
     this.sessionStore.clearActiveRun(sessionId);
+    if (this.pendingPrompts.size === 0) {
+      this.clearDisconnectTimer();
+    }
     const sessionSnapshot = await this.getSessionSnapshot(pending.sessionKey);
     try {
       await this.sendSessionSnapshotUpdate(sessionId, sessionSnapshot, {
@@ -971,6 +992,22 @@ export class AcpGatewayAgent implements Agent {
       return pending;
     }
     return undefined;
+  }
+
+  private clearDisconnectTimer(): void {
+    if (!this.disconnectTimer) {
+      return;
+    }
+    clearTimeout(this.disconnectTimer);
+    this.disconnectTimer = null;
+  }
+
+  private rejectPendingPrompts(error: Error): void {
+    for (const pending of this.pendingPrompts.values()) {
+      pending.reject(error);
+      this.sessionStore.clearActiveRun(pending.sessionId);
+    }
+    this.pendingPrompts.clear();
   }
 
   private async sendAvailableCommands(sessionId: string): Promise<void> {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -65,6 +65,7 @@ type PendingPrompt = {
   sessionId: string;
   sessionKey: string;
   idempotencyKey: string;
+  sendAccepted?: boolean;
   resolve: (response: PromptResponse) => void;
   reject: (err: Error) => void;
   sentTextLength?: number;
@@ -705,12 +706,20 @@ export class AcpGatewayAgent implements Agent {
             },
             { timeoutMs: null },
           );
+          const pending = this.pendingPrompts.get(params.sessionId);
+          if (pending) {
+            pending.sendAccepted = true;
+          }
         } catch (err) {
           if (
             (systemInputProvenance || systemProvenanceReceipt) &&
             isAdminScopeProvenanceRejection(err)
           ) {
             await this.gateway.request("chat.send", requestParams, { timeoutMs: null });
+            const pending = this.pendingPrompts.get(params.sessionId);
+            if (pending) {
+              pending.sendAccepted = true;
+            }
             return;
           }
           throw err;
@@ -1039,6 +1048,7 @@ export class AcpGatewayAgent implements Agent {
     }
 
     const pendingEntries = [...this.pendingPrompts.entries()];
+    let keepDisconnectTimer = false;
     for (const [sessionId, pending] of pendingEntries) {
       if (this.pendingPrompts.get(sessionId) !== pending) {
         continue;
@@ -1055,6 +1065,7 @@ export class AcpGatewayAgent implements Agent {
         );
       } catch (err) {
         this.log(`agent.wait reconcile failed for ${pending.idempotencyKey}: ${String(err)}`);
+        keepDisconnectTimer = true;
         continue;
       }
 
@@ -1067,10 +1078,15 @@ export class AcpGatewayAgent implements Agent {
       }
       if (result?.status === "error") {
         void this.finishPrompt(sessionId, pending, "end_turn");
+        continue;
+      }
+      if (result?.status === "timeout" && !pending.sendAccepted) {
+        keepDisconnectTimer = true;
+        continue;
       }
     }
 
-    if (this.disconnectGeneration === observedDisconnectGeneration) {
+    if (!keepDisconnectTimer && this.disconnectGeneration === observedDisconnectGeneration) {
       this.clearDisconnectTimer();
     }
   }

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -143,6 +143,11 @@ type SessionSnapshot = SessionPresentation & {
   usage?: SessionUsageSnapshot;
 };
 
+type AgentWaitResult = {
+  status?: "ok" | "error" | "timeout";
+  error?: string;
+};
+
 type GatewayTranscriptMessage = {
   role?: unknown;
   content?: unknown;
@@ -432,8 +437,8 @@ export class AcpGatewayAgent implements Agent {
   }
 
   handleGatewayReconnect(): void {
-    this.clearDisconnectTimer();
     this.log("gateway reconnected");
+    void this.reconcilePendingPromptsOnReconnect();
   }
 
   handleGatewayDisconnect(reason: string): void {
@@ -1019,6 +1024,47 @@ export class AcpGatewayAgent implements Agent {
       this.sessionStore.clearActiveRun(pending.sessionId);
     }
     this.pendingPrompts.clear();
+  }
+
+  private async reconcilePendingPromptsOnReconnect(): Promise<void> {
+    if (this.pendingPrompts.size === 0) {
+      this.clearDisconnectTimer();
+      return;
+    }
+
+    const pendingEntries = [...this.pendingPrompts.entries()];
+    for (const [sessionId, pending] of pendingEntries) {
+      if (this.pendingPrompts.get(sessionId) !== pending) {
+        continue;
+      }
+      let result: AgentWaitResult | undefined;
+      try {
+        result = await this.gateway.request<AgentWaitResult>(
+          "agent.wait",
+          {
+            runId: pending.idempotencyKey,
+            timeoutMs: 0,
+          },
+          { timeoutMs: null },
+        );
+      } catch (err) {
+        this.log(`agent.wait reconcile failed for ${pending.idempotencyKey}: ${String(err)}`);
+        continue;
+      }
+
+      if (this.pendingPrompts.get(sessionId) !== pending) {
+        continue;
+      }
+      if (result?.status === "ok") {
+        await this.finishPrompt(sessionId, pending, "end_turn");
+        continue;
+      }
+      if (result?.status === "error") {
+        void this.finishPrompt(sessionId, pending, "end_turn");
+      }
+    }
+
+    this.clearDisconnectTimer();
   }
 
   private async sendAvailableCommands(sessionId: string): Promise<void> {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -409,7 +409,7 @@ export class AcpGatewayAgent implements Agent {
   private sessionStore: AcpSessionStore;
   private sessionCreateRateLimiter: FixedWindowRateLimiter;
   private pendingPrompts = new Map<string, PendingPrompt>();
-  private disconnectDeadlineSessionIds = new Set<string>();
+  private disconnectDeadlineRunIds = new Map<string, string>();
   private disconnectTimer: NodeJS.Timeout | null = null;
   private disconnectGeneration = 0;
 
@@ -458,7 +458,12 @@ export class AcpGatewayAgent implements Agent {
       return;
     }
     this.disconnectGeneration += 1;
-    this.disconnectDeadlineSessionIds = new Set(this.pendingPrompts.keys());
+    this.disconnectDeadlineRunIds = new Map(
+      [...this.pendingPrompts.entries()].map(([sessionId, pending]) => [
+        sessionId,
+        pending.idempotencyKey,
+      ]),
+    );
     this.clearDisconnectTimer();
     this.disconnectTimer = setTimeout(() => {
       this.disconnectTimer = null;
@@ -741,7 +746,7 @@ export class AcpGatewayAgent implements Agent {
           return;
         }
         this.pendingPrompts.delete(params.sessionId);
-        this.disconnectDeadlineSessionIds.delete(params.sessionId);
+        this.disconnectDeadlineRunIds.delete(params.sessionId);
         this.sessionStore.clearActiveRun(params.sessionId);
         if (this.pendingPrompts.size === 0) {
           this.clearDisconnectTimer();
@@ -1004,7 +1009,7 @@ export class AcpGatewayAgent implements Agent {
     stopReason: StopReason,
   ): Promise<void> {
     this.pendingPrompts.delete(sessionId);
-    this.disconnectDeadlineSessionIds.delete(sessionId);
+    this.disconnectDeadlineRunIds.delete(sessionId);
     this.sessionStore.clearActiveRun(sessionId);
     if (this.pendingPrompts.size === 0) {
       this.clearDisconnectTimer();
@@ -1041,29 +1046,32 @@ export class AcpGatewayAgent implements Agent {
     this.disconnectTimer = null;
   }
 
-  private rejectPendingPrompts(error: Error, sessionIds: Iterable<string>): void {
-    for (const sessionId of sessionIds) {
-      const pending = this.pendingPrompts.get(sessionId);
+  private rejectPendingPrompts(
+    error: Error,
+    promptRuns: Iterable<readonly [string, string]>,
+  ): void {
+    for (const [sessionId, runId] of promptRuns) {
+      const pending = this.getPendingPrompt(sessionId, runId);
       if (!pending) {
         continue;
       }
       pending.reject(error);
       this.sessionStore.clearActiveRun(pending.sessionId);
       this.pendingPrompts.delete(sessionId);
-      this.disconnectDeadlineSessionIds.delete(sessionId);
+      this.disconnectDeadlineRunIds.delete(sessionId);
     }
   }
 
   private async expireDisconnectDeadline(error: Error): Promise<void> {
-    const deadlineSessionIds = [...this.disconnectDeadlineSessionIds];
-    for (const sessionId of deadlineSessionIds) {
-      const pending = this.pendingPrompts.get(sessionId);
+    const deadlinePromptRuns = [...this.disconnectDeadlineRunIds.entries()];
+    for (const [sessionId, runId] of deadlinePromptRuns) {
+      const pending = this.getPendingPrompt(sessionId, runId);
       if (!pending) {
-        this.disconnectDeadlineSessionIds.delete(sessionId);
+        this.disconnectDeadlineRunIds.delete(sessionId);
         continue;
       }
       if (!pending.sendAccepted) {
-        this.rejectPendingPrompts(error, [sessionId]);
+        this.rejectPendingPrompts(error, [[sessionId, runId]]);
         continue;
       }
 
@@ -1072,17 +1080,17 @@ export class AcpGatewayAgent implements Agent {
         result = await this.gateway.request<AgentWaitResult>(
           "agent.wait",
           {
-            runId: pending.idempotencyKey,
+            runId,
             timeoutMs: 0,
           },
           { timeoutMs: null },
         );
       } catch {
-        this.rejectPendingPrompts(error, [sessionId]);
+        this.rejectPendingPrompts(error, [[sessionId, runId]]);
         continue;
       }
 
-      const currentPending = this.getPendingPrompt(sessionId, pending.idempotencyKey);
+      const currentPending = this.getPendingPrompt(sessionId, runId);
       if (!currentPending) {
         continue;
       }
@@ -1094,7 +1102,7 @@ export class AcpGatewayAgent implements Agent {
         void this.finishPrompt(sessionId, currentPending, "end_turn");
         continue;
       }
-      this.rejectPendingPrompts(error, [sessionId]);
+      this.rejectPendingPrompts(error, [[sessionId, runId]]);
     }
   }
 
@@ -1110,7 +1118,7 @@ export class AcpGatewayAgent implements Agent {
 
     const pendingEntries = [...this.pendingPrompts.entries()];
     let keepDisconnectTimer = false;
-    const nextDisconnectDeadlineSessionIds = new Set<string>();
+    const nextDisconnectDeadlineRunIds = new Map<string, string>();
     for (const [sessionId, pending] of pendingEntries) {
       if (this.pendingPrompts.get(sessionId) !== pending) {
         continue;
@@ -1128,7 +1136,7 @@ export class AcpGatewayAgent implements Agent {
       } catch (err) {
         this.log(`agent.wait reconcile failed for ${pending.idempotencyKey}: ${String(err)}`);
         keepDisconnectTimer = true;
-        nextDisconnectDeadlineSessionIds.add(sessionId);
+        nextDisconnectDeadlineRunIds.set(sessionId, pending.idempotencyKey);
         continue;
       }
 
@@ -1145,13 +1153,13 @@ export class AcpGatewayAgent implements Agent {
       }
       if (result?.status === "timeout") {
         keepDisconnectTimer = true;
-        nextDisconnectDeadlineSessionIds.add(sessionId);
+        nextDisconnectDeadlineRunIds.set(sessionId, pending.idempotencyKey);
         continue;
       }
     }
 
     if (this.disconnectGeneration === observedDisconnectGeneration) {
-      this.disconnectDeadlineSessionIds = nextDisconnectDeadlineSessionIds;
+      this.disconnectDeadlineRunIds = nextDisconnectDeadlineRunIds;
     }
     if (!keepDisconnectTimer && this.disconnectGeneration === observedDisconnectGeneration) {
       this.clearDisconnectTimer();

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -409,6 +409,7 @@ export class AcpGatewayAgent implements Agent {
   private sessionStore: AcpSessionStore;
   private sessionCreateRateLimiter: FixedWindowRateLimiter;
   private pendingPrompts = new Map<string, PendingPrompt>();
+  private disconnectDeadlineSessionIds = new Set<string>();
   private disconnectTimer: NodeJS.Timeout | null = null;
   private disconnectGeneration = 0;
 
@@ -457,10 +458,14 @@ export class AcpGatewayAgent implements Agent {
       return;
     }
     this.disconnectGeneration += 1;
+    this.disconnectDeadlineSessionIds = new Set(this.pendingPrompts.keys());
     this.clearDisconnectTimer();
     this.disconnectTimer = setTimeout(() => {
       this.disconnectTimer = null;
-      this.rejectPendingPrompts(new Error(`Gateway disconnected: ${reason}`));
+      this.rejectPendingPrompts(
+        new Error(`Gateway disconnected: ${reason}`),
+        this.disconnectDeadlineSessionIds,
+      );
     }, ACP_GATEWAY_DISCONNECT_GRACE_MS);
     this.disconnectTimer.unref?.();
   }
@@ -739,6 +744,7 @@ export class AcpGatewayAgent implements Agent {
           return;
         }
         this.pendingPrompts.delete(params.sessionId);
+        this.disconnectDeadlineSessionIds.delete(params.sessionId);
         this.sessionStore.clearActiveRun(params.sessionId);
         if (this.pendingPrompts.size === 0) {
           this.clearDisconnectTimer();
@@ -1001,6 +1007,7 @@ export class AcpGatewayAgent implements Agent {
     stopReason: StopReason,
   ): Promise<void> {
     this.pendingPrompts.delete(sessionId);
+    this.disconnectDeadlineSessionIds.delete(sessionId);
     this.sessionStore.clearActiveRun(sessionId);
     if (this.pendingPrompts.size === 0) {
       this.clearDisconnectTimer();
@@ -1037,12 +1044,17 @@ export class AcpGatewayAgent implements Agent {
     this.disconnectTimer = null;
   }
 
-  private rejectPendingPrompts(error: Error): void {
-    for (const pending of this.pendingPrompts.values()) {
+  private rejectPendingPrompts(error: Error, sessionIds: Iterable<string>): void {
+    for (const sessionId of sessionIds) {
+      const pending = this.pendingPrompts.get(sessionId);
+      if (!pending) {
+        continue;
+      }
       pending.reject(error);
       this.sessionStore.clearActiveRun(pending.sessionId);
+      this.pendingPrompts.delete(sessionId);
+      this.disconnectDeadlineSessionIds.delete(sessionId);
     }
-    this.pendingPrompts.clear();
   }
 
   private async reconcilePendingPromptsOnReconnect(
@@ -1057,6 +1069,7 @@ export class AcpGatewayAgent implements Agent {
 
     const pendingEntries = [...this.pendingPrompts.entries()];
     let keepDisconnectTimer = false;
+    const nextDisconnectDeadlineSessionIds = new Set<string>();
     for (const [sessionId, pending] of pendingEntries) {
       if (this.pendingPrompts.get(sessionId) !== pending) {
         continue;
@@ -1074,6 +1087,7 @@ export class AcpGatewayAgent implements Agent {
       } catch (err) {
         this.log(`agent.wait reconcile failed for ${pending.idempotencyKey}: ${String(err)}`);
         keepDisconnectTimer = true;
+        nextDisconnectDeadlineSessionIds.add(sessionId);
         continue;
       }
 
@@ -1090,10 +1104,14 @@ export class AcpGatewayAgent implements Agent {
       }
       if (result?.status === "timeout" && !pending.sendAccepted) {
         keepDisconnectTimer = true;
+        nextDisconnectDeadlineSessionIds.add(sessionId);
         continue;
       }
     }
 
+    if (this.disconnectGeneration === observedDisconnectGeneration) {
+      this.disconnectDeadlineSessionIds = nextDisconnectDeadlineSessionIds;
+    }
     if (!keepDisconnectTimer && this.disconnectGeneration === observedDisconnectGeneration) {
       this.clearDisconnectTimer();
     }

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -412,6 +412,14 @@ export class AcpGatewayAgent implements Agent {
   private disconnectTimer: NodeJS.Timeout | null = null;
   private disconnectGeneration = 0;
 
+  private getPendingPrompt(sessionId: string, runId: string): PendingPrompt | undefined {
+    const pending = this.pendingPrompts.get(sessionId);
+    if (pending?.idempotencyKey !== runId) {
+      return undefined;
+    }
+    return pending;
+  }
+
   constructor(
     connection: AgentSideConnection,
     gateway: GatewayClient,
@@ -706,7 +714,7 @@ export class AcpGatewayAgent implements Agent {
             },
             { timeoutMs: null },
           );
-          const pending = this.pendingPrompts.get(params.sessionId);
+          const pending = this.getPendingPrompt(params.sessionId, runId);
           if (pending) {
             pending.sendAccepted = true;
           }
@@ -716,7 +724,7 @@ export class AcpGatewayAgent implements Agent {
             isAdminScopeProvenanceRejection(err)
           ) {
             await this.gateway.request("chat.send", requestParams, { timeoutMs: null });
-            const pending = this.pendingPrompts.get(params.sessionId);
+            const pending = this.getPendingPrompt(params.sessionId, runId);
             if (pending) {
               pending.sendAccepted = true;
             }
@@ -727,8 +735,7 @@ export class AcpGatewayAgent implements Agent {
       };
 
       void sendWithProvenanceFallback().catch((err) => {
-        const currentPending = this.pendingPrompts.get(params.sessionId);
-        if (isGatewayCloseError(err) && currentPending?.idempotencyKey === runId) {
+        if (isGatewayCloseError(err) && this.getPendingPrompt(params.sessionId, runId)) {
           return;
         }
         this.pendingPrompts.delete(params.sessionId);

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -727,7 +727,8 @@ export class AcpGatewayAgent implements Agent {
       };
 
       void sendWithProvenanceFallback().catch((err) => {
-        if (isGatewayCloseError(err) && this.pendingPrompts.has(params.sessionId)) {
+        const currentPending = this.pendingPrompts.get(params.sessionId);
+        if (isGatewayCloseError(err) && currentPending?.idempotencyKey === runId) {
           return;
         }
         this.pendingPrompts.delete(params.sessionId);

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -462,10 +462,7 @@ export class AcpGatewayAgent implements Agent {
     this.clearDisconnectTimer();
     this.disconnectTimer = setTimeout(() => {
       this.disconnectTimer = null;
-      this.rejectPendingPrompts(
-        new Error(`Gateway disconnected: ${reason}`),
-        this.disconnectDeadlineSessionIds,
-      );
+      void this.expireDisconnectDeadline(new Error(`Gateway disconnected: ${reason}`));
     }, ACP_GATEWAY_DISCONNECT_GRACE_MS);
     this.disconnectTimer.unref?.();
   }
@@ -1057,6 +1054,50 @@ export class AcpGatewayAgent implements Agent {
     }
   }
 
+  private async expireDisconnectDeadline(error: Error): Promise<void> {
+    const deadlineSessionIds = [...this.disconnectDeadlineSessionIds];
+    for (const sessionId of deadlineSessionIds) {
+      const pending = this.pendingPrompts.get(sessionId);
+      if (!pending) {
+        this.disconnectDeadlineSessionIds.delete(sessionId);
+        continue;
+      }
+      if (!pending.sendAccepted) {
+        this.rejectPendingPrompts(error, [sessionId]);
+        continue;
+      }
+
+      let result: AgentWaitResult | undefined;
+      try {
+        result = await this.gateway.request<AgentWaitResult>(
+          "agent.wait",
+          {
+            runId: pending.idempotencyKey,
+            timeoutMs: 0,
+          },
+          { timeoutMs: null },
+        );
+      } catch {
+        this.rejectPendingPrompts(error, [sessionId]);
+        continue;
+      }
+
+      const currentPending = this.getPendingPrompt(sessionId, pending.idempotencyKey);
+      if (!currentPending) {
+        continue;
+      }
+      if (result?.status === "ok") {
+        await this.finishPrompt(sessionId, currentPending, "end_turn");
+        continue;
+      }
+      if (result?.status === "error") {
+        void this.finishPrompt(sessionId, currentPending, "end_turn");
+        continue;
+      }
+      this.rejectPendingPrompts(error, [sessionId]);
+    }
+  }
+
   private async reconcilePendingPromptsOnReconnect(
     observedDisconnectGeneration: number,
   ): Promise<void> {
@@ -1102,7 +1143,7 @@ export class AcpGatewayAgent implements Agent {
         void this.finishPrompt(sessionId, pending, "end_turn");
         continue;
       }
-      if (result?.status === "timeout" && !pending.sendAccepted) {
+      if (result?.status === "timeout") {
         keepDisconnectTimer = true;
         nextDisconnectDeadlineSessionIds.add(sessionId);
         continue;


### PR DESCRIPTION
## Summary
- stop treating ACP prompt completion as both a long-lived `chat.send` request and an event stream; the translator now waits only for send acceptance and keeps completion event-driven
- keep in-flight ACP prompts alive across transient gateway reconnects
- lock the regression with a reconnect-focused translator test

## Testing
- `pnpm test -- src/acp/translator.stop-reason.test.ts src/acp/translator.prompt-prefix.test.ts src/acp/translator.cancel-scoping.test.ts src/acp/translator.session-rate-limit.test.ts`
- `pnpm tsgo`

Fixes #59334
Fixes #31686
Fixes #28708