### PR TITLE
fix: use linked task activity for TaskFlow audit freshness

### DIFF
--- a/src/tasks/task-flow-registry.audit.test.ts
+++ b/src/tasks/task-flow-registry.audit.test.ts
@@ -134,6 +134,40 @@ describe("task-flow-registry audit", () => {
     });
   });
 
+  it("uses linked task activity to suppress stale-running findings for active managed flows", async () => {
+    await withTaskFlowAuditStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-audit",
+        goal: "Inspect queue",
+        status: "running",
+        createdAt: 1,
+        updatedAt: 1,
+      });
+
+      createRunningTaskRun({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: "agent:main:child",
+        runId: "task-flow-audit-active-child",
+        task: "Inspect PR 1",
+        startedAt: 1,
+        lastEventAt: 29 * 60_000,
+      });
+
+      expect(listTaskFlowAuditFindings({ now: 31 * 60_000 })).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "stale_running",
+            flow: expect.objectContaining({ flowId: flow.flowId }),
+          }),
+        ]),
+      );
+    });
+  });
+
   it("does not flag managed flows with active linked tasks as missing", async () => {
     await withTaskFlowAuditStateDir(async () => {
       const flow = createManagedTaskFlow({

--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -76,12 +76,23 @@ function compareFindings(left: TaskFlowAuditFinding, right: TaskFlowAuditFinding
   return (left.flow?.createdAt ?? 0) - (right.flow?.createdAt ?? 0);
 }
 
-function getReferenceAt(flow: TaskFlowRecord): number {
-  return flow.updatedAt ?? flow.createdAt;
-}
-
 function getLinkedTasks(flowId: string): TaskRecord[] {
   return listTasksForFlowId(flowId);
+}
+
+function getTaskActivityAt(task: TaskRecord): number {
+  return task.lastEventAt ?? task.startedAt ?? task.createdAt;
+}
+
+function getReferenceAt(flow: TaskFlowRecord, linkedTasks: TaskRecord[]): number {
+  let referenceAt = flow.updatedAt ?? flow.createdAt;
+  for (const task of linkedTasks) {
+    const taskActivityAt = getTaskActivityAt(task);
+    if (taskActivityAt > referenceAt) {
+      referenceAt = taskActivityAt;
+    }
+  }
+  return referenceAt;
 }
 
 function hasBlockingMetadata(flow: TaskFlowRecord): boolean {
@@ -159,9 +170,9 @@ export function listTaskFlowAuditFindings(
   }
 
   for (const flow of flows) {
-    const referenceAt = getReferenceAt(flow);
-    const ageMs = Math.max(0, now - referenceAt);
     const linkedTasks = getLinkedTasks(flow.flowId);
+    const referenceAt = getReferenceAt(flow, linkedTasks);
+    const ageMs = Math.max(0, now - referenceAt);
     const activeTasks = linkedTasks.filter(
       (task) => task.status === "queued" || task.status === "running",
     );


### PR DESCRIPTION
## Summary
- use linked task activity when computing TaskFlow audit freshness
- avoid stale_running findings when a managed flow is still progressing via linked child task activity
- add regression coverage for linked task activity freshness

## Notes
- the freshness calculation now considers the most recent activity across the TaskFlow record and its linked tasks
- linked task activity is resolved from `lastEventAt ?? startedAt ?? createdAt`

## Testing
- pnpm exec vitest run src/tasks/task-flow-registry.audit.test.ts src/commands/tasks.test.ts src/cli/program/register.status-health-sessions.test.ts
- commit hook checks (tsgo/lint/check) via git commit
