### PR TITLE
fix(mattermost): use formatErrorMessage instead of String(err)

### DIFF
--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -1,5 +1,6 @@
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { z } from "openclaw/plugin-sdk/zod";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type MattermostFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
@@ -311,7 +312,7 @@ export async function createMattermostDirectChannelWithRetry(
         clearTimeout(timeoutId);
       }
     } catch (err) {
-      lastError = err instanceof Error ? err : new Error(String(err));
+      lastError = err instanceof Error ? err : new Error(formatErrorMessage(err));
 
       // Don't retry on the last attempt
       if (attempt >= maxRetries) {

--- a/extensions/mattermost/src/mattermost/interactions.ts
+++ b/extensions/mattermost/src/mattermost/interactions.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { getMattermostRuntime } from "../runtime.js";
 import { updateMattermostPost, type MattermostClient, type MattermostPost } from "./client.js";
 import { isTrustedProxyAddress, resolveClientIp, type OpenClawConfig } from "./runtime-api.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const INTERACTION_MAX_BODY_BYTES = 64 * 1024;
 const INTERACTION_BODY_TIMEOUT_MS = 10_000;
@@ -454,7 +455,7 @@ export function createMattermostInteractionHandler(params: {
       const raw = await readInteractionBody(req);
       payload = JSON.parse(raw) as MattermostInteractionPayload;
     } catch (err) {
-      log?.(`mattermost interaction: failed to parse body: ${String(err)}`);
+      log?.(`mattermost interaction: failed to parse body: ${formatErrorMessage(err)}`);
       res.statusCode = 400;
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ error: "Invalid request body" }));
@@ -550,7 +551,7 @@ export function createMattermostInteractionHandler(params: {
         return;
       }
     } catch (err) {
-      log?.(`mattermost interaction: failed to validate post ${payload.post_id}: ${String(err)}`);
+      log?.(`mattermost interaction: failed to validate post ${payload.post_id}: ${formatErrorMessage(err)}`);
       res.statusCode = 500;
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ error: "Failed to validate interaction" }));
@@ -589,7 +590,7 @@ export function createMattermostInteractionHandler(params: {
           return;
         }
       } catch (err) {
-        log?.(`mattermost interaction: authorization failed: ${String(err)}`);
+        log?.(`mattermost interaction: authorization failed: ${formatErrorMessage(err)}`);
         res.statusCode = 500;
         res.setHeader("Content-Type", "application/json");
         res.end(JSON.stringify({ error: "Interaction authorization failed" }));
@@ -615,7 +616,7 @@ export function createMattermostInteractionHandler(params: {
           return;
         }
       } catch (err) {
-        log?.(`mattermost interaction: custom handler failed: ${String(err)}`);
+        log?.(`mattermost interaction: custom handler failed: ${formatErrorMessage(err)}`);
         res.statusCode = 500;
         res.setHeader("Content-Type", "application/json");
         res.end(JSON.stringify({ error: "Interaction handler failed" }));
@@ -645,7 +646,7 @@ export function createMattermostInteractionHandler(params: {
         contextKey: `mattermost:interaction:${payload.post_id}:${actionId}`,
       });
     } catch (err) {
-      log?.(`mattermost interaction: system event dispatch failed: ${String(err)}`);
+      log?.(`mattermost interaction: system event dispatch failed: ${formatErrorMessage(err)}`);
     }
 
     // Update the post via API to replace buttons with a completion indicator.
@@ -661,7 +662,7 @@ export function createMattermostInteractionHandler(params: {
         },
       });
     } catch (err) {
-      log?.(`mattermost interaction: failed to update post ${payload.post_id}: ${String(err)}`);
+      log?.(`mattermost interaction: failed to update post ${payload.post_id}: ${formatErrorMessage(err)}`);
     }
 
     // Respond with empty JSON — the post update is handled above
