### PR TITLE
fix(minimax): invert usage_percent when no count fields are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Usage/MiniMax: invert remaining-style `usage_percent` fields when MiniMax reports only remaining percentage data, so usage bars stop showing nearly-full remaining quota as nearly-exhausted usage. (#60254) Thanks @jwchmodx.
 - MiniMax: advertise image input on bundled `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` model definitions so image-capable flows can route through the M2.7 family correctly. (#54843) Thanks @MerlinMiao88888888.
 - Agents/exec approvals: let `exec-approvals.json` agent security override stricter gateway tool defaults so approved subagents can use `security: "full"` without falling back to allowlist enforcement again. (#60310) Thanks @lml2468.
 - Tasks/maintenance: mark stale cron runs and CLI tasks backed only by long-lived chat sessions as lost again so task cleanup does not keep dead work alive indefinitely. (#60310) Thanks @lml2468.

--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -131,6 +131,19 @@ describe("fetchMinimaxUsage", () => {
       },
     },
     {
+      name: "inverts usage_percent when no count fields are present (remaining to used)",
+      payload: {
+        data: {
+          usage_percent: 98,
+          plan_name: "Coding Plan",
+        },
+      },
+      expected: {
+        plan: "Coding Plan",
+        windows: [{ label: "5h", usedPercent: 2, resetAt: undefined }],
+      },
+    },
+    {
       name: "falls back to payload-level reset and plan when nested usage records omit them",
       payload: {
         data: {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -40,8 +40,6 @@ const RESET_KEYS = [
 const PERCENT_KEYS = [
   "used_percent",
   "usedPercent",
-  "usage_percent",
-  "usagePercent",
   "used_rate",
   "usage_rate",
   "used_ratio",
@@ -49,6 +47,11 @@ const PERCENT_KEYS = [
   "usedRatio",
   "usageRatio",
 ] as const;
+
+// MiniMax's usage_percent / usagePercent fields report the remaining quota
+// as a percentage, not the consumed quota. Treat them as "remaining percent"
+// and invert to get usedPercent. Count-based fromCounts always takes priority.
+const REMAINING_PERCENT_KEYS = ["usage_percent", "usagePercent"] as const;
 
 const USED_KEYS = [
   "used",
@@ -289,17 +292,27 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
       ? clampPercent((used / total) * 100)
       : null;
 
-  const percentRaw = pickNumber(payload, PERCENT_KEYS);
-  if (percentRaw !== undefined) {
-    const normalized = clampPercent(percentRaw <= 1 ? percentRaw * 100 : percentRaw);
-    if (fromCounts !== null) {
-      // Count-derived usage is more stable across provider percent field variations.
-      return fromCounts;
-    }
-    return normalized;
+  // Count-derived usage is more stable across provider percent field variations.
+  if (fromCounts !== null) {
+    return fromCounts;
   }
 
-  return fromCounts;
+  const percentRaw = pickNumber(payload, PERCENT_KEYS);
+  if (percentRaw !== undefined) {
+    return clampPercent(percentRaw <= 1 ? percentRaw * 100 : percentRaw);
+  }
+
+  // usage_percent / usagePercent in MiniMax's API represents remaining quota,
+  // not consumed quota. Invert to get usedPercent.
+  const remainingPercentRaw = pickNumber(payload, REMAINING_PERCENT_KEYS);
+  if (remainingPercentRaw !== undefined) {
+    const remainingNormalized = clampPercent(
+      remainingPercentRaw <= 1 ? remainingPercentRaw * 100 : remainingPercentRaw,
+    );
+    return clampPercent(100 - remainingNormalized);
+  }
+
+  return null;
 }
 
 export async function fetchMinimaxUsage(


### PR DESCRIPTION
## Summary

Fixes #60193.

MiniMax's `usage_percent` / `usagePercent` fields report the **remaining** quota as a percentage, not the consumed quota. This is evidenced by the existing test named *"prefers count-based usage when percent looks inverted"*: when `prompt_remain: 150` and `prompt_limit: 200` are present alongside `usage_percent: 75`, the correct answer is `usedPercent: 25` (75% remaining → 25% used).

When count fields are present, `fromCounts` already overrides the inverted value — so the bug was silent. When the API returns **only** `usage_percent` (no count fields), `fromCounts` is `null`, and the remaining-percent value was passed through unchanged as if it were a used-percent, causing the menu bar to show **"2% left" instead of "98% left"**.

### Fix

- Moves `usage_percent` / `usagePercent` from `PERCENT_KEYS` to a new `REMAINING_PERCENT_KEYS` array (local to the MiniMax fetcher, no other provider is affected)
- `deriveUsedPercent` now inverts remaining-percent values: `usedPercent = 100 − remainingPercent`
- `fromCounts` still takes priority over both key groups

## Test plan
- [x] 22/22 tests pass (`provider-usage.fetch.minimax.test.ts`, `provider-usage.test.ts`)
- [x] New test: `usage_percent: 98` alone → `usedPercent: 2` (the exact bug scenario)
- [x] Existing "prefers count-based when percent looks inverted" test unchanged — `fromCounts` still wins when count fields are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)