### PR TITLE
fix(memory-lancedb): add radix to parseInt for search limit

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -506,7 +506,7 @@ export default definePluginEntry({
           .option("--limit <n>", "Max results", "5")
           .action(async (query, opts) => {
             const vector = await embeddings.embed(query);
-            const results = await db.search(vector, parseInt(opts.limit), 0.3);
+            const results = await db.search(vector, parseInt(opts.limit, 10), 0.3);
             // Strip vectors for output
             const output = results.map((r) => ({
               id: r.entry.id,


### PR DESCRIPTION
## Summary
`parseInt(opts.limit)` without radix can misbehave with certain string inputs. Since `opts.limit` comes from CLI args (user-controlled string), always specify radix 10 explicitly.

🤖 AI-assisted (Claude Code). I understand what the code does.

## Test plan
- [ ] `pnpm check` passes
- [ ] `memory search --limit 08` returns 8 results (not 0)