### PR TITLE
fix(session-lock): prevent stale lock file from permanently killing channel after timeout

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1970,15 +1970,39 @@ export async function runEmbeddedAttempt(
       // flushPendingToolResults() fires while tools are still executing, inserting
       // synthetic "missing tool result" errors and causing silent agent failures.
       // See: https://github.com/openclaw/openclaw/issues/8643
+      //
+      // BUGFIX(#59983): Each cleanup step is individually guarded so that an
+      // exception in any one of them cannot prevent sessionLock.release() from
+      // executing.  A leaked lock file leaves the channel permanently dead
+      // because subsequent acquireSessionWriteLock calls for the same session
+      // will time out.
       removeToolResultContextGuard?.();
-      await flushPendingToolResultsAfterIdle({
-        agent: session?.agent,
-        sessionManager,
-        clearPendingOnTimeout: true,
-      });
-      session?.dispose();
+      try {
+        await flushPendingToolResultsAfterIdle({
+          agent: session?.agent,
+          sessionManager,
+          clearPendingOnTimeout: true,
+        });
+      } catch (flushErr) {
+        log.warn(
+          `flush pending tool results failed during cleanup: runId=${params.runId} ${String(flushErr)}`,
+        );
+      }
+      try {
+        session?.dispose();
+      } catch (disposeErr) {
+        log.warn(
+          `session dispose failed during cleanup: runId=${params.runId} ${String(disposeErr)}`,
+        );
+      }
       releaseWsSession(params.sessionId);
-      await bundleLspRuntime?.dispose();
+      try {
+        await bundleLspRuntime?.dispose();
+      } catch (lspErr) {
+        log.warn(
+          `bundleLspRuntime dispose failed during cleanup: runId=${params.runId} ${String(lspErr)}`,
+        );
+      }
       await sessionLock.release();
     }
   } finally {

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -370,12 +370,66 @@ describe("acquireSessionWriteLock", () => {
     });
   });
 
