### PR TITLE
fix(imessage): use formatErrorMessage instead of String(err)

### DIFF
--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -3,6 +3,7 @@ import { createInterface, type Interface } from "node:readline";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { resolveUserPath } from "openclaw/plugin-sdk/text-runtime";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type IMessageRpcError = {
   code?: number;
@@ -103,7 +104,7 @@ export class IMessageRpcClient {
     });
 
     child.on("error", (err) => {
-      this.failAll(err instanceof Error ? err : new Error(String(err)));
+      this.failAll(err instanceof Error ? err : new Error(formatErrorMessage(err)));
       this.closedResolve?.();
     });
 
@@ -188,7 +189,7 @@ export class IMessageRpcClient {
     try {
       parsed = JSON.parse(line) as IMessageRpcResponse<unknown>;
     } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
+      const detail = err instanceof Error ? err.message : formatErrorMessage(err);
       this.runtime?.error?.(`imsg rpc: failed to parse ${line}: ${detail}`);
       return;
     }

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -55,6 +55,7 @@ import { parseIMessageNotification } from "./parse-notification.js";
 import { normalizeAllowList, resolveRuntime } from "./runtime.js";
 import { createSelfChatCache } from "./self-chat-cache.js";
 import type { IMessagePayload, MonitorIMessageOpts } from "./types.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 /**
  * Try to detect remote host from an SSH wrapper script like:
@@ -200,7 +201,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       await handleMessageNow(syntheticMessage);
     },
     onError: (err) => {
-      runtime.error?.(`imessage debounce flush failed: ${String(err)}`);
+      runtime.error?.(`imessage debounce flush failed: ${formatErrorMessage(err)}`);
     },
   });
 
@@ -320,7 +321,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           });
         },
         onReplyError: (err) => {
-          logVerbose(`imessage pairing reply failed for ${decision.senderId}: ${String(err)}`);
+          logVerbose(`imessage pairing reply failed for ${decision.senderId}: ${formatErrorMessage(err)}`);
         },
       });
       return;
@@ -381,7 +382,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
             }
           : undefined,
       onRecordError: (err) => {
-        logVerbose(`imessage: failed updating session meta: ${String(err)}`);
+        logVerbose(`imessage: failed updating session meta: ${formatErrorMessage(err)}`);
       },
     });
 
@@ -422,7 +423,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         });
       },
       onError: (err, info) => {
-        runtime.error?.(danger(`imessage ${info.kind} reply failed: ${String(err)}`));
+        runtime.error?.(danger(`imessage ${info.kind} reply failed: ${formatErrorMessage(err)}`));
       },
     });
 
@@ -498,7 +499,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     onNotification: (msg) => {
       if (msg.method === "message") {
         void handleMessage(msg.params).catch((err) => {
-          runtime.error?.(`imessage: handler failed: ${String(err)}`);
+          runtime.error?.(`imessage: handler failed: ${formatErrorMessage(err)}`);
         });
       } else if (msg.method === "error") {
         runtime.error?.(`imessage: watch error ${JSON.stringify(msg.params)}`);
@@ -524,7 +525,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     if (abort?.aborted) {
       return;
     }
-    runtime.error?.(danger(`imessage: monitor failed: ${String(err)}`));
+    runtime.error?.(danger(`imessage: monitor failed: ${formatErrorMessage(err)}`));
     throw err;
   } finally {
     detachAbortHandler();

--- a/extensions/imessage/src/probe.ts
+++ b/extensions/imessage/src/probe.ts
@@ -5,6 +5,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { detectBinary } from "openclaw/plugin-sdk/setup";
 import { createIMessageRpcClient } from "./client.js";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 // Re-export for backwards compatibility
 export { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
@@ -55,7 +56,7 @@ async function probeRpcSupport(cliPath: string, timeoutMs: number): Promise<RpcS
       error: combined || `imsg rpc --help failed (code ${String(result.code ?? "unknown")})`,
     };
   } catch (err) {
-    return { supported: false, error: String(err) };
+    return { supported: false, error: formatErrorMessage(err) };
   }
 }
 
@@ -98,7 +99,7 @@ export async function probeIMessage(
     await client.request("chats.list", { limit: 1 }, { timeoutMs: effectiveTimeout });
     return { ok: true };
   } catch (err) {
-    return { ok: false, error: String(err) };
+    return { ok: false, error: formatErrorMessage(err) };
   } finally {
     await client.stop();
   }


### PR DESCRIPTION
## Summary
Replace `String(err)` with `formatErrorMessage()` from `openclaw/plugin-sdk/error-runtime` across the imessage extension.

`String(err)` produces `[object Object]` when the caught value is a non-Error object, hiding actual error details. `formatErrorMessage()` properly handles Error instances (with `.cause` chain traversal), strings, and arbitrary objects.

Follows the same pattern as:
- msteams (merged PR #59321)
- feishu (PR #59491, Greptile 5/5)

🤖 AI-assisted (Claude Code). Mechanical replacement, no logic changes. I understand what the code does.

## Test plan
- [ ] `pnpm check` passes
- [ ] imessage error logs show readable messages instead of `[object Object]`