### PR TITLE
fix: use text-level dedup instead of blanket suppression for same-target messaging tool replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply: keep final text replies after same-target media-only messaging tool sends while preserving duplicate short/text suppression and account-scoped followup routing. Fixes #59743; carries forward #59752 and #59795. Thanks @solavrc and @jameslcowan.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Cron/Telegram: preserve explicit `:topic:` delivery targets over stale session-derived thread IDs when isolated cron announces to Telegram forum topics. Carries forward #59069; refs #49704 and #43808. Thanks @roytong9.
 - Build/runtime: write the runtime-postbuild stamp after `pnpm build` writes the build stamp, so the next CLI invocation does not re-sync runtime artifacts after a successful build. Fixes #73151. Thanks @bittoby.

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -688,6 +688,11 @@ describe("isMessagingToolDuplicate", () => {
     {
       input: "short",
       sentTexts: ["short"],
+      expected: true,
+    },
+    {
+      input: "okay",
+      sentTexts: ["ok"],
       expected: false,
     },
     {

--- a/src/agents/pi-embedded-helpers/messaging-dedupe.ts
+++ b/src/agents/pi-embedded-helpers/messaging-dedupe.ts
@@ -23,11 +23,20 @@ export function isMessagingToolDuplicateNormalized(
   if (normalizedSentTexts.length === 0) {
     return false;
   }
-  if (!normalized || normalized.length < MIN_DUPLICATE_TEXT_LENGTH) {
+  if (!normalized) {
     return false;
   }
   return normalizedSentTexts.some((normalizedSent) => {
-    if (!normalizedSent || normalizedSent.length < MIN_DUPLICATE_TEXT_LENGTH) {
+    if (!normalizedSent) {
+      return false;
+    }
+    if (normalized === normalizedSent) {
+      return true;
+    }
+    if (
+      normalized.length < MIN_DUPLICATE_TEXT_LENGTH ||
+      normalizedSent.length < MIN_DUPLICATE_TEXT_LENGTH
+    ) {
       return false;
     }
     return normalized.includes(normalizedSent) || normalizedSent.includes(normalized);
@@ -39,7 +48,7 @@ export function isMessagingToolDuplicate(text: string, sentTexts: string[]): boo
     return false;
   }
   const normalized = normalizeTextForComparison(text);
-  if (!normalized || normalized.length < MIN_DUPLICATE_TEXT_LENGTH) {
+  if (!normalized) {
     return false;
   }
   return isMessagingToolDuplicateNormalized(normalized, sentTexts.map(normalizeTextForComparison));

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -570,4 +570,27 @@ describe("buildReplyPayloads media filter integration", () => {
     });
     expect(replyPayloads).toHaveLength(0);
   });
+
+  it("suppresses exact short duplicate text without substring-matching unrelated short text", async () => {
+    const { replyPayloads: dropped } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "ok" }],
+      messageProvider: "telegram",
+      originatingTo: "268300329",
+      messagingToolSentTexts: ["ok"],
+      messagingToolSentTargets: [{ tool: "telegram", provider: "telegram", to: "268300329" }],
+    });
+    expect(dropped).toHaveLength(0);
+
+    const { replyPayloads: kept } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "okay" }],
+      messageProvider: "telegram",
+      originatingTo: "268300329",
+      messagingToolSentTexts: ["ok"],
+      messagingToolSentTargets: [{ tool: "telegram", provider: "telegram", to: "268300329" }],
+    });
+    expect(kept).toHaveLength(1);
+    expect(kept[0]?.text).toBe("okay");
+  });
 });

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -11,8 +11,13 @@ const baseParams = {
   replyToMode: "off" as const,
 };
 
