### PR TITLE
feat(cli): add --dry-run flag to cron add

### DIFF
--- a/src/cli/cron-cli/register.cron-add.test.ts
+++ b/src/cli/cron-cli/register.cron-add.test.ts
@@ -1,0 +1,148 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultRuntime } from "../../runtime.js";
+import { registerCronAddCommand } from "./register.cron-add.js";
+
+const callGatewayMock = vi.hoisted(() => vi.fn());
+vi.mock("../gateway-rpc.js", () => ({
+  addGatewayClientOptions: (cmd: Command) => cmd,
+  callGatewayFromCli: callGatewayMock,
+}));
+
+const warnMock = vi.hoisted(() => vi.fn());
+vi.mock("./shared.js", () => ({
+  getCronChannelOptions: () => "telegram,whatsapp",
+  handleCronCliError: (err: unknown) => {
+    throw err;
+  },
+  parseCronToolsAllow: vi.fn().mockReturnValue(undefined),
+  printCronJson: vi.fn(),
+  printCronList: vi.fn(),
+  warnIfCronSchedulerDisabled: warnMock,
+}));
+
+// Mock schedule-options so we don't drag in shared.js parse functions
+vi.mock("./schedule-options.js", () => ({
+  addScheduleOptions: (cmd: Command) => cmd,
+  resolveCronCreateSchedule: vi.fn().mockReturnValue({
+    kind: "agentTurn",
+    every: 3600000,
+    requestedStaggerMs: undefined,
+  }),
+  resolveCronEditScheduleRequest: vi.fn().mockReturnValue({}),
+}));
+
+describe("cron add --dry-run", () => {
+  let program: Command;
+  let writeStdoutSpy: ReturnType<typeof vi.spyOn>;
+  let writeJsonSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    program = new Command().exitOverride();
+    program.configureOutput({ writeErr: () => {} });
+    callGatewayMock.mockReset();
+    warnMock.mockReset();
+    writeStdoutSpy = vi.spyOn(defaultRuntime, "writeStdout").mockImplementation(() => {});
+    writeJsonSpy = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prints params preview and skips RPC when --dry-run is passed", async () => {
+    const cron = program.command("cron");
+    registerCronAddCommand(cron);
+
+    await program.parseAsync(
+      [
+        "node",
+        "openclaw",
+        "cron",
+        "add",
+        "--name",
+        "my-job",
+        "--message",
+        "hello",
+        "--every",
+        "1h",
+        "--dry-run",
+      ],
+      { from: "node" },
+    );
+
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(warnMock).not.toHaveBeenCalled();
+    expect(writeJsonSpy).not.toHaveBeenCalled();
+    expect(writeStdoutSpy).toHaveBeenCalledOnce();
+    const output = writeStdoutSpy.mock.calls[0][0] as string;
+    expect(output).toMatch(/Dry run/);
+    expect(output).toMatch(/"name":\s*"my-job"/);
+    expect(output).toMatch(/"kind":\s*"agentTurn"/);
+  });
+
+  it("emits raw JSON via writeJson when --dry-run --json are both passed", async () => {
+    const cron = program.command("cron");
+    registerCronAddCommand(cron);
+
+    await program.parseAsync(
+      [
+        "node",
+        "openclaw",
+        "cron",
+        "add",
+        "--name",
+        "my-job",
+        "--message",
+        "hello",
+        "--every",
+        "1h",
+        "--dry-run",
+        "--json",
+      ],
+      { from: "node" },
+    );
+
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(writeStdoutSpy).not.toHaveBeenCalled();
+    expect(writeJsonSpy).toHaveBeenCalledOnce();
+    const params = writeJsonSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(params).toMatchObject({ name: "my-job" });
+  });
+
+  it("--dry-run --json output is a plain object with no human-readable wrapper text", async () => {
+    const cron = program.command("cron");
+    registerCronAddCommand(cron);
+
+    await program.parseAsync(
+      [
+        "node",
+        "openclaw",
+        "cron",
+        "add",
+        "--name",
+        "json-purity-test",
+        "--message",
+        "ping",
+        "--every",
+        "30m",
+        "--dry-run",
+        "--json",
+      ],
+      { from: "node" },
+    );
+
+    expect(writeStdoutSpy).not.toHaveBeenCalled();
+    expect(writeJsonSpy).toHaveBeenCalledOnce();
+
+    const params = writeJsonSpy.mock.calls[0][0];
+    // Must be a plain object, not a string (no "Dry run — …" prefix wrapping)
+    expect(typeof params).toBe("object");
+    expect(params).not.toBeNull();
+    expect(typeof params).not.toBe("string");
+    // Spot-check expected fields are present at top level (not buried in a string)
+    expect(params).toMatchObject({ name: "json-purity-test" });
+    expect(params).toHaveProperty("payload");
+    expect(params).toHaveProperty("schedule");
+  });
+});

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -107,6 +107,7 @@ export function registerCronAddCommand(cron: Command) {
       )
       .option("--account <id>", "Channel account id for delivery (multi-account setups)")
       .option("--best-effort-deliver", "Do not fail the job if delivery fails", false)
+      .option("--dry-run", "Preview the job that would be created without submitting it", false)
       .option("--json", "Output JSON", false)
       .action(async (opts: GatewayRpcOpts & Record<string, unknown>, cmd?: Command) => {
         try {
@@ -237,6 +238,17 @@ export function registerCronAddCommand(cron: Command) {
                 }
               : undefined,
           };
+
+          if (opts.dryRun) {
+            if (opts.json) {
+              defaultRuntime.writeJson(params);
+            } else {
+              defaultRuntime.writeStdout(
+                `Dry run — job would be created with the following parameters:\n${JSON.stringify(params, null, 2)}\n`,
+              );
+            }
+            return;
+          }
 
           const res = await callGatewayFromCli("cron.add", opts, params);
           printCronJson(res);


### PR DESCRIPTION
## Summary

- add `--dry-run` to `openclaw cron add`
- build and print the resolved params object without calling `cron.add`
- emit human-readable output by default, or the raw params object with `--json`
- add CLI tests covering preview output, JSON output, and the no-RPC path

## Why

Users currently have to create a cron job before they can verify that the resolved schedule and payload are what they intended. `--dry-run` gives them a safe way to validate the command before persisting anything.

## Scope

- CLI only
- no scheduler logic changes
- no gateway contract changes
- no workflow / release / docs automation changes

## Behavior

- `openclaw cron add ... --dry-run` prints the params that would be sent to the gateway and exits
- `openclaw cron add ... --dry-run --json` emits the plain params object
- validation still runs before output, so invalid flag combinations still fail normally

## Testing

- `src/cli/cron-cli/register.cron-add.test.ts`
- verifies preview output on `--dry-run`
- verifies `--dry-run --json` writes a plain object
- verifies the gateway RPC is not called in either dry-run mode

## Related

Closes #59452

## Reviewer Note

This branch was rebased onto current `main` and cleaned up to remove unrelated workflow-sync changes from the earlier iteration of this PR.
