### PR TITLE
fix(telegram): preserve topic thread when message replies include replyTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/crypto persistence: capture and write the IndexedDB snapshot while holding the snapshot file lock so concurrent gateway and CLI persists cannot overwrite newer crypto state. (#59851) Thanks @al3mart.
 - Telegram/media: keep inbound image attachments readable on upgraded installs where legacy state roots still differ from the managed config-dir media cache. (#59971) Thanks @neeravmakwana.
 - Telegram/local Bot API: thread `channels.telegram.apiRoot` through buffered reply-media and album downloads so self-hosted Bot API file paths stop falling back to `api.telegram.org` and 404ing. (#59544) Thanks @SARAMALI15792.
+- Telegram/replies: preserve explicit topic targets when `replyTo` is present while still inheriting the current topic for same-chat replies without an explicit topic. (#59634) Thanks @dashhuang.
 
 ## 2026.4.2
 

--- a/extensions/telegram/src/action-threading.test.ts
+++ b/extensions/telegram/src/action-threading.test.ts
@@ -17,7 +17,7 @@ describe("resolveTelegramAutoThreadId", () => {
   it("matches chats across Telegram target formats", () => {
     expect(
       resolveTelegramAutoThreadId({
-        to: "telegram:group:-100123:topic:77",
+        to: "telegram:group:-100123",
         toolContext: createToolContext(),
       }),
     ).toBe("thread-1");
@@ -33,6 +33,15 @@ describe("resolveTelegramAutoThreadId", () => {
       resolveTelegramAutoThreadId({
         to: "-100123",
         toolContext: createToolContext({ currentChannelId: undefined }),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not override an explicit target topic", () => {
+    expect(
+      resolveTelegramAutoThreadId({
+        to: "telegram:group:-100123:topic:77",
+        toolContext: createToolContext(),
       }),
     ).toBeUndefined();
   });

--- a/extensions/telegram/src/action-threading.ts
+++ b/extensions/telegram/src/action-threading.ts
@@ -9,6 +9,9 @@ export function resolveTelegramAutoThreadId(params: {
     return undefined;
   }
   const parsedTo = parseTelegramTarget(params.to);
+  if (parsedTo.messageThreadId != null) {
+    return undefined;
+  }
   const parsedChannel = parseTelegramTarget(context.currentChannelId);
   if (parsedTo.chatId.toLowerCase() !== parsedChannel.chatId.toLowerCase()) {
     return undefined;

--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -268,6 +268,20 @@ describe("telegramPlugin threading", () => {
 
     expect(resolved).toBe("533274");
   });
+
+  it("does not override an explicit target topic when replyToId is present", () => {
+    const resolved = telegramPlugin.threading?.resolveAutoThreadId?.({
+      cfg: createCfg(),
+      to: "telegram:-1001:topic:99",
+      replyToId: "4103",
+      toolContext: {
+        currentChannelId: "telegram:-1001:topic:77",
+        currentThreadTs: "77",
+      },
+    });
+
+    expect(resolved).toBeUndefined();
+  });
 });
 
 describe("telegramPlugin bindings", () => {

--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -254,6 +254,20 @@ describe("telegramPlugin threading", () => {
       currentThreadTs: "77",
     });
   });
+
+  it("keeps current DM topic threadId even when replyToId is present", () => {
+    const resolved = telegramPlugin.threading?.resolveAutoThreadId?.({
+      cfg: createCfg(),
+      to: "telegram:1234",
+      replyToId: "4103",
+      toolContext: {
+        currentChannelId: "telegram:1234",
+        currentThreadTs: "533274",
+      },
+    });
+
+    expect(resolved).toBe("533274");
+  });
 });
 
 describe("telegramPlugin bindings", () => {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -824,8 +824,8 @@ export const telegramPlugin = createChatChannelPlugin({
   threading: {
     topLevelReplyToMode: "telegram",
     buildToolContext: (params) => buildTelegramThreadingToolContext(params),
-    resolveAutoThreadId: ({ to, toolContext, replyToId }) =>
-      replyToId ? undefined : resolveTelegramAutoThreadId({ to, toolContext }),
+    resolveAutoThreadId: ({ to, toolContext }) =>
+      resolveTelegramAutoThreadId({ to, toolContext }),
   },
   outbound: {
     base: {


### PR DESCRIPTION
## Summary

Fix Telegram topic routing for `message` tool sends that include `replyTo`.

Today the Telegram plugin stops auto-inheriting the current topic/thread whenever `replyToId` is present. That breaks a common DM-topic / forum-topic flow:

- the agent is replying inside a Telegram topic
- the agent sends an attachment via `message`
- the tool call includes `replyTo`
- outbound send loses `threadId`
- Telegram accepts the send, but posts it into the chat's main stream instead of the active topic

This PR keeps topic auto-thread inheritance active even when `replyToId` is present.

## Root cause

In `extensions/telegram/src/channel.ts`, the plugin currently treats `replyToId` as a reason to suppress topic routing:

```ts
resolveAutoThreadId: ({ to, toolContext, replyToId }) =>
  replyToId ? undefined : resolveTelegramAutoThreadId({ to, toolContext })
```

For Telegram, these are different concerns:

- `replyToId` answers which message to reply to
- `threadId` answers which topic/thread the outbound message belongs to

Suppressing `threadId` when `replyToId` is present causes replies with attachments to fall out of the active topic.

## Change

- remove the `replyToId ? undefined : ...` guard
- continue resolving topic `threadId` from the current Telegram context whenever the target chat still matches the current chat
- add a regression test covering the failing `replyToId` path in a DM topic

## Why this is safe

`resolveTelegramAutoThreadId` already checks that:

- `toolContext.currentThreadTs` exists
- `toolContext.currentChannelId` exists
- the outbound target chat matches the current chat

So this does not force thread inheritance across chats. It only stops incorrectly dropping thread routing for same-chat replies.

## Validation

Validated on a source checkout with:

- `pnpm test -- --run extensions/telegram/src/channel.test.ts extensions/telegram/src/action-threading.test.ts src/infra/outbound/message-action-runner.threading.test.ts`
- `pnpm build`

## Related

Fixes #59023
