### PR TITLE
Fix Feishu streaming recovery after transient reply errors

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -4,6 +4,7 @@ type StreamingSessionStub = {
   active: boolean;
   start: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
+  clearText: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
   isActive: ReturnType<typeof vi.fn>;
 };
@@ -74,6 +75,7 @@ vi.mock("./streaming-card.js", () => {
         this.active = true;
       });
       update = vi.fn(async () => {});
+      clearText = vi.fn(async () => {});
       close = vi.fn(async () => {
         this.active = false;
       });
@@ -364,6 +366,43 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
+
+  it("clears stale streaming text and reuses the same card across transient reply errors", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: "Let me explain" });
+
+    await options.onError?.(new Error("terminated"), { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].clearText).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).not.toHaveBeenCalled();
+
+    await options.deliver({ text: "Here's the answer:" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("Here's the answer:", {
+      note: "Agent: agent",
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
   it("suppresses duplicate final text while still sending media", async () => {
     const options = setupNonStreamingAutoDispatcher();
     await options.deliver({ text: "plain final" }, { kind: "final" });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -5,6 +5,7 @@ import {
   resolveTextChunksWithFallback,
   sendMediaWithLeadingCaption,
 } from "openclaw/plugin-sdk/reply-payload";
+import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-runtime";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { sendMediaFeishu } from "./media.js";
@@ -299,6 +300,21 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     })();
   };
 
+  const resetStreamingBuffers = () => {
+    streamText = "";
+    lastPartial = "";
+    reasoningText = "";
+  };
+
+  const clearStreamingProgress = async () => {
+    if (streamingStartPromise) {
+      await streamingStartPromise;
+    }
+    await partialUpdateQueue;
+    await streaming?.clearText();
+    resetStreamingBuffers();
+  };
+
   const closeStreaming = async () => {
     if (streamingStartPromise) {
       await streamingStartPromise;
@@ -314,9 +330,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     }
     streaming = null;
     streamingStartPromise = null;
-    streamText = "";
-    lastPartial = "";
-    reasoningText = "";
+    resetStreamingBuffers();
   };
 
   const sendChunkedTextReply = async (params: {
@@ -474,7 +488,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         params.runtime.error?.(
           `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
         );
-        await closeStreaming();
+        // Keep the active streaming session open here so upstream failover or
+        // retry logic can continue updating the same card instead of closing a
+        // partial card and emitting a second visible final reply later.
+        await clearStreamingProgress();
         typingCallbacks?.onIdle?.();
       },
       onIdle: async () => {
@@ -497,7 +514,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (!payload.text) {
               return;
             }
-            queueStreamingUpdate(payload.text, {
+            const cleaned = stripReasoningTagsFromText(payload.text, {
+              mode: "strict",
+              trim: "both",
+            });
+            if (!cleaned) {
+              return;
+            }
+            queueStreamingUpdate(cleaned, {
               dedupeWithLastPartial: true,
               mode: "snapshot",
             });

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { mergeStreamingText, resolveStreamingCardSendMode } from "./streaming-card.js";
+import {
+  FeishuStreamingSession,
+  mergeStreamingText,
+  resolveStreamingCardSendMode,
+} from "./streaming-card.js";
 
 describe("mergeStreamingText", () => {
   it("prefers the latest full text when it already includes prior text", () => {
@@ -50,5 +54,46 @@ describe("resolveStreamingCardSendMode", () => {
         replyInThread: true,
       }),
     ).toBe("create");
+  });
+});
+
+describe("FeishuStreamingSession.clearText", () => {
+  it("drops buffered text so recovered finals can overwrite stale partials", async () => {
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app_id",
+      appSecret: "app_secret",
+    });
+    const state = session as unknown as {
+      state: {
+        cardId: string;
+        messageId: string;
+        sequence: number;
+        currentText: string;
+        hasNote: boolean;
+      } | null;
+      pendingText: string | null;
+      queue: Promise<void>;
+      flushTimer: ReturnType<typeof setTimeout> | null;
+      lastUpdateTime: number;
+    };
+
+    state.state = {
+      cardId: "card_1",
+      messageId: "om_1",
+      sequence: 1,
+      currentText: "partial answer",
+      hasNote: false,
+    };
+    state.pendingText = "partial answer with pending suffix";
+    state.lastUpdateTime = Date.now();
+    state.flushTimer = setTimeout(() => undefined, 1000);
+    state.queue = Promise.resolve();
+
+    await session.clearText();
+
+    expect(state.state?.currentText).toBe("");
+    expect(state.pendingText).toBeNull();
+    expect(state.lastUpdateTime).toBe(0);
+    expect(state.flushTimer).toBeNull();
   });
 });

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -17,6 +17,71 @@ type CardState = {
   hasNote: boolean;
 };
 
+/**
+ * Sanitize markdown text for Feishu Card Kit streaming mode.
+ *
+ * Card Kit's streaming renderer parses markdown incrementally. Unmatched
+ * backticks (`` ` `` or ` ``` `) cause the renderer to treat everything
+ * after the opener as code, effectively truncating visible output.
+ * Similarly, bare angle brackets (`<` / `>`) can be misinterpreted as
+ * unclosed HTML tags, also causing truncation.
+ *
+ * This function:
+ *  1. Balances triple-backtick fences so an unclosed fence is closed.
+ *  2. Balances inline backtick spans so an unmatched `` ` `` is closed.
+ *  3. Escapes angle brackets that are NOT inside a balanced code span/fence
+ *     and do NOT look like a well-formed HTML tag or Feishu mention tag.
+ */
+export function sanitizeCardKitMarkdown(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  let result = text;
+
+  // --- 1. Balance triple-backtick fences ---
+  const fencePattern = /^```/gm;
+  const fenceMatches = result.match(fencePattern);
+  if (fenceMatches && fenceMatches.length % 2 !== 0) {
+    result += "\n```";
+  }
+
+  // --- 2. Balance inline backticks (outside of fenced blocks) ---
+  const fencedParts = result.split(/(^```[\s\S]*?^```)/m);
+  for (let i = 0; i < fencedParts.length; i++) {
+    if (i % 2 === 0) {
+      const segment = fencedParts[i];
+      const inlineTicks = segment.replace(/\\`/g, "").match(/`/g);
+      if (inlineTicks && inlineTicks.length % 2 !== 0) {
+        fencedParts[i] = segment + "`";
+      }
+    }
+  }
+  result = fencedParts.join("");
+
+  // --- 3. Escape problematic angle brackets outside code spans/fences ---
+  const codeBlocks: string[] = [];
+  result = result.replace(/```[\s\S]*?```/g, (match) => {
+    codeBlocks.push(match);
+    return `\uE001CODEBLOCK${codeBlocks.length - 1}\uE001`;
+  });
+  const codeSpans: string[] = [];
+  result = result.replace(/`[^`\n]*`/g, (match) => {
+    codeSpans.push(match);
+    return `\uE002CODESPAN${codeSpans.length - 1}\uE002`;
+  });
+  result = result.replace(
+    /<(?!\/?(?:a|b|i|em|strong|br|p|div|span|img|at|code|pre)\b)[^>\n]*$/gm,
+    (m) => {
+      return m.replace(/</g, "\\<");
+    },
+  );
+  result = result.replace(/\uE002CODESPAN(\d+)\uE002/g, (_, idx) => codeSpans[Number(idx)]);
+  result = result.replace(/\uE001CODEBLOCK(\d+)\uE001/g, (_, idx) => codeBlocks[Number(idx)]);
+
+  return result;
+}
+
 /** Options for customising the initial streaming card appearance. */
 export type StreamingCardOptions = {
   /** Optional header with title and color template. */
@@ -104,11 +169,13 @@ async function getToken(creds: Credentials): Promise<string> {
   return data.tenant_access_token;
 }
 
-function truncateSummary(text: string, max = 50): string {
+function truncateSummary(text: string | undefined, max = 50): string {
   if (!text) {
     return "";
   }
-  const clean = text.replace(/\n/g, " ").trim();
+  // Strip backticks and angle brackets from summary to prevent Card Kit
+  // from interpreting them as markdown / HTML in the summary line.
+  const clean = text.replace(/\n/g, " ").replace(/[`<>]/g, "").trim();
   return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
 }
 
@@ -328,6 +395,8 @@ export class FeishuStreamingSession {
     if (!this.state || this.closed) {
       return;
     }
+    // Sanitize markdown to prevent Card Kit streaming truncation (#26708)
+    text = sanitizeCardKitMarkdown(text);
     const mergedInput = mergeStreamingText(this.pendingText ?? this.state.currentText, text);
     if (!mergedInput || mergedInput === this.state.currentText) {
       return;
@@ -358,6 +427,20 @@ export class FeishuStreamingSession {
       await this.updateCardContent(mergedText, (e) => this.log?.(`Update failed: ${String(e)}`));
     });
     await this.queue;
+  }
+
+  async clearText(): Promise<void> {
+    if (!this.state || this.closed) {
+      return;
+    }
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    await this.queue;
+    this.pendingText = null;
+    this.lastUpdateTime = 0;
+    this.state.currentText = "";
   }
 
   private async updateNoteContent(note: string): Promise<void> {


### PR DESCRIPTION
## Summary
- keep the active Feishu streaming card open when `onError` fires for a reply item
- add a regression test covering partial streaming content followed by a transient error and a recovered final reply
- preserve the existing idle close path for genuinely incomplete replies

## Why
We reproduced a Feishu duplicate-reply bug locally on OpenClaw 2026.4.1 where a single inbound DM could produce:
- one visible streaming card carrying partial/final-looking text from an errored attempt
- then a second visible final reply after the upstream run recovered

The proximate cause is that `createFeishuReplyDispatcher()` currently calls `closeStreaming()` inside `onError`. That finalizes the active card too early, so any later failover/retry has to create a second card/message.

With this change, transient reply errors no longer finalize the current streaming card. If the run later recovers, the final text closes the original card instead of producing a second visible reply.

Refs: #49381

## Testing
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/feishu/src/reply-dispatcher.test.ts`
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/streaming-card.test.ts`
