### PR TITLE
fix: extend CA bundle auto-injection to all 8 Node version managers

### DIFF
--- a/src/bootstrap/node-extra-ca-certs.test.ts
+++ b/src/bootstrap/node-extra-ca-certs.test.ts
@@ -48,6 +48,44 @@ describe("isNodeVersionManagerRuntime", () => {
   it("returns false for non-nvm node paths", () => {
     expect(isNodeVersionManagerRuntime({}, "/usr/bin/node")).toBe(false);
   });
+
+  it("detects fnm via execPath", () => {
+    expect(
+      isNodeVersionManagerRuntime({}, "/home/test/.fnm/node-versions/v22/installation/bin/node"),
+    ).toBe(true);
+  });
+
+  it("detects volta via execPath", () => {
+    expect(
+      isNodeVersionManagerRuntime({}, "/home/test/.volta/tools/image/node/22.14.0/bin/node"),
+    ).toBe(true);
+  });
+
+  it("detects asdf via execPath", () => {
+    expect(
+      isNodeVersionManagerRuntime({}, "/home/test/.asdf/installs/nodejs/22.14.0/bin/node"),
+    ).toBe(true);
+  });
+
+  it("detects n via execPath", () => {
+    expect(isNodeVersionManagerRuntime({}, "/home/test/.n/bin/node")).toBe(true);
+  });
+
+  it("detects nodenv via execPath", () => {
+    expect(isNodeVersionManagerRuntime({}, "/home/test/.nodenv/versions/22.14.0/bin/node")).toBe(
+      true,
+    );
+  });
+
+  it("detects nodebrew via execPath", () => {
+    expect(isNodeVersionManagerRuntime({}, "/home/test/.nodebrew/node/v22.14.0/bin/node")).toBe(
+      true,
+    );
+  });
+
+  it("detects nvs via execPath", () => {
+    expect(isNodeVersionManagerRuntime({}, "/home/test/nvs/node/22.14.0/x64/bin/node")).toBe(true);
+  });
 });
 
 describe("resolveAutoNodeExtraCaCerts", () => {

--- a/src/bootstrap/node-extra-ca-certs.test.ts
+++ b/src/bootstrap/node-extra-ca-certs.test.ts
@@ -55,6 +55,19 @@ describe("isNodeVersionManagerRuntime", () => {
     ).toBe(true);
   });
 
+  it("detects fnm via XDG data path", () => {
+    expect(
+      isNodeVersionManagerRuntime(
+        {},
+        "/home/test/.local/share/fnm/node-versions/v22/installation/bin/node",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects nvs via dotted home path", () => {
+    expect(isNodeVersionManagerRuntime({}, "/home/test/.nvs/node/22.14.0/x64/bin/node")).toBe(true);
+  });
+
   it("detects volta via execPath", () => {
     expect(
       isNodeVersionManagerRuntime({}, "/home/test/.volta/tools/image/node/22.14.0/bin/node"),

--- a/src/bootstrap/node-extra-ca-certs.test.ts
+++ b/src/bootstrap/node-extra-ca-certs.test.ts
@@ -80,6 +80,12 @@ describe("isNodeVersionManagerRuntime", () => {
     ).toBe(true);
   });
 
+  it("detects mise via execPath", () => {
+    expect(
+      isNodeVersionManagerRuntime({}, "/home/test/.local/share/mise/installs/node/22.14.0/bin/node"),
+    ).toBe(true);
+  });
+
   it("detects n via execPath", () => {
     expect(isNodeVersionManagerRuntime({}, "/home/test/.n/bin/node")).toBe(true);
   });

--- a/src/bootstrap/node-extra-ca-certs.ts
+++ b/src/bootstrap/node-extra-ca-certs.ts
@@ -32,6 +32,22 @@ export function resolveLinuxSystemCaBundle(
   return undefined;
 }
 
+/**
+ * Version manager path markers, aligned with src/daemon/service-audit.ts.
+ * Version-manager-installed Node does not inherit system CA certificates,
+ * so we need to detect this to auto-inject NODE_EXTRA_CA_CERTS.
+ */
+const VERSION_MANAGER_PATH_MARKERS: readonly string[] = [
+  "/.nvm/",
+  "/.fnm/",
+  "/.volta/",
+  "/.asdf/",
+  "/.n/",
+  "/.nodenv/",
+  "/.nodebrew/",
+  "/nvs/",
+];
+
 export function isNodeVersionManagerRuntime(
   env: EnvMap = process.env as EnvMap,
   execPath: string = process.execPath,
@@ -39,7 +55,7 @@ export function isNodeVersionManagerRuntime(
   if (env.NVM_DIR?.trim()) {
     return true;
   }
-  return execPath.includes("/.nvm/");
+  return VERSION_MANAGER_PATH_MARKERS.some((marker) => execPath.includes(marker));
 }
 
 export function resolveAutoNodeExtraCaCerts(

--- a/src/bootstrap/node-extra-ca-certs.ts
+++ b/src/bootstrap/node-extra-ca-certs.ts
@@ -33,19 +33,23 @@ export function resolveLinuxSystemCaBundle(
 }
 
 /**
- * Version manager path markers, aligned with src/daemon/service-audit.ts.
+ * Version manager path markers (Linux subset), mirroring VERSION_MANAGER_MARKERS
+ * in src/daemon/runtime-paths.ts. Not imported directly because bootstrap code
+ * must avoid daemon-layer dependencies at startup.
  * Version-manager-installed Node does not inherit system CA certificates,
- * so we need to detect this to auto-inject NODE_EXTRA_CA_CERTS.
+ * so we detect this to auto-inject NODE_EXTRA_CA_CERTS.
  */
 const VERSION_MANAGER_PATH_MARKERS: readonly string[] = [
   "/.nvm/",
   "/.fnm/",
+  "/.local/share/fnm/",
   "/.volta/",
   "/.asdf/",
   "/.n/",
   "/.nodenv/",
   "/.nodebrew/",
   "/nvs/",
+  "/.nvs/",
 ];
 
 export function isNodeVersionManagerRuntime(

--- a/src/bootstrap/node-extra-ca-certs.ts
+++ b/src/bootstrap/node-extra-ca-certs.ts
@@ -45,6 +45,7 @@ const VERSION_MANAGER_PATH_MARKERS: readonly string[] = [
   "/.local/share/fnm/",
   "/.volta/",
   "/.asdf/",
+  "/.local/share/mise/",
   "/.n/",
   "/.nodenv/",
   "/.nodebrew/",


### PR DESCRIPTION
Fixes #59494

`isNodeVersionManagerRuntime()` in `src/bootstrap/node-extra-ca-certs.ts` only detected **nvm** (via `NVM_DIR` env and `/.nvm/` path marker), but users running Node via fnm, volta, asdf, n, nodenv, nodebrew, or nvs on Linux behind corporate proxies encounter the same TLS handshake failures.

`src/daemon/service-audit.ts` already recognizes all 8 version managers (lines 302–309). This PR aligns the bootstrap layer with the daemon layer.

### Changes

- **`src/bootstrap/node-extra-ca-certs.ts`**: Extract `VERSION_MANAGER_PATH_MARKERS` array (8 markers) and use `.some()` instead of single `.includes("/.nvm/")`
- **`src/bootstrap/node-extra-ca-certs.test.ts`**: Add 7 new tests for fnm/volta/asdf/n/nodenv/nodebrew/nvs detection (15/15 passing)

---


## Real behavior proof

- **Behavior or issue addressed:** `isNodeVersionManagerRuntime()` (bootstrap CA cert auto-injection) only detected nvm, so fnm/volta/asdf/n/nodenv/nodebrew/nvs users on Linux behind corporate proxies hit TLS handshake failures because version-manager Node does not inherit system CA certs. This extends detection to all 8 version managers, aligned with the markers already recognized in the daemon layer.

- **Real environment tested:** Linux (Ubuntu 24.04, WSL2), Node.js 24.14.0, OpenClaw built from this PR head. Exercised the exported `isNodeVersionManagerRuntime()` and `resolveAutoNodeExtraCaCerts()` against representative version-manager execPath layouts.

- **Exact steps or command run after this patch:** invoked the patched exported functions against each version-manager execPath via tsx:
```bash
$ node --import tsx run-check.ts
```

- **Evidence after fix:** Actual output running the patched `isNodeVersionManagerRuntime()` against each version manager's execPath (clean env, no NVM_DIR):
```
DETECTED  nvm       /home/user/.nvm/versions/node/v24.14.0/bin/node
DETECTED  fnm       /home/user/.fnm/node-versions/v24.14.0/installation/bin/node
DETECTED  fnm-xdg   /home/user/.local/share/fnm/node-versions/v24.14.0/installation/bin/node
DETECTED  volta     /home/user/.volta/tools/image/node/24.14.0/bin/node
DETECTED  asdf      /home/user/.asdf/installs/nodejs/24.14.0/bin/node
DETECTED  mise      /home/user/.local/share/mise/installs/node/24.14.0/bin/node
DETECTED  n         /home/user/.n/bin/node
DETECTED  nodenv    /home/user/.nodenv/versions/24.14.0/bin/node
DETECTED  nodebrew  /home/user/.nodebrew/node/v24.14.0/bin/node
DETECTED  nvs       /home/user/nvs/node/24.14.0/x64/bin/node
DETECTED  nvs-dot   /home/user/.nvs/node/24.14.0/x64/bin/node

NVM_DIR env (backward compat)  -> true
/usr/bin/node (system, no false positive)  -> false

resolveAutoNodeExtraCaCerts (Linux + fnm) -> /etc/ssl/certs/ca-certificates.crt
```

- **Observed result after fix:** All 8 version managers are detected by execPath; the NVM_DIR env fast-path still works (backward compatible); a system Node path returns false (no false positive); and end-to-end `resolveAutoNodeExtraCaCerts` resolves the system CA bundle for an fnm runtime on Linux. Before this patch only nvm was detected; the others returned false and missed CA injection. Default fnm XDG (`~/.local/share/fnm/`) and nvs dotted-home (`~/.nvs/`) layouts are also covered.

- **What was not tested:** Live corporate-proxy TLS handshake was not reproduced (requires a proxy MITM setup); the fix targets the detection gate that precedes injection. Non-Linux platforms are skipped by design.


