### PR TITLE
Fix macOS exec-host JSONL socket deadlock by half-closing the request stream

### DIFF
--- a/src/infra/jsonl-socket.test.ts
+++ b/src/infra/jsonl-socket.test.ts
@@ -54,6 +54,42 @@ describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
     });
   });
 
+  it("half-closes the write side after sending the request line", async () => {
+    await withTempDir({ prefix: "openclaw-jsonl-socket-" }, async (dir) => {
+      const socketPath = path.join(dir, "socket.sock");
+      const server = net.createServer((socket) => {
+        let buffer = "";
+        socket.on("data", (chunk) => {
+          buffer += chunk.toString("utf8");
+        });
+        socket.on("end", () => {
+          expect(buffer).toBe('{"hello":"world"}\n');
+          socket.end('{"type":"done","value":7}\n');
+        });
+      });
+      const listening = await listenOnSocket(server, socketPath);
+      if (!listening) {
+        return;
+      }
+
+      try {
+        await expect(
+          requestJsonlSocket({
+            socketPath,
+            payload: '{"hello":"world"}',
+            timeoutMs: 500,
+            accept: (msg) => {
+              const value = msg as { type?: string; value?: number };
+              return value.type === "done" ? (value.value ?? null) : undefined;
+            },
+          }),
+        ).resolves.toBe(7);
+      } finally {
+        server.close();
+      }
+    });
+  });
+
   it("returns null on timeout and on socket errors", async () => {
     await withTempDir({ prefix: "openclaw-jsonl-socket-" }, async (dir) => {
       const socketPath = path.join(dir, "socket.sock");

--- a/src/infra/jsonl-socket.test.ts
+++ b/src/infra/jsonl-socket.test.ts
@@ -57,13 +57,14 @@ describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
   it("half-closes the write side after sending the request line", async () => {
     await withTempDir({ prefix: "openclaw-jsonl-socket-" }, async (dir) => {
       const socketPath = path.join(dir, "socket.sock");
+      let receivedBuffer: string | null = null;
       const server = net.createServer((socket) => {
         let buffer = "";
         socket.on("data", (chunk) => {
           buffer += chunk.toString("utf8");
         });
         socket.on("end", () => {
-          expect(buffer).toBe('{"hello":"world"}\n');
+          receivedBuffer = buffer;
           socket.end('{"type":"done","value":7}\n');
         });
       });
@@ -84,6 +85,7 @@ describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
             },
           }),
         ).resolves.toBe(7);
+        expect(receivedBuffer).toBe('{"hello":"world"}\n');
       } finally {
         server.close();
       }

--- a/src/infra/jsonl-socket.ts
+++ b/src/infra/jsonl-socket.ts
@@ -30,7 +30,8 @@ export async function requestJsonlSocket<T>(params: {
 
     client.on("error", () => finish(null));
     client.connect(socketPath, () => {
-      client.write(`${payload}\n`);
+      // The macOS exec host can wait for EOF before responding, so finish writing.
+      client.end(`${payload}\n`);
     });
     client.on("data", (data) => {
       buffer += data.toString("utf8");


### PR DESCRIPTION
## Summary

This fixes a macOS exec-host deadlock on `exec-approvals.sock` by half-closing the client write side after sending the single JSONL request line.

## Root Cause

`requestJsonlSocket()` was sending the request with `client.write(...)` and leaving the socket write side open.

On the macOS app side, the exec-host socket server reads with `FileHandle.read(upToCount:)` inside `readLineFromHandle(...)`. In practice, that can leave the server waiting for more input / EOF, while the client is waiting for a response, so the request hangs.

Switching the client send to `client.end(...)` matches the one-request / one-response JSONL protocol and avoids the deadlock.

## Changes

- replace `client.write(`${payload}\n`)` with `client.end(`${payload}\n`)`
- add a regression test that only replies after the client half-closes the write side

## Verification

Local targeted test:

```bash
pnpm exec vitest run --config vitest.unit.config.ts src/infra/jsonl-socket.test.ts
```

Result:

- `1` test file passed
- `3` tests passed

## Related

- Closes #59633
