### PR TITLE
fix(btw): strip empty tools array for strict OpenAI-compatible endpoints

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -296,6 +296,21 @@ describe("runBtwSideQuestion", () => {
     expect(result).toEqual({ text: "Final answer." });
   });
 
+  it("strips empty tools arrays from BTW payloads before sending", async () => {
+    mockDoneAnswer("Final answer.");
+
+    await runSideQuestion();
+
+    const [, , options] = streamSimpleMock.mock.calls[0] ?? [];
+    const onPayload = (options as { onPayload?: (payload: unknown) => void })?.onPayload;
+    const payloadWithEmptyTools = { messages: [], tools: [] as unknown[] };
+
+    const result = onPayload?.(payloadWithEmptyTools);
+
+    expect(payloadWithEmptyTools).not.toHaveProperty("tools");
+    expect(result).toBeUndefined();
+  });
+
   it("forces provider reasoning off even when the session think level is adaptive", async () => {
     streamSimpleMock.mockImplementation((_model, _input, options?: { reasoning?: unknown }) => {
       return options?.reasoning === undefined

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -307,6 +307,14 @@ export async function runBtwSideQuestion(
       // reasoning off so we reliably receive answer text instead of thinking-only output.
       reasoning: undefined,
       signal: params.opts?.abortSignal,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object" && "tools" in payload) {
+          const p = payload as { tools?: unknown[] };
+          if (Array.isArray(p.tools) && p.tools.length === 0) {
+            delete p.tools;
+          }
+        }
+      },
     },
   );
 


### PR DESCRIPTION
## Summary

- **Problem**: The `/btw` command fails with `400 [] is too short - 'tools'` error when using Qwen, GLM, Kimi and some strict OpenAI-compatible endpoints.
- **Why it matters**: Users cannot use the side-question feature (`/btw`) with these models if the active session has prior tool call history.
- **What changed**: Added an `onPayload` hook in `src/agents/btw.ts` to intercept the provider request and safely strip the `tools` property if it is an empty array.
- **What did NOT change**: Core agent tool calling logic, upstream `@mariozechner/pi-ai` behavior, and main session tool calls remain untouched.

## Change Type

- [x] Bug fix

## Scope

- [x] Skills / tool execution

## Linked Issue/PR


## Root Cause / Regression History

- **Root cause**: Upstream `@mariozechner/pi-ai` injects `tools: []` when `hasToolHistory(context.messages)` is true (to satisfy certain Anthropic proxy requirements). However, the `/btw` side-channel deliberately omits tools. When `tools: []` is sent to Kimi/GLM APIs, they strictly reject it with a 400 error.
- **Missing detection / guardrail**: Provider compatibility testing for empty tool arrays in tool-disabled execution paths.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Seam / integration test
- **Target test or file**: `src/agents/btw.test.ts`
- **Scenario the test should lock in**: `/btw` command execution with a session history containing tool calls, asserting that the outgoing payload does not contain an empty `tools` array.

## User-visible / Behavior Changes

Users of Kimi, Qwen, GLM, and strict OpenAI-compatible endpoints will now be able to use `/btw` successfully without receiving a 400 Bad Request error.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Tahoe 26.4
- Runtime/container:  nodejs v25.8.1
- Model/provider: `qwen3.5-plus` `GLM-5` `MiniMax-M2.5` `kimi-k2.5`
- Integration/channel: Telegram

### Steps

1. Start a session using an qwen3.5-plus model.
2. Trigger a normal tool call (e.g., "Search the web").
3. Once the tool call finishes, send a BTW command: `/btw what did we just do?`

### Expected

- The BTW command returns a successful context-aware response.

### Actual (before fix)

- The BTW command fails with `400 [] is too short - 'tools'`.

## Evidence

- [x] Trace/log snippets
- [x] Manual testing with Qwen model

## Human Verification

- **Verified scenarios**: Local testing with qwen3.5-plus model enforcing non-empty tools array.
- **Edge cases checked**: Ensured normal tool calls in the main session are not affected since the hook is only injected in `runBtwSideQuestion`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk**: Certain Anthropic proxies explicitly required `tools: []` when tool history is present.
- **Mitigation**: If an upstream proxy explicitly requires this for `/btw`, it might fail. However, standardizing on omitting the empty array is the safer universal default, as it conforms strictly to the OpenAI API specification.
