### PR TITLE
fix(providers): centralize stream request headers

### DIFF
--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -15,7 +15,7 @@
 
 import { EventEmitter } from "node:events";
 import WebSocket, { type ClientOptions } from "ws";
-import { resolveProviderRequestAttributionHeaders } from "./provider-attribution.js";
+import { resolveProviderRequestHeaders } from "./provider-request-config.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // WebSocket Event Types (Server → Client)
@@ -403,17 +403,18 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
       }
 
       const socket = this.socketFactory(this.wsUrl, {
-        headers: {
-          Authorization: `Bearer ${this.apiKey}`,
-          "OpenAI-Beta": "responses-websocket=v1",
-          ...resolveProviderRequestAttributionHeaders({
-            provider: "openai",
-            api: "openai-responses",
-            baseUrl: this.wsUrl,
-            capability: "llm",
-            transport: "websocket",
-          }),
-        },
+        headers: resolveProviderRequestHeaders({
+          provider: "openai",
+          api: "openai-responses",
+          baseUrl: this.wsUrl,
+          capability: "llm",
+          transport: "websocket",
+          defaultHeaders: {
+            Authorization: `Bearer ${this.apiKey}`,
+            "OpenAI-Beta": "responses-websocket=v1",
+          },
+          precedence: "defaults-win",
+        }),
       });
 
       this.ws = socket;

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -6,10 +6,8 @@ import {
   patchCodexNativeWebSearchPayload,
   resolveCodexNativeSearchActivation,
 } from "../codex-native-web-search.js";
-import {
-  resolveProviderRequestAttributionHeaders,
-  resolveProviderRequestPolicy,
-} from "../provider-attribution.js";
+import { resolveProviderRequestPolicy } from "../provider-attribution.js";
+import { resolveProviderRequestHeaders } from "../provider-request-config.js";
 import { log } from "./logger.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 
@@ -540,16 +538,15 @@ export function createOpenAIAttributionHeadersWrapper(
     }
     return underlying(model, context, {
       ...options,
-      headers: {
-        ...options?.headers,
-        ...resolveProviderRequestAttributionHeaders({
-          provider: attributionProvider,
-          api: typeof model.api === "string" ? model.api : undefined,
-          baseUrl: typeof model.baseUrl === "string" ? model.baseUrl : undefined,
-          capability: "llm",
-          transport: "stream",
-        }),
-      },
+      headers: resolveProviderRequestHeaders({
+        provider: attributionProvider,
+        api: typeof model.api === "string" ? model.api : undefined,
+        baseUrl: typeof model.baseUrl === "string" ? model.baseUrl : undefined,
+        capability: "llm",
+        transport: "stream",
+        callerHeaders: options?.headers,
+        precedence: "defaults-win",
+      }),
     });
   };
 }

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -1,7 +1,7 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
-import { resolveProviderRequestAttributionHeaders } from "../provider-attribution.js";
+import { resolveProviderRequestHeaders } from "../provider-request-config.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 const KILOCODE_FEATURE_HEADER = "X-KILOCODE-FEATURE";
 const KILOCODE_FEATURE_DEFAULT = "openclaw";
