### PR TITLE
fix(gateway): suppress /new startup chatter in chat history

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -105,6 +105,24 @@ type ChatAbortRequester = {
 const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
+const SESSION_RESET_PROMPT_REQUIRED_MARKERS = [
+  "/new or /reset",
+  "session startup sequence",
+] as const;
+const SESSION_RESET_PROMPT_OPTIONAL_MARKERS = [
+  "read the required files before responding",
+  "do not mention internal steps, files, tools, or reasoning",
+] as const;
+const STARTUP_BOOTSTRAP_BASENAMES = new Set([
+  "agents.md",
+  "soul.md",
+  "tools.md",
+  "identity.md",
+  "user.md",
+  "heartbeat.md",
+  "bootstrap.md",
+  "memory.md",
+]);
 let chatHistoryPlaceholderEmitCount = 0;
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
   "main",
@@ -718,7 +736,41 @@ function sanitizeChatHistoryMessages(messages: unknown[], maxChars: number): unk
   }
   let changed = false;
   const next: unknown[] = [];
+  const startupReadToolCallIds = new Set<string>();
+  let suppressStartupSequence = false;
   for (const message of messages) {
+    if (isResetCommandMessage(message)) {
+      changed = true;
+      suppressStartupSequence = true;
+      continue;
+    }
+    if (isSessionResetInstructionMessage(message)) {
+      changed = true;
+      suppressStartupSequence = true;
+      continue;
+    }
+    if (suppressStartupSequence) {
+      const startupRead = classifyStartupBootstrapReadMessage(message);
+      if (startupRead.kind === "assistant-read-tool-calls") {
+        changed = true;
+        for (const callId of startupRead.callIds) {
+          startupReadToolCallIds.add(callId);
+        }
+        continue;
+      }
+      if (
+        startupRead.kind === "tool-result" &&
+        startupRead.callId &&
+        startupReadToolCallIds.has(startupRead.callId)
+      ) {
+        changed = true;
+        continue;
+      }
+      if (hasAssistantVisibleText(message)) {
+        suppressStartupSequence = false;
+      }
+    }
+
     // Drop assistant messages whose entire visible text is the silent reply token.
     const text = extractAssistantTextForSilentCheck(message);
     if (text !== undefined && isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
@@ -730,6 +782,111 @@ function sanitizeChatHistoryMessages(messages: unknown[], maxChars: number): unk
     next.push(res.message);
   }
   return changed ? next : messages;
+}
+
+function isSessionResetInstructionMessage(message: unknown): boolean {
+  const text = extractVisibleTextForHistoryFilter(message);
+  if (text === undefined) {
+    return false;
+  }
+  const normalized = text.replace(/\s+/g, " ").trim().toLowerCase();
+  if (!SESSION_RESET_PROMPT_REQUIRED_MARKERS.every((marker) => normalized.includes(marker))) {
+    return false;
+  }
+  return SESSION_RESET_PROMPT_OPTIONAL_MARKERS.some((marker) => normalized.includes(marker));
+}
+
+function hasAssistantVisibleText(message: unknown): boolean {
+  const text = extractAssistantTextForSilentCheck(message);
+  return typeof text === "string" && text.trim().length > 0;
+}
+
+function extractVisibleTextForHistoryFilter(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const entry = message as Record<string, unknown>;
+  if (typeof entry.text === "string") {
+    return entry.text;
+  }
+  if (typeof entry.content === "string") {
+    return entry.content;
+  }
+  if (!Array.isArray(entry.content) || entry.content.length === 0) {
+    return undefined;
+  }
+  const texts: string[] = [];
+  for (const block of entry.content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typed = block as Record<string, unknown>;
+    if (typed.type === "text" && typeof typed.text === "string") {
+      texts.push(typed.text);
+    }
+  }
+  return texts.length > 0 ? texts.join("\n") : undefined;
+}
+
+function classifyStartupBootstrapReadMessage(
+  message: unknown,
+):
+  | { kind: "none" }
+  | { kind: "assistant-read-tool-calls"; callIds: string[] }
+  | { kind: "tool-result"; callId?: string } {
+  if (!message || typeof message !== "object") {
+    return { kind: "none" };
+  }
+  const entry = message as Record<string, unknown>;
+  const role = typeof entry.role === "string" ? entry.role.toLowerCase() : "";
+  if (role === "toolresult") {
+    return {
+      kind: "tool-result",
+      callId: typeof entry.toolCallId === "string" ? entry.toolCallId : undefined,
+    };
+  }
+  if (role !== "assistant" || !Array.isArray(entry.content) || entry.content.length === 0) {
+    return { kind: "none" };
+  }
+  const callIds: string[] = [];
+  for (const block of entry.content) {
+    if (!block || typeof block !== "object") {
+      return { kind: "none" };
+    }
+    const typed = block as Record<string, unknown>;
+    if (typed.type !== "toolCall" || typed.name !== "read") {
+      return { kind: "none" };
+    }
+    const args = typed.arguments as Record<string, unknown> | undefined;
+    const filePath = typeof args?.file_path === "string" ? args.file_path : "";
+    const baseName = filePath.split(/[\\/]/).pop()?.toLowerCase() ?? "";
+    if (!STARTUP_BOOTSTRAP_BASENAMES.has(baseName)) {
+      return { kind: "none" };
+    }
+    if (typeof typed.id === "string" && typed.id.trim()) {
+      callIds.push(typed.id);
+    }
+  }
+  return { kind: "assistant-read-tool-calls", callIds };
+}
+
+function isResetCommandMessage(message: unknown): boolean {
+  const text = extractVisibleTextForHistoryFilter(message);
+  if (typeof text !== "string") {
+    return false;
+  }
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const role =
+    typeof (message as { role?: unknown }).role === "string"
+      ? (message as { role: string }).role.toLowerCase()
+      : "";
+  if (role !== "user") {
+    return false;
+  }
+  const normalized = text.trim().toLowerCase();
+  return normalized === "/new" || normalized === "/reset";
 }
 
 function buildOversizedHistoryPlaceholder(message?: unknown): Record<string, unknown> {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -685,6 +685,141 @@ describe("gateway server chat", () => {
     ]);
   });
 
