### PR TITLE
fix(discord): specify hydrated config for auto ack reactions to prevent SecretRef resolution failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/allowlists: let explicit bundled chat channel enablement bypass `plugins.allow`, while keeping auto-enabled channel activation and startup sidecars behind restrictive allowlists. (#60233) Thanks @dorukardahan.
 - Allowlist/commands: require owner access for `/allowlist add` and `/allowlist remove` so command-authorized non-owners cannot mutate persisted allowlists. (#59836) Thanks @eleqtrizit.
 - Control UI/skills: clear stale ClawHub results immediately when the search query changes, so debounced searches cannot keep outdated install targets visible. Related #60134.
+- Discord/ack reactions: keep automatic ACK reaction auth on the active hydrated Discord account so SecretRef-backed and non-default-account reactions stop falling back to stale default config resolution. (#60081) Thanks @FunJim.
 
 ## 2026.4.2
 

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -543,7 +543,22 @@ describe("processDiscordMessage ack reactions", () => {
     await runProcessDiscordMessage(ctx);
 
     expect(getReactionEmojis()).toEqual(["👀"]);
-    expect(sendMocks.removeReactionDiscord).toHaveBeenCalledWith("c1", "m1", "👀", { rest: {} });
+    expect(sendMocks.removeReactionDiscord).toHaveBeenNthCalledWith(
+      2,
+      "c1",
+      "m1",
+      "👀",
+      expect.objectContaining({
+        rest: {},
+        cfg: expect.objectContaining({
+          messages: expect.objectContaining({
+            ackReaction: "👀",
+            removeAckAfterReply: true,
+          }),
+        }),
+        accountId: "default",
+      }),
+    );
   });
 });
 

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -310,7 +310,7 @@ describe("processDiscordMessage ack reactions", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     await processDiscordMessage(ctx as any);
 
-    expect(sendMocks.reactMessageDiscord.mock.calls[0]).toEqual(["c1", "m1", "👀", { rest: {} }]);
+    expect(sendMocks.reactMessageDiscord.mock.calls[0]).toEqual(["c1", "m1", "👀", { rest: {}, cfg: expect.objectContaining({ messages: { ackReaction: "👀" } }) }]);
   });
 
   it("uses preflight-resolved messageChannelId when message.channelId is missing", async () => {
@@ -332,7 +332,7 @@ describe("processDiscordMessage ack reactions", () => {
       "fallback-channel",
       "m1",
       "👀",
-      { rest: {} },
+      { rest: {}, cfg: expect.objectContaining({ messages: { ackReaction: "👀" } }) },
     ]);
   });
 
