### PR TITLE
Add Silent Ingest for Group Chat Messages (v2)

### DIFF
--- a/extensions/telegram/src/bot-message-context.silent-ingest.test.ts
+++ b/extensions/telegram/src/bot-message-context.silent-ingest.test.ts
@@ -87,6 +87,7 @@ describe("telegram mention-skip silent ingest", () => {
     expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
 
+
   it("uses wildcard ingest when a specific group override omits ingest", async () => {
     internalHookMocks.createInternalHookEvent.mockClear();
     internalHookMocks.triggerInternalHook.mockClear();


### PR DESCRIPTION
## Summary\n- add passive (silent) ingest hooks for mention-skipped group messages\n- keep ingest path non-intrusive and route-free for normal reply flow\n- wire Telegram + Signal handling through shared channel ingest path\n\n## Notes\n- follow-up PR after #15841 was closed\n- branch rebased on latest main\n\n## Testing\n- focused local checks around silent-ingest path\n