### PR TITLE
feat: raise CLI watchdog timeout defaults for long-running exec commands

### DIFF
--- a/src/agents/cli-watchdog-defaults.ts
+++ b/src/agents/cli-watchdog-defaults.ts
@@ -3,11 +3,16 @@ export const CLI_WATCHDOG_MIN_TIMEOUT_MS = 1_000;
 export const CLI_FRESH_WATCHDOG_DEFAULTS = {
   noOutputTimeoutRatio: 0.8,
   minMs: 180_000,
-  maxMs: 600_000,
+  maxMs: 1_800_000, // Raised from 600_000 (10min) to 1_800_000 (30min)
 } as const;
 
 export const CLI_RESUME_WATCHDOG_DEFAULTS = {
   noOutputTimeoutRatio: 0.3,
   minMs: 60_000,
-  maxMs: 180_000,
+  maxMs: 600_000, // Raised from 180_000 (3min) to 600_000 (10min)
 } as const;
+
+// Backwards-compatible: users who need longer watchdog timeouts can override via
+// backend.reliability.watchdog.fresh.maxMs / resume.maxMs in openclaw.json.
+// See CliBackendWatchdogModeSchema in zod-schema.core.ts.
+


### PR DESCRIPTION
## Summary

Raises the CLI watchdog `maxMs` defaults so long-running exec commands (builds, downloads, data processing) are no longer killed after 10 minutes of no output.

## Changes

| Setting | Before | After |
|---|---|---|
| `CLI_FRESH_WATCHDOG_DEFAULTS.maxMs` | 600,000 (10 min) | 1,800,000 (30 min) |
| `CLI_RESUME_WATCHDOG_DEFAULTS.maxMs` | 180,000 (3 min) | 600,000 (10 min) |

## Problem

The CLI watchdog `\`no-output-timeout\`` was capping at 10 minutes for fresh runs and 3 minutes for resumed runs. Commands producing infrequent output (large file downloads, slow builds, data pipelines) would get SIGKILL'd before completing. Users reported this as a 600s exec timeout.

## Backwards compatibility

- Users can still override via \`backend.reliability.watchdog.fresh.maxMs\` / \`resume.maxMs\` in \`openclaw.json\`
- Schema already supports this (see \`CliBackendWatchdogModeSchema\` in \`zod-schema.core.ts\`)

## Related

Closes #60151
Closes #14228
Closes #20436