### PR TITLE
fix(qqbot): use formatErrorMessage instead of String(err)

### DIFF
--- a/extensions/qqbot/src/api.ts
+++ b/extensions/qqbot/src/api.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import { debugLog, debugError } from "./utils/debug-log.js";
 import { sanitizeFileName } from "./utils/platform.js";
 import { computeFileHash, getCachedFileInfo, setCachedFileInfo } from "./utils/upload-cache.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const API_BASE = "https://api.sgroup.qq.com";
 const TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken";
@@ -105,7 +106,7 @@ async function doFetchToken(appId: string, clientSecret: string): Promise<string
   } catch (err) {
     debugError(`[qqbot-api:${appId}] <<< Network error:`, err);
     throw new Error(
-      `Network error getting access_token: ${err instanceof Error ? err.message : String(err)}`,
+      `Network error getting access_token: ${err instanceof Error ? err.message : formatErrorMessage(err)}`,
     );
   }
 
@@ -129,7 +130,7 @@ async function doFetchToken(appId: string, clientSecret: string): Promise<string
   } catch (err) {
     debugError(`[qqbot-api:${appId}] <<< Parse error:`, err);
     throw new Error(
-      `Failed to parse access_token response: ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to parse access_token response: ${err instanceof Error ? err.message : formatErrorMessage(err)}`,
     );
   }
 
@@ -240,7 +241,7 @@ export async function apiRequest<T = unknown>(
       throw new Error(`Request timeout[${path}]: exceeded ${timeout}ms`);
     }
     debugError(`[qqbot-api] <<< Network error:`, err);
