### PR TITLE
fix: Half-close JSONL socket write side to prevent deadlock

### DIFF
--- a/src/infra/jsonl-socket.ts
+++ b/src/infra/jsonl-socket.ts
@@ -30,7 +30,11 @@ export async function requestJsonlSocket<T>(params: {
 
     client.on("error", () => finish(null));
     client.connect(socketPath, () => {
-      client.write(`${payload}\n`);
+      // Use end() instead of write() to half-close the write side.
+      // This signals to the server that no more data will be sent,
+      // allowing it to complete the read/respond cycle for JSONL protocols.
+      // See: https://github.com/openclaw/openclaw/issues/59633
+      client.end(`${payload}\n`);
     });
     client.on("data", (data) => {
       buffer += data.toString("utf8");


### PR DESCRIPTION
## Description

This PR fixes a deadlock issue in the JSONL socket client that prevented exec approval communication on macOS.

## Problem

The JSONL socket client was using write() which leaves the write side open, causing the server to wait indefinitely for more data. This results in a deadlock where the server never completes the read/respond cycle.

## Solution

Changed write() to end() to properly signal end-of-stream to the server, which half-closes the write side of the socket.

## Root Cause

The server uses FileHandle.read(upToCount:) in a loop and expects the client to signal when it's done sending. Without half-close, the server blocks forever waiting for more input.

## Impact

Fixes exec approval socket communication on macOS when called from remote gateway via pc-steward -> mac-cli-host path.

## Testing

The fix was verified by the issue reporter with the following scenarios working after the patch:
- \OCI -> pc-steward -> mac-cli-host -> system.run /usr/bin/uname -a\
- \OCI -> pc-steward -> mac-cli-host -> system.run /bin/cat /etc/hosts\
- \OCI -> pc-steward -> mac-cli-host -> system.run /usr/sbin/screencapture -x ...\

Fixes: #59633

## Type of Change

- [x] Bug fix
- [ ] Documentation
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] My code follows the code style of this project
- [x] My changes do not introduce new warnings
- [x] I have tested my changes (verified by issue reporter)