### PR TITLE
fix(agents): honor defaults subagent allowlist for sessions_spawn

### DIFF
--- a/src/agents/openclaw-tools.agents.test.ts
+++ b/src/agents/openclaw-tools.agents.test.ts
@@ -86,6 +86,34 @@ describe("agents_list", () => {
     expect(agents?.map((agent) => agent.id)).toEqual(["main", "research"]);
   });
 
+  it("reads defaults.subagents.allowAgents when agent-level allowlist is unset", async () => {
+    configOverride = {
+      session: createPerSenderSessionConfig(),
+      agents: {
+        defaults: {
+          subagents: {
+            allowAgents: ["research"],
+          },
+        },
+        list: [
+          {
+            id: "main",
+            name: "Main",
+          },
+          {
+            id: "research",
+            name: "Research",
+          },
+        ],
+      },
+    };
+
+    const tool = requireAgentsListTool();
+    const result = await tool.execute("call2-defaults", {});
+    const agents = readAgentList(result);
+    expect(agents?.map((agent) => agent.id)).toEqual(["main", "research"]);
+  });
+
   it("returns configured agents when allowlist is *", async () => {
     setConfigWithAgentList([
       {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -189,6 +189,36 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     });
   });
 
+  it("sessions_spawn uses defaults.subagents.allowAgents when agent-level allowlist is unset", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          subagents: {
+            allowAgents: ["beta"],
+          },
+        },
+        list: [
+          {
+            id: "main",
+          },
+        ],
+      },
+    });
+    const getChildSessionKey = mockAcceptedSpawn(5050);
+
+    const result = await executeSpawn("call7-defaults", "beta");
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-1",
+    });
+    expect(getChildSessionKey()?.startsWith("agent:beta:subagent:")).toBe(true);
+  });
+
   it("sessions_spawn allows any agent when allowlist is *", async () => {
     await expectAllowedSpawn({
       allowAgents: ["*"],

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -460,7 +460,10 @@ export async function spawnSubagentDirect(
   }
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
-    const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+    const allowAgents: string[] =
+      resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
+      cfg.agents?.defaults?.subagents?.allowAgents ??
+      [];
     const allowAny = allowAgents.some((value) => value.trim() === "*");
     const normalizedTargetId = targetAgentId.toLowerCase();
     const allowSet = new Set(

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -46,7 +46,10 @@ export function createAgentsListTool(opts?: {
           DEFAULT_AGENT_ID,
       );
 
-      const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+      const allowAgents =
+        resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
+        cfg.agents?.defaults?.subagents?.allowAgents ??
+        [];
       const allowAny = allowAgents.some((value) => value.trim() === "*");
       const allowSet = new Set(
         allowAgents

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -278,6 +278,8 @@ export type AgentDefaultsConfig = {
   maxConcurrent?: number;
   /** Sub-agent defaults (spawned via sessions_spawn). */
   subagents?: {
+    /** Default allowlist for cross-agent spawning. Use "*" to allow any configured agent. */
+    allowAgents?: string[];
     /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 1. */
     maxConcurrent?: number;
     /** Maximum depth allowed for sessions_spawn chains. Default behavior: 1 (no nested spawns). */

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "vitest";
 import { AgentDefaultsSchema } from "./zod-schema.agent-defaults.js";
 
 describe("agent defaults schema", () => {
+  it("accepts defaults.subagents.allowAgents", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        subagents: {
+          allowAgents: ["research", "qa"],
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it("accepts subagent archiveAfterMinutes=0 to disable archiving", () => {
     expect(() =>
       AgentDefaultsSchema.parse({

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -182,6 +182,7 @@ export const AgentDefaultsSchema = z
     maxConcurrent: z.number().int().positive().optional(),
     subagents: z
       .object({
+        allowAgents: z.array(z.string()).optional(),
         maxConcurrent: z.number().int().positive().optional(),
         maxSpawnDepth: z
           .number()


### PR DESCRIPTION
## Motivation

`agents.defaults.subagents.allowAgents` was accepted by config but ignored by runtime allowlist checks.
As a result, cross-agent `sessions_spawn` failed unless `allowAgents` was duplicated per-agent in `agents.list`, which caused confusing `allowed: none` behavior.

Fixes #59938

## Changes

- make `sessions_spawn` allowlist resolution fall back to `agents.defaults.subagents.allowAgents` when agent-level `subagents.allowAgents` is unset
- apply the same fallback in `agents_list` so discovery output matches actual spawn authorization behavior
- add `allowAgents?: string[]` to `AgentDefaultsConfig.subagents`
- extend `AgentDefaultsSchema` to validate `defaults.subagents.allowAgents`
- add regression tests for default-level allowlist behavior in `sessions_spawn`, `agents_list`, and schema parsing

## Testing

- `pnpm test -- src/config/zod-schema.agent-defaults.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts src/agents/openclaw-tools.agents.test.ts`