### PR TITLE
fix(control-ui): use catalog names in model picker

### DIFF
--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -13,6 +13,7 @@ export type ModelCatalogEntry = {
   id: string;
   name: string;
   provider: string;
+  alias?: string;
   contextWindow?: number;
   reasoning?: boolean;
   input?: ModelInputType[];

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -432,7 +432,102 @@ describe("model-selection", () => {
       expect(result.allowAny).toBe(false);
       expect(result.allowedKeys.has("anthropic/claude-sonnet-4-6")).toBe(true);
       expect(result.allowedCatalog).toEqual([
-        { provider: "anthropic", id: "claude-sonnet-4-6", name: "claude-sonnet-4-6" },
+        {
+          provider: "anthropic",
+          id: "claude-sonnet-4-6",
+          name: "claude-sonnet-4-6",
+          alias: "sonnet",
+        },
+      ]);
+    });
+
+    it("overlays configured provider metadata and alias onto matching catalog entries", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-test-z" },
+            models: {
+              "openai/gpt-test-z": { alias: "GPT Test Z Alias" },
+            },
+          },
+        },
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://openai.example.com",
+              models: [
+                {
+                  id: "gpt-test-z",
+                  name: "Configured GPT Test Z",
+                  contextWindow: 64_000,
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = buildAllowedModelSet({
+        cfg,
+        catalog: [{ provider: "openai", id: "gpt-test-z", name: "gpt-test-z" }],
+        defaultProvider: "anthropic",
+      });
+
+      expect(result.allowAny).toBe(false);
+      expect(result.allowedCatalog).toEqual([
+        {
+          provider: "openai",
+          id: "gpt-test-z",
+          name: "Configured GPT Test Z",
+          alias: "GPT Test Z Alias",
+          contextWindow: 64_000,
+        },
+      ]);
+    });
+
+    it("applies configured provider metadata and alias to synthetic allowlist entries", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "nvidia/moonshotai/kimi-k2.5" },
+            models: {
+              "nvidia/moonshotai/kimi-k2.5": { alias: "Kimi K2.5 (NVIDIA)" },
+            },
+          },
+        },
+        models: {
+          providers: {
+            nvidia: {
+              baseUrl: "https://nvidia.example.com",
+              models: [
+                {
+                  id: "moonshotai/kimi-k2.5",
+                  name: "Kimi K2.5 (Configured)",
+                  contextWindow: 32_000,
+                  reasoning: true,
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = buildAllowedModelSet({
+        cfg,
+        catalog: [],
+        defaultProvider: "anthropic",
+      });
+
+      expect(result.allowAny).toBe(false);
+      expect(result.allowedCatalog).toEqual([
+        {
+          provider: "nvidia",
+          id: "moonshotai/kimi-k2.5",
+          name: "Kimi K2.5 (Configured)",
+          alias: "Kimi K2.5 (NVIDIA)",
+          contextWindow: 32_000,
+          reasoning: true,
+        },
       ]);
     });
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -334,6 +334,84 @@ export function buildModelAliasIndex(params: {
   return { byAlias, byKey };
 }
 
+type ModelCatalogMetadata = {
+  configuredByKey: Map<string, ModelCatalogEntry>;
+  aliasByKey: Map<string, string>;
+};
+
+function buildModelCatalogMetadata(params: {
+  cfg: OpenClawConfig;
+  defaultProvider: string;
+}): ModelCatalogMetadata {
+  const configuredByKey = new Map<string, ModelCatalogEntry>();
+  for (const entry of buildConfiguredModelCatalog({ cfg: params.cfg })) {
+    configuredByKey.set(modelKey(entry.provider, entry.id), entry);
+  }
+
+  const aliasByKey = new Map<string, string>();
+  const configuredModels = params.cfg.agents?.defaults?.models ?? {};
+  for (const [rawKey, entryRaw] of Object.entries(configuredModels)) {
+    const key = resolveAllowlistModelKey(String(rawKey ?? ""), params.defaultProvider);
+    if (!key) {
+      continue;
+    }
+    const alias = String((entryRaw as { alias?: string } | undefined)?.alias ?? "").trim();
+    if (!alias) {
+      continue;
+    }
+    aliasByKey.set(key, alias);
+  }
+
+  return { configuredByKey, aliasByKey };
+}
+
+function applyModelCatalogMetadata(params: {
+  entry: ModelCatalogEntry;
+  metadata: ModelCatalogMetadata;
+}): ModelCatalogEntry {
+  const key = modelKey(params.entry.provider, params.entry.id);
+  const configuredEntry = params.metadata.configuredByKey.get(key);
+  const alias = params.metadata.aliasByKey.get(key);
+  if (!configuredEntry && !alias) {
+    return params.entry;
+  }
+  const nextAlias = alias ?? params.entry.alias;
+  const nextContextWindow = configuredEntry?.contextWindow ?? params.entry.contextWindow;
+  const nextReasoning = configuredEntry?.reasoning ?? params.entry.reasoning;
+  const nextInput = configuredEntry?.input ?? params.entry.input;
+
+  return {
+    ...params.entry,
+    name: configuredEntry?.name ?? params.entry.name,
+    ...(nextAlias ? { alias: nextAlias } : {}),
+    ...(nextContextWindow !== undefined ? { contextWindow: nextContextWindow } : {}),
+    ...(nextReasoning !== undefined ? { reasoning: nextReasoning } : {}),
+    ...(nextInput ? { input: nextInput } : {}),
+  };
+}
+
+function buildSyntheticAllowedCatalogEntry(params: {
+  parsed: ModelRef;
+  metadata: ModelCatalogMetadata;
+}): ModelCatalogEntry {
+  const key = modelKey(params.parsed.provider, params.parsed.model);
+  const configuredEntry = params.metadata.configuredByKey.get(key);
+  const alias = params.metadata.aliasByKey.get(key);
+  const nextContextWindow = configuredEntry?.contextWindow;
+  const nextReasoning = configuredEntry?.reasoning;
+  const nextInput = configuredEntry?.input;
+
+  return {
+    id: params.parsed.model,
+    name: configuredEntry?.name ?? params.parsed.model,
+    provider: params.parsed.provider,
+    ...(alias ? { alias } : {}),
+    ...(nextContextWindow !== undefined ? { contextWindow: nextContextWindow } : {}),
+    ...(nextReasoning !== undefined ? { reasoning: nextReasoning } : {}),
+    ...(nextInput ? { input: nextInput } : {}),
+  };
+}
+
 export function resolveModelRefFromString(params: {
   raw: string;
   defaultProvider: string;
@@ -503,6 +581,11 @@ export function buildAllowedModelSet(params: {
   allowedCatalog: ModelCatalogEntry[];
   allowedKeys: Set<string>;
 } {
+  const metadata = buildModelCatalogMetadata({
+    cfg: params.cfg,
+    defaultProvider: params.defaultProvider,
+  });
+  const catalog = params.catalog.map((entry) => applyModelCatalogMetadata({ entry, metadata }));
   const rawAllowlist = (() => {
     const modelMap = params.cfg.agents?.defaults?.models ?? {};
     return Object.keys(modelMap);
@@ -514,7 +597,7 @@ export function buildAllowedModelSet(params: {
       ? parseModelRef(defaultModel, params.defaultProvider)
       : null;
   const defaultKey = defaultRef ? modelKey(defaultRef.provider, defaultRef.model) : undefined;
-  const catalogKeys = new Set(params.catalog.map((entry) => modelKey(entry.provider, entry.id)));
+  const catalogKeys = new Set(catalog.map((entry) => modelKey(entry.provider, entry.id)));
 
   if (allowAny) {
     if (defaultKey) {
@@ -522,7 +605,7 @@ export function buildAllowedModelSet(params: {
     }
     return {
       allowAny: true,
-      allowedCatalog: params.catalog,
+      allowedCatalog: catalog,
       allowedKeys: catalogKeys,
     };
   }
@@ -540,11 +623,7 @@ export function buildAllowedModelSet(params: {
     allowedKeys.add(key);
 
     if (!catalogKeys.has(key) && !syntheticCatalogEntries.has(key)) {
-      syntheticCatalogEntries.set(key, {
-        id: parsed.model,
-        name: parsed.model,
-        provider: parsed.provider,
-      });
+      syntheticCatalogEntries.set(key, buildSyntheticAllowedCatalogEntry({ parsed, metadata }));
     }
   }
 
@@ -558,11 +637,7 @@ export function buildAllowedModelSet(params: {
       allowedKeys.add(key);
 
       if (!catalogKeys.has(key) && !syntheticCatalogEntries.has(key)) {
-        syntheticCatalogEntries.set(key, {
-          id: parsed.model,
-          name: parsed.model,
-          provider: parsed.provider,
-        });
+        syntheticCatalogEntries.set(key, buildSyntheticAllowedCatalogEntry({ parsed, metadata }));
       }
     }
   }
@@ -572,7 +647,7 @@ export function buildAllowedModelSet(params: {
   }
 
   const allowedCatalog = [
-    ...params.catalog.filter((entry) => allowedKeys.has(modelKey(entry.provider, entry.id))),
+    ...catalog.filter((entry) => allowedKeys.has(modelKey(entry.provider, entry.id))),
     ...syntheticCatalogEntries.values(),
   ];
 
@@ -582,7 +657,7 @@ export function buildAllowedModelSet(params: {
     }
     return {
       allowAny: true,
-      allowedCatalog: params.catalog,
+      allowedCatalog: catalog,
       allowedKeys: catalogKeys,
     };
   }

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -6,6 +6,7 @@ export const ModelChoiceSchema = Type.Object(
     id: NonEmptyString,
     name: NonEmptyString,
     provider: NonEmptyString,
+    alias: Type.Optional(NonEmptyString),
     contextWindow: Type.Optional(Type.Integer({ minimum: 1 })),
     reasoning: Type.Optional(Type.Boolean()),
   },

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -89,6 +89,7 @@ type ModelCatalogRpcEntry = {
   id: string;
   name: string;
   provider: string;
+  alias?: string;
   contextWindow?: number;
 };
 
@@ -358,6 +359,92 @@ describe("gateway server models + voicewake", () => {
         },
       ],
     });
+  });
+
+  test("models.list applies configured metadata and alias to synthetic allowlist entries", async () => {
+    await withModelsConfig(
+      {
+        agents: {
+          defaults: {
+            model: { primary: "nvidia/moonshotai/kimi-k2.5" },
+            models: {
+              "nvidia/moonshotai/kimi-k2.5": { alias: "Kimi K2.5 (NVIDIA)" },
+            },
+          },
+        },
+        models: {
+          providers: {
+            nvidia: {
+              baseUrl: "https://nvidia.example.com",
+              models: [
+                {
+                  id: "moonshotai/kimi-k2.5",
+                  name: "Kimi K2.5 (Configured)",
+                  contextWindow: 32_000,
+                },
+              ],
+            },
+          },
+        },
+      },
+      async () => {
+        seedPiCatalog();
+        const res = await listModels();
+        expect(res.ok).toBe(true);
+        expect(res.payload?.models).toEqual([
+          {
+            id: "moonshotai/kimi-k2.5",
+            name: "Kimi K2.5 (Configured)",
+            alias: "Kimi K2.5 (NVIDIA)",
+            provider: "nvidia",
+            contextWindow: 32_000,
+          },
+        ]);
+      },
+    );
+  });
+
+  test("models.list prefers configured provider metadata over discovered entries", async () => {
+    await withModelsConfig(
+      {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-test-z" },
+            models: {
+              "openai/gpt-test-z": { alias: "GPT Test Z Alias" },
+            },
+          },
+        },
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://openai.example.com",
+              models: [
+                {
+                  id: "gpt-test-z",
+                  name: "Configured GPT Test Z",
+                  contextWindow: 64_000,
+                },
+              ],
+            },
+          },
+        },
+      },
+      async () => {
+        seedPiCatalog();
+        const res = await listModels();
+        expect(res.ok).toBe(true);
+        expect(res.payload?.models).toEqual([
+          {
+            id: "gpt-test-z",
+            name: "Configured GPT Test Z",
+            alias: "GPT Test Z Alias",
+            provider: "openai",
+            contextWindow: 64_000,
+          },
+        ]);
+      },
+    );
   });
 
   test("models.list rejects unknown params", async () => {

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -8,6 +8,7 @@ import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.j
 import { loadConfig } from "../config/config.js";
 import { withSessionStoreLockForTest } from "../config/sessions/store.js";
 import { isSessionPatchEvent, type InternalHookEvent } from "../hooks/internal-hooks.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "./protocol/client-info.js";
 import { startGatewayServerHarness, type GatewayServerHarness } from "./server.e2e-ws-harness.js";
 import { createToolSummaryPreviewTranscriptLines } from "./session-preview.test-helpers.js";
@@ -19,6 +20,7 @@ import {
   installGatewayTestHooks,
   piSdkMock,
   rpcReq,
+  startConnectedServerWithClient,
   testState,
   trackConnectChallengeNonce,
   writeSessionStore,
@@ -1207,6 +1209,82 @@ describe("gateway server sessions", () => {
     );
 
     ws.close();
+  });
+
+  test("sessions.patch preserves nested model ids under provider overrides", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-sessions-nested-"));
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+        },
+      }),
+      "utf-8",
+    );
+
+    await withEnvAsync({ OPENCLAW_CONFIG_PATH: undefined }, async () => {
+      clearConfigCache();
+      clearRuntimeConfigSnapshot();
+      const cfg = {
+        session: { store: storePath, mainKey: "main" },
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-test-a" },
+          },
+          list: [{ id: "main", default: true, workspace: dir }],
+        },
+      };
+      const configPath = path.join(dir, "openclaw.json");
+      await fs.writeFile(configPath, JSON.stringify(cfg, null, 2), "utf-8");
+
+      await withEnvAsync({ OPENCLAW_CONFIG_PATH: configPath }, async () => {
+        const started = await startConnectedServerWithClient();
+        const { server, ws } = started;
+        try {
+          piSdkMock.enabled = true;
+          piSdkMock.models = [
+            { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5 (NVIDIA)", provider: "nvidia" },
+          ];
+
+          const patched = await rpcReq<{
+            ok: true;
+            entry: {
+              modelOverride?: string;
+              providerOverride?: string;
+              model?: string;
+              modelProvider?: string;
+            };
+            resolved?: { model?: string; modelProvider?: string };
+          }>(ws, "sessions.patch", {
+            key: "agent:main:main",
+            model: "nvidia/moonshotai/kimi-k2.5",
+          });
+          expect(patched.ok).toBe(true);
+          expect(patched.payload?.entry.modelOverride).toBe("moonshotai/kimi-k2.5");
+          expect(patched.payload?.entry.providerOverride).toBe("nvidia");
+          expect(patched.payload?.entry.model).toBeUndefined();
+          expect(patched.payload?.entry.modelProvider).toBeUndefined();
+          expect(patched.payload?.resolved?.modelProvider).toBe("nvidia");
+          expect(patched.payload?.resolved?.model).toBe("moonshotai/kimi-k2.5");
+
+          const listed = await rpcReq<{
+            sessions: Array<{ key: string; modelProvider?: string; model?: string }>;
+          }>(ws, "sessions.list", {});
+          expect(listed.ok).toBe(true);
+          const mainSession = listed.payload?.sessions.find(
+            (session) => session.key === "agent:main:main",
+          );
+          expect(mainSession?.modelProvider).toBe("nvidia");
+          expect(mainSession?.model).toBe("moonshotai/kimi-k2.5");
+        } finally {
+          ws.close();
+          await server.close();
+        }
+      });
+    });
   });
 
   test("sessions.preview returns transcript previews", async () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -655,6 +655,36 @@ describe("resolveSessionModelRef", () => {
     expect(resolved).toEqual({ provider: "openai-codex", model: "gpt-5.4" });
   });
 
+  test("keeps nested model ids under the stored provider override", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "anthropic/claude-opus-4-6",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "s-nested",
+      updatedAt: Date.now(),
+      providerOverride: "nvidia",
+      modelOverride: "moonshotai/kimi-k2.5",
+    });
+
+    expect(resolved).toEqual({ provider: "nvidia", model: "moonshotai/kimi-k2.5" });
+  });
+
+  test("strips a duplicated provider prefix from stored overrides", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "anthropic/claude-opus-4-6",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "s-qualified-override",
+      updatedAt: Date.now(),
+      providerOverride: "openai-codex",
+      modelOverride: "openai-codex/gpt-5.4",
+    });
+
+    expect(resolved).toEqual({ provider: "openai-codex", model: "gpt-5.4" });
+  });
+
   test("falls back to resolved provider for unprefixed legacy runtime model", () => {
     const cfg = createModelDefaultsConfig({
       primary: "google-gemini-cli/gemini-3-pro-preview",

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1062,7 +1062,19 @@ export function resolveSessionModelRef(
   // then finally to configured defaults.
   const storedModelOverride = entry?.modelOverride?.trim();
   if (storedModelOverride) {
-    const overrideProvider = entry?.providerOverride?.trim() || provider || DEFAULT_PROVIDER;
+    const storedProviderOverride = entry?.providerOverride?.trim();
+    if (storedProviderOverride) {
+      const providerPrefix = `${storedProviderOverride.toLowerCase()}/`;
+      const normalizedModel = storedModelOverride.toLowerCase().startsWith(providerPrefix)
+        ? storedModelOverride.slice(storedProviderOverride.length + 1).trim() || storedModelOverride
+        : storedModelOverride;
+      return {
+        provider: storedProviderOverride,
+        model: normalizedModel,
+      };
+    }
+
+    const overrideProvider = provider || DEFAULT_PROVIDER;
     const parsedOverride = parseModelRef(storedModelOverride, overrideProvider);
     if (parsedOverride) {
       provider = parsedOverride.provider;

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -190,4 +190,13 @@ describe("chat-model-ref helpers", () => {
       source: "qualified",
     });
   });
+
+  it("preserves already-qualified server model values when the provider is stale", () => {
+    expect(
+      resolvePreferredServerChatModel("openai/gpt-5-mini", "zai", [OPENAI_GPT5_MINI_MODEL]),
+    ).toEqual({
+      value: "openai/gpt-5-mini",
+      source: "qualified",
+    });
+  });
 });

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -30,6 +30,23 @@ describe("chat-model-ref helpers", () => {
     });
   });
 
+  it("prefers alias over name for picker labels", () => {
+    const aliasedModel = {
+      id: "moonshotai/kimi-k2.5",
+      alias: "Kimi K2.5 (NVIDIA)",
+      name: "Kimi K2.5",
+      provider: "nvidia",
+    };
+
+    expect(buildChatModelOption(aliasedModel, [aliasedModel])).toEqual({
+      value: "nvidia/moonshotai/kimi-k2.5",
+      label: "Kimi K2.5 (NVIDIA)",
+    });
+    expect(formatCatalogChatModelDisplay("nvidia/moonshotai/kimi-k2.5", [aliasedModel])).toBe(
+      "Kimi K2.5 (NVIDIA)",
+    );
+  });
+
   it("uses friendly catalog names for qualified nested model ids", () => {
     const nestedModel = {
       id: "moonshotai/kimi-k2.5",
@@ -141,10 +158,12 @@ describe("chat-model-ref helpers", () => {
     });
   });
 
-  it("prefers the catalog provider over a stale server provider when the match is unique", () => {
-    expect(resolvePreferredServerChatModel("deepseek-chat", "zai", [DEEPSEEK_CHAT_MODEL])).toEqual({
+  it("uses the recorded server provider when it is present", () => {
+    expect(
+      resolvePreferredServerChatModel("deepseek-chat", "deepseek", [DEEPSEEK_CHAT_MODEL]),
+    ).toEqual({
       value: "deepseek/deepseek-chat",
-      source: "catalog",
+      source: "server",
     });
   });
 
@@ -152,7 +171,6 @@ describe("chat-model-ref helpers", () => {
     expect(resolvePreferredServerChatModel("gpt-5-mini", "openai", [])).toEqual({
       value: "openai/gpt-5-mini",
       source: "server",
-      reason: "missing",
     });
     expect(
       resolvePreferredServerChatModel(
@@ -163,11 +181,10 @@ describe("chat-model-ref helpers", () => {
     ).toEqual({
       value: "openai/gpt-5-mini",
       source: "server",
-      reason: "ambiguous",
     });
   });
 
-  it("does not treat slash-containing server model ids as already provider-qualified", () => {
+  it("qualifies slash-containing server model ids with the recorded provider", () => {
     expect(
       resolvePreferredServerChatModel("moonshotai/kimi-k2.5", "nvidia", [
         {
@@ -178,7 +195,7 @@ describe("chat-model-ref helpers", () => {
       ]),
     ).toEqual({
       value: "nvidia/moonshotai/kimi-k2.5",
-      source: "catalog",
+      source: "server",
     });
   });
 
@@ -191,12 +208,10 @@ describe("chat-model-ref helpers", () => {
     });
   });
 
-  it("preserves already-qualified server model values when the provider is stale", () => {
-    expect(
-      resolvePreferredServerChatModel("openai/gpt-5-mini", "zai", [OPENAI_GPT5_MINI_MODEL]),
-    ).toEqual({
+  it("uses catalog resolution for provider-less raw server model values", () => {
+    expect(resolvePreferredServerChatModel("gpt-5-mini", null, [OPENAI_GPT5_MINI_MODEL])).toEqual({
       value: "openai/gpt-5-mini",
-      source: "qualified",
+      source: "catalog",
     });
   });
 });

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -5,9 +5,8 @@ import {
   formatCatalogChatModelDisplay,
   formatChatModelDisplay,
   normalizeChatModelOverrideValue,
-  resolveChatModelOverride,
-  resolvePreferredServerChatModel,
   resolveServerChatModelValue,
+  resolvePreferredServerChatModelValue,
 } from "./chat-model-ref.ts";
 import {
   createAmbiguousModelCatalog,
@@ -138,80 +137,55 @@ describe("chat-model-ref helpers", () => {
     expect(resolveServerChatModelValue("alias-only", null)).toBe("alias-only");
   });
 
-  it("reports the override resolution source for unique catalog matches", () => {
-    expect(resolveChatModelOverride(createChatModelOverride("gpt-5-mini"), catalog)).toEqual({
-      value: "openai/gpt-5-mini",
-      source: "catalog",
-    });
-  });
-
-  it("reports ambiguous raw overrides without guessing a provider", () => {
+  it("keeps ambiguous raw overrides without guessing a provider", () => {
     expect(
-      resolveChatModelOverride(
+      normalizeChatModelOverrideValue(
         createChatModelOverride("gpt-5-mini"),
         createAmbiguousModelCatalog("gpt-5-mini", "openai", "openrouter"),
       ),
-    ).toEqual({
-      value: "gpt-5-mini",
-      source: "raw",
-      reason: "ambiguous",
-    });
+    ).toBe("gpt-5-mini");
   });
 
   it("uses the recorded server provider when it is present", () => {
     expect(
-      resolvePreferredServerChatModel("deepseek-chat", "deepseek", [DEEPSEEK_CHAT_MODEL]),
-    ).toEqual({
-      value: "deepseek/deepseek-chat",
-      source: "server",
-    });
+      resolvePreferredServerChatModelValue("deepseek-chat", "deepseek", [DEEPSEEK_CHAT_MODEL]),
+    ).toBe("deepseek/deepseek-chat");
   });
 
   it("falls back to the server provider when the catalog misses or is ambiguous", () => {
-    expect(resolvePreferredServerChatModel("gpt-5-mini", "openai", [])).toEqual({
-      value: "openai/gpt-5-mini",
-      source: "server",
-    });
+    expect(resolvePreferredServerChatModelValue("gpt-5-mini", "openai", [])).toBe(
+      "openai/gpt-5-mini",
+    );
     expect(
-      resolvePreferredServerChatModel(
+      resolvePreferredServerChatModelValue(
         "gpt-5-mini",
         "openai",
         createAmbiguousModelCatalog("gpt-5-mini", "openai", "openrouter"),
       ),
-    ).toEqual({
-      value: "openai/gpt-5-mini",
-      source: "server",
-    });
+    ).toBe("openai/gpt-5-mini");
   });
 
   it("qualifies slash-containing server model ids with the recorded provider", () => {
     expect(
-      resolvePreferredServerChatModel("moonshotai/kimi-k2.5", "nvidia", [
+      resolvePreferredServerChatModelValue("moonshotai/kimi-k2.5", "nvidia", [
         {
           id: "moonshotai/kimi-k2.5",
           name: "Kimi K2.5 (NVIDIA)",
           provider: "nvidia",
         },
       ]),
-    ).toEqual({
-      value: "nvidia/moonshotai/kimi-k2.5",
-      source: "server",
-    });
+    ).toBe("nvidia/moonshotai/kimi-k2.5");
   });
 
   it("preserves already-qualified server model values when the provider matches", () => {
     expect(
-      resolvePreferredServerChatModel("openai/gpt-5-mini", "openai", [OPENAI_GPT5_MINI_MODEL]),
-    ).toEqual({
-      value: "openai/gpt-5-mini",
-      source: "qualified",
-    });
+      resolvePreferredServerChatModelValue("openai/gpt-5-mini", "openai", [OPENAI_GPT5_MINI_MODEL]),
+    ).toBe("openai/gpt-5-mini");
   });
 
   it("uses catalog resolution for provider-less raw server model values", () => {
-    expect(resolvePreferredServerChatModel("gpt-5-mini", null, [OPENAI_GPT5_MINI_MODEL])).toEqual({
-      value: "openai/gpt-5-mini",
-      source: "catalog",
-    });
+    expect(resolvePreferredServerChatModelValue("gpt-5-mini", null, [OPENAI_GPT5_MINI_MODEL])).toBe(
+      "openai/gpt-5-mini",
+    );
   });
 });

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildChatModelOption,
   createChatModelOverride,
+  formatCatalogChatModelDisplay,
   formatChatModelDisplay,
   normalizeChatModelOverrideValue,
   resolveChatModelOverride,
@@ -22,11 +23,49 @@ const catalog = createModelCatalog(OPENAI_GPT5_MINI_MODEL, {
 });
 
 describe("chat-model-ref helpers", () => {
-  it("builds provider-qualified option values and labels", () => {
-    expect(buildChatModelOption(catalog[0])).toEqual({
+  it("builds provider-qualified option values and prefers catalog names for labels", () => {
+    expect(buildChatModelOption(catalog[0], catalog)).toEqual({
       value: "openai/gpt-5-mini",
-      label: "gpt-5-mini · openai",
+      label: "GPT-5 Mini",
     });
+  });
+
+  it("uses friendly catalog names for qualified nested model ids", () => {
+    const nestedModel = {
+      id: "moonshotai/kimi-k2.5",
+      name: "Kimi K2.5 (NVIDIA)",
+      provider: "nvidia",
+    };
+    expect(buildChatModelOption(nestedModel, [nestedModel])).toEqual({
+      value: "nvidia/moonshotai/kimi-k2.5",
+      label: "Kimi K2.5 (NVIDIA)",
+    });
+    expect(formatCatalogChatModelDisplay("nvidia/moonshotai/kimi-k2.5", [nestedModel])).toBe(
+      "Kimi K2.5 (NVIDIA)",
+    );
+  });
+
+  it("disambiguates duplicate friendly names with the provider", () => {
+    const duplicateNameCatalog = createModelCatalog(
+      {
+        id: "claude-3-7-sonnet",
+        name: "Claude Sonnet",
+        provider: "anthropic",
+      },
+      {
+        id: "claude-3-7-sonnet",
+        name: "Claude Sonnet",
+        provider: "openrouter",
+      },
+    );
+
+    expect(buildChatModelOption(duplicateNameCatalog[0], duplicateNameCatalog)).toEqual({
+      value: "anthropic/claude-3-7-sonnet",
+      label: "Claude Sonnet · anthropic",
+    });
+    expect(
+      formatCatalogChatModelDisplay("openrouter/claude-3-7-sonnet", duplicateNameCatalog),
+    ).toBe("Claude Sonnet · openrouter");
   });
 
   it("normalizes raw overrides when the catalog match is unique", () => {
@@ -97,6 +136,21 @@ describe("chat-model-ref helpers", () => {
       value: "openai/gpt-5-mini",
       source: "server",
       reason: "ambiguous",
+    });
+  });
+
+  it("does not treat slash-containing server model ids as already provider-qualified", () => {
+    expect(
+      resolvePreferredServerChatModel("moonshotai/kimi-k2.5", "nvidia", [
+        {
+          id: "moonshotai/kimi-k2.5",
+          name: "Kimi K2.5 (NVIDIA)",
+          provider: "nvidia",
+        },
+      ]),
+    ).toEqual({
+      value: "nvidia/moonshotai/kimi-k2.5",
+      source: "catalog",
     });
   });
 });

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -181,4 +181,13 @@ describe("chat-model-ref helpers", () => {
       source: "catalog",
     });
   });
+
+  it("preserves already-qualified server model values when the provider matches", () => {
+    expect(
+      resolvePreferredServerChatModel("openai/gpt-5-mini", "openai", [OPENAI_GPT5_MINI_MODEL]),
+    ).toEqual({
+      value: "openai/gpt-5-mini",
+      source: "qualified",
+    });
+  });
 });

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -68,6 +68,34 @@ describe("chat-model-ref helpers", () => {
     ).toBe("Claude Sonnet · openrouter");
   });
 
+  it("falls back to the raw catalog label when name and provider still collide", () => {
+    const duplicateNameAndProviderCatalog = createModelCatalog(
+      {
+        id: "claude-3-7-sonnet",
+        name: "Claude Sonnet",
+        provider: "anthropic",
+      },
+      {
+        id: "claude-3-7-sonnet-thinking",
+        name: "Claude Sonnet",
+        provider: "anthropic",
+      },
+    );
+
+    expect(
+      buildChatModelOption(duplicateNameAndProviderCatalog[0], duplicateNameAndProviderCatalog),
+    ).toEqual({
+      value: "anthropic/claude-3-7-sonnet",
+      label: "Claude Sonnet · claude-3-7-sonnet · anthropic",
+    });
+    expect(
+      formatCatalogChatModelDisplay(
+        "anthropic/claude-3-7-sonnet-thinking",
+        duplicateNameAndProviderCatalog,
+      ),
+    ).toBe("Claude Sonnet · claude-3-7-sonnet-thinking · anthropic");
+  });
+
   it("normalizes raw overrides when the catalog match is unique", () => {
     expect(normalizeChatModelOverrideValue(createChatModelOverride("gpt-5-mini"), catalog)).toBe(
       "openai/gpt-5-mini",

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -105,8 +105,9 @@ export function resolvePreferredServerChatModel(
     return { value: "", source: "empty", reason: "empty" };
   }
 
+  const trimmedProvider = provider?.trim();
   const overrideResolution = resolveChatModelOverride(
-    createChatModelOverride(trimmedModel),
+    trimmedProvider ? { kind: "raw", value: trimmedModel } : createChatModelOverride(trimmedModel),
     catalog,
   );
   if (overrideResolution.source === "qualified" || overrideResolution.source === "catalog") {
@@ -114,7 +115,7 @@ export function resolvePreferredServerChatModel(
   }
 
   return {
-    value: resolveServerChatModelValue(trimmedModel, provider),
+    value: resolveServerChatModelValue(trimmedModel, trimmedProvider),
     source: "server",
     reason: overrideResolution.reason,
   };
@@ -140,10 +141,72 @@ export function formatChatModelDisplay(value: string): string {
   return `${trimmed.slice(separator + 1)} · ${trimmed.slice(0, separator)}`;
 }
 
-export function buildChatModelOption(entry: ModelCatalogEntry): { value: string; label: string } {
+function formatRawCatalogLabel(entry: ModelCatalogEntry): string {
+  const provider = entry.provider?.trim();
+  return provider ? `${entry.id} · ${provider}` : entry.id;
+}
+
+function hasCatalogNameCollision(entry: ModelCatalogEntry, catalog: ModelCatalogEntry[]): boolean {
+  const name = entry.name.trim();
+  if (!name) {
+    return false;
+  }
+
+  const normalizedName = name.toLowerCase();
+  const entryValue = buildQualifiedChatModelValue(entry.id, entry.provider).trim().toLowerCase();
+  for (const candidate of catalog) {
+    if (candidate.name.trim().toLowerCase() !== normalizedName) {
+      continue;
+    }
+    const candidateValue = buildQualifiedChatModelValue(candidate.id, candidate.provider)
+      .trim()
+      .toLowerCase();
+    if (candidateValue !== entryValue) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function formatCatalogEntryDisplay(entry: ModelCatalogEntry, catalog: ModelCatalogEntry[]): string {
+  const name = entry.name.trim();
+  if (!name) {
+    return formatRawCatalogLabel(entry);
+  }
+
+  if (!hasCatalogNameCollision(entry, catalog)) {
+    return name;
+  }
+
+  const provider = entry.provider?.trim();
+  return provider ? `${name} · ${provider}` : `${name} · ${entry.id}`;
+}
+
+export function formatCatalogChatModelDisplay(value: string, catalog: ModelCatalogEntry[]): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const normalized = trimmed.toLowerCase();
+  for (const entry of catalog) {
+    const candidate = buildQualifiedChatModelValue(entry.id, entry.provider).trim().toLowerCase();
+    if (candidate !== normalized) {
+      continue;
+    }
+    return formatCatalogEntryDisplay(entry, catalog);
+  }
+
+  return formatChatModelDisplay(trimmed);
+}
+
+export function buildChatModelOption(
+  entry: ModelCatalogEntry,
+  catalog: ModelCatalogEntry[] = [entry],
+): { value: string; label: string } {
   const provider = entry.provider?.trim();
   return {
     value: buildQualifiedChatModelValue(entry.id, provider),
-    label: provider ? `${entry.id} · ${provider}` : entry.id,
+    label: formatCatalogEntryDisplay(entry, catalog),
   };
 }

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -10,16 +10,6 @@ export type ChatModelOverride =
       value: string;
     };
 
-export type ChatModelResolutionSource = "empty" | "qualified" | "catalog" | "raw" | "server";
-
-export type ChatModelResolutionReason = "empty" | "missing" | "ambiguous";
-
-export type ChatModelResolution = {
-  value: string;
-  source: ChatModelResolutionSource;
-  reason?: ChatModelResolutionReason;
-};
-
 export function buildQualifiedChatModelValue(model: string, provider?: string | null): string {
   const trimmedModel = model.trim();
   if (!trimmedModel) {
@@ -44,22 +34,15 @@ export function normalizeChatModelOverrideValue(
   override: ChatModelOverride | null | undefined,
   catalog: ModelCatalogEntry[],
 ): string {
-  return resolveChatModelOverride(override, catalog).value;
-}
-
-export function resolveChatModelOverride(
-  override: ChatModelOverride | null | undefined,
-  catalog: ModelCatalogEntry[],
-): ChatModelResolution {
   if (!override) {
-    return { value: "", source: "empty", reason: "empty" };
+    return "";
   }
   const trimmed = override?.value.trim();
   if (!trimmed) {
-    return { value: "", source: "empty", reason: "empty" };
+    return "";
   }
   if (override.kind === "qualified") {
-    return { value: trimmed, source: "qualified" };
+    return trimmed;
   }
 
   let matchedValue = "";
@@ -73,13 +56,10 @@ export function resolveChatModelOverride(
       continue;
     }
     if (matchedValue.toLowerCase() !== candidate.toLowerCase()) {
-      return { value: trimmed, source: "raw", reason: "ambiguous" };
+      return trimmed;
     }
   }
-  if (matchedValue) {
-    return { value: matchedValue, source: "catalog" };
-  }
-  return { value: trimmed, source: "raw", reason: "missing" };
+  return matchedValue || trimmed;
 }
 
 export function resolveServerChatModelValue(
@@ -103,51 +83,26 @@ export function resolveServerChatModelValue(
     : buildQualifiedChatModelValue(trimmedModel, trimmedProvider);
 }
 
-export function resolvePreferredServerChatModel(
-  model: string | null | undefined,
-  provider: string | null | undefined,
-  catalog: ModelCatalogEntry[],
-): ChatModelResolution {
-  if (typeof model !== "string") {
-    return { value: "", source: "empty", reason: "empty" };
-  }
-  const trimmedModel = model.trim();
-  if (!trimmedModel) {
-    return { value: "", source: "empty", reason: "empty" };
-  }
-
-  const trimmedProvider = provider?.trim();
-
-  if (trimmedProvider) {
-    return {
-      value: resolveServerChatModelValue(trimmedModel, trimmedProvider),
-      source: trimmedModel.toLowerCase().startsWith(`${trimmedProvider.toLowerCase()}/`)
-        ? "qualified"
-        : "server",
-    };
-  }
-
-  const overrideResolution = resolveChatModelOverride(
-    createChatModelOverride(trimmedModel),
-    catalog,
-  );
-  if (overrideResolution.source === "qualified" || overrideResolution.source === "catalog") {
-    return overrideResolution;
-  }
-
-  return {
-    value: trimmedModel,
-    source: trimmedModel.includes("/") ? "qualified" : "raw",
-    reason: overrideResolution.reason,
-  };
-}
-
 export function resolvePreferredServerChatModelValue(
   model: string | null | undefined,
   provider: string | null | undefined,
   catalog: ModelCatalogEntry[],
 ): string {
-  return resolvePreferredServerChatModel(model, provider, catalog).value;
+  if (typeof model !== "string") {
+    return "";
+  }
+  const trimmedModel = model.trim();
+  if (!trimmedModel) {
+    return "";
+  }
+
+  const trimmedProvider = provider?.trim();
+
+  if (trimmedProvider) {
+    return resolveServerChatModelValue(trimmedModel, trimmedProvider);
+  }
+
+  return normalizeChatModelOverrideValue(createChatModelOverride(trimmedModel), catalog);
 }
 
 export function formatChatModelDisplay(value: string): string {

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -89,7 +89,18 @@ export function resolveServerChatModelValue(
   if (typeof model !== "string") {
     return "";
   }
-  return buildQualifiedChatModelValue(model, provider);
+  const trimmedModel = model.trim();
+  if (!trimmedModel) {
+    return "";
+  }
+  const trimmedProvider = provider?.trim();
+  if (!trimmedProvider) {
+    return trimmedModel;
+  }
+  const providerPrefix = `${trimmedProvider.toLowerCase()}/`;
+  return trimmedModel.toLowerCase().startsWith(providerPrefix)
+    ? trimmedModel
+    : buildQualifiedChatModelValue(trimmedModel, trimmedProvider);
 }
 
 export function resolvePreferredServerChatModel(
@@ -107,22 +118,17 @@ export function resolvePreferredServerChatModel(
 
   const trimmedProvider = provider?.trim();
 
-  if (trimmedModel.includes("/")) {
-    if (trimmedProvider) {
-      const nestedRawResolution = resolveChatModelOverride(
-        { kind: "raw", value: trimmedModel },
-        catalog,
-      );
-      if (nestedRawResolution.source === "catalog") {
-        return nestedRawResolution;
-      }
-    }
-
-    return { value: trimmedModel, source: "qualified" };
+  if (trimmedProvider) {
+    return {
+      value: resolveServerChatModelValue(trimmedModel, trimmedProvider),
+      source: trimmedModel.toLowerCase().startsWith(`${trimmedProvider.toLowerCase()}/`)
+        ? "qualified"
+        : "server",
+    };
   }
 
   const overrideResolution = resolveChatModelOverride(
-    trimmedProvider ? { kind: "raw", value: trimmedModel } : createChatModelOverride(trimmedModel),
+    createChatModelOverride(trimmedModel),
     catalog,
   );
   if (overrideResolution.source === "qualified" || overrideResolution.source === "catalog") {
@@ -130,8 +136,8 @@ export function resolvePreferredServerChatModel(
   }
 
   return {
-    value: resolveServerChatModelValue(trimmedModel, trimmedProvider),
-    source: "server",
+    value: trimmedModel,
+    source: trimmedModel.includes("/") ? "qualified" : "raw",
     reason: overrideResolution.reason,
   };
 }
@@ -161,6 +167,10 @@ function formatRawCatalogLabel(entry: ModelCatalogEntry): string {
   return provider ? `${entry.id} · ${provider}` : entry.id;
 }
 
+function resolveCatalogDisplayName(entry: ModelCatalogEntry): string {
+  return entry.alias?.trim() || entry.name.trim();
+}
+
 function createQualifiedCatalogKey(entry: ModelCatalogEntry): string {
   return buildQualifiedChatModelValue(entry.id, entry.provider).trim().toLowerCase();
 }
@@ -176,7 +186,7 @@ export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<str
   const nameProviderToValues = new Map<string, Set<string>>();
 
   for (const entry of catalog) {
-    const name = entry.name.trim();
+    const name = resolveCatalogDisplayName(entry);
     if (!name) {
       continue;
     }
@@ -197,7 +207,7 @@ export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<str
   const displayLookup = new Map<string, string>();
   for (const entry of catalog) {
     const qualifiedKey = createQualifiedCatalogKey(entry);
-    const name = entry.name.trim();
+    const name = resolveCatalogDisplayName(entry);
     if (!name) {
       displayLookup.set(qualifiedKey, formatRawCatalogLabel(entry));
       continue;

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -106,10 +106,18 @@ export function resolvePreferredServerChatModel(
   }
 
   const trimmedProvider = provider?.trim();
-  if (
-    trimmedProvider &&
-    trimmedModel.toLowerCase().startsWith(`${trimmedProvider.toLowerCase()}/`)
-  ) {
+
+  if (trimmedModel.includes("/")) {
+    if (trimmedProvider) {
+      const nestedRawResolution = resolveChatModelOverride(
+        { kind: "raw", value: trimmedModel },
+        catalog,
+      );
+      if (nestedRawResolution.source === "catalog") {
+        return nestedRawResolution;
+      }
+    }
+
     return { value: trimmedModel, source: "qualified" };
   }
 

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -146,67 +146,103 @@ function formatRawCatalogLabel(entry: ModelCatalogEntry): string {
   return provider ? `${entry.id} · ${provider}` : entry.id;
 }
 
-function hasCatalogNameCollision(entry: ModelCatalogEntry, catalog: ModelCatalogEntry[]): boolean {
-  const name = entry.name.trim();
-  if (!name) {
-    return false;
-  }
+function createQualifiedCatalogKey(entry: ModelCatalogEntry): string {
+  return buildQualifiedChatModelValue(entry.id, entry.provider).trim().toLowerCase();
+}
 
-  const normalizedName = name.toLowerCase();
-  const entryValue = buildQualifiedChatModelValue(entry.id, entry.provider).trim().toLowerCase();
-  for (const candidate of catalog) {
-    if (candidate.name.trim().toLowerCase() !== normalizedName) {
+function createNameProviderKey(name: string, provider?: string | null): string {
+  return `${name.toLowerCase()}\u0000${provider?.trim().toLowerCase() ?? ""}`;
+}
+
+export type ChatModelDisplayLookup = ReadonlyMap<string, string>;
+
+export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<string, string> {
+  const nameToValues = new Map<string, Set<string>>();
+  const nameProviderToValues = new Map<string, Set<string>>();
+
+  for (const entry of catalog) {
+    const name = entry.name.trim();
+    if (!name) {
       continue;
     }
-    const candidateValue = buildQualifiedChatModelValue(candidate.id, candidate.provider)
-      .trim()
-      .toLowerCase();
-    if (candidateValue !== entryValue) {
-      return true;
+
+    const qualifiedKey = createQualifiedCatalogKey(entry);
+    const normalizedName = name.toLowerCase();
+    const providerKey = createNameProviderKey(name, entry.provider);
+
+    const nameValues = nameToValues.get(normalizedName) ?? new Set<string>();
+    nameValues.add(qualifiedKey);
+    nameToValues.set(normalizedName, nameValues);
+
+    const nameProviderValues = nameProviderToValues.get(providerKey) ?? new Set<string>();
+    nameProviderValues.add(qualifiedKey);
+    nameProviderToValues.set(providerKey, nameProviderValues);
+  }
+
+  const displayLookup = new Map<string, string>();
+  for (const entry of catalog) {
+    const qualifiedKey = createQualifiedCatalogKey(entry);
+    const name = entry.name.trim();
+    if (!name) {
+      displayLookup.set(qualifiedKey, formatRawCatalogLabel(entry));
+      continue;
     }
+
+    const normalizedName = name.toLowerCase();
+    if ((nameToValues.get(normalizedName)?.size ?? 0) <= 1) {
+      displayLookup.set(qualifiedKey, name);
+      continue;
+    }
+
+    const provider = entry.provider?.trim();
+    if ((nameProviderToValues.get(createNameProviderKey(name, provider))?.size ?? 0) <= 1) {
+      displayLookup.set(qualifiedKey, provider ? `${name} · ${provider}` : `${name} · ${entry.id}`);
+      continue;
+    }
+
+    displayLookup.set(qualifiedKey, `${name} · ${formatRawCatalogLabel(entry)}`);
   }
-  return false;
+
+  return displayLookup;
 }
 
-function formatCatalogEntryDisplay(entry: ModelCatalogEntry, catalog: ModelCatalogEntry[]): string {
-  const name = entry.name.trim();
-  if (!name) {
-    return formatRawCatalogLabel(entry);
-  }
-
-  if (!hasCatalogNameCollision(entry, catalog)) {
-    return name;
-  }
-
-  const provider = entry.provider?.trim();
-  return provider ? `${name} · ${provider}` : `${name} · ${entry.id}`;
+export function formatCatalogEntryDisplay(
+  entry: ModelCatalogEntry,
+  displayLookup: ChatModelDisplayLookup,
+): string {
+  return displayLookup.get(createQualifiedCatalogKey(entry)) ?? formatRawCatalogLabel(entry);
 }
 
-export function formatCatalogChatModelDisplay(value: string, catalog: ModelCatalogEntry[]): string {
+export function formatCatalogChatModelDisplayFromLookup(
+  value: string,
+  displayLookup: ChatModelDisplayLookup,
+): string {
   const trimmed = value.trim();
   if (!trimmed) {
     return "";
   }
 
-  const normalized = trimmed.toLowerCase();
-  for (const entry of catalog) {
-    const candidate = buildQualifiedChatModelValue(entry.id, entry.provider).trim().toLowerCase();
-    if (candidate !== normalized) {
-      continue;
-    }
-    return formatCatalogEntryDisplay(entry, catalog);
-  }
+  return displayLookup.get(trimmed.toLowerCase()) ?? formatChatModelDisplay(trimmed);
+}
 
-  return formatChatModelDisplay(trimmed);
+export function formatCatalogChatModelDisplay(value: string, catalog: ModelCatalogEntry[]): string {
+  return formatCatalogChatModelDisplayFromLookup(value, buildCatalogDisplayLookup(catalog));
 }
 
 export function buildChatModelOption(
   entry: ModelCatalogEntry,
   catalog: ModelCatalogEntry[] = [entry],
 ): { value: string; label: string } {
+  return buildChatModelOptionFromLookup(entry, buildCatalogDisplayLookup(catalog));
+}
+
+export function buildChatModelOptionFromLookup(
+  entry: ModelCatalogEntry,
+  displayLookup: ChatModelDisplayLookup,
+): { value: string; label: string } {
   const provider = entry.provider?.trim();
   return {
     value: buildQualifiedChatModelValue(entry.id, provider),
-    label: formatCatalogEntryDisplay(entry, catalog),
+    label: formatCatalogEntryDisplay(entry, displayLookup),
   };
 }

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -106,6 +106,13 @@ export function resolvePreferredServerChatModel(
   }
 
   const trimmedProvider = provider?.trim();
+  if (
+    trimmedProvider &&
+    trimmedModel.toLowerCase().startsWith(`${trimmedProvider.toLowerCase()}/`)
+  ) {
+    return { value: trimmedModel, source: "qualified" };
+  }
+
   const overrideResolution = resolveChatModelOverride(
     trimmedProvider ? { kind: "raw", value: trimmedModel } : createChatModelOverride(trimmedModel),
     catalog,

--- a/ui/src/ui/chat-model-select-state.test.ts
+++ b/ui/src/ui/chat-model-select-state.test.ts
@@ -11,14 +11,14 @@ import {
 } from "./chat-model.test-helpers.ts";
 
 describe("chat-model-select-state", () => {
-  it("prefers the catalog provider when the active session provider is stale", () => {
+  it("uses the server-qualified value when the active session provider is present", () => {
     const state = {
       sessionKey: "main",
       chatModelOverrides: {},
       chatModelCatalog: createModelCatalog(DEEPSEEK_CHAT_MODEL),
       sessionsResult: createSessionsListResult({
         model: "deepseek-chat",
-        modelProvider: "zai",
+        modelProvider: "deepseek",
       }),
     };
 
@@ -62,6 +62,7 @@ describe("chat-model-select-state", () => {
       chatModelOverrides: {},
       chatModelCatalog: createModelCatalog({
         id: "moonshotai/kimi-k2.5",
+        alias: "Kimi K2.5 (NVIDIA)",
         name: "Kimi K2.5 (NVIDIA)",
         provider: "nvidia",
       }),

--- a/ui/src/ui/chat-model-select-state.test.ts
+++ b/ui/src/ui/chat-model-select-state.test.ts
@@ -118,4 +118,43 @@ describe("chat-model-select-state", () => {
       label: "Claude Sonnet · openrouter",
     });
   });
+
+  it("falls back to id and provider when duplicate names share the same provider", () => {
+    const state = {
+      sessionKey: "main",
+      chatModelOverrides: {},
+      chatModelCatalog: createModelCatalog(
+        {
+          id: "claude-3-7-sonnet",
+          name: "Claude Sonnet",
+          provider: "anthropic",
+        },
+        {
+          id: "claude-3-7-sonnet-thinking",
+          name: "Claude Sonnet",
+          provider: "anthropic",
+        },
+      ),
+      sessionsResult: createSessionsListResult({
+        model: "claude-3-7-sonnet",
+        modelProvider: "anthropic",
+        defaultsModel: "claude-3-7-sonnet-thinking",
+        defaultsProvider: "anthropic",
+      }),
+    };
+
+    const resolved = resolveChatModelSelectState(state);
+    expect(resolved.currentOverride).toBe("anthropic/claude-3-7-sonnet");
+    expect(resolved.defaultLabel).toBe(
+      "Default (Claude Sonnet · claude-3-7-sonnet-thinking · anthropic)",
+    );
+    expect(resolved.options).toContainEqual({
+      value: "anthropic/claude-3-7-sonnet",
+      label: "Claude Sonnet · claude-3-7-sonnet · anthropic",
+    });
+    expect(resolved.options).toContainEqual({
+      value: "anthropic/claude-3-7-sonnet-thinking",
+      label: "Claude Sonnet · claude-3-7-sonnet-thinking · anthropic",
+    });
+  });
 });

--- a/ui/src/ui/chat-model-select-state.test.ts
+++ b/ui/src/ui/chat-model-select-state.test.ts
@@ -55,4 +55,67 @@ describe("chat-model-select-state", () => {
     expect(resolved.options.map((option) => option.value)).toContain("openai/gpt-5-mini");
     expect(resolved.options.map((option) => option.value)).not.toContain("gpt-5-mini");
   });
+
+  it("uses catalog names for the default label and matching picker options", () => {
+    const state = {
+      sessionKey: "main",
+      chatModelOverrides: {},
+      chatModelCatalog: createModelCatalog({
+        id: "moonshotai/kimi-k2.5",
+        name: "Kimi K2.5 (NVIDIA)",
+        provider: "nvidia",
+      }),
+      sessionsResult: createSessionsListResult({
+        model: "moonshotai/kimi-k2.5",
+        modelProvider: "nvidia",
+        defaultsModel: "moonshotai/kimi-k2.5",
+        defaultsProvider: "nvidia",
+      }),
+    };
+
+    const resolved = resolveChatModelSelectState(state);
+    expect(resolved.currentOverride).toBe("nvidia/moonshotai/kimi-k2.5");
+    expect(resolved.defaultLabel).toBe("Default (Kimi K2.5 (NVIDIA))");
+    expect(resolved.options).toContainEqual({
+      value: "nvidia/moonshotai/kimi-k2.5",
+      label: "Kimi K2.5 (NVIDIA)",
+    });
+  });
+
+  it("disambiguates duplicate friendly names in picker options and default labels", () => {
+    const state = {
+      sessionKey: "main",
+      chatModelOverrides: {},
+      chatModelCatalog: createModelCatalog(
+        {
+          id: "claude-3-7-sonnet",
+          name: "Claude Sonnet",
+          provider: "anthropic",
+        },
+        {
+          id: "claude-3-7-sonnet",
+          name: "Claude Sonnet",
+          provider: "openrouter",
+        },
+      ),
+      sessionsResult: createSessionsListResult({
+        model: "claude-3-7-sonnet",
+        modelProvider: "anthropic",
+        defaultsModel: "claude-3-7-sonnet",
+        defaultsProvider: "openrouter",
+      }),
+    };
+
+    const resolved = resolveChatModelSelectState(state);
+    expect(resolved.currentOverride).toBe("anthropic/claude-3-7-sonnet");
+    expect(resolved.defaultLabel).toBe("Default (Claude Sonnet · openrouter)");
+    expect(resolved.options).toContainEqual({
+      value: "anthropic/claude-3-7-sonnet",
+      label: "Claude Sonnet · anthropic",
+    });
+    expect(resolved.options).toContainEqual({
+      value: "openrouter/claude-3-7-sonnet",
+      label: "Claude Sonnet · openrouter",
+    });
+  });
 });

--- a/ui/src/ui/chat-model-select-state.ts
+++ b/ui/src/ui/chat-model-select-state.ts
@@ -1,7 +1,7 @@
 import type { AppViewState } from "./app-view-state.ts";
 import {
   buildChatModelOption,
-  formatChatModelDisplay,
+  formatCatalogChatModelDisplay,
   normalizeChatModelOverrideValue,
   resolvePreferredServerChatModelValue,
 } from "./chat-model-ref.ts";
@@ -75,15 +75,15 @@ function buildChatModelOptions(
   };
 
   for (const entry of catalog) {
-    const option = buildChatModelOption(entry);
+    const option = buildChatModelOption(entry, catalog);
     addOption(option.value, option.label);
   }
 
   if (currentOverride) {
-    addOption(currentOverride);
+    addOption(currentOverride, formatCatalogChatModelDisplay(currentOverride, catalog));
   }
   if (defaultModel) {
-    addOption(defaultModel);
+    addOption(defaultModel, formatCatalogChatModelDisplay(defaultModel, catalog));
   }
   return options;
 }
@@ -91,15 +91,16 @@ function buildChatModelOptions(
 export function resolveChatModelSelectState(
   state: ChatModelSelectStateInput,
 ): ChatModelSelectState {
+  const catalog = state.chatModelCatalog ?? [];
   const currentOverride = resolveChatModelOverrideValue(state);
   const defaultModel = resolveDefaultModelValue(state);
-  const defaultDisplay = formatChatModelDisplay(defaultModel);
+  const defaultDisplay = formatCatalogChatModelDisplay(defaultModel, catalog);
 
   return {
     currentOverride,
     defaultModel,
     defaultDisplay,
     defaultLabel: defaultModel ? `Default (${defaultDisplay})` : "Default model",
-    options: buildChatModelOptions(state.chatModelCatalog ?? [], currentOverride, defaultModel),
+    options: buildChatModelOptions(catalog, currentOverride, defaultModel),
   };
 }

--- a/ui/src/ui/chat-model-select-state.ts
+++ b/ui/src/ui/chat-model-select-state.ts
@@ -1,7 +1,8 @@
 import type { AppViewState } from "./app-view-state.ts";
 import {
-  buildChatModelOption,
-  formatCatalogChatModelDisplay,
+  buildCatalogDisplayLookup,
+  buildChatModelOptionFromLookup,
+  formatCatalogChatModelDisplayFromLookup,
   normalizeChatModelOverrideValue,
   resolvePreferredServerChatModelValue,
 } from "./chat-model-ref.ts";
@@ -60,6 +61,7 @@ function buildChatModelOptions(
 ): ChatModelSelectOption[] {
   const seen = new Set<string>();
   const options: ChatModelSelectOption[] = [];
+  const displayLookup = buildCatalogDisplayLookup(catalog);
 
   const addOption = (value: string, label?: string) => {
     const trimmed = value.trim();
@@ -75,15 +77,18 @@ function buildChatModelOptions(
   };
 
   for (const entry of catalog) {
-    const option = buildChatModelOption(entry, catalog);
+    const option = buildChatModelOptionFromLookup(entry, displayLookup);
     addOption(option.value, option.label);
   }
 
   if (currentOverride) {
-    addOption(currentOverride, formatCatalogChatModelDisplay(currentOverride, catalog));
+    addOption(
+      currentOverride,
+      formatCatalogChatModelDisplayFromLookup(currentOverride, displayLookup),
+    );
   }
   if (defaultModel) {
-    addOption(defaultModel, formatCatalogChatModelDisplay(defaultModel, catalog));
+    addOption(defaultModel, formatCatalogChatModelDisplayFromLookup(defaultModel, displayLookup));
   }
   return options;
 }
@@ -92,9 +97,10 @@ export function resolveChatModelSelectState(
   state: ChatModelSelectStateInput,
 ): ChatModelSelectState {
   const catalog = state.chatModelCatalog ?? [];
+  const displayLookup = buildCatalogDisplayLookup(catalog);
   const currentOverride = resolveChatModelOverrideValue(state);
   const defaultModel = resolveDefaultModelValue(state);
-  const defaultDisplay = formatCatalogChatModelDisplay(defaultModel, catalog);
+  const defaultDisplay = formatCatalogChatModelDisplayFromLookup(defaultModel, displayLookup);
 
   return {
     currentOverride,

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -15,7 +15,10 @@ import {
   isSubagentSessionKey,
   parseAgentSessionKey,
 } from "../../../../src/routing/session-key.js";
-import { createChatModelOverride, resolvePreferredServerChatModel } from "../chat-model-ref.ts";
+import {
+  createChatModelOverride,
+  resolvePreferredServerChatModelValue,
+} from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type {
   AgentsListResult,
@@ -177,11 +180,11 @@ async function executeModel(
         ? Promise.resolve(modelCatalog)
         : loadModelCatalog(client, { allowFailure: true }),
     ]);
-    const resolvedValue = resolvePreferredServerChatModel(
+    const resolvedValue = resolvePreferredServerChatModelValue(
       patched.resolved?.model ?? args.trim(),
       patched.resolved?.modelProvider,
       resolvedModelCatalog,
-    ).value;
+    );
     return {
       content: `Model set to \`${args.trim()}\`.`,
       action: "refresh",

--- a/ui/src/ui/controllers/agents.ts
+++ b/ui/src/ui/controllers/agents.ts
@@ -1,6 +1,6 @@
 import { resolveAgentIdFromSessionKey } from "../../../../src/routing/session-key.js";
 import {
-  resolveChatModelOverride,
+  normalizeChatModelOverrideValue,
   resolvePreferredServerChatModelValue,
 } from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
@@ -227,7 +227,7 @@ function resolveEffectiveToolsModelKey(
     return defaultModel;
   }
   if (cachedOverride) {
-    return resolveChatModelOverride(cachedOverride, catalog).value;
+    return normalizeChatModelOverrideValue(cachedOverride, catalog);
   }
   const activeRow = state.sessionsResult?.sessions?.find((row) => row.key === resolvedSessionKey);
   if (activeRow?.model) {

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -643,6 +643,7 @@ export type ModelCatalogEntry = {
   id: string;
   name: string;
   provider: string;
+  alias?: string;
   contextWindow?: number;
   reasoning?: boolean;
   input?: Array<"text" | "image" | "document">;


### PR DESCRIPTION
## Summary

- Problem: the Control UI chat model picker ignores friendly `name` values from `models.list` and can restore slash-containing model ids against the wrong provider when `modelProvider` is already present separately.
- Why it matters: users see raw `model-id · provider` labels instead of readable names, and models like `nvidia/moonshotai/kimi-k2.5` can jump to the wrong provider after refresh.
- What changed: the picker/default label now prefer catalog `name`, slash-containing model ids remain provider-qualified on restore, and duplicate friendly names are disambiguated with `· provider`.
- What did NOT change (scope boundary): this PR does not add full `alias` support from `agents.defaults.models`, and it does not change the backend model catalog payload.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related #58835
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the picker built labels from raw qualified values instead of catalog display metadata, and the restore path treated slash-containing `model` strings as already qualified even when `modelProvider` was provided separately.
- Missing detection / guardrail: there was no unit coverage for friendly-name rendering, duplicate-name disambiguation, or nested slash-containing ids paired with a separate provider.
- Prior context (`git blame`, prior PR, issue, or refactor if known): reported in #58835 against the built-in Control UI; the gateway already exposed `name` in `models.list`, but the chat picker path did not use it.
- Why this regressed now: this appears to be longstanding UI behavior rather than a newly introduced regression.
- If unknown, what was ruled out: ruled out missing `name` data for the reproduced cases; the issue is in Control UI rendering and restore logic.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `ui/src/ui/chat-model-ref.test.ts`
  - `ui/src/ui/chat-model-select-state.test.ts`
- Scenario the test should lock in:
  - picker labels use catalog `name`
  - slash-containing model ids stay provider-qualified when restored from session/default state
  - duplicate friendly names stay distinguishable with `· provider`
- Why this is the smallest reliable guardrail: the bug lives in local picker/label resolution logic and can be covered deterministically without booting the full gateway/UI stack.
- Existing test that already covers this (if any): none before this PR
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- The chat model picker now shows friendly catalog names from `models.list`.
- The default model label uses the same display logic.
- Models with slash-containing ids keep the correct provider-qualified value after refresh.
- If two entries share the same friendly name, the picker appends `· provider` to keep them distinct.

## Diagram (if applicable)

```text
Before:
[user opens picker] -> [raw "model-id · provider" labels]
[user selects nvidia/moonshotai/kimi-k2.5] -> [refresh] -> [wrong provider mapping possible]

After:
[user opens picker] -> [friendly catalog name]
[user selects nvidia/moonshotai/kimi-k2.5] -> [refresh] -> [provider-qualified value preserved]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw `main`, built-in Control UI
- Model/provider: `nvidia/moonshotai/kimi-k2.5` and other catalog-backed models
- Integration/channel (if any): none
- Relevant config (redacted): model catalog entries with `id`, `name`, and `provider`

### Steps

1. Start the gateway and open the built-in Control UI.
2. Open the chat model picker and inspect the displayed labels.
3. Select a slash-containing model id, then refresh or reload the session state.

### Expected

- Friendly catalog names are shown in the picker.
- Provider-qualified slash-containing model ids remain stable after refresh.

### Actual

- Before this change, the picker showed raw `model-id · provider` labels.
- Before this change, slash-containing ids could be restored against the wrong provider.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - rebuilt the Control UI and confirmed the picker shows friendly catalog names
  - confirmed the default label uses the same display logic
  - confirmed slash-containing model ids remain provider-qualified after refresh
- Edge cases checked:
  - duplicate friendly names across providers
  - nested slash-containing ids
  - fallback to raw formatting when no catalog match exists
- What you did **not** verify:
  - full `alias` support from `agents.defaults.models`
  - other Control UI surfaces outside the chat model picker

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: duplicate friendly names could become visually ambiguous.
  - Mitigation: append `· provider` only when duplicate visible names exist in the catalog.
- Risk: the original issue also mentions alias support, which this PR does not fully implement.
  - Mitigation: scope is called out explicitly; this PR is limited to `name` display and provider-qualified persistence.
