### PR TITLE
ci: raise Windows checks timeout to 90 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,7 +724,9 @@ jobs:
     needs: [preflight, build-artifacts]
     if: always() && needs.preflight.outputs.run_checks_windows == 'true' && needs.build-artifacts.result == 'success'
     runs-on: blacksmith-32vcpu-windows-2025
-    timeout-minutes: 60
+    # Some Windows shards occasionally exceed the default 60 minute cap even when
+    # the underlying test run is still making progress.
+    timeout-minutes: 90
     env:
       NODE_OPTIONS: --max-old-space-size=6144
       # Keep total concurrency predictable on the 32 vCPU runner.


### PR DESCRIPTION
## Summary

Increase the `checks-windows` job timeout from 60 minutes to 90 minutes.

## Why

PR #58965 hit a Windows-only timeout on `checks-windows-node-test-5` even though the job made it all the way into `Run test (node)` before GitHub cancelled it for exceeding the 1 hour cap.

This does not look like a functional regression in the PR itself. It looks more like a CI stability issue where one Windows shard occasionally runs longer than the current budget.

## Change

- raise `checks-windows` `timeout-minutes` from `60` to `90`

## Context

The failing run was:
- https://github.com/openclaw/openclaw/actions/runs/23846550633

GitHub reported:
- `The job has exceeded the maximum execution time of 1h0m0s`

## Note

This is intentionally a small stabilization change. If the same shard keeps drifting upward, the better long-term follow-up would be to rebalance or further split the Windows test shards.