### PR TITLE
fix(cli): prevent unconditional model check when skipping auth in agents add

### DIFF
--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -11,6 +11,11 @@ const wizardMocks = vi.hoisted(() => ({
   createClackPrompter: vi.fn(),
 }));
 
+const warnIfModelConfigLooksOffMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const applyAuthChoiceMock = vi.hoisted(() => vi.fn());
+const setupChannelsMock = vi.hoisted(() => vi.fn(async (cfg: unknown) => cfg));
+const ensureWorkspaceAndSessionsMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
 vi.mock("../config/config.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../config/config.js")>()),
   readConfigFileSnapshot: readConfigFileSnapshotMock,
@@ -20,6 +25,22 @@ vi.mock("../config/config.js", async (importOriginal) => ({
 
 vi.mock("../wizard/clack-prompter.js", () => ({
   createClackPrompter: wizardMocks.createClackPrompter,
+}));
+
+vi.mock("./auth-choice.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./auth-choice.js")>()),
+  applyAuthChoice: applyAuthChoiceMock,
+  warnIfModelConfigLooksOff: warnIfModelConfigLooksOffMock,
+}));
+
+vi.mock("./onboard-channels.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./onboard-channels.js")>()),
+  setupChannels: setupChannelsMock,
+}));
+
+vi.mock("./onboard-helpers.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./onboard-helpers.js")>()),
+  ensureWorkspaceAndSessions: ensureWorkspaceAndSessionsMock,
 }));
 
 import { WizardCancelledError } from "../wizard/prompts.js";
@@ -33,6 +54,10 @@ describe("agents add command", () => {
     writeConfigFileMock.mockClear();
     replaceConfigFileMock.mockClear();
     wizardMocks.createClackPrompter.mockClear();
+    warnIfModelConfigLooksOffMock.mockClear();
+    applyAuthChoiceMock.mockClear();
+    setupChannelsMock.mockClear();
+    ensureWorkspaceAndSessionsMock.mockClear();
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();
@@ -74,5 +99,34 @@ describe("agents add command", () => {
 
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(writeConfigFileMock).not.toHaveBeenCalled();
+  });
+
+  it("does not call warnIfModelConfigLooksOff when user skips auth setup", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
+
+    let _confirmCallCount = 0;
+    const prompter = {
+      intro: vi.fn().mockResolvedValue(undefined),
+      text: vi.fn().mockResolvedValue("ops"),
+      confirm: vi.fn().mockImplementation(() => {
+        _confirmCallCount++;
+        // 1st confirm: "Update existing agent?" — not reached for new agents
+        // 1st confirm: "Copy auth profiles from main?" — No
+        // 2nd confirm: "Configure model/auth for this agent now?" — No
+        // 3rd confirm: "Route selected channels?" — No
+        return Promise.resolve(false);
+      }),
+      select: vi.fn().mockResolvedValue(undefined),
+      multiselect: vi.fn().mockResolvedValue([]),
+      note: vi.fn().mockResolvedValue(undefined),
+      outro: vi.fn().mockResolvedValue(undefined),
+      progress: vi.fn().mockReturnValue({ start: vi.fn(), stop: vi.fn() }),
+    };
+    wizardMocks.createClackPrompter.mockReturnValue(prompter);
+
+    await agentsAddCommand({}, runtime);
+
+    expect(warnIfModelConfigLooksOffMock).not.toHaveBeenCalled();
+    expect(setupChannelsMock).toHaveBeenCalled();
   });
 });

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -290,12 +290,11 @@ export async function agentsAddCommand(
           model: authResult.agentModelOverride,
         });
       }
+      await warnIfModelConfigLooksOff(nextConfig, prompter, {
+        agentId,
+        agentDir,
+      });
     }
-
-    await warnIfModelConfigLooksOff(nextConfig, prompter, {
-      agentId,
-      agentDir,
-    });
 
     let selection: ChannelChoice[] = [];
     const channelAccountIds: Partial<Record<ChannelChoice, string>> = {};


### PR DESCRIPTION
### Summary

- **Problem**: When running `openclaw agents add` and answering "No" to "Configure model/auth for this agent now?", the CLI crashes with `TypeError: Cannot read properties of undefined (reading 'resolveConfigured')`. This completely blocks adding new agents without immediate auth configuration. (Issue #59654)
- **Root Cause**: The `warnIfModelConfigLooksOff` function was being called unconditionally after the auth prompt, even when `wantsAuth === false`. This function triggers `loadModelCatalog`, which loads provider plugins and initializes the plugin registry. Because the new agent's directory and auth state are not fully initialized when auth is skipped, subsequent channel setup logic (`setupChannels` -> `collectChannelStatus`) attempts to resolve the status of lazy-loaded channel setup wizards. These wizards fail to initialize their `status` property correctly in this incomplete state, leading to the `TypeError` when `wizard.status.resolveConfigured` is accessed.
- **Fix**: Moved the `warnIfModelConfigLooksOff` call inside the `if (wantsAuth)` block. This ensures the model/auth consistency check only runs when the user actually configures auth, matching the behavior in the main `setup.ts` wizard. This prevents premature plugin registry initialization and avoids the downstream crash in channel setup.
- **What changed**: 
  - `src/commands/agents.commands.add.ts`: Moved `warnIfModelConfigLooksOff` inside the `wantsAuth` condition.
  - `src/commands/agents.add.test.ts`: Added a regression test to verify `warnIfModelConfigLooksOff` is not called when auth setup is skipped.
- **What did NOT change (scope boundary)**: The logic inside `warnIfModelConfigLooksOff` itself was not changed. The channel setup logic (`setupChannels`) and plugin loading mechanisms remain untouched. The fix is strictly limited to the control flow of the `agents add` wizard.

### Reproduction

1. Run `openclaw agents add test-agent`
2. Enter a workspace directory
3. Answer "No" to "Copy auth profiles from main?" (if prompted)
4. Answer "No" to "Configure model/auth for this agent now?"
5. Observe that the wizard continues to channel setup instead of crashing with a TypeError.

### Risk / Mitigation

- **Risk**: The model check warning might be skipped in cases where it would have been useful to warn the user about a missing default model.
- **Mitigation**: This is the intended behavior when a user explicitly chooses *not* to configure auth/models at creation time. They can always run `openclaw configure` later. A regression test was added to `agents.add.test.ts` to ensure this specific interactive path remains stable and does not trigger the check.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] CLI

### Linked Issue/PR

Fixes #59654