### PR TITLE
feat(telegram): coalesce inbound messages while agent is busy

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -199,6 +199,7 @@ export const registerTelegramHandlers = ({
   };
   const inboundDebouncer = createInboundDebouncer<TelegramDebounceEntry>({
     debounceMs,
+    coalesceWhileBusy: true,
     resolveDebounceMs: (entry) =>
       entry.debounceLane === "forward" ? FORWARD_BURST_DEBOUNCE_MS : debounceMs,
     buildKey: (entry) => entry.debounceKey,

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -58,8 +58,13 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   const threadId = isGroup
     ? resolveTelegramForumThreadId({ isForum, messageThreadId })
     : messageThreadId;
+  const messageId = msg?.message_id;
   if (typeof chatId === "number") {
-    return threadId != null ? `telegram:${chatId}:topic:${threadId}` : `telegram:${chatId}`;
+    const base = threadId != null ? `telegram:${chatId}:topic:${threadId}` : `telegram:${chatId}`;
+    if (typeof messageId === "number") {
+      return `${base}:msg:${messageId}`;
+    }
+    return base;
   }
   return "telegram:unknown";
 }

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -52,10 +52,19 @@ export type InboundDebounceCreateParams<T> = {
   resolveDebounceMs?: (item: T) => number | undefined;
   onFlush: (items: T[]) => Promise<void>;
   onError?: (err: unknown, items: T[]) => void;
+  /**
+   * When true, items arriving while a previous flush for the same key is still
+   * running are buffered and coalesced into a single `onFlush` call once the
+   * active flush completes — even when `debounceMs` is 0 or `shouldDebounce`
+   * returns false.  This prevents serial one-at-a-time processing that blocks
+   * queue-level collect/coalesce logic in the agent runner.
+   */
+  coalesceWhileBusy?: boolean;
 };
 
 export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>) {
   const buffers = new Map<string, DebounceBuffer<T>>();
+  const busyBuffers = new Map<string, T[]>();
   const keyChains = new Map<string, Promise<void>>();
   const defaultDebounceMs = Math.max(0, Math.trunc(params.debounceMs));
   const maxTrackedKeys = Math.max(1, Math.trunc(params.maxTrackedKeys ?? DEFAULT_MAX_TRACKED_KEYS));
@@ -184,6 +193,25 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
           return;
         }
         if (keyChains.has(key)) {
+          // When coalesceWhileBusy is enabled, buffer the item so it will be
+          // flushed together with other items that arrive while the current
+          // flush is still running, instead of queuing a separate serial task.
+          if (params.coalesceWhileBusy && canTrackKey(key)) {
+            const existing = busyBuffers.get(key);
+            if (existing) {
+              existing.push(item);
+              return;
+            }
+            const pending = [item];
+            busyBuffers.set(key, pending);
+            void enqueueKeyTask(key, async () => {
+              busyBuffers.delete(key);
+              if (pending.length > 0) {
+                await runFlush(pending);
+              }
+            });
+            return;
+          }
           await enqueueKeyTask(key, async () => {
             await runFlush([item]);
           });


### PR DESCRIPTION
## Problem

When an agent run is active, subsequent inbound Telegram messages from the same chat are serialized at two layers before reaching the queue-level collect logic:

1. **grammY `sequentialize` middleware** — uses a per-chat key (`telegram:{chatId}`), blocking all messages from the same chat until the current handler completes.
2. **Inbound debouncer `enqueueKeyTask`** — chains same-key flushes serially, so each message waits for the previous `onFlush` (which includes the entire agent run) to finish.

As a result, each follow-up message sees `isActive = false` when it finally reaches `resolveActiveRunQueueAction`, and the documented `collect` queue mode never triggers. Messages are always processed one-at-a-time, even when the user sends a rapid burst while the agent is busy.

## Solution

Three minimal changes:

### 1. `coalesceWhileBusy` option on `createInboundDebouncer`

New opt-in parameter. When enabled and a previous flush for the same key is still running (`keyChains.has(key)`), incoming items are buffered in a `busyBuffers` map instead of being queued as separate serial tasks. Once the active flush completes, all buffered items are flushed together in a single `onFlush` call.

### 2. Enable `coalesceWhileBusy: true` in Telegram handler

One-line addition to the Telegram inbound debouncer creation.

### 3. Per-message `sequentialize` key

Append `message_id` to the sequential key for regular messages so grammY no longer serializes same-chat messages. The session lane queue downstream still guarantees one agent run per session at a time, so there is no risk of concurrent session writes.

## Testing

Verified on a live Telegram DM session:
- Sent a task that triggers multiple tool calls (web browsing)
- Rapidly sent 4 follow-up messages during the agent run
- All 4 messages arrived as a single `[Queued messages while agent was busy]` turn with Queued #1–#4

Before the fix, each message was processed individually in serial.