### PR TITLE
fix(tui): preserve fallback display after error events

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -403,6 +403,79 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(state.activeChatRunId).toBe("run-active");
   });
 
+  it("displays fallback output after a chat error event", () => {
+    const { state, chatLog, setActivityStatus, loadHistory, handleChatEvent } =
+      createHandlersHarness({
+        state: { activeChatRunId: null },
+      });
+
+    handleChatEvent({
+      runId: "run-fallback",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "partial from primary" },
+    });
+    expect(state.activeChatRunId).toBe("run-fallback");
+
+    handleChatEvent({
+      runId: "run-fallback",
+      sessionKey: state.currentSessionKey,
+      state: "error",
+      errorMessage: "API rate limit reached",
+    });
+    expect(chatLog.addSystem).toHaveBeenCalledWith("run error: API rate limit reached");
+    expect(state.activeChatRunId).toBeNull();
+    expect(loadHistory).not.toHaveBeenCalled();
+
+    chatLog.updateAssistant.mockClear();
+    setActivityStatus.mockClear();
+
+    handleChatEvent({
+      runId: "run-fallback",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "response from fallback model" },
+    });
+    expect(state.activeChatRunId).toBe("run-fallback");
+    expect(chatLog.updateAssistant).toHaveBeenCalledWith(
+      "response from fallback model",
+      "run-fallback",
+    );
+    expect(setActivityStatus).toHaveBeenCalledWith("streaming");
+
+    handleChatEvent({
+      runId: "run-fallback",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "complete fallback response" }] },
+    });
+    expect(chatLog.finalizeAssistant).toHaveBeenCalled();
+  });
+
+  it("does not reload history when error event fires for a local run", () => {
+    const ctx = makeContext(makeState({ activeChatRunId: null }));
+    ctx.noteLocalRunId("run-local-err");
+    const handlers = createEventHandlers({
+      chatLog: ctx.chatLog,
+      tui: ctx.tui,
+      state: ctx.state,
+      setActivityStatus: ctx.setActivityStatus,
+      loadHistory: ctx.loadHistory,
+      isLocalRunId: ctx.isLocalRunId,
+      forgetLocalRunId: ctx.forgetLocalRunId,
+    });
+
+    handlers.handleChatEvent({
+      runId: "run-local-err",
+      sessionKey: ctx.state.currentSessionKey,
+      state: "error",
+      errorMessage: "timeout",
+    });
+
+    expect(ctx.loadHistory).not.toHaveBeenCalled();
+    expect(ctx.isLocalRunId("run-local-err")).toBe(true);
+  });
+
   it("drops streaming assistant when chat final has no message", () => {
     const { state, chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -225,8 +225,17 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.state === "error") {
       const wasActiveRun = state.activeChatRunId === evt.runId;
       chatLog.addSystem(`run error: ${evt.errorMessage ?? "unknown"}`);
-      terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
-      maybeRefreshHistoryForRun(evt.runId);
+      // Soft-terminate: clear stale stream state and active-run claim, but
+      // keep the runId in sessionRuns and skip the history refresh. The
+      // gateway may retry the same runId with a fallback model; a full
+      // terminateRun + maybeRefreshHistoryForRun would drop the stream
+      // assembler, forget the local-run flag, and trigger loadHistory,
+      // preventing fallback delta/final events from displaying.
+      streamAssembler.drop(evt.runId);
+      clearActiveRunIfMatch(evt.runId);
+      if (wasActiveRun) {
+        setActivityStatus("error");
+      }
     }
     tui.requestRender();
   };


### PR DESCRIPTION
## Summary

- **Fix:** TUI/webchat stops displaying output after a model fallback error event, even when the fallback succeeds in the background (fixes #59570)
- **Root cause:** The `handleChatEvent` error handler called `terminateRun()` + `maybeRefreshHistoryForRun()` which dropped stream assembler state, forgot the local-run flag, and triggered a disruptive `loadHistory()` call -- preventing fallback delta/final events from rendering
- **Change:** Soft-terminate on error events: drop stale stream assembler state and clear the active-run claim so fallback or new-run events can re-activate the run, but keep the runId in `sessionRuns` and skip the history refresh

## Detailed Analysis

When the gateway retries a model request via `runWithModelFallback`, it reuses the same `runId`. The embedded Pi runner emits a lifecycle `"error"` event when the primary model fails (e.g., 429 rate limit), which the gateway broadcasts as a `state: "error"` chat event to the TUI.

Previously, the TUI error handler:
1. Called `terminateRun()` which dropped stream assembler state, removed the runId from `sessionRuns`, and cleared `activeChatRunId`
2. Called `maybeRefreshHistoryForRun()` which called `forgetLocalRunId()` (breaking local-run tracking) and triggered `loadHistory()` (replacing the chat display with error-state history)

When the fallback model succeeded and emitted new delta/final events with the same runId, the display flow was disrupted.

Now the error handler:
1. Drops stream assembler state (the primary attempt partial text is irrelevant to the fallback)
2. Clears `activeChatRunId` (so fallback events can claim it)
3. Keeps the runId in `sessionRuns` (preserving agent event routing)
4. Skips `maybeRefreshHistoryForRun` (no disruptive history reload, no local-run flag loss)

## Test Plan

- [x] New test: "displays fallback output after a chat error event" -- verifies error then delta then final sequence renders correctly
- [x] New test: "does not reload history when error event fires for a local run" -- verifies local-run flag is preserved and history is not triggered
- [x] All 17 TUI test files pass (159 tests)
- [x] `pnpm check` passes

---

[Joel Nishanth](https://offlyn.ai) | [offlyn.AI](https://offlyn.ai)