@@ -682,7 +683,7 @@ export function createMattermostInteractionHandler(params: {
           post: originalPost,
         });
       } catch (err) {
-        log?.(`mattermost interaction: dispatchButtonClick failed: ${String(err)}`);
+        log?.(`mattermost interaction: dispatchButtonClick failed: ${formatErrorMessage(err)}`);
       }
     }
   };

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -8,6 +8,7 @@ import {
   type MattermostUser,
 } from "./client.js";
 import { buildButtonProps, type MattermostInteractionResponse } from "./interactions.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type MattermostMediaKind = "image" | "audio" | "video" | "document" | "unknown";
 
@@ -92,7 +93,7 @@ export function createMattermostMonitorResources(params: {
           kind: mediaKindFromMime(contentType) ?? "unknown",
         });
       } catch (err) {
-        logger.debug?.(`mattermost: failed to download file ${fileId}: ${String(err)}`);
+        logger.debug?.(`mattermost: failed to download file ${fileId}: ${formatErrorMessage(err)}`);
       }
     }
     return out;
@@ -115,7 +116,7 @@ export function createMattermostMonitorResources(params: {
       });
       return info;
     } catch (err) {
-      logger.debug?.(`mattermost: channel lookup failed: ${String(err)}`);
+      logger.debug?.(`mattermost: channel lookup failed: ${formatErrorMessage(err)}`);
       channelCache.set(channelId, {
         value: null,
         expiresAt: Date.now() + CHANNEL_CACHE_TTL_MS,
@@ -137,7 +138,7 @@ export function createMattermostMonitorResources(params: {
       });
       return info;
     } catch (err) {
-      logger.debug?.(`mattermost: user lookup failed: ${String(err)}`);
+      logger.debug?.(`mattermost: user lookup failed: ${formatErrorMessage(err)}`);
       userCache.set(userId, {
         value: null,
         expiresAt: Date.now() + USER_CACHE_TTL_MS,

--- a/extensions/mattermost/src/mattermost/monitor-slash.ts
+++ b/extensions/mattermost/src/mattermost/monitor-slash.ts
@@ -21,6 +21,7 @@ import {
   type MattermostSlashCommandConfig,
 } from "./slash-commands.js";
 import { activateSlashCommands } from "./slash-state.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 function isLoopbackHost(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
@@ -50,7 +51,7 @@ function buildSlashCommands(params: {
       });
     }
   } catch (err) {
-    params.runtime.error?.(`mattermost: failed to list skill commands: ${String(err)}`);
+    params.runtime.error?.(`mattermost: failed to list skill commands: ${formatErrorMessage(err)}`);
   }
   return commandsToRegister;
 }
@@ -124,7 +125,7 @@ async function registerSlashCommandsAcrossTeams(params: {
     } catch (err) {
       teamRegistrationFailures += 1;
       params.runtime.error?.(
-        `mattermost: failed to register slash commands for team ${team.id}: ${String(err)}`,
+        `mattermost: failed to register slash commands for team ${team.id}: ${formatErrorMessage(err)}`,
       );
     }
   }
@@ -206,6 +207,6 @@ export async function registerMattermostMonitorSlashCommands(params: {
       `mattermost: slash commands registered (${registered.length} commands across ${teams.length} teams, callback=${slashCallbackUrl})`,
     );
   } catch (err) {
-    params.runtime.error?.(`mattermost: failed to register slash commands: ${String(err)}`);
+    params.runtime.error?.(`mattermost: failed to register slash commands: ${formatErrorMessage(err)}`);
   }
 }

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -4,6 +4,7 @@ import WebSocket from "ws";
 import { MattermostPostSchema, type MattermostPost } from "./client.js";
 import { rawDataToString } from "./monitor-helpers.js";
 import type { ChannelAccountSnapshot, RuntimeEnv } from "./runtime-api.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type MattermostEventPayload = {
   event?: string;
@@ -202,7 +203,7 @@ export function createMattermostConnectOnce(
               initialUpdateAt === undefined
                 ? "mattermost: failed to get initial update_at"
                 : "mattermost: health check error";
-            opts.runtime.error?.(`${label}: ${String(err)}`);
+            opts.runtime.error?.(`${label}: ${formatErrorMessage(err)}`);
           } finally {
             healthCheckInFlight = false;
             scheduleHealthCheck();
@@ -265,7 +266,7 @@ export function createMattermostConnectOnce(
             try {
               await opts.onReaction(payload);
             } catch (err) {
-              opts.runtime.error?.(`mattermost reaction handler failed: ${String(err)}`);
+              opts.runtime.error?.(`mattermost reaction handler failed: ${formatErrorMessage(err)}`);
             }
             return;
           }
@@ -280,7 +281,7 @@ export function createMattermostConnectOnce(
           try {
             await opts.onPosted(parsed.post, parsed.payload);
           } catch (err) {
-            opts.runtime.error?.(`mattermost handler failed: ${String(err)}`);
+            opts.runtime.error?.(`mattermost handler failed: ${formatErrorMessage(err)}`);
           }
         });
 
@@ -303,9 +304,9 @@ export function createMattermostConnectOnce(
         });
 
         ws.on("error", (err) => {
-          opts.runtime.error?.(`mattermost websocket error: ${String(err)}`);
+          opts.runtime.error?.(`mattermost websocket error: ${formatErrorMessage(err)}`);
           opts.statusSink?.({
-            lastError: String(err),
+            lastError: formatErrorMessage(err),
           });
           try {
             ws.close();

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -85,6 +85,7 @@ import {
 import { sendMessageMattermost } from "./send.js";
 import { cleanupSlashCommands } from "./slash-commands.js";
 import { deactivateSlashCommands, getSlashCommandState } from "./slash-state.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export {
   evaluateMattermostMentionGate,
@@ -291,8 +292,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       jitterRatio: 0.2,
       shouldReconnect: ({ outcome }) => outcome === "rejected",
       onError: (err) => {
-        runtime.error?.(`mattermost: API auth failed: ${String(err)}`);
-        opts.statusSink?.({ lastError: String(err), connected: false });
+        runtime.error?.(`mattermost: API auth failed: ${formatErrorMessage(err)}`);
+        opts.statusSink?.({ lastError: formatErrorMessage(err), connected: false });
       },
       onReconnect: (delayMs) => {
         runtime.log?.(`mattermost: API not accessible, retrying in ${Math.round(delayMs / 1000)}s`);
@@ -538,7 +539,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               runtime.log?.(`delivered button-click reply to ${to}`);
             },
             onError: (err, info) => {
-              runtime.error?.(`mattermost button-click ${info.kind} reply failed: ${String(err)}`);
+              runtime.error?.(`mattermost button-click ${info.kind} reply failed: ${formatErrorMessage(err)}`);
             },
             onReplyStart: typingCallbacks?.onReplyStart,
           });
@@ -745,7 +746,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           });
         },
         onError: (err, info) => {
-          runtime.error?.(`mattermost model picker ${info.kind} reply failed: ${String(err)}`);
+          runtime.error?.(`mattermost model picker ${info.kind} reply failed: ${formatErrorMessage(err)}`);
         },
         onReplyStart: typingCallbacks?.onReplyStart,
       });
