### PR TITLE
fix(matrix): add advisory file locking to IDB crypto persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/OpenAI: enable reference-image edits for `gpt-image-1` by routing edit calls to `/images/edits` with multipart image uploads, and update image-generation capability/docs metadata accordingly.
 - Agents/tools: include value-shape hints in missing-parameter tool errors so dropped, empty-string, and wrong-type write payloads are easier to diagnose from logs. (#55317) Thanks @priyansh19.
 - Android/assistant: keep queued App Actions prompts pending when auto-send enqueue is rejected, so transient chat-health drops do not silently lose the assistant request. Thanks @obviyus.
+- Matrix/crypto persistence: capture and write the IndexedDB snapshot while holding the snapshot file lock so concurrent gateway and CLI persists cannot overwrite newer crypto state. (#59851) thanks @al3mart.
 - Plugins/Google: separate OAuth CSRF state from PKCE code verifier during Gemini browser sign-in so state validation and token exchange use independent values. (#59116) Thanks @eleqtrizit.
 - Plugins/browser: block SSRF redirect bypass by installing a real-time Playwright route handler before `page.goto()` so navigation to private/internal IPs is intercepted and aborted mid-redirect instead of checked post-hoc. (#58771) Thanks @pgondhi987.
 - Android/gateway: require TLS for non-loopback remote gateway endpoints while still allowing local loopback and emulator cleartext setup flows. (#58475) Thanks @eleqtrizit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Docs: https://docs.openclaw.ai
 - Plugins/OpenAI: enable reference-image edits for `gpt-image-1` by routing edit calls to `/images/edits` with multipart image uploads, and update image-generation capability/docs metadata accordingly.
 - Agents/tools: include value-shape hints in missing-parameter tool errors so dropped, empty-string, and wrong-type write payloads are easier to diagnose from logs. (#55317) Thanks @priyansh19.
 - Android/assistant: keep queued App Actions prompts pending when auto-send enqueue is rejected, so transient chat-health drops do not silently lose the assistant request. Thanks @obviyus.
-- Matrix/crypto persistence: capture and write the IndexedDB snapshot while holding the snapshot file lock so concurrent gateway and CLI persists cannot overwrite newer crypto state. (#59851) thanks @al3mart.
 - Plugins/Google: separate OAuth CSRF state from PKCE code verifier during Gemini browser sign-in so state validation and token exchange use independent values. (#59116) Thanks @eleqtrizit.
 - Plugins/browser: block SSRF redirect bypass by installing a real-time Playwright route handler before `page.goto()` so navigation to private/internal IPs is intercepted and aborted mid-redirect instead of checked post-hoc. (#58771) Thanks @pgondhi987.
 - Android/gateway: require TLS for non-loopback remote gateway endpoints while still allowing local loopback and emulator cleartext setup flows. (#58475) Thanks @eleqtrizit.
@@ -30,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Agents/tool policy: preserve restrictive plugin-only allowlists instead of silently widening access to core tools, and keep allowlist warnings aligned with the enforced policy. (#58476) Thanks @eleqtrizit.
 - Telegram/native commands: clean up metadata-driven progress placeholders when replies fall back, edits fail, or local exec approval prompts are suppressed. (#59300) Thanks @jalehman.
 - Matrix: allow secret-storage recreation during automatic repair bootstrap so clients that lose their recovery key can recover and persist new cross-signing keys. (#59846) Thanks @al3mart.
+- Matrix/crypto persistence: capture and write the IndexedDB snapshot while holding the snapshot file lock so concurrent gateway and CLI persists cannot overwrite newer crypto state. (#59851) Thanks @al3mart.
 
 ## 2026.4.2
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -422,6 +422,7 @@ OpenClaw currently provides that in Node by:
 - using `fake-indexeddb` as the IndexedDB API shim expected by the SDK
 - restoring the Rust crypto IndexedDB contents from `crypto-idb-snapshot.json` before `initRustCrypto`
 - persisting the updated IndexedDB contents back to `crypto-idb-snapshot.json` after init and during runtime
+- serializing snapshot restore and persist against `crypto-idb-snapshot.json` with an advisory file lock so gateway runtime persistence and CLI maintenance do not race on the same snapshot file
 
 This is compatibility/storage plumbing, not a custom crypto implementation.
 The snapshot file is sensitive runtime state and is stored with restrictive file permissions.

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1194,7 +1194,9 @@ describe("MatrixClient crypto bootstrapping", () => {
     const callsAfterStart = databasesSpy.mock.calls.length;
 
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(databasesSpy.mock.calls.length).toBeGreaterThan(callsAfterStart);
+    await vi.waitFor(() => {
+      expect(databasesSpy.mock.calls.length).toBeGreaterThan(callsAfterStart);
+    });
 
     client.stop();
     const callsAfterStop = databasesSpy.mock.calls.length;

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.lock-order.test.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.lock-order.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearAllIndexedDbState, seedDatabase } from "./idb-persistence.test-helpers.js";
 
 const { withFileLockMock } = vi.hoisted(() => ({
   withFileLockMock: vi.fn(
@@ -19,55 +20,6 @@ vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
 });
 
 let persistIdbToDisk: typeof import("./idb-persistence.js").persistIdbToDisk;
-
-async function clearAllIndexedDbState(): Promise<void> {
-  const databases = await indexedDB.databases();
-  await Promise.all(
-    databases
-      .map((entry) => entry.name)
-      .filter((name): name is string => Boolean(name))
-      .map(
-        (name) =>
-          new Promise<void>((resolve, reject) => {
-            const req = indexedDB.deleteDatabase(name);
-            req.onsuccess = () => resolve();
-            req.onerror = () => reject(req.error);
-            req.onblocked = () => resolve();
-          }),
-      ),
-  );
-}
-
-async function seedDatabase(params: {
-  name: string;
-  version?: number;
-  storeName: string;
-  records: Array<{ key: IDBValidKey; value: unknown }>;
-}): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const req = indexedDB.open(params.name, params.version ?? 1);
-    req.onupgradeneeded = () => {
-      const db = req.result;
-      if (!db.objectStoreNames.contains(params.storeName)) {
-        db.createObjectStore(params.storeName);
-      }
-    };
-    req.onsuccess = () => {
-      const db = req.result;
-      const tx = db.transaction(params.storeName, "readwrite");
-      const store = tx.objectStore(params.storeName);
-      for (const record of params.records) {
-        store.put(record.value, record.key);
-      }
-      tx.oncomplete = () => {
-        db.close();
-        resolve();
-      };
-      tx.onerror = () => reject(tx.error);
-    };
-    req.onerror = () => reject(req.error);
-  });
-}
 
 beforeAll(async () => {
   ({ persistIdbToDisk } = await import("./idb-persistence.js"));

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.lock-order.test.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.lock-order.test.ts
@@ -1,0 +1,122 @@
+import "fake-indexeddb/auto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { withFileLockMock } = vi.hoisted(() => ({
+  withFileLockMock: vi.fn(
+    async <T>(_filePath: string, _options: unknown, fn: () => Promise<T>) => await fn(),
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  return {
+    ...actual,
+    withFileLock: withFileLockMock,
+  };
+});
+
+let persistIdbToDisk: typeof import("./idb-persistence.js").persistIdbToDisk;
+
+async function clearAllIndexedDbState(): Promise<void> {
+  const databases = await indexedDB.databases();
+  await Promise.all(
+    databases
+      .map((entry) => entry.name)
+      .filter((name): name is string => Boolean(name))
+      .map(
+        (name) =>
+          new Promise<void>((resolve, reject) => {
+            const req = indexedDB.deleteDatabase(name);
+            req.onsuccess = () => resolve();
+            req.onerror = () => reject(req.error);
+            req.onblocked = () => resolve();
+          }),
+      ),
+  );
+}
+
+async function seedDatabase(params: {
+  name: string;
+  version?: number;
+  storeName: string;
+  records: Array<{ key: IDBValidKey; value: unknown }>;
+}): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.open(params.name, params.version ?? 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(params.storeName)) {
+        db.createObjectStore(params.storeName);
+      }
+    };
+    req.onsuccess = () => {
+      const db = req.result;
+      const tx = db.transaction(params.storeName, "readwrite");
+      const store = tx.objectStore(params.storeName);
+      for (const record of params.records) {
+        store.put(record.value, record.key);
+      }
+      tx.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      tx.onerror = () => reject(tx.error);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+beforeAll(async () => {
+  ({ persistIdbToDisk } = await import("./idb-persistence.js"));
+});
+
+describe("Matrix IndexedDB persistence lock ordering", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-idb-lock-order-"));
+    withFileLockMock.mockReset();
+    withFileLockMock.mockImplementation(
+      async <T>(_filePath: string, _options: unknown, fn: () => Promise<T>) => await fn(),
+    );
+    await clearAllIndexedDbState();
+  });
+
+  afterEach(async () => {
+    await clearAllIndexedDbState();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("captures the snapshot after the file lock is acquired", async () => {
+    const snapshotPath = path.join(tmpDir, "crypto-idb-snapshot.json");
+    const dbName = "openclaw-matrix-test::matrix-sdk-crypto";
+    await seedDatabase({
+      name: dbName,
+      storeName: "sessions",
+      records: [{ key: "room-1", value: { session: "old-session" } }],
+    });
+
+    withFileLockMock.mockImplementationOnce(async (_filePath, _options, fn) => {
+      await seedDatabase({
+        name: dbName,
+        storeName: "sessions",
+        records: [{ key: "room-1", value: { session: "new-session" } }],
+      });
+      return await fn();
+    });
+
+    await persistIdbToDisk({ snapshotPath, databasePrefix: "openclaw-matrix-test" });
+
+    const data = JSON.parse(fs.readFileSync(snapshotPath, "utf8")) as Array<{
+      stores: Array<{
+        name: string;
+        records: Array<{ key: IDBValidKey; value: { session: string } }>;
+      }>;
+    }>;
+    const sessionsStore = data[0]?.stores.find((store) => store.name === "sessions");
+    expect(sessionsStore?.records).toEqual([{ key: "room-1", value: { session: "new-session" } }]);
+  });
+});

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.test-helpers.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.test-helpers.ts
@@ -1,0 +1,88 @@
+export async function clearAllIndexedDbState(): Promise<void> {
+  const databases = await indexedDB.databases();
+  await Promise.all(
+    databases
+      .map((entry) => entry.name)
+      .filter((name): name is string => Boolean(name))
+      .map(
+        (name) =>
+          new Promise<void>((resolve, reject) => {
+            const req = indexedDB.deleteDatabase(name);
+            req.onsuccess = () => resolve();
+            req.onerror = () => reject(req.error);
+            req.onblocked = () => resolve();
+          }),
+      ),
+  );
+}
+
+export async function seedDatabase(params: {
+  name: string;
+  version?: number;
+  storeName: string;
+  records: Array<{ key: IDBValidKey; value: unknown }>;
+}): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.open(params.name, params.version ?? 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(params.storeName)) {
+        db.createObjectStore(params.storeName);
+      }
+    };
+    req.onsuccess = () => {
+      const db = req.result;
+      const tx = db.transaction(params.storeName, "readwrite");
+      const store = tx.objectStore(params.storeName);
+      for (const record of params.records) {
+        store.put(record.value, record.key);
+      }
+      tx.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      tx.onerror = () => reject(tx.error);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function readDatabaseRecords(params: {
+  name: string;
+  version?: number;
+  storeName: string;
+}): Promise<Array<{ key: IDBValidKey; value: unknown }>> {
+  return await new Promise((resolve, reject) => {
+    const req = indexedDB.open(params.name, params.version ?? 1);
+    req.onsuccess = () => {
+      const db = req.result;
+      const tx = db.transaction(params.storeName, "readonly");
+      const store = tx.objectStore(params.storeName);
+      const keysReq = store.getAllKeys();
+      const valuesReq = store.getAll();
+      let keys: IDBValidKey[] | null = null;
+      let values: unknown[] | null = null;
+
+      const maybeResolve = () => {
+        if (!keys || !values) {
+          return;
+        }
+        db.close();
+        const resolvedValues = values;
+        resolve(keys.map((key, index) => ({ key, value: resolvedValues[index] })));
+      };
+
+      keysReq.onsuccess = () => {
+        keys = keysReq.result;
+        maybeResolve();
+      };
+      valuesReq.onsuccess = () => {
+        values = valuesReq.result;
+        maybeResolve();
+      };
+      keysReq.onerror = () => reject(keysReq.error);
+      valuesReq.onerror = () => reject(valuesReq.error);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
@@ -8,96 +8,12 @@ import {
 } from "openclaw/plugin-sdk/infra-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { persistIdbToDisk, restoreIdbFromDisk } from "./idb-persistence.js";
+import {
+  clearAllIndexedDbState,
+  readDatabaseRecords,
+  seedDatabase,
+} from "./idb-persistence.test-helpers.js";
 import { LogService } from "./logger.js";
-
-async function clearAllIndexedDbState(): Promise<void> {
-  const databases = await indexedDB.databases();
-  await Promise.all(
-    databases
-      .map((entry) => entry.name)
-      .filter((name): name is string => Boolean(name))
-      .map(
-        (name) =>
-          new Promise<void>((resolve, reject) => {
-            const req = indexedDB.deleteDatabase(name);
-            req.onsuccess = () => resolve();
-            req.onerror = () => reject(req.error);
-            req.onblocked = () => resolve();
-          }),
-      ),
-  );
-}
-
-async function seedDatabase(params: {
-  name: string;
-  version?: number;
-  storeName: string;
-  records: Array<{ key: IDBValidKey; value: unknown }>;
-}): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const req = indexedDB.open(params.name, params.version ?? 1);
-    req.onupgradeneeded = () => {
-      const db = req.result;
-      if (!db.objectStoreNames.contains(params.storeName)) {
-        db.createObjectStore(params.storeName);
-      }
-    };
-    req.onsuccess = () => {
-      const db = req.result;
-      const tx = db.transaction(params.storeName, "readwrite");
-      const store = tx.objectStore(params.storeName);
-      for (const record of params.records) {
-        store.put(record.value, record.key);
-      }
-      tx.oncomplete = () => {
-        db.close();
-        resolve();
-      };
-      tx.onerror = () => reject(tx.error);
-    };
-    req.onerror = () => reject(req.error);
-  });
-}
-
-async function readDatabaseRecords(params: {
-  name: string;
-  version?: number;
-  storeName: string;
-}): Promise<Array<{ key: IDBValidKey; value: unknown }>> {
-  return await new Promise((resolve, reject) => {
-    const req = indexedDB.open(params.name, params.version ?? 1);
-    req.onsuccess = () => {
-      const db = req.result;
-      const tx = db.transaction(params.storeName, "readonly");
-      const store = tx.objectStore(params.storeName);
-      const keysReq = store.getAllKeys();
-      const valuesReq = store.getAll();
-      let keys: IDBValidKey[] | null = null;
-      let values: unknown[] | null = null;
-
-      const maybeResolve = () => {
-        if (!keys || !values) {
-          return;
-        }
-        db.close();
-        const resolvedValues = values;
-        resolve(keys.map((key, index) => ({ key, value: resolvedValues[index] })));
-      };
-
-      keysReq.onsuccess = () => {
-        keys = keysReq.result;
-        maybeResolve();
-      };
-      valuesReq.onsuccess = () => {
-        values = valuesReq.result;
-        maybeResolve();
-      };
-      keysReq.onerror = () => reject(keysReq.error);
-      valuesReq.onerror = () => reject(valuesReq.error);
-    };
-    req.onerror = () => reject(req.error);
-  });
-}
 
 describe("Matrix IndexedDB persistence", () => {
   let tmpDir: string;

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
@@ -185,12 +185,11 @@ describe("Matrix IndexedDB persistence", () => {
       records: [{ key: "room-1", value: { session: "abc123" } }],
     });
 
-    const results = await Promise.allSettled([
+    await Promise.all([
       persistIdbToDisk({ snapshotPath, databasePrefix: "openclaw-matrix-test" }),
       persistIdbToDisk({ snapshotPath, databasePrefix: "openclaw-matrix-test" }),
     ]);
 
-    expect(results.every((r) => r.status === "fulfilled")).toBe(true);
     expect(fs.existsSync(snapshotPath)).toBe(true);
 
     const data = JSON.parse(fs.readFileSync(snapshotPath, "utf8"));
@@ -207,10 +206,10 @@ describe("Matrix IndexedDB persistence", () => {
     });
 
     await persistIdbToDisk({ snapshotPath, databasePrefix: "openclaw-matrix-test" });
-    await drainFileLockStateForTest();
 
     const lockPath = `${snapshotPath}.lock`;
     expect(fs.existsSync(lockPath)).toBe(false);
+    await drainFileLockStateForTest();
   });
 
   it("releases lock after restore completes", async () => {
@@ -226,9 +225,9 @@ describe("Matrix IndexedDB persistence", () => {
     await drainFileLockStateForTest();
 
     await restoreIdbFromDisk(snapshotPath);
-    await drainFileLockStateForTest();
 
     const lockPath = `${snapshotPath}.lock`;
     expect(fs.existsSync(lockPath)).toBe(false);
+    await drainFileLockStateForTest();
   });
 });

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
@@ -2,6 +2,10 @@ import "fake-indexeddb/auto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import {
+  drainFileLockStateForTest,
+  resetFileLockStateForTest,
+} from "openclaw/plugin-sdk/infra-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { persistIdbToDisk, restoreIdbFromDisk } from "./idb-persistence.js";
 import { LogService } from "./logger.js";
@@ -108,6 +112,7 @@ describe("Matrix IndexedDB persistence", () => {
   afterEach(async () => {
     warnSpy.mockRestore();
     await clearAllIndexedDbState();
+    resetFileLockStateForTest();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -170,5 +175,60 @@ describe("Matrix IndexedDB persistence", () => {
 
     const dbs = await indexedDB.databases();
     expect(dbs).toEqual([]);
+  });
+
+  it("serializes concurrent persist operations via file lock", async () => {
+    const snapshotPath = path.join(tmpDir, "concurrent-persist.json");
+    await seedDatabase({
+      name: "openclaw-matrix-test::matrix-sdk-crypto",
+      storeName: "sessions",
+      records: [{ key: "room-1", value: { session: "abc123" } }],
+    });
+
+    const results = await Promise.allSettled([
+      persistIdbToDisk({ snapshotPath, databasePrefix: "openclaw-matrix-test" }),
+      persistIdbToDisk({ snapshotPath, databasePrefix: "openclaw-matrix-test" }),
+    ]);
+
+    expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+    expect(fs.existsSync(snapshotPath)).toBe(true);
+
+    const data = JSON.parse(fs.readFileSync(snapshotPath, "utf8"));
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBe(1);
+  });
+
+  it("releases lock after persist completes", async () => {
+    const snapshotPath = path.join(tmpDir, "lock-release.json");
+    await seedDatabase({
+      name: "openclaw-matrix-test::matrix-sdk-crypto",
+      storeName: "sessions",
+      records: [{ key: "room-1", value: { session: "abc123" } }],
+    });
+
+    await persistIdbToDisk({ snapshotPath, databasePrefix: "openclaw-matrix-test" });
+    await drainFileLockStateForTest();
+
+    const lockPath = `${snapshotPath}.lock`;
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("releases lock after restore completes", async () => {
+    const snapshotPath = path.join(tmpDir, "lock-release-restore.json");
+    await seedDatabase({
+      name: "openclaw-matrix-test::matrix-sdk-crypto",
+      storeName: "sessions",
+      records: [{ key: "room-1", value: { session: "abc123" } }],
+    });
+
+    await persistIdbToDisk({ snapshotPath, databasePrefix: "openclaw-matrix-test" });
+    await clearAllIndexedDbState();
+    await drainFileLockStateForTest();
+
+    await restoreIdbFromDisk(snapshotPath);
+    await drainFileLockStateForTest();
+
+    const lockPath = `${snapshotPath}.lock`;
+    expect(fs.existsSync(lockPath)).toBe(false);
   });
 });

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.ts
@@ -8,6 +8,9 @@ import { LogService } from "./logger.js";
 // Advisory lock options for IDB snapshot file access. Without locking, the
 // gateway's periodic 60-second persist cycle and CLI crypto commands (e.g.
 // `openclaw matrix verify bootstrap`) can corrupt each other's state.
+// Use a longer stale window than the generic 30s default because snapshot
+// restore and large crypto-store dumps can legitimately hold the lock for
+// longer, and reclaiming a live lock would reintroduce concurrent corruption.
 const IDB_SNAPSHOT_LOCK_OPTIONS: FileLockOptions = {
   retries: {
     retries: 10,
@@ -16,7 +19,7 @@ const IDB_SNAPSHOT_LOCK_OPTIONS: FileLockOptions = {
     maxTimeout: 5_000,
     randomize: true,
   },
-  stale: 30_000,
+  stale: 5 * 60_000,
 };
 
 type IdbStoreSnapshot = {

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.ts
@@ -248,16 +248,20 @@ export async function persistIdbToDisk(params?: {
 }): Promise<void> {
   const snapshotPath = params?.snapshotPath ?? resolveDefaultIdbSnapshotPath();
   try {
-    const snapshot = await dumpIndexedDatabases(params?.databasePrefix);
-    if (snapshot.length === 0) return;
     fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
-    await withFileLock(snapshotPath, IDB_SNAPSHOT_LOCK_OPTIONS, async () => {
+    const persistedCount = await withFileLock(snapshotPath, IDB_SNAPSHOT_LOCK_OPTIONS, async () => {
+      const snapshot = await dumpIndexedDatabases(params?.databasePrefix);
+      if (snapshot.length === 0) {
+        return 0;
+      }
       fs.writeFileSync(snapshotPath, JSON.stringify(snapshot));
       fs.chmodSync(snapshotPath, 0o600);
+      return snapshot.length;
     });
+    if (persistedCount === 0) return;
     LogService.debug(
       "IdbPersistence",
-      `Persisted ${snapshot.length} IndexedDB database(s) to ${snapshotPath}`,
+      `Persisted ${persistedCount} IndexedDB database(s) to ${snapshotPath}`,
     );
   } catch (err) {
     LogService.warn("IdbPersistence", "Failed to persist IndexedDB snapshot:", err);

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.ts
@@ -1,7 +1,23 @@
 import fs from "node:fs";
 import path from "node:path";
 import { indexedDB as fakeIndexedDB } from "fake-indexeddb";
+import type { FileLockOptions } from "openclaw/plugin-sdk/infra-runtime";
+import { withFileLock } from "openclaw/plugin-sdk/infra-runtime";
 import { LogService } from "./logger.js";
+
+// Advisory lock options for IDB snapshot file access. Without locking, the
+// gateway's periodic 60-second persist cycle and CLI crypto commands (e.g.
+// `openclaw matrix verify bootstrap`) can corrupt each other's state.
+const IDB_SNAPSHOT_LOCK_OPTIONS: FileLockOptions = {
+  retries: {
+    retries: 10,
+    factor: 2,
+    minTimeout: 50,
+    maxTimeout: 5_000,
+    randomize: true,
+  },
+  stale: 30_000,
+};
 
 type IdbStoreSnapshot = {
   name: string;
@@ -198,17 +214,22 @@ export async function restoreIdbFromDisk(snapshotPath?: string): Promise<boolean
   const candidatePaths = snapshotPath ? [snapshotPath] : [resolveDefaultIdbSnapshotPath()];
   for (const resolvedPath of candidatePaths) {
     try {
-      const data = fs.readFileSync(resolvedPath, "utf8");
-      const snapshot = parseSnapshotPayload(data);
-      if (!snapshot) {
-        continue;
+      const restored = await withFileLock(resolvedPath, IDB_SNAPSHOT_LOCK_OPTIONS, async () => {
+        const data = fs.readFileSync(resolvedPath, "utf8");
+        const snapshot = parseSnapshotPayload(data);
+        if (!snapshot) {
+          return false;
+        }
+        await restoreIndexedDatabases(snapshot);
+        LogService.info(
+          "IdbPersistence",
+          `Restored ${snapshot.length} IndexedDB database(s) from ${resolvedPath}`,
+        );
+        return true;
+      });
+      if (restored) {
+        return true;
       }
-      await restoreIndexedDatabases(snapshot);
-      LogService.info(
-        "IdbPersistence",
-        `Restored ${snapshot.length} IndexedDB database(s) from ${resolvedPath}`,
-      );
-      return true;
     } catch (err) {
       LogService.warn(
         "IdbPersistence",
@@ -230,8 +251,10 @@ export async function persistIdbToDisk(params?: {
     const snapshot = await dumpIndexedDatabases(params?.databasePrefix);
     if (snapshot.length === 0) return;
     fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
-    fs.writeFileSync(snapshotPath, JSON.stringify(snapshot));
-    fs.chmodSync(snapshotPath, 0o600);
+    await withFileLock(snapshotPath, IDB_SNAPSHOT_LOCK_OPTIONS, async () => {
+      fs.writeFileSync(snapshotPath, JSON.stringify(snapshot));
+      fs.chmodSync(snapshotPath, 0o600);
+    });
     LogService.debug(
       "IdbPersistence",
       `Persisted ${snapshot.length} IndexedDB database(s) to ${snapshotPath}`,


### PR DESCRIPTION
## Summary

- **Problem:** `persistIdbToDisk` and `restoreIdbFromDisk` operate on shared snapshot files with no file locking. The gateway persists IDB every 60 seconds while CLI tools (e.g. `openclaw matrix verify bootstrap`) may read or write the same files at any time, corrupting the crypto store.
- **Why it matters:** Running CLI crypto commands while the gateway is active is a common operational pattern (verifying devices, bootstrapping E2EE) that silently corrupts the shared crypto state, leading to permanent decryption failures requiring a full crypto reset.
- **What changed:** Wrapped both `persistIdbToDisk` and `restoreIdbFromDisk` with the existing `withFileLock` utility from `openclaw/plugin-sdk/infra-runtime`. Concurrent access now serializes through an advisory lock rather than racing.
- **What did NOT change:** The snapshot format, file permissions (0o600), IDB dump/restore logic, and persistence timing remain unchanged. Only the file I/O is now protected by a lock.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations
- [x] Memory / storage

## Linked Issue/PR

- Related #57776
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- **Root cause:** `persistIdbToDisk` and `restoreIdbFromDisk` were written as single-process operations. As the CLI grew crypto management commands that touch the same files as the running gateway, the lack of locking became a corruption vector.
- **Missing detection:** The existing test suite (3 tests) covered only single-caller happy-path and error scenarios. No concurrent access tests existed.
- **Prior context:** The project already has a battle-tested `withFileLock` utility used by `persistent-dedupe.ts` and `pairing-store.ts` for the same purpose. The IDB persistence was simply never updated to use it.

## Regression Test Plan

- [x] Unit test
- **Target:** `extensions/matrix/src/matrix/sdk/idb-persistence.test.ts`
- **Scenarios added:**
  - Concurrent persist operations serialize via file lock and produce valid output
  - Lock is released after persist completes
  - Lock is released after restore completes
- **Why this is the smallest reliable guardrail:** The tests verify the lock lifecycle (acquire → operate → release) which is the exact contract that prevents corruption.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] Failing test before + passing after (new coverage for previously untested concurrent access)
- All 6 tests pass (3 existing + 3 new)

## Human Verification

- Verified: locking wraps both persist and restore; `withFileLock` guarantees release via try/finally
- Edge cases: stale lock cleanup is handled by the existing `withFileLock` implementation (PID-based staleness detection with configurable `stale` timeout)
- Not verified: cross-process locking with a live gateway (requires integration test environment)

## AI-Assisted

This PR was AI-assisted (Claude). The fix uses the project's existing `withFileLock` utility and follows established patterns from `persistent-dedupe.ts`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible: Yes
- Config/env changes: No
- Migration needed: No

## Risks and Mitigations

- **Risk:** Lock file left behind after crash could delay startup.
  - **Mitigation:** The `withFileLock` implementation uses PID-based staleness detection (`stale: 30_000`ms). A lock from a dead process is automatically reclaimed.
- **Risk:** Lock contention could delay the gateway's 60-second persist cycle.
  - **Mitigation:** Retry backoff is capped at 5 seconds with 10 retries. Worst-case delay is bounded and logged.