### PR TITLE
fix(gateway): reserve admin prefixes in scope resolution

### DIFF
--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -50,6 +50,22 @@ describe("method scope resolution", () => {
       "operator.write",
     ]);
   });
+
+  it("keeps admin-prefixed plugin methods admin-only", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.gatewayMethodScopes = {
+      "config.getAll": "operator.read",
+      "exec.approvals.get": "operator.write",
+    };
+    setActivePluginRegistry(registry);
+
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("config.getAll")).toEqual([
+      "operator.admin",
+    ]);
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("exec.approvals.get")).toEqual([
+      "operator.admin",
+    ]);
+  });
 });
 
 describe("operator scope authorization", () => {
@@ -97,6 +113,22 @@ describe("operator scope authorization", () => {
     expect(authorizeOperatorScopesForMethod("unknown.method", ["operator.read"])).toEqual({
       allowed: false,
       missingScope: "operator.admin",
+    });
+  });
+
+  it("rejects non-admin scopes for admin-prefixed plugin methods", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.gatewayMethodScopes = {
+      "config.getAll": "operator.read",
+    };
+    setActivePluginRegistry(registry);
+
+    expect(authorizeOperatorScopesForMethod("config.getAll", ["operator.read"])).toEqual({
+      allowed: false,
+      missingScope: "operator.admin",
+    });
+    expect(authorizeOperatorScopesForMethod("config.getAll", ["operator.admin"])).toEqual({
+      allowed: true,
     });
   });
 });

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -160,12 +160,12 @@ function resolveScopedMethod(method: string): OperatorScope | undefined {
   if (explicitScope) {
     return explicitScope;
   }
+  if (ADMIN_METHOD_PREFIXES.some((prefix) => method.startsWith(prefix))) {
+    return ADMIN_SCOPE;
+  }
   const pluginScope = getActivePluginRegistry()?.gatewayMethodScopes?.[method];
   if (pluginScope) {
     return pluginScope;
-  }
-  if (ADMIN_METHOD_PREFIXES.some((prefix) => method.startsWith(prefix))) {
-    return ADMIN_SCOPE;
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- Reserves admin-prefixed gateway method namespaces before plugin scope lookup
- Keeps plugin-registered methods outside reserved namespaces using their declared scopes

## Changes
- Reordered `resolveScopedMethod()` so reserved admin prefixes resolve to `operator.admin` before consulting plugin-registered scopes
- Added regression coverage for admin-prefixed plugin methods in both least-privilege resolution and authorization

## Validation
- Ran `corepack pnpm test -- src/gateway/method-scopes.test.ts`
- Verified admin-prefixed plugin methods no longer downgrade to non-admin scopes in the targeted regression tests
- Attempted local agentic review with `claude -p "/review"`, but this CLI requires a PR number; will run PR review after creation

## Notes
- This is a narrow behavior change limited to plugin-registered methods in reserved admin namespaces
- No broader gateway scope mapping changes were made