### PR TITLE
CLI: tolerate malformed cron list rows

### DIFF
--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -74,7 +74,20 @@ describe("printCronList", () => {
     const job = createBaseJob({ id: undefined as unknown as string, name: "Missing ID" });
 
     expect(() => printCronList([job], runtime)).not.toThrow();
-    expect(logs.length).toBeGreaterThan(1);
+    expect(logs.some((line) => line.includes("Missing ID"))).toBe(true);
+    expect(logs.some((line) => line.includes("-"))).toBe(true);
+  });
+
+  it("handles job with undefined payload from persisted legacy data", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const job = createBaseJob({
+      id: "missing-payload-job",
+      payload: undefined as unknown as CronJob["payload"],
+    });
+
+    expect(() => printCronList([job], runtime)).not.toThrow();
+    expect(logs.some((line) => line.includes("missing-payload-job"))).toBe(true);
+    expect(logs.some((line) => line.includes("-"))).toBe(true);
   });
 
   it("handles job with defined sessionTarget", () => {

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -61,6 +61,22 @@ describe("printCronList", () => {
     expect(logs.some((line) => line.includes("test-job-id"))).toBe(true);
   });
 
+  it("handles job with undefined name from persisted legacy data", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const job = createBaseJob({ id: "missing-name-job", name: undefined as unknown as string });
+
+    expect(() => printCronList([job], runtime)).not.toThrow();
+    expect(logs.some((line) => line.includes("missing-name-job"))).toBe(true);
+  });
+
+  it("handles job with undefined id from persisted legacy data", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const job = createBaseJob({ id: undefined as unknown as string, name: "Missing ID" });
+
+    expect(() => printCronList([job], runtime)).not.toThrow();
+    expect(logs.length).toBeGreaterThan(1);
+  });
+
   it("handles job with defined sessionTarget", () => {
     const { logs, runtime } = createRuntimeLogCapture();
     const jobWithTarget = createBaseJob({

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -251,6 +251,8 @@ export function printCronList(jobs: CronJob[], runtime: RuntimeEnv = defaultRunt
 
   for (const job of jobs) {
     // Stored legacy jobs can be malformed; keep `cron list` readable instead of crashing.
+    const payload = job.payload;
+    const payloadModel = payload && payload.kind === "agentTurn" ? displayText(payload.model) : "-";
     const idLabel = pad(job.id, CRON_ID_PAD);
     const nameLabel = pad(truncate(job.name, CRON_NAME_PAD), CRON_NAME_PAD);
     const scheduleLabel = pad(
@@ -266,13 +268,7 @@ export function printCronList(jobs: CronJob[], runtime: RuntimeEnv = defaultRunt
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget ?? "-", CRON_TARGET_PAD);
     const agentLabel = pad(truncate(job.agentId ?? "-", CRON_AGENT_PAD), CRON_AGENT_PAD);
-    const modelLabel = pad(
-      truncate(
-        (job.payload.kind === "agentTurn" ? job.payload.model : undefined) ?? "-",
-        CRON_MODEL_PAD,
-      ),
-      CRON_MODEL_PAD,
-    );
+    const modelLabel = pad(truncate(payloadModel, CRON_MODEL_PAD), CRON_MODEL_PAD);
 
     const coloredStatus = (() => {
       if (statusRaw === "ok") {
@@ -307,7 +303,7 @@ export function printCronList(jobs: CronJob[], runtime: RuntimeEnv = defaultRunt
       coloredStatus,
       coloredTarget,
       coloredAgent,
-      job.payload.kind === "agentTurn" && job.payload.model
+      payload?.kind === "agentTurn" && payload.model
         ? colorize(rich, theme.info, modelLabel)
         : colorize(rich, theme.muted, modelLabel),
     ].join(" ");

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -138,16 +138,26 @@ const CRON_TARGET_PAD = 9;
 const CRON_AGENT_PAD = 10;
 const CRON_MODEL_PAD = 20;
 
-const pad = (value: string, width: number) => value.padEnd(width);
+const displayText = (value: unknown, fallback = "-") => {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  return trimmed || fallback;
+};
 
-const truncate = (value: string, width: number) => {
-  if (value.length <= width) {
-    return value;
+const pad = (value: unknown, width: number, fallback = "-") =>
+  displayText(value, fallback).padEnd(width);
+
+const truncate = (value: unknown, width: number, fallback = "-") => {
+  const text = displayText(value, fallback);
+  if (text.length <= width) {
+    return text;
   }
   if (width <= 3) {
-    return value.slice(0, width);
+    return text.slice(0, width);
   }
-  return `${value.slice(0, width - 3)}...`;
+  return `${text.slice(0, width - 3)}...`;
 };
 
 const formatIsoMinute = (iso: string) => {
@@ -182,14 +192,24 @@ const formatRelative = (ms: number | null | undefined, nowMs: number) => {
   return delta >= 0 ? `in ${label}` : `${label} ago`;
 };
 
-const formatSchedule = (schedule: CronSchedule) => {
+const formatSchedule = (schedule: CronSchedule | null | undefined) => {
+  if (!schedule || typeof schedule !== "object") {
+    return "-";
+  }
   if (schedule.kind === "at") {
-    return `at ${formatIsoMinute(schedule.at)}`;
+    return `at ${formatIsoMinute(displayText(schedule.at))}`;
   }
   if (schedule.kind === "every") {
-    return `every ${formatDurationHuman(schedule.everyMs)}`;
+    return typeof schedule.everyMs === "number"
+      ? `every ${formatDurationHuman(schedule.everyMs)}`
+      : "every -";
   }
-  const base = schedule.tz ? `cron ${schedule.expr} @ ${schedule.tz}` : `cron ${schedule.expr}`;
+  if (schedule.kind !== "cron") {
+    return "-";
+  }
+  const expr = displayText(schedule.expr, "?");
+  const tz = typeof schedule.tz === "string" && schedule.tz.trim() ? schedule.tz.trim() : "";
+  const base = tz ? `cron ${expr} @ ${tz}` : `cron ${expr}`;
   const staggerMs = resolveCronStaggerMs(schedule);
   if (staggerMs <= 0) {
     return `${base} (exact)`;
@@ -201,10 +221,10 @@ const formatStatus = (job: CronJob) => {
   if (!job.enabled) {
     return "disabled";
   }
-  if (job.state.runningAtMs) {
+  if (job.state?.runningAtMs) {
     return "running";
   }
-  return job.state.lastStatus ?? "idle";
+  return job.state?.lastStatus ?? "idle";
 };
 
 export function printCronList(jobs: CronJob[], runtime: RuntimeEnv = defaultRuntime) {
@@ -230,6 +250,7 @@ export function printCronList(jobs: CronJob[], runtime: RuntimeEnv = defaultRunt
   const now = Date.now();
 
   for (const job of jobs) {
+    // Stored legacy jobs can be malformed; keep `cron list` readable instead of crashing.
     const idLabel = pad(job.id, CRON_ID_PAD);
     const nameLabel = pad(truncate(job.name, CRON_NAME_PAD), CRON_NAME_PAD);
     const scheduleLabel = pad(
@@ -237,10 +258,10 @@ export function printCronList(jobs: CronJob[], runtime: RuntimeEnv = defaultRunt
       CRON_SCHEDULE_PAD,
     );
     const nextLabel = pad(
-      job.enabled ? formatRelative(job.state.nextRunAtMs, now) : "-",
+      job.enabled ? formatRelative(job.state?.nextRunAtMs, now) : "-",
       CRON_NEXT_PAD,
     );
-    const lastLabel = pad(formatRelative(job.state.lastRunAtMs, now), CRON_LAST_PAD);
+    const lastLabel = pad(formatRelative(job.state?.lastRunAtMs, now), CRON_LAST_PAD);
     const statusRaw = formatStatus(job);
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget ?? "-", CRON_TARGET_PAD);


### PR DESCRIPTION
## Summary

- Problem: `openclaw cron list` could crash while rendering human-readable output if a persisted cron job row was malformed, even though the scheduler still loaded it.
- Why it matters: the JSON path could still work, but the default CLI listing path crashed instead of degrading gracefully for legacy or partially invalid stored jobs.
- What changed: hardened `src/cli/cron-cli/shared.ts` so row rendering falls back to placeholders for malformed string/state fields, and added regression coverage for missing `name` and `id` rows.
- What did NOT change (scope boundary): this does not change cron storage, protocol validation, or repair malformed jobs on disk.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59968
- Related #59968
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `printCronList()` assumed stored cron job fields like `id`, `name`, and `state` were always present and string-shaped, then called `padEnd()` / `length` on them directly.
- Missing detection / guardrail: the cron store load path preserves backward compatibility for malformed legacy rows, but the CLI list formatter had regression coverage only for missing `sessionTarget`, not other malformed display fields.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #59968 reported the same user-facing symptom, although the exact stale payload shape in the report uses older field naming.
- Why this regressed now: legacy or hand-edited persisted jobs can still reach the CLI renderer without full shape repair, so the formatter remained a crash point.
- If unknown, what was ruled out: ruled out the typed `cron.list --json` response path and the general table renderer; the crash came from the dedicated cron CLI formatter.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/cron-cli/shared.test.ts`
- Scenario the test should lock in: malformed persisted rows with missing display fields like `name` or `id` do not crash `printCronList()`.
- Why this is the smallest reliable guardrail: the bug is isolated to the dedicated cron CLI renderer, so a focused formatter test covers the exact failure mode without expanding cron service scope.
- Existing test that already covers this (if any): existing coverage already handled missing `sessionTarget` only.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw cron list` now renders placeholders instead of throwing when loaded cron jobs are missing expected display fields.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.6
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local repo checkout

### Steps

1. Create or load a persisted cron job with a missing display field such as `name` or `id`.
2. Run the human-readable cron list path.
3. Confirm the CLI prints the job table instead of throwing.

### Expected

- `openclaw cron list` stays readable and uses placeholders for malformed fields.

### Actual

- Before the fix, the dedicated formatter could throw from direct `padEnd()` / `length` access on malformed stored rows.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced the formatter crash locally with malformed stored rows, then verified the fixed formatter and new regression tests; also reran the focused cron CLI test files.
- Edge cases checked: missing `sessionTarget`, missing `name`, missing `id`, and missing `state` reads in the cron list formatter path.
- What you did **not** verify: I did not broaden scope into repairing malformed jobs on disk.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: placeholder rendering could hide malformed stored data from operators.
  - Mitigation: scope is limited to display safety, and malformed rows remain visible instead of crashing the command.

## Additional Notes

- Local verification completed: `pnpm build`, `pnpm check`, `pnpm test -- src/cli/cron-cli/shared.test.ts src/cli/cron-cli.test.ts`.
- Local `pnpm test` currently hits an unrelated failure in `src/tts/status-config.test.ts` (`provider: \"auto\"` vs `\"microsoft\"`), outside this PR's diff.

## AI Assistance

- [x] AI-assisted
- [x] Degree of testing noted above
- [ ] Prompts/session logs attached
- [x] I reviewed the final code and understand the change

Made with [Cursor](https://cursor.com)