### PR TITLE
fix: detect PID recycling in gateway lock on Windows and macOS

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -31,7 +31,9 @@ export async function runGatewayLoop(params: {
   runtime: RuntimeEnv;
   lockPort?: number;
 }) {
+  gatewayLog.info("acquiring gateway lock...");
   let lock = await acquireGatewayLock({ port: params.lockPort });
+  gatewayLog.info("gateway lock acquired");
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let shuttingDown = false;
   let restartResolver: (() => void) | null = null;

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -12,7 +12,6 @@ import {
 } from "../../config/config.js";
 import { hasConfiguredSecretInput } from "../../config/types.secrets.js";
 import { resolveGatewayAuth } from "../../gateway/auth.js";
-import { startGatewayServer } from "../../gateway/server.js";
 import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setGatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setVerbose } from "../../globals.js";
@@ -25,6 +24,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { inheritOptionFromParent } from "../command-options.js";
+import { withProgress } from "../progress.js";
 import { forceFreePortAndWait, waitForPortBindable } from "../ports.js";
 import { ensureDevGatewayConfig } from "./dev.js";
 import { runGatewayLoop } from "./run-loop.js";
@@ -188,7 +188,6 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     return;
   }
 
-  setConsoleTimestampPrefix(true);
   setVerbose(Boolean(opts.verbose));
   if (opts.cliBackendLogs || opts.claudeCliLogs) {
     setConsoleSubsystemFilter(["agent/cli-backend"]);
@@ -216,10 +215,21 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     process.env.OPENCLAW_RAW_STREAM_PATH = rawStreamPath;
   }
 
+  // The heaviest part of gateway startup is loading the server module tree
+  // (channels, plugins, HTTP stack, etc.). Show a spinner so the user sees
+  // progress instead of a silent 15-20 s pause (especially on Windows/NTFS).
+  const { startGatewayServer } = await withProgress(
+    { label: "Loading gateway modules…", indeterminate: true },
+    async () => import("../../gateway/server.js"),
+  );
+
+  setConsoleTimestampPrefix(true);
+
   if (devMode) {
     await ensureDevGatewayConfig({ reset: Boolean(opts.reset) });
   }
 
+  gatewayLog.info("loading configuration…");
   const cfg = loadConfig();
   const portOverride = parsePort(opts.port);
   if (opts.port !== undefined && portOverride === null) {
@@ -333,6 +343,7 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
   }
   const tokenRaw = toOptionString(opts.token);
 
+  gatewayLog.info("resolving authentication…");
   const snapshot = await readConfigFileSnapshot().catch(() => null);
   const configExists = snapshot?.exists ?? fs.existsSync(CONFIG_PATH);
   const configAuditPath = path.join(resolveStateDir(process.env), "logs", "config-audit.jsonl");
@@ -441,6 +452,7 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
         }
       : undefined;
 
