### PR TITLE
fix(bluebubbles): use formatErrorMessage instead of String(err)

### DIFF
--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -18,6 +18,7 @@ import {
   type BlueBubblesSendTarget,
   type SsrFPolicy,
 } from "./types.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 function blueBubblesPolicy(allowPrivateNetwork: boolean | undefined): SsrFPolicy {
   return allowPrivateNetwork ? { allowPrivateNetwork: true } : {};
@@ -129,7 +130,7 @@ export async function downloadBlueBubblesAttachment(
     if (readMediaFetchErrorCode(error) === "max_bytes") {
       throw new Error(`BlueBubbles attachment too large (limit ${maxBytes} bytes)`);
     }
-    const text = error instanceof Error ? error.message : String(error);
+    const text = error instanceof Error ? error.message : formatErrorMessage(error);
     throw new Error(`BlueBubbles attachment download failed: ${text}`);
   }
 }

--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -1,6 +1,7 @@
 import type { NormalizedWebhookMessage } from "./monitor-normalize.js";
 import type { BlueBubblesCoreRuntime, WebhookTarget } from "./monitor-shared.js";
 import type { OpenClawConfig } from "./runtime-api.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 /**
  * Entry type for debouncing inbound messages.
@@ -207,7 +208,7 @@ export function createBlueBubblesDebounceRegistry(params: {
         },
         onError: (err) => {
           runtime.error?.(
-            `[${account.accountId}] [bluebubbles] debounce flush failed: ${String(err)}`,
+            `[${account.accountId}] [bluebubbles] debounce flush failed: ${formatErrorMessage(err)}`,
           );
         },
       });

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -65,6 +65,7 @@ import {
   normalizeBlueBubblesHandle,
 } from "./targets.js";
 import { blueBubblesFetchWithTimeout, buildBlueBubblesApiUrl } from "./types.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const DEFAULT_TEXT_LIMIT = 4000;
 const invalidAckReactions = new Set<string>();
@@ -804,10 +805,10 @@ export async function processMessage(
           logVerbose(
             core,
             runtime,
-            `bluebubbles pairing reply failed for ${message.senderId}: ${String(err)}`,
+            `bluebubbles pairing reply failed for ${message.senderId}: ${formatErrorMessage(err)}`,
           );
           runtime.error?.(
-            `[bluebubbles] pairing reply failed sender=${message.senderId}: ${String(err)}`,
+            `[bluebubbles] pairing reply failed sender=${message.senderId}: ${formatErrorMessage(err)}`,
           );
         },
       });
@@ -936,7 +937,7 @@ export async function processMessage(
       logVerbose(
         core,
         runtime,
-        `bluebubbles: participant fallback lookup failed chat=${peerId}: ${String(err)}`,
+        `bluebubbles: participant fallback lookup failed chat=${peerId}: ${formatErrorMessage(err)}`,
       );
     }
   }
@@ -1002,7 +1003,7 @@ export async function processMessage(
           logVerbose(
             core,
             runtime,
-            `attachment download failed guid=${attachment.guid} err=${String(err)}`,
+            `attachment download failed guid=${attachment.guid} err=${formatErrorMessage(err)}`,
           );
         }
       }
@@ -1147,7 +1148,7 @@ export async function processMessage(
             logVerbose(
               core,
               runtime,
-              `ack reaction failed chatGuid=${chatGuidForActions} msg=${ackMessageId}: ${String(err)}`,
+              `ack reaction failed chatGuid=${chatGuidForActions} msg=${ackMessageId}: ${formatErrorMessage(err)}`,
             );
             return false;
           },
@@ -1164,7 +1165,7 @@ export async function processMessage(
       });
       logVerbose(core, runtime, `marked read chatGuid=${chatGuidForActions}`);
     } catch (err) {
-      runtime.error?.(`[bluebubbles] mark read failed: ${String(err)}`);
+      runtime.error?.(`[bluebubbles] mark read failed: ${formatErrorMessage(err)}`);
     }
   } else if (!sendReadReceipts) {
     logVerbose(core, runtime, "mark read skipped (sendReadReceipts=false)");
@@ -1306,7 +1307,7 @@ export async function processMessage(
         logVerbose(
           core,
           runtime,
-          `history backfill failed for ${historyIdentifier}: ${String(err)} (retries left=${Math.max(remainingAttempts, 0)} next_in_ms=${nextBackoffMs})`,
+          `history backfill failed for ${historyIdentifier}: ${formatErrorMessage(err)} (retries left=${Math.max(remainingAttempts, 0)} next_in_ms=${nextBackoffMs})`,
         );
       }
     }
