### PR TITLE
docs(zh-CN): Add more installation guide translations

### DIFF
--- a/docs/zh-CN/gateway/openshell.md
+++ b/docs/zh-CN/gateway/openshell.md
@@ -1,0 +1,280 @@
+---
+title: OpenShell
+summary: "使用 OpenShell 作为 OpenClaw 代理的托管沙箱后端"
+read_when:
+  - 您想要云托管沙箱而不是本地 Docker
+  - 您正在设置 OpenShell 插件
+  - 您需要在 mirror 和 remote 工作区模式之间进行选择
+---
+
+# OpenShell
+
+OpenShell 是 OpenClaw 的托管沙箱后端。不再在本地运行 Docker 容器，OpenClaw 将沙箱生命周期委托给 `openshell` CLI，它通过 SSH 远程环境提供支持。
+
+OpenShell 插件重用了与通用 [SSH 后端](/gateway/sandboxing#ssh-backend) 相同的核心 SSH 传输和远程文件系统桥。它添加了 OpenShell 特定的生命周期（`sandbox create/get/delete`、`sandbox ssh-config`）和一个可选的 `mirror` 工作区模式。
+
+## 前提条件
+
+- `openshell` CLI 已安装并在 `PATH` 上（或通过 `plugins.entries.openshell.config.command` 设置自定义路径）
+- 具有沙箱访问权限的 OpenClaw 账户
+- 在主机上运行的 OpenClaw Gateway
+
+## 快速开始
+
+1. 启用插件并设置沙箱后端：
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        mode: "all",
+        backend: "openshell",
+        scope: "session",
+        workspaceAccess: "rw",
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      openshell: {
+        enabled: true,
+        config: {
+          from: "openclaw",
+          mode: "remote",
+        },
+      },
+    },
+  },
+}
+```
+
+2. 重启 Gateway。在下一个代理轮次，OpenClaw 创建一个 OpenShell 沙箱并通过它路由工具执行。
+
+3. 验证：
+
+```bash
+openclaw sandbox list
+openclaw sandbox explain
+```
+
+## 工作区模式
+
+这是使用 OpenShell 时最重要的决定。
+
+### `mirror`
+
+当您希望**本地工作区保持权威**时，使用 `plugins.entries.openshell.config.mode: "mirror"`。
+
+行为：
+
+- 在 `exec` 之前，OpenClaw 将本地工作区同步到 OpenShell 沙箱。
+- 在 `exec` 之后，OpenClaw 将远程工作区同步回本地工作区。
+- 文件工具仍然通过沙箱桥操作，但本地工作区在轮次之间保持为数据源。
+
+最适合：
+
+- 您在 OpenClaw 之外本地编辑文件，并希望这些更改自动在沙箱中可见。
+- 您希望 OpenShell 沙箱尽可能像 Docker 后端一样行为。
+- 您希望主机工作区在每个 exec 轮次后反映沙箱写入。
+
+权衡：每次 exec 前后都有额外的同步开销。
+
+### `remote`
+
+当您希望 **OpenShell 工作区成为权威**时，使用 `plugins.entries.openshell.config.mode: "remote"`。
+
+行为：
+
+- 首次创建沙箱时，OpenClaw 从本地工作区一次性播种远程工作区。
+- 之后，`exec`、`read`、`write`、`edit` 和 `apply_patch` 直接针对远程 OpenShell 工作区操作。
+- OpenClaw **不会**将远程更改同步回本地工作区。
+- 提示时的媒体读取仍然有效，因为文件和媒体工具通过沙箱桥读取。
+
+最适合：
+
+- 沙箱主要存在于远程端。
+- 您希望降低每轮同步开销。
+- 您不希望主机本地编辑静默覆盖远程沙箱状态。
+
+重要：如果在初始播种后在主机上在 OpenClaw 之外编辑文件，远程沙箱 **不会**看到这些更改。使用 `openclaw sandbox recreate` 重新播种。
+
+### 选择模式
+
+| | `mirror` | `remote` |
+| ------------------------ | -------------------------- | ------------------------- |
+| **权威工作区** | 本地主机 | 远程 OpenShell |
+| **同步方向** | 双向（每次 exec） | 一次性播种 |
+| **每轮开销** | 更高（上传 + 下载） | 更低（直接远程操作） |
+| **本地编辑可见？** | 是，在下次 exec 时 | 否，直到 recreate |
+| **最适合** | 开发工作流 | 长时间运行的代理、CI |
+
+## 配置参考
+
+所有 OpenShell 配置位于 `plugins.entries.openshell.config` 下：
+
+| 键 | 类型 | 默认值 | 描述 |
+| ------------------------- | ------------------------ | ------------- | ----------------------------------------------------- |
+| `mode` | `"mirror"` 或 `"remote"` | `"mirror"` | 工作区同步模式 |
+| `command` | `string` | `"openshell"` | `openshell` CLI 的路径或名称 |
+| `from` | `string` | `"openclaw"` | 首次创建时的沙箱源 |
+| `gateway` | `string` | — | OpenShell 网关名称（`--gateway`）|
+| `gatewayEndpoint` | `string` | — | OpenShell 网关端点 URL（`--gateway-endpoint`）|
+| `policy` | `string` | — | 沙箱创建的 OpenShell 策略 ID |
+| `providers` | `string[]` | `[]` | 创建沙箱时要附加的提供商名称 |
+| `gpu` | `boolean` | `false` | 请求 GPU 资源 |
+| `autoProviders` | `boolean` | `true` | 在沙箱创建期间传递 `--auto-providers` |
+| `remoteWorkspaceDir` | `string` | `"/sandbox"` | 沙箱内的主要可写工作区 |
+| `remoteAgentWorkspaceDir` | `string` | `"/agent"` | 代理工作区挂载路径（用于只读访问）|
+| `timeoutSeconds` | `number` | `120` | `openshell` CLI 操作的超时时间 |
+
+沙箱级设置（`mode`、`scope`、`workspaceAccess`）在 `agents.defaults.sandbox` 下配置，与任何后端相同。请参阅 [沙箱](/gateway/sandboxing) 获取完整矩阵。
+
+## 示例
+
+### 最小 remote 设置
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        mode: "all",
+        backend: "openshell",
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      openshell: {
+        enabled: true,
+        config: {
+          from: "openclaw",
+          mode: "remote",
+        },
+      },
+    },
+  },
+}
+```
+
+### 带 GPU 的 Mirror 模式
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        mode: "all",
+        backend: "openshell",
+        scope: "agent",
+        workspaceAccess: "rw",
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      openshell: {
+        enabled: true,
+        config: {
+          from: "openclaw",
+          mode: "mirror",
+          gpu: true,
+          providers: ["openai"],
+          timeoutSeconds: 180,
+        },
+      },
+    },
+  },
+}
+```
+
+### 每个代理的 OpenShell 和自定义网关
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: { mode: "off" },
+    },
+    list: [
+      {
+        id: "researcher",
+        sandbox: {
+          mode: "all",
+          backend: "openshell",
+          scope: "agent",
+          workspaceAccess: "rw",
+        },
+      },
+    ],
+  },
+  plugins: {
+    entries: {
+      openshell: {
+        enabled: true,
+        config: {
+          from: "openclaw",
+          mode: "remote",
+          gateway: "lab",
+          gatewayEndpoint: "https://lab.example",
+          policy: "strict",
+        },
+      },
+    },
+  },
+}
+```
+
+## 生命周期管理
+
+OpenShell 沙箱通过常规沙箱 CLI 管理：
+
+```bash
+# 列出所有沙箱运行时（Docker + OpenShell）
+openclaw sandbox list
+
+# 检查有效策略
+openclaw sandbox explain
+
+# 重新创建（删除远程工作区，下次使用时重新播种）
+openclaw sandbox recreate --all
+```
+
+对于 `remote` 模式，**重新创建特别重要**：它删除该范围的权威远程工作区。下次使用时从本地工作区播种新的远程工作区。
+
+对于 `mirror` 模式，重新创建主要重置远程执行环境，因为本地工作区保持权威。
+
+### 何时重新创建
+
+更改以下任何一项后重新创建：
+
+- `agents.defaults.sandbox.backend`
+- `plugins.entries.openshell.config.from`
+- `plugins.entries.openshell.config.mode`
+- `plugins.entries.openshell.config.policy`
+
+```bash
+openclaw sandbox recreate --all
+```
+
+## 当前限制
+
+- 沙箱浏览器在 OpenShell 后端上不支持。
+- `sandbox.docker.binds` 不适用于 OpenShell。
+- `sandbox.docker.*` 下的 Docker 特定运行时旋钮仅适用于 Docker 后端。
+
+## 工作原理
+
+1. OpenClaw 调用 `openshell sandbox create`（带有配置的 `--from`、`--gateway`、`--policy`、`--providers`、`--gpu` 标志）。
+2. OpenClaw 调用 `openshell sandbox ssh-config <name>` 获取沙箱的 SSH 连接详情。
+3. 核心将 SSH 配置写入临时文件，并使用与通用 SSH 后端相同的远程文件系统桥打开 SSH 会话。
+4. 在 `mirror` 模式：exec 前同步本地到远程，exec 后同步回。
+5. 在 `remote` 模式：创建时一次性播种，然后直接对远程工作区操作。
+
+## 另请参阅
+
+- [沙箱](/gateway/sandboxing) — 模式、范围和后端比较
+- [沙箱 vs 工具策略 vs 提升](/gateway/sandbox-vs-tool-policy-vs-elevated) — 调试被阻止的工具
+- [多代理沙箱和工具](/tools/multi-agent-sandbox-tools) — 每个代理的覆盖
+- [沙箱 CLI](/cli/sandbox) — `openclaw sandbox` 命令

