### PR TITLE
fix(subagents): allowAgents falls back to agents.defaults.subagents

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -377,4 +377,56 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     // Must pass: "research" is in allowAgents even though not in agents.list
     expect(details.status).toBe("accepted");
   });
+
+  // ---------------------------------------------------------------------------
+  // allowAgents from agents.defaults.subagents (#59938)
+  // ---------------------------------------------------------------------------
+
+  it("sessions_spawn reads allowAgents from agents.defaults.subagents", async () => {
+    // setAllowAgents sets per-agent subagents.allowAgents; here we use defaults instead
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: {
+          subagents: { allowAgents: ["worker"] },
+        },
+        list: [{ id: "main" }, { id: "worker" }],
+      },
+    });
+
+    const getChildSessionKey = mockAcceptedSpawn(5500);
+    const result = await executeSpawn("call-defaults-allow", "worker");
+    expect(result.details).toMatchObject({ status: "accepted", runId: "run-1" });
+    expect(getChildSessionKey()?.startsWith("agent:worker:subagent:")).toBe(true);
+  });
+
+  it("sessions_spawn per-agent allowAgents overrides agents.defaults.subagents", async () => {
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: {
+          subagents: { allowAgents: ["alpha"] },
+        },
+        list: [
+          { id: "main", subagents: { allowAgents: ["beta"] } },
+          { id: "alpha" },
+          { id: "beta" },
+        ],
+      },
+    });
+    const tool = await getSessionsSpawnTool({ agentSessionKey: "main", agentChannel: "whatsapp" });
+
+    // alpha is allowed by defaults but NOT by the per-agent config
+    const resultAlpha = await tool.execute("call-override-1", {
+      task: "do thing",
+      agentId: "alpha",
+    });
+    expect(resultAlpha.details).toMatchObject({ status: "forbidden" });
+
+    // beta is allowed by the per-agent config
+    const getChildSessionKey = mockAcceptedSpawn(5600);
+    const resultBeta = await tool.execute("call-override-2", { task: "do thing", agentId: "beta" });
+    expect(resultBeta.details).toMatchObject({ status: "accepted" });
+    expect(getChildSessionKey()?.startsWith("agent:beta:subagent:")).toBe(true);
+  });
 });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -460,7 +460,10 @@ export async function spawnSubagentDirect(
   }
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
-    const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+    const allowAgents =
+      resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
+      cfg.agents?.defaults?.subagents?.allowAgents ??
+      [];
     const allowAny = allowAgents.some((value) => value.trim() === "*");
     const normalizedTargetId = targetAgentId.toLowerCase();
     const allowSet = new Set(


### PR DESCRIPTION
## Summary

When  is set in  rather than on the individual agent's  config, it was silently ignored. Every  call with an explicit  returned `allowed: none`.

## Root Cause

In `src/agents/subagent-spawn.ts`, the  variable was resolved with only one fallback step:

```typescript
const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
```

But `resolveAgentConfig()` returns only the agent's own config — it does **not** merge with `agents.defaults`. Meanwhile, `requireAgentId` (three lines above, same pattern) already had the correct two-step fallback:

```typescript
const requireAgentId =
  resolveAgentConfig(cfg, requesterAgentId)?.subagents?.requireAgentId ??
  cfg.agents?.defaults?.subagents?.requireAgentId ??
  false;
```

The fix adds the same defaults fallback to .

## Fix

```typescript
const allowAgents =
  resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
  cfg.agents?.defaults?.subagents?.allowAgents ??
  [];
```

## Testing

Added two regression tests:
1. `sessions_spawn reads allowAgents from agents.defaults.subagents` — verifies that when allowAgents is only in defaults, cross-agent spawning is allowed
2. `sessions_spawn per-agent allowAgents overrides agents.defaults.subagents` — verifies per-agent config still takes priority over defaults

All 17 allowlist tests pass.

Fixes #59938.