### PR TITLE
fix(whatsapp): honor blockStreaming config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Kimi Coding: parse tagged Kimi tool-call text into structured tool calls on the provider stream path so tools execute instead of echoing raw markup. (#60051) Thanks @obviyus.
 - Channels: emit passive message hooks for mention-skipped Telegram and Signal group messages when `ingest` is enabled, including wildcard/default fallback and per-group override handling. (#60018) Thanks @obviyus.
 - Plugins/manifest registry: stop warning when an explicit manifest `id` intentionally differs from the discovery hint. (#59185) Thanks @samzong.
+- WhatsApp/streaming: honor `channels.whatsapp.blockStreaming` again for inbound auto-replies so progressive block replies can be enabled explicitly instead of being forced to final-only delivery. thanks @mcaxtr.
 
 ## 2026.4.2
 

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -5,7 +5,7 @@ let capturedDispatchParams: unknown;
 const { dispatchReplyWithBufferedBlockDispatcherMock } = vi.hoisted(() => ({
   dispatchReplyWithBufferedBlockDispatcherMock: vi.fn(async (params: { ctx: unknown }) => {
     capturedDispatchParams = params;
-    return { queuedFinal: false };
+    return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
   }),
 }));
 
@@ -84,6 +84,19 @@ function makeMsg(overrides: Partial<TestMsg> = {}): TestMsg {
     sendMedia: async () => {},
     ...overrides,
   };
+}
+
+function getCapturedDeliver() {
+  return (
+    capturedDispatchParams as {
+      dispatcherOptions?: {
+        deliver?: (
+          payload: { text?: string; isReasoning?: boolean; isCompactionNotice?: boolean },
+          info: { kind: "tool" | "block" | "final" },
+        ) => Promise<void>;
+      };
+    }
+  )?.dispatcherOptions?.deliver;
 }
 
 describe("whatsapp inbound dispatch", () => {
@@ -214,7 +227,7 @@ describe("whatsapp inbound dispatch", () => {
     expect(groupHistories.get("whatsapp:default:group:123@g.us") ?? []).toHaveLength(0);
   });
 
-  it("suppresses non-final WhatsApp payload delivery", async () => {
+  it("delivers block and final WhatsApp payloads, but suppresses tool payloads", async () => {
     const deliverReply = vi.fn(async () => undefined);
     const rememberSentText = vi.fn();
 
@@ -241,30 +254,59 @@ describe("whatsapp inbound dispatch", () => {
       shouldClearGroupHistory: false,
     });
 
-    const deliver = (
-      capturedDispatchParams as {
-        dispatcherOptions?: {
-          deliver?: (
-            payload: { text?: string },
-            info: { kind: "tool" | "block" | "final" },
-          ) => Promise<void>;
-        };
-      }
-    )?.dispatcherOptions?.deliver;
-
+    const deliver = getCapturedDeliver();
     expect(deliver).toBeTypeOf("function");
 
     await deliver?.({ text: "tool payload" }, { kind: "tool" });
-    await deliver?.({ text: "block payload" }, { kind: "block" });
     expect(deliverReply).not.toHaveBeenCalled();
     expect(rememberSentText).not.toHaveBeenCalled();
 
+    await deliver?.({ text: "block payload" }, { kind: "block" });
     await deliver?.({ text: "final payload" }, { kind: "final" });
-    expect(deliverReply).toHaveBeenCalledTimes(1);
-    expect(rememberSentText).toHaveBeenCalledTimes(1);
+    expect(deliverReply).toHaveBeenCalledTimes(2);
+    expect(rememberSentText).toHaveBeenCalledTimes(2);
   });
 
-  it("forces disableBlockStreaming for WhatsApp dispatch", async () => {
+  it("suppresses reasoning and compaction payloads before WhatsApp delivery", async () => {
+    const deliverReply = vi.fn(async () => undefined);
+    const rememberSentText = vi.fn();
+
+    await dispatchWhatsAppBufferedReply({
+      cfg: { channels: { whatsapp: { blockStreaming: true } } } as never,
+      connectionId: "conn",
+      context: { Body: "hi" },
+      conversationId: "+1000",
+      deliverReply,
+      groupHistories: new Map(),
+      groupHistoryKey: "+1000",
+      maxMediaBytes: 1,
+      msg: makeMsg(),
+      rememberSentText,
+      replyLogger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      } as never,
+      replyPipeline: {},
+      replyResolver: (async () => undefined) as never,
+      route: makeRoute(),
+      shouldClearGroupHistory: false,
+    });
+
+    const deliver = getCapturedDeliver();
+    expect(deliver).toBeTypeOf("function");
+
+    await deliver?.({ text: "Reasoning:\n_hidden_", isReasoning: true }, { kind: "block" });
+    await deliver?.(
+      { text: "🧹 Compacting context...", isCompactionNotice: true },
+      { kind: "block" },
+    );
+    expect(deliverReply).not.toHaveBeenCalled();
+    expect(rememberSentText).not.toHaveBeenCalled();
+  });
+
+  it("maps WhatsApp blockStreaming=true to disableBlockStreaming=false", async () => {
     await dispatchWhatsAppBufferedReply({
       cfg: { channels: { whatsapp: { blockStreaming: true } } } as never,
       connectionId: "conn",
@@ -294,7 +336,121 @@ describe("whatsapp inbound dispatch", () => {
           replyOptions?: { disableBlockStreaming?: boolean };
         }
       )?.replyOptions?.disableBlockStreaming,
+    ).toBe(false);
+  });
+
+  it("maps WhatsApp blockStreaming=false to disableBlockStreaming=true", async () => {
+    await dispatchWhatsAppBufferedReply({
+      cfg: { channels: { whatsapp: { blockStreaming: false } } } as never,
+      connectionId: "conn",
+      context: { Body: "hi" },
+      conversationId: "+1000",
+      deliverReply: async () => {},
+      groupHistories: new Map(),
+      groupHistoryKey: "+1000",
+      maxMediaBytes: 1,
+      msg: makeMsg(),
+      rememberSentText: () => {},
+      replyLogger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      } as never,
+      replyPipeline: {},
+      replyResolver: (async () => undefined) as never,
+      route: makeRoute(),
+      shouldClearGroupHistory: false,
+    });
+
+    expect(
+      (
+        capturedDispatchParams as {
+          replyOptions?: { disableBlockStreaming?: boolean };
+        }
+      )?.replyOptions?.disableBlockStreaming,
     ).toBe(true);
+  });
+
+  it("leaves disableBlockStreaming undefined when WhatsApp blockStreaming is unset", async () => {
+    await dispatchWhatsAppBufferedReply({
+      cfg: { channels: { whatsapp: {} } } as never,
+      connectionId: "conn",
+      context: { Body: "hi" },
+      conversationId: "+1000",
+      deliverReply: async () => {},
+      groupHistories: new Map(),
+      groupHistoryKey: "+1000",
+      maxMediaBytes: 1,
+      msg: makeMsg(),
+      rememberSentText: () => {},
+      replyLogger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      } as never,
+      replyPipeline: {},
+      replyResolver: (async () => undefined) as never,
+      route: makeRoute(),
+      shouldClearGroupHistory: false,
+    });
+
+    expect(
+      (
+        capturedDispatchParams as {
+          replyOptions?: { disableBlockStreaming?: boolean };
+        }
+      )?.replyOptions?.disableBlockStreaming,
+    ).toBeUndefined();
+  });
+
+  it("treats block-only turns as visible replies instead of silent turns", async () => {
+    const deliverReply = vi.fn(async () => undefined);
+    const rememberSentText = vi.fn();
+    dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(
+      async (params: {
+        ctx: unknown;
+        dispatcherOptions?: {
+          deliver?: (
+            payload: { text?: string },
+            info: { kind: "tool" | "block" | "final" },
+          ) => Promise<void>;
+        };
+      }) => {
+        capturedDispatchParams = params;
+        await params.dispatcherOptions?.deliver?.({ text: "partial block" }, { kind: "block" });
+        return { queuedFinal: false, counts: { tool: 0, block: 1, final: 0 } };
+      },
+    );
+
+    await expect(
+      dispatchWhatsAppBufferedReply({
+        cfg: { channels: { whatsapp: { blockStreaming: true } } } as never,
+        connectionId: "conn",
+        context: { Body: "hi" },
+        conversationId: "+1000",
+        deliverReply,
+        groupHistories: new Map(),
+        groupHistoryKey: "+1000",
+        maxMediaBytes: 1,
+        msg: makeMsg(),
+        rememberSentText,
+        replyLogger: {
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+          debug: () => {},
+        } as never,
+        replyPipeline: {},
+        replyResolver: (async () => undefined) as never,
+        route: makeRoute(),
+        shouldClearGroupHistory: false,
+      }),
+    ).resolves.toBe(true);
+
+    expect(deliverReply).toHaveBeenCalledTimes(1);
+    expect(rememberSentText).toHaveBeenCalledTimes(1);
   });
 
   it("passes sendComposing through as the reply typing callback", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -46,6 +46,28 @@ type SenderContext = {
   e164?: string;
 };
 
+function resolveWhatsAppDisableBlockStreaming(
+  cfg: ReturnType<typeof loadConfig>,
+): boolean | undefined {
+  if (typeof cfg.channels?.whatsapp?.blockStreaming !== "boolean") {
+    return undefined;
+  }
+  return !cfg.channels.whatsapp.blockStreaming;
+}
+
+function shouldSuppressWhatsAppPayload(
+  payload: ReplyPayload,
+  info: { kind: ReplyLifecycleKind },
+): boolean {
+  if (info.kind === "tool") {
+    return true;
+  }
+  if (payload.isReasoning === true || payload.isCompactionNotice === true) {
+    return true;
+  }
+  return false;
+}
+
 export function resolveWhatsAppResponsePrefix(params: {
   cfg: ReturnType<typeof loadConfig>;
   agentId: string;
@@ -239,10 +261,11 @@ export async function dispatchWhatsAppBufferedReply(params: {
     accountId: params.route.accountId,
   });
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(params.cfg, params.route.agentId);
+  const disableBlockStreaming = resolveWhatsAppDisableBlockStreaming(params.cfg);
   let didSendReply = false;
   let didLogHeartbeatStrip = false;
 
-  const { queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
+  const { queuedFinal, counts } = await dispatchReplyWithBufferedBlockDispatcher({
     ctx: params.context,
     cfg: params.cfg,
     replyResolver: params.replyResolver,
@@ -255,7 +278,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
         }
       },
       deliver: async (payload: ReplyPayload, info: { kind: ReplyLifecycleKind }) => {
-        if (info.kind !== "final") {
+        if (shouldSuppressWhatsAppPayload(payload, info)) {
           return;
         }
         await params.deliverReply({
@@ -288,12 +311,13 @@ export async function dispatchWhatsAppBufferedReply(params: {
       onReplyStart: params.msg.sendComposing,
     },
     replyOptions: {
-      disableBlockStreaming: true,
+      disableBlockStreaming,
       onModelSelected: params.onModelSelected,
     },
   });
 
-  if (!queuedFinal) {
+  const didQueueVisibleReply = queuedFinal || counts.block > 0 || counts.final > 0;
+  if (!didQueueVisibleReply) {
     if (params.shouldClearGroupHistory) {
       params.groupHistories.set(params.groupHistoryKey, []);
     }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: WhatsApp still exposed a `channels.whatsapp.blockStreaming` config, but the current inbound wrapper ignored it by hardcoding `disableBlockStreaming: true` and suppressing all non-final payloads.
- Why it matters: users could not re-enable streamed partial replies on WhatsApp even though the config still existed, and the old final-only wrapper would regress to silent turns if core block streaming was turned back on without a WhatsApp-side fix.
- What changed: WhatsApp now maps `channels.whatsapp.blockStreaming` back into reply dispatch, delivers visible block payloads when streaming is enabled, still suppresses `tool` payloads plus reasoning/compaction notices, and counts block-only turns as successful delivery.
- What did NOT change (scope boundary): this PR does not change generic reply dispatch, message-tool behavior, or WhatsApp quoted-reply plumbing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #56865
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: WhatsApp’s inbound wrapper still enforced the old final-only workaround by dropping every non-final payload and hardcoding `disableBlockStreaming: true`, even though generic dispatch now already suppresses reasoning payloads safely.
- Missing detection / guardrail: no current WhatsApp test asserted that `channels.whatsapp.blockStreaming` actually affected dispatch behavior, so the config remained dead while the field stayed wired through config/account resolution.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the hardcode came from the February 24, 2026 silent-turn fix after WhatsApp moved to final-only delivery; later refactors preserved the hardcode without revisiting the newer generic reasoning suppression.
- Why this regressed now: the old workaround became stale once reasoning suppression moved into generic dispatch, but the WhatsApp wrapper kept behaving as if final-only delivery was still required for safety.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts`
- Scenario the test should lock in: enabling `channels.whatsapp.blockStreaming` delivers visible block payloads, suppresses tool/reasoning/internal notice payloads, and treats block-only turns as non-silent.
- Why this is the smallest reliable guardrail: the regression lives entirely in the WhatsApp inbound wrapper’s dispatch decisions, so a focused unit test around that wrapper is enough to catch it.
- Existing test that already covers this (if any): `src/auto-reply/reply/dispatch-from-config.test.ts` already covers generic reasoning suppression.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- `channels.whatsapp.blockStreaming=true` works again for inbound auto-replies.
- WhatsApp still does not surface tool payloads, reasoning payloads, or compaction notices.
- Block-only streamed turns are no longer treated as “silent” by the WhatsApp wrapper.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[blockStreaming=true in config] -> [WhatsApp wrapper hardcodes disableBlockStreaming=true] -> [final-only delivery]

After:
[blockStreaming=true in config] -> [WhatsApp wrapper enables block streaming] -> [deliver visible block replies]
                                                             -> [suppress tool/reasoning/internal notices]
                                                             -> [count block-only delivery as success]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local worktree, Node 22+, pnpm 10.32.1
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): `channels.whatsapp.blockStreaming=true|false`

### Steps

1. Configure `channels.whatsapp.blockStreaming=true`.
2. Run a WhatsApp auto-reply path that emits block payloads before the final reply.
3. Observe whether the wrapper forwards visible block payloads and still suppresses tool/reasoning payloads.

### Expected

- With `blockStreaming=true`, visible block replies can be delivered and block-only turns are not treated as silent.

### Actual

- Before this change, WhatsApp forced final-only delivery and ignored the config entirely.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted WhatsApp inbound-dispatch tests for config on/off behavior, block delivery, suppression of tool/reasoning/compaction payloads, and block-only success handling.
- Edge cases checked: `blockStreaming=false`, `blockStreaming` unset, reasoning block payloads, compaction notices, and preserved generic reasoning suppression coverage.
- What you did **not** verify: live WhatsApp manual testing against a real session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Allowing block payload delivery on WhatsApp could re-expose internal/non-user-facing payloads if the wrapper lets the wrong kinds through.
- Mitigation:
  - The WhatsApp wrapper still suppresses `tool` payloads plus reasoning and compaction-notice payloads, and targeted tests lock that behavior in.
