### PR TITLE
fix: Add ffmpeg to Dockerfile for media processing skills

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,7 +140,7 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends; \
     fi && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      procps hostname curl git lsof openssl
+      procps hostname curl git lsof openssl ffmpeg
 
 RUN chown node:node /app
 


### PR DESCRIPTION
## Description

This PR adds ffmpeg to the base system packages in the OpenClaw Dockerfile.

## Changes

- Added ffmpeg to apt-get install line in Dockerfile

## Motivation

Many skills require media processing capabilities (video transcoding, audio extraction, etc.) that depend on ffmpeg being available in the container.

This addresses issue #59621 which identified missing skill dependencies in the upstream Docker image.

## Type of Change

- [x] Bug fix
- [ ] Documentation
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] My code follows the code style of this project
- [x] My changes do not introduce new warnings

## Stats

- Files changed: 1
- Lines changed: 1 insertion, 1 deletion