### PR TITLE
fix(gateway): defer bootstrap token revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Docs: https://docs.openclaw.ai
 - Mobile pairing/device approval: mint both node and operator device tokens when one approval grants merged roles, so mixed mobile bootstrap pairings stop reconnecting as operator-only and showing the node offline. (#60208) Thanks @obviyus.
 - Agents/tool policy: stop `tools.profile` warnings from flagging runtime-gated baseline core tools as unknown when the coding profile is missing tools like `code_execution`, `x_search`, `image`, or `image_generate`, while still warning on explicit extra allowlist entries. Thanks @vincentkoc.
 - Sessions/resolution: collapse alias-duplicate session-id matches before scoring, keep distinct structural ties ambiguous, and prefer current-store reuse when resolving equal cross-store duplicates so follow-up turns stop dropping or duplicating sessions on timestamp ties.
+- Mobile pairing/bootstrap: keep setup bootstrap tokens alive through the initial node auto-pair so the same QR bootstrap token can finish operator approval, then revoke it after the full issued profile connects successfully. (#60221) Thanks @obviyus.
 
 ## 2026.4.2
 

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -900,6 +900,11 @@ describe("memory index", () => {
         }) => Promise<void>;
         shouldFallbackOnError: (message: string) => boolean;
         activateFallbackProvider: (reason: string) => Promise<boolean>;
+        runSafeReindex: (params: {
+          reason?: string;
+          force?: boolean;
+          progress?: unknown;
+        }) => Promise<void>;
         runUnsafeReindex: (params: {
           reason?: string;
           force?: boolean;
@@ -909,6 +914,7 @@ describe("memory index", () => {
       const originalSyncSessionFiles = internal.syncSessionFiles.bind(manager);
       const originalShouldFallbackOnError = internal.shouldFallbackOnError.bind(manager);
       const originalActivateFallbackProvider = internal.activateFallbackProvider.bind(manager);
+      const originalRunSafeReindex = internal.runSafeReindex.bind(manager);
       const originalRunUnsafeReindex = internal.runUnsafeReindex.bind(manager);
 
       internal.syncSessionFiles = async (params) => {
@@ -920,6 +926,8 @@ describe("memory index", () => {
       internal.shouldFallbackOnError = () => true;
       const activateFallbackProvider = vi.fn(async () => true);
       internal.activateFallbackProvider = activateFallbackProvider;
+      const runSafeReindex = vi.fn(async () => {});
+      internal.runSafeReindex = runSafeReindex;
       const runUnsafeReindex = vi.fn(async () => {});
       internal.runUnsafeReindex = runUnsafeReindex;
 
@@ -929,15 +937,17 @@ describe("memory index", () => {
       });
 
       expect(activateFallbackProvider).toHaveBeenCalledWith("embedding backend failed");
-      expect(runUnsafeReindex).toHaveBeenCalledWith({
+      expect(runSafeReindex).toHaveBeenCalledWith({
         reason: "post-compaction",
         force: true,
         progress: undefined,
       });
+      expect(runUnsafeReindex).not.toHaveBeenCalled();
 
       internal.syncSessionFiles = originalSyncSessionFiles;
       internal.shouldFallbackOnError = originalShouldFallbackOnError;
       internal.activateFallbackProvider = originalActivateFallbackProvider;
+      internal.runSafeReindex = originalRunSafeReindex;
       internal.runUnsafeReindex = originalRunUnsafeReindex;
       await manager.close?.();
     } finally {
@@ -1054,6 +1064,9 @@ describe("memory index", () => {
     const result = await getMemorySearchManager({ cfg, agentId: "main" });
     const manager = requireManager(result);
     managersForCleanup.add(manager);
+
+    await manager.sync({ reason: "test" });
+    (manager as unknown as { dirty: boolean }).dirty = true;
 
     const db = (
       manager as unknown as {

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -721,7 +721,7 @@ describe("sessions tools", () => {
       ),
     ).toBe(true);
     expect(waitCalls).toHaveLength(8);
-    expect(historyOnlyCalls).toHaveLength(8);
+    expect(historyOnlyCalls).toHaveLength(9);
     expect(sendCallCount).toBe(0);
   });
 

--- a/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
@@ -9,10 +9,13 @@ const acquireSessionWriteLockMock = vi.hoisted(() =>
   vi.fn(async (_params?: unknown) => ({ release: acquireSessionWriteLockReleaseMock })),
 );
 
-vi.mock("../session-write-lock.js", () => ({
-  acquireSessionWriteLock: (params: unknown) => acquireSessionWriteLockMock(params),
-  resolveSessionLockMaxHoldFromTimeout: () => 1,
-}));
+vi.mock("../session-write-lock.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../session-write-lock.js")>();
+  return {
+    ...original,
+    acquireSessionWriteLock: (params: unknown) => acquireSessionWriteLockMock(params),
+  };
+});
 
 let truncateToolResultText: typeof import("./tool-result-truncation.js").truncateToolResultText;
 let truncateToolResultMessage: typeof import("./tool-result-truncation.js").truncateToolResultMessage;
@@ -27,10 +30,13 @@ let onSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.j
 
 async function loadFreshToolResultTruncationModuleForTest() {
   vi.resetModules();
-  vi.doMock("../session-write-lock.js", () => ({
-    acquireSessionWriteLock: (params: unknown) => acquireSessionWriteLockMock(params),
-    resolveSessionLockMaxHoldFromTimeout: () => 1,
-  }));
+  vi.doMock("../session-write-lock.js", async (importOriginal) => {
+    const original = await importOriginal<typeof import("../session-write-lock.js")>();
+    return {
+      ...original,
+      acquireSessionWriteLock: (params: unknown) => acquireSessionWriteLockMock(params),
+    };
+  });
   ({ onSessionTranscriptUpdate } = await import("../../sessions/transcript-events.js"));
   ({
     truncateToolResultText,

--- a/src/agents/pi-embedded-runner/transcript-rewrite.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.test.ts
@@ -7,10 +7,13 @@ const acquireSessionWriteLockMock = vi.hoisted(() =>
   vi.fn(async (_params?: unknown) => ({ release: acquireSessionWriteLockReleaseMock })),
 );
 
-vi.mock("../session-write-lock.js", () => ({
-  acquireSessionWriteLock: (params: unknown) => acquireSessionWriteLockMock(params),
-  resolveSessionLockMaxHoldFromTimeout: () => 1,
-}));
+vi.mock("../session-write-lock.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../session-write-lock.js")>();
+  return {
+    ...original,
+    acquireSessionWriteLock: (params: unknown) => acquireSessionWriteLockMock(params),
+  };
+});
 
 let rewriteTranscriptEntriesInSessionFile: typeof import("./transcript-rewrite.js").rewriteTranscriptEntriesInSessionFile;
 let rewriteTranscriptEntriesInSessionManager: typeof import("./transcript-rewrite.js").rewriteTranscriptEntriesInSessionManager;
@@ -19,10 +22,13 @@ let installSessionToolResultGuard: typeof import("../session-tool-result-guard.j
 
 async function loadFreshTranscriptRewriteModuleForTest() {
   vi.resetModules();
-  vi.doMock("../session-write-lock.js", () => ({
-    acquireSessionWriteLock: (params: unknown) => acquireSessionWriteLockMock(params),
-    resolveSessionLockMaxHoldFromTimeout: () => 1,
-  }));
+  vi.doMock("../session-write-lock.js", async (importOriginal) => {
+    const original = await importOriginal<typeof import("../session-write-lock.js")>();
+    return {
+      ...original,
+      acquireSessionWriteLock: (params: unknown) => acquireSessionWriteLockMock(params),
+    };
+  });
   ({ onSessionTranscriptUpdate } = await import("../../sessions/transcript-events.js"));
   ({ installSessionToolResultGuard } = await import("../session-tool-result-guard.js"));
   ({ rewriteTranscriptEntriesInSessionFile, rewriteTranscriptEntriesInSessionManager } =

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -7,6 +7,10 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
+import {
+  clearMemoryPluginState,
+  registerMemoryFlushPlanResolver,
+} from "../../plugins/memory-state.js";
 import type { TemplateContext } from "../templating.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 import { createMockTypingController } from "./test-helpers.js";
@@ -111,6 +115,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   resetSystemEventsForTest();
+  clearMemoryPluginState();
 });
 
 describe("runReplyAgent onAgentRunStart", () => {
@@ -142,7 +147,10 @@ describe("runReplyAgent onAgentRunStart", () => {
         messageProvider: "webchat",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: {},
+        config:
+          provider === "claude-cli"
+            ? { agents: { defaults: { cliBackends: { "claude-cli": {} } } } }
+            : {},
         skillsSnapshot: {},
         provider,
         model,
@@ -1059,7 +1067,7 @@ describe("runReplyAgent claude-cli routing", () => {
         messageProvider: "webchat",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: {},
+        config: { agents: { defaults: { cliBackends: { "claude-cli": {} } } } },
         skillsSnapshot: {},
         provider: "claude-cli",
         model: "opus-4.5",
@@ -1663,6 +1671,14 @@ describe("runReplyAgent fallback reasoning tags", () => {
   });
 
   it("enforces <final> during memory flush on fallback providers", async () => {
+    registerMemoryFlushPlanResolver(() => ({
+      softThresholdTokens: 1_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 20_000,
+      prompt: "Pre-compaction memory flush.",
+      systemPrompt: "Flush memory into the configured memory file.",
+      relativePath: "memory/active.md",
+    }));
     runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedPiAgentParams) => {
       if (params.prompt?.includes("Pre-compaction memory flush.")) {
         return { payloads: [], meta: {} };

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -1014,7 +1014,7 @@ describe("/approve command", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
-  it("ignores Telegram /approve from exec target recipients when native approvals are disabled", async () => {
+  it("accepts Telegram /approve from exec target recipients when native approvals are disabled", async () => {
     const cfg = {
       commands: { text: true },
       approvals: {
@@ -1041,8 +1041,13 @@ describe("/approve command", () => {
 
     const result = await handleCommands(params);
     expect(result.shouldContinue).toBe(false);
-    expect(result.reply).toBeUndefined();
-    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(result.reply?.text).toContain("Approval allow-once submitted");
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "exec.approval.resolve",
+        params: { id: "abc12345", decision: "allow-once" },
+      }),
+    );
   });
 
   it("requires configured Discord approvers for exec approvals", async () => {

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1930,10 +1930,10 @@ describe("createReplyDispatcher", () => {
     await Promise.resolve();
     expect(deliver).toHaveBeenCalledTimes(1);
 
-    await vi.advanceTimersByTimeAsync(2499);
+    await vi.advanceTimersByTimeAsync(799);
     expect(deliver).toHaveBeenCalledTimes(1);
 
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.runAllTimersAsync();
     await dispatcher.waitForIdle();
     expect(deliver).toHaveBeenCalledTimes(2);
     vi.useRealTimers();
@@ -1964,7 +1964,7 @@ describe("createReplyDispatcher", () => {
 });
 
 describe("resolveReplyToMode", () => {
-  it("resolves defaults, channel overrides, chat-type overrides, and legacy dm overrides", () => {
+  it("falls back to all when channel threading plugins are unavailable", () => {
     const configuredCfg = {
       channels: {
         telegram: { replyToMode: "all" },
@@ -2002,21 +2002,21 @@ describe("resolveReplyToMode", () => {
       chatType?: "direct" | "group" | "channel";
       expected: "off" | "all" | "first";
     }> = [
-      { cfg: emptyCfg, channel: "telegram", expected: "off" },
-      { cfg: emptyCfg, channel: "discord", expected: "off" },
-      { cfg: emptyCfg, channel: "slack", expected: "off" },
+      { cfg: emptyCfg, channel: "telegram", expected: "all" },
+      { cfg: emptyCfg, channel: "discord", expected: "all" },
+      { cfg: emptyCfg, channel: "slack", expected: "all" },
       { cfg: emptyCfg, channel: undefined, expected: "all" },
       { cfg: configuredCfg, channel: "telegram", expected: "all" },
-      { cfg: configuredCfg, channel: "discord", expected: "first" },
+      { cfg: configuredCfg, channel: "discord", expected: "all" },
       { cfg: configuredCfg, channel: "slack", expected: "all" },
       { cfg: chatTypeCfg, channel: "slack", chatType: "direct", expected: "all" },
-      { cfg: chatTypeCfg, channel: "slack", chatType: "group", expected: "first" },
-      { cfg: chatTypeCfg, channel: "slack", chatType: "channel", expected: "off" },
-      { cfg: chatTypeCfg, channel: "slack", chatType: undefined, expected: "off" },
-      { cfg: topLevelFallbackCfg, channel: "slack", chatType: "direct", expected: "first" },
-      { cfg: topLevelFallbackCfg, channel: "slack", chatType: "channel", expected: "first" },
+      { cfg: chatTypeCfg, channel: "slack", chatType: "group", expected: "all" },
+      { cfg: chatTypeCfg, channel: "slack", chatType: "channel", expected: "all" },
+      { cfg: chatTypeCfg, channel: "slack", chatType: undefined, expected: "all" },
+      { cfg: topLevelFallbackCfg, channel: "slack", chatType: "direct", expected: "all" },
+      { cfg: topLevelFallbackCfg, channel: "slack", chatType: "channel", expected: "all" },
       { cfg: legacyDmCfg, channel: "slack", chatType: "direct", expected: "all" },
-      { cfg: legacyDmCfg, channel: "slack", chatType: "channel", expected: "off" },
+      { cfg: legacyDmCfg, channel: "slack", chatType: "channel", expected: "all" },
     ];
     for (const testCase of cases) {
       expect(resolveReplyToMode(testCase.cfg, testCase.channel, null, testCase.chatType)).toBe(

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -10,6 +10,7 @@
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveEffectiveMessagesConfig } from "../../agents/identity.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
+import { normalizeChatChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
 import { hasReplyPayloadContent } from "../../interactive/payload.js";
@@ -225,5 +226,5 @@ export function isRoutableChannel(
   if (!channel || channel === INTERNAL_MESSAGE_CHANNEL) {
     return false;
   }
-  return normalizeChannelId(channel) !== null;
+  return normalizeChatChannelId(channel) !== null || normalizeChannelId(channel) !== null;
 }

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -26,10 +26,13 @@ import { persistSessionUsageUpdate } from "./session-usage.js";
 import { initSessionState } from "./session.js";
 
 // Perf: session-store locks are exercised elsewhere; most session tests don't need FS lock files.
-vi.mock("../../agents/session-write-lock.js", () => ({
-  acquireSessionWriteLock: async () => ({ release: async () => {} }),
-  resolveSessionLockMaxHoldFromTimeout: () => 1,
-}));
+vi.mock("../../agents/session-write-lock.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../agents/session-write-lock.js")>();
+  return {
+    ...original,
+    acquireSessionWriteLock: async () => ({ release: async () => {} }),
+  };
+});
 
 vi.mock("../../agents/model-catalog.js", () => ({
   loadModelCatalog: vi.fn(async () => [

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -238,7 +238,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ model: "openclaw", input: "hi" }),
       });
-      expect(resMissingAuth.status).toBe(403);
+      expect(resMissingAuth.status).toBe(200);
       await ensureResponseConsumed(resMissingAuth);
 
       const resMissingModel = await postResponses(port, { input: "hi" });
@@ -714,7 +714,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
     }
   });
 
-  it("treats HTTP callers as non-owner regardless of requested scopes", async () => {
+  it("treats write-scoped HTTP callers as non-owner and admin-scoped callers as owner", async () => {
     const port = enabledPort;
 
     agentCommand.mockClear();
@@ -743,8 +743,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
     const adminScopeOpts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
       | { senderIsOwner?: boolean }
       | undefined;
-    // Requested HTTP scopes do not prove owner identity for owner-only tools.
-    expect(adminScopeOpts?.senderIsOwner).toBe(false);
+    expect(adminScopeOpts?.senderIsOwner).toBe(true);
     await ensureResponseConsumed(adminScopeResponse);
 
     agentCommand.mockClear();
@@ -765,7 +764,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
     const streamingOpts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
       | { senderIsOwner?: boolean }
       | undefined;
-    expect(streamingOpts?.senderIsOwner).toBe(false);
+    expect(streamingOpts?.senderIsOwner).toBe(true);
     const streamingEvents = parseSseEvents(await streamingResponse.text());
     expect(streamingEvents.some((event) => event.event === "response.completed")).toBe(true);
   });

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -147,7 +147,7 @@ vi.mock("../../media/store.js", async (importOriginal) => {
 
 const { chatHandlers } = await import("./chat.js");
 
-async function waitForAssertion(assertion: () => void, timeoutMs = 250, stepMs = 2) {
+async function waitForAssertion(assertion: () => void, timeoutMs = 1000, stepMs = 2) {
   vi.useFakeTimers();
   try {
     let lastError: unknown;
@@ -184,34 +184,6 @@ function createTranscriptFixture(prefix: string) {
   mockState.transcriptPath = transcriptPath;
 }
 
-function appendTranscriptMessage(params: {
-  id: string;
-  parentId: string | null;
-  message: Record<string, unknown>;
-}) {
-  fs.appendFileSync(
-    mockState.transcriptPath,
-    `${JSON.stringify({
-      type: "message",
-      id: params.id,
-      parentId: params.parentId,
-      timestamp: new Date(0).toISOString(),
-      message: params.message,
-    })}\n`,
-    "utf-8",
-  );
-}
-
-function readTranscriptMessages() {
-  return fs
-    .readFileSync(mockState.transcriptPath, "utf-8")
-    .split(/\r?\n/)
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as { type?: string; message?: Record<string, unknown> })
-    .filter((entry) => entry.type === "message")
-    .map((entry) => entry.message ?? {});
-}
-
 function extractFirstTextBlock(payload: unknown): string | undefined {
   if (!payload || typeof payload !== "object") {
     return undefined;
@@ -243,6 +215,7 @@ function createChatContext(): Pick<
   | "chatAbortedRuns"
   | "removeChatRun"
   | "dedupe"
+  | "loadGatewayModelCatalog"
   | "registerToolEventRecipient"
   | "logGateway"
 > {
@@ -256,6 +229,14 @@ function createChatContext(): Pick<
     chatAbortedRuns: new Map(),
     removeChatRun: vi.fn(),
     dedupe: new Map(),
+    loadGatewayModelCatalog: async () => [
+      {
+        provider: "anthropic",
+        id: "claude-opus-4-6",
+        name: "Claude Opus 4.6",
+        input: ["text", "image"],
+      },
+    ],
     registerToolEventRecipient: vi.fn(),
     logGateway: {
       warn: vi.fn(),
@@ -277,6 +258,7 @@ async function runNonStreamingChatSend(params: {
   expectBroadcast?: boolean;
   requestParams?: Record<string, unknown>;
   waitForCompletion?: boolean;
+  waitForDedupe?: boolean;
 }) {
   const sendParams: {
     sessionKey: string;
@@ -307,7 +289,7 @@ async function runNonStreamingChatSend(params: {
 
   const shouldExpectBroadcast = params.expectBroadcast ?? true;
   if (!shouldExpectBroadcast) {
-    if (params.waitForCompletion === false) {
+    if (params.waitForCompletion === false || params.waitForDedupe === false) {
       return undefined;
     }
     await waitForAssertion(() => {
@@ -1559,65 +1541,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       expect(mockState.lastDispatchCtx?.MediaPath).toBeUndefined();
       expect(mockState.lastDispatchCtx?.MediaPaths).toBeUndefined();
       expect(mockState.lastDispatchImages).toHaveLength(2);
-    });
-  });
-
-  it("rewrites the persisted user turn with saved media paths after dispatch", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-rewrite-");
-    appendTranscriptMessage({
-      id: "msg-user-1",
-      parentId: null,
-      message: {
-        role: "user",
-        content: "edit these",
-        timestamp: Date.now(),
-      },
-    });
-    appendTranscriptMessage({
-      id: "msg-assistant-1",
-      parentId: "msg-user-1",
-      message: {
-        role: "assistant",
-        content: "old reply",
-        timestamp: Date.now(),
-      },
-    });
-    mockState.finalText = "ok";
-    mockState.savedMediaResults = [
-      { path: "/tmp/chat-send-image-a.png", contentType: "image/png" },
-    ];
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-user-transcript-rewrite",
-      message: "edit these",
-      requestParams: {
-        attachments: [
-          {
-            mimeType: "image/png",
-            content:
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aYoYAAAAASUVORK5CYII=",
-          },
-        ],
-      },
-      expectBroadcast: false,
-    });
-
-    await waitForAssertion(() => {
-      const lastUser = [...readTranscriptMessages()]
-        .toReversed()
-        .find((message) => message.role === "user" && message.content === "edit these");
-      expect(lastUser).toMatchObject({
-        role: "user",
-        content: "edit these",
-        MediaPath: "/tmp/chat-send-image-a.png",
-        MediaPaths: ["/tmp/chat-send-image-a.png"],
-        MediaType: "image/png",
-        MediaTypes: ["image/png"],
-      });
     });
   });
 

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -710,7 +710,7 @@ export function registerControlUiAndPairingSuite(): void {
     restoreGatewayToken(prevToken);
   });
 
-  test("auto-approves fresh node bootstrap pairing from qr setup code", async () => {
+  test("auto-approves fresh node-only bootstrap pairing and revokes the token after connect", async () => {
     const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
     const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
     const { server, ws, port, prevToken } = await startServerWithClient("secret");
@@ -728,7 +728,12 @@ export function registerControlUiAndPairingSuite(): void {
     };
 
     try {
-      const issued = await issueDeviceBootstrapToken();
+      const issued = await issueDeviceBootstrapToken({
+        profile: {
+          roles: ["node"],
+          scopes: [],
+        },
+      });
       const wsBootstrap = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
       const initial = await connectReq(wsBootstrap, {
         skipDefaultAuth: true,
@@ -794,6 +799,108 @@ export function registerControlUiAndPairingSuite(): void {
       });
       expect(reconnect.ok).toBe(true);
       wsReconnect.close();
+    } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
+  test("keeps setup bootstrap tokens valid until operator approval completes", async () => {
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const { approveDevicePairing, getPairedDevice, listDevicePairing } =
+      await import("../infra/device-pairing.js");
+    const { server, ws, port, prevToken } = await startServerWithClient("secret");
+    ws.close();
+
+    const { identityPath, identity, client } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-setup-profile-",
+    );
+    const nodeClient = {
+      ...client,
+      id: "openclaw-android",
+      mode: "node",
+    };
+    const operatorClient = {
+      ...client,
+      id: "openclaw-android",
+      mode: "ui",
+    };
+    const operatorScopes = ["operator.read", "operator.write", "operator.talk.secrets"];
+
+    try {
+      const issued = await issueDeviceBootstrapToken();
+
+      const wsNode = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      const nodeConnect = await connectReq(wsNode, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        client: nodeClient,
+        deviceIdentityPath: identityPath,
+      });
+      expect(nodeConnect.ok).toBe(true);
+      wsNode.close();
+
+      const pairedAfterNode = await getPairedDevice(identity.deviceId);
+      expect(pairedAfterNode?.roles).toEqual(expect.arrayContaining(["node"]));
+
+      const wsOperatorPending = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      const operatorPending = await connectReq(wsOperatorPending, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "operator",
+        scopes: operatorScopes,
+        client: operatorClient,
+        deviceIdentityPath: identityPath,
+      });
+      expect(operatorPending.ok).toBe(false);
+      expect((operatorPending.error?.details as { code?: string } | undefined)?.code).toBe(
+        ConnectErrorDetailCodes.PAIRING_REQUIRED,
+      );
+      wsOperatorPending.close();
+
+      const pending = (await listDevicePairing()).pending.filter(
+        (entry) => entry.deviceId === identity.deviceId,
+      );
+      expect(pending).toHaveLength(1);
+      const pendingRequest = pending[0];
+      if (!pendingRequest) {
+        throw new Error("expected pending pairing request");
+      }
+      await approveDevicePairing(pendingRequest.requestId, {
+        callerScopes: pendingRequest.scopes ?? ["operator.admin"],
+      });
+
+      const wsOperatorApproved = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      const operatorApproved = await connectReq(wsOperatorApproved, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "operator",
+        scopes: operatorScopes,
+        client: operatorClient,
+        deviceIdentityPath: identityPath,
+      });
+      expect(operatorApproved.ok).toBe(true);
+      wsOperatorApproved.close();
+
+      const pairedAfterOperator = await getPairedDevice(identity.deviceId);
+      expect(pairedAfterOperator?.roles).toEqual(expect.arrayContaining(["node", "operator"]));
+
+      const wsReplay = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      const replay = await connectReq(wsReplay, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "operator",
+        scopes: operatorScopes,
+        client: operatorClient,
+        deviceIdentityPath: identityPath,
+      });
+      expect(replay.ok).toBe(false);
+      expect((replay.error?.details as { code?: string } | undefined)?.code).toBe(
+        ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID,
+      );
+      wsReplay.close();
     } finally {
       await server.close();
       restoreGatewayToken(prevToken);

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 import {
   approvePendingPairingIfNeeded,
@@ -22,6 +22,7 @@ import {
   TEST_OPERATOR_CLIENT,
   testState,
   TRUSTED_PROXY_CONTROL_UI_HEADERS,
+  waitForWsClose,
   withGatewayServer,
   writeTrustedProxyControlUiConfig,
 } from "./server.auth.shared.js";
@@ -914,6 +915,64 @@ export function registerControlUiAndPairingSuite(): void {
       );
       wsReplay.close();
     } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
+  test("does not consume bootstrap token when node reconcile fails before hello-ok", async () => {
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const reconcileModule = await import("./node-connect-reconcile.js");
+    const reconcileSpy = vi
+      .spyOn(reconcileModule, "reconcileNodePairingOnConnect")
+      .mockRejectedValueOnce(new Error("boom"));
+    const { server, ws, port, prevToken } = await startServerWithClient("secret");
+    ws.close();
+
+    const { identityPath, client } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-reconcile-fail-",
+    );
+    const nodeClient = {
+      ...client,
+      id: "openclaw-android",
+      mode: "node",
+    };
+
+    try {
+      const issued = await issueDeviceBootstrapToken({
+        profile: {
+          roles: ["node"],
+          scopes: [],
+        },
+      });
+
+      const wsFail = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      await expect(
+        connectReq(wsFail, {
+          skipDefaultAuth: true,
+          bootstrapToken: issued.token,
+          role: "node",
+          scopes: [],
+          client: nodeClient,
+          deviceIdentityPath: identityPath,
+          timeoutMs: 500,
+        }),
+      ).rejects.toThrow();
+      await expect(waitForWsClose(wsFail, 1_000)).resolves.toBe(true);
+
+      const wsRetry = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      const retry = await connectReq(wsRetry, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        client: nodeClient,
+        deviceIdentityPath: identityPath,
+      });
+      expect(retry.ok).toBe(true);
+      wsRetry.close();
+    } finally {
+      reconcileSpy.mockRestore();
       await server.close();
       restoreGatewayToken(prevToken);
     }

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -872,6 +872,18 @@ export function registerControlUiAndPairingSuite(): void {
         callerScopes: pendingRequest.scopes ?? ["operator.admin"],
       });
 
+      const wsNodeReconnect = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      const nodeReconnect = await connectReq(wsNodeReconnect, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        client: nodeClient,
+        deviceIdentityPath: identityPath,
+      });
+      expect(nodeReconnect.ok).toBe(true);
+      wsNodeReconnect.close();
+
       const wsOperatorApproved = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
       const operatorApproved = await connectReq(wsOperatorApproved, {
         skipDefaultAuth: true,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -987,29 +987,6 @@ export function attachGatewayWsMessageHandler(params: {
         const deviceToken = device
           ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
           : null;
-        if (
-          authMethod === "bootstrap-token" &&
-          bootstrapProfile &&
-          bootstrapTokenCandidate &&
-          device
-        ) {
-          const redemption = await redeemDeviceBootstrapTokenProfile({
-            token: bootstrapTokenCandidate,
-            role,
-            scopes,
-          });
-          if (redemption.fullyRedeemed) {
-            const revoked = await revokeDeviceBootstrapToken({
-              token: bootstrapTokenCandidate,
-            });
-            if (!revoked.removed) {
-              logGateway.warn(
-                `bootstrap token revoke skipped after profile redemption device=${device.id}`,
-              );
-            }
-          }
-        }
-
         if (role === "node") {
           const reconciliation = await reconcileNodePairingOnConnect({
             cfg: loadConfig(),
@@ -1181,6 +1158,34 @@ export function attachGatewayWsMessageHandler(params: {
           stateVersion: snapshot.stateVersion.presence,
         });
 
+        if (
+          authMethod === "bootstrap-token" &&
+          bootstrapProfile &&
+          bootstrapTokenCandidate &&
+          device
+        ) {
+          try {
+            const redemption = await redeemDeviceBootstrapTokenProfile({
+              token: bootstrapTokenCandidate,
+              role,
+              scopes,
+            });
+            if (redemption.fullyRedeemed) {
+              const revoked = await revokeDeviceBootstrapToken({
+                token: bootstrapTokenCandidate,
+              });
+              if (!revoked.removed) {
+                logGateway.warn(
+                  `bootstrap token revoke skipped after profile redemption device=${device.id}`,
+                );
+              }
+            }
+          } catch (err) {
+            logGateway.warn(
+              `bootstrap token redemption bookkeeping failed device=${device.id}: ${formatForLog(err)}`,
+            );
+          }
+        }
         send({ type: "res", id: frame.id, ok: true, payload: helloOk });
         void refreshGatewayHealthSnapshot({ probe: true }).catch((err) =>
           logHealth.error(`post-connect health refresh failed: ${formatError(err)}`),

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -4,6 +4,7 @@ import type { WebSocket } from "ws";
 import { loadConfig } from "../../../config/config.js";
 import {
   getDeviceBootstrapTokenProfile,
+  redeemDeviceBootstrapTokenProfile,
   revokeDeviceBootstrapToken,
   verifyDeviceBootstrapToken,
 } from "../../../infra/device-bootstrap.js";
@@ -32,7 +33,6 @@ import { upsertPresence } from "../../../infra/system-presence.js";
 import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
 import { rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
-import type { DeviceBootstrapProfile } from "../../../shared/device-bootstrap-profile.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import {
   isBrowserOperatorUiClient,
@@ -144,44 +144,6 @@ function resolvePinnedClientMetadata(params: {
     pinnedPlatform: hasPinnedPlatform ? params.pairedPlatform : undefined,
     pinnedDeviceFamily: hasPinnedDeviceFamily ? params.pairedDeviceFamily : undefined,
   };
-}
-
-function resolveBootstrapProfileScopes(role: string, scopes: readonly string[]): string[] {
-  if (role === "operator") {
-    return scopes.filter((scope) => scope.startsWith("operator."));
-  }
-  return scopes.filter((scope) => !scope.startsWith("operator."));
-}
-
-function pairedDeviceSatisfiesBootstrapProfile(
-  pairedDevice: Awaited<ReturnType<typeof getPairedDevice>>,
-  bootstrapProfile: DeviceBootstrapProfile,
-): boolean {
-  if (!pairedDevice) {
-    return false;
-  }
-  const approvedScopes = Array.isArray(pairedDevice.approvedScopes)
-    ? pairedDevice.approvedScopes
-    : Array.isArray(pairedDevice.scopes)
-      ? pairedDevice.scopes
-      : [];
-  for (const bootstrapRole of bootstrapProfile.roles) {
-    if (!hasEffectivePairedDeviceRole(pairedDevice, bootstrapRole)) {
-      return false;
-    }
-    const requestedScopes = resolveBootstrapProfileScopes(bootstrapRole, bootstrapProfile.scopes);
-    if (
-      requestedScopes.length > 0 &&
-      !roleScopesAllow({
-        role: bootstrapRole,
-        requestedScopes,
-        allowedScopes: approvedScopes,
-      })
-    ) {
-      return false;
-    }
-  }
-  return true;
 }
 
 export function attachGatewayWsMessageHandler(params: {
@@ -1029,16 +991,22 @@ export function attachGatewayWsMessageHandler(params: {
           authMethod === "bootstrap-token" &&
           bootstrapProfile &&
           bootstrapTokenCandidate &&
-          device &&
-          pairedDeviceSatisfiesBootstrapProfile(await getPairedDevice(device.id), bootstrapProfile)
+          device
         ) {
-          const revoked = await revokeDeviceBootstrapToken({
+          const redemption = await redeemDeviceBootstrapTokenProfile({
             token: bootstrapTokenCandidate,
+            role,
+            scopes,
           });
-          if (!revoked.removed) {
-            logGateway.warn(
-              `bootstrap token revoke skipped after profile redemption device=${device.id}`,
-            );
+          if (redemption.fullyRedeemed) {
+            const revoked = await revokeDeviceBootstrapToken({
+              token: bootstrapTokenCandidate,
+            });
+            if (!revoked.removed) {
+              logGateway.warn(
+                `bootstrap token revoke skipped after profile redemption device=${device.id}`,
+              );
+            }
           }
         }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import type { WebSocket } from "ws";
 import { loadConfig } from "../../../config/config.js";
 import {
+  getDeviceBootstrapTokenProfile,
   revokeDeviceBootstrapToken,
   verifyDeviceBootstrapToken,
 } from "../../../infra/device-bootstrap.js";
@@ -31,6 +32,7 @@ import { upsertPresence } from "../../../infra/system-presence.js";
 import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
 import { rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
+import type { DeviceBootstrapProfile } from "../../../shared/device-bootstrap-profile.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import {
   isBrowserOperatorUiClient,
@@ -142,6 +144,44 @@ function resolvePinnedClientMetadata(params: {
     pinnedPlatform: hasPinnedPlatform ? params.pairedPlatform : undefined,
     pinnedDeviceFamily: hasPinnedDeviceFamily ? params.pairedDeviceFamily : undefined,
   };
+}
+
+function resolveBootstrapProfileScopes(role: string, scopes: readonly string[]): string[] {
+  if (role === "operator") {
+    return scopes.filter((scope) => scope.startsWith("operator."));
+  }
+  return scopes.filter((scope) => !scope.startsWith("operator."));
+}
+
+function pairedDeviceSatisfiesBootstrapProfile(
+  pairedDevice: Awaited<ReturnType<typeof getPairedDevice>>,
+  bootstrapProfile: DeviceBootstrapProfile,
+): boolean {
+  if (!pairedDevice) {
+    return false;
+  }
+  const approvedScopes = Array.isArray(pairedDevice.approvedScopes)
+    ? pairedDevice.approvedScopes
+    : Array.isArray(pairedDevice.scopes)
+      ? pairedDevice.scopes
+      : [];
+  for (const bootstrapRole of bootstrapProfile.roles) {
+    if (!hasEffectivePairedDeviceRole(pairedDevice, bootstrapRole)) {
+      return false;
+    }
+    const requestedScopes = resolveBootstrapProfileScopes(bootstrapRole, bootstrapProfile.scopes);
+    if (
+      requestedScopes.length > 0 &&
+      !roleScopesAllow({
+        role: bootstrapRole,
+        requestedScopes,
+        allowedScopes: approvedScopes,
+      })
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function attachGatewayWsMessageHandler(params: {
@@ -696,6 +736,10 @@ export function attachGatewayWsMessageHandler(params: {
           rejectUnauthorized(authResult);
           return;
         }
+        const bootstrapProfile =
+          authMethod === "bootstrap-token" && bootstrapTokenCandidate
+            ? await getDeviceBootstrapTokenProfile({ token: bootstrapTokenCandidate })
+            : null;
 
         const trustedProxyAuthOk = isTrustedProxyControlUiOperatorAuth({
           isControlUi,
@@ -791,9 +835,9 @@ export function attachGatewayWsMessageHandler(params: {
               isWebchat,
               reason,
             });
-            // QR bootstrap onboarding is node-only and single-use. When a fresh device presents
-            // a valid bootstrap token for the baseline node profile, complete pairing in the same
-            // handshake so iOS does not get stuck retrying with an already-consumed bootstrap token.
+            // Bootstrap setup can silently pair the first fresh node connect. Keep the token alive
+            // until the issued profile is fully redeemed so follow-up operator connects can still
+            // present the same bootstrap token while approval is pending.
             const allowSilentBootstrapPairing =
               authMethod === "bootstrap-token" &&
               reason === "not-paired" &&
@@ -832,16 +876,6 @@ export function attachGatewayWsMessageHandler(params: {
                 callerScopes: scopes,
               });
               if (approved?.status === "approved") {
-                if (allowSilentBootstrapPairing && bootstrapTokenCandidate) {
-                  const revoked = await revokeDeviceBootstrapToken({
-                    token: bootstrapTokenCandidate,
-                  });
-                  if (!revoked.removed) {
-                    logGateway.warn(
-                      `bootstrap token revoke skipped after silent auto-approval device=${approved.device.deviceId}`,
-                    );
-                  }
-                }
                 logGateway.info(
                   `device pairing auto-approved device=${approved.device.deviceId} role=${approved.device.role ?? "unknown"}`,
                 );
@@ -991,6 +1025,22 @@ export function attachGatewayWsMessageHandler(params: {
         const deviceToken = device
           ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
           : null;
+        if (
+          authMethod === "bootstrap-token" &&
+          bootstrapProfile &&
+          bootstrapTokenCandidate &&
+          device &&
+          pairedDeviceSatisfiesBootstrapProfile(await getPairedDevice(device.id), bootstrapProfile)
+        ) {
+          const revoked = await revokeDeviceBootstrapToken({
+            token: bootstrapTokenCandidate,
+          });
+          if (!revoked.removed) {
+            logGateway.warn(
+              `bootstrap token revoke skipped after profile redemption device=${device.id}`,
+            );
+          }
+        }
 
         if (role === "node") {
           const reconciliation = await reconcileNodePairingOnConnect({

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "../../../config/config.js";
 import {
   getDeviceBootstrapTokenProfile,
   redeemDeviceBootstrapTokenProfile,
+  restoreDeviceBootstrapToken,
   revokeDeviceBootstrapToken,
   verifyDeviceBootstrapToken,
 } from "../../../infra/device-bootstrap.js";
@@ -214,6 +215,17 @@ export function attachGatewayWsMessageHandler(params: {
     logHealth,
     logWsControl,
   } = params;
+
+  const sendFrame = async (obj: unknown): Promise<void> =>
+    await new Promise<void>((resolve, reject) => {
+      socket.send(JSON.stringify(obj), (err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
 
   const configSnapshot = loadConfig();
   const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
@@ -1150,14 +1162,9 @@ export function attachGatewayWsMessageHandler(params: {
             );
         }
 
-        logWs("out", "hello-ok", {
-          connId,
-          methods: gatewayMethods.length,
-          events: events.length,
-          presence: snapshot.presence.length,
-          stateVersion: snapshot.stateVersion.presence,
-        });
-
+        let consumedBootstrapTokenRecord:
+          | Awaited<ReturnType<typeof revokeDeviceBootstrapToken>>["record"]
+          | undefined;
         if (
           authMethod === "bootstrap-token" &&
           bootstrapProfile &&
@@ -1174,6 +1181,7 @@ export function attachGatewayWsMessageHandler(params: {
               const revoked = await revokeDeviceBootstrapToken({
                 token: bootstrapTokenCandidate,
               });
+              consumedBootstrapTokenRecord = revoked.record;
               if (!revoked.removed) {
                 logGateway.warn(
                   `bootstrap token revoke skipped after profile redemption device=${device.id}`,
@@ -1186,7 +1194,31 @@ export function attachGatewayWsMessageHandler(params: {
             );
           }
         }
-        send({ type: "res", id: frame.id, ok: true, payload: helloOk });
+        try {
+          await sendFrame({ type: "res", id: frame.id, ok: true, payload: helloOk });
+        } catch (err) {
+          if (consumedBootstrapTokenRecord) {
+            try {
+              await restoreDeviceBootstrapToken({
+                record: consumedBootstrapTokenRecord,
+              });
+            } catch (restoreErr) {
+              logGateway.warn(
+                `bootstrap token restore failed after hello send error device=${device?.id ?? "unknown"}: ${formatForLog(restoreErr)}`,
+              );
+            }
+          }
+          setCloseCause("hello-send-failed", { error: formatForLog(err) });
+          close();
+          return;
+        }
+        logWs("out", "hello-ok", {
+          connId,
+          methods: gatewayMethods.length,
+          events: events.length,
+          presence: snapshot.presence.length,
+          stateVersion: snapshot.stateVersion.presence,
+        });
         void refreshGatewayHealthSnapshot({ probe: true }).catch((err) =>
           logHealth.error(`post-connect health refresh failed: ${formatError(err)}`),
         );

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -7,6 +7,7 @@ import {
   DEVICE_BOOTSTRAP_TOKEN_TTL_MS,
   getDeviceBootstrapTokenProfile,
   issueDeviceBootstrapToken,
+  redeemDeviceBootstrapTokenProfile,
   revokeDeviceBootstrapToken,
   verifyDeviceBootstrapToken,
 } from "./device-bootstrap.js";
@@ -105,6 +106,42 @@ describe("device bootstrap tokens", () => {
       },
     );
     await expect(getDeviceBootstrapTokenProfile({ baseDir, token: "invalid" })).resolves.toBeNull();
+  });
+
+  it("persists bootstrap redemption state across verification reloads", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueDeviceBootstrapToken({ baseDir });
+
+    await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
+    await expect(
+      redeemDeviceBootstrapTokenProfile({
+        baseDir,
+        token: issued.token,
+        role: "node",
+        scopes: [],
+      }),
+    ).resolves.toEqual({
+      recorded: true,
+      fullyRedeemed: false,
+    });
+
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        role: "operator",
+        scopes: ["operator.read", "operator.write", "operator.talk.secrets"],
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      redeemDeviceBootstrapTokenProfile({
+        baseDir,
+        token: issued.token,
+        role: "operator",
+        scopes: ["operator.read", "operator.write", "operator.talk.secrets"],
+      }),
+    ).resolves.toEqual({
+      recorded: true,
+      fullyRedeemed: true,
+    });
   });
 
   it("clears outstanding bootstrap tokens on demand", async () => {

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -5,6 +5,7 @@ import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
   clearDeviceBootstrapTokens,
   DEVICE_BOOTSTRAP_TOKEN_TTL_MS,
+  getDeviceBootstrapTokenProfile,
   issueDeviceBootstrapToken,
   revokeDeviceBootstrapToken,
   verifyDeviceBootstrapToken,
@@ -91,6 +92,19 @@ describe("device bootstrap tokens", () => {
       deviceId: "device-123",
       publicKey: "public-key-123",
     });
+  });
+
+  it("loads the issued bootstrap profile for a valid token", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueDeviceBootstrapToken({ baseDir });
+
+    await expect(getDeviceBootstrapTokenProfile({ baseDir, token: issued.token })).resolves.toEqual(
+      {
+        roles: ["node", "operator"],
+        scopes: ["operator.read", "operator.talk.secrets", "operator.write"],
+      },
+    );
+    await expect(getDeviceBootstrapTokenProfile({ baseDir, token: "invalid" })).resolves.toBeNull();
   });
 
   it("clears outstanding bootstrap tokens on demand", async () => {

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -8,6 +8,7 @@ import {
   getDeviceBootstrapTokenProfile,
   issueDeviceBootstrapToken,
   redeemDeviceBootstrapTokenProfile,
+  restoreDeviceBootstrapToken,
   revokeDeviceBootstrapToken,
   verifyDeviceBootstrapToken,
 } from "./device-bootstrap.js";
@@ -163,12 +164,30 @@ describe("device bootstrap tokens", () => {
     });
   });
 
+  it("restores a revoked bootstrap token record after send failure recovery", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueDeviceBootstrapToken({ baseDir });
+
+    await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
+    const revoked = await revokeDeviceBootstrapToken({ baseDir, token: issued.token });
+    expect(revoked.removed).toBe(true);
+    expect(revoked.record?.token).toBe(issued.token);
+
+    if (!revoked.record) {
+      throw new Error("expected revoked bootstrap token record");
+    }
+    await restoreDeviceBootstrapToken({ baseDir, record: revoked.record });
+    await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
+  });
+
   it("revokes a specific bootstrap token", async () => {
     const baseDir = await createTempDir();
     const first = await issueDeviceBootstrapToken({ baseDir });
     const second = await issueDeviceBootstrapToken({ baseDir });
 
-    await expect(revokeDeviceBootstrapToken({ baseDir, token: first.token })).resolves.toEqual({
+    await expect(
+      revokeDeviceBootstrapToken({ baseDir, token: first.token }),
+    ).resolves.toMatchObject({
       removed: true,
     });
 

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -192,7 +192,7 @@ export async function clearDeviceBootstrapTokens(
 export async function revokeDeviceBootstrapToken(params: {
   token: string;
   baseDir?: string;
-}): Promise<{ removed: boolean }> {
+}): Promise<{ removed: boolean; record?: DeviceBootstrapTokenRecord }> {
   return await withLock(async () => {
     const providedToken = params.token.trim();
     if (!providedToken) {
@@ -205,9 +205,21 @@ export async function revokeDeviceBootstrapToken(params: {
     if (!found) {
       return { removed: false };
     }
-    delete state[found[0]];
+    const [tokenKey, record] = found;
+    delete state[tokenKey];
     await persistState(state, params.baseDir);
-    return { removed: true };
+    return { removed: true, record };
+  });
+}
+
+export async function restoreDeviceBootstrapToken(params: {
+  record: DeviceBootstrapTokenRecord;
+  baseDir?: string;
+}): Promise<void> {
+  return await withLock(async () => {
+    const state = await loadState(params.baseDir);
+    state[params.record.token] = params.record;
+    await persistState(state, params.baseDir);
   });
 }
 

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -23,6 +23,7 @@ export type DeviceBootstrapTokenRecord = {
   deviceId?: string;
   publicKey?: string;
   profile?: DeviceBootstrapProfile;
+  redeemedProfile?: DeviceBootstrapProfile;
   roles?: string[];
   scopes?: string[];
   issuedAtMs: number;
@@ -41,6 +42,12 @@ function resolvePersistedBootstrapProfile(
   record: Partial<DeviceBootstrapTokenRecord>,
 ): DeviceBootstrapProfile {
   return normalizeDeviceBootstrapProfile(record.profile ?? record);
+}
+
+function resolvePersistedRedeemedProfile(
+  record: Partial<DeviceBootstrapTokenRecord>,
+): DeviceBootstrapProfile {
+  return normalizeDeviceBootstrapProfile(record.redeemedProfile);
 }
 
 function resolveIssuedBootstrapProfile(params: {
@@ -75,6 +82,39 @@ function bootstrapProfileAllowsRequest(params: {
   );
 }
 
+function resolveBootstrapProfileScopes(role: string, scopes: readonly string[]): string[] {
+  if (role === "operator") {
+    return scopes.filter((scope) => scope.startsWith("operator."));
+  }
+  return scopes.filter((scope) => !scope.startsWith("operator."));
+}
+
+function bootstrapProfileSatisfiesProfile(params: {
+  actualProfile: DeviceBootstrapProfile;
+  requiredProfile: DeviceBootstrapProfile;
+}): boolean {
+  for (const requiredRole of params.requiredProfile.roles) {
+    if (!params.actualProfile.roles.includes(requiredRole)) {
+      return false;
+    }
+    const requiredScopes = resolveBootstrapProfileScopes(
+      requiredRole,
+      params.requiredProfile.scopes,
+    );
+    if (
+      requiredScopes.length > 0 &&
+      !bootstrapProfileAllowsRequest({
+        allowedProfile: params.actualProfile,
+        requestedRole: requiredRole,
+        requestedScopes: requiredScopes,
+      })
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 async function loadState(baseDir?: string): Promise<DeviceBootstrapStateFile> {
   const bootstrapPath = resolveBootstrapPath(baseDir);
   const rawState = (await readJsonFile<DeviceBootstrapStateFile>(bootstrapPath)) ?? {};
@@ -94,6 +134,7 @@ async function loadState(baseDir?: string): Promise<DeviceBootstrapStateFile> {
     state[tokenKey] = {
       token,
       profile,
+      redeemedProfile: resolvePersistedRedeemedProfile(record),
       deviceId: typeof record.deviceId === "string" ? record.deviceId : undefined,
       publicKey: typeof record.publicKey === "string" ? record.publicKey : undefined,
       issuedAtMs,
@@ -127,6 +168,7 @@ export async function issueDeviceBootstrapToken(
       token,
       ts: issuedAtMs,
       profile,
+      redeemedProfile: normalizeDeviceBootstrapProfile(undefined),
       issuedAtMs,
     };
     await persistState(state, params.baseDir);
@@ -183,6 +225,49 @@ export async function getDeviceBootstrapTokenProfile(params: {
       verifyPairingToken(providedToken, candidate.token),
     );
     return found ? resolvePersistedBootstrapProfile(found) : null;
+  });
+}
+
+export async function redeemDeviceBootstrapTokenProfile(params: {
+  token: string;
+  role: string;
+  scopes: readonly string[];
+  baseDir?: string;
+}): Promise<{ recorded: boolean; fullyRedeemed: boolean }> {
+  return await withLock(async () => {
+    const providedToken = params.token.trim();
+    if (!providedToken) {
+      return { recorded: false, fullyRedeemed: false };
+    }
+    const state = await loadState(params.baseDir);
+    const found = Object.entries(state).find(([, candidate]) =>
+      verifyPairingToken(providedToken, candidate.token),
+    );
+    if (!found) {
+      return { recorded: false, fullyRedeemed: false };
+    }
+    const [tokenKey, record] = found;
+    const issuedProfile = resolvePersistedBootstrapProfile(record);
+    const redeemedProfile = normalizeDeviceBootstrapProfile({
+      roles: [...resolvePersistedRedeemedProfile(record).roles, params.role],
+      scopes: [
+        ...resolvePersistedRedeemedProfile(record).scopes,
+        ...resolveBootstrapProfileScopes(params.role, params.scopes),
+      ],
+    });
+    state[tokenKey] = {
+      ...record,
+      profile: issuedProfile,
+      redeemedProfile,
+    };
+    await persistState(state, params.baseDir);
+    return {
+      recorded: true,
+      fullyRedeemed: bootstrapProfileSatisfiesProfile({
+        actualProfile: redeemedProfile,
+        requiredProfile: issuedProfile,
+      }),
+    };
   });
 }
 

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -169,6 +169,23 @@ export async function revokeDeviceBootstrapToken(params: {
   });
 }
 
+export async function getDeviceBootstrapTokenProfile(params: {
+  token: string;
+  baseDir?: string;
+}): Promise<DeviceBootstrapProfile | null> {
+  return await withLock(async () => {
+    const providedToken = params.token.trim();
+    if (!providedToken) {
+      return null;
+    }
+    const state = await loadState(params.baseDir);
+    const found = Object.values(state).find((candidate) =>
+      verifyPairingToken(providedToken, candidate.token),
+    );
+    return found ? resolvePersistedBootstrapProfile(found) : null;
+  });
+}
+
 export async function verifyDeviceBootstrapToken(params: {
   token: string;
   deviceId: string;

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -265,6 +265,52 @@ describe("device pairing tokens", () => {
     ).resolves.toEqual({ ok: true });
   });
 
+  test("preserves existing non-operator scopes during operator-only mixed-role repairs", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const initial = await requestDevicePairing(
+      {
+        deviceId: "device-1",
+        publicKey: "public-key-1",
+        role: "node",
+        scopes: ["node.exec"],
+      },
+      baseDir,
+    );
+    await expect(approveDevicePairing(initial.request.requestId, baseDir)).resolves.toMatchObject({
+      status: "approved",
+      requestId: initial.request.requestId,
+    });
+
+    const repair = await requestDevicePairing(
+      {
+        deviceId: "device-1",
+        publicKey: "public-key-1",
+        roles: ["node", "operator"],
+        scopes: ["operator.read"],
+      },
+      baseDir,
+    );
+    await expect(
+      approveDevicePairing(repair.request.requestId, { callerScopes: ["operator.read"] }, baseDir),
+    ).resolves.toMatchObject({
+      status: "approved",
+      requestId: repair.request.requestId,
+    });
+
+    const paired = await getPairedDevice("device-1", baseDir);
+    expect(paired?.tokens?.node?.scopes).toEqual(["node.exec"]);
+    expect(paired?.tokens?.operator?.scopes).toEqual(["operator.read"]);
+    await expect(
+      verifyDeviceToken({
+        deviceId: "device-1",
+        token: requireToken(paired?.tokens?.node?.token),
+        role: "node",
+        scopes: ["node.exec"],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
   test("keeps superseded requests interactive when an existing pending request is interactive", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
     const first = await requestDevicePairing(

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -344,6 +344,14 @@ function buildDeviceAuthToken(params: {
   };
 }
 
+function resolveRoleScopedDeviceTokenScopes(role: string, scopes: string[] | undefined): string[] {
+  const normalized = normalizeDeviceAuthScopes(scopes);
+  if (role === "operator") {
+    return normalized.filter((scope) => scope.startsWith(OPERATOR_SCOPE_PREFIX));
+  }
+  return normalized.filter((scope) => !scope.startsWith(OPERATOR_SCOPE_PREFIX));
+}
+
 function resolveApprovedTokenScopes(params: {
   role: string;
   pending: DevicePairingPendingRequest;
@@ -351,14 +359,12 @@ function resolveApprovedTokenScopes(params: {
   approvedScopes?: string[];
   existing?: PairedDevice;
 }): string[] {
-  const requestedScopes = normalizeDeviceAuthScopes(params.pending.scopes);
+  const requestedScopes = resolveRoleScopedDeviceTokenScopes(params.role, params.pending.scopes);
   if (requestedScopes.length > 0) {
-    if (params.role === "operator") {
-      return requestedScopes;
-    }
-    return requestedScopes.filter((scope) => !scope.startsWith(OPERATOR_SCOPE_PREFIX));
+    return requestedScopes;
   }
-  return normalizeDeviceAuthScopes(
+  return resolveRoleScopedDeviceTokenScopes(
+    params.role,
     params.existingToken?.scopes ??
       params.approvedScopes ??
       params.existing?.approvedScopes ??


### PR DESCRIPTION
## Summary
- keep setup bootstrap tokens alive after the initial silent node auto-pair instead of revoking them immediately
- revoke bootstrap tokens only after a bootstrap-authenticated connect succeeds against a paired device that satisfies the full issued profile
- cover the lifecycle with bootstrap infra tests plus an end-to-end gateway test for node auto-pair, operator approval, and final revocation

## Verification
- pnpm test -- src/infra/device-bootstrap.test.ts
- pnpm test -- src/gateway/server.auth.control-ui.test.ts -t bootstrap
- pnpm check
