### PR TITLE
fix(exec): reuse gateway allow-always approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Kimi Coding: keep native Anthropic tool payloads on the Kimi coding endpoint while still parsing tagged tool-call text on the response path, so tool calls execute again instead of echoing raw markup. (#60391) Thanks @Eric-Guo.
 - Plugins/install: preserve `--dangerously-force-unsafe-install` across linked plugin probes and linked hook-pack fallback probes so local `--link` installs honor the documented unsafe override. (#60624) Thanks @JerrettDavis.
 - Auto-reply/reasoning: preserve reasoning and compaction markers while coalescing adjacent reply blocks so hidden reasoning does not leak when mixed with visible text on channels like WhatsApp. Thanks @mcaxtr.
+- Exec/gateway: reuse durable exact-command `allow-always` approvals in allowlist mode so repeated gateway exec reruns stop re-prompting or failing on allowlist misses. (#59880) Thanks @luoyanglang.
 
 ## 2026.4.2
 

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -405,7 +405,11 @@ export async function processGatewayAllowlist(
     };
   }
 
-  if (hostSecurity === "allowlist" && (!analysisOk || !allowlistSatisfied)) {
+  if (
+    hostSecurity === "allowlist" &&
+    (!analysisOk || !allowlistSatisfied) &&
+    !durableApprovalSatisfied
+  ) {
     throw new Error("exec denied: allowlist miss");
   }
 

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -542,6 +542,62 @@ describe("exec approvals", () => {
     expect(result.details.status).toBe("approval-pending");
   });
 
+  it("reuses gateway allow-always approvals for repeated exact commands", async () => {
+    await writeExecApprovalsConfig({
+      version: 1,
+      defaults: { security: "allowlist", ask: "on-miss", askFallback: "deny" },
+      agents: {},
+    });
+    const calls: string[] = [];
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      calls.push(method);
+      if (method === "exec.approval.request") {
+        return acceptedApprovalResponse(params);
+      }
+      if (method === "exec.approval.waitDecision") {
+        return { decision: "allow-always" };
+      }
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "on-miss",
+      security: "allowlist",
+      approvalRunningNoticeMs: 0,
+    });
+    const command = `${JSON.stringify(process.execPath)} --version`;
+
+    const first = await tool.execute("call-gateway-allow-always-initial", {
+      command,
+    });
+
+    expect(first.details.status).toBe("approval-pending");
+    expect(calls).toContain("exec.approval.request");
+    expect(calls).toContain("exec.approval.waitDecision");
+
+    const approvalsPath = path.join(process.env.HOME ?? "", ".openclaw", "exec-approvals.json");
+    await expect
+      .poll(async () => {
+        const raw = await fs.readFile(approvalsPath, "utf8");
+        const parsed = JSON.parse(raw) as {
+          agents?: { main?: { allowlist?: Array<{ source?: string }> } };
+        };
+        return parsed.agents?.main?.allowlist?.some((entry) => entry.source === "allow-always");
+      })
+      .toBe(true);
+
+    calls.length = 0;
+
+    const second = await tool.execute("call-gateway-allow-always-repeat", {
+      command,
+    });
+
+    expect(second.details.status).toBe("completed");
+    expect(calls).not.toContain("exec.approval.request");
+    expect(calls).not.toContain("exec.approval.waitDecision");
+  });
+
   it("keeps ask=always prompts for node-host runs even with durable trust", async () => {
     const calls: string[] = [];
     vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {


### PR DESCRIPTION
## Summary
- let gateway-host allowlist mode honor durable exact-command trust that was persisted via `allow-always`
- add a regression test covering repeated exact gateway commands after an `allow-always` approval

## Testing
- pnpm.cmd exec vitest run src/agents/bash-tools.exec.approval-id.test.ts -t 'reuses gateway allow-always approvals for repeated exact commands|keeps ask=always prompts even when durable allow-always trust matches|keeps ask=always prompts for static allowlist entries without allow-always trust'
- pnpm.cmd exec vitest run src/agents/bash-tools.exec-host-gateway.test.ts
- pnpm.cmd lint src/agents/bash-tools.exec-host-gateway.ts src/agents/bash-tools.exec.approval-id.test.ts

Closes #59847.