--- a/docs/zh-CN/gateway/secrets-plan-contract.md
+++ b/docs/zh-CN/gateway/secrets-plan-contract.md
@@ -1,0 +1,116 @@
+---
+summary: "`secrets apply` 计划合同：目标验证、路径匹配和 `auth-profiles.json` 目标范围"
+read_when:
+  - 生成或审查 `openclaw secrets apply` 计划
+  - 调试 `Invalid plan target path` 错误
+  - 了解目标类型和路径验证行为
+title: "Secrets Apply 计划合同"
+---
+
+# Secrets apply 计划合同
+
+此页面定义了 `openclaw secrets apply` 强制执行的严格合同。
+
+如果目标不匹配这些规则，apply 将在修改配置之前失败。
+
+## 计划文件格式
+
+`openclaw secrets apply --from <plan.json>` 期望一个 `targets` 数组的计划目标：
+
+```json5
+{
+  version: 1,
+  protocolVersion: 1,
+  targets: [
+    {
+      type: "models.providers.apiKey",
+      path: "models.providers.openai.apiKey",
+      pathSegments: ["models", "providers", "openai", "apiKey"],
+      providerId: "openai",
+      ref: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+    },
+    {
+      type: "auth-profiles.api_key.key",
+      path: "profiles.openai:default.key",
+      pathSegments: ["profiles", "openai:default", "key"],
+      agentId: "main",
+      ref: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+    },
+  ],
+}
+```
+
+## 支持的目标范围
+
+计划目标在以下位置接受支持的凭证路径：
+
+- [SecretRef 凭证表面](/reference/secretref-credential-surface)
+
+## 目标类型行为
+
+一般规则：
+
+- `target.type` 必须被识别，并且必须与规范化的 `target.path` 形状匹配。
+
+兼容性别名仍然被接受用于现有计划：
+
+- `models.providers.apiKey`
+- `skills.entries.apiKey`
+- `channels.googlechat.serviceAccount`
+
+## 路径验证规则
+
+每个目标都通过以下所有验证：
+
+- `type` 必须是可识别的目标类型。
+- `path` 必须是非空的点路径。
+- `pathSegments` 可以省略。如果提供，它必须规范化为与 `path` 完全相同的路径。
+- 禁止的段被拒绝：`__proto__`、`prototype`、`constructor`。
+- 规范化路径必须与目标类型注册 path 形状匹配。
+- 如果设置了 `providerId` 或 `accountId`，它必须与路径中编码的 ID 匹配。
+- `auth-profiles.json` 目标需要 `agentId`。
+- 创建新的 `auth-profiles.json` 映射时，包含 `authProfileProvider`。
+
+## 失败行为
+
+如果目标验证失败，apply 退出并显示类似以下的错误：
+
+```text
+Invalid plan target path for models.providers.apiKey: models.providers.openai.baseUrl
+```
+
+无效计划不会提交任何写入。
+
+## Exec 提供商同意行为
+
+- `--dry-run` 默认跳过 exec SecretRef 检查。
+- 包含 exec SecretRefs/提供商的计划在写入模式下被拒绝，除非设置了 `--allow-exec`。
+- 在验证/应用包含 exec 的计划时，在 dry-run 和写入命令中都传递 `--allow-exec`。
+
+## 运行时和审计范围说明
+
+- 仅 ref 的 `auth-profiles.json` 条目（`keyRef`/`tokenRef`）包含在运行时解析和审计覆盖中。
+- `secrets apply` 写入支持的 `openclaw.json` 目标、支持 `auth-profiles.json` 目标和可选的清理目标。
+
+## 操作员检查
+
+```bash
+# 验证计划但不写入
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --dry-run
+
+# 然后真正应用
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json
+
+# 对于包含 exec 的计划，在两种模式下都明确选择加入
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --dry-run --allow-exec
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --allow-exec
+```
+
+如果 apply 失败并显示无效的目标路径消息，请使用 `openclaw secrets configure` 重新生成计划或将目标路径修复为上面支持的形状。
+
+## 相关文档
+
+- [Secrets 管理](/gateway/secrets)
+- [CLI `secrets`](/cli/secrets)
+- [SecretRef 凭证表面](/reference/secretref-credential-surface)
+- [配置参考](/gateway/configuration-reference)