-async function expectSameTargetRepliesSuppressed(params: { provider: string; to: string }) {
-  const { replyPayloads } = await buildReplyPayloads({
+async function expectSameTargetDuplicateRepliesSuppressed(params: {
+  provider: string;
+  to: string;
+}) {
+  // When the messaging tool sent a DIFFERENT text to the same target,
+  // the final reply should NOT be suppressed (text dedup doesn't match).
+  const { replyPayloads: kept } = await buildReplyPayloads({
     ...baseParams,
     payloads: [{ text: "hello world!" }],
     messageProvider: "heartbeat",
@@ -21,8 +26,21 @@ async function expectSameTargetRepliesSuppressed(params: { provider: string; to:
     messagingToolSentTexts: ["different message"],
     messagingToolSentTargets: [{ tool: "message", provider: params.provider, to: params.to }],
   });
+  expect(kept).toHaveLength(1);
+  expect(kept[0]?.text).toBe("hello world!");
 
-  expect(replyPayloads).toHaveLength(0);
+  // When the messaging tool sent the SAME text to the same target,
+  // the final reply should be suppressed (text dedup matches).
+  const { replyPayloads: dropped } = await buildReplyPayloads({
+    ...baseParams,
+    payloads: [{ text: "hello world!" }],
+    messageProvider: "heartbeat",
+    originatingChannel: "feishu",
+    originatingTo: "ou_abc123",
+    messagingToolSentTexts: ["hello world!"],
+    messagingToolSentTargets: [{ tool: "message", provider: params.provider, to: params.to }],
+  });
+  expect(dropped).toHaveLength(0);
 }
 
 describe("buildReplyPayloads media filter integration", () => {
@@ -157,8 +175,9 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads[0]?.mediaUrl).toBe("file:///tmp/photo.jpg");
   });
 
-  it("suppresses same-target replies when messageProvider is synthetic but originatingChannel is set", async () => {
-    const { replyPayloads } = await buildReplyPayloads({
+  it("deduplicates same-target replies by text content, not blanket suppression", async () => {
+    // Different text → should NOT be suppressed
+    const { replyPayloads: kept } = await buildReplyPayloads({
       ...baseParams,
       payloads: [{ text: "hello world!" }],
       messageProvider: "heartbeat",
@@ -167,15 +186,27 @@ describe("buildReplyPayloads media filter integration", () => {
       messagingToolSentTexts: ["different message"],
       messagingToolSentTargets: [{ tool: "telegram", provider: "telegram", to: "268300329" }],
     });
+    expect(kept).toHaveLength(1);
+    expect(kept[0]?.text).toBe("hello world!");
 
-    expect(replyPayloads).toHaveLength(0);
+    // Same text → should be suppressed
+    const { replyPayloads: dropped } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "hello world!" }],
+      messageProvider: "heartbeat",
+      originatingChannel: "telegram",
+      originatingTo: "268300329",
+      messagingToolSentTexts: ["hello world!"],
+      messagingToolSentTargets: [{ tool: "telegram", provider: "telegram", to: "268300329" }],
+    });
+    expect(dropped).toHaveLength(0);
   });
 
-  it("suppresses same-target replies when message tool target provider is generic", async () => {
-    await expectSameTargetRepliesSuppressed({ provider: "message", to: "ou_abc123" });
+  it("deduplicates same-target replies when message tool target provider is generic", async () => {
+    await expectSameTargetDuplicateRepliesSuppressed({ provider: "message", to: "ou_abc123" });
   });
 
-  it("suppresses same-target replies when target provider is channel alias", async () => {
+  it("deduplicates same-target replies when target provider is channel alias", async () => {
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(
       createTestRegistry([
@@ -198,7 +229,26 @@ describe("buildReplyPayloads media filter integration", () => {
         },
       ]),
     );
-    await expectSameTargetRepliesSuppressed({ provider: "lark", to: "ou_abc123" });
+    await expectSameTargetDuplicateRepliesSuppressed({ provider: "lark", to: "ou_abc123" });
+  });
+
+  it("does not suppress final reply when message tool sent media-only to same target", async () => {
+    // When the message tool sent media (with a short label like "🟢") but the final reply
+    // is substantive new text, it should NOT be suppressed.
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "Setup complete! Here is the summary..." }],
+      messageProvider: "heartbeat",
+      originatingChannel: "discord",
+      originatingTo: "channel:1489265252167323680",
+      messagingToolSentTexts: ["Test audio 🟢"],
+      messagingToolSentMediaUrls: ["file:///tmp/test.mp3"],
+      messagingToolSentTargets: [
+        { tool: "message", provider: "discord", to: "channel:1489265252167323680" },
+      ],
+    });
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("Setup complete! Here is the summary...");
   });
 
   it("strips media already sent by the block pipeline after normalizing both paths", async () => {
@@ -502,5 +552,18 @@ describe("buildReplyPayloads media filter integration", () => {
 
     expect(replyPayloads).toHaveLength(1);
     expect(replyPayloads[0]?.text).toBe("hello world!");
+  });
+
+  it("suppresses duplicate text even when sent to same target", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "exact same message" }],
+      messageProvider: "heartbeat",
+      originatingChannel: "telegram",
+      originatingTo: "268300329",
+      messagingToolSentTexts: ["exact same message"],
+      messagingToolSentTargets: [{ tool: "telegram", provider: "telegram", to: "268300329" }],
+    });
+    expect(replyPayloads).toHaveLength(0);
   });
 });

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
-import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ChannelId } from "../../channels/plugins/types.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
 
 const baseParams = {
@@ -206,30 +210,30 @@ describe("buildReplyPayloads media filter integration", () => {
     await expectSameTargetDuplicateRepliesSuppressed({ provider: "message", to: "ou_abc123" });
   });
 
-  it("deduplicates same-target replies when target provider is channel alias", async () => {
-    resetPluginRuntimeStateForTest();
-    setActivePluginRegistry(
-      createTestRegistry([
-        {
-          pluginId: "feishu-plugin",
-          source: "test",
-          plugin: {
-            id: "feishu",
-            meta: {
-              id: "feishu",
-              label: "Feishu",
-              selectionLabel: "Feishu",
-              docsPath: "/channels/feishu",
-              blurb: "test stub",
-              aliases: ["lark"],
-            },
-            capabilities: { chatTypes: ["direct"] },
-            config: { listAccountIds: () => [], resolveAccount: () => ({}) },
-          },
+  describe("channel alias resolution (requires plugin registry)", () => {
+    beforeAll(() => {
+      const feishuPlugin = {
+        ...createChannelTestPluginBase({ id: "feishu" as ChannelId }),
+        meta: {
+          id: "feishu" as ChannelId,
+          label: "Feishu",
+          selectionLabel: "Feishu",
+          docsPath: "/channels/feishu",
+          blurb: "test stub.",
+          aliases: ["lark"],
         },
-      ]),
-    );
-    await expectSameTargetDuplicateRepliesSuppressed({ provider: "lark", to: "ou_abc123" });
+      };
+      setActivePluginRegistry(
+        createTestRegistry([{ pluginId: "feishu", plugin: feishuPlugin, source: "test" }]),
+      );
+    });
+    afterAll(() => {
+      setActivePluginRegistry(createTestRegistry([]));
+    });
+
+    it("deduplicates same-target replies when target provider is channel alias", async () => {
+      await expectSameTargetDuplicateRepliesSuppressed({ provider: "lark", to: "ou_abc123" });
+    });
   });
 
   it("does not suppress final reply when message tool sent media-only to same target", async () => {

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -182,7 +182,7 @@ export async function buildReplyPayloads(params: {
   const dedupeRuntime = shouldCheckMessagingToolDedupe
     ? await loadReplyPayloadsDedupeRuntime()
     : null;
-  const suppressMessagingToolReplies =
+  const messagingToolTargetsMatchOrigin =
     dedupeRuntime?.shouldSuppressMessagingToolReplies({
       messageProvider: resolveOriginMessageProvider({
         originatingChannel: params.originatingChannel,
@@ -200,8 +200,13 @@ export async function buildReplyPayloads(params: {
   // Cross-target sends (for example posting to another channel) must not
   // suppress the current conversation's final reply.
   // If target metadata is unavailable, keep legacy dedupe behavior.
+  // When the messaging tool sent to the same target, apply text and media
+  // dedup (filterMessagingToolDuplicates / filterMessagingToolMediaDuplicates)
+  // instead of blanket-suppressing all payloads. This ensures that a message
+  // tool send containing only media (e.g., an audio file) does not suppress a
+  // legitimate, non-duplicate final text reply in the same turn.
   const dedupeMessagingToolPayloads =
-    suppressMessagingToolReplies || messagingToolSentTargets.length === 0;
+    messagingToolTargetsMatchOrigin || messagingToolSentTargets.length === 0;
   const messagingToolSentMediaUrls = dedupeMessagingToolPayloads
     ? await normalizeSentMediaUrlsForDedupe({
         sentMediaUrls: params.messagingToolSentMediaUrls ?? [],
@@ -278,9 +283,7 @@ export async function buildReplyPayloads(params: {
           sentMediaUrls: blockSentMediaUrls,
         })
       : contentSuppressedPayloads;
-  const replyPayloads = suppressMessagingToolReplies
-    ? []
-    : filteredPayloads.filter(isRenderablePayload);
+  const replyPayloads = filteredPayloads.filter(isRenderablePayload);
 
   return {
     replyPayloads,

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -43,19 +43,20 @@ describe("resolveFollowupDeliveryPayloads", () => {
     ).toEqual([{ mediaUrl: undefined, mediaUrls: undefined }]);
   });
 
-  it("suppresses replies when a messaging tool already sent to the same provider and target", () => {
+  it("keeps different-text replies when a messaging tool already sent to the same provider and target", () => {
     expect(
       resolveFollowupDeliveryPayloads({
         cfg: baseConfig,
         payloads: [{ text: "hello world!" }],
         messageProvider: "slack",
         originatingTo: "channel:C1",
+        sentTexts: ["different message"],
         sentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
       }),
-    ).toEqual([]);
+    ).toEqual([{ text: "hello world!" }]);
   });
 
-  it("suppresses replies when originating channel resolves the provider", () => {
+  it("deduplicates same-text replies when originating channel resolves the provider", () => {
     expect(
       resolveFollowupDeliveryPayloads({
         cfg: baseConfig,
@@ -63,8 +64,24 @@ describe("resolveFollowupDeliveryPayloads", () => {
         messageProvider: "heartbeat",
         originatingChannel: "telegram",
         originatingTo: "268300329",
+        sentTexts: ["hello world!"],
         sentTargets: [{ tool: "telegram", provider: "telegram", to: "268300329" }],
       }),
     ).toEqual([]);
+  });
+
+  it("keeps final text when a same-target messaging tool send only duplicated media", () => {
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [{ text: "Setup complete! Here is the summary..." }],
+        messageProvider: "heartbeat",
+        originatingChannel: "discord",
+        originatingTo: "channel:1489265252167323680",
+        sentMediaUrls: ["file:///tmp/test.mp3"],
+        sentTargets: [{ tool: "message", provider: "discord", to: "channel:1489265252167323680" }],
+        sentTexts: ["Test audio 🟢"],
+      }),
+    ).toEqual([{ text: "Setup complete! Here is the summary..." }]);
   });
 });

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -84,4 +84,16 @@ describe("resolveFollowupDeliveryPayloads", () => {
       }),
     ).toEqual([{ text: "Setup complete! Here is the summary..." }]);
   });
+
+  it("keeps final text when sent target metadata exists but followup origin target is missing", () => {
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [{ text: "hello world!" }],
+        messageProvider: "slack",
+        sentTexts: ["hello world!"],
+        sentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
+      }),
+    ).toEqual([{ text: "hello world!" }]);
+  });
 });

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -62,15 +62,7 @@ export function resolveFollowupDeliveryPayloads(params: {
     replyToMode,
     replyToChannel,
   });
-  const dedupedPayloads = filterMessagingToolDuplicates({
-    payloads: replyTaggedPayloads,
-    sentTexts: params.sentTexts ?? [],
-  });
-  const mediaFilteredPayloads = filterMessagingToolMediaDuplicates({
-    payloads: dedupedPayloads,
-    sentMediaUrls: params.sentMediaUrls ?? [],
-  });
-  const suppressMessagingToolReplies = shouldSuppressMessagingToolReplies({
+  const messagingToolTargetsMatchOrigin = shouldSuppressMessagingToolReplies({
     messageProvider: replyToChannel,
     messagingToolSentTargets: params.sentTargets,
     originatingTo: resolveOriginMessageTo({
@@ -80,5 +72,18 @@ export function resolveFollowupDeliveryPayloads(params: {
       originatingAccountId: params.originatingAccountId,
     }),
   });
-  return suppressMessagingToolReplies ? [] : mediaFilteredPayloads;
+  const shouldDedupeMessagingToolPayloads =
+    messagingToolTargetsMatchOrigin || (params.sentTargets?.length ?? 0) === 0;
+  const mediaFilteredPayloads = shouldDedupeMessagingToolPayloads
+    ? filterMessagingToolMediaDuplicates({
+        payloads: replyTaggedPayloads,
+        sentMediaUrls: params.sentMediaUrls ?? [],
+      })
+    : replyTaggedPayloads;
+  return shouldDedupeMessagingToolPayloads
+    ? filterMessagingToolDuplicates({
+        payloads: mediaFilteredPayloads,
+        sentTexts: params.sentTexts ?? [],
+      })
+    : mediaFilteredPayloads;
 }

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1117,7 +1117,7 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
   function makeTextReplyDedupeResult(overrides?: Record<string, unknown>) {
     return {
       payloads: [{ text: "hello world!" }],
-      messagingToolSentTexts: ["different message"],
+      messagingToolSentTexts: ["hello world!"],
       ...overrides,
     };
   }

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1692,6 +1692,32 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     );
     expect(onBlockReply).not.toHaveBeenCalled();
   });
+
+  it("falls back to the run account when routing followups without originating account metadata", async () => {
+    const queued = baseQueuedRun("discord");
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: { payloads: [{ text: "hello world!" }] },
+      queued: {
+        ...queued,
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        originatingAccountId: undefined,
+        run: {
+          ...queued.run,
+          agentAccountId: "work",
+        },
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        to: "channel:C1",
+        accountId: "work",
+      }),
+    );
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
 });
 
 describe("createFollowupRunner typing cleanup", () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1122,6 +1122,134 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     };
   }
 
+  it("drops payloads already sent via messaging tool", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [{ text: "hello world!" }],
+        messagingToolSentTexts: ["hello world!"],
+      },
+    });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("delivers payloads when not duplicates", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: makeTextReplyDedupeResult({
+        messagingToolSentTexts: ["different message"],
+      }),
+    });
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses duplicate text replies when messaging tool sent to the same provider + target", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [{ text: "hello world!" }],
+        messagingToolSentTexts: ["hello world!"],
+        messagingToolSentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
+      },
+      queued: baseQueuedRun("slack"),
+    });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("delivers non-duplicate text when messaging tool sent to the same target", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        ...makeTextReplyDedupeResult({
+          messagingToolSentTexts: ["different message"],
+        }),
+        messagingToolSentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
+      },
+      queued: baseQueuedRun("slack"),
+    });
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses duplicate text replies when provider is synthetic but originating channel matches", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [{ text: "hello world!" }],
+        messagingToolSentTexts: ["hello world!"],
+        messagingToolSentTargets: [{ tool: "telegram", provider: "telegram", to: "268300329" }],
+      },
+      queued: {
+        ...baseQueuedRun("heartbeat"),
+        originatingChannel: "telegram",
+        originatingTo: "268300329",
+      } as FollowupRun,
+    });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("skips dedup when messaging tool sent to a different target", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [{ text: "hello world!" }],
+        messagingToolSentTexts: ["hello world!"],
+        messagingToolSentTargets: [{ tool: "slack", provider: "slack", to: "channel:OTHER" }],
+      },
+      queued: baseQueuedRun("slack"),
+    });
+
+    // Same text but different target → cross-target guard prevents dedup
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not suppress replies for same target when account differs", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        ...makeTextReplyDedupeResult(),
+        messagingToolSentTargets: [
+          { tool: "telegram", provider: "telegram", to: "268300329", accountId: "work" },
+        ],
+      },
+      queued: {
+        ...baseQueuedRun("heartbeat"),
+        originatingChannel: "telegram",
+        originatingTo: "268300329",
+        originatingAccountId: "personal",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "268300329",
+        accountId: "personal",
+      }),
+    );
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("drops media URL from payload when messaging tool already sent it", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [{ mediaUrl: "/tmp/img.png" }],
+        messagingToolSentMediaUrls: ["/tmp/img.png"],
+      },
+    });
+
+    // Media stripped → payload becomes non-renderable → not delivered.
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("delivers media payload when not a duplicate", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [{ mediaUrl: "/tmp/img.png" }],
+        messagingToolSentMediaUrls: ["/tmp/other.png"],
+      },
+    });
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+  });
+
   it("persists usage even when replies are suppressed", async () => {
     const storePath = "/tmp/openclaw-followup-usage.json";
     const sessionKey = "main";
@@ -1145,7 +1273,8 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
 
     const { onBlockReply } = await runMessagingCase({
       agentResult: {
-        ...makeTextReplyDedupeResult(),
+        payloads: [{ text: "hello world!" }],
+        messagingToolSentTexts: ["hello world!"],
         messagingToolSentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
         meta: {
           agentMeta: {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -144,7 +144,7 @@ export function createFollowupRunner(params: {
           channel: originatingChannel,
           to: originatingTo,
           sessionKey: queued.run.sessionKey,
-          accountId: queued.originatingAccountId,
+          accountId: queued.originatingAccountId ?? queued.run.agentAccountId,
           requesterSenderId: queued.run.senderId,
           requesterSenderName: queued.run.senderName,
           requesterSenderUsername: queued.run.senderUsername,


### PR DESCRIPTION
## Summary

- **Problem:** When the `message` tool sends content to the **same channel** that originated the message, `shouldSuppressMessagingToolReplies()` blanket-suppressed **all** post-turn final reply payloads (`replyPayloads = suppressMessagingToolReplies ? [] : filteredPayloads`). This caused legitimate final text replies to be silently dropped when the message tool had sent media (e.g., an audio file) with a short label to the same channel — even though the final reply text was completely different content.
- **Why it matters:** Users lost substantive final replies without any error or warning whenever the message tool had sent any content (including media-only) to the originating channel in the same turn.
- **What changed:** Removed the blanket `suppressMessagingToolReplies ? [] : filteredPayloads` path in both `agent-runner-payloads.ts` and `followup-runner.ts`. Same-target sends now go through content-level dedup (`filterMessagingToolDuplicates` for text, `filterMessagingToolMediaDuplicates` for media). Added cross-target guard to `followup-runner.ts` to align with `agent-runner-payloads.ts`. Updated and added tests in both test files.
- **What did NOT change (scope boundary):** `shouldSuppressMessagingToolReplies()` is still used to **enable** same-target dedup (vs. cross-target sends which skip dedup entirely). `MIN_DUPLICATE_TEXT_LENGTH` threshold unchanged — short-text dedup is an intentionally accepted edge case (see comment thread).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59743
- Related #15147 #9281 #9471
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** `shouldSuppressMessagingToolReplies()` only checks if **any** `messagingToolSentTargets` entry matches the originating channel. When targets match, it returns `true`, and the entire `filteredPayloads` array is replaced with `[]` — the text-level dedup in `filterMessagingToolDuplicates()` is never reached.
- **Missing detection / guardrail:** No test case existed for the scenario where the message tool sends media-only (with a short label) to the same target while a substantively different final text reply should still be delivered.
- **Prior context (`git blame`, prior PR, issue, or refactor if known):** The blanket suppression logic was the original design — it worked correctly when the message tool only sent text, but broke when media-with-short-label sends were introduced.
- **Why this regressed now:** The message tool gained the ability to send media (audio files, images) with short text labels. The blanket suppression never distinguished between "sent duplicate text" and "sent media with a label".
- **If unknown, what was ruled out:** N/A — root cause is clear.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `agent-runner-payloads.test.ts`, `followup-runner.test.ts`
- **Scenario the test should lock in:** Message tool sends media-only (e.g., audio file with short label "🟢") to the same target → final text reply with different content must still be delivered.
- **Why this is the smallest reliable guardrail:** Unit test directly exercises `buildReplyPayloads` with the exact payload combination that triggered the bug — no integration setup needed.
- **Existing test that already covers this (if any):** None previously. Added `"does not suppress final reply when message tool sent media-only to same target"` in `agent-runner-payloads.test.ts`.
- **If no new test is added, why not:** New tests were added (see above).

## User-visible / Behavior Changes

- **Before:** When the message tool sent any content (including media with a short label) to the originating channel, all final text replies in that turn were silently dropped.
- **After:** Only exact text duplicates and matching media URLs are suppressed. Non-duplicate final text replies are correctly delivered even when the message tool sent to the same channel.

## Diagram (if applicable)

```text
Before:
[message tool sends audio+label to same channel] -> shouldSuppressMessagingToolReplies = true
  -> replyPayloads = [] (ALL replies dropped, including non-duplicate text)

After:
[message tool sends audio+label to same channel] -> messagingToolTargetsMatchOrigin = true
  -> filterMessagingToolDuplicates (text dedup: only drops matching text)
  -> filterMessagingToolMediaDuplicates (media dedup: only strips matching URLs)
  -> replyPayloads = [non-duplicate final text reply delivered ✓]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any (server-side logic)
- Runtime/container: Node.js
- Model/provider: Any LLM provider
- Integration/channel (if any): Any messaging channel (Slack, Discord, Telegram, etc.)
- Relevant config (redacted): Default config, no special settings required

### Steps

1. Send a message to a bot on any messaging channel (e.g., Discord).
2. The bot's agent run uses the `message` tool to send an audio file with a short label (e.g., "🟢") back to the **same channel**.
3. The agent also generates a substantive final text reply (e.g., "Setup complete! Here is the summary...").

### Expected

- The audio file is sent.
- The final text reply ("Setup complete! Here is the summary...") is also delivered to the channel.

### Actual

- **Before fix:** The audio file is sent, but the final text reply is silently dropped (blanket suppression).
- **After fix:** Both the audio file and the final text reply are delivered correctly.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test results after fix:
```
✓ src/auto-reply/reply/agent-runner-payloads.test.ts (16 tests passed)
✓ src/auto-reply/reply/followup-runner.test.ts (22 tests passed, 3 pre-existing failures unrelated to this PR)
```

The 3 pre-existing test failures in `followup-runner.test.ts` are caused by a missing `resolveSessionLockMaxHoldFromTimeout` mock in the test setup — these fail identically on the base branch.

## Human Verification (required)

- **Verified scenarios:**
  - Media-only send (audio + short label) to same target → final text reply is delivered
  - Duplicate text send to same target → correctly suppressed
  - Cross-target send → no dedup applied, reply delivered
  - Same-target send with different text → reply delivered (not suppressed)
- **Edge cases checked:**
  - Cross-target guard in both `agent-runner-payloads.ts` and `followup-runner.ts`
  - Synthetic provider matching (e.g., `heartbeat` → `telegram`)
  - Account ID mismatch → no suppression
- **What you did not verify:** End-to-end verification on a live messaging channel (verified via unit tests only).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

| Bot | Finding | Status |
|-----|---------|--------|
| Greptile P0 ×2 | Stale `followup-runner.test.ts` tests relying on removed blanket suppression | ✅ Fixed in commit `3537e78` — updated 3 tests to use matching sent texts for text-level dedup |
| Greptile P1 | Cross-target dedup guard missing in `followup-runner.ts` | ✅ Fixed in commit `3537e78` — added `shouldSuppressMessagingToolReplies` cross-target guard |
| Codex P2 | Short same-target duplicate suppression (`MIN_DUPLICATE_TEXT_LENGTH`) | ✅ Acknowledged — intentional tradeoff (see [comment](https://github.com/openclaw/openclaw/pull/59752#issuecomment-4182692243)) |
| Codex P2 | Keep short duplicate guard in followup delivery path | ✅ Acknowledged — same as above |
| Codex P2 | Preserve account fallback in same-target dedupe check | ✅ Addressed — account fallback preserved via `resolveOriginAccountId` |

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** Short identical texts (< `MIN_DUPLICATE_TEXT_LENGTH` chars, e.g., "ok", "done") sent by the message tool to the same target will no longer be suppressed and may result in duplicate short replies.
  - **Mitigation:** This is a much narrower edge case than the original bug. If it becomes a practical issue, it should be addressed by lowering `MIN_DUPLICATE_TEXT_LENGTH` or adding an exact-match check in `filterMessagingToolDuplicates`, not by restoring blanket suppression.

---

### AI-assisted PR Checklist

- [x] Mark as AI-assisted in the PR title or description — This PR was authored with AI assistance (Claude Code agent for followup commits addressing bot review feedback)
- [x] Note the degree of testing: **Fully tested** — all changes covered by updated and new unit tests
- [x] Include prompts or session logs if possible — Bot review findings were used as prompts for the followup commit
- [x] Confirm you understand what the code does — Yes, the author understands the dedup pipeline and the distinction between blanket suppression vs. content-level dedup
- [x] If you have access to Codex, run `codex review --base origin/main` locally and address the findings before asking for review — Codex review findings addressed (see Review Conversations above)
- [x] Resolve or reply to bot review conversations after you address them — All Greptile and Codex conversations addressed
