### PR TITLE
fix(plugin-sdk): narrow groups runtime discord seam

### DIFF
--- a/src/auto-reply/reply/groups.runtime.ts
+++ b/src/auto-reply/reply/groups.runtime.ts
@@ -1,3 +1,3 @@
 export { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
-export { resolveDiscordGroupRequireMention } from "../../plugin-sdk/discord.js";
+export { resolveDiscordGroupRequireMention } from "../../plugin-sdk/discord-surface.js";
 export { resolveSlackGroupRequireMention } from "../../plugin-sdk/slack.js";


### PR DESCRIPTION
## Summary
- switch `src/auto-reply/reply/groups.runtime.ts` from the broad Discord plugin-sdk barrel to the narrower `discord-surface` facade
- finish the last remaining production Discord barrel caller after the earlier seam-narrowing PRs

## Testing
- [x] `pnpm test -- extensions/discord/src/targets.test.ts`
- [x] `codex review --base origin/main`
- [ ] `pnpm check` currently fails on unrelated `origin/main` errors in `src/agents/pi-embedded-runner/thinking.ts` and `src/agents/pi-embedded-runner/thinking.test.ts`
- [ ] `pnpm build` currently fails on the same unrelated `pi-embedded-runner` type error on latest `origin/main`

## Notes
- AI-assisted
- `src/auto-reply/reply/groups.test.ts` already hangs on clean `origin/main` in this worktree, so I did not use it as a landing gate for this one-line seam change
- no changelog: internal boundary hardening only