### PR TITLE
fix(cron): validate custom session ids

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -604,6 +604,28 @@ describe("normalizeCronJobCreate", () => {
 
     expect(normalized.sessionTarget).toBe("isolated");
   });
+
+  it("rejects custom session ids with backslash", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "custom-session-backslash",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "session:bad\\id",
+      payload: { kind: "agentTurn", message: "hello" },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionTarget).toBe("isolated");
+  });
+
+  it("rejects custom session ids with NUL byte", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "custom-session-nul",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "session:bad\0id",
+      payload: { kind: "agentTurn", message: "hello" },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionTarget).toBe("isolated");
+  });
 });
 
 describe("normalizeCronJobPatch", () => {

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -594,6 +594,17 @@ describe("normalizeCronJobCreate", () => {
     expect(normalized.sessionTarget).toBe("session:MySessionID");
   });
 
+  it("preserves explicit agent session keys with a session: prefix", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "explicit-agent-session",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "session:agent:main:discord:group:ops",
+      payload: { kind: "agentTurn", message: "hello" },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionTarget).toBe("session:agent:main:discord:group:ops");
+  });
+
   it("rejects custom session ids with path separators", () => {
     const normalized = normalizeCronJobCreate({
       name: "custom-session-invalid",

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -593,6 +593,17 @@ describe("normalizeCronJobCreate", () => {
 
     expect(normalized.sessionTarget).toBe("session:MySessionID");
   });
+
+  it("rejects custom session ids with path separators", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "custom-session-invalid",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "session:../../escape",
+      payload: { kind: "agentTurn", message: "hello" },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionTarget).toBe("isolated");
+  });
 });
 
 describe("normalizeCronJobPatch", () => {

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -1,3 +1,4 @@
+import { SAFE_SESSION_ID_RE } from "../config/sessions/paths.js";
 import { sanitizeAgentId } from "../routing/session-key.js";
 import { isRecord } from "../utils.js";
 import {
@@ -313,6 +314,9 @@ function unwrapJob(raw: UnknownRecord) {
 export function normalizeCronCustomSessionId(raw: string): string | undefined {
   const trimmed = raw.trim();
   if (!trimmed || trimmed.includes("/") || trimmed.includes("\\") || trimmed.includes("\0")) {
+    return undefined;
+  }
+  if (!SAFE_SESSION_ID_RE.test(trimmed)) {
     return undefined;
   }
   return trimmed;

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -1,5 +1,5 @@
 import { SAFE_SESSION_ID_RE } from "../config/sessions/paths.js";
-import { sanitizeAgentId } from "../routing/session-key.js";
+import { parseAgentSessionKey, sanitizeAgentId } from "../routing/session-key.js";
 import { isRecord } from "../utils.js";
 import {
   TimeoutSecondsFieldSchema,
@@ -333,7 +333,12 @@ function normalizeSessionTarget(raw: unknown) {
   }
   // Support custom session IDs with "session:" prefix
   if (lower.startsWith("session:")) {
-    const sessionId = normalizeCronCustomSessionId(trimmed.slice(8));
+    const rawSessionId = trimmed.slice(8);
+    const parsedSessionKey = parseAgentSessionKey(rawSessionId);
+    if (parsedSessionKey) {
+      return `session:agent:${parsedSessionKey.agentId}:${parsedSessionKey.rest}`;
+    }
+    const sessionId = normalizeCronCustomSessionId(rawSessionId);
     if (sessionId) {
       return `session:${sessionId}`;
     }

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -310,6 +310,14 @@ function unwrapJob(raw: UnknownRecord) {
   return raw;
 }
 
+export function normalizeCronCustomSessionId(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.includes("/") || trimmed.includes("\\") || trimmed.includes("\0")) {
+    return undefined;
+  }
+  return trimmed;
+}
+
 function normalizeSessionTarget(raw: unknown) {
   if (typeof raw !== "string") {
     return undefined;
@@ -321,7 +329,7 @@ function normalizeSessionTarget(raw: unknown) {
   }
   // Support custom session IDs with "session:" prefix
   if (lower.startsWith("session:")) {
-    const sessionId = trimmed.slice(8).trim();
+    const sessionId = normalizeCronCustomSessionId(trimmed.slice(8));
     if (sessionId) {
       return `session:${sessionId}`;
     }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -202,4 +202,36 @@ describe("buildGatewayCronService", () => {
       state.cron.stop();
     }
   });
+
+  it("preserves resolved current session targets for isolated cron runs", async () => {
+    const cfg = createCronConfig("server-cron-resolved-session");
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "resolved-current-session",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "session:agent:main:discord:group:ops",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "hello" },
+      });
+
+      await state.cron.run(job.id, "force");
+
+      expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          job: expect.objectContaining({ id: job.id }),
+          sessionKey: "agent:main:discord:group:ops",
+        }),
+      );
+    } finally {
+      state.cron.stop();
+    }
+  });
 });

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -28,7 +28,11 @@ import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { getChildLogger } from "../logging.js";
-import { normalizeAgentId, toAgentStoreSessionKey } from "../routing/session-key.js";
+import {
+  normalizeAgentId,
+  parseAgentSessionKey,
+  toAgentStoreSessionKey,
+} from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 
 export type GatewayCronState = {
@@ -287,9 +291,14 @@ export function buildGatewayCronService(params: {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       let sessionKey = `cron:${job.id}`;
       if (job.sessionTarget.startsWith("session:")) {
-        const customSessionId = normalizeCronCustomSessionId(job.sessionTarget.slice(8));
-        if (customSessionId) {
-          sessionKey = customSessionId;
+        const requestedSessionKey = job.sessionTarget.slice(8);
+        if (parseAgentSessionKey(requestedSessionKey)) {
+          sessionKey = requestedSessionKey;
+        } else {
+          const customSessionId = normalizeCronCustomSessionId(requestedSessionKey);
+          if (customSessionId) {
+            sessionKey = customSessionId;
+          }
         }
       }
       return await runCronIsolatedAgentTurn({

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -11,6 +11,7 @@ import { resolveStorePath } from "../config/sessions/paths.js";
 import { resolveFailureDestination, sendFailureNotificationAnnounce } from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { resolveDeliveryTarget } from "../cron/isolated-agent/delivery-target.js";
+import { normalizeCronCustomSessionId } from "../cron/normalize.js";
 import {
   appendCronRunLog,
   resolveCronRunLogPath,
@@ -286,7 +287,7 @@ export function buildGatewayCronService(params: {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       let sessionKey = `cron:${job.id}`;
       if (job.sessionTarget.startsWith("session:")) {
-        const customSessionId = job.sessionTarget.slice(8).trim();
+        const customSessionId = normalizeCronCustomSessionId(job.sessionTarget.slice(8));
         if (customSessionId) {
           sessionKey = customSessionId;
         }

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -678,6 +678,56 @@ describe("gateway server cron", () => {
     }
   });
 
+  test("falls back to the cron session key for stored jobs with invalid custom session ids", async () => {
+    const now = Date.now();
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-run-invalid-session-",
+      jobs: [
+        {
+          id: "invalid-session-job",
+          name: "invalid session job",
+          enabled: true,
+          createdAtMs: now - 60_000,
+          updatedAtMs: now - 60_000,
+          schedule: { kind: "at", at: new Date(now + 60_000).toISOString() },
+          sessionTarget: "session:../../escape",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "agentTurn", message: "still isolated" },
+          delivery: { mode: "none" },
+          state: {
+            nextRunAtMs: now + 60_000,
+          },
+        },
+      ],
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      const finishedRun = waitForCronEvent(
+        ws,
+        (payload) => payload?.jobId === "invalid-session-job" && payload?.action === "finished",
+      );
+      const runRes = await rpcReq(
+        ws,
+        "cron.run",
+        { id: "invalid-session-job", mode: "force" },
+        1_000,
+      );
+      expect(runRes.ok).toBe(true);
+      expect(runRes.payload).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+      await finishedRun;
+      expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      expect(cronIsolatedRun.mock.calls[0]?.[0]).toMatchObject({
+        job: { id: "invalid-session-job" },
+        sessionKey: "cron:invalid-session-job",
+      });
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  });
+
   test("returns not-due without starting background work", async () => {
     const now = Date.now();
     const { prevSkipCron } = await setupCronTestRun({


### PR DESCRIPTION
## Summary
- Reject invalid `session:<id>` cron targets that contain path separator characters or NULs
- Reuse the same validation when resolving the isolated cron run `sessionKey`

## Changes
- Added a shared cron custom-session validator in `src/cron/normalize.ts`
- Applied that validator during cron job normalization so invalid custom session targets fall back to default isolated behavior
- Applied the same validator in the gateway cron runner so previously stored invalid jobs fall back to `cron:<job-id>`
- Added regression coverage for create-time normalization and run-time fallback behavior

## Validation
- Ran `corepack pnpm test -- src/cron/normalize.test.ts src/gateway/server.cron.test.ts`
- Verified invalid `session:../../...` values no longer survive normalization
- Verified stored invalid `session:` targets do not override the cron-scoped fallback session key
- Attempted local agentic review with `claude -p "/review"`; it requested interactive GitHub approval and returned no code findings in this environment

## Notes
- Scope is limited to custom cron session IDs; valid `session:<id>` inputs still behave as before
- This also hardens previously persisted invalid jobs by failing closed at execution time
