### PR TITLE
Android: add assistant entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Tasks/TaskFlow: restore the core TaskFlow substrate with managed-vs-mirrored sync modes, durable flow state/revision tracking, and `openclaw flows` inspection/recovery primitives so background orchestration can persist and be operated separately from plugin authoring layers. (#58930) Thanks @mbelinky.
 - Tasks/TaskFlow: add managed child task spawning plus sticky cancel intent, so external orchestrators can stop scheduling immediately and let parent TaskFlows settle to `cancelled` once active child tasks finish. (#59610) Thanks @mbelinky.
 - Plugins/TaskFlow: add a bound `api.runtime.taskFlow` seam so plugins and trusted authoring layers can create and drive managed TaskFlows from host-resolved OpenClaw context without passing owner identifiers on each call. (#59622) Thanks @mbelinky.
+- Android/assistant: add assistant-role entrypoints plus Google Assistant App Actions metadata so Android can launch OpenClaw from the assistant trigger and hand prompts into the chat composer. (#59596) Thanks @obviyus.
 
 ### Fixes
 

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -80,6 +80,10 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.ASSIST" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -49,9 +49,6 @@
         android:supportsRtl="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/Theme.OpenClawNode">
-        <meta-data
-            android:name="android.app.shortcuts"
-            android:resource="@xml/shortcuts" />
         <service
             android:name=".NodeForegroundService"
             android:exported="false"
@@ -79,6 +76,9 @@
             android:exported="true"
             android:windowSoftInputMode="adjustResize"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|uiMode|density|keyboard|keyboardHidden|navigation">
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -49,6 +49,9 @@
         android:supportsRtl="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/Theme.OpenClawNode">
+        <meta-data
+            android:name="android.app.shortcuts"
+            android:resource="@xml/shortcuts" />
         <service
             android:name=".NodeForegroundService"
             android:exported="false"

--- a/apps/android/app/src/main/java/ai/openclaw/app/AssistantLaunch.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AssistantLaunch.kt
@@ -1,0 +1,40 @@
+package ai.openclaw.app
+
+import android.content.Intent
+
+const val actionAskOpenClaw = "ai.openclaw.app.action.ASK_OPENCLAW"
+const val extraAssistantPrompt = "prompt"
+
+enum class HomeDestination {
+  Connect,
+  Chat,
+  Voice,
+  Screen,
+  Settings,
+}
+
+data class AssistantLaunchRequest(
+  val source: String,
+  val prompt: String?,
+)
+
+fun parseAssistantLaunchIntent(intent: Intent?): AssistantLaunchRequest? {
+  val action = intent?.action ?: return null
+  return when (action) {
+    Intent.ACTION_ASSIST ->
+      AssistantLaunchRequest(
+        source = "assist",
+        prompt = null,
+      )
+
+    actionAskOpenClaw -> {
+      val prompt = intent.getStringExtra(extraAssistantPrompt)?.trim()?.ifEmpty { null }
+      AssistantLaunchRequest(
+        source = "app_action",
+        prompt = prompt,
+      )
+    }
+
+    else -> null
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
@@ -23,6 +23,7 @@ class MainActivity : ComponentActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    handleAssistantIntent(intent)
     WindowCompat.setDecorFitsSystemWindows(window, false)
     permissionRequester = PermissionRequester(this)
 
@@ -69,5 +70,16 @@ class MainActivity : ComponentActivity() {
   override fun onStop() {
     viewModel.setForeground(false)
     super.onStop()
+  }
+
+  override fun onNewIntent(intent: android.content.Intent) {
+    super.onNewIntent(intent)
+    setIntent(intent)
+    handleAssistantIntent(intent)
+  }
+
+  private fun handleAssistantIntent(intent: android.content.Intent?) {
+    val request = parseAssistantLaunchIntent(intent) ?: return
+    viewModel.handleAssistantLaunch(request)
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -27,6 +27,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   private val prefs = nodeApp.prefs
   private val runtimeRef = MutableStateFlow<NodeRuntime?>(null)
   private var foreground = true
+  private val _requestedHomeDestination = MutableStateFlow<HomeDestination?>(null)
+  val requestedHomeDestination: StateFlow<HomeDestination?> = _requestedHomeDestination
+  private val _chatDraft = MutableStateFlow<String?>(null)
+  val chatDraft: StateFlow<String?> = _chatDraft
 
   private fun ensureRuntime(): NodeRuntime {
     runtimeRef.value?.let { return it }
@@ -244,6 +248,19 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setVoiceScreenActive(active: Boolean) {
     ensureRuntime().setVoiceScreenActive(active)
+  }
+
+  fun handleAssistantLaunch(request: AssistantLaunchRequest) {
+    _requestedHomeDestination.value = HomeDestination.Chat
+    _chatDraft.value = request.prompt
+  }
+
+  fun clearRequestedHomeDestination() {
+    _requestedHomeDestination.value = null
+  }
+
+  fun clearChatDraft() {
+    _chatDraft.value = null
   }
 
   fun setMicEnabled(enabled: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/PostOnboardingTabs.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import ai.openclaw.app.HomeDestination
 import ai.openclaw.app.MainViewModel
 
 private enum class HomeTab(
@@ -72,6 +73,20 @@ fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) 
   var activeTab by rememberSaveable { mutableStateOf(HomeTab.Connect) }
   var chatTabStarted by rememberSaveable { mutableStateOf(false) }
   var screenTabStarted by rememberSaveable { mutableStateOf(false) }
+  val requestedHomeDestination by viewModel.requestedHomeDestination.collectAsState()
+
+  LaunchedEffect(requestedHomeDestination) {
+    val destination = requestedHomeDestination ?: return@LaunchedEffect
+    activeTab =
+      when (destination) {
+        HomeDestination.Connect -> HomeTab.Connect
+        HomeDestination.Chat -> HomeTab.Chat
+        HomeDestination.Voice -> HomeTab.Voice
+        HomeDestination.Screen -> HomeTab.Screen
+        HomeDestination.Settings -> HomeTab.Settings
+      }
+    viewModel.clearRequestedHomeDestination()
+  }
 
   // Stop TTS when user navigates away from voice tab, and lazily keep the Chat/Screen tabs
   // alive after the first visit so repeated tab switches do not rebuild their UI trees.

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -9,6 +9,7 @@ import android.hardware.SensorManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
+import android.app.role.RoleManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -150,6 +151,8 @@ fun SettingsSheet(viewModel: MainViewModel) {
         versionName
       }
     }
+  var assistantRoleAvailable by remember(context) { mutableStateOf(isAssistantRoleAvailable(context)) }
+  var assistantRoleHeld by remember(context) { mutableStateOf(isAssistantRoleHeld(context)) }
   val listItemColors =
     ListItemDefaults.colors(
       containerColor = Color.Transparent,
@@ -326,6 +329,12 @@ fun SettingsSheet(viewModel: MainViewModel) {
       viewModel.refreshGatewayConnection()
     }
 
+  val assistantRoleLauncher =
+    rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+      assistantRoleAvailable = isAssistantRoleAvailable(context)
+      assistantRoleHeld = isAssistantRoleHeld(context)
+    }
+
   DisposableEffect(lifecycleOwner, context) {
     val observer =
       LifecycleEventObserver { _, event ->
@@ -362,6 +371,8 @@ fun SettingsSheet(viewModel: MainViewModel) {
             ||
               ContextCompat.checkSelfPermission(context, Manifest.permission.READ_SMS) ==
               PackageManager.PERMISSION_GRANTED
+          assistantRoleAvailable = isAssistantRoleAvailable(context)
+          assistantRoleHeld = isAssistantRoleHeld(context)
         }
       }
     lifecycleOwner.lifecycle.addObserver(observer)
@@ -476,6 +487,42 @@ fun SettingsSheet(viewModel: MainViewModel) {
               instanceId.take(8) + "…",
               style = mobileCaption1.copy(fontFamily = FontFamily.Monospace),
               color = mobileTextTertiary,
+            )
+          }
+          if (assistantRoleAvailable) {
+            HorizontalDivider(color = mobileBorder)
+            ListItem(
+              modifier = Modifier.fillMaxWidth(),
+              colors = listItemColors,
+              headlineContent = { Text("Default Assistant", style = mobileHeadline) },
+              supportingContent = {
+                Text(
+                  if (assistantRoleHeld) {
+                    "OpenClaw is registered as the device assistant."
+                  } else {
+                    "Let Android launch OpenClaw from the assistant gesture. Google Assistant App Actions still work separately."
+                  },
+                  style = mobileCallout,
+                )
+              },
+              trailingContent = {
+                Button(
+                  onClick = {
+                    assistantRoleLauncher.launch(
+                      context
+                        .getSystemService(RoleManager::class.java)
+                        .createRequestRoleIntent(RoleManager.ROLE_ASSISTANT),
+                    )
+                  },
+                  colors = settingsPrimaryButtonColors(),
+                  shape = RoundedCornerShape(14.dp),
+                ) {
+                  Text(
+                    if (assistantRoleHeld) "Manage" else "Enable",
+                    style = mobileCallout.copy(fontWeight = FontWeight.Bold),
+                  )
+                }
+              },
             )
           }
         }
@@ -1293,4 +1340,12 @@ private fun hasMotionCapabilities(context: Context): Boolean {
   val sensorManager = context.getSystemService(SensorManager::class.java) ?: return false
   return sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) != null ||
     sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER) != null
+}
+
+private fun isAssistantRoleAvailable(context: Context): Boolean {
+  return context.getSystemService(RoleManager::class.java).isRoleAvailable(RoleManager.ROLE_ASSISTANT)
+}
+
+private fun isAssistantRoleHeld(context: Context): Boolean {
+  return context.getSystemService(RoleManager::class.java).isRoleHeld(RoleManager.ROLE_ASSISTANT)
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -61,10 +62,12 @@ import ai.openclaw.app.ui.mobileTextTertiary
 
 @Composable
 fun ChatComposer(
+  draftText: String?,
   healthOk: Boolean,
   thinkingLevel: String,
   pendingRunCount: Int,
   attachments: List<PendingImageAttachment>,
+  onDraftApplied: () -> Unit,
   onPickImages: () -> Unit,
   onRemoveAttachment: (id: String) -> Unit,
   onSetThinkingLevel: (level: String) -> Unit,
@@ -73,7 +76,16 @@ fun ChatComposer(
   onSend: (text: String) -> Unit,
 ) {
   var input by rememberSaveable { mutableStateOf("") }
+  var lastAppliedDraft by rememberSaveable { mutableStateOf<String?>(null) }
   var showThinkingMenu by remember { mutableStateOf(false) }
+
+  LaunchedEffect(draftText) {
+    val draft = draftText?.trim()?.ifEmpty { null } ?: return@LaunchedEffect
+    if (draft == lastAppliedDraft) return@LaunchedEffect
+    input = draft
+    lastAppliedDraft = draft
+    onDraftApplied()
+  }
 
   val canSend = pendingRunCount == 0 && (input.trim().isNotEmpty() || attachments.isNotEmpty()) && healthOk
   val sendBusy = pendingRunCount > 0

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
@@ -60,6 +60,37 @@ import ai.openclaw.app.ui.mobileText
 import ai.openclaw.app.ui.mobileTextSecondary
 import ai.openclaw.app.ui.mobileTextTertiary
 
+internal data class DraftApplication(
+  val input: String,
+  val lastAppliedDraft: String?,
+  val consumed: Boolean,
+)
+
+internal fun applyDraftText(
+  draftText: String?,
+  currentInput: String,
+  lastAppliedDraft: String?,
+): DraftApplication {
+  val draft =
+    draftText?.trim()?.ifEmpty { null } ?: return DraftApplication(
+      input = currentInput,
+      lastAppliedDraft = null,
+      consumed = false,
+    )
+  if (draft == lastAppliedDraft) {
+    return DraftApplication(
+      input = currentInput,
+      lastAppliedDraft = lastAppliedDraft,
+      consumed = false,
+    )
+  }
+  return DraftApplication(
+    input = draft,
+    lastAppliedDraft = draft,
+    consumed = true,
+  )
+}
+
 @Composable
 fun ChatComposer(
   draftText: String?,
@@ -80,11 +111,12 @@ fun ChatComposer(
   var showThinkingMenu by remember { mutableStateOf(false) }
 
   LaunchedEffect(draftText) {
-    val draft = draftText?.trim()?.ifEmpty { null } ?: return@LaunchedEffect
-    if (draft == lastAppliedDraft) return@LaunchedEffect
-    input = draft
-    lastAppliedDraft = draft
-    onDraftApplied()
+    val next = applyDraftText(draftText = draftText, currentInput = input, lastAppliedDraft = lastAppliedDraft)
+    input = next.input
+    lastAppliedDraft = next.lastAppliedDraft
+    if (next.consumed) {
+      onDraftApplied()
+    }
   }
 
   val canSend = pendingRunCount == 0 && (input.trim().isNotEmpty() || attachments.isNotEmpty()) && healthOk

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
@@ -60,6 +60,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
   val streamingAssistantText by viewModel.chatStreamingAssistantText.collectAsState()
   val pendingToolCalls by viewModel.chatPendingToolCalls.collectAsState()
   val sessions by viewModel.chatSessions.collectAsState()
+  val chatDraft by viewModel.chatDraft.collectAsState()
 
   LaunchedEffect(Unit) {
     viewModel.loadChat(mainSessionKey)
@@ -118,10 +119,12 @@ fun ChatSheetContent(viewModel: MainViewModel) {
 
     Row(modifier = Modifier.fillMaxWidth().imePadding()) {
       ChatComposer(
+        draftText = chatDraft,
         healthOk = healthOk,
         thinkingLevel = thinkingLevel,
         pendingRunCount = pendingRunCount,
         attachments = attachments,
+        onDraftApplied = viewModel::clearChatDraft,
         onPickImages = { pickImages.launch("image/*") },
         onRemoveAttachment = { id -> attachments.removeAll { it.id == id } },
         onSetThinkingLevel = { level -> viewModel.setChatThinkingLevel(level) },

--- a/apps/android/app/src/main/res/values/assistant.xml
+++ b/apps/android/app/src/main/res/values/assistant.xml
@@ -1,0 +1,7 @@
+<resources>
+    <string-array name="ask_openclaw_query_patterns">
+        <item>ask OpenClaw $prompt</item>
+        <item>tell OpenClaw to $prompt</item>
+        <item>open OpenClaw and ask $prompt</item>
+    </string-array>
+</resources>

--- a/apps/android/app/src/main/res/xml/shortcuts.xml
+++ b/apps/android/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,17 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <capability
+        android:name="custom.actions.intent.ASK_OPENCLAW"
+        app:queryPatterns="@array/ask_openclaw_query_patterns">
+        <intent
+            android:action="ai.openclaw.app.action.ASK_OPENCLAW"
+            android:targetPackage="ai.openclaw.app"
+            android:targetClass="ai.openclaw.app.MainActivity">
+            <parameter
+                android:name="prompt"
+                android:key="prompt"
+                android:mimeType="text/*"
+                android:required="true" />
+        </intent>
+    </capability>
+</shortcuts>

--- a/apps/android/app/src/test/java/ai/openclaw/app/AssistantLaunchTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AssistantLaunchTest.kt
@@ -1,0 +1,39 @@
+package ai.openclaw.app
+
+import android.content.Intent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AssistantLaunchTest {
+  @Test
+  fun parsesAssistGestureIntent() {
+    val parsed = parseAssistantLaunchIntent(Intent(Intent.ACTION_ASSIST))
+
+    requireNotNull(parsed)
+    assertEquals("assist", parsed.source)
+    assertNull(parsed.prompt)
+  }
+
+  @Test
+  fun parsesAppActionPrompt() {
+    val parsed =
+      parseAssistantLaunchIntent(
+        Intent(actionAskOpenClaw).putExtra(extraAssistantPrompt, "  summarize my unread texts  "),
+      )
+
+    requireNotNull(parsed)
+    assertEquals("app_action", parsed.source)
+    assertEquals("summarize my unread texts", parsed.prompt)
+  }
+
+  @Test
+  fun ignoresUnrelatedIntents() {
+    assertNull(parseAssistantLaunchIntent(Intent(Intent.ACTION_VIEW)))
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerDraftTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerDraftTest.kt
@@ -1,0 +1,44 @@
+package ai.openclaw.app.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatComposerDraftTest {
+  @Test
+  fun clearsLastAppliedDraftWhenViewModelDraftResets() {
+    val consumed =
+      applyDraftText(
+        draftText = "repeat this",
+        currentInput = "",
+        lastAppliedDraft = null,
+      )
+
+    assertTrue(consumed.consumed)
+    assertEquals("repeat this", consumed.input)
+    assertEquals("repeat this", consumed.lastAppliedDraft)
+
+    val cleared =
+      applyDraftText(
+        draftText = null,
+        currentInput = consumed.input,
+        lastAppliedDraft = consumed.lastAppliedDraft,
+      )
+
+    assertFalse(cleared.consumed)
+    assertEquals("repeat this", cleared.input)
+    assertEquals(null, cleared.lastAppliedDraft)
+
+    val repeated =
+      applyDraftText(
+        draftText = "repeat this",
+        currentInput = cleared.input,
+        lastAppliedDraft = cleared.lastAppliedDraft,
+      )
+
+    assertTrue(repeated.consumed)
+    assertEquals("repeat this", repeated.input)
+    assertEquals("repeat this", repeated.lastAppliedDraft)
+  }
+}


### PR DESCRIPTION
## Summary
- add Android assistant launch handling that routes into chat
- add assistant role request flow in Settings
- add Google Assistant App Actions shortcuts metadata

## Testing
- ./gradlew :app:compileThirdPartyDebugKotlin
- ./gradlew :app:testThirdPartyDebugUnitTest --tests 'ai.openclaw.app.AssistantLaunchTest'