### PR TITLE
fix(whatsapp): ignore self-chat quoted replies in groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/local Bot API: preserve media MIME types for absolute-path downloads so local audio files still trigger transcription and other MIME-based handling. (#54603) Thanks @jzakirov
 - Channels/WhatsApp: pass inbound message timestamp to model context so the AI can see when WhatsApp messages were sent. (#58590) Thanks @Maninae
 - QQBot/voice: lazy-load `silk-wasm` in `audio-convert.ts` so qqbot still starts when the optional voice dependency is missing, while voice encode/decode degrades gracefully instead of crashing at module load time. (#58829) Thanks @WideLee.
+- WhatsApp/groups: fix bot waking up on self-number quoted replies in groups with `selfChatMode` enabled. (#60148) Thanks @lurebat
 
 ## 2026.3.31
 

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -143,10 +143,16 @@ export function applyGroupGating(params: ApplyGroupGatingParams) {
   });
   const requireMention = activation !== "always";
   const replyContext = getReplyContext(params.msg, params.authDir);
+  const sharedNumberSelfChat = params.cfg.channels?.whatsapp?.selfChatMode === true;
+  const senderLooksLikeSelf = identitiesOverlap(self, sender);
   // Detect reply-to-bot: compare JIDs, LIDs, and E.164 numbers.
   // WhatsApp may report the quoted message sender as either a phone JID
   // (xxxxx@s.whatsapp.net) or a LID (xxxxx@lid), so we compare both.
-  const implicitMention = identitiesOverlap(self, replyContext?.sender);
+  // But in shared-number/selfChatMode setups, replies from the same self number
+  // should not count as implicit bot mentions unless the message explicitly
+  // mentioned the bot in text.
+  const implicitReplyToSelf = sharedNumberSelfChat && senderLooksLikeSelf;
+  const implicitMention = !implicitReplyToSelf && identitiesOverlap(self, replyContext?.sender);
   const mentionGate = resolveMentionGating({
     requireMention,
     canDetectMention: true,

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -6,6 +6,7 @@ import {
   getSenderIdentity,
   identitiesOverlap,
 } from "../../identity.js";
+import { resolveWhatsAppAccount } from "../../accounts.js";
 import type { MentionConfig } from "../mentions.js";
 import { buildMentionConfig, debugMention, resolveOwnerList } from "../mentions.js";
 import type { WebInboundMsg } from "../types.js";
@@ -143,7 +144,8 @@ export function applyGroupGating(params: ApplyGroupGatingParams) {
   });
   const requireMention = activation !== "always";
   const replyContext = getReplyContext(params.msg, params.authDir);
-  const sharedNumberSelfChat = params.cfg.channels?.whatsapp?.selfChatMode === true;
+  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.msg.accountId });
+  const sharedNumberSelfChat = account.selfChatMode === true;
   // Detect reply-to-bot: compare JIDs, LIDs, and E.164 numbers.
   // WhatsApp may report the quoted message sender as either a phone JID
   // (xxxxx@s.whatsapp.net) or a LID (xxxxx@lid), so we compare both.

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -144,14 +144,14 @@ export function applyGroupGating(params: ApplyGroupGatingParams) {
   const requireMention = activation !== "always";
   const replyContext = getReplyContext(params.msg, params.authDir);
   const sharedNumberSelfChat = params.cfg.channels?.whatsapp?.selfChatMode === true;
-  const senderLooksLikeSelf = identitiesOverlap(self, sender);
   // Detect reply-to-bot: compare JIDs, LIDs, and E.164 numbers.
   // WhatsApp may report the quoted message sender as either a phone JID
   // (xxxxx@s.whatsapp.net) or a LID (xxxxx@lid), so we compare both.
   // But in shared-number/selfChatMode setups, replies from the same self number
   // should not count as implicit bot mentions unless the message explicitly
   // mentioned the bot in text.
-  const implicitReplyToSelf = sharedNumberSelfChat && senderLooksLikeSelf;
+  const implicitReplyToSelf =
+    sharedNumberSelfChat && identitiesOverlap(self, sender);
   const implicitMention = !implicitReplyToSelf && identitiesOverlap(self, replyContext?.sender);
   const mentionGate = resolveMentionGating({
     requireMention,

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -6,7 +6,6 @@ import {
   getSenderIdentity,
   identitiesOverlap,
 } from "../../identity.js";
-import { resolveWhatsAppAccount } from "../../accounts.js";
 import type { MentionConfig } from "../mentions.js";
 import { buildMentionConfig, debugMention, resolveOwnerList } from "../mentions.js";
 import type { WebInboundMsg } from "../types.js";
@@ -41,6 +40,7 @@ type ApplyGroupGatingParams = {
   groupHistories: Map<string, GroupHistoryEntry[]>;
   groupHistoryLimit: number;
   groupMemberNames: Map<string, Map<string, string>>;
+  selfChatMode?: boolean;
   logVerbose: (msg: string) => void;
   replyLogger: { debug: (obj: unknown, msg: string) => void };
 };
@@ -144,16 +144,14 @@ export function applyGroupGating(params: ApplyGroupGatingParams) {
   });
   const requireMention = activation !== "always";
   const replyContext = getReplyContext(params.msg, params.authDir);
-  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.msg.accountId });
-  const sharedNumberSelfChat = account.selfChatMode === true;
+  const sharedNumberSelfChat = params.selfChatMode === true;
   // Detect reply-to-bot: compare JIDs, LIDs, and E.164 numbers.
   // WhatsApp may report the quoted message sender as either a phone JID
   // (xxxxx@s.whatsapp.net) or a LID (xxxxx@lid), so we compare both.
   // But in shared-number/selfChatMode setups, replies from the same self number
   // should not count as implicit bot mentions unless the message explicitly
   // mentioned the bot in text.
-  const implicitReplyToSelf =
-    sharedNumberSelfChat && identitiesOverlap(self, sender);
+  const implicitReplyToSelf = sharedNumberSelfChat && identitiesOverlap(self, sender);
   const implicitMention = !implicitReplyToSelf && identitiesOverlap(self, replyContext?.sender);
   const mentionGate = resolveMentionGating({
     requireMention,

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -29,7 +29,7 @@ export function createWebOnMessageHandler(params: {
   replyResolver: typeof getReplyFromConfig;
   replyLogger: ReturnType<(typeof import("openclaw/plugin-sdk/runtime-env"))["getChildLogger"]>;
   baseMentionConfig: MentionConfig;
-  account: { authDir?: string; accountId?: string };
+  account: { authDir?: string; accountId?: string; selfChatMode?: boolean };
 }) {
   const processForRoute = async (
     msg: WebInboundMsg,
@@ -135,6 +135,7 @@ export function createWebOnMessageHandler(params: {
         sessionKey: route.sessionKey,
         baseMentionConfig: params.baseMentionConfig,
         authDir: params.account.authDir,
+        selfChatMode: params.account.selfChatMode,
         groupHistories: params.groupHistories,
         groupHistoryLimit: params.groupHistoryLimit,
         groupMemberNames: params.groupMemberNames,

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -125,6 +125,39 @@ describe("applyGroupGating", () => {
     expect(result.shouldProcess).toBe(true);
   });
 
+  it("does not treat self-number quoted replies as implicit mention in selfChatMode groups", () => {
+    const cfg = makeConfig({
+      channels: {
+        whatsapp: {
+          selfChatMode: true,
+          groupPolicy: "open",
+          groups: { "*": { requireMention: true } },
+        },
+      },
+    });
+    const { result } = runGroupGating({
+      cfg,
+      msg: createGroupMessage({
+        id: "m-self-reply",
+        to: "+15550000",
+        accountId: "default",
+        body: "following up on my own message",
+        timestamp: Date.now(),
+        senderE164: "+15551234567",
+        senderJid: "15551234567@s.whatsapp.net",
+        selfJid: "15551234567@s.whatsapp.net",
+        selfE164: "+15551234567",
+        replyToId: "m0",
+        replyToBody: "my earlier message",
+        replyToSender: "+15551234567",
+        replyToSenderJid: "15551234567@s.whatsapp.net",
+        replyToSenderE164: "+15551234567",
+      }),
+    });
+
+    expect(result.shouldProcess).toBe(false);
+  });
+
   it.each([
     { id: "g-new", command: "/new" },
     { id: "g-status", command: "/status" },

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -40,6 +40,7 @@ function runGroupGating(params: {
   msg: Record<string, unknown>;
   conversationId?: string;
   agentId?: string;
+  selfChatMode?: boolean;
 }) {
   const groupHistories = new Map<string, GroupHistoryEntry[]>();
   const conversationId = params.conversationId ?? "123@g.us";
@@ -55,6 +56,7 @@ function runGroupGating(params: {
     agentId,
     sessionKey,
     baseMentionConfig,
+    selfChatMode: params.selfChatMode,
     groupHistories,
     groupHistoryLimit: 10,
     groupMemberNames: new Map(),
@@ -137,6 +139,7 @@ describe("applyGroupGating", () => {
     });
     const { result } = runGroupGating({
       cfg,
+      selfChatMode: true,
       msg: createGroupMessage({
         id: "m-self-reply",
         to: "+15550000",
@@ -170,6 +173,7 @@ describe("applyGroupGating", () => {
     });
     const { result } = runGroupGating({
       cfg,
+      selfChatMode: true,
       msg: createGroupMessage({
         id: "m-other-reply",
         to: "+15550000",
@@ -206,8 +210,10 @@ describe("applyGroupGating", () => {
         },
       },
     });
+    // Per-account override: work account has selfChatMode: false despite root being true
     const { result } = runGroupGating({
       cfg,
+      selfChatMode: false,
       msg: createGroupMessage({
         id: "m-account-override",
         to: "+15550000",

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -158,6 +158,39 @@ describe("applyGroupGating", () => {
     expect(result.shouldProcess).toBe(false);
   });
 
+  it("still treats reply-to-bot as implicit mention in selfChatMode when sender is a different user", () => {
+    const cfg = makeConfig({
+      channels: {
+        whatsapp: {
+          selfChatMode: true,
+          groupPolicy: "open",
+          groups: { "*": { requireMention: true } },
+        },
+      },
+    });
+    const { result } = runGroupGating({
+      cfg,
+      msg: createGroupMessage({
+        id: "m-other-reply",
+        to: "+15550000",
+        accountId: "default",
+        body: "following up on bot reply",
+        timestamp: Date.now(),
+        senderE164: "+15559999999",
+        senderJid: "15559999999@s.whatsapp.net",
+        selfJid: "15551234567@s.whatsapp.net",
+        selfE164: "+15551234567",
+        replyToId: "m0",
+        replyToBody: "bot earlier response",
+        replyToSender: "+15551234567",
+        replyToSenderJid: "15551234567@s.whatsapp.net",
+        replyToSenderE164: "+15551234567",
+      }),
+    });
+
+    expect(result.shouldProcess).toBe(true);
+  });
+
   it.each([
     { id: "g-new", command: "/new" },
     { id: "g-status", command: "/status" },

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -191,6 +191,44 @@ describe("applyGroupGating", () => {
     expect(result.shouldProcess).toBe(true);
   });
 
+  it("honors per-account selfChatMode overrides before suppressing implicit mentions", () => {
+    const cfg = makeConfig({
+      channels: {
+        whatsapp: {
+          selfChatMode: true,
+          groupPolicy: "open",
+          groups: { "*": { requireMention: true } },
+          accounts: {
+            work: {
+              selfChatMode: false,
+            },
+          },
+        },
+      },
+    });
+    const { result } = runGroupGating({
+      cfg,
+      msg: createGroupMessage({
+        id: "m-account-override",
+        to: "+15550000",
+        accountId: "work",
+        body: "following up on bot reply",
+        timestamp: Date.now(),
+        senderE164: "+15551234567",
+        senderJid: "15551234567@s.whatsapp.net",
+        selfJid: "15551234567@s.whatsapp.net",
+        selfE164: "+15551234567",
+        replyToId: "m0",
+        replyToBody: "bot earlier response",
+        replyToSender: "+15551234567",
+        replyToSenderJid: "15551234567@s.whatsapp.net",
+        replyToSenderE164: "+15551234567",
+      }),
+    });
+
+    expect(result.shouldProcess).toBe(true);
+  });
+
   it.each([
     { id: "g-new", command: "/new" },
     { id: "g-status", command: "/status" },


### PR DESCRIPTION
## Summary

- Problem: in WhatsApp group chats with `selfChatMode` enabled, a user replying to their own earlier message could be mistaken for replying to the bot because the sender identity overlaps with the bot's shared self identity.
- Why it matters: that false implicit mention makes the bot jump into group chats unprompted.
- What changed: suppress implicit reply-to-bot detection only for shared-number self-replies in `selfChatMode`, keep explicit text mentions unchanged, and add regression coverage for both the suppressed self-reply path and the still-allowed cross-user reply path.
- What did NOT change (scope boundary): this does not change mention handling outside WhatsApp group gating, and it does not change normal reply-to-bot behavior for different users in the group.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: implicit reply-to-bot detection treated any sender identity overlapping the bot's self identity as a bot reply, which is wrong in shared-number `selfChatMode` setups where the human user and the bot intentionally share the same number.
- Missing detection / guardrail: there was no guard distinguishing self-replies from replies sent by a different participant, and no regression test covering the shared-number group flow.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: the bug only shows up in the narrower `selfChatMode` deployment shape, so the default/non-shared-number path did not expose it.
- If unknown, what was ruled out: explicit text mention matching was ruled out; the unintended wake-up came from the implicit reply path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts`
- Scenario the test should lock in: in `selfChatMode`, self-number quoted replies in group chats should not count as implicit mentions, while replies from a different group member to the bot should still count.
- Why this is the smallest reliable guardrail: the bug is in the group gating decision logic, and the existing monitor tests already exercise that seam with realistic sender/reply metadata.
- Existing test that already covers this (if any): the PR now includes both the self-reply suppression case and the complementary cross-user reply case.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- In WhatsApp group chats with `selfChatMode` enabled, replying to your own earlier message no longer wakes the bot as an implicit mention.
- Explicit text mentions still work as before.
- Different group members replying to the bot in the same setup still trigger the bot as before.

## Diagram (if applicable)

```text
Before:
[selfChatMode user replies to own quoted message] -> [sender overlaps self identity] -> [treated as implicit mention] -> [bot wakes up]

After:
[selfChatMode user replies to own quoted message] -> [shared self-number detected] -> [implicit mention suppressed] -> [bot stays quiet unless explicitly mentioned]
[different group member replies to quoted bot message] -> [sender does not overlap self identity] -> [implicit mention preserved] -> [bot responds]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (local OpenClaw host)
- Runtime/container: OpenClaw local source checkout + live package install hotfix for immediate mitigation
- Model/provider: N/A
- Integration/channel (if any): WhatsApp group auto-reply monitor
- Relevant config (redacted): `channels.whatsapp.selfChatMode=true`, group gating requires mention

### Steps

1. Configure WhatsApp with `selfChatMode: true` and group mention gating enabled.
2. In a group chat, send a message from the shared self number and then reply to that earlier message from the same shared self number without an explicit text mention.
3. Repeat with a different participant replying to a quoted bot/self message in the same group.

### Expected

- Self-number quoted replies should not count as implicit mentions.
- Cross-user replies to the bot should still count as implicit mentions.

### Actual

- Before the fix, self-number quoted replies were treated like reply-to-bot implicit mentions and woke the bot.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the live behavior, hot-patched the installed runtime to stop the immediate false wake-up, and added targeted regression coverage for the self-reply suppression case plus the complementary cross-user case.
- Edge cases checked: explicit mentions remain unchanged; non-self senders in `selfChatMode` still use implicit reply-to-bot detection.
- What you did **not** verify: I did not complete the full local `pnpm build && pnpm check && pnpm test` lane in this checkout because the local workspace was missing the `vitest` binary when invoking the targeted test directly; CI is the source of truth for full validation here.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: suppressing implicit mentions too broadly in `selfChatMode` could block legitimate reply-to-bot behavior from other participants.
  - Mitigation: add the complementary regression test that proves different-user replies still trigger implicit mention handling.

## AI Assistance

- [x] AI-assisted: this fix and PR were prepared with AI assistance.
- Testing degree: lightly tested locally (live hotfix reproduction) + CI validation.
- Prompts/session logs: available from the authoring session if needed.
- I understand what the code does: yes.
