### PR TITLE
fix(providers): centralize Anthropic endpoint classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Mattermost/probes: route status probes through the SSRF guard and honor `allowPrivateNetwork` so connectivity checks stay safe for self-hosted Mattermost deployments. (#58529) Thanks @mappel-nv.
 - QQBot/structured payloads: restrict local file paths to QQ Bot-owned media storage, block traversal outside that root, reduce path leakage in logs, and keep inline image data URLs working. (#58453) Thanks @jacobtomlinson.
 - Providers/streaming headers: centralize default and attribution header merging across OpenAI websocket, embedded-runner, and proxy stream paths so provider-specific headers stay consistent and caller overrides only win where intended. (#59542) Thanks @vincentkoc.
+- Providers/Anthropic routing: centralize native-vs-proxy endpoint classification for direct Anthropic `service_tier` handling so spoofed or proxied hosts do not inherit native Anthropic defaults. (#59608) Thanks @vincentkoc.
 - Browser/host inspection: keep static Chrome inspection helpers out of the activated browser runtime so `openclaw doctor browser` and related checks do not eagerly load the bundled browser plugin. (#59471) Thanks @vincentkoc.
 - Image tool/paths: resolve relative local media paths against the agent `workspaceDir` instead of `process.cwd()` so inputs like `inbox/receipt.png` pass the local-path allowlist reliably. (#57222) Thanks Priyansh Gupta.
 - Podman/launch: remove noisy container output from `scripts/run-openclaw-podman.sh` and align the Podman install guidance with the quieter startup flow. (#59368) Thanks @sallyom.

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -1,5 +1,6 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
+import { resolveProviderEndpoint } from "openclaw/plugin-sdk/provider-http";
 import { streamWithPayloadPatch } from "openclaw/plugin-sdk/provider-stream";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 
@@ -58,12 +59,7 @@ function isAnthropicPublicApiBaseUrl(baseUrl: unknown): boolean {
   if (typeof baseUrl !== "string" || !baseUrl.trim()) {
     return true;
   }
-
-  try {
-    return new URL(baseUrl).hostname.toLowerCase() === "api.anthropic.com";
-  } catch {
-    return baseUrl.toLowerCase().includes("api.anthropic.com");
-  }
+  return resolveProviderEndpoint(baseUrl).endpointClass === "anthropic-public";
 }
 
 function resolveAnthropicFastServiceTier(enabled: boolean): AnthropicServiceTier {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2844,6 +2844,24 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("service_tier");
   });
 
+  it("does not inject Anthropic service_tier for spoofed Anthropic-looking hosts", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "anthropic",
+      applyModelId: "claude-sonnet-4-5",
+      extraParamsOverride: {
+        serviceTier: "standard_only",
+      },
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        baseUrl: "https://api.anthropic.com.attacker.example/v1",
+      } as unknown as Model<"anthropic-messages">,
+      payload: {},
+    });
+    expect(payload).not.toHaveProperty("service_tier");
+  });
+
   it("maps fast mode to priority service_tier for openai-codex responses", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "openai-codex",

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -219,6 +219,10 @@ export {
 
 const MAX_BTW_SNAPSHOT_MESSAGES = 100;
 
+function shouldEnableAnthropicThinkingRecovery(api: string | null | undefined): boolean {
+  return api === "anthropic-messages" || api === "bedrock-converse-stream";
+}
+
 export function resolveEmbeddedAgentStreamFn(params: {
   currentStreamFn: StreamFn | undefined;
   providerStreamFn?: StreamFn;
@@ -1095,10 +1099,7 @@ export async function runEmbeddedAttempt(
         );
       }
 
-      if (
-        params.model.api === "anthropic-messages" ||
-        params.model.api === "bedrock-converse-stream"
-      ) {
+      if (shouldEnableAnthropicThinkingRecovery(params.model.api)) {
         activeSession.agent.streamFn = wrapAnthropicStreamWithRecovery(
           activeSession.agent.streamFn,
           { id: activeSession.sessionId },
@@ -1130,10 +1131,7 @@ export async function runEmbeddedAttempt(
       }
 
       try {
-        if (
-          params.model.api === "anthropic-messages" ||
-          params.model.api === "bedrock-converse-stream"
-        ) {
+        if (shouldEnableAnthropicThinkingRecovery(params.model.api)) {
           const originalMessageCount = activeSession.messages.length;
           const { messages, prefill } = sanitizeThinkingForRecovery(activeSession.messages);
           if (messages !== activeSession.messages) {

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -277,6 +277,18 @@ describe("provider attribution", () => {
     });
   });
 
+  it("classifies native Anthropic endpoints separately from custom hosts", () => {
+    expect(resolveProviderEndpoint("https://api.anthropic.com/v1")).toMatchObject({
+      endpointClass: "anthropic-public",
+      hostname: "api.anthropic.com",
+    });
+
+    expect(resolveProviderEndpoint("https://proxy.example.com/anthropic")).toMatchObject({
+      endpointClass: "custom",
+      hostname: "proxy.example.com",
+    });
+  });
+
   it("classifies Google Gemini and Vertex endpoints separately from custom hosts", () => {
     expect(resolveProviderEndpoint("https://generativelanguage.googleapis.com")).toMatchObject({
       endpointClass: "google-generative-ai",
@@ -326,6 +338,11 @@ describe("provider attribution", () => {
   });
 
   it("does not trust schemeless or embedded trusted-provider substrings", () => {
+    expect(resolveProviderEndpoint("api.anthropic.com.attacker.example")).toMatchObject({
+      endpointClass: "custom",
+      hostname: "api.anthropic.com.attacker.example",
+    });
+
     expect(resolveProviderEndpoint("api.openai.com.attacker.example")).toMatchObject({
       endpointClass: "custom",
       hostname: "api.openai.com.attacker.example",

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -33,6 +33,7 @@ export type ProviderRequestCapability = "llm" | "audio" | "image" | "video" | "o
 
 export type ProviderEndpointClass =
   | "default"
+  | "anthropic-public"
   | "openai-public"
   | "openai-codex"
   | "azure-openai"
@@ -131,6 +132,9 @@ export function resolveProviderEndpoint(
   }
   if (host === "api.openai.com") {
     return { endpointClass: "openai-public", hostname: host };
+  }
+  if (host === "api.anthropic.com") {
+    return { endpointClass: "anthropic-public", hostname: host };
   }
   if (host === "chatgpt.com") {
     return { endpointClass: "openai-codex", hostname: host };


### PR DESCRIPTION
## Summary

- Problem: Anthropic native-host detection for `service_tier` injection still lived in `extensions/anthropic/stream-wrappers.ts`, while the shared request-policy engine already owned equivalent native-vs-proxy classification for OpenAI-family and Google-family.
- Why it matters: provider-local host parsing is easy to drift, and the old Anthropic helper used a loose fallback that could treat Anthropic-looking hosts as native.
- What changed: added `anthropic-public` to the shared endpoint classifier in `src/agents/provider-attribution.ts`, migrated the Anthropic stream wrappers to use that classifier, and added spoofed-host regressions at both the classifier and payload-mutation layers.
- What did NOT change (scope boundary): this PR does not add Anthropic attribution behavior, does not change missing-`baseUrl` semantics, and does not broaden request policy beyond endpoint classification for `service_tier` gating.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix
- [ ] Feature
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #59556
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Anthropic kept a private `api.anthropic.com` detector in the stream wrapper instead of consuming the shared endpoint classifier.
- Missing detection / guardrail: there was no shared `anthropic-public` endpoint class, so the stream wrapper owned its own native-vs-proxy policy branch.
- Prior context (`git blame`, prior PR, issue, or refactor if known): follows the request-policy rollout in #59433, #59454, #59469, #59542, and the Google-family endpoint classification in #59556.
- Why this regressed now: once OpenAI-family and Google-family moved onto the shared classifier, Anthropic became the next obvious duplicated policy pocket.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/provider-attribution.test.ts`, `src/agents/pi-embedded-runner-extraparams.test.ts`
- Scenario the test should lock in: only native `api.anthropic.com` endpoints get Anthropic `service_tier` injection; proxied and spoofed Anthropic-looking hosts do not.
- Why this is the smallest reliable guardrail: the classifier test pins endpoint resolution, and the payload-mutation test proves the actual user-visible Anthropic behavior stays correct.
- Existing test that already covers this (if any): proxied Anthropic `service_tier` non-injection coverage already existed and was extended.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Anthropic `service_tier` defaults still apply on native Anthropic endpoints.
- Anthropic-looking spoofed/custom hosts no longer qualify as native Anthropic endpoints for `service_tier` injection.

## Diagram (if applicable)

```text
Before:
[Anthropic stream wrapper] -> local api.anthropic.com check -> inject service_tier
[shared endpoint policy] -> no Anthropic-native class

After:
[Anthropic stream wrapper] -> shared endpoint classifier -> inject service_tier only on anthropic-public
[shared endpoint policy] -> Anthropic joins the central native-vs-proxy model
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 25 + pnpm worktree
- Model/provider: Anthropic message transport
- Integration/channel (if any): N/A
- Relevant config (redacted): native vs proxied `baseUrl` for Anthropic models

### Steps

1. Resolve native and proxied Anthropic endpoints through the shared classifier.
2. Apply Anthropic fast-mode/service-tier payload mutation against native, proxied, and spoofed Anthropic-looking hosts.
3. Run focused tests plus `pnpm build` and `pnpm check`.

### Expected

- Native `api.anthropic.com` classifies as `anthropic-public`.
- Proxy/custom/spoofed hosts classify as non-native.
- `service_tier` injects only on native Anthropic endpoints.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: shared classifier returns `anthropic-public` for native Anthropic; Anthropic fast-mode and explicit service-tier injection still work on native hosts; spoofed Anthropic-looking hosts do not get `service_tier`.
- Edge cases checked: proxied Anthropic URLs stay non-native; missing `baseUrl` still preserves prior native-default behavior.
- What you did **not** verify: any broader Anthropic auth/header policy beyond `service_tier` endpoint gating.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: another provider-specific endpoint class slightly grows the shared enum.
  - Mitigation: this is the intended architecture direction, and the new class is immediately consumed by Anthropic instead of staying dead surface.