### PR TITLE
refactor: finish moving stream-wrapper ownership into provider plugins

### DIFF
--- a/extensions/minimax/index.ts
+++ b/extensions/minimax/index.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/provider-auth";
 import { buildOauthProviderAuthResult } from "openclaw/plugin-sdk/provider-auth";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { createMinimaxFastModeWrapper } from "openclaw/plugin-sdk/provider-stream";
 import { fetchMinimaxUsage } from "openclaw/plugin-sdk/provider-usage";
 import { isMiniMaxModernModelId, MINIMAX_DEFAULT_MODEL_ID } from "./api.js";
 import {
@@ -232,6 +233,8 @@ export default definePluginEntry({
         });
         return apiKey ? { token: apiKey } : null;
       },
+      wrapStreamFn: (ctx) =>
+        createMinimaxFastModeWrapper(ctx.streamFn, ctx.extraParams?.fastMode === true),
       resolveReasoningOutputMode: () => resolveMinimaxReasoningOutputMode(),
       isModernModelRef: ({ modelId }) => isMiniMaxModernModelId(modelId),
       fetchUsageSnapshot: async (ctx) =>
@@ -282,6 +285,8 @@ export default definePluginEntry({
           run: createOAuthHandler("cn"),
         },
       ],
+      wrapStreamFn: (ctx) =>
+        createMinimaxFastModeWrapper(ctx.streamFn, ctx.extraParams?.fastMode === true),
       resolveReasoningOutputMode: () => resolveMinimaxReasoningOutputMode(),
       isModernModelRef: ({ modelId }) => isMiniMaxModernModelId(modelId),
     });

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -296,6 +296,28 @@ describe("buildOpenAIProvider", () => {
     expect(result.payload).not.toHaveProperty("reasoning");
   });
 
