### PR TITLE
test: slim test setup runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ changelog/fragments/
 # Local scratch workspace
 .tmp/
 test/fixtures/openclaw-vitest-unit-report.json
+analysis/

--- a/src/agents/context-runtime-state.ts
+++ b/src/agents/context-runtime-state.ts
@@ -1,0 +1,37 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { MODEL_CONTEXT_TOKEN_CACHE } from "./context-cache.js";
+
+const CONTEXT_WINDOW_RUNTIME_STATE_KEY = Symbol.for("openclaw.contextWindowRuntimeState");
+
+type ContextWindowRuntimeState = {
+  loadPromise: Promise<void> | null;
+  configuredConfig: OpenClawConfig | undefined;
+  configLoadFailures: number;
+  nextConfigLoadAttemptAtMs: number;
+  modelsConfigRuntimePromise: Promise<typeof import("./models-config.runtime.js")> | undefined;
+};
+
+export const CONTEXT_WINDOW_RUNTIME_STATE = (() => {
+  const globalState = globalThis as typeof globalThis & {
+    [CONTEXT_WINDOW_RUNTIME_STATE_KEY]?: ContextWindowRuntimeState;
+  };
+  if (!globalState[CONTEXT_WINDOW_RUNTIME_STATE_KEY]) {
+    globalState[CONTEXT_WINDOW_RUNTIME_STATE_KEY] = {
+      loadPromise: null,
+      configuredConfig: undefined,
+      configLoadFailures: 0,
+      nextConfigLoadAttemptAtMs: 0,
+      modelsConfigRuntimePromise: undefined,
+    };
+  }
+  return globalState[CONTEXT_WINDOW_RUNTIME_STATE_KEY];
+})();
+
+export function resetContextWindowCacheForTest(): void {
+  CONTEXT_WINDOW_RUNTIME_STATE.loadPromise = null;
+  CONTEXT_WINDOW_RUNTIME_STATE.configuredConfig = undefined;
+  CONTEXT_WINDOW_RUNTIME_STATE.configLoadFailures = 0;
+  CONTEXT_WINDOW_RUNTIME_STATE.nextConfigLoadAttemptAtMs = 0;
+  CONTEXT_WINDOW_RUNTIME_STATE.modelsConfigRuntimePromise = undefined;
+  MODEL_CONTEXT_TOKEN_CACHE.clear();
+}

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -8,7 +8,10 @@ import { computeBackoff, type BackoffPolicy } from "../infra/backoff.js";
 import { consumeRootOptionToken, FLAG_TERMINATOR } from "../infra/cli-root-options.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
 import { lookupCachedContextTokens, MODEL_CONTEXT_TOKEN_CACHE } from "./context-cache.js";
+import { CONTEXT_WINDOW_RUNTIME_STATE } from "./context-runtime-state.js";
 import { normalizeProviderId } from "./model-selection.js";