+  gatewayLog.info("starting gateway…");
   const startLoop = async () =>
     await runGatewayLoop({
       runtime: defaultRuntime,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -606,6 +606,7 @@ export async function startGatewayServer(
   let pluginRegistry = emptyPluginRegistry;
   let baseGatewayMethods = baseMethods;
   if (!minimalTestGateway) {
+    log.info("loading plugins...");
     ({ pluginRegistry, gatewayMethods: baseGatewayMethods } = loadGatewayStartupPlugins({
       cfg: gatewayPluginConfigAtStart,
       workspaceDir: defaultWorkspaceDir,
@@ -615,6 +616,7 @@ export async function startGatewayServer(
       pluginIds: startupPluginIds,
       preferSetupRuntimeForChannelPlugins: deferredConfiguredChannelPluginIds.length > 0,
     }));
+    log.info(`plugins loaded (${pluginRegistry.plugins.length} plugins)`);
   } else {
     setActivePluginRegistry(emptyPluginRegistry);
   }
@@ -726,6 +728,7 @@ export async function startGatewayServer(
     channelManager,
     startedAt: serverStartedAt,
   });
+  log.info("starting HTTP server...");
   const {
     canvasHost,
     releasePluginRouteRegistry,
@@ -1373,6 +1376,7 @@ export async function startGatewayServer(
           logDiagnostics: false,
         }));
       }
+      log.info("starting channels and sidecars...");
       ({ pluginServices } = await startGatewaySidecars({
         cfg: gatewayPluginConfigAtStart,
         pluginRegistry,

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -273,6 +273,7 @@ describe("gateway lock", () => {
         staleMs: 10_000,
         platform: "darwin",
         port: 18789,
+        readProcessCmdline: () => ["/usr/local/bin/openclaw", "gateway", "run"],
       });
       await expect(pending).rejects.toBeInstanceOf(GatewayLockError);
     } finally {

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -309,4 +309,110 @@ describe("gateway lock", () => {
     await expect(acquireForTest(env)).rejects.toBeInstanceOf(GatewayLockError);
     openSpy.mockRestore();
   });
+
+  it("clears stale lock on win32 when process cmdline is not a gateway", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    await writeRecentLockFile(env);
+
+    const connectSpy = createPortProbeConnectionSpy("connect");
+
+    const lock = await acquireForTest(env, {
+      timeoutMs: 80,
+      pollIntervalMs: 5,
+      staleMs: 10_000,
+      platform: "win32",
+      port: 18789,
+      readProcessCmdline: () => ["chrome.exe", "--no-sandbox"],
+    });
+    expect(lock).not.toBeNull();
+    await lock?.release();
+
+    connectSpy.mockRestore();
+  });
+
+  it("keeps lock on win32 when process cmdline is a gateway", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    await writeRecentLockFile(env);
+
+    const connectSpy = createPortProbeConnectionSpy("connect");
+
+    const pending = acquireForTest(env, {
+      timeoutMs: 20,
+      pollIntervalMs: 2,
+      staleMs: 10_000,
+      platform: "win32",
+      port: 18789,
+      readProcessCmdline: () => [
+        "C:\\Users\\me\\AppData\\Roaming\\npm\\openclaw.cmd",
+        "gateway",
+        "run",
+      ],
+    });
+    await expect(pending).rejects.toBeInstanceOf(GatewayLockError);
+
+    connectSpy.mockRestore();
+  });
+
+  it("falls back to unknown on win32 when cmdline reader returns null", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    await writeRecentLockFile(env);
+
+    const connectSpy = createPortProbeConnectionSpy("connect");
+
+    const pending = acquireForTest(env, {
+      timeoutMs: 20,
+      pollIntervalMs: 2,
+      staleMs: 10_000,
+      platform: "win32",
+      port: 18789,
+      readProcessCmdline: () => null,
+    });
+    await expect(pending).rejects.toBeInstanceOf(GatewayLockError);
+
+    connectSpy.mockRestore();
+  });
+
+  it("clears stale lock on darwin when process cmdline is not a gateway", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    await writeRecentLockFile(env);
+
+    const connectSpy = createPortProbeConnectionSpy("connect");
+
+    const lock = await acquireForTest(env, {
+      timeoutMs: 80,
+      pollIntervalMs: 5,
+      staleMs: 10_000,
+      platform: "darwin",
+      port: 18789,
+      readProcessCmdline: () => ["/Applications/Safari.app/Contents/MacOS/Safari"],
+    });
+    expect(lock).not.toBeNull();
+    await lock?.release();
+
+    connectSpy.mockRestore();
+  });
+
+  it("keeps lock on darwin when process cmdline is a gateway", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    await writeRecentLockFile(env);
+
+    const connectSpy = createPortProbeConnectionSpy("connect");
+
+    const pending = acquireForTest(env, {
+      timeoutMs: 20,
+      pollIntervalMs: 2,
+      staleMs: 10_000,
+      platform: "darwin",
+      port: 18789,
+      readProcessCmdline: () => ["/usr/local/bin/openclaw", "gateway", "run", "--port", "18789"],
+    });
+    await expect(pending).rejects.toBeInstanceOf(GatewayLockError);
+
+    connectSpy.mockRestore();
+  });
 });

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
@@ -7,7 +8,7 @@ import { z } from "zod";
 import { resolveConfigPath, resolveGatewayLockDir, resolveStateDir } from "../config/paths.js";
 import { isPidAlive } from "../shared/pid-alive.js";
 import { safeParseJsonWithSchema } from "../utils/zod-parse.js";
