### PR TITLE
Fix compaction safeguard auth lookup for newer model registries [AI-assisted]

### DIFF
--- a/apps/macos/Sources/OpenClawDiscovery/WideAreaGatewayDiscovery.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/WideAreaGatewayDiscovery.swift
@@ -43,8 +43,8 @@ enum WideAreaGatewayDiscovery {
         guard let statusJson = context.tailscaleStatus(),
               !collectTailnetIPv4s(statusJson: statusJson).isEmpty,
               let discovery = loadWideAreaPtrRecords(
-            remaining: remaining,
-            dig: context.dig)
+                  remaining: remaining,
+                  dig: context.dig)
         else { return [] }
 
         let domainTrimmed = discovery.domainTrimmed

--- a/src/agents/pi-hooks/compaction-safeguard.test.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.test.ts
@@ -132,13 +132,16 @@ const createCompactionEvent = (params: { messageText: string; tokensBefore: numb
 const createCompactionContext = (params: {
   sessionManager: ExtensionContext["sessionManager"];
   getApiKeyAndHeadersMock?: ReturnType<typeof vi.fn>;
+  getApiKeyForProviderMock?: ReturnType<typeof vi.fn>;
   getApiKeyMock?: ReturnType<typeof vi.fn>;
+  includeGetApiKeyAndHeaders?: boolean;
+  includeGetApiKeyForProvider?: boolean;
+  includeGetApiKey?: boolean;
 }) =>
-  ({
-    model: undefined,
-    sessionManager: params.sessionManager,
-    modelRegistry: {
-      getApiKeyAndHeaders:
+  {
+    const modelRegistry: Record<string, unknown> = {};
+    if (params.includeGetApiKeyAndHeaders !== false) {
+      modelRegistry.getApiKeyAndHeaders =
         params.getApiKeyAndHeadersMock ??
         vi.fn(async (model) => {
           const legacyGetApiKey = params.getApiKeyMock as
@@ -146,9 +149,21 @@ const createCompactionContext = (params: {
             | ((model: NonNullable<ExtensionContext["model"]>) => Promise<string | undefined>);
           const apiKey = await legacyGetApiKey?.(model);
           return apiKey !== undefined ? { ok: true, apiKey } : { ok: false, error: "missing auth" };
-        }),
-    },
-  }) as unknown as Partial<ExtensionContext>;
+        });
+    }
+    if (params.includeGetApiKeyForProvider) {
+      modelRegistry.getApiKeyForProvider =
+        params.getApiKeyForProviderMock ?? vi.fn(async () => undefined);
+    }
+    if (params.includeGetApiKey) {
+      modelRegistry.getApiKey = params.getApiKeyMock ?? vi.fn(async () => undefined);
+    }
+    return {
+      model: undefined,
+      sessionManager: params.sessionManager,
+      modelRegistry,
+    } as unknown as Partial<ExtensionContext>;
+  };
 
 async function runCompactionScenario(params: {
   sessionManager: ExtensionContext["sessionManager"];
@@ -1686,6 +1701,100 @@ describe("compaction-safeguard extension model fallback", () => {
 
     // Verify early return: request auth should NOT have been resolved when both models are missing.
     expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to provider auth lookup when request auth lookup is unavailable", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(
+      [
+        "## Decisions",
+        "Used provider lookup.",
+        "## Open TODOs",
+        "None.",
+        "## Constraints/Rules",
+        "None.",
+        "## Pending user asks",
+        "Handled.",
+        "## Exact identifiers",
+        "None.",
+      ].join("\n"),
+    );
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    const getApiKeyForProviderMock = vi.fn().mockResolvedValue("test-key");
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const compactionHandler = createCompactionHandler();
+    const mockContext = createCompactionContext({
+      sessionManager,
+      includeGetApiKeyAndHeaders: false,
+      includeGetApiKeyForProvider: true,
+      getApiKeyForProviderMock,
+    });
+    const result = await compactionHandler(createCompactionEvent({ messageText: "test", tokensBefore: 500 }), mockContext);
+
+    expect(result).toBeDefined();
+    expect(getApiKeyForProviderMock).toHaveBeenCalledWith(model.provider);
+    expect(consumeCompactionSafeguardCancelReason(sessionManager) ?? "").not.toContain(
+      "model registry auth lookup unavailable",
+    );
+  });
+
+  it("falls back to legacy getApiKey when request auth lookup is unavailable", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(
+      [
+        "## Decisions",
+        "Used legacy lookup.",
+        "## Open TODOs",
+        "None.",
+        "## Constraints/Rules",
+        "None.",
+        "## Pending user asks",
+        "Handled.",
+        "## Exact identifiers",
+        "None.",
+      ].join("\n"),
+    );
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const compactionHandler = createCompactionHandler();
+    const mockContext = createCompactionContext({
+      sessionManager,
+      includeGetApiKeyAndHeaders: false,
+      includeGetApiKey: true,
+      getApiKeyMock,
+    });
+    const result = await compactionHandler(createCompactionEvent({ messageText: "test", tokensBefore: 500 }), mockContext);
+
+    expect(result).toBeDefined();
+    expect(getApiKeyMock).toHaveBeenCalledWith(model);
+    expect(consumeCompactionSafeguardCancelReason(sessionManager) ?? "").not.toContain(
+      "model registry auth lookup unavailable",
+    );
+  });
+
+  it("records a clear cancel reason when no compatible auth lookup exists", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const compactionHandler = createCompactionHandler();
+    const mockContext = createCompactionContext({
+      sessionManager,
+      includeGetApiKeyAndHeaders: false,
+    });
+    const result = await compactionHandler(createCompactionEvent({ messageText: "test", tokensBefore: 500 }), mockContext);
+
+    expect(result).toEqual({ cancel: true });
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toContain(
+      "model registry auth lookup unavailable",
+    );
   });
 });
 

