### PR TITLE
fix(hooks): harden before_tool_call hook runner to fail-closed on error [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(hooks): harden before_tool_call hook runner to fail-closed on error [AI]. (#59822) Thanks @pgondhi987.
 - Skills/uv install: block workspace `.env` from overriding `UV_PYTHON` and strip related interpreter override keys from uv skill-install subprocesses so repository-controlled env files cannot steer the selected Python runtime. (#59178) Thanks @pgondhi987.
 - Telegram/reactions: preserve `reactionNotifications: "own"` across gateway restarts by persisting sent-message ownership state instead of treating cold cache as a permissive fallback. (#59207) Thanks @samzong.
 - Gateway/startup: detect PID recycling in gateway lock files on Windows and macOS, and add startup progress so stale lock conflicts no longer block healthy restarts. (#59843) Thanks @TonyDerek-dot.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- fix(hooks): harden before_tool_call hook runner to fail-closed on error [AI]. (#59822) Thanks @pgondhi987.
 - Skills/uv install: block workspace `.env` from overriding `UV_PYTHON` and strip related interpreter override keys from uv skill-install subprocesses so repository-controlled env files cannot steer the selected Python runtime. (#59178) Thanks @pgondhi987.
 - Telegram/reactions: preserve `reactionNotifications: "own"` across gateway restarts by persisting sent-message ownership state instead of treating cold cache as a permissive fallback. (#59207) Thanks @samzong.
 - Gateway/startup: detect PID recycling in gateway lock files on Windows and macOS, and add startup progress so stale lock conflicts no longer block healthy restarts. (#59843) Thanks @TonyDerek-dot.
@@ -95,6 +94,7 @@ Docs: https://docs.openclaw.ai
 - Agents/workspace: respect `agents.defaults.workspace` for non-default agents by resolving them under the configured base path instead of falling back to `workspace-<id>`. (#59858) Thanks @joelnishanth.
 - Config/All Settings: keep the raw config view intact when sensitive fields are blank instead of corrupting or dropping the snapshot during redaction. (#28214) thanks @solodmd.
 - Plugins/runtime: honor explicit capability allowlists during fallback speech, media-understanding, and image-generation provider loading so bundled capability plugins do not bypass restrictive `plugins.allow` config. (#52262) Thanks @PerfectPan.
+- Hooks/tool policy: block tool calls when a `before_tool_call` hook crashes so hook failures fail closed instead of silently allowing execution. (#59822) Thanks @pgondhi987.
 
 ## 2026.4.2
 

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -391,9 +391,6 @@ describe("before_tool_call requireApproval handling", () => {
   });
 
   it("blocks when before_tool_call hook execution throws", async () => {
-    const { callGatewayTool } = await import("./tools/gateway.js");
-    const mockCallGateway = vi.mocked(callGatewayTool);
-
     hookRunner.runBeforeToolCall.mockRejectedValueOnce(new Error("hook crashed"));
 
     const result = await runBeforeToolCallHook({
@@ -407,7 +404,6 @@ describe("before_tool_call requireApproval handling", () => {
       "reason",
       "Tool call blocked because before_tool_call hook failed",
     );
-    expect(mockCallGateway).not.toHaveBeenCalled();
   });
 
   it("calls gateway RPC and unblocks on allow-once", async () => {

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -390,6 +390,26 @@ describe("before_tool_call requireApproval handling", () => {
     expect(mockCallGateway).not.toHaveBeenCalled();
   });
 
+  it("blocks when before_tool_call hook execution throws", async () => {
+    const { callGatewayTool } = await import("./tools/gateway.js");
+    const mockCallGateway = vi.mocked(callGatewayTool);
+
+    hookRunner.runBeforeToolCall.mockRejectedValueOnce(new Error("hook crashed"));
+
+    const result = await runBeforeToolCallHook({
+      toolName: "bash",
+      params: { command: "ls" },
+      ctx: { agentId: "main", sessionKey: "main" },
+    });
+
+    expect(result.blocked).toBe(true);
+    expect(result).toHaveProperty(
+      "reason",
+      "Tool call blocked because before_tool_call hook failed",
+    );
+    expect(mockCallGateway).not.toHaveBeenCalled();
+  });
+
   it("calls gateway RPC and unblocks on allow-once", async () => {
     hookRunner.runBeforeToolCall.mockResolvedValue({
       requireApproval: {

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -167,7 +167,7 @@ describe("before_tool_call hook integration", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
-  it("continues execution when hook throws", async () => {
+  it("blocks tool execution when hook throws", async () => {
     beforeToolCallHook = installBeforeToolCallHook({
       runBeforeToolCallImpl: async () => {
         throw new Error("boom");
@@ -178,14 +178,10 @@ describe("before_tool_call hook integration", () => {
     const tool = wrapToolWithBeforeToolCallHook({ name: "read", execute } as any);
     const extensionContext = {} as Parameters<typeof tool.execute>[3];
 
-    await tool.execute("call-4", { path: "/tmp/file" }, undefined, extensionContext);
-
-    expect(execute).toHaveBeenCalledWith(
-      "call-4",
-      { path: "/tmp/file" },
-      undefined,
-      extensionContext,
-    );
+    await expect(
+      tool.execute("call-4", { path: "/tmp/file" }, undefined, extensionContext),
+    ).rejects.toThrow("Tool call blocked because before_tool_call hook failed");
+    expect(execute).not.toHaveBeenCalled();
   });
 
   it("normalizes non-object params for hook contract", async () => {

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -69,6 +69,13 @@ function isAbortSignalCancellation(err: unknown, signal?: AbortSignal): boolean 
   return false;
 }
 
+function unwrapErrorCause(err: unknown): unknown {
+  if (err instanceof Error && err.cause !== undefined) {
+    return err.cause;
+  }
+  return err;
+}
+
 function shouldEmitLoopWarning(state: SessionState, warningKey: string, count: number): boolean {
   if (!state.toolLoopWarningBuckets) {
     state.toolLoopWarningBuckets = new Map();
@@ -359,7 +366,8 @@ export async function runBeforeToolCallHook(args: {
     }
   } catch (err) {
     const toolCallId = args.toolCallId ? ` toolCallId=${args.toolCallId}` : "";
-    log.error(`before_tool_call hook failed: tool=${toolName}${toolCallId} error=${String(err)}`);
+    const cause = unwrapErrorCause(err);
+    log.error(`before_tool_call hook failed: tool=${toolName}${toolCallId} error=${String(cause)}`);
     return {
       blocked: true,
       reason: BEFORE_TOOL_CALL_HOOK_FAILURE_REASON,

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -24,6 +24,8 @@ type HookOutcome = { blocked: true; reason: string } | { blocked: false; params:
 
 const log = createSubsystemLogger("agents/tools");
 const BEFORE_TOOL_CALL_WRAPPED = Symbol("beforeToolCallWrapped");
+const BEFORE_TOOL_CALL_HOOK_FAILURE_REASON =
+  "Tool call blocked because before_tool_call hook failed";
 const adjustedParamsByToolCallId = new Map<string, unknown>();
 const MAX_TRACKED_ADJUSTED_PARAMS = 1024;
 const LOOP_WARNING_BUCKET_SIZE = 10;
@@ -357,7 +359,11 @@ export async function runBeforeToolCallHook(args: {
     }
   } catch (err) {
     const toolCallId = args.toolCallId ? ` toolCallId=${args.toolCallId}` : "";
-    log.warn(`before_tool_call hook failed: tool=${toolName}${toolCallId} error=${String(err)}`);
+    log.error(`before_tool_call hook failed: tool=${toolName}${toolCallId} error=${String(err)}`);
+    return {
+      blocked: true,
+      reason: BEFORE_TOOL_CALL_HOOK_FAILURE_REASON,
+    };
   }
 
   return { blocked: false, params };

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -40,6 +40,9 @@ export function initializeGlobalHookRunner(registry: PluginRegistry): void {
       error: (msg) => log.error(msg),
     },
     catchErrors: true,
+    failurePolicyByHook: {
+      before_tool_call: "fail-closed",
+    },
   });
 
   const hookCount = registry.hooks.length;

--- a/src/plugins/hooks.security.test.ts
+++ b/src/plugins/hooks.security.test.ts
@@ -163,6 +163,32 @@ describe("before_tool_call terminal block semantics", () => {
     expect(result?.block).toBe(true);
     expect(low).not.toHaveBeenCalled();
   });
+
+  it("throws for before_tool_call when configured as fail-closed", async () => {
+    addStaticTestHooks(registry, {
+      hookName: "before_tool_call",
+      hooks: [
+        {
+          pluginId: "failing",
+          result: {},
+          priority: 100,
+          handler: () => {
+            throw new Error("boom");
+          },
+        },
+      ],
+    });
+    const runner = createHookRunner(registry, {
+      catchErrors: true,
+      failurePolicyByHook: {
+        before_tool_call: "fail-closed",
+      },
+    });
+
+    await expect(runner.runBeforeToolCall(toolEvent, toolCtx)).rejects.toThrow(
+      "before_tool_call handler from failing failed: Error: boom",
+    );
+  });
 });
 
 describe("message_sending terminal cancel semantics", () => {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -124,10 +124,17 @@ export type HookRunnerLogger = {
   error: (message: string) => void;
 };
 
+export type HookFailurePolicy = "fail-open" | "fail-closed";
+
 export type HookRunnerOptions = {
   logger?: HookRunnerLogger;
   /** If true, errors in hooks will be caught and logged instead of thrown */
   catchErrors?: boolean;
+  /**
+   * Optional per-hook failure policy.
+   * Defaults to fail-open unless explicitly overridden for a hook name.
+   */
+  failurePolicyByHook?: Partial<Record<PluginHookName, HookFailurePolicy>>;
 };
 
 type ModifyingHookPolicy<K extends PluginHookName, TResult> = {
@@ -186,6 +193,10 @@ function getHooksForNameAndPlugin<K extends PluginHookName>(
 export function createHookRunner(registry: PluginRegistry, options: HookRunnerOptions = {}) {
   const logger = options.logger;
   const catchErrors = options.catchErrors ?? true;
+  const failurePolicyByHook = options.failurePolicyByHook ?? {};
+
+  const shouldCatchHookErrors = (hookName: PluginHookName): boolean =>
+    catchErrors && (failurePolicyByHook[hookName] ?? "fail-open") === "fail-open";
 
   const firstDefined = <T>(prev: T | undefined, next: T | undefined): T | undefined => prev ?? next;
   const lastDefined = <T>(prev: T | undefined, next: T | undefined): T | undefined => next ?? prev;
@@ -255,7 +266,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     const msg = `[hooks] ${params.hookName} handler from ${params.pluginId} failed: ${String(
       params.error,
     )}`;
-    if (catchErrors) {
+    if (shouldCatchHookErrors(params.hookName)) {
       logger?.error(msg);
       return;
     }
@@ -797,7 +808,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
           const msg =
             `[hooks] tool_result_persist handler from ${hook.pluginId} returned a Promise; ` +
             `this hook is synchronous and the result was ignored.`;
-          if (catchErrors) {
+          if (shouldCatchHookErrors("tool_result_persist")) {
             logger?.warn?.(msg);
             continue;
           }
@@ -810,7 +821,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
         }
       } catch (err) {
         const msg = `[hooks] tool_result_persist handler from ${hook.pluginId} failed: ${String(err)}`;
-        if (catchErrors) {
+        if (shouldCatchHookErrors("tool_result_persist")) {
           logger?.error(msg);
         } else {
           throw new Error(msg, { cause: err });
@@ -862,7 +873,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
           const msg =
             `[hooks] before_message_write handler from ${hook.pluginId} returned a Promise; ` +
             `this hook is synchronous and the result was ignored.`;
-          if (catchErrors) {
+          if (shouldCatchHookErrors("before_message_write")) {
             logger?.warn?.(msg);
             continue;
           }
@@ -882,7 +893,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
         }
       } catch (err) {
         const msg = `[hooks] before_message_write handler from ${hook.pluginId} failed: ${String(err)}`;
-        if (catchErrors) {
+        if (shouldCatchHookErrors("before_message_write")) {
           logger?.error(msg);
         } else {
           throw new Error(msg, { cause: err });


### PR DESCRIPTION
## Summary

- **Problem:** The global hook runner used `catchErrors: true` unconditionally, causing any exception thrown by a `before_tool_call` hook to be silently swallowed. An outer catch in `runBeforeToolCallHook` compounded this by returning `{ blocked: false }` on any error, guaranteeing fail-open behavior regardless of hook intent.
- **Why it matters:** Security-critical hooks (e.g. `before_tool_call`) must fail closed — if a hook throws, the tool call must be blocked, not permitted. Silent fail-open allows a crashing security hook to be fully bypassed with only a log-level error emitted.
- **What changed:** Introduced a per-hook `failurePolicyByHook` option (`"fail-open"` | `"fail-closed"`) on `HookRunnerOptions`; configured the global runner with `before_tool_call: "fail-closed"`; updated `runBeforeToolCallHook`'s catch block to return `{ blocked: true }` instead of falling through to `{ blocked: false }`; elevated log level from `warn` to `error`.
- **What did NOT change:** Failure policy for all other hooks defaults to `fail-open`, preserving existing behavior for non-security hooks (telemetry, logging, etc.).

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `catchErrors: true` was hardcoded in `initializeGlobalHookRunner` and applied uniformly to all hooks including security-critical ones. A second independent catch in `runBeforeToolCallHook` returned `{ blocked: false }` on any error, creating a two-layer fail-open guarantee.
- Missing detection / guardrail: No test asserted that a throwing `before_tool_call` hook resulted in a blocked tool call. The integration test for this scenario was explicitly titled "continues execution when hook throws" — asserting the wrong (fail-open) behavior.
- Prior context: `catchErrors` option was designed for resilience of non-critical hooks; its unconditional application to `before_tool_call` was an unintended side effect.
- Why this regressed now: The fail-open behavior was present since the hook runner was introduced; no security test locked in fail-closed semantics for this hook.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Seam / integration test
  - [x] End-to-end test
- Target test or file: `src/plugins/hooks.security.test.ts`, `src/agents/pi-tools.before-tool-call.integration.e2e.test.ts`, `src/agents/pi-tools.before-tool-call.e2e.test.ts`
- Scenario the test should lock in: A `before_tool_call` hook that throws must result in a blocked outcome; the wrapped tool must not be executed.
- Why this is the smallest reliable guardrail: The integration test exercises the full `wrapToolWithBeforeToolCallHook` path; the security test exercises the hook runner's `fail-closed` policy in isolation.
- Existing test that already covers this (if any): None — the existing test asserted the inverse (fail-open).
- If no new test is added, why not: N/A — tests are added.

## User-visible / Behavior Changes

If a `before_tool_call` plugin hook throws an unhandled exception, the tool call will now be **blocked** instead of proceeding silently. Operators will see an `error`-level log entry. This only affects hooks that crash; correctly-implemented hooks are unaffected.

## Diagram (if applicable)

```text
Before:
[before_tool_call hook throws] -> [error caught, logged] -> [tool call proceeds] ← fail-open bypass

After:
[before_tool_call hook throws] -> [error rethrown] -> [runBeforeToolCallHook catches] -> [blocked: true] -> [tool call blocked]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — tool calls that would previously proceed when a security hook crashed are now blocked.
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: This change *reduces* the execution surface; a crashing hook now blocks rather than permits. The only risk is a legitimate hook that throws due to a bug causing unexpected tool blocking — operators should ensure their security hooks handle errors internally if partial-block semantics are needed.

## Repro + Verification

### Environment

- OS: Linux (CI)
- Runtime/container: Node.js v22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Register a `before_tool_call` hook that throws unconditionally.
2. Attempt to invoke a tool that the hook is meant to block.
3. Before fix: tool executes, hook error logged at `warn` level.
4. After fix: tool is blocked, hook error logged at `error` level.

### Expected

- Tool call blocked with reason `"Tool call blocked because before_tool_call hook failed"`.

### Actual (after fix)

- Tool call is blocked as expected; `execute` is never called.

## Evidence

- [x] Failing test/log before + passing after

Updated integration test (`pi-tools.before-tool-call.integration.e2e.test.ts`) previously asserted `execute` was called when the hook threw; it now asserts the opposite. New test in `hooks.security.test.ts` and `pi-tools.before-tool-call.e2e.test.ts` lock in fail-closed semantics.

## Human Verification (required)

> This PR was generated by OpenAI Codex and reviewed by Claude (AI-assisted). No human has manually verified runtime behavior.

- Verified scenarios: Code review confirmed the two-layer fail-open was closed; test assertions match the new control flow.
- Edge cases checked: No-hook case (unaffected), non-`before_tool_call` hooks (policy defaults to `fail-open`, no behavior change), approval-required path (separate try/catch, unaffected).
- What you did **not** verify: Live gateway execution with a real crashing plugin hook.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — only fail behavior of crashing hooks changes; correctly-implemented hooks are unaffected.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: A plugin's `before_tool_call` hook that throws due to a non-security bug will now block tool calls it previously allowed through.
  - Mitigation: Plugin authors should handle internal errors within their hooks. The fail-closed default is the correct security posture; operators with misbehaving plugins should fix the hook, not rely on fail-open infrastructure.

---

> **AI-assisted:** This fix was generated by OpenAI Codex and reviewed by Claude. No human code modifications were made.