### PR TITLE
fix(line): use formatErrorMessage instead of String(err)

### DIFF
--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -52,6 +52,7 @@ import { downloadLineMedia } from "./download.js";
 import { resolveLineGroupConfigEntry } from "./group-keys.js";
 import { pushMessageLine, replyMessageLine } from "./send.js";
 import type { LineGroupConfig, ResolvedLineAccount } from "./types.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 interface MediaRef {
   path: string;
@@ -269,7 +270,7 @@ async function sendLinePairingReply(params: {
           });
           return;
         } catch (err) {
-          logVerbose(`line pairing reply failed for ${senderId}: ${String(err)}`);
+          logVerbose(`line pairing reply failed for ${senderId}: ${formatErrorMessage(err)}`);
         }
       }
       try {
@@ -278,7 +279,7 @@ async function sendLinePairingReply(params: {
           channelAccessToken: context.account.channelAccessToken,
         });
       } catch (err) {
-        logVerbose(`line pairing reply failed for ${senderId}: ${String(err)}`);
+        logVerbose(`line pairing reply failed for ${senderId}: ${formatErrorMessage(err)}`);
       }
     },
   });
@@ -543,7 +544,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
         contentType: media.contentType,
       });
     } catch (err) {
-      const errMsg = String(err);
+      const errMsg = formatErrorMessage(err);
       if (errMsg.includes("exceeds") && errMsg.includes("limit")) {
         logVerbose(`line: media exceeds size limit for message ${message.id}`);
       } else {
@@ -644,7 +645,7 @@ export async function handleLineWebhookEvents(
         try {
           await replaySkip.inFlightResult;
         } catch (err) {
-          context.runtime.error?.(danger(`line: replayed in-flight event failed: ${String(err)}`));
+          context.runtime.error?.(danger(`line: replayed in-flight event failed: ${formatErrorMessage(err)}`));
           firstError ??= err;
         }
       }
@@ -686,7 +687,7 @@ export async function handleLineWebhookEvents(
         inFlightReservation?.reject(err);
         clearLineReplayEventInFlight(replayCandidate);
       }
-      context.runtime.error?.(danger(`line: event handler failed: ${String(err)}`));
+      context.runtime.error?.(danger(`line: event handler failed: ${formatErrorMessage(err)}`));
       firstError ??= err;
     }
   }

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -25,6 +25,7 @@ import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeAllowFrom } from "./bot-access.js";
 import { resolveLineGroupConfigEntry, resolveLineGroupHistoryKey } from "./group-keys.js";
 import type { LineGroupConfig, ResolvedLineAccount } from "./types.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 interface MediaRef {
   path: string;
@@ -406,7 +407,7 @@ async function finalizeLineInboundContext(params: {
         }
       : undefined,
     onRecordError: (err) => {
-      logVerbose(`line: failed updating session meta: ${String(err)}`);
+      logVerbose(`line: failed updating session meta: ${formatErrorMessage(err)}`);
     },
   });
 

--- a/extensions/line/src/card-command.ts
+++ b/extensions/line/src/card-command.ts
@@ -8,6 +8,7 @@ import {
   type CardAction,
   type ListItem,
 } from "../api.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const CARD_USAGE = `Usage: /card <type> "title" "body" [options]
 
@@ -337,7 +338,7 @@ export function registerLineCardCommand(api: OpenClawPluginApi): void {
             };
         }
       } catch (err) {
-        return { text: `Error creating card: ${String(err)}` };
+        return { text: `Error creating card: ${formatErrorMessage(err)}` };
       }
     },
   });

