### PR TITLE
fix: thread dangerouslyForceUnsafeInstall through plugins update command

### DIFF
--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -53,6 +53,7 @@ export type PluginInspectOptions = {
 export type PluginUpdateOptions = {
   all?: boolean;
   dryRun?: boolean;
+  dangerouslyForceUnsafeInstall?: boolean;
 };
 
 export type PluginMarketplaceListOptions = {
@@ -793,6 +794,11 @@ export function registerPluginsCli(program: Command) {
     .argument("[id]", "Plugin or hook-pack id (omit with --all)")
     .option("--all", "Update all tracked plugins and hook packs", false)
     .option("--dry-run", "Show what would change without writing", false)
+    .option(
+      "--dangerously-force-unsafe-install",
+      "Bypass built-in dangerous-code install blocking (plugin hooks may still block)",
+      false,
+    )
     .action(async (id: string | undefined, opts: PluginUpdateOptions) => {
       await runPluginUpdateCommand({ id, opts });
     });

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -89,7 +89,7 @@ function resolveHookPackUpdateSelection(params: {
 
 export async function runPluginUpdateCommand(params: {
   id?: string;
-  opts: { all?: boolean; dryRun?: boolean };
+  opts: { all?: boolean; dryRun?: boolean; dangerouslyForceUnsafeInstall?: boolean };
 }) {
   const sourceSnapshotPromise = readConfigFileSnapshot().catch(() => null);
   const cfg = loadConfig();
@@ -122,6 +122,7 @@ export async function runPluginUpdateCommand(params: {
     pluginIds: pluginSelection.pluginIds,
     specOverrides: pluginSelection.specOverrides,
     dryRun: params.opts.dryRun,
+    dangerouslyForceUnsafeInstall: params.opts.dangerouslyForceUnsafeInstall,
     logger,
     onIntegrityDrift: async (drift) => {
       const specLabel = drift.resolvedSpec ?? drift.spec;

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -258,6 +258,7 @@ export async function updateNpmInstalledPlugins(params: {
   pluginIds?: string[];
   skipIds?: Set<string>;
   dryRun?: boolean;
+  dangerouslyForceUnsafeInstall?: boolean;
   specOverrides?: Record<string, string>;
   onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
 }): Promise<PluginUpdateSummary> {
@@ -361,6 +362,7 @@ export async function updateNpmInstalledPlugins(params: {
                 dryRun: true,
                 expectedPluginId: pluginId,
                 expectedIntegrity,
+                dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
                 onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
                   pluginId,
                   dryRun: true,
@@ -376,6 +378,7 @@ export async function updateNpmInstalledPlugins(params: {
                   mode: "update",
                   dryRun: true,
                   expectedPluginId: pluginId,
+                  dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
                   logger,
                 })
               : await installPluginFromMarketplace({
@@ -384,6 +387,7 @@ export async function updateNpmInstalledPlugins(params: {
                   mode: "update",
                   dryRun: true,
                   expectedPluginId: pluginId,
+                  dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
                   logger,
                 });
       } catch (err) {
@@ -458,6 +462,7 @@ export async function updateNpmInstalledPlugins(params: {
               mode: "update",
               expectedPluginId: pluginId,
               expectedIntegrity,
+              dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
               onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
                 pluginId,
                 dryRun: false,
@@ -472,6 +477,7 @@ export async function updateNpmInstalledPlugins(params: {
                 baseUrl: record.clawhubUrl,
                 mode: "update",
                 expectedPluginId: pluginId,
+                dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
                 logger,
               })
             : await installPluginFromMarketplace({
@@ -479,6 +485,7 @@ export async function updateNpmInstalledPlugins(params: {
                 plugin: record.marketplacePlugin!,
                 mode: "update",
                 expectedPluginId: pluginId,
+                dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
                 logger,
               });
     } catch (err) {


### PR DESCRIPTION
## Summary

Add `--dangerously-force-unsafe-install` flag to `plugins update` command and thread it through the entire update flow.

Currently, `plugins update` has no way to bypass the dangerous code scanner, causing **all plugins using `child_process`** to fail updating. This affects plugins that legitimately need process management: feishu, codex, clawarena, clawnetwork, etc.

## Changes

3 files, 15 insertions:

- **`src/cli/plugins-cli.ts`**: Add `dangerouslyForceUnsafeInstall` to `PluginUpdateOptions` type + add `--dangerously-force-unsafe-install` option to the `update` command definition
- **`src/cli/plugins-update-command.ts`**: Accept the flag and pass it to `updateNpmInstalledPlugins`
- **`src/plugins/update.ts`**: Add parameter to function signature, thread it to all 6 `installPluginFrom*` calls (npm/clawhub/marketplace × dryRun/actual)

## Test plan

```bash
# Before: blocked
openclaw plugins update clawnetwork
# → Failed to update clawnetwork: Plugin "clawnetwork" installation blocked: dangerous code patterns detected

# After: works with flag
openclaw plugins update clawnetwork --dangerously-force-unsafe-install
# → Updated clawnetwork 0.1.3 → 0.1.4
```

Fixes #60138
Related: #59241 #59171 #59508 #59521 #40162