### PR TITLE
refactor(plugins): drop generic status report alias

### DIFF
--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -20,7 +20,6 @@ export const recordPluginInstall = vi.fn();
 export const clearPluginManifestRegistryCache = vi.fn();
 export const buildPluginSnapshotReport = vi.fn();
 export const buildPluginDiagnosticsReport = vi.fn();
-export const buildPluginStatusReport = buildPluginDiagnosticsReport;
 export const buildPluginCompatibilityNotices = vi.fn();
 export const applyExclusiveSlotSelection = vi.fn();
 export const uninstallPlugin = vi.fn();

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -3,7 +3,7 @@ import { installedPluginRoot } from "../../test/helpers/bundled-plugin-paths.js"
 import type { OpenClawConfig } from "../config/config.js";
 import {
   applyExclusiveSlotSelection,
-  buildPluginStatusReport,
+  buildPluginDiagnosticsReport,
   clearPluginManifestRegistryCache,
   enablePluginInConfig,
   installHooksFromNpmSpec,
@@ -179,7 +179,7 @@ describe("plugins cli install", () => {
     });
     enablePluginInConfig.mockReturnValue({ config: enabledCfg });
     recordPluginInstall.mockReturnValue(installedCfg);
-    buildPluginStatusReport.mockReturnValue({
+    buildPluginDiagnosticsReport.mockReturnValue({
       plugins: [{ id: "alpha", kind: "provider" }],
       diagnostics: [],
     });

--- a/src/cli/plugins-cli.uninstall.test.ts
+++ b/src/cli/plugins-cli.uninstall.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { installedPluginRoot } from "../../test/helpers/bundled-plugin-paths.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
-  buildPluginStatusReport,
+  buildPluginDiagnosticsReport,
   loadConfig,
   parseClawHubPluginSpec,
   promptYesNo,
@@ -39,7 +39,7 @@ describe("plugins cli uninstall", () => {
         },
       },
     } as OpenClawConfig);
-    buildPluginStatusReport.mockReturnValue({
+    buildPluginDiagnosticsReport.mockReturnValue({
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
@@ -74,7 +74,7 @@ describe("plugins cli uninstall", () => {
     } as OpenClawConfig;
 
     loadConfig.mockReturnValue(baseConfig);
-    buildPluginStatusReport.mockReturnValue({
+    buildPluginDiagnosticsReport.mockReturnValue({
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
@@ -111,7 +111,7 @@ describe("plugins cli uninstall", () => {
         installs: {},
       },
     } as OpenClawConfig);
-    buildPluginStatusReport.mockReturnValue({
+    buildPluginDiagnosticsReport.mockReturnValue({
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
@@ -139,7 +139,7 @@ describe("plugins cli uninstall", () => {
         },
       },
     } as OpenClawConfig);
-    buildPluginStatusReport.mockReturnValue({
+    buildPluginDiagnosticsReport.mockReturnValue({
       plugins: [{ id: "linkmind-context", name: "linkmind-context" }],
       diagnostics: [],
     });
@@ -170,7 +170,7 @@ describe("plugins cli uninstall", () => {
         },
       },
     } as OpenClawConfig);
-    buildPluginStatusReport.mockReturnValue({
+    buildPluginDiagnosticsReport.mockReturnValue({
       plugins: [{ id: "linkmind-context", name: "linkmind-context" }],
       diagnostics: [],
     });

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -143,6 +143,8 @@ describe("plugin-sdk facade runtime", () => {
       }),
     ).toThrow("plugin load failure");
 
+    expect(listImportedBundledPluginFacadeIds()).toEqual(["bad"]);
+
     // A second call must also throw (not return a stale empty sentinel).
     expect(() =>
       loadBundledPluginPublicSurfaceModuleSync<{ marker: string }>({

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -337,9 +337,11 @@ export function loadBundledPluginPublicSurfaceModuleSync<T extends object>(param
 
   let loaded: T;
   try {
+    // Track the owning plugin once module evaluation begins. Facade top-level
+    // code may have already executed even if the module later throws.
+    loadedFacadePluginIds.add(resolveTrackedFacadePluginId(params.dirName));
     loaded = getJiti(location.modulePath)(location.modulePath) as T;
     Object.assign(sentinel, loaded);
-    loadedFacadePluginIds.add(resolveTrackedFacadePluginId(params.dirName));
   } catch (err) {
     loadedFacadeModules.delete(location.modulePath);
     throw err;

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -17,7 +17,6 @@ const withBundledPluginAllowlistCompatMock = vi.fn();
 const withBundledPluginEnablementCompatMock = vi.fn();
 const listImportedBundledPluginFacadeIdsMock = vi.fn();
 const listImportedRuntimePluginIdsMock = vi.fn();
-let buildPluginStatusReport: typeof import("./status.js").buildPluginStatusReport;
 let buildPluginSnapshotReport: typeof import("./status.js").buildPluginSnapshotReport;
 let buildPluginDiagnosticsReport: typeof import("./status.js").buildPluginDiagnosticsReport;
 let buildPluginInspectReport: typeof import("./status.js").buildPluginInspectReport;
@@ -242,7 +241,7 @@ function expectBundleInspectState(
   expect(inspect.shape).toBe(params.shape);
 }
 
-describe("buildPluginStatusReport", () => {
+describe("plugin status reports", () => {
   beforeAll(async () => {
     ({
       buildAllPluginInspectReports,
@@ -251,7 +250,6 @@ describe("buildPluginStatusReport", () => {
       buildPluginCompatibilityWarnings,
       buildPluginInspectReport,
       buildPluginSnapshotReport,
-      buildPluginStatusReport,
       formatPluginCompatibilityNotice,
       summarizePluginCompatibility,
     } = await import("./status.js"));
@@ -454,7 +452,7 @@ describe("buildPluginStatusReport", () => {
       }),
     );
 
-    const report = buildPluginStatusReport({
+    const report = buildPluginDiagnosticsReport({
       config: {},
       env: {
         OPENCLAW_VERSION: "2026.3.23-1",

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -228,12 +228,6 @@ export function buildPluginDiagnosticsReport(params?: PluginReportParams): Plugi
   return buildPluginReport(params, true);
 }
 
-// Compatibility alias for existing hot/reporting callers while the repo finishes
-// migrating to explicit snapshot vs diagnostics builders.
-export function buildPluginStatusReport(params?: PluginReportParams): PluginStatusReport {
-  return buildPluginDiagnosticsReport(params);
-}
-
 function buildCapabilityEntries(plugin: PluginRegistry["plugins"][number]) {
   return [
     { kind: "cli-backend" as const, ids: plugin.cliBackendIds ?? [] },


### PR DESCRIPTION
## Summary
- remove the generic plugin status report alias so callers must choose snapshot vs diagnostics explicitly
- update the remaining CLI test helpers to use the explicit diagnostics builder name
- track facade-backed plugin imports when module evaluation throws after top-level execution

## Verification
- pnpm test -- src/plugins/status.test.ts src/plugin-sdk/facade-runtime.test.ts src/cli/plugins-cli.install.test.ts src/cli/plugins-cli.uninstall.test.ts
- pnpm check
- pnpm build