### PR TITLE
Isolate browser-origin auth throttling by origin

### DIFF
--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  AUTH_RATE_LIMIT_CLIENT_KEY_BROWSER_ORIGIN_PREFIX,
   AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
   AUTH_RATE_LIMIT_SCOPE_HOOK_AUTH,
   AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
@@ -171,6 +172,17 @@ describe("auth rate limiter", () => {
     });
     limiter.recordFailure("127.0.0.1");
     expect(limiter.check("127.0.0.1").allowed).toBe(false);
+  });
+
+  it("preserves browser-origin synthetic keys and tracks each origin independently", () => {
+    createLimiter({ maxAttempts: 1 });
+    const trustedUiKey = `${AUTH_RATE_LIMIT_CLIENT_KEY_BROWSER_ORIGIN_PREFIX}https://ui.example`;
+    const maliciousPageKey = `${AUTH_RATE_LIMIT_CLIENT_KEY_BROWSER_ORIGIN_PREFIX}https://evil.example`;
+
+    limiter.recordFailure(maliciousPageKey);
+
+    expect(limiter.check(maliciousPageKey).allowed).toBe(false);
+    expect(limiter.check(trustedUiKey).allowed).toBe(true);
   });
 
   // ---------- reset ----------

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -39,6 +39,7 @@ export const AUTH_RATE_LIMIT_SCOPE_DEFAULT = "default";
 export const AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET = "shared-secret";
 export const AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN = "device-token";
 export const AUTH_RATE_LIMIT_SCOPE_HOOK_AUTH = "hook-auth";
