### PR TITLE
fix(agents): add critical threshold check to generic_repeat loop detector

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -299,6 +299,28 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("escalates generic_repeat to critical at criticalThreshold", () => {
+      const state = createState();
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordToolCall(state, "read", { path: "/same.txt" }, `crit-${i}`);
+      }
+
+      const result = detectToolCallLoop(
+        state,
+        "read",
+        { path: "/same.txt" },
+        enabledLoopDetectionConfig,
+      );
+
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("critical");
+        expect(result.detector).toBe("generic_repeat");
+        expect(result.count).toBe(CRITICAL_THRESHOLD);
+        expect(result.message).toContain("BLOCKED");
+      }
+    });
+
     it("keeps generic loops warn-only below global breaker threshold", () => {
       const fixture = createReadNoProgressFixture();
       const loopResult = detectLoopAfterRepeatedCalls({

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -480,7 +480,7 @@ export function detectToolCallLoop(
     resolvedConfig.detectors.genericRepeat &&
     recentCount >= resolvedConfig.criticalThreshold
   ) {
-    log.warn(`Loop critical: ${toolName} called ${recentCount} times with identical arguments`);
+    log.error(`Loop critical: ${toolName} called ${recentCount} times with identical arguments`);
     return {
       stuck: true,
       level: "critical",

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -478,6 +478,21 @@ export function detectToolCallLoop(
   if (
     !knownPollTool &&
     resolvedConfig.detectors.genericRepeat &&
+    recentCount >= resolvedConfig.criticalThreshold
+  ) {
+    log.warn(`Loop critical: ${toolName} called ${recentCount} times with identical arguments`);
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "generic_repeat",
+      count: recentCount,
+      message: `BLOCKED: You have called ${toolName} ${recentCount} times with identical arguments. This is not making progress. Stop retrying and report the task as failed or try a different approach.`,
+      warningKey: `generic:${toolName}:${currentHash}`,
+    };
+  }
+  if (
+    !knownPollTool &&
+    resolvedConfig.detectors.genericRepeat &&
     recentCount >= resolvedConfig.warningThreshold
   ) {
     log.warn(`Loop warning: ${toolName} called ${recentCount} times with identical arguments`);


### PR DESCRIPTION
lobster-biscuit

Closes #60111

## Problem

The `generic_repeat` loop detector only checks `warningThreshold` and always returns `level: "warning"`. It never checks `criticalThreshold`, so repeated identical tool calls can never be blocked — only warned. The documentation says `criticalThreshold` is "threshold for blocking repetitive loop patterns" but this never applies to `generic_repeat`.

## Root cause

`src/agents/tool-loop-detection.ts:478-492` — single warning check without a preceding critical check. All other detectors (`polling_stall`, `output_unchanged`, `error_repeat`) check `criticalThreshold` first and return `level: "critical"` when exceeded.

## User impact

Agents stuck in identical-argument tool call loops can never be blocked by the loop detector. They waste tokens indefinitely with only warnings.

## Fix

Add `criticalThreshold` check before `warningThreshold` check, matching the pattern used by all other detectors. 1 file, +15 lines.

## How to verify

1. Set `criticalThreshold: 5`, `warningThreshold: 3`
2. Have agent call same tool with same args 6 times
3. Before: always "warning". After: "critical" at 5+, "warning" at 3-4.

Generated with Claude Code