@@ -111,12 +111,14 @@ export function createOpenRouterWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
-    const attributionHeaders = resolveProviderRequestAttributionHeaders({
+    const headers = resolveProviderRequestHeaders({
       provider: typeof model.provider === "string" ? model.provider : "openrouter",
       api: typeof model.api === "string" ? model.api : undefined,
       baseUrl: typeof model.baseUrl === "string" ? model.baseUrl : undefined,
       capability: "llm",
       transport: "stream",
+      callerHeaders: options?.headers,
+      precedence: "caller-wins",
     });
     return streamWithPayloadPatch(
       underlying,
@@ -124,10 +126,7 @@ export function createOpenRouterWrapper(
       context,
       {
         ...options,
-        headers: {
-          ...attributionHeaders,
-          ...options?.headers,
-        },
+        headers,
       },
       (payload) => {
         normalizeProxyReasoningPayload(payload, thinkingLevel);
@@ -146,16 +145,23 @@ export function createKilocodeWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
+    const headers = resolveProviderRequestHeaders({
+      provider: typeof model.provider === "string" ? model.provider : "kilocode",
+      api: typeof model.api === "string" ? model.api : undefined,
+      baseUrl: typeof model.baseUrl === "string" ? model.baseUrl : undefined,
+      capability: "llm",
+      transport: "stream",
+      callerHeaders: options?.headers,
+      defaultHeaders: resolveKilocodeAppHeaders(),
+      precedence: "defaults-win",
+    });
     return streamWithPayloadPatch(
       underlying,
       model,
       context,
       {
         ...options,
-        headers: {
-          ...options?.headers,
-          ...resolveKilocodeAppHeaders(),
-        },
+        headers,
       },
       (payload) => {
         normalizeProxyReasoningPayload(payload, thinkingLevel);

--- a/src/agents/provider-request-config.test.ts
+++ b/src/agents/provider-request-config.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveProviderRequestConfig } from "./provider-request-config.js";
+import {
+  resolveProviderRequestConfig,
+  resolveProviderRequestHeaders,
+} from "./provider-request-config.js";
 
 describe("provider request config", () => {
   it("merges discovered, provider, and model headers in precedence order", () => {
@@ -61,5 +64,49 @@ describe("provider request config", () => {
     expect(resolved.tls).toEqual({ configured: false });
     expect(resolved.policy.endpointClass).toBe("openrouter");
     expect(resolved.policy.attributionProvider).toBe("openrouter");
+  });
+
+  it("lets defaults override caller headers when requested", () => {
+    const resolved = resolveProviderRequestHeaders({
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      capability: "llm",
+      transport: "stream",
+      callerHeaders: {
+        originator: "spoofed",
+        "User-Agent": "spoofed/0.0.0",
+        "X-Custom": "1",
+      },
+      precedence: "defaults-win",
+    });
+
+    expect(resolved).toMatchObject({
+      originator: "openclaw",
+      version: expect.any(String),
+      "User-Agent": expect.stringMatching(/^openclaw\//),
+      "X-Custom": "1",
+    });
+  });
+
+  it("lets caller headers override defaults when requested", () => {
+    const resolved = resolveProviderRequestHeaders({
+      provider: "openrouter",
+      api: "openai-completions",
+      capability: "llm",
+      transport: "stream",
+      callerHeaders: {
+        "HTTP-Referer": "https://example.com",
+        "X-Custom": "1",
+      },
+      precedence: "caller-wins",
+    });
+
+    expect(resolved).toEqual({
+      "HTTP-Referer": "https://example.com",
+      "X-OpenRouter-Title": "OpenClaw",
+      "X-OpenRouter-Categories": "cli-agent",
+      "X-Custom": "1",
+    });
   });
 });

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -111,6 +111,8 @@ export function resolveProviderRequestHeaders(params: {
     requestConfig.headers,
     requestConfig.policy.attributionHeaders,
   );
+  // When precedence is omitted, defaults-win is the conservative choice:
+  // attribution/default headers cannot be silently overridden by callers.
   return params.precedence === "caller-wins"
     ? mergeProviderRequestHeaders(mergedDefaults, params.callerHeaders)
     : mergeProviderRequestHeaders(params.callerHeaders, mergedDefaults);

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -32,6 +32,8 @@ export type ResolvedProviderRequestConfig = {
   policy: ProviderRequestPolicyResolution;
 };
 
+export type ProviderRequestHeaderPrecedence = "caller-wins" | "defaults-win";
+
 export function mergeProviderRequestHeaders(
   ...headerSets: Array<Record<string, string> | undefined>
 ): Record<string, string> | undefined {
@@ -85,4 +87,31 @@ export function resolveProviderRequestConfig(params: {
     tls: { configured: false },
     policy,
   };
+}
+
+export function resolveProviderRequestHeaders(params: {
+  provider: string;
+  api?: RequestApi;
+  baseUrl?: string;
+  capability?: ProviderRequestCapability;
+  transport?: ProviderRequestTransport;
+  callerHeaders?: Record<string, string>;
+  defaultHeaders?: Record<string, string>;
+  precedence?: ProviderRequestHeaderPrecedence;
+}): Record<string, string> | undefined {
+  const requestConfig = resolveProviderRequestConfig({
+    provider: params.provider,
+    api: params.api,
+    baseUrl: params.baseUrl,
+    capability: params.capability,
+    transport: params.transport,
+    providerHeaders: params.defaultHeaders,
+  });
+  const mergedDefaults = mergeProviderRequestHeaders(
+    requestConfig.headers,
+    requestConfig.policy.attributionHeaders,
+  );
+  return params.precedence === "caller-wins"
+    ? mergeProviderRequestHeaders(mergedDefaults, params.callerHeaders)
+    : mergeProviderRequestHeaders(params.callerHeaders, mergedDefaults);
 }


### PR DESCRIPTION
## Summary

- Problem: stream and websocket request-header mutation still lived in three separate paths with different merge rules for attribution/default headers versus caller headers.
- Why it matters: phase 1 centralized request policy, phase 2 centralized model and provider HTTP request shaping, but stream/websocket paths were still a duplication hotspot that could silently drift.
- What changed: added `resolveProviderRequestHeaders` in `src/agents/provider-request-config.ts` and migrated OpenAI stream attribution, OpenRouter stream attribution, Kilocode stream defaults, and OpenAI websocket headers onto that shared seam.
- What did NOT change (scope boundary): payload mutation logic, provider routing policy, and provider HTTP request shaping were left unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #59454
- Related #59469
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: stream and websocket paths accumulated separate header merge implementations after request policy and HTTP request shaping were centralized, so precedence behavior was encoded ad hoc per call site.
- Missing detection / guardrail: there was no shared seam test for caller-wins versus defaults-win header precedence across non-HTTP request paths.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this continues the provider request-policy/request-config work from #59454 and the shared HTTP seam from #59469.
- Why this regressed now: older duplication became the main remaining drift point after HTTP paths moved onto the shared helper.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/provider-request-config.test.ts`, `src/agents/openai-ws-connection.test.ts`, `src/agents/pi-embedded-runner/extra-params.openai.test.ts`, `src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts`, `src/agents/pi-embedded-runner/extra-params.kilocode.test.ts`
- Scenario the test should lock in: OpenAI defaults can override spoofed caller attribution, OpenRouter caller headers still win over documented attribution defaults, Kilocode runtime headers remain non-overridable, and websocket headers use the same centralized merge path.
- Why this is the smallest reliable guardrail: the new helper is now the merge point, and the existing transport tests prove the migrated call sites preserve their prior behavior.
- Existing test that already covers this (if any): the transport tests already covered each behavior separately but not through one shared seam.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- None intended. This PR centralizes stream/websocket request-header shaping while preserving current OpenAI, OpenRouter, Kilocode, and OpenAI websocket behavior.

## Diagram (if applicable)

```text
Before:
[OpenAI stream] -> [manual merge A]
[OpenRouter stream] -> [manual merge B]
[OpenAI websocket] -> [manual merge C]

After:
[stream/websocket path] -> [resolveProviderRequestHeaders] -> [transport call]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: OpenAI, OpenAI Codex, OpenRouter, Kilocode
- Integration/channel (if any): N/A
- Relevant config (redacted): default provider config plus transport test fixtures

### Steps

1. Run the stream/websocket wrapper tests that exercise OpenAI, OpenRouter, Kilocode, and websocket header injection.
2. Verify caller header precedence stays provider-specific where intended.
3. Verify the shared helper tests cover both precedence modes directly.

### Expected

- Stream/websocket paths share one request-header seam while preserving existing transport behavior.

### Actual

- The migrated paths use `resolveProviderRequestHeaders(...)`, and targeted tests/build/check all pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: OpenAI stream attribution override behavior, OpenRouter caller-header precedence, Kilocode non-overridable runtime header behavior, OpenAI websocket default header injection, and shared precedence tests.
- Edge cases checked: native OpenAI attribution on verified endpoints, custom websocket endpoints without hidden attribution, explicit caller spoofing versus OpenAI defaults, caller override versus OpenRouter defaults.
- What you did **not** verify: full `pnpm test` and live provider traffic.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a future caller could assume one universal precedence rule across all providers and transports.
  - Mitigation: the helper makes precedence explicit, and tests lock both `defaults-win` and `caller-wins` behavior.
- Risk: more provider families may eventually need different request-header semantics.
  - Mitigation: this PR centralizes only the merge mechanism; provider policy and payload behavior remain separate.
