### PR TITLE
fix(agents): pin subagent gateway calls to admin scope to prevent scope-upgrade pairing failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 - ACP/gateway reconnects: keep ACP prompts alive across transient websocket drops while still failing boundedly when reconnect recovery does not complete. (#59473) Thanks @obviyus.
 - ACP/gateway reconnects: reject stale pre-ack ACP prompts after reconnect grace expiry so callers fail cleanly instead of hanging indefinitely when the gateway never confirms the run.
 - Exec approvals/doctor: report host policy sources from the real approvals file path and ignore malformed host override values when attributing effective policy conflicts. (#59367) Thanks @gumadeiras.
+- Agents/subagents: pin admin-only subagent gateway calls to `operator.admin` while keeping `agent` at least privilege, so `sessions_spawn` no longer dies on loopback scope-upgrade pairing with `close(1008) "pairing required"`. (#59555) Thanks @openperf.
 - Exec approvals/config: strip invalid `security`, `ask`, and `askFallback` values from `~/.openclaw/exec-approvals.json` during normalization so malformed policy enums fall back cleanly to the documented defaults instead of corrupting runtime policy resolution. (#59112) Thanks @openperf.
 - Gateway/session kill: enforce HTTP operator scopes on session kill requests and gate authorization before session lookup so unauthenticated callers cannot probe session existence. (#59128) Thanks @jacobtomlinson.
 - MS Teams/logging: format non-`Error` failures with the shared unknown-error helper so logs stop collapsing caught SDK or Axios objects into `[object Object]`. (#59321) Thanks @bradgroux.

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -157,4 +157,50 @@ describe("spawnSubagentDirect seam flow", () => {
     );
     expect(operations.indexOf("gateway:agent")).toBeGreaterThan(operations.indexOf("store:update"));
   });
+
+  it("pins admin-only methods to operator.admin and preserves least-privilege for others (#59428)", async () => {
+    const capturedCalls: Array<{ method?: string; scopes?: string[] }> = [];
+
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: { method?: string; scopes?: string[] }) => {
+        capturedCalls.push({ method: request.method, scopes: request.scopes });
+        if (request.method === "agent") {
+          return { runId: "run-1" };
+        }
+        if (request.method?.startsWith("sessions.")) {
+          return { ok: true };
+        }
+        return {};
+      },
+    );
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock);
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "verify per-method scope routing",
+        model: "openai-codex/gpt-5.4",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "acct-1",
+        agentTo: "user-1",
+        workspaceDir: "/tmp/requester-workspace",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(capturedCalls.length).toBeGreaterThan(0);
+
+    for (const call of capturedCalls) {
+      if (call.method === "sessions.patch" || call.method === "sessions.delete") {
+        // Admin-only methods must be pinned to operator.admin.
+        expect(call.scopes).toEqual(["operator.admin"]);
+      } else {
+        // Non-admin methods (e.g. "agent") must NOT be forced to admin scope
+        // so the gateway preserves least-privilege and senderIsOwner stays false.
+        expect(call.scopes).toBeUndefined();
+      }
+    }
+  });
 });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -5,6 +5,7 @@ import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
 import { mergeSessionEntry, updateSessionStore } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
