### PR TITLE
docs(skills): add advanced features section to creating-skills guide

### DIFF
--- a/docs/tools/creating-skills.md
+++ b/docs/tools/creating-skills.md
@@ -109,6 +109,28 @@ The YAML frontmatter supports these fields:
 | Bundled (shipped with OpenClaw) | Lowest     | Global                |
 | `skills.load.extraDirs`         | Lowest     | Custom shared folders |
 
+## Advanced features
+
+Once your basic skill works, these features help you build production-quality
+skills:
+
+- **Conditional activation** — Use `requires.bins`, `requires.env`, or
+  `requires.config` to gate your skill so it only loads when dependencies
+  are available. See [Skills reference — Gating](/tools/skills#gating).
+- **API key and env injection** — Skills can receive secrets via
+  `skills.entries.<name>.apiKey` and `skills.entries.<name>.env` in your
+  config. See [Skills reference — Config/env wiring](/tools/skills#config-wiring).
+- **Invocation control** — Set `user-invocable: false` to hide a skill from
+  slash commands, or `disable-model-invocation: true` to exclude it from the
+  model prompt. See [Skills reference — Frontmatter](/tools/skills#frontmatter).
+- **Multi-command skills** — Use `command-dispatch: tool` with `command-tool`
+  to bypass the model and dispatch slash commands directly to a tool. See
+  [Skills reference — Frontmatter](/tools/skills#frontmatter).
+- **Template variables** — Use `{baseDir}` in your SKILL.md to reference
+  the skill directory portably. See [Skills reference](/tools/skills).
+- **Publish to ClawHub** — Share your skill with the community:
+  `clawhub publish <skill-dir>`. See [ClawHub](/tools/clawhub).
+
 ## Related
 
 - [Skills reference](/tools/skills) — loading, precedence, and gating rules


### PR DESCRIPTION
## Summary

Add an "Advanced features" section to `docs/tools/creating-skills.md` that bridges the gap between the basic getting-started guide and the full skills reference.

### Problem

As reported in #39681, the creating-skills guide only covers a bare-bones hello-world example. Critical skill authoring features (conditional activation, API key injection, multi-command dispatch, invocation control, template variables) are only discoverable by reading the full `skills.md` reference — or never discovered at all.

### Changes

Added a new "Advanced features" section covering:

- **Conditional activation** — `requires.bins`, `requires.env`, `requires.config`
- **API key and env injection** — `skills.entries.<name>.apiKey` / `.env`
- **Invocation control** — `user-invocable`, `disable-model-invocation`
- **Multi-command skills** — `command-dispatch: tool` with `command-tool`
- **Template variables** — `{baseDir}`
- **Publishing to ClawHub**

Each item links to the relevant section in the skills reference for details.

Closes #39681