### PR TITLE
docs: document required channels.slack.execApprovals config for Slack exec approvals

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -487,7 +487,9 @@ Exec approval prompts can route natively through Slack using interactive buttons
 
 This uses the same shared approval button surface as other channels. When `interactivity` is enabled in your Slack app settings, approval prompts render as Block Kit buttons directly in the conversation.
 
-Configuration uses the shared `approvals.exec` config with Slack targets:
+Configuration requires **two** parts: the top-level routing config and a Slack-channel-specific `execApprovals` block.
+
+**Step 1 — Top-level routing** (routes approval prompts to Slack):
 
 ```json5
 {
@@ -499,6 +501,36 @@ Configuration uses the shared `approvals.exec` config with Slack targets:
   },
 }
 ```
+
+**Step 2 — Slack channel config** (enables the Slack approval client and sets approvers):
+
+```json5
+{
+  channels: {
+    slack: {
+      execApprovals: {
+        enabled: true,
+        // List Slack user IDs who can approve or deny exec requests.
+        // Note: channels.slack.allowFrom is NOT automatically used here —
+        // approvers must be listed explicitly, or set via commands.ownerAllowFrom.
+        approvers: ["U12345678"],
+      },
+    },
+  },
+}
+```
+
+<Warning>
+Both blocks are required. If `channels.slack.execApprovals.enabled` is missing or false,
+OpenClaw will report "chat exec approvals are not enabled on Slack" even when the
+top-level `approvals.exec` config is present.
+</Warning>
+
+**Approver resolution order:**
+1. `channels.slack.execApprovals.approvers` — explicit list (recommended)
+2. `commands.ownerAllowFrom` — fallback if no explicit approvers are set
+
+Existing `channels.slack.allowFrom` entries are **not** automatically used as exec approvers.
 
 Same-chat `/approve` also works in Slack channels and DMs that already support commands. See [Exec approvals](/tools/exec-approvals) for the full approval forwarding model.
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -527,6 +527,7 @@ top-level `approvals.exec` config is present.
 </Warning>
 
 **Approver resolution order:**
+
 1. `channels.slack.execApprovals.approvers` — explicit list (recommended)
 2. `commands.ownerAllowFrom` — fallback if no explicit approvers are set
 


### PR DESCRIPTION
## Summary

- **Problem:** Slack exec approvals require a `channels.slack.execApprovals` config block, but this was undocumented. Users got `"chat exec approvals are not enabled on Slack"` even after correctly configuring `approvals.exec`.
- **Why it matters:** Blocks users from enabling exec approvals on Slack with no useful error hint.
- **What changed:** Added missing `channels.slack.execApprovals` config example, `<Warning>` callout that both blocks are required, and documented approver resolution order.
- **What did NOT change:** Docs only — no runtime code changed.

## Change Type
- [x] Docs

## Scope
- [x] UI / DX

## Linked Issue/PR
- Closes #59664
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `channels.slack.execApprovals` block added in v2026.4.1 without corresponding doc update.
- Why now: New feature shipped without doc coverage.

## Regression Test Plan
N/A — docs only.

## User-visible / Behavior Changes
Docs now show the complete config required for Slack exec approvals.

## Diagram
N/A

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OpenClaw v2026.4.1, Amazon Linux 2023

### Steps
1. Configure `approvals.exec` with Slack target per existing docs
2. Send exec command → see: "chat exec approvals are not enabled on Slack"
3. Add `channels.slack.execApprovals.enabled: true` + approvers
4. Exec approvals work

### Expected
Docs show the complete config upfront.

### Actual
Only `approvals.exec` was documented; `channels.slack.execApprovals` was missing.

## Evidence
- Reported in #59664 with exact reproduction config
- Confirmed via source: `isSlackExecApprovalClientEnabled()` checks `channels.slack.execApprovals.enabled`

## Human Verification
- Verified documented config matches source code behavior described in #59664
- Documented that `allowFrom` is NOT used for exec approvers (common gotcha)
- Did NOT verify in a live Slack environment (no Slack bot access)

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes — docs only
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
None — docs only.

---

> **AI-assisted:** Prepared with Claude via OpenClaw. Fix identified by reading #59664 and cross-referencing source. Content verified by contributor.