### PR TITLE
fix(minimax): correct coding_plan usage_count as remaining quota

### DIFF
--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -117,6 +117,20 @@ describe("fetchMinimaxUsage", () => {
       },
     },
     {
+      name: "treats MiniMax current_interval_usage_count as remaining quota (not consumed)",
+      payload: {
+        data: {
+          current_interval_total_count: 100,
+          current_interval_usage_count: 98,
+          plan_name: "Coding Plan",
+        },
+      },
+      expected: {
+        plan: "Coding Plan",
+        windows: [{ label: "5h", usedPercent: 2, resetAt: undefined }],
+      },
+    },
+    {
       name: "falls back to payload-level reset and plan when nested usage records omit them",
       payload: {
         data: {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -67,8 +67,6 @@ const USED_KEYS = [
   "usedPrompt",
   "prompts_used",
   "promptsUsed",
-  "current_interval_usage_count",
-  "currentIntervalUsageCount",
   "consumed",
 ] as const;
 
@@ -96,6 +94,8 @@ const TOTAL_KEYS = [
   "totalPrompts",
   "current_interval_total_count",
   "currentIntervalTotalCount",
+  "current_weekly_total_count",
+  "currentWeeklyTotalCount",
   "limit",
   "quota",
   "quota_limit",
@@ -133,6 +133,12 @@ const REMAINING_KEYS = [
   "prompts_left",
   "promptsLeft",
   "left",
+  // MiniMax `/coding_plan/remains` misnames these: values are remaining quota, not consumed.
+  // See https://github.com/MiniMax-AI/MiniMax-M2/issues/99
+  "current_interval_usage_count",
+  "currentIntervalUsageCount",
+  "current_weekly_usage_count",
+  "currentWeeklyUsageCount",
 ] as const;
 
 const PLAN_KEYS = ["plan", "plan_name", "planName", "product", "tier"] as const;

--- a/src/infra/provider-usage.test.ts
+++ b/src/infra/provider-usage.test.ts
@@ -214,12 +214,13 @@ describe("provider usage loading", () => {
             end_time: 1736235600,
             remains_time: 600,
             current_interval_total_count: 120,
+            // API field is remaining quota, not consumed (MiniMax-M2#99).
             current_interval_usage_count: 30,
             model_name: "MiniMax-M2.5",
           },
         ],
       },
-      expected: { usedPercent: 25 },
+      expected: { usedPercent: 75 },
     },
     {
       name: "keeps payload-level MiniMax plan metadata when the usage candidate is nested",


### PR DESCRIPTION
## Summary

- Problem: MiniMax `/coding_plan/remains` fields `current_interval_usage_count` and `current_weekly_usage_count` are misleadingly named: values are **remaining** quota, not consumed usage (see MiniMax-AI/MiniMax-M2#99). They were listed under `USED_KEYS`, so `usedPercent` became remaining divided by total. macOS derives percent left as `100 - usedPercent`, which inverted the menu display (#60193).
- Why it matters: Users see wrong remaining quota for MiniMax in the menu bar.
- What changed: Move those fields to `REMAINING_KEYS`, add weekly total keys to `TOTAL_KEYS`, update integration test expectations, add a unit test.
- What did NOT change: Other providers, Swift UI, unrelated MiniMax paths.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue

- Closes #60193

## Root cause

MiniMax API field names suggest usage/consumed counts but return remaining counts; the parser treated them as consumed.

## Regression test

- [x] Unit tests in `src/infra/provider-usage.fetch.minimax.test.ts` and `src/infra/provider-usage.test.ts`

## User-visible changes

Usage summary should show correct percent remaining for MiniMax coding plan.

## Security impact

- New permissions: No
- Secrets / network / command execution / data scope: No

## Verification

- `pnpm test -- src/infra/provider-usage.fetch.minimax.test.ts src/infra/provider-usage.test.ts`

## Compatibility

- Backward compatible: Yes
