### PR TITLE
fix: improve WS handshake reliability on slow-startup environments

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { CHANNEL_IDS } from "../channels/registry.js";
+import { CHANNEL_IDS } from "../channels/ids.js";
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
 import { GENERATED_BASE_CONFIG_SCHEMA } from "./schema.base.generated.js";
 import type { ConfigUiHint, ConfigUiHints } from "./schema.hints.js";

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/registry.js";
+import { CHANNEL_IDS } from "../channels/ids.js";
+import { normalizeChatChannelId } from "../channels/chat-meta.js";
 import { withBundledPluginAllowlistCompat } from "../plugins/bundled-compat.js";
 import { listBundledWebSearchPluginIds } from "../plugins/bundled-web-search-ids.js";
 import {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -800,6 +800,11 @@ async function executeGatewayRequestWithScopes<T>(params: {
 }): Promise<T> {
   const { opts, scopes, url, token, password, tlsFingerprint, timeoutMs, safeTimerTimeoutMs } =
     params;
+  // Yield to the event loop before starting the WebSocket connection.
+  // On Windows with large dist bundles, heavy synchronous module loading
+  // can starve the event loop, preventing timely processing of the
+  // connect.challenge frame and causing handshake timeouts (#48736).
+  await new Promise<void>((r) => setImmediate(r));
   return await new Promise<T>((resolve, reject) => {
     let settled = false;
     let ignoreClose = false;

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -727,12 +727,18 @@ export class GatewayClient {
 
   private armConnectChallengeTimeout() {
     const connectChallengeTimeoutMs = resolveGatewayClientConnectChallengeTimeoutMs(this.opts);
+    const armedAt = Date.now();
     this.clearConnectChallengeTimeout();
     this.connectTimer = setTimeout(() => {
       if (this.connectSent || this.ws?.readyState !== WebSocket.OPEN) {
         return;
       }
-      this.opts.onConnectError?.(new Error("gateway connect challenge timeout"));
+      const elapsedMs = Date.now() - armedAt;
+      this.opts.onConnectError?.(
+        new Error(
+          `gateway connect challenge timeout (waited ${elapsedMs}ms, limit ${connectChallengeTimeoutMs}ms)`,
+        ),
+      );
       this.ws?.close(1008, "connect challenge timeout");
     }, connectChallengeTimeoutMs);
   }

--- a/src/gateway/handshake-timeouts.test.ts
+++ b/src/gateway/handshake-timeouts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   clampConnectChallengeTimeoutMs,
   DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS,
+  getConnectChallengeTimeoutMsFromEnv,
   getPreauthHandshakeTimeoutMsFromEnv,
   MAX_CONNECT_CHALLENGE_TIMEOUT_MS,
   MIN_CONNECT_CHALLENGE_TIMEOUT_MS,
@@ -33,5 +34,31 @@ describe("gateway handshake timeouts", () => {
         VITEST: "1",
       }),
     ).toBe(20);
+  });
+
+  test("getConnectChallengeTimeoutMsFromEnv reads OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS", () => {
+    expect(getConnectChallengeTimeoutMsFromEnv({})).toBeUndefined();
+    expect(
+      getConnectChallengeTimeoutMsFromEnv({ OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS: "15000" }),
+    ).toBe(15_000);
+    expect(
+      getConnectChallengeTimeoutMsFromEnv({ OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS: "garbage" }),
+    ).toBeUndefined();
+  });
+
+  test("resolveConnectChallengeTimeoutMs falls back to env override", () => {
+    const original = process.env.OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS;
+    try {
+      process.env.OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS = "5000";
+      expect(resolveConnectChallengeTimeoutMs()).toBe(5_000);
+      // Explicit value still takes precedence over env
+      expect(resolveConnectChallengeTimeoutMs(3_000)).toBe(3_000);
+    } finally {
+      if (original === undefined) {
+        delete process.env.OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS;
+      } else {
+        process.env.OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS = original;
+      }
+    }
   });
 });

--- a/src/gateway/handshake-timeouts.ts
+++ b/src/gateway/handshake-timeouts.ts
@@ -9,10 +9,28 @@ export function clampConnectChallengeTimeoutMs(timeoutMs: number): number {
   );
 }
 
+export function getConnectChallengeTimeoutMsFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): number | undefined {
+  const raw = env.OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
 export function resolveConnectChallengeTimeoutMs(timeoutMs?: number | null): number {
-  return typeof timeoutMs === "number" && Number.isFinite(timeoutMs)
-    ? clampConnectChallengeTimeoutMs(timeoutMs)
-    : DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
+  if (typeof timeoutMs === "number" && Number.isFinite(timeoutMs)) {
+    return clampConnectChallengeTimeoutMs(timeoutMs);
+  }
+  const envOverride = getConnectChallengeTimeoutMsFromEnv();
+  if (envOverride !== undefined) {
+    return clampConnectChallengeTimeoutMs(envOverride);
+  }
+  return DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
 }
 
 export function getPreauthHandshakeTimeoutMsFromEnv(env: NodeJS.ProcessEnv = process.env): number {


### PR DESCRIPTION
Fixes #48736

## Problem

On Windows with large dist bundles (46MB / 639 files), heavy synchronous module loading during CLI startup blocks the event loop, preventing timely processing of the `connect.challenge` frame. This causes ~80% handshake timeout failures for CLI commands that use WebSocket connections (e.g. `openclaw cron list`), while the gateway itself is healthy.

Key evidence from the issue:
- Manual Node.js script implementing v2 handshake connects 100% of the time
- `openclaw --version`: 127ms vs `openclaw cron list` first stdout: 3,775ms
- CLI doesn't send connect frame within the challenge timeout window

## Changes

1. **Event loop yield before WS connection** (`call.ts`): Added `setImmediate` yield before `client.start()` so pending I/O from heavy module loading can drain before the handshake begins.

2. **Client-side env var override** (`handshake-timeouts.ts`): Added `OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS` env var for the client-side connect challenge timeout. The server already supports `OPENCLAW_HANDSHAKE_TIMEOUT_MS` — this gives users a client-side escape hatch for slow environments.

3. **Diagnostic timing in error messages** (`client.ts`): Challenge timeout errors now include elapsed time and configured limit (e.g. `waited 10023ms, limit 10000ms`), making it much easier to diagnose timing issues.

4. **Tests**: Added coverage for env var parsing, resolution precedence, and fallback behavior.

## Testing

- `pnpm build` — passes
- `pnpm check` — passes (tsgo, lint, all checks)
- `pnpm vitest run src/gateway/handshake-timeouts.test.ts` — 5/5 tests pass