### PR TITLE
fix(agents): fall back to defaults for subagents.allowAgents

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -460,7 +460,10 @@ export async function spawnSubagentDirect(
   }
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
-    const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+    const allowAgents =
+      resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
+      cfg?.agents?.defaults?.subagents?.allowAgents ??
+      [];
     const allowAny = allowAgents.some((value) => value.trim() === "*");
     const normalizedTargetId = targetAgentId.toLowerCase();
     const allowSet = new Set(

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -46,7 +46,10 @@ export function createAgentsListTool(opts?: {
           DEFAULT_AGENT_ID,
       );
 
-      const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+      const allowAgents =
+        resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
+        cfg?.agents?.defaults?.subagents?.allowAgents ??
+        [];
       const allowAny = allowAgents.some((value) => value.trim() === "*");
       const allowSet = new Set(
         allowAgents


### PR DESCRIPTION
lobster-biscuit

Closes #59938

## Problem

Setting `allowAgents` in `agents.defaults.subagents` has no effect. Despite agents being correctly registered, `sessions_spawn` returns `allowed: none`. Only setting `allowAgents` directly on the per-agent entry works.

Other subagent defaults like `runTimeoutSeconds` and `maxConcurrent` correctly inherit from `agents.defaults.subagents` — `allowAgents` was missed.

## Root cause

`src/agents/subagent-spawn.ts:463` and `src/agents/tools/agents-list-tool.ts:49` — both read `resolveAgentConfig(cfg, agentId)?.subagents?.allowAgents` which returns only the per-agent config. No fallback to `cfg.agents.defaults.subagents.allowAgents`.

The established pattern (line 403 for `runTimeoutSeconds`) reads from `cfg.agents.defaults.subagents` directly.

## User impact

Multi-agent setups silently broken. `allowAgents` in defaults does nothing — everything looks correct but spawning is completely blocked. Hard to debug because config is accepted without error.

## Fix

Add `cfg.agents.defaults.subagents.allowAgents` as fallback at both call sites. Matches existing pattern for `runTimeoutSeconds`.

2 files, +6/-2.

## How to verify

1. Set `agents.defaults.subagents.allowAgents: ["researcher"]`
2. `sessions_spawn` with `agentId: "researcher"`
3. Before: `allowed: none`. After: spawns correctly.

Generated with Claude Code