### PR TITLE
fix(heartbeat): prevent :heartbeat suffix accumulation on session key

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -587,8 +587,7 @@ export async function runHeartbeatOnce(opts: {
   let runSessionKey = sessionKey;
   let runStorePath = storePath;
   if (useIsolatedSession) {
-    const baseKey = sessionKey.endsWith(":heartbeat") ? sessionKey : `${sessionKey}:heartbeat`;
-    const isolatedKey = baseKey;
+    const isolatedKey = sessionKey.endsWith(":heartbeat") ? sessionKey : `${sessionKey}:heartbeat`;
     const cronSession = resolveCronSession({
       cfg,
       sessionKey: isolatedKey,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -587,7 +587,8 @@ export async function runHeartbeatOnce(opts: {
   let runSessionKey = sessionKey;
   let runStorePath = storePath;
   if (useIsolatedSession) {
-    const isolatedKey = `${sessionKey}:heartbeat`;
+    const baseKey = sessionKey.endsWith(":heartbeat") ? sessionKey : `${sessionKey}:heartbeat`;
+    const isolatedKey = baseKey;
     const cronSession = resolveCronSession({
       cfg,
       sessionKey: isolatedKey,


### PR DESCRIPTION
lobster-biscuit

Closes #59493

## Problem

With isolatedSession: true, each heartbeat tick appends :heartbeat to the session key. If the key from a previous tick already has the suffix, it accumulates: agent:main:main:heartbeat:heartbeat:heartbeat...

## Root cause

src/infra/heartbeat-runner.ts:590 — blindly concatenates :heartbeat without checking if suffix already present.

## User impact

Session store grows with orphan entries on every tick. Memory leak over time.

## Fix

Skip appending if sessionKey already ends with :heartbeat. 1 file, +2/-1.

## How to verify

1. Configure heartbeat with isolatedSession: true
2. Wait 3+ ticks
3. Before: key grows each tick. After: stays stable.

Generated with Claude Code