### PR TITLE
fix(config): reject workspace trust-root env overrides

### DIFF
--- a/src/config/config-env-vars.ts
+++ b/src/config/config-env-vars.ts
@@ -3,11 +3,16 @@ import {
   isDangerousHostEnvVarName,
   normalizeEnvVarKey,
 } from "../infra/host-env-security.js";
+import { isBlockedWorkspaceOpenClawEnvVar } from "../infra/workspace-env-policy.js";
 import { containsEnvVarReference } from "./env-substitution.js";
 import type { OpenClawConfig } from "./types.js";
 
 function isBlockedConfigEnvVar(key: string): boolean {
-  return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
+  return (
+    isDangerousHostEnvVarName(key) ||
+    isDangerousHostEnvOverrideVarName(key) ||
+    isBlockedWorkspaceOpenClawEnvVar(key)
+  );
 }
 
 function collectConfigEnvVarsByTarget(cfg?: OpenClawConfig): Record<string, string> {

--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -83,6 +83,37 @@ describe("config env vars", () => {
     );
   });
 
+  it("blocks OpenClaw trust-root env vars from config env", async () => {
+    await withEnvOverride(
+      {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+        OPENCLAW_STATE_DIR: undefined,
+        OPENROUTER_API_KEY: undefined,
+      },
+      async () => {
+        const config = {
+          env: {
+            vars: {
+              OPENCLAW_BUNDLED_PLUGINS_DIR: "/tmp/attacker-plugins",
+              OPENCLAW_STATE_DIR: "/tmp/attacker-state",
+              OPENROUTER_API_KEY: "config-key",
+            },
+          },
+        };
+
+        const entries = collectConfigRuntimeEnvVars(config as OpenClawConfig);
+        expect(entries.OPENCLAW_BUNDLED_PLUGINS_DIR).toBeUndefined();
+        expect(entries.OPENCLAW_STATE_DIR).toBeUndefined();
+        expect(entries.OPENROUTER_API_KEY).toBe("config-key");
+
+        applyConfigEnvVars(config as OpenClawConfig);
+        expect(process.env.OPENCLAW_BUNDLED_PLUGINS_DIR).toBeUndefined();
+        expect(process.env.OPENCLAW_STATE_DIR).toBeUndefined();
+        expect(process.env.OPENROUTER_API_KEY).toBe("config-key");
+      },
+    );
+  });
+
   it("drops non-portable env keys from config env", async () => {
     await withEnvOverride({ OPENROUTER_API_KEY: undefined }, async () => {
       const config = {

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -7,6 +7,7 @@ import {
   isDangerousHostEnvVarName,
   normalizeEnvVarKey,
 } from "./host-env-security.js";
+import { isBlockedWorkspaceOpenClawEnvVar } from "./workspace-env-policy.js";
 
 const BLOCKED_WORKSPACE_DOTENV_KEYS = new Set([
   "ALL_PROXY",
@@ -16,27 +17,18 @@ const BLOCKED_WORKSPACE_DOTENV_KEYS = new Set([
   "HTTPS_PROXY",
   "NODE_TLS_REJECT_UNAUTHORIZED",
   "NO_PROXY",
-  "OPENCLAW_AGENT_DIR",
-  "OPENCLAW_BUNDLED_HOOKS_DIR",
-  "OPENCLAW_BUNDLED_PLUGINS_DIR",
-  "OPENCLAW_BUNDLED_SKILLS_DIR",
-  "OPENCLAW_CONFIG_PATH",
   "OPENCLAW_GATEWAY_PASSWORD",
   "OPENCLAW_GATEWAY_SECRET",
   "OPENCLAW_GATEWAY_TOKEN",
-  "OPENCLAW_HOME",
   "OPENCLAW_LIVE_ANTHROPIC_KEY",
   "OPENCLAW_LIVE_ANTHROPIC_KEYS",
   "OPENCLAW_LIVE_GEMINI_KEY",
   "OPENCLAW_LIVE_OPENAI_KEY",
-  "OPENCLAW_OAUTH_DIR",
   "OPENCLAW_PINNED_PYTHON",
   "OPENCLAW_PINNED_WRITE_PYTHON",
   "OPENCLAW_PROFILE",
-  "OPENCLAW_STATE_DIR",
   "OPENAI_API_KEY",
   "OPENAI_API_KEYS",
-  "PI_CODING_AGENT_DIR",
 ]);
 
 const BLOCKED_WORKSPACE_DOTENV_SUFFIXES = ["_BASE_URL"];
@@ -59,6 +51,7 @@ function shouldBlockWorkspaceDotEnvKey(key: string): boolean {
   const upper = key.toUpperCase();
   return (
     shouldBlockWorkspaceRuntimeDotEnvKey(upper) ||
+    isBlockedWorkspaceOpenClawEnvVar(upper) ||
     BLOCKED_WORKSPACE_DOTENV_KEYS.has(upper) ||
     BLOCKED_WORKSPACE_DOTENV_PREFIXES.some((prefix) => upper.startsWith(prefix)) ||
     BLOCKED_WORKSPACE_DOTENV_SUFFIXES.some((suffix) => upper.endsWith(suffix))

--- a/src/infra/workspace-env-policy.ts
+++ b/src/infra/workspace-env-policy.ts
@@ -1,0 +1,21 @@
+import { normalizeEnvVarKey } from "./host-env-security.js";
+
+const BLOCKED_WORKSPACE_OPENCLAW_ENV_KEYS = new Set([
+  "OPENCLAW_AGENT_DIR",
+  "OPENCLAW_BUNDLED_HOOKS_DIR",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_BUNDLED_SKILLS_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_HOME",
+  "OPENCLAW_OAUTH_DIR",
+  "OPENCLAW_STATE_DIR",
+  "PI_CODING_AGENT_DIR",
+]);
+
+export function isBlockedWorkspaceOpenClawEnvVar(rawKey: string): boolean {
+  const key = normalizeEnvVarKey(rawKey);
+  if (!key) {
+    return false;
+  }
+  return BLOCKED_WORKSPACE_OPENCLAW_ENV_KEYS.has(key.toUpperCase());
+}

--- a/src/infra/workspace-env-policy.ts
+++ b/src/infra/workspace-env-policy.ts
@@ -13,7 +13,7 @@ const BLOCKED_WORKSPACE_OPENCLAW_ENV_KEYS = new Set([
 ]);
 
 export function isBlockedWorkspaceOpenClawEnvVar(rawKey: string): boolean {
-  const key = normalizeEnvVarKey(rawKey);
+  const key = normalizeEnvVarKey(rawKey, { portable: true });
   if (!key) {
     return false;
   }


### PR DESCRIPTION
## Summary
- Rejects workspace `config.env.vars` entries that try to override OpenClaw trust-root path variables
- Keeps workspace `.env` and config env filtering aligned for these privileged overrides

## Changes
- Added a shared workspace env policy helper for OpenClaw trust-root path variables
- Updated `src/config/config-env-vars.ts` to block those overrides in untrusted workspace config
- Updated dotenv filtering to use the same helper
- Added regression coverage for blocked trust-root overrides and the downstream daemon-install merge path

## Validation
- Ran `corepack pnpm test -- src/config/config.env-vars.test.ts src/infra/dotenv.test.ts`
- Ran `corepack pnpm test -- src/commands/daemon-install-helpers.test.ts -t "drops dangerous config env vars before service merge"`
- Ran `claude -p "/review"` and it requested GitHub approval to inspect PRs instead of returning a review in this environment

## Notes
- This stays narrow on OpenClaw trust-root/path overrides so existing config-driven provider auth env vars continue to work
- No earlier fix PR was found to incorporate
