### PR TITLE
fix(signal): use formatErrorMessage instead of String(err)

### DIFF
--- a/extensions/signal/src/client.ts
+++ b/extensions/signal/src/client.ts
@@ -1,6 +1,7 @@
 import { generateSecureUuid } from "openclaw/plugin-sdk/core";
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
 import { fetchWithTimeout } from "openclaw/plugin-sdk/text-runtime";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type SignalRpcOptions = {
   baseUrl: string;
@@ -126,7 +127,7 @@ export async function signalCheck(
     return {
       ok: false,
       status: null,
-      error: err instanceof Error ? err.message : String(err),
+      error: err instanceof Error ? err.message : formatErrorMessage(err),
     };
   }
 }

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type SignalDaemonOpts = {
   cliPath: string;
@@ -130,7 +131,7 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
     });
   });
   child.on("error", (err) => {
-    error(`signal-cli spawn error: ${String(err)}`);
+    error(`signal-cli spawn error: ${formatErrorMessage(err)}`);
     settleExit({ source: "spawn-error", code: null, signal: null });
   });
 

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -38,6 +38,7 @@ import type {
 } from "./monitor/event-handler.types.js";
 import { sendMessageSignal } from "./send.js";
 import { runSignalSseLoop } from "./sse-reconnect.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type MonitorSignalOpts = {
   runtime?: RuntimeEnv;
@@ -468,7 +469,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       policy: opts.reconnectPolicy,
       onEvent: (event) => {
         void handleEvent(event).catch((err) => {
-          runtime.error?.(`event handler failed: ${String(err)}`);
+          runtime.error?.(`event handler failed: ${formatErrorMessage(err)}`);
         });
       },
     });

--- a/extensions/signal/src/monitor/access-policy.ts
+++ b/extensions/signal/src/monitor/access-policy.ts
@@ -5,6 +5,7 @@ import {
   resolveDmGroupAccessWithLists,
 } from "openclaw/plugin-sdk/security-runtime";
 import { isSignalSenderAllowed, type SignalSender } from "../identity.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 type SignalDmPolicy = "open" | "pairing" | "allowlist" | "disabled";
 type SignalGroupPolicy = "open" | "allowlist" | "disabled";
@@ -80,7 +81,7 @@ export async function handleSignalDirectMessageAccess(params: {
         params.log(`signal pairing request sender=${params.senderId}`);
       },
       onReplyError: (err) => {
-        params.log(`signal pairing reply failed for ${params.senderId}: ${String(err)}`);
+        params.log(`signal pairing reply failed for ${params.senderId}: ${formatErrorMessage(err)}`);
       },
     });
   }

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -57,6 +57,7 @@ import type {
   SignalReceivePayload,
 } from "./event-handler.types.js";
 import { renderSignalMentions } from "./mentions.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 function formatAttachmentKindCount(kind: string, count: number): string {
   if (kind === "attachment") {
@@ -250,7 +251,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           }
         : undefined,
       onRecordError: (err) => {
-        logVerbose(`signal: failed updating session meta: ${String(err)}`);
+        logVerbose(`signal: failed updating session meta: ${formatErrorMessage(err)}`);
       },
     });
 
@@ -303,7 +304,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         });
       },
       onError: (err, info) => {
-        deps.runtime.error?.(danger(`signal ${info.kind} reply failed: ${String(err)}`));
+        deps.runtime.error?.(danger(`signal ${info.kind} reply failed: ${formatErrorMessage(err)}`));
       },
     });
 
@@ -381,7 +382,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       });
     },
     onError: (err) => {
-      deps.runtime.error?.(`signal debounce flush failed: ${String(err)}`);
+      deps.runtime.error?.(`signal debounce flush failed: ${formatErrorMessage(err)}`);
     },
   });
 
