### PR TITLE
fix(whatsapp): use formatErrorMessage instead of String(err)

### DIFF
--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -13,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk/security-runtime";
 import { isSelfChatMode, normalizeE164 } from "openclaw/plugin-sdk/text-runtime";
 import { resolveWhatsAppAccount } from "../accounts.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type InboundAccessControlResult = {
   allowed: boolean;
@@ -193,7 +194,7 @@ export async function checkInboundAccessControl(params: {
             await params.sock.sendMessage(params.remoteJid, { text });
           },
           onReplyError: (err) => {
-            logVerbose(`whatsapp pairing reply failed for ${candidate}: ${String(err)}`);
+            logVerbose(`whatsapp pairing reply failed for ${candidate}: ${formatErrorMessage(err)}`);
           },
         });
       }

--- a/extensions/whatsapp/src/inbound/media.ts
+++ b/extensions/whatsapp/src/inbound/media.ts
@@ -2,6 +2,7 @@ import type { proto, WAMessage } from "@whiskeysockets/baileys";
 import { downloadMediaMessage, normalizeMessageContent } from "@whiskeysockets/baileys";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { createWaSocket } from "../session.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 function unwrapMessage(message: proto.IMessage | undefined): proto.IMessage | undefined {
   const normalized = normalizeMessageContent(message);
@@ -70,7 +71,7 @@ export async function downloadInboundMedia(
     );
     return { buffer, mimetype, fileName };
   } catch (err) {
-    logVerbose(`downloadMediaMessage failed: ${String(err)}`);
+    logVerbose(`downloadMediaMessage failed: ${formatErrorMessage(err)}`);
     return undefined;
   }
 }

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -27,6 +27,7 @@ import { attachEmitterListener, closeInboundMonitorSocket } from "./lifecycle.js
 import { downloadInboundMedia } from "./media.js";
 import { createWebSendApi } from "./send-api.js";
 import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401;
 
@@ -77,7 +78,7 @@ export async function monitorWebInbox(options: {
       logVerbose(`Sent global '${presence}' presence on connect`);
     }
   } catch (err) {
-    logVerbose(`Failed to send '${presence}' presence on connect: ${String(err)}`);
+    logVerbose(`Failed to send '${presence}' presence on connect: ${formatErrorMessage(err)}`);
   }
 
   const self = await readWebSelfIdentity(
@@ -131,8 +132,8 @@ export async function monitorWebInbox(options: {
       await options.onMessage(combinedMessage);
     },
     onError: (err) => {
-      inboundLogger.error({ error: String(err) }, "failed handling inbound web message");
-      inboundConsoleLog.error(`Failed handling inbound web message: ${String(err)}`);
+      inboundLogger.error({ error: formatErrorMessage(err) }, "failed handling inbound web message");
+      inboundConsoleLog.error(`Failed handling inbound web message: ${formatErrorMessage(err)}`);
     },
   });
   const groupMetaCache = new Map<
@@ -190,7 +191,7 @@ export async function monitorWebInbox(options: {
       groupMetaCache.set(jid, entry);
       return entry;
     } catch (err) {
-      logVerbose(`Failed to fetch group metadata for ${jid}: ${String(err)}`);
+      logVerbose(`Failed to fetch group metadata for ${jid}: ${formatErrorMessage(err)}`);
       return { expires: Date.now() + GROUP_META_TTL_MS };
     }
   };
