### PR TITLE
fix: decouple approval availability from native delivery enablement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/exec approvals: fall back to the origin session key for async approval followups and keep resume-failure status delivery sanitized so Telegram followups still land without leaking raw exec metadata. (#59351) Thanks @seonang.
 - Node-host/exec approvals: bind `pnpm dlx` invocations through the approval planner's mutable-script path so the effective runtime command is resolved for approval instead of being left unbound. (#58374)
 - Exec/node hosts: stop forwarding the gateway workspace cwd to remote node exec when no workdir was explicitly requested, so cross-platform node approvals fall back to the node default cwd instead of failing with `SYSTEM_RUN_DENIED`. (#58977) Thanks @Starhappysh.
+- Exec approvals/channels: decouple initiating-surface approval availability from native delivery enablement so Telegram, Slack, and Discord still expose approvals when approvers exist and native target routing is configured separately. (#59776) Thanks @joelnishanth.
 
 ## 2026.4.2
 

--- a/extensions/discord/src/approval-native.test.ts
+++ b/extensions/discord/src/approval-native.test.ts
@@ -21,6 +21,47 @@ function writeStore(store: Record<string, unknown>) {
 }
 
 describe("createDiscordNativeApprovalAdapter", () => {
+  it("keeps approval availability enabled when approvers exist but native delivery is off", () => {
+    const adapter = createDiscordNativeApprovalAdapter({
+      enabled: false,
+      approvers: ["555555555"],
+      target: "channel",
+    } as never);
+
+    expect(
+      adapter.auth?.getActionAvailabilityState?.({
+        cfg: NATIVE_APPROVAL_CFG as never,
+        accountId: "main",
+        action: "approve",
+      }),
+    ).toEqual({ kind: "enabled" });
+    expect(
+      adapter.native?.describeDeliveryCapabilities({
+        cfg: NATIVE_APPROVAL_CFG as never,
+        accountId: "main",
+        approvalKind: "exec",
+        request: {
+          id: "approval-1",
+          request: {
+            command: "pwd",
+            turnSourceChannel: "discord",
+            turnSourceTo: "channel:123456789",
+            turnSourceAccountId: "main",
+            sessionKey: "agent:main:discord:channel:123456789",
+          },
+          createdAtMs: 1,
+          expiresAtMs: 2,
+        },
+      }),
+    ).toEqual({
+      enabled: false,
+      preferredSurface: "origin",
+      supportsOriginSurface: true,
+      supportsApproverDmSurface: true,
+      notifyOriginWhenDmOnly: true,
+    });
+  });
+
   it("honors ownerAllowFrom fallback when gating approval requests", () => {
     expect(
       shouldHandleDiscordApprovalRequest({

--- a/extensions/slack/src/approval-native.test.ts
+++ b/extensions/slack/src/approval-native.test.ts
@@ -33,6 +33,49 @@ function writeStore(store: Record<string, unknown>) {
 }
 
 describe("slack native approval adapter", () => {
+  it("keeps approval availability enabled when approvers exist but native delivery is off", () => {
+    const cfg = buildConfig({
+      execApprovals: {
+        enabled: false,
+        approvers: ["U123APPROVER"],
+        target: "channel",
+      },
+    });
+
+    expect(
+      slackNativeApprovalAdapter.auth?.getActionAvailabilityState?.({
+        cfg,
+        accountId: "default",
+        action: "approve",
+      }),
+    ).toEqual({ kind: "enabled" });
+    expect(
+      slackNativeApprovalAdapter.native?.describeDeliveryCapabilities({
+        cfg,
+        accountId: "default",
+        approvalKind: "exec",
+        request: {
+          id: "req-disabled-1",
+          request: {
+            command: "echo hi",
+            turnSourceChannel: "slack",
+            turnSourceTo: "channel:C123",
+            turnSourceAccountId: "default",
+            sessionKey: "agent:main:slack:channel:c123",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 1000,
+        },
+      }),
+    ).toEqual({
+      enabled: false,
+      preferredSurface: "origin",
+      supportsOriginSurface: true,
+      supportsApproverDmSurface: true,
+      notifyOriginWhenDmOnly: true,
+    });
+  });
+
   it("describes native slack approval delivery capabilities", () => {
     const capabilities = slackNativeApprovalAdapter.native?.describeDeliveryCapabilities({
       cfg: buildConfig(),

--- a/src/plugin-sdk/approval-delivery-helpers.test.ts
+++ b/src/plugin-sdk/approval-delivery-helpers.test.ts
@@ -106,7 +106,7 @@ describe("createApproverRestrictedNativeApprovalAdapter", () => {
         accountId: "disabled",
         action: "approve",
       }),
-    ).toEqual({ kind: "disabled" });
+    ).toEqual({ kind: "enabled" });
     expect(hasConfiguredDmRoute.hasConfiguredDmRoute({ cfg: {} as never })).toBe(true);
     expect(nativeCapabilities).toEqual({
       enabled: true,
@@ -115,6 +115,30 @@ describe("createApproverRestrictedNativeApprovalAdapter", () => {
       supportsApproverDmSurface: true,
       notifyOriginWhenDmOnly: false,
     });
+  });
+
+  it("reports enabled when approvers exist even if native delivery is off (#59620)", () => {
+    const adapter = createApproverRestrictedNativeApprovalAdapter({
+      channel: "telegram",
+      channelLabel: "Telegram",
+      listAccountIds: () => ["default"],
+      hasApprovers: () => true,
+      isExecAuthorizedSender: () => true,
+      isNativeDeliveryEnabled: () => false,
+      resolveNativeDeliveryMode: () => "both",
+    });
+    const getActionAvailabilityState = adapter.auth.getActionAvailabilityState;
+    if (!getActionAvailabilityState) {
+      throw new Error("approval availability helper unavailable");
+    }
+
+    expect(
+      getActionAvailabilityState({
+        cfg: {} as never,
+        accountId: "default",
+        action: "approve",
+      }),
+    ).toEqual({ kind: "enabled" });
   });
 
   it("suppresses forwarding fallback only for matching native-delivery surfaces", () => {

--- a/src/plugin-sdk/approval-delivery-helpers.ts
+++ b/src/plugin-sdk/approval-delivery-helpers.ts
@@ -92,7 +92,7 @@ function buildApproverRestrictedNativeApprovalCapability(
       accountId?: string | null;
       action: "approve";
     }) =>
-      params.hasApprovers({ cfg, accountId }) && params.isNativeDeliveryEnabled({ cfg, accountId })
+      params.hasApprovers({ cfg, accountId })
         ? ({ kind: "enabled" } as const)
         : ({ kind: "disabled" } as const),
     approvals: {


### PR DESCRIPTION
## Summary

Fixes #59620.

`getActionAvailabilityState` in `createApproverRestrictedNativeApprovalAdapter` was gating on **both** `hasApprovers` and `isNativeDeliveryEnabled`. This caused Telegram exec approvals to report "approvals not allowed on this platform" when `channels.telegram.execApprovals.target` was configured (e.g. `"dm"`, `"channel"`, or `"both"`) but `execApprovals.enabled` was not explicitly `true`.

### Root cause

The regression was introduced in v2026.4.1 during the approval capability refactor. The availability check should only depend on whether **approvers exist** — native delivery mode (`dm`/`channel`/`both`) is a routing concern handled downstream in `resolveChannelNativeApprovalDeliveryPlan`, not a gating condition for the approval surface itself.

### Changes

- **`src/plugin-sdk/approval-delivery-helpers.ts`**: Remove the `isNativeDeliveryEnabled` guard from `getActionAvailabilityState` so the approval surface reports `kind: "enabled"` whenever approvers are configured, regardless of the native delivery toggle.
- **`src/plugin-sdk/approval-delivery-helpers.test.ts`**: Add a dedicated regression test that validates `getActionAvailabilityState` returns `kind: "enabled"` when approvers exist but native delivery is off, and update the existing assertion that was masking the bug.

## Test plan

- [x] `npx vitest run src/plugin-sdk/approval-delivery-helpers.test.ts` — 5/5 pass (including new regression test)
- [x] `npx vitest run src/infra/exec-approval-surface.test.ts` — 11/11 pass
- [x] `npx vitest run src/infra/approval-turn-source.test.ts` — 3/3 pass
- [x] Oxlint clean on both changed files

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)