### PR TITLE
fix(update): use manager binary associated with installed global root

### DIFF
--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -147,6 +147,12 @@ describe("update global helpers", () => {
         ? path.join("C:\\Users\\me\\AppData\\Roaming\\npm", "node_modules")
         : "/opt/homebrew/lib/node_modules";
     expect(resolveGlobalManagerCommand("npm", npmRoot)).toBe(npmCommand);
+    const pnpmRoot = process.platform === "win32"
+      ? path.join("C:\\Users\\me\\AppData\\Local\\pnpm", "global", "5", "node_modules")
+      : "/home/me/.local/share/pnpm/global/5/node_modules";
+    expect(resolveGlobalManagerCommand("pnpm", pnpmRoot)).toBe(
+      process.platform === "win32" ? "pnpm.cmd" : "pnpm",
+    );
     expect(globalInstallArgs("npm", "openclaw@latest", npmCommand)).toEqual([
       npmCommand,
       "i",

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -12,6 +12,7 @@ import {
   detectGlobalInstallManagerByPresence,
   detectGlobalInstallManagerForRoot,
   globalInstallArgs,
+  resolveGlobalManagerCommand,
   globalInstallFallbackArgs,
   isExplicitPackageInstallSpec,
   isMainPackageTarget,
@@ -137,8 +138,17 @@ describe("update global helpers", () => {
   });
 
   it("builds install argv and npm fallback argv", () => {
-    expect(globalInstallArgs("npm", "openclaw@latest")).toEqual([
-      "npm",
+    const npmCommand =
+      process.platform === "win32"
+        ? path.join("C:\\Users\\me\\AppData\\Roaming\\npm", "npm.cmd")
+        : "/opt/homebrew/bin/npm";
+    const npmRoot =
+      process.platform === "win32"
+        ? path.join("C:\\Users\\me\\AppData\\Roaming\\npm", "node_modules")
+        : "/opt/homebrew/lib/node_modules";
+    expect(resolveGlobalManagerCommand("npm", npmRoot)).toBe(npmCommand);
+    expect(globalInstallArgs("npm", "openclaw@latest", npmCommand)).toEqual([
+      npmCommand,
       "i",
       "-g",
       "openclaw@latest",
@@ -159,8 +169,8 @@ describe("update global helpers", () => {
       "openclaw@latest",
     ]);
 
-    expect(globalInstallFallbackArgs("npm", "openclaw@latest")).toEqual([
-      "npm",
+    expect(globalInstallFallbackArgs("npm", "openclaw@latest", npmCommand)).toEqual([
+      npmCommand,
       "i",
       "-g",
       "openclaw@latest",

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -281,24 +281,65 @@ export async function detectGlobalInstallManagerByPresence(
   return null;
 }
 
-export function globalInstallArgs(manager: GlobalInstallManager, spec: string): string[] {
+export function resolveGlobalManagerCommand(
+  manager: GlobalInstallManager,
+  globalRoot?: string | null,
+): string {
+  const baseCommand =
+    manager === "pnpm"
+      ? process.platform === "win32"
+        ? "pnpm.cmd"
+        : "pnpm"
+      : manager === "bun"
+        ? process.platform === "win32"
+          ? "bun.exe"
+          : "bun"
+        : process.platform === "win32"
+          ? "npm.cmd"
+          : "npm";
+
+  const trimmedRoot = globalRoot?.trim();
+  if (!trimmedRoot || manager === "bun") {
+    return baseCommand;
+  }
+
+  const resolvedRoot = path.resolve(trimmedRoot);
+  if (path.basename(resolvedRoot) === "node_modules") {
+    return path.join(path.dirname(resolvedRoot), baseCommand);
+  }
+
+  const libNodeModulesSuffix = path.join("lib", "node_modules");
+  if (resolvedRoot.endsWith(libNodeModulesSuffix)) {
+    const prefix = resolvedRoot.slice(0, -libNodeModulesSuffix.length);
+    return path.join(prefix, "bin", baseCommand);
+  }
+
+  return baseCommand;
+}
+
+export function globalInstallArgs(
+  manager: GlobalInstallManager,
+  spec: string,
+  command = resolveGlobalManagerCommand(manager),
+): string[] {
   if (manager === "pnpm") {
-    return ["pnpm", "add", "-g", spec];
+    return [command, "add", "-g", spec];
   }
   if (manager === "bun") {
-    return ["bun", "add", "-g", spec];
+    return [command, "add", "-g", spec];
   }
-  return ["npm", "i", "-g", spec, ...NPM_GLOBAL_INSTALL_QUIET_FLAGS];
+  return [command, "i", "-g", spec, ...NPM_GLOBAL_INSTALL_QUIET_FLAGS];
 }
 
 export function globalInstallFallbackArgs(
   manager: GlobalInstallManager,
   spec: string,
+  command = resolveGlobalManagerCommand(manager),
 ): string[] | null {
   if (manager !== "npm") {
     return null;
   }
-  return ["npm", "i", "-g", spec, ...NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS];
+  return [command, "i", "-g", spec, ...NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS];
 }
 
 export async function cleanupGlobalRenameDirs(params: {

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -299,19 +299,19 @@ export function resolveGlobalManagerCommand(
           : "npm";
 
   const trimmedRoot = globalRoot?.trim();
-  if (!trimmedRoot || manager === "bun") {
+  if (!trimmedRoot || manager === "bun" || manager === "pnpm") {
     return baseCommand;
   }
 
   const resolvedRoot = path.resolve(trimmedRoot);
-  if (path.basename(resolvedRoot) === "node_modules") {
-    return path.join(path.dirname(resolvedRoot), baseCommand);
-  }
-
   const libNodeModulesSuffix = path.join("lib", "node_modules");
   if (resolvedRoot.endsWith(libNodeModulesSuffix)) {
     const prefix = resolvedRoot.slice(0, -libNodeModulesSuffix.length);
     return path.join(prefix, "bin", baseCommand);
+  }
+
+  if (path.basename(resolvedRoot) === "node_modules") {
+    return path.join(path.dirname(resolvedRoot), baseCommand);
   }
 
   return baseCommand;

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -1032,12 +1032,12 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
 
     let finalStep = updateStep;
     if (updateStep.exitCode !== 0) {
-      const fallbackArgv = globalInstallFallbackArgs(globalManager, spec);
+      const fallbackArgv = globalInstallFallbackArgs(globalManager, spec, globalCommand);
       if (fallbackArgv) {
         const fallbackStep = await runStep({
           runCommand,
           name: "global update (omit optional)",
-          argv: globalInstallFallbackArgs(globalManager, spec, globalCommand)!,
+          argv: fallbackArgv,
           cwd: pkgRoot,
           timeoutMs,
           env: globalInstallEnv,

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -28,6 +28,7 @@ import {
   globalInstallArgs,
   globalInstallFallbackArgs,
   resolveExpectedInstalledVersionFromSpec,
+  resolveGlobalManagerCommand,
   resolveGlobalInstallSpec,
   resolveGlobalPackageRoot,
 } from "./update-global.js";
@@ -1015,10 +1016,11 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       tag,
       env: globalInstallEnv,
     });
+    const globalCommand = resolveGlobalManagerCommand(globalManager, path.dirname(pkgRoot));
     const updateStep = await runStep({
       runCommand,
       name: "global update",
-      argv: globalInstallArgs(globalManager, spec),
+      argv: globalInstallArgs(globalManager, spec, globalCommand),
       cwd: pkgRoot,
       timeoutMs,
       env: globalInstallEnv,
@@ -1035,7 +1037,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
         const fallbackStep = await runStep({
           runCommand,
           name: "global update (omit optional)",
-          argv: fallbackArgv,
+          argv: globalInstallFallbackArgs(globalManager, spec, globalCommand)!,
           cwd: pkgRoot,
           timeoutMs,
           env: globalInstallEnv,


### PR DESCRIPTION
## Summary
- derive the npm/pnpm executable from the installed package's global root instead of always using the bare PATH command
- thread the resolved executable into global update and fallback update steps
- add coverage for manager-command resolution and argv construction

## Why
When OpenClaw is installed under one global prefix but a different npm is first on PATH, `openclaw update` should use the package owner's npm (for example `/opt/homebrew/bin/npm`) rather than the unrelated PATH npm.

Fixes #60150