### PR TITLE
fix(pairing): mint tokens for merged device roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,9 @@ Docs: https://docs.openclaw.ai
 - Agents/sessions: release embedded runner session locks even when teardown cleanup throws, so timed-out or failed cleanup paths no longer leave sessions wedged until the stale-lock watchdog recovers them. (#59194) Thanks @samzong.
 - Slack/app manifest: add the missing `groups:read` scope to the onboarding and example Slack app manifest so apps copied from the OpenClaw templates can resolve private group conversations reliably.
 - Mobile pairing/Android: stop generating Tailscale and public mobile setup codes that point at unusable cleartext remote gateways, keep private LAN pairing allowed, and make Android reject insecure remote endpoints with clearer guidance while mixed bootstrap approvals honor operator scopes correctly. (#60128) Thanks @obviyus.
-- Mobile pairing/device approval: mint both node and operator device tokens when one approval grants merged roles, so mixed mobile bootstrap pairings stop reconnecting as operator-only and showing the node offline.
 - Telegram/media: add `channels.telegram.network.dangerouslyAllowPrivateNetwork` for trusted fake-IP or transparent-proxy environments where Telegram media downloads resolve `api.telegram.org` to private/internal/special-use addresses.
 - Discord/proxy: keep Carbon REST, monitor startup, and webhook sends on the configured Discord proxy while falling back cleanly when the proxy URL is invalid, so Discord replies and deploys do not hard-fail on malformed proxy config. (#57465) Thanks @geekhuashan.
+- Mobile pairing/device approval: mint both node and operator device tokens when one approval grants merged roles, so mixed mobile bootstrap pairings stop reconnecting as operator-only and showing the node offline. (#60208) Thanks @obviyus.
 
 ## 2026.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Agents/sessions: release embedded runner session locks even when teardown cleanup throws, so timed-out or failed cleanup paths no longer leave sessions wedged until the stale-lock watchdog recovers them. (#59194) Thanks @samzong.
 - Slack/app manifest: add the missing `groups:read` scope to the onboarding and example Slack app manifest so apps copied from the OpenClaw templates can resolve private group conversations reliably.
 - Mobile pairing/Android: stop generating Tailscale and public mobile setup codes that point at unusable cleartext remote gateways, keep private LAN pairing allowed, and make Android reject insecure remote endpoints with clearer guidance while mixed bootstrap approvals honor operator scopes correctly. (#60128) Thanks @obviyus.
+- Mobile pairing/device approval: mint both node and operator device tokens when one approval grants merged roles, so mixed mobile bootstrap pairings stop reconnecting as operator-only and showing the node offline.
 - Telegram/media: add `channels.telegram.network.dangerouslyAllowPrivateNetwork` for trusted fake-IP or transparent-proxy environments where Telegram media downloads resolve `api.telegram.org` to private/internal/special-use addresses.
 - Discord/proxy: keep Carbon REST, monitor startup, and webhook sends on the configured Discord proxy while falling back cleanly when the proxy URL is invalid, so Discord replies and deploys do not hard-fail on malformed proxy config. (#57465) Thanks @geekhuashan.
 

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -206,6 +206,33 @@ describe("device pairing tokens", () => {
       status: "approved",
       requestId: request.request.requestId,
     });
+
+    const paired = await getPairedDevice("device-1", baseDir);
+    expect(paired && listEffectivePairedDeviceRoles(paired)).toEqual(["node", "operator"]);
+    expect(paired?.tokens?.node?.scopes).toEqual([]);
+    expect(paired?.tokens?.operator?.scopes).toEqual([
+      "operator.read",
+      "operator.talk.secrets",
+      "operator.write",
+    ]);
+    await expect(
+      verifyDeviceToken({
+        deviceId: "device-1",
+        token: requireToken(paired?.tokens?.node?.token),
+        role: "node",
+        scopes: [],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      verifyDeviceToken({
+        deviceId: "device-1",
+        token: requireToken(paired?.tokens?.operator?.token),
+        role: "operator",
+        scopes: ["operator.read"],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
   });
 
   test("keeps superseded requests interactive when an existing pending request is interactive", async () => {

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -235,6 +235,36 @@ describe("device pairing tokens", () => {
     ).resolves.toEqual({ ok: true });
   });
 
+  test("preserves requested non-operator scopes on newly minted role tokens", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const request = await requestDevicePairing(
+      {
+        deviceId: "device-1",
+        publicKey: "public-key-1",
+        role: "node",
+        scopes: ["node.exec"],
+      },
+      baseDir,
+    );
+
+    await expect(approveDevicePairing(request.request.requestId, baseDir)).resolves.toMatchObject({
+      status: "approved",
+      requestId: request.request.requestId,
+    });
+
+    const paired = await getPairedDevice("device-1", baseDir);
+    expect(paired?.tokens?.node?.scopes).toEqual(["node.exec"]);
+    await expect(
+      verifyDeviceToken({
+        deviceId: "device-1",
+        token: requireToken(paired?.tokens?.node?.token),
+        role: "node",
+        scopes: ["node.exec"],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
   test("keeps superseded requests interactive when an existing pending request is interactive", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
     const first = await requestDevicePairing(

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -351,19 +351,19 @@ function resolveApprovedTokenScopes(params: {
   approvedScopes?: string[];
   existing?: PairedDevice;
 }): string[] {
-  if (params.role === "operator") {
-    const requestedScopes = normalizeDeviceAuthScopes(params.pending.scopes);
-    if (requestedScopes.length > 0) {
+  const requestedScopes = normalizeDeviceAuthScopes(params.pending.scopes);
+  if (requestedScopes.length > 0) {
+    if (params.role === "operator") {
       return requestedScopes;
     }
-    return normalizeDeviceAuthScopes(
-      params.existingToken?.scopes ??
-        params.approvedScopes ??
-        params.existing?.approvedScopes ??
-        params.existing?.scopes,
-    );
+    return requestedScopes.filter((scope) => !scope.startsWith(OPERATOR_SCOPE_PREFIX));
   }
-  return normalizeDeviceAuthScopes(params.existingToken?.scopes);
+  return normalizeDeviceAuthScopes(
+    params.existingToken?.scopes ??
+      params.approvedScopes ??
+      params.existing?.approvedScopes ??
+      params.existing?.scopes,
+  );
 }
 
 function resolveApprovedDeviceScopeBaseline(device: PairedDevice): string[] | null {

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -344,6 +344,28 @@ function buildDeviceAuthToken(params: {
   };
 }
 
+function resolveApprovedTokenScopes(params: {
+  role: string;
+  pending: DevicePairingPendingRequest;
+  existingToken?: DeviceAuthToken;
+  approvedScopes?: string[];
+  existing?: PairedDevice;
+}): string[] {
+  if (params.role === "operator") {
+    const requestedScopes = normalizeDeviceAuthScopes(params.pending.scopes);
+    if (requestedScopes.length > 0) {
+      return requestedScopes;
+    }
+    return normalizeDeviceAuthScopes(
+      params.existingToken?.scopes ??
+        params.approvedScopes ??
+        params.existing?.approvedScopes ??
+        params.existing?.scopes,
+    );
+  }
+  return normalizeDeviceAuthScopes(params.existingToken?.scopes);
+}
+
 function resolveApprovedDeviceScopeBaseline(device: PairedDevice): string[] | null {
   const baseline = device.approvedScopes ?? device.scopes;
   if (!Array.isArray(baseline)) {
@@ -506,19 +528,15 @@ export async function approveDevicePairing(
       pending.scopes,
     );
     const tokens = existing?.tokens ? { ...existing.tokens } : {};
-    const roleForToken = normalizeRole(pending.role);
-    if (roleForToken) {
+    for (const roleForToken of requestedRoles) {
       const existingToken = tokens[roleForToken];
-      const requestedScopes = normalizeDeviceAuthScopes(pending.scopes);
-      const nextScopes =
-        requestedScopes.length > 0
-          ? requestedScopes
-          : normalizeDeviceAuthScopes(
-              existingToken?.scopes ??
-                approvedScopes ??
-                existing?.approvedScopes ??
-                existing?.scopes,
-            );
+      const nextScopes = resolveApprovedTokenScopes({
+        role: roleForToken,
+        pending,
+        existingToken,
+        approvedScopes,
+        existing,
+      });
       const now = Date.now();
       tokens[roleForToken] = {
         token: newToken(),


### PR DESCRIPTION
## Summary
- mint both node and operator device tokens when one approval grants merged roles
- keep operator requested scopes on the operator token while leaving the node token scope-free
- add unit coverage proving one approval now grants both reconnect paths

## Root Cause
`approveDevicePairing()` merged `roles`, but only minted a token for `pending.role`. Mixed mobile bootstrap approvals could therefore land as operator-only in active token state, which made the node reconnect path look unpaired/offline even after one approval.

## Verification
- `pnpm test -- src/infra/device-pairing.test.ts`
- `pnpm check`