@@ -471,7 +472,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     try {
       payload = JSON.parse(event.data) as SignalReceivePayload;
     } catch (err) {
-      deps.runtime.error?.(`failed to parse event: ${String(err)}`);
+      deps.runtime.error?.(`failed to parse event: ${formatErrorMessage(err)}`);
       return;
     }
     if (payload?.exception?.message) {
@@ -729,7 +730,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
             }
           }
         } catch (err) {
-          deps.runtime.error?.(danger(`attachment fetch failed: ${String(err)}`));
+          deps.runtime.error?.(danger(`attachment fetch failed: ${formatErrorMessage(err)}`));
         }
       }
     }
@@ -764,7 +765,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           accountId: deps.accountId,
         });
       } catch (err) {
-        logVerbose(`signal read receipt failed for ${senderDisplay}: ${String(err)}`);
+        logVerbose(`signal read receipt failed for ${senderDisplay}: ${formatErrorMessage(err)}`);
       }
     } else if (
       deps.sendReadReceipts &&

--- a/extensions/signal/src/probe.ts
+++ b/extensions/signal/src/probe.ts
@@ -1,5 +1,6 @@
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import { signalCheck, signalRpcRequest } from "./client.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type SignalProbe = BaseProbeResult & {
   status?: number | null;
@@ -45,7 +46,7 @@ export async function probeSignal(baseUrl: string, timeoutMs: number): Promise<S
     });
     result.version = parseSignalVersion(version);
   } catch (err) {
-    result.error = err instanceof Error ? err.message : String(err);
+    result.error = err instanceof Error ? err.message : formatErrorMessage(err);
   }
   return {
     ...result,

--- a/extensions/signal/src/setup-surface.ts
+++ b/extensions/signal/src/setup-surface.ts
@@ -14,6 +14,7 @@ import {
   signalNumberTextInput,
   signalSetupAdapter,
 } from "./setup-core.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const channel = "signal" as const;
 
@@ -67,7 +68,7 @@ export const signalSetupWizard: ChannelSetupWizard = {
         await prompter.note(result.error ?? "signal-cli install failed.", "Signal");
       }
     } catch (error) {
-      await prompter.note(`signal-cli install failed: ${String(error)}`, "Signal");
+      await prompter.note(`signal-cli install failed: ${formatErrorMessage(error)}`, "Signal");
     }
   },
   credentials: [],

--- a/extensions/signal/src/sse-reconnect.ts
+++ b/extensions/signal/src/sse-reconnect.ts
@@ -7,6 +7,7 @@ import {
   type RuntimeEnv,
 } from "openclaw/plugin-sdk/runtime-env";
 import { type SignalSseEvent, streamSignalEvents } from "./client.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const DEFAULT_RECONNECT_POLICY: BackoffPolicy = {
   initialMs: 1_000,
@@ -67,7 +68,7 @@ export async function runSignalSseLoop({
       if (abortSignal?.aborted) {
         return;
       }
-      runtime.error?.(`Signal SSE stream error: ${String(err)}`);
+      runtime.error?.(`Signal SSE stream error: ${formatErrorMessage(err)}`);
       reconnectAttempts += 1;
       const delayMs = computeBackoff(reconnectPolicy, reconnectAttempts);
       runtime.log?.(`Signal SSE connection lost, reconnecting in ${delayMs / 1000}s...`);


### PR DESCRIPTION
## Summary
Replace `String(err)` with `formatErrorMessage()` from `openclaw/plugin-sdk/error-runtime` across the signal extension.

`String(err)` produces `[object Object]` when the caught value is a non-Error object, hiding actual error details. `formatErrorMessage()` properly handles Error instances (with `.cause` chain traversal), strings, and arbitrary objects.

Follows the same pattern as:
- msteams (merged PR #59321)
- feishu (PR #59491, Greptile 5/5)
- whatsapp (#59496), bluebubbles (#59497), imessage (#59498), line (#59499)

🤖 AI-assisted (Claude Code). Mechanical replacement, no logic changes. I understand what the code does.

## Test plan
- [ ] `pnpm check` passes
- [ ] signal error logs show readable messages instead of `[object Object]`