### PR TITLE
fix(loop-detection): escalate generic_repeat to critical at criticalThreshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/loop detection: require no-progress evidence before generic repeated tool calls escalate from warning to critical blocking, so legitimate repeated calls with changing output can continue. Fixes #54559; refs #60111, #60248, and #70546. Thanks @jwchmodx.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -67,9 +67,9 @@ Per-agent override (optional):
 - `enabled`: Master switch. `false` means no loop detection is performed.
 - `historySize`: number of recent tool calls kept for analysis.
 - `warningThreshold`: threshold before classifying a pattern as warning-only.
-- `criticalThreshold`: threshold for blocking repetitive loop patterns.
+- `criticalThreshold`: threshold for blocking repetitive loop patterns once no-progress evidence is present.
 - `globalCircuitBreakerThreshold`: global no-progress breaker threshold.
-- `detectors.genericRepeat`: detects repeated same-tool + same-params patterns.
+- `detectors.genericRepeat`: detects repeated same-tool + same-params patterns. It warns on repeated arguments and escalates to critical only when the repeated calls also produce identical outcomes.
 - `detectors.knownPollNoProgress`: detects known polling-like patterns with no state change.
 - `detectors.pingPong`: detects alternating ping-pong patterns.
 

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -380,7 +380,7 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("keeps generic loops warn-only below global breaker threshold", () => {
+    it("escalates generic repeat loops to critical at criticalThreshold", () => {
       const fixture = createReadNoProgressFixture();
       const loopResult = detectLoopAfterRepeatedCalls({
         toolName: fixture.toolName,
@@ -390,7 +390,9 @@ describe("tool-loop-detection", () => {
       });
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
-        expect(loopResult.level).toBe("warning");
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("generic_repeat");
+        expect(loopResult.message).toContain("CRITICAL");
       }
     });
 

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -396,6 +396,32 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("does not escalate generic repeats to critical when outcomes are progressing", () => {
+      const state = createState();
+      const params = { path: "/same.txt" };
+
+      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
+        recordSuccessfulCall(
+          state,
+          "read",
+          params,
+          {
+            content: [{ type: "text", text: `changed output ${index}` }],
+            details: { ok: true },
+          },
+          index,
+        );
+      }
+
+      const loopResult = detectToolCallLoop(state, "read", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+        expect(loopResult.detector).toBe("generic_repeat");
+        expect(loopResult.count).toBe(CRITICAL_THRESHOLD);
+      }
+    });
+
     it("applies custom thresholds when detection is enabled", () => {
       const state = createState();
       const { params, result } = createNoProgressPollFixture("sess-custom");

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -609,10 +609,28 @@ export function detectToolCallLoop(
     };
   }
 
-  // Generic detector: warn-only for repeated identical calls.
+  // Generic detector: warn then block for repeated identical calls.
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
   ).length;
+
+  if (
+    !knownPollTool &&
+    resolvedConfig.detectors.genericRepeat &&
+    recentCount >= resolvedConfig.criticalThreshold
+  ) {
+    log.error(
+      `Critical loop detected: ${toolName} called ${recentCount} times with identical arguments`,
+    );
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "generic_repeat",
+      count: recentCount,
+      message: `CRITICAL: You have called ${toolName} ${recentCount} times with identical arguments and are making no progress. Session execution blocked to prevent runaway loops.`,
+      warningKey: `generic:${toolName}:${currentHash}`,
+    };
+  }
 
   if (
     !knownPollTool &&

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -609,7 +609,7 @@ export function detectToolCallLoop(
     };
   }
 
-  // Generic detector: warn then block for repeated identical calls.
+  // Generic detector: warn on repeated identical calls, but block only with no-progress evidence.
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
   ).length;
@@ -617,18 +617,18 @@ export function detectToolCallLoop(
   if (
     !knownPollTool &&
     resolvedConfig.detectors.genericRepeat &&
-    recentCount >= resolvedConfig.criticalThreshold
+    noProgressStreak >= resolvedConfig.criticalThreshold
   ) {
     log.error(
-      `Critical loop detected: ${toolName} called ${recentCount} times with identical arguments`,
+      `Critical loop detected: ${toolName} repeated ${noProgressStreak} times with no progress`,
     );
     return {
       stuck: true,
       level: "critical",
       detector: "generic_repeat",
-      count: recentCount,
-      message: `CRITICAL: You have called ${toolName} ${recentCount} times with identical arguments and are making no progress. Session execution blocked to prevent runaway loops.`,
-      warningKey: `generic:${toolName}:${currentHash}`,
+      count: noProgressStreak,
+      message: `CRITICAL: You have called ${toolName} ${noProgressStreak} times with identical arguments and identical outcomes. Session execution blocked to prevent runaway loops.`,
+      warningKey: `generic:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes #60111.

The `generic_repeat` detector only checked `warningThreshold` and always returned `level: "warning"`, making `criticalThreshold` a no-op for the most common runaway loop pattern (same tool, same arguments, repeated calls).

- Added a `criticalThreshold` check in the `generic_repeat` code path, before the existing `warningThreshold` check
- Updated the test that was asserting the broken warn-only behavior to assert the correct critical escalation

This makes `generic_repeat` consistent with `known_poll_no_progress` and `ping_pong`, which both escalate to `"critical"` at `criticalThreshold`.

| Detector | warningThreshold | criticalThreshold |
|---|---|---|
| `known_poll_no_progress` | ⚠️ Warns | ✅ Blocks |
| `ping_pong` | ⚠️ Warns | ✅ Blocks (with noProgressEvidence) |
| `generic_repeat` (before) | ⚠️ Warns | ❌ Not checked |
| `generic_repeat` (after) | ⚠️ Warns | ✅ Blocks |

## Test plan
- [x] Existing 29 tests pass
- [x] Updated test now asserts `level: "critical"` and `detector: "generic_repeat"` at `criticalThreshold`

🤖 Generated with [Claude Code](https://claude.com/claude-code)