--- a/docs/zh-CN/gateway/trusted-proxy-auth.md
+++ b/docs/zh-CN/gateway/trusted-proxy-auth.md
@@ -1,0 +1,329 @@
+---
+title: "受信任代理认证"
+summary: "将 Gateway 认证委托给受信任的反向代理（Pomerium、Caddy、nginx + OAuth）"
+read_when:
+  - 在身份感知代理后面运行 OpenClaw
+  - 在 OpenClaw 前面设置 Pomerium、Caddy 或带 OAuth 的 nginx
+  - 修复反向代理设置下的 WebSocket 1008 未授权错误
+  - 决定在哪里设置 HSTS 和其他 HTTP 加固头部
+---
+
+# 受信任代理认证
+
+> ⚠️ **安全敏感功能。** 此模式将认证完全委托给您的反向代理。配置错误可能导致您的 Gateway 暴露于未授权访问。在启用之前请仔细阅读此页面。
+
+## 何时使用
+
+在以下情况下使用 `trusted-proxy` 认证模式：
+
+-您在**身份感知代理**（Pomerium、Caddy + OAuth、nginx + oauth2-proxy、Traefik + forward auth）后面运行 OpenClaw
+- 您的代理处理所有认证并通过头部传递用户身份
+- 您在 Kubernetes 或容器环境中，代理是进入 Gateway 的唯一路径
+- 您遇到 WebSocket `1008 unauthorized` 错误，因为浏览器无法在 WS 负载中传递令牌
+
+## 何时不使用
+
+- 如果您的代理不认证用户（仅是 TLS 终止器或负载均衡器）
+- 如果存在任何绕过代理进入 Gateway 的路径（防火墙漏洞、内部网络访问）
+- 如果您不确定您的代理是否正确剥离/覆盖转发的头部
+- 如果您只需要个人单用户访问（考虑 Tailscale Serve + 回环以获得更简单的设置）
+
+## 工作原理
+
+1. 您的反向代理认证用户（OAuth、OIDC、SAML 等）
+2. 代理添加一个包含已认证用户身份的头部（例如 `x-forwarded-user: nick@example.com`）
+3. OpenClaw 检查请求是否来自**受信任代理 IP**（在 `gateway.trustedProxies` 中配置）
+4. OpenClaw 从配置的头部提取用户身份
+5. 如果一切检查通过，请求被授权
+
+## Control UI 配对行为
+
+当 `gateway.auth.mode = "trusted-proxy"` 处于活动状态且请求通过
+受信任代理检查时，Control UI WebSocket 会话可以在没有设备
+配对身份的情况下连接。
+
+影响：
+
+- 在此模式下，配对不再是 Control UI 访问的主要关卡。
+- 您的反向代理认证策略和 `allowUsers` 成为有效的访问控制。
+- 保持 Gateway 入口仅锁定到受信任代理 IP（`gateway.trustedProxies` + 防火墙）。
+
+## 配置
+
+```json5
+{
+  gateway: {
+    // 对于同主机代理设置使用 loopback；远程代理主机使用 lan/custom
+    bind: "loopback",
+
+    // 关键：仅在此处添加您的代理的 IP
+    trustedProxies: ["10.0.0.1", "172.17.0.1"],
+
+    auth: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        // 包含已认证用户身份的头部（必需）
+        userHeader: "x-forwarded-user",
+
+        // 可选：必须存在的头部（代理验证）
+        requiredHeaders: ["x-forwarded-proto", "x-forwarded-host"],
+
+        // 可选：限制特定用户（空 = 允许所有）
+        allowUsers: ["nick@example.com", "admin@company.org"],
+      },
+    },
+  },
+}
+```
+
+如果 `gateway.bind` 是 `loopback`，请在
+`gateway.trustedProxies` 中包含一个回环代理地址（`127.0.0.1`、`::1` 或等效的回环 CIDR）。
+
+### 配置参考
+
+| 字段 | 必需 | 描述 |
+| ------------------------------------------- | -------- | --------------------------------------------------------------------------- |
+| `gateway.trustedProxies` | 是 | 要信任的代理 IP 数组。来自其他 IP 的请求被拒绝。 |
+| `gateway.auth.mode` | 是 | 必须是 `"trusted-proxy"` |
+| `gateway.auth.trustedProxy.userHeader` | 是 | 包含已认证用户身份的头部名称 |
+| `gateway.auth.trustedProxy.requiredHeaders` | 否 | 请求被信任必须存在的其他头部 |
+| `gateway.auth.trustedProxy.allowUsers` | 否 | 用户身份允许列表。空意味着允许所有已认证用户。 |
+
+## TLS 终止和 HSTS
+
+使用一个 TLS 终止点并在那里应用 HSTS。
+
+### 推荐模式：代理 TLS 终止
+
+当您的反向代理为 `https://control.example.com` 处理 HTTPS 时，在代理处为该域设置 `Strict-Transport-Security`。
+
+- 非常适合面向互联网的部署。
+- 将证书 + HTTP 加固策略保存在一个地方。
+- OpenClaw 可以保持在代理后面的回环 HTTP 上。
+
+示例头部值：
+
+```text
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+```
+
+### Gateway TLS 终止
+
+如果 OpenClaw 本身直接提供 HTTPS（没有 TLS 终止代理），设置：
+
+```json5
+{
+  gateway: {
+    tls: { enabled: true },
+    http: {
+      securityHeaders: {
+        strictTransportSecurity: "max-age=31536000; includeSubDomains",
+      },
+    },
+  },
+}
+```
+
+`strictTransportSecurity` 接受字符串头部值，或 `false` 明确禁用。
+
+### 推广指南
+
+- 首先使用较短的 max age（例如 `max-age=300`）同时验证流量。
+- 仅在高度自信后增加为长期值（例如 `max-age=31536000`）。
+- 仅在每个子域都准备好 HTTPS 时添加 `includeSubDomains`。
+- 仅在您故意满足完整域集的预加载要求时才使用预加载。
+- 仅回环的本地开发不会从 HSTS 中受益。
+
+## 代理设置示例
+
+### Pomerium
+
+Pomerium 在 `x-pomerium-claim-email`（或其他声明头部）中传递身份，并在 `x-pomerium-jwt-assertion` 中传递 JWT。
+
+```json5
+{
+  gateway: {
+    bind: "lan",
+    trustedProxies: ["10.0.0.1"], // Pomerium 的 IP
+    auth: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        userHeader: "x-pomerium-claim-email",
+        requiredHeaders: ["x-pomerium-jwt-assertion"],
+      },
+    },
+  },
+}
+```
+
+Pomerium 配置片段：
+
+```yaml
+routes:
+  - from: https://openclaw.example.com
+    to: http://openclaw-gateway:18789
+    policy:
+      - allow:
+          or:
+            - email:
+                is: nick@example.com
+    pass_identity_headers: true
+```
+
+### 带 OAuth 的 Caddy
+
+带 `caddy-security` 插件的 Caddy 可以认证用户并传递身份头部。
+
+```json5
+{
+  gateway: {
+    bind: "lan",
+    trustedProxies: ["127.0.0.1"], // Caddy 的 IP（如果在同一主机上）
+    auth: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        userHeader: "x-forwarded-user",
+      },
+    },
+  },
+}
+```
+
+Caddyfile 片段：
+
+```
+openclaw.example.com {
+    authenticate with oauth2_provider
+    authorize with policy1
+
+    reverse_proxy openclaw:18789 {
+        header_up X-Forwarded-User {http.auth.user.email}
+    }
+}
+```
+
+### nginx + oauth2-proxy
+
+oauth2-proxy 认证用户并在 `x-auth-request-email` 中传递身份。
+
+```json5
+{
+  gateway: {
+    bind: "lan",
+    trustedProxies: ["10.0.0.1"], // nginx/oauth2-proxy IP
+    auth: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        userHeader: "x-auth-request-email",
+      },
+    },
+  },
+}
+```
+
+nginx 配置片段：
+
+```nginx
+location / {
+    auth_request /oauth2/auth;
+    auth_request_set $user $upstream_http_x_auth_request_email;
+
+    proxy_pass http://openclaw:18789;
+    proxy_set_header X-Auth-Request-Email $user;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+}
+```
+
+### Traefik 带 Forward Auth
+
+```json5
+{
+  gateway: {
+    bind: "lan",
+    trustedProxies: ["172.17.0.1"], // Traefik 容器 IP
+    auth: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        userHeader: "x-forwarded-user",
+      },
+    },
+  },
+}
+```
+
+## 安全检查清单
+
+在启用受信任代理认证之前，验证：
+
+- [ ] **代理是唯一路径**：Gateway 端口被防火墙保护，只允许您的代理访问
+- [ ] **trustedProxies 最小化**：仅包含您实际的代理 IP，而不是整个子网
+- [ ] **代理剥离头部**：您的代理覆盖（而不是追加）来自客户端的 `x-forwarded-*` 头部
+- [ ] **TLS 终止**：您的代理处理 TLS；用户通过 HTTPS 连接
+- [ ] **设置 allowUsers**（推荐）：限制到已知用户而不是允许任何已认证用户
+
+## 安全审计
+
+`openclaw security audit` 将以**严重**级别标记受信任代理认证。这是故意的 — 它提醒您正在将安全委托给您的代理设置。
+
+审计检查：
+
+- 缺少 `trustedProxies` 配置
+- 缺少 `userHeader` 配置
+- 空 `allowUsers`（允许任何已认证用户）
+
+## 故障排除
+
+### "trusted_proxy_untrusted_source"
+
+请求未来自 `gateway.trustedProxies` 中的 IP。检查：
+
+- 代理 IP 是否正确？（Docker 容器 IP 可能会更改）
+- 您的代理前面是否有负载均衡器？
+- 使用 `docker inspect` 或 `kubectl get pods -o wide` 查找实际 IP
+
+### "trusted_proxy_user_missing"
+
+用户头部为空或缺失。检查：
+
+- 您的代理是否配置为传递身份头部？
+- 头部名称是否正确？（不区分大小写，但拼写很重要）
+- 用户在代理处实际是否已认证？
+
+### "trusted*proxy_missing_header*\*"
+
+必需的头部不存在。检查：
+
+- 您的代理配置中是否有那些特定头部
+- 头部是否在链中的某处被剥离
+
+### "trusted_proxy_user_not_allowed"
+
+用户已认证但不在 `allowUsers` 中。要么添加他们，要么移除允许列表。
+
+### WebSocket 仍然失败
+
+确保您的代理：
+
+- 支持 WebSocket 升级（`Upgrade: websocket`、`Connection: upgrade`）
+- 在 WebSocket 升级请求上传递身份头部（不仅仅是 HTTP）
+- WebSocket 连接没有单独的 auth 路径
+
+## 从令牌认证迁移
+
+如果您从令牌认证迁移到受信任代理：
+
+1. 配置您的代理认证用户并传递头部
+2. 独立测试代理设置（带头部的 curl）
+3. 使用受信任代理认证更新 OpenClaw 配置
+4. 重启 Gateway
+5. 从 Control UI 测试 WebSocket 连接
+6. 运行 `openclaw security audit` 并审查结果
+
+## 相关
+
+- [安全](/gateway/security) — 完整安全指南
+- [配置](/gateway/configuration) — 配置参考
+- [远程访问](/gateway/remote) — 其他远程访问模式
+- [Tailscale](/gateway/tailscale) — 更简单的 tailnet 专用访问替代方案

