### PR TITLE
doctor: add version skew health check

### DIFF
--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -56,6 +56,7 @@ import { runStartupMatrixMigration } from "../gateway/server-startup-matrix-migr
 import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import { shortenHomePath } from "../utils.js";
+import { runVersionSkewHealth } from "./doctor-version-skew.js";
 import type { FlowContribution } from "./types.js";
 
 export type DoctorFlowMode = "local" | "remote";
@@ -478,6 +479,11 @@ async function runFinalConfigValidationHealth(_ctx: DoctorHealthFlowContext): Pr
 
 export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
   return [
+    createDoctorHealthContribution({
+      id: "doctor:version-skew",
+      label: "Version skew",
+      run: runVersionSkewHealth,
+    }),
     createDoctorHealthContribution({
       id: "doctor:gateway-config",
       label: "Gateway config",

--- a/src/flows/doctor-version-skew.test.ts
+++ b/src/flows/doctor-version-skew.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../version.js", () => ({ VERSION: "2026.3.23" }));
+vi.mock("../terminal/note.js", () => ({ note: vi.fn() }));
+
+import { note } from "../terminal/note.js";
+import type { DoctorHealthFlowContext } from "./doctor-health-contributions.js";
+import { runVersionSkewHealth } from "./doctor-version-skew.js";
+
+function makeCtx(lastTouchedVersion: string | undefined): DoctorHealthFlowContext {
+  return {
+    cfg: {
+      meta: lastTouchedVersion ? { lastTouchedVersion } : undefined,
+    },
+  } as unknown as DoctorHealthFlowContext;
+}
+
+describe("runVersionSkewHealth", () => {
+  beforeEach(() => {
+    vi.mocked(note).mockClear();
+  });
+
+  it("emits no warning when versions match", async () => {
+    await runVersionSkewHealth(makeCtx("2026.3.23"));
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it("warns when config version is newer than the binary", async () => {
+    await runVersionSkewHealth(makeCtx("2026.4.1"));
+    expect(note).toHaveBeenCalledOnce();
+    expect(note).toHaveBeenCalledWith(expect.stringContaining("2026.4.1"), "Version skew");
+  });
+
+  it("emits no warning when binary version is newer than config", async () => {
+    await runVersionSkewHealth(makeCtx("2026.2.1"));
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it("emits no warning when lastTouchedVersion is missing", async () => {
+    await runVersionSkewHealth(makeCtx(undefined));
+    expect(note).not.toHaveBeenCalled();
+  });
+});

--- a/src/flows/doctor-version-skew.test.ts
+++ b/src/flows/doctor-version-skew.test.ts
@@ -7,10 +7,10 @@ import { note } from "../terminal/note.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contributions.js";
 import { runVersionSkewHealth } from "./doctor-version-skew.js";
 
-function makeCtx(lastTouchedVersion: string | undefined): DoctorHealthFlowContext {
+function makeCtx(lastTouchedVersion: unknown): DoctorHealthFlowContext {
   return {
     cfg: {
-      meta: lastTouchedVersion ? { lastTouchedVersion } : undefined,
+      meta: lastTouchedVersion !== undefined ? { lastTouchedVersion } : undefined,
     },
   } as unknown as DoctorHealthFlowContext;
 }
@@ -38,6 +38,11 @@ describe("runVersionSkewHealth", () => {
 
   it("emits no warning when lastTouchedVersion is missing", async () => {
     await runVersionSkewHealth(makeCtx(undefined));
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it("emits no warning when lastTouchedVersion is a non-string value", async () => {
+    await runVersionSkewHealth(makeCtx(12345));
     expect(note).not.toHaveBeenCalled();
   });
 });

--- a/src/flows/doctor-version-skew.ts
+++ b/src/flows/doctor-version-skew.ts
@@ -6,7 +6,9 @@ import type { DoctorHealthFlowContext } from "./doctor-health-contributions.js";
 
 export async function runVersionSkewHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const touched = ctx.cfg.meta?.lastTouchedVersion;
-  if (!touched || typeof touched !== "string") return;
+  if (!touched || typeof touched !== "string") {
+    return;
+  }
 
   if (shouldWarnOnTouchedVersion(VERSION, touched)) {
     note(

--- a/src/flows/doctor-version-skew.ts
+++ b/src/flows/doctor-version-skew.ts
@@ -1,0 +1,22 @@
+import { formatCliCommand } from "../cli/command-format.js";
+import { shouldWarnOnTouchedVersion } from "../config/version.js";
+import { note } from "../terminal/note.js";
+import { VERSION } from "../version.js";
+import type { DoctorHealthFlowContext } from "./doctor-health-contributions.js";
+
+export async function runVersionSkewHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  const touched = ctx.cfg.meta?.lastTouchedVersion;
+  if (!touched) return;
+
+  if (shouldWarnOnTouchedVersion(VERSION, touched)) {
+    note(
+      [
+        `Config was last written by OpenClaw ${touched}, but the running binary is ${VERSION}.`,
+        "Plugins or features added by the newer version may not load correctly.",
+        `Fix: run ${formatCliCommand("openclaw update")} to update the binary.`,
+        `Or: run ${formatCliCommand("npm install -g openclaw@latest")} for a manual update.`,
+      ].join("\n"),
+      "Version skew",
+    );
+  }
+}

--- a/src/flows/doctor-version-skew.ts
+++ b/src/flows/doctor-version-skew.ts
@@ -6,7 +6,7 @@ import type { DoctorHealthFlowContext } from "./doctor-health-contributions.js";
 
 export async function runVersionSkewHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const touched = ctx.cfg.meta?.lastTouchedVersion;
-  if (!touched) return;
+  if (!touched || typeof touched !== "string") return;
 
   if (shouldWarnOnTouchedVersion(VERSION, touched)) {
     note(


### PR DESCRIPTION
## Summary
- Adds a new `doctor:version-skew` health check as the first check in `openclaw doctor`.
- Detects when the config's `meta.lastTouchedVersion` is newer than the running binary and warns with remediation steps (`openclaw update` or `npm install -g openclaw@latest`).
- Catches version skew early before it causes downstream issues like plugins failing to load or config features being silently ignored.

## Test plan
- [ ] Verify warning when config version > binary version
- [ ] Verify no warning when versions match or binary is newer
- [ ] Verify no warning when `lastTouchedVersion` is missing
- [ ] Run `pnpm test -- src/flows/doctor-version-skew.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)