### PR TITLE
[codex] fix sandbox browser SSRF bridge policy propagation

### DIFF
--- a/extensions/browser/src/browser-runtime.ts
+++ b/extensions/browser/src/browser-runtime.ts
@@ -37,7 +37,11 @@ export type {
 } from "./browser/client.js";
 export type { BrowserExecutable } from "./browser/chrome.executables.js";
 export type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./browser/config.js";
-export { resolveBrowserConfig, resolveProfile } from "./browser/config.js";
+export {
+  resolveBrowserConfig,
+  resolveBrowserSsrFPolicy,
+  resolveProfile,
+} from "./browser/config.js";
 export {
   DEFAULT_AI_SNAPSHOT_MAX_CHARS,
   DEFAULT_BROWSER_EVALUATE_ENABLED,

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -99,7 +99,7 @@ function normalizeStringList(raw: string[] | undefined): string[] | undefined {
   return values.length > 0 ? values : undefined;
 }
 
-function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | undefined {
+export function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | undefined {
   const allowPrivateNetwork = cfg?.ssrfPolicy?.allowPrivateNetwork;
   const dangerouslyAllowPrivateNetwork = cfg?.ssrfPolicy?.dangerouslyAllowPrivateNetwork;
   const allowedHostnames = normalizeStringList(cfg?.ssrfPolicy?.allowedHostnames);

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { collectDockerFlagValues, findDockerArgsCall } from "./test-args.js";
 import type { SandboxConfig } from "./types.js";
 import { SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
@@ -235,5 +236,64 @@ describe("ensureSandboxBrowser create args", () => {
     const createArgs = findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create");
     const labels = collectDockerFlagValues(createArgs ?? [], "--label");
     expect(labels).toContain(`openclaw.mountFormatVersion=${SANDBOX_MOUNT_FORMAT_VERSION}`);
+  });
+
+  it("recreates a cached bridge when ssrfPolicy changes", async () => {
+    const cfg = buildConfig(false);
+    const existingBridge = {
+      server: {} as never,
+      port: 19000,
+      baseUrl: "http://127.0.0.1:19000",
+      state: {
+        server: null,
+        port: 19000,
+        resolved: {
+          cdpProtocol: "http",
+          cdpHost: "127.0.0.1",
+          cdpIsLoopback: true,
+          defaultProfile: "openclaw",
+          profiles: {
+            openclaw: {
+              cdpPort: 49100,
+              color: "#4F46E5",
+            },
+          },
+          ssrfPolicy: { dangerouslyAllowPrivateNetwork: true } satisfies SsrFPolicy,
+        },
+        profiles: new Map(),
+      },
+    };
+    BROWSER_BRIDGES.set("session:test", {
+      bridge: existingBridge,
+      containerName: "openclaw-sbx-browser-session-test-0661d10a",
+      authToken: undefined,
+      authPassword: undefined,
+    });
+    dockerMocks.dockerContainerState.mockResolvedValue({ exists: true, running: true });
+    dockerMocks.readDockerContainerLabel.mockResolvedValue("matching-hash");
+    registryMocks.readBrowserRegistry.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-sbx-browser-session-test-0661d10a",
+          configHash: "matching-hash",
+          lastUsedAtMs: Date.now(),
+        },
+      ],
+    });
+
+    await ensureSandboxBrowser({
+      scopeKey: "session:test",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg,
+      ssrfPolicy: { allowedHostnames: ["example.com"] },
+    });
+
+    expect(BROWSER_BRIDGES.get("session:test")).toMatchObject({
+      containerName: "openclaw-sbx-browser-session-test-0661d10a",
+    });
+    expect((BROWSER_BRIDGES.get("session:test") as { bridge: unknown }).bridge).not.toBe(
+      existingBridge,
+    );
   });
 });

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { deriveDefaultBrowserCdpPortRange } from "../../config/port-defaults.js";
+import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import {
   DEFAULT_BROWSER_EVALUATE_ENABLED,
   DEFAULT_OPENCLAW_BROWSER_COLOR,
@@ -40,6 +41,17 @@ import { appendWorkspaceMountArgs, SANDBOX_MOUNT_FORMAT_VERSION } from "./worksp
 const HOT_BROWSER_WINDOW_MS = 5 * 60 * 1000;
 const CDP_SOURCE_RANGE_ENV_KEY = "OPENCLAW_BROWSER_CDP_SOURCE_RANGE";
 
+function normalizeSandboxBridgeSsrFPolicyKey(ssrfPolicy?: SsrFPolicy): string {
+  if (!ssrfPolicy) {
+    return "";
+  }
+  return JSON.stringify({
+    dangerouslyAllowPrivateNetwork: ssrfPolicy.dangerouslyAllowPrivateNetwork === true,
+    allowedHostnames: [...(ssrfPolicy.allowedHostnames ?? [])].toSorted(),
+    hostnameAllowlist: [...(ssrfPolicy.hostnameAllowlist ?? [])].toSorted(),
+  });
+}
+
 async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number }): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, params.timeoutMs);
   const url = `http://127.0.0.1:${params.cdpPort}/json/version`;
@@ -68,6 +80,7 @@ function buildSandboxBrowserResolvedConfig(params: {
   cdpPort: number;
   headless: boolean;
   evaluateEnabled: boolean;
+  ssrfPolicy?: SsrFPolicy;
 }): ResolvedBrowserConfig {
   const cdpHost = "127.0.0.1";
   const cdpPortRange = deriveDefaultBrowserCdpPortRange(params.controlPort);
@@ -95,6 +108,7 @@ function buildSandboxBrowserResolvedConfig(params: {
         color: DEFAULT_OPENCLAW_BROWSER_COLOR,
       },
     },
+    ssrfPolicy: params.ssrfPolicy,
   };
 }
 
