### PR TITLE
"fix(telegram): surface media placeholder and file_id when download f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/connect: omit admin-scoped config and auth metadata from lower-privilege `hello-ok` snapshots while preserving those fields for admin reconnects. (#58469) Thanks @eleqtrizit.
 - iOS/canvas: restrict A2UI bridge trust to the bundled scaffold and exact capability-backed remote canvas URLs, so generic `canvas.navigate` and `canvas.present` loads no longer gain action-dispatch authority. (#58471) Thanks @eleqtrizit.
 - Agents/tool policy: preserve restrictive plugin-only allowlists instead of silently widening access to core tools, and keep allowlist warnings aligned with the enforced policy. (#58476) Thanks @eleqtrizit.
+- Telegram/media: preserve `<media:...>` placeholders and `file_id` in captioned messages when Bot API downloads fail, so agents still receive media context. (#59948) Thanks @v1p0r.
 - Telegram/native commands: clean up metadata-driven progress placeholders when replies fall back, edits fail, or local exec approval prompts are suppressed. (#59300) Thanks @jalehman.
 - Matrix: allow secret-storage recreation during automatic repair bootstrap so clients that lose their recovery key can recover and persist new cross-signing keys. (#59846) Thanks @al3mart.
 - Matrix/crypto persistence: capture and write the IndexedDB snapshot while holding the snapshot file lock so concurrent gateway and CLI persists cannot overwrite newer crypto state. (#59851) Thanks @al3mart.

--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -10,6 +10,51 @@ vi.mock("./media-understanding.runtime.js", () => ({
 const { resolveTelegramInboundBody } = await import("./bot-message-context.body.js");
 
 describe("resolveTelegramInboundBody", () => {
+  it("keeps the media marker when a captioned video has no downloaded media", async () => {
+    const result = await resolveTelegramInboundBody({
+      cfg: {
+        channels: { telegram: {} },
+      } as never,
+      primaryCtx: {
+        me: { id: 7, username: "bot" },
+      } as never,
+      msg: {
+        message_id: 0,
+        date: 1_700_000_000,
+        chat: { id: 42, type: "private", first_name: "Pat" },
+        from: { id: 42, first_name: "Pat" },
+        caption: "episode caption",
+        video: {
+          file_id: "video-1",
+          file_unique_id: "video-u1",
+          duration: 10,
+          width: 320,
+          height: 240,
+        },
+      } as never,
+      allMedia: [],
+      isGroup: false,
+      chatId: 42,
+      senderId: "42",
+      senderUsername: "",
+      routeAgentId: undefined,
+      effectiveGroupAllow: normalizeAllowFrom([]),
+      effectiveDmAllow: normalizeAllowFrom([]),
+      groupConfig: undefined,
+      topicConfig: undefined,
+      requireMention: false,
+      options: undefined,
+      groupHistories: new Map(),
+      historyLimit: 0,
+      logger: { info: vi.fn() },
+    });
+
+    expect(result).toMatchObject({
+      rawBody: "episode caption",
+      bodyText: "<media:video> [file_id:video-1]\nepisode caption",
+    });
+  });
+
   it("does not transcribe group audio for unauthorized senders", async () => {
     transcribeFirstAudioMock.mockReset();
     const logger = { info: vi.fn() };

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -33,7 +33,7 @@ import {
   extractTelegramLocation,
   getTelegramTextParts,
   hasBotMention,
-  resolveTelegramMediaPlaceholder,
+  resolveTelegramPrimaryMedia,
 } from "./bot/body-helpers.js";
 import { buildTelegramGroupPeerId } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
@@ -127,7 +127,8 @@ export async function resolveTelegramInboundBody(params: {
   const commandAuthorized = commandGate.commandAuthorized;
   const historyKey = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : undefined;
 
-  let placeholder = resolveTelegramMediaPlaceholder(msg) ?? "";
+  const primaryMedia = resolveTelegramPrimaryMedia(msg);
+  let placeholder = primaryMedia?.placeholder ?? "";
   const cachedStickerDescription = allMedia[0]?.stickerMetadata?.cachedDescription;
   const stickerSupportsVision = msg.sticker
     ? await resolveStickerVisionSupport({ cfg, agentId: routeAgentId })
@@ -154,15 +155,8 @@ export async function resolveTelegramInboundBody(params: {
 
   let bodyText = rawBody;
   if (allMedia.length === 0 && placeholder && rawBody !== placeholder) {
-    const mediaFileRef =
-      msg.video ??
-      msg.video_note ??
-      msg.document ??
-      msg.audio ??
-      msg.voice ??
-      (msg.photo ? msg.photo[msg.photo.length - 1] : undefined);
-    const mediaTag = mediaFileRef?.file_id
-      ? `${placeholder} [file_id:${mediaFileRef.file_id}]`
+    const mediaTag = primaryMedia?.fileRef.file_id
+      ? `${placeholder} [file_id:${primaryMedia.fileRef.file_id}]`
       : placeholder;
     bodyText = `${mediaTag}\n${bodyText}`.trim();
   }

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -153,6 +153,19 @@ export async function resolveTelegramInboundBody(params: {
   }
 
   let bodyText = rawBody;
+  if (allMedia.length === 0 && placeholder && rawBody !== placeholder) {
+    const mediaFileRef =
+      msg.video ??
+      msg.video_note ??
+      msg.document ??
+      msg.audio ??
+      msg.voice ??
+      (msg.photo ? msg.photo[msg.photo.length - 1] : undefined);
+    const mediaTag = mediaFileRef?.file_id
+      ? `${placeholder} [file_id:${mediaFileRef.file_id}]`
+      : placeholder;
+    bodyText = `${mediaTag}\n${bodyText}`.trim();
+  }
   const hasAudio = allMedia.some((media) => media.contentType?.startsWith("audio/"));
   const disableAudioPreflight =
     (topicConfig?.disableAudioPreflight ??

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -1,6 +1,25 @@
 import type { Chat, Message, MessageOrigin, User } from "@grammyjs/types";
 import type { NormalizedLocation } from "openclaw/plugin-sdk/channel-inbound";
 
+type TelegramMediaMessage = Pick<
+  Message,
+  "photo" | "video" | "video_note" | "audio" | "voice" | "document" | "sticker"
+>;
+
+type TelegramMediaFileRef =
+  | NonNullable<Message["photo"]>[number]
+  | NonNullable<Message["video"]>
+  | NonNullable<Message["video_note"]>
+  | NonNullable<Message["audio"]>
+  | NonNullable<Message["voice"]>
+  | NonNullable<Message["document"]>
+  | NonNullable<Message["sticker"]>;
+
+export type TelegramPrimaryMedia = {
+  placeholder: string;
+  fileRef: TelegramMediaFileRef;
+};
+
 export function buildSenderName(msg: Message) {
   const name =
     [msg.from?.first_name, msg.from?.last_name].filter(Boolean).join(" ").trim() ||
@@ -8,31 +27,41 @@ export function buildSenderName(msg: Message) {
   return name || undefined;
 }
 
-export function resolveTelegramMediaPlaceholder(
-  msg:
-    | Pick<Message, "photo" | "video" | "video_note" | "audio" | "voice" | "document" | "sticker">
-    | undefined
-    | null,
-): string | undefined {
+export function resolveTelegramPrimaryMedia(
+  msg: TelegramMediaMessage | undefined | null,
+): TelegramPrimaryMedia | undefined {
   if (!msg) {
     return undefined;
   }
-  if (msg.photo) {
-    return "<media:image>";
+  const photo = msg.photo?.[msg.photo.length - 1];
+  if (photo) {
+    return { placeholder: "<media:image>", fileRef: photo };
   }
-  if (msg.video || msg.video_note) {
-    return "<media:video>";
+  if (msg.video) {
+    return { placeholder: "<media:video>", fileRef: msg.video };
   }
-  if (msg.audio || msg.voice) {
-    return "<media:audio>";
+  if (msg.video_note) {
+    return { placeholder: "<media:video>", fileRef: msg.video_note };
+  }
+  if (msg.audio) {
+    return { placeholder: "<media:audio>", fileRef: msg.audio };
+  }
+  if (msg.voice) {
+    return { placeholder: "<media:audio>", fileRef: msg.voice };
   }
   if (msg.document) {
-    return "<media:document>";
+    return { placeholder: "<media:document>", fileRef: msg.document };
   }
   if (msg.sticker) {
-    return "<media:sticker>";
+    return { placeholder: "<media:sticker>", fileRef: msg.sticker };
   }
   return undefined;
+}
+
+export function resolveTelegramMediaPlaceholder(
+  msg: TelegramMediaMessage | undefined | null,
+): string | undefined {
+  return resolveTelegramPrimaryMedia(msg)?.placeholder;
 }
 
 export function buildSenderLabel(msg: Message, senderId?: number | string) {


### PR DESCRIPTION
## Summary

  - **Problem:** When a Telegram message has both a caption and a video/media attachment, and the file exceeds the Bot API 20MB download limit, `resolveMedia()` returns null and
  `allMedia` ends up empty. The `placeholder` variable (e.g. `<media:video>`) is correctly computed but silently discarded because `rawBody` (the caption) is non-empty — the agent
  receives only the caption text with no indication that media was present.
  - **Why it matters:** Agents cannot act on media they don't know exists. Channel posts (e.g. video episodes with captions) are a common pattern and are completely invisible to the agent
   when the file is large.
  - **What changed:** After `let bodyText = rawBody`, when `allMedia` is empty but a media placeholder is set and the caption is not already that placeholder, the placeholder (plus
  `file_id` if available) is prepended to `bodyText` so the agent can see it and attempt alternative download methods.
  - **What did NOT change:** Download behavior is unchanged. No new network calls. Only affects message body text construction when a media download was skipped.

  ## Change Type (select all)

  - [x] Bug fix

  ## Scope (select all touched areas)

  - [x] Integrations

  ## Linked Issue/PR

  - [ ] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)

  - **Root cause:** `placeholder` is only used as a fallback when `rawBody` is empty (line `if (!rawBody) rawBody = placeholder`). For captioned media messages, `rawBody` is always
  non-empty so `placeholder` is never surfaced. When `allMedia` is also empty (download failed), no media indicator reaches the agent.
  - **Missing detection / guardrail:** No test covered the case of captioned video message + failed/skipped download.
  - **Prior context:** N/A — this appears to be a gap in the original implementation rather than a regression.
  - **Why this regressed now:** N/A
  - **If unknown, what was ruled out:** N/A

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
  - **Target test or file:** `bot-message-context.body.test.ts`
  - **Scenario the test should lock in:** Captioned video message with `allMedia = []` should produce a `bodyText` that starts with `<media:video>`.
  - **Why this is the smallest reliable guardrail:** `resolveTelegramInboundBody` is a pure function — a unit test with a mock message object and empty `allMedia` is sufficient.
  - **Existing test that already covers this:** None.
  - **If no new test is added, why not:** N/A

  ## User-visible / Behavior Changes

  When a bot receives a forwarded video message with a caption where the file exceeds 20MB, the agent now sees:
  media:video [file_id:XXX]
  caption text here...
  instead of just the caption text.

  ## Diagram (if applicable)

  ```text
  Before:
  [captioned video msg, >20MB] -> allMedia=[] -> bodyText = caption only -> agent sees no media

  After:
  [captioned video msg, >20MB] -> allMedia=[] -> bodyText = "<media:video> [file_id:XXX]\ncaption" -> agent sees media

  Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  Repro + Verification

  Environment

  - OS: Linux (Ubuntu 24.04)
  - Runtime/container: Node 25.8.0
  - Integration/channel: Telegram

  Steps

  1. Have a Telegram channel post a video with a caption (episode file, >20MB)
  2. Forward that message to a group where the bot is active
  3. Observe what the agent receives

  Expected

  - Agent message body contains <media:video> [file_id:XXX] followed by the caption

  Actual (before fix)

  - Agent message body contains only the caption text — no indication media was present

  Evidence

  - Trace/log snippets — confirmed via openclaw session logs showing forwarded channel messages arriving with only caption text and no media placeholder

  Human Verification (required)

  - Verified scenarios: Forwarded channel video with caption — agent now sees <media:video> [file_id:XXX] prepended to caption text
  - Edge cases checked: Caption-only messages (no media) unaffected. Video-only messages (no caption) unaffected — existing placeholder path handles those.
  - What you did not verify: Behavior with protected content channels; behavior with media groups

  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

