### PR TITLE
fix: add enabledByDefault to groq and deepgram media plugin manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ Docs: https://docs.openclaw.ai
 - Android/Talk Mode: restore spoken assistant replies on node-scoped sessions by keeping reply routing synced to the resolved node session key and pausing mic capture during reply playback. (#60306) Thanks @MKV21.
 - Cron: replay interrupted recurring jobs on the first gateway restart instead of clearing the stale running marker and skipping catch-up until a second restart. (#60583) Thanks @joelnishanth.
 - Matrix/backup reset: recreate secret storage during backup reset when stale SSSS state blocks durable backup-key reload, including no-backup repair paths. (#60599) thanks @emonty.
+- Plugins/media understanding: enable bundled Groq and Deepgram providers by default so configured audio transcription models load without extra plugin activation config. (#59982) Thanks @yxjsxy.
 
 ## 2026.4.2
 

--- a/extensions/deepgram/openclaw.plugin.json
+++ b/extensions/deepgram/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "deepgram",
+  "enabledByDefault": true,
   "contracts": {
     "mediaUnderstandingProviders": ["deepgram"]
   },

--- a/extensions/groq/openclaw.plugin.json
+++ b/extensions/groq/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "groq",
+  "enabledByDefault": true,
   "contracts": {
     "mediaUnderstandingProviders": ["groq"]
   },


### PR DESCRIPTION
## Problem

The `groq` and `deepgram` plugin manifests were missing `"enabledByDefault": true`. Without this flag, both plugins are treated as **bundled-but-disabled-by-default** during gateway startup.

`resolveRuntimePluginRegistry()` loads without them. When `buildProviderRegistry` later needs to resolve audio providers, `resolvePluginCapabilityProviders` short-circuits to the active registry (skipping the compat path), so groq and deepgram are absent from the registry.

This caused the error in #59875:
```
audio understanding failed: Error: Media provider not available: groq
```

Even with `GROQ_API_KEY` / `DEEPGRAM_API_KEY` correctly configured, the plugin never loaded.

## Root cause

`resolvePluginActivationState` in `src/plugins/config-state.ts` reaches this branch for groq/deepgram:
```ts
if (params.origin === 'bundled') {
  return { enabled: false, reason: 'bundled (disabled by default)' };
}
```

Because `params.enabledByDefault` is `undefined` (missing from manifest).

## Fix

Add `"enabledByDefault": true` to both `extensions/groq/openclaw.plugin.json` and `extensions/deepgram/openclaw.plugin.json`, matching the pattern used by `mistral` and other audio/media providers.

## Testing

- All 1213 plugin tests pass (`pnpm exec vitest run src/plugins/`)
- All 117 media-understanding tests pass (`pnpm exec vitest run src/media-understanding/`)
- Pre-commit hook (tsgo + oxlint) passes

Fixes #59875