--- a/src/agents/pi-hooks/compaction-safeguard.test.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.test.ts
@@ -1732,16 +1732,33 @@ describe("compaction-safeguard extension model fallback", () => {
       includeGetApiKeyForProvider: true,
       getApiKeyForProviderMock,
     });
-    const result = await compactionHandler(createCompactionEvent({ messageText: "test", tokensBefore: 500 }), mockContext);
+    const event = createCompactionEvent({ messageText: "test", tokensBefore: 500 });
+    const result = (await compactionHandler(
+      {
+        ...event,
+        preparation: {
+          ...event.preparation,
+          settings: { reserveTokens: 4_000 },
+        },
+      },
+      mockContext,
+    )) as {
+      cancel?: boolean;
+      compaction?: {
+        summary: string;
+        firstKeptEntryId: string;
+        tokensBefore: number;
+      };
+    };
 
-    expect(result).toBeDefined();
+    const compaction = expectCompactionResult(result);
     expect(getApiKeyForProviderMock).toHaveBeenCalledWith(model.provider);
-    expect(consumeCompactionSafeguardCancelReason(sessionManager) ?? "").not.toContain(
-      "model registry auth lookup unavailable",
-    );
+    expect(compaction.firstKeptEntryId).toBe("entry-1");
+    expect(compaction.tokensBefore).toBe(500);
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
   });
 
