### PR TITLE
docs(slack): clarify exec approvals native config requirements

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -529,6 +529,10 @@ opt into origin-chat delivery:
 Shared `approvals.exec` forwarding is separate. Use it only when approval prompts must also route
 to other chats or explicit out-of-band targets.
 
+When `approvals.exec.targets` forwards prompts to Slack, Slack still needs approver resolution via
+`channels.slack.execApprovals.approvers` or `commands.ownerAllowFrom`. Slack DM allowlists
+(`channels.slack.allowFrom` / `dm.allowFrom`) do not grant exec approval permissions.
+
 Same-chat `/approve` also works in Slack channels and DMs that already support commands. See [Exec approvals](/tools/exec-approvals) for the full approval forwarding model.
 
 ## Troubleshooting

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -528,11 +528,38 @@ Shared behavior:
 - for Discord and Telegram, only resolved approvers can approve or deny
 - Discord and Telegram approvers can be explicit (`execApprovals.approvers`) or inferred from existing owner config (`allowFrom`, plus direct-message `defaultTo` where supported)
 - Slack approvers can be explicit (`execApprovals.approvers`) or inferred from `commands.ownerAllowFrom`
+- `channels.slack.allowFrom` does not grant Slack exec approval permissions
 - the requester does not need to be an approver
 - the originating chat can approve directly with `/approve` when that chat already supports commands and replies
 - when native `target` enables origin-chat delivery, approval prompts include the command text
 - pending exec approvals expire after 30 minutes by default
 - if no operator UI or configured approval client can accept the request, the prompt falls back to `askFallback`
+
+If you route `approvals.exec.targets` to Slack, also ensure Slack approvers resolve through
+`channels.slack.execApprovals.approvers` or `commands.ownerAllowFrom`. Routing alone only controls
+where prompts are delivered, not who can approve them.
+
+```json5
+{
+  approvals: {
+    exec: {
+      enabled: true,
+      mode: "targets",
+      targets: [{ channel: "slack", to: "U12345678" }],
+    },
+  },
+  commands: {
+    ownerAllowFrom: ["slack:U12345678"], // or set channels.slack.execApprovals.approvers
+  },
+  channels: {
+    slack: {
+      execApprovals: {
+        enabled: true,
+      },
+    },
+  },
+}
+```
 
 Telegram defaults to approver DMs (`target: "dm"`). You can switch to `channel` or `both` when you
 want approval prompts to appear in the originating Telegram chat/topic as well. For Telegram forum


### PR DESCRIPTION
## Summary

- Problem: Slack exec approvals docs did not clearly state that routing via `approvals.exec` is separate from Slack native approver resolution.
- Why it matters: operators could configure `approvals.exec.targets` for Slack and still get `chat exec approvals are not enabled on Slack` without understanding why.
- What changed: clarified in docs that Slack approvers must resolve from `channels.slack.execApprovals.approvers` or `commands.ownerAllowFrom`, and that `channels.slack.allowFrom` does not grant exec approval permissions.
- What did NOT change (scope boundary): no runtime code paths, auth logic, or approval behavior were changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59664
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: docs coverage gap and ambiguous wording around Slack-native approval enablement.
- Missing detection / guardrail: no docs example tying `approvals.exec.targets` to Slack approver resolution requirements.
- Prior context (`git blame`, prior PR, issue, or refactor if known): reported in #59664.
- Why this regressed now: feature docs explained generic native approval model, but Slack-specific approver path was easy to miss in practical setup.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `docs/channels/slack.md`, `docs/tools/exec-approvals.md`
- Scenario the test should lock in: docs explicitly differentiate forwarding vs native approver resolution for Slack.
- Why this is the smallest reliable guardrail: this is a docs-only clarification; runtime behavior is unchanged.
- Existing test that already covers this (if any): docs lint/format/link checks.
- If no new test is added, why not: no code behavior changed.

## User-visible / Behavior Changes

- Documentation now explicitly states:
  - `approvals.exec.targets` controls delivery only.
  - Slack approvers come from `channels.slack.execApprovals.approvers` or `commands.ownerAllowFrom`.
  - `channels.slack.allowFrom`/`dm.allowFrom` do not grant exec approval permissions.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows (authoring environment)
- Runtime/container: Node + pnpm
- Model/provider: N/A (docs change)
- Integration/channel (if any): Slack (documentation target)
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm run lint:docs`
2. Run `pnpm dlx oxfmt --check docs/channels/slack.md docs/tools/exec-approvals.md`
3. Run `pnpm run docs:check-i18n-glossary`
4. Run `pnpm run docs:check-links`

### Expected

- Docs checks pass and new wording is present in both pages.

### Actual

- Passed.

## Evidence

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reviewed rendered markdown snippets and final diff for Slack exec approval guidance.
- Edge cases checked: explicit note that `allowFrom` is not used for Slack exec approvers.
- What you did **not** verify: runtime Slack approval flows (docs-only change).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: readers may still overlook dual-config behavior.
  - Mitigation: clarified in both Slack channel docs and shared exec-approvals docs, including explicit config snippet.