@@ -981,7 +982,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           buttons: view.buttons,
         });
       } catch (err) {
-        runtime.error?.(`mattermost model picker select failed: ${String(err)}`);
+        runtime.error?.(`mattermost model picker select failed: ${formatErrorMessage(err)}`);
       }
     })();
 
@@ -1127,7 +1128,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               );
               opts.statusSink?.({ lastOutboundAt: Date.now() });
             } catch (err) {
-              logVerboseMessage(`mattermost: pairing reply failed for ${senderId}: ${String(err)}`);
+              logVerboseMessage(`mattermost: pairing reply failed for ${senderId}: ${formatErrorMessage(err)}`);
             }
           }
           return;
@@ -1456,7 +1457,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           runtime.log?.(`delivered reply to ${to}`);
         },
         onError: (err, info) => {
-          runtime.error?.(`mattermost ${info.kind} reply failed: ${String(err)}`);
+          runtime.error?.(`mattermost ${info.kind} reply failed: ${formatErrorMessage(err)}`);
         },
       });
 
@@ -1657,7 +1658,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       await handlePost(mergedPost, last.payload, ids.length > 0 ? ids : undefined);
     },
     onError: (err) => {
-      runtime.error?.(`mattermost debounce flush failed: ${String(err)}`);
+      runtime.error?.(`mattermost debounce flush failed: ${formatErrorMessage(err)}`);
     },
   });
 