-import { isGatewayArgv, parseProcCmdline } from "./gateway-process-argv.js";
+import { isGatewayArgv, parseProcCmdline, parseWindowsCmdline } from "./gateway-process-argv.js";
 
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_POLL_INTERVAL_MS = 100;
@@ -45,6 +46,8 @@ export type GatewayLockOptions = {
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
   lockDir?: string;
+  /** Override process command-line reader (testing seam). */
+  readProcessCmdline?: (pid: number) => string[] | null;
 };
 
 export class GatewayLockError extends Error {
@@ -63,6 +66,50 @@ function readLinuxCmdline(pid: number): string[] | null {
   try {
     const raw = fsSync.readFileSync(`/proc/${pid}/cmdline`, "utf8");
     return parseProcCmdline(raw);
+  } catch {
+    return null;
+  }
+}
+
+const CMDLINE_EXEC_TIMEOUT_MS = 3000;
+
+/**
+ * Read the command line of a Windows process via `wmic`.
+ * Returns an argv-style array, or null when the lookup fails (process gone,
+ * `wmic` missing/deprecated, timeout, etc.).
+ */
+function readWindowsCmdline(pid: number): string[] | null {
+  try {
+    const raw = execFileSync(
+      "wmic",
+      ["process", "where", `processid=${pid}`, "get", "CommandLine", "/value"],
+      { encoding: "utf8", timeout: CMDLINE_EXEC_TIMEOUT_MS, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const match = raw.match(/CommandLine=(.+)/);
+    if (!match) {
+      return null;
+    }
+    return parseWindowsCmdline(match[1].trim());
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the command line of a macOS/BSD process via `ps`.
+ */
+function readDarwinCmdline(pid: number): string[] | null {
+  try {
+    const raw = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+      encoding: "utf8",
+      timeout: CMDLINE_EXEC_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const line = raw.trim();
+    if (!line) {
+      return null;
+    }
+    return line.split(/\s+/).filter(Boolean);
   } catch {
     return null;
   }
@@ -112,11 +159,25 @@ async function checkPortFree(port: number, host = "127.0.0.1"): Promise<boolean>
   });
 }
 
+function defaultReadProcessCmdline(pid: number, platform: NodeJS.Platform): string[] | null {
+  if (platform === "linux") {
+    return readLinuxCmdline(pid);
+  }
+  if (platform === "win32") {
+    return readWindowsCmdline(pid);
+  }
+  if (platform === "darwin") {
+    return readDarwinCmdline(pid);
+  }
+  return null;
+}
+
 async function resolveGatewayOwnerStatus(
   pid: number,
   payload: LockPayload | null,
   platform: NodeJS.Platform,
   port: number | undefined,
+  readCmdline?: (pid: number) => string[] | null,
 ): Promise<LockOwnerStatus> {
   if (port != null) {
     const portFree = await checkPortFree(port);
@@ -128,22 +189,28 @@ async function resolveGatewayOwnerStatus(
   if (!isPidAlive(pid)) {
     return "dead";
   }
-  if (platform !== "linux") {
-    return "alive";
-  }
 
-  const payloadStartTime = payload?.startTime;
-  if (Number.isFinite(payloadStartTime)) {
-    const currentStartTime = readLinuxStartTime(pid);
-    if (currentStartTime == null) {
-      return "unknown";
+  // On Linux, an extra start-time comparison catches PID recycling even when
+  // the replacement process also looks like a gateway (same argv shape).
+  if (platform === "linux") {
+    const payloadStartTime = payload?.startTime;
+    if (Number.isFinite(payloadStartTime)) {
+      const currentStartTime = readLinuxStartTime(pid);
+      if (currentStartTime == null) {
+        return "unknown";
+      }
+      return currentStartTime === payloadStartTime ? "alive" : "dead";
     }
-    return currentStartTime === payloadStartTime ? "alive" : "dead";
   }
 
-  const args = readLinuxCmdline(pid);
+  const readFn = readCmdline ?? ((p: number) => defaultReadProcessCmdline(p, platform));
+  const args = readFn(pid);
   if (!args) {
-    return "unknown";
+    // No cmdline reader available or it failed — fall back to "unknown" so
+    // the stale-lock heuristic can still reclaim very old locks.
+    return platform === "linux" || platform === "win32" || platform === "darwin"
+      ? "unknown"
+      : "alive";
   }
   return isGatewayArgv(args) ? "alive" : "dead";
 }
@@ -221,7 +288,7 @@ export async function acquireGatewayLock(
       lastPayload = await readLockPayload(lockPath);
       const ownerPid = lastPayload?.pid;
       const ownerStatus = ownerPid
-        ? await resolveGatewayOwnerStatus(ownerPid, lastPayload, platform, port)
+        ? await resolveGatewayOwnerStatus(ownerPid, lastPayload, platform, port, opts.readProcessCmdline)
         : "unknown";
       if (ownerStatus === "dead" && ownerPid) {
         await fs.rm(lockPath, { force: true });

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -71,7 +71,7 @@ function readLinuxCmdline(pid: number): string[] | null {
   }
 }
 
-const CMDLINE_EXEC_TIMEOUT_MS = 3000;
+const CMDLINE_EXEC_TIMEOUT_MS = 1000;
 
 /**
  * Read the command line of a Windows process via `wmic`.
@@ -80,11 +80,17 @@ const CMDLINE_EXEC_TIMEOUT_MS = 3000;
  */
 function readWindowsCmdline(pid: number): string[] | null {
   try {
-    const raw = execFileSync(
+    // Omit `encoding` so execFileSync returns a Buffer — wmic emits UTF-16LE
+    // (with BOM) on most Windows 10/11 builds, which would be garbled as UTF-8.
+    const buf = execFileSync(
       "wmic",
       ["process", "where", `processid=${pid}`, "get", "CommandLine", "/value"],
-      { encoding: "utf8", timeout: CMDLINE_EXEC_TIMEOUT_MS, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] },
-    );
+      { timeout: CMDLINE_EXEC_TIMEOUT_MS, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] },
+    ) as Buffer;
+    const raw =
+      buf.length >= 2 && buf[0] === 0xff && buf[1] === 0xfe
+        ? buf.toString("utf16le")
+        : buf.toString("utf8");
     const match = raw.match(/CommandLine=(.+)/);
     if (!match) {
       return null;
@@ -97,6 +103,11 @@ function readWindowsCmdline(pid: number): string[] | null {
 
 /**
  * Read the command line of a macOS/BSD process via `ps`.
+ *
+ * `ps -o command=` outputs an unquoted flat string, so the naive whitespace
+ * split will misparse paths containing spaces. This is acceptable because
+ * standard macOS install paths do not contain spaces, and when the split
+ * does fail the caller falls back to "alive" (conservative).
  */
 function readDarwinCmdline(pid: number): string[] | null {
   try {
@@ -206,11 +217,11 @@ async function resolveGatewayOwnerStatus(
   const readFn = readCmdline ?? ((p: number) => defaultReadProcessCmdline(p, platform));
   const args = readFn(pid);
   if (!args) {
-    // No cmdline reader available or it failed — fall back to "unknown" so
-    // the stale-lock heuristic can still reclaim very old locks.
-    return platform === "linux" || platform === "win32" || platform === "darwin"
-      ? "unknown"
-      : "alive";
+    // Cmdline reader unavailable or failed. On Linux legacy locks (no
+    // start-time), "unknown" lets the stale-lock heuristic eventually reclaim
+    // very old locks. On win32/darwin/other, conservatively assume "alive" to
+    // preserve single-instance guarantees when wmic/ps is unavailable.
+    return platform === "linux" ? "unknown" : "alive";
   }
   return isGatewayArgv(args) ? "alive" : "dead";
 }

--- a/src/infra/gateway-process-argv.test.ts
+++ b/src/infra/gateway-process-argv.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isGatewayArgv, parseProcCmdline } from "./gateway-process-argv.js";
+import { isGatewayArgv, parseProcCmdline, parseWindowsCmdline } from "./gateway-process-argv.js";
 
 describe("parseProcCmdline", () => {
   it("splits null-delimited argv and trims empty entries", () => {
@@ -14,6 +14,31 @@ describe("parseProcCmdline", () => {
   it("keeps non-delimited single arguments and drops whitespace-only entries", () => {
     expect(parseProcCmdline(" gateway ")).toEqual(["gateway"]);
     expect(parseProcCmdline(" \0\t\0 ")).toEqual([]);
+  });
+});
+
+describe("parseWindowsCmdline", () => {
+  it("splits unquoted tokens by whitespace", () => {
+    expect(parseWindowsCmdline("node.exe gateway run")).toEqual(["node.exe", "gateway", "run"]);
+  });
+
+  it("handles double-quoted paths with spaces", () => {
+    expect(
+      parseWindowsCmdline('"C:\\Program Files\\node.exe" "C:\\my app\\dist\\index.js" gateway run'),
+    ).toEqual(["C:\\Program Files\\node.exe", "C:\\my app\\dist\\index.js", "gateway", "run"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(parseWindowsCmdline("")).toEqual([]);
+    expect(parseWindowsCmdline("   ")).toEqual([]);
+  });
+
+  it("collapses consecutive spaces outside quotes", () => {
+    expect(parseWindowsCmdline("node.exe   gateway   run")).toEqual([
+      "node.exe",
+      "gateway",
+      "run",
+    ]);
   });
 });
 

--- a/src/infra/gateway-process-argv.ts
+++ b/src/infra/gateway-process-argv.ts
@@ -9,6 +9,32 @@ export function parseProcCmdline(raw: string): string[] {
     .filter(Boolean);
 }
 
+/**
+ * Parse a Windows command line string into argv-style tokens,
+ * handling double-quoted paths (e.g. `"C:\Program Files\node.exe" gateway run`).
+ */
+export function parseWindowsCmdline(raw: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let inQuote = false;
+  for (const char of raw) {
+    if (char === '"') {
+      inQuote = !inQuote;
+    } else if (char === " " && !inQuote) {
+      if (current) {
+        args.push(current);
+        current = "";
+      }
+    } else {
+      current += char;
+    }
+  }
+  if (current) {
+    args.push(current);
+  }
+  return args;
+}
+
 export function isGatewayArgv(args: string[], opts?: { allowGatewayBinary?: boolean }): boolean {
   const normalized = args.map(normalizeProcArg);
   if (!normalized.includes("gateway")) {


### PR DESCRIPTION
## Summary

On non-Linux platforms (Windows, macOS), `resolveGatewayOwnerStatus` previously returned `"alive"` for any live PID without verifying the process was actually a gateway instance. Because Windows recycles PIDs aggressively, a stale lock file whose PID was reassigned to an unrelated process (e.g. `chrome.exe`, `svchost.exe`) would block `openclaw gateway run` for the full 5-second lock timeout, producing a misleading "gateway already running" error even when no gateway was running.

### Root cause

When the gateway crashes or is killed without releasing its lock file (`%TEMP%\openclaw\gateway.<hash>.lock`), the lock persists with the old PID. On Linux, `resolveGatewayOwnerStatus` reads `/proc/<pid>/cmdline` and `/proc/<pid>/stat` to verify the owner process is actually a gateway. On Windows and macOS, there was no equivalent check -- if `process.kill(pid, 0)` succeeded (i.e. *any* process held that PID), the lock was treated as valid.

### Changes

- **`readWindowsCmdline(pid)`**: reads the process command line via `wmic process ... get CommandLine` (with a 3-second timeout and `windowsHide`). Falls back to `null` when `wmic` is unavailable or times out.
- **`readDarwinCmdline(pid)`**: reads the process command line via `ps -p <pid> -o command=`. Falls back to `null` on failure.
- **`parseWindowsCmdline(raw)`**: splits a Windows command line string respecting double-quoted paths (e.g. `"C:\Program Files\node.exe" gateway run`).
- **`resolveGatewayOwnerStatus`** now delegates to the platform-appropriate reader and feeds the result through `isGatewayArgv()`. Recycled PIDs that belong to non-gateway processes are detected as `"dead"` and the stale lock is removed immediately. When the lookup fails, the status falls back to `"unknown"` so the existing stale-lock heuristic can still reclaim old locks.
- **`readProcessCmdline` option** added to `GatewayLockOptions` as a testing seam.

### Reproduction (Windows)

1. Run `openclaw gateway run` then kill the process via Task Manager (lock file remains)
2. Wait for Windows to recycle the PID to another process
3. Run `openclaw gateway run` again -- previously waited 5 s then errored with "gateway already running (pid XXXXX)"
4. With this fix -- stale lock is detected and removed immediately

## Test plan

- [x] New unit tests for `parseWindowsCmdline` (quoted paths, empty input, multiple spaces)
- [x] New lock tests for win32: non-gateway cmdline clears lock, gateway cmdline keeps lock, null cmdline falls back to unknown
- [x] New lock tests for darwin: non-gateway cmdline clears lock, gateway cmdline keeps lock
- [x] Existing tests still pass (24/24)
