### PR TITLE
fix(matrix): surface user-visible 'too large' marker when Matrix media exceeds size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,10 @@ Docs: https://docs.openclaw.ai
 - Agents/workspace: respect `agents.defaults.workspace` for non-default agents by resolving them under the configured base path instead of falling back to `workspace-<id>`. (#59858) Thanks @joelnishanth.
 - Config/All Settings: keep the raw config view intact when sensitive fields are blank instead of corrupting or dropping the snapshot during redaction. (#28214) thanks @solodmd.
 - Plugins/runtime: honor explicit capability allowlists during fallback speech, media-understanding, and image-generation provider loading so bundled capability plugins do not bypass restrictive `plugins.allow` config. (#52262) Thanks @PerfectPan.
+<<<<<<< HEAD
+- Matrix/media: surface a dedicated `[matrix <kind> attachment too large]` marker for oversized inbound media instead of the generic unavailable marker, and classify size-limit failures with a typed Matrix error. (#60289) Thanks @efe-arv.
 - Hooks/tool policy: block tool calls when a `before_tool_call` hook crashes so hook failures fail closed instead of silently allowing execution. (#59822) Thanks @pgondhi987.
+- Matrix/media: surface a dedicated `[matrix <kind> attachment too large]` marker for oversized inbound media instead of the generic unavailable marker, and classify size-limit failures with a typed Matrix error. (#60289) Thanks @efe-arv.
 
 ## 2026.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,6 @@ Docs: https://docs.openclaw.ai
 - Agents/workspace: respect `agents.defaults.workspace` for non-default agents by resolving them under the configured base path instead of falling back to `workspace-<id>`. (#59858) Thanks @joelnishanth.
 - Config/All Settings: keep the raw config view intact when sensitive fields are blank instead of corrupting or dropping the snapshot during redaction. (#28214) thanks @solodmd.
 - Plugins/runtime: honor explicit capability allowlists during fallback speech, media-understanding, and image-generation provider loading so bundled capability plugins do not bypass restrictive `plugins.allow` config. (#52262) Thanks @PerfectPan.
-<<<<<<< HEAD
-- Matrix/media: surface a dedicated `[matrix <kind> attachment too large]` marker for oversized inbound media instead of the generic unavailable marker, and classify size-limit failures with a typed Matrix error. (#60289) Thanks @efe-arv.
 - Hooks/tool policy: block tool calls when a `before_tool_call` hook crashes so hook failures fail closed instead of silently allowing execution. (#59822) Thanks @pgondhi987.
 - Matrix/media: surface a dedicated `[matrix <kind> attachment too large]` marker for oversized inbound media instead of the generic unavailable marker, and classify size-limit failures with a typed Matrix error. (#60289) Thanks @efe-arv.
 

--- a/extensions/matrix/src/matrix/media-errors.ts
+++ b/extensions/matrix/src/matrix/media-errors.ts
@@ -1,0 +1,20 @@
+export const MATRIX_MEDIA_SIZE_LIMIT_ERROR_MESSAGE = "Matrix media exceeds configured size limit";
+
+export class MatrixMediaSizeLimitError extends Error {
+  readonly code = "MATRIX_MEDIA_SIZE_LIMIT" as const;
+
+  constructor(message = MATRIX_MEDIA_SIZE_LIMIT_ERROR_MESSAGE, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "MatrixMediaSizeLimitError";
+  }
+}
+
+export function isMatrixMediaSizeLimitError(err: unknown): err is MatrixMediaSizeLimitError {
+  if (err instanceof MatrixMediaSizeLimitError) {
+    return true;
+  }
+  if (!(err instanceof Error) || err.cause === undefined) {
+    return false;
+  }
+  return isMatrixMediaSizeLimitError(err.cause);
+}

--- a/extensions/matrix/src/matrix/media-text.ts
+++ b/extensions/matrix/src/matrix/media-text.ts
@@ -26,9 +26,13 @@ function resolveMatrixMediaLabel(
 
 function formatMatrixAttachmentMarker(params: {
   kind?: MatrixMessageAttachmentKind;
+  tooLarge?: boolean;
   unavailable?: boolean;
 }): string {
   const label = resolveMatrixMediaLabel(params.kind);
+  if (params.tooLarge) {
+    return `[matrix ${label} too large]`;
+  }
   return params.unavailable ? `[matrix ${label} unavailable]` : `[matrix ${label}]`;
 }
 
@@ -96,6 +100,7 @@ export function resolveMatrixMessageBody(params: {
 
 export function formatMatrixAttachmentText(params: {
   attachment?: MatrixMessageAttachmentSummary;
+  tooLarge?: boolean;
   unavailable?: boolean;
 }): string | undefined {
   if (!params.attachment) {
@@ -103,6 +108,7 @@ export function formatMatrixAttachmentText(params: {
   }
   return formatMatrixAttachmentMarker({
     kind: params.attachment.kind,
+    tooLarge: params.tooLarge,
     unavailable: params.unavailable,
   });
 }
@@ -110,11 +116,13 @@ export function formatMatrixAttachmentText(params: {
 export function formatMatrixMessageText(params: {
   body?: string;
   attachment?: MatrixMessageAttachmentSummary;
+  tooLarge?: boolean;
   unavailable?: boolean;
 }): string | undefined {
   const body = params.body?.trim() ?? "";
   const marker = formatMatrixAttachmentText({
     attachment: params.attachment,
+    tooLarge: params.tooLarge,
     unavailable: params.unavailable,
   });
   if (!marker) {
@@ -151,10 +159,11 @@ export function formatMatrixMediaTooLargeText(params: {
   filename?: string;
   msgtype?: string;
 }): string {
-  const kind = resolveMatrixMediaKind(params.msgtype);
-  const label = resolveMatrixMediaLabel(kind ?? undefined);
-  const marker = `[matrix ${label} too large]`;
-  const caption = resolveMatrixMessageBody(params)?.trim() ?? "";
-  if (!caption) return marker;
-  return `${caption}\n\n${marker}`;
+  return (
+    formatMatrixMessageText({
+      body: resolveMatrixMessageBody(params),
+      attachment: resolveMatrixMessageAttachment(params),
+      tooLarge: true,
+    }) ?? ""
+  );
 }

--- a/extensions/matrix/src/matrix/media-text.ts
+++ b/extensions/matrix/src/matrix/media-text.ts
@@ -145,3 +145,16 @@ export function formatMatrixMediaUnavailableText(params: {
     }) ?? ""
   );
 }
+
+export function formatMatrixMediaTooLargeText(params: {
+  body?: string;
+  filename?: string;
+  msgtype?: string;
+}): string {
+  const kind = resolveMatrixMediaKind(params.msgtype);
+  const label = resolveMatrixMediaLabel(kind ?? undefined);
+  const marker = `[matrix ${label} too large]`;
+  const caption = resolveMatrixMessageBody(params)?.trim() ?? "";
+  if (!caption) return marker;
+  return `${caption}\n\n${marker}`;
+}

--- a/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
@@ -9,9 +9,13 @@ const { downloadMatrixMediaMock } = vi.hoisted(() => ({
   downloadMatrixMediaMock: vi.fn(),
 }));
 
-vi.mock("./media.js", () => ({
-  downloadMatrixMedia: (...args: unknown[]) => downloadMatrixMediaMock(...args),
-}));
+vi.mock("./media.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./media.js")>();
+  return {
+    ...actual,
+    downloadMatrixMedia: (...args: unknown[]) => downloadMatrixMediaMock(...args),
+  };
+});
 
 function createMediaFailureHarness() {
   const logger = {
@@ -207,6 +211,58 @@ describe("createMatrixRoomMessageHandler media failures", () => {
         ctx: expect.objectContaining({
           RawBody: "can you see this image?\n\n[matrix image attachment unavailable]",
           CommandBody: "can you see this image?\n\n[matrix image attachment unavailable]",
+        }),
+      }),
+    );
+  });
+
+  it("shows a too-large marker when the download is rejected due to size limit", async () => {
+    downloadMatrixMediaMock.mockRejectedValue(
+      new Error("Matrix media exceeds configured size limit"),
+    );
+    const { handler, recordInboundSession } = createMediaFailureHarness();
+
+    await handler(
+      "!room:example.org",
+      createImageEvent({
+        msgtype: "m.image",
+        body: "big-photo.jpg",
+        url: "mxc://example/big-image",
+      }),
+    );
+
+    expect(recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          RawBody: "[matrix image attachment too large]",
+          CommandBody: "[matrix image attachment too large]",
+          MediaPath: undefined,
+        }),
+      }),
+    );
+  });
+
+  it("preserves a real caption while marking the attachment too large on size limit error", async () => {
+    downloadMatrixMediaMock.mockRejectedValue(
+      new Error("Matrix media exceeds configured size limit (10485760 bytes > 5242880 bytes)"),
+    );
+    const { handler, recordInboundSession } = createMediaFailureHarness();
+
+    await handler(
+      "!room:example.org",
+      createImageEvent({
+        msgtype: "m.image",
+        body: "check this out",
+        filename: "large-photo.jpg",
+        url: "mxc://example/big-image",
+      }),
+    );
+
+    expect(recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          RawBody: "check this out\n\n[matrix image attachment too large]",
+          CommandBody: "check this out\n\n[matrix image attachment too large]",
         }),
       }),
     );

--- a/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { installMatrixMonitorTestRuntime } from "../../test-runtime.js";
+import { MatrixMediaSizeLimitError } from "../media-errors.js";
 import {
   createMatrixHandlerTestHarness,
   createMatrixRoomMessageEvent,
@@ -217,9 +218,7 @@ describe("createMatrixRoomMessageHandler media failures", () => {
   });
 
   it("shows a too-large marker when the download is rejected due to size limit", async () => {
-    downloadMatrixMediaMock.mockRejectedValue(
-      new Error("Matrix media exceeds configured size limit"),
-    );
+    downloadMatrixMediaMock.mockRejectedValue(new MatrixMediaSizeLimitError());
     const { handler, recordInboundSession } = createMediaFailureHarness();
 
     await handler(
@@ -243,9 +242,7 @@ describe("createMatrixRoomMessageHandler media failures", () => {
   });
 
   it("preserves a real caption while marking the attachment too large on size limit error", async () => {
-    downloadMatrixMediaMock.mockRejectedValue(
-      new Error("Matrix media exceeds configured size limit (10485760 bytes > 5242880 bytes)"),
-    );
+    downloadMatrixMediaMock.mockRejectedValue(new MatrixMediaSizeLimitError());
     const { handler, recordInboundSession } = createMediaFailureHarness();
 
     await handler(

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -5,6 +5,7 @@ import { evaluateSupplementalContextVisibility } from "openclaw/plugin-sdk/secur
 import type { CoreConfig, MatrixRoomConfig, ReplyToMode } from "../../types.js";
 import { createMatrixDraftStream } from "../draft-stream.js";
 import {
+  formatMatrixMediaTooLargeText,
   formatMatrixMediaUnavailableText,
   formatMatrixMessageText,
   resolveMatrixMessageAttachment,
@@ -30,7 +31,7 @@ import { resolveMatrixAckReactionConfig } from "./ack-config.js";
 import { resolveMatrixAllowListMatch } from "./allowlist.js";
 import type { MatrixInboundEventDeduper } from "./inbound-dedupe.js";
 import { resolveMatrixLocation, type MatrixLocationPayload } from "./location.js";
-import { downloadMatrixMedia } from "./media.js";
+import { downloadMatrixMedia, isMatrixMediaSizeLimitError } from "./media.js";
 import { resolveMentions } from "./mentions.js";
 import { handleInboundMatrixReaction } from "./reaction-events.js";
 import { deliverMatrixReplies } from "./replies.js";
@@ -139,12 +140,20 @@ function resolveMatrixInboundBodyText(params: {
   msgtype?: string;
   hadMediaUrl: boolean;
   mediaDownloadFailed: boolean;
+  mediaSizeLimitExceeded?: boolean;
 }): string {
   if (params.mediaPlaceholder) {
     return params.rawBody || params.mediaPlaceholder;
   }
   if (!params.mediaDownloadFailed || !params.hadMediaUrl) {
     return params.rawBody;
+  }
+  if (params.mediaSizeLimitExceeded) {
+    return formatMatrixMediaTooLargeText({
+      body: params.rawBody,
+      filename: params.filename,
+      msgtype: params.msgtype,
+    });
   }
   return formatMatrixMediaUnavailableText({
     body: params.rawBody,
@@ -766,6 +775,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           placeholder: string;
         } | null = null;
         let mediaDownloadFailed = false;
+        let mediaSizeLimitExceeded = false;
         const finalContentUrl =
           "url" in content && typeof content.url === "string" ? content.url : undefined;
         const finalContentFile =
@@ -795,6 +805,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             });
           } catch (err) {
             mediaDownloadFailed = true;
+            if (isMatrixMediaSizeLimitError(err)) {
+              mediaSizeLimitExceeded = true;
+            }
             const errorText = err instanceof Error ? err.message : String(err);
             logVerboseMessage(
               `matrix: media download failed room=${roomId} id=${event.event_id ?? "unknown"} type=${content.msgtype} error=${errorText}`,
@@ -817,6 +830,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           msgtype: content.msgtype,
           hadMediaUrl: Boolean(finalMediaUrl),
           mediaDownloadFailed,
+          mediaSizeLimitExceeded,
         });
         if (!bodyText) {
           await commitInboundEventIfClaimed();

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -4,6 +4,7 @@ import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-runti
 import { evaluateSupplementalContextVisibility } from "openclaw/plugin-sdk/security-runtime";
 import type { CoreConfig, MatrixRoomConfig, ReplyToMode } from "../../types.js";
 import { createMatrixDraftStream } from "../draft-stream.js";
+import { isMatrixMediaSizeLimitError } from "../media-errors.js";
 import {
   formatMatrixMediaTooLargeText,
   formatMatrixMediaUnavailableText,
@@ -31,7 +32,7 @@ import { resolveMatrixAckReactionConfig } from "./ack-config.js";
 import { resolveMatrixAllowListMatch } from "./allowlist.js";
 import type { MatrixInboundEventDeduper } from "./inbound-dedupe.js";
 import { resolveMatrixLocation, type MatrixLocationPayload } from "./location.js";
-import { downloadMatrixMedia, isMatrixMediaSizeLimitError } from "./media.js";
+import { downloadMatrixMedia } from "./media.js";
 import { resolveMentions } from "./mentions.js";
 import { handleInboundMatrixReaction } from "./reaction-events.js";
 import { deliverMatrixReplies } from "./replies.js";

--- a/extensions/matrix/src/matrix/monitor/media.test.ts
+++ b/extensions/matrix/src/matrix/monitor/media.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime } from "../../../runtime-api.js";
 import { setMatrixRuntime } from "../../runtime.js";
+import { MatrixMediaSizeLimitError } from "../media-errors.js";
 import { downloadMatrixMedia } from "./media.js";
 
 function createEncryptedClient() {
@@ -111,10 +112,29 @@ describe("downloadMatrixMedia", () => {
         maxBytes: 1024,
         file,
       }),
-    ).rejects.toThrow("Matrix media exceeds configured size limit");
+    ).rejects.toBeInstanceOf(MatrixMediaSizeLimitError);
 
     expect(decryptMedia).not.toHaveBeenCalled();
     expect(saveMediaBuffer).not.toHaveBeenCalled();
+  });
+
+  it("preserves typed size-limit errors from plain media downloads", async () => {
+    const tooLargeError = new MatrixMediaSizeLimitError(
+      "Matrix media exceeds configured size limit (8192 bytes > 4096 bytes)",
+    );
+    const downloadContent = vi.fn().mockRejectedValue(tooLargeError);
+    const client = {
+      downloadContent,
+    } as unknown as import("../sdk.js").MatrixClient;
+
+    await expect(
+      downloadMatrixMedia({
+        client,
+        mxcUrl: "mxc://example/file",
+        contentType: "image/png",
+        maxBytes: 4096,
+      }),
+    ).rejects.toBe(tooLargeError);
   });
 
   it("passes byte limits through plain media downloads", async () => {

--- a/extensions/matrix/src/matrix/monitor/media.ts
+++ b/extensions/matrix/src/matrix/monitor/media.ts
@@ -62,6 +62,15 @@ async function fetchEncryptedMediaBuffer(params: {
   return { buffer: decrypted };
 }
 
+/**
+ * Returns true if the error is a Matrix media size limit error (pre-download
+ * metadata check or streaming cap). Used to distinguish oversized media from
+ * transient network failures so the handler can surface a clear user message.
+ */
+export function isMatrixMediaSizeLimitError(err: unknown): boolean {
+  return String(err).includes("exceeds configured size limit");
+}
+
 export async function downloadMatrixMedia(params: {
   client: MatrixClient;
   mxcUrl: string;

--- a/extensions/matrix/src/matrix/monitor/media.ts
+++ b/extensions/matrix/src/matrix/monitor/media.ts
@@ -1,4 +1,5 @@
 import { getMatrixRuntime } from "../../runtime.js";
+import { MatrixMediaSizeLimitError, isMatrixMediaSizeLimitError } from "../media-errors.js";
 import type { MatrixClient } from "../sdk.js";
 
 // Type for encrypted file info
@@ -30,6 +31,9 @@ async function fetchMatrixMediaBuffer(params: {
     });
     return { buffer };
   } catch (err) {
+    if (isMatrixMediaSizeLimitError(err)) {
+      throw err;
+    }
     throw new Error(`Matrix media download failed: ${String(err)}`, { cause: err });
   }
 }
@@ -56,19 +60,10 @@ async function fetchEncryptedMediaBuffer(params: {
   );
 
   if (decrypted.byteLength > params.maxBytes) {
-    throw new Error("Matrix media exceeds configured size limit");
+    throw new MatrixMediaSizeLimitError();
   }
 
   return { buffer: decrypted };
-}
-
-/**
- * Returns true if the error is a Matrix media size limit error (pre-download
- * metadata check or streaming cap). Used to distinguish oversized media from
- * transient network failures so the handler can surface a clear user message.
- */
-export function isMatrixMediaSizeLimitError(err: unknown): boolean {
-  return String(err).includes("exceeds configured size limit");
 }
 
 export async function downloadMatrixMedia(params: {
@@ -86,7 +81,7 @@ export async function downloadMatrixMedia(params: {
 } | null> {
   let fetched: { buffer: Buffer; headerType?: string } | null;
   if (typeof params.sizeBytes === "number" && params.sizeBytes > params.maxBytes) {
-    throw new Error("Matrix media exceeds configured size limit");
+    throw new MatrixMediaSizeLimitError();
   }
 
   if (params.file) {

--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MatrixMediaSizeLimitError } from "../media-errors.js";
 import { performMatrixRequest } from "./transport.js";
 
 describe("performMatrixRequest", () => {
@@ -31,7 +32,7 @@ describe("performMatrixRequest", () => {
         maxBytes: 1024,
         ssrfPolicy: { allowPrivateNetwork: true },
       }),
-    ).rejects.toThrow("Matrix media exceeds configured size limit");
+    ).rejects.toBeInstanceOf(MatrixMediaSizeLimitError);
   });
 
   it("applies streaming byte limits when raw responses omit content-length", async () => {
@@ -64,7 +65,7 @@ describe("performMatrixRequest", () => {
         maxBytes: 1024,
         ssrfPolicy: { allowPrivateNetwork: true },
       }),
-    ).rejects.toThrow("Matrix media exceeds configured size limit");
+    ).rejects.toBeInstanceOf(MatrixMediaSizeLimitError);
   });
 
   it("uses the matrix-specific idle-timeout error for stalled raw downloads", async () => {

--- a/extensions/matrix/src/matrix/sdk/transport.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.ts
@@ -6,6 +6,7 @@ import {
   resolvePinnedHostnameWithPolicy,
   type SsrFPolicy,
 } from "../../runtime-api.js";
+import { MatrixMediaSizeLimitError } from "../media-errors.js";
 import { readResponseWithLimit } from "./read-response-with-limit.js";
 
 export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
@@ -280,7 +281,7 @@ export async function performMatrixRequest(params: {
       if (params.maxBytes && contentLength) {
         const length = Number(contentLength);
         if (Number.isFinite(length) && length > params.maxBytes) {
-          throw new Error(
+          throw new MatrixMediaSizeLimitError(
             `Matrix media exceeds configured size limit (${length} bytes > ${params.maxBytes} bytes)`,
           );
         }
@@ -288,7 +289,7 @@ export async function performMatrixRequest(params: {
       const bytes = params.maxBytes
         ? await readResponseWithLimit(response, params.maxBytes, {
             onOverflow: ({ maxBytes, size }) =>
-              new Error(
+              new MatrixMediaSizeLimitError(
                 `Matrix media exceeds configured size limit (${size} bytes > ${maxBytes} bytes)`,
               ),
             chunkTimeoutMs: params.readIdleTimeoutMs,


### PR DESCRIPTION
## What

When Matrix media exceeds the configured size limit (`mediaMaxMb`), the handler previously fell back to the generic `[matrix <kind> attachment unavailable]` marker — indistinguishable from transient network failures. This PR adds a dedicated `[matrix <kind> attachment too large]` marker for the oversize case, matching the UX already shipped for Telegram (#27454) and Discord (#54112).

## Context

The size guards themselves already existed on main:
- `media.ts` rejects `sizeBytes > maxBytes` before download
- `transport.ts` rejects oversized bodies during streaming

What was missing was surfacing **why** the attachment was unavailable. This PR wires the distinction through the handler so users see a meaningful marker.

## Changes

- **`media.ts`**: Replace string-matched `isMatrixMediaSizeLimitError` with a typed `MatrixMediaSizeLimitError extends Error` sentinel class; guard is now `instanceof` (robust against message rewording)
- **`media-text.ts`**: Thread `tooLarge?: boolean` through `formatMatrixAttachmentMarker` → `formatMatrixAttachmentText` → `formatMatrixMessageText`; `formatMatrixMediaTooLargeText` delegates to `formatMatrixMessageText` (no duplicated layout logic)
- **`handler.ts`**: Catch site sets `mediaSizeLimitExceeded = true` when `isMatrixMediaSizeLimitError`, branches to `tooLarge` path in `resolveMatrixInboundBodyText`
- **Tests**: Two new cases (caption-absent + caption-present) using `MatrixMediaSizeLimitError`

## Related

- #27454 — Telegram oversize UX (merged, same pattern)
- #54112 / #54159 — Discord oversize UX

AI-assisted: Yes