### PR TITLE
Avoid config fallback for channels status probe failures

### DIFF
--- a/src/commands/channels.status.command-flow.test.ts
+++ b/src/commands/channels.status.command-flow.test.ts
@@ -171,4 +171,25 @@ describe("channelsStatusCommand SecretRef fallback flow", () => {
     expect(joined).not.toContain("secret unavailable in this command path");
     expect(joined).not.toContain("token:config (unavailable)");
   });
+
+  it("does not fall back to config-only status when probe mode fails after reaching the gateway", async () => {
+    callGateway.mockRejectedValue(new Error("channel probe timed out"));
+    requireValidConfigSnapshot.mockResolvedValue({ secretResolved: false, channels: {} });
+    resolveCommandSecretRefsViaGateway.mockResolvedValue({
+      resolvedConfig: { secretResolved: false, channels: {} },
+      diagnostics: [],
+      targetStatesByPath: {},
+      hadUnresolvedTargets: false,
+    });
+
+    const { runtime, logs, errors } = createRuntimeCapture();
+
+    await expect(channelsStatusCommand({ probe: true }, runtime as never)).rejects.toThrow(
+      "channel probe timed out",
+    );
+
+    expect(errors).toEqual([]);
+    expect(logs).toEqual(["Checking channel status (probe)…"]);
+    expect(requireValidConfigSnapshot).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -306,6 +306,10 @@ export async function channelsStatusCommand(
     }
     runtime.log(formatGatewayChannelsStatusLines(payload).join("\n"));
   } catch (err) {
+    if (opts.probe) {
+      throw err;
+    }
+
     runtime.error(`Gateway not reachable: ${String(err)}`);
     const cfg = await requireValidConfigSnapshot(runtime);
     if (!cfg) {


### PR DESCRIPTION
## Summary

Avoid falling back to config-only status when `channels status --probe` fails after reaching the gateway.

## What changed

- Updated `src/commands/channels/status.ts` so probe-mode failures are rethrown instead of being treated as generic gateway-unreachable failures
- Kept the existing config-only fallback behavior for non-probe failures
- Added a focused regression test covering probe-mode failure after the gateway path is reached

## Why

`channels status --probe` previously treated any `callGateway(...)` failure as if the gateway itself were unreachable. That caused probe-specific failures to be reported through the generic config-only fallback path, which is misleading when the command has already reached the gateway and only the probe step failed.

This change preserves the original probe failure instead of misreporting it as a gateway reachability problem.

## Scope boundary

This PR only changes probe-mode failure handling in `channels status`. It does not change the normal config-only fallback behavior for non-probe failures.

## Manual verification

1. Added a focused test in `src/commands/channels.status.command-flow.test.ts`
2. Verified that probe-mode failures now rethrow the original error instead of falling back to config-only status
3. Ran:
   - `pnpm vitest run src/commands/channels.status.command-flow.test.ts -t "does not fall back to config-only status when probe mode fails after reaching the gateway"`
   - `pnpm vitest run src/commands/channels.status.command-flow.test.ts`
4. Ran the repo checks during commit