### PR TITLE
fix: drop replayed tool-call stubs from malformed assistant history

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -355,6 +355,31 @@ describe("sanitizeSessionHistory", () => {
     });
   });
 
+  it("drops stub-only malformed assistant history content before replay sanitization", async () => {
+    setNonGoogleModelApi();
+
+    const messages = castAgentMessages([
+      { role: "user", content: "Question" },
+      { role: "assistant", content: "[TOOL CALL STUB]" },
+      { role: "assistant", content: "Before [TOOL CALL STUB] after" },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(messages[0]);
+    expect(result[1]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Before after" }],
+    });
+  });
+
   it("annotates inter-session user messages before context sanitization", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -161,12 +161,20 @@ function describeAssistantContentKind(content: unknown): string {
   return typeof content;
 }
 
+const TOOL_CALL_STUB_PLACEHOLDER_RE = /\[\s*tool call stub\s*\]/gi;
+const TOOL_CALL_STUB_PLACEHOLDER_SINGLE_RE = /\[\s*tool call stub\s*\]/i;
+
+function stripToolCallStubPlaceholder(content: string): string {
+  return content.replaceAll(TOOL_CALL_STUB_PLACEHOLDER_RE, " ").replace(/\s{2,}/g, " ").trim();
+}
+
 function canonicalizeAssistantHistoryMessages(params: {
   messages: AgentMessage[];
   sessionId: string;
 }): AgentMessage[] {
   let touched = false;
   let repairedCount = 0;
+  let droppedStubOnlyCount = 0;
   const repairedKinds = new Set<string>();
   const out: AgentMessage[] = [];
 
@@ -185,7 +193,20 @@ function canonicalizeAssistantHistoryMessages(params: {
     // Session transcripts and custom stream boundaries have historically leaked
     // malformed assistant payloads. Repair them here so Pi replay only sees the
     // canonical array-based assistant content contract.
-    const repairedText = typeof assistant.content === "string" ? assistant.content : "";
+    const repairedText =
+      typeof assistant.content === "string"
+        ? stripToolCallStubPlaceholder(assistant.content)
+        : "";
+    if (
+      typeof assistant.content === "string" &&
+      repairedText.length === 0 &&
+      TOOL_CALL_STUB_PLACEHOLDER_SINGLE_RE.test(assistant.content)
+    ) {
+      touched = true;
+      droppedStubOnlyCount += 1;
+      repairedKinds.add("tool-call-stub");
+      continue;
+    }
     out.push({
       ...(assistant as unknown as Record<string, unknown>),
       content: [{ type: "text", text: repairedText }],
@@ -201,7 +222,8 @@ function canonicalizeAssistantHistoryMessages(params: {
 
   log.warn(
     `sanitizeSessionHistory: canonicalized ${repairedCount} malformed assistant message(s) before replay ` +
-      `session=${params.sessionId} contentKinds=${Array.from(repairedKinds).join(",")}`,
+      `droppedStubOnly=${droppedStubOnlyCount} session=${params.sessionId} ` +
+      `contentKinds=${Array.from(repairedKinds).join(",")}`,
   );
   return out;
 }

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -165,6 +165,9 @@ const TOOL_CALL_STUB_PLACEHOLDER_RE = /\[\s*tool call stub\s*\]/gi;
 const TOOL_CALL_STUB_PLACEHOLDER_SINGLE_RE = /\[\s*tool call stub\s*\]/i;
 
 function stripToolCallStubPlaceholder(content: string): string {
+  if (!TOOL_CALL_STUB_PLACEHOLDER_SINGLE_RE.test(content)) {
+    return content;
+  }
   return content.replaceAll(TOOL_CALL_STUB_PLACEHOLDER_RE, " ").replace(/\s{2,}/g, " ").trim();
 }
 


### PR DESCRIPTION
## Summary

- Problem: provider-switched or malformed assistant transcript entries can replay literal `[TOOL CALL STUB]` placeholder text back into context.
- Why it matters: those stub-only turns are dead transcript artifacts, not meaningful memory, and they can pollute replayed context after provider changes.
- What changed: `sanitizeSessionHistory` now strips tool-call stub placeholders from malformed assistant string content and drops assistant entries that are stub-only after cleanup.
- What did NOT change (scope boundary): this does not change transcript storage format, provider translation, or tool-call/result pairing rules for valid structured history.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: malformed assistant history entries with string `content` were canonicalized into plain text replay messages without filtering known transcript placeholder artifacts.
- Missing detection / guardrail: replay sanitization covered malformed assistant content shape, but not the specific case where that malformed content was only a tool-call placeholder.
- Prior context (`git blame`, prior PR, issue, or refactor if known): current replay sanitizer already canonicalizes malformed assistant content in `src/agents/pi-embedded-runner/google.ts`, and existing tests cover that generic path plus provider-switch replay edge cases.
- Why this regressed now: provider switching can leave transcript artifacts that are valid strings structurally, so they bypassed stricter tool-call normalization and survived as replayable text.
- If unknown, what was ruled out: this fix does not rely on changing persisted session format or provider-specific tool ID logic; existing OpenAI tool ID preservation coverage still passes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
- Scenario the test should lock in: malformed assistant string content containing `[TOOL CALL STUB]` is either dropped when stub-only or preserved as prose with the placeholder removed.
- Why this is the smallest reliable guardrail: the behavior lives entirely inside replay sanitization and does not require provider IO or session file rewriting to reproduce.
- Existing test that already covers this (if any): `src/agents/pi-embedded-runner.openai-tool-id-preservation.test.ts` was rerun to confirm adjacent replay behavior still holds.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Users no longer get replay context polluted by literal `[TOOL CALL STUB]` assistant history placeholders after malformed/provider-switched transcript history is sanitized.

## Diagram (if applicable)

```text
Before:
[malformed assistant string: "[TOOL CALL STUB]"] -> canonicalized to replayable text block

After:
[malformed assistant string: "[TOOL CALL STUB]"] -> recognized as placeholder-only -> dropped
[malformed assistant string: "Before [TOOL CALL STUB] after"] -> placeholder stripped -> "Before after"
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Vitest
- Model/provider: replay sanitizer coverage for `openai` plus adjacent OpenAI replay regression
- Integration/channel (if any): N/A
- Relevant config (redacted): default unit test harness

### Steps

1. Create malformed assistant replay history with string content equal to `[TOOL CALL STUB]`.
2. Run `sanitizeSessionHistory(...)` for replay.
3. Repeat with mixed prose plus placeholder text.

### Expected

- Stub-only assistant history is not replayed.
- Mixed prose remains replayable, but the placeholder is removed.

### Actual

- Before this change, malformed assistant string content was canonicalized directly into replay text, preserving the placeholder artifact.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted replay sanitizer test suite and adjacent OpenAI tool ID preservation regression test.
- Edge cases checked: stub-only placeholder entry, prose surrounding placeholder, existing OpenAI replay ID preservation.
- What you did **not** verify: full `pnpm build && pnpm check && pnpm test` repo-wide lane.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: placeholder stripping could remove literal user-authored text if an assistant malformed history string intentionally contains `[TOOL CALL STUB]`.
  - Mitigation: the change is limited to malformed assistant replay entries already on the canonicalization fallback path, and the cleanup only removes the specific placeholder token.
