### PR TITLE
fix: resolve CHANNEL_IDS temporal dead zone on module init (#48832)

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { CHANNEL_IDS } from "../channels/registry.js";
+import { CHANNEL_IDS } from "../channels/ids.js";
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
 import { GENERATED_BASE_CONFIG_SCHEMA } from "./schema.base.generated.js";
 import type { ConfigUiHint, ConfigUiHints } from "./schema.hints.js";

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/registry.js";
+import { CHANNEL_IDS } from "../channels/ids.js";
+import { normalizeChatChannelId } from "../channels/chat-meta.js";
 import { withBundledPluginAllowlistCompat } from "../plugins/bundled-compat.js";
 import { listBundledWebSearchPluginIds } from "../plugins/bundled-web-search-ids.js";
 import {


### PR DESCRIPTION
## Problem

`CHANNEL_IDS` throws "is not iterable" on startup (Windows, also reproduced on Debian/Docker). This is a temporal dead zone (TDZ) error.

## Root Cause

`src/config/schema.ts` and `src/config/validation.ts` imported `CHANNEL_IDS` from `channels/registry.js`, which re-exports from the leaf module `channels/ids.js` but also imports `plugins/runtime.js` and `channels/chat-meta.js`. When the bundler (tsdown/ESM) resolves this dependency graph, the re-exported `CHANNEL_IDS` binding can be `undefined` at the point where config modules evaluate — classic TDZ from circular or deep import chains.

## Fix

Import `CHANNEL_IDS` directly from `channels/ids.js` (zero-dependency leaf module) and `normalizeChatChannelId` from `channels/chat-meta.js` instead of routing through the heavyweight `channels/registry.js` barrel.

**Files changed:** `src/config/schema.ts`, `src/config/validation.ts`

Fixes #48832