### PR TITLE
ci: auto-close new core plugin PRs

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -84,6 +84,16 @@ jobs:
                   "Please make this as a third-party plugin that you maintain yourself in your own repo. Docs: https://docs.openclaw.ai/plugin. Feel free to open a PR after to add it to our community plugins page: https://docs.openclaw.ai/plugins/community",
               },
               {
+                label: "r: plugin-clawhub",
+                close: true,
+                message:
+                  "Thanks for this contribution. We’re moving new plugins like this to ClawHub instead of `openclaw/openclaw` core. Please consider resubmitting it there.\n\n" +
+                  "- ClawHub: https://clawhub.ai\n" +
+                  "- GitHub: https://github.com/openclaw/clawhub\n" +
+                  "- Plugin docs: https://docs.openclaw.ai/plugins\n\n" +
+                  "If you believe this should be considered for core, please open an enhancement issue first describing why it belongs in core rather than ClawHub.",
+              },
+              {
                 label: "r: moltbook",
                 close: true,
                 lock: true,
@@ -271,6 +281,8 @@ jobs:
             const triggerLabel = "trigger-response";
             const activePrLimitLabel = "r: too-many-prs";
             const activePrLimitOverrideLabel = "r: too-many-prs-override";
+            const pluginClawhubLabel = "r: plugin-clawhub";
+            const corePluginApprovedLabel = "core-plugin-approved";
             const target = context.payload.issue ?? context.payload.pull_request;
             if (!target) {
               return;
@@ -495,6 +507,34 @@ jobs:
 
             if (pullRequest && labelSet.has(activePrLimitOverrideLabel)) {
               labelSet.delete(activePrLimitLabel);
+            }
+
+            if (
+              pullRequest &&
+              labelSet.has(corePluginApprovedLabel) &&
+              labelSet.has(pluginClawhubLabel)
+            ) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullRequest.number,
+                  name: pluginClawhubLabel,
+                });
+              } catch (error) {
+                if (error?.status !== 404) {
+                  throw error;
+                }
+              }
+              labelSet.delete(pluginClawhubLabel);
+              if (pullRequest.state === "closed" && !pullRequest.merged_at) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullRequest.number,
+                  state: "open",
+                });
+              }
             }
 
             const rule = rules.find((item) => labelSet.has(item.label));

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -209,6 +209,124 @@ jobs:
             //     labels: [trustedLabel],
             //   });
             // }
+      - name: Apply core-plugin routing labels
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          script: |
+            const pullRequest = context.payload.pull_request;
+            if (!pullRequest) {
+              return;
+            }
+
+            const closeLabel = "r: plugin-clawhub";
+            const overrideLabel = "core-plugin-approved";
+
+            const ensureLabel = async (name, color, description) => {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                });
+              } catch (error) {
+                if (error?.status !== 404) {
+                  throw error;
+                }
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color,
+                  description,
+                });
+              }
+            };
+
+            await ensureLabel(
+              closeLabel,
+              "B60205",
+              "Close new plugin PRs and redirect them to ClawHub",
+            );
+            await ensureLabel(
+              overrideLabel,
+              "0E8A16",
+              "Explicit maintainer approval to consider a new plugin for core",
+            );
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            });
+
+            const manifestDirs = new Set();
+            const packageDirs = new Set();
+
+            for (const file of files) {
+              const path = file.filename ?? "";
+              if (file.status !== "added") {
+                continue;
+              }
+              const manifestMatch = path.match(/^extensions\/([^/]+)\/openclaw\.plugin\.json$/);
+              if (manifestMatch) {
+                manifestDirs.add(manifestMatch[1]);
+                continue;
+              }
+              const packageMatch = path.match(/^extensions\/([^/]+)\/package\.json$/);
+              if (packageMatch) {
+                packageDirs.add(packageMatch[1]);
+              }
+            }
+
+            const isNewPluginPr = [...manifestDirs].some((dir) => packageDirs.has(dir));
+
+            const currentLabels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequest.number,
+              per_page: 100,
+            });
+            const labelSet = new Set(currentLabels.map((label) => label.name ?? ""));
+            const hasCloseLabel = labelSet.has(closeLabel);
+            const hasOverrideLabel = labelSet.has(overrideLabel);
+            const isReopened = context.payload.action === "reopened";
+
+            if (isNewPluginPr && !hasOverrideLabel && hasCloseLabel && isReopened) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                name: closeLabel,
+              });
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                labels: [closeLabel],
+              });
+              return;
+            }
+
+            if (isNewPluginPr && !hasOverrideLabel && !hasCloseLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                labels: [closeLabel],
+              });
+              return;
+            }
+
+            if ((!isNewPluginPr || hasOverrideLabel) && hasCloseLabel) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                name: closeLabel,
+              });
+            }
       - name: Apply beta-blocker title label
         uses: actions/github-script@v8
         with:


### PR DESCRIPTION
We might not be quite ready for this yet but....

## Summary

  1. Contributor opens a PR that adds a new plugin under extensions/*, specifically:
    - extensions/<name>/openclaw.plugin.json
    - extensions/<name>/package.json

  2. labeler.yml runs on the PR open/sync event.
  3. It detects that this is a new plugin PR.
  4. If the PR does not already have core-plugin-approved, it adds:
    - r: plugin-clawhub
  5. Adding r: plugin-clawhub triggers auto-response.yml.
  6. auto-response.yml posts the ClawHub redirect comment with:
    - https://clawhub.ai
    - https://github.com/openclaw/clawhub
    - https://docs.openclaw.ai/plugins

  7. auto-response.yml closes the PR. If maintainers want to keep it open:
      - A maintainer adds `core-plugin-approved` label

  9. On that labeled event, auto-response.yml sees both labels and:
    - removes r: plugin-clawhub
    - reopens the PR if it was closed by the default flow

  10. Because the close label is removed before rule evaluation, the PR stays open for review.
  11.  If PR is re-opened without override:
    - labeler.yml runs on reopened
    - It sees:
        - still a new plugin PR
        - no core-plugin-approved
        - r: plugin-clawhub is already present
    - It removes and re-adds r: plugin-clawhub
    - That re-triggers auto-response.yml
    - auto-response.yml comments/closes the PR again