### PR TITLE
gateway: fall back to restart in hot reload mode

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -212,6 +212,12 @@ export type GatewayReloadConfig = {
   /** Debounce window for config reloads (ms). Default: 300. */
   debounceMs?: number;
   /**
+   * When true, `hot` mode falls back to a full gateway restart for changes
+   * that cannot be hot-reloaded. When false, those changes are silently
+   * ignored (legacy behavior). Default: true.
+   */
+  fallbackToRestart?: boolean;
+  /**
    * Maximum time (ms) to wait for in-flight operations to complete before
    * forcing a SIGUSR1 restart. Default: 300000 (5 minutes).
    * Lower values risk aborting active subagent LLM calls.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -769,6 +769,7 @@ export const OpenClawSchema = z
               .optional(),
             debounceMs: z.number().int().min(0).optional(),
             deferralTimeoutMs: z.number().int().min(0).optional(),
+            fallbackToRestart: z.boolean().optional(),
           })
           .strict()
           .optional(),

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -279,6 +279,28 @@ describe("resolveGatewayReloadSettings", () => {
     const settings = resolveGatewayReloadSettings({});
     expect(settings.mode).toBe("hybrid");
     expect(settings.debounceMs).toBe(300);
+    expect(settings.fallbackToRestart).toBe(true);
+  });
+
+  it("parses fallbackToRestart=false", () => {
+    const settings = resolveGatewayReloadSettings({
+      gateway: { reload: { fallbackToRestart: false } },
+    });
+    expect(settings.fallbackToRestart).toBe(false);
+  });
+
+  it("parses fallbackToRestart=true", () => {
+    const settings = resolveGatewayReloadSettings({
+      gateway: { reload: { fallbackToRestart: true } },
+    });
+    expect(settings.fallbackToRestart).toBe(true);
+  });
+
+  it("defaults fallbackToRestart to true for non-boolean values", () => {
+    const settings = resolveGatewayReloadSettings({
+      gateway: { reload: { fallbackToRestart: "yes" as unknown as boolean } },
+    });
+    expect(settings.fallbackToRestart).toBe(true);
   });
 });
 
@@ -323,7 +345,10 @@ function makeSnapshot(partial: Partial<ConfigFileSnapshot> = {}): ConfigFileSnap
 
 function createReloaderHarness(
   readSnapshot: () => Promise<ConfigFileSnapshot>,
-  options: { initialInternalWriteHash?: string | null } = {},
+  options: {
+    initialInternalWriteHash?: string | null;
+    initialConfig?: Record<string, unknown>;
+  } = {},
 ) {
   const watcher = createWatcherMock();
   vi.spyOn(chokidar, "watch").mockReturnValue(watcher as unknown as never);
@@ -344,7 +369,7 @@ function createReloaderHarness(
     error: vi.fn(),
   };
   const reloader = startGatewayConfigReloader({
-    initialConfig: { gateway: { reload: { debounceMs: 0 } } },
+    initialConfig: options.initialConfig ?? { gateway: { reload: { debounceMs: 0 } } },
     initialInternalWriteHash: options.initialInternalWriteHash,
     readSnapshot,
     subscribeToWrites,
@@ -572,6 +597,84 @@ describe("startGatewayConfigReloader", () => {
 
     expect(readSnapshot).toHaveBeenCalledTimes(2);
     expect(harness.onRestart).toHaveBeenCalledTimes(1);
+
+    await harness.reloader.stop();
+  });
+
+  it("hot mode with fallbackToRestart=true calls onRestart for restart-required changes", async () => {
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        config: {
+          gateway: { reload: { debounceMs: 0, mode: "hot", fallbackToRestart: true }, port: 19999 },
+        },
+        hash: "hot-fallback-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, {
+      initialConfig: {
+        gateway: { reload: { debounceMs: 0, mode: "hot", fallbackToRestart: true } },
+      },
+    });
+
+    harness.watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(harness.onHotReload).not.toHaveBeenCalled();
+    expect(harness.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("hot mode falling back to restart"),
+    );
+
+    await harness.reloader.stop();
+  });
+
+  it("hot mode with fallbackToRestart=false does NOT call onRestart for restart-required changes", async () => {
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        config: {
+          gateway: {
+            reload: { debounceMs: 0, mode: "hot", fallbackToRestart: false },
+            port: 19999,
+          },
+        },
+        hash: "hot-no-fallback-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, {
+      initialConfig: {
+        gateway: { reload: { debounceMs: 0, mode: "hot", fallbackToRestart: false } },
+      },
+    });
+
+    harness.watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(harness.onRestart).not.toHaveBeenCalled();
+    expect(harness.onHotReload).not.toHaveBeenCalled();
+    expect(harness.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("hot mode skipping restart-required changes"),
+    );
+
+    await harness.reloader.stop();
+  });
+
+  it("hybrid mode still restarts for restart-required changes regardless of fallbackToRestart", async () => {
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        config: {
+          gateway: { reload: { debounceMs: 0 }, port: 19999 },
+        },
+        hash: "hybrid-1",
+      }),
+    );
+    // Default mode is hybrid, fallbackToRestart irrelevant for hybrid.
+    const harness = createReloaderHarness(readSnapshot);
+
+    harness.watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(harness.onHotReload).not.toHaveBeenCalled();
 
     await harness.reloader.stop();
   });

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -16,11 +16,13 @@ export type { ChannelKind, GatewayReloadPlan } from "./config-reload-plan.js";
 export type GatewayReloadSettings = {
   mode: GatewayReloadMode;
   debounceMs: number;
+  fallbackToRestart: boolean;
 };
 
 const DEFAULT_RELOAD_SETTINGS: GatewayReloadSettings = {
   mode: "hybrid",
   debounceMs: 300,
+  fallbackToRestart: true,
 };
 const MISSING_CONFIG_RETRY_DELAY_MS = 150;
 const MISSING_CONFIG_MAX_RETRIES = 2;
@@ -67,7 +69,10 @@ export function resolveGatewayReloadSettings(cfg: OpenClawConfig): GatewayReload
     typeof debounceRaw === "number" && Number.isFinite(debounceRaw)
       ? Math.max(0, Math.floor(debounceRaw))
       : DEFAULT_RELOAD_SETTINGS.debounceMs;
-  return { mode, debounceMs };
+  const fallbackRaw = cfg.gateway?.reload?.fallbackToRestart;
+  const fallbackToRestart =
+    typeof fallbackRaw === "boolean" ? fallbackRaw : DEFAULT_RELOAD_SETTINGS.fallbackToRestart;
+  return { mode, debounceMs, fallbackToRestart };
 }
 
 export type GatewayConfigReloader = {
@@ -176,11 +181,16 @@ export function startGatewayConfigReloader(opts: {
     }
     if (plan.restartGateway) {
       if (settings.mode === "hot") {
-        opts.log.warn(
-          `config reload requires gateway restart; hot mode ignoring (${plan.restartReasons.join(
-            ", ",
-          )})`,
-        );
+        if (settings.fallbackToRestart) {
+          opts.log.info(
+            `config reload requires gateway restart; hot mode falling back to restart (${plan.restartReasons.join(", ")})`,
+          );
+          queueRestart(plan, nextConfig);
+        } else {
+          opts.log.warn(
+            `config reload requires gateway restart; hot mode skipping restart-required changes (${plan.restartReasons.join(", ")})`,
+          );
+        }
         return;
       }
       queueRestart(plan, nextConfig);


### PR DESCRIPTION
## Summary
- When `gateway.reload.mode` is `hot`, restart-required config changes were silently ignored with only a warning log. This caused confusion when users expected changes (like plugin config) to take effect.
- Adds `gateway.reload.fallbackToRestart` option (default: `true`) that makes hot mode fall through to restart for restart-required changes instead of silently ignoring them.
- When `fallbackToRestart: false`, preserves the old behavior (warn + skip).

## Test plan
- [ ] Verify `hot` mode with `fallbackToRestart: true` triggers restart for restart-required changes
- [ ] Verify `hot` mode with `fallbackToRestart: false` preserves old silent-skip behavior
- [ ] Verify `hybrid` mode is unaffected
- [ ] Run `pnpm test -- src/gateway/config-reload.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)