### PR TITLE
fix(ui): stub node:module in browser build to fix createRequire warning

### DIFF
--- a/ui/src/shims/node-module.ts
+++ b/ui/src/shims/node-module.ts
@@ -1,0 +1,7 @@
+/**
+ * Browser-safe stub for "node:module".
+ * createRequire is not available in browser environments; callers (e.g. src/version.ts)
+ * already guard against this with a try/catch and fall back to injected build constants.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const createRequire: ((url: string) => any) | undefined = undefined;

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -24,6 +24,13 @@ export default defineConfig(() => {
   return {
     base,
     publicDir: path.resolve(here, "public"),
+    resolve: {
+      alias: {
+        // Provide a browser-safe stub for "node:module". The callers (e.g. src/version.ts)
+        // already wrap createRequire usage in try/catch and fall back to injected constants.
+        "node:module": path.resolve(here, "src/shims/node-module.ts"),
+      },
+    },
     optimizeDeps: {
       include: ["lit/directives/repeat.js"],
     },


### PR DESCRIPTION
## Problem

`src/version.ts` imports `createRequire` from `"node:module"` at the module level:

```ts
import { createRequire } from "node:module";
```

In Vite browser builds, `node:module` is not available. Depending on the Vite version and configuration, this can cause a hard build error or a warning like:

```
Module "node:module" has been externalized for browser compatibility.
Cannot access "node:module.createRequire" in client code.
```

The existing `readVersionFromJsonCandidates` function already wraps `createRequire` usage in a `try/catch` and falls back to `__OPENCLAW_VERSION__` (a build constant injected by Vite define), so it handles this gracefully — but only if the module resolves at all.

Fixes #60013

## Solution

Add a `resolve.alias` in `ui/vite.config.ts` that maps `"node:module"` to a thin browser-safe stub:

```ts
// ui/src/shims/node-module.ts
export const createRequire: ((url: string) => any) | undefined = undefined;
```

The stub exports `createRequire` as `undefined`. The existing `try/catch` in `readVersionFromJsonCandidates` catches the resulting error and falls back to the injected build constant — no behavior change at runtime.

## Files changed

- `ui/vite.config.ts` — added `resolve.alias` for `"node:module"`
- `ui/src/shims/node-module.ts` — new browser-safe stub (exports `createRequire` as `undefined`)