### PR TITLE
fix(exec): ignore invalid host policy fields consistently

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1,7 +1,9 @@
 import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import { withEnvAsync as withEnvAsyncPluginSdk } from "openclaw/plugin-sdk/testing";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { withEnvAsync } from "../../../src/test-utils/env.js";
+import { withEnvAsync as withEnvAsyncCompat } from "../../../src/test-utils/env.js";
 import { escapeRegExp, formatEnvelopeTimestamp } from "../../../test/helpers/envelope-timestamp.js";
+const withEnvAsync = withEnvAsyncCompat ?? withEnvAsyncPluginSdk;
 const harness = await import("./bot.create-telegram-bot.test-harness.js");
 const EYES_EMOJI = "\u{1F440}";
 const {

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1,5 +1,4 @@
 import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
-import { withEnvAsync } from "openclaw/plugin-sdk/testing";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../../../src/test-utils/env.js";
 import { escapeRegExp, formatEnvelopeTimestamp } from "../../../test/helpers/envelope-timestamp.js";

--- a/extensions/telegram/src/thread-bindings.test.ts
+++ b/extensions/telegram/src/thread-bindings.test.ts
@@ -3,9 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+import { loadBundledPluginTestApiSync as loadBundledPluginTestApiSyncPluginSdk } from "openclaw/plugin-sdk/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadBundledPluginTestApiSync } from "../../../src/test-utils/bundled-plugin-public-surface.js";
+import { loadBundledPluginTestApiSync as loadBundledPluginTestApiSyncCompat } from "../../../src/test-utils/bundled-plugin-public-surface.js";
 import { importFreshModule } from "../../../test/helpers/import-fresh.js";
+const loadBundledPluginTestApiSync =
+  loadBundledPluginTestApiSyncCompat ?? loadBundledPluginTestApiSyncPluginSdk;
 import {
   __testing,
   createTelegramThreadBindingManager,

--- a/extensions/telegram/src/thread-bindings.test.ts
+++ b/extensions/telegram/src/thread-bindings.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
-import { loadBundledPluginTestApiSync } from "openclaw/plugin-sdk/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadBundledPluginTestApiSync } from "../../../src/test-utils/bundled-plugin-public-surface.js";
 import { importFreshModule } from "../../../test/helpers/import-fresh.js";

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -3,9 +3,11 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
+import { withEnvAsync as withEnvAsyncPluginSdk } from "openclaw/plugin-sdk/testing";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { withEnvAsync } from "../../../src/test-utils/env.js";
+import { withEnvAsync as withEnvAsyncCompat } from "../../../src/test-utils/env.js";
 import { escapeRegExp, formatEnvelopeTimestamp } from "../../../test/helpers/envelope-timestamp.js";
+const withEnvAsync = withEnvAsyncCompat ?? withEnvAsyncPluginSdk;
 import {
   createWebInboundDeliverySpies,
   createMockWebListener,

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -3,7 +3,6 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
-import { withEnvAsync } from "openclaw/plugin-sdk/testing";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../../../src/test-utils/env.js";
 import { escapeRegExp, formatEnvelopeTimestamp } from "../../../test/helpers/envelope-timestamp.js";

--- a/src/agents/skills.test-helpers.ts
+++ b/src/agents/skills.test-helpers.ts
@@ -37,6 +37,12 @@ export function createCanonicalFixtureSkill(params: {
     filePath: params.filePath,
     baseDir: params.baseDir,
     source: params.source,
+    sourceInfo: {
+      source: params.source,
+      baseDir: params.baseDir,
+      scope: "project",
+      origin: "top-level",
+    },
     disableModelInvocation: params.disableModelInvocation ?? false,
-  };
+  } as Skill;
 }

--- a/src/agents/skills.test-helpers.ts
+++ b/src/agents/skills.test-helpers.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createSyntheticSourceInfo, type Skill } from "@mariozechner/pi-coding-agent";
+import type { Skill } from "@mariozechner/pi-coding-agent";
 
 export async function writeSkill(params: {
   dir: string;
@@ -37,12 +37,6 @@ export function createCanonicalFixtureSkill(params: {
     filePath: params.filePath,
     baseDir: params.baseDir,
     source: params.source,
-    sourceInfo: createSyntheticSourceInfo(params.filePath, {
-      source: params.source,
-      baseDir: params.baseDir,
-      scope: "project",
-      origin: "top-level",
-    }),
     disableModelInvocation: params.disableModelInvocation ?? false,
   };
 }

--- a/src/agents/skills/local-loader.ts
+++ b/src/agents/skills/local-loader.ts
@@ -74,8 +74,14 @@ function loadSingleSkillDirectory(params: {
     filePath,
     baseDir,
     source: params.source,
+    sourceInfo: {
+      source: params.source,
+      baseDir,
+      scope: "project",
+      origin: "top-level",
+    },
     disableModelInvocation: invocation.disableModelInvocation,
-  };
+  } as Skill;
 }
 
 function listCandidateSkillDirs(dir: string): string[] {

--- a/src/agents/skills/local-loader.ts
+++ b/src/agents/skills/local-loader.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { createSyntheticSourceInfo, type Skill } from "@mariozechner/pi-coding-agent";
+import type { Skill } from "@mariozechner/pi-coding-agent";
 import { openVerifiedFileSync } from "../../infra/safe-open-sync.js";
 import { parseFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
 
@@ -74,12 +74,6 @@ function loadSingleSkillDirectory(params: {
     filePath,
     baseDir,
     source: params.source,
-    sourceInfo: createSyntheticSourceInfo(filePath, {
-      source: params.source,
-      baseDir,
-      scope: "project",
-      origin: "top-level",
-    }),
     disableModelInvocation: invocation.disableModelInvocation,
   };
 }

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -485,9 +485,21 @@ type ResolvedExecPolicyField<TValue extends ExecSecurity | ExecAsk> = {
   source: string | null;
 };
 
+function hasOwnPolicyField(
+  value: unknown,
+  field: "security" | "ask" | "askFallback",
+): boolean {
+  if (!value || typeof value !== "object" || !Object.hasOwn(value, field)) {
+    return false;
+  }
+  const fieldValue = (value as Record<string, unknown>)[field];
+  return fieldValue !== null && fieldValue !== undefined;
+}
+
 function resolveDefaultSecurityField(params: {
   field: "security" | "askFallback";
   defaults: ExecApprovalsDefaults;
+  rawDefaults: ExecApprovalsDefaults;
   fallback: ExecSecurity;
 }): ResolvedExecPolicyField<ExecSecurity> {
   const defaultValue = params.defaults[params.field];
@@ -495,6 +507,12 @@ function resolveDefaultSecurityField(params: {
     return {
       value: defaultValue,
       source: `defaults.${params.field}`,
+    };
+  }
+  if (hasOwnPolicyField(params.rawDefaults, params.field)) {
+    return {
+      value: params.fallback,
+      source: null,
     };
   }
   return {
@@ -505,12 +523,19 @@ function resolveDefaultSecurityField(params: {
 
 function resolveDefaultAskField(params: {
   defaults: ExecApprovalsDefaults;
+  rawDefaults: ExecApprovalsDefaults;
   fallback: ExecAsk;
 }): ResolvedExecPolicyField<ExecAsk> {
   if (isExecAsk(params.defaults.ask)) {
     return {
       value: params.defaults.ask,
       source: "defaults.ask",
+    };
+  }
+  if (hasOwnPolicyField(params.rawDefaults, "ask")) {
+    return {
+      value: params.fallback,
+      source: null,
     };
   }
   return {
@@ -522,6 +547,7 @@ function resolveDefaultAskField(params: {
 function resolveAgentSecurityField(params: {
   field: "security" | "askFallback";
   defaults: ExecApprovalsDefaults;
+  rawDefaults: ExecApprovalsDefaults;
   agent: ExecApprovalsAgent;
   rawAgent: ExecApprovalsAgent;
   wildcard: ExecApprovalsAgent;
@@ -532,10 +558,10 @@ function resolveAgentSecurityField(params: {
   const fallbackField = resolveDefaultSecurityField({
     field: params.field,
     defaults: params.defaults,
+    rawDefaults: params.rawDefaults,
     fallback: params.fallback,
   });
-  const rawAgentValue = params.rawAgent[params.field];
-  if (rawAgentValue != null) {
+  if (hasOwnPolicyField(params.rawAgent, params.field)) {
     if (isExecSecurity(params.agent[params.field])) {
       return {
         value: params.agent[params.field] as ExecSecurity,
@@ -544,8 +570,7 @@ function resolveAgentSecurityField(params: {
     }
     return fallbackField;
   }
-  const rawWildcardValue = params.rawWildcard[params.field];
-  if (rawWildcardValue != null) {
+  if (hasOwnPolicyField(params.rawWildcard, params.field)) {
     if (isExecSecurity(params.wildcard[params.field])) {
       return {
         value: params.wildcard[params.field] as ExecSecurity,
@@ -559,6 +584,7 @@ function resolveAgentSecurityField(params: {
 
 function resolveAgentAskField(params: {
   defaults: ExecApprovalsDefaults;
+  rawDefaults: ExecApprovalsDefaults;
   agent: ExecApprovalsAgent;
   rawAgent: ExecApprovalsAgent;
   wildcard: ExecApprovalsAgent;
@@ -568,9 +594,10 @@ function resolveAgentAskField(params: {
 }): ResolvedExecPolicyField<ExecAsk> {
   const fallbackField = resolveDefaultAskField({
     defaults: params.defaults,
+    rawDefaults: params.rawDefaults,
     fallback: params.fallback,
   });
-  if (params.rawAgent.ask != null) {
+  if (hasOwnPolicyField(params.rawAgent, "ask")) {
     if (isExecAsk(params.agent.ask)) {
       return {
         value: params.agent.ask,
@@ -579,7 +606,7 @@ function resolveAgentAskField(params: {
     }
     return fallbackField;
   }
-  if (params.rawWildcard.ask != null) {
+  if (hasOwnPolicyField(params.rawWildcard, "ask")) {
     if (isExecAsk(params.wildcard.ask)) {
       return {
         value: params.wildcard.ask,
@@ -624,6 +651,7 @@ export function resolveExecApprovalsFromFile(params: {
   const rawFile = params.file;
   const file = normalizeExecApprovals(params.file);
   const defaults = file.defaults ?? {};
+  const rawDefaults = rawFile.defaults ?? {};
   const agentKey = params.agentId ?? DEFAULT_AGENT_ID;
   const agent = file.agents?.[agentKey] ?? {};
   const wildcard = file.agents?.["*"] ?? {};
@@ -645,6 +673,7 @@ export function resolveExecApprovalsFromFile(params: {
   const resolvedAgentSecurity = resolveAgentSecurityField({
     field: "security",
     defaults,
+    rawDefaults,
     agent,
     rawAgent,
     wildcard,
@@ -654,6 +683,7 @@ export function resolveExecApprovalsFromFile(params: {
   });
   const resolvedAgentAsk = resolveAgentAskField({
     defaults,
+    rawDefaults,
     agent,
     rawAgent,
     wildcard,
@@ -664,6 +694,7 @@ export function resolveExecApprovalsFromFile(params: {
   const resolvedAgentAskFallback = resolveAgentSecurityField({
     field: "askFallback",
     defaults,
+    rawDefaults,
     agent,
     rawAgent,
     wildcard,

--- a/src/plugins/bundle-manifest.ts
+++ b/src/plugins/bundle-manifest.ts
@@ -118,7 +118,7 @@ function loadBundleManifestFile(params: {
     });
   }
   try {
-    const raw = JSON5.parse(fs.readFileSync(opened.fd, "utf-8")) as unknown;
+    const raw = JSON5.parse(fs.readFileSync(opened.fd, "utf-8"));
     if (!isRecord(raw)) {
       return { ok: false, error: "plugin manifest must be an object", manifestPath };
     }

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -274,7 +274,7 @@ export function loadPluginManifest(
   }
   let raw: unknown;
   try {
-    raw = JSON5.parse(fs.readFileSync(opened.fd, "utf-8")) as unknown;
+    raw = JSON5.parse(fs.readFileSync(opened.fd, "utf-8"));
   } catch (err) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary
- treat invalid agent-scoped host policy values as explicit masks that fall back to defaults instead of wildcard entries
- ignore mixed-case host policy strings when attributing effective host policy sources
- preserve explicit null semantics so null still behaves like unset and may fall through to wildcard/defaults

## Testing
- pnpm test -- src/infra/exec-approvals-config.test.ts src/infra/exec-approvals-policy.test.ts
- pnpm test -- src/agents/bash-tools.exec-host-shared.test.ts