### PR TITLE
fix(test): default local Vitest to one worker

### DIFF
--- a/test/vitest-config.test.ts
+++ b/test/vitest-config.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import baseConfig, { resolveLocalVitestMaxWorkers } from "../vitest.config.ts";
 
 describe("resolveLocalVitestMaxWorkers", () => {
-  it("derives a moderate local cap for 64 GiB hosts", () => {
+  it("defaults local runs to a single worker even on larger hosts", () => {
     expect(
       resolveLocalVitestMaxWorkers(
         {
@@ -13,7 +13,7 @@ describe("resolveLocalVitestMaxWorkers", () => {
           totalMemoryBytes: 64 * 1024 ** 3,
         },
       ),
-    ).toBe(4);
+    ).toBe(1);
   });
 
   it("lets OPENCLAW_VITEST_MAX_WORKERS override the inferred cap", () => {
@@ -45,7 +45,7 @@ describe("resolveLocalVitestMaxWorkers", () => {
     ).toBe(3);
   });
 
-  it("keeps memory-constrained hosts conservative", () => {
+  it("keeps memory-constrained hosts on the same single-worker default", () => {
     expect(
       resolveLocalVitestMaxWorkers(
         {},
@@ -54,10 +54,10 @@ describe("resolveLocalVitestMaxWorkers", () => {
           totalMemoryBytes: 16 * 1024 ** 3,
         },
       ),
-    ).toBe(2);
+    ).toBe(1);
   });
 
-  it("lets roomy hosts use a higher default cap", () => {
+  it("keeps roomy hosts on the same single-worker default", () => {
     expect(
       resolveLocalVitestMaxWorkers(
         {},
@@ -66,7 +66,7 @@ describe("resolveLocalVitestMaxWorkers", () => {
           totalMemoryBytes: 128 * 1024 ** 3,
         },
       ),
-    ).toBe(6);
+    ).toBe(1);
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,3 @@
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
@@ -16,27 +15,12 @@ function parsePositiveInt(value) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }
 
-export function resolveLocalVitestMaxWorkers(
-  env = process.env,
-  system = {
-    cpuCount: os.cpus().length || 1,
-    totalMemoryBytes: os.totalmem(),
-  },
-) {
+export function resolveLocalVitestMaxWorkers(env = process.env, _system = undefined) {
   const override = parsePositiveInt(env.OPENCLAW_VITEST_MAX_WORKERS ?? env.OPENCLAW_TEST_WORKERS);
   if (override !== null) {
     return clamp(override, 1, 16);
   }
-
-  const cpuCount = Math.max(1, system.cpuCount || 1);
-  const memoryGiB = (system.totalMemoryBytes || 0) / 1024 ** 3;
-  let workers = cpuCount >= 16 ? 6 : cpuCount >= 10 ? 4 : cpuCount >= 6 ? 3 : 2;
-  if (memoryGiB < 24) {
-    workers = Math.min(workers, 2);
-  } else if (memoryGiB < 48) {
-    workers = Math.min(workers, 3);
-  }
-  return clamp(workers, 1, 16);
+  return 1;
 }
 
 const repoRoot = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary

- Problem: local `pnpm test` still defaulted to dynamic multi-worker Vitest sizing even after local heavy-check serialization landed.
- Why it matters: the lock prevents overlapping local runs across sessions, but each individual local run can still burst CPU/RAM harder than desired.
- What changed: default local `resolveLocalVitestMaxWorkers` now returns `1`, while explicit env overrides still win.
- What did NOT change (scope boundary): CI worker policy, fork pool choice, and the `OPENCLAW_VITEST_MAX_WORKERS` / `OPENCLAW_TEST_WORKERS` override path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #60273
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: local worker selection still scaled by host CPU/RAM, so a single local run could stay wider than desired.
- Missing detection / guardrail: no explicit local-default policy that separates "local defaults" from CI and env override behavior.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `#60273` serialized local heavy checks across sessions, but intentionally did not change per-run local Vitest workers.
- Why this regressed now: more concurrent local agent usage exposed that admission control alone was not the whole fix.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/vitest-config.test.ts`
- Scenario the test should lock in: local defaults stay at `1` worker while explicit env overrides still work.
- Why this is the smallest reliable guardrail: the policy lives in `resolveLocalVitestMaxWorkers` and does not need a broader integration harness.
- Existing test that already covers this (if any): the same file covered prior dynamic behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Local `pnpm test` now defaults to one Vitest worker unless an explicit worker override env var is set.

## Diagram (if applicable)

```text
Before:
[local pnpm test] -> [dynamic local worker count based on host size]

After:
[local pnpm test] -> [1 worker by default]
[explicit env override] -> [requested worker count]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `OPENCLAW_LOCAL_CHECK=0` for the verification run only, to avoid waiting on another live local test lock holder

### Steps

1. Run `pnpm test -- test/vitest-config.test.ts` locally.
2. Inspect the default worker policy and override behavior.

### Expected

- Local default resolves to `1`.
- `OPENCLAW_VITEST_MAX_WORKERS` and `OPENCLAW_TEST_WORKERS` still override it.

### Actual

- The targeted test file passes with the new local-default behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test -- test/vitest-config.test.ts`; direct import sanity check for default and override behavior.
- Edge cases checked: legacy `OPENCLAW_TEST_WORKERS` override still honored.
- What you did **not** verify: broader suite impact beyond the targeted config test.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: local developers who relied on automatic multi-worker local runs may see slower default test throughput.
  - Mitigation: explicit worker override env vars still work, and CI remains unchanged.
