### PR TITLE
fix: ensure ToolAuthorizationError.status is always 403 across transpilers

### DIFF
--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -35,10 +35,20 @@ export class ToolInputError extends Error {
 }
 
 export class ToolAuthorizationError extends ToolInputError {
-  override readonly status = 403;
+  // Use `declare` to keep the narrowed type without relying on a class field
+  // initializer, which may not be applied correctly on Error subclasses in
+  // certain transpiler/engine combinations. The value is set explicitly via
+  // Object.defineProperty in the constructor instead.
+  declare readonly status: 403;
 
   constructor(message: string) {
     super(message);
+    Object.defineProperty(this, "status", {
+      value: 403,
+      writable: false,
+      enumerable: true,
+      configurable: true,
+    });
     this.name = "ToolAuthorizationError";
   }
 }


### PR DESCRIPTION
## Summary

- `ToolAuthorizationError` used a class field initializer (`override readonly status = 403`) to set its HTTP status code
- Class field initializers on `Error` subclasses are not reliably applied in all transpiler/engine combinations (observed failures in CI with Node 24 + esbuild, where `status` ends up `undefined` on the instance)
- Replace the class field with `declare readonly status: 403` (type-only, no runtime effect) and an explicit `Object.defineProperty` call in the constructor body, which works correctly in all environments

## Test plan

- [ ] `pnpm test -- extensions/whatsapp/src/action-runtime.test.ts` — all 13 tests pass
- [ ] `pnpm check` — no errors
- [ ] CI `extension-fast (whatsapp)` and `checks-node-channels-3` — should now pass the `applies default account allowFrom when accountId is omitted` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)