+  it("reclaims orphan lock files with valid starttime when PID matches current process", async () => {
+    if (process.platform !== "linux") {
+      // starttime detection requires /proc; skip on non-Linux.
+      return;
+    }
+    await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+      // Simulate a lock left behind by a timed-out run in the same process:
+      // PID matches, starttime matches (FAKE_STARTTIME from mock), but the
+      // lock is NOT tracked in HELD_LOCKS.  Before the fix, this lock was
+      // incorrectly treated as non-orphan because shouldTreatAsOrphanSelfLock
+      // returned false whenever starttime was present.
+      // Use a createdAt timestamp older than ORPHAN_MIN_AGE_MS (5 s) so the
+      // age guard in shouldTreatAsOrphanSelfLock does not reject the reclaim.
+      const staleCreatedAt = new Date(Date.now() - 10_000).toISOString();
+      await writeCurrentProcessLock(lockPath, {
+        starttime: FAKE_STARTTIME,
+        createdAt: staleCreatedAt,
+      });
+
+      await expectCurrentPidOwnsLock({ sessionFile, timeoutMs: 500 });
+    });
+  });
+
   it("does not reclaim active in-process lock files without starttime", async () => {
     await expectActiveInProcessLockIsNotReclaimed();
   });
 
   it("does not reclaim active in-process lock files with malformed starttime", async () => {
     await expectActiveInProcessLockIsNotReclaimed({ legacyStarttime: 123.5 });
+  });
+
+  it("does not reclaim active in-process lock files with valid starttime", async () => {
+    if (process.platform !== "linux") {
+      return;
+    }
+    // Ensure that an actively held lock with a matching starttime is NOT
+    // reclaimed.  This is the counterpart to the orphan-with-starttime test:
+    // when the lock IS in HELD_LOCKS, it must remain protected.
+    await expectActiveInProcessLockIsNotReclaimed({ legacyStarttime: FAKE_STARTTIME });
+  });
+
+  it("does not reclaim a recently-created same-process lock not yet in HELD_LOCKS", async () => {
+    if (process.platform !== "linux") {
+      return;
+    }
+    // Regression test for the race condition identified in code review:
+    // a concurrent acquireSessionWriteLock call may have created the .lock
+    // file but not yet inserted into HELD_LOCKS.  The createdAt age guard
+    // (ORPHAN_MIN_AGE_MS) must prevent the lock from being misidentified
+    // as an orphan and deleted out from under the creating call.
+    await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+      // Write a lock with matching pid/starttime but a very recent createdAt.
+      await writeCurrentProcessLock(lockPath, { starttime: FAKE_STARTTIME });
+
+      // The lock should NOT be reclaimed (treated as in-flight, not orphan),
+      // so acquireSessionWriteLock should time out.
+      await expect(acquireSessionWriteLock({ sessionFile, timeoutMs: 200 })).rejects.toThrow(
+        /session file locked/,
+      );
+    });
   });
 
   it("registers cleanup for SIGQUIT and SIGABRT", () => {

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -394,11 +394,47 @@ function shouldTreatAsOrphanSelfLock(params: {
   if (pid !== process.pid) {
     return false;
   }
-  const hasValidStarttime = isValidLockNumber(params.payload?.starttime);
-  if (hasValidStarttime) {
+  // If the lock is actively held in-memory, it is not an orphan.
+  if (HELD_LOCKS.has(params.normalizedSessionFile)) {
     return false;
   }
-  return !HELD_LOCKS.has(params.normalizedSessionFile);
+  // Lock belongs to our PID but is not tracked in HELD_LOCKS.
+  // When starttime is absent or invalid, treat as orphan for backward
+  // compatibility with old-format lock files.
+  const hasValidStarttime = isValidLockNumber(params.payload?.starttime);
+  if (!hasValidStarttime) {
+    return true;
+  }
+  // When starttime is present, verify it matches the current process to
+  // confirm the lock was created by this exact process instance (not a
+  // recycled PID).  If it matches, the lock is an in-process orphan left
+  // behind by a crashed or timed-out run whose finally block never called
+  // release().  If it does not match, the PID was recycled and normal
+  // stale-detection (recycled-pid reason) will handle it.
+  const currentStarttime = getProcessStartTime(process.pid);
+  // If we cannot read our own starttime (non-Linux), be conservative and
+  // fall back to the legacy behavior (not orphan) to avoid false reclaims.
+  if (currentStarttime === null) {
+    return false;
+  }
+  if (currentStarttime !== params.payload!.starttime) {
+    return false;
+  }
+  // Guard against a narrow race with a concurrent acquireSessionWriteLock
+  // call in the same process: the other call may have already created and
+  // written the .lock file but not yet inserted into HELD_LOCKS.  A very
+  // recent createdAt timestamp indicates the lock is likely still being
+  // set up rather than orphaned, so we conservatively skip reclaim.
+  const ORPHAN_MIN_AGE_MS = 5_000;
+  const createdAtStr =
+    typeof params.payload?.createdAt === "string" ? params.payload.createdAt : null;
+  if (createdAtStr !== null) {
+    const createdAtMs = Date.parse(createdAtStr);
+    if (Number.isFinite(createdAtMs) && Date.now() - createdAtMs < ORPHAN_MIN_AGE_MS) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export async function cleanStaleLockFiles(params: {


### PR DESCRIPTION
### Summary

- **Problem**: When an agent run times out (e.g. Opus hitting turn timeout in a Signal group with no fallback configured), a `.jsonl.lock` file is left behind in the sessions directory with no corresponding `.jsonl` transcript. All subsequent inbound messages for that channel are silently consumed with no agent response — no logs, no errors, zero visibility. The only recovery is manually deleting the lock file. See #59983.

- **Root Cause**: The `finally` block in `src/agents/pi-embedded-runner/run/attempt.ts` (line ~1964) executes several async cleanup steps — `flushPendingToolResultsAfterIdle()`, `session?.dispose()`, `bundleLspRuntime?.dispose()` — **sequentially without individual error guards** before calling `sessionLock.release()`. If any cleanup step throws, the `finally` block short-circuits and `sessionLock.release()` is never reached. This causes two cascading failures depending on the process lifecycle:

  **In-process cascade (long-running daemon)**: The `HELD_LOCKS` in-memory map retains a stale entry with `count = 1`. On subsequent message arrivals, `acquireSessionWriteLock` finds the entry and takes the reentrant path (`count += 1` → 2). When that run completes, `release()` decrements count to 1 but never reaches 0, so the lock file is never deleted. The watchdog timer will eventually force-release after `maxHoldMs` (up to ~12 minutes for Opus timeouts), but until then the lock accumulates reentrant count that never drains.

  **Cross-process cascade (CLI/restart)**: If the process exits before the watchdog fires, the `.lock` file persists on disk while `HELD_LOCKS` state is lost. On restart, `acquireSessionWriteLock` encounters the orphaned lock file. If the original PID is dead, stale-detection reclaims it. However, on macOS where PID spaces are smaller and recycling is faster, the original PID may be reused by an unrelated process. Without `starttime` (unavailable on macOS via `/proc`), PID recycling cannot be detected, and the lock becomes permanently un-reclaimable — `acquireSessionWriteLock` times out and throws `"session file locked"`, killing the channel.

  Additionally, `shouldTreatAsOrphanSelfLock` in `src/agents/session-write-lock.ts` has a logic gap on Linux: when a lock file contains a valid `starttime` field (always the case on Linux), the function unconditionally returns `false`, preventing the orphan-self-lock reclaim path from ever activating for same-process orphans. This matters in the edge case where the watchdog's `fs.rm` fails (best-effort) but `HELD_LOCKS` is already cleared.

- **Fix**:
  1. **Primary fix** (`attempt.ts`): Wrap each cleanup step in the `finally` block with its own `try/catch`, ensuring `sessionLock.release()` is **always** reached regardless of cleanup failures. Errors are logged at `warn` level with the `runId` for debuggability. This eliminates the root cause — lock files can no longer leak due to cleanup exceptions.
  2. **Secondary fix** (`session-write-lock.ts`): Restructure `shouldTreatAsOrphanSelfLock` to correctly detect same-process orphan locks on Linux by comparing the lock file's `starttime` against the current process's `starttime` via `getProcessStartTime(process.pid)`. The `HELD_LOCKS.has()` guard is moved to the top so actively-held locks are never misidentified. On non-Linux platforms where `getProcessStartTime` returns `null`, the function conservatively falls back to `false` to avoid false reclaims.

  The primary fix eliminates the root cause. The secondary fix provides defense-in-depth for the edge case where the primary fix is bypassed (e.g. process crash during cleanup, or `fs.rm` failure in watchdog force-release on Linux).

- **What changed**:
  - `src/agents/pi-embedded-runner/run/attempt.ts`: Added individual `try/catch` guards around `flushPendingToolResultsAfterIdle`, `session?.dispose()`, and `bundleLspRuntime?.dispose()` in the `finally` block, with `log.warn` for each failure.
  - `src/agents/session-write-lock.ts`: Restructured `shouldTreatAsOrphanSelfLock` — moved `HELD_LOCKS.has()` check first, then added `starttime` comparison logic with `getProcessStartTime(process.pid)` for Linux and conservative fallback for non-Linux.
  - `src/agents/session-write-lock.test.ts`: Added 2 regression tests — one verifying orphan locks with valid `starttime` are reclaimed on Linux, one verifying actively-held locks with valid `starttime` are NOT reclaimed.

- **What did NOT change (scope boundary)**:
  - No changes to lock acquisition logic, reentrant counting, or timeout behavior in `acquireSessionWriteLock`.
  - No changes to watchdog timer, `releaseHeldLock`, or `releaseAllLocksSync`.
  - No changes to `inspectLockPayload`, `shouldReclaimContendedLockFile`, or cross-process stale detection.
  - No changes to gateway message routing, queue policy, or dispatch logic.
  - No changes to `run.ts` failover/retry logic.
  - `releaseWsSession` is not wrapped because it is synchronous and does not throw in practice.

### Reproduction

1. Configure a Signal group channel with `claude-opus-4-6` and no fallback model.
2. Send a message that triggers a long agent run.
3. Wait for the run to time out (or force timeout via config).
4. Observe that a `.jsonl.lock` file exists in the sessions directory but no `.jsonl` transcript.
5. Send another message to the same channel.
6. Observe that the message is silently consumed with no agent response.
7. Manually delete the `.lock` file → channel recovers immediately.

### Risk / Mitigation

- **Risk**: The individual `try/catch` blocks in the `finally` clause could mask cleanup errors that indicate deeper issues.
- **Mitigation**: Each caught error is logged at `warn` level with the `runId`, ensuring full visibility in logs. The cleanup operations (`dispose`, `flush`) are already best-effort by design — their failure should never prevent lock release. The `shouldTreatAsOrphanSelfLock` change is conservative: on non-Linux (macOS), it falls back to the existing behavior (`false`), so there is zero behavioral change for the Issue reporter's platform. On Linux, the new `starttime` comparison is strictly more correct than the previous unconditional `false`. The new regression tests verify both the positive case (orphan reclaimed) and the negative case (active lock not reclaimed).

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agent Runner
- [x] Session Management
- [x] Tests

### Linked Issue/PR

Fixes #59983