### PR TITLE
fix(discord): pass proxy-configured fetch client to Carbon REST client

### DIFF
--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -70,6 +70,7 @@ export function createDiscordMonitorClient(params: {
   accountId: string;
   applicationId: string;
   token: string;
+  discordRestFetch: typeof fetch;
   commands: BaseCommand[];
   components: BaseMessageInteractiveComponent[];
   modals: Modal[];
@@ -108,13 +109,14 @@ export function createDiscordMonitorClient(params: {
   });
   const client = params.createClient(
     {
-      baseUrl: "http://localhost",
+      baseUrl: "https://discord.com/api",
       deploySecret: "a",
       clientId: params.applicationId,
       publicKey: "a",
       token: params.token,
       autoDeploy: false,
       eventQueue: eventQueueOpts,
+      requestOptions: { fetch: params.discordRestFetch },
     },
     {
       commands: params.commands,

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -903,6 +903,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       accountId: account.accountId,
       applicationId,
       token,
+      discordRestFetch,
       commands,
       components,
       modals,


### PR DESCRIPTION
### Bug type
Behavior bug (incorrect output/state without crash)

### Summary
When operating behind a proxy via `proxy` config overrides, Discord gateway connections successfully connect but REST fetches (e.g., fetching bot identity, deploying slash commands, and posting reactions) silently fail with `fetch failed | Connect Timeout Error`.
Since the underlying HTTP client utilized by `@buape/carbon` falls back on resolving `discord.com` independently from the configured proxy options, the `proxy` configuration inside OpenClaw Gateway config gets sidestepped. 

Passing `discordRestFetch` to the client configuration's `requestOptions: { fetch: params.discordRestFetch }` provides the appropriately instrumented `ProxyAgent` wrapper to resolve timeout and fetch errors when hitting endpoints like `/applications/xxxx/commands`.

### Steps to reproduce
1. Run OpenClaw gateway from an environment requiring an explicit proxy configuration.
2. In the config, set up `proxy: 'http://localhost:XXXX'`.
3. Try starting the provider.
4. Gateway emits `failed to deploy native commands: fetch failed | Connect Timeout Error` and doesn't push the sync/identity successfully.

### Expected behavior
The `discordRestFetch` is used within the API client instead of the generic Node.js `fetch` so it works over proxy seamlessly.

### Actual behavior
Gateway drops the connection locally when encountering a timeout over unproxied Fetch.

### OpenClaw version
2026.4.3