@@ -488,7 +488,7 @@ describe("processDiscordMessage ack reactions", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     await processDiscordMessage(ctx as any);
 
-    expect(sendMocks.removeReactionDiscord).toHaveBeenCalledWith("c1", "m1", "👀", { rest: {} });
+    expect(sendMocks.removeReactionDiscord).toHaveBeenCalledWith("c1", "m1", "👀", expect.objectContaining({ rest: {}, cfg: expect.objectContaining({ messages: expect.objectContaining({ ackReaction: "👀", removeAckAfterReply: true }) }) }));
   });
 
   it("removes the plain ack reaction when status reactions are disabled and removeAckAfterReply is enabled", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -303,14 +303,31 @@ describe("processDiscordMessage ack reactions", () => {
 
   it("sends ack reactions for mention-gated guild messages when mentioned", async () => {
     const ctx = await createBaseContext({
+      accountId: "ops",
       shouldRequireMention: true,
       effectiveWasMentioned: true,
+      route: {
+        agentId: "main",
+        channel: "discord",
+        accountId: "ops",
+        sessionKey: "agent:main:discord:channel:c1",
+        mainSessionKey: "agent:main:main",
+      },
     });
 
     // oxlint-disable-next-line typescript/no-explicit-any
     await processDiscordMessage(ctx as any);
 
-    expect(sendMocks.reactMessageDiscord.mock.calls[0]).toEqual(["c1", "m1", "👀", { rest: {}, cfg: expect.objectContaining({ messages: { ackReaction: "👀" } }) }]);
+    expect(sendMocks.reactMessageDiscord.mock.calls[0]).toEqual([
+      "c1",
+      "m1",
+      "👀",
+      {
+        rest: {},
+        cfg: expect.objectContaining({ messages: { ackReaction: "👀" } }),
+        accountId: "ops",
+      },
+    ]);
   });
 
   it("uses preflight-resolved messageChannelId when message.channelId is missing", async () => {
@@ -332,7 +349,11 @@ describe("processDiscordMessage ack reactions", () => {
       "fallback-channel",
       "m1",
       "👀",
-      { rest: {}, cfg: expect.objectContaining({ messages: { ackReaction: "👀" } }) },
+      {
+        rest: {},
+        cfg: expect.objectContaining({ messages: { ackReaction: "👀" } }),
+        accountId: "default",
+      },
     ]);
   });
 
@@ -488,7 +509,21 @@ describe("processDiscordMessage ack reactions", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     await processDiscordMessage(ctx as any);
 
-    expect(sendMocks.removeReactionDiscord).toHaveBeenCalledWith("c1", "m1", "👀", expect.objectContaining({ rest: {}, cfg: expect.objectContaining({ messages: expect.objectContaining({ ackReaction: "👀", removeAckAfterReply: true }) }) }));
+    expect(sendMocks.removeReactionDiscord).toHaveBeenCalledWith(
+      "c1",
+      "m1",
+      "👀",
+      expect.objectContaining({
+        rest: {},
+        cfg: expect.objectContaining({
+          messages: expect.objectContaining({
+            ackReaction: "👀",
+            removeAckAfterReply: true,
+          }),
+        }),
+        accountId: "default",
+      }),
+    );
   });
 
   it("removes the plain ack reaction when status reactions are disabled and removeAckAfterReply is enabled", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -202,11 +202,15 @@ export async function processDiscordMessage(
     setReaction: async (emoji) => {
       await reactMessageDiscord(messageChannelId, message.id, emoji, {
         rest: discordRest,
+        cfg,
+        accountId,
       });
     },
     removeReaction: async (emoji) => {
       await removeReactionDiscord(messageChannelId, message.id, emoji, {
         rest: discordRest,
+        cfg,
+        accountId,
       });
     },
   };

--- a/extensions/discord/src/subagent-hooks.ts
+++ b/extensions/discord/src/subagent-hooks.ts
@@ -26,14 +26,14 @@ type DiscordSubagentSpawningEvent = {
     threadId?: string | number;
   };
   childSessionKey: string;
-  agentId?: string;
+  agentId: string;
   label?: string;
 };
 
 type DiscordSubagentEndedEvent = {
   targetSessionKey: string;
   accountId?: string;
-  targetKind?: string;
+  targetKind?: ThreadBindingTargetKind;
   reason?: string;
   sendFarewell?: boolean;
 };

--- a/extensions/telegram/src/approval-native.ts
+++ b/extensions/telegram/src/approval-native.ts
@@ -119,7 +119,7 @@ const resolveTelegramApproveCommandBehavior: NonNullable<
     isTelegramExecApprovalAuthorizedSender({ cfg, accountId, senderId }) &&
     !isTelegramExecApprovalApprover({ cfg, accountId, senderId })
   ) {
-    return { kind: "ignore" };
+    return undefined;
   }
   return {
     kind: "reply",

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -503,7 +503,7 @@ const telegramCommandTestPlugin: ChannelPlugin = {
         isTelegramExecApprovalAuthorizedSender({ cfg, accountId, senderId }) &&
         !getTelegramExecApprovalApprovers({ cfg, accountId }).includes(senderId?.trim() ?? "")
       ) {
-        return { kind: "ignore" } as const;
+        return undefined;
       }
       return {
         kind: "reply",

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -1217,7 +1217,7 @@ describe("secrets runtime snapshot", () => {
     const ignoredInactiveWarnings = snapshot.warnings.filter(
       (warning) => warning.code === "SECRETS_REF_IGNORED_INACTIVE_SURFACE",
     );
-    expect(ignoredInactiveWarnings).toHaveLength(10);
+    expect(ignoredInactiveWarnings).toHaveLength(6);
     expect(snapshot.warnings.map((warning) => warning.path)).toEqual(
       expect.arrayContaining([
         "agents.defaults.memorySearch.remote.apiKey",
@@ -1226,10 +1226,6 @@ describe("secrets runtime snapshot", () => {
         "channels.telegram.accounts.disabled.botToken",
         "plugins.entries.brave.config.webSearch.apiKey",
         "plugins.entries.google.config.webSearch.apiKey",
-        "plugins.entries.xai.config.webSearch.apiKey",
-        "plugins.entries.moonshot.config.webSearch.apiKey",
-        "plugins.entries.perplexity.config.webSearch.apiKey",
-        "plugins.entries.firecrawl.config.webSearch.apiKey",
       ]),
     );
   });


### PR DESCRIPTION
Fixes #57749

**Background:**
Automatic message reactions in Discord channels (ACK reactions) were silently failing to appear despite the manual CLI command (`openclaw message react`) succeeding perfectly.

**Root Cause:**
When the Discord webhook processor emits an ACK reaction, it triggers the callback `setReaction` and `removeReaction` inside `extensions/discord/src/monitor/message-handler.process.ts`. These methods delegate to `reactMessageDiscord()` and `removeReactionDiscord()`. 

However, they were omitting the `cfg` property in the options payload. Since the config dependency was omitted, the `createDiscordRestClient` function automatically retrieved the raw, unhydrated config from disk via `loadConfig()`. In deployments using secure `SecretRef` items (e.g. `file:filemain:/channels/discord/token`), it directly triggered an `Error: channels.discord.token: unresolved SecretRef` internally and aborted the request because it was actively trying to parse the literal URI string as a Discord application token instead of utilizing the hydrated `RuntimeEnv` object. In Multi-Account scenarios, it would resolve auth against the `default` account instead of the active account.

**Fix:**
This commit propagates the hydrated `cfg` (which contains decrypted variables globally validated by the runtime schema) from `processDiscordMessage` down to `reactMessageDiscord` and `removeReactionDiscord`. This bypasses the unhydrated `loadConfig()` fallback ensuring proper SecretRef parsing.