+export const AUTH_RATE_LIMIT_CLIENT_KEY_BROWSER_ORIGIN_PREFIX = "browser-origin:";
 
 export interface RateLimitEntry {
   /** Timestamps (epoch ms) of recent failed attempts inside the window. */
@@ -89,6 +90,10 @@ const PRUNE_INTERVAL_MS = 60_000; // prune stale entries every minute
  * share one representation (including IPv4-mapped IPv6 forms).
  */
 export function normalizeRateLimitClientIp(ip: string | undefined): string {
+  const trimmed = ip?.trim();
+  if (trimmed?.startsWith(AUTH_RATE_LIMIT_CLIENT_KEY_BROWSER_ORIGIN_PREFIX)) {
+    return trimmed;
+  }
   return resolveClientIp({ remoteAddr: ip }) ?? "unknown";
 }
 

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -29,12 +29,31 @@ describe("handshake auth helpers", () => {
       browserRateLimiter,
     });
 
+    // URL parsing strips the default HTTPS port, so :443 is normalized away.
     expect(resolved).toMatchObject({
       hasBrowserOriginHeader: true,
       enforceOriginCheckForAnyClient: true,
-      rateLimitClientIp: `${AUTH_RATE_LIMIT_CLIENT_KEY_BROWSER_ORIGIN_PREFIX}https://app.example:443`,
+      rateLimitClientIp: `${AUTH_RATE_LIMIT_CLIENT_KEY_BROWSER_ORIGIN_PREFIX}https://app.example`,
       authRateLimiter: browserRateLimiter,
     });
+  });
+
+  it("canonicalizes equivalent origins to the same rate-limit bucket", () => {
+    const rateLimiter = createRateLimiter();
+    const browserRateLimiter = createRateLimiter();
+    const withPort = resolveHandshakeBrowserSecurityContext({
+      requestOrigin: "https://app.example:443",
+      clientIp: "127.0.0.1",
+      rateLimiter,
+      browserRateLimiter,
+    });
+    const withoutPort = resolveHandshakeBrowserSecurityContext({
+      requestOrigin: "https://app.example",
+      clientIp: "127.0.0.1",
+      rateLimiter,
+      browserRateLimiter,
+    });
+    expect(withPort.rateLimitClientIp).toBe(withoutPort.rateLimitClientIp);
   });
 
   it("recommends device-token retry only for shared-token mismatch with device identity", () => {

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { AUTH_RATE_LIMIT_CLIENT_KEY_BROWSER_ORIGIN_PREFIX } from "../../auth-rate-limit.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import {
-  BROWSER_ORIGIN_LOOPBACK_RATE_LIMIT_IP,
   resolveHandshakeBrowserSecurityContext,
   resolveUnauthorizedHandshakeContext,
   shouldAllowSilentLocalPairing,
@@ -19,11 +19,11 @@ function createRateLimiter(): AuthRateLimiter {
 }
 
 describe("handshake auth helpers", () => {
-  it("pins browser-origin loopback clients to the synthetic rate-limit ip", () => {
+  it("keys browser-origin loopback clients by origin for rate limiting", () => {
     const rateLimiter = createRateLimiter();
     const browserRateLimiter = createRateLimiter();
     const resolved = resolveHandshakeBrowserSecurityContext({
-      requestOrigin: "https://app.example",
+      requestOrigin: "https://App.Example:443",
       clientIp: "127.0.0.1",
       rateLimiter,
       browserRateLimiter,
@@ -32,7 +32,7 @@ describe("handshake auth helpers", () => {
     expect(resolved).toMatchObject({
       hasBrowserOriginHeader: true,
       enforceOriginCheckForAnyClient: true,
-      rateLimitClientIp: BROWSER_ORIGIN_LOOPBACK_RATE_LIMIT_IP,
+      rateLimitClientIp: `${AUTH_RATE_LIMIT_CLIENT_KEY_BROWSER_ORIGIN_PREFIX}https://app.example:443`,
       authRateLimiter: browserRateLimiter,
     });
   });

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -8,7 +8,15 @@ import type { ConnectParams } from "../../protocol/index.js";
 import type { AuthProvidedKind } from "./auth-messages.js";
 
 function resolveBrowserOriginRateLimitKey(requestOrigin: string): string {
-  const normalizedOrigin = requestOrigin.trim().toLowerCase();
+  const trimmed = requestOrigin.trim();
+  let normalizedOrigin: string;
+  try {
+    // Use URL-parsed canonical origin so equivalent forms like
+    // "https://app.example:443" and "https://app.example" share one bucket.
+    normalizedOrigin = new URL(trimmed).origin.toLowerCase();
+  } catch {
+    normalizedOrigin = trimmed.toLowerCase();
+  }
   return `${AUTH_RATE_LIMIT_CLIENT_KEY_BROWSER_ORIGIN_PREFIX}${normalizedOrigin}`;
 }
 

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -1,4 +1,5 @@
 import { verifyDeviceSignature } from "../../../infra/device-identity.js";
+import { AUTH_RATE_LIMIT_CLIENT_KEY_BROWSER_ORIGIN_PREFIX } from "../../auth-rate-limit.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult } from "../../auth.js";
 import { buildDeviceAuthPayload, buildDeviceAuthPayloadV3 } from "../../device-auth.js";
@@ -6,7 +7,10 @@ import { isLoopbackAddress } from "../../net.js";
 import type { ConnectParams } from "../../protocol/index.js";
 import type { AuthProvidedKind } from "./auth-messages.js";
 
-export const BROWSER_ORIGIN_LOOPBACK_RATE_LIMIT_IP = "198.18.0.1";
+function resolveBrowserOriginRateLimitKey(requestOrigin: string): string {
+  const normalizedOrigin = requestOrigin.trim().toLowerCase();
+  return `${AUTH_RATE_LIMIT_CLIENT_KEY_BROWSER_ORIGIN_PREFIX}${normalizedOrigin}`;
+}
 
 export type HandshakeBrowserSecurityContext = {
   hasBrowserOriginHeader: boolean;
@@ -36,7 +40,7 @@ export function resolveHandshakeBrowserSecurityContext(params: {
     enforceOriginCheckForAnyClient: hasBrowserOriginHeader,
     rateLimitClientIp:
       hasBrowserOriginHeader && isLoopbackAddress(params.clientIp)
-        ? BROWSER_ORIGIN_LOOPBACK_RATE_LIMIT_IP
+        ? resolveBrowserOriginRateLimitKey(params.requestOrigin ?? "")
         : params.clientIp,
     authRateLimiter:
       hasBrowserOriginHeader && params.browserRateLimiter


### PR DESCRIPTION
## Summary
- isolate loopback browser-origin auth throttling by `Origin` instead of a shared synthetic bucket
- preserve the synthetic browser-origin key through auth rate-limit normalization

## Changes
- updated `resolveHandshakeBrowserSecurityContext()` to derive a per-origin synthetic limiter key for loopback browser traffic
- updated auth rate-limit normalization to preserve the reserved browser-origin key namespace
- added regression coverage for origin-specific handshake keys and independent limiter buckets

## Validation
- Ran `corepack pnpm test -- src/gateway/server/ws-connection/handshake-auth-helpers.test.ts`
- Ran `corepack pnpm test -- src/gateway/auth-rate-limit.test.ts`
- Ran `claude -p "/review"` locally; the tool exited asking for GitHub approval before producing review findings, so there was no actionable feedback to address
- Ran the pre-commit local gate via `scripts/committer ...`, including `pnpm check`

## Notes
- Residual risk: browser-origin buckets now depend on the normalized `Origin` header value, so malformed-but-present origins still share a bucket by their trimmed lowercase string
