### PR TITLE
Fix browser gateway methods after deferred plugin reload

### DIFF
--- a/src/gateway/server-plugin-bootstrap.browser-plugin.integration.test.ts
+++ b/src/gateway/server-plugin-bootstrap.browser-plugin.integration.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createBundledBrowserPluginFixture } from "../../test/helpers/browser-bundled-plugin-fixture.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { clearPluginDiscoveryCache } from "../plugins/discovery.js";
@@ -58,6 +60,45 @@ describe("loadGatewayStartupPlugins browser plugin integration", () => {
     expect(loaded.gatewayMethods).toContain("browser.request");
     expect(
       loaded.pluginRegistry.services.some(
+        (entry) => entry.pluginId === "browser" && entry.service.id === "browser-control",
+      ),
+    ).toBe(true);
+  });
+
+  it("refreshes browser gateway ownership when deferred reload replaces the active registry", () => {
+    const startupLoaded = loadGatewayStartupPlugins({
+      cfg: {
+        plugins: {
+          allow: ["browser"],
+        },
+      } as OpenClawConfig,
+      workspaceDir: process.cwd(),
+      log: createTestLog(),
+      coreGatewayHandlers,
+      baseMethods: listGatewayMethods(),
+      logDiagnostics: false,
+    });
+
+    expect(startupLoaded.gatewayMethods).toContain("browser.request");
+
+    setActivePluginRegistry(createEmptyPluginRegistry());
+
+    const deferredLoaded = loadGatewayStartupPlugins({
+      cfg: {
+        plugins: {
+          allow: ["browser"],
+        },
+      } as OpenClawConfig,
+      workspaceDir: process.cwd(),
+      log: createTestLog(),
+      coreGatewayHandlers,
+      baseMethods: listGatewayMethods(),
+      logDiagnostics: false,
+    });
+
+    expect(deferredLoaded.gatewayMethods).toContain("browser.request");
+    expect(
+      deferredLoaded.pluginRegistry.services.some(
         (entry) => entry.pluginId === "browser" && entry.service.id === "browser-control",
       ),
     ).toBe(true);

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -624,8 +624,12 @@ export async function startGatewayServer(
   const channelRuntimeEnvs = Object.fromEntries(
     Object.entries(channelLogs).map(([id, logger]) => [id, runtimeForLogger(logger)]),
   ) as unknown as Record<ChannelId, RuntimeEnv>;
-  const channelMethods = listChannelPlugins().flatMap((plugin) => plugin.gatewayMethods ?? []);
-  const gatewayMethods = Array.from(new Set([...baseGatewayMethods, ...channelMethods]));
+  let gatewayMethods = Array.from(
+    new Set([
+      ...baseGatewayMethods,
+      ...listChannelPlugins().flatMap((plugin) => plugin.gatewayMethods ?? []),
+    ]),
+  );
   let pluginServices: PluginServicesHandle | null = null;
   const runtimeConfig = await resolveGatewayRuntimeConfig({
     cfg: cfgAtStart,
@@ -1363,7 +1367,7 @@ export async function startGatewayServer(
 
     if (!minimalTestGateway) {
       if (deferredConfiguredChannelPluginIds.length > 0) {
-        ({ pluginRegistry } = reloadDeferredGatewayPlugins({
+        ({ pluginRegistry, gatewayMethods: baseGatewayMethods } = reloadDeferredGatewayPlugins({
           cfg: gatewayPluginConfigAtStart,
           workspaceDir: defaultWorkspaceDir,
           log,
@@ -1372,6 +1376,12 @@ export async function startGatewayServer(
           pluginIds: startupPluginIds,
           logDiagnostics: false,
         }));
+        gatewayMethods = Array.from(
+          new Set([
+            ...baseGatewayMethods,
+            ...listChannelPlugins().flatMap((plugin) => plugin.gatewayMethods ?? []),
+          ]),
+        );
       }
       ({ pluginServices } = await startGatewaySidecars({
         cfg: gatewayPluginConfigAtStart,


### PR DESCRIPTION
## Summary

- Problem: `openclaw browser status` / `openclaw browser start` could fail with `GatewayClientRequestError: unknown method: browser.request` even though the browser plugin was loaded and the browser control sidecar was running.
- Why it matters: browser automation looked partially healthy (service alive) but the gateway RPC surface was stale, so browser commands failed at runtime.
- What changed: refresh plugin-derived `gatewayMethods` after deferred gateway plugin reload, instead of only updating `pluginRegistry`.
- What did NOT change (scope boundary): this does not change browser sidecar startup behavior, browser auth/policy behavior, or plugin registration semantics outside the deferred reload path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: gateway startup loaded plugin gateway methods correctly at first, but a later deferred plugin reload replaced `pluginRegistry` without refreshing the derived `gatewayMethods` list used by the gateway websocket/runtime handler layer.
- Missing detection / guardrail: there was coverage proving the browser plugin contributes both `browser.request` and the browser control service during startup plugin load, but no coverage for the deferred reload path replacing the active registry after startup.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: the deferred reload path updates runtime plugin state after startup, but the gateway-visible method surface remained tied to the earlier snapshot.
- If unknown, what was ruled out: ruled out browser plugin disablement, browser sidecar startup failure, sandbox restrictions, and missing browser plugin load. The browser control service was running while `browser.request` was still missing from the gateway method surface.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
 - [ ] Unit test
 - [x] Seam / integration test
 - [ ] End-to-end test
 - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-plugin-bootstrap.browser-plugin.integration.test.ts`
- Scenario the test should lock in: when gateway plugin state is refreshed/reloaded after startup, browser plugin ownership should still contribute both the `browser.request` gateway method and the `browser-control` service.
- Why this is the smallest reliable guardrail: the failure is caused by interaction between plugin bootstrap output and later gateway reload behavior, so an integration-level plugin bootstrap test is the smallest reliable place to assert both surfaces together.
- Existing test that already covers this (if any): existing startup integration coverage in `src/gateway/server-plugin-bootstrap.browser-plugin.integration.test.ts` already verified the initial load path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw browser status` no longer fails with `unknown method: browser.request` after deferred gateway plugin reload.
- `openclaw browser start` works again in the affected runtime path.
- No config or default behavior changes.

## Diagram (if applicable)

```text
Before:
[gateway startup] -> [plugin methods loaded]
               -> [deferred reload replaces pluginRegistry]
               -> [gatewayMethods stay stale]
               -> [browser sidecar running]
               -> [openclaw browser status]
               -> [unknown method: browser.request]

After:
[gateway startup] -> [plugin methods loaded]
               -> [deferred reload replaces pluginRegistry]
               -> [gatewayMethods refreshed from reloaded plugin state]
               -> [browser sidecar running]
               -> [openclaw browser status]
               -> [browser RPC succeeds]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw gateway
- Model/provider: N/A
- Integration/channel (if any): bundled browser plugin
- Relevant config (redacted): browser plugin enabled; deferred gateway plugin reload path active

### Steps

1. Start gateway with browser plugin enabled.
2. Let deferred gateway plugin reload replace the active plugin registry.
3. Run `openclaw browser status` or `openclaw browser start`.

### Expected

- Browser commands should resolve `browser.request` and work normally.

### Actual

- Browser commands failed with `GatewayClientRequestError: unknown method: browser.request`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Relevant before-fix runtime symptom:

```text
GatewayClientRequestError: unknown method: browser.request
```

Additional observed state before fix:
- browser plugin loaded
- browser control service listening
- browser commands still failed because gateway method surface was stale

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Verified the runtime failure before the fix: `openclaw browser status` / `openclaw browser start` failed with `unknown method: browser.request`.
  - Verified the runtime behavior after the fix: browser status/start succeeded again.
- Edge cases checked:
  - Confirmed browser plugin was enabled/loaded.
  - Confirmed browser control sidecar/service was actually running, so the issue was specifically method-surface drift rather than plugin startup failure.
- What you did **not** verify:
  - Full CI/test suite was not run in this environment.
  - Cross-platform verification was not performed.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: refreshing `gatewayMethods` after deferred reload could expose drift if another part of startup implicitly relied on the old snapshot remaining frozen.
 - Mitigation: the change is narrowly scoped to recomputing methods from the already-reloaded plugin state, and test coverage was added around browser plugin ownership in the reload path.

- Risk: the added regression coverage may not fully represent the exact runtime ordering in all gateway startup variants.
 - Mitigation: the test focuses on the smallest invariant that should hold regardless of ordering: reloaded browser plugin state must continue to contribute both the gateway method and the service.
