### PR TITLE
docs(slack): document required channels.slack.execApprovals config

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -487,7 +487,7 @@ Exec approval prompts can route natively through Slack using interactive buttons
 
 This uses the same shared approval button surface as other channels. When `interactivity` is enabled in your Slack app settings, approval prompts render as Block Kit buttons directly in the conversation.
 
-Configuration uses the shared `approvals.exec` config with Slack targets:
+Slack-native exec approvals require both shared exec approval routing and a Slack account `execApprovals` block. If `channels.slack.execApprovals.enabled` is unset or false, Slack messages and buttons cannot approve exec requests even when `approvals.exec` is configured.
 
 ```json5
 {
@@ -497,8 +497,22 @@ Configuration uses the shared `approvals.exec` config with Slack targets:
       targets: [{ channel: "slack", to: "U12345678" }],
     },
   },
+  channels: {
+    slack: {
+      execApprovals: {
+        enabled: true,
+        approvers: ["U12345678"],
+      },
+    },
+  },
 }
 ```
+
+Approver resolution order:
+
+- `channels.slack.execApprovals.approvers`
+- fallback: `commands.ownerAllowFrom`
+- `channels.slack.allowFrom` is not used for Slack exec approvers
 
 Same-chat `/approve` also works in Slack channels and DMs that already support commands. See [Exec approvals](/tools/exec-approvals) for the full approval forwarding model.
 

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -426,7 +426,7 @@ resolved approver list for authorization even when native approval delivery is d
 Discord, Slack, and Telegram can also act as native approval-delivery adapters with channel-specific config.
 
 - Discord: `channels.discord.execApprovals.*`
-- Slack: uses shared `approvals.exec.targets` with `channel: "slack"` and renders Block Kit approval buttons when interactivity is enabled
+- Slack: `channels.slack.execApprovals.*` plus shared `approvals.exec` routing; Slack renders Block Kit approval buttons when interactivity is enabled
 - Telegram: `channels.telegram.execApprovals.*`
 
 These native delivery adapters are opt-in. They add DM routing and channel fanout on top of the
@@ -436,6 +436,9 @@ Shared behavior:
 
 - Slack, Matrix, Microsoft Teams, and similar deliverable chats use the normal channel auth model
   for same-chat `/approve`
+- Slack native delivery stays disabled until `channels.slack.execApprovals.enabled: true`
+- Slack approvers resolve from `channels.slack.execApprovals.approvers`, then fall back to `commands.ownerAllowFrom`
+- `channels.slack.allowFrom` is not used to infer Slack exec approvers
 - for Discord and Telegram, only resolved approvers can approve or deny
 - Discord and Telegram approvers can be explicit (`execApprovals.approvers`) or inferred from existing owner config (`allowFrom`, plus direct-message `defaultTo` where supported)
 - the requester does not need to be an approver


### PR DESCRIPTION
## Summary

Document the required `channels.slack.execApprovals` config block for Slack exec approvals, addressing #59664.

### Problem

Slack-native exec approvals silently fail when only the top-level `approvals.exec` is configured. The per-channel `channels.slack.execApprovals.enabled: true` block is required but was not documented in either `docs/channels/slack.md` or `docs/tools/exec-approvals.md`.

### Changes

**`docs/channels/slack.md`:**
- Clarify that both shared routing AND per-channel config are required
- Add `channels.slack.execApprovals` block to the config example
- Document approver resolution order: explicit approvers → `commands.ownerAllowFrom`
- Note that `channels.slack.allowFrom` is NOT used for exec approvers

**`docs/tools/exec-approvals.md`:**
- Update Slack entry in native delivery adapter list
- Add Slack-specific notes: enabled gate, approver resolution, allowFrom exclusion

### Source references
- `extensions/slack/src/exec-approvals.ts` — approver resolution logic
- `extensions/slack/src/monitor/provider.ts` — `execApprovals.enabled` gate
- `src/config/types.slack.ts` — `SlackExecApprovalConfig` schema

Closes #59664