+  test("chat.history hides internal /new startup sequence and bootstrap read tool chatter", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content:
+          "A new session was started via /new or /reset. Run your Session Startup sequence - read the required files before responding to the user. Then greet the user in your configured persona, if one is provided. Do not mention internal steps, files, tools, or reasoning.\nCurrent time: Thursday, April 2nd, 2026 — 20:49 (Asia/Shanghai) / 2026-04-02 12:49 UTC",
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "read:0",
+            name: "read",
+            arguments: { file_path: "/home/user/.openclaw/workspace/SOUL.md" },
+          },
+          {
+            type: "toolCall",
+            id: "read:1",
+            name: "read",
+            arguments: { file_path: "/home/user/.openclaw/workspace/USER.md" },
+          },
+          {
+            type: "toolCall",
+            id: "read:2",
+            name: "read",
+            arguments: { file_path: "/home/user/.openclaw/workspace/IDENTITY.md" },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "read:0",
+        toolName: "read",
+        content: [{ type: "text", text: "SOUL" }],
+        timestamp: 3,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "read:1",
+        toolName: "read",
+        content: [{ type: "text", text: "USER" }],
+        timestamp: 4,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "read:2",
+        toolName: "read",
+        content: [{ type: "text", text: "IDENTITY" }],
+        timestamp: 5,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Hey. I just came online. Who am I? Who are you?" }],
+        timestamp: 6,
+      },
+    ]);
+
+    const roleAndText = historyMessages
+      .map((message) => {
+        const role =
+          message &&
+          typeof message === "object" &&
+          typeof (message as { role?: unknown }).role === "string"
+            ? (message as { role: string }).role
+            : "unknown";
+        const text =
+          message &&
+          typeof message === "object" &&
+          typeof (message as { text?: unknown }).text === "string"
+            ? (message as { text: string }).text
+            : (extractFirstTextBlock(message) ?? "");
+        return `${role}:${text}`;
+      })
+      .filter((entry) => entry !== "unknown:");
+
+    expect(roleAndText).toEqual(["assistant:Hey. I just came online. Who am I? Who are you?"]);
+  });
+
+  test("chat.history hides bare /new command and subsequent startup bootstrap chatter", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "/new" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "read:0",
+            name: "read",
+            arguments: { file_path: "/home/user/.openclaw/workspace/SOUL.md" },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "read:0",
+        toolName: "read",
+        content: [{ type: "text", text: "SOUL" }],
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello after reset" }],
+        timestamp: 4,
+      },
+    ]);
+
+    const roleAndText = historyMessages
+      .map((message) => {
+        const role =
+          message &&
+          typeof message === "object" &&
+          typeof (message as { role?: unknown }).role === "string"
+            ? (message as { role: string }).role
+            : "unknown";
+        const text =
+          message &&
+          typeof message === "object" &&
+          typeof (message as { text?: unknown }).text === "string"
+            ? (message as { text: string }).text
+            : (extractFirstTextBlock(message) ?? "");
+        return `${role}:${text}`;
+      })
+      .filter((entry) => entry !== "unknown:");
+
+    expect(roleAndText).toEqual(["assistant:Hello after reset"]);
+  });
+
   test("chat.send does not persist verboseLevel for operator.write callers", async () => {
     await withGatewayServer(async ({ port }) => {
       await withMainSessionStore(async () => {


### PR DESCRIPTION
## Summary

- Fixes a WebChat history leak where `/new`/`/reset` startup control content could appear as user-visible chat messages.
- Suppresses startup-sequence chatter in `chat.history`, including reset control turns and bootstrap `read` toolCall/toolResult noise.
- Keeps real assistant replies visible while preserving existing NO_REPLY filtering behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #59651
- Related #59651

## User-visible / Behavior Changes

- WebChat no longer shows internal `/new` or `/reset` startup instructions and bootstrap read chatter in chat history.
- Normal assistant replies still appear after reset/new startup.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: local gateway + WebChat
- Model/provider: openrouter/free (issue report), plus local regression fixtures
- Integration/channel (if any): WebChat (`chat.history`)
- Relevant config (redacted): default session setup

### Steps

1. Trigger a fresh `/new` or `/reset` session startup.
2. Let startup sequence run bootstrap file reads.
3. Call `chat.history` for that session.

### Expected

- Internal startup control prompt and bootstrap read tool chatter are hidden.
- Final assistant greeting/reply remains visible.

### Actual

- Before fix: startup control content leaked into `chat.history`.
- After fix: startup control content is suppressed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `chat.history` suppresses startup chatter after `/new` and `/reset`-equivalent startup content.
  - `chat.history` still keeps regular assistant messages.
  - Existing NO_REPLY filtering tests remain green.
- Edge cases checked:
  - Bare `/new` command history entries.
  - Startup toolCall + toolResult sequences for bootstrap file reads.
- What you did **not** verify:
  - Full end-to-end browser UI manual run in this PR branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this single commit on the fix branch.
- Files/config to restore:
  - `src/gateway/server-methods/chat.ts`
  - `src/gateway/server.chat.gateway-server-chat.test.ts`
- Known bad symptoms reviewers should watch for:
  - `chat.history` unexpectedly dropping valid non-startup user/assistant messages.

## Risks and Mitigations

- Risk:
  - Over-filtering non-startup transcript entries if they mimic startup patterns.
  - Mitigation:
    - Combined command + sequence-aware filtering and targeted gateway history regression tests.