### PR TITLE
fix(subagents): honor default allowAgents

### DIFF
--- a/src/agents/openclaw-tools.agents.test.ts
+++ b/src/agents/openclaw-tools.agents.test.ts
@@ -86,6 +86,34 @@ describe("agents_list", () => {
     expect(agents?.map((agent) => agent.id)).toEqual(["main", "research"]);
   });
 
+  it("falls back to agents.defaults.subagents.allowAgents", async () => {
+    configOverride = {
+      session: createPerSenderSessionConfig(),
+      agents: {
+        defaults: {
+          subagents: {
+            allowAgents: ["research"],
+          },
+        },
+        list: [
+          {
+            id: "main",
+            name: "Main",
+          },
+          {
+            id: "research",
+            name: "Research",
+          },
+        ],
+      },
+    };
+
+    const tool = requireAgentsListTool();
+    const result = await tool.execute("call2-defaults", {});
+    const agents = readAgentList(result);
+    expect(agents?.map((agent) => agent.id)).toEqual(["main", "research"]);
+  });
+
   it("returns configured agents when allowlist is *", async () => {
     setConfigWithAgentList([
       {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -189,6 +189,32 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     });
   });
 
+  it("sessions_spawn falls back to agents.defaults.subagents.allowAgents", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          subagents: {
+            allowAgents: ["beta"],
+          },
+        },
+        list: [{ id: "main" }],
+      },
+    });
+    const getChildSessionKey = mockAcceptedSpawn(5050);
+
+    const result = await executeSpawn("call7-defaults", "beta");
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-1",
+    });
+    expect(getChildSessionKey()?.startsWith("agent:beta:subagent:")).toBe(true);
+  });
+
   it("sessions_spawn allows any agent when allowlist is *", async () => {
     await expectAllowedSpawn({
       allowAgents: ["*"],

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -460,7 +460,10 @@ export async function spawnSubagentDirect(
   }
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
-    const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+    const allowAgents =
+      resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
+      cfg.agents?.defaults?.subagents?.allowAgents ??
+      [];
     const allowAny = allowAgents.some((value) => value.trim() === "*");
     const normalizedTargetId = targetAgentId.toLowerCase();
     const allowSet = new Set(

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -46,7 +46,10 @@ export function createAgentsListTool(opts?: {
           DEFAULT_AGENT_ID,
       );
 
-      const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+      const allowAgents =
+        resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
+        cfg.agents?.defaults?.subagents?.allowAgents ??
+        [];
       const allowAny = allowAgents.some((value) => value.trim() === "*");
       const allowSet = new Set(
         allowAgents

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -278,6 +278,8 @@ export type AgentDefaultsConfig = {
   maxConcurrent?: number;
   /** Sub-agent defaults (spawned via sessions_spawn). */
   subagents?: {
+    /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
+    allowAgents?: string[];
     /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 1. */
     maxConcurrent?: number;
     /** Maximum depth allowed for sessions_spawn chains. Default behavior: 1 (no nested spawns). */


### PR DESCRIPTION
## Summary
- fall back to `agents.defaults.subagents.allowAgents` when an agent entry does not override it
- apply the same fallback to `agents_list` so the visible allowlist matches spawn behavior
- add regression coverage for both `sessions_spawn` and `agents_list`

## Testing
- pnpm.cmd exec vitest run src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
- pnpm.cmd exec vitest run src/agents/openclaw-tools.agents.test.ts
- pnpm.cmd lint src/agents/subagent-spawn.ts src/agents/tools/agents-list-tool.ts src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts src/agents/openclaw-tools.agents.test.ts

Closes #59938.
