### PR TITLE
fix(msteams): re-land revoked-context proactive fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Fixes
+
+- MS Teams: re-land revoked-context proactive fallback — when a thread reply's turn context is revoked (e.g. due to message debouncing), fall back to proactive messaging per-message so remaining replies still reach the user instead of being silently lost. (#27224) Thanks @openperf.
+
 ## 2026.2.9
 
 ### Added

--- a/extensions/msteams/src/errors.ts
+++ b/extensions/msteams/src/errors.ts
@@ -174,6 +174,13 @@ export function classifyMSTeamsSendError(err: unknown): MSTeamsSendErrorClassifi
   };
 }
 
+export function isRevokedProxyError(err: unknown): boolean {
+  if (!(err instanceof TypeError)) {
+    return false;
+  }
+  return /proxy that has been revoked/i.test(err.message);
+}
+
 export function formatMSTeamsSendErrorHint(
   classification: MSTeamsSendErrorClassification,
 ): string | undefined {

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -33,6 +33,23 @@ const runtimeStub = {
   },
 } as unknown as PluginRuntime;
 
+const createRecordedSendActivity = (
+  sink: string[],
+  failFirstWithStatusCode?: number,
+): ((activity: unknown) => Promise<{ id: string }>) => {
+  let attempts = 0;
+  return async (activity: unknown) => {
+    const { text } = activity as { text?: string };
+    const content = text ?? "";
+    sink.push(content);
+    attempts += 1;
+    if (failFirstWithStatusCode !== undefined && attempts === 1) {
+      throw Object.assign(new Error("send failed"), { statusCode: failFirstWithStatusCode });
+    }
+    return { id: `id:${content}` };
+  };
+};
+
 describe("msteams messenger", () => {
   beforeEach(() => {
     setMSTeamsRuntime(runtimeStub);
@@ -210,6 +227,79 @@ describe("msteams messenger", () => {
           retry: { maxAttempts: 3, baseDelayMs: 0, maxDelayMs: 0 },
         }),
       ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it("falls back to proactive messaging when thread context is revoked", async () => {
+      const proactiveSent: string[] = [];
+
+      const ctx = {
+        sendActivity: async () => {
+          throw new TypeError("Cannot perform 'set' on a proxy that has been revoked");
+        },
+      };
+
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, _reference, logic) => {
+          await logic({
+            sendActivity: createRecordedSendActivity(proactiveSent),
+          });
+        },
+        process: async () => {},
+      };
+
+      const ids = await sendMSTeamsMessages({
+        replyStyle: "thread",
+        adapter,
+        appId: "app123",
+        conversationRef: baseRef,
+        context: ctx,
+        messages: [{ text: "hello" }],
+      });
+
+      // Should have fallen back to proactive messaging
+      expect(proactiveSent).toEqual(["hello"]);
+      expect(ids).toEqual(["id:hello"]);
+    });
+
+    it("falls back only for remaining thread messages after context revocation", async () => {
+      const threadSent: string[] = [];
+      const proactiveSent: string[] = [];
+      let attempt = 0;
+
+      const ctx = {
+        sendActivity: async (activity: unknown) => {
+          const { text } = activity as { text?: string };
+          const content = text ?? "";
+          attempt += 1;
+          if (attempt === 1) {
+            threadSent.push(content);
+            return { id: `id:${content}` };
+          }
+          throw new TypeError("Cannot perform 'set' on a proxy that has been revoked");
+        },
+      };
+
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, _reference, logic) => {
+          await logic({
+            sendActivity: createRecordedSendActivity(proactiveSent),
+          });
+        },
+        process: async () => {},
+      };
+
+      const ids = await sendMSTeamsMessages({
+        replyStyle: "thread",
+        adapter,
+        appId: "app123",
+        conversationRef: baseRef,
+        context: ctx,
+        messages: [{ text: "one" }, { text: "two" }, { text: "three" }],
+      });
+
+      expect(threadSent).toEqual(["one"]);
+      expect(proactiveSent).toEqual(["two", "three"]);
+      expect(ids).toEqual(["id:one", "id:two", "id:three"]);
     });
 
     it("retries top-level sends on transient (5xx)", async () => {

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -10,7 +10,7 @@ import {
 } from "openclaw/plugin-sdk";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import type { StoredConversationReference } from "./conversation-store.js";
-import { classifyMSTeamsSendError } from "./errors.js";
+import { classifyMSTeamsSendError, isRevokedProxyError } from "./errors.js";
 import { prepareFileConsentActivity, requiresFileConsent } from "./file-consent-helpers.js";
 import { buildTeamsFileInfoCard } from "./graph-chat.js";
 import {
@@ -432,6 +432,48 @@ export async function sendMSTeamsMessages(params: {
     }
   };
 
+  const sendMessagesInContext = async (
+    ctx: SendContext,
+    batch: MSTeamsRenderedMessage[] = messages,
+    offset = 0,
+  ): Promise<string[]> => {
+    const messageIds: string[] = [];
+    for (const [idx, message] of batch.entries()) {
+      const response = await sendWithRetry(
+        async () =>
+          await ctx.sendActivity(
+            await buildActivity(
+              message,
+              params.conversationRef,
+              params.tokenProvider,
+              params.sharePointSiteId,
+              params.mediaMaxBytes,
+            ),
+          ),
+        { messageIndex: offset + idx, messageCount: messages.length },
+      );
+      messageIds.push(extractMessageId(response) ?? "unknown");
+    }
+    return messageIds;
+  };
+
+  const sendProactively = async (
+    batch: MSTeamsRenderedMessage[] = messages,
+    offset = 0,
+  ): Promise<string[]> => {
+    const baseRef = buildConversationReference(params.conversationRef);
+    const proactiveRef: MSTeamsConversationReference = {
+      ...baseRef,
+      activityId: undefined,
+    };
+
+    const messageIds: string[] = [];
+    await params.adapter.continueConversation(params.appId, proactiveRef, async (ctx) => {
+      messageIds.push(...(await sendMessagesInContext(ctx, batch, offset)));
+    });
+    return messageIds;
+  };
+
   if (params.replyStyle === "thread") {
     const ctx = params.context;
     if (!ctx) {
@@ -439,48 +481,21 @@ export async function sendMSTeamsMessages(params: {
     }
     const messageIds: string[] = [];
     for (const [idx, message] of messages.entries()) {
-      const response = await sendWithRetry(
-        async () =>
-          await ctx.sendActivity(
-            await buildActivity(
-              message,
-              params.conversationRef,
-              params.tokenProvider,
-              params.sharePointSiteId,
-              params.mediaMaxBytes,
-            ),
-          ),
-        { messageIndex: idx, messageCount: messages.length },
-      );
-      messageIds.push(extractMessageId(response) ?? "unknown");
+      try {
+        messageIds.push(...(await sendMessagesInContext(ctx, [message], idx)));
+      } catch (err) {
+        if (!isRevokedProxyError(err)) {
+          throw err;
+        }
+        const remaining = messages.slice(idx);
+        if (remaining.length > 0) {
+          messageIds.push(...(await sendProactively(remaining, idx)));
+        }
+        return messageIds;
+      }
     }
     return messageIds;
   }
 
-  const baseRef = buildConversationReference(params.conversationRef);
-  const proactiveRef: MSTeamsConversationReference = {
-    ...baseRef,
-    activityId: undefined,
-  };
-
-  const messageIds: string[] = [];
-  await params.adapter.continueConversation(params.appId, proactiveRef, async (ctx) => {
-    for (const [idx, message] of messages.entries()) {
-      const response = await sendWithRetry(
-        async () =>
-          await ctx.sendActivity(
-            await buildActivity(
-              message,
-              params.conversationRef,
-              params.tokenProvider,
-              params.sharePointSiteId,
-              params.mediaMaxBytes,
-            ),
-          ),
-        { messageIndex: idx, messageCount: messages.length },
-      );
-      messageIds.push(extractMessageId(response) ?? "unknown");
-    }
-  });
-  return messageIds;
+  return await sendProactively(messages, 0);
 }


### PR DESCRIPTION
## Summary

Re-lands the revoked-context proactive fallback from #27224 (originally by @openperf, merged by @steipete on Mar 2) which was lost during a subsequent force-push to main.

This is a prerequisite for #55198 (channel reply threading fix).

## Problem

When a thread reply's turn context is revoked (e.g. due to Bot Framework message debouncing), all remaining messages in the batch are silently lost. The original fix landed in #27224 but the merge commit (`089a878`) is no longer on `main`.

## Changes

- **`messenger.ts`**: Extract `sendMessagesInContext` and `sendProactively` helpers from inline code. Thread path now uses per-message try/catch with `isRevokedProxyError` detection — on revocation, remaining messages fall through to the proactive delivery path.
- **`errors.ts`**: Add `isRevokedProxyError()` utility (also lost in the refactor).
- **`messenger.test.ts`**: Add test coverage for both full revocation (all messages) and partial revocation (first succeeds, rest fall back). Add shared `createRecordedSendActivity` test helper.
- **`CHANGELOG.md`**: Entry under Unreleased > Fixes.

## Testing

- Existing tests pass (pre-existing `getOAuthProviders` import chain issue is unrelated — reproduces on `main` without this PR)
- New tests cover: full context revocation fallback, partial revocation with per-message granularity

## Related

- Closes: none (re-land, not a new issue)
- Prerequisite for: #55198
- Supersedes: #56608 (closed as duplicate)