@@ -1703,7 +1704,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         commands,
         log: (msg) => runtime.log?.(msg),
       }).catch((err) => {
-        runtime.error?.(`mattermost: slash cleanup failed: ${String(err)}`);
+        runtime.error?.(`mattermost: slash cleanup failed: ${formatErrorMessage(err)}`);
       });
     };
 
@@ -1719,8 +1720,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       abortSignal: opts.abortSignal,
       jitterRatio: 0.2,
       onError: (err) => {
-        runtime.error?.(`mattermost connection failed: ${String(err)}`);
-        opts.statusSink?.({ lastError: String(err), connected: false });
+        runtime.error?.(`mattermost connection failed: ${formatErrorMessage(err)}`);
+        opts.statusSink?.({ lastError: formatErrorMessage(err), connected: false });
       },
       onReconnect: (delayMs) => {
         runtime.log?.(`mattermost reconnecting in ${Math.round(delayMs / 1000)}s`);

--- a/extensions/mattermost/src/mattermost/probe.ts
+++ b/extensions/mattermost/src/mattermost/probe.ts
@@ -1,5 +1,6 @@
 import { normalizeMattermostBaseUrl, readMattermostError, type MattermostUser } from "./client.js";
 import type { BaseProbeResult } from "./runtime-api.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type MattermostProbe = BaseProbeResult & {
   status?: number | null;
@@ -46,7 +47,7 @@ export async function probeMattermost(
       bot,
     };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = err instanceof Error ? err.message : formatErrorMessage(err);
     return {
       ok: false,
       status: null,

--- a/extensions/mattermost/src/mattermost/reactions.ts
+++ b/extensions/mattermost/src/mattermost/reactions.ts
@@ -6,6 +6,7 @@ import {
   type MattermostFetch,
 } from "./client.js";
 import type { OpenClawConfig } from "./runtime-api.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 type Result = { ok: true } | { ok: false; error: string };
 type ReactionParams = {
@@ -102,7 +103,7 @@ async function runMattermostReaction(
       emojiName: params.emojiName,
     });
   } catch (err) {
-    return { ok: false, error: `Mattermost ${options.action} reaction failed: ${String(err)}` };
+    return { ok: false, error: `Mattermost ${options.action} reaction failed: ${formatErrorMessage(err)}` };
   }
 
   return { ok: true };

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -23,6 +23,7 @@ import {
 } from "./interactions.js";
 import { loadOutboundMediaFromUrl, type OpenClawConfig } from "./runtime-api.js";
 import { isMattermostId, resolveMattermostOpaqueTarget } from "./target-resolution.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type MattermostSendOpts = {
   cfg?: OpenClawConfig;
@@ -428,10 +429,10 @@ export async function sendMessageMattermost(
       });
       fileIds = [fileInfo.id];
     } catch (err) {
-      uploadError = err instanceof Error ? err : new Error(String(err));
+      uploadError = err instanceof Error ? err : new Error(formatErrorMessage(err));
       if (core.logging.shouldLogVerbose()) {
         logger.debug?.(
-          `mattermost send: media upload failed, falling back to URL text: ${String(err)}`,
+          `mattermost send: media upload failed, falling back to URL text: ${formatErrorMessage(err)}`,
         );
       }
       message = normalizeMessage(message, isHttpUrl(mediaUrl) ? mediaUrl : "");

--- a/extensions/mattermost/src/mattermost/slash-commands.ts
+++ b/extensions/mattermost/src/mattermost/slash-commands.ts
@@ -13,6 +13,7 @@
  */
 
 import type { MattermostClient } from "./client.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -262,7 +263,7 @@ export async function registerSlashCommands(params: {
   try {
     existing = await listMattermostCommands(client, teamId);
   } catch (err) {
-    log?.(`mattermost: failed to list existing commands: ${String(err)}`);
+    log?.(`mattermost: failed to list existing commands: ${formatErrorMessage(err)}`);
     // Fail closed: if we can't list existing commands, we should not attempt to
     // create/update anything because we may create duplicates and end up with an
     // empty/partial token set (causing callbacks to be rejected until restart).
@@ -343,7 +344,7 @@ export async function registerSlashCommands(params: {
         continue;
       } catch (err) {
         log?.(
-          `mattermost: failed to update command /${spec.trigger} (id=${existingCmd.id}): ${String(err)}`,
+          `mattermost: failed to update command /${spec.trigger} (id=${existingCmd.id}): ${formatErrorMessage(err)}`,
         );
         // Fallback: try delete+recreate for commands owned by this bot user.
         try {
@@ -380,7 +381,7 @@ export async function registerSlashCommands(params: {
         managed: true,
       });
     } catch (err) {
-      log?.(`mattermost: failed to register command /${spec.trigger}: ${String(err)}`);
+      log?.(`mattermost: failed to register command /${spec.trigger}: ${formatErrorMessage(err)}`);
     }
   }
 
@@ -404,7 +405,7 @@ export async function cleanupSlashCommands(params: {
       await deleteMattermostCommand(client, cmd.id);
       log?.(`mattermost: deleted command /${cmd.trigger} (id=${cmd.id})`);
     } catch (err) {
-      log?.(`mattermost: failed to delete command /${cmd.trigger}: ${String(err)}`);
+      log?.(`mattermost: failed to delete command /${cmd.trigger}: ${formatErrorMessage(err)}`);
     }
   }
 }

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -43,6 +43,7 @@ import {
   resolveCommandText,
   type MattermostSlashCommandResponse,
 } from "./slash-commands.js";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 type SlashHttpHandlerParams = {
   account: ResolvedMattermostAccount;
@@ -108,7 +109,7 @@ async function authorizeSlashInvocation(params: {
   try {
     channelInfo = await fetchMattermostChannel(client, channelId);
   } catch (err) {
-    log?.(`mattermost: slash channel lookup failed for ${channelId}: ${String(err)}`);
+    log?.(`mattermost: slash channel lookup failed for ${channelId}: ${formatErrorMessage(err)}`);
   }
 
   if (!channelInfo) {
@@ -313,7 +314,7 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
         log,
       });
     } catch (err) {
-      log?.(`mattermost: slash command handler error: ${String(err)}`);
+      log?.(`mattermost: slash command handler error: ${formatErrorMessage(err)}`);
       try {
         const to = `channel:${channelId}`;
         await sendMessageMattermost(to, "Sorry, something went wrong processing that command.", {
@@ -507,7 +508,7 @@ async function handleSlashCommandAsync(params: {
         runtime.log?.(`delivered slash reply to ${to}`);
       },
       onError: (err, info) => {
-        runtime.error?.(`mattermost slash ${info.kind} reply failed: ${String(err)}`);
+        runtime.error?.(`mattermost slash ${info.kind} reply failed: ${formatErrorMessage(err)}`);
       },
       onReplyStart: typingCallbacks?.onReplyStart,
     });


### PR DESCRIPTION
## Summary
Replace `String(err)` with `formatErrorMessage()` from `openclaw/plugin-sdk/error-runtime` across 11 files in the mattermost extension.

`String(err)` produces `[object Object]` when the caught value is a non-Error object, hiding actual error details. `formatErrorMessage()` properly handles Error instances (with `.cause` chain traversal), strings, and arbitrary objects.

> Previous PR #59505 was auto-closed by Barnacle (>10 PR limit). Greptile scored 5/5, Safe to merge.

🤖 AI-assisted (Claude Code). Mechanical replacement, no logic changes. I understand what the code does.

## Test plan
- [ ] `pnpm check` passes
- [ ] Error logs show readable messages instead of `[object Object]`