### PR TITLE
fix(imessage): catch delayed reflected echoes

### DIFF
--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -17,17 +17,20 @@ export type SentMessageCache = {
   has: (scope: string, lookup: SentMessageLookup, skipIdShortCircuit?: boolean) => boolean;
 };
 
-// Echo arrival observed at ~2.2s on M4 Mac Mini (SQLite poll interval is the bottleneck).
-// 4s provides ~80% margin. If echoes arrive after TTL expiry, the system degrades to
-// duplicate delivery (noisy but not lossy) — never message loss.
-const SENT_MESSAGE_TEXT_TTL_MS = 4_000;
+// Echoes can arrive several seconds after send completion, so keep the text
+// fallback long enough to catch delayed reflections without affecting the
+// longer-lived message-ID path.
+const SENT_MESSAGE_TEXT_TTL_MS = 30_000;
 const SENT_MESSAGE_ID_TTL_MS = 60_000;
 
 function normalizeEchoTextKey(text: string | undefined): string | null {
   if (!text) {
     return null;
   }
-  const normalized = text.replace(/\r\n?/g, "\n").trim();
+  const normalized = text
+    .replace(/\r\n?/g, "\n")
+    .replace(/^[\u0000-\u001f\ufeff\ufffd\ufffe\uffff]+/u, "")
+    .trim();
   return normalized ? normalized : null;
 }
 

--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
@@ -17,6 +17,16 @@ describe("iMessage sent-message echo cache", () => {
     expect(cache.has("acct:imessage:+1666", { text: "Reasoning:\n_step_" })).toBe(false);
   });
 
