### PR TITLE
feat(plugins): surface imported runtime state in status tooling

### DIFF
--- a/src/auto-reply/reply/commands-plugins.toggle.test.ts
+++ b/src/auto-reply/reply/commands-plugins.toggle.test.ts
@@ -8,12 +8,14 @@ const {
   readConfigFileSnapshotMock,
   validateConfigObjectWithPluginsMock,
   writeConfigFileMock,
-  buildPluginStatusReportMock,
+  buildPluginSnapshotReportMock,
+  buildPluginDiagnosticsReportMock,
 } = vi.hoisted(() => ({
   readConfigFileSnapshotMock: vi.fn(),
   validateConfigObjectWithPluginsMock: vi.fn(),
   writeConfigFileMock: vi.fn(),
-  buildPluginStatusReportMock: vi.fn(),
+  buildPluginSnapshotReportMock: vi.fn(),
+  buildPluginDiagnosticsReportMock: vi.fn(),
 }));
 
 vi.mock("../../config/config.js", async () => {
@@ -32,7 +34,8 @@ vi.mock("../../plugins/status.js", async () => {
     await vi.importActual<typeof import("../../plugins/status.js")>("../../plugins/status.js");
   return {
     ...actual,
-    buildPluginStatusReport: buildPluginStatusReportMock,
+    buildPluginSnapshotReport: buildPluginSnapshotReportMock,
+    buildPluginDiagnosticsReport: buildPluginDiagnosticsReportMock,
   };
 });
 
@@ -56,7 +59,8 @@ describe("handleCommands /plugins toggle", () => {
     readConfigFileSnapshotMock.mockReset();
     validateConfigObjectWithPluginsMock.mockReset();
     writeConfigFileMock.mockReset();
-    buildPluginStatusReportMock.mockReset();
+    buildPluginSnapshotReportMock.mockReset();
+    buildPluginDiagnosticsReportMock.mockReset();
   });
 
   it("enables a discovered plugin", async () => {
@@ -66,7 +70,7 @@ describe("handleCommands /plugins toggle", () => {
       path: "/tmp/openclaw.json",
       resolved: config,
     });
-    buildPluginStatusReportMock.mockReturnValue(
+    buildPluginDiagnosticsReportMock.mockReturnValue(
       createPluginStatusReport({
         workspaceDir: "/tmp/workspace",
         plugins: [
@@ -106,7 +110,7 @@ describe("handleCommands /plugins toggle", () => {
       path: "/tmp/openclaw.json",
       resolved: config,
     });
-    buildPluginStatusReportMock.mockReturnValue(
+    buildPluginDiagnosticsReportMock.mockReturnValue(
       createPluginStatusReport({
         workspaceDir: "/tmp/workspace",
         plugins: [
@@ -136,5 +140,54 @@ describe("handleCommands /plugins toggle", () => {
         }),
       }),
     );
+  });
+
+  it("resolves write targets by runtime-derived plugin name", async () => {
+    const config = buildCfg();
+    readConfigFileSnapshotMock.mockResolvedValue({
+      valid: true,
+      path: "/tmp/openclaw.json",
+      resolved: config,
+    });
+    buildPluginSnapshotReportMock.mockReturnValue(
+      createPluginStatusReport({
+        workspaceDir: "/tmp/workspace",
+        plugins: [
+          createPluginRecord({
+            id: "superpowers",
+            name: "superpowers",
+            format: "bundle",
+            source: WORKSPACE_PLUGIN_ROOT,
+            enabled: false,
+            status: "disabled",
+          }),
+        ],
+      }),
+    );
+    buildPluginDiagnosticsReportMock.mockReturnValue(
+      createPluginStatusReport({
+        workspaceDir: "/tmp/workspace",
+        plugins: [
+          createPluginRecord({
+            id: "superpowers",
+            name: "Super Powers",
+            format: "bundle",
+            source: WORKSPACE_PLUGIN_ROOT,
+            enabled: false,
+            status: "disabled",
+          }),
+        ],
+      }),
+    );
+    validateConfigObjectWithPluginsMock.mockImplementation((next) => ({ ok: true, config: next }));
+    writeConfigFileMock.mockResolvedValue(undefined);
+
+    const params = buildCommandTestParams("/plugins enable Super Powers", buildCfg());
+    params.command.senderIsOwner = true;
+
+    const result = await handleCommands(params);
+    expect(result.reply?.text).toContain('Plugin "superpowers" enabled');
+    expect(buildPluginDiagnosticsReportMock).toHaveBeenCalled();
+    expect(buildPluginSnapshotReportMock).not.toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/commands-plugins.ts
+++ b/src/auto-reply/reply/commands-plugins.ts
@@ -339,7 +339,7 @@ export const handlePluginsCommand: CommandHandler = async (params, allowTextComm
   }
 
   const loaded = await loadPluginCommandState(params.workspaceDir, {
-    loadModules: pluginsCommand.action === "inspect",
+    loadModules: pluginsCommand.action !== "list",
   });
   if (!loaded.ok) {
     return {

--- a/src/auto-reply/reply/commands-plugins.ts
+++ b/src/auto-reply/reply/commands-plugins.ts
@@ -22,8 +22,9 @@ import { clearPluginManifestRegistryCache } from "../../plugins/manifest-registr
 import type { PluginRecord } from "../../plugins/registry.js";
 import {
   buildAllPluginInspectReports,
+  buildPluginDiagnosticsReport,
   buildPluginInspectReport,
-  buildPluginStatusReport,
+  buildPluginSnapshotReport,
   formatPluginCompatibilityNotice,
   type PluginStatusReport,
 } from "../../plugins/status.js";
@@ -284,7 +285,6 @@ async function loadPluginCommandState(
     }
   | { ok: false; path: string; error: string }
 > {
-  const loadModules = options?.loadModules ?? false;
   const snapshot = await readConfigFileSnapshot();
   if (!snapshot.valid) {
     return {
@@ -298,7 +298,10 @@ async function loadPluginCommandState(
     ok: true,
     path: snapshot.path,
     config,
-    report: buildPluginStatusReport({ config, workspaceDir, loadModules }),
+    report:
+      options?.loadModules === true
+        ? buildPluginDiagnosticsReport({ config, workspaceDir })
+        : buildPluginSnapshotReport({ config, workspaceDir }),
   };
 }
 

--- a/src/auto-reply/reply/commands-plugins.ts
+++ b/src/auto-reply/reply/commands-plugins.ts
@@ -272,7 +272,10 @@ async function installPluginFromPluginsCommand(params: {
   return { ok: true, pluginId: result.pluginId };
 }
 
-async function loadPluginCommandState(workspaceDir: string): Promise<
+async function loadPluginCommandState(
+  workspaceDir: string,
+  options?: { loadModules?: boolean },
+): Promise<
   | {
       ok: true;
       path: string;
@@ -281,6 +284,7 @@ async function loadPluginCommandState(workspaceDir: string): Promise<
     }
   | { ok: false; path: string; error: string }
 > {
+  const loadModules = options?.loadModules ?? false;
   const snapshot = await readConfigFileSnapshot();
   if (!snapshot.valid) {
     return {
@@ -294,7 +298,7 @@ async function loadPluginCommandState(workspaceDir: string): Promise<
     ok: true,
     path: snapshot.path,
     config,
-    report: buildPluginStatusReport({ config, workspaceDir }),
+    report: buildPluginStatusReport({ config, workspaceDir, loadModules }),
   };
 }
 
@@ -331,7 +335,9 @@ export const handlePluginsCommand: CommandHandler = async (params, allowTextComm
     };
   }
 
-  const loaded = await loadPluginCommandState(params.workspaceDir);
+  const loaded = await loadPluginCommandState(params.workspaceDir, {
+    loadModules: pluginsCommand.action === "inspect",
+  });
   if (!loaded.ok) {
     return {
       shouldContinue: false,

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -10,7 +10,7 @@ import {
 import { resolveHookEntries } from "../hooks/policy.js";
 import type { HookEntry } from "../hooks/types.js";
 import { loadWorkspaceHookEntries } from "../hooks/workspace.js";
-import { buildPluginStatusReport } from "../plugins/status.js";
+import { buildPluginDiagnosticsReport } from "../plugins/status.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
@@ -46,7 +46,7 @@ function mergeHookEntries(pluginEntries: HookEntry[], workspaceEntries: HookEntr
 function buildHooksReport(config: OpenClawConfig): HookStatusReport {
   const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
   const workspaceEntries = loadWorkspaceHookEntries(workspaceDir, { config });
-  const pluginReport = buildPluginStatusReport({ config, workspaceDir });
+  const pluginReport = buildPluginDiagnosticsReport({ config, workspaceDir });
   const pluginEntries = pluginReport.hooks.map((hook) => hook.entry);
   const entries = mergeHookEntries(pluginEntries, workspaceEntries);
   return buildWorkspaceHookStatus(workspaceDir, { config, entries });

--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -19,6 +19,7 @@ export const enablePluginInConfig = vi.fn();
 export const recordPluginInstall = vi.fn();
 export const clearPluginManifestRegistryCache = vi.fn();
 export const buildPluginStatusReport = vi.fn();
+export const buildPluginCompatibilityNotices = vi.fn();
 export const applyExclusiveSlotSelection = vi.fn();
 export const uninstallPlugin = vi.fn();
 export const updateNpmInstalledPlugins = vi.fn();
@@ -73,6 +74,7 @@ vi.mock("../plugins/manifest-registry.js", () => ({
 
 vi.mock("../plugins/status.js", () => ({
   buildPluginStatusReport: (...args: unknown[]) => buildPluginStatusReport(...args),
+  buildPluginCompatibilityNotices: (...args: unknown[]) => buildPluginCompatibilityNotices(...args),
 }));
 
 vi.mock("../plugins/slots.js", () => ({
@@ -155,6 +157,7 @@ export function resetPluginsCliTestState() {
   recordPluginInstall.mockReset();
   clearPluginManifestRegistryCache.mockReset();
   buildPluginStatusReport.mockReset();
+  buildPluginCompatibilityNotices.mockReset();
   applyExclusiveSlotSelection.mockReset();
   uninstallPlugin.mockReset();
   updateNpmInstalledPlugins.mockReset();
@@ -203,6 +206,7 @@ export function resetPluginsCliTestState() {
     plugins: [],
     diagnostics: [],
   });
+  buildPluginCompatibilityNotices.mockReturnValue([]);
   applyExclusiveSlotSelection.mockImplementation(({ config }: { config: OpenClawConfig }) => ({
     config,
     warnings: [],

--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -18,7 +18,9 @@ export const resolveMarketplaceInstallShortcut = vi.fn();
 export const enablePluginInConfig = vi.fn();
 export const recordPluginInstall = vi.fn();
 export const clearPluginManifestRegistryCache = vi.fn();
-export const buildPluginStatusReport = vi.fn();
+export const buildPluginSnapshotReport = vi.fn();
+export const buildPluginDiagnosticsReport = vi.fn();
+export const buildPluginStatusReport = buildPluginDiagnosticsReport;
 export const buildPluginCompatibilityNotices = vi.fn();
 export const applyExclusiveSlotSelection = vi.fn();
 export const uninstallPlugin = vi.fn();
@@ -73,7 +75,8 @@ vi.mock("../plugins/manifest-registry.js", () => ({
 }));
 
 vi.mock("../plugins/status.js", () => ({
-  buildPluginStatusReport: (...args: unknown[]) => buildPluginStatusReport(...args),
+  buildPluginSnapshotReport: (...args: unknown[]) => buildPluginSnapshotReport(...args),
+  buildPluginDiagnosticsReport: (...args: unknown[]) => buildPluginDiagnosticsReport(...args),
   buildPluginCompatibilityNotices: (...args: unknown[]) => buildPluginCompatibilityNotices(...args),
 }));
 
@@ -156,7 +159,8 @@ export function resetPluginsCliTestState() {
   enablePluginInConfig.mockReset();
   recordPluginInstall.mockReset();
   clearPluginManifestRegistryCache.mockReset();
-  buildPluginStatusReport.mockReset();
+  buildPluginSnapshotReport.mockReset();
+  buildPluginDiagnosticsReport.mockReset();
   buildPluginCompatibilityNotices.mockReset();
   applyExclusiveSlotSelection.mockReset();
   uninstallPlugin.mockReset();
@@ -202,10 +206,12 @@ export function resetPluginsCliTestState() {
   });
   enablePluginInConfig.mockImplementation((cfg: OpenClawConfig) => ({ config: cfg }));
   recordPluginInstall.mockImplementation((cfg: OpenClawConfig) => cfg);
-  buildPluginStatusReport.mockReturnValue({
+  const defaultPluginReport = {
     plugins: [],
     diagnostics: [],
-  });
+  };
+  buildPluginSnapshotReport.mockReturnValue(defaultPluginReport);
+  buildPluginDiagnosticsReport.mockReturnValue(defaultPluginReport);
   buildPluginCompatibilityNotices.mockReturnValue([]);
   applyExclusiveSlotSelection.mockImplementation(({ config }: { config: OpenClawConfig }) => ({
     config,

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPluginRecord } from "../plugins/status.test-helpers.js";
+import {
+  buildPluginStatusReport,
+  resetPluginsCliTestState,
+  runPluginsCommand,
+  runtimeLogs,
+} from "./plugins-cli-test-helpers.js";
+
+describe("plugins cli list", () => {
+  beforeEach(() => {
+    resetPluginsCliTestState();
+  });
+
+  it("includes imported state in JSON output", async () => {
+    buildPluginStatusReport.mockReturnValue({
+      workspaceDir: "/workspace",
+      plugins: [
+        createPluginRecord({
+          id: "demo",
+          imported: true,
+          activated: true,
+          explicitlyEnabled: true,
+        }),
+      ],
+      diagnostics: [],
+    });
+
+    await runPluginsCommand(["plugins", "list", "--json"]);
+
+    expect(JSON.parse(runtimeLogs[0] ?? "null")).toEqual({
+      workspaceDir: "/workspace",
+      plugins: [
+        expect.objectContaining({
+          id: "demo",
+          imported: true,
+          activated: true,
+          explicitlyEnabled: true,
+        }),
+      ],
+      diagnostics: [],
+    });
+  });
+
+  it("shows imported state in verbose output", async () => {
+    buildPluginStatusReport.mockReturnValue({
+      plugins: [
+        createPluginRecord({
+          id: "demo",
+          name: "Demo Plugin",
+          imported: false,
+          activated: true,
+          explicitlyEnabled: false,
+        }),
+      ],
+      diagnostics: [],
+    });
+
+    await runPluginsCommand(["plugins", "list", "--verbose"]);
+
+    const output = runtimeLogs.join("\n");
+    expect(output).toContain("activated: yes");
+    expect(output).toContain("imported: no");
+    expect(output).toContain("explicitly enabled: no");
+  });
+});

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -67,4 +67,16 @@ describe("plugins cli list", () => {
     expect(output).toContain("imported: no");
     expect(output).toContain("explicitly enabled: no");
   });
+
+  it("keeps doctor on a module-loading snapshot", async () => {
+    buildPluginStatusReport.mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
+
+    await runPluginsCommand(["plugins", "doctor"]);
+
+    expect(buildPluginStatusReport).toHaveBeenCalledWith({ loadModules: true });
+    expect(runtimeLogs).toContain("No plugin issues detected.");
+  });
 });

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { createPluginRecord } from "../plugins/status.test-helpers.js";
 import {
-  buildPluginStatusReport,
+  buildPluginDiagnosticsReport,
+  buildPluginSnapshotReport,
   resetPluginsCliTestState,
   runPluginsCommand,
   runtimeLogs,
@@ -13,7 +14,7 @@ describe("plugins cli list", () => {
   });
 
   it("includes imported state in JSON output", async () => {
-    buildPluginStatusReport.mockReturnValue({
+    buildPluginSnapshotReport.mockReturnValue({
       workspaceDir: "/workspace",
       plugins: [
         createPluginRecord({
@@ -28,7 +29,7 @@ describe("plugins cli list", () => {
 
     await runPluginsCommand(["plugins", "list", "--json"]);
 
-    expect(buildPluginStatusReport).toHaveBeenCalledWith({ loadModules: false });
+    expect(buildPluginSnapshotReport).toHaveBeenCalledWith();
 
     expect(JSON.parse(runtimeLogs[0] ?? "null")).toEqual({
       workspaceDir: "/workspace",
@@ -45,7 +46,7 @@ describe("plugins cli list", () => {
   });
 
   it("shows imported state in verbose output", async () => {
-    buildPluginStatusReport.mockReturnValue({
+    buildPluginSnapshotReport.mockReturnValue({
       plugins: [
         createPluginRecord({
           id: "demo",
@@ -60,7 +61,7 @@ describe("plugins cli list", () => {
 
     await runPluginsCommand(["plugins", "list", "--verbose"]);
 
-    expect(buildPluginStatusReport).toHaveBeenCalledWith({ loadModules: false });
+    expect(buildPluginSnapshotReport).toHaveBeenCalledWith();
 
     const output = runtimeLogs.join("\n");
     expect(output).toContain("activated: yes");
@@ -69,14 +70,14 @@ describe("plugins cli list", () => {
   });
 
   it("keeps doctor on a module-loading snapshot", async () => {
-    buildPluginStatusReport.mockReturnValue({
+    buildPluginDiagnosticsReport.mockReturnValue({
       plugins: [],
       diagnostics: [],
     });
 
     await runPluginsCommand(["plugins", "doctor"]);
 
-    expect(buildPluginStatusReport).toHaveBeenCalledWith({ loadModules: true });
+    expect(buildPluginDiagnosticsReport).toHaveBeenCalledWith();
     expect(runtimeLogs).toContain("No plugin issues detected.");
   });
 });

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -28,6 +28,8 @@ describe("plugins cli list", () => {
 
     await runPluginsCommand(["plugins", "list", "--json"]);
 
+    expect(buildPluginStatusReport).toHaveBeenCalledWith({ loadModules: false });
+
     expect(JSON.parse(runtimeLogs[0] ?? "null")).toEqual({
       workspaceDir: "/workspace",
       plugins: [
@@ -57,6 +59,8 @@ describe("plugins cli list", () => {
     });
 
     await runPluginsCommand(["plugins", "list", "--verbose"]);
+
+    expect(buildPluginStatusReport).toHaveBeenCalledWith({ loadModules: false });
 
     const output = runtimeLogs.join("\n");
     expect(output).toContain("activated: yes");

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -12,9 +12,10 @@ import type { PluginRecord } from "../plugins/registry.js";
 import { formatPluginSourceForTable, resolvePluginSourceRoots } from "../plugins/source-display.js";
 import {
   buildAllPluginInspectReports,
+  buildPluginDiagnosticsReport,
   buildPluginCompatibilityNotices,
   buildPluginInspectReport,
-  buildPluginStatusReport,
+  buildPluginSnapshotReport,
   formatPluginCompatibilityNotice,
 } from "../plugins/status.js";
 import {
@@ -239,7 +240,7 @@ export function registerPluginsCli(program: Command) {
     .option("--enabled", "Only show enabled plugins", false)
     .option("--verbose", "Show detailed entries", false)
     .action((opts: PluginsListOptions) => {
-      const report = buildPluginStatusReport({ loadModules: false });
+      const report = buildPluginSnapshotReport();
       const list = opts.enabled
         ? report.plugins.filter((p) => p.status === "loaded")
         : report.plugins;
@@ -341,7 +342,7 @@ export function registerPluginsCli(program: Command) {
     .option("--json", "Print JSON")
     .action((id: string | undefined, opts: PluginInspectOptions) => {
       const cfg = loadConfig();
-      const report = buildPluginStatusReport({ config: cfg, loadModules: true });
+      const report = buildPluginDiagnosticsReport({ config: cfg });
       if (opts.all) {
         if (id) {
           defaultRuntime.error("Pass either a plugin id or --all, not both.");
@@ -606,7 +607,7 @@ export function registerPluginsCli(program: Command) {
     .action(async (id: string, opts: PluginUninstallOptions) => {
       const snapshot = await readConfigFileSnapshot();
       const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-      const report = buildPluginStatusReport({ config: cfg });
+      const report = buildPluginDiagnosticsReport({ config: cfg });
       const extensionsDir = path.join(resolveStateDir(process.env, os.homedir), "extensions");
       const keepFiles = Boolean(opts.keepFiles || opts.keepConfig);
 
@@ -793,7 +794,7 @@ export function registerPluginsCli(program: Command) {
     .command("doctor")
     .description("Report plugin load issues")
     .action(() => {
-      const report = buildPluginStatusReport({ loadModules: true });
+      const report = buildPluginDiagnosticsReport();
       const errors = report.plugins.filter((p) => p.status === "error");
       const diags = report.diagnostics.filter((d) => d.level === "error");
       const compatibility = buildPluginCompatibilityNotices({ report });

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -239,7 +239,7 @@ export function registerPluginsCli(program: Command) {
     .option("--enabled", "Only show enabled plugins", false)
     .option("--verbose", "Show detailed entries", false)
     .action((opts: PluginsListOptions) => {
-      const report = buildPluginStatusReport();
+      const report = buildPluginStatusReport({ loadModules: false });
       const list = opts.enabled
         ? report.plugins.filter((p) => p.status === "loaded")
         : report.plugins;
@@ -341,7 +341,7 @@ export function registerPluginsCli(program: Command) {
     .option("--json", "Print JSON")
     .action((id: string | undefined, opts: PluginInspectOptions) => {
       const cfg = loadConfig();
-      const report = buildPluginStatusReport({ config: cfg });
+      const report = buildPluginStatusReport({ config: cfg, loadModules: true });
       if (opts.all) {
         if (id) {
           defaultRuntime.error("Pass either a plugin id or --all, not both.");
@@ -793,7 +793,7 @@ export function registerPluginsCli(program: Command) {
     .command("doctor")
     .description("Report plugin load issues")
     .action(() => {
-      const report = buildPluginStatusReport();
+      const report = buildPluginStatusReport({ loadModules: false });
       const errors = report.plugins.filter((p) => p.status === "error");
       const diags = report.diagnostics.filter((d) => d.level === "error");
       const compatibility = buildPluginCompatibilityNotices({ report });

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -793,7 +793,7 @@ export function registerPluginsCli(program: Command) {
     .command("doctor")
     .description("Report plugin load issues")
     .action(() => {
-      const report = buildPluginStatusReport({ loadModules: false });
+      const report = buildPluginStatusReport({ loadModules: true });
       const errors = report.plugins.filter((p) => p.status === "error");
       const diags = report.diagnostics.filter((d) => d.level === "error");
       const compatibility = buildPluginCompatibilityNotices({ report });

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -140,6 +140,9 @@ function formatPluginLine(plugin: PluginRecord, verbose = false): string {
   if (plugin.activated !== undefined) {
     parts.push(`  activated: ${plugin.activated ? "yes" : "no"}`);
   }
+  if (plugin.imported !== undefined) {
+    parts.push(`  imported: ${plugin.imported ? "yes" : "no"}`);
+  }
   if (plugin.explicitlyEnabled !== undefined) {
     parts.push(`  explicitly enabled: ${plugin.explicitlyEnabled ? "yes" : "no"}`);
   }

--- a/src/cli/plugins-command-helpers.ts
+++ b/src/cli/plugins-command-helpers.ts
@@ -4,7 +4,7 @@ import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "../plugins/clawhub.js";
 import { applyExclusiveSlotSelection } from "../plugins/slots.js";
-import { buildPluginSnapshotReport } from "../plugins/status.js";
+import { buildPluginDiagnosticsReport } from "../plugins/status.js";
 import { defaultRuntime } from "../runtime.js";
 import { theme } from "../terminal/theme.js";
 
@@ -40,7 +40,7 @@ export function applySlotSelectionForPlugin(
   config: OpenClawConfig,
   pluginId: string,
 ): { config: OpenClawConfig; warnings: string[] } {
-  const report = buildPluginSnapshotReport({ config });
+  const report = buildPluginDiagnosticsReport({ config });
   const plugin = report.plugins.find((entry) => entry.id === pluginId);
   if (!plugin) {
     return { config, warnings: [] };

--- a/src/cli/plugins-command-helpers.ts
+++ b/src/cli/plugins-command-helpers.ts
@@ -4,7 +4,7 @@ import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "../plugins/clawhub.js";
 import { applyExclusiveSlotSelection } from "../plugins/slots.js";
-import { buildPluginStatusReport } from "../plugins/status.js";
+import { buildPluginSnapshotReport } from "../plugins/status.js";
 import { defaultRuntime } from "../runtime.js";
 import { theme } from "../terminal/theme.js";
 
@@ -40,7 +40,7 @@ export function applySlotSelectionForPlugin(
   config: OpenClawConfig,
   pluginId: string,
 ): { config: OpenClawConfig; warnings: string[] } {
-  const report = buildPluginStatusReport({ config });
+  const report = buildPluginSnapshotReport({ config });
   const plugin = report.plugins.find((entry) => entry.id === pluginId);
   if (!plugin) {
     return { config, warnings: [] };

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -124,6 +124,30 @@ describe("noteWorkspaceStatus", () => {
     }
   });
 
+  it("includes imported plugin counts in the plugins note", async () => {
+    const noteSpy = await runNoteWorkspaceStatusForTest(
+      createPluginLoadResult({
+        plugins: [
+          createPluginRecord({
+            id: "imported-plugin",
+            imported: true,
+          }),
+          createPluginRecord({
+            id: "cold-plugin",
+            imported: false,
+          }),
+        ],
+      }),
+    );
+    try {
+      const pluginCalls = noteSpy.mock.calls.filter(([, title]) => title === "Plugins");
+      expect(pluginCalls).toHaveLength(1);
+      expect(String(pluginCalls[0]?.[0])).toContain("Imported: 1");
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
   it("omits plugin compatibility note when no legacy compatibility paths are present", async () => {
     const noteSpy = await runNoteWorkspaceStatusForTest(
       createPluginLoadResult({

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   resolveDefaultAgentId: vi.fn(),
   buildWorkspaceSkillStatus: vi.fn(),
   buildPluginSnapshotReport: vi.fn(),
+  buildPluginDiagnosticsReport: vi.fn(),
   buildPluginCompatibilityWarnings: vi.fn(),
   listTaskFlowRecords: vi.fn<() => unknown[]>(() => []),
   listTasksForFlowId: vi.fn<(flowId: string) => unknown[]>((_flowId: string) => []),
@@ -28,6 +29,7 @@ vi.mock("../agents/skills-status.js", () => ({
 
 vi.mock("../plugins/status.js", () => ({
   buildPluginSnapshotReport: (...args: unknown[]) => mocks.buildPluginSnapshotReport(...args),
+  buildPluginDiagnosticsReport: (...args: unknown[]) => mocks.buildPluginDiagnosticsReport(...args),
   buildPluginCompatibilityWarnings: (...args: unknown[]) =>
     mocks.buildPluginCompatibilityWarnings(...args),
 }));
@@ -54,6 +56,10 @@ async function runNoteWorkspaceStatusForTest(
     skills: [],
   });
   mocks.buildPluginSnapshotReport.mockReturnValue({
+    workspaceDir: "/workspace",
+    ...loadResult,
+  });
+  mocks.buildPluginDiagnosticsReport.mockReturnValue({
     workspaceDir: "/workspace",
     ...loadResult,
   });
@@ -86,6 +92,10 @@ describe("noteWorkspaceStatus", () => {
     );
     try {
       expect(mocks.buildPluginSnapshotReport).toHaveBeenCalledWith({
+        config: {},
+        workspaceDir: "/workspace",
+      });
+      expect(mocks.buildPluginDiagnosticsReport).toHaveBeenCalledWith({
         config: {},
         workspaceDir: "/workspace",
       });
@@ -182,6 +192,10 @@ describe("noteWorkspaceStatus", () => {
       "legacy-plugin still uses legacy before_agent_start",
     ]);
     try {
+      expect(mocks.buildPluginDiagnosticsReport).toHaveBeenCalledWith({
+        config: {},
+        workspaceDir: "/workspace",
+      });
       expect(mocks.buildPluginCompatibilityWarnings).toHaveBeenCalledWith({
         config: {},
         workspaceDir: "/workspace",

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -11,7 +11,6 @@ const mocks = vi.hoisted(() => ({
   resolveAgentWorkspaceDir: vi.fn(),
   resolveDefaultAgentId: vi.fn(),
   buildWorkspaceSkillStatus: vi.fn(),
-  buildPluginSnapshotReport: vi.fn(),
   buildPluginDiagnosticsReport: vi.fn(),
   buildPluginCompatibilityWarnings: vi.fn(),
   listTaskFlowRecords: vi.fn<() => unknown[]>(() => []),
@@ -28,7 +27,6 @@ vi.mock("../agents/skills-status.js", () => ({
 }));
 
 vi.mock("../plugins/status.js", () => ({
-  buildPluginSnapshotReport: (...args: unknown[]) => mocks.buildPluginSnapshotReport(...args),
   buildPluginDiagnosticsReport: (...args: unknown[]) => mocks.buildPluginDiagnosticsReport(...args),
   buildPluginCompatibilityWarnings: (...args: unknown[]) =>
     mocks.buildPluginCompatibilityWarnings(...args),
@@ -54,10 +52,6 @@ async function runNoteWorkspaceStatusForTest(
   mocks.resolveAgentWorkspaceDir.mockReturnValue("/workspace");
   mocks.buildWorkspaceSkillStatus.mockReturnValue({
     skills: [],
-  });
-  mocks.buildPluginSnapshotReport.mockReturnValue({
-    workspaceDir: "/workspace",
-    ...loadResult,
   });
   mocks.buildPluginDiagnosticsReport.mockReturnValue({
     workspaceDir: "/workspace",
@@ -91,10 +85,6 @@ describe("noteWorkspaceStatus", () => {
       }),
     );
     try {
-      expect(mocks.buildPluginSnapshotReport).toHaveBeenCalledWith({
-        config: {},
-        workspaceDir: "/workspace",
-      });
       expect(mocks.buildPluginDiagnosticsReport).toHaveBeenCalledWith({
         config: {},
         workspaceDir: "/workspace",

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   resolveAgentWorkspaceDir: vi.fn(),
   resolveDefaultAgentId: vi.fn(),
   buildWorkspaceSkillStatus: vi.fn(),
-  buildPluginStatusReport: vi.fn(),
+  buildPluginSnapshotReport: vi.fn(),
   buildPluginCompatibilityWarnings: vi.fn(),
   listTaskFlowRecords: vi.fn<() => unknown[]>(() => []),
   listTasksForFlowId: vi.fn<(flowId: string) => unknown[]>((_flowId: string) => []),
@@ -27,7 +27,7 @@ vi.mock("../agents/skills-status.js", () => ({
 }));
 
 vi.mock("../plugins/status.js", () => ({
-  buildPluginStatusReport: (...args: unknown[]) => mocks.buildPluginStatusReport(...args),
+  buildPluginSnapshotReport: (...args: unknown[]) => mocks.buildPluginSnapshotReport(...args),
   buildPluginCompatibilityWarnings: (...args: unknown[]) =>
     mocks.buildPluginCompatibilityWarnings(...args),
 }));
@@ -53,7 +53,7 @@ async function runNoteWorkspaceStatusForTest(
   mocks.buildWorkspaceSkillStatus.mockReturnValue({
     skills: [],
   });
-  mocks.buildPluginStatusReport.mockReturnValue({
+  mocks.buildPluginSnapshotReport.mockReturnValue({
     workspaceDir: "/workspace",
     ...loadResult,
   });
@@ -85,10 +85,9 @@ describe("noteWorkspaceStatus", () => {
       }),
     );
     try {
-      expect(mocks.buildPluginStatusReport).toHaveBeenCalledWith({
+      expect(mocks.buildPluginSnapshotReport).toHaveBeenCalledWith({
         config: {},
         workspaceDir: "/workspace",
-        loadModules: false,
       });
       const compatibilityCalls = noteSpy.mock.calls.filter(
         ([, title]) => title === "Plugin compatibility",

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -88,6 +88,7 @@ describe("noteWorkspaceStatus", () => {
       expect(mocks.buildPluginStatusReport).toHaveBeenCalledWith({
         config: {},
         workspaceDir: "/workspace",
+        loadModules: false,
       });
       const compatibilityCalls = noteSpy.mock.calls.filter(
         ([, title]) => title === "Plugin compatibility",

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -2,7 +2,11 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { buildPluginCompatibilityWarnings, buildPluginSnapshotReport } from "../plugins/status.js";
+import {
+  buildPluginCompatibilityWarnings,
+  buildPluginDiagnosticsReport,
+  buildPluginSnapshotReport,
+} from "../plugins/status.js";
 import { listTasksForFlowId } from "../tasks/runtime-internal.js";
 import { listTaskFlowRecords } from "../tasks/task-flow-runtime-internal.js";
 import { note } from "../terminal/note.js";
@@ -105,7 +109,10 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig) {
   const compatibilityWarnings = buildPluginCompatibilityWarnings({
     config: cfg,
     workspaceDir,
-    report: pluginRegistry,
+    report: buildPluginDiagnosticsReport({
+      config: cfg,
+      workspaceDir,
+    }),
   });
   if (compatibilityWarnings.length > 0) {
     note(compatibilityWarnings.map((line) => `- ${line}`).join("\n"), "Plugin compatibility");

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -72,6 +72,7 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig) {
   const pluginRegistry = buildPluginStatusReport({
     config: cfg,
     workspaceDir,
+    loadModules: false,
   });
   if (pluginRegistry.plugins.length > 0) {
     const loaded = pluginRegistry.plugins.filter((p) => p.status === "loaded");

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -2,7 +2,7 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { buildPluginCompatibilityWarnings, buildPluginStatusReport } from "../plugins/status.js";
+import { buildPluginCompatibilityWarnings, buildPluginSnapshotReport } from "../plugins/status.js";
 import { listTasksForFlowId } from "../tasks/runtime-internal.js";
 import { listTaskFlowRecords } from "../tasks/task-flow-runtime-internal.js";
 import { note } from "../terminal/note.js";
@@ -69,10 +69,9 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig) {
     "Skills status",
   );
 
-  const pluginRegistry = buildPluginStatusReport({
+  const pluginRegistry = buildPluginSnapshotReport({
     config: cfg,
     workspaceDir,
-    loadModules: false,
   });
   if (pluginRegistry.plugins.length > 0) {
     const loaded = pluginRegistry.plugins.filter((p) => p.status === "loaded");

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -5,7 +5,6 @@ import type { OpenClawConfig } from "../config/config.js";
 import {
   buildPluginCompatibilityWarnings,
   buildPluginDiagnosticsReport,
-  buildPluginSnapshotReport,
 } from "../plugins/status.js";
 import { listTasksForFlowId } from "../tasks/runtime-internal.js";
 import { listTaskFlowRecords } from "../tasks/task-flow-runtime-internal.js";
@@ -73,7 +72,7 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig) {
     "Skills status",
   );
 
-  const pluginRegistry = buildPluginSnapshotReport({
+  const pluginRegistry = buildPluginDiagnosticsReport({
     config: cfg,
     workspaceDir,
   });
@@ -109,10 +108,7 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig) {
   const compatibilityWarnings = buildPluginCompatibilityWarnings({
     config: cfg,
     workspaceDir,
-    report: buildPluginDiagnosticsReport({
-      config: cfg,
-      workspaceDir,
-    }),
+    report: pluginRegistry,
   });
   if (compatibilityWarnings.length > 0) {
     note(compatibilityWarnings.map((line) => `- ${line}`).join("\n"), "Plugin compatibility");

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -77,9 +77,11 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig) {
     const loaded = pluginRegistry.plugins.filter((p) => p.status === "loaded");
     const disabled = pluginRegistry.plugins.filter((p) => p.status === "disabled");
     const errored = pluginRegistry.plugins.filter((p) => p.status === "error");
+    const imported = pluginRegistry.plugins.filter((p) => p.imported);
 
     const lines = [
       `Loaded: ${loaded.length}`,
+      `Imported: ${imported.length}`,
       `Disabled: ${disabled.length}`,
       `Errors: ${errored.length}`,
       errored.length > 0

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -5,8 +5,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
 import {
   canLoadActivatedBundledPluginPublicSurface,
+  listImportedBundledPluginFacadeIds,
   loadActivatedBundledPluginPublicSurfaceModuleSync,
   loadBundledPluginPublicSurfaceModuleSync,
+  resetFacadeRuntimeStateForTest,
   tryLoadActivatedBundledPluginPublicSurfaceModuleSync,
 } from "./facade-runtime.js";
 
@@ -70,6 +72,7 @@ function createCircularPluginDir(prefix: string): string {
 afterEach(() => {
   vi.restoreAllMocks();
   clearRuntimeConfigSnapshot();
+  resetFacadeRuntimeStateForTest();
   if (originalBundledPluginsDir === undefined) {
     delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
   } else {
@@ -114,6 +117,7 @@ describe("plugin-sdk facade runtime", () => {
     });
     expect(first).toBe(second);
     expect(first.marker).toBe("identity-check");
+    expect(listImportedBundledPluginFacadeIds()).toEqual(["demo"]);
   });
 
   it("breaks circular facade re-entry during module evaluation", () => {

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -387,6 +387,7 @@ export function listImportedBundledPluginFacadeIds(): string[] {
 export function resetFacadeRuntimeStateForTest(): void {
   loadedFacadeModules.clear();
   loadedFacadePluginIds.clear();
+  jitiLoaders.clear();
   cachedBoundaryRawConfig = undefined;
   cachedBoundaryResolvedConfig = undefined;
 }

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -37,6 +37,7 @@ const ALWAYS_ALLOWED_RUNTIME_DIR_NAMES = new Set([
 const EMPTY_FACADE_BOUNDARY_CONFIG: OpenClawConfig = {};
 const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
 const loadedFacadeModules = new Map<string, unknown>();
+const loadedFacadePluginIds = new Set<string>();
 let cachedBoundaryRawConfig: OpenClawConfig | undefined;
 let cachedBoundaryResolvedConfig:
   | {
@@ -173,6 +174,10 @@ function resolveBundledPluginManifestRecordByDirName(dirName: string): PluginMan
       (plugin) => plugin.origin === "bundled" && path.basename(plugin.rootDir) === dirName,
     ) ?? null
   );
+}
+
+function resolveTrackedFacadePluginId(dirName: string): string {
+  return resolveBundledPluginManifestRecordByDirName(dirName)?.id ?? dirName;
 }
 
 function resolveBundledPluginPublicSurfaceAccess(params: {
@@ -334,6 +339,7 @@ export function loadBundledPluginPublicSurfaceModuleSync<T extends object>(param
   try {
     loaded = getJiti(location.modulePath)(location.modulePath) as T;
     Object.assign(sentinel, loaded);
+    loadedFacadePluginIds.add(resolveTrackedFacadePluginId(params.dirName));
   } catch (err) {
     loadedFacadeModules.delete(location.modulePath);
     throw err;
@@ -372,4 +378,15 @@ export function tryLoadActivatedBundledPluginPublicSurfaceModuleSync<T extends o
     return null;
   }
   return loadBundledPluginPublicSurfaceModuleSync<T>(params);
+}
+
+export function listImportedBundledPluginFacadeIds(): string[] {
+  return [...loadedFacadePluginIds].toSorted((left, right) => left.localeCompare(right));
+}
+
+export function resetFacadeRuntimeStateForTest(): void {
+  loadedFacadeModules.clear();
+  loadedFacadePluginIds.clear();
+  cachedBoundaryRawConfig = undefined;
+  cachedBoundaryResolvedConfig = undefined;
 }

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1289,6 +1289,65 @@ module.exports = { id: "manifest-only-plugin", register() { throw new Error("man
       },
     },
     {
+      label: "marks a selected memory slot as matched during manifest-only snapshots",
+      run: () => {
+        useNoBundledPlugins();
+        const memoryPlugin = writePlugin({
+          id: "memory-demo",
+          filename: "memory-demo.cjs",
+          body: `module.exports = {
+  id: "memory-demo",
+  kind: "memory",
+  register() {},
+};`,
+        });
+        fs.writeFileSync(
+          path.join(memoryPlugin.dir, "openclaw.plugin.json"),
+          JSON.stringify(
+            {
+              id: "memory-demo",
+              kind: "memory",
+              configSchema: EMPTY_PLUGIN_SCHEMA,
+            },
+            null,
+            2,
+          ),
+          "utf-8",
+        );
+
+        const registry = loadOpenClawPlugins({
+          cache: false,
+          activate: false,
+          loadModules: false,
+          config: {
+            plugins: {
+              load: { paths: [memoryPlugin.file] },
+              allow: ["memory-demo"],
+              slots: { memory: "memory-demo" },
+              entries: {
+                "memory-demo": { enabled: true },
+              },
+            },
+          },
+        });
+
+        expect(
+          registry.diagnostics.some(
+            (entry) =>
+              entry.message === "memory slot plugin not found or not marked as memory: memory-demo",
+          ),
+        ).toBe(false);
+        expect(registry.plugins).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: "memory-demo",
+              memorySlotSelected: true,
+            }),
+          ]),
+        );
+      },
+    },
+    {
       label: "keeps scoped plugin loads in a separate cache entry",
       run: () => {
         useNoBundledPlugins();

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1251,6 +1251,44 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
       },
     },
     {
+      label: "can build a manifest-only snapshot without importing plugin modules",
+      run: () => {
+        useNoBundledPlugins();
+        const importedMarker = path.join(makeTempDir(), "manifest-only-imported.txt");
+        const plugin = writePlugin({
+          id: "manifest-only-plugin",
+          filename: "manifest-only-plugin.cjs",
+          body: `require("node:fs").writeFileSync(${JSON.stringify(importedMarker)}, "loaded", "utf-8");
+module.exports = { id: "manifest-only-plugin", register() { throw new Error("manifest-only snapshot should not register"); } };`,
+        });
+
+        const registry = loadOpenClawPlugins({
+          cache: false,
+          activate: false,
+          loadModules: false,
+          config: {
+            plugins: {
+              load: { paths: [plugin.file] },
+              allow: ["manifest-only-plugin"],
+              entries: {
+                "manifest-only-plugin": { enabled: true },
+              },
+            },
+          },
+        });
+
+        expect(fs.existsSync(importedMarker)).toBe(false);
+        expect(registry.plugins).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: "manifest-only-plugin",
+              status: "loaded",
+            }),
+          ]),
+        );
+      },
+    },
+    {
       label: "keeps scoped plugin loads in a separate cache entry",
       run: () => {
         useNoBundledPlugins();

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -35,6 +35,7 @@ import { createEmptyPluginRegistry } from "./registry.js";
 import {
   getActivePluginRegistry,
   getActivePluginRegistryKey,
+  listImportedRuntimePluginIds,
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "./runtime.js";
@@ -1345,6 +1346,48 @@ module.exports = { id: "manifest-only-plugin", register() { throw new Error("man
             }),
           ]),
         );
+      },
+    },
+    {
+      label: "tracks plugins as imported when module evaluation throws after top-level execution",
+      run: () => {
+        useNoBundledPlugins();
+        const importMarker = "__openclaw_loader_import_throw_marker";
+        Reflect.deleteProperty(globalThis, importMarker);
+
+        const plugin = writePlugin({
+          id: "throws-after-import",
+          filename: "throws-after-import.cjs",
+          body: `globalThis.${importMarker} = (globalThis.${importMarker} ?? 0) + 1;
+throw new Error("boom after import");
+module.exports = { id: "throws-after-import", register() {} };`,
+        });
+
+        const registry = loadOpenClawPlugins({
+          cache: false,
+          activate: false,
+          config: {
+            plugins: {
+              load: { paths: [plugin.file] },
+              allow: ["throws-after-import"],
+            },
+          },
+        });
+
+        try {
+          expect(registry.plugins).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                id: "throws-after-import",
+                status: "error",
+              }),
+            ]),
+          );
+          expect(listImportedRuntimePluginIds()).toContain("throws-after-import");
+          expect(Number(Reflect.get(globalThis, importMarker) ?? 0)).toBeGreaterThan(0);
+        } finally {
+          Reflect.deleteProperty(globalThis, importMarker);
+        }
       },
     },
     {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1333,6 +1333,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
       if (memoryDecision.selected && hasKind(record.kind, "memory")) {
         selectedMemoryPluginId = record.id;
+        memorySlotMatched = true;
         record.memorySlotSelected = true;
       }
     }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -96,6 +96,7 @@ export type PluginLoadOptions = {
    */
   preferSetupRuntimeForChannelPlugins?: boolean;
   activate?: boolean;
+  loadModules?: boolean;
   throwOnLoadError?: boolean;
 };
 
@@ -241,6 +242,7 @@ function buildCacheKey(params: {
   onlyPluginIds?: string[];
   includeSetupOnlyChannelPlugins?: boolean;
   preferSetupRuntimeForChannelPlugins?: boolean;
+  loadModules?: boolean;
   runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
   pluginSdkResolution?: PluginSdkResolutionPreference;
   coreGatewayMethodNames?: string[];
@@ -270,13 +272,14 @@ function buildCacheKey(params: {
   const setupOnlyKey = params.includeSetupOnlyChannelPlugins === true ? "setup-only" : "runtime";
   const startupChannelMode =
     params.preferSetupRuntimeForChannelPlugins === true ? "prefer-setup" : "full";
+  const moduleLoadMode = params.loadModules === false ? "manifest-only" : "load-modules";
   const gatewayMethodsKey = JSON.stringify(params.coreGatewayMethodNames ?? []);
   return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
     ...params.plugins,
     installs,
     loadPaths,
     activationMetadataKey: params.activationMetadataKey ?? "",
-  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${params.runtimeSubagentMode ?? "default"}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}`;
+  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${moduleLoadMode}::${params.runtimeSubagentMode ?? "default"}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}`;
 }
 
 function normalizeScopedPluginIds(ids?: string[]): string[] | undefined {
@@ -360,7 +363,8 @@ function hasExplicitCompatibilityInputs(options: PluginLoadOptions): boolean {
     options.pluginSdkResolution !== undefined ||
     options.coreGatewayHandlers !== undefined ||
     options.includeSetupOnlyChannelPlugins === true ||
-    options.preferSetupRuntimeForChannelPlugins === true,
+    options.preferSetupRuntimeForChannelPlugins === true ||
+    options.loadModules === false,
   );
 }
 
@@ -387,6 +391,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     onlyPluginIds,
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
+    loadModules: options.loadModules,
     runtimeSubagentMode: resolveRuntimeSubagentMode(options.runtimeOptions),
     pluginSdkResolution: options.pluginSdkResolution,
     coreGatewayMethodNames,
@@ -402,6 +407,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
     shouldActivate: options.activate !== false,
+    shouldLoadModules: options.loadModules !== false,
     runtimeSubagentMode: resolveRuntimeSubagentMode(options.runtimeOptions),
     cacheKey,
   };
@@ -924,6 +930,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
     shouldActivate,
+    shouldLoadModules,
     cacheKey,
     runtimeSubagentMode,
   } = resolvePluginLoadCacheContext(options);
@@ -1306,6 +1313,48 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       continue;
     }
 
+    if (!shouldLoadModules && registrationMode === "full") {
+      const memoryDecision = resolveMemorySlotDecision({
+        id: record.id,
+        kind: record.kind,
+        slot: memorySlot,
+        selectedId: selectedMemoryPluginId,
+      });
+
+      if (!memoryDecision.enabled) {
+        record.enabled = false;
+        record.status = "disabled";
+        record.error = memoryDecision.reason;
+        markPluginActivationDisabled(record, memoryDecision.reason);
+        registry.plugins.push(record);
+        seenIds.set(pluginId, candidate.origin);
+        continue;
+      }
+
+      if (memoryDecision.selected && hasKind(record.kind, "memory")) {
+        selectedMemoryPluginId = record.id;
+        record.memorySlotSelected = true;
+      }
+    }
+
+    const validatedConfig = validatePluginConfig({
+      schema: manifestRecord.configSchema,
+      cacheKey: manifestRecord.schemaCacheKey,
+      value: entry?.config,
+    });
+
+    if (!validatedConfig.ok) {
+      logger.error(`[plugins] ${record.id} invalid config: ${validatedConfig.errors?.join(", ")}`);
+      pushPluginLoadError(`invalid config: ${validatedConfig.errors?.join(", ")}`);
+      continue;
+    }
+
+    if (!shouldLoadModules) {
+      registry.plugins.push(record);
+      seenIds.set(pluginId, candidate.origin);
+      continue;
+    }
+
     const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
     const loadSource =
       (registrationMode === "setup-only" || registrationMode === "setup-runtime") &&
@@ -1421,18 +1470,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         selectedMemoryPluginId = record.id;
         record.memorySlotSelected = true;
       }
-    }
-
-    const validatedConfig = validatePluginConfig({
-      schema: manifestRecord.configSchema,
-      cacheKey: manifestRecord.schemaCacheKey,
-      value: entry?.config,
-    });
-
-    if (!validatedConfig.ok) {
-      logger.error(`[plugins] ${record.id} invalid config: ${validatedConfig.errors?.join(", ")}`);
-      pushPluginLoadError(`invalid config: ${validatedConfig.errors?.join(", ")}`);
-      continue;
     }
 
     if (validateOnly) {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -44,6 +44,7 @@ import { resolvePluginCacheInputs } from "./roots.js";
 import {
   getActivePluginRegistry,
   getActivePluginRegistryKey,
+  recordImportedPluginId,
   setActivePluginRegistry,
 } from "./runtime.js";
 import type { CreatePluginRuntimeOptions } from "./runtime/index.js";
@@ -1379,6 +1380,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     let mod: OpenClawPluginModule | null = null;
     try {
       mod = getJiti(safeSource)(safeSource) as OpenClawPluginModule;
+      recordImportedPluginId(record.id);
     } catch (err) {
       recordPluginError({
         logger,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1379,8 +1379,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
     let mod: OpenClawPluginModule | null = null;
     try {
-      mod = getJiti(safeSource)(safeSource) as OpenClawPluginModule;
+      // Track the plugin as imported once module evaluation begins. Top-level
+      // code may have already executed even if evaluation later throws.
       recordImportedPluginId(record.id);
+      mod = getJiti(safeSource)(safeSource) as OpenClawPluginModule;
     } catch (err) {
       recordPluginError({
         logger,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -200,6 +200,7 @@ export type PluginRecord = {
   enabled: boolean;
   explicitlyEnabled?: boolean;
   activated?: boolean;
+  imported?: boolean;
   activationSource?: PluginActivationSource;
   activationReason?: string;
   status: "loaded" | "disabled" | "error";

--- a/src/plugins/runtime.test.ts
+++ b/src/plugins/runtime.test.ts
@@ -7,6 +7,7 @@ import {
   getActivePluginRegistry,
   listImportedRuntimePluginIds,
   pinActivePluginHttpRouteRegistry,
+  recordImportedPluginId,
   releasePinnedPluginHttpRouteRegistry,
   resetPluginRuntimeStateForTest,
   resolveActivePluginHttpRouteRegistry,
@@ -240,6 +241,12 @@ describe("setActivePluginRegistry", () => {
     setActivePluginRegistry(registry);
 
     expect(listImportedRuntimePluginIds()).toEqual(["runtime-plugin"]);
+  });
+
+  it("includes plugin ids imported before registration failed", () => {
+    recordImportedPluginId("broken-plugin");
+
+    expect(listImportedRuntimePluginIds()).toEqual(["broken-plugin"]);
   });
 });
 

--- a/src/plugins/runtime.test.ts
+++ b/src/plugins/runtime.test.ts
@@ -5,6 +5,7 @@ import {
   getActivePluginHttpRouteRegistryVersion,
   getActivePluginRegistryVersion,
   getActivePluginRegistry,
+  listImportedRuntimePluginIds,
   pinActivePluginHttpRouteRegistry,
   releasePinnedPluginHttpRouteRegistry,
   resetPluginRuntimeStateForTest,
@@ -179,6 +180,66 @@ describe("setActivePluginRegistry", () => {
     setActivePluginRegistry(registry);
     setActivePluginRegistry(registry);
     expect(getActivePluginRegistry()?.httpRoutes).toHaveLength(1);
+  });
+
+  it("does not treat bundle-only loaded entries as imported runtime plugins", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push({
+      id: "bundle-only",
+      name: "Bundle Only",
+      source: "/tmp/bundle",
+      origin: "bundled",
+      enabled: true,
+      status: "loaded",
+      format: "bundle",
+      toolNames: [],
+      hookNames: [],
+      channelIds: [],
+      cliBackendIds: [],
+      providerIds: [],
+      speechProviderIds: [],
+      mediaUnderstandingProviderIds: [],
+      imageGenerationProviderIds: [],
+      webFetchProviderIds: [],
+      webSearchProviderIds: [],
+      gatewayMethods: [],
+      cliCommands: [],
+      services: [],
+      commands: [],
+      httpRoutes: 0,
+      hookCount: 0,
+      configSchema: true,
+    });
+    registry.plugins.push({
+      id: "runtime-plugin",
+      name: "Runtime Plugin",
+      source: "/tmp/runtime",
+      origin: "workspace",
+      enabled: true,
+      status: "loaded",
+      format: "openclaw",
+      toolNames: [],
+      hookNames: [],
+      channelIds: [],
+      cliBackendIds: [],
+      providerIds: [],
+      speechProviderIds: [],
+      mediaUnderstandingProviderIds: [],
+      imageGenerationProviderIds: [],
+      webFetchProviderIds: [],
+      webSearchProviderIds: [],
+      gatewayMethods: [],
+      cliCommands: [],
+      services: [],
+      commands: [],
+      httpRoutes: 0,
+      hookCount: 0,
+      configSchema: true,
+    });
+
+    setActivePluginRegistry(registry);
+
+    expect(listImportedRuntimePluginIds()).toEqual(["runtime-plugin"]);
   });
 });
 

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -198,12 +198,20 @@ function collectLoadedPluginIds(
     return;
   }
   for (const plugin of registry.plugins) {
-    if (plugin.status === "loaded") {
+    if (plugin.status === "loaded" && plugin.format !== "bundle") {
       ids.add(plugin.id);
     }
   }
 }
 
+/**
+ * Returns plugin ids that are currently represented by loaded runtime registries.
+ *
+ * This is a process-level runtime view, not a fresh import trace: cached registry
+ * reuse still counts because the plugin code was loaded earlier in this process.
+ * Bundle-format plugins are excluded because they can be "loaded" from metadata
+ * without importing any JS entrypoint.
+ */
 export function listImportedRuntimePluginIds(): string[] {
   const imported = new Set<string>();
   collectLoadedPluginIds(state.activeRegistry, imported);

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -16,6 +16,7 @@ type RegistryState = {
   channel: RegistrySurfaceState;
   key: string | null;
   runtimeSubagentMode: "default" | "explicit" | "gateway-bindable";
+  importedPluginIds: Set<string>;
 };
 
 const state: RegistryState = (() => {
@@ -38,10 +39,15 @@ const state: RegistryState = (() => {
       },
       key: null,
       runtimeSubagentMode: "default",
+      importedPluginIds: new Set<string>(),
     };
   }
   return globalState[REGISTRY_STATE];
 })();
+
+export function recordImportedPluginId(pluginId: string): void {
+  state.importedPluginIds.add(pluginId);
+}
 
 function installSurfaceRegistry(
   surface: RegistrySurfaceState,
@@ -205,15 +211,18 @@ function collectLoadedPluginIds(
 }
 
 /**
- * Returns plugin ids that are currently represented by loaded runtime registries.
+ * Returns plugin ids that were imported by plugin runtime or registry loading in
+ * the current process.
  *
- * This is a process-level runtime view, not a fresh import trace: cached registry
- * reuse still counts because the plugin code was loaded earlier in this process.
+ * This is a process-level view, not a fresh import trace: cached registry reuse
+ * still counts because the plugin code was loaded earlier in this process.
+ * Explicit loader import tracking covers plugins that were imported but later
+ * ended in an error state during registration.
  * Bundle-format plugins are excluded because they can be "loaded" from metadata
  * without importing any JS entrypoint.
  */
 export function listImportedRuntimePluginIds(): string[] {
-  const imported = new Set<string>();
+  const imported = new Set(state.importedPluginIds);
   collectLoadedPluginIds(state.activeRegistry, imported);
   collectLoadedPluginIds(state.channel.registry, imported);
   collectLoadedPluginIds(state.httpRoute.registry, imported);
@@ -227,4 +236,5 @@ export function resetPluginRuntimeStateForTest(): void {
   installSurfaceRegistry(state.channel, null, false);
   state.key = null;
   state.runtimeSubagentMode = "default";
+  state.importedPluginIds.clear();
 }

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -190,6 +190,28 @@ export function getActivePluginRegistryVersion(): number {
   return state.activeVersion;
 }
 
+function collectLoadedPluginIds(
+  registry: PluginRegistry | null | undefined,
+  ids: Set<string>,
+): void {
+  if (!registry) {
+    return;
+  }
+  for (const plugin of registry.plugins) {
+    if (plugin.status === "loaded") {
+      ids.add(plugin.id);
+    }
+  }
+}
+
+export function listImportedRuntimePluginIds(): string[] {
+  const imported = new Set<string>();
+  collectLoadedPluginIds(state.activeRegistry, imported);
+  collectLoadedPluginIds(state.channel.registry, imported);
+  collectLoadedPluginIds(state.httpRoute.registry, imported);
+  return [...imported].toSorted((left, right) => left.localeCompare(right));
+}
+
 export function resetPluginRuntimeStateForTest(): void {
   state.activeRegistry = null;
   state.activeVersion += 1;

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -103,6 +103,7 @@ function expectPluginLoaderCall(params: {
   autoEnabledReasons?: Record<string, string[]>;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  loadModules?: boolean;
 }) {
   expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -115,6 +116,7 @@ function expectPluginLoaderCall(params: {
         : {}),
       ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
       ...(params.env ? { env: params.env } : {}),
+      ...(params.loadModules !== undefined ? { loadModules: params.loadModules } : {}),
     }),
   );
 }
@@ -285,22 +287,25 @@ describe("buildPluginStatusReport", () => {
       config: {},
       workspaceDir: "/workspace",
       env,
+      loadModules: false,
     });
 
     expectPluginLoaderCall({
       config: {},
       workspaceDir: "/workspace",
       env,
+      loadModules: false,
     });
   });
 
   it("uses a non-activating snapshot load for status reports", () => {
-    buildPluginStatusReport({ config: {}, workspaceDir: "/workspace" });
+    buildPluginStatusReport({ config: {}, workspaceDir: "/workspace", loadModules: false });
 
     expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         activate: false,
         cache: false,
+        loadModules: false,
       }),
     );
   });
@@ -320,7 +325,7 @@ describe("buildPluginStatusReport", () => {
       },
     });
 
-    buildPluginStatusReport({ config: rawConfig });
+    buildPluginStatusReport({ config: rawConfig, loadModules: false });
 
     expectAutoEnabledStatusLoad({
       rawConfig,
@@ -329,6 +334,7 @@ describe("buildPluginStatusReport", () => {
         demo: ["demo configured"],
       },
     });
+    expectPluginLoaderCall({ loadModules: false });
   });
 
   it("uses the auto-enabled config snapshot for inspect policy summaries", () => {
@@ -371,6 +377,7 @@ describe("buildPluginStatusReport", () => {
       allowedModels: ["openai/gpt-5.4"],
       hasAllowedModelsConfig: true,
     });
+    expectPluginLoaderCall({ loadModules: true });
   });
 
   it("preserves raw config activation context when compatibility notices build their own report", () => {
@@ -412,6 +419,7 @@ describe("buildPluginStatusReport", () => {
         demo: ["demo configured"],
       },
     });
+    expectPluginLoaderCall({ loadModules: true });
   });
 
   it("applies the full bundled provider compat chain before loading plugins", () => {
@@ -421,7 +429,7 @@ describe("buildPluginStatusReport", () => {
     withBundledPluginAllowlistCompatMock.mockReturnValue(compatConfig);
     withBundledPluginEnablementCompatMock.mockReturnValue(enabledConfig);
 
-    buildPluginStatusReport({ config });
+    buildPluginStatusReport({ config, loadModules: false });
 
     expectBundledCompatChainApplied({
       config,
@@ -458,19 +466,39 @@ describe("buildPluginStatusReport", () => {
       plugins: [
         createPluginRecord({ id: "runtime-loaded" }),
         createPluginRecord({ id: "facade-loaded" }),
+        createPluginRecord({ id: "bundle-loaded", format: "bundle" }),
         createPluginRecord({ id: "cold-plugin" }),
       ],
     });
-    listImportedRuntimePluginIdsMock.mockReturnValue(["runtime-loaded"]);
+    listImportedRuntimePluginIdsMock.mockReturnValue(["runtime-loaded", "bundle-loaded"]);
     listImportedBundledPluginFacadeIdsMock.mockReturnValue(["facade-loaded"]);
 
-    const report = buildPluginStatusReport({ config: {} });
+    const report = buildPluginStatusReport({ config: {}, loadModules: false });
 
     expect(report.plugins).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: "runtime-loaded", imported: true }),
         expect.objectContaining({ id: "facade-loaded", imported: true }),
+        expect.objectContaining({ id: "bundle-loaded", imported: false }),
         expect.objectContaining({ id: "cold-plugin", imported: false }),
+      ]),
+    );
+  });
+
+  it("marks snapshot-loaded plugin modules as imported during full report loads", () => {
+    setPluginLoadResult({
+      plugins: [
+        createPluginRecord({ id: "runtime-loaded" }),
+        createPluginRecord({ id: "bundle-loaded", format: "bundle" }),
+      ],
+    });
+
+    const report = buildPluginStatusReport({ config: {}, loadModules: true });
+
+    expect(report.plugins).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "runtime-loaded", imported: true }),
+        expect.objectContaining({ id: "bundle-loaded", imported: false }),
       ]),
     );
   });

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -18,6 +18,8 @@ const withBundledPluginEnablementCompatMock = vi.fn();
 const listImportedBundledPluginFacadeIdsMock = vi.fn();
 const listImportedRuntimePluginIdsMock = vi.fn();
 let buildPluginStatusReport: typeof import("./status.js").buildPluginStatusReport;
+let buildPluginSnapshotReport: typeof import("./status.js").buildPluginSnapshotReport;
+let buildPluginDiagnosticsReport: typeof import("./status.js").buildPluginDiagnosticsReport;
 let buildPluginInspectReport: typeof import("./status.js").buildPluginInspectReport;
 let buildAllPluginInspectReports: typeof import("./status.js").buildAllPluginInspectReports;
 let buildPluginCompatibilityNotices: typeof import("./status.js").buildPluginCompatibilityNotices;
@@ -245,8 +247,10 @@ describe("buildPluginStatusReport", () => {
     ({
       buildAllPluginInspectReports,
       buildPluginCompatibilityNotices,
+      buildPluginDiagnosticsReport,
       buildPluginCompatibilityWarnings,
       buildPluginInspectReport,
+      buildPluginSnapshotReport,
       buildPluginStatusReport,
       formatPluginCompatibilityNotice,
       summarizePluginCompatibility,
@@ -283,11 +287,10 @@ describe("buildPluginStatusReport", () => {
   it("forwards an explicit env to plugin loading", () => {
     const env = { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv;
 
-    buildPluginStatusReport({
+    buildPluginSnapshotReport({
       config: {},
       workspaceDir: "/workspace",
       env,
-      loadModules: false,
     });
 
     expectPluginLoaderCall({
@@ -298,8 +301,8 @@ describe("buildPluginStatusReport", () => {
     });
   });
 
-  it("uses a non-activating snapshot load for status reports", () => {
-    buildPluginStatusReport({ config: {}, workspaceDir: "/workspace", loadModules: false });
+  it("uses a non-activating snapshot load for snapshot reports", () => {
+    buildPluginSnapshotReport({ config: {}, workspaceDir: "/workspace" });
 
     expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -325,7 +328,7 @@ describe("buildPluginStatusReport", () => {
       },
     });
 
-    buildPluginStatusReport({ config: rawConfig, loadModules: false });
+    buildPluginSnapshotReport({ config: rawConfig });
 
     expectAutoEnabledStatusLoad({
       rawConfig,
@@ -429,7 +432,7 @@ describe("buildPluginStatusReport", () => {
     withBundledPluginAllowlistCompatMock.mockReturnValue(compatConfig);
     withBundledPluginEnablementCompatMock.mockReturnValue(enabledConfig);
 
-    buildPluginStatusReport({ config, loadModules: false });
+    buildPluginSnapshotReport({ config });
 
     expectBundledCompatChainApplied({
       config,
@@ -473,7 +476,7 @@ describe("buildPluginStatusReport", () => {
     listImportedRuntimePluginIdsMock.mockReturnValue(["runtime-loaded", "bundle-loaded"]);
     listImportedBundledPluginFacadeIdsMock.mockReturnValue(["facade-loaded"]);
 
-    const report = buildPluginStatusReport({ config: {}, loadModules: false });
+    const report = buildPluginSnapshotReport({ config: {} });
 
     expect(report.plugins).toEqual(
       expect.arrayContaining([
@@ -493,7 +496,7 @@ describe("buildPluginStatusReport", () => {
       ],
     });
 
-    const report = buildPluginStatusReport({ config: {}, loadModules: true });
+    const report = buildPluginDiagnosticsReport({ config: {} });
 
     expect(report.plugins).toEqual(
       expect.arrayContaining([

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -506,6 +506,21 @@ describe("buildPluginStatusReport", () => {
     );
   });
 
+  it("marks errored plugin modules as imported when full diagnostics already evaluated them", () => {
+    setPluginLoadResult({
+      plugins: [createPluginRecord({ id: "broken-plugin", status: "error" })],
+    });
+    listImportedRuntimePluginIdsMock.mockReturnValue(["broken-plugin"]);
+
+    const report = buildPluginDiagnosticsReport({ config: {} });
+
+    expect(report.plugins).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "broken-plugin", status: "error", imported: true }),
+      ]),
+    );
+  });
+
   it("builds an inspect report with capability shape and policy", () => {
     loadConfigMock.mockReturnValue({
       plugins: {

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -15,6 +15,8 @@ const applyPluginAutoEnableMock = vi.fn();
 const resolveBundledProviderCompatPluginIdsMock = vi.fn();
 const withBundledPluginAllowlistCompatMock = vi.fn();
 const withBundledPluginEnablementCompatMock = vi.fn();
+const listImportedBundledPluginFacadeIdsMock = vi.fn();
+const listImportedRuntimePluginIdsMock = vi.fn();
 let buildPluginStatusReport: typeof import("./status.js").buildPluginStatusReport;
 let buildPluginInspectReport: typeof import("./status.js").buildPluginInspectReport;
 let buildAllPluginInspectReports: typeof import("./status.js").buildAllPluginInspectReports;
@@ -45,6 +47,15 @@ vi.mock("./bundled-compat.js", () => ({
     withBundledPluginAllowlistCompatMock(...args),
   withBundledPluginEnablementCompat: (...args: unknown[]) =>
     withBundledPluginEnablementCompatMock(...args),
+}));
+
+vi.mock("../plugin-sdk/facade-runtime.js", () => ({
+  listImportedBundledPluginFacadeIds: (...args: unknown[]) =>
+    listImportedBundledPluginFacadeIdsMock(...args),
+}));
+
+vi.mock("./runtime.js", () => ({
+  listImportedRuntimePluginIds: (...args: unknown[]) => listImportedRuntimePluginIdsMock(...args),
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
@@ -247,6 +258,8 @@ describe("buildPluginStatusReport", () => {
     resolveBundledProviderCompatPluginIdsMock.mockReset();
     withBundledPluginAllowlistCompatMock.mockReset();
     withBundledPluginEnablementCompatMock.mockReset();
+    listImportedBundledPluginFacadeIdsMock.mockReset();
+    listImportedRuntimePluginIdsMock.mockReset();
     loadConfigMock.mockReturnValue({});
     applyPluginAutoEnableMock.mockImplementation((params: { config: unknown }) => ({
       config: params.config,
@@ -260,6 +273,8 @@ describe("buildPluginStatusReport", () => {
     withBundledPluginEnablementCompatMock.mockImplementation(
       (params: { config: unknown }) => params.config,
     );
+    listImportedBundledPluginFacadeIdsMock.mockReturnValue([]);
+    listImportedRuntimePluginIdsMock.mockReturnValue([]);
     setPluginLoadResult({ plugins: [] });
   });
 
@@ -425,6 +440,28 @@ describe("buildPluginStatusReport", () => {
     });
 
     expect(report.plugins[0]?.version).toBe("2026.3.23");
+  });
+
+  it("marks plugins as imported when runtime or facade state has loaded them", () => {
+    setPluginLoadResult({
+      plugins: [
+        createPluginRecord({ id: "runtime-loaded" }),
+        createPluginRecord({ id: "facade-loaded" }),
+        createPluginRecord({ id: "cold-plugin" }),
+      ],
+    });
+    listImportedRuntimePluginIdsMock.mockReturnValue(["runtime-loaded"]);
+    listImportedBundledPluginFacadeIdsMock.mockReturnValue(["facade-loaded"]);
+
+    const report = buildPluginStatusReport({ config: {} });
+
+    expect(report.plugins).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "runtime-loaded", imported: true }),
+        expect.objectContaining({ id: "facade-loaded", imported: true }),
+        expect.objectContaining({ id: "cold-plugin", imported: false }),
+      ]),
+    );
   });
 
   it("builds an inspect report with capability shape and policy", () => {

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -294,6 +294,17 @@ describe("buildPluginStatusReport", () => {
     });
   });
 
+  it("uses a non-activating snapshot load for status reports", () => {
+    buildPluginStatusReport({ config: {}, workspaceDir: "/workspace" });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activate: false,
+        cache: false,
+      }),
+    );
+  });
+
   it("loads plugin status from the auto-enabled config snapshot", () => {
     const { rawConfig, autoEnabledConfig } = createAutoEnabledStatusConfig(
       {

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -4,6 +4,7 @@ import { loadConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { normalizeOpenClawVersionBase } from "../config/version.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { listImportedBundledPluginFacadeIds } from "../plugin-sdk/facade-runtime.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { inspectBundleLspRuntimeSupport } from "./bundle-lsp.js";
 import { inspectBundleMcpRuntimeSupport } from "./bundle-mcp.js";
@@ -16,6 +17,7 @@ import { loadOpenClawPlugins } from "./loader.js";
 import { createPluginLoaderLogger } from "./logger.js";
 import { resolveBundledProviderCompatPluginIds } from "./providers.js";
 import type { PluginRegistry } from "./registry.js";
+import { listImportedRuntimePluginIds } from "./runtime.js";
 import type { PluginDiagnostic, PluginHookName } from "./types.js";
 
 export type PluginStatusReport = PluginRegistry & {
@@ -189,12 +191,17 @@ export function buildPluginStatusReport(params?: {
     env: params?.env,
     logger: createPluginLoaderLogger(log),
   });
+  const importedPluginIds = new Set([
+    ...listImportedRuntimePluginIds(),
+    ...listImportedBundledPluginFacadeIds(),
+  ]);
 
   return {
     workspaceDir,
     ...registry,
     plugins: registry.plugins.map((plugin) => ({
       ...plugin,
+      imported: importedPluginIds.has(plugin.id),
       version: resolveReportedPluginVersion(plugin, params?.env),
     })),
   };

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -149,14 +149,17 @@ function resolveReportedPluginVersion(
   );
 }
 
-export function buildPluginStatusReport(params?: {
+type PluginReportParams = {
   config?: ReturnType<typeof loadConfig>;
   workspaceDir?: string;
   /** Use an explicit env when plugin roots should resolve independently from process.env. */
   env?: NodeJS.ProcessEnv;
-  /** Use false for cold snapshot surfaces like list/doctor that must avoid plugin code execution. */
-  loadModules?: boolean;
-}): PluginStatusReport {
+};
+
+function buildPluginReport(
+  params: PluginReportParams | undefined,
+  loadModules: boolean,
+): PluginStatusReport {
   const rawConfig = params?.config ?? loadConfig();
   const autoEnabled = resolveStatusConfig(rawConfig, params?.env);
   const config = autoEnabled.config;
@@ -194,10 +197,10 @@ export function buildPluginStatusReport(params?: {
     logger: createPluginLoaderLogger(log),
     activate: false,
     cache: false,
-    loadModules: params?.loadModules ?? true,
+    loadModules,
   });
   const importedPluginIds = new Set([
-    ...(params?.loadModules !== false
+    ...(loadModules
       ? registry.plugins
           .filter((plugin) => plugin.status === "loaded" && plugin.format !== "bundle")
           .map((plugin) => plugin.id)
@@ -218,6 +221,20 @@ export function buildPluginStatusReport(params?: {
       version: resolveReportedPluginVersion(plugin, params?.env),
     })),
   };
+}
+
+export function buildPluginSnapshotReport(params?: PluginReportParams): PluginStatusReport {
+  return buildPluginReport(params, false);
+}
+
+export function buildPluginDiagnosticsReport(params?: PluginReportParams): PluginStatusReport {
+  return buildPluginReport(params, true);
+}
+
+// Compatibility alias for existing hot/reporting callers while the repo finishes
+// migrating to explicit snapshot vs diagnostics builders.
+export function buildPluginStatusReport(params?: PluginReportParams): PluginStatusReport {
+  return buildPluginDiagnosticsReport(params);
 }
 
 function buildCapabilityEntries(plugin: PluginRegistry["plugins"][number]) {
@@ -275,11 +292,10 @@ export function buildPluginInspectReport(params: {
   const config = resolvedConfig.config;
   const report =
     params.report ??
-    buildPluginStatusReport({
+    buildPluginDiagnosticsReport({
       config: rawConfig,
       workspaceDir: params.workspaceDir,
       env: params.env,
-      loadModules: true,
     });
   const plugin = report.plugins.find((entry) => entry.id === params.id || entry.name === params.id);
   if (!plugin) {
@@ -409,11 +425,10 @@ export function buildAllPluginInspectReports(params?: {
   const rawConfig = params?.config ?? loadConfig();
   const report =
     params?.report ??
-    buildPluginStatusReport({
+    buildPluginDiagnosticsReport({
       config: rawConfig,
       workspaceDir: params?.workspaceDir,
       env: params?.env,
-      loadModules: true,
     });
 
   return report.plugins

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -154,6 +154,8 @@ export function buildPluginStatusReport(params?: {
   workspaceDir?: string;
   /** Use an explicit env when plugin roots should resolve independently from process.env. */
   env?: NodeJS.ProcessEnv;
+  /** Use false for cold snapshot surfaces like list/doctor that must avoid plugin code execution. */
+  loadModules?: boolean;
 }): PluginStatusReport {
   const rawConfig = params?.config ?? loadConfig();
   const autoEnabled = resolveStatusConfig(rawConfig, params?.env);
@@ -192,8 +194,14 @@ export function buildPluginStatusReport(params?: {
     logger: createPluginLoaderLogger(log),
     activate: false,
     cache: false,
+    loadModules: params?.loadModules ?? true,
   });
   const importedPluginIds = new Set([
+    ...(params?.loadModules !== false
+      ? registry.plugins
+          .filter((plugin) => plugin.status === "loaded" && plugin.format !== "bundle")
+          .map((plugin) => plugin.id)
+      : []),
     ...listImportedRuntimePluginIds(),
     ...listImportedBundledPluginFacadeIds(),
   ]);
@@ -203,7 +211,10 @@ export function buildPluginStatusReport(params?: {
     ...registry,
     plugins: registry.plugins.map((plugin) => ({
       ...plugin,
-      imported: importedPluginIds.has(plugin.id),
+      imported:
+        plugin.status === "loaded" &&
+        plugin.format !== "bundle" &&
+        importedPluginIds.has(plugin.id),
       version: resolveReportedPluginVersion(plugin, params?.env),
     })),
   };
@@ -268,6 +279,7 @@ export function buildPluginInspectReport(params: {
       config: rawConfig,
       workspaceDir: params.workspaceDir,
       env: params.env,
+      loadModules: true,
     });
   const plugin = report.plugins.find((entry) => entry.id === params.id || entry.name === params.id);
   if (!plugin) {
@@ -401,6 +413,7 @@ export function buildAllPluginInspectReports(params?: {
       config: rawConfig,
       workspaceDir: params?.workspaceDir,
       env: params?.env,
+      loadModules: true,
     });
 
   return report.plugins

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -214,10 +214,7 @@ function buildPluginReport(
     ...registry,
     plugins: registry.plugins.map((plugin) => ({
       ...plugin,
-      imported:
-        plugin.status === "loaded" &&
-        plugin.format !== "bundle" &&
-        importedPluginIds.has(plugin.id),
+      imported: plugin.format !== "bundle" && importedPluginIds.has(plugin.id),
       version: resolveReportedPluginVersion(plugin, params?.env),
     })),
   };

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -190,6 +190,8 @@ export function buildPluginStatusReport(params?: {
     workspaceDir,
     env: params?.env,
     logger: createPluginLoaderLogger(log),
+    activate: false,
+    cache: false,
   });
   const importedPluginIds = new Set([
     ...listImportedRuntimePluginIds(),


### PR DESCRIPTION
## Summary

- Problem: plugin status/reporting could explain `enabled` and `activated`, but not whether plugin code had actually been pulled into the current process.
- Why it matters: the plugin-loading hardening work is much harder to verify without an observable imported/runtime state.
- What changed: status reports now add `imported` metadata sourced from runtime registries plus bundled facade loads, expose it in verbose `plugins list` and JSON output, and include imported counts in doctor workspace plugin notes.
- What did NOT change (scope boundary): no user-facing config changes, no loader policy changes beyond making status snapshots non-activating.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the runtime hardening work added `activated` state, but there was still no first-class reporting for whether plugin code had been imported in-process.
- Missing detection / guardrail: status tooling only reflected config/load decisions, not runtime import state.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this is the reporting follow-through after the plugin activation-boundary PR series.
- Why this regressed now: once activation hardening landed, the remaining gap was observability rather than loader correctness.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/plugins/status.test.ts`
  - `src/plugin-sdk/facade-runtime.test.ts`
  - `src/commands/doctor-workspace-status.test.ts`
  - `src/cli/plugins-cli.list.test.ts`
- Scenario the test should lock in: imported state stays visible in status/doctor/CLI output without the reporting snapshot mutating runtime activation.
- Why this is the smallest reliable guardrail: the bug sits at the reporting seam between plugin loader snapshots, runtime registry state, and bundled facade tracking.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `plugins list --verbose` now shows `imported: yes/no`.
- `plugins list --json` now includes `imported` per plugin.
- `doctor` workspace plugin notes now include `Imported: N`.

## Diagram (if applicable)

```text
Before:
[plugins status request] -> [enabled/activated only]

After:
[plugins status request] -> [non-activating snapshot] -> [enabled/activated/imported]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): plugin runtime + CLI status tooling
- Relevant config (redacted): default local config

### Steps

1. Run `openclaw plugins list --verbose` or `--json`.
2. Inspect plugin entries after runtime/facade loads have happened in-process.
3. Run `openclaw doctor` and inspect the Plugins note.

### Expected

- Imported state is visible.
- Reporting does not activate/load plugins just to compute imported state.

### Actual

- This PR implements that behavior.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - targeted status/facade/doctor/CLI tests pass
  - `pnpm check` passes
  - `pnpm build` passes
- Edge cases checked:
  - status reporting now uses `activate: false, cache: false`
  - facade-imported bundled plugins show imported state in status reports
- What you did **not** verify:
  - full `pnpm test`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: bundled facade imported-state is process-level, so it reflects imported code in the current process rather than per-workspace unloading semantics.
  - Mitigation: status reporting is now snapshot-only and does not mutate runtime state; tests lock the current semantics.

## AI Assistance

- AI-assisted: Yes
- Testing: fully tested for the touched surface