--- a/extensions/line/src/gateway.ts
+++ b/extensions/line/src/gateway.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedLineAccount,
 } from "../api.js";
 import { getLineRuntime } from "./runtime.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export const lineGatewayAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>["gateway"]> = {
   startAccount: async (ctx) => {
@@ -33,7 +34,7 @@ export const lineGatewayAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>[
       }
     } catch (err) {
       if (getLineRuntime().logging.shouldLogVerbose()) {
-        ctx.log?.debug?.(`[${account.accountId}] bot probe failed: ${String(err)}`);
+        ctx.log?.debug?.(`[${account.accountId}] bot probe failed: ${formatErrorMessage(err)}`);
       }
     }
 

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -39,6 +39,7 @@ import {
 import { buildTemplateMessageFromPayload } from "./template-messages.js";
 import type { LineChannelData, ResolvedLineAccount } from "./types.js";
 import { createLineNodeWebhookHandler } from "./webhook-node.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export interface MonitorLineProviderOptions {
   channelAccessToken: string;
@@ -256,7 +257,7 @@ export async function monitorLineProvider(
               });
             },
             onError: (err, info) => {
-              runtime.error?.(danger(`line ${info.kind} reply failed: ${String(err)}`));
+              runtime.error?.(danger(`line ${info.kind} reply failed: ${formatErrorMessage(err)}`));
             },
           },
           replyOptions: {
@@ -268,7 +269,7 @@ export async function monitorLineProvider(
           logVerbose(`line: no response generated for message from ${ctxPayload.From}`);
         }
       } catch (err) {
-        runtime.error?.(danger(`line: auto-reply failed: ${String(err)}`));
+        runtime.error?.(danger(`line: auto-reply failed: ${formatErrorMessage(err)}`));
 
         if (replyToken) {
           try {

--- a/extensions/line/src/probe.ts
+++ b/extensions/line/src/probe.ts
@@ -1,6 +1,7 @@
 import { messagingApi } from "@line/bot-sdk";
 import { withTimeout } from "openclaw/plugin-sdk/text-runtime";
 import type { LineProbeResult } from "./types.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export async function probeLineBot(
   channelAccessToken: string,
@@ -27,7 +28,7 @@ export async function probeLineBot(
       },
     };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = err instanceof Error ? err.message : formatErrorMessage(err);
     return { ok: false, error: message };
   }
 }

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -5,6 +5,7 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveLineAccount } from "./accounts.js";
 import { resolveLineChannelAccessToken } from "./channel-access-token.js";
 import type { LineSendResult } from "./types.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 type Message = messagingApi.Message;
 type TextMessage = messagingApi.TextMessage;
@@ -433,7 +434,7 @@ export async function showLoadingAnimation(
     });
     logVerbose(`line: showing loading animation to ${chatId}`);
   } catch (err) {
-    logVerbose(`line: loading animation failed (non-fatal): ${String(err)}`);
+    logVerbose(`line: loading animation failed (non-fatal): ${formatErrorMessage(err)}`);
   }
 }
 
@@ -466,7 +467,7 @@ export async function getUserProfile(
 
     return result;
   } catch (err) {
-    logVerbose(`line: failed to fetch profile for ${userId}: ${String(err)}`);
+    logVerbose(`line: failed to fetch profile for ${userId}: ${formatErrorMessage(err)}`);
     return null;
   }
 }

--- a/extensions/line/src/webhook-node.ts
+++ b/extensions/line/src/webhook-node.ts
@@ -7,6 +7,7 @@ import {
   requestBodyErrorToText,
 } from "openclaw/plugin-sdk/webhook-request-guards";
 import { parseLineWebhookBody, validateLineSignature } from "./webhook-utils.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const LINE_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const LINE_WEBHOOK_PREAUTH_MAX_BODY_BYTES = 64 * 1024;
@@ -120,7 +121,7 @@ export function createLineNodeWebhookHandler(params: {
         res.end(JSON.stringify({ error: requestBodyErrorToText("REQUEST_BODY_TIMEOUT") }));
         return;
       }
-      params.runtime.error?.(danger(`line webhook error: ${String(err)}`));
+      params.runtime.error?.(danger(`line webhook error: ${formatErrorMessage(err)}`));
       if (!res.headersSent) {
         res.statusCode = 500;
         res.setHeader("Content-Type", "application/json");

--- a/extensions/line/src/webhook.ts
+++ b/extensions/line/src/webhook.ts
@@ -2,6 +2,7 @@ import type { WebhookRequestBody } from "@line/bot-sdk";
 import type { NextFunction, Request, Response } from "express";
 import { danger, logVerbose, type RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { parseLineWebhookBody, validateLineSignature } from "./webhook-utils.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const LINE_WEBHOOK_MAX_RAW_BODY_BYTES = 64 * 1024;
 
@@ -73,7 +74,7 @@ export function createLineWebhookMiddleware(
 
       res.status(200).json({ status: "ok" });
     } catch (err) {
-      runtime?.error?.(danger(`line webhook error: ${String(err)}`));
+      runtime?.error?.(danger(`line webhook error: ${formatErrorMessage(err)}`));
       if (!res.headersSent) {
         res.status(500).json({ error: "Internal server error" });
       }


### PR DESCRIPTION
## Summary
Replace `String(err)` with `formatErrorMessage()` from `openclaw/plugin-sdk/error-runtime` across 9 files in the LINE extension.

`String(err)` produces `[object Object]` when the caught value is a non-Error object, hiding actual error details. `formatErrorMessage()` properly handles Error instances (with `.cause` chain traversal), strings, and arbitrary objects.

Follows the same pattern as:
- msteams (merged PR #59321)
- feishu (PR #59491, Greptile 5/5)

🤖 AI-assisted (Claude Code). Mechanical replacement, no logic changes. I understand what the code does.

## Test plan
- [ ] `pnpm check` passes
- [ ] LINE channel error logs show readable messages instead of `[object Object]`