### PR TITLE
fix(exec): keep strict inline-eval interpreter approvals reusable

### DIFF
--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { resolveAllowAlwaysPatternEntries } from "./exec-approvals-allowlist.js";
 import {
   makeMockCommandResolution,
   makeMockExecutableResolution,
@@ -266,6 +267,29 @@ describe("resolveAllowAlwaysPatterns", () => {
       strictInlineEval: true,
     });
     expect(persisted).toEqual([]);
+  });
+
+  it("persists benign awk interpreters without argv binding in strict inline-eval mode on Windows", () => {
+    const awk = "C:\\temp\\awk.exe";
+    const entries = resolveAllowAlwaysPatternEntries({
+      segments: [
+        {
+          raw: `${awk} -F , -f script.awk data.csv`,
+          argv: [awk, "-F", ",", "-f", "script.awk", "data.csv"],
+          resolution: makeMockCommandResolution({
+            execution: makeMockExecutableResolution({
+              rawExecutable: awk,
+              resolvedPath: awk,
+              executableName: "awk",
+            }),
+          }),
+        },
+      ],
+      platform: "win32",
+      strictInlineEval: true,
+    });
+
+    expect(entries).toEqual([{ pattern: awk }]);
   });
 
   it("unwraps shell wrappers and persists the inner executable instead", () => {

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -698,7 +698,10 @@ function hasSegmentExecutableMatch(
   const execution = resolveExecutionTargetResolution(segment.resolution);
   const candidates = [execution?.executableName, execution?.rawExecutable, segment.argv[0]];
   for (const candidate of candidates) {
-    const trimmed = candidate?.trim();
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const trimmed = candidate.trim();
     if (!trimmed) {
       continue;
     }

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -958,7 +958,14 @@ function collectAllowAlwaysPatterns(params: {
     }
   }
   if (!trustPlan.shellWrapperExecutable) {
-    const argPattern = buildArgPatternFromArgv(segment.argv, params.platform);
+    // In strict inline-eval mode we deliberately persist benign interpreter
+    // executables without an argv binding so later inline-eval attempts match
+    // the binary and get rejected by strictInlineEval instead of reopening the
+    // generic allowlist approval prompt on Windows.
+    const argPattern =
+      params.strictInlineEval === true && isInterpreterLikeAllowlistPattern(candidatePath)
+        ? undefined
+        : buildArgPatternFromArgv(segment.argv, params.platform);
     addAllowAlwaysPattern(params.out, candidatePath, argPattern);
     return;
   }

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -172,6 +172,7 @@ async function withTaskRegistryTempDir<T>(run: (root: string) => Promise<T>): Pr
   return await withTempDir({ prefix: "openclaw-task-registry-" }, async (root) => {
     process.env.OPENCLAW_STATE_DIR = root;
     resetTaskRegistryForTests();
+    resetTaskFlowRegistryForTests();
     try {
       return await run(root);
     } finally {


### PR DESCRIPTION
## Summary
- persist benign interpreter allow-always approvals without an argv binding when strictInlineEval is enabled
- keep strict inline-eval blocking later inline-program attempts instead of reopening the generic allowlist approval prompt on Windows
- add a Windows-focused regression test for the persisted pattern shape

## Testing
- pnpm.cmd test -- src/node-host/invoke-system-run.test.ts
- pnpm.cmd test -- src/infra/exec-approvals-allow-always.test.ts
- pnpm.cmd exec oxlint src/infra/exec-approvals-allowlist.ts src/infra/exec-approvals-allow-always.test.ts src/node-host/invoke-system-run.test.ts