### PR TITLE
feat: Add errorPolicy support to WhatsApp channel

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -37751,6 +37751,31 @@
       "hasChildren": false
     },
     {
+      "path": "channels.whatsapp.accounts.*.errorCooldownMs",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.whatsapp.accounts.*.errorPolicy",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": [
+        "always",
+        "once",
+        "silent"
+      ],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.whatsapp.accounts.*.groupAllowFrom",
       "kind": "channel",
       "type": "array",
@@ -38459,6 +38484,31 @@
       "kind": "channel",
       "type": "boolean",
       "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.whatsapp.errorCooldownMs",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.whatsapp.errorPolicy",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": [
+        "always",
+        "once",
+        "silent"
+      ],
       "deprecated": false,
       "sensitive": false,
       "tags": [],

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5780}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5784}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3388,6 +3388,8 @@
 {"recordType":"path","path":"channels.whatsapp.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.errorCooldownMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.errorPolicy","kind":"channel","type":"string","required":false,"enumValues":["always","once","silent"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groupAllowFrom.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groupPolicy","kind":"channel","type":"string","required":true,"enumValues":["open","disabled","allowlist"],"defaultValue":"allowlist","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3454,6 +3456,8 @@
 {"recordType":"path","path":"channels.whatsapp.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.errorCooldownMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.errorPolicy","kind":"channel","type":"string","required":false,"enumValues":["always","once","silent"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groupAllowFrom.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.groupPolicy","kind":"channel","type":"string","required":true,"enumValues":["open","disabled","allowlist"],"defaultValue":"allowlist","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -34,6 +34,8 @@ export type ResolvedWhatsAppAccount = {
   reactionLevel?: WhatsAppAccountConfig["reactionLevel"];
   groups?: WhatsAppAccountConfig["groups"];
   debounceMs?: number;
+  errorPolicy?: "always" | "once" | "silent";
+  errorCooldownMs?: number;
 };
 
 export const DEFAULT_WHATSAPP_MEDIA_MAX_MB = 50;
@@ -147,6 +149,8 @@ export function resolveWhatsAppAccount(params: {
     reactionLevel: merged.reactionLevel,
     groups: merged.groups,
     debounceMs: merged.debounceMs,
+    errorPolicy: merged.errorPolicy,
+    errorCooldownMs: merged.errorCooldownMs,
   };
 }
 

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -405,6 +405,19 @@ export async function processMessage(params: {
   });
   trackBackgroundTask(params.backgroundTasks, metaTask);
 
+  // Resolve WhatsApp account config once for error policy checks in both deliver and onError callbacks.
+  const whatsAppAccountForErrorPolicy = resolveWhatsAppAccount({
+    cfg: params.cfg,
+    accountId: params.msg.accountId,
+  });
+  const errorPolicyResolved = resolveWhatsAppErrorPolicy({
+    accountConfig: whatsAppAccountForErrorPolicy,
+  });
+  const errorScopeKey = buildWhatsAppErrorScopeKey({
+    accountId: params.msg.accountId,
+    chatId: conversationId ?? params.msg.from,
+  });
+
   const { queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
     ctx: ctxPayload,
     cfg: params.cfg,
@@ -427,25 +440,15 @@ export async function processMessage(params: {
         }
         // Suppress error payloads based on errorPolicy config.
         if (payload.isError === true) {
-          const whatsAppAccount = resolveWhatsAppAccount({
-            cfg: params.cfg,
-            accountId: params.msg.accountId,
-          });
-          const errorPolicy = resolveWhatsAppErrorPolicy({
-            accountConfig: whatsAppAccount,
-          });
-          if (isSilentErrorPolicy(errorPolicy.policy)) {
+          if (isSilentErrorPolicy(errorPolicyResolved.policy)) {
             logVerbose("Suppressed error reply (errorPolicy: silent)");
             return;
           }
           if (
-            errorPolicy.policy === "once" &&
+            errorPolicyResolved.policy === "once" &&
             shouldSuppressWhatsAppError({
-              scopeKey: buildWhatsAppErrorScopeKey({
-                accountId: params.route.accountId,
-                chatId: conversationId ?? params.msg.from,
-              }),
-              cooldownMs: errorPolicy.cooldownMs,
+              scopeKey: errorScopeKey,
+              cooldownMs: errorPolicyResolved.cooldownMs,
               errorMessage: payload.text,
             })
           ) {
@@ -483,29 +486,8 @@ export async function processMessage(params: {
         }
       },
       onError: (err, info) => {
-        const whatsAppAccount = resolveWhatsAppAccount({
-          cfg: params.cfg,
-          accountId: params.msg.accountId,
-        });
-        const errorPolicy = resolveWhatsAppErrorPolicy({
-          accountConfig: whatsAppAccount,
-        });
-        if (isSilentErrorPolicy(errorPolicy.policy)) {
-          return;
-        }
-        if (
-          errorPolicy.policy === "once" &&
-          shouldSuppressWhatsAppError({
-            scopeKey: buildWhatsAppErrorScopeKey({
-              accountId: params.route.accountId,
-              chatId: conversationId ?? params.msg.from,
-            }),
-            cooldownMs: errorPolicy.cooldownMs,
-            errorMessage: String(err),
-          })
-        ) {
-          return;
-        }
+        // Always log delivery failures regardless of errorPolicy — suppressing logs
+        // would hide real send outages and make operational debugging much harder.
         const label =
           info.kind === "tool"
             ? "tool update"

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -7,8 +7,8 @@ import { formatInboundEnvelope } from "openclaw/plugin-sdk/channel-inbound";
 import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
 import { shouldComputeCommandAuthorized } from "openclaw/plugin-sdk/command-detection";
 import type { loadConfig } from "openclaw/plugin-sdk/config-runtime";
-import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { recordSessionMetaFromInbound } from "openclaw/plugin-sdk/config-runtime";
+import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import {
   buildHistoryContextFromEntries,
@@ -33,6 +33,12 @@ import {
 } from "openclaw/plugin-sdk/security-runtime";
 import { jidToE164, normalizeE164 } from "openclaw/plugin-sdk/text-runtime";
 import { resolveWhatsAppAccount } from "../../accounts.js";
+import {
+  buildWhatsAppErrorScopeKey,
+  isSilentErrorPolicy,
+  resolveWhatsAppErrorPolicy,
+  shouldSuppressWhatsAppError,
+} from "../../error-policy.js";
 import {
   getPrimaryIdentityId,
   getReplyContext,
@@ -419,6 +425,34 @@ export async function processMessage(params: {
           // web UI only; sending them here leaks chain-of-thought to end users.
           return;
         }
+        // Suppress error payloads based on errorPolicy config.
+        if (payload.isError === true) {
+          const whatsAppAccount = resolveWhatsAppAccount({
+            cfg: params.cfg,
+            accountId: params.msg.accountId,
+          });
+          const errorPolicy = resolveWhatsAppErrorPolicy({
+            accountConfig: whatsAppAccount,
+          });
+          if (isSilentErrorPolicy(errorPolicy.policy)) {
+            logVerbose("Suppressed error reply (errorPolicy: silent)");
+            return;
+          }
+          if (
+            errorPolicy.policy === "once" &&
+            shouldSuppressWhatsAppError({
+              scopeKey: buildWhatsAppErrorScopeKey({
+                accountId: params.route.accountId,
+                chatId: conversationId ?? params.msg.from,
+              }),
+              cooldownMs: errorPolicy.cooldownMs,
+              errorMessage: payload.text,
+            })
+          ) {
+            logVerbose("Suppressed error reply (errorPolicy: once, within cooldown)");
+            return;
+          }
+        }
         await deliverWebReply({
           replyResult: payload,
           msg: params.msg,
@@ -449,6 +483,29 @@ export async function processMessage(params: {
         }
       },
       onError: (err, info) => {
+        const whatsAppAccount = resolveWhatsAppAccount({
+          cfg: params.cfg,
+          accountId: params.msg.accountId,
+        });
+        const errorPolicy = resolveWhatsAppErrorPolicy({
+          accountConfig: whatsAppAccount,
+        });
+        if (isSilentErrorPolicy(errorPolicy.policy)) {
+          return;
+        }
+        if (
+          errorPolicy.policy === "once" &&
+          shouldSuppressWhatsAppError({
+            scopeKey: buildWhatsAppErrorScopeKey({
+              accountId: params.route.accountId,
+              chatId: conversationId ?? params.msg.from,
+            }),
+            cooldownMs: errorPolicy.cooldownMs,
+            errorMessage: String(err),
+          })
+        ) {
+          return;
+        }
         const label =
           info.kind === "tool"
             ? "tool update"

--- a/extensions/whatsapp/src/error-policy.test.ts
+++ b/extensions/whatsapp/src/error-policy.test.ts
@@ -68,7 +68,7 @@ describe("whatsapp error policy", () => {
     it("combines account and chat ids", () => {
       expect(
         buildWhatsAppErrorScopeKey({ accountId: "default", chatId: "+14801234567" }),
-      ).toBe("default:+14801234567");
+      ).toBe("default\x00+14801234567");
     });
   });
 

--- a/extensions/whatsapp/src/error-policy.test.ts
+++ b/extensions/whatsapp/src/error-policy.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildWhatsAppErrorScopeKey,
+  isSilentErrorPolicy,
+  resolveWhatsAppErrorPolicy,
+  resetWhatsAppErrorPolicyStoreForTest,
+  shouldSuppressWhatsAppError,
+} from "./error-policy.js";
+
+describe("whatsapp error policy", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    resetWhatsAppErrorPolicyStoreForTest();
+  });
+
+  afterEach(() => {
+    resetWhatsAppErrorPolicyStoreForTest();
+    vi.useRealTimers();
+  });
+
+  describe("resolveWhatsAppErrorPolicy", () => {
+    it("defaults to always with standard cooldown when no config provided", () => {
+      expect(resolveWhatsAppErrorPolicy({})).toEqual({
+        policy: "always",
+        cooldownMs: 14400000,
+      });
+    });
+
+    it("resolves policy and cooldown from account config", () => {
+      expect(
+        resolveWhatsAppErrorPolicy({
+          accountConfig: { errorPolicy: "once", errorCooldownMs: 5000 },
+        }),
+      ).toEqual({
+        policy: "once",
+        cooldownMs: 5000,
+      });
+    });
+
+    it("resolves silent policy", () => {
+      expect(
+        resolveWhatsAppErrorPolicy({
+          accountConfig: { errorPolicy: "silent" },
+        }),
+      ).toEqual({
+        policy: "silent",
+        cooldownMs: 14400000,
+      });
+    });
+  });
+
+  describe("isSilentErrorPolicy", () => {
+    it("returns true for silent", () => {
+      expect(isSilentErrorPolicy("silent")).toBe(true);
+    });
+
+    it("returns false for always", () => {
+      expect(isSilentErrorPolicy("always")).toBe(false);
+    });
+
+    it("returns false for once", () => {
+      expect(isSilentErrorPolicy("once")).toBe(false);
+    });
+  });
+
+  describe("buildWhatsAppErrorScopeKey", () => {
+    it("combines account and chat ids", () => {
+      expect(
+        buildWhatsAppErrorScopeKey({ accountId: "default", chatId: "+14801234567" }),
+      ).toBe("default:+14801234567");
+    });
+  });
+
+  describe("shouldSuppressWhatsAppError", () => {
+    it("does not suppress the first occurrence of an error", () => {
+      const scopeKey = buildWhatsAppErrorScopeKey({
+        accountId: "default",
+        chatId: "+14801234567",
+      });
+
+      expect(
+        shouldSuppressWhatsAppError({
+          scopeKey,
+          cooldownMs: 1000,
+          errorMessage: "429",
+        }),
+      ).toBe(false);
+    });
+
+    it("suppresses repeated matching errors within cooldown", () => {
+      const scopeKey = buildWhatsAppErrorScopeKey({
+        accountId: "default",
+        chatId: "+14801234567",
+      });
+
+      expect(
+        shouldSuppressWhatsAppError({
+          scopeKey,
+          cooldownMs: 1000,
+          errorMessage: "429",
+        }),
+      ).toBe(false);
+      expect(
+        shouldSuppressWhatsAppError({
+          scopeKey,
+          cooldownMs: 1000,
+          errorMessage: "429",
+        }),
+      ).toBe(true);
+    });
+
+    it("does not suppress different error messages", () => {
+      const scopeKey = buildWhatsAppErrorScopeKey({
+        accountId: "default",
+        chatId: "+14801234567",
+      });
+
+      expect(
+        shouldSuppressWhatsAppError({
+          scopeKey,
+          cooldownMs: 1000,
+          errorMessage: "429",
+        }),
+      ).toBe(false);
+      expect(
+        shouldSuppressWhatsAppError({
+          scopeKey,
+          cooldownMs: 1000,
+          errorMessage: "500",
+        }),
+      ).toBe(false);
+    });
+
+    it("allows errors again after cooldown expires", () => {
+      const scopeKey = buildWhatsAppErrorScopeKey({
+        accountId: "default",
+        chatId: "+14801234567",
+      });
+
+      expect(
+        shouldSuppressWhatsAppError({
+          scopeKey,
+          cooldownMs: 1000,
+          errorMessage: "429",
+        }),
+      ).toBe(false);
+      vi.advanceTimersByTime(1001);
+      expect(
+        shouldSuppressWhatsAppError({
+          scopeKey,
+          cooldownMs: 1000,
+          errorMessage: "429",
+        }),
+      ).toBe(false);
+    });
+
+    it("does not leak suppression across accounts", () => {
+      const scope1 = buildWhatsAppErrorScopeKey({
+        accountId: "work",
+        chatId: "+14801234567",
+      });
+      const scope2 = buildWhatsAppErrorScopeKey({
+        accountId: "personal",
+        chatId: "+14801234567",
+      });
+
+      expect(
+        shouldSuppressWhatsAppError({
+          scopeKey: scope1,
+          cooldownMs: 1000,
+          errorMessage: "429",
+        }),
+      ).toBe(false);
+      expect(
+        shouldSuppressWhatsAppError({
+          scopeKey: scope2,
+          cooldownMs: 1000,
+          errorMessage: "429",
+        }),
+      ).toBe(false);
+    });
+
+    it("does not leak suppression across chats", () => {
+      const scope1 = buildWhatsAppErrorScopeKey({
+        accountId: "default",
+        chatId: "+14801234567",
+      });
+      const scope2 = buildWhatsAppErrorScopeKey({
+        accountId: "default",
+        chatId: "+14809876543",
+      });
+
+      expect(
+        shouldSuppressWhatsAppError({
+          scopeKey: scope1,
+          cooldownMs: 1000,
+          errorMessage: "429",
+        }),
+      ).toBe(false);
+      expect(
+        shouldSuppressWhatsAppError({
+          scopeKey: scope2,
+          cooldownMs: 1000,
+          errorMessage: "429",
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/extensions/whatsapp/src/error-policy.ts
+++ b/extensions/whatsapp/src/error-policy.ts
@@ -1,0 +1,76 @@
+import type { WhatsAppAccountConfig } from "./runtime-api.js";
+
+export type WhatsAppErrorPolicy = "always" | "once" | "silent";
+
+const errorCooldownStore = new Map<string, Map<string, number>>();
+const DEFAULT_ERROR_COOLDOWN_MS = 14400000;
+
+function pruneExpiredCooldowns(messageStore: Map<string, number>, now: number) {
+  for (const [message, expiresAt] of messageStore) {
+    if (expiresAt <= now) {
+      messageStore.delete(message);
+    }
+  }
+}
+
+export function resolveWhatsAppErrorPolicy(params: { accountConfig?: WhatsAppAccountConfig }): {
+  policy: WhatsAppErrorPolicy;
+  cooldownMs: number;
+} {
+  const policy: WhatsAppErrorPolicy = params.accountConfig?.errorPolicy ?? "always";
+  const cooldownMs =
+    typeof params.accountConfig?.errorCooldownMs === "number"
+      ? params.accountConfig.errorCooldownMs
+      : DEFAULT_ERROR_COOLDOWN_MS;
+
+  return { policy, cooldownMs };
+}
+
+export function buildWhatsAppErrorScopeKey(params: { accountId: string; chatId: string }): string {
+  return `${params.accountId}:${params.chatId}`;
+}
+
+export function shouldSuppressWhatsAppError(params: {
+  scopeKey: string;
+  cooldownMs: number;
+  errorMessage?: string;
+}): boolean {
+  const { scopeKey, cooldownMs, errorMessage } = params;
+  const now = Date.now();
+  const messageKey = errorMessage ?? "";
+  const scopeStore = errorCooldownStore.get(scopeKey);
+
+  if (scopeStore) {
+    pruneExpiredCooldowns(scopeStore, now);
+    if (scopeStore.size === 0) {
+      errorCooldownStore.delete(scopeKey);
+    }
+  }
+
+  if (errorCooldownStore.size > 100) {
+    for (const [scope, messageStore] of errorCooldownStore) {
+      pruneExpiredCooldowns(messageStore, now);
+      if (messageStore.size === 0) {
+        errorCooldownStore.delete(scope);
+      }
+    }
+  }
+
+  const expiresAt = scopeStore?.get(messageKey);
+  if (typeof expiresAt === "number" && expiresAt > now) {
+    return true;
+  }
+
+  const nextScopeStore = scopeStore ?? new Map<string, number>();
+  nextScopeStore.set(messageKey, now + cooldownMs);
+  errorCooldownStore.set(scopeKey, nextScopeStore);
+  return false;
+}
+
+export function isSilentErrorPolicy(policy: WhatsAppErrorPolicy): boolean {
+  return policy === "silent";
+}
+
+export function resetWhatsAppErrorPolicyStoreForTest() {
+  errorCooldownStore.clear();
+}

--- a/extensions/whatsapp/src/error-policy.ts
+++ b/extensions/whatsapp/src/error-policy.ts
@@ -27,7 +27,7 @@ export function resolveWhatsAppErrorPolicy(params: { accountConfig?: WhatsAppAcc
 }
 
 export function buildWhatsAppErrorScopeKey(params: { accountId: string; chatId: string }): string {
-  return `${params.accountId}:${params.chatId}`;
+  return `${params.accountId}\x00${params.chatId}`;
 }
 
 export function shouldSuppressWhatsAppError(params: {

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -14354,6 +14354,15 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           minimum: 0,
           maximum: 9007199254740991,
         },
+        errorPolicy: {
+          type: "string",
+          enum: ["always", "once", "silent"],
+        },
+        errorCooldownMs: {
+          type: "integer",
+          minimum: 0,
+          maximum: 9007199254740991,
+        },
         heartbeat: {
           type: "object",
           properties: {
@@ -14599,6 +14608,15 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               debounceMs: {
                 default: 0,
+                type: "integer",
+                minimum: 0,
+                maximum: 9007199254740991,
+              },
+              errorPolicy: {
+                type: "string",
+                enum: ["always", "once", "silent"],
+              },
+              errorCooldownMs: {
                 type: "integer",
                 minimum: 0,
                 maximum: 9007199254740991,

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -90,6 +90,10 @@ type WhatsAppSharedConfig = {
   reactionLevel?: WhatsAppReactionLevel;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
   debounceMs?: number;
+  /** Controls outbound error reporting: always, once per cooldown window, or silent. Default: "always". */
+  errorPolicy?: "always" | "once" | "silent";
+  /** Cooldown window for `errorPolicy: "once"` in milliseconds. */
+  errorCooldownMs?: number;
   /** Heartbeat visibility settings. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Channel health monitor overrides for this channel/account. */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -59,6 +59,8 @@ const WhatsAppSharedSchema = z.object({
   ackReaction: WhatsAppAckReactionSchema,
   reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
   debounceMs: z.number().int().nonnegative().optional().default(0),
+  errorPolicy: z.enum(["always", "once", "silent"]).optional(),
+  errorCooldownMs: z.number().int().nonnegative().optional(),
   heartbeat: ChannelHeartbeatVisibilitySchema,
   healthMonitor: ChannelHealthMonitorSchema,
 });


### PR DESCRIPTION
## Summary

Adds errorPolicy configuration support to WhatsApp channels, matching the existing functionality available in Telegram channels.

## Changes

- **Config schema**: Add errorPolicy (always|once|silent) and errorCooldownMs to WhatsApp channel config
- **Runtime implementation**: Wire up error suppression logic in WhatsApp auto-reply monitor
- **Error handling**: Implements proper cooldown tracking for once policy, complete silence for silent policy
- **Tests**: Full unit test suite for error policy resolution, suppression, and scope isolation
- **Backward compatibility**: Default behavior unchanged (errorPolicy: always)

## Motivation

WhatsApp channels currently have no way to suppress repetitive error messages during rate limits or other transient failures. Users can now configure:

- errorPolicy: silent - suppress all error replies
- errorPolicy: once - show error once per cooldown window (default 4hrs)
- errorPolicy: always - current behavior (default)

## Testing

Full unit test suite added (extensions/whatsapp/src/error-policy.test.ts) covering:
- Default policy resolution
- Config-driven policy and cooldown
- Silent policy helper
- Scope key generation
- Suppression within cooldown windows
- Cooldown expiry
- Cross-account and cross-chat isolation