### PR TITLE
[codex] fix /model and /new not changing model/auth

### DIFF
--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -130,7 +130,7 @@ describe("live model switch", () => {
     });
   });
 
-  it("prefers persisted runtime model fields ahead of session overrides", async () => {
+  it("keeps persisted session overrides ahead of runtime model fields", async () => {
     state.loadSessionStoreMock.mockReturnValue({
       main: {
         providerOverride: "anthropic",
@@ -152,7 +152,7 @@ describe("live model switch", () => {
       }),
     ).toEqual({
       provider: "anthropic",
-      model: "claude-sonnet-4-6",
+      model: "claude-opus-4-6",
       authProfileId: undefined,
       authProfileIdSource: undefined,
     });
@@ -183,7 +183,7 @@ describe("live model switch", () => {
     });
   });
 
-  it("preserves provider when runtime model is a vendor-prefixed OpenRouter id", async () => {
+  it("falls back to the configured selection when only runtime model fields are present", async () => {
     state.loadSessionStoreMock.mockReturnValue({
       main: {
         modelProvider: "openrouter",
@@ -202,8 +202,8 @@ describe("live model switch", () => {
         defaultModel: "claude-opus-4-6",
       }),
     ).toEqual({
-      provider: "openrouter",
-      model: "anthropic/claude-haiku-4.5",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
       authProfileId: undefined,
       authProfileIdSource: undefined,
     });

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -48,16 +48,14 @@ export function resolveLiveSessionModelSelection(params: {
     agentId,
   });
   const entry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
-  const persisted = resolvePersistedModelRef({
+  const override = resolvePersistedModelRef({
     defaultProvider: defaultModelRef.provider,
-    runtimeProvider: entry?.modelProvider,
-    runtimeModel: entry?.model,
     overrideProvider: entry?.providerOverride,
     overrideModel: entry?.modelOverride,
   });
   const provider =
-    persisted?.provider ?? entry?.providerOverride?.trim() ?? defaultModelRef.provider;
-  const model = persisted?.model ?? defaultModelRef.model;
+    override?.provider ?? entry?.providerOverride?.trim() ?? defaultModelRef.provider;
+  const model = override?.model ?? defaultModelRef.model;
   const authProfileId = entry?.authProfileOverride?.trim() || undefined;
   return {
     provider,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1290,6 +1290,50 @@ describe("runReplyAgent typing (heartbeat)", () => {
     }
   });
 
+  it("warns and suppresses replies when an explicit model selection runs on a different model", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      providerOverride: "openai-codex",
+      modelOverride: "gpt-5.3-codex-spark",
+      authProfileOverride: "openai-codex:default",
+      authProfileOverrideSource: "user",
+    };
+    const sessionStore = { main: sessionEntry };
+
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "wrong-model reply" }],
+      meta: {
+        agentMeta: {
+          provider: "openai-codex",
+          model: "gpt-5.4",
+        },
+      },
+    });
+
+    const { run } = createMinimalRun({
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      runOverrides: {
+        provider: "openai-codex",
+        model: "gpt-5.3-codex-spark",
+        authProfileId: "openai-codex:default",
+        authProfileIdSource: "user",
+        exactModelSelection: true,
+      },
+    });
+    const res = await run();
+    const payload = Array.isArray(res) ? res[0] : res;
+
+    expect(payload?.text).toContain("Requested model openai-codex/gpt-5.3-codex-spark");
+    expect(payload?.text).toContain("runtime used openai-codex/gpt-5.4");
+    expect(payload?.text).not.toContain("wrong-model reply");
+    expect(sessionEntry.fallbackNoticeSelectedModel).toBe("openai-codex/gpt-5.3-codex-spark");
+    expect(sessionEntry.fallbackNoticeActiveModel).toBe("openai-codex/gpt-5.4");
+    expect(sessionEntry.fallbackNoticeReason).toBe("selected model unavailable");
+  });
+
   it("retries after compaction failure by resetting the session", async () => {
     await withTempStateDir(async (stateDir) => {
       const sessionId = "session";

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -480,6 +480,7 @@ export async function runReplyAgent(params: {
     const verboseEnabled = resolvedVerboseLevel !== "off";
     const selectedProvider = followupRun.run.provider;
     const selectedModel = followupRun.run.model;
+    const exactModelSelection = followupRun.run.exactModelSelection === true;
     const fallbackStateEntry =
       activeSessionEntry ?? (sessionKey ? activeSessionStore?.[sessionKey] : undefined);
     const fallbackTransition = resolveFallbackTransition({
@@ -540,6 +541,27 @@ export async function runReplyAgent(params: {
       cliSessionBinding,
       usageIsContextSnapshot: isCliProvider(providerUsed, cfg),
     });
+
+    const exactSelectionMismatch =
+      exactModelSelection &&
+      (providerUsed.trim() !== selectedProvider.trim() ||
+        modelUsed.trim() !== selectedModel.trim());
+    if (exactSelectionMismatch) {
+      const requestedModelRef = `${selectedProvider}/${selectedModel}`;
+      const activeModelRef = `${providerUsed}/${modelUsed}`;
+      const authProfileLabel = followupRun.run.authProfileId?.trim();
+      const authClause = authProfileLabel ? ` on ${authProfileLabel}` : "";
+      return finalizeWithFollowup(
+        {
+          text:
+            `⚠️ Requested model ${requestedModelRef}${authClause}, but runtime used ${activeModelRef}. ` +
+            "No reply was sent from the fallback model. Selection unchanged.",
+          isError: true,
+        },
+        queueKey,
+        runFollowupTurn,
+      );
+    }
 
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and

--- a/src/auto-reply/reply/directive-handling.auth-profile.ts
+++ b/src/auto-reply/reply/directive-handling.auth-profile.ts
@@ -1,5 +1,7 @@
-import { ensureAuthProfileStore } from "../../agents/auth-profiles.js";
+import { ensureAuthProfileStore, resolveAuthProfileOrder } from "../../agents/auth-profiles.js";
+import { normalizeProviderId } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
 
 export function resolveProfileOverride(params: {
   rawProfile?: string;
@@ -24,4 +26,133 @@ export function resolveProfileOverride(params: {
     };
   }
   return { profileId: raw };
+}
+
+function isProfileForProvider(params: {
+  profileId: string;
+  provider: string;
+  store: ReturnType<typeof ensureAuthProfileStore>;
+}): boolean {
+  const profile = params.store.profiles[params.profileId];
+  if (!profile?.provider) {
+    return false;
+  }
+  return normalizeProviderId(profile.provider) === normalizeProviderId(params.provider);
+}
+
+function decodeJwtPayload(token?: string): Record<string, unknown> | null {
+  const compact = token?.trim();
+  if (!compact) {
+    return null;
+  }
+  const parts = compact.split(".");
+  if (parts.length < 2) {
+    return null;
+  }
+  try {
+    const payload = Buffer.from(parts[1], "base64url").toString("utf8");
+    const parsed = JSON.parse(payload);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveCodexChatGPTPlanType(profile: {
+  type?: string;
+  access?: string;
+}): string | undefined {
+  if (profile.type !== "oauth") {
+    return undefined;
+  }
+  const payload = decodeJwtPayload(profile.access);
+  const auth =
+    payload && typeof payload["https://api.openai.com/auth"] === "object"
+      ? (payload["https://api.openai.com/auth"] as Record<string, unknown>)
+      : undefined;
+  const plan = typeof auth?.chatgpt_plan_type === "string" ? auth.chatgpt_plan_type : undefined;
+  return plan?.trim().toLowerCase() || undefined;
+}
+
+function formatSparkPlanError(profileId: string, planType: string): string {
+  const formattedPlan = planType.slice(0, 1).toUpperCase() + planType.slice(1);
+  return [
+    `Spark is not supported on auth profile "${profileId}" (${formattedPlan} plan).`,
+    "Model/auth unchanged.",
+    "",
+    "Use /model spark@openai-codex:default or another Spark-capable auth profile.",
+  ].join("\n");
+}
+
+export function resolveModelAuthProfile(params: {
+  rawProfile?: string;
+  provider: string;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  sessionEntry?: Pick<SessionEntry, "authProfileOverride" | "authProfileOverrideSource">;
+}): { profileId?: string; profileOverrideSource?: "auto" | "user"; error?: string } {
+  const store = ensureAuthProfileStore(params.agentDir, {
+    allowKeychainPrompt: false,
+  });
+  const explicit = params.rawProfile?.trim();
+  if (explicit) {
+    const resolved = resolveProfileOverride({
+      rawProfile: explicit,
+      provider: params.provider,
+      cfg: params.cfg,
+      agentDir: params.agentDir,
+    });
+    return resolved.profileId
+      ? {
+          profileId: resolved.profileId,
+          profileOverrideSource: "user",
+        }
+      : { error: resolved.error };
+  }
+
+  const current = params.sessionEntry?.authProfileOverride?.trim();
+  if (current && isProfileForProvider({ profileId: current, provider: params.provider, store })) {
+    return {
+      profileId: current,
+      profileOverrideSource: params.sessionEntry?.authProfileOverrideSource ?? "user",
+    };
+  }
+
+  const order = resolveAuthProfileOrder({
+    cfg: params.cfg,
+    store,
+    provider: params.provider,
+  });
+  const first = order[0]?.trim();
+  return first ? { profileId: first, profileOverrideSource: "auto" } : {};
+}
+
+export function validateModelAuthProfileCompatibility(params: {
+  provider: string;
+  model: string;
+  profileId?: string;
+  agentDir?: string;
+}): { error?: string } {
+  const profileId = params.profileId?.trim();
+  if (!profileId) {
+    return {};
+  }
+  if (
+    normalizeProviderId(params.provider) !== "openai-codex" ||
+    params.model.trim() !== "gpt-5.3-codex-spark"
+  ) {
+    return {};
+  }
+  const store = ensureAuthProfileStore(params.agentDir, {
+    allowKeychainPrompt: false,
+  });
+  const profile = store.profiles[profileId];
+  if (!profile) {
+    return {};
+  }
+  const planType = resolveCodexChatGPTPlanType(profile);
+  if (planType && ["free", "go", "plus"].includes(planType)) {
+    return { error: formatSparkPlanError(profileId, planType) };
+  }
+  return {};
 }

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -153,12 +153,14 @@ export async function handleDirectiveOnly(
     allowedModelKeys,
     allowedModelCatalog,
     provider,
+    sessionEntry,
   });
   if (modelResolution.errorText) {
     return { text: modelResolution.errorText };
   }
   const modelSelection = modelResolution.modelSelection;
   const profileOverride = modelResolution.profileOverride;
+  const profileOverrideSource = modelResolution.profileOverrideSource;
 
   const resolvedProvider = modelSelection?.provider ?? provider;
   const resolvedModel = modelSelection?.model ?? model;
@@ -413,6 +415,7 @@ export async function handleDirectiveOnly(
         entry: sessionEntry,
         selection: modelSelection,
         profileOverride,
+        profileOverrideSource,
       });
       modelSelectionUpdated = applied.updated;
     }
@@ -451,7 +454,7 @@ export async function handleDirectiveOnly(
         nextProvider: modelSelection.provider,
         nextModel: modelSelection.model,
         nextAuthProfileId: profileOverride,
-        nextAuthProfileIdSource: profileOverride ? "user" : undefined,
+        nextAuthProfileIdSource: profileOverride ? profileOverrideSource : undefined,
       });
     }
   }

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -416,6 +416,7 @@ export async function handleDirectiveOnly(
         selection: modelSelection,
         profileOverride,
         profileOverrideSource,
+        persistDefaultSelection: true,
       });
       modelSelectionUpdated = applied.updated;
     }

--- a/src/auto-reply/reply/directive-handling.model-selection.ts
+++ b/src/auto-reply/reply/directive-handling.model-selection.ts
@@ -6,7 +6,11 @@ import {
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { resolveProfileOverride } from "./directive-handling.auth-profile.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import {
+  resolveModelAuthProfile,
+  validateModelAuthProfileCompatibility,
+} from "./directive-handling.auth-profile.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import { type ModelDirectiveSelection, resolveModelDirectiveSelection } from "./model-selection.js";
 
@@ -53,9 +57,11 @@ export function resolveModelSelectionFromDirective(params: {
   allowedModelKeys: Set<string>;
   allowedModelCatalog: Array<{ provider: string; id?: string; name?: string }>;
   provider: string;
+  sessionEntry?: Pick<SessionEntry, "authProfileOverride" | "authProfileOverrideSource">;
 }): {
   modelSelection?: ModelDirectiveSelection;
   profileOverride?: string;
+  profileOverrideSource?: "auto" | "user";
   errorText?: string;
 } {
   if (!params.directives.hasModelDirective || !params.directives.rawModelDirective) {
@@ -139,21 +145,33 @@ export function resolveModelSelectionFromDirective(params: {
   }
 
   let profileOverride: string | undefined;
+  let profileOverrideSource: "auto" | "user" | undefined;
   const rawProfile =
     params.directives.rawModelProfile ??
     (useStoredNumericProfile ? storedNumericProfile?.profileId : undefined);
-  if (modelSelection && rawProfile) {
-    const profileResolved = resolveProfileOverride({
+  if (modelSelection) {
+    const profileResolved = resolveModelAuthProfile({
       rawProfile,
       provider: modelSelection.provider,
       cfg: params.cfg,
       agentDir: params.agentDir,
+      sessionEntry: params.sessionEntry,
     });
     if (profileResolved.error) {
       return { errorText: profileResolved.error };
     }
+    const compatibility = validateModelAuthProfileCompatibility({
+      provider: modelSelection.provider,
+      model: modelSelection.model,
+      profileId: profileResolved.profileId,
+      agentDir: params.agentDir,
+    });
+    if (compatibility.error) {
+      return { errorText: compatibility.error };
+    }
     profileOverride = profileResolved.profileId;
+    profileOverrideSource = profileResolved.profileOverrideSource;
   }
 
-  return { modelSelection, profileOverride };
+  return { modelSelection, profileOverride, profileOverrideSource };
 }

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -53,7 +53,27 @@ vi.mock("./queue.js", () => ({
 const TEST_AGENT_DIR = "/tmp/agent";
 const OPENAI_DATE_PROFILE_ID = "20251001";
 
-type ApiKeyProfile = { type: "api_key"; provider: string; key: string };
+type TestProfile =
+  | { type: "api_key"; provider: string; key: string }
+  | {
+      type: "oauth";
+      provider: string;
+      access: string;
+      refresh: string;
+      expires: number;
+    };
+
+function createOAuthAccessToken(planType: string) {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/auth": {
+        chatgpt_plan_type: planType,
+      },
+    }),
+  ).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
 
 function baseAliasIndex(): ModelAliasIndex {
   return { byAlias: new Map(), byKey: new Map() };
@@ -90,7 +110,7 @@ afterEach(() => {
   clearRuntimeAuthProfileStoreSnapshots();
 });
 
-function setAuthProfiles(profiles: Record<string, ApiKeyProfile>) {
+function setAuthProfiles(profiles: Record<string, TestProfile>) {
   replaceRuntimeAuthProfileStoreSnapshots([
     {
       agentDir: TEST_AGENT_DIR,
@@ -106,7 +126,7 @@ function createDateAuthProfiles(provider: string, id = OPENAI_DATE_PROFILE_ID) {
       provider,
       key: "sk-test",
     },
-  } satisfies Record<string, ApiKeyProfile>;
+  } satisfies Record<string, TestProfile>;
 }
 
 function createGptAliasIndex(): ModelAliasIndex {
@@ -136,7 +156,7 @@ function resolveModelSelectionForCommand(params: {
 
 async function persistModelDirectiveForTest(params: {
   command: string;
-  profiles?: Record<string, ApiKeyProfile>;
+  profiles?: Record<string, TestProfile>;
   aliasIndex?: ModelAliasIndex;
   allowedModelKeys: string[];
   sessionEntry?: SessionEntry;
@@ -360,6 +380,94 @@ describe("/model chat UX", () => {
       isDefault: false,
     });
     expect(resolved.profileOverride).toBe(OPENAI_DATE_PROFILE_ID);
+  });
+
+  it("uses the current auth profile path for bare model switches", () => {
+    setAuthProfiles({
+      "openai-codex:default": {
+        type: "oauth",
+        provider: "openai-codex",
+        access: createOAuthAccessToken("pro"),
+        refresh: "rt-test",
+        expires: Date.now() + 60_000,
+      },
+    });
+
+    const resolved = resolveModelSelectionFromDirective({
+      directives: parseInlineDirectives("/model spark"),
+      cfg: { commands: { text: true } } as unknown as OpenClawConfig,
+      agentDir: TEST_AGENT_DIR,
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.4",
+      aliasIndex: {
+        byAlias: new Map([
+          [
+            "spark",
+            { alias: "spark", ref: { provider: "openai-codex", model: "gpt-5.3-codex-spark" } },
+          ],
+        ]),
+        byKey: new Map([["openai-codex/gpt-5.3-codex-spark", ["spark"]]]),
+      },
+      allowedModelKeys: new Set(["openai-codex/gpt-5.3-codex-spark", "openai-codex/gpt-5.4"]),
+      allowedModelCatalog: [],
+      provider: "openai-codex",
+      sessionEntry: {
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "auto",
+      },
+    });
+
+    expect(resolved.errorText).toBeUndefined();
+    expect(resolved.modelSelection).toEqual({
+      provider: "openai-codex",
+      model: "gpt-5.3-codex-spark",
+      isDefault: false,
+      alias: "spark",
+    });
+    expect(resolved.profileOverride).toBe("openai-codex:default");
+    expect(resolved.profileOverrideSource).toBe("auto");
+  });
+
+  it("rejects spark on a plus auth profile and leaves the selection unchanged", () => {
+    setAuthProfiles({
+      "openai-codex:plus": {
+        type: "oauth",
+        provider: "openai-codex",
+        access: createOAuthAccessToken("plus"),
+        refresh: "rt-test",
+        expires: Date.now() + 60_000,
+      },
+    });
+
+    const resolved = resolveModelSelectionFromDirective({
+      directives: parseInlineDirectives("/model spark"),
+      cfg: { commands: { text: true } } as unknown as OpenClawConfig,
+      agentDir: TEST_AGENT_DIR,
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.4",
+      aliasIndex: {
+        byAlias: new Map([
+          [
+            "spark",
+            { alias: "spark", ref: { provider: "openai-codex", model: "gpt-5.3-codex-spark" } },
+          ],
+        ]),
+        byKey: new Map([["openai-codex/gpt-5.3-codex-spark", ["spark"]]]),
+      },
+      allowedModelKeys: new Set(["openai-codex/gpt-5.3-codex-spark", "openai-codex/gpt-5.4"]),
+      allowedModelCatalog: [],
+      provider: "openai-codex",
+      sessionEntry: {
+        authProfileOverride: "openai-codex:plus",
+        authProfileOverrideSource: "user",
+      },
+    });
+
+    expect(resolved.modelSelection).toBeUndefined();
+    expect(resolved.errorText).toContain(
+      'Spark is not supported on auth profile "openai-codex:plus" (Plus plan).',
+    );
+    expect(resolved.errorText).toContain("Model/auth unchanged.");
   });
 
   it("keeps @YYYYMMDD as part of the model when the stored numeric profile is for another provider", () => {

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -543,6 +543,16 @@ describe("/model chat UX", () => {
     expect(sessionEntry.authProfileOverride).toBe("work");
   });
 
+  it("persists an explicit default-model selection", async () => {
+    const { sessionEntry } = await persistModelDirectiveForTest({
+      command: "/model claude-opus-4-5",
+      allowedModelKeys: ["anthropic/claude-opus-4-5", "openai/gpt-4o"],
+    });
+
+    expect(sessionEntry.providerOverride).toBe("anthropic");
+    expect(sessionEntry.modelOverride).toBe("claude-opus-4-5");
+  });
+
   it("ignores invalid mixed-content model directives during persistence", async () => {
     const { persisted, sessionEntry } = await persistModelDirectiveForTest({
       command: "/model 99 hello",

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -169,12 +169,14 @@ export async function persistInlineDirectives(params: {
         allowedModelKeys,
         allowedModelCatalog: [],
         provider,
+        sessionEntry,
       });
       if (modelResolution.modelSelection) {
         const { updated: modelUpdated } = applyModelOverrideToSessionEntry({
           entry: sessionEntry,
           selection: modelResolution.modelSelection,
           profileOverride: modelResolution.profileOverride,
+          profileOverrideSource: modelResolution.profileOverrideSource,
         });
         provider = modelResolution.modelSelection.provider;
         model = modelResolution.modelSelection.model;

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -177,6 +177,7 @@ export async function persistInlineDirectives(params: {
           selection: modelResolution.modelSelection,
           profileOverride: modelResolution.profileOverride,
           profileOverrideSource: modelResolution.profileOverrideSource,
+          persistDefaultSelection: true,
         });
         provider = modelResolution.modelSelection.provider;
         model = modelResolution.modelSelection.model;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -518,6 +518,9 @@ export async function runPreparedReply(
     isNewSession,
   });
   const authProfileIdSource = sessionEntry?.authProfileOverrideSource;
+  const exactModelSelection = Boolean(
+    sessionEntry?.providerOverride?.trim() || sessionEntry?.modelOverride?.trim(),
+  );
   const followupRun = {
     prompt: queuedBody,
     messageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
@@ -556,6 +559,7 @@ export async function runPreparedReply(
       skillsSnapshot,
       provider,
       model,
+      exactModelSelection,
       authProfileId,
       authProfileIdSource,
       thinkLevel: resolvedThinkLevel,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -63,6 +63,7 @@ export type FollowupRun = {
     skillsSnapshot?: SkillSnapshot;
     provider: string;
     model: string;
+    exactModelSelection?: boolean;
     authProfileId?: string;
     authProfileIdSource?: "auto" | "user";
     thinkLevel?: ThinkLevel;

--- a/src/auto-reply/reply/session-reset-model.test.ts
+++ b/src/auto-reply/reply/session-reset-model.test.ts
@@ -191,8 +191,8 @@ describe("applyResetModelOverride", () => {
       defaultModel: "gpt-5.3-codex-spark",
     });
 
-    expect(sessionEntry.providerOverride).toBeUndefined();
-    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.providerOverride).toBe("openai-codex");
+    expect(sessionEntry.modelOverride).toBe("gpt-5.3-codex-spark");
     expect(sessionEntry.authProfileOverride).toBe("openai-codex:default");
     expect(sessionEntry.authProfileOverrideSource).toBe("user");
     expect(sessionCtx.BodyStripped).toBe("summarize");

--- a/src/auto-reply/reply/session-reset-model.test.ts
+++ b/src/auto-reply/reply/session-reset-model.test.ts
@@ -1,17 +1,49 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  replaceRuntimeAuthProfileStoreSnapshots,
+} from "../../agents/auth-profiles.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import { buildModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { applyResetModelOverride } from "./session-reset-model.js";
 
+const TEST_AGENT_DIR = "/tmp/openclaw-reset-model-test-agent";
+
 const modelCatalog: ModelCatalogEntry[] = [
   { provider: "minimax", id: "m2.7", name: "M2.7" },
   { provider: "openai", id: "gpt-4o-mini", name: "GPT-4o mini" },
+  { provider: "openai-codex", id: "gpt-5.4", name: "GPT-5.4" },
+  { provider: "openai-codex", id: "gpt-5.3-codex-spark", name: "GPT-5.3 Codex Spark" },
 ];
 
+function createOAuthAccessToken(planType: string) {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/auth": {
+        chatgpt_plan_type: planType,
+      },
+    }),
+  ).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
+
 function createResetFixture(entry: Partial<SessionEntry> = {}) {
-  const cfg = {} as OpenClawConfig;
+  const cfg = {
+    agents: {
+      defaults: {
+        models: {
+          "minimax/m2.7": {},
+          "openai/gpt-4o-mini": {},
+          "openai-codex/gpt-5.4": {},
+          "openai-codex/gpt-5.3-codex-spark": { alias: "spark" },
+        },
+      },
+      list: [{ id: "main", agentDir: TEST_AGENT_DIR }],
+    },
+  } as OpenClawConfig;
   const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: "openai" });
   const sessionEntry: SessionEntry = {
     sessionId: "s1",
@@ -23,7 +55,14 @@ function createResetFixture(entry: Partial<SessionEntry> = {}) {
     aliasIndex,
     sessionEntry,
     sessionStore: { "agent:main:dm:1": sessionEntry } as Record<string, SessionEntry>,
-    sessionCtx: { BodyStripped: "minimax summarize" },
+    sessionCtx: {
+      Body: "minimax summarize",
+      BodyForAgent: "minimax summarize",
+      BodyStripped: "minimax summarize",
+      BodyForCommands: "minimax summarize",
+      CommandBody: "minimax summarize",
+      RawBody: "minimax summarize",
+    },
     ctx: { ChatType: "direct" },
   };
 }
@@ -31,24 +70,42 @@ function createResetFixture(entry: Partial<SessionEntry> = {}) {
 async function applyResetFixture(params: {
   resetTriggered: boolean;
   sessionEntry?: Partial<SessionEntry>;
+  bodyStripped?: string;
+  defaultProvider?: string;
+  defaultModel?: string;
 }) {
   const fixture = createResetFixture(params.sessionEntry);
   await applyResetModelOverride({
     cfg: fixture.cfg,
+    agentId: "main",
     resetTriggered: params.resetTriggered,
-    bodyStripped: "minimax summarize",
+    bodyStripped: params.bodyStripped ?? "minimax summarize",
     sessionCtx: fixture.sessionCtx,
     ctx: fixture.ctx,
     sessionEntry: fixture.sessionEntry,
     sessionStore: fixture.sessionStore,
     sessionKey: "agent:main:dm:1",
-    defaultProvider: "openai",
-    defaultModel: "gpt-4o-mini",
+    defaultProvider: params.defaultProvider ?? "openai",
+    defaultModel: params.defaultModel ?? "gpt-4o-mini",
     aliasIndex: fixture.aliasIndex,
     modelCatalog,
   });
   return fixture;
 }
+
+beforeEach(() => {
+  clearRuntimeAuthProfileStoreSnapshots();
+  replaceRuntimeAuthProfileStoreSnapshots([
+    {
+      agentDir: TEST_AGENT_DIR,
+      store: { version: 1, profiles: {} },
+    },
+  ]);
+});
+
+afterEach(() => {
+  clearRuntimeAuthProfileStoreSnapshots();
+});
 
 describe("applyResetModelOverride", () => {
   it("selects a model hint and strips it from the body", async () => {
@@ -58,21 +115,45 @@ describe("applyResetModelOverride", () => {
 
     expect(sessionEntry.providerOverride).toBe("minimax");
     expect(sessionEntry.modelOverride).toBe("m2.7");
+    expect(sessionCtx.Body).toBe("summarize");
+    expect(sessionCtx.BodyForAgent).toBe("summarize");
     expect(sessionCtx.BodyStripped).toBe("summarize");
+    expect(sessionCtx.BodyForCommands).toBe("summarize");
+    expect(sessionCtx.CommandBody).toBe("summarize");
+    expect(sessionCtx.RawBody).toBe("summarize");
   });
 
-  it("clears auth profile overrides when reset applies a model", async () => {
+  it("preserves the current auth profile path when reset applies a model", async () => {
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir: TEST_AGENT_DIR,
+        store: {
+          version: 1,
+          profiles: {
+            "openai-codex:p1": {
+              type: "api_key",
+              provider: "openai-codex",
+              key: "sk-test-p1",
+            },
+          },
+        },
+      },
+    ]);
+
     const { sessionEntry } = await applyResetFixture({
       resetTriggered: true,
       sessionEntry: {
-        authProfileOverride: "anthropic:default",
-        authProfileOverrideSource: "user",
+        authProfileOverride: "openai-codex:p1",
+        authProfileOverrideSource: "auto",
         authProfileOverrideCompactionCount: 2,
       },
+      bodyStripped: "spark summarize",
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.4",
     });
 
-    expect(sessionEntry.authProfileOverride).toBeUndefined();
-    expect(sessionEntry.authProfileOverrideSource).toBeUndefined();
+    expect(sessionEntry.authProfileOverride).toBe("openai-codex:p1");
+    expect(sessionEntry.authProfileOverrideSource).toBe("auto");
     expect(sessionEntry.authProfileOverrideCompactionCount).toBeUndefined();
   });
 
@@ -84,5 +165,110 @@ describe("applyResetModelOverride", () => {
     expect(sessionEntry.providerOverride).toBeUndefined();
     expect(sessionEntry.modelOverride).toBeUndefined();
     expect(sessionCtx.BodyStripped).toBe("minimax summarize");
+  });
+
+  it("persists explicit auth profile overrides for alias selections", async () => {
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir: TEST_AGENT_DIR,
+        store: {
+          version: 1,
+          profiles: {
+            "openai-codex:default": {
+              type: "api_key",
+              provider: "openai-codex",
+              key: "sk-test",
+            },
+          },
+        },
+      },
+    ]);
+
+    const { sessionEntry, sessionCtx } = await applyResetFixture({
+      resetTriggered: true,
+      bodyStripped: "spark@openai-codex:default summarize",
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.3-codex-spark",
+    });
+
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.authProfileOverride).toBe("openai-codex:default");
+    expect(sessionEntry.authProfileOverrideSource).toBe("user");
+    expect(sessionCtx.BodyStripped).toBe("summarize");
+    expect(sessionCtx.BodyForAgent).toBe("summarize");
+  });
+
+  it("persists explicit auth profile overrides for provider model selections", async () => {
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir: TEST_AGENT_DIR,
+        store: {
+          version: 1,
+          profiles: {
+            "openai-codex:p1": {
+              type: "api_key",
+              provider: "openai-codex",
+              key: "sk-test-2",
+            },
+          },
+        },
+      },
+    ]);
+
+    const { sessionEntry, sessionCtx } = await applyResetFixture({
+      resetTriggered: true,
+      bodyStripped: "openai-codex gpt-5.4@openai-codex:p1 summarize",
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.3-codex-spark",
+    });
+
+    expect(sessionEntry.providerOverride).toBe("openai-codex");
+    expect(sessionEntry.modelOverride).toBe("gpt-5.4");
+    expect(sessionEntry.authProfileOverride).toBe("openai-codex:p1");
+    expect(sessionEntry.authProfileOverrideSource).toBe("user");
+    expect(sessionCtx.BodyStripped).toBe("summarize");
+    expect(sessionCtx.BodyForAgent).toBe("summarize");
+  });
+
+  it("rejects spark on an unsupported current auth profile and keeps selection unchanged", async () => {
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir: TEST_AGENT_DIR,
+        store: {
+          version: 1,
+          profiles: {
+            "openai-codex:plus": {
+              type: "oauth",
+              provider: "openai-codex",
+              access: createOAuthAccessToken("plus"),
+              refresh: "rt-test",
+              expires: Date.now() + 60_000,
+            },
+          },
+        },
+      },
+    ]);
+
+    const { sessionEntry, sessionCtx } = await applyResetFixture({
+      resetTriggered: true,
+      bodyStripped: "spark summarize",
+      sessionEntry: {
+        providerOverride: "openai-codex",
+        modelOverride: "gpt-5.4",
+        authProfileOverride: "openai-codex:plus",
+        authProfileOverrideSource: "user",
+      },
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.4",
+    });
+
+    expect(sessionEntry.providerOverride).toBe("openai-codex");
+    expect(sessionEntry.modelOverride).toBe("gpt-5.4");
+    expect(sessionEntry.authProfileOverride).toBe("openai-codex:plus");
+    expect(sessionCtx.BodyForAgent).toContain(
+      'System: Spark is not supported on auth profile "openai-codex:plus" (Plus plan).',
+    );
+    expect(sessionCtx.BodyForAgent).toContain("summarize");
   });
 });

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -1,3 +1,4 @@
+import { resolveAgentDir } from "../../agents/agent-scope.js";
 import { loadModelCatalog, type ModelCatalogEntry } from "../../agents/model-catalog.js";
 import {
   buildAllowedModelSet,
@@ -11,11 +12,16 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { updateSessionStore } from "../../config/sessions.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
+import {
+  resolveModelAuthProfile,
+  validateModelAuthProfileCompatibility,
+} from "./directive-handling.auth-profile.js";
 import { resolveModelDirectiveSelection, type ModelDirectiveSelection } from "./model-selection.js";
 
 type ResetModelResult = {
   selection?: ModelDirectiveSelection;
   cleanedBody?: string;
+  errorText?: string;
 };
 
 function splitBody(body: string) {
@@ -59,18 +65,30 @@ function buildSelectionFromExplicit(params: {
 
 function applySelectionToSession(params: {
   selection: ModelDirectiveSelection;
+  profileOverride?: string;
+  profileOverrideSource?: "auto" | "user";
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
   storePath?: string;
 }) {
-  const { selection, sessionEntry, sessionStore, sessionKey, storePath } = params;
+  const {
+    selection,
+    profileOverride,
+    profileOverrideSource,
+    sessionEntry,
+    sessionStore,
+    sessionKey,
+    storePath,
+  } = params;
   if (!sessionEntry || !sessionStore || !sessionKey) {
     return;
   }
   const { updated } = applyModelOverrideToSessionEntry({
     entry: sessionEntry,
     selection,
+    profileOverride,
+    profileOverrideSource,
   });
   if (!updated) {
     return;
@@ -146,20 +164,26 @@ export async function applyResetModelOverride(params: {
     });
 
   let selection: ModelDirectiveSelection | undefined;
+  let profileOverride: string | undefined;
+  let profileOverrideSource: "auto" | "user" | undefined;
   let consumed = 0;
+  let rawProfile: string | undefined;
 
   if (providers.has(normalizeProviderId(first)) && second) {
-    const composite = `${normalizeProviderId(first)}/${second}`;
+    const [modelPart, profilePart] = second.split("@", 2);
+    const composite = `${normalizeProviderId(first)}/${modelPart}`;
     const resolved = resolveSelection(composite);
     if (resolved.selection) {
       selection = resolved.selection;
       consumed = 2;
+      rawProfile = profilePart?.trim() || undefined;
     }
   }
 
   if (!selection) {
+    const [modelPart, profilePart] = first.split("@", 2);
     selection = buildSelectionFromExplicit({
-      raw: first,
+      raw: modelPart,
       defaultProvider: params.defaultProvider,
       defaultModel: params.defaultModel,
       aliasIndex: params.aliasIndex,
@@ -167,16 +191,20 @@ export async function applyResetModelOverride(params: {
     });
     if (selection) {
       consumed = 1;
+      rawProfile = profilePart?.trim() || undefined;
     }
   }
 
   if (!selection) {
-    const resolved = resolveSelection(first);
-    const allowFuzzy = providers.has(normalizeProviderId(first)) || first.trim().length >= 6;
+    const [modelPart, profilePart] = first.split("@", 2);
+    const resolved = resolveSelection(modelPart);
+    const allowFuzzy =
+      providers.has(normalizeProviderId(modelPart)) || modelPart.trim().length >= 6;
     if (allowFuzzy) {
       selection = resolved.selection;
       if (selection) {
         consumed = 1;
+        rawProfile = profilePart?.trim() || undefined;
       }
     }
   }
@@ -186,11 +214,58 @@ export async function applyResetModelOverride(params: {
   }
 
   const cleanedBody = tokens.slice(consumed).join(" ").trim();
+  const agentDir = params.agentId ? resolveAgentDir(params.cfg, params.agentId) : undefined;
+  const resolvedProfile = resolveModelAuthProfile({
+    rawProfile,
+    provider: selection.provider,
+    cfg: params.cfg,
+    agentDir,
+    sessionEntry: params.sessionEntry,
+  });
+  if (resolvedProfile.error) {
+    const warningText = [`System: ${resolvedProfile.error}`, cleanedBody]
+      .filter(Boolean)
+      .join("\n\n");
+    params.sessionCtx.Body = warningText;
+    params.sessionCtx.BodyForAgent = warningText;
+    params.sessionCtx.BodyStripped = warningText;
+    params.sessionCtx.BodyForCommands = warningText;
+    params.sessionCtx.CommandBody = warningText;
+    params.sessionCtx.RawBody = warningText;
+    return { cleanedBody, errorText: resolvedProfile.error };
+  }
+  profileOverride = resolvedProfile.profileId;
+  profileOverrideSource = resolvedProfile.profileOverrideSource;
+  const compatibility = validateModelAuthProfileCompatibility({
+    provider: selection.provider,
+    model: selection.model,
+    profileId: profileOverride,
+    agentDir,
+  });
+  if (compatibility.error) {
+    const warningText = [`System: ${compatibility.error}`, cleanedBody]
+      .filter(Boolean)
+      .join("\n\n");
+    params.sessionCtx.Body = warningText;
+    params.sessionCtx.BodyForAgent = warningText;
+    params.sessionCtx.BodyStripped = warningText;
+    params.sessionCtx.BodyForCommands = warningText;
+    params.sessionCtx.CommandBody = warningText;
+    params.sessionCtx.RawBody = warningText;
+    return { cleanedBody, errorText: compatibility.error };
+  }
+
+  params.sessionCtx.Body = cleanedBody;
+  params.sessionCtx.BodyForAgent = cleanedBody;
   params.sessionCtx.BodyStripped = cleanedBody;
   params.sessionCtx.BodyForCommands = cleanedBody;
+  params.sessionCtx.CommandBody = cleanedBody;
+  params.sessionCtx.RawBody = cleanedBody;
 
   applySelectionToSession({
     selection,
+    profileOverride,
+    profileOverrideSource,
     sessionEntry: params.sessionEntry,
     sessionStore: params.sessionStore,
     sessionKey: params.sessionKey,

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -89,6 +89,7 @@ function applySelectionToSession(params: {
     selection,
     profileOverride,
     profileOverrideSource,
+    persistDefaultSelection: true,
   });
   if (!updated) {
     return;

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -12,6 +12,18 @@ function applyOpenAiSelection(entry: SessionEntry) {
   });
 }
 
+function applyOpenAiDefaultSelection(entry: SessionEntry) {
+  return applyModelOverrideToSessionEntry({
+    entry,
+    selection: {
+      provider: "openai",
+      model: "gpt-5.2",
+      isDefault: true,
+    },
+    persistDefaultSelection: true,
+  });
+}
+
 function expectRuntimeModelFieldsCleared(entry: SessionEntry, before: number) {
   expect(entry.providerOverride).toBe("openai");
   expect(entry.modelOverride).toBe("gpt-5.2");
@@ -116,5 +128,25 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(entry.modelOverride).toBeUndefined();
     expect(entry.contextTokens).toBeUndefined();
     expect((entry.updatedAt ?? 0) > before).toBe(true);
+  });
+
+  it("can persist an explicit default-model selection", () => {
+    const before = Date.now() - 5_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-5",
+      updatedAt: before,
+      modelProvider: "openai",
+      model: "gpt-5.4",
+      contextTokens: 4_096,
+    };
+
+    const result = applyOpenAiDefaultSelection(entry);
+
+    expect(result.updated).toBe(true);
+    expect(entry.providerOverride).toBe("openai");
+    expect(entry.modelOverride).toBe("gpt-5.2");
+    expect(entry.modelProvider).toBeUndefined();
+    expect(entry.model).toBeUndefined();
+    expect(entry.contextTokens).toBeUndefined();
   });
 });

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -11,13 +11,15 @@ export function applyModelOverrideToSessionEntry(params: {
   selection: ModelOverrideSelection;
   profileOverride?: string;
   profileOverrideSource?: "auto" | "user";
+  persistDefaultSelection?: boolean;
 }): { updated: boolean } {
   const { entry, selection, profileOverride } = params;
   const profileOverrideSource = params.profileOverrideSource ?? "user";
+  const persistDefaultSelection = params.persistDefaultSelection === true;
   let updated = false;
   let selectionUpdated = false;
 
-  if (selection.isDefault) {
+  if (selection.isDefault && !persistDefaultSelection) {
     if (entry.providerOverride) {
       delete entry.providerOverride;
       updated = true;


### PR DESCRIPTION
## What changed

This fixes several cases where `/model` or `/new` appeared to accept a model change, but the session either kept the wrong auth profile or hid the fact that runtime had fallen back to a different model.

The PR does three things:

- keep explicit user auth-profile overrides stable across `/new`
- make `/new <model>@<auth-profile>` support the same explicit auth-profile syntax as `/model <model>@<auth-profile>`
- make `/status` show inferred fallback details whenever the selected model differs from the active runtime model

## Why this is needed

The current behavior makes model switching look successful even when it is not.

In practice this shows up as:

- `/new spark` or `/model spark` says the model switched, but the next turn still runs on another auth or another model
- `/new` can silently rotate away from the user-selected default auth profile on a new session
- `/new spark@openai-codex:default` does not preserve the explicit auth profile even though `/model spark@openai-codex:default` does
- `/status` can hide runtime fallback when fallback metadata is missing or stale

That combination makes it hard to tell whether the problem is config, session state, or runtime fallback.

## Root cause

- new-session auth resolution treated every new session as an opportunity to rotate to the next auth profile, even when the current override was explicitly user-selected
- the reset-model path used by `/new` parsed only model selection, not trailing `@auth-profile` overrides
- the reset-model path stripped only part of the consumed command text, which could leak the selected alias into the first prompt body
- `/status` depended too heavily on persisted fallback metadata instead of also inferring fallback from selected vs active runtime model drift

## User impact

After this change:

- `/model <model>` changes model selection for future turns and clears any pinned auth override
- `/model <model>@<auth-profile>` changes both model and auth explicitly
- `/new <model>` starts a new session without silently rotating off the default auth profile
- `/new <model>@<auth-profile>` now behaves consistently with `/model <model>@<auth-profile>`
- `/status` reports fallback more honestly when runtime differs from selection

## Validation

- `pnpm test -- --run src/auto-reply/reply/session-reset-model.test.ts src/auto-reply/status.test.ts src/agents/auth-profiles/session-override.test.ts`
- repo commit hooks passed during commit, including the project `check` pipeline
