### PR TITLE
fix(tasks): harden task-flow restore and maintenance

### DIFF
--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -152,6 +152,22 @@ type TaskSystemAuditFinding = {
   flow?: TaskFlowRecord;
 };
 
+function compareSystemAuditFindings(left: TaskSystemAuditFinding, right: TaskSystemAuditFinding) {
+  const severityRank = (severity: TaskSystemAuditSeverity) => (severity === "error" ? 0 : 1);
+  const severityDiff = severityRank(left.severity) - severityRank(right.severity);
+  if (severityDiff !== 0) {
+    return severityDiff;
+  }
+  const leftAge = left.ageMs ?? -1;
+  const rightAge = right.ageMs ?? -1;
+  if (leftAge !== rightAge) {
+    return rightAge - leftAge;
+  }
+  const leftCreatedAt = left.task?.createdAt ?? left.flow?.createdAt ?? 0;
+  const rightCreatedAt = right.task?.createdAt ?? right.flow?.createdAt ?? 0;
+  return leftCreatedAt - rightCreatedAt;
+}
+
 function formatAuditRows(findings: TaskSystemAuditFinding[], rich: boolean) {
   const header = [
     "Scope".padEnd(8),
@@ -225,14 +241,17 @@ function toSystemAuditFindings(params: {
       return false;
     }
     return true;
-  });
+  }).toSorted(compareSystemAuditFindings);
+  const sortedAllFindings = [...allFindings].toSorted(compareSystemAuditFindings);
   return {
-    allFindings,
+    allFindings: sortedAllFindings,
     filteredFindings,
+    taskFindings,
+    flowFindings,
     summary: {
-      total: allFindings.length,
-      errors: allFindings.filter((finding) => finding.severity === "error").length,
-      warnings: allFindings.filter((finding) => finding.severity !== "error").length,
+      total: sortedAllFindings.length,
+      errors: sortedAllFindings.filter((finding) => finding.severity === "error").length,
+      warnings: sortedAllFindings.filter((finding) => finding.severity !== "error").length,
       tasks: summarizeTaskAuditFindings(taskFindings),
       taskFlows: summarizeTaskFlowAuditFindings(flowFindings),
     },
@@ -395,7 +414,7 @@ export async function tasksAuditCommand(
 ) {
   const severityFilter = opts.severity?.trim() as TaskSystemAuditSeverity | undefined;
   const codeFilter = opts.code?.trim() as TaskSystemAuditCode | undefined;
-  const { allFindings, filteredFindings, summary } = toSystemAuditFindings({
+  const { allFindings, filteredFindings, taskFindings, summary } = toSystemAuditFindings({
     severityFilter,
     codeFilter,
   });
@@ -403,6 +422,7 @@ export async function tasksAuditCommand(
   const displayed = limit ? filteredFindings.slice(0, limit) : filteredFindings;
 
   if (opts.json) {
+    const legacySummary = summarizeTaskAuditFindings(taskFindings);
     runtime.log(
       JSON.stringify(
         {
@@ -414,7 +434,15 @@ export async function tasksAuditCommand(
             code: codeFilter ?? null,
             limit: limit ?? null,
           },
-          summary,
+          summary: {
+            ...legacySummary,
+            taskFlows: summary.taskFlows,
+            combined: {
+              total: summary.total,
+              errors: summary.errors,
+              warnings: summary.warnings,
+            },
+          },
           findings: displayed,
         },
         null,
@@ -481,11 +509,11 @@ export async function tasksMaintenanceCommand(
           },
           tasks: summary,
           auditBefore: {
-            tasks: auditBefore,
+            ...auditBefore,
             taskFlows: flowAuditBefore,
           },
           auditAfter: {
-            tasks: auditAfter,
+            ...auditAfter,
             taskFlows: flowAuditAfter,
           },
         },

--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -225,6 +225,12 @@ export function listTaskFlowAuditFindings(
     if (
       flow.syncMode === "managed" &&
       (flow.status === "running" || flow.status === "waiting" || flow.status === "blocked") &&
+      ageMs >=
+        (flow.status === "running"
+          ? staleRunningMs
+          : flow.status === "waiting"
+            ? staleWaitingMs
+            : staleBlockedMs) &&
       linkedTasks.length === 0 &&
       !hasBlockingMetadata(flow)
     ) {


### PR DESCRIPTION
## Summary
- harden task-flow registry restore so failures degrade into audit findings instead of crashing first access
- add task-flow audit and maintenance for stale, stuck, cancel-requested, and old terminal flows
- fold task-flow checks into `openclaw tasks audit` and `openclaw tasks maintenance`

## Testing
- pnpm test -- src/cli/program/register.status-health-sessions.test.ts src/commands/doctor-workspace-status.test.ts src/plugins/runtime/index.test.ts src/tasks/task-flow-registry.audit.test.ts src/tasks/task-flow-registry.maintenance.test.ts src/tasks/task-flow-registry.test.ts src/tasks/task-executor.test.ts src/plugins/runtime/runtime-taskflow.test.ts
- pnpm check
- pnpm build