### PR TITLE
fix(script): clawdock ignores docker-compose.sandbox.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -583,6 +583,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: send captioned `MEDIA:` directive auto-replies once instead of emitting an empty media message before the captioned media reply. (#78770) Thanks @ai-hpc.
 - Hooks/cron: log returned `/hooks/agent` isolated-run errors and failed cron jobs with cron diagnostic summaries, so rejected `payload.model` values are visible instead of looking like accepted-but-missing runs. Fixes #78597. (#78655) Thanks @kevinslin.
 - Managed proxy/security: classify raw socket callsites and proxy runtime mutations in boundary checks so new direct egress or unmanaged proxy-state changes cannot land without explicit review. (#77126) Thanks @jesse-merhi.
+- scripts/ClawDock: docker compose does not load docker-compose.sandbox.yml if this files exists. (#59523) Thanks @chanjarster.
 
 ## 2026.5.3-1
 

--- a/scripts/clawdock/clawdock-helpers.sh
+++ b/scripts/clawdock/clawdock-helpers.sh
@@ -154,6 +154,9 @@ _clawdock_compose() {
   if [[ -f "${CLAWDOCK_DIR}/docker-compose.extra.yml" ]]; then
     compose_args+=(-f "${CLAWDOCK_DIR}/docker-compose.extra.yml")
   fi
+  if [[ -f "${CLAWDOCK_DIR}/docker-compose.sandbox.yml" ]]; then
+    compose_args+=(-f "${CLAWDOCK_DIR}/docker-compose.sandbox.yml")
+  fi
   command docker compose "${compose_args[@]}" "$@"
 }
 


### PR DESCRIPTION
bug fix: clawdock ignores docker-compose.sandbox.yml

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: clawdock ignores docker-compose.sandbox.yml

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