-  it("falls back to legacy getApiKey when request auth lookup is unavailable", async () => {
+  it("falls through to legacy getApiKey when provider auth lookup misses", async () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages.mockResolvedValue(
       [
@@ -1760,6 +1777,7 @@ describe("compaction-safeguard extension model fallback", () => {
 
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture();
+    const getApiKeyForProviderMock = vi.fn().mockResolvedValue(undefined);
     const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
     setCompactionSafeguardRuntime(sessionManager, { model });
 
@@ -1767,16 +1785,36 @@ describe("compaction-safeguard extension model fallback", () => {
     const mockContext = createCompactionContext({
       sessionManager,
       includeGetApiKeyAndHeaders: false,
+      includeGetApiKeyForProvider: true,
+      getApiKeyForProviderMock,
       includeGetApiKey: true,
       getApiKeyMock,
     });
-    const result = await compactionHandler(createCompactionEvent({ messageText: "test", tokensBefore: 500 }), mockContext);
+    const event = createCompactionEvent({ messageText: "test", tokensBefore: 500 });
+    const result = (await compactionHandler(
+      {
+        ...event,
+        preparation: {
+          ...event.preparation,
+          settings: { reserveTokens: 4_000 },
+        },
+      },
+      mockContext,
+    )) as {
+      cancel?: boolean;
+      compaction?: {
+        summary: string;
+        firstKeptEntryId: string;
+        tokensBefore: number;
+      };
+    };
 
-    expect(result).toBeDefined();
+    const compaction = expectCompactionResult(result);
+    expect(getApiKeyForProviderMock).toHaveBeenCalledWith(model.provider);
     expect(getApiKeyMock).toHaveBeenCalledWith(model);
-    expect(consumeCompactionSafeguardCancelReason(sessionManager) ?? "").not.toContain(
-      "model registry auth lookup unavailable",
-    );
+    expect(compaction.firstKeptEntryId).toBe("entry-1");
+    expect(compaction.tokensBefore).toBe(500);
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
   });
 
   it("records a clear cancel reason when no compatible auth lookup exists", async () => {

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -99,9 +99,9 @@ async function resolveCompactionRequestAuth(
 
   if (typeof modelRegistry.getApiKeyForProvider === "function") {
     const apiKey = await modelRegistry.getApiKeyForProvider(model.provider);
-    return apiKey !== undefined
-      ? { ok: true, apiKey }
-      : { ok: false, error: `missing auth for provider "${model.provider}"` };
+    if (apiKey !== undefined) {
+      return { ok: true, apiKey };
+    }
   }
 
   if (typeof modelRegistry.getApiKey === "function") {

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -74,6 +74,8 @@ type ModelRegistryWithRequestAuthLookup = {
   getApiKeyAndHeaders?: (
     model: NonNullable<ExtensionContext["model"]>,
   ) => Promise<ResolvedRequestAuth>;
+  getApiKeyForProvider?: (provider: string) => Promise<string | undefined>;
+  getApiKey?: (model: NonNullable<ExtensionContext["model"]>) => Promise<string | undefined>;
 };
 
 type ResolvedRequestAuth =
@@ -86,6 +88,31 @@ type ResolvedRequestAuth =
       ok: false;
       error: string;
     };
+
+async function resolveCompactionRequestAuth(
+  modelRegistry: ModelRegistryWithRequestAuthLookup,
+  model: NonNullable<ExtensionContext["model"]>,
+): Promise<ResolvedRequestAuth> {
+  if (typeof modelRegistry.getApiKeyAndHeaders === "function") {
+    return await modelRegistry.getApiKeyAndHeaders(model);
+  }
+
+  if (typeof modelRegistry.getApiKeyForProvider === "function") {
+    const apiKey = await modelRegistry.getApiKeyForProvider(model.provider);
+    return apiKey !== undefined
+      ? { ok: true, apiKey }
+      : { ok: false, error: `missing auth for provider "${model.provider}"` };
+  }
+
+  if (typeof modelRegistry.getApiKey === "function") {
+    const apiKey = await modelRegistry.getApiKey(model);
+    return apiKey !== undefined
+      ? { ok: true, apiKey }
+      : { ok: false, error: `missing auth for provider "${model.provider}"` };
+  }
+
+  throw new Error("model registry auth lookup unavailable");
+}
 
 function clampNonNegativeInt(value: unknown, fallback: number): number {
   const normalized = typeof value === "number" && Number.isFinite(value) ? value : fallback;
@@ -634,10 +661,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     let requestAuth: ResolvedRequestAuth;
     try {
       const modelRegistry = ctx.modelRegistry as ModelRegistryWithRequestAuthLookup;
-      if (typeof modelRegistry.getApiKeyAndHeaders !== "function") {
-        throw new Error("model registry auth lookup unavailable");
-      }
-      requestAuth = await modelRegistry.getApiKeyAndHeaders(model);
+      requestAuth = await resolveCompactionRequestAuth(modelRegistry, model);
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       log.warn(


### PR DESCRIPTION
﻿## Summary
- add a compat request-auth resolver for compaction safeguard that tries `getApiKeyAndHeaders`, `getApiKeyForProvider`, and legacy `getApiKey`
- use that resolver in the safeguard instead of assuming a single model-registry auth API shape
- cover provider fallback, legacy fallback, and the no-compatible-auth path in `compaction-safeguard.test.ts`

## Why
Newer or custom model registries do not always expose the same auth lookup methods. Compaction was cancelling early when `getApiKeyAndHeaders` was absent even though auth could still be resolved through a compatible fallback.

## Testing
- `pnpm test -- src/agents/pi-hooks/compaction-safeguard.test.ts`
- `pnpm check`

## AI Transparency
- AI-assisted: Codex
- Degree of testing: targeted safeguard test plus repo `check`