@@ -1389,7 +1390,7 @@ export async function processMessage(
         cfg: config,
         accountId: account.accountId,
       }).catch((err) => {
-        runtime.error?.(`[bluebubbles] typing restart failed: ${String(err)}`);
+        runtime.error?.(`[bluebubbles] typing restart failed: ${formatErrorMessage(err)}`);
       });
     }, typingRestartDelayMs);
   };
@@ -1415,7 +1416,7 @@ export async function processMessage(
               accountId: account.accountId,
             });
           } catch (err) {
-            runtime.error?.(`[bluebubbles] typing start failed: ${String(err)}`);
+            runtime.error?.(`[bluebubbles] typing start failed: ${formatErrorMessage(err)}`);
           }
         },
         onIdle: () => {
@@ -1555,7 +1556,7 @@ export async function processMessage(
         onReplyStart: typingCallbacks?.onReplyStart,
         onIdle: typingCallbacks?.onIdle,
         onError: (err, info) => {
-          runtime.error?.(`BlueBubbles ${info.kind} reply failed: ${String(err)}`);
+          runtime.error?.(`BlueBubbles ${info.kind} reply failed: ${formatErrorMessage(err)}`);
         },
       },
       replyOptions: {

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -26,6 +26,7 @@ import {
   withResolvedWebhookRequestPipeline,
 } from "./runtime-api.js";
 import { getBlueBubblesRuntime } from "./runtime.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const webhookTargets = new Map<string, WebhookTarget[]>();
 const webhookRateLimiter = createFixedWindowRateLimiter({
@@ -87,7 +88,7 @@ function parseBlueBubblesWebhookPayload(
     try {
       return { ok: true, value: JSON.parse(payload) as unknown };
     } catch (error) {
-      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+      return { ok: false, error: error instanceof Error ? error.message : formatErrorMessage(error) };
     }
   }
 }
@@ -281,7 +282,7 @@ export async function handleBlueBubblesWebhookRequest(
       if (reaction) {
         processReaction(reaction, target).catch((err) => {
           target.runtime.error?.(
-            `[${target.account.accountId}] BlueBubbles reaction failed: ${String(err)}`,
+            `[${target.account.accountId}] BlueBubbles reaction failed: ${formatErrorMessage(err)}`,
           );
         });
       } else if (message) {
@@ -290,7 +291,7 @@ export async function handleBlueBubblesWebhookRequest(
         const debouncer = debounceRegistry.getOrCreateDebouncer(target);
         debouncer.enqueue({ message, target }).catch((err) => {
           target.runtime.error?.(
-            `[${target.account.accountId}] BlueBubbles webhook failed: ${String(err)}`,
+            `[${target.account.accountId}] BlueBubbles webhook failed: ${formatErrorMessage(err)}`,
           );
         });
       }

--- a/extensions/bluebubbles/src/probe.ts
+++ b/extensions/bluebubbles/src/probe.ts
@@ -1,6 +1,7 @@
 import type { BaseProbeResult } from "./runtime-api.js";
 import { normalizeSecretInputString } from "./secret-input.js";
 import { buildBlueBubblesApiUrl, blueBubblesFetchWithTimeout } from "./types.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type BlueBubblesProbe = BaseProbeResult & {
   status?: number | null;
@@ -172,7 +173,7 @@ export async function probeBlueBubbles(params: {
     return {
       ok: false,
       status: null,
-      error: err instanceof Error ? err.message : String(err),
+      error: err instanceof Error ? err.message : formatErrorMessage(err),
     };
   }
 }


### PR DESCRIPTION
## Summary
Replace `String(err)` with `formatErrorMessage()` from `openclaw/plugin-sdk/error-runtime` across the bluebubbles extension.

`String(err)` produces `[object Object]` when the caught value is a non-Error object, hiding actual error details. `formatErrorMessage()` properly handles Error instances (with `.cause` chain traversal), strings, and arbitrary objects.

Follows the same pattern as:
- msteams (merged PR #59321)
- feishu (PR #59491, Greptile 5/5)

🤖 AI-assisted (Claude Code). Mechanical replacement, no logic changes. I understand what the code does.

## Test plan
- [ ] `pnpm check` passes
- [ ] bluebubbles error logs show readable messages instead of `[object Object]`