@@ -305,7 +306,7 @@ export async function monitorWebInbox(options: {
           logVerbose(`Marked message ${id} as read for ${remoteJid}${suffix}`);
         }
       } catch (err) {
-        logVerbose(`Failed to mark message ${id} read: ${String(err)}`);
+        logVerbose(`Failed to mark message ${id} read: ${formatErrorMessage(err)}`);
       }
     } else if (id && access.isSelfChat && shouldLogVerbose()) {
       // Self-chat mode: never auto-send read receipts (blue ticks) on behalf of the owner.
@@ -360,7 +361,7 @@ export async function monitorWebInbox(options: {
         mediaFileName = inboundMedia.fileName;
       }
     } catch (err) {
-      logVerbose(`Inbound media download failed: ${String(err)}`);
+      logVerbose(`Inbound media download failed: ${formatErrorMessage(err)}`);
     }
 
     return {
@@ -383,7 +384,7 @@ export async function monitorWebInbox(options: {
       try {
         await sock.sendPresenceUpdate("composing", chatJid);
       } catch (err) {
-        logVerbose(`Presence update failed: ${String(err)}`);
+        logVerbose(`Presence update failed: ${formatErrorMessage(err)}`);
       }
     };
     const reply = async (text: string) => {
@@ -453,12 +454,12 @@ export async function monitorWebInbox(options: {
     try {
       const task = Promise.resolve(debouncer.enqueue(inboundMessage));
       void task.catch((err) => {
-        inboundLogger.error({ error: String(err) }, "failed handling inbound web message");
-        inboundConsoleLog.error(`Failed handling inbound web message: ${String(err)}`);
+        inboundLogger.error({ error: formatErrorMessage(err) }, "failed handling inbound web message");
+        inboundConsoleLog.error(`Failed handling inbound web message: ${formatErrorMessage(err)}`);
       });
     } catch (err) {
-      inboundLogger.error({ error: String(err) }, "failed handling inbound web message");
-      inboundConsoleLog.error(`Failed handling inbound web message: ${String(err)}`);
+      inboundLogger.error({ error: formatErrorMessage(err) }, "failed handling inbound web message");
+      inboundConsoleLog.error(`Failed handling inbound web message: ${formatErrorMessage(err)}`);
     }
   };
 
@@ -511,7 +512,7 @@ export async function monitorWebInbox(options: {
         });
       }
     } catch (err) {
-      inboundLogger.error({ error: String(err) }, "connection.update handler error");
+      inboundLogger.error({ error: formatErrorMessage(err) }, "connection.update handler error");
       resolveClose({ status: undefined, isLoggedOut: false, error: err });
     }
   };
@@ -541,7 +542,7 @@ export async function monitorWebInbox(options: {
         logVerbose(`Hydrated ${Object.keys(groups ?? {}).length} participating groups on connect`);
       }
     } catch (err) {
-      const error = String(err);
+      const error = formatErrorMessage(err);
       inboundLogger.warn({ error }, "failed hydrating participating groups on connect");
       inboundConsoleLog.warn(`Failed hydrating participating groups on connect: ${error}`);
       logVerbose(`Failed to hydrate participating groups on connect: ${error}`);
@@ -563,7 +564,7 @@ export async function monitorWebInbox(options: {
         detachConnectionUpdate();
         closeInboundMonitorSocket(sock);
       } catch (err) {
-        logVerbose(`Socket close failed: ${String(err)}`);
+        logVerbose(`Socket close failed: ${formatErrorMessage(err)}`);
       }
     },
     onClose,

--- a/extensions/whatsapp/src/login-qr.ts
+++ b/extensions/whatsapp/src/login-qr.ts
@@ -16,6 +16,7 @@ import {
   waitForWaConnection,
   webAuthExists,
 } from "./session.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401;
 
@@ -177,7 +178,7 @@ export async function startWebLoginWithQr(
     clearTimeout(qrTimer);
     await resetActiveLogin(account.accountId);
     return {
-      message: `Failed to start WhatsApp login: ${String(err)}`,
+      message: `Failed to start WhatsApp login: ${formatErrorMessage(err)}`,
     };
   }
   const login: ActiveLogin = {
@@ -205,7 +206,7 @@ export async function startWebLoginWithQr(
     clearTimeout(qrTimer);
     await resetActiveLogin(account.accountId);
     return {
-      message: `Failed to get QR: ${String(err)}`,
+      message: `Failed to get QR: ${formatErrorMessage(err)}`,
     };
   }
 

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -11,6 +11,7 @@ import { toWhatsappJid } from "openclaw/plugin-sdk/text-runtime";
 import { resolveWhatsAppAccount, resolveWhatsAppMediaMaxBytes } from "./accounts.js";
 import { type ActiveWebSendOptions, requireActiveWebListener } from "./active-listener.js";
 import { loadOutboundMediaFromUrl } from "./runtime-api.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const outboundLog = createSubsystemLogger("gateway/channels/whatsapp").child("outbound");
 
@@ -114,7 +115,7 @@ export async function sendMessageWhatsApp(
     return { messageId, toJid: jid };
   } catch (err) {
     logger.error(
-      { err: String(err), to: redactedTo, hasMedia: Boolean(options.mediaUrl) },
+      { err: formatErrorMessage(err), to: redactedTo, hasMedia: Boolean(options.mediaUrl) },
       "failed to send via web session",
     );
     throw err;
@@ -157,7 +158,7 @@ export async function sendReactionWhatsApp(
     logger.info({ chatJid: redactedJid, messageId, emoji }, "sent reaction");
   } catch (err) {
     logger.error(
-      { err: String(err), chatJid: redactedChatJid, messageId, emoji },
+      { err: formatErrorMessage(err), chatJid: redactedChatJid, messageId, emoji },
       "failed to send reaction via web session",
     );
     throw err;
@@ -198,7 +199,7 @@ export async function sendPollWhatsApp(
     logger.info({ jid: redactedJid, messageId }, "sent poll");
     return { messageId, toJid: jid };
   } catch (err) {
-    logger.error({ err: String(err), to: redactedTo }, "failed to send poll via web session");
+    logger.error({ err: formatErrorMessage(err), to: redactedTo }, "failed to send poll via web session");
     throw err;
   }
 }

--- a/extensions/whatsapp/src/session-errors.ts
+++ b/extensions/whatsapp/src/session-errors.ts
@@ -79,7 +79,7 @@ export function formatError(err: unknown): string {
     return err;
   }
   if (!err || typeof err !== "object") {
-    return String(err);
+    return formatErrorMessage(err);
   }
 
   const boom =

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -21,6 +21,7 @@ import {
   resolveWebCredsPath,
 } from "./auth-store.js";
 import { formatError, getStatusCode } from "./session-errors.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 export { formatError, getStatusCode } from "./session-errors.js";
 
 export {
@@ -47,7 +48,7 @@ function enqueueSaveCreds(
   const next = prev
     .then(() => safeSaveCreds(authDir, saveCreds, logger))
     .catch((err) => {
-      logger.warn({ error: String(err) }, "WhatsApp creds save queue error");
+      logger.warn({ error: formatErrorMessage(err) }, "WhatsApp creds save queue error");
     })
     .finally(() => {
       if (credsSaveQueues.get(authDir) === next) credsSaveQueues.delete(authDir);
@@ -90,7 +91,7 @@ async function safeSaveCreds(
       // best-effort on platforms that support it
     }
   } catch (err) {
-    logger.warn({ error: String(err) }, "failed saving WhatsApp creds");
+    logger.warn({ error: formatErrorMessage(err) }, "failed saving WhatsApp creds");
   }
 }
 
@@ -156,7 +157,7 @@ export async function createWaSocket(
           console.log(success("WhatsApp Web connected."));
         }
       } catch (err) {
-        sessionLogger.error({ error: String(err) }, "connection.update handler error");
+        sessionLogger.error({ error: formatErrorMessage(err) }, "connection.update handler error");
       }
     },
   );
@@ -164,7 +165,7 @@ export async function createWaSocket(
   // Handle WebSocket-level errors to prevent unhandled exceptions from crashing the process
   if (sock.ws && typeof (sock.ws as unknown as { on?: unknown }).on === "function") {
     sock.ws.on("error", (err: Error) => {
-      sessionLogger.error({ error: String(err) }, "WebSocket error");
+      sessionLogger.error({ error: formatErrorMessage(err) }, "WebSocket error");
     });
   }
 

--- a/extensions/whatsapp/src/setup-surface.ts
+++ b/extensions/whatsapp/src/setup-surface.ts
@@ -15,6 +15,7 @@ import { formatCliCommand, formatDocsLink } from "openclaw/plugin-sdk/setup-tool
 import { listWhatsAppAccountIds, resolveWhatsAppAuthDir } from "./accounts.js";
 import { loginWeb } from "./login.js";
 import { whatsappSetupAdapter } from "./setup-core.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const channel = "whatsapp" as const;
 
@@ -337,7 +338,7 @@ export const whatsappSetupWizard: ChannelSetupWizard = {
       try {
         await loginWeb(false, undefined, runtime, accountId);
       } catch (error) {
-        runtime.error(`WhatsApp login failed: ${String(error)}`);
+        runtime.error(`WhatsApp login failed: ${formatErrorMessage(error)}`);
         await prompter.note(`Docs: ${formatDocsLink("/whatsapp", "whatsapp")}`, "WhatsApp help");
       }
     } else if (!linked) {


### PR DESCRIPTION
## Summary
Replace `String(err)` with `formatErrorMessage()` from `openclaw/plugin-sdk/error-runtime` across the whatsapp extension.

`String(err)` produces `[object Object]` when the caught value is a non-Error object, hiding actual error details. `formatErrorMessage()` properly handles Error instances (with `.cause` chain traversal), strings, and arbitrary objects.

Follows the same pattern as:
- msteams (merged PR #59321)
- feishu (PR #59491, Greptile 5/5)

🤖 AI-assisted (Claude Code). Mechanical replacement, no logic changes. I understand what the code does.

## Test plan
- [ ] `pnpm check` passes
- [ ] whatsapp error logs show readable messages instead of `[object Object]`