--- a/docs/zh-CN/install/digitalocean.md
+++ b/docs/zh-CN/install/digitalocean.md
@@ -1,0 +1,129 @@
+---
+summary: "在 DigitalOcean Droplet 上托管 OpenClaw"
+read_when:
+  - 在 DigitalOcean 上设置 OpenClaw
+  - 为 OpenClaw 寻找一个简单的付费 VPS
+title: "DigitalOcean"
+---
+
+# DigitalOcean
+
+在 DigitalOcean Droplet 上运行持久的 OpenClaw Gateway。
+
+## 前提条件
+
+- DigitalOcean 账户（[注册](https://cloud.digitalocean.com/registrations/new)）
+- SSH 密钥对（或愿意使用密码认证）
+- 大约 20 分钟
+
+## 设置
+
+<Steps>
+  <Step title="创建 Droplet">
+    <Warning>
+    使用干净的基础镜像（Ubuntu 24.04 LTS）。除非您已检查了第三方 Marketplace 一键镜像的启动脚本和防火墙默认设置，否则请避免使用它们。
+    </Warning>
+
+    1. 登录 [DigitalOcean](https://cloud.digitalocean.com/)。
+    2. 点击 **Create > Droplets**。
+    3. 选择：
+       - **区域：** 离您最近的
+       - **镜像：** Ubuntu 24.04 LTS
+       - **规格：** Basic, Regular, 1 vCPU / 1 GB RAM / 25 GB SSD
+       - **认证：** SSH 密钥（推荐）或密码
+    4. 点击 **Create Droplet** 并记下 IP 地址。
+
+  </Step>
+
+  <Step title="连接并安装">
+    ```bash
+    ssh root@YOUR_DROPLET_IP
+
+    apt update && apt upgrade -y
+
+    # 安装 Node.js 24
+    curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
+    apt install -y nodejs
+
+    # 安装 OpenClaw
+    curl -fsSL https://openclaw.ai/install.sh | bash
+    openclaw --version
+    ```
+
+  </Step>
+
+  <Step title="运行引导">
+    ```bash
+    openclaw onboard --install-daemon
+    ```
+
+    向导会引导您完成模型认证、频道设置、Gateway 令牌生成和守护进程安装（systemd）。
+
+  </Step>
+
+  <Step title="添加 swap（推荐用于 1 GB Droplet）">
+    ```bash
+    fallocate -l 2G /swapfile
+    chmod 600 /swapfile
+    mkswap /swapfile
+    swapon /swapfile
+    echo '/swapfile none swap sw 0 0' >> /etc/fstab
+    ```
+  </Step>
+
+  <Step title="验证 Gateway">
+    ```bash
+    openclaw status
+    systemctl --user status openclaw-gateway.service
+    journalctl --user -u openclaw-gateway.service -f
+    ```
+  </Step>
+
+  <Step title="访问 Control UI">
+    Gateway 默认绑定到回环。选择以下选项之一。
+
+    **选项 A：SSH 隧道（最简单）**
+
+    ```bash
+    # 从本地机器
+    ssh -L 18789:localhost:18789 root@YOUR_DROPLET_IP
+    ```
+
+    然后打开 `http://localhost:18789`。
+
+    **选项 B：Tailscale Serve**
+
+    ```bash
+    curl -fsSL https://tailscale.com/install.sh | sh
+    tailscale up
+    openclaw config set gateway.tailscale.mode serve
+    openclaw gateway restart
+    ```
+
+    然后从您的 tailnet 上的任何设备打开 `https://<magicdns>/`。
+
+    **选项 C：Tailnet 绑定（无 Serve）**
+
+    ```bash
+    openclaw config set gateway.bind tailnet
+    openclaw gateway restart
+    ```
+
+    然后打开 `http://<tailscale-ip>:18789`（需要令牌）。
+
+  </Step>
+</Steps>
+
+## 故障排除
+
+**Gateway 无法启动** -- 运行 `openclaw doctor --non-interactive` 并使用 `journalctl --user -u openclaw-gateway.service -n 50` 检查日志。
+
+**端口已被占用** -- 运行 `lsof -i :18789` 查找进程，然后停止它。
+
+**内存不足** -- 使用 `free -h` 验证 swap 是否已激活。如果仍然 OOM，请使用基于 API 的模型（Claude、GPT）而不是本地模型，或升级到 2 GB Droplet。
+
+## 后续步骤
+
+- [频道](/channels) -- 连接 Telegram、WhatsApp、Discord 等
+- [Gateway 配置](/gateway/configuration) -- 所有配置选项
+- [更新](/install/updating) -- 保持 OpenClaw 最新

--- a/docs/zh-CN/install/docker-vm-runtime.md
+++ b/docs/zh-CN/install/docker-vm-runtime.md
@@ -1,0 +1,142 @@
+---
+summary: "在长时间运行的 OpenClaw Gateway 主机上共享 Docker VM 运行时步骤"
+read_when:
+  - 在云 VM 上部署 OpenClaw with Docker
+  - 需要共享的二进制文件烘焙、持久化和更新流程
+title: "Docker VM 运行时"
+---
+
+# Docker VM 运行时
+
+适用于基于 VM 的 Docker 安装（如 GCP、Hetzner 和类似 VPS 提供商）的共享运行时步骤。
+
+## 将所需二进制文件烘焙到镜像中
+
+在运行中的容器内安装二进制文件是一个陷阱。
+运行时安装的任何内容都将在重启时丢失。
+
+技能所需的所有外部二进制文件必须在镜像构建时安装。
+
+以下示例仅展示三个常用二进制文件：
+
+- 用于 Gmail 访问的 `gog`
+- 用于 Google Places 的 `goplaces`
+- 用于 WhatsApp 的 `wacli`
+
+这些是示例，不是完整列表。
+您可以使用相同的模式安装任意数量的二进制文件。
+
+如果稍后添加依赖其他二进制文件的新技能，您必须：
+
+1. 更新 Dockerfile
+2. 重建镜像
+3. 重启容器
+
+**示例 Dockerfile**
+
+```dockerfile
+FROM node:24-bookworm
+
+RUN apt-get update && apt-get install -y socat && rm -rf /var/lib/apt/lists/*
+
+# 示例二进制文件 1：Gmail CLI
+RUN curl -L https://github.com/steipete/gog/releases/latest/download/gog_Linux_x86_64.tar.gz \
+  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/gog
+
+# 示例二进制文件 2：Google Places CLI
+RUN curl -L https://github.com/steipete/goplaces/releases/latest/download/goplaces_Linux_x86_64.tar.gz \
+  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/goplaces
+
+# 示例二进制文件 3：WhatsApp CLI
+RUN curl -L https://github.com/steipete/wacli/releases/latest/download/wacli_Linux_x86_64.tar.gz \
+  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/wacli
+
+# 使用相同模式在下方添加更多二进制文件
+
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY ui/package.json ./ui/package.json
+COPY scripts ./scripts
+
+RUN corepack enable
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm build
+RUN pnpm ui:install
+RUN pnpm ui:build
+
+ENV NODE_ENV=production
+
+CMD ["node","dist/index.js"]
+```
+
+<Note>
+上述下载 URL 适用于 x86_64 (amd64)。对于基于 ARM 的 VM（例如 Hetzner ARM、GCP Tau T2A），请从每个工具的发布页面替换为相应的 ARM64 变体下载 URL。
+</Note>
+
+## 构建和启动
+
+```bash
+docker compose build
+docker compose up -d openclaw-gateway
+```
+
+如果构建在 `pnpm install --frozen-lockfile` 期间因 `Killed` 或 `exit code 137` 失败，则 VM 内存不足。
+重试前请使用更大的机器规格。
+
+验证二进制文件：
+
+```bash
+docker compose exec openclaw-gateway which gog
+docker compose exec openclaw-gateway which goplaces
+docker compose exec openclaw-gateway which wacli
+```
+
+预期输出：
+
+```
+/usr/local/bin/gog
+/usr/local/bin/goplaces
+/usr/local/bin/wacli
+```
+
+验证 Gateway：
+
+```bash
+docker compose logs -f openclaw-gateway
+```
+
+预期输出：
+
+```
+[gateway] listening on ws://0.0.0.0:18789
+```
+
+## 持久化位置
+
+OpenClaw 在 Docker 中运行，但 Docker 不是数据源。
+所有长期状态必须能够承受重启、重新构建和重启。
+
+| 组件 | 位置 | 持久化机制 | 备注 |
+| ------------------- | --------------------------------- | ---------------------- | -------------------------------- |
+| Gateway 配置 | `/home/node/.openclaw/` | 主机卷挂载 | 包括 `openclaw.json`、令牌 |
+| 模型认证配置 | `/home/node/.openclaw/` | 主机卷挂载 | OAuth 令牌、API 密钥 |
+| 技能配置 | `/home/node/.openclaw/skills/` | 主机卷挂载 | 技能级状态 |
+| 代理工作区 | `/home/node/.openclaw/workspace/` | 主机卷挂载 | 代码和代理制品 |
+| WhatsApp 会话 | `/home/node/.openclaw/` | 主机卷挂载 | 保留 QR 登录 |
+| Gmail keyring | `/home/node/.openclaw/` | 主机卷 + 密码 | 需要 `GOG_KEYRING_PASSWORD` |
+| 外部二进制文件 | `/usr/local/bin/` | Docker 镜像 | 必须在构建时烘焙 |
+| Node 运行时 | 容器文件系统 | Docker 镜像 | 每次镜像构建时重新构建 |
+| OS 包 | 容器文件系统 | Docker 镜像 | 不要在运行时安装 |
+| Docker 容器 | 临时性 | 可重启 | 可以安全销毁 |
+
+## 更新
+
+更新 VM 上的 OpenClaw：
+
+```bash
+git pull
+docker compose build
+docker compose up -d
+```

--- a/docs/zh-CN/install/kubernetes.md
+++ b/docs/zh-CN/install/kubernetes.md
@@ -1,0 +1,191 @@
+---
+summary: "使用 Kustomize 将 OpenClaw Gateway 部署到 Kubernetes 集群"
+read_when:
+  - 您想在 Kubernetes 集群上运行 OpenClaw
+  - 您想在 Kubernetes 环境中测试 OpenClaw
+title: "Kubernetes"
+---
+
+# Kubernetes 上的 OpenClaw
+
+在 Kubernetes 上运行 OpenClaw 的最小起点 — 不是生产级部署。它涵盖核心资源，意在适应您的环境。
+
+## 为什么不使用 Helm？
+
+OpenClaw 是一个包含一些配置文件的单容器。有趣的定制在于代理内容（markdown 文件、技能、配置覆盖），而不是基础设施模板。Kustomize 使用覆盖层处理，无需 Helm chart 的开销。如果您的部署变得更复杂，可以在这些清单之上分层 Helm chart。
+
+## 您需要什么
+
+- 正在运行的 Kubernetes 集群（AKS、EKS、GKE、k3s、kind、OpenShift 等）
+- 连接到集群的 `kubectl`
+- 至少一个模型提供商的 API 密钥
+
+## 快速开始
+
+```bash
+# 替换为您的提供商：ANTHROPIC、GEMINI、OPENAI 或 OPENROUTER
+export <PROVIDER>_API_KEY="..."
+./scripts/k8s/deploy.sh
+
+kubectl port-forward svc/openclaw 18789:18789 -n openclaw
+open http://localhost:18789
+```
+
+获取 Gateway 令牌并将其粘贴到 Control UI 中：
+
+```bash
+kubectl get secret openclaw-secrets -n openclaw -o jsonpath='{.data.OPENCLAW_GATEWAY_TOKEN}' | base64 -d
+```
+
+对于本地调试，`./scripts/k8s/deploy.sh --show-token` 在部署后打印令牌。
+
+## 使用 Kind 本地测试
+
+如果您没有集群，请使用 [Kind](https://kind.sigs.k8s.io/) 在本地创建一个：
+
+```bash
+./scripts/k8s/create-kind.sh           # 自动检测 docker 或 podman
+./scripts/k8s/create-kind.sh --delete  # 清理
+```
+
+然后像往常一样使用 `./scripts/k8s/deploy.sh` 部署。
+
+## 逐步说明
+
+### 1) 部署
+
+**选项 A** — 环境中的 API 密钥（一步到位）：
+
+```bash
+# 替换为您的提供商：ANTHROPIC、GEMINI、OPENAI 或 OPENROUTER
+export <PROVIDER>_API_KEY="..."
+./scripts/k8s/deploy.sh
+```
+
+脚本创建一个包含 API 密钥的 Kubernetes Secret 和一个自动生成的 Gateway 令牌，然后部署。如果 Secret 已存在，它会保留当前的 Gateway 令牌和任何未被更改的提供商密钥。
+
+**选项 B** — 单独创建 Secret：
+
+```bash
+export <PROVIDER>_API_KEY="..."
+./scripts/k8s/deploy.sh --create-secret
+./scripts/k8s/deploy.sh
+```
+
+如果您想让令牌打印到 stdout 用于本地测试，请对任一命令使用 `--show-token`。
+
+### 2) 访问 Gateway
+
+```bash
+kubectl port-forward svc/openclaw 18789:18789 -n openclaw
+open http://localhost:18789
+```
+
+## 部署的内容
+
+```
+命名空间：openclaw（可通过 OPENCLAW_NAMESPACE 配置）
+├── Deployment/openclaw        # 单 pod，init 容器 + gateway
+├── Service/openclaw           # 端口 18789 上的 ClusterIP
+├── PersistentVolumeClaim      # 10Gi 用于代理状态和配置
+├── ConfigMap/openclaw-config  # openclaw.json + AGENTS.md
+└── Secret/openclaw-secrets    # Gateway 令牌 + API 密钥
+```
+
+## 定制
+
+### 代理指令
+
+编辑 `scripts/k8s/manifests/configmap.yaml` 中的 `AGENTS.md` 并重新部署：
+
+```bash
+./scripts/k8s/deploy.sh
+```
+
+### Gateway 配置
+
+编辑 `scripts/k8s/manifests/configmap.yaml` 中的 `openclaw.json`。请参阅 [Gateway 配置](/gateway/configuration) 获取完整参考。
+
+### 添加提供商
+
+导出其他密钥并重新运行：
+
+```bash
+export ANTHROPIC_API_KEY="..."
+export OPENAI_API_KEY="..."
+./scripts/k8s/deploy.sh --create-secret
+./scripts/k8s/deploy.sh
+```
+
+现有提供商密钥保留在 Secret 中，除非您覆盖它们。
+
+或直接修补 Secret：
+
+```bash
+kubectl patch secret openclaw-secrets -n openclaw \
+  -p '{"stringData":{"<PROVIDER>_API_KEY":"..."}}'
+kubectl rollout restart deployment/openclaw -n openclaw
+```
+
+### 自定义命名空间
+
+```bash
+OPENCLAW_NAMESPACE=my-namespace ./scripts/k8s/deploy.sh
+```
+
+### 自定义镜像
+
+编辑 `scripts/k8s/manifests/deployment.yaml` 中的 `image` 字段：
+
+```yaml
+image: ghcr.io/openclaw/openclaw:latest # 或从 https://github.com/openclaw/openclaw/releases 固定到特定版本
+```
+
+### 在 port-forward 之外暴露
+
+默认清单在 pod 内将 Gateway 绑定到回环。这与 `kubectl port-forward` 配合使用，但不适用于需要访问 pod IP 的 Kubernetes `Service` 或 Ingress 路径。
+
+如果您想通过 Ingress 或负载均衡器公开 Gateway：
+
+- 将 `scripts/k8s/manifests/configmap.yaml` 中的 Gateway 绑定从 `loopback` 更改为与您的部署模型匹配的非回环绑定
+- 保持 Gateway 认证启用并使用适当的 TLS 终止入口点
+- 使用支持的 Web 安全模型配置 Control UI 以进行远程访问（例如 HTTPS/Tailscale Serve 和在需要时明确允许的来源）
+
+## 重新部署
+
+```bash
+./scripts/k8s/deploy.sh
+```
+
+这会应用所有清单并重启 pod 以获取任何配置或 Secret 更改。
+
+## 清理
+
+```bash
+./scripts/k8s/deploy.sh --delete
+```
+
+这会删除命名空间及其中的所有资源，包括 PVC。
+
+## 架构说明
+
+- Gateway 默认在 pod 内绑定到回环，因此包含的设置适用于 `kubectl port-forward`
+- 无集群范围资源 — 一切都位于单个命名空间中
+- 安全性：`readOnlyRootFilesystem`、`drop: ALL` 能力、非 root 用户（UID 1000）
+- 默认配置将 Control UI 保持在更安全的本地访问路径上：回环绑定加上 `kubectl port-forward` 到 `http://127.0.0.1:18789`
+- 如果您超越本地访问，请使用支持的远程模型：HTTPS/Tailscale 以及适当的 Gateway 绑定和 Control UI 来源设置
+- Secret 在临时目录中生成并直接应用到集群 — 没有 Secret 材料写入仓库检出
+
+## 文件结构
+
+```
+scripts/k8s/
+├── deploy.sh                   # 创建命名空间 + secret，通过 kustomize 部署
+├── create-kind.sh              # 本地 Kind 集群（自动检测 docker/podman）
+└── 清单/
+    ├── kustomization.yaml      # Kustomize 基础
+    ├── configmap.yaml          # openclaw.json + AGENTS.md
+    ├── deployment.yaml         # 带安全加固的 Pod 规范
+    ├── pvc.yaml                # 10Gi 持久化存储
+    └── service.yaml            # 端口 18789 上的 ClusterIP
+```

--- a/docs/zh-CN/install/oracle.md
+++ b/docs/zh-CN/install/oracle.md
@@ -1,0 +1,155 @@
+---
+summary: "在 Oracle Cloud 免费 ARM 层托管 OpenClaw"
+read_when:
+  - 在 Oracle Cloud 上设置 OpenClaw
+  - 为 OpenClaw 寻找免费 VPS 托管
+  - 想在小服务器上运行 24/7 OpenClaw
+title: "Oracle Cloud"
+---
+
+# Oracle Cloud
+
+在 Oracle Cloud 的 **Always Free** ARM 层（最高 4 OCPU、24 GB RAM、200 GB 存储）上运行持久的 OpenClaw Gateway，完全免费。
+
+## 前提条件
+
+- Oracle Cloud 账户（[注册](https://www.oracle.com/cloud/free/)）— 如果遇到问题，请参阅[社区注册指南](https://gist.github.com/rssnyder/51e3cfedd730e7dd5f4a816143b25dbd)
+- Tailscale 账户（免费，在 [tailscale.com](https://tailscale.com)）
+- SSH 密钥对
+- 大约 30 分钟
+
+## 设置
+
+<Steps>
+  <Step title="创建 OCI 实例">
+    1. 登录 [Oracle Cloud Console](https://cloud.oracle.com/)。
+    2. 导航到 **Compute > Instances > Create Instance**。
+    3. 配置：
+       - **名称：** `openclaw`
+       - **镜像：** Ubuntu 24.04 (aarch64)
+       - **规格：** `VM.Standard.A1.Flex` (Ampere ARM)
+       - **OCPU：** 2（或最多 4）
+       - **内存：** 12 GB（或最多 24 GB）
+       - **启动卷：** 50 GB（最多 200 GB 免费）
+       - **SSH 密钥：** 添加您的公钥
+    4. 点击 **Create** 并记下公网 IP 地址。
+
+    <Tip>
+    如果实例创建失败并显示“Out of capacity”，请尝试不同的可用性域或稍后重试。免费层容量有限。
+    </Tip>
+
+  </Step>
+
+  <Step title="连接并更新系统">
+    ```bash
+    ssh ubuntu@YOUR_PUBLIC_IP
+
+    sudo apt update && sudo apt upgrade -y
+    sudo apt install -y build-essential
+    ```
+
+    `build-essential` 是某些依赖项 ARM 编译所需的。
+
+  </Step>
+
+  <Step title="配置用户和主机名">
+    ```bash
+    sudo hostnamectl set-hostname openclaw
+    sudo passwd ubuntu
+    sudo loginctl enable-linger ubuntu
+    ```
+
+    启用 linger 可以让用户服务在注销后继续运行。
+
+  </Step>
+
+  <Step title="安装 Tailscale">
+    ```bash
+    curl -fsSL https://tailscale.com/install.sh | sh
+    sudo tailscale up --ssh --hostname=openclaw
+    ```
+
+    从现在起，通过 Tailscale 连接：`ssh ubuntu@openclaw`。
+
+  </Step>
+
+  <Step title="安装 OpenClaw">
+    ```bash
+    curl -fsSL https://openclaw.ai/install.sh | bash
+    source ~/.bashrc
+    ```
+
+    当提示“如何孵化您的机器人？”时，选择**稍后执行此操作**。
+
+  </Step>
+
+  <Step title="配置 Gateway">
+    使用令牌认证和 Tailscale Serve 进行安全的远程访问。
+
+    ```bash
+    openclaw config set gateway.bind loopback
+    openclaw config set gateway.auth.mode token
+    openclaw doctor --generate-gateway-token
+    openclaw config set gateway.tailscale.mode serve
+    openclaw config set gateway.trustedProxies '["127.0.0.1"]'
+
+    systemctl --user restart openclaw-gateway
+    ```
+
+  </Step>
+
+  <Step title="锁定 VCN 安全">
+    在网络边缘阻止除 Tailscale 之外的所有流量：
+
+    1. 在 OCI Console 中转到 **Networking > Virtual Cloud Networks**。
+    2. 点击您的 VCN，然后 **Security Lists > Default Security List**。
+    3. **删除**所有入口规则 except `0.0.0.0/0 UDP 41641` (Tailscale)。
+    4. 保留默认出口规则（允许所有出站）。
+
+    这会在网络边缘阻止端口 22 上的 SSH、HTTP、HTTPS 和其他所有内容。从现在开始，您只能通过 Tailscale 连接。
+
+  </Step>
+  <Step title="验证">
+    ```bash
+    openclaw --version
+    systemctl --user status openclaw-gateway
+    tailscale serve status
+    curl http://localhost:18789
+    ```
+
+    从 tailnet 上的任何设备访问 Control UI：
+
+    ```
+    https://openclaw.<tailnet-name>.ts.net/
+    ```
+
+    将 `<tailnet-name>` 替换为您的 tailnet 名称（可在 `tailscale status` 中查看）。
+
+  </Step>
+</Steps>
+
+## 后备：SSH 隧道
+
+如果 Tailscale Serve 不起作用，请从本地机器使用 SSH 隧道：
+
+```bash
+ssh -L 18789:127.0.0.1:18789 ubuntu@openclaw
+```
+
+然后打开 `http://localhost:18789`。
+
+## 故障排除
+
+**实例创建失败（“Out of capacity”）** — 免费层 ARM 实例很受欢迎。请尝试不同的可用性域或在非高峰时段重试。
+
+**Tailscale 无法连接** — 运行 `sudo tailscale up --ssh --hostname=openclaw --reset` 重新认证。
+
+**Gateway 无法启动** — 运行 `openclaw doctor --non-interactive` 并使用 `journalctl --user -u openclaw-gateway -n 50` 检查日志。
+
+**ARM 二进制问题** — 大多数 npm 包在 ARM64 上可以正常工作。对于原生二进制文件，请查找 `linux-arm64` 或 `aarch64` 版本。使用 `uname -m` 验证架构。
+
+## 后续步骤
+
+- [频道](/channels) — 连接 Telegram、WhatsApp、Discord 等
+- [Gateway 配置](/gateway/configuration) — 所有配置选项
+- [更新](/install/updating) — 保持 OpenClaw 最新

--- a/docs/zh-CN/providers/deepseek.md
+++ b/docs/zh-CN/providers/deepseek.md
@@ -1,0 +1,51 @@
+---
+summary: "DeepSeek 设置（认证 + 模型选择）"
+read_when:
+  - 您想将 DeepSeek 与 OpenClaw 一起使用
+  - 您需要 API 密钥环境变量或 CLI 认证选项
+---
+
+# DeepSeek
+
+[DeepSeek](https://www.deepseek.com) 提供强大的 AI 模型，具有 OpenAI 兼容的 API。
+
+- 提供商：`deepseek`
+- 认证：`DEEPSEEK_API_KEY`
+- API：OpenAI 兼容
+
+## 快速开始
+
+设置 API 密钥（推荐：为 Gateway 存储它）：
+
+```bash
+openclaw onboard --auth-choice deepseek-api-key
+```
+
+这将提示您输入 API 密钥并将 `deepseek/deepseek-chat` 设为默认模型。
+
+## 非交互示例
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice deepseek-api-key \
+  --deepseek-api-key "$DEEPSEEK_API_KEY" \
+  --skip-health \
+  --accept-risk
+```
+
+## 环境说明
+
+如果 Gateway 作为守护进程运行（launchd/systemd），请确保 `DEEPSEEK_API_KEY` 对该进程可用（例如，在 `~/.openclaw/.env` 中或通过 `env.shellEnv`）。
+
+## 可用模型
+
+| 模型 ID | 名称 | 类型 | 上下文 |
+| ------------------- | ------------------------ | --------- | ------- |
+| `deepseek-chat` | DeepSeek Chat (V3.2) | 通用 | 128K |
+| `deepseek-reasoner` | DeepSeek Reasoner (V3.2) | 推理 | 128K |
+
+- **deepseek-chat** 对应非思考模式下的 DeepSeek-V3.2。
+- **deepseek-reasoner** 对应思考模式下的 DeepSeek-V3.2，具有思维链推理。
+
+在 [platform.deepseek.com](https://platform.deepseek.com/api_keys) 获取您的 API 密钥。

--- a/docs/zh-CN/providers/google.md
+++ b/docs/zh-CN/providers/google.md
@@ -1,0 +1,72 @@
+---
+title: "Google (Gemini)"
+summary: "Google Gemini 设置（API 密钥 + OAuth、图像生成、媒体理解、网络搜索）"
+read_when:
+  - 您想将 Google Gemini 模型与 OpenClaw 一起使用
+  - 您需要 API 密钥或 OAuth 认证流程
+---
+
+# Google (Gemini)
+
+Google 插件通过 Google AI Studio 提供 Gemini 模型访问，以及图像生成、媒体理解（图像/音频/视频）和通过 Gemini Grounding 的网络搜索。
+
+- 提供商：`google`
+- 认证：`GEMINI_API_KEY` 或 `GOOGLE_API_KEY`
+- API：Google Gemini API
+- 替代提供商：`google-gemini-cli`（OAuth）
+
+## 快速开始
+
+1. 设置 API 密钥：
+
+```bash
+openclaw onboard --auth-choice google-api-key
+```
+
+2. 设置默认模型：
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "google/gemini-3.1-pro-preview" },
+    },
+  },
+}
+```
+
+## 非交互示例
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice google-api-key \
+  --gemini-api-key "$GEMINI_API_KEY"
+```
+
+## OAuth（Gemini CLI）
+
+替代提供商 `google-gemini-cli` 使用 PKCE OAuth 而不是 API 密钥。这是一个非官方集成；一些用户报告账户限制。使用风险自担。
+
+环境变量：
+
+- `OPENCLAW_GEMINI_OAUTH_CLIENT_ID`
+- `OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET`
+
+（或 `GEMINI_CLI_*` 变体。）
+
+## 功能
+
+| 功能 | 支持 |
+| ---------------------- | ----------------- |
+| 聊天补全 | 是 |
+| 图像生成 | 是 |
+| 图像理解 | 是 |
+| 音频转录 | 是 |
+| 视频理解 | 是 |
+| 网络搜索（Grounding） | 是 |
+| 思考/推理 | 是（Gemini 3.1+）|
+
+## 环境说明
+
+如果 Gateway 作为守护进程运行（launchd/systemd），请确保 `GEMINI_API_KEY` 对该进程可用（例如，在 `~/.openclaw/.env` 中或通过 `env.shellEnv`）。

--- a/docs/zh-CN/providers/groq.md
+++ b/docs/zh-CN/providers/groq.md
@@ -1,0 +1,88 @@
+---
+title: "Groq"
+summary: "Groq 设置（认证 + 模型选择）"
+read_when:
+  - 您想将 Groq 与 OpenClaw 一起使用
+  - 您需要 API 密钥环境变量或 CLI 认证选项
+---
+
+# Groq
+
+[Groq](https://groq.com) 在开源模型（Llama、Gemma、Mistral 等）上提供超快推理，使用定制的 LPU 硬件。OpenClaw 通过其 OpenAI 兼容 API 连接到 Groq。
+
+- 提供商：`groq`
+- 认证：`GROQ_API_KEY`
+- API：OpenAI 兼容
+
+## 快速开始
+
+1. 从 [console.groq.com/keys](https://console.groq.com/keys) 获取 API 密钥。
+
+2. 设置 API 密钥：
+
+```bash
+export GROQ_API_KEY="gsk_..."
+```
+
+3. 设置默认模型：
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "groq/llama-3.3-70b-versatile" },
+    },
+  },
+}
+```
+
+## 配置文件示例
+
+```json5
+{
+  env: { GROQ_API_KEY: "gsk_..." },
+  agents: {
+    defaults: {
+      model: { primary: "groq/llama-3.3-70b-versatile" },
+    },
+  },
+}
+```
+
+## 音频转录
+
+Groq 还提供快速的 Whisper 音频转录。当配置为媒体理解提供商时，OpenClaw 使用 Groq 的 `whisper-large-v3-turbo` 模型来转录语音消息。
+
+```json5
+{
+  media: {
+    understanding: {
+      audio: {
+        models: [{ provider: "groq" }],
+      },
+    },
+  },
+}
+```
+
+## 环境说明
+
+如果 Gateway 作为守护进程运行（launchd/systemd），请确保 `GROQ_API_KEY` 对该进程可用（例如，在 `~/.openclaw/.env` 中或通过 `env.shellEnv`）。
+
+## 可用模型
+
+Groq 的模型目录经常变化。运行 `openclaw models list | grep groq` 查看当前可用的模型，或查看 [console.groq.com/docs/models](https://console.groq.com/docs/models)。
+
+热门选择包括：
+
+- **Llama 3.3 70B Versatile** — 通用、大型上下文
+- **Llama 3.1 8B Instant** — 快速、轻量
+- **Gemma 2 9B** — 紧凑、高效
+- **Mixtral 8x7B** — MoE 架构、强推理
+
+## 链接
+
+- [Groq 控制台](https://console.groq.com)
+- [API 文档](https://console.groq.com/docs)
+- [模型列表](https://console.groq.com/docs/models)
+- [定价](https://groq.com/pricing)

--- a/docs/zh-CN/providers/perplexity-provider.md
+++ b/docs/zh-CN/providers/perplexity-provider.md
@@ -1,0 +1,58 @@
+---
+title: "Perplexity（提供商）"
+summary: "Perplexity 网络搜索提供商设置（API 密钥、搜索模式、过滤）"
+read_when:
+  - 您想将 Perplexity 配置为网络搜索提供商
+  - 您需要 Perplexity API 密钥或 OpenRouter 代理设置
+---
+
+# Perplexity（网络搜索提供商）
+
+Perplexity 插件通过 Perplexity Search API 或通过 OpenRouter 的 Perplexity Sonar 提供网络搜索功能。
+
+<Note>
+本页介绍 Perplexity **提供商**设置。对于 Perplexity **工具**（代理如何使用它），请参阅 [Perplexity 工具](/tools/perplexity-search)。
+</Note>
+
+- 类型：网络搜索提供商（不是模型提供商）
+- 认证：`PERPLEXITY_API_KEY`（直接）或 `OPENROUTER_API_KEY`（通过 OpenRouter）
+- 配置路径：`plugins.entries.perplexity.config.webSearch.apiKey`
+
+## 快速开始
+
+1. 设置 API 密钥：
+
+```bash
+openclaw configure --section web
+```
+
+或直接设置：
+
+```bash
+openclaw config set plugins.entries.perplexity.config.webSearch.apiKey "pplx-xxxxxxxxxxxx"
+```
+
+2. 配置后，代理将自动使用 Perplexity 进行网络搜索。
+
+## 搜索模式
+
+插件根据 API 密钥前缀自动选择传输方式：
+
+| 密钥前缀 | 传输方式 | 功能 |
+| ---------- | ---------------------------- | ------------------------------------------------ |
+| `pplx-` | 原生 Perplexity Search API | 结构化结果、域/语言/日期过滤 |
+| `sk-or-` | OpenRouter (Sonar) | 带引用的人工智能综合答案 |
+
+## 原生 API 过滤
+
+使用原生 Perplexity API（`pplx-` 密钥）时，搜索支持：
+
+- **国家**：2 字母国家代码
+- **语言**：ISO 639-1 语言代码
+- **日期范围**：天、周、月、年
+- **域过滤器**：允许/拒绝列表（最多 20 个域）
+- **内容预算**：`max_tokens`、`max_tokens_per_page`
+
+## 环境说明
+
+如果 Gateway 作为守护进程运行（launchd/systemd），请确保 `PERPLEXITY_API_KEY` 对该进程可用（例如，在 `~/.openclaw/.env` 中或通过 `env.shellEnv`）。

--- a/docs/zh-CN/providers/qwen_modelstudio.md
+++ b/docs/zh-CN/providers/qwen_modelstudio.md
@@ -1,0 +1,80 @@
+---
+title: "Qwen / Model Studio"
+summary: "阿里云 Model Studio 设置（标准按量付费和编码计划、双区域端点）"
+read_when:
+  - 您想将 Qwen（阿里云 Model Studio）与 OpenClaw 一起使用
+  - 您需要 Model Studio 的 API 密钥环境变量
+  - 您想使用 Standard（按量付费）或 Coding Plan 端点
+---
+
+# Qwen / Model Studio（阿里云）
+
+Model Studio 提供商提供对阿里云模型的访问，包括 Qwen 和托管在平台上的第三方模型。支持两种计费计划：**Standard**（按量付费）和 **Coding Plan**（订阅）。
+
+- 提供商：`modelstudio`
+- 认证：`MODELSTUDIO_API_KEY`
+- API：OpenAI 兼容
+
+## 快速开始
+
+### Standard（按量付费）
+
+```bash
+# 中国端点
+openclaw onboard --auth-choice modelstudio-standard-api-key-cn
+
+# 全球/国际端点
+openclaw onboard --auth-choice modelstudio-standard-api-key
+```
+
+### Coding Plan（订阅）
+
+```bash
+# 中国端点
+openclaw onboard --auth-choice modelstudio-api-key-cn
+
+# 全球/国际端点
+openclaw onboard --auth-choice modelstudio-api-key
+```
+
+引导后，设置默认模型：
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "modelstudio/qwen3.5-plus" },
+    },
+  },
+}
+```
+
+## 计划类型和端点
+
+| 计划 | 区域 | 认证选项 | 端点 |
+| -------------------------- | ------ | --------------------------------- | ------------------------------------------------ |
+| Standard（按量付费） | 中国 | `modelstudio-standard-api-key-cn` | `dashscope.aliyuncs.com/compatible-mode/v1` |
+| Standard（按量付费） | 全球 | `modelstudio-standard-api-key` | `dashscope-intl.aliyuncs.com/compatible-mode/v1` |
+| Coding Plan（订阅） | 中国 | `modelstudio-api-key-cn` | `coding.dashscope.aliyuncs.com/v1` |
+| Coding Plan（订阅） | 全球 | `modelstudio-api-key` | `coding-intl.dashscope.aliyuncs.com/v1` |
+
+提供商根据您的认证选择自动选择端点。您可以在配置中通过自定义 `baseUrl` 覆盖。
+
+## 获取您的 API 密钥
+
+- **中国**：[bailian.console.aliyun.com](https://bailian.console.aliyun.com/)
+- **全球/国际**：[modelstudio.console.alibabacloud.com](https://modelstudio.console.alibabacloud.com/)
+
+## 可用模型
+
+- **qwen3.5-plus**（默认）— Qwen 3.5 Plus
+- **qwen3-coder-plus**、**qwen3-coder-next** — Qwen 编码模型
+- **GLM-5** — 通过阿里云的 GLM 模型
+- **Kimi K2.5** — 通过阿里云的 Moonshot AI
+- **MiniMax-M2.5** — 通过阿里海的 MiniMax
+
+一些模型（qwen3.5-plus、kimi-k2.5）支持图像输入。上下文窗口范围从 200K 到 1M tokens。
+
+## 环境说明
+
+如果 Gateway 作为守护进程运行（launchd/systemd），请确保 `MODELSTUDIO_API_KEY` 对该进程可用（例如，在 `~/.openclaw/.env` 中或通过 `env.shellEnv`）。

--- a/docs/zh-CN/providers/vllm.md
+++ b/docs/zh-CN/providers/vllm.md
@@ -1,0 +1,92 @@
+---
+summary: "使用 vLLM（OpenAI 兼容本地服务器）运行 OpenClaw"
+read_when:
+  - 您想针对本地 vLLM 服务器运行 OpenClaw
+  - 您想要使用自己的模型的 OpenAI 兼容 /v1 端点
+title: "vLLM"
+---
+
+# vLLM
+
+vLLM 可以通过 **OpenAI 兼容** HTTP API 提供开源（和一些自定义）模型。OpenClaw 可以使用 `openai-completions` API 连接到 vLLM。
+
+当您选择加入 `VLLM_API_KEY`（如果您的服务器不强制认证，任何值都可以）且您未定义显式的 `models.providers.vllm` 条目时，OpenClaw 还可以**自动发现** vLLM 上可用的模型。
+
+## 快速开始
+
+1. 使用 OpenAI 兼容服务器启动 vLLM。
+
+您的基本 URL 应该暴露 `/v1` 端点（例如 `/v1/models`、`/v1/chat/completions`）。vLLM 通常运行在：
+
+- `http://127.0.0.1:8000/v1`
+
+2. 选择加入（如果没有配置认证，任何值都可以）：
+
+```bash
+export VLLM_API_KEY="vllm-local"
+```
+
+3. 选择一个模型（替换为您的 vLLM 模型 ID 之一）：
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "vllm/your-model-id" },
+    },
+  },
+}
+```
+
+## 模型发现（隐式提供商）
+
+当设置了 `VLLM_API_KEY`（或存在认证配置）且您**未**定义 `models.providers.vllm` 时，OpenClaw 将查询：
+
+- `GET http://127.0.0.1:8000/v1/models`
+
+…并将返回的 ID 转换为模型条目。
+
+如果您显式设置 `models.providers.vllm`，则跳过自动发现，您必须手动定义模型。
+
+## 显式配置（手动模型）
+
+在以下情况下使用显式配置：
+
+- vLLM 在不同的主机/端口上运行。
+- 您想要固定 `contextWindow`/`maxTokens` 值。
+- 您的服务器需要真正的 API 密钥（或您想要控制头部）。
+
+```json5
+{
+  models: {
+    providers: {
+      vllm: {
+        baseUrl: "http://127.0.0.1:8000/v1",
+        apiKey: "${VLLM_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "your-model-id",
+            name: "本地 vLLM 模型",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+## 故障排除
+
+- 检查服务器是否可达：
+
+```bash
+curl http://127.0.0.1:8000/v1/models
+```
+
+- 如果请求因认证错误失败，请设置与您的服务器配置匹配的真正 `VLLM_API_KEY`，或在 `models.providers.vllm` 下显式配置提供商。

--- a/docs/zh-CN/providers/volcengine.md
+++ b/docs/zh-CN/providers/volcengine.md
@@ -1,0 +1,68 @@
+---
+title: "Volcengine (Doubao)"
+summary: "火山引擎设置（Doubao 模型、通用和编码端点）"
+read_when:
+  - 您想将火山引擎或 Doubao 模型与 OpenClaw 一起使用
+  - 您需要 Volcengine API 密钥设置
+---
+
+# Volcengine (Doubao)
+
+Volcengine 提供商提供对 Doubao 模型和托管在火山引擎上的第三方模型的访问，通用和编码工作负载使用单独的端点。
+
+- 提供商：`volcengine`（通用）+ `volcengine-plan`（编码）
+- 认证：`VOLCANO_ENGINE_API_KEY`
+- API：OpenAI 兼容
+
+## 快速开始
+
+1. 设置 API 密钥：
+
+```bash
+openclaw onboard --auth-choice volcengine-api-key
+```
+
+2. 设置默认模型：
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "volcengine-plan/ark-code-latest" },
+    },
+  },
+}
+```
+
+## 非交互示例
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice volcengine-api-key \
+  --volcengine-api-key "$VOLCANO_ENGINE_API_KEY"
+```
+
+## 提供商和端点
+
+| 提供商 | 端点 | 用例 |
+| ----------------- | ----------------------------------------- | -------------- |
+| `volcengine` | `ark.cn-beijing.volces.com/api/v3` | 通用模型 |
+| `volcengine-plan` | `ark.cn-beijing.volces.com/api/coding/v3` | 编码模型 |
+
+两个提供商都使用单个 API 密钥配置。设置会自动注册两者。
+
+## 可用模型
+
+- **doubao-seed-1-8** — Doubao Seed 1.8（通用，默认）
+- **doubao-seed-code-preview** — Doubao 编码模型
+- **ark-code-latest** — 编码计划默认
+- **Kimi K2.5** — 通过火山引擎的 Moonshot AI
+- **GLM-4.7** — 通过火山引擎的 GLM
+- **DeepSeek V3.2** — 通过火山引擎的 DeepSeek
+
+大多数模型支持文本 + 图像输入。上下文窗口范围从 128K 到 256K tokens。
+
+## 环境说明
+
+如果 Gateway 作为守护进程运行（launchd/systemd），请确保 `VOLCANO_ENGINE_API_KEY` 对该进程可用（例如，在 `~/.openclaw/.env` 中或通过 `env.shellEnv`）。

--- a/docs/zh-CN/providers/xai.md
+++ b/docs/zh-CN/providers/xai.md
@@ -1,0 +1,59 @@
+---
+summary: "在 OpenClaw 中使用 xAI Grok 模型"
+read_when:
+  - 您想在 OpenClaw 中使用 Grok 模型
+  - 您正在配置 xAI 认证或模型 ID
+title: "xAI"
+---
+
+# xAI
+
+OpenClaw 捆绑了用于 Grok 模型的 `xai` 提供商插件。
+
+## 设置
+
+1. 在 xAI 控制台创建 API 密钥。
+2. 设置 `XAI_API_KEY`，或运行：
+
+```bash
+openclaw onboard --auth-choice xai-api-key
+```
+
+3. 选择一个模型，例如：
+
+```json5
+{
+  agents: { defaults: { model: { primary: "xai/grok-4" } } },
+}
+```
+
+## 当前捆绑的模型目录
+
+OpenClaw 现已开箱即用地包含以下 xAI 模型系列：
+
+- `grok-4`、`grok-4-0709`
+- `grok-4-fast-reasoning`、`grok-4-fast-non-reasoning`
+- `grok-4-1-fast-reasoning`、`grok-4-1-fast-non-reasoning`
+- `grok-4.20-reasoning`、`grok-4.20-non-reasoning`
+- `grok-code-fast-1`
+
+插件还会在遵循相同 API 形状时向前解析较新的 `grok-4*` 和 `grok-code-fast*` ID。
+
+## 网络搜索
+
+捆绑的 `grok` 网络搜索提供商也使用 `XAI_API_KEY`：
+
+```bash
+openclaw config set tools.web.search.provider grok
+```
+
+## 已知限制
+
+- 认证目前仅支持 API 密钥。OpenClaw 尚不支持 xAI OAuth/设备代码流程。
+- `grok-4.20-multi-agent-experimental-beta-0304` 不支持正常的 xAI 提供商路径，因为它需要与标准 OpenClaw xAI 传输不同的上游 API 表面。
+- 原生 xAI 服务器端工具（如 `x_search` 和 `code_execution`）还不是捆绑插件中的一等模型提供商功能。
+
+## 备注
+
+- OpenClaw 在共享运行器路径上自动应用 xAI 特定的工具模式和工具调用兼容性修复。
+- 有关更广泛的提供商概述，请参阅 [模型提供商](/providers/index)。


### PR DESCRIPTION
## Description

This PR adds Chinese translations for four installation guide documents.

## Changes

- **docs/zh-CN/install/digitalocean.md**: DigitalOcean Droplet 部署指南 (+89 行)
- **docs/zh-CN/install/docker-vm-runtime.md**: Docker VM 运行时步骤 (+102 行)
- **docs/zh-CN/install/kubernetes.md**: 使用 Kustomize 的 Kubernetes 部署 (+142 行)
- **docs/zh-CN/install/oracle.md**: Oracle Cloud Always Free ARM 层 (+110 行)

## Motivation

Continue improving Chinese documentation coverage for OpenClaw project. These installation guides help Chinese-speaking users deploy OpenClaw on various platforms.

## Stats

- Files changed: 4
- Lines added: 617