### PR TITLE
Standardize URL base to localhost in gateway HTTP handlers

### DIFF
--- a/src/gateway/http-endpoint-helpers.ts
+++ b/src/gateway/http-endpoint-helpers.ts
@@ -26,7 +26,7 @@ export async function handleGatewayPostJsonEndpoint(
     ) => string[];
   },
 ): Promise<false | { body: unknown; requestAuth: AuthorizedGatewayHttpRequest } | undefined> {
-  const url = new URL(req.url ?? "/", `http://${req.headers.host || "localhost"}`);
+  const url = new URL(req.url ?? "/", "http://localhost");
   if (url.pathname !== opts.pathname) {
     return false;
   }

--- a/src/gateway/models-http.ts
+++ b/src/gateway/models-http.ts
@@ -66,7 +66,7 @@ function loadAgentModelIds(): string[] {
 }
 
 function resolveRequestPath(req: IncomingMessage): string {
-  return new URL(req.url ?? "/", `http://${req.headers.host || "localhost"}`).pathname;
+  return new URL(req.url ?? "/", "http://localhost").pathname;
 }
 
 export async function handleOpenAiModelsHttpRequest(

--- a/src/gateway/session-kill-http.ts
+++ b/src/gateway/session-kill-http.ts
@@ -42,7 +42,7 @@ export async function handleSessionKillHttpRequest(
   },
 ): Promise<boolean> {
   const cfg = loadConfig();
-  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  const url = new URL(req.url ?? "/", "http://localhost");
   const sessionKey = resolveSessionKeyFromPath(url.pathname);
   if (!sessionKey) {
     return false;

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -28,7 +28,7 @@ import {
 
 const MAX_SESSION_HISTORY_LIMIT = 1000;
 function resolveSessionHistoryPath(req: IncomingMessage): string | null {
-  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  const url = new URL(req.url ?? "/", "http://localhost");
   const match = url.pathname.match(/^\/sessions\/([^/]+)\/history$/);
   if (!match) {
     return null;
@@ -46,7 +46,7 @@ function shouldStreamSse(req: IncomingMessage): boolean {
 }
 
 function getRequestUrl(req: IncomingMessage): URL {
-  return new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  return new URL(req.url ?? "/", "http://localhost");
 }
 
 function resolveLimit(req: IncomingMessage): number | undefined {

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -151,7 +151,7 @@ export async function handleToolsInvokeHttpRequest(
     rateLimiter?: AuthRateLimiter;
   },
 ): Promise<boolean> {
-  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  const url = new URL(req.url ?? "/", "http://localhost");
   if (url.pathname !== "/tools/invoke") {
     return false;
   }


### PR DESCRIPTION
## Summary

Several gateway HTTP handlers construct `URL` objects using `` `http://${req.headers.host}` `` as the base, which is attacker-controlled input. Since only `pathname` and `searchParams` are ever extracted from these URLs (never the host), this is unnecessary and inconsistent — other handlers in the same codebase already correctly use the literal `"http://localhost"` as the base.

This PR standardizes all gateway HTTP handlers to use `"http://localhost"` as the URL base, matching the existing pattern used elsewhere in the codebase.

## Changed files

- `src/gateway/http-endpoint-helpers.ts` — `req.headers.host || "localhost"` → `"http://localhost"`
- `src/gateway/sessions-history-http.ts` — `req.headers.host ?? "localhost"` → `"http://localhost"` (2 occurrences)
- `src/gateway/session-kill-http.ts` — `req.headers.host ?? "localhost"` → `"http://localhost"`
- `src/gateway/tools-invoke-http.ts` — `req.headers.host ?? "localhost"` → `"http://localhost"`
- `src/gateway/models-http.ts` — `req.headers.host || "localhost"` → `"http://localhost"`

## Why this is safe

- The `URL` constructor requires a base for relative URLs, but only `pathname` and `searchParams` are read from the result
- The host component of the constructed URL is never used
- `"http://localhost"` is the minimal valid base that satisfies the `URL` constructor
- This removes reliance on attacker-controlled `Host` header for URL parsing
- No functional change in behavior