### PR TITLE
fix(providers): centralize Google endpoint classification

### DIFF
--- a/extensions/anthropic-vertex/region.test.ts
+++ b/extensions/anthropic-vertex/region.test.ts
@@ -29,4 +29,10 @@ describe("anthropic vertex region helpers", () => {
       "global",
     );
   });
+
+  it("does not infer a Vertex region from custom proxy hosts", () => {
+    expect(
+      resolveAnthropicVertexRegionFromBaseUrl("https://proxy.example.com/google/aiplatform"),
+    ).toBeUndefined();
+  });
 });

--- a/extensions/anthropic-vertex/region.ts
+++ b/extensions/anthropic-vertex/region.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
+import { resolveProviderEndpoint } from "openclaw/plugin-sdk/provider-http";
 
 const ANTHROPIC_VERTEX_DEFAULT_REGION = "global";
 const ANTHROPIC_VERTEX_REGION_RE = /^[a-z0-9-]+$/;
@@ -47,21 +48,8 @@ export function resolveAnthropicVertexProjectId(
 }
 
 export function resolveAnthropicVertexRegionFromBaseUrl(baseUrl?: string): string | undefined {
-  const trimmed = baseUrl?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-
-  try {
-    const host = new URL(trimmed).hostname.toLowerCase();
-    if (host === "aiplatform.googleapis.com") {
-      return "global";
-    }
-    const match = /^([a-z0-9-]+)-aiplatform\.googleapis\.com$/.exec(host);
-    return match?.[1];
-  } catch {
-    return undefined;
-  }
+  const endpoint = resolveProviderEndpoint(baseUrl);
+  return endpoint.endpointClass === "google-vertex" ? endpoint.googleVertexRegion : undefined;
 }
 
 export function resolveAnthropicVertexClientRegion(params?: {

--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -21,6 +21,9 @@ describe("google generative ai helpers", () => {
     expect(normalizeGoogleGenerativeAiBaseUrl("https://proxy.example.com/google/v1beta")).toBe(
       "https://proxy.example.com/google/v1beta",
     );
+    expect(normalizeGoogleGenerativeAiBaseUrl("https://aiplatform.googleapis.com")).toBe(
+      "https://aiplatform.googleapis.com",
+    );
     expect(normalizeGoogleGenerativeAiBaseUrl()).toBeUndefined();
   });
 

--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -24,6 +24,12 @@ describe("google generative ai helpers", () => {
     expect(normalizeGoogleGenerativeAiBaseUrl("https://aiplatform.googleapis.com")).toBe(
       "https://aiplatform.googleapis.com",
     );
+    expect(normalizeGoogleGenerativeAiBaseUrl("proxy/generativelanguage.googleapis.com")).toBe(
+      "proxy/generativelanguage.googleapis.com",
+    );
+    expect(normalizeGoogleGenerativeAiBaseUrl("https://xgenerativelanguage.googleapis.com")).toBe(
+      "https://xgenerativelanguage.googleapis.com",
+    );
     expect(normalizeGoogleGenerativeAiBaseUrl()).toBeUndefined();
   });
 

--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -27,6 +27,9 @@ describe("google generative ai helpers", () => {
     expect(normalizeGoogleGenerativeAiBaseUrl("proxy/generativelanguage.googleapis.com")).toBe(
       "proxy/generativelanguage.googleapis.com",
     );
+    expect(normalizeGoogleGenerativeAiBaseUrl("generativelanguage.googleapis.com")).toBe(
+      "generativelanguage.googleapis.com",
+    );
     expect(normalizeGoogleGenerativeAiBaseUrl("https://xgenerativelanguage.googleapis.com")).toBe(
       "https://xgenerativelanguage.googleapis.com",
     );

--- a/extensions/google/api.ts
+++ b/extensions/google/api.ts
@@ -21,6 +21,10 @@ function trimTrailingSlashes(value: string): string {
   return value.replace(/\/+$/, "");
 }
 
+function isCanonicalGoogleApiOriginShorthand(value: string): boolean {
+  return /^https:\/\/generativelanguage\.googleapis\.com\/?$/i.test(value);
+}
+
 export function normalizeGoogleApiBaseUrl(baseUrl?: string): string {
   const raw = trimTrailingSlashes(baseUrl?.trim() || DEFAULT_GOOGLE_API_BASE_URL);
   try {
@@ -35,7 +39,7 @@ export function normalizeGoogleApiBaseUrl(baseUrl?: string): string {
     }
     return trimTrailingSlashes(url.toString());
   } catch {
-    if (resolveProviderEndpoint(raw).endpointClass === "google-generative-ai") {
+    if (isCanonicalGoogleApiOriginShorthand(raw)) {
       return DEFAULT_GOOGLE_API_BASE_URL;
     }
     return raw;

--- a/extensions/google/api.ts
+++ b/extensions/google/api.ts
@@ -1,3 +1,4 @@
+import { resolveProviderEndpoint } from "openclaw/plugin-sdk/provider-http";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   applyAgentDefaultModelPrimary,
@@ -14,8 +15,6 @@ type GoogleProviderConfigLike = GoogleApiCarrier & {
   models?: ReadonlyArray<GoogleApiCarrier | null | undefined> | null;
 };
 
-const DEFAULT_GOOGLE_API_HOST = "generativelanguage.googleapis.com";
-
 export const DEFAULT_GOOGLE_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 
 function trimTrailingSlashes(value: string): string {
@@ -29,14 +28,14 @@ export function normalizeGoogleApiBaseUrl(baseUrl?: string): string {
     url.hash = "";
     url.search = "";
     if (
-      url.hostname.toLowerCase() === DEFAULT_GOOGLE_API_HOST &&
+      resolveProviderEndpoint(url.toString()).endpointClass === "google-generative-ai" &&
       trimTrailingSlashes(url.pathname || "") === ""
     ) {
       url.pathname = "/v1beta";
     }
     return trimTrailingSlashes(url.toString());
   } catch {
-    if (/^https:\/\/generativelanguage\.googleapis\.com\/?$/i.test(raw)) {
+    if (resolveProviderEndpoint(raw).endpointClass === "google-generative-ai") {
       return DEFAULT_GOOGLE_API_BASE_URL;
     }
     return raw;

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -305,7 +305,8 @@ describe("provider attribution", () => {
 
   it("does not classify malformed or embedded Google host strings as native endpoints", () => {
     expect(resolveProviderEndpoint("proxy/generativelanguage.googleapis.com")).toMatchObject({
-      endpointClass: "invalid",
+      endpointClass: "custom",
+      hostname: "proxy",
     });
 
     expect(resolveProviderEndpoint("https://xgenerativelanguage.googleapis.com")).toMatchObject({
@@ -314,12 +315,30 @@ describe("provider attribution", () => {
     });
 
     expect(resolveProviderEndpoint("proxy/aiplatform.googleapis.com")).toMatchObject({
-      endpointClass: "invalid",
+      endpointClass: "custom",
+      hostname: "proxy",
     });
 
     expect(resolveProviderEndpoint("https://xaiplatform.googleapis.com")).toMatchObject({
       endpointClass: "custom",
       hostname: "xaiplatform.googleapis.com",
+    });
+  });
+
+  it("does not trust schemeless or embedded trusted-provider substrings", () => {
+    expect(resolveProviderEndpoint("api.openai.com.attacker.example")).toMatchObject({
+      endpointClass: "custom",
+      hostname: "api.openai.com.attacker.example",
+    });
+
+    expect(resolveProviderEndpoint("attacker.example/?target=api.openai.com")).toMatchObject({
+      endpointClass: "custom",
+      hostname: "attacker.example",
+    });
+
+    expect(resolveProviderEndpoint("openrouter.ai.attacker.example")).toMatchObject({
+      endpointClass: "custom",
+      hostname: "openrouter.ai.attacker.example",
     });
   });
 

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -4,6 +4,7 @@ import {
   resolveProviderAttributionHeaders,
   resolveProviderAttributionIdentity,
   resolveProviderAttributionPolicy,
+  resolveProviderEndpoint,
   resolveProviderRequestAttributionHeaders,
   resolveProviderRequestPolicy,
 } from "./provider-attribution.js";
@@ -273,6 +274,32 @@ describe("provider attribution", () => {
       knownProviderFamily: "github-copilot",
       attributionProvider: undefined,
       allowsHiddenAttribution: false,
+    });
+  });
+
+  it("classifies Google Gemini and Vertex endpoints separately from custom hosts", () => {
+    expect(resolveProviderEndpoint("https://generativelanguage.googleapis.com")).toMatchObject({
+      endpointClass: "google-generative-ai",
+      hostname: "generativelanguage.googleapis.com",
+    });
+
+    expect(
+      resolveProviderEndpoint("https://europe-west4-aiplatform.googleapis.com/v1/projects/test"),
+    ).toMatchObject({
+      endpointClass: "google-vertex",
+      hostname: "europe-west4-aiplatform.googleapis.com",
+      googleVertexRegion: "europe-west4",
+    });
+
+    expect(resolveProviderEndpoint("https://aiplatform.googleapis.com")).toMatchObject({
+      endpointClass: "google-vertex",
+      hostname: "aiplatform.googleapis.com",
+      googleVertexRegion: "global",
+    });
+
+    expect(resolveProviderEndpoint("https://proxy.example.com/google")).toMatchObject({
+      endpointClass: "custom",
+      hostname: "proxy.example.com",
     });
   });
 

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -303,6 +303,26 @@ describe("provider attribution", () => {
     });
   });
 
+  it("does not classify malformed or embedded Google host strings as native endpoints", () => {
+    expect(resolveProviderEndpoint("proxy/generativelanguage.googleapis.com")).toMatchObject({
+      endpointClass: "invalid",
+    });
+
+    expect(resolveProviderEndpoint("https://xgenerativelanguage.googleapis.com")).toMatchObject({
+      endpointClass: "custom",
+      hostname: "xgenerativelanguage.googleapis.com",
+    });
+
+    expect(resolveProviderEndpoint("proxy/aiplatform.googleapis.com")).toMatchObject({
+      endpointClass: "invalid",
+    });
+
+    expect(resolveProviderEndpoint("https://xaiplatform.googleapis.com")).toMatchObject({
+      endpointClass: "custom",
+      hostname: "xaiplatform.googleapis.com",
+    });
+  });
+
   it("requires the dedicated OpenAI audio transcription API for audio attribution", () => {
     expect(
       resolveProviderRequestPolicy({

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -37,9 +37,17 @@ export type ProviderEndpointClass =
   | "openai-codex"
   | "azure-openai"
   | "openrouter"
+  | "google-generative-ai"
+  | "google-vertex"
   | "local"
   | "custom"
   | "invalid";
+
+export type ProviderEndpointResolution = {
+  endpointClass: ProviderEndpointClass;
+  hostname?: string;
+  googleVertexRegion?: string;
+};
 
 export type ProviderRequestPolicyInput = {
   provider?: string | null;
@@ -96,6 +104,15 @@ function resolveUrlHostname(value: unknown): string | undefined {
     if (normalized.includes("openrouter.ai")) {
       return "openrouter.ai";
     }
+    if (normalized.includes("generativelanguage.googleapis.com")) {
+      return "generativelanguage.googleapis.com";
+    }
+    if (normalized.includes("aiplatform.googleapis.com")) {
+      const match = /([a-z0-9-]+-aiplatform\.googleapis\.com|aiplatform\.googleapis\.com)/.exec(
+        normalized,
+      );
+      return match?.[1];
+    }
     if (
       normalized.includes("localhost") ||
       normalized.includes("127.0.0.1") ||
@@ -117,31 +134,53 @@ function isLocalEndpointHost(host: string): boolean {
   );
 }
 
-function classifyProviderEndpoint(baseUrl: string | null | undefined): ProviderEndpointClass {
+export function resolveProviderEndpoint(
+  baseUrl: string | null | undefined,
+): ProviderEndpointResolution {
   if (typeof baseUrl !== "string" || !baseUrl.trim()) {
-    return "default";
+    return { endpointClass: "default" };
   }
 
   const host = resolveUrlHostname(baseUrl);
   if (!host) {
-    return "invalid";
+    return { endpointClass: "invalid" };
   }
   if (host === "api.openai.com") {
-    return "openai-public";
+    return { endpointClass: "openai-public", hostname: host };
   }
   if (host === "chatgpt.com") {
-    return "openai-codex";
+    return { endpointClass: "openai-codex", hostname: host };
   }
   if (host === "openrouter.ai" || host.endsWith(".openrouter.ai")) {
-    return "openrouter";
+    return { endpointClass: "openrouter", hostname: host };
   }
   if (host.endsWith(".openai.azure.com")) {
-    return "azure-openai";
+    return { endpointClass: "azure-openai", hostname: host };
+  }
+  if (host === "generativelanguage.googleapis.com") {
+    return { endpointClass: "google-generative-ai", hostname: host };
+  }
+  if (host === "aiplatform.googleapis.com") {
+    return {
+      endpointClass: "google-vertex",
+      hostname: host,
+      googleVertexRegion: "global",
+    };
+  }
+  {
+    const googleVertexHost = /^([a-z0-9-]+)-aiplatform\.googleapis\.com$/.exec(host);
+    if (googleVertexHost) {
+      return {
+        endpointClass: "google-vertex",
+        hostname: host,
+        googleVertexRegion: googleVertexHost[1],
+      };
+    }
   }
   if (isLocalEndpointHost(host)) {
-    return "local";
+    return { endpointClass: "local", hostname: host };
   }
-  return "custom";
+  return { endpointClass: "custom", hostname: host };
 }
 
 function resolveKnownProviderFamily(provider: string | undefined): string {
@@ -320,7 +359,8 @@ export function resolveProviderRequestPolicy(
 ): ProviderRequestPolicyResolution {
   const provider = normalizeProviderId(input.provider ?? "");
   const policy = resolveProviderAttributionPolicy(provider, env);
-  const endpointClass = classifyProviderEndpoint(input.baseUrl);
+  const endpointResolution = resolveProviderEndpoint(input.baseUrl);
+  const endpointClass = endpointResolution.endpointClass;
   const api = input.api?.trim().toLowerCase();
   const usesConfiguredBaseUrl = endpointClass !== "default";
   const usesKnownNativeOpenAIEndpoint =

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -104,13 +104,16 @@ function resolveUrlHostname(value: unknown): string | undefined {
     if (normalized.includes("openrouter.ai")) {
       return "openrouter.ai";
     }
-    if (normalized.includes("generativelanguage.googleapis.com")) {
+    if (/^(?:https?:\/\/)?generativelanguage\.googleapis\.com(?:[:/?#]|$)/.test(normalized)) {
       return "generativelanguage.googleapis.com";
     }
-    if (normalized.includes("aiplatform.googleapis.com")) {
-      const match = /([a-z0-9-]+-aiplatform\.googleapis\.com|aiplatform\.googleapis\.com)/.exec(
-        normalized,
-      );
+    if (
+      /^(?:https?:\/\/)?(?:[a-z0-9-]+-)?aiplatform\.googleapis\.com(?:[:/?#]|$)/.test(normalized)
+    ) {
+      const match =
+        /^(?:https?:\/\/)?([a-z0-9-]+-aiplatform\.googleapis\.com|aiplatform\.googleapis\.com)(?:[:/?#]|$)/.exec(
+          normalized,
+        );
       return match?.[1];
     }
     if (
@@ -167,15 +170,13 @@ export function resolveProviderEndpoint(
       googleVertexRegion: "global",
     };
   }
-  {
-    const googleVertexHost = /^([a-z0-9-]+)-aiplatform\.googleapis\.com$/.exec(host);
-    if (googleVertexHost) {
-      return {
-        endpointClass: "google-vertex",
-        hostname: host,
-        googleVertexRegion: googleVertexHost[1],
-      };
-    }
+  const googleVertexHost = /^([a-z0-9-]+)-aiplatform\.googleapis\.com$/.exec(host);
+  if (googleVertexHost) {
+    return {
+      endpointClass: "google-vertex",
+      hostname: host,
+      googleVertexRegion: googleVertexHost[1],
+    };
   }
   if (isLocalEndpointHost(host)) {
     return { endpointClass: "local", hostname: host };

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -81,51 +81,32 @@ function formatOpenClawUserAgent(version: string): string {
   return `${OPENCLAW_ATTRIBUTION_ORIGINATOR}/${version}`;
 }
 
+function tryParseHostname(value: string): string | undefined {
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+function isSchemelessHostnameCandidate(value: string): boolean {
+  return /^[a-z0-9.[\]-]+(?::\d+)?(?:[/?#].*)?$/i.test(value);
+}
+
 function resolveUrlHostname(value: unknown): string | undefined {
   if (typeof value !== "string" || !value.trim()) {
     return undefined;
   }
 
-  try {
-    return new URL(value).hostname.toLowerCase();
-  } catch {
-    const normalized = value.trim().toLowerCase();
-    if (normalized.includes("api.openai.com")) {
-      return "api.openai.com";
-    }
-    if (normalized.includes("chatgpt.com")) {
-      return "chatgpt.com";
-    }
-    if (normalized.includes(".openai.azure.com")) {
-      const suffixStart = normalized.indexOf(".openai.azure.com");
-      const prefix = normalized.slice(0, suffixStart).replace(/^https?:\/\//, "");
-      return `${prefix}.openai.azure.com`;
-    }
-    if (normalized.includes("openrouter.ai")) {
-      return "openrouter.ai";
-    }
-    if (/^(?:https?:\/\/)?generativelanguage\.googleapis\.com(?:[:/?#]|$)/.test(normalized)) {
-      return "generativelanguage.googleapis.com";
-    }
-    if (
-      /^(?:https?:\/\/)?(?:[a-z0-9-]+-)?aiplatform\.googleapis\.com(?:[:/?#]|$)/.test(normalized)
-    ) {
-      const match =
-        /^(?:https?:\/\/)?([a-z0-9-]+-aiplatform\.googleapis\.com|aiplatform\.googleapis\.com)(?:[:/?#]|$)/.exec(
-          normalized,
-        );
-      return match?.[1];
-    }
-    if (
-      normalized.includes("localhost") ||
-      normalized.includes("127.0.0.1") ||
-      normalized.includes("[::1]") ||
-      normalized.includes("://::1")
-    ) {
-      return "localhost";
-    }
+  const trimmed = value.trim();
+  const parsedHostname = tryParseHostname(trimmed);
+  if (parsedHostname) {
+    return parsedHostname;
+  }
+  if (!isSchemelessHostnameCandidate(trimmed)) {
     return undefined;
   }
+  return tryParseHostname(`https://${trimmed}`);
 }
 
 function isLocalEndpointHost(host: string): boolean {

--- a/src/infra/google-api-base-url.test.ts
+++ b/src/infra/google-api-base-url.test.ts
@@ -27,6 +27,10 @@ describe("normalizeGoogleApiBaseUrl", () => {
       value: "https://proxy.example.com/google/v1beta/",
       expected: "https://proxy.example.com/google/v1beta",
     },
+    {
+      value: "generativelanguage.googleapis.com",
+      expected: "generativelanguage.googleapis.com",
+    },
   ])("normalizes %s", ({ value, expected }) => {
     expect(normalizeGoogleApiBaseUrl(value)).toBe(expected);
   });

--- a/src/infra/google-api-base-url.ts
+++ b/src/infra/google-api-base-url.ts
@@ -6,6 +6,10 @@ function trimTrailingSlashes(value: string): string {
   return value.replace(/\/+$/, "");
 }
 
+function isCanonicalGoogleApiOriginShorthand(value: string): boolean {
+  return /^https:\/\/generativelanguage\.googleapis\.com\/?$/i.test(value);
+}
+
 export function normalizeGoogleApiBaseUrl(baseUrl?: string): string {
   const raw = trimTrailingSlashes(baseUrl?.trim() || DEFAULT_GOOGLE_API_BASE_URL);
   try {
@@ -20,7 +24,7 @@ export function normalizeGoogleApiBaseUrl(baseUrl?: string): string {
     }
     return trimTrailingSlashes(url.toString());
   } catch {
-    if (resolveProviderEndpoint(raw).endpointClass === "google-generative-ai") {
+    if (isCanonicalGoogleApiOriginShorthand(raw)) {
       return DEFAULT_GOOGLE_API_BASE_URL;
     }
     return raw;

--- a/src/infra/google-api-base-url.ts
+++ b/src/infra/google-api-base-url.ts
@@ -1,4 +1,4 @@
-const DEFAULT_GOOGLE_API_HOST = "generativelanguage.googleapis.com";
+import { resolveProviderEndpoint } from "../agents/provider-attribution.js";
 
 export const DEFAULT_GOOGLE_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 
@@ -13,14 +13,14 @@ export function normalizeGoogleApiBaseUrl(baseUrl?: string): string {
     url.hash = "";
     url.search = "";
     if (
-      url.hostname.toLowerCase() === DEFAULT_GOOGLE_API_HOST &&
+      resolveProviderEndpoint(url.toString()).endpointClass === "google-generative-ai" &&
       trimTrailingSlashes(url.pathname || "") === ""
     ) {
       url.pathname = "/v1beta";
     }
     return trimTrailingSlashes(url.toString());
   } catch {
-    if (/^https:\/\/generativelanguage\.googleapis\.com\/?$/i.test(raw)) {
+    if (resolveProviderEndpoint(raw).endpointClass === "google-generative-ai") {
       return DEFAULT_GOOGLE_API_BASE_URL;
     }
     return raw;

--- a/src/plugin-sdk/provider-http.ts
+++ b/src/plugin-sdk/provider-http.ts
@@ -12,6 +12,7 @@ export {
   requireTranscriptionText,
 } from "../media-understanding/shared.js";
 export type {
+  ProviderAttributionPolicy,
   ProviderEndpointClass,
   ProviderEndpointResolution,
   ProviderRequestCapability,

--- a/src/plugin-sdk/provider-http.ts
+++ b/src/plugin-sdk/provider-http.ts
@@ -11,3 +11,15 @@ export {
   resolveProviderHttpRequestConfig,
   requireTranscriptionText,
 } from "../media-understanding/shared.js";
+export type {
+  ProviderEndpointClass,
+  ProviderEndpointResolution,
+  ProviderRequestCapability,
+  ProviderRequestPolicyInput,
+  ProviderRequestPolicyResolution,
+  ProviderRequestTransport,
+} from "../agents/provider-attribution.js";
+export {
+  resolveProviderEndpoint,
+  resolveProviderRequestPolicy,
+} from "../agents/provider-attribution.js";


### PR DESCRIPTION
## Summary

- Problem: Google-family official-host knowledge was still split across provider-specific helpers, while the shared request-policy engine only classified OpenAI-family endpoints.
- Why it matters: Gemini base URL normalization and Anthropic Vertex region parsing could drift apart from the central native-vs-proxy model, making future proxy/auth/header policy work harder to centralize.
- What changed: added shared Google-family endpoint classes in `src/agents/provider-attribution.ts`, exported the minimal classifier seam through `openclaw/plugin-sdk/provider-http`, and migrated Gemini normalization plus Anthropic Vertex region parsing onto that seam.
- What did NOT change (scope boundary): this PR does not change hidden attribution behavior, does not add new config surface, and does not yet centralize Anthropic or Copilot endpoint policy.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix
- [ ] Feature
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #59542
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: endpoint-family classification was centralized for OpenAI-family first, but Gemini and Anthropic Vertex still kept their own official-host parsing logic outside that shared policy layer.
- Missing detection / guardrail: there was no single classifier covering Google Generative AI and Vertex hosts, so provider-local helpers remained the source of truth.
- Prior context (`git blame`, prior PR, issue, or refactor if known): follows the provider request-policy work landed in #59433, #59454, #59469, and #59542.
- Why this regressed now: the architecture gap became more visible once request config and header shaping were centralized, because Google-family endpoint handling was one of the remaining duplicated host-classification pockets.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/provider-attribution.test.ts`, `extensions/google/api.test.ts`, `extensions/anthropic-vertex/region.test.ts`, `src/infra/google-api-base-url.test.ts`
- Scenario the test should lock in: native Gemini hosts classify separately from Vertex hosts and custom proxies; Vertex region parsing should come from the shared classifier rather than bespoke URL parsing.
- Why this is the smallest reliable guardrail: these tests pin the shared endpoint seam plus the two provider consumers without needing a full transport-path integration test.
- Existing test that already covers this (if any): existing Google normalization and Anthropic Vertex region tests were extended.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Custom/proxied Gemini endpoints continue to avoid official Gemini host normalization.
- Anthropic Vertex region detection now comes from the shared endpoint classifier, keeping native Vertex endpoints and proxy endpoints distinct.

## Diagram (if applicable)

```text
Before:
[Gemini helper] -> parse Google host locally
[Anthropic Vertex helper] -> parse Vertex host locally
[shared request policy] -> knows only OpenAI-family hosts

After:
[Gemini helper] -> shared endpoint classifier -> normalized Gemini base URL
[Anthropic Vertex helper] -> shared endpoint classifier -> Vertex region
[shared request policy] -> one endpoint model for OpenAI-family + Google-family
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 25 + pnpm worktree
- Model/provider: Google Gemini, Anthropic Vertex helper paths
- Integration/channel (if any): N/A
- Relevant config (redacted): custom `baseUrl` vs native Google/Vertex hosts

### Steps

1. Classify native Gemini, regional Vertex, global Vertex, and proxy base URLs through the shared endpoint helper.
2. Normalize Google API base URLs and resolve Anthropic Vertex regions using that shared classifier.
3. Run targeted tests plus full `pnpm build` and `pnpm check`.

### Expected

- Native Gemini and Vertex hosts classify distinctly; proxy/custom hosts remain custom.
- Google normalization only applies to native Gemini hosts.
- Anthropic Vertex region inference only applies to native Vertex hosts.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: shared classifier returns `google-generative-ai` and `google-vertex` for native hosts; Gemini normalization still appends `/v1beta` only for native Gemini; Anthropic Vertex resolves regional/global hosts and ignores proxies.
- Edge cases checked: malformed/custom URLs stay non-native; global Vertex resolves to `global`; proxy Gemini/Vertex URLs do not get native classification.
- What you did **not** verify: full transport-path integration beyond the covered unit/seam tests; Anthropic public-host service-tier centralization is intentionally deferred.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: exposing the shared classifier through `provider-http` broadens the public SDK surface.
  - Mitigation: the seam is minimal, generic, and already backed by full `build` export verification plus focused tests.