### PR TITLE
config: add version skew warning with update guidance

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -19,9 +19,12 @@ export {
   resolveConfigSnapshotHash,
   setRuntimeConfigSnapshotRefreshHandler,
   setRuntimeConfigSnapshot,
+  warnIfConfigFromFuture,
   writeConfigFile,
 } from "./io.js";
 export type { ConfigWriteNotification } from "./io.js";
+export type { VersionSkewResult } from "./version.js";
+export { checkVersionSkew } from "./version.js";
 export { migrateLegacyConfig } from "./legacy-migrate.js";
 export { ConfigMutationConflictError, mutateConfigFile, replaceConfigFile } from "./mutate.js";
 export * from "./paths.js";

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -46,7 +46,7 @@ import {
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
 } from "./validation.js";
-import { shouldWarnOnTouchedVersion } from "./version.js";
+import { type VersionSkewResult, checkVersionSkew } from "./version.js";
 
 // Re-export for backwards compatibility
 export { CircularIncludeError, ConfigIncludeError } from "./includes.js";
@@ -1509,16 +1509,23 @@ function stampConfigVersion(cfg: OpenClawConfig): OpenClawConfig {
   };
 }
 
-function warnIfConfigFromFuture(cfg: OpenClawConfig, logger: Pick<typeof console, "warn">): void {
-  const touched = cfg.meta?.lastTouchedVersion;
-  if (!touched) {
-    return;
+/**
+ * Check whether the loaded config was written by a newer OpenClaw version.
+ * Logs a warning with actionable guidance and returns a structured result
+ * so callers (doctor, gateway startup) can surface the skew programmatically.
+ */
+export function warnIfConfigFromFuture(
+  cfg: OpenClawConfig,
+  logger: Pick<typeof console, "warn">,
+): VersionSkewResult {
+  const result = checkVersionSkew(VERSION, cfg.meta?.lastTouchedVersion);
+  if (result.skewed && result.message) {
+    logger.warn(result.message);
+    if (result.guidance) {
+      logger.warn(result.guidance);
+    }
   }
-  if (shouldWarnOnTouchedVersion(VERSION, touched)) {
-    logger.warn(
-      `Config was last written by a newer OpenClaw (${touched}); current version is ${VERSION}.`,
-    );
-  }
+  return result;
 }
 
 function resolveConfigPathForDeps(deps: Required<ConfigIoDeps>): string {

--- a/src/config/version.test.ts
+++ b/src/config/version.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  checkVersionSkew,
   compareOpenClawVersions,
   isSameOpenClawStableFamily,
   parseOpenClawVersion,
@@ -85,5 +86,64 @@ describe("shouldWarnOnTouchedVersion", () => {
     expect(shouldWarnOnTouchedVersion("2026.3.23-beta.1", "2026.3.23")).toBe(true);
     expect(shouldWarnOnTouchedVersion("2026.3.23", "2026.3.24")).toBe(true);
     expect(shouldWarnOnTouchedVersion("2026.3.23", "2027.1.1")).toBe(true);
+  });
+});
+
+describe("checkVersionSkew", () => {
+  it("returns not skewed when touched version is null", () => {
+    const result = checkVersionSkew("2026.3.23", null);
+    expect(result.skewed).toBe(false);
+    expect(result.message).toBeNull();
+    expect(result.guidance).toBeNull();
+    expect(result.configVersion).toBeNull();
+    expect(result.currentVersion).toBe("2026.3.23");
+  });
+
+  it("returns not skewed when touched version is undefined", () => {
+    const result = checkVersionSkew("2026.3.23", undefined);
+    expect(result.skewed).toBe(false);
+    expect(result.configVersion).toBeNull();
+  });
+
+  it("returns not skewed for same-family versions", () => {
+    const result = checkVersionSkew("2026.3.23", "2026.3.23-1");
+    expect(result.skewed).toBe(false);
+    expect(result.message).toBeNull();
+    expect(result.guidance).toBeNull();
+    expect(result.configVersion).toBe("2026.3.23-1");
+  });
+
+  it("returns not skewed when current is newer", () => {
+    const result = checkVersionSkew("2026.3.24", "2026.3.23");
+    expect(result.skewed).toBe(false);
+    expect(result.configVersion).toBe("2026.3.23");
+  });
+
+  it("returns skewed with message and guidance when config is from a newer version", () => {
+    const result = checkVersionSkew("2026.3.23", "2026.3.24");
+    expect(result.skewed).toBe(true);
+    expect(result.message).toBe(
+      "Config was last written by a newer OpenClaw (2026.3.24); current version is 2026.3.23.",
+    );
+    expect(result.guidance).toBe(
+      "Run `openclaw update` to update, or `openclaw doctor` to check compatibility.",
+    );
+    expect(result.configVersion).toBe("2026.3.24");
+    expect(result.currentVersion).toBe("2026.3.23");
+  });
+
+  it("returns skewed when major version differs", () => {
+    const result = checkVersionSkew("2026.3.23", "2027.1.1");
+    expect(result.skewed).toBe(true);
+    expect(result.message).toContain("2027.1.1");
+    expect(result.guidance).toContain("openclaw update");
+    expect(result.guidance).toContain("openclaw doctor");
+  });
+
+  it("returns skewed when beta is older than stable", () => {
+    const result = checkVersionSkew("2026.3.23-beta.1", "2026.3.23");
+    expect(result.skewed).toBe(true);
+    expect(result.message).toContain("2026.3.23");
+    expect(result.guidance).not.toBeNull();
   });
 });

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -123,6 +123,56 @@ export function shouldWarnOnTouchedVersion(
   return cmp !== null && cmp < 0;
 }
 
+/** Structured result from a version skew check at config load time. */
+export type VersionSkewResult = {
+  /** True when the config was last written by a newer OpenClaw version. */
+  skewed: boolean;
+  /** Human-readable warning message (only set when skewed). */
+  message: string | null;
+  /** Actionable guidance for the user (only set when skewed). */
+  guidance: string | null;
+  /** The version that last touched the config (null if unknown). */
+  configVersion: string | null;
+  /** The running binary version. */
+  currentVersion: string;
+};
+
+/**
+ * Check whether the loaded config was written by a newer OpenClaw version
+ * and return a structured result with actionable guidance.
+ */
+export function checkVersionSkew(
+  currentVersion: string,
+  touchedVersion: string | null | undefined,
+): VersionSkewResult {
+  if (!touchedVersion) {
+    return {
+      skewed: false,
+      message: null,
+      guidance: null,
+      configVersion: null,
+      currentVersion,
+    };
+  }
+  const skewed = shouldWarnOnTouchedVersion(currentVersion, touchedVersion);
+  if (!skewed) {
+    return {
+      skewed: false,
+      message: null,
+      guidance: null,
+      configVersion: touchedVersion,
+      currentVersion,
+    };
+  }
+  return {
+    skewed: true,
+    message: `Config was last written by a newer OpenClaw (${touchedVersion}); current version is ${currentVersion}.`,
+    guidance: "Run `openclaw update` to update, or `openclaw doctor` to check compatibility.",
+    configVersion: touchedVersion,
+    currentVersion,
+  };
+}
+
 function releaseRank(version: OpenClawVersion): number {
   if (version.prerelease?.length) {
     return 0;

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import {
+  checkVersionSkew,
   createConfigIO,
   parseConfigJson5,
   readConfigFileSnapshot,
@@ -46,6 +47,7 @@ import {
   validateConfigSetParams,
 } from "../protocol/index.js";
 import { resolveBaseHashParam } from "./base-hash.js";
+import { VERSION } from "../../version.js";
 import { parseRestartRequestParams } from "./restart-request.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -386,6 +388,10 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!(await ensureResolvableSecretRefsOrRespond({ config: parsed.config, respond }))) {
       return;
     }
+
+    // Warn when the config was last written by a newer OpenClaw version.
+    const versionSkew = checkVersionSkew(VERSION, snapshot.config.meta?.lastTouchedVersion);
+
     await writeConfigFile(parsed.config, writeOptions);
     respond(
       true,
@@ -393,6 +399,7 @@ export const configHandlers: GatewayRequestHandlers = {
         ok: true,
         path: createConfigIO().configPath,
         config: redactConfigObject(parsed.config, parsed.schema.uiHints),
+        ...(versionSkew.skewed ? { versionWarning: versionSkew.message } : {}),
       },
       undefined,
     );
@@ -413,6 +420,10 @@ export const configHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+
+    // Warn when the config was last written by a newer OpenClaw version.
+    const versionSkew = checkVersionSkew(VERSION, snapshot.config.meta?.lastTouchedVersion);
+
     const rawValue = (params as { raw?: unknown }).raw;
     if (typeof rawValue !== "string") {
       respond(
@@ -492,6 +503,7 @@ export const configHandlers: GatewayRequestHandlers = {
           noop: true,
           path: createConfigIO().configPath,
           config: redactConfigObject(validated.config, schemaPatch.uiHints),
+          ...(versionSkew.skewed ? { versionWarning: versionSkew.message } : {}),
         },
         undefined,
       );
@@ -540,6 +552,7 @@ export const configHandlers: GatewayRequestHandlers = {
           path: sentinelPath,
           payload,
         },
+        ...(versionSkew.skewed ? { versionWarning: versionSkew.message } : {}),
       },
       undefined,
     );

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -421,9 +421,6 @@ export const configHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    // Warn when the config was last written by a newer OpenClaw version.
-    const versionSkew = checkVersionSkew(VERSION, snapshot.config.meta?.lastTouchedVersion);
-
     const rawValue = (params as { raw?: unknown }).raw;
     if (typeof rawValue !== "string") {
       respond(
@@ -485,6 +482,10 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!(await ensureResolvableSecretRefsOrRespond({ config: validated.config, respond }))) {
       return;
     }
+
+    // Warn when the config was last written by a newer OpenClaw version.
+    const versionSkew = checkVersionSkew(VERSION, snapshot.config.meta?.lastTouchedVersion);
+
     const changedPaths = diffConfigPaths(snapshot.config, validated.config);
     const actor = resolveControlPlaneActor(client);
 
@@ -572,6 +573,10 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!(await ensureResolvableSecretRefsOrRespond({ config: parsed.config, respond }))) {
       return;
     }
+
+    // Warn when the config was last written by a newer OpenClaw version.
+    const versionSkew = checkVersionSkew(VERSION, snapshot.config.meta?.lastTouchedVersion);
+
     const changedPaths = diffConfigPaths(snapshot.config, parsed.config);
     const actor = resolveControlPlaneActor(client);
     context?.logGateway?.info(
@@ -616,6 +621,7 @@ export const configHandlers: GatewayRequestHandlers = {
           path: sentinelPath,
           payload,
         },
+        ...(versionSkew.skewed ? { versionWarning: versionSkew.message } : {}),
       },
       undefined,
     );


### PR DESCRIPTION
## Summary
- Enhanced `warnIfConfigFromFuture` to return a structured `VersionSkewResult` with actionable guidance ("run `openclaw update`") instead of just logging a bare warning.
- Added version skew warnings in `config.set` and `config.patch` RPC handlers — when the config was last touched by a newer OpenClaw version, the response includes a `versionWarning` field.
- Prevents silent breakage when the binary is older than the config expects (e.g., plugins requiring newer host versions fail to load).

## Test plan
- [ ] Verify version skew detection for config-from-future scenario
- [ ] Verify no false warnings for same-family or older config versions
- [ ] Verify `config.patch` response includes `versionWarning` when skewed
- [ ] Run `pnpm test -- src/config/version.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)