### PR TITLE
fix: respect agents.defaults.workspace for non-default agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/Telegram exec approvals: recover stored same-channel account bindings even when session reply state drifted to another channel, so foreign-channel approvals route to the bound account instead of fanning out or being rejected as ambiguous. (#60417) thanks @gumadeiras.
 - Slack/app manifest: set `bot_user.always_online` to `true` in the onboarding and example Slack app manifest so the Slack app appears ready to respond.
 - Gateway/websocket auth: refresh auth on new websocket connects after secrets reload so rotated gateway tokens take effect immediately without requiring a restart. (#60323) Thanks @mappel-nv.
+- Agents/workspace: respect `agents.defaults.workspace` for non-default agents by resolving them under the configured base path instead of falling back to `workspace-<id>`. (#59858) Thanks @joelnishanth.
 
 ## 2026.4.2
 

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -444,15 +444,15 @@ describe("resolveAgentConfig", () => {
     expect(workspace).toBe(path.resolve("/shared-ws/main"));
   });
 
-  it("default agent uses agents.defaults.workspace directly", () => {
+  it("default agent without per-agent workspace uses agents.defaults.workspace directly", () => {
     const cfg: OpenClawConfig = {
       agents: {
         defaults: { workspace: "/shared-ws" },
-        list: [{ id: "main" }, { id: "work", default: true, workspace: "/work-ws" }],
+        list: [{ id: "main" }, { id: "work", default: true }],
       },
     };
     const workspace = resolveAgentWorkspaceDir(cfg, "work");
-    expect(workspace).toBe(path.resolve("/work-ws"));
+    expect(workspace).toBe(path.resolve("/shared-ws"));
   });
 
   it("non-default agent without defaults.workspace falls back to stateDir", () => {

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -432,6 +432,40 @@ describe("resolveAgentConfig", () => {
     const agentDir = resolveAgentDir({} as OpenClawConfig, "main");
     expect(agentDir).toBe(path.join(path.resolve(home), ".openclaw", "agents", "main", "agent"));
   });
+
+  it("non-default agent uses agents.defaults.workspace as base (#59789)", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [{ id: "main" }, { id: "work", default: true, workspace: "/work-ws" }],
+      },
+    };
+    const workspace = resolveAgentWorkspaceDir(cfg, "main");
+    expect(workspace).toBe(path.resolve("/shared-ws/main"));
+  });
+
+  it("default agent uses agents.defaults.workspace directly", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [{ id: "main" }, { id: "work", default: true, workspace: "/work-ws" }],
+      },
+    };
+    const workspace = resolveAgentWorkspaceDir(cfg, "work");
+    expect(workspace).toBe(path.resolve("/work-ws"));
+  });
+
+  it("non-default agent without defaults.workspace falls back to stateDir", () => {
+    const stateDir = path.join(path.sep, "tmp", "test-state");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main" }, { id: "work", default: true, workspace: "/work-ws" }],
+      },
+    };
+    const workspace = resolveAgentWorkspaceDir(cfg, "main");
+    expect(workspace).toBe(path.join(stateDir, "workspace-main"));
+  });
 });
 
 describe("resolveAgentIdByWorkspacePath", () => {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -272,12 +272,17 @@ export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
     return stripNullBytes(resolveUserPath(configured));
   }
   const defaultAgentId = resolveDefaultAgentId(cfg);
+  const fallback = cfg.agents?.defaults?.workspace?.trim();
   if (id === defaultAgentId) {
-    const fallback = cfg.agents?.defaults?.workspace?.trim();
     if (fallback) {
       return stripNullBytes(resolveUserPath(fallback));
     }
     return stripNullBytes(resolveDefaultAgentWorkspaceDir(process.env));
+  }
+  // Non-default agents: use the configured default workspace as a base so that
+  // agents.defaults.workspace is respected for all agents, not just the default.
+  if (fallback) {
+    return stripNullBytes(path.join(resolveUserPath(fallback), id));
   }
   const stateDir = resolveStateDir(process.env);
   return stripNullBytes(path.join(stateDir, `workspace-${id}`));

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -1,8 +1,6 @@
-import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveStateDir } from "../config/paths.js";
 import {
   applyAgentBindings,
   applyAgentConfig,
@@ -45,9 +43,7 @@ describe("agents helpers", () => {
     const work = summaries.find((summary) => summary.id === "work");
 
     expect(main).toBeTruthy();
-    expect(main?.workspace).toBe(
-      path.join(resolveStateDir(process.env, os.homedir), "workspace-main"),
-    );
+    expect(main?.workspace).toBe(path.resolve("/main-ws/main"));
     expect(main?.bindings).toBe(1);
     expect(main?.model).toBe("anthropic/claude");
     expect(main?.agentDir.endsWith(path.join("agents", "main", "agent"))).toBe(true);


### PR DESCRIPTION
Closes #59789

## Summary

- `resolveAgentWorkspaceDir` in `src/agents/agent-scope.ts` now consults `agents.defaults.workspace` for **all** agents, not just the default agent.  
- Non-default agents that have no per-agent `workspace` configured use `agents.defaults.workspace/<agentId>` as their workspace directory, keeping workspaces isolated while honoring the user's configured base path.  
- Previously, non-default agents fell through to `<stateDir>/workspace-<id>` regardless of the `agents.defaults.workspace` config, causing duplicate workspace folders and data fragmentation (the Control UI's "main" session creates `workspace-main` even when the user configured a different default workspace.

## Root Cause

 had a conditional that only checked  when . Any agent that wasn't the configured default skipped that fallback entirely and derived its workspace from the state directory.

## Changes

**** — hoisted the  lookup above the default-agent branch so non-default agents also benefit, using  for isolation.

**** — added 3 new tests:
- non-default agent uses  as base (#59789)
- default agent still uses  directly
- non-default agent without  falls back to stateDir

**** — updated  assertion to match the new workspace resolution (and removed now-unused  /  imports).

## Test Plan

- [x] 
 RUN  v4.1.2 /Users/nishanthreddy/Documents/SideQuests/openclaw


 Test Files  1 passed (1)
      Tests  22 passed (22)
   Start at  13:33:44
   Duration  2.45s (transform 197ms, setup 2.36s, import 24ms, tests 7ms, environment 0ms) — 22/22 pass
- [x] 
 RUN  v4.1.2 /Users/nishanthreddy/Documents/SideQuests/openclaw


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  13:33:47
   Duration  2.68s (transform 249ms, setup 2.10s, import 515ms, tests 5ms, environment 0ms) — 7/7 pass
- [x] No lint errors on touched files

## Risks and Mitigations

- **Existing non-default agents may see a workspace path change** if  is configured. This is the correct/expected behavior per the issue — previously the config was silently ignored for those agents.
- No breaking API changes;  signature is unchanged.

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)
EOF
)