### PR TITLE
fix(plugin-sdk): narrow discord and matrix core seam imports

### DIFF
--- a/src/channels/plugins/contracts/registry.ts
+++ b/src/channels/plugins/contracts/registry.ts
@@ -8,18 +8,18 @@ import {
   type SessionBindingCapabilities,
   type SessionBindingRecord,
 } from "../../../infra/outbound/session-binding-service.js";
-import { createDiscordThreadBindingManager } from "../../../plugin-sdk/discord.js";
+import { createThreadBindingManager as createDiscordThreadBindingManager } from "../../../plugin-sdk/discord-thread-bindings.js";
 import { createFeishuThreadBindingManager } from "../../../plugin-sdk/feishu.js";
 import {
   listLineAccountIds,
   resolveDefaultLineAccountId,
   resolveLineAccount,
 } from "../../../plugin-sdk/line.js";
+import { setMatrixRuntime } from "../../../plugin-sdk/matrix-runtime-surface.js";
 import {
   createMatrixThreadBindingManager,
   resetMatrixThreadBindingsForTests,
-  setMatrixRuntime,
-} from "../../../plugin-sdk/matrix.js";
+} from "../../../plugin-sdk/matrix-surface.js";
 import { loadBundledPluginTestApiSync } from "../../../test-utils/bundled-plugin-public-surface.js";
 import {
   listBundledChannelPlugins,

--- a/src/channels/read-only-account-inspect.discord.runtime.ts
+++ b/src/channels/read-only-account-inspect.discord.runtime.ts
@@ -1,8 +1,9 @@
-import { inspectDiscordAccount as inspectDiscordAccountImpl } from "../plugin-sdk/discord.js";
+import { inspectDiscordAccount as inspectDiscordAccountImpl } from "../plugin-sdk/discord-surface.js";
 
-export type { InspectedDiscordAccount } from "../plugin-sdk/discord.js";
+export type { InspectedDiscordAccount } from "../plugin-sdk/discord-surface.js";
 
-type InspectDiscordAccount = typeof import("../plugin-sdk/discord.js").inspectDiscordAccount;
+type InspectDiscordAccount =
+  typeof import("../plugin-sdk/discord-surface.js").inspectDiscordAccount;
 
 export function inspectDiscordAccount(
   ...args: Parameters<InspectDiscordAccount>

--- a/src/config/sessions/explicit-session-key-normalization.ts
+++ b/src/config/sessions/explicit-session-key-normalization.ts
@@ -1,5 +1,5 @@
 import type { MsgContext } from "../../auto-reply/templating.js";
-import { normalizeExplicitDiscordSessionKey } from "../../plugin-sdk/discord.js";
+import { normalizeExplicitDiscordSessionKey } from "../../plugin-sdk/discord-session-key.js";
 
 type ExplicitSessionKeyNormalizer = (sessionKey: string, ctx: MsgContext) => string;
 type ExplicitSessionKeyNormalizerEntry = {

--- a/src/plugins/runtime/runtime-channel.ts
+++ b/src/plugins/runtime/runtime-channel.ts
@@ -64,7 +64,7 @@ import {
 import {
   setThreadBindingIdleTimeoutBySessionKey,
   setThreadBindingMaxAgeBySessionKey,
-} from "../../plugin-sdk/discord.js";
+} from "../../plugin-sdk/discord-thread-bindings.js";
 import { buildAgentSessionKey, resolveAgentRoute } from "../../routing/resolve-route.js";
 import { defineCachedValue } from "./runtime-cache.js";
 import { createRuntimeDiscord } from "./runtime-discord.js";

--- a/src/plugins/runtime/runtime-discord-ops.runtime.ts
+++ b/src/plugins/runtime/runtime-discord-ops.runtime.ts
@@ -6,8 +6,6 @@ import {
   probeDiscord as probeDiscordImpl,
   resolveDiscordChannelAllowlist as resolveDiscordChannelAllowlistImpl,
   resolveDiscordUserAllowlist as resolveDiscordUserAllowlistImpl,
-} from "../../plugin-sdk/discord.js";
-import {
   createThreadDiscord as createThreadDiscordImpl,
   deleteMessageDiscord as deleteMessageDiscordImpl,
   editChannelDiscord as editChannelDiscordImpl,
@@ -18,7 +16,7 @@ import {
   sendPollDiscord as sendPollDiscordImpl,
   sendTypingDiscord as sendTypingDiscordImpl,
   unpinMessageDiscord as unpinMessageDiscordImpl,
-} from "../../plugin-sdk/discord.js";
+} from "../../plugin-sdk/discord-runtime-surface.js";
 import type { PluginRuntimeChannel } from "./types-channel.js";
 
 type RuntimeDiscordOps = Pick<

--- a/src/plugins/runtime/runtime-discord.ts
+++ b/src/plugins/runtime/runtime-discord.ts
@@ -1,5 +1,5 @@
+import { discordMessageActions } from "../../plugin-sdk/discord-runtime-surface.js";
 import {
-  discordMessageActions,
   getThreadBindingManager,
   resolveThreadBindingIdleTimeoutMs,
   resolveThreadBindingInactivityExpiresAt,
@@ -8,7 +8,7 @@ import {
   setThreadBindingIdleTimeoutBySessionKey,
   setThreadBindingMaxAgeBySessionKey,
   unbindThreadBindingsBySessionKey,
-} from "../../plugin-sdk/discord.js";
+} from "../../plugin-sdk/discord-thread-bindings.js";
 import {
   createLazyRuntimeMethodBinder,
   createLazyRuntimeSurface,

--- a/src/plugins/runtime/types-channel.ts
+++ b/src/plugins/runtime/types-channel.ts
@@ -9,6 +9,9 @@ type ReadChannelAllowFromStore =
   typeof import("../../pairing/pairing-store.js").readChannelAllowFromStore;
 type UpsertChannelPairingRequest =
   typeof import("../../pairing/pairing-store.js").upsertChannelPairingRequest;
+type DiscordRuntimeSurface = typeof import("../../plugin-sdk/discord-runtime-surface.js");
+type DiscordThreadBindings = typeof import("../../plugin-sdk/discord-thread-bindings.js");
+type MatrixThreadBindings = typeof import("../../plugin-sdk/matrix-thread-bindings.js");
 
 type ReadChannelAllowFromStoreForAccount = (params: {
   channel: Parameters<ReadChannelAllowFromStore>[0];
@@ -120,29 +123,29 @@ export type PluginRuntimeChannel = {
     }) => RuntimeThreadBindingLifecycleRecord[];
   };
   discord: {
-    messageActions: typeof import("../../plugin-sdk/discord.js").discordMessageActions;
-    auditChannelPermissions: typeof import("../../plugin-sdk/discord.js").auditDiscordChannelPermissions;
-    listDirectoryGroupsLive: typeof import("../../plugin-sdk/discord.js").listDiscordDirectoryGroupsLive;
-    listDirectoryPeersLive: typeof import("../../plugin-sdk/discord.js").listDiscordDirectoryPeersLive;
-    probeDiscord: typeof import("../../plugin-sdk/discord.js").probeDiscord;
-    resolveChannelAllowlist: typeof import("../../plugin-sdk/discord.js").resolveDiscordChannelAllowlist;
-    resolveUserAllowlist: typeof import("../../plugin-sdk/discord.js").resolveDiscordUserAllowlist;
-    sendComponentMessage: typeof import("../../plugin-sdk/discord.js").sendDiscordComponentMessage;
-    sendMessageDiscord: typeof import("../../plugin-sdk/discord.js").sendMessageDiscord;
-    sendPollDiscord: typeof import("../../plugin-sdk/discord.js").sendPollDiscord;
-    monitorDiscordProvider: typeof import("../../plugin-sdk/discord.js").monitorDiscordProvider;
+    messageActions: DiscordRuntimeSurface["discordMessageActions"];
+    auditChannelPermissions: DiscordRuntimeSurface["auditDiscordChannelPermissions"];
+    listDirectoryGroupsLive: DiscordRuntimeSurface["listDiscordDirectoryGroupsLive"];
+    listDirectoryPeersLive: DiscordRuntimeSurface["listDiscordDirectoryPeersLive"];
+    probeDiscord: DiscordRuntimeSurface["probeDiscord"];
+    resolveChannelAllowlist: DiscordRuntimeSurface["resolveDiscordChannelAllowlist"];
+    resolveUserAllowlist: DiscordRuntimeSurface["resolveDiscordUserAllowlist"];
+    sendComponentMessage: DiscordRuntimeSurface["sendDiscordComponentMessage"];
+    sendMessageDiscord: DiscordRuntimeSurface["sendMessageDiscord"];
+    sendPollDiscord: DiscordRuntimeSurface["sendPollDiscord"];
+    monitorDiscordProvider: DiscordRuntimeSurface["monitorDiscordProvider"];
     threadBindings: {
-      getManager: typeof import("../../plugin-sdk/discord.js").getThreadBindingManager;
-      resolveIdleTimeoutMs: typeof import("../../plugin-sdk/discord.js").resolveThreadBindingIdleTimeoutMs;
-      resolveInactivityExpiresAt: typeof import("../../plugin-sdk/discord.js").resolveThreadBindingInactivityExpiresAt;
-      resolveMaxAgeMs: typeof import("../../plugin-sdk/discord.js").resolveThreadBindingMaxAgeMs;
-      resolveMaxAgeExpiresAt: typeof import("../../plugin-sdk/discord.js").resolveThreadBindingMaxAgeExpiresAt;
-      setIdleTimeoutBySessionKey: typeof import("../../plugin-sdk/discord.js").setThreadBindingIdleTimeoutBySessionKey;
-      setMaxAgeBySessionKey: typeof import("../../plugin-sdk/discord.js").setThreadBindingMaxAgeBySessionKey;
-      unbindBySessionKey: typeof import("../../plugin-sdk/discord.js").unbindThreadBindingsBySessionKey;
+      getManager: DiscordThreadBindings["getThreadBindingManager"];
+      resolveIdleTimeoutMs: DiscordThreadBindings["resolveThreadBindingIdleTimeoutMs"];
+      resolveInactivityExpiresAt: DiscordThreadBindings["resolveThreadBindingInactivityExpiresAt"];
+      resolveMaxAgeMs: DiscordThreadBindings["resolveThreadBindingMaxAgeMs"];
+      resolveMaxAgeExpiresAt: DiscordThreadBindings["resolveThreadBindingMaxAgeExpiresAt"];
+      setIdleTimeoutBySessionKey: DiscordThreadBindings["setThreadBindingIdleTimeoutBySessionKey"];
+      setMaxAgeBySessionKey: DiscordThreadBindings["setThreadBindingMaxAgeBySessionKey"];
+      unbindBySessionKey: DiscordThreadBindings["unbindThreadBindingsBySessionKey"];
     };
     typing: {
-      pulse: typeof import("../../plugin-sdk/discord.js").sendTypingDiscord;
+      pulse: DiscordRuntimeSurface["sendTypingDiscord"];
       start: (params: {
         channelId: string;
         accountId?: string;
@@ -154,12 +157,12 @@ export type PluginRuntimeChannel = {
       }>;
     };
     conversationActions: {
-      editMessage: typeof import("../../plugin-sdk/discord.js").editMessageDiscord;
-      deleteMessage: typeof import("../../plugin-sdk/discord.js").deleteMessageDiscord;
-      pinMessage: typeof import("../../plugin-sdk/discord.js").pinMessageDiscord;
-      unpinMessage: typeof import("../../plugin-sdk/discord.js").unpinMessageDiscord;
-      createThread: typeof import("../../plugin-sdk/discord.js").createThreadDiscord;
-      editChannel: typeof import("../../plugin-sdk/discord.js").editChannelDiscord;
+      editMessage: DiscordRuntimeSurface["editMessageDiscord"];
+      deleteMessage: DiscordRuntimeSurface["deleteMessageDiscord"];
+      pinMessage: DiscordRuntimeSurface["pinMessageDiscord"];
+      unpinMessage: DiscordRuntimeSurface["unpinMessageDiscord"];
+      createThread: DiscordRuntimeSurface["createThreadDiscord"];
+      editChannel: DiscordRuntimeSurface["editChannelDiscord"];
     };
   };
   slack: {
@@ -174,8 +177,8 @@ export type PluginRuntimeChannel = {
   };
   matrix: {
     threadBindings: {
-      setIdleTimeoutBySessionKey: typeof import("../../plugin-sdk/matrix.js").setMatrixThreadBindingIdleTimeoutBySessionKey;
-      setMaxAgeBySessionKey: typeof import("../../plugin-sdk/matrix.js").setMatrixThreadBindingMaxAgeBySessionKey;
+      setIdleTimeoutBySessionKey: MatrixThreadBindings["setMatrixThreadBindingIdleTimeoutBySessionKey"];
+      setMaxAgeBySessionKey: MatrixThreadBindings["setMatrixThreadBindingMaxAgeBySessionKey"];
     };
   };
   signal: {


### PR DESCRIPTION
## Summary
- switch core Discord/Matrix callers from broad plugin-sdk barrels to the narrower seam-specific facades
- keep runtime, contract, and session-key paths aligned with the guarded surfaces already on main
- narrow the internal runtime type map to the same seam-specific imports

## Testing
- [x] `pnpm check`
- [x] `pnpm build`
- [x] `pnpm test -- src/config/sessions/explicit-session-key-normalization.test.ts`
- [x] `OPENCLAW_TEST_PROFILE=serial OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test -- src/channels/plugins/contracts/registry-backed.contract.test.ts`
- [x] `OPENCLAW_TEST_PROFILE=serial OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test -- src/gateway/server.sessions.gateway-server-sessions-a.test.ts`

## Notes
- AI-assisted
- no changelog: internal boundary cleanup only