### PR TITLE
refactor: distill ACP reconnect prompt state

### DIFF
--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -295,6 +295,49 @@ describe("acp translator stop reason mapping", () => {
     }
   });
 
+  it("keeps accepted prompts pending when the deadline recheck still reports timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const sessionId = "session-1";
+      const sessionKey = "agent:main:main";
+      const request = vi.fn(async (method: string) => {
+        if (method === "chat.send") {
+          return {};
+        }
+        if (method === "agent.wait") {
+          return { status: "timeout" };
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const sessionStore = createInMemorySessionStore();
+      sessionStore.createSession({
+        sessionId,
+        sessionKey,
+        cwd: "/tmp",
+      });
+      const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+        sessionStore,
+      });
+      const promptPromise = agent.prompt({
+        sessionId,
+        prompt: [{ type: "text", text: "hello" }],
+        _meta: {},
+      } as unknown as PromptRequest);
+
+      await Promise.resolve();
+      agent.handleGatewayDisconnect("1006: connection lost");
+      agent.handleGatewayReconnect();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(Promise.race([promptPromise, Promise.resolve("pending")])).resolves.toBe(
+        "pending",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not clear a newer disconnect deadline while reconnect reconciliation is still running", async () => {
     vi.useFakeTimers();
     try {
@@ -353,7 +396,10 @@ describe("acp translator stop reason mapping", () => {
       expect(settleSpy).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(1);
-      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: second disconnect");
+      expect(request).toHaveBeenCalledTimes(3);
+      await expect(Promise.race([promptPromise, Promise.resolve("pending")])).resolves.toBe(
+        "pending",
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -396,16 +396,13 @@ describe("acp translator stop reason mapping", () => {
       expect(settleSpy).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(1);
-      expect(request).toHaveBeenCalledTimes(3);
-      await expect(Promise.race([promptPromise, Promise.resolve("pending")])).resolves.toBe(
-        "pending",
-      );
+      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: second disconnect");
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("keeps the disconnect deadline after reconnect when a pre-ack send never started", async () => {
+  it("keeps pre-ack prompts pending after reconnect timeout", async () => {
     vi.useFakeTimers();
     try {
       const sessionId = "session-1";
@@ -440,13 +437,14 @@ describe("acp translator stop reason mapping", () => {
       agent.handleGatewayReconnect();
       await Promise.resolve();
 
-      await vi.advanceTimersByTimeAsync(4_999);
       await expect(Promise.race([promptPromise, Promise.resolve("pending")])).resolves.toBe(
         "pending",
       );
 
-      await vi.advanceTimersByTimeAsync(1);
-      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(Promise.race([promptPromise, Promise.resolve("pending")])).resolves.toBe(
+        "pending",
+      );
     } finally {
       vi.useRealTimers();
     }
@@ -550,13 +548,15 @@ describe("acp translator stop reason mapping", () => {
       agent.handleGatewayReconnect();
       await vi.advanceTimersByTimeAsync(5_000);
 
-      await expect(secondPrompt).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+      await expect(Promise.race([secondPrompt, Promise.resolve("pending")])).resolves.toBe(
+        "pending",
+      );
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("rejects only unrecovered prompts after reconnect reconciliation", async () => {
+  it("finishes terminal prompts without rejecting other reconnecting prompts", async () => {
     vi.useFakeTimers();
     try {
       let acceptedRunId: string | undefined;
@@ -621,10 +621,56 @@ describe("acp translator stop reason mapping", () => {
       await vi.advanceTimersByTimeAsync(5_000);
 
       await expect(acceptedPrompt).resolves.toEqual({ stopReason: "end_turn" });
-      await expect(preAckPrompt).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+      await expect(Promise.race([preAckPrompt, Promise.resolve("pending")])).resolves.toBe(
+        "pending",
+      );
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("reconciles prompts started while the gateway is disconnected", async () => {
+    const sessionId = "session-1";
+    const sessionKey = "agent:main:main";
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        throw new Error("gateway closed (1006): connection lost");
+      }
+      if (method === "agent.wait") {
+        return { status: "ok" };
+      }
+      return {};
+    }) as GatewayClient["request"];
+    const sessionStore = createInMemorySessionStore();
+    sessionStore.createSession({
+      sessionId,
+      sessionKey,
+      cwd: "/tmp",
+    });
+    const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+      sessionStore,
+    });
+
+    agent.handleGatewayDisconnect("1006: connection lost");
+    const promptPromise = agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "hello" }],
+      _meta: {},
+    } as unknown as PromptRequest);
+    const settleSpy = vi.fn();
+    void promptPromise.then(
+      (value) => settleSpy({ kind: "resolve", value }),
+      (error) => settleSpy({ kind: "reject", error }),
+    );
+    await Promise.resolve();
+    agent.handleGatewayReconnect();
+
+    await vi.waitFor(() => {
+      expect(settleSpy).toHaveBeenCalledWith({
+        kind: "resolve",
+        value: { stopReason: "end_turn" },
+      });
+    });
   });
 
   it("does not let a stale disconnect deadline reject a newer prompt on the same session", async () => {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -1052,6 +1052,11 @@ export class AcpGatewayAgent implements Agent {
     pending.reject(error);
   }
 
+  private clearPendingDisconnectState(pending: PendingPrompt): void {
+    pending.disconnectGeneration = undefined;
+    pending.disconnectReason = undefined;
+  }
+
   private async reconcilePendingPrompts(
     observedDisconnectGeneration: number,
     deadlineExpired: boolean,
@@ -1116,10 +1121,7 @@ export class AcpGatewayAgent implements Agent {
     } catch (err) {
       this.log(`agent.wait reconcile failed for ${pending.idempotencyKey}: ${String(err)}`);
       if (deadlineExpired) {
-        this.rejectPendingPrompt(
-          pending,
-          new Error(`Gateway disconnected: ${pending.disconnectReason}`),
-        );
+        this.clearPendingDisconnectState(pending);
         return false;
       }
       return true;
@@ -1138,10 +1140,7 @@ export class AcpGatewayAgent implements Agent {
       return false;
     }
     if (deadlineExpired) {
-      this.rejectPendingPrompt(
-        currentPending,
-        new Error(`Gateway disconnected: ${currentPending.disconnectReason}`),
-      );
+      this.clearPendingDisconnectState(currentPending);
       return false;
     }
     return true;

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -1078,7 +1078,13 @@ export class AcpGatewayAgent implements Agent {
     pending.reject(error);
   }
 
-  private clearPendingDisconnectState(pending: PendingPrompt): void {
+  private clearPendingDisconnectState(
+    pending: PendingPrompt,
+    disconnectContext: DisconnectContext,
+  ): void {
+    if (pending.disconnectContext !== disconnectContext) {
+      return;
+    }
     pending.disconnectContext = undefined;
   }
 
@@ -1150,7 +1156,7 @@ export class AcpGatewayAgent implements Agent {
           );
           return false;
         }
-        this.clearPendingDisconnectState(pending);
+        this.clearPendingDisconnectState(pending, disconnectContext);
         return false;
       }
       return true;
@@ -1180,7 +1186,7 @@ export class AcpGatewayAgent implements Agent {
         );
         return false;
       }
-      this.clearPendingDisconnectState(currentPending);
+      this.clearPendingDisconnectState(currentPending, disconnectContext);
       return false;
     }
     return true;

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -66,6 +66,8 @@ type PendingPrompt = {
   sessionKey: string;
   idempotencyKey: string;
   sendAccepted?: boolean;
+  disconnectGeneration?: number;
+  disconnectReason?: string;
   resolve: (response: PromptResponse) => void;
   reject: (err: Error) => void;
   sentTextLength?: number;
@@ -409,7 +411,6 @@ export class AcpGatewayAgent implements Agent {
   private sessionStore: AcpSessionStore;
   private sessionCreateRateLimiter: FixedWindowRateLimiter;
   private pendingPrompts = new Map<string, PendingPrompt>();
-  private disconnectDeadlineRunIds = new Map<string, string>();
   private disconnectTimer: NodeJS.Timeout | null = null;
   private disconnectGeneration = 0;
 
@@ -449,7 +450,7 @@ export class AcpGatewayAgent implements Agent {
 
   handleGatewayReconnect(): void {
     this.log("gateway reconnected");
-    void this.reconcilePendingPromptsOnReconnect(this.disconnectGeneration);
+    void this.reconcilePendingPrompts(this.disconnectGeneration, false);
   }
 
   handleGatewayDisconnect(reason: string): void {
@@ -458,16 +459,14 @@ export class AcpGatewayAgent implements Agent {
       return;
     }
     this.disconnectGeneration += 1;
-    this.disconnectDeadlineRunIds = new Map(
-      [...this.pendingPrompts.entries()].map(([sessionId, pending]) => [
-        sessionId,
-        pending.idempotencyKey,
-      ]),
-    );
+    for (const pending of this.pendingPrompts.values()) {
+      pending.disconnectGeneration = this.disconnectGeneration;
+      pending.disconnectReason = reason;
+    }
     this.clearDisconnectTimer();
     this.disconnectTimer = setTimeout(() => {
       this.disconnectTimer = null;
-      void this.expireDisconnectDeadline(new Error(`Gateway disconnected: ${reason}`));
+      void this.reconcilePendingPrompts(this.disconnectGeneration, true);
     }, ACP_GATEWAY_DISCONNECT_GRACE_MS);
     this.disconnectTimer.unref?.();
   }
@@ -746,7 +745,6 @@ export class AcpGatewayAgent implements Agent {
           return;
         }
         this.pendingPrompts.delete(params.sessionId);
-        this.disconnectDeadlineRunIds.delete(params.sessionId);
         this.sessionStore.clearActiveRun(params.sessionId);
         if (this.pendingPrompts.size === 0) {
           this.clearDisconnectTimer();
@@ -1009,7 +1007,6 @@ export class AcpGatewayAgent implements Agent {
     stopReason: StopReason,
   ): Promise<void> {
     this.pendingPrompts.delete(sessionId);
-    this.disconnectDeadlineRunIds.delete(sessionId);
     this.sessionStore.clearActiveRun(sessionId);
     if (this.pendingPrompts.size === 0) {
       this.clearDisconnectTimer();
@@ -1046,68 +1043,18 @@ export class AcpGatewayAgent implements Agent {
     this.disconnectTimer = null;
   }
 
-  private rejectPendingPrompts(
-    error: Error,
-    promptRuns: Iterable<readonly [string, string]>,
-  ): void {
-    for (const [sessionId, runId] of promptRuns) {
-      const pending = this.getPendingPrompt(sessionId, runId);
-      if (!pending) {
-        continue;
-      }
-      pending.reject(error);
-      this.sessionStore.clearActiveRun(pending.sessionId);
-      this.pendingPrompts.delete(sessionId);
-      this.disconnectDeadlineRunIds.delete(sessionId);
+  private rejectPendingPrompt(pending: PendingPrompt, error: Error): void {
+    this.pendingPrompts.delete(pending.sessionId);
+    this.sessionStore.clearActiveRun(pending.sessionId);
+    if (this.pendingPrompts.size === 0) {
+      this.clearDisconnectTimer();
     }
+    pending.reject(error);
   }
 
-  private async expireDisconnectDeadline(error: Error): Promise<void> {
-    const deadlinePromptRuns = [...this.disconnectDeadlineRunIds.entries()];
-    for (const [sessionId, runId] of deadlinePromptRuns) {
-      const pending = this.getPendingPrompt(sessionId, runId);
-      if (!pending) {
-        this.disconnectDeadlineRunIds.delete(sessionId);
-        continue;
-      }
-      if (!pending.sendAccepted) {
-        this.rejectPendingPrompts(error, [[sessionId, runId]]);
-        continue;
-      }
-
-      let result: AgentWaitResult | undefined;
-      try {
-        result = await this.gateway.request<AgentWaitResult>(
-          "agent.wait",
-          {
-            runId,
-            timeoutMs: 0,
-          },
-          { timeoutMs: null },
-        );
-      } catch {
-        this.rejectPendingPrompts(error, [[sessionId, runId]]);
-        continue;
-      }
-
-      const currentPending = this.getPendingPrompt(sessionId, runId);
-      if (!currentPending) {
-        continue;
-      }
-      if (result?.status === "ok") {
-        await this.finishPrompt(sessionId, currentPending, "end_turn");
-        continue;
-      }
-      if (result?.status === "error") {
-        void this.finishPrompt(sessionId, currentPending, "end_turn");
-        continue;
-      }
-      this.rejectPendingPrompts(error, [[sessionId, runId]]);
-    }
-  }
-
-  private async reconcilePendingPromptsOnReconnect(
+  private async reconcilePendingPrompts(
     observedDisconnectGeneration: number,
+    deadlineExpired: boolean,
   ): Promise<void> {
     if (this.pendingPrompts.size === 0) {
       if (this.disconnectGeneration === observedDisconnectGeneration) {
@@ -1118,52 +1065,86 @@ export class AcpGatewayAgent implements Agent {
 
     const pendingEntries = [...this.pendingPrompts.entries()];
     let keepDisconnectTimer = false;
-    const nextDisconnectDeadlineRunIds = new Map<string, string>();
     for (const [sessionId, pending] of pendingEntries) {
       if (this.pendingPrompts.get(sessionId) !== pending) {
         continue;
       }
-      let result: AgentWaitResult | undefined;
-      try {
-        result = await this.gateway.request<AgentWaitResult>(
-          "agent.wait",
-          {
-            runId: pending.idempotencyKey,
-            timeoutMs: 0,
-          },
-          { timeoutMs: null },
-        );
-      } catch (err) {
-        this.log(`agent.wait reconcile failed for ${pending.idempotencyKey}: ${String(err)}`);
+      if (pending.disconnectGeneration !== observedDisconnectGeneration) {
+        continue;
+      }
+      const shouldKeepPending = await this.reconcilePendingPrompt(
+        sessionId,
+        pending,
+        deadlineExpired,
+      );
+      if (shouldKeepPending) {
         keepDisconnectTimer = true;
-        nextDisconnectDeadlineRunIds.set(sessionId, pending.idempotencyKey);
-        continue;
-      }
-
-      if (this.pendingPrompts.get(sessionId) !== pending) {
-        continue;
-      }
-      if (result?.status === "ok") {
-        await this.finishPrompt(sessionId, pending, "end_turn");
-        continue;
-      }
-      if (result?.status === "error") {
-        void this.finishPrompt(sessionId, pending, "end_turn");
-        continue;
-      }
-      if (result?.status === "timeout") {
-        keepDisconnectTimer = true;
-        nextDisconnectDeadlineRunIds.set(sessionId, pending.idempotencyKey);
-        continue;
       }
     }
 
-    if (this.disconnectGeneration === observedDisconnectGeneration) {
-      this.disconnectDeadlineRunIds = nextDisconnectDeadlineRunIds;
-    }
     if (!keepDisconnectTimer && this.disconnectGeneration === observedDisconnectGeneration) {
       this.clearDisconnectTimer();
     }
+  }
+
+  private async reconcilePendingPrompt(
+    sessionId: string,
+    pending: PendingPrompt,
+    deadlineExpired: boolean,
+  ): Promise<boolean> {
+    if (!pending.sendAccepted) {
+      if (deadlineExpired) {
+        this.rejectPendingPrompt(
+          pending,
+          new Error(`Gateway disconnected: ${pending.disconnectReason}`),
+        );
+        return false;
+      }
+      return true;
+    }
+
+    let result: AgentWaitResult | undefined;
+    try {
+      result = await this.gateway.request<AgentWaitResult>(
+        "agent.wait",
+        {
+          runId: pending.idempotencyKey,
+          timeoutMs: 0,
+        },
+        { timeoutMs: null },
+      );
+    } catch (err) {
+      this.log(`agent.wait reconcile failed for ${pending.idempotencyKey}: ${String(err)}`);
+      if (deadlineExpired) {
+        this.rejectPendingPrompt(
+          pending,
+          new Error(`Gateway disconnected: ${pending.disconnectReason}`),
+        );
+        return false;
+      }
+      return true;
+    }
+
+    const currentPending = this.getPendingPrompt(sessionId, pending.idempotencyKey);
+    if (!currentPending) {
+      return false;
+    }
+    if (result?.status === "ok") {
+      await this.finishPrompt(sessionId, currentPending, "end_turn");
+      return false;
+    }
+    if (result?.status === "error") {
+      void this.finishPrompt(sessionId, currentPending, "end_turn");
+      return false;
+    }
+    if (deadlineExpired) {
+      this.rejectPendingPrompt(
+        currentPending,
+        new Error(`Gateway disconnected: ${currentPending.disconnectReason}`),
+      );
+      return false;
+    }
+    return true;
   }
 
   private async sendAvailableCommands(sessionId: string): Promise<void> {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -61,13 +61,17 @@ const ACP_ELEVATED_LEVEL_CONFIG_ID = "elevated_level";
 const ACP_LOAD_SESSION_REPLAY_LIMIT = 1_000_000;
 const ACP_GATEWAY_DISCONNECT_GRACE_MS = 5_000;
 
+type DisconnectContext = {
+  generation: number;
+  reason: string;
+};
+
 type PendingPrompt = {
   sessionId: string;
   sessionKey: string;
   idempotencyKey: string;
   sendAccepted?: boolean;
-  disconnectGeneration?: number;
-  disconnectReason?: string;
+  disconnectContext?: DisconnectContext;
   resolve: (response: PromptResponse) => void;
   reject: (err: Error) => void;
   sentTextLength?: number;
@@ -412,6 +416,7 @@ export class AcpGatewayAgent implements Agent {
   private sessionCreateRateLimiter: FixedWindowRateLimiter;
   private pendingPrompts = new Map<string, PendingPrompt>();
   private disconnectTimer: NodeJS.Timeout | null = null;
+  private activeDisconnectContext: DisconnectContext | null = null;
   private disconnectGeneration = 0;
 
   private getPendingPrompt(sessionId: string, runId: string): PendingPrompt | undefined {
@@ -450,25 +455,29 @@ export class AcpGatewayAgent implements Agent {
 
   handleGatewayReconnect(): void {
     this.log("gateway reconnected");
-    void this.reconcilePendingPrompts(this.disconnectGeneration, false);
+    const disconnectContext = this.activeDisconnectContext;
+    this.activeDisconnectContext = null;
+    if (!disconnectContext) {
+      return;
+    }
+    void this.reconcilePendingPrompts(disconnectContext.generation, false);
   }
 
   handleGatewayDisconnect(reason: string): void {
     this.log(`gateway disconnected: ${reason}`);
+    const disconnectContext = {
+      generation: this.disconnectGeneration + 1,
+      reason,
+    };
+    this.disconnectGeneration = disconnectContext.generation;
+    this.activeDisconnectContext = disconnectContext;
     if (this.pendingPrompts.size === 0) {
       return;
     }
-    this.disconnectGeneration += 1;
     for (const pending of this.pendingPrompts.values()) {
-      pending.disconnectGeneration = this.disconnectGeneration;
-      pending.disconnectReason = reason;
+      pending.disconnectContext = disconnectContext;
     }
-    this.clearDisconnectTimer();
-    this.disconnectTimer = setTimeout(() => {
-      this.disconnectTimer = null;
-      void this.reconcilePendingPrompts(this.disconnectGeneration, true);
-    }, ACP_GATEWAY_DISCONNECT_GRACE_MS);
-    this.disconnectTimer.unref?.();
+    this.armDisconnectTimer(disconnectContext);
   }
 
   async handleGatewayEvent(evt: EventFrame): Promise<void> {
@@ -705,9 +714,13 @@ export class AcpGatewayAgent implements Agent {
         sessionId: params.sessionId,
         sessionKey: session.sessionKey,
         idempotencyKey: runId,
+        disconnectContext: this.activeDisconnectContext ?? undefined,
         resolve,
         reject,
       });
+      if (this.activeDisconnectContext && !this.disconnectTimer) {
+        this.armDisconnectTimer(this.activeDisconnectContext);
+      }
 
       const sendWithProvenanceFallback = async () => {
         try {
@@ -1043,7 +1056,20 @@ export class AcpGatewayAgent implements Agent {
     this.disconnectTimer = null;
   }
 
+  private armDisconnectTimer(disconnectContext: DisconnectContext): void {
+    this.clearDisconnectTimer();
+    this.disconnectTimer = setTimeout(() => {
+      this.disconnectTimer = null;
+      void this.reconcilePendingPrompts(disconnectContext.generation, true);
+    }, ACP_GATEWAY_DISCONNECT_GRACE_MS);
+    this.disconnectTimer.unref?.();
+  }
+
   private rejectPendingPrompt(pending: PendingPrompt, error: Error): void {
+    const currentPending = this.getPendingPrompt(pending.sessionId, pending.idempotencyKey);
+    if (currentPending !== pending) {
+      return;
+    }
     this.pendingPrompts.delete(pending.sessionId);
     this.sessionStore.clearActiveRun(pending.sessionId);
     if (this.pendingPrompts.size === 0) {
@@ -1053,8 +1079,7 @@ export class AcpGatewayAgent implements Agent {
   }
 
   private clearPendingDisconnectState(pending: PendingPrompt): void {
-    pending.disconnectGeneration = undefined;
-    pending.disconnectReason = undefined;
+    pending.disconnectContext = undefined;
   }
 
   private async reconcilePendingPrompts(
@@ -1070,17 +1095,20 @@ export class AcpGatewayAgent implements Agent {
 
     const pendingEntries = [...this.pendingPrompts.entries()];
     let keepDisconnectTimer = false;
+    const shouldRejectPending =
+      deadlineExpired && this.activeDisconnectContext?.generation === observedDisconnectGeneration;
     for (const [sessionId, pending] of pendingEntries) {
       if (this.pendingPrompts.get(sessionId) !== pending) {
         continue;
       }
-      if (pending.disconnectGeneration !== observedDisconnectGeneration) {
+      if (pending.disconnectContext?.generation !== observedDisconnectGeneration) {
         continue;
       }
       const shouldKeepPending = await this.reconcilePendingPrompt(
         sessionId,
         pending,
         deadlineExpired,
+        shouldRejectPending,
       );
       if (shouldKeepPending) {
         keepDisconnectTimer = true;
@@ -1096,18 +1124,12 @@ export class AcpGatewayAgent implements Agent {
     sessionId: string,
     pending: PendingPrompt,
     deadlineExpired: boolean,
+    shouldRejectPending: boolean,
   ): Promise<boolean> {
-    if (!pending.sendAccepted) {
-      if (deadlineExpired) {
-        this.rejectPendingPrompt(
-          pending,
-          new Error(`Gateway disconnected: ${pending.disconnectReason}`),
-        );
-        return false;
-      }
-      return true;
+    const disconnectContext = pending.disconnectContext;
+    if (!disconnectContext) {
+      return false;
     }
-
     let result: AgentWaitResult | undefined;
     try {
       result = await this.gateway.request<AgentWaitResult>(
@@ -1121,6 +1143,13 @@ export class AcpGatewayAgent implements Agent {
     } catch (err) {
       this.log(`agent.wait reconcile failed for ${pending.idempotencyKey}: ${String(err)}`);
       if (deadlineExpired) {
+        if (shouldRejectPending) {
+          this.rejectPendingPrompt(
+            pending,
+            new Error(`Gateway disconnected: ${disconnectContext.reason}`),
+          );
+          return false;
+        }
         this.clearPendingDisconnectState(pending);
         return false;
       }
@@ -1140,6 +1169,17 @@ export class AcpGatewayAgent implements Agent {
       return false;
     }
     if (deadlineExpired) {
+      if (shouldRejectPending) {
+        const currentDisconnectContext = currentPending.disconnectContext;
+        if (!currentDisconnectContext) {
+          return false;
+        }
+        this.rejectPendingPrompt(
+          currentPending,
+          new Error(`Gateway disconnected: ${currentDisconnectContext.reason}`),
+        );
+        return false;
+      }
       this.clearPendingDisconnectState(currentPending);
       return false;
     }


### PR DESCRIPTION
Follow-up cleanup for #59473.

- move disconnect state onto each pending prompt
- use one reconcile path for reconnect and grace expiry
- drop the separate disconnect deadline map