@@ -135,6 +149,7 @@ export async function ensureSandboxBrowser(params: {
   cfg: SandboxConfig;
   evaluateEnabled?: boolean;
   bridgeAuth?: { token?: string; password?: string };
+  ssrfPolicy?: SsrFPolicy;
 }): Promise<SandboxBrowserContext | null> {
   if (!params.cfg.browser.enabled) {
     return null;
@@ -308,10 +323,18 @@ export async function ensureSandboxBrowser(params: {
 
   const shouldReuse =
     existing && existing.containerName === containerName && existingProfile?.cdpPort === mappedCdp;
+  const policyMatches =
+    !existing ||
+    normalizeSandboxBridgeSsrFPolicyKey(existing.bridge.state.resolved.ssrfPolicy) ===
+      normalizeSandboxBridgeSsrFPolicyKey(params.ssrfPolicy);
   const authMatches =
     !existing ||
     (existing.authToken === desiredAuthToken && existing.authPassword === desiredAuthPassword);
   if (existing && !shouldReuse) {
+    await stopBrowserBridgeServer(existing.bridge.server).catch(() => undefined);
+    BROWSER_BRIDGES.delete(params.scopeKey);
+  }
+  if (existing && shouldReuse && !policyMatches) {
     await stopBrowserBridgeServer(existing.bridge.server).catch(() => undefined);
     BROWSER_BRIDGES.delete(params.scopeKey);
   }
@@ -321,7 +344,7 @@ export async function ensureSandboxBrowser(params: {
   }
 
   const bridge = (() => {
-    if (shouldReuse && authMatches && existing) {
+    if (shouldReuse && policyMatches && authMatches && existing) {
       return existing.bridge;
     }
     return null;
@@ -356,6 +379,7 @@ export async function ensureSandboxBrowser(params: {
         cdpPort: mappedCdp,
         headless: params.cfg.browser.headless,
         evaluateEnabled: params.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED,
+        ssrfPolicy: params.ssrfPolicy,
       }),
       authToken: desiredAuthToken,
       authPassword: desiredAuthPassword,
@@ -365,7 +389,7 @@ export async function ensureSandboxBrowser(params: {
   };
 
   const resolvedBridge = await ensureBridge();
-  if (!shouldReuse || !authMatches) {
+  if (!shouldReuse || !policyMatches || !authMatches) {
     BROWSER_BRIDGES.set(params.scopeKey, {
       bridge: resolvedBridge,
       containerName,

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_BROWSER_EVALUATE_ENABLED,
   ensureBrowserControlAuth,
   resolveBrowserControlAuth,
+  resolveBrowserSsrFPolicy,
 } from "../../plugin-sdk/browser-runtime.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveUserPath } from "../../utils.js";
@@ -187,6 +188,7 @@ export async function resolveSandboxContext(params: {
           cfg: resolvedCfg,
           evaluateEnabled,
           bridgeAuth,
+          ssrfPolicy: resolveBrowserSsrFPolicy(params.config?.browser),
         })
       : null;
 

--- a/src/plugin-sdk/browser-config.ts
+++ b/src/plugin-sdk/browser-config.ts
@@ -1,12 +1,12 @@
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveGatewayPort } from "../config/paths.js";
-import type { BrowserConfig, BrowserProfileConfig } from "../config/types.browser.js";
 import {
   DEFAULT_BROWSER_CONTROL_PORT,
   deriveDefaultBrowserCdpPortRange,
   deriveDefaultBrowserControlPort,
 } from "../config/port-defaults.js";
+import type { BrowserConfig, BrowserProfileConfig } from "../config/types.browser.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
@@ -133,7 +133,7 @@ function normalizeStringList(raw: string[] | undefined): string[] | undefined {
   return values.length > 0 ? values : undefined;
 }
 
-function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | undefined {
+export function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | undefined {
   const allowPrivateNetwork = cfg?.ssrfPolicy?.allowPrivateNetwork;
   const dangerouslyAllowPrivateNetwork = cfg?.ssrfPolicy?.dangerouslyAllowPrivateNetwork;
   const allowedHostnames = normalizeStringList(cfg?.ssrfPolicy?.allowedHostnames);

--- a/src/plugin-sdk/browser-runtime.ts
+++ b/src/plugin-sdk/browser-runtime.ts
@@ -11,6 +11,7 @@ export {
   redactCdpUrl,
   resolveBrowserConfig,
   resolveBrowserControlAuth,
+  resolveBrowserSsrFPolicy,
   resolveProfile,
 } from "./browser-config.js";
 import {


### PR DESCRIPTION
## Summary
- propagate the normalized top-level browser SSRF policy into sandbox browser bridge config
- recreate cached sandbox browser bridges when the effective SSRF policy changes
- add a regression test covering cached-bridge invalidation on policy change

## Root Cause
The sandbox browser path builds its own bridge-local `ResolvedBrowserConfig` instead of reusing the regular browser runtime config. That path was not carrying the normalized SSRF policy into the bridge, and cached bridges were still being reused after the effective policy changed.

## Validation
- `pnpm exec vitest run src/agents/sandbox/browser.create.test.ts`
- repository commit checks passed during `git commit` (`pnpm check`, `pnpm tsgo`, `pnpm lint`, and related auth/webhook checks)
