### PR TITLE
Use owning npm prefix for global updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Google: separate OAuth CSRF state from PKCE code verifier during Gemini browser sign-in so state validation and token exchange use independent values. (#59116) Thanks @eleqtrizit.
 - Agents/subagents: honor `agents.defaults.subagents.allowAgents` for `sessions_spawn` and `agents_list`, so default cross-agent allowlists work without duplicating per-agent config. (#59944) Thanks @hclsys.
 - Agents/tools: normalize only truly empty MCP tool schemas to `{ type: "object", properties: {} }` so OpenAI accepts parameter-free tools without rewriting unrelated conditional schemas. (#60176) Thanks @Bartok9.
+- Update/npm: prefer the npm binary that owns the installed global OpenClaw prefix during package self-update, so mixed Homebrew-plus-nvm setups update the right install. (#60153) Thanks @jayeshp19.
 - Plugins/browser: block SSRF redirect bypass by installing a real-time Playwright route handler before `page.goto()` so navigation to private/internal IPs is intercepted and aborted mid-redirect instead of checked post-hoc. (#58771) Thanks @pgondhi987.
 - Android/gateway: require TLS for non-loopback remote gateway endpoints while still allowing local loopback and emulator cleartext setup flows. (#58475) Thanks @eleqtrizit.
 - Exec/Windows: hide transient console windows for `runExec` and `runCommandWithTimeout` child-process launches, matching other Windows exec paths and stopping visible shell flashes during tool runs. (#59466) Thanks @lawrence3699.

--- a/extensions/feishu/src/bot-runtime-api.ts
+++ b/extensions/feishu/src/bot-runtime-api.ts
@@ -1,6 +1,9 @@
-export { buildAgentMediaPayload } from "openclaw/plugin-sdk/media-runtime";
-export { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/config-runtime";
-export type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
+export {
+  buildAgentMediaPayload,
+  resolveChannelContextVisibilityMode,
+  type ClawdbotConfig,
+  type RuntimeEnv,
+} from "../runtime-api.js";
 export {
   evaluateSupplementalContextVisibility,
   filterSupplementalContextItems,

--- a/extensions/feishu/src/channel-runtime-api.ts
+++ b/extensions/feishu/src/channel-runtime-api.ts
@@ -5,11 +5,12 @@ export type {
   ClawdbotConfig,
 } from "../runtime-api.js";
 
-export { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
-export { createActionGate } from "openclaw/plugin-sdk/channel-actions";
-export { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
 export {
+  buildChannelConfigSchema,
   buildProbeChannelStatusSummary,
+  chunkTextForOutbound,
+  createActionGate,
+  createDefaultChannelRuntimeState,
+  DEFAULT_ACCOUNT_ID,
   PAIRING_APPROVED_MESSAGE,
-} from "openclaw/plugin-sdk/channel-status";
-export { chunkTextForOutbound, createDefaultChannelRuntimeState } from "openclaw/plugin-sdk/feishu";
+} from "../runtime-api.js";

--- a/extensions/feishu/src/outbound-runtime-api.ts
+++ b/extensions/feishu/src/outbound-runtime-api.ts
@@ -1,1 +1,1 @@
-export { chunkTextForOutbound, type ChannelOutboundAdapter } from "openclaw/plugin-sdk/feishu";
+export { chunkTextForOutbound, type ChannelOutboundAdapter } from "../runtime-api.js";

--- a/extensions/msteams/src/file-lock.ts
+++ b/extensions/msteams/src/file-lock.ts
@@ -1,1 +1,1 @@
-export { withFileLock } from "openclaw/plugin-sdk/msteams";
+export { withFileLock } from "../runtime-api.js";

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -8,7 +8,7 @@ import {
   resolveSendableOutboundReplyParts,
   SILENT_REPLY_TOKEN,
   sleep,
-} from "openclaw/plugin-sdk/msteams";
+} from "../runtime-api.js";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import type { StoredConversationReference } from "./conversation-store.js";
 import { classifyMSTeamsSendError } from "./errors.js";

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -1,6 +1,6 @@
 import { createAttachedChannelResultAdapter } from "openclaw/plugin-sdk/channel-send-result";
-import { chunkTextForOutbound, type ChannelOutboundAdapter } from "openclaw/plugin-sdk/msteams";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/outbound-runtime";
+import { chunkTextForOutbound, type ChannelOutboundAdapter } from "../runtime-api.js";
 import { createMSTeamsPollStoreFs } from "./polls.js";
 import { sendMessageMSTeams, sendPollMSTeams } from "./send.js";
 

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -1,6 +1,6 @@
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/config-runtime";
-import { loadOutboundMediaFromUrl, type OpenClawConfig } from "openclaw/plugin-sdk/msteams";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-runtime";
+import { loadOutboundMediaFromUrl, type OpenClawConfig } from "../runtime-api.js";
 import { createMSTeamsConversationStoreFs } from "./conversation-store-fs.js";
 import {
   classifyMSTeamsSendError,

--- a/extensions/msteams/src/store-fs.ts
+++ b/extensions/msteams/src/store-fs.ts
@@ -3,7 +3,7 @@ import {
   readJsonFileWithFallback,
   withFileLock as withPathLock,
   writeJsonFileAtomically,
-} from "openclaw/plugin-sdk/msteams";
+} from "../runtime-api.js";
 
 const STORE_LOCK_OPTIONS = {
   retries: {

--- a/scripts/check-extension-plugin-sdk-boundary.mjs
+++ b/scripts/check-extension-plugin-sdk-boundary.mjs
@@ -67,7 +67,9 @@ function isTestLikeFile(relativePath) {
   return (
     /(^|\/)(__tests__|fixtures|test|tests|test-support)\//.test(relativePath) ||
     /(^|\/)test-support\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(relativePath) ||
-    /(^|\/)[^/]*test-(support|helpers)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(relativePath) ||
+    /(^|\/)[^/]*test-(support|helpers|fixtures)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(
+      relativePath,
+    ) ||
     /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(relativePath)
   );
 }

--- a/scripts/check-no-extension-src-imports.ts
+++ b/scripts/check-no-extension-src-imports.ts
@@ -14,7 +14,12 @@ function isProductionExtensionFile(filePath: string): boolean {
     filePath.includes(".snap") ||
     filePath.includes("test-harness") ||
     filePath.includes("test-support") ||
+    filePath.includes("test-helpers") ||
+    filePath.includes("test-fixtures") ||
     filePath.includes("/__tests__/") ||
+    filePath.includes("/fixtures/") ||
+    filePath.includes("/test/") ||
+    filePath.includes("/tests/") ||
     filePath.includes("/coverage/") ||
     filePath.includes("/dist/") ||
     filePath.includes("/node_modules/")

--- a/scripts/pnpm-runner.mjs
+++ b/scripts/pnpm-runner.mjs
@@ -1,0 +1,53 @@
+import path from "node:path";
+
+const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>%\r\n]/;
+
+function isPnpmExecPath(value) {
+  return /^pnpm(?:-cli)?(?:\.(?:c?js|cmd|exe))?$/.test(path.basename(value).toLowerCase());
+}
+
+function escapeForCmdExe(arg) {
+  if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
+    throw new Error(`unsafe Windows cmd.exe argument detected: ${JSON.stringify(arg)}`);
+  }
+  const escaped = arg.replace(/\^/g, "^^");
+  if (!escaped.includes(" ") && !escaped.includes('"')) {
+    return escaped;
+  }
+  return `"${escaped.replace(/"/g, '""')}"`;
+}
+
+function buildCmdExeCommandLine(command, args) {
+  return [escapeForCmdExe(command), ...args.map(escapeForCmdExe)].join(" ");
+}
+
+export function resolvePnpmRunner(params = {}) {
+  const pnpmArgs = params.pnpmArgs ?? [];
+  const npmExecPath = params.npmExecPath ?? process.env.npm_execpath;
+  const nodeExecPath = params.nodeExecPath ?? process.execPath;
+  const platform = params.platform ?? process.platform;
+  const comSpec = params.comSpec ?? process.env.ComSpec ?? "cmd.exe";
+
+  if (typeof npmExecPath === "string" && npmExecPath.length > 0 && isPnpmExecPath(npmExecPath)) {
+    return {
+      command: nodeExecPath,
+      args: [npmExecPath, ...pnpmArgs],
+      shell: false,
+    };
+  }
+
+  if (platform === "win32") {
+    return {
+      command: comSpec,
+      args: ["/d", "/s", "/c", buildCmdExeCommandLine("pnpm.cmd", pnpmArgs)],
+      shell: false,
+      windowsVerbatimArguments: true,
+    };
+  }
+
+  return {
+    command: "pnpm",
+    args: pnpmArgs,
+    shell: false,
+  };
+}

--- a/scripts/test-live.mjs
+++ b/scripts/test-live.mjs
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { resolvePnpmRunner } from "./pnpm-runner.mjs";
 
 const forwardedArgs = [];
 let quietOverride;
@@ -24,15 +25,15 @@ const env = {
   OPENCLAW_LIVE_TEST_QUIET: quietOverride ?? process.env.OPENCLAW_LIVE_TEST_QUIET ?? "1",
 };
 
-const command = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-const child = spawn(
-  command,
-  ["exec", "vitest", "run", "--config", "vitest.live.config.ts", ...forwardedArgs],
-  {
-    stdio: "inherit",
-    env,
-  },
-);
+const pnpmRunner = resolvePnpmRunner({
+  pnpmArgs: ["exec", "vitest", "run", "--config", "vitest.live.config.ts", ...forwardedArgs],
+});
+const child = spawn(pnpmRunner.command, pnpmRunner.args, {
+  stdio: "inherit",
+  env: pnpmRunner.env ?? env,
+  shell: pnpmRunner.shell,
+  windowsVerbatimArguments: pnpmRunner.windowsVerbatimArguments,
+});
 
 child.on("exit", (code, signal) => {
   if (signal) {

--- a/scripts/test-projects.mjs
+++ b/scripts/test-projects.mjs
@@ -1,9 +1,10 @@
 import { spawn } from "node:child_process";
 import { acquireLocalHeavyCheckLockSync } from "./lib/local-heavy-check-runtime.mjs";
+import { resolvePnpmRunner } from "./pnpm-runner.mjs";
 import { buildVitestArgs } from "./test-projects.test-support.mjs";
 
-const command = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const vitestArgs = buildVitestArgs(process.argv.slice(2));
+const pnpmRunner = resolvePnpmRunner({ pnpmArgs: vitestArgs });
 const releaseLock = acquireLocalHeavyCheckLockSync({
   cwd: process.cwd(),
   env: process.env,
@@ -20,10 +21,11 @@ const releaseLockOnce = () => {
   releaseLock();
 };
 
-const child = spawn(command, vitestArgs, {
+const child = spawn(pnpmRunner.command, pnpmRunner.args, {
   stdio: "inherit",
-  env: process.env,
-  shell: process.platform === "win32",
+  env: pnpmRunner.env ?? process.env,
+  shell: pnpmRunner.shell,
+  windowsVerbatimArguments: pnpmRunner.windowsVerbatimArguments,
 });
 
 child.on("exit", (code, signal) => {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -351,7 +351,7 @@ async function runPackageInstallUpdate(params: {
   const installEnv = await createGlobalInstallEnv();
   const runCommand = createGlobalCommandRunner();
 
-  const pkgRoot = await resolveGlobalPackageRoot(manager, runCommand, params.timeoutMs);
+  const pkgRoot = await resolveGlobalPackageRoot(manager, runCommand, params.timeoutMs, params.root);
   const packageName =
     (pkgRoot ? await readPackageName(pkgRoot) : await readPackageName(params.root)) ??
     DEFAULT_PACKAGE_NAME;
@@ -371,7 +371,7 @@ async function runPackageInstallUpdate(params: {
 
   const updateStep = await runUpdateStep({
     name: "global update",
-    argv: globalInstallArgs(manager, installSpec),
+    argv: globalInstallArgs(manager, installSpec, params.root),
     env: installEnv,
     timeoutMs: params.timeoutMs,
     progress: params.progress,
@@ -381,7 +381,7 @@ async function runPackageInstallUpdate(params: {
   let afterVersion = beforeVersion;
 
   const verifiedPackageRoot =
-    (await resolveGlobalPackageRoot(manager, runCommand, params.timeoutMs)) ?? pkgRoot;
+    (await resolveGlobalPackageRoot(manager, runCommand, params.timeoutMs, params.root)) ?? pkgRoot;
   if (verifiedPackageRoot) {
     afterVersion = await readPackageVersion(verifiedPackageRoot);
     const expectedVersion = resolveExpectedInstalledVersionFromSpec(packageName, installSpec);
@@ -484,7 +484,7 @@ async function runGitUpdate(params: {
     });
     const installStep = await runUpdateStep({
       name: "global install",
-      argv: globalInstallArgs(manager, updateRoot),
+      argv: globalInstallArgs(manager, updateRoot, params.root),
       cwd: updateRoot,
       env: installEnv,
       timeoutMs: effectiveTimeout,

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { bundledDistPluginFile } from "../../test/helpers/bundled-plugin-paths.js";
 import { BUNDLED_RUNTIME_SIDECAR_PATHS } from "../plugins/runtime-sidecar-paths.js";
 import { captureEnv } from "../test-utils/env.js";
@@ -143,10 +143,7 @@ describe("update global helpers", () => {
     const brewRoot = path.join(brewPrefix, "lib", "node_modules");
     const pkgRoot = path.join(brewRoot, "openclaw");
     const pathNpmRoot = path.join(base, "nvm", "lib", "node_modules");
-    const brewNpm = path.join(
-      brewBin,
-      process.platform === "win32" ? "npm.cmd" : "npm",
-    );
+    const brewNpm = path.join(brewBin, process.platform === "win32" ? "npm.cmd" : "npm");
     await fs.mkdir(pkgRoot, { recursive: true });
     await fs.mkdir(brewBin, { recursive: true });
     await fs.writeFile(brewNpm, "", "utf8");
@@ -164,13 +161,9 @@ describe("update global helpers", () => {
       throw new Error(`unexpected command: ${argv.join(" ")}`);
     };
 
-    await expect(detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000)).resolves.toBe(
-      "npm",
-    );
+    await expect(detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000)).resolves.toBe("npm");
     await expect(resolveGlobalRoot("npm", runCommand, 1000, pkgRoot)).resolves.toBe(brewRoot);
-    await expect(resolveGlobalPackageRoot("npm", runCommand, 1000, pkgRoot)).resolves.toBe(
-      pkgRoot,
-    );
+    await expect(resolveGlobalPackageRoot("npm", runCommand, 1000, pkgRoot)).resolves.toBe(pkgRoot);
     expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
       brewNpm,
       "i",
@@ -190,6 +183,74 @@ describe("update global helpers", () => {
       "--no-audit",
       "--loglevel=error",
     ]);
+  });
+
+  it("does not infer npm ownership from path shape alone when the owning npm binary is absent", async () => {
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-npm-missing-bin-"));
+    const brewRoot = path.join(base, "opt", "homebrew", "lib", "node_modules");
+    const pkgRoot = path.join(brewRoot, "openclaw");
+    const pathNpmRoot = path.join(base, "nvm", "lib", "node_modules");
+    await fs.mkdir(pkgRoot, { recursive: true });
+
+    const runCommand: CommandRunner = async (argv) => {
+      if (argv[0] === "npm") {
+        return { stdout: `${pathNpmRoot}\n`, stderr: "", code: 0 };
+      }
+      if (argv[0] === "pnpm") {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      throw new Error(`unexpected command: ${argv.join(" ")}`);
+    };
+
+    await expect(detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000)).resolves.toBeNull();
+    expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
+      "npm",
+      "i",
+      "-g",
+      "openclaw@latest",
+      "--no-fund",
+      "--no-audit",
+      "--loglevel=error",
+    ]);
+  });
+
+  it("prefers npm.cmd for win32-style global npm roots", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-win32-npm-prefix-"));
+    const npmPrefix = path.join(base, "Roaming", "npm");
+    const npmRoot = path.join(npmPrefix, "node_modules");
+    const pkgRoot = path.join(npmRoot, "openclaw");
+    const npmCmd = path.join(npmPrefix, "npm.cmd");
+    const pathNpmRoot = path.join(base, "nvm", "node_modules");
+    await fs.mkdir(pkgRoot, { recursive: true });
+    await fs.writeFile(npmCmd, "", "utf8");
+
+    const runCommand: CommandRunner = async (argv) => {
+      if (argv[0] === "npm") {
+        return { stdout: `${pathNpmRoot}\n`, stderr: "", code: 0 };
+      }
+      if (argv[0] === npmCmd) {
+        return { stdout: `${npmRoot}\n`, stderr: "", code: 0 };
+      }
+      if (argv[0] === "pnpm") {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      throw new Error(`unexpected command: ${argv.join(" ")}`);
+    };
+
+    await expect(detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000)).resolves.toBe("npm");
+    await expect(resolveGlobalRoot("npm", runCommand, 1000, pkgRoot)).resolves.toBe(npmRoot);
+    expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
+      npmCmd,
+      "i",
+      "-g",
+      "openclaw@latest",
+      "--no-fund",
+      "--no-audit",
+      "--loglevel=error",
+    ]);
+
+    platformSpy.mockRestore();
   });
 
   it("builds install argv and npm fallback argv", () => {

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -136,6 +136,62 @@ describe("update global helpers", () => {
     await expect(detectGlobalInstallManagerByPresence(runCommand, 1000)).resolves.toBe("bun");
   });
 
+  it("prefers the owning npm prefix when PATH npm points at a different global root", async () => {
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-npm-prefix-"));
+    const brewPrefix = path.join(base, "opt", "homebrew");
+    const brewBin = path.join(brewPrefix, "bin");
+    const brewRoot = path.join(brewPrefix, "lib", "node_modules");
+    const pkgRoot = path.join(brewRoot, "openclaw");
+    const pathNpmRoot = path.join(base, "nvm", "lib", "node_modules");
+    const brewNpm = path.join(
+      brewBin,
+      process.platform === "win32" ? "npm.cmd" : "npm",
+    );
+    await fs.mkdir(pkgRoot, { recursive: true });
+    await fs.mkdir(brewBin, { recursive: true });
+    await fs.writeFile(brewNpm, "", "utf8");
+
+    const runCommand: CommandRunner = async (argv) => {
+      if (argv[0] === "npm") {
+        return { stdout: `${pathNpmRoot}\n`, stderr: "", code: 0 };
+      }
+      if (argv[0] === brewNpm) {
+        return { stdout: `${brewRoot}\n`, stderr: "", code: 0 };
+      }
+      if (argv[0] === "pnpm") {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      throw new Error(`unexpected command: ${argv.join(" ")}`);
+    };
+
+    await expect(detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000)).resolves.toBe(
+      "npm",
+    );
+    await expect(resolveGlobalRoot("npm", runCommand, 1000, pkgRoot)).resolves.toBe(brewRoot);
+    await expect(resolveGlobalPackageRoot("npm", runCommand, 1000, pkgRoot)).resolves.toBe(
+      pkgRoot,
+    );
+    expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
+      brewNpm,
+      "i",
+      "-g",
+      "openclaw@latest",
+      "--no-fund",
+      "--no-audit",
+      "--loglevel=error",
+    ]);
+    expect(globalInstallFallbackArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
+      brewNpm,
+      "i",
+      "-g",
+      "openclaw@latest",
+      "--omit=optional",
+      "--no-fund",
+      "--no-audit",
+      "--loglevel=error",
+    ]);
+  });
+
   it("builds install argv and npm fallback argv", () => {
     expect(globalInstallArgs("npm", "openclaw@latest")).toEqual([
       "npm",

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -137,52 +137,61 @@ describe("update global helpers", () => {
   });
 
   it("prefers the owning npm prefix when PATH npm points at a different global root", async () => {
-    const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-npm-prefix-"));
-    const brewPrefix = path.join(base, "opt", "homebrew");
-    const brewBin = path.join(brewPrefix, "bin");
-    const brewRoot = path.join(brewPrefix, "lib", "node_modules");
-    const pkgRoot = path.join(brewRoot, "openclaw");
-    const pathNpmRoot = path.join(base, "nvm", "lib", "node_modules");
-    const brewNpm = path.join(brewBin, process.platform === "win32" ? "npm.cmd" : "npm");
-    await fs.mkdir(pkgRoot, { recursive: true });
-    await fs.mkdir(brewBin, { recursive: true });
-    await fs.writeFile(brewNpm, "", "utf8");
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    try {
+      const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-npm-prefix-"));
+      const brewPrefix = path.join(base, "opt", "homebrew");
+      const brewBin = path.join(brewPrefix, "bin");
+      const brewRoot = path.join(brewPrefix, "lib", "node_modules");
+      const pkgRoot = path.join(brewRoot, "openclaw");
+      const pathNpmRoot = path.join(base, "nvm", "lib", "node_modules");
+      const brewNpm = path.join(brewBin, "npm");
+      await fs.mkdir(pkgRoot, { recursive: true });
+      await fs.mkdir(brewBin, { recursive: true });
+      await fs.writeFile(brewNpm, "", "utf8");
 
-    const runCommand: CommandRunner = async (argv) => {
-      if (argv[0] === "npm") {
-        return { stdout: `${pathNpmRoot}\n`, stderr: "", code: 0 };
-      }
-      if (argv[0] === brewNpm) {
-        return { stdout: `${brewRoot}\n`, stderr: "", code: 0 };
-      }
-      if (argv[0] === "pnpm") {
-        return { stdout: "", stderr: "", code: 1 };
-      }
-      throw new Error(`unexpected command: ${argv.join(" ")}`);
-    };
+      const runCommand: CommandRunner = async (argv) => {
+        if (argv[0] === "npm") {
+          return { stdout: `${pathNpmRoot}\n`, stderr: "", code: 0 };
+        }
+        if (argv[0] === brewNpm) {
+          return { stdout: `${brewRoot}\n`, stderr: "", code: 0 };
+        }
+        if (argv[0] === "pnpm") {
+          return { stdout: "", stderr: "", code: 1 };
+        }
+        throw new Error(`unexpected command: ${argv.join(" ")}`);
+      };
 
-    await expect(detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000)).resolves.toBe("npm");
-    await expect(resolveGlobalRoot("npm", runCommand, 1000, pkgRoot)).resolves.toBe(brewRoot);
-    await expect(resolveGlobalPackageRoot("npm", runCommand, 1000, pkgRoot)).resolves.toBe(pkgRoot);
-    expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
-      brewNpm,
-      "i",
-      "-g",
-      "openclaw@latest",
-      "--no-fund",
-      "--no-audit",
-      "--loglevel=error",
-    ]);
-    expect(globalInstallFallbackArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
-      brewNpm,
-      "i",
-      "-g",
-      "openclaw@latest",
-      "--omit=optional",
-      "--no-fund",
-      "--no-audit",
-      "--loglevel=error",
-    ]);
+      await expect(detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000)).resolves.toBe(
+        "npm",
+      );
+      await expect(resolveGlobalRoot("npm", runCommand, 1000, pkgRoot)).resolves.toBe(brewRoot);
+      await expect(resolveGlobalPackageRoot("npm", runCommand, 1000, pkgRoot)).resolves.toBe(
+        pkgRoot,
+      );
+      expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
+        brewNpm,
+        "i",
+        "-g",
+        "openclaw@latest",
+        "--no-fund",
+        "--no-audit",
+        "--loglevel=error",
+      ]);
+      expect(globalInstallFallbackArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
+        brewNpm,
+        "i",
+        "-g",
+        "openclaw@latest",
+        "--omit=optional",
+        "--no-fund",
+        "--no-audit",
+        "--loglevel=error",
+      ]);
+    } finally {
+      platformSpy.mockRestore();
+    }
   });
 
   it("does not infer npm ownership from path shape alone when the owning npm binary is absent", async () => {

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -191,11 +191,24 @@ function inferNpmPrefixFromPackageRoot(pkgRoot?: string | null): string | null {
   if (path.basename(nodeModulesDir) !== "node_modules") {
     return null;
   }
-  const libDir = path.dirname(nodeModulesDir);
-  if (path.basename(libDir) !== "lib") {
+  const parentDir = path.dirname(nodeModulesDir);
+  if (path.basename(parentDir) === "lib") {
+    return path.dirname(parentDir);
+  }
+  if (process.platform === "win32" && path.basename(parentDir).toLowerCase() === "npm") {
+    return parentDir;
+  }
+  return null;
+}
+
+function resolvePreferredNpmCommand(pkgRoot?: string | null): string | null {
+  const prefix = inferNpmPrefixFromPackageRoot(pkgRoot);
+  if (!prefix) {
     return null;
   }
-  return path.dirname(libDir);
+  const candidate =
+    process.platform === "win32" ? path.join(prefix, "npm.cmd") : path.join(prefix, "bin", "npm");
+  return fsSync.existsSync(candidate) ? candidate : null;
 }
 
 function resolvePreferredGlobalManagerCommand(
@@ -205,13 +218,7 @@ function resolvePreferredGlobalManagerCommand(
   if (manager !== "npm") {
     return manager;
   }
-  const prefix = inferNpmPrefixFromPackageRoot(pkgRoot);
-  if (!prefix) {
-    return manager;
-  }
-  const candidate =
-    process.platform === "win32" ? path.join(prefix, "npm.cmd") : path.join(prefix, "bin", "npm");
-  return fsSync.existsSync(candidate) ? candidate : manager;
+  return resolvePreferredNpmCommand(pkgRoot) ?? manager;
 }
 
 export async function resolveGlobalRoot(
@@ -290,7 +297,7 @@ export async function detectGlobalInstallManagerForRoot(
     }
   }
 
-  if (inferNpmPrefixFromPackageRoot(pkgRoot)) {
+  if (resolvePreferredNpmCommand(pkgRoot)) {
     return "npm";
   }
 

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -180,15 +181,50 @@ function resolveBunGlobalRoot(): string {
   return path.join(bunInstall, "install", "global", "node_modules");
 }
 
+function inferNpmPrefixFromPackageRoot(pkgRoot?: string | null): string | null {
+  const trimmed = pkgRoot?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const normalized = path.resolve(trimmed);
+  const nodeModulesDir = path.dirname(normalized);
+  if (path.basename(nodeModulesDir) !== "node_modules") {
+    return null;
+  }
+  const libDir = path.dirname(nodeModulesDir);
+  if (path.basename(libDir) !== "lib") {
+    return null;
+  }
+  return path.dirname(libDir);
+}
+
+function resolvePreferredGlobalManagerCommand(
+  manager: GlobalInstallManager,
+  pkgRoot?: string | null,
+): string {
+  if (manager !== "npm") {
+    return manager;
+  }
+  const prefix = inferNpmPrefixFromPackageRoot(pkgRoot);
+  if (!prefix) {
+    return manager;
+  }
+  const candidate =
+    process.platform === "win32" ? path.join(prefix, "npm.cmd") : path.join(prefix, "bin", "npm");
+  return fsSync.existsSync(candidate) ? candidate : manager;
+}
+
 export async function resolveGlobalRoot(
   manager: GlobalInstallManager,
   runCommand: CommandRunner,
   timeoutMs: number,
+  pkgRoot?: string | null,
 ): Promise<string | null> {
   if (manager === "bun") {
     return resolveBunGlobalRoot();
   }
-  const argv = manager === "pnpm" ? ["pnpm", "root", "-g"] : ["npm", "root", "-g"];
+  const command = resolvePreferredGlobalManagerCommand(manager, pkgRoot);
+  const argv = [command, "root", "-g"];
   const res = await runCommand(argv, { timeoutMs }).catch(() => null);
   if (!res || res.code !== 0) {
     return null;
@@ -201,8 +237,9 @@ export async function resolveGlobalPackageRoot(
   manager: GlobalInstallManager,
   runCommand: CommandRunner,
   timeoutMs: number,
+  pkgRoot?: string | null,
 ): Promise<string | null> {
-  const root = await resolveGlobalRoot(manager, runCommand, timeoutMs);
+  const root = await resolveGlobalRoot(manager, runCommand, timeoutMs, pkgRoot);
   if (!root) {
     return null;
   }
@@ -253,6 +290,10 @@ export async function detectGlobalInstallManagerForRoot(
     }
   }
 
+  if (inferNpmPrefixFromPackageRoot(pkgRoot)) {
+    return "npm";
+  }
+
   return null;
 }
 
@@ -281,24 +322,31 @@ export async function detectGlobalInstallManagerByPresence(
   return null;
 }
 
-export function globalInstallArgs(manager: GlobalInstallManager, spec: string): string[] {
+export function globalInstallArgs(
+  manager: GlobalInstallManager,
+  spec: string,
+  pkgRoot?: string | null,
+): string[] {
+  const command = resolvePreferredGlobalManagerCommand(manager, pkgRoot);
   if (manager === "pnpm") {
-    return ["pnpm", "add", "-g", spec];
+    return [command, "add", "-g", spec];
   }
   if (manager === "bun") {
-    return ["bun", "add", "-g", spec];
+    return [command, "add", "-g", spec];
   }
-  return ["npm", "i", "-g", spec, ...NPM_GLOBAL_INSTALL_QUIET_FLAGS];
+  return [command, "i", "-g", spec, ...NPM_GLOBAL_INSTALL_QUIET_FLAGS];
 }
 
 export function globalInstallFallbackArgs(
   manager: GlobalInstallManager,
   spec: string,
+  pkgRoot?: string | null,
 ): string[] | null {
   if (manager !== "npm") {
     return null;
   }
-  return ["npm", "i", "-g", spec, ...NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS];
+  const command = resolvePreferredGlobalManagerCommand(manager, pkgRoot);
+  return [command, "i", "-g", spec, ...NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS];
 }
 
 export async function cleanupGlobalRenameDirs(params: {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -1018,7 +1018,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     const updateStep = await runStep({
       runCommand,
       name: "global update",
-      argv: globalInstallArgs(globalManager, spec),
+      argv: globalInstallArgs(globalManager, spec, pkgRoot),
       cwd: pkgRoot,
       timeoutMs,
       env: globalInstallEnv,
@@ -1030,7 +1030,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
 
     let finalStep = updateStep;
     if (updateStep.exitCode !== 0) {
-      const fallbackArgv = globalInstallFallbackArgs(globalManager, spec);
+      const fallbackArgv = globalInstallFallbackArgs(globalManager, spec, pkgRoot);
       if (fallbackArgv) {
         const fallbackStep = await runStep({
           runCommand,
@@ -1049,7 +1049,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     }
 
     const verifiedPackageRoot =
-      (await resolveGlobalPackageRoot(globalManager, runCommand, timeoutMs)) ?? pkgRoot;
+      (await resolveGlobalPackageRoot(globalManager, runCommand, timeoutMs, pkgRoot)) ?? pkgRoot;
     const expectedVersion = resolveExpectedInstalledVersionFromSpec(packageName, spec);
     const verificationErrors = await collectInstalledGlobalPackageErrors({
       packageRoot: verifiedPackageRoot,

--- a/test/scripts/pnpm-runner.test.ts
+++ b/test/scripts/pnpm-runner.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { resolvePnpmRunner } from "../../scripts/pnpm-runner.mjs";
+
+describe("resolvePnpmRunner", () => {
+  it("uses npm_execpath when it points to pnpm", () => {
+    expect(
+      resolvePnpmRunner({
+        npmExecPath: "/home/test/.cache/node/corepack/v1/pnpm/10.32.1/bin/pnpm.cjs",
+        nodeExecPath: "/usr/local/bin/node",
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "linux",
+      }),
+    ).toEqual({
+      command: "/usr/local/bin/node",
+      args: [
+        "/home/test/.cache/node/corepack/v1/pnpm/10.32.1/bin/pnpm.cjs",
+        "exec",
+        "vitest",
+        "run",
+      ],
+      shell: false,
+    });
+  });
+
+  it("falls back to bare pnpm on non-Windows when npm_execpath is missing", () => {
+    expect(
+      resolvePnpmRunner({
+        npmExecPath: "",
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "linux",
+      }),
+    ).toEqual({
+      command: "pnpm",
+      args: ["exec", "vitest", "run"],
+      shell: false,
+    });
+  });
+
+  it("wraps pnpm.cmd via cmd.exe on Windows when npm_execpath is unavailable", () => {
+    expect(
+      resolvePnpmRunner({
+        comSpec: "C:\\Windows\\System32\\cmd.exe",
+        npmExecPath: "",
+        pnpmArgs: ["exec", "vitest", "run", "-t", "path with spaces"],
+        platform: "win32",
+      }),
+    ).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", 'pnpm.cmd exec vitest run -t "path with spaces"'],
+      shell: false,
+      windowsVerbatimArguments: true,
+    });
+  });
+
+  it("escapes caret arguments for Windows cmd.exe", () => {
+    expect(
+      resolvePnpmRunner({
+        comSpec: "C:\\Windows\\System32\\cmd.exe",
+        npmExecPath: "",
+        pnpmArgs: ["exec", "vitest", "-t", "@scope/pkg@^1.2.3"],
+        platform: "win32",
+      }),
+    ).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", "pnpm.cmd exec vitest -t @scope/pkg@^^1.2.3"],
+      shell: false,
+      windowsVerbatimArguments: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: `openclaw update` uses bare `npm` from `PATH` for npm-based global updates, even after it has already identified the installed OpenClaw package root.
- Why it matters: in mixed global Node setups like Homebrew-installed OpenClaw with `nvm` first on `PATH`, the updater targets the wrong global npm root and can fail or update the wrong install context.
- What changed: infer the owning npm prefix from the installed package root, prefer that npm executable for `npm root -g` and global install commands, and add regression coverage for the Homebrew-vs-nvm case.
- What did NOT change (scope boundary): no changes to non-npm update flows, git checkout update logic, plugin install behavior, or daemon/runtime behavior outside the updater path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes https://github.com/openclaw/openclaw/issues/60150
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: updater logic treats `manager = npm` as “run `npm` from `PATH`” instead of resolving the npm executable associated with the installed package root being updated.
- Missing detection / guardrail: no guardrail or test covered mixed global npm environments where the current OpenClaw install belongs to one prefix and `PATH` points at another npm.
- Prior context (`git blame`, prior PR, issue, or refactor if known): unknown.
- Why this regressed now: not confirmed as a recent regression; likely a latent bug that only shows up when users mix global Node toolchains.
- If unknown, what was ruled out: ruled out a generic child-process spawn failure and ruled out a broken OpenClaw runtime install. The failure is isolated to updater package-manager resolution.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/update-global.test.ts`
- Scenario the test should lock in: package root is under a Homebrew-style global npm prefix, while bare `npm root -g` resolves a different global root from `PATH`; updater should still choose the owning npm executable and correct package root.
- Why this is the smallest reliable guardrail: the bug is in path/prefix resolution logic, so a focused unit test around manager/root/argv selection catches it without requiring full global install setup.
- Existing test that already covers this (if any): existing tests covered manager detection and install argv generation, but not mixed-prefix npm environments.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw update` now prefers the npm executable associated with the installed OpenClaw package root for npm-based global installs when it can infer that prefix.
- This changes behavior only in mixed npm-prefix environments; behavior is unchanged for single-prefix installs.

## Diagram (if applicable)

```text
Before:
[openclaw update] -> [detect install root=/opt/homebrew/lib/node_modules/openclaw]
                 -> [run bare npm from PATH]
                 -> [npm root -g = ~/.nvm/.../node_modules]
                 -> [wrong global context]

After:
[openclaw update] -> [detect install root=/opt/homebrew/lib/node_modules/openclaw]
                 -> [infer owning prefix=/opt/homebrew]
                 -> [run /opt/homebrew/bin/npm]
                 -> [npm root -g = /opt/homebrew/lib/node_modules]
                 -> [correct global context]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - The updater now chooses a more specific npm executable instead of bare `npm` from `PATH` when the installed package root clearly maps to an owning npm prefix. This reduces ambiguity rather than expanding execution scope. Fallback remains the existing behavior when no prefix can be inferred.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local global install
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted):
  - installed package root: `/opt/homebrew/lib/node_modules/openclaw`
  - `npm` on `PATH`: `/Users/jayesh/.nvm/versions/node/v23.6.0/bin/npm`

### Steps

1. Install OpenClaw under Homebrew global npm so the package root is `/opt/homebrew/lib/node_modules/openclaw`.
2. Put `nvm` npm first on `PATH`.
3. Run:
   ```sh
   which npm
   npm root -g
   /opt/homebrew/bin/npm root -g
   openclaw update
   ```

### Expected

- Updater should use the npm executable that owns the installed OpenClaw package root.
- For the example above, that means `/opt/homebrew/bin/npm`.

### Actual

- Updater uses bare `npm` from `PATH`, which resolves the nvm global root instead of the Homebrew global root.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Machine-level evidence from the repro environment:

```json
{
  "pkgRoot": "/opt/homebrew/lib/node_modules/openclaw",
  "pathNpm": "/Users/jayesh/.nvm/versions/node/v23.6.0/bin/npm",
  "pathNpmRoot": "/Users/jayesh/.nvm/versions/node/v23.6.0/lib/node_modules",
  "selectedNpm": "/opt/homebrew/bin/npm",
  "selectedRoot": "/opt/homebrew/lib/node_modules",
  "oldUpdaterWouldMismatch": true,
  "patchedUpdaterMatches": true
}
```

## Human Verification (required)

- Verified scenarios:
  - confirmed mixed-prefix environment on a real macOS machine
  - confirmed bare `npm root -g` points at nvm while installed package root is under Homebrew
  - confirmed patched resolution logic selects `/opt/homebrew/bin/npm`
  - confirmed patched resolution logic maps back to `/opt/homebrew/lib/node_modules/openclaw`
- Edge cases checked:
  - fallback behavior remains unchanged when no npm prefix can be inferred from package root
  - pnpm/bun argument generation remains unchanged
- What you did **not** verify:
  - full repo test suite in this checkout
  - full end-to-end `openclaw update` execution from the patched repo build

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk:
  - inferring npm prefix from package-root shape could be too narrow and miss some valid npm global layouts
  - Mitigation:
    - only prefer the owning npm executable when the package root has the expected `.../lib/node_modules/<pkg>` shape and the derived npm binary exists; otherwise fall back to existing behavior

- Risk:
  - package-manager resolution behavior changes for npm global installs
  - Mitigation:
    - change is scoped to npm installs only and regression coverage was added for the mixed-prefix scenario that triggered the bug
