### PR TITLE
perf(msteams): narrow secret and ssrf runtime seams

### DIFF
--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -5,8 +5,8 @@ import {
   isHttpsUrlAllowedByHostnameSuffixAllowlist,
   isPrivateIpAddress,
   normalizeHostnameSuffixAllowlist,
-} from "../../runtime-api.js";
-import type { SsrFPolicy } from "../../runtime-api.js";
+  type SsrFPolicy,
+} from "openclaw/plugin-sdk/ssrf-policy";
 import type { MSTeamsAttachmentLike } from "./types.js";
 
 type InlineImageCandidate =

--- a/extensions/msteams/src/secret-input.ts
+++ b/extensions/msteams/src/secret-input.ts
@@ -2,6 +2,6 @@ import {
   hasConfiguredSecretInput,
   normalizeResolvedSecretInputString,
   normalizeSecretInputString,
-} from "../runtime-api.js";
+} from "openclaw/plugin-sdk/secret-input";
 
 export { hasConfiguredSecretInput, normalizeResolvedSecretInputString, normalizeSecretInputString };

--- a/package.json
+++ b/package.json
@@ -143,6 +143,10 @@
       "types": "./dist/plugin-sdk/runtime-group-policy.d.ts",
       "default": "./dist/plugin-sdk/runtime-group-policy.js"
     },
+    "./plugin-sdk/ssrf-policy": {
+      "types": "./dist/plugin-sdk/ssrf-policy.d.ts",
+      "default": "./dist/plugin-sdk/ssrf-policy.js"
+    },
     "./plugin-sdk/ssrf-runtime": {
       "types": "./dist/plugin-sdk/ssrf-runtime.d.ts",
       "default": "./dist/plugin-sdk/ssrf-runtime.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -25,6 +25,7 @@
   "infra-runtime",
   "runtime-config-snapshot",
   "runtime-group-policy",
+  "ssrf-policy",
   "ssrf-runtime",
   "media-runtime",
   "media-understanding-runtime",

--- a/src/plugin-sdk/ssrf-policy.ts
+++ b/src/plugin-sdk/ssrf-policy.ts
@@ -6,6 +6,8 @@ import {
   type SsrFPolicy,
 } from "../infra/net/ssrf.js";
 
+export { isPrivateIpAddress };
+
 export function ssrfPolicyFromAllowPrivateNetwork(
   allowPrivateNetwork: boolean | null | undefined,
 ): SsrFPolicy | undefined {


### PR DESCRIPTION
## Summary

- Problem: small MSTeams helpers like `secret-input.ts` and `attachments/shared.ts` were routing through the full `runtime-api` / `plugin-sdk/msteams` barrel, so lightweight tests pulled a much larger module graph than they needed.
- Why it matters: `extensions/msteams/src/token.test.ts`, `graph-members.test.ts`, and `graph-messages.test.ts` were showing up as extension memory hotspots even though the interesting logic in those files is relatively small.
- What changed: switched `secret-input.ts` to the narrower `openclaw/plugin-sdk/secret-input` seam, switched attachment SSRF helpers to a dedicated `openclaw/plugin-sdk/ssrf-policy` seam, and made `ssrf-policy` a real exported SDK subpath.
- What did NOT change (scope boundary): no Teams behavior changes and no test-only isolation tweaks; this is a runtime-surface narrowing change.
- AI-assisted: yes. Fully tested on the touched MSTeams + Plugin SDK surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: bundled MSTeams internals reused the extension-wide `runtime-api` barrel for helper imports that only needed secret-input or SSRF utilities. That barrel re-exported the entire `plugin-sdk/msteams` surface, inflating the runtime graph for otherwise small modules.
- Missing detection / guardrail: no targeted guardrail against helper modules depending on broad bundled-plugin SDK barrels when narrow public seams already exist.
- Prior context (`git blame`, prior PR, issue, or refactor if known): follows the current extension-memory hotspot work and the refreshed hotspot manifests.
- Why this regressed now: the broad barrel was convenient, but it compounded as more helpers were added to `plugin-sdk/msteams`.
- If unknown, what was ruled out: this is not a behavior regression in MSTeams message logic; the effect is on module load shape and test memory.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/msteams/src/token.test.ts`, `extensions/msteams/src/graph-members.test.ts`, `extensions/msteams/src/graph-messages.test.ts`, `src/plugins/contracts/plugin-sdk-subpaths.test.ts`, `src/plugin-sdk/ssrf-policy.test.ts`
- Scenario the test should lock in: MSTeams helpers still resolve through the new narrow SDK seams, and the new `ssrf-policy` public subpath remains exported.
- Why this is the smallest reliable guardrail: the regression lives at the helper-import / public-subpath boundary.
- Existing test that already covers this (if any): existing MSTeams helper tests covered behavior; the subpath contract test covers export presence.
- If no new test is added, why not: existing coverage already exercises the touched behavior and contract once the seam exists.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
MSTeams helper -> runtime-api -> plugin-sdk/msteams -> large bundled SDK graph

After:
MSTeams helper -> narrow SDK seam (`secret-input` / `ssrf-policy`) -> only needed helpers
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): MSTeams extension + Plugin SDK
- Relevant config (redacted): default local env

### Steps

1. Run `pnpm test -- extensions/msteams/src/token.test.ts extensions/msteams/src/graph-members.test.ts extensions/msteams/src/graph-messages.test.ts`.
2. Run `pnpm test -- src/plugin-sdk/ssrf-policy.test.ts`.
3. Run `pnpm test -- src/plugins/contracts/plugin-sdk-subpaths.test.ts`.
4. Run `pnpm build`.

### Expected

- MSTeams helper tests and Plugin SDK contract/build checks all pass while using the narrower seams.

### Actual

- Before this change, those MSTeams helpers went through the broad bundled SDK barrel.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

Memory-shape check used during development:
- `OPENCLAW_TEST_MEMORY_TRACE=1 OPENCLAW_TEST_PROFILE=serial pnpm test -- extensions/msteams/src/token.test.ts extensions/msteams/src/graph-members.test.ts extensions/msteams/src/graph-messages.test.ts`
- Patched branch completed that shape with a shared `extensions` pass peaking at about `714 MiB` plus an isolated `graph-members` follow-up peaking at about `780 MiB`.

## Human Verification (required)

- Verified scenarios: MSTeams token/graph tests; Plugin SDK subpath contract test; `ssrf-policy` unit test; full `pnpm build`.
- Edge cases checked: new `ssrf-policy` subpath resolves in local test/build flows; `isPrivateIpAddress` remains available through the new seam.
- What you did **not** verify: full `pnpm test`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: `ssrf-policy` becomes a new supported Plugin SDK subpath.
  - Mitigation: it is additive, narrowly scoped, covered by the subpath contract test, and already existed as an internal plugin-sdk module.
