### PR TITLE
fix(discord): record history entry when dropping bot message in allowBots=mentions mode

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -18,6 +18,7 @@ import {
   __testing as sessionBindingTesting,
   registerSessionBindingAdapter,
 } from "openclaw/plugin-sdk/conversation-runtime";
+import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import {
   createDiscordMessage,
   createDiscordPreflightArgs,
@@ -572,6 +573,49 @@ describe("preflightDiscordMessage", () => {
     const result = await runMentionOnlyBotPreflight({ channelId, guildId, message });
 
     expect(result).toBeNull();
+  });
+
+  it("records history when dropping bot message without mention (allowBots=mentions)", async () => {
+    const channelId = "channel-bot-hist";
+    const guildId = "guild-bot-hist";
+    const message = createDiscordMessage({
+      id: "m-bot-hist",
+      channelId,
+      content: "relay chatter",
+      author: {
+        id: "relay-bot-1",
+        bot: true,
+        username: "Relay",
+      },
+    });
+
+    const guildHistories = new Map<string, HistoryEntry[]>();
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg: DEFAULT_PREFLIGHT_CFG,
+        discordConfig: { allowBots: "mentions" } as DiscordConfig,
+        data: createGuildEvent({
+          channelId,
+          guildId,
+          author: message.author,
+          message,
+        }),
+        client: createGuildTextClient(channelId),
+      }),
+      guildHistories,
+      historyLimit: 50,
+    });
+
+    expect(result).toBeNull();
+    const channelHistory = guildHistories.get(channelId);
+    expect(channelHistory).toBeDefined();
+    expect(channelHistory).toHaveLength(1);
+    expect(channelHistory?.[0]).toEqual(
+      expect.objectContaining({
+        messageId: "m-bot-hist",
+        body: "relay chatter",
+      }),
+    );
   });
 
   it("allows bot messages with explicit mention when allowBots=mentions", async () => {

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -998,6 +998,12 @@ export async function preflightDiscordMessage(
     if (!botMentioned) {
       logDebug(`[discord-preflight] drop: bot message missing mention (allowBots=mentions)`);
       logVerbose("discord: drop bot message (allowBots=mentions, missing mention)");
+      recordPendingHistoryEntryIfEnabled({
+        historyMap: params.guildHistories,
+        historyKey: messageChannelId,
+        limit: params.historyLimit,
+        entry: historyEntry ?? null,
+      });
       return null;
     }
   }


### PR DESCRIPTION
## Summary

- **Problem:** When `allowBots=mentions` is configured on a Discord account, bot messages that are dropped (no mention) skip `recordPendingHistoryEntryIfEnabled()`, causing gaps in guild channel history. Other bots in the same channel lose context about dropped messages.
- **Why it matters:** In multi-bot setups, history continuity is critical for context-aware responses. Missing history entries cause bots to "forget" recent bot messages in the channel.
- **What changed:** Added `recordPendingHistoryEntryIfEnabled()` call in the `allowBots=mentions` drop path before `return null`, matching the pattern already used in the `requireMention` drop path.
- **What did NOT change:** No logic change to when messages are dropped; only ensures history is recorded before dropping.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The `allowBots=mentions` drop path was added without the `recordPendingHistoryEntryIfEnabled()` call that other drop paths already have.
- Missing detection / guardrail: No test for history recording in the `allowBots=mentions` drop path.
- Prior context: The `requireMention` drop path at line ~900 already records history before returning null.
- Why this regressed now: The `allowBots` feature was added after the history recording pattern was established.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/discord/src/monitor/message-handler.preflight.test.ts`
- Scenario the test should lock in: When a bot message is dropped due to missing mention in `allowBots=mentions` mode, the guild history map should still contain the dropped message entry.
- Why this is the smallest reliable guardrail: Unit test directly verifies the history map state after the drop.
- Existing test that already covers this: None previously; added in this PR.

## User-visible / Behavior Changes

In multi-bot Discord setups with `allowBots=mentions`, bot messages that are not directly mentioned are now properly recorded in channel history, improving context continuity for other bots.

## Diagram (if applicable)

```text
Before:
[bot message, no @mention] -> drop (history NOT recorded) -> other bots lose context

After:
[bot message, no @mention] -> record history -> drop -> other bots retain context
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: Discord (multi-bot gateway, 6 bots)

### Steps

1. Configure 2+ Discord bot accounts with `allowBots: "mentions"`
2. Bot A sends a message in a shared channel without @mentioning Bot B
3. Bot B drops the message (correct behavior)
4. Check Bot B's guild history for the channel

### Expected

Bot B's guild history contains Bot A's dropped message.

### Actual

Before fix: history entry missing. After fix: history entry recorded.

## Evidence

- [x] Failing test/log before + passing after
- Test: `pnpm test -- extensions/discord/src/monitor/message-handler.preflight.test.ts` — "records history when dropping bot message without mention (allowBots=mentions)" passes.

## Human Verification (required)

- Verified scenarios: Bot message drop with history recording, bot message with mention (still passes through)
- Edge cases checked: PluralKit bots (exempt from allowBots gate), DM messages (no history recording needed)
- What you did **not** verify: History playback in actual LLM responses across bots