+  it("matches recent text with a corrupted leading prefix", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+    const cache = createSentMessageCache();
+
+    cache.remember("acct:imessage:+1555", { text: "Hello there" });
+
+    expect(cache.has("acct:imessage:+1555", { text: "\ufffd\u0000Hello there" })).toBe(true);
+  });
+
   it("matches by outbound message id and ignores placeholder ids", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
@@ -29,14 +39,13 @@ describe("iMessage sent-message echo cache", () => {
     expect(cache.has("acct:imessage:+1555", { messageId: "ok" })).toBe(false);
   });
 
-  it("keeps message-id lookups longer than text fallback", () => {
+  it("keeps message-id lookups longer than the delayed text fallback window", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
     const cache = createSentMessageCache();
 
     cache.remember("acct:imessage:+1555", { text: "hello", messageId: "m-1" });
-    // Text fallback stays short to avoid suppressing legitimate repeated user text.
-    vi.advanceTimersByTime(6_000);
+    vi.advanceTimersByTime(31_000);
 
     expect(cache.has("acct:imessage:+1555", { text: "hello" })).toBe(false);
     expect(cache.has("acct:imessage:+1555", { messageId: "m-1" })).toBe(true);

--- a/extensions/imessage/src/monitor/self-chat-cache.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-cache.test.ts
@@ -28,6 +28,26 @@ describe("createSelfChatCache", () => {
     ).toBe(true);
   });
 
+  it("matches reflected copies with a corrupted leading prefix", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T00:00:00Z"));
+
+    const cache = createSelfChatCache();
+    cache.remember({
+      ...directLookup,
+      text: "hello world",
+      createdAt: 123,
+    });
+
+    expect(
+      cache.has({
+        ...directLookup,
+        text: "\ufffd\u0000hello world",
+        createdAt: 123,
+      }),
+    ).toBe(true);
+  });
+
   it("expires entries after the ttl window", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-07T00:00:00Z"));

--- a/extensions/imessage/src/monitor/self-chat-cache.ts
+++ b/extensions/imessage/src/monitor/self-chat-cache.ts
@@ -26,7 +26,10 @@ function normalizeText(text: string | undefined): string | null {
   if (!text) {
     return null;
   }
-  const normalized = text.replace(/\r\n?/g, "\n").trim();
+  const normalized = text
+    .replace(/\r\n?/g, "\n")
+    .replace(/^[\u0000-\u001f\ufeff\ufffd\ufffe\uffff]+/u, "")
+    .trim();
   return normalized ? normalized : null;
 }
 

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -123,7 +123,7 @@ describe("echo cache — backward compat for channels without messageId", () => 
     expect(echoCache.has(scope, { text: "no id message" })).toBe(true);
   });
 
-  it("text-only has returns false after TTL expiry", () => {
+  it("text-only has returns false after the delayed fallback window", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
 
@@ -132,7 +132,7 @@ describe("echo cache — backward compat for channels without messageId", () => 
 
     echoCache.remember(scope, { text: "no id message" });
 
-    vi.advanceTimersByTime(5000);
+    vi.advanceTimersByTime(31_000);
     expect(echoCache.has(scope, { text: "no id message" })).toBe(false);
   });
 
@@ -283,7 +283,7 @@ describe("self-chat dedupe — #47830", () => {
     expect(decision.kind).toBe("dispatch");
   });
 
-  it("drops echo after text TTL expiry (4s TTL: expired at 5s)", () => {
+  it("still catches delayed text echoes after 5 seconds", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
 
@@ -293,35 +293,28 @@ describe("self-chat dedupe — #47830", () => {
     // Agent sends text (no message id available)
     echoCache.remember(scope, { text: "Hello there" });
 
-    // After 5 seconds — beyond the 4s TTL, should NOT match
+    // After 5 seconds, the delayed text echo should still match.
     vi.advanceTimersByTime(5000);
 
     const result = echoCache.has(scope, { text: "Hello there" });
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 
-  // Safe failure mode: TTL expiry causes duplicate delivery (noisy), never message loss (lossy)
-  it("does NOT catch echo after TTL expiry — safe failure mode is duplicate delivery", () => {
+  it("catches delayed echoes with a corrupted leading prefix", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
 
     const echoCache = createSentMessageCache();
     const scope = "default:imessage:+15551234567";
 
-    // Agent sends "Delayed echo test"
     echoCache.remember(scope, { text: "Delayed echo test", messageId: "agent-msg-delayed" });
 
-    // 4.5 seconds later — beyond 4s TTL
-    vi.advanceTimersByTime(4500);
+    vi.advanceTimersByTime(5000);
 
-    // Echo arrives with no messageId (text-only fallback path)
-    const result = echoCache.has(scope, { text: "Delayed echo test" });
-
-    // TTL expired → not caught → duplicate delivery (noisy but safe, not lossy)
-    expect(result).toBe(false);
+    expect(echoCache.has(scope, { text: "\ufffd\ufffdDelayed echo test" })).toBe(true);
   });
 
-  it("still drops text echo within 4s TTL window", () => {
+  it("expires the text fallback after 30 seconds", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
 
@@ -330,11 +323,10 @@ describe("self-chat dedupe — #47830", () => {
 
     echoCache.remember(scope, { text: "Hello there" });
 
-    // After 3 seconds — within the 4s TTL, should still match
-    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(31_000);
 
     const result = echoCache.has(scope, { text: "Hello there" });
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Problem: iMessage reflected copies can miss dedupe when they arrive after the 4 second text fallback window or when the reflected text starts with replacement/control garbage.
- Why it matters: missed echo suppression can re-ingest the assistant's own outbound reply as a fresh inbound message and create duplicate or looping replies.
- What changed: extended the iMessage text fallback TTL to 30 seconds and normalized leading replacement/control characters in both the sent-message echo cache and the self-chat reflection cache.
- What did NOT change (scope boundary): message ID matching, routing, outbound send behavior, and non-iMessage channels were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59973
- Related #59973
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `extensions/imessage/src/monitor/echo-cache.ts` only normalized CRLF plus trim and expired text fallback entries after 4 seconds, so delayed or prefix-corrupted reflected copies failed exact-text matching.
- Missing detection / guardrail: coverage preserved the short TTL behavior instead of locking in delayed and corrupted-prefix echoes as dedupe cases.
- Prior context (`git blame`, prior PR, issue, or refactor if known): existing iMessage echo-cache tests documented the 4 second text fallback assumption; the linked issue showed reflected text arriving 5 to 10 seconds later with leading `U+FFFD` characters.
- Why this regressed now: the current iMessage reflection path can deliver slower or text-corrupted reflected copies than the original fallback assumptions allowed for.
- If unknown, what was ruled out: ruled out a current fix in the active iMessage cache and inbound-processing paths; the issue behavior still reproduced against the current cache logic.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts`, `extensions/imessage/src/monitor/self-chat-cache.test.ts`, and `extensions/imessage/src/monitor/self-chat-dedupe.test.ts`.
- Scenario the test should lock in: delayed 5 second reflections and reflected copies with leading replacement/control characters should still dedupe in both normal and self-chat flows.
- Why this is the smallest reliable guardrail: the failure is inside the two normalization and TTL caches, so focused cache tests cover the bug directly without requiring live iMessage infrastructure.
- Existing test that already covers this (if any): existing iMessage echo-cache tests covered the same caches but encoded the old 4 second miss behavior.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- iMessage now suppresses delayed reflected echoes for longer and also matches reflected copies whose text starts with replacement/control characters.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 25.3.0
- Runtime/container: `pnpm` workspace, Bun/Node repo defaults
- Model/provider: N/A
- Integration/channel (if any): iMessage
- Relevant config (redacted): default test config

### Steps

1. Cache a recently sent iMessage text in the iMessage echo cache.
2. Advance time by 5 seconds and query the cache with the same text, or with the same text prefixed by replacement/control characters.
3. Observe whether the reflected copy is dropped as an echo.

### Expected

- Delayed reflected copies still match the text fallback window.
- Leading replacement/control garbage does not break text dedupe.

### Actual

- Before this change, the 5 second text-only reflection missed the cache and prefix-corrupted text failed normalization.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts extensions/imessage/src/monitor/self-chat-cache.test.ts extensions/imessage/src/monitor/self-chat-dedupe.test.ts extensions/imessage/src/monitor/inbound-processing.test.ts`; ran `pnpm test:extension imessage`; ran `pnpm build`; also sanity-checked the cache behavior directly before the fix and confirmed 5 second text-only and corrupted-prefix matches failed on the old logic.
- Edge cases checked: self-chat dedupe uses the same normalization fix; message ID retention still outlives the shorter text fallback window.
- What you did **not** verify: a live local iMessage roundtrip on macOS.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a longer text fallback window could suppress a legitimate repeated identical text message if no message ID is available and it lands inside the same 30 second scope window.
  - Mitigation: the cache stays conversation-scoped, the longer-lived message ID path is unchanged, and the new normalization is limited to leading replacement/control garbage that should not be semantically meaningful for reflected copies.

## Notes

- `pnpm check` currently fails in unrelated pre-existing `extensions/diffs/src/language-hints.test.ts` type assertions on this tree; the iMessage-focused tests, extension lane, and `pnpm build` passed for this PR.
- AI assistance: used an LLM coding agent for implementation and drafting, then reviewed the touched code paths and validation results before opening this PR.

Made with [Cursor](https://cursor.com)