### PR TITLE
fix(web-ui): hide user memory scaffolding in chat history

### DIFF
--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -71,6 +71,26 @@ describe("stripEnvelopeFromMessage", () => {
     expect(result.senderLabel).toBe("alice");
   });
 
+  test("removes relevant-memories scaffolding from sanitized user messages", () => {
+    const input = {
+      role: "user",
+      content: [
+        "Conversation info (untrusted metadata):",
+        "```json",
+        '{"message_id":"123"}',
+        "```",
+        "",
+        "<relevant-memories>",
+        "Internal memory context",
+        "</relevant-memories>",
+        "",
+        "Actual user message",
+      ].join("\n"),
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe("Actual user message");
+  });
+
   test("strips metadata-like blocks even when not a prefix", () => {
     const input = {
       role: "user",

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -3,6 +3,7 @@ import {
   stripInboundMetadata,
 } from "../auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
+import { stripRelevantMemoriesScaffolding } from "../shared/text/assistant-visible-text.js";
 
 export { stripEnvelope };
 
@@ -48,9 +49,12 @@ function stripEnvelopeFromContentWithRole(
       return item;
     }
     const inboundStripped = stripInboundMetadata(entry.text);
-    const stripped = stripUserEnvelope
+    const visibleText = stripUserEnvelope
       ? stripMessageIdHints(stripEnvelope(inboundStripped))
       : inboundStripped;
+    const stripped = stripUserEnvelope
+      ? stripRelevantMemoriesScaffolding(visibleText).trimStart()
+      : visibleText;
     if (stripped === entry.text) {
       return item;
     }
@@ -81,9 +85,12 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
 
   if (typeof entry.content === "string") {
     const inboundStripped = stripInboundMetadata(entry.content);
-    const stripped = stripUserEnvelope
+    const visibleText = stripUserEnvelope
       ? stripMessageIdHints(stripEnvelope(inboundStripped))
       : inboundStripped;
+    const stripped = stripUserEnvelope
+      ? stripRelevantMemoriesScaffolding(visibleText).trimStart()
+      : visibleText;
     if (stripped !== entry.content) {
       next.content = stripped;
       changed = true;
@@ -96,9 +103,12 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
     }
   } else if (typeof entry.text === "string") {
     const inboundStripped = stripInboundMetadata(entry.text);
-    const stripped = stripUserEnvelope
+    const visibleText = stripUserEnvelope
       ? stripMessageIdHints(stripEnvelope(inboundStripped))
       : inboundStripped;
+    const stripped = stripUserEnvelope
+      ? stripRelevantMemoriesScaffolding(visibleText).trimStart()
+      : visibleText;
     if (stripped !== entry.text) {
       next.text = stripped;
       changed = true;

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { stripAssistantInternalScaffolding } from "./assistant-visible-text.js";
+import {
+  stripAssistantInternalScaffolding,
+  stripRelevantMemoriesScaffolding,
+} from "./assistant-visible-text.js";
 
 describe("stripAssistantInternalScaffolding", () => {
   function expectVisibleText(input: string, expected: string) {
@@ -98,5 +101,32 @@ describe("stripAssistantInternalScaffolding", () => {
       return;
     }
     expectVisibleText(input, expected);
+  });
+});
+
+describe("stripRelevantMemoriesScaffolding", () => {
+  it("strips relevant-memories blocks without touching surrounding visible text", () => {
+    const input = [
+      "Visible intro",
+      "<relevant-memories>",
+      "Internal memory note",
+      "</relevant-memories>",
+      "",
+      "Visible outro",
+    ].join("\n");
+    expect(stripRelevantMemoriesScaffolding(input)).toBe("Visible intro\n\n\nVisible outro");
+  });
+
+  it("preserves literal relevant-memories tags inside fenced code", () => {
+    const input = [
+      "```xml",
+      "<relevant-memories>",
+      "sample",
+      "</relevant-memories>",
+      "```",
+      "",
+      "Visible text",
+    ].join("\n");
+    expect(stripRelevantMemoriesScaffolding(input)).toBe(input);
   });
 });

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -4,7 +4,7 @@ import { stripReasoningTagsFromText } from "./reasoning-tags.js";
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
 
-function stripRelevantMemoriesTags(text: string): string {
+export function stripRelevantMemoriesScaffolding(text: string): string {
   if (!text || !MEMORY_TAG_QUICK_RE.test(text)) {
     return text;
   }
@@ -43,5 +43,5 @@ function stripRelevantMemoriesTags(text: string): string {
 
 export function stripAssistantInternalScaffolding(text: string): string {
   const withoutReasoning = stripReasoningTagsFromText(text, { mode: "preserve", trim: "start" });
-  return stripRelevantMemoriesTags(withoutReasoning).trimStart();
+  return stripRelevantMemoriesScaffolding(withoutReasoning).trimStart();
 }

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -42,6 +42,26 @@ describe("extractTextCached", () => {
     expect(extractText(message)).toBe("Final user answer");
     expect(extractTextCached(message)).toBe("Final user answer");
   });
+
+  it("strips user inbound metadata and relevant-memories scaffolding together", () => {
+    const message = {
+      role: "user",
+      content: [
+        "Conversation info (untrusted metadata):",
+        "```json",
+        '{"message_id":"123"}',
+        "```",
+        "",
+        "<relevant-memories>",
+        "Internal memory context",
+        "</relevant-memories>",
+        "",
+        "Actual user message",
+      ].join("\n"),
+    };
+    expect(extractText(message)).toBe("Actual user message");
+    expect(extractTextCached(message)).toBe("Actual user message");
+  });
 });
 
 describe("extractThinkingCached", () => {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,5 +1,6 @@
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
+import { stripRelevantMemoriesScaffolding } from "../../../../src/shared/text/assistant-visible-text.js";
 import { stripThinkingTags } from "../format.ts";
 
 const textCache = new WeakMap<object, string | null>();
@@ -11,7 +12,7 @@ function processMessageText(text: string, role: string): string {
     return stripThinkingTags(text);
   }
   return shouldStripInboundMetadata
-    ? stripInboundMetadata(stripEnvelope(text))
+    ? stripRelevantMemoriesScaffolding(stripInboundMetadata(stripEnvelope(text))).trimStart()
     : stripEnvelope(text);
 }
 

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -145,6 +145,26 @@ describe("message-normalizer", () => {
 
       expect(result.senderLabel).toBe("Iris");
     });
+
+    it("strips user relevant-memories scaffolding after inbound metadata cleanup", () => {
+      const result = normalizeMessage({
+        role: "user",
+        content: [
+          "Conversation info (untrusted metadata):",
+          "```json",
+          '{"message_id":"123"}',
+          "```",
+          "",
+          "<relevant-memories>",
+          "Internal memory context",
+          "</relevant-memories>",
+          "",
+          "Actual user message",
+        ].join("\n"),
+      });
+
+      expect(result.content).toEqual([{ type: "text", text: "Actual user message" }]);
+    });
   });
 
   describe("normalizeRoleForGrouping", () => {

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -8,6 +8,7 @@ import {
   isToolResultContentType,
   resolveToolBlockArgs,
 } from "../../../../src/chat/tool-content.js";
+import { stripRelevantMemoriesScaffolding } from "../../../../src/shared/text/assistant-visible-text.js";
 import type { NormalizedMessage, MessageContentItem } from "../types/chat-types.ts";
 
 /**
@@ -61,7 +62,10 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   if (role === "user" || role === "User") {
     content = content.map((item) => {
       if (item.type === "text" && typeof item.text === "string") {
-        return { ...item, text: stripInboundMetadata(item.text) };
+        return {
+          ...item,
+          text: stripRelevantMemoriesScaffolding(stripInboundMetadata(item.text)).trimStart(),
+        };
       }
       return item;
     });


### PR DESCRIPTION
## Summary
- strip user-facing `<relevant-memories>` scaffolding after inbound metadata cleanup in gateway chat history sanitization
- reuse the same cleanup in Web UI message extraction and normalization so history rendering stays consistent client/server
- add regression coverage for mixed `Conversation info` + `<relevant-memories>` user messages

## Testing
- `pnpm test -- src/shared/text/assistant-visible-text.test.ts src/gateway/chat-sanitize.test.ts ui/src/ui/chat/message-extract.test.ts ui/src/ui/chat/message-normalizer.test.ts`
- `pnpm check`

Closes #59568
