### PR TITLE
fix(browser): clean up browser tabs/processes when cron tasks and subagents complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ Docs: https://docs.openclaw.ai
 - Browser/host inspection: keep static Chrome inspection helpers out of the activated browser runtime so `openclaw doctor browser` and related checks do not eagerly load the bundled browser plugin. (#59471) Thanks @vincentkoc.
 - Browser/CDP: normalize trailing-dot localhost absolute-form hosts before loopback checks so remote CDP websocket URLs like `ws://localhost.:...` rewrite back to the configured remote host. (#59236) Thanks @mappel-nv.
 - Browser/attach-only profiles: disconnect cached Playwright CDP sessions when stopping attach-only or remote CDP profiles, while still reporting never-started local managed profiles as not stopped. (#60097) Thanks @pedh.
+- Browser/task cleanup: close tracked browser tabs and best-effort browser processes when cron-isolated agents and subagents finish, so background browser runs stop leaking orphaned sessions. (#60146) Thanks @BrianWang1990.
 - Agents/output sanitization: strip namespaced `antml:thinking` blocks from user-visible text so Anthropic-style internal monologue tags do not leak into replies. (#59550) Thanks @obviyus.
 - Kimi Coding/tools: normalize Anthropic tool payloads into the OpenAI-compatible function shape Kimi Coding expects so tool calls stop losing required arguments. (#59440) Thanks @obviyus.
 - Image tool/paths: resolve relative local media paths against the agent `workspaceDir` instead of `process.cwd()` so inputs like `inbox/receipt.png` pass the local-path allowlist reliably. (#57222) Thanks Priyansh Gupta.

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -17,6 +17,10 @@ const lifecycleEventMocks = vi.hoisted(() => ({
   emitSessionLifecycleEvent: vi.fn(),
 }));
 
+const browserMaintenanceMocks = vi.hoisted(() => ({
+  closeTrackedBrowserTabsForSessions: vi.fn(async () => 0),
+}));
+
 vi.mock("../tasks/task-executor.js", () => ({
   completeTaskRunByRunId: taskExecutorMocks.completeTaskRunByRunId,
   failTaskRunByRunId: taskExecutorMocks.failTaskRunByRunId,
@@ -25,6 +29,10 @@ vi.mock("../tasks/task-executor.js", () => ({
 
 vi.mock("../sessions/session-lifecycle-events.js", () => ({
   emitSessionLifecycleEvent: lifecycleEventMocks.emitSessionLifecycleEvent,
+}));
+
+vi.mock("../plugin-sdk/browser-maintenance.js", () => ({
+  closeTrackedBrowserTabsForSessions: browserMaintenanceMocks.closeTrackedBrowserTabsForSessions,
 }));
 
 vi.mock("./subagent-registry-helpers.js", async () => {
@@ -58,6 +66,7 @@ describe("subagent registry lifecycle hardening", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    browserMaintenanceMocks.closeTrackedBrowserTabsForSessions.mockClear();
     mod = await import("./subagent-registry-lifecycle.js");
   });
 
@@ -163,5 +172,87 @@ describe("subagent registry lifecycle hardening", () => {
     );
     expect(entry.cleanupCompletedAt).toBeTypeOf("number");
     expect(persist).toHaveBeenCalled();
+  });
+
+  it("cleans up tracked browser sessions before subagent cleanup flow", async () => {
+    const persist = vi.fn();
+    const entry = createRunEntry({
+      expectsCompletionMessage: false,
+    });
+    const runSubagentAnnounceFlow = vi.fn(async () => true);
+
+    const controller = mod.createSubagentRegistryLifecycleController({
+      runs: new Map([[entry.runId, entry]]),
+      resumedRuns: new Set(),
+      subagentAnnounceTimeoutMs: 1_000,
+      persist,
+      clearPendingLifecycleError: vi.fn(),
+      countPendingDescendantRuns: () => 0,
+      suppressAnnounceForSteerRestart: () => false,
+      shouldEmitEndedHookForRun: () => false,
+      emitSubagentEndedHookForRun: vi.fn(async () => {}),
+      notifyContextEngineSubagentEnded: vi.fn(async () => {}),
+      resumeSubagentRun: vi.fn(),
+      captureSubagentCompletionReply: vi.fn(async () => "final completion reply"),
+      runSubagentAnnounceFlow,
+      warn: vi.fn(),
+    });
+
+    await expect(
+      controller.completeSubagentRun({
+        runId: entry.runId,
+        endedAt: 4_000,
+        outcome: { status: "ok" },
+        reason: SUBAGENT_ENDED_REASON_COMPLETE,
+        triggerCleanup: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(browserMaintenanceMocks.closeTrackedBrowserTabsForSessions).toHaveBeenCalledWith({
+      sessionKeys: [entry.childSessionKey],
+      onWarn: expect.any(Function),
+    });
+    expect(runSubagentAnnounceFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childSessionKey: entry.childSessionKey,
+      }),
+    );
+  });
+
+  it("skips browser cleanup when steer restart suppresses cleanup flow", async () => {
+    const entry = createRunEntry({
+      expectsCompletionMessage: false,
+    });
+    const runSubagentAnnounceFlow = vi.fn(async () => true);
+
+    const controller = mod.createSubagentRegistryLifecycleController({
+      runs: new Map([[entry.runId, entry]]),
+      resumedRuns: new Set(),
+      subagentAnnounceTimeoutMs: 1_000,
+      persist: vi.fn(),
+      clearPendingLifecycleError: vi.fn(),
+      countPendingDescendantRuns: () => 0,
+      suppressAnnounceForSteerRestart: () => true,
+      shouldEmitEndedHookForRun: () => false,
+      emitSubagentEndedHookForRun: vi.fn(async () => {}),
+      notifyContextEngineSubagentEnded: vi.fn(async () => {}),
+      resumeSubagentRun: vi.fn(),
+      captureSubagentCompletionReply: vi.fn(async () => "final completion reply"),
+      runSubagentAnnounceFlow,
+      warn: vi.fn(),
+    });
+
+    await expect(
+      controller.completeSubagentRun({
+        runId: entry.runId,
+        endedAt: 4_000,
+        outcome: { status: "ok" },
+        reason: SUBAGENT_ENDED_REASON_COMPLETE,
+        triggerCleanup: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(browserMaintenanceMocks.closeTrackedBrowserTabsForSessions).not.toHaveBeenCalled();
+    expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -1,5 +1,6 @@
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { formatErrorMessage, readErrorName } from "../infra/errors.js";
+import { closeTrackedBrowserTabsForSessions } from "../plugin-sdk/browser-maintenance.js";
 import { defaultRuntime } from "../runtime.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import {
@@ -604,6 +605,19 @@ export function createSubagentRegistryLifecycleController(params: {
     if (!completeParams.triggerCleanup || suppressedForSteerRestart) {
       return;
     }
+
+    // Clean up browser tabs/processes opened by this subagent session.
+    // Without this, browser processes become orphaned after the subagent
+    // exits. See #60104.
+    try {
+      await closeTrackedBrowserTabsForSessions({
+        sessionKeys: [entry.childSessionKey],
+        onWarn: (msg) => params.warn(msg, { runId: entry.runId }),
+      });
+    } catch {
+      // Best-effort cleanup.
+    }
+
     startSubagentAnnounceCleanupFlow(completeParams.runId, entry);
   };
 

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -12,12 +12,14 @@ const {
   loadConfigMock,
   fetchWithSsrFGuardMock,
   runCronIsolatedAgentTurnMock,
+  closeTrackedBrowserTabsForSessionsMock,
 } = vi.hoisted(() => ({
   enqueueSystemEventMock: vi.fn(),
   requestHeartbeatNowMock: vi.fn(),
   loadConfigMock: vi.fn(),
   fetchWithSsrFGuardMock: vi.fn(),
   runCronIsolatedAgentTurnMock: vi.fn(async () => ({ status: "ok" as const, summary: "ok" })),
+  closeTrackedBrowserTabsForSessionsMock: vi.fn(async () => 0),
 }));
 
 function enqueueSystemEvent(...args: unknown[]) {
@@ -59,6 +61,10 @@ vi.mock("../cron/isolated-agent.js", () => ({
   runCronIsolatedAgentTurn: runCronIsolatedAgentTurnMock,
 }));
 
+vi.mock("../plugin-sdk/browser-maintenance.js", () => ({
+  closeTrackedBrowserTabsForSessions: closeTrackedBrowserTabsForSessionsMock,
+}));
+
 import { buildGatewayCronService } from "./server-cron.js";
 
 function createCronConfig(name: string): OpenClawConfig {
@@ -80,6 +86,7 @@ describe("buildGatewayCronService", () => {
     loadConfigMock.mockClear();
     fetchWithSsrFGuardMock.mockClear();
     runCronIsolatedAgentTurnMock.mockClear();
+    closeTrackedBrowserTabsForSessionsMock.mockClear();
   });
 
   it("routes main-target jobs to the scoped session for enqueue + wake", async () => {
@@ -200,6 +207,10 @@ describe("buildGatewayCronService", () => {
           sessionKey: "project-alpha-monitor",
         }),
       );
+      expect(closeTrackedBrowserTabsForSessionsMock).toHaveBeenCalledWith({
+        sessionKeys: ["project-alpha-monitor"],
+        onWarn: expect.any(Function),
+      });
     } finally {
       state.cron.stop();
     }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -10,6 +10,7 @@ import {
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { resolveFailureDestination, sendFailureNotificationAnnounce } from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
+import { closeTrackedBrowserTabsForSessions } from "../plugin-sdk/browser-maintenance.js";
 import { resolveDeliveryTarget } from "../cron/isolated-agent/delivery-target.js";
 import {
   appendCronRunLog,
@@ -291,16 +292,31 @@ export function buildGatewayCronService(params: {
           sessionKey = customSessionId;
         }
       }
-      return await runCronIsolatedAgentTurn({
-        cfg: runtimeConfig,
-        deps: params.deps,
-        job,
-        message,
-        abortSignal,
-        agentId,
-        sessionKey,
-        lane: "cron",
-      });
+      try {
+        return await runCronIsolatedAgentTurn({
+          cfg: runtimeConfig,
+          deps: params.deps,
+          job,
+          message,
+          abortSignal,
+          agentId,
+          sessionKey,
+          lane: "cron",
+        });
+      } finally {
+        // Clean up browser tabs/processes opened during this cron run.
+        // Without this, browser processes become orphaned (PPID=1) after
+        // the cron task completes. See #60104.
+        try {
+          await closeTrackedBrowserTabsForSessions({
+            sessionKeys: [sessionKey],
+            onWarn: (msg) => cronLogger.warn({ jobId: job.id }, msg),
+          });
+        } catch {
+          // Best-effort cleanup — do not let browser cleanup failures
+          // mask the actual cron run result.
+        }
+      }
     },
     sendCronFailureAlert: async ({ job, text, channel, to, mode, accountId }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -10,8 +10,8 @@ import {
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { resolveFailureDestination, sendFailureNotificationAnnounce } from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
-import { closeTrackedBrowserTabsForSessions } from "../plugin-sdk/browser-maintenance.js";
 import { resolveDeliveryTarget } from "../cron/isolated-agent/delivery-target.js";
+import { closeTrackedBrowserTabsForSessions } from "../plugin-sdk/browser-maintenance.js";
 import {
   appendCronRunLog,
   resolveCronRunLogPath,


### PR DESCRIPTION
## Problem

When cron tasks or subagents use browser automation (e.g., headless Chrome for web scraping, email checking, etc.), the browser processes are not cleaned up after the task completes. This leads to orphaned Chrome processes (PPID=1) accumulating over time, consuming memory and CPU resources.

## Root Cause

`closeTrackedBrowserTabsForSessions` was only called during `session-reset`/`session-delete` (via `ensureSessionRuntimeCleanup` in `session-reset-service.ts`), but:

1. **Cron isolated runs** complete without triggering a session reset — the session reaper (`session-reaper.ts`) only cleans up session store entries and transcript files, not browser processes.
2. **Subagent completions** (`completeSubagentRun` in `subagent-registry-lifecycle.ts`) handle lifecycle hooks and announce flows but never close tracked browser tabs.

## Fix

Add browser tab cleanup in two places:

1. **`server-cron.ts`**: Wrap `runCronIsolatedAgentTurn` in `try/finally` to ensure browser tabs are cleaned up after every cron run, regardless of success or failure.
2. **`subagent-registry-lifecycle.ts`**: Call `closeTrackedBrowserTabsForSessions` when a subagent run completes (in `completeSubagentRun`), before the announce cleanup flow begins.

Both cleanup calls are best-effort (errors are caught and logged) so they never mask the actual task result or break the completion flow.

## Changes

- `src/gateway/server-cron.ts`: Added `try/finally` around `runCronIsolatedAgentTurn` with browser tab cleanup in `finally` block
- `src/agents/subagent-registry-lifecycle.ts`: Added browser tab cleanup call in `completeSubagentRun` before `startSubagentAnnounceCleanupFlow`

## Testing

This fix addresses a real-world issue observed with cron tasks that use browser automation for monitoring (e.g., checking web-based messaging platforms). After 2-3 days of cron tasks running, dozens of orphaned Chrome processes accumulate.

Fixes #60104