### PR TITLE
fix(status): avoid leaking multiline subagent tasks

### DIFF
--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -38,7 +38,7 @@ import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "..
 import type { ReplyPayload } from "../types.js";
 import type { CommandContext } from "./commands-types.js";
 import { getFollowupQueueDepth, resolveQueueSettings } from "./queue.js";
-import { resolveSubagentLabel } from "./subagents-utils.js";
+import { formatRunLabel } from "./subagents-utils.js";
 
 // Some usage endpoints only work with CLI/session OAuth tokens, not API keys.
 // Skip those probes when the active auth mode cannot satisfy the endpoint.
@@ -278,7 +278,7 @@ export async function buildStatusText(params: {
       const done = runs.length - active.length;
       if (verboseEnabled) {
         const labels = active
-          .map((entry) => resolveSubagentLabel(entry, ""))
+          .map((entry) => formatRunLabel(entry, { maxLength: 80 }))
           .filter(Boolean)
           .slice(0, 3);
         const labelText = labels.length ? ` (${labels.join(", ")})` : "";

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -2689,6 +2689,24 @@ describe("handleCommands subagents", () => {
       expectedText: ["🤖 Subagents: 1 active", "· 1 done"],
       unexpectedText: [] as string[],
     },
+    {
+      name: "does not leak multiline subagent task text in verbose /status",
+      seedRuns: () => {
+        addSubagentRunForTests({
+          runId: "run-1",
+          childSessionKey: "agent:main:subagent:abc",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "visible title\ninternal runtime context\nsession key: secret",
+          cleanup: "keep",
+          createdAt: 1000,
+          startedAt: 1000,
+        });
+      },
+      verboseLevel: "on" as const,
+      expectedText: ["🤖 Subagents: 1 active", "visible title"],
+      unexpectedText: ["internal runtime context", "session key: secret"],
+    },
   ])("$name", async ({ seedRuns, verboseLevel, expectedText, unexpectedText }) => {
     seedRuns();
     const cfg = {

--- a/src/auto-reply/reply/subagents-utils.test.ts
+++ b/src/auto-reply/reply/subagents-utils.test.ts
@@ -48,6 +48,11 @@ describe("subagents utils", () => {
   it("resolves subagent label with fallback", () => {
     expect(resolveSubagentLabel(makeRun({ label: "  runner " }))).toBe("runner");
     expect(resolveSubagentLabel(makeRun({ label: " ", task: "  task value " }))).toBe("task value");
+    expect(
+      resolveSubagentLabel(
+        makeRun({ label: " ", task: "  first line  \nsecond line with prompt details" }),
+      ),
+    ).toBe("first line");
     expect(resolveSubagentLabel(makeRun({ label: " ", task: " " }), "fallback")).toBe("fallback");
   });
 

--- a/src/auto-reply/reply/subagents-utils.ts
+++ b/src/auto-reply/reply/subagents-utils.ts
@@ -2,7 +2,9 @@ import type { SubagentRunRecord } from "../../agents/subagent-registry.js";
 import { truncateUtf16Safe } from "../../utils.js";
 
 export function resolveSubagentLabel(entry: SubagentRunRecord, fallback = "subagent") {
-  const raw = entry.label?.trim() || entry.task?.trim() || "";
+  const rawLabel = entry.label?.trim() || "";
+  const rawTask = entry.task?.trim() || "";
+  const raw = rawLabel || rawTask.split(/\r?\n/, 1)[0]?.trim() || "";
   return raw || fallback;
 }
 


### PR DESCRIPTION
## Summary
- use only the first line of `task` when a subagent run has no explicit label
- truncate verbose `/status` subagent labels before rendering them inline
- add regressions for multiline task fallback and verbose `/status` output

## Testing
- `pnpm test -- src/auto-reply/reply/subagents-utils.test.ts`
- commit hook `pnpm check` suite
