### PR TITLE
fix: clear stale ClawHub query results on input change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Skills/uv install: block workspace `.env` from overriding `UV_PYTHON` and strip related interpreter override keys from uv skill-install subprocesses so repository-controlled env files cannot steer the selected Python runtime. (#59178) Thanks @pgondhi987.
+- Control UI/skills: clear stale ClawHub results immediately when the search query changes, so debounced searches cannot keep outdated install targets visible. Related #60134.
 - Telegram/reactions: preserve `reactionNotifications: "own"` across gateway restarts by persisting sent-message ownership state instead of treating cold cache as a permissive fallback. (#59207) Thanks @samzong.
 - Gateway/startup: detect PID recycling in gateway lock files on Windows and macOS, and add startup progress so stale lock conflicts no longer block healthy restarts. (#59843) Thanks @TonyDerek-dot.
 - MS Teams/DM media: download inline images in 1:1 chats via Graph API so Teams DM image attachments stop failing to load. (#52212) Thanks @Ted-developer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Skills/uv install: block workspace `.env` from overriding `UV_PYTHON` and strip related interpreter override keys from uv skill-install subprocesses so repository-controlled env files cannot steer the selected Python runtime. (#59178) Thanks @pgondhi987.
-- Control UI/skills: clear stale ClawHub results immediately when the search query changes, so debounced searches cannot keep outdated install targets visible. Related #60134.
 - Telegram/reactions: preserve `reactionNotifications: "own"` across gateway restarts by persisting sent-message ownership state instead of treating cold cache as a permissive fallback. (#59207) Thanks @samzong.
 - Gateway/startup: detect PID recycling in gateway lock files on Windows and macOS, and add startup progress so stale lock conflicts no longer block healthy restarts. (#59843) Thanks @TonyDerek-dot.
 - MS Teams/DM media: download inline images in 1:1 chats via Graph API so Teams DM image attachments stop failing to load. (#52212) Thanks @Ted-developer.
@@ -69,6 +68,7 @@ Docs: https://docs.openclaw.ai
 - Mobile pairing/bootstrap: keep setup bootstrap tokens alive through the initial node auto-pair so the same QR bootstrap token can finish operator approval, then revoke it after the full issued profile connects successfully. (#60221) Thanks @obviyus.
 - Plugins/allowlists: let explicit bundled chat channel enablement bypass `plugins.allow`, while keeping auto-enabled channel activation and startup sidecars behind restrictive allowlists. (#60233) Thanks @dorukardahan.
 - Allowlist/commands: require owner access for `/allowlist add` and `/allowlist remove` so command-authorized non-owners cannot mutate persisted allowlists. (#59836) Thanks @eleqtrizit.
+- Control UI/skills: clear stale ClawHub results immediately when the search query changes, so debounced searches cannot keep outdated install targets visible. Related #60134.
 
 ## 2026.4.2
 

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -87,6 +87,7 @@ import {
   loadSkills,
   saveSkillApiKey,
   searchClawHub,
+  setClawHubSearchQuery,
   updateSkillEdit,
   updateSkillEnabled,
 } from "./controllers/skills.ts";
@@ -1340,8 +1341,7 @@ export function renderApp(state: AppViewState) {
                 onDetailOpen: (key) => (state.skillsDetailKey = key),
                 onDetailClose: () => (state.skillsDetailKey = null),
                 onClawHubQueryChange: (query) => {
-                  state.clawhubSearchQuery = query;
-                  state.clawhubInstallMessage = null;
+                  setClawHubSearchQuery(state, query);
                   if (clawhubSearchTimer) {
                     clearTimeout(clawhubSearchTimer);
                   }

--- a/ui/src/ui/controllers/skills.test.ts
+++ b/ui/src/ui/controllers/skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { searchClawHub, type SkillsState } from "./skills.ts";
+import { searchClawHub, setClawHubSearchQuery, type SkillsState } from "./skills.ts";
 
 function createState(): { state: SkillsState; request: ReturnType<typeof vi.fn> } {
   const request = vi.fn();
@@ -37,6 +37,21 @@ function createState(): { state: SkillsState; request: ReturnType<typeof vi.fn> 
 }
 
 describe("searchClawHub", () => {
+  it("clears stale query state immediately when the input changes", () => {
+    const { state } = createState();
+
+    state.clawhubSearchLoading = true;
+    state.clawhubInstallMessage = { kind: "success", text: "Installed github" };
+
+    setClawHubSearchQuery(state, "github app");
+
+    expect(state.clawhubSearchQuery).toBe("github app");
+    expect(state.clawhubSearchResults).toBeNull();
+    expect(state.clawhubSearchError).toBeNull();
+    expect(state.clawhubSearchLoading).toBe(false);
+    expect(state.clawhubInstallMessage).toBeNull();
+  });
+
   it("clears stale results as soon as a new search starts", async () => {
     const { state, request } = createState();
     type SearchResponse = { results: SkillsState["clawhubSearchResults"] };

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -87,6 +87,14 @@ function getErrorMessage(err: unknown) {
   return String(err);
 }
 
+export function setClawHubSearchQuery(state: SkillsState, query: string) {
+  state.clawhubSearchQuery = query;
+  state.clawhubInstallMessage = null;
+  state.clawhubSearchResults = null;
+  state.clawhubSearchError = null;
+  state.clawhubSearchLoading = false;
+}
+
 export async function loadSkills(state: SkillsState, options?: LoadSkillsOptions) {
   if (options?.clearMessages && Object.keys(state.skillMessages).length > 0) {
     state.skillMessages = {};


### PR DESCRIPTION
## Summary
- clear stale ClawHub search state immediately when the query input changes
- keep the debounce timer for the actual network request, but stop showing/installing rows from the previous query during that window
- add a regression test for the immediate query-change reset and document the user-visible fix in the changelog

## Why
PR #60134 already fixed stale results once `searchClawHub()` starts, but the debounce path in `onClawHubQueryChange` still left the previous result list visible for 300ms. That meant users could still click or install an outdated row before the next search request began.

Follow-up for #60134.

## Verification
- `pnpm exec vitest run ui/src/ui/controllers/skills.test.ts ui/src/ui/views/skills.test.ts`
- `pnpm build`
- `pnpm check`
