### PR TITLE
fix(moonshot/kimi-web-search): Ensure reasoning_content is always included in assistant tool-call messages when thinking is enabled.

### DIFF
--- a/extensions/moonshot/src/kimi-web-search-provider.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.ts
@@ -191,7 +191,10 @@ async function runKimiSearch(params: {
         messages.push({
           role: "assistant",
           content: message?.content ?? "",
-          ...(message?.reasoning_content ? { reasoning_content: message.reasoning_content } : {}),
+          reasoning_content:
+            typeof message?.reasoning_content === "string" && message.reasoning_content.trim()
+              ? message.reasoning_content
+              : " ",
           tool_calls: toolCalls,
         });
 
@@ -203,7 +206,14 @@ async function runKimiSearch(params: {
             continue;
           }
           pushed = true;
-          messages.push({ role: "tool", tool_call_id: toolCallId, content: toolContent });
+          const functionName = toolCall.function?.name?.trim();
+          const argumentsContent = toolCall.function?.arguments ?? "";
+          messages.push({
+            role: "tool",
+            tool_call_id: toolCallId,
+            content: argumentsContent ?? toolContent,
+            ...(functionName ? { name: functionName } : {}),
+          });
         }
         if (!pushed) {
           return { done: true, content: text ?? "No response", citations: [...collectedCitations] };


### PR DESCRIPTION
## Summary

- Problem: When web search using Kimi provider and  Kimi (Moonshot) thinking is enabled (e.g. kimi-k2-thinking / kimi-k2.5 thinking) , the Moonshot API requires the assistant tool-call message to include `reasoning_content`; otherwise it returns a 400 `invalid_request_error`.
- Why it matters: `web_search` (Kimi provider) becomes unusable under these models/modes and web search fails hard.
- What changed: In the Kimi web_search provider, ensure the assistant `tool_calls` message always contains a non-empty `reasoning_content` (fallback placeholder when missing) so the request payload passes Moonshot validation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes # https://github.com/openclaw/openclaw/issues/56971
- Related # N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: In the `finish_reason="tool_calls"` flow, the provider appended an assistant message back into `messages` without guaranteeing `reasoning_content` is present/non-empty; Moonshot thinking mode validates this field strictly.
- Missing detection / guardrail: No unit/contract test covering the “tool_calls + missing/empty reasoning_content” payload shape.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown
- Why this regressed now: Triggered when switching to/using thinking-enabled Kimi models/modes (non-thinking models or non-tool-call responses don’t hit the strict validation).
- If unknown, what was ruled out: Ruled out API key/auth issues and basic network blocking (this is a 400 schema/validation error, not 401/timeout).

## User-visible / Behavior Changes

- Kimi (Moonshot) `web_search` no longer fails with a 400 due to missing `reasoning_content` when thinking is enabled and tool calls are involved.


### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: Moonshot / Kimi (`web_search` provider = `kimi` model='kimi-k2.5')
- Integration/channel (if any): N/A
- Relevant config (redacted):
  - `tools.web.search.provider = "kimi"`
  - `KIMI_API_KEY` / `MOONSHOT_API_KEY` set (redacted)

### Steps

1. Configure `web_search` provider to `kimi` and use a thinking-enabled Kimi model/mode that triggers `tool_calls`.
2. Run a `web_search` query.
3. Observe the Moonshot response.

### Expected

- Request succeeds and the tool-call loop completes, producing content and citations.

### Actual

- Before fix: 400 `invalid_request_error` with `thinking is enabled but reasoning_content is missing in assistant tool call message ...`.

## Evidence

- [x] Failing test/log before + passing after
  - Example pre-fix error: `Kimi API error (400): {"error":{"message":"thinking is enabled but reasoning_content is missing ...","type":"invalid_request_error"}}`