+
+export { resetContextWindowCacheForTest } from "./context-runtime-state.js";
 
 type ModelEntry = { id: string; contextWindow?: number };
 type ModelRegistryLike = {
@@ -79,15 +82,9 @@ export function applyConfiguredContextWindows(params: {
   }
 }
 
-let loadPromise: Promise<void> | null = null;
-let configuredConfig: OpenClawConfig | undefined;
-let configLoadFailures = 0;
-let nextConfigLoadAttemptAtMs = 0;
-let modelsConfigRuntimePromise: Promise<typeof import("./models-config.runtime.js")> | undefined;
-
 function loadModelsConfigRuntime() {
-  modelsConfigRuntimePromise ??= import("./models-config.runtime.js");
-  return modelsConfigRuntimePromise;
+  CONTEXT_WINDOW_RUNTIME_STATE.modelsConfigRuntimePromise ??= import("./models-config.runtime.js");
+  return CONTEXT_WINDOW_RUNTIME_STATE.modelsConfigRuntimePromise;
 }
 
 function isLikelyOpenClawCliProcess(argv: string[] = process.argv): boolean {
@@ -160,10 +157,10 @@ function shouldEagerWarmContextWindowCache(argv: string[] = process.argv): boole
 }
 
 function primeConfiguredContextWindows(): OpenClawConfig | undefined {
-  if (configuredConfig) {
-    return configuredConfig;
+  if (CONTEXT_WINDOW_RUNTIME_STATE.configuredConfig) {
+    return CONTEXT_WINDOW_RUNTIME_STATE.configuredConfig;
   }
-  if (Date.now() < nextConfigLoadAttemptAtMs) {
+  if (Date.now() < CONTEXT_WINDOW_RUNTIME_STATE.nextConfigLoadAttemptAtMs) {
     return undefined;
   }
   try {
@@ -172,22 +169,25 @@ function primeConfiguredContextWindows(): OpenClawConfig | undefined {
       cache: MODEL_CONTEXT_TOKEN_CACHE,
       modelsConfig: cfg.models as ModelsConfig | undefined,
     });
-    configuredConfig = cfg;
-    configLoadFailures = 0;
-    nextConfigLoadAttemptAtMs = 0;
+    CONTEXT_WINDOW_RUNTIME_STATE.configuredConfig = cfg;
+    CONTEXT_WINDOW_RUNTIME_STATE.configLoadFailures = 0;
+    CONTEXT_WINDOW_RUNTIME_STATE.nextConfigLoadAttemptAtMs = 0;
     return cfg;
   } catch {
-    configLoadFailures += 1;
-    const backoffMs = computeBackoff(CONFIG_LOAD_RETRY_POLICY, configLoadFailures);
-    nextConfigLoadAttemptAtMs = Date.now() + backoffMs;
+    CONTEXT_WINDOW_RUNTIME_STATE.configLoadFailures += 1;
+    const backoffMs = computeBackoff(
+      CONFIG_LOAD_RETRY_POLICY,
+      CONTEXT_WINDOW_RUNTIME_STATE.configLoadFailures,
+    );
+    CONTEXT_WINDOW_RUNTIME_STATE.nextConfigLoadAttemptAtMs = Date.now() + backoffMs;
     // If config can't be loaded, leave cache empty and retry after backoff.
     return undefined;
   }
 }
 
 function ensureContextWindowCacheLoaded(): Promise<void> {
-  if (loadPromise) {
-    return loadPromise;
+  if (CONTEXT_WINDOW_RUNTIME_STATE.loadPromise) {
+    return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
   }
 
   const cfg = primeConfiguredContextWindows();
@@ -195,7 +195,7 @@ function ensureContextWindowCacheLoaded(): Promise<void> {
     return Promise.resolve();
   }
 
-  loadPromise = (async () => {
+  CONTEXT_WINDOW_RUNTIME_STATE.loadPromise = (async () => {
     try {
       await (await loadModelsConfigRuntime()).ensureOpenClawModelsJson(cfg);
     } catch {
@@ -227,16 +227,7 @@ function ensureContextWindowCacheLoaded(): Promise<void> {
   })().catch(() => {
     // Keep lookup best-effort.
   });
-  return loadPromise;
-}
-
-export function resetContextWindowCacheForTest(): void {
-  loadPromise = null;
-  configuredConfig = undefined;
-  configLoadFailures = 0;
-  nextConfigLoadAttemptAtMs = 0;
-  modelsConfigRuntimePromise = undefined;
-  MODEL_CONTEXT_TOKEN_CACHE.clear();
+  return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
 }
 
 export function lookupContextTokens(

--- a/src/agents/models-config-state.ts
+++ b/src/agents/models-config-state.ts
@@ -1,0 +1,29 @@
+const MODELS_JSON_STATE_KEY = Symbol.for("openclaw.modelsJsonState");
+
+type ModelsJsonState = {
+  writeLocks: Map<string, Promise<void>>;
+  readyCache: Map<
+    string,
+    Promise<{ fingerprint: string; result: { agentDir: string; wrote: boolean } }>
+  >;
+};
+
+export const MODELS_JSON_STATE = (() => {
+  const globalState = globalThis as typeof globalThis & {
+    [MODELS_JSON_STATE_KEY]?: ModelsJsonState;
+  };
+  if (!globalState[MODELS_JSON_STATE_KEY]) {
+    globalState[MODELS_JSON_STATE_KEY] = {
+      writeLocks: new Map<string, Promise<void>>(),
+      readyCache: new Map<
+        string,
+        Promise<{ fingerprint: string; result: { agentDir: string; wrote: boolean } }>
+      >(),
+    };
+  }
+  return globalState[MODELS_JSON_STATE_KEY];
+})();
+
+export function resetModelsJsonReadyCacheForTest(): void {
+  MODELS_JSON_STATE.readyCache.clear();
+}

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -8,13 +8,10 @@ import {
 } from "../config/config.js";
 import { createConfigRuntimeEnv } from "../config/env-vars.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import { MODELS_JSON_STATE } from "./models-config-state.js";
 import { planOpenClawModelsJson } from "./models-config.plan.js";
 
-const MODELS_JSON_WRITE_LOCKS = new Map<string, Promise<void>>();
-const MODELS_JSON_READY_CACHE = new Map<
-  string,
-  Promise<{ fingerprint: string; result: { agentDir: string; wrote: boolean } }>
->();
+export { resetModelsJsonReadyCacheForTest } from "./models-config-state.js";
 
 async function readFileMtimeMs(pathname: string): Promise<number | null> {
   try {
@@ -117,20 +114,20 @@ function resolveModelsConfigInput(config?: OpenClawConfig): {
 }
 
 async function withModelsJsonWriteLock<T>(targetPath: string, run: () => Promise<T>): Promise<T> {
-  const prior = MODELS_JSON_WRITE_LOCKS.get(targetPath) ?? Promise.resolve();
+  const prior = MODELS_JSON_STATE.writeLocks.get(targetPath) ?? Promise.resolve();
   let release: () => void = () => {};
   const gate = new Promise<void>((resolve) => {
     release = resolve;
   });
   const pending = prior.then(() => gate);
-  MODELS_JSON_WRITE_LOCKS.set(targetPath, pending);
+  MODELS_JSON_STATE.writeLocks.set(targetPath, pending);
   try {
     await prior;
     return await run();
   } finally {
     release();
-    if (MODELS_JSON_WRITE_LOCKS.get(targetPath) === pending) {
-      MODELS_JSON_WRITE_LOCKS.delete(targetPath);
+    if (MODELS_JSON_STATE.writeLocks.get(targetPath) === pending) {
+      MODELS_JSON_STATE.writeLocks.delete(targetPath);
     }
   }
 }
@@ -148,7 +145,7 @@ export async function ensureOpenClawModelsJson(
     sourceConfigForSecrets: resolved.sourceConfigForSecrets,
     agentDir,
   });
-  const cached = MODELS_JSON_READY_CACHE.get(targetPath);
+  const cached = MODELS_JSON_STATE.readyCache.get(targetPath);
   if (cached) {
     const settled = await cached;
     if (settled.fingerprint === fingerprint) {
@@ -185,18 +182,14 @@ export async function ensureOpenClawModelsJson(
     await ensureModelsFileMode(targetPath);
     return { fingerprint, result: { agentDir, wrote: true } };
   });
-  MODELS_JSON_READY_CACHE.set(targetPath, pending);
+  MODELS_JSON_STATE.readyCache.set(targetPath, pending);
   try {
     const settled = await pending;
     return settled.result;
   } catch (error) {
-    if (MODELS_JSON_READY_CACHE.get(targetPath) === pending) {
-      MODELS_JSON_READY_CACHE.delete(targetPath);
+    if (MODELS_JSON_STATE.readyCache.get(targetPath) === pending) {
+      MODELS_JSON_STATE.readyCache.delete(targetPath);
     }
     throw error;
   }
-}
-
-export function resetModelsJsonReadyCacheForTest(): void {
-  MODELS_JSON_READY_CACHE.clear();
 }

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -48,10 +48,14 @@ vi.mock("../infra/update-runner.js", () => ({
   runGatewayUpdate: vi.fn(),
 }));
 
-vi.mock("../infra/openclaw-root.js", () => ({
-  resolveOpenClawPackageRoot: vi.fn(),
-  resolveOpenClawPackageRootSync: vi.fn(() => process.cwd()),
-}));
+vi.mock("../infra/openclaw-root.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/openclaw-root.js")>();
+  return {
+    ...actual,
+    resolveOpenClawPackageRoot: vi.fn(),
+    resolveOpenClawPackageRootSync: vi.fn(() => process.cwd()),
+  };
+});
 
 vi.mock("../config/config.js", () => ({
   readConfigFileSnapshot: vi.fn(),

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -448,10 +448,14 @@ vi.mock("../gateway/session-utils.js", async (importOriginal) => {
     ...actual,
   };
 });
-vi.mock("../infra/openclaw-root.js", () => ({
-  resolveOpenClawPackageRoot: vi.fn().mockResolvedValue("/tmp/openclaw"),
-  resolveOpenClawPackageRootSync: vi.fn(() => "/tmp/openclaw"),
-}));
+vi.mock("../infra/openclaw-root.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/openclaw-root.js")>();
+  return {
+    ...actual,
+    resolveOpenClawPackageRoot: vi.fn().mockResolvedValue("/tmp/openclaw"),
+    resolveOpenClawPackageRootSync: vi.fn(() => "/tmp/openclaw"),
+  };
+});
 vi.mock("../infra/os-summary.js", () => ({
   resolveOsSummary: () => ({
     platform: "darwin",

--- a/src/config/sessions/store-lock-state.ts
+++ b/src/config/sessions/store-lock-state.ts
@@ -1,0 +1,51 @@
+import { clearSessionStoreCaches } from "./store-cache.js";
+
+export type SessionStoreLockTask = {
+  fn: () => Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+  timeoutMs?: number;
+  staleMs: number;
+};
+
+export type SessionStoreLockQueue = {
+  running: boolean;
+  pending: SessionStoreLockTask[];
+  drainPromise: Promise<void> | null;
+};
+
+export const LOCK_QUEUES = new Map<string, SessionStoreLockQueue>();
+
+export function clearSessionStoreCacheForTest(): void {
+  clearSessionStoreCaches();
+  for (const queue of LOCK_QUEUES.values()) {
+    for (const task of queue.pending) {
+      task.reject(new Error("session store queue cleared for test"));
+    }
+  }
+  LOCK_QUEUES.clear();
+}
+
+export async function drainSessionStoreLockQueuesForTest(): Promise<void> {
+  while (LOCK_QUEUES.size > 0) {
+    const queues = [...LOCK_QUEUES.values()];
+    for (const queue of queues) {
+      for (const task of queue.pending) {
+        task.reject(new Error("session store queue cleared for test"));
+      }
+      queue.pending.length = 0;
+    }
+    const activeDrains = queues.flatMap((queue) =>
+      queue.drainPromise ? [queue.drainPromise] : [],
+    );
+    if (activeDrains.length === 0) {
+      LOCK_QUEUES.clear();
+      return;
+    }
+    await Promise.allSettled(activeDrains);
+  }
+}
+
+export function getSessionStoreLockQueueSizeForTest(): number {
+  return LOCK_QUEUES.size;
+}

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -18,7 +18,6 @@ import { getFileStatSnapshot } from "../cache-utils.js";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
 import {
-  clearSessionStoreCaches,
   dropSessionStoreObjectCache,
   getSerializedSessionStore,
   isSessionStoreCacheEnabled,
@@ -26,6 +25,14 @@ import {
   setSerializedSessionStore,
   writeSessionStoreCache,
 } from "./store-cache.js";
+import {
+  clearSessionStoreCacheForTest,
+  drainSessionStoreLockQueuesForTest,
+  getSessionStoreLockQueueSizeForTest,
+  LOCK_QUEUES,
+  type SessionStoreLockQueue,
+  type SessionStoreLockTask,
+} from "./store-lock-state.js";
 import {
   capEntryCount,
   getActiveSessionMaintenanceWarning,
@@ -42,6 +49,12 @@ import {
   normalizeSessionRuntimeModelFields,
   type SessionEntry,
 } from "./types.js";
+
+export {
+  clearSessionStoreCacheForTest,
+  drainSessionStoreLockQueuesForTest,
+  getSessionStoreLockQueueSizeForTest,
+} from "./store-lock-state.js";
 
 const log = createSubsystemLogger("sessions/store");
 let sessionArchiveRuntimePromise: Promise<
@@ -157,16 +170,6 @@ function normalizeSessionStore(store: Record<string, SessionEntry>): void {
   }
 }
 
-export function clearSessionStoreCacheForTest(): void {
-  clearSessionStoreCaches();
-  for (const queue of LOCK_QUEUES.values()) {
-    for (const task of queue.pending) {
-      task.reject(new Error("session store queue cleared for test"));
-    }
-  }
-  LOCK_QUEUES.clear();
-}
-
 export function setSessionWriteLockAcquirerForTests(
   acquirer: typeof acquireSessionWriteLock | null,
 ): void {
@@ -175,31 +178,6 @@ export function setSessionWriteLockAcquirerForTests(
 
 export function resetSessionStoreLockRuntimeForTests(): void {
   sessionWriteLockAcquirerForTests = null;
-}
-
-export async function drainSessionStoreLockQueuesForTest(): Promise<void> {
-  while (LOCK_QUEUES.size > 0) {
-    const queues = [...LOCK_QUEUES.values()];
-    for (const queue of queues) {
-      for (const task of queue.pending) {
-        task.reject(new Error("session store queue cleared for test"));
-      }
-      queue.pending.length = 0;
-    }
-    const activeDrains = queues.flatMap((queue) =>
-      queue.drainPromise ? [queue.drainPromise] : [],
-    );
-    if (activeDrains.length === 0) {
-      LOCK_QUEUES.clear();
-      return;
-    }
-    await Promise.allSettled(activeDrains);
-  }
-}
-
-/** Expose lock queue size for tests. */
-export function getSessionStoreLockQueueSizeForTest(): number {
-  return LOCK_QUEUES.size;
 }
 
 export async function withSessionStoreLockForTest<T>(
@@ -632,22 +610,6 @@ type SessionStoreLockOptions = {
 
 const SESSION_STORE_LOCK_MIN_HOLD_MS = 5_000;
 const SESSION_STORE_LOCK_TIMEOUT_GRACE_MS = 5_000;
-
-type SessionStoreLockTask = {
-  fn: () => Promise<unknown>;
-  resolve: (value: unknown) => void;
-  reject: (reason: unknown) => void;
-  timeoutMs?: number;
-  staleMs: number;
-};
-
-type SessionStoreLockQueue = {
-  running: boolean;
-  pending: SessionStoreLockTask[];
-  drainPromise: Promise<void> | null;
-};
-
-const LOCK_QUEUES = new Map<string, SessionStoreLockQueue>();
 
 function getErrorCode(error: unknown): string | null {
   if (!error || typeof error !== "object" || !("code" in error)) {

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -32,9 +32,13 @@ vi.mock("../../config/sessions.js", () => ({
   },
 }));
 
-vi.mock("../../infra/openclaw-root.js", () => ({
-  resolveOpenClawPackageRoot: async () => "/tmp/openclaw",
-}));
+vi.mock("../../infra/openclaw-root.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/openclaw-root.js")>();
+  return {
+    ...actual,
+    resolveOpenClawPackageRoot: async () => "/tmp/openclaw",
+  };
+});
 
 vi.mock("../../infra/restart-sentinel.js", async (importOriginal) => {
   const actual = await importOriginal();

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -5,9 +5,13 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { captureEnv } from "../test-utils/env.js";
 import type { UpdateCheckResult } from "./update-check.js";
 
-vi.mock("./openclaw-root.js", () => ({
-  resolveOpenClawPackageRoot: vi.fn(),
-}));
+vi.mock("./openclaw-root.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./openclaw-root.js")>();
+  return {
+    ...actual,
+    resolveOpenClawPackageRoot: vi.fn(),
+  };
+});
 
 vi.mock("./update-check.js", async () => {
   const parse = (value: string) => value.split(".").map((part) => Number.parseInt(part, 10));

--- a/src/test-utils/session-state-cleanup.ts
+++ b/src/test-utils/session-state-cleanup.ts
@@ -1,8 +1,6 @@
 import { drainSessionWriteLockStateForTest } from "../agents/session-write-lock.js";
-import {
-  clearSessionStoreCacheForTest,
-  drainSessionStoreLockQueuesForTest,
-} from "../config/sessions/store.js";
+import { clearSessionStoreCaches } from "../config/sessions/store-cache.js";
+import { drainSessionStoreLockQueuesForTest } from "../config/sessions/store-lock-state.js";
 import { drainFileLockStateForTest } from "../infra/file-lock.js";
 
 let fileLockDrainerForTests: typeof drainFileLockStateForTest | null = null;
@@ -33,7 +31,7 @@ export function resetSessionStateCleanupRuntimeForTests(): void {
 
 export async function cleanupSessionStateForTest(): Promise<void> {
   await (sessionStoreLockQueueDrainerForTests ?? drainSessionStoreLockQueuesForTest)();
-  clearSessionStoreCacheForTest();
+  clearSessionStoreCaches();
   await (fileLockDrainerForTests ?? drainFileLockStateForTest)();
   await (sessionWriteLockDrainerForTests ?? drainSessionWriteLockStateForTest)();
 }

--- a/test/setup-openclaw-runtime.ts
+++ b/test/setup-openclaw-runtime.ts
@@ -6,6 +6,7 @@ import type {
 } from "../src/channels/plugins/types.js";
 import type { OpenClawConfig } from "../src/config/config.js";
 import type { OutboundSendDeps } from "../src/infra/outbound/deliver.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../src/plugins/runtime.js";
 import type { PluginRegistry } from "../src/plugins/registry.js";
 import { installSharedTestSetup } from "./setup.shared.js";
 
@@ -27,37 +28,12 @@ const [
   import("../src/test-utils/session-state-cleanup.js"),
 ]);
 
-const REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
 const WORKER_RUNTIME_STATE = Symbol.for("openclaw.testSetupRuntimeState");
-
-type RegistryState = {
-  registry: PluginRegistry | null;
-  httpRouteRegistry: PluginRegistry | null;
-  httpRouteRegistryPinned: boolean;
-  key: string | null;
-  version: number;
-};
 
 type WorkerRuntimeState = {
   defaultPluginRegistry: PluginRegistry | null;
   materializedDefaultPluginRegistry: PluginRegistry | null;
 };
-
-const globalRegistryState = (() => {
-  const globalState = globalThis as typeof globalThis & {
-    [REGISTRY_STATE]?: RegistryState;
-  };
-  if (!globalState[REGISTRY_STATE]) {
-    globalState[REGISTRY_STATE] = {
-      registry: null,
-      httpRouteRegistry: null,
-      httpRouteRegistryPinned: false,
-      key: null,
-      version: 0,
-    };
-  }
-  return globalState[REGISTRY_STATE];
-})();
 
 const workerRuntimeState = (() => {
   const globalState = globalThis as typeof globalThis & {
@@ -289,11 +265,9 @@ function resolveDefaultPluginRegistryProxy(): PluginRegistry {
 }
 
 function installDefaultPluginRegistry(): void {
-  const defaultRegistry = resolveDefaultPluginRegistryProxy();
-  globalRegistryState.registry = defaultRegistry;
-  if (!globalRegistryState.httpRouteRegistryPinned) {
-    globalRegistryState.httpRouteRegistry = defaultRegistry;
-  }
+  workerRuntimeState.materializedDefaultPluginRegistry = null;
+  resetPluginRuntimeStateForTest();
+  setActivePluginRegistry(resolveDefaultPluginRegistryProxy());
 }
 
 beforeAll(() => {
@@ -305,11 +279,7 @@ afterEach(async () => {
   resetContextWindowCacheForTest();
   resetModelsJsonReadyCacheForTest();
   resetSessionWriteLockStateForTest();
-  if (globalRegistryState.registry !== resolveDefaultPluginRegistryProxy()) {
-    installDefaultPluginRegistry();
-    globalRegistryState.key = null;
-    globalRegistryState.version += 1;
-  }
+  installDefaultPluginRegistry();
 });
 
 afterAll(async () => {

--- a/test/setup-openclaw-runtime.ts
+++ b/test/setup-openclaw-runtime.ts
@@ -270,6 +270,11 @@ function installDefaultPluginRegistry(): void {
   setActivePluginRegistry(resolveDefaultPluginRegistryProxy());
 }
 
+// Some suites import channel/plugin consumers at module top level, before
+// Vitest runs hooks. Seed the lazy registry during setup module evaluation so
+// import-time lookups still see the default test registry.
+installDefaultPluginRegistry();
+
 beforeAll(() => {
   installDefaultPluginRegistry();
 });

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -141,6 +141,25 @@ describe("installTestEnv", () => {
     expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
   });
 
+  it("does not load ~/.profile for normal isolated test runs", () => {
+    const realHome = createTempHome();
+    writeFile(path.join(realHome, ".profile"), "export TEST_PROFILE_ONLY=from-profile\n");
+
+    process.env.HOME = realHome;
+    process.env.USERPROFILE = realHome;
+    delete process.env.LIVE;
+    delete process.env.OPENCLAW_LIVE_TEST;
+    delete process.env.OPENCLAW_LIVE_GATEWAY;
+    delete process.env.OPENCLAW_LIVE_USE_REAL_HOME;
+    delete process.env.OPENCLAW_LIVE_TEST_QUIET;
+
+    const testEnv = installTestEnv();
+    cleanupFns.push(testEnv.cleanup);
+
+    expect(testEnv.tempHome).not.toBe(realHome);
+    expect(process.env.TEST_PROFILE_ONLY).toBeUndefined();
+  });
+
   it("falls back to parsing ~/.profile when bash is unavailable", async () => {
     const realHome = createTempHome();
     writeFile(path.join(realHome, ".profile"), "export TEST_PROFILE_ONLY=from-profile\n");


### PR DESCRIPTION
## Summary

- Problem: test bootstrap was carrying unnecessary non-live setup work, and shared runtime singleton state for session locking and context/models config was embedded in broader modules.
- Why it matters: that makes test setup more eager than necessary, increases import/setup fan-out, and makes later test-system cleanup harder to reason about.
- What changed: non-live setup was trimmed, shared runtime state was moved behind narrower state modules, `test/setup-openclaw-runtime.ts` was simplified to use the runtime plugin-state seam directly, and package-root-sensitive tests were hardened to stay deterministic under the lighter setup.
- What did NOT change (scope boundary): no intended product behavior changes; this PR is limited to test bootstrap/runtime state structure and the tests needed to keep that structure stable.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #60249
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: shared test/runtime state had accumulated inside broader startup modules, and non-live setup was still doing work that only live-oriented paths needed.
- Missing detection / guardrail: setup cost and coupling were not isolated enough for ownership boundaries to stay obvious.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this is part of the ongoing test-system cleanup and performance work tracked in the local redesign notes and split out from #60249.
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[test bootstrap] -> [broader shared runtime state + extra setup work]

After:
[test bootstrap] -> [narrower state modules + lighter non-live setup]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local test/build setup

### Steps

1. Check out `refactor/test-setup-slimming`
2. Run `pnpm check`
3. Run `pnpm build`
4. Run the scoped verification command below

### Expected

- check/build pass
- touched setup/runtime tests stay green
- lighter setup remains deterministic for package-root-sensitive test cases

### Actual

- `pnpm check` passed
- `pnpm build` passed
- scoped owner tests passed

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Scoped verification used:

- `pnpm test -- test/test-env.test.ts src/cli/update-cli.test.ts src/commands/status.test.ts src/gateway/server-methods/update.test.ts src/infra/update-startup.test.ts src/config/sessions/store.lock.test.ts src/config/sessions/store-read.test.ts src/agents/context.test.ts src/agents/models-config.merge.test.ts src/agents/models-config.runtime-source-snapshot.test.ts src/agents/context.lookup.test.ts -t "returns configured model context window on first lookup|returns sync config overrides for read-only callers|only warms eagerly for real openclaw startup commands that need model metadata" --reporter=verbose`

## Human Verification (required)

- Verified scenarios: non-live test env behavior, setup/runtime state changes for session store locking and context/models-config, package-root-sensitive test paths, and final rebased `pnpm check` / `pnpm build`.
- Edge cases checked: live vs non-live test env branching, runtime plugin-state setup, and the context lookup fast-path assertions used by the touched startup modules.
- What you did **not** verify: full-suite `pnpm test` was not used as the gate for this small slice; verification was scoped to the touched setup/runtime surfaces plus repo-wide `check` and `build`.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: lighter setup can expose brittle tests that previously passed only because heavier setup happened first.
  - Mitigation: package-root-sensitive tests were updated in the same PR, and the touched setup/runtime surfaces were revalidated on the rebased tip.
- Risk: moving runtime singleton state into narrower modules can break callers that relied on implicit shared state.
  - Mitigation: the affected setup and owner tests were rerun, and `pnpm build` passed on the rebased branch.
