### PR TITLE
fix(discord): extract forwarded message text in thread starter resolution

### DIFF
--- a/extensions/discord/src/monitor/threading.starter.test.ts
+++ b/extensions/discord/src/monitor/threading.starter.test.ts
@@ -81,4 +81,97 @@ describe("resolveDiscordThreadStarter", () => {
       memberRoleIds: ["role-1", "role-2"],
     });
   });
+
+  it("extracts text from forwarded message snapshots when content is empty", async () => {
+    const result = await resolveStarter(
+      {
+        content: "",
+        embeds: [],
+        message_snapshots: [
+          {
+            message: {
+              content: "forwarded task content",
+              attachments: [],
+              embeds: [],
+            },
+          },
+        ],
+        author: { id: "u2", username: "Bob", discriminator: "0" },
+        timestamp: "2026-04-03T07:00:00.000Z",
+      } as never,
+      () => 456,
+    );
+
+    expect(result).toBeTruthy();
+    expect(result!.text).toContain("forwarded task content");
+    expect(result!.author).toBe("Bob");
+    expect(result!.timestamp).toBe(456);
+  });
+
+  it("prefers content over forwarded message snapshots", async () => {
+    const result = await resolveStarter(
+      {
+        content: "direct content",
+        message_snapshots: [
+          {
+            message: {
+              content: "forwarded content",
+              attachments: [],
+              embeds: [],
+            },
+          },
+        ],
+        author: { id: "u3", username: "Charlie", discriminator: "0" },
+      } as never,
+      () => undefined,
+    );
+
+    expect(result).toBeTruthy();
+    expect(result!.text).toBe("direct content");
+  });
+
+  it("joins multiple forwarded message snapshots", async () => {
+    const result = await resolveStarter(
+      {
+        content: "",
+        embeds: [],
+        message_snapshots: [
+          {
+            message: {
+              content: "first forwarded message",
+              attachments: [],
+              embeds: [],
+            },
+          },
+          {
+            message: {
+              content: "second forwarded message",
+              attachments: [],
+              embeds: [],
+            },
+          },
+        ],
+        author: { id: "u5", username: "Eve", discriminator: "0" },
+      } as never,
+      () => undefined,
+    );
+
+    expect(result).toBeTruthy();
+    expect(result!.text).toContain("first forwarded message");
+    expect(result!.text).toContain("second forwarded message");
+  });
+
+  it("returns null when content, embeds, and snapshots are all empty", async () => {
+    const result = await resolveStarter(
+      {
+        content: "",
+        embeds: [],
+        message_snapshots: [],
+        author: { id: "u4", username: "Dave", discriminator: "0" },
+      } as never,
+      () => undefined,
+    );
+
+    expect(result).toBeNull();
+  });
 });

