### PR TITLE
fix: preserve selected session model after fallback

### DIFF
--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -118,6 +118,33 @@ describe("live model switch", () => {
     });
   });
 
+  it("uses the default provider when only modelOverride is persisted", async () => {
+    state.loadSessionStoreMock.mockReturnValue({
+      main: {
+        modelOverride: "gpt-5.4",
+        modelProvider: "anthropic",
+        model: "claude-sonnet-4-6",
+      },
+    });
+
+    const { resolveLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      resolveLiveSessionModelSelection({
+        cfg: { session: { store: "/tmp/custom-store.json" } },
+        sessionKey: "main",
+        agentId: "reply",
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.4",
+      }),
+    ).toEqual({
+      provider: "anthropic",
+      model: "gpt-5.4",
+      authProfileId: undefined,
+      authProfileIdSource: undefined,
+    });
+  });
+
   it("queues a live switch only when an active run was aborted", async () => {
     state.abortEmbeddedPiRunMock.mockReturnValue(true);
 

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -90,7 +90,7 @@ describe("live model switch", () => {
     });
   });
 
-  it("prefers persisted runtime model fields ahead of session overrides", async () => {
+  it("prefers persisted session overrides ahead of runtime model fields", async () => {
     state.loadSessionStoreMock.mockReturnValue({
       main: {
         providerOverride: "anthropic",
@@ -112,7 +112,7 @@ describe("live model switch", () => {
       }),
     ).toEqual({
       provider: "anthropic",
-      model: "claude-sonnet-4-6",
+      model: "claude-opus-4-6",
       authProfileId: undefined,
       authProfileIdSource: undefined,
     });

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -52,8 +52,9 @@ export function resolveLiveSessionModelSelection(params: {
   const overrideModel = entry?.modelOverride?.trim();
   const runtimeProvider = entry?.modelProvider?.trim();
   const runtimeModel = entry?.model?.trim();
-  const provider =
-    (overrideModel ? overrideProvider : undefined) || runtimeProvider || defaultModelRef.provider;
+  const provider = overrideModel
+    ? overrideProvider || defaultModelRef.provider
+    : runtimeProvider || defaultModelRef.provider;
   const model = overrideModel || runtimeModel || defaultModelRef.model;
   const authProfileId = entry?.authProfileOverride?.trim() || undefined;
   return {

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -48,10 +48,13 @@ export function resolveLiveSessionModelSelection(params: {
     agentId,
   });
   const entry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+  const overrideProvider = entry?.providerOverride?.trim();
+  const overrideModel = entry?.modelOverride?.trim();
   const runtimeProvider = entry?.modelProvider?.trim();
   const runtimeModel = entry?.model?.trim();
-  const provider = runtimeProvider || entry?.providerOverride?.trim() || defaultModelRef.provider;
-  const model = runtimeModel || entry?.modelOverride?.trim() || defaultModelRef.model;
+  const provider =
+    (overrideModel ? overrideProvider : undefined) || runtimeProvider || defaultModelRef.provider;
+  const model = overrideModel || runtimeModel || defaultModelRef.model;
   const authProfileId = entry?.authProfileOverride?.trim() || undefined;
   return {
     provider,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -606,7 +606,7 @@ describe("gateway session utils", () => {
 });
 
 describe("resolveSessionModelRef", () => {
-  test("prefers runtime model/provider from session entry", () => {
+  test("prefers explicit session override ahead of runtime model fields", () => {
     const cfg = createModelDefaultsConfig({
       primary: "anthropic/claude-opus-4-6",
     });
@@ -618,6 +618,21 @@ describe("resolveSessionModelRef", () => {
       model: "gpt-5.4",
       modelOverride: "claude-opus-4-6",
       providerOverride: "anthropic",
+    });
+
+    expect(resolved).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+  });
+
+  test("falls back to runtime model/provider when no session override is set", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "anthropic/claude-opus-4-6",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+      modelProvider: "openai-codex",
+      model: "gpt-5.4",
     });
 
     expect(resolved).toEqual({ provider: "openai-codex", model: "gpt-5.4" });
@@ -1043,6 +1058,30 @@ describe("listSessionsFromStore search", () => {
 
     expect(result.sessions[0]?.modelProvider).toBe(expectedProvider);
     expect(result.sessions[0]?.model).toBe(runtimeModel);
+  });
+
+  test("lists the selected override model even when a fallback runtime model was recorded", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "anthropic/claude-opus-4-6",
+    });
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+          providerOverride: "anthropic",
+          modelOverride: "claude-opus-4-6",
+          modelProvider: "openai-codex",
+          model: "gpt-5.4",
+        } as SessionEntry,
+      },
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.modelProvider).toBe("anthropic");
+    expect(result.sessions[0]?.model).toBe("claude-opus-4-6");
   });
 
   test("exposes unknown totals when freshness is stale or missing", () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -638,6 +638,26 @@ describe("resolveSessionModelRef", () => {
     expect(resolved).toEqual({ provider: "openai-codex", model: "gpt-5.4" });
   });
 
+  test("keeps explicit override provider for vendor-prefixed override models", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "anthropic/claude-opus-4-6",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "s-openrouter-override",
+      updatedAt: Date.now(),
+      providerOverride: "openrouter",
+      modelOverride: "anthropic/claude-haiku-4.5",
+      modelProvider: "openrouter",
+      model: "openrouter/minimax/minimax-m2.7",
+    });
+
+    expect(resolved).toEqual({
+      provider: "openrouter",
+      model: "anthropic/claude-haiku-4.5",
+    });
+  });
+
   test("preserves openrouter provider when model contains vendor prefix", () => {
     const cfg = createModelDefaultsConfig({
       primary: "openrouter/minimax/minimax-m2.7",

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1032,10 +1032,25 @@ export function resolveSessionModelRef(
         defaultModel: DEFAULT_MODEL,
       });
 
-  // Prefer the last runtime model recorded on the session entry.
-  // This is the actual model used by the latest run and must win over defaults.
   let provider = resolved.provider;
   let model = resolved.model;
+  // Gateway control paths should resolve the selected session model first.
+  // Runtime model fields track the last executed fallback and belong to the
+  // runtime identity helper below.
+  const storedModelOverride = entry?.modelOverride?.trim();
+  if (storedModelOverride) {
+    const overrideProvider = entry?.providerOverride?.trim() || provider || DEFAULT_PROVIDER;
+    const parsedOverride = parseModelRef(storedModelOverride, overrideProvider);
+    if (parsedOverride) {
+      provider = parsedOverride.provider;
+      model = parsedOverride.model;
+    } else {
+      provider = overrideProvider;
+      model = storedModelOverride;
+    }
+    return { provider, model };
+  }
+
   const runtimeModel = entry?.model?.trim();
   const runtimeProvider = entry?.modelProvider?.trim();
   if (runtimeModel) {
@@ -1056,21 +1071,6 @@ export function resolveSessionModelRef(
       model = runtimeModel;
     }
     return { provider, model };
-  }
-
-  // Fall back to explicit per-session override (set at spawn/model-patch time),
-  // then finally to configured defaults.
-  const storedModelOverride = entry?.modelOverride?.trim();
-  if (storedModelOverride) {
-    const overrideProvider = entry?.providerOverride?.trim() || provider || DEFAULT_PROVIDER;
-    const parsedOverride = parseModelRef(storedModelOverride, overrideProvider);
-    if (parsedOverride) {
-      provider = parsedOverride.provider;
-      model = parsedOverride.model;
-    } else {
-      provider = overrideProvider;
-      model = storedModelOverride;
-    }
   }
   return { provider, model };
 }
@@ -1190,6 +1190,9 @@ export function buildGatewaySessionRow(params: {
   const subagentStartedAt = subagentRun ? getSubagentSessionStartedAt(subagentRun) : undefined;
   const subagentEndedAt = subagentRun ? subagentRun.endedAt : undefined;
   const subagentRuntimeMs = subagentRun ? resolveSessionRuntimeMs(subagentRun, now) : undefined;
+  const selectedModel = entry?.modelOverride?.trim()
+    ? resolveSessionModelRef(cfg, entry, sessionAgentId)
+    : null;
   const resolvedModel = resolveSessionModelIdentityRef(
     cfg,
     entry,
@@ -1322,8 +1325,8 @@ export function buildGatewaySessionRow(params: {
     parentSessionKey: subagentOwner || entry?.parentSessionKey,
     childSessions,
     responseUsage: entry?.responseUsage,
-    modelProvider,
-    model,
+    modelProvider: selectedModel?.provider ?? modelProvider,
+    model: selectedModel?.model ?? model,
     contextTokens,
     deliveryContext: deliveryFields.deliveryContext,
     lastChannel: deliveryFields.lastChannel ?? entry?.lastChannel,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1039,7 +1039,14 @@ export function resolveSessionModelRef(
   // runtime identity helper below.
   const storedModelOverride = entry?.modelOverride?.trim();
   if (storedModelOverride) {
-    const overrideProvider = entry?.providerOverride?.trim() || provider || DEFAULT_PROVIDER;
+    const explicitOverrideProvider = entry?.providerOverride?.trim();
+    if (explicitOverrideProvider) {
+      return {
+        provider: explicitOverrideProvider,
+        model: storedModelOverride,
+      };
+    }
+    const overrideProvider = provider || DEFAULT_PROVIDER;
     const parsedOverride = parseModelRef(storedModelOverride, overrideProvider);
     if (parsedOverride) {
       provider = parsedOverride.provider;


### PR DESCRIPTION
## Summary

- Problem: session control paths and the session list kept preferring persisted runtime model fields after a fallback run, so a fallback model could look like the selected model and stick across follow-up control operations.
- Why it matters: after one fallback, switching or resetting a session could continue to reflect the fallback model instead of the configured primary or explicit session override.
- What changed: `resolveSessionModelRef()` and `resolveLiveSessionModelSelection()` now prefer explicit session overrides ahead of runtime model fields, and `sessions.list` now surfaces the selected override model while preserving runtime identity behavior when no override exists.
- What did NOT change (scope boundary): this PR does not redesign fallback notices or add separate selected-vs-active model fields to the gateway session payload.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59928
- Related #59928
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `src/gateway/session-utils.ts` resolved the effective session model by preferring persisted runtime fields before session overrides, and `src/agents/live-model-switch.ts` mirrored that precedence for live selection.
- Missing detection / guardrail: regression tests covered runtime-first behavior, but there was no test asserting that explicit session overrides remain authoritative after a fallback run.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #59928 reported the stuck-fallback behavior; this PR addresses the verified control-path cause in the current code.
- Why this regressed now: persisted runtime fields were treated as the effective session model instead of last-run identity.
- If unknown, what was ruled out: the generic fallback runner itself was not changed here; the verified issue was in session model resolution and session row rendering.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/session-utils.test.ts`, `src/agents/live-model-switch.test.ts`
- Scenario the test should lock in: a session with a configured override and persisted fallback runtime fields should still resolve and report the selected override model.
- Why this is the smallest reliable guardrail: the bug lives in small model-resolution helpers used by gateway control paths and the session list.
- Existing test that already covers this (if any): existing helper tests covered runtime/model parsing and were updated to assert the corrected precedence.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Session control paths now respect the configured primary or explicit session override after a fallback run.
- The session list reports the selected override model instead of showing the persisted fallback runtime model as current.

## Diagram (if applicable)

```text
Before:
[fallback run persists runtime model] -> [session control paths read runtime fields first] -> [fallback looks like selected model]

After:
[fallback run persists runtime model] -> [session control paths read selected override/default first] -> [fallback stays runtime-only identity]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 25.3.0
- Runtime/container: local Node/Bun repo workflow
- Model/provider: N/A
- Integration/channel (if any): gateway session model resolution
- Relevant config (redacted): agent default primary plus session override with persisted runtime fallback fields

### Steps

1. Configure a primary model and at least one fallback model.
2. Persist a session override or switch the session back to the primary model after a fallback run.
3. Read the session via gateway control paths or `sessions.list`.

### Expected

- Explicit session selection remains authoritative.
- Runtime fallback identity does not replace the selected session model.

### Actual

- Before this fix, persisted runtime fields could continue to win and make the fallback model appear selected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test -- src/gateway/session-utils.test.ts src/agents/live-model-switch.test.ts`
  - `pnpm check`
  - `pnpm build`
- Edge cases checked:
  - runtime model still resolves when no session override exists
  - session list keeps legacy/runtime identity behavior when no override exists
  - live model switching now keeps the explicit session override authoritative
- What you did **not** verify:
  - live Control UI repro against a running OpenClaw instance
  - full `pnpm test` completion, because the suite currently fails on unrelated `src/tts/status-config.test.ts` expectations (`provider: \"auto\"` vs `\"microsoft\"`) outside this touched surface

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: gateway session rows still expose a single model field, so this fix intentionally keeps runtime identity separate only where the selected override is present.
  - Mitigation: regression tests now lock in both override-first control resolution and the no-override runtime fallback behavior.

## AI Assistance

- This PR was prepared with AI assistance.
- Testing level: locally verified with focused regression tests plus `pnpm check` and `pnpm build`.

Made with [Cursor](https://cursor.com)