+  it("owns Azure OpenAI reasoning compatibility without forcing OpenAI transport defaults", () => {
+    const provider = buildOpenAIProvider();
+    const result = runWrappedPayloadCase({
+      wrap: provider.wrapStreamFn as NonNullable<typeof provider.wrapStreamFn>,
+      provider: "azure-openai-responses",
+      modelId: "gpt-5.4",
+      model: {
+        api: "azure-openai-responses",
+        provider: "azure-openai-responses",
+        id: "gpt-5.4",
+        baseUrl: "https://example.openai.azure.com/openai/v1",
+      } as Model<"azure-openai-responses">,
+      payload: {
+        reasoning: { effort: "none" },
+      },
+    });
+
+    expect(result.options?.transport).toBeUndefined();
+    expect(result.options?.openaiWsWarmup).toBeUndefined();
+    expect(result.payload).not.toHaveProperty("reasoning");
+  });
+
   it("owns Codex wrapper composition for responses payloads", () => {
     const provider = buildOpenAICodexProviderPlugin();
     const result = runWrappedPayloadCase({

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -200,6 +200,7 @@ export function buildOpenAIProvider(): ProviderPlugin {
   return {
     id: PROVIDER_ID,
     label: "OpenAI",
+    hookAliases: ["azure-openai", "azure-openai-responses"],
     docsPath: "/providers/models",
     envVars: ["OPENAI_API_KEY"],
     auth: [

--- a/extensions/openai/stream-hooks.ts
+++ b/extensions/openai/stream-hooks.ts
@@ -43,6 +43,11 @@ export function wrapOpenAIProviderStream(ctx: ProviderWrapStreamFnContext) {
   return applySharedOpenAIWrappers(ctx.streamFn, ctx);
 }
 
+/** Compose the Azure OpenAI wrapper chain without direct OpenAI transport defaults. */
+export function wrapAzureOpenAIProviderStream(ctx: ProviderWrapStreamFnContext) {
+  return applySharedOpenAIWrappers(ctx.streamFn, ctx);
+}
+
 /** Compose the Codex-specific wrapper chain inside the owning provider plugin. */
 export function wrapOpenAICodexProviderStream(ctx: ProviderWrapStreamFnContext) {
   return applySharedOpenAIWrappers(ctx.streamFn, ctx);

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -147,6 +147,9 @@ beforeEach(() => {
       if (params.provider === "openai-codex") {
         return createTestOpenAIProviderWrapper(params, false);
       }
+      if (params.provider === "azure-openai" || params.provider === "azure-openai-responses") {
+        return createTestOpenAIProviderWrapper(params, false);
+      }
       if (params.provider === "ollama") {
         return createConfiguredOllamaCompatNumCtxWrapper(params.context);
       }

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -76,7 +76,17 @@ import {
   resolveExtraParams,
   resolvePreparedExtraParams,
 } from "./pi-embedded-runner.js";
+import {
+  createBedrockNoCacheWrapper,
+  isAnthropicBedrockModel,
+} from "./pi-embedded-runner/bedrock-stream-wrappers.js";
+import { createGoogleThinkingPayloadWrapper } from "./pi-embedded-runner/google-stream-wrappers.js";
 import { log } from "./pi-embedded-runner/logger.js";
+import { createMinimaxFastModeWrapper } from "./pi-embedded-runner/minimax-stream-wrappers.js";
+import {
+  createMoonshotThinkingWrapper,
+  resolveMoonshotThinkingType,
+} from "./pi-embedded-runner/moonshot-stream-wrappers.js";
 import {
   createCodexNativeWebSearchWrapper,
   createOpenAIAttributionHeadersWrapper,
@@ -149,6 +159,30 @@ beforeEach(() => {
       }
       if (params.provider === "azure-openai" || params.provider === "azure-openai-responses") {
         return createTestOpenAIProviderWrapper(params, false);
+      }
+      if (params.provider === "amazon-bedrock") {
+        return isAnthropicBedrockModel(params.context.modelId)
+          ? params.context.streamFn
+          : createBedrockNoCacheWrapper(params.context.streamFn);
+      }
+      if (params.provider === "moonshot") {
+        const thinkingType = resolveMoonshotThinkingType({
+          configuredThinking: params.context.extraParams?.thinking,
+          thinkingLevel: params.context.thinkingLevel,
+        });
+        return createMoonshotThinkingWrapper(params.context.streamFn, thinkingType);
+      }
+      if (params.provider === "google") {
+        return createGoogleThinkingPayloadWrapper(
+          params.context.streamFn,
+          params.context.thinkingLevel,
+        );
+      }
+      if (params.provider === "minimax" || params.provider === "minimax-portal") {
+        return createMinimaxFastModeWrapper(
+          params.context.streamFn,
+          params.context.extraParams?.fastMode === true,
+        );
       }
       if (params.provider === "ollama") {
         return createConfiguredOllamaCompatNumCtxWrapper(params.context);

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -22,10 +22,7 @@ import {
   shouldApplyMoonshotPayloadCompat,
   shouldApplySiliconFlowThinkingOffCompat,
 } from "./moonshot-stream-wrappers.js";
-import {
-  createOpenAIReasoningCompatibilityWrapper,
-  createOpenAIResponsesContextManagementWrapper,
-} from "./openai-stream-wrappers.js";
+import { createOpenAIResponsesContextManagementWrapper } from "./openai-stream-wrappers.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 
 const defaultProviderRuntimeDeps = {
@@ -370,12 +367,6 @@ function applyPostPluginStreamWrappers(
     ctx.agent.streamFn,
     ctx.effectiveExtraParams,
   );
-
-  // Azure OpenAI does not yet have an owning provider plugin, so keep its
-  // Responses payload compatibility in core until that provider surface exists.
-  if (ctx.provider === "azure-openai" || ctx.provider === "azure-openai-responses") {
-    ctx.agent.streamFn = createOpenAIReasoningCompatibilityWrapper(ctx.agent.streamFn);
-  }
 
   const rawParallelToolCalls = resolveAliasedParamValue(
     [ctx.resolvedExtraParams, ctx.override],

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -11,15 +11,10 @@ import {
 import type { ProviderRuntimeModel } from "../../plugins/types.js";
 import { resolveCacheRetention } from "./anthropic-cache-retention.js";
 import { createAnthropicToolPayloadCompatibilityWrapper } from "./anthropic-family-tool-payload-compat.js";
-import { createBedrockNoCacheWrapper, isAnthropicBedrockModel } from "./bedrock-stream-wrappers.js";
 import { createGoogleThinkingPayloadWrapper } from "./google-stream-wrappers.js";
 import { log } from "./logger.js";
-import { createMinimaxFastModeWrapper } from "./minimax-stream-wrappers.js";
 import {
-  createMoonshotThinkingWrapper,
-  resolveMoonshotThinkingType,
   createSiliconFlowThinkingWrapper,
-  shouldApplyMoonshotPayloadCompat,
   shouldApplySiliconFlowThinkingOffCompat,
 } from "./moonshot-stream-wrappers.js";
 import { createOpenAIResponsesContextManagementWrapper } from "./openai-stream-wrappers.js";
@@ -322,43 +317,10 @@ function applyPrePluginStreamWrappers(ctx: ApplyExtraParamsContext): void {
   });
 }
 
-function applyPostPluginStreamWrappers(
-  ctx: ApplyExtraParamsContext & { providerWrapperHandled: boolean },
-): void {
-  if (
-    !ctx.providerWrapperHandled &&
-    shouldApplyMoonshotPayloadCompat({ provider: ctx.provider, modelId: ctx.modelId })
-  ) {
-    // Preserve the legacy Moonshot compatibility path when no plugin wrapper
-    // actually handled the stream function. This mainly covers tests and
-    // disabled plugins for the native Moonshot provider.
-    const thinkingType = resolveMoonshotThinkingType({
-      configuredThinking: ctx.effectiveExtraParams?.thinking,
-      thinkingLevel: ctx.thinkingLevel,
-    });
-    ctx.agent.streamFn = createMoonshotThinkingWrapper(ctx.agent.streamFn, thinkingType);
-  }
-
-  if (ctx.provider === "amazon-bedrock" && !isAnthropicBedrockModel(ctx.modelId)) {
-    log.debug(
-      `disabling prompt caching for non-Anthropic Bedrock model ${ctx.provider}/${ctx.modelId}`,
-    );
-    ctx.agent.streamFn = createBedrockNoCacheWrapper(ctx.agent.streamFn);
-  }
-
+function applyPostPluginStreamWrappers(ctx: ApplyExtraParamsContext): void {
   // Guard Google payloads against invalid negative thinking budgets emitted by
   // upstream model-ID heuristics for Gemini 3.1 variants.
   ctx.agent.streamFn = createGoogleThinkingPayloadWrapper(ctx.agent.streamFn, ctx.thinkingLevel);
-
-  if (typeof ctx.effectiveExtraParams?.fastMode === "boolean") {
-    log.debug(
-      `applying MiniMax fast mode=${ctx.effectiveExtraParams.fastMode} for ${ctx.provider}/${ctx.modelId}`,
-    );
-    ctx.agent.streamFn = createMinimaxFastModeWrapper(
-      ctx.agent.streamFn,
-      ctx.effectiveExtraParams.fastMode,
-    );
-  }
 
   // Work around upstream pi-ai hardcoding `store: false` for Responses API.
   // Force `store=true` for direct OpenAI Responses models and auto-enable
@@ -458,12 +420,7 @@ export function applyExtraParamsToAgent(
     },
   });
   agent.streamFn = pluginWrappedStreamFn ?? providerStreamBase;
-  const providerWrapperHandled =
-    pluginWrappedStreamFn !== undefined && pluginWrappedStreamFn !== providerStreamBase;
-  applyPostPluginStreamWrappers({
-    ...wrapperContext,
-    providerWrapperHandled,
-  });
+  applyPostPluginStreamWrappers(wrapperContext);
 
   return { effectiveExtraParams };
 }

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -8,6 +8,7 @@ export {
   createGoogleThinkingPayloadWrapper,
   sanitizeGoogleThinkingPayload,
 } from "../agents/pi-embedded-runner/google-stream-wrappers.js";
+export { createMinimaxFastModeWrapper } from "../agents/pi-embedded-runner/minimax-stream-wrappers.js";
 export {
   createKilocodeWrapper,
   createOpenRouterSystemCacheWrapper,

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -379,6 +379,29 @@ describe("provider-runtime", () => {
     });
   });
 
+  it("resolves stream wrapper hooks through hook-only aliases without provider ownership", () => {
+    const wrappedStreamFn = vi.fn();
+    resolvePluginProvidersMock.mockReturnValue([
+      {
+        id: "openai",
+        label: "OpenAI",
+        hookAliases: ["azure-openai-responses"],
+        auth: [],
+        wrapStreamFn: ({ streamFn }) => streamFn ?? wrappedStreamFn,
+      },
+    ]);
+
+    expect(
+      wrapProviderStreamFn({
+        provider: "azure-openai-responses",
+        context: createDemoResolvedModelContext({
+          provider: "azure-openai-responses",
+          streamFn: wrappedStreamFn,
+        }),
+      }),
+    ).toBe(wrappedStreamFn);
+  });
+
   it("normalizes transport hooks without needing provider ownership", () => {
     resolvePluginProvidersMock.mockReturnValue([
       {

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -530,7 +530,7 @@ export function wrapProviderStreamFn(params: {
   env?: NodeJS.ProcessEnv;
   context: ProviderWrapStreamFnContext;
 }) {
-  return resolveProviderRuntimePlugin(params)?.wrapStreamFn?.(params.context) ?? undefined;
+  return resolveProviderHookPlugin(params)?.wrapStreamFn?.(params.context) ?? undefined;
 }
 
 export async function createProviderEmbeddingProvider(params: {


### PR DESCRIPTION
## Summary

- Problem: `src/agents/pi-embedded-runner/extra-params.ts` still selected several provider-specific wrapper chains directly, even after the provider hook migrations landed.
- Why it matters: that kept core coupled to Azure OpenAI, MiniMax, Moonshot, and Bedrock wrapper behavior, which made the runner less generic and harder to reason about.
- What changed: Azure reasoning compatibility, MiniMax fast-mode wrapping, and the remaining direct-provider wrapper expectations now live behind provider hook ownership, and the stale core branches were deleted.
- What did NOT change (scope boundary): the Google thinking-budget sanitizer and Responses context-management wrapper remain in core because they still protect transport-level behavior beyond a single provider plugin.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #59147
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[runner extra-params] -> [provider-specific wrapper branches in core]

After:
[runner extra-params] -> [provider wrapStreamFn hooks]
                         -> [generic transport wrappers kept in core]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: OpenAI, Azure OpenAI, MiniMax, Moonshot, Bedrock, Google-compatible transports
- Integration/channel (if any): N/A
- Relevant config (redacted): default local dev config

### Steps

1. Route remaining provider wrapper behavior through provider hooks.
2. Remove stale provider-family branches from `src/agents/pi-embedded-runner/extra-params.ts`.
3. Run focused extra-params coverage and a full build.

### Expected

- Provider-specific wrapper ownership lives with the owning plugins.
- Core `extra-params.ts` retains only generic orchestration and transport-level wrappers.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Azure OpenAI reasoning compatibility is provider-owned.
  - MiniMax fast mode is provider-owned.
  - Runner extra-params tests still pass with dead core branches removed.
  - Full build still passes.
- Edge cases checked:
  - Google-compatible `google-generative-ai` sanitizer remains in core for non-Google providers like `atproxy`.
  - OpenAI Responses context management remains core-owned because it is transport-level.
- What you did **not** verify:
  - Full repo test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Removing core fallback branches could miss a provider path that was still depending on runner-owned wrapping.
  - Mitigation: Focused extra-params coverage exercises the affected providers, and the Google/Responses transport-level wrappers were intentionally left in core where ownership is still generic.

## Stack

Part 6 of 6.
Base branch: `oc-3c3/provider-replay-compaction-hooks`
Previous PR: #59147 https://github.com/openclaw/openclaw/pull/59147