--- a/extensions/discord/src/monitor/threading.ts
+++ b/extensions/discord/src/monitor/threading.ts
@@ -198,6 +198,14 @@ export async function resolveDiscordThreadStarter(params: {
     )) as {
       content?: string | null;
       embeds?: Array<{ title?: string | null; description?: string | null }>;
+      message_snapshots?: Array<{
+        message?: {
+          content?: string | null;
+          attachments?: unknown[];
+          embeds?: Array<{ title?: string | null; description?: string | null }>;
+          sticker_items?: unknown[];
+        };
+      }>;
       member?: { nick?: string | null; displayName?: string | null };
       author?: {
         id?: string | null;
@@ -211,7 +219,8 @@ export async function resolveDiscordThreadStarter(params: {
     }
     const content = starter.content?.trim() ?? "";
     const embedText = resolveDiscordEmbedText(starter.embeds?.[0]);
-    const text = content || embedText;
+    const forwardedText = resolveStarterForwardedText(starter.message_snapshots);
+    const text = content || embedText || forwardedText;
     if (!text) {
       return null;
     }
@@ -586,4 +595,32 @@ export function resolveDiscordReplyDeliveryPlan(params: {
     allowReference,
   });
   return { deliverTarget, replyTarget, replyReference };
+}
+
+/**
+ * Extract text from forwarded message snapshots for thread starter resolution.
+ * Discord forwarded messages have empty `content` and store the original text
+ * in `message_snapshots[0].message.content`.
+ */
+function resolveStarterForwardedText(
+  snapshots?: Array<{
+    message?: {
+      content?: string | null;
+      attachments?: unknown[];
+      embeds?: Array<{ title?: string | null; description?: string | null }>;
+      sticker_items?: unknown[];
+    };
+  }>,
+): string {
+  if (!Array.isArray(snapshots) || snapshots.length === 0) {
+    return "";
+  }
+  const blocks: string[] = [];
+  for (const snapshot of snapshots) {
+    const msg = snapshot.message;
+    if (!msg) continue;
+    const text = msg.content?.trim() || resolveDiscordEmbedText(msg.embeds?.[0]) || "";
+    if (text) blocks.push(`[Forwarded message]\n${text}`);
+  }
+  return blocks.join("\n\n");
 }


### PR DESCRIPTION
## Summary

- **Problem:** `resolveDiscordThreadStarter` returns `null` for Discord Forwarded Messages because it only checks `content` and `embeds`, but FMs store their text in `message_snapshots[0].message.content` while `content` is empty (`""`)
- **Why it matters:** `includeThreadStarter: true` is broken for FM-based threads — the agent session receives zero context about what was forwarded. This blocks FM-based task dispatch workflows (Channel→Forward→Thread→Agent)
- **What changed:** Added a local `resolveStarterForwardedText` helper in `threading.ts` that extracts text from `message_snapshots` on the REST response object, used as a third fallback after `content` and `embeds`
- **What did NOT change:** No changes to `message-utils.ts`. No changes to how forwarded messages are handled in regular message processing (`resolveDiscordMessageText`). No export surface changes.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #60129
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** `resolveDiscordThreadStarter` was written before Discord added the Forward feature (message_reference type 1). It only handles `content` and `embeds`, which covers normal messages and rich embeds but not forwarded messages where `content` is empty and the actual text is in `message_snapshots`.
- **Missing detection / guardrail:** No test case for forwarded message as thread starter.
- **Prior context:** The regular message path (`resolveDiscordMessageText` at L525) already handles `message_snapshots` correctly via `resolveDiscordForwardedMessagesText`. The thread starter path was simply never updated.
- **Why this regressed now:** Not a regression — it was never supported. Discord's Forward feature is relatively new.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `threading.starter.test.ts`
- Scenario the test should lock in: Thread starter with empty content + populated `message_snapshots` → text extracted
- Why this is the smallest reliable guardrail: Unit test on `resolveDiscordThreadStarter` with mocked REST response covers the exact code path
- 3 new tests added:
  1. FM with content in `message_snapshots` → extracts text
  2. Normal message with content + snapshots → prefers `content`
  3. Empty content + empty snapshots → returns `null`

## User-visible / Behavior Changes

When `includeThreadStarter: true` is configured and a thread is created on a Forwarded Message, the agent session now receives the forwarded text as context. Previously it received nothing.

## Diagram (if applicable)

```text
Before:
[FM as thread starter] -> resolveDiscordThreadStarter
  -> content="" -> embeds=[] -> return null ❌

After:
[FM as thread starter] -> resolveDiscordThreadStarter
  -> content="" -> embeds=[] -> message_snapshots[0].message.content="task text"
  -> return "[Forwarded message]\ntask text" ✅
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.4.0 arm64)
- Runtime: Node v22.17.0
- OpenClaw: latest npm (2026.4.3)
- Integration: Discord with `includeThreadStarter: true`

### Steps

1. Forward a message to a Discord channel
2. Create a thread on the forwarded message (manual or autoThread)
3. Mention the bot in the thread

### Expected

Session includes forwarded message text as thread starter context

### Actual (before fix)

Thread starter is `null`, session has no FM context

## Evidence

- [x] Failing test/log before + passing after
- All 6 tests pass (3 existing + 3 new): `vitest run threading.starter.test.ts`
- Pre-commit hooks pass: `pnpm check` (tsgo, lint, all checks)
- Verified with live Discord API data: FM message has `content: ""`, `flags: 16416` (IS_FORWARD + HAS_THREAD), text in `message_snapshots[0].message.content`

## Human Verification (required)

- **Verified scenarios:** Inspected live Discord API responses for forwarded messages, confirmed `content` is empty and `message_snapshots` contains the text. Ran full test suite locally.
- **Edge cases checked:** Empty snapshots array, snapshots with no message, normal messages with both content and snapshots (content takes priority)
- **What I did NOT verify:** End-to-end with a running OpenClaw instance (verified data structure against live API responses and unit tests only)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

v1 had Greptile concerns about fragile `as unknown as Message` cast and unnecessary export of `resolveDiscordMessageSnapshots`. v2 addresses both: uses a self-contained local helper (`resolveStarterForwardedText`) that operates directly on the typed REST response, no cross-module imports or casts needed.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** `message_snapshots` structure could change in future Discord API versions
  - **Mitigation:** The helper gracefully returns `""` for any unexpected structure (missing array, missing message, missing content). Falls through to existing `return null` path.

## AI-Assisted

- [x] AI-assisted (OpenClaw agent authored the code with human direction and review)
- [x] Fully tested (6 unit tests, pre-commit checks)
- [x] Understand what the code does