### PR TITLE
fix(matrix): allow secret storage recreation during repair bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - iOS/canvas: restrict A2UI bridge trust to the bundled scaffold and exact capability-backed remote canvas URLs, so generic `canvas.navigate` and `canvas.present` loads no longer gain action-dispatch authority. (#58471) Thanks @eleqtrizit.
 - Agents/tool policy: preserve restrictive plugin-only allowlists instead of silently widening access to core tools, and keep allowlist warnings aligned with the enforced policy. (#58476) Thanks @eleqtrizit.
 - Telegram/native commands: clean up metadata-driven progress placeholders when replies fall back, edits fail, or local exec approval prompts are suppressed. (#59300) Thanks @jalehman.
+- Matrix: allow secret-storage recreation during automatic repair bootstrap so clients that lose their recovery key can recover and persist new cross-signing keys. (#59846) Thanks @al3mart.
 
 ## 2026.4.2
 

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1050,6 +1050,7 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(bootstrapSpy).toHaveBeenCalledTimes(2);
     expect((bootstrapSpy.mock.calls as unknown[][])[1]?.[1] ?? {}).toEqual({
       forceResetCrossSigning: true,
+      allowSecretStorageRecreateWithoutRecoveryKey: true,
       strict: true,
     });
   });

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -15,7 +15,10 @@ import { resolveMatrixRoomKeyBackupReadinessError } from "./backup-health.js";
 import { FileBackedMatrixSyncStore } from "./client/file-sync-store.js";
 import { createMatrixJsSdkClientLogger } from "./client/logging.js";
 import { isMatrixNotFoundError } from "./errors.js";
-import type { MatrixCryptoBootstrapResult } from "./sdk/crypto-bootstrap.js";
+import type {
+  MatrixCryptoBootstrapOptions,
+  MatrixCryptoBootstrapResult,
+} from "./sdk/crypto-bootstrap.js";
 import type { MatrixCryptoFacade } from "./sdk/crypto-facade.js";
 import type { MatrixDecryptBridge } from "./sdk/decrypt-bridge.js";
 import { matrixEventToRaw, parseMxc } from "./sdk/event-helpers.js";
@@ -118,6 +121,26 @@ export type MatrixVerificationBootstrapResult = {
   pendingVerifications: number;
   cryptoBootstrap: MatrixCryptoBootstrapResult | null;
 };
+
+const MATRIX_INITIAL_CRYPTO_BOOTSTRAP_OPTIONS = {
+  allowAutomaticCrossSigningReset: false,
+} satisfies MatrixCryptoBootstrapOptions;
+
+const MATRIX_AUTOMATIC_REPAIR_BOOTSTRAP_OPTIONS = {
+  forceResetCrossSigning: true,
+  allowSecretStorageRecreateWithoutRecoveryKey: true,
+  strict: true,
+} satisfies MatrixCryptoBootstrapOptions;
+
+function createMatrixExplicitBootstrapOptions(params?: {
+  forceResetCrossSigning?: boolean;
+}): MatrixCryptoBootstrapOptions {
+  return {
+    forceResetCrossSigning: params?.forceResetCrossSigning === true,
+    allowSecretStorageRecreateWithoutRecoveryKey: true,
+    strict: true,
+  };
+}
 
 export type MatrixOwnDeviceInfo = {
   deviceId: string;
@@ -453,9 +476,10 @@ export class MatrixClient {
     if (!cryptoBootstrapper) {
       return;
     }
-    const initial = await cryptoBootstrapper.bootstrap(crypto, {
-      allowAutomaticCrossSigningReset: false,
-    });
+    const initial = await cryptoBootstrapper.bootstrap(
+      crypto,
+      MATRIX_INITIAL_CRYPTO_BOOTSTRAP_OPTIONS,
+    );
     if (!initial.crossSigningPublished || initial.ownDeviceVerified === false) {
       const status = await this.getOwnDeviceVerificationStatus();
       if (status.signedByOwner) {
@@ -469,11 +493,10 @@ export class MatrixClient {
           // recreation so the new keys can be persisted. Without this, a device that
           // lost its recovery key enters a permanent failure loop because the new
           // cross-signing keys have nowhere to be stored.
-          const repaired = await cryptoBootstrapper.bootstrap(crypto, {
-            forceResetCrossSigning: true,
-            allowSecretStorageRecreateWithoutRecoveryKey: true,
-            strict: true,
-          });
+          const repaired = await cryptoBootstrapper.bootstrap(
+            crypto,
+            MATRIX_AUTOMATIC_REPAIR_BOOTSTRAP_OPTIONS,
+          );
           if (repaired.crossSigningPublished && repaired.ownDeviceVerified !== false) {
             LogService.info(
               "MatrixClientLite",
@@ -1266,11 +1289,10 @@ export class MatrixClient {
       if (!cryptoBootstrapper) {
         throw new Error("Matrix crypto bootstrapper is not available");
       }
-      bootstrapSummary = await cryptoBootstrapper.bootstrap(crypto, {
-        forceResetCrossSigning: params?.forceResetCrossSigning === true,
-        allowSecretStorageRecreateWithoutRecoveryKey: true,
-        strict: true,
-      });
+      bootstrapSummary = await cryptoBootstrapper.bootstrap(
+        crypto,
+        createMatrixExplicitBootstrapOptions(params),
+      );
       await this.ensureRoomKeyBackupEnabled(crypto);
     } catch (err) {
       this.recoveryKeyStore.discardStagedRecoveryKey();

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -465,8 +465,13 @@ export class MatrixClient {
         );
       } else if (this.password?.trim()) {
         try {
+          // The repair path already force-resets cross-signing; allow secret storage
+          // recreation so the new keys can be persisted. Without this, a device that
+          // lost its recovery key enters a permanent failure loop because the new
+          // cross-signing keys have nowhere to be stored.
           const repaired = await cryptoBootstrapper.bootstrap(crypto, {
             forceResetCrossSigning: true,
+            allowSecretStorageRecreateWithoutRecoveryKey: true,
             strict: true,
           });
           if (repaired.crossSigningPublished && repaired.ownDeviceVerified !== false) {


### PR DESCRIPTION
## Summary

- **Problem:** The gateway's automatic repair bootstrap path calls `forceResetCrossSigning: true` but does not pass `allowSecretStorageRecreateWithoutRecoveryKey: true`. When a device loses its recovery key (crypto reset, fresh install, migration), the repair creates new cross-signing keys but cannot persist them in secret storage. On next restart, the gateway fails again with `getSecretStorageKey callback returned falsey`.
- **Why it matters:** Any Matrix bot that loses its recovery key enters a permanent failure loop. The repair path is designed to recover from exactly this scenario but doesn't go far enough — it force-resets cross-signing without allowing the new keys to be stored.
- **What changed:** Pass `allowSecretStorageRecreateWithoutRecoveryKey: true` in the repair bootstrap call only (where `forceResetCrossSigning` is already `true`). This matches the explicit CLI bootstrap (`bootstrapOwnDeviceVerification`) which already passes this flag.
- **What did NOT change:** The initial conservative bootstrap remains unchanged (`allowSecretStorageRecreateWithoutRecoveryKey` defaults to `false`) so operators are notified when secret storage becomes inaccessible. Only the repair path — which already performs the most destructive operation (force cross-signing reset) — now also allows secret storage recreation.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Related #57776
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- **Root cause:** The repair path at `sdk.ts:bootstrapCryptoIfNeeded` was asymmetric — it force-reset cross-signing (the most destructive crypto operation) without allowing secret storage recreation (a less destructive prerequisite). The new cross-signing keys had nowhere to be persisted, causing the same failure on next restart.
- **Missing detection:** The existing test for the repair path (`"retries bootstrap with forced reset"`) asserted only `forceResetCrossSigning` and `strict`, not the secret storage flag.
- **Prior context:** The explicit CLI bootstrap (`bootstrapOwnDeviceVerification` at sdk.ts:1264) correctly passes `allowSecretStorageRecreateWithoutRecoveryKey: true`. The automatic repair path was not updated to match when the flag was introduced.
- **Why this regressed now:** The flag was designed for explicit bootstraps; the automatic repair path predates it and was never updated.

## Regression Test Plan

- [x] Unit test
- **Target:** `extensions/matrix/src/matrix/sdk.test.ts` — existing test `"retries bootstrap with forced reset when initial publish/verification is incomplete"`
- **Scenario:** Initial bootstrap returns unpublished cross-signing + unverified device → repair path is invoked → assertion now verifies `allowSecretStorageRecreateWithoutRecoveryKey: true` is passed alongside `forceResetCrossSigning: true`
- **Why this is the smallest reliable guardrail:** The repair path options are the exact contract boundary — if the flag is removed, this test fails immediately.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — recovery key generation already exists and is used by the explicit CLI bootstrap
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (also reproduced on Ubuntu 25.10 per #57776)
- Runtime: Node 22+
- Integration: Matrix with encryption enabled and password configured

### Steps

1. Configure Matrix channel with `encryption: true` and a password
2. Delete the local crypto store (simulating a reset or fresh install)
3. Restart the gateway
4. Observe: initial bootstrap fails (no recovery key for existing server secret storage), repair path runs with `forceResetCrossSigning: true` but also fails at secret storage recreation

### Expected

Repair bootstrap creates new cross-signing keys AND recreates secret storage with a fresh recovery key.

### Actual (before fix)

Repair bootstrap creates new cross-signing keys but fails to persist them. Next restart hits the same `getSecretStorageKey callback returned falsey` error.

## Evidence

- [x] Failing test before + passing after
- Existing test updated to assert the new flag; all 53 tests in `sdk.test.ts` pass

## Human Verification

- Verified: repair bootstrap now passes `allowSecretStorageRecreateWithoutRecoveryKey: true`; test confirms
- Edge cases: initial (non-repair) bootstrap still does NOT pass the flag — verified by reading the code diff
- Not verified: full end-to-end Matrix restart cycle with live homeserver

## AI-Assisted

This PR was AI-assisted (Claude). The fix and test update were reviewed against existing codebase patterns for correctness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible: Yes
- Config/env changes: No
- Migration needed: No