+import { ADMIN_SCOPE, isAdminOnlyMethod } from "../gateway/method-scopes.js";
 import {
   pruneLegacyStoreKeys,
   resolveGatewaySessionStoreTarget,
@@ -148,7 +149,21 @@ async function updateSubagentSessionStore(
 async function callSubagentGateway(
   params: Parameters<typeof callGateway>[0],
 ): Promise<Awaited<ReturnType<typeof callGateway>>> {
-  return await subagentSpawnDeps.callGateway(params);
+  // Subagent lifecycle requires methods spanning multiple scope tiers
+  // (sessions.patch / sessions.delete → admin, agent → write).  When each call
+  // independently negotiates least-privilege scopes the first connection pairs
+  // at a lower tier and every subsequent higher-tier call triggers a
+  // scope-upgrade handshake that headless gateway-client connections cannot
+  // complete interactively, causing close(1008) "pairing required" (#59428).
+  //
+  // Only admin-only methods are pinned to ADMIN_SCOPE; other methods (e.g.
+  // "agent" → write) keep their least-privilege scope so that the gateway does
+  // not treat the caller as owner (senderIsOwner) and expose owner-only tools.
+  const scopes = params.scopes ?? (isAdminOnlyMethod(params.method) ? [ADMIN_SCOPE] : undefined);
+  return await subagentSpawnDeps.callGateway({
+    ...params,
+    ...(scopes != null ? { scopes } : {}),
+  });
 }
 
 function readGatewayRunId(response: Awaited<ReturnType<typeof callGateway>>): string | undefined {


### PR DESCRIPTION
### Summary

- **Problem**: `sessions_spawn` sub-agent calls fail with close(1008) "pairing required" on v2026.4.1. Every `callSubagentGateway` invocation in `src/agents/subagent-spawn.ts` delegates to `callGateway` without explicit `scopes`, causing `callGatewayLeastPrivilege` to negotiate the minimum scope per method independently. The first connection (e.g. `agent` → `operator.write`) silently pairs the device at a lower tier. Subsequent calls requiring a higher tier (e.g. `sessions.patch` → `operator.admin`) trigger a `scope-upgrade` handshake that the headless gateway-client cannot complete interactively.

- **Root Cause**: `callSubagentGateway` (line 148–152 of `subagent-spawn.ts`) forwards params to `callGateway` without `scopes`. `callGateway` falls through to `callGatewayLeastPrivilege`, which resolves the minimum scope for each method via `resolveLeastPrivilegeOperatorScopesForMethod`. Because subagent lifecycle spans multiple scope tiers (`sessions.patch`/`sessions.delete` → `operator.admin`, `agent` → `operator.write`), the device gets paired at a lower tier on the first call, and every subsequent higher-tier call triggers `scope-upgrade`. The gateway's `message-handler.ts:806` intentionally forces `silent: false` for scope-upgrade to prevent silent privilege escalation by external devices — this is correct security behavior, but it blocks the legitimate local gateway-client self-connection.

- **Fix**: Pin `callSubagentGateway` to `scopes: [ADMIN_SCOPE]` so the device is paired at the ceiling scope (`operator.admin`) on the very first (silent, local-loopback) handshake. All subsequent calls match the already-paired scope and never trigger scope-upgrade. This preserves the security-critical `silent: false` enforcement in `message-handler.ts` for external devices.

- **What changed**:
  - `src/agents/subagent-spawn.ts`: `callSubagentGateway` now injects `scopes: params.scopes ?? [ADMIN_SCOPE]` before forwarding to `callGateway`, bypassing per-method least-privilege negotiation and ensuring a consistent admin-tier pairing.
  - `src/agents/subagent-spawn.test.ts`: Added test asserting every gateway call from `spawnSubagentDirect` carries `scopes: ["operator.admin"]`.

- **What did NOT change (scope boundary)**:
  - `message-handler.ts` — the scope-upgrade `silent: false` security guard is untouched.
  - `handshake-auth-helpers.ts` — `shouldAllowSilentLocalPairing` logic is untouched.
  - `server.silent-scope-upgrade-reconnect.poc.test.ts` — all existing security tests pass as-is.
  - `call.ts` and `method-scopes.ts` — the least-privilege resolution logic is untouched.
  - No gateway auth flow, bootstrap token, or device pairing logic is modified.

### Reproduction

1. Install openclaw v2026.4.1 with device pairing enabled
2. Start a conversation and trigger `sessions_spawn` (e.g. ask the agent to run a long research task)
3. Observe gateway-client log: `reason=scope-upgrade scopesFrom=operator.read scopesTo=operator.admin`
4. Connection closes with code 1008 "pairing required"
5. Sub-agent never starts; main agent reports spawn failure

### Risk / Mitigation

- **Risk**: Subagent gateway calls now always request `operator.admin` instead of least-privilege per method. A compromised subagent process could theoretically invoke admin-only methods it previously could not reach in a single connection.
- **Mitigation**: (1) Subagent gateway-client connections are local loopback only — they never traverse the network. (2) The gateway still enforces `authorizeOperatorScopesForMethod` per-request, so method-level authorization is unchanged. (3) The `callSubagentGateway` wrapper respects `params.scopes` if explicitly provided, preserving the ability to narrow scope for future callers. (4) Test added to verify the scope pinning behavior.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents
- [x] Subagent Spawn

### Linked Issue/PR

Fixes #59428