### PR TITLE
cli-runner: add promptFlag to CliBackendConfig for ordered prompt ins…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Kimi Coding: keep native Anthropic tool payloads on the Kimi coding endpoint while still parsing tagged tool-call text on the response path, so tool calls execute again instead of echoing raw markup. (#60391) Thanks @Eric-Guo.
 - Plugins/install: preserve `--dangerously-force-unsafe-install` across linked plugin probes and linked hook-pack fallback probes so local `--link` installs honor the documented unsafe override. (#60624) Thanks @JerrettDavis.
 - Auto-reply/reasoning: preserve reasoning and compaction markers while coalescing adjacent reply blocks so hidden reasoning does not leak when mixed with visible text on channels like WhatsApp. Thanks @mcaxtr.
+- Agents/Claude CLI: insert the prompt immediately after `-p` for CLI-backed Claude runs so prompts are not misparsed as later positional or session arguments. (#59640) Thanks @wangshu94.
 
 ## 2026.4.2
 

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -37,6 +37,7 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
       ],
       output: "jsonl",
       input: "arg",
+      promptFlag: "-p",
       modelArg: "--model",
       modelAliases: CLAUDE_CLI_MODEL_ALIASES,
       sessionArg: "--session-id",

--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -133,6 +133,66 @@ describe("buildCliArgs", () => {
       }),
     ).toEqual(["-p", "--append-system-prompt", "Stable prefix\nDynamic suffix"]);
   });
+  
+  it("places the prompt immediately after Claude CLI -p", () => {
+    expect(
+      buildCliArgs({
+        backend: {
+          command: "claude",
+          promptFlag: "-p",
+        },
+        baseArgs: [
+          "-p",
+          "--output-format",
+          "stream-json",
+          "--verbose",
+          "--permission-mode",
+          "bypassPermissions",
+        ],
+        modelId: "claude-opus-4-6",
+        promptArg: "user prompt",
+        useResume: false,
+      }),
+    ).toEqual([
+      "-p",
+      "user prompt",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+  });
+
+  it("places the prompt immediately after --prompt for generic prompt-flag backends", () => {
+    expect(
+      buildCliArgs({
+        backend: {
+          command: "gemini",
+          promptFlag: "--prompt",
+        },
+        baseArgs: ["--resume", "sid-1", "--prompt", "--output-format", "json"],
+        modelId: "gemini-3.1-pro-preview",
+        promptArg: "resume prompt",
+        useResume: true,
+      }),
+    ).toEqual(["--resume", "sid-1", "--prompt", "resume prompt", "--output-format", "json"]);
+  });
+
+  it("appends the prompt when no prompt flag exists in base args", () => {
+    expect(
+      buildCliArgs({
+        backend: {
+          command: "codex",
+          modelArg: "--model",
+        },
+        baseArgs: ["exec", "--json"],
+        modelId: "gpt-5.4",
+        promptArg: "user prompt",
+        useResume: false,
+      }),
+    ).toEqual(["exec", "--json", "--model", "gpt-5.4", "user prompt"]);
+  });
 });
 
 describe("resolveCliRunQueueKey", () => {

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -303,7 +303,17 @@ export function buildCliArgs(params: {
     }
   }
   if (params.promptArg !== undefined) {
-    args.push(params.promptArg);
+    const promptFlag = params.backend.promptFlag;
+    if (promptFlag) {
+      const flagIndex = args.findIndex((arg) => arg === promptFlag);
+      if (flagIndex >= 0) {
+        args.splice(flagIndex + 1, 0, params.promptArg);
+      } else {
+        args.push(params.promptArg);
+      }
+    } else {
+      args.push(params.promptArg);
+    }
   }
   return args;
 }

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -2897,6 +2897,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                         },
                       ],
                     },
+                    promptFlag: {
+                      type: "string",
+                    },
                     serialize: {
                       type: "boolean",
                     },

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -85,6 +85,8 @@ export type CliBackendConfig = {
   imageArg?: string;
   /** How to pass multiple images. */
   imageMode?: "repeat" | "list";
+  /** If set, splice the prompt value immediately after this flag in argv (e.g. "-p" for Claude Code CLI). */
+  promptFlag?: string;
   /** Serialize runs for this CLI. */
   serialize?: boolean;
   /** Runtime reliability tuning for this backend's process lifecycle. */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -535,6 +535,7 @@ export const CliBackendSchema = z
       .optional(),
     imageArg: z.string().optional(),
     imageMode: z.union([z.literal("repeat"), z.literal("list")]).optional(),
+    promptFlag: z.string().optional(),
     serialize: z.boolean().optional(),
     reliability: z
       .object({


### PR DESCRIPTION
## Summary
Problem: When running the Claude CLI command with -p flag and placing the prompt at the end of all flags, the prompt text was being misinterpreted as a session path instead of the actual prompt, causing the error:  CP config file not found     

Root Cause: The -p (--print) flag enables non-interactive mode and expects the prompt as the first positional argument immediately after -p.
  When the prompt is placed at the end of all flags, the argument parser misidentifies it as a session ID/path parameter.

Fix: Either place the prompt right after -p:
  claude -p "your prompt" --output-format stream-json --model sonnet ...

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