-    throw new Error(`Network error [${path}]: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`Network error [${path}]: ${err instanceof Error ? err.message : formatErrorMessage(err)}`);
   } finally {
     clearTimeout(timeoutId);
   }
@@ -262,7 +263,7 @@ export async function apiRequest<T = unknown>(
     data = JSON.parse(rawBody) as T;
   } catch (err) {
     throw new Error(
-      `Failed to parse response[${path}]: ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to parse response[${path}]: ${err instanceof Error ? err.message : formatErrorMessage(err)}`,
     );
   }
 
@@ -292,7 +293,7 @@ async function apiRequestWithRetry<T = unknown>(
     try {
       return await apiRequest<T>(accessToken, method, path, body);
     } catch (err) {
-      lastError = err instanceof Error ? err : new Error(String(err));
+      lastError = err instanceof Error ? err : new Error(formatErrorMessage(err));
 
       const errMsg = lastError.message;
       if (

--- a/extensions/qqbot/src/gateway.ts
+++ b/extensions/qqbot/src/gateway.ts
@@ -59,6 +59,7 @@ import { TypingKeepAlive, TYPING_INPUT_SECOND } from "./typing-keepalive.js";
 import { isGlobalTTSAvailable, resolveTTSConfig } from "./utils/audio-convert.js";
 import { runDiagnostics } from "./utils/platform.js";
 import { parseFaceTags, parseRefIndices, buildAttachmentSummaries } from "./utils/text-parsing.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 // QQ Bot intents grouped by permission level.
 const INTENTS = {
@@ -1095,7 +1096,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                     timeoutId = null;
                   }
 
-                  const errMsg = String(err);
+                  const errMsg = formatErrorMessage(err);
                   if (errMsg.includes("401") || errMsg.includes("key") || errMsg.includes("auth")) {
                     log?.error(`[qqbot:${account.accountId}] AI auth error: ${errMsg}`);
                   } else {
@@ -1453,7 +1454,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
       });
     } catch (err) {
       isConnecting = false;
-      const errMsg = String(err);
+      const errMsg = formatErrorMessage(err);
       log?.error(`[qqbot:${account.accountId}] Connection failed: ${err}`);
 
       // Back off more aggressively after rate-limit failures.

--- a/extensions/qqbot/src/outbound.ts
+++ b/extensions/qqbot/src/outbound.ts
@@ -42,6 +42,7 @@ import {
   getQQBotDataDir,
   getQQBotMediaDir,
 } from "./utils/platform.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 // Limit passive replies per message_id within the QQ Bot reply window.
 const MESSAGE_REPLY_LIMIT = 4;
@@ -347,7 +348,7 @@ export async function sendPhoto(
       return { channel: "qqbot", error: "Channel does not support local/Base64 images" };
     }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = err instanceof Error ? err.message : formatErrorMessage(err);
 
     // Fall back to plugin-managed download + Base64 when QQ fails to fetch the URL directly.
     if (isHttp && !isData) {
@@ -429,7 +430,7 @@ export async function sendVoice(
           return { channel: "qqbot", error: "Voice not supported in channel" };
         }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
+        const msg = err instanceof Error ? err.message : formatErrorMessage(err);
         debugWarn(
           `${prefix} sendVoice: URL direct upload failed (${msg}), downloading locally and retrying...`,
         );
@@ -524,7 +525,7 @@ async function sendVoiceFromLocal(
       return { channel: "qqbot", error: "Voice not supported in channel" };
     }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = err instanceof Error ? err.message : formatErrorMessage(err);
     debugError(`${prefix} sendVoice (local) failed: ${msg}`);
     return { channel: "qqbot", error: msg };
   }
@@ -580,7 +581,7 @@ export async function sendVideoMsg(
 
     return await sendVideoFromLocal(ctx, mediaPath, prefix);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = err instanceof Error ? err.message : formatErrorMessage(err);
 
     // If direct URL upload fails, retry through a local download path.
     if (isHttp) {
@@ -645,7 +646,7 @@ async function sendVideoFromLocal(
       return { channel: "qqbot", error: "Video not supported in channel" };
     }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = err instanceof Error ? err.message : formatErrorMessage(err);
     debugError(`${prefix} sendVideoMsg (local) failed: ${msg}`);
     return { channel: "qqbot", error: msg };
   }
@@ -704,7 +705,7 @@ export async function sendDocument(
 
     return await sendDocumentFromLocal(ctx, mediaPath, prefix);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = err instanceof Error ? err.message : formatErrorMessage(err);
 
     // If direct URL upload fails, retry through a local download path.
     if (isHttp) {
@@ -774,7 +775,7 @@ async function sendDocumentFromLocal(
       return { channel: "qqbot", error: "File not supported in channel" };
     }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = err instanceof Error ? err.message : formatErrorMessage(err);
     debugError(`${prefix} sendDocument (local) failed: ${msg}`);
     return { channel: "qqbot", error: msg };
   }
@@ -1076,7 +1077,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
           });
         }
       } catch (err) {
-        const errMsg = err instanceof Error ? err.message : String(err);
+        const errMsg = err instanceof Error ? err.message : formatErrorMessage(err);
         debugError(`[qqbot] sendText: Failed to send ${item.type}: ${errMsg}`);
         lastResult = { channel: "qqbot", error: errMsg };
       }
@@ -1170,7 +1171,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
       };
     }
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = err instanceof Error ? err.message : formatErrorMessage(err);
     return { channel: "qqbot", error: message };
   }
 }
@@ -1251,7 +1252,7 @@ export async function sendProactiveMessage(
     }
     return outResult;
   } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
+    const errorMessage = err instanceof Error ? err.message : formatErrorMessage(err);
     debugError(`[${timestamp}] [qqbot] sendProactiveMessage: error: ${errorMessage}`);
     debugError(
       `[${timestamp}] [qqbot] sendProactiveMessage: error stack: ${err instanceof Error ? err.stack : "No stack trace"}`,

--- a/extensions/qqbot/src/proactive.ts
+++ b/extensions/qqbot/src/proactive.ts
@@ -7,6 +7,7 @@
 
 import type { ResolvedQQBotAccount } from "./types.js";
 import { debugLog, debugError } from "./utils/debug-log.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 // Re-export known-user types and functions from the canonical module.
 export type { KnownUser } from "./known-users.js";
@@ -158,7 +159,7 @@ export async function sendProactive(
       timestamp: result.timestamp,
     };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = err instanceof Error ? err.message : formatErrorMessage(err);
     debugError(`[qqbot:proactive] Failed to send message: ${message}`);
 
     return {
@@ -299,7 +300,7 @@ export async function sendProactiveMessageDirect(
   } catch (err) {
     return {
       success: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: err instanceof Error ? err.message : formatErrorMessage(err),
     };
   }
 }

--- a/extensions/qqbot/src/reply-dispatcher.ts
+++ b/extensions/qqbot/src/reply-dispatcher.ts
@@ -44,6 +44,7 @@ import {
   resolveQQBotLocalMediaPath,
   sanitizeFileName,
 } from "./utils/platform.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export interface MessageTarget {
   type: "c2c" | "guild" | "dm" | "group";
@@ -77,7 +78,7 @@ export async function sendWithTokenRetry<T>(
     const token = await getAccessToken(appId, clientSecret);
     return await sendFn(token);
   } catch (err) {
-    const errMsg = String(err);
+    const errMsg = formatErrorMessage(err);
     if (errMsg.includes("401") || errMsg.includes("token") || errMsg.includes("access_token")) {
       log?.info(`[qqbot:${accountId}] Token may be expired, refreshing...`);
       clearTokenCache(appId);

--- a/extensions/qqbot/src/tools/channel.ts
+++ b/extensions/qqbot/src/tools/channel.ts
@@ -2,6 +2,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { getAccessToken } from "../api.js";
 import { listQQBotAccountIds, resolveQQBotAccount } from "../config.js";
 import { debugError, debugLog } from "../utils/debug-log.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const API_BASE = "https://api.sgroup.qq.com";
 const DEFAULT_TIMEOUT_MS = 30000;
@@ -188,7 +189,7 @@ export function registerChannelTool(api: OpenClawPluginApi): void {
             }
             debugError("[qqbot-channel-api] <<< Network error:", err);
             return json({
-              error: `Network error: ${err instanceof Error ? err.message : String(err)}`,
+              error: `Network error: ${err instanceof Error ? err.message : formatErrorMessage(err)}`,
               path: p.path,
             });
           } finally {
@@ -238,7 +239,7 @@ export function registerChannelTool(api: OpenClawPluginApi): void {
           });
         } catch (err) {
           return json({
-            error: err instanceof Error ? err.message : String(err),
+            error: err instanceof Error ? err.message : formatErrorMessage(err),
             path: p.path,
           });
         }

--- a/extensions/qqbot/src/utils/audio-convert.ts
+++ b/extensions/qqbot/src/utils/audio-convert.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { decode, encode, isSilk } from "silk-wasm";
 import { debugLog, debugError, debugWarn } from "./debug-log.js";
 import { detectFfmpeg, isWindows } from "./platform.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 /** Wrap PCM s16le bytes in a WAV container. */
 function pcmToWav(
@@ -376,7 +377,7 @@ export async function textToSpeechPCM(
       }
     } catch (err) {
       clearTimeout(ttsTimeout);
-      lastError = err instanceof Error ? err : new Error(String(err));
+      lastError = err instanceof Error ? err : new Error(formatErrorMessage(err));
       debugLog(`[tts] Error for format=${format}: ${lastError.message.slice(0, 200)}`);
       if (format === "pcm") {
         continue;
@@ -488,7 +489,7 @@ export async function audioFileToSilkBase64(
       return silkBuffer.toString("base64");
     } catch (err) {
       debugError(
-        `[audio-convert] ffmpeg conversion failed: ${err instanceof Error ? err.message : String(err)}`,
+        `[audio-convert] ffmpeg conversion failed: ${err instanceof Error ? err.message : formatErrorMessage(err)}`,
       );
     }
   }
@@ -725,7 +726,7 @@ async function wasmDecodeMp3ToPCM(buf: Buffer, targetRate: number): Promise<Buff
     return Buffer.from(pcm.buffer, pcm.byteOffset, pcm.byteLength);
   } catch (err) {
     debugError(
-      `[audio-convert] WASM MP3 decode failed: ${err instanceof Error ? err.message : String(err)}`,
+      `[audio-convert] WASM MP3 decode failed: ${err instanceof Error ? err.message : formatErrorMessage(err)}`,
     );
     if (err instanceof Error && err.stack) {
       debugError(`[audio-convert] stack: ${err.stack}`);

--- a/extensions/qqbot/src/utils/file-utils.ts
+++ b/extensions/qqbot/src/utils/file-utils.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 /** Maximum file size accepted by the QQ Bot API. */
 export const MAX_UPLOAD_SIZE = 20 * 1024 * 1024;
@@ -33,7 +34,7 @@ export function checkFileSize(filePath: string, maxSize = MAX_UPLOAD_SIZE): File
     return {
       ok: false,
       size: 0,
-      error: `Failed to read file metadata: ${err instanceof Error ? err.message : String(err)}`,
+      error: `Failed to read file metadata: ${err instanceof Error ? err.message : formatErrorMessage(err)}`,
     };
   }
 }

--- a/extensions/qqbot/src/utils/platform.ts
+++ b/extensions/qqbot/src/utils/platform.ts
@@ -10,6 +10,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { debugLog, debugWarn } from "./debug-log.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 // Basic platform information.
 
@@ -306,7 +307,7 @@ export async function checkSilkWasmAvailable(): Promise<boolean> {
   } catch (err) {
     _silkWasmAvailable = false;
     debugWarn(
-      `[platform] silk-wasm: NOT available (${err instanceof Error ? err.message : String(err)})`,
+      `[platform] silk-wasm: NOT available (${err instanceof Error ? err.message : formatErrorMessage(err)})`,
     );
   }
   return _silkWasmAvailable;


### PR DESCRIPTION
## Summary
Replace `String(err)` with `formatErrorMessage()` from `openclaw/plugin-sdk/error-runtime` across the qqbot extension.

`String(err)` produces `[object Object]` when the caught value is a non-Error object, hiding actual error details. `formatErrorMessage()` properly handles Error instances (with `.cause` chain traversal), strings, and arbitrary objects.

Follows the same pattern as:
- msteams (merged PR #59321)
- feishu (PR #59491, Greptile 5/5)
- whatsapp (#59496), bluebubbles (#59497), imessage (#59498), line (#59499)

🤖 AI-assisted (Claude Code). Mechanical replacement, no logic changes. I understand what the code does.

## Test plan
- [ ] `pnpm check` passes
- [ ] qqbot error logs show readable messages instead of `[object Object]`