### PR TITLE
Fix Xiaomi MiMo reasoning-only completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Slack: keep finalized draft-preview replies visible when a later same-turn tool warning is delivered normally instead of clearing the edited answer. Fixes #81903. (#81979) Thanks @neeravmakwana.
 - Providers/Xiaomi: preserve MiMo `reasoning_content` on multi-turn tool-call replay, including custom Xiaomi-compatible proxy routes, so follow-up turns no longer fail with `400 Param Incorrect`. Fixes #81419. (#81589) Thanks @lovelefeng-glitch and @jimdawdy-hub.
 - Slack/plugins: route plugin-owned modal `view_submission` and `view_closed` events through Slack interactive handlers before compacting the agent-visible system event, so plugins can persist full submitted form state while the transcript stays compact. Fixes #82102. Thanks @shannon0430.
+- Providers/Xiaomi: promote legacy MiMo V2 reasoning-only final answers to visible text, including Xiaomi-compatible proxy routes, so `mimo-v2-pro` and `mimo-v2-omni` replies no longer appear blank when the answer arrives in `reasoning_content`. Fixes #60261. (#60304) Thanks @HiddenPuppy.
 - Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @frankekn, @loyur, and @JanPlessow.
 
 ## 2026.5.14

--- a/extensions/xiaomi/index.test.ts
+++ b/extensions/xiaomi/index.test.ts
@@ -1,3 +1,4 @@
+import type { StreamFn } from "@earendil-works/pi-agent-core";
 import type { Context, Model } from "@earendil-works/pi-ai";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 import {
@@ -30,6 +31,10 @@ type ReplayToolCall = {
 };
 
 type RegisteredProvider = Awaited<ReturnType<typeof registerSingleProviderPlugin>>;
+type FakeStream = {
+  result: () => Promise<unknown>;
+  [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
+};
 
 const emptyUsage = {
   input: 0,
@@ -139,6 +144,29 @@ function createPayloadCapturingStream(capture: PayloadCapture, model: OpenAIComp
     queueMicrotask(() => stream.end());
     return stream;
   };
+}
+
+function createFakeStream(params: { events: unknown[]; resultMessage: unknown }): FakeStream {
+  return {
+    async result() {
+      return params.resultMessage;
+    },
+    [Symbol.asyncIterator]() {
+      return (async function* () {
+        for (const event of params.events) {
+          yield event;
+        }
+      })();
+    },
+  };
+}
+
+function createResultStreamFn(params: { events?: unknown[]; resultMessage: unknown }): StreamFn {
+  return () =>
+    createFakeStream({
+      events: params.events ?? [],
+      resultMessage: params.resultMessage,
+    }) as ReturnType<StreamFn>;
 }
 
 function requireThinkingWrapper(
@@ -311,5 +339,100 @@ describe("xiaomi provider plugin", () => {
     expect((capture.payload?.messages as Array<Record<string, unknown>>)[1]).not.toHaveProperty(
       "reasoning_content",
     );
+  });
+
+  it.each(["mimo-v2-pro", "mimo-v2-omni"] as const)(
+    "promotes reasoning-only terminal output to visible text for %s",
+    async (modelId) => {
+      const model = mimoReasoningModel(modelId);
+      const wrapped = requireThinkingWrapper(
+        createMiMoThinkingWrapper(
+          createResultStreamFn({
+            events: [
+              {
+                type: "message_end",
+                message: {
+                  role: "assistant",
+                  content: [{ type: "thinking", thinking: "MiMo final answer" }],
+                  stopReason: "stop",
+                },
+              },
+            ],
+            resultMessage: {
+              role: "assistant",
+              content: [{ type: "thinking", thinking: "MiMo final answer" }],
+              stopReason: "stop",
+            },
+          }),
+          "high",
+        ),
+        modelId,
+      );
+
+      const stream = (await wrapped(model, { messages: [] } as Context, {})) as FakeStream;
+      const events: unknown[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      expect(events).toEqual([
+        {
+          type: "message_end",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "MiMo final answer" }],
+            stopReason: "stop",
+          },
+        },
+      ]);
+      await expect(stream.result()).resolves.toEqual({
+        role: "assistant",
+        content: [{ type: "text", text: "MiMo final answer" }],
+        stopReason: "stop",
+      });
+    },
+  );
+
+  it("does not promote reasoning when the MiMo assistant turn also has text or tool calls", async () => {
+    const model = mimoReasoningModel("mimo-v2-pro");
+    const textMessage = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "internal" },
+        { type: "text", text: "already visible" },
+      ],
+      stopReason: "stop",
+    };
+    const toolMessage = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "call reasoning" }, readToolCall],
+      stopReason: "toolUse",
+    };
+
+    for (const resultMessage of [textMessage, toolMessage]) {
+      const wrapped = requireThinkingWrapper(
+        createMiMoThinkingWrapper(createResultStreamFn({ resultMessage }), "high"),
+        "mixed-content",
+      );
+      const stream = (await wrapped(model, { messages: [] } as Context, {})) as FakeStream;
+
+      await expect(stream.result()).resolves.toEqual(resultMessage);
+    }
+  });
+
+  it("does not promote reasoning-only output for newer MiMo replay models", async () => {
+    const model = mimoReasoningModel("mimo-v2.5-pro");
+    const resultMessage = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "actual reasoning" }],
+      stopReason: "stop",
+    };
+    const wrapped = requireThinkingWrapper(
+      createMiMoThinkingWrapper(createResultStreamFn({ resultMessage }), "high"),
+      "mimo-v2.5-pro",
+    );
+    const stream = (await wrapped(model, { messages: [] } as Context, {})) as FakeStream;
+
+    await expect(stream.result()).resolves.toEqual(resultMessage);
   });
 });

--- a/extensions/xiaomi/index.test.ts
+++ b/extensions/xiaomi/index.test.ts
@@ -59,49 +59,52 @@ function runWrappedXiaomiStream(params: {
 }
 
 describe("xiaomi provider plugin", () => {
-  it("normalizes reasoning-only final assistant messages into text for MiMo reasoning models", async () => {
-    const stream = runWrappedXiaomiStream({
-      modelId: "mimo-v2-pro",
-      events: [
+  it.each(["mimo-v2-pro", "mimo-v2-omni"])(
+    "normalizes reasoning-only final assistant messages into text for %s",
+    async (modelId) => {
+      const stream = runWrappedXiaomiStream({
+        modelId,
+        events: [
+          {
+            type: "done",
+            reason: "stop",
+            message: {
+              role: "assistant",
+              content: [{ type: "thinking", thinking: "MiMo final answer" }],
+              stopReason: "stop",
+            },
+          },
+        ],
+        resultMessage: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "MiMo final answer" }],
+          stopReason: "stop",
+        },
+      });
+
+      const events: unknown[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      await expect(stream.result()).resolves.toEqual({
+        role: "assistant",
+        content: [{ type: "text", text: "MiMo final answer" }],
+        stopReason: "stop",
+      });
+      expect(events).toEqual([
         {
           type: "done",
           reason: "stop",
           message: {
             role: "assistant",
-            content: [{ type: "thinking", thinking: "MiMo final answer" }],
+            content: [{ type: "text", text: "MiMo final answer" }],
             stopReason: "stop",
           },
         },
-      ],
-      resultMessage: {
-        role: "assistant",
-        content: [{ type: "thinking", thinking: "MiMo final answer" }],
-        stopReason: "stop",
-      },
-    });
-
-    const events: unknown[] = [];
-    for await (const event of stream) {
-      events.push(event);
-    }
-
-    await expect(stream.result()).resolves.toEqual({
-      role: "assistant",
-      content: [{ type: "text", text: "MiMo final answer" }],
-      stopReason: "stop",
-    });
-    expect(events).toEqual([
-      {
-        type: "done",
-        reason: "stop",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "MiMo final answer" }],
-          stopReason: "stop",
-        },
-      },
-    ]);
-  });
+      ]);
+    },
+  );
 
   it("leaves non-target Xiaomi models unchanged", async () => {
     const stream = runWrappedXiaomiStream({

--- a/extensions/xiaomi/index.test.ts
+++ b/extensions/xiaomi/index.test.ts
@@ -1,0 +1,149 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import plugin from "./index.js";
+
+type FakeStream = {
+  result: () => Promise<unknown>;
+  [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
+};
+
+function createFakeStream(params: { events: unknown[]; resultMessage: unknown }): FakeStream {
+  return {
+    async result() {
+      return params.resultMessage;
+    },
+    [Symbol.asyncIterator]() {
+      return (async function* () {
+        for (const event of params.events) {
+          yield event;
+        }
+      })();
+    },
+  };
+}
+
+function runWrappedXiaomiStream(params: {
+  modelId: string;
+  events: unknown[];
+  resultMessage: unknown;
+}) {
+  const provider = registerSingleProviderPlugin(plugin);
+  const baseStreamFn: StreamFn = () =>
+    createFakeStream({
+      events: params.events,
+      resultMessage: params.resultMessage,
+    }) as ReturnType<StreamFn>;
+
+  const wrapped =
+    provider.wrapStreamFn?.({
+      provider: "xiaomi",
+      modelId: params.modelId,
+      model: {
+        api: "openai-completions",
+        provider: "xiaomi",
+        id: params.modelId,
+      },
+      streamFn: baseStreamFn,
+    } as never) ?? baseStreamFn;
+
+  return wrapped(
+    {
+      api: "openai-completions",
+      provider: "xiaomi",
+      id: params.modelId,
+    } as never,
+    { messages: [] } as never,
+    {},
+  ) as FakeStream;
+}
+
+describe("xiaomi provider plugin", () => {
+  it("normalizes reasoning-only final assistant messages into text for MiMo reasoning models", async () => {
+    const stream = runWrappedXiaomiStream({
+      modelId: "mimo-v2-pro",
+      events: [
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "thinking", thinking: "MiMo final answer" }],
+            stopReason: "stop",
+          },
+        },
+      ],
+      resultMessage: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "MiMo final answer" }],
+        stopReason: "stop",
+      },
+    });
+
+    const events: unknown[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "MiMo final answer" }],
+      stopReason: "stop",
+    });
+    expect(events).toEqual([
+      {
+        type: "done",
+        reason: "stop",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "MiMo final answer" }],
+          stopReason: "stop",
+        },
+      },
+    ]);
+  });
+
+  it("leaves non-target Xiaomi models unchanged", async () => {
+    const stream = runWrappedXiaomiStream({
+      modelId: "mimo-v2-flash",
+      events: [
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "thinking", thinking: "keep as thinking" }],
+            stopReason: "stop",
+          },
+        },
+      ],
+      resultMessage: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "keep as thinking" }],
+        stopReason: "stop",
+      },
+    });
+
+    const events: unknown[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "keep as thinking" }],
+      stopReason: "stop",
+    });
+    expect(events).toEqual([
+      {
+        type: "done",
+        reason: "stop",
+        message: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "keep as thinking" }],
+          stopReason: "stop",
+        },
+      },
+    ]);
+  });
+});

--- a/extensions/xiaomi/index.ts
+++ b/extensions/xiaomi/index.ts
@@ -2,6 +2,10 @@ import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-en
 import { PROVIDER_LABELS } from "openclaw/plugin-sdk/provider-usage";
 import { applyXiaomiConfig, XIAOMI_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildXiaomiProvider } from "./provider-catalog.js";
+import {
+  createXiaomiReasoningContentTextWrapper,
+  shouldNormalizeXiaomiReasoningContentAsTextModel,
+} from "./stream.js";
 
 const PROVIDER_ID = "xiaomi";
 
@@ -39,5 +43,9 @@ export default defineSingleProviderPluginEntry({
       displayName: PROVIDER_LABELS.xiaomi,
       windows: [],
     }),
+    wrapStreamFn: ({ streamFn, model }) =>
+      shouldNormalizeXiaomiReasoningContentAsTextModel(model)
+        ? createXiaomiReasoningContentTextWrapper(streamFn)
+        : streamFn,
   },
 });

--- a/extensions/xiaomi/stream.ts
+++ b/extensions/xiaomi/stream.ts
@@ -1,14 +1,45 @@
+import type { StreamFn } from "@earendil-works/pi-agent-core";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
-import { createDeepSeekV4OpenAICompatibleThinkingWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
+import {
+  createDeepSeekV4OpenAICompatibleThinkingWrapper,
+  createThinkingOnlyFinalTextWrapper,
+} from "openclaw/plugin-sdk/provider-stream-shared";
 import { isMiMoReasoningModelRef } from "./thinking.js";
+
+const MIMO_REASONING_AS_VISIBLE_TEXT_MODEL_IDS = new Set(["mimo-v2-pro", "mimo-v2-omni"]);
+
+function normalizeMiMoModelId(modelId: unknown): string | undefined {
+  if (typeof modelId !== "string") {
+    return undefined;
+  }
+  const normalized = modelId.trim().toLowerCase().split(":", 1)[0];
+  if (!normalized) {
+    return undefined;
+  }
+  const parts = normalized.split("/").filter(Boolean);
+  return parts[parts.length - 1] ?? normalized;
+}
+
+function shouldPromoteMiMoReasoningToVisibleText(model: Parameters<StreamFn>[0]): boolean {
+  return (
+    model.provider === "xiaomi" &&
+    MIMO_REASONING_AS_VISIBLE_TEXT_MODEL_IDS.has(normalizeMiMoModelId(model.id) ?? "")
+  );
+}
 
 export function createMiMoThinkingWrapper(
   baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
   thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
 ): ProviderWrapStreamFnContext["streamFn"] {
-  return createDeepSeekV4OpenAICompatibleThinkingWrapper({
+  const wrapped = createDeepSeekV4OpenAICompatibleThinkingWrapper({
     baseStreamFn,
     thinkingLevel,
     shouldPatchModel: isMiMoReasoningModelRef,
+  });
+  // Legacy MiMo V2 can put the final user-visible answer in reasoning_content.
+  // Only promote terminal thinking-only output; replay/tool-call reasoning stays untouched.
+  return createThinkingOnlyFinalTextWrapper({
+    baseStreamFn: wrapped,
+    shouldPatchModel: shouldPromoteMiMoReasoningToVisibleText,
   });
 }

--- a/extensions/xiaomi/stream.ts
+++ b/extensions/xiaomi/stream.ts
@@ -61,7 +61,6 @@ function rewriteXiaomiReasoningContentAsTextInMessage(message: unknown): void {
       typedBlock.text.trim()
     ) {
       hasRenderableText = true;
-      break;
     }
     if (typedBlock.type === "toolCall") {
       hasToolCalls = true;

--- a/extensions/xiaomi/stream.ts
+++ b/extensions/xiaomi/stream.ts
@@ -1,0 +1,158 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { streamSimple } from "@mariozechner/pi-ai";
+
+const XIAOMI_REASONING_AS_TEXT_MODEL_IDS = new Set(["mimo-v2-pro", "mimo-v2-omni"]);
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+type XiaomiRuntimeModel = {
+  provider?: unknown;
+  id?: unknown;
+};
+
+type XiaomiMessageRecord = {
+  content?: unknown;
+  stopReason?: unknown;
+};
+
+type XiaomiContentBlock = {
+  type?: unknown;
+  text?: unknown;
+  thinking?: unknown;
+};
+
+export function shouldNormalizeXiaomiReasoningContentAsTextModel(
+  model: XiaomiRuntimeModel | undefined,
+): boolean {
+  return (
+    normalizeString(model?.provider) === "xiaomi" &&
+    XIAOMI_REASONING_AS_TEXT_MODEL_IDS.has(normalizeString(model?.id))
+  );
+}
+
+function rewriteXiaomiReasoningContentAsTextInMessage(message: unknown): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+
+  const typedMessage = message as XiaomiMessageRecord;
+  if (typedMessage.stopReason !== "stop" && typedMessage.stopReason !== "length") {
+    return;
+  }
+
+  const content = typedMessage.content;
+  if (!Array.isArray(content) || content.length === 0) {
+    return;
+  }
+
+  let hasRenderableText = false;
+  let hasToolCalls = false;
+  let hasRenderableThinking = false;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as XiaomiContentBlock;
+    if (
+      typedBlock.type === "text" &&
+      typeof typedBlock.text === "string" &&
+      typedBlock.text.trim()
+    ) {
+      hasRenderableText = true;
+      break;
+    }
+    if (typedBlock.type === "toolCall") {
+      hasToolCalls = true;
+    }
+    if (
+      typedBlock.type === "thinking" &&
+      typeof typedBlock.thinking === "string" &&
+      typedBlock.thinking.trim()
+    ) {
+      hasRenderableThinking = true;
+    }
+  }
+
+  if (hasRenderableText || hasToolCalls || !hasRenderableThinking) {
+    return;
+  }
+
+  let changed = false;
+  const nextContent = content.map((block) => {
+    if (!block || typeof block !== "object") {
+      return block;
+    }
+    const typedBlock = block as XiaomiContentBlock;
+    if (
+      typedBlock.type !== "thinking" ||
+      typeof typedBlock.thinking !== "string" ||
+      !typedBlock.thinking.trim()
+    ) {
+      return block;
+    }
+    changed = true;
+    return {
+      type: "text" as const,
+      text: typedBlock.thinking,
+    };
+  });
+
+  if (changed) {
+    typedMessage.content = nextContent;
+  }
+}
+
+function wrapXiaomiReasoningContentTextStream(
+  stream: ReturnType<typeof streamSimple>,
+): ReturnType<typeof streamSimple> {
+  const originalResult = stream.result.bind(stream);
+  stream.result = async () => {
+    const message = await originalResult();
+    rewriteXiaomiReasoningContentAsTextInMessage(message);
+    return message;
+  };
+
+  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
+  (stream as { [Symbol.asyncIterator]: typeof originalAsyncIterator })[Symbol.asyncIterator] =
+    function () {
+      const iterator = originalAsyncIterator();
+      return {
+        async next() {
+          const result = await iterator.next();
+          if (!result.done && result.value && typeof result.value === "object") {
+            const event = result.value as { message?: unknown };
+            rewriteXiaomiReasoningContentAsTextInMessage(event.message);
+          }
+          return result;
+        },
+        async return(value?: unknown) {
+          return iterator.return?.(value) ?? { done: true as const, value: undefined };
+        },
+        async throw(error?: unknown) {
+          return iterator.throw?.(error) ?? { done: true as const, value: undefined };
+        },
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
+    };
+
+  return stream;
+}
+
+export function createXiaomiReasoningContentTextWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const maybeStream = underlying(model, context, options);
+    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+      return Promise.resolve(maybeStream).then((stream) =>
+        wrapXiaomiReasoningContentTextStream(stream),
+      );
+    }
+    return wrapXiaomiReasoningContentTextStream(maybeStream);
+  };
+}

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1,5 +1,6 @@
 import type { StreamFn } from "@earendil-works/pi-agent-core";
 import type { Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __testing as extraParamsTesting } from "./pi-embedded-runner/extra-params.js";
 
@@ -722,6 +723,64 @@ describe("applyExtraParamsToAgent", () => {
     expect(messages[0]).not.toHaveProperty("reasoning_content");
     expect(messages[1]).toHaveProperty("reasoning_content", "");
     expect(messages[2]).not.toHaveProperty("reasoning_content");
+  });
+
+  it("promotes reasoning-only MiMo V2 proxy finals to visible text", async () => {
+    const resultMessage = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "proxy final answer" }],
+      api: "openai-completions",
+      provider: "opencode",
+      model: "xiaomi/mimo-v2-pro",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 1,
+    } as const;
+    const baseStreamFn: StreamFn = () => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        stream.push({ type: "done", reason: "stop", message: resultMessage as never });
+      });
+      return stream;
+    };
+    const agent = { streamFn: baseStreamFn };
+    applyExtraParamsToAgent(agent, undefined, "opencode", "xiaomi/mimo-v2-pro", undefined, "high");
+
+    const model = {
+      api: "openai-completions",
+      provider: "opencode",
+      id: "xiaomi/mimo-v2-pro",
+    } as Model<"openai-completions">;
+    const stream = await agent.streamFn?.(model, { messages: [] }, {});
+    expect(stream).toBeDefined();
+    if (!stream) {
+      throw new Error("expected stream function");
+    }
+    const events: unknown[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      {
+        type: "done",
+        reason: "stop",
+        message: {
+          ...resultMessage,
+          content: [{ type: "text", text: "proxy final answer" }],
+        },
+      },
+    ]);
+    await expect(stream.result()).resolves.toMatchObject({
+      content: [{ type: "text", text: "proxy final answer" }],
+    });
   });
 
   it("strips xai Responses reasoning payload fields", () => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -4,7 +4,10 @@ import { streamSimple } from "@earendil-works/pi-ai";
 import type { SettingsManager } from "@earendil-works/pi-coding-agent";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { createDeepSeekV4OpenAICompatibleThinkingWrapper } from "../../plugin-sdk/provider-stream-shared.js";
+import {
+  createDeepSeekV4OpenAICompatibleThinkingWrapper,
+  createThinkingOnlyFinalTextWrapper,
+} from "../../plugin-sdk/provider-stream-shared.js";
 import {
   prepareProviderExtraParams as prepareProviderExtraParamsRuntime,
   type ProviderRuntimePluginHandle,
@@ -762,6 +765,12 @@ function applyPostPluginStreamWrappers(
       thinkingLevel: ctx.thinkingLevel,
       shouldPatchModel: isMiMoReasoningOpenAICompatibleModel,
     });
+    // Legacy MiMo V2 can put final visible answers in reasoning_content. Apply
+    // the response-side fallback here for custom Xiaomi-compatible proxy routes.
+    ctx.agent.streamFn = createThinkingOnlyFinalTextWrapper({
+      baseStreamFn: ctx.agent.streamFn,
+      shouldPatchModel: isMiMoReasoningAsVisibleTextOpenAICompatibleModel,
+    });
 
     // Guard Google-family payloads against invalid negative thinking budgets
     // emitted by upstream model-ID heuristics for Gemini 3.1 variants.
@@ -848,6 +857,7 @@ const MIMO_REASONING_OPENAI_COMPATIBLE_MODEL_IDS = new Set([
   "mimo-v2.5",
   "mimo-v2.5-pro",
 ]);
+const MIMO_REASONING_AS_VISIBLE_TEXT_MODEL_IDS = new Set(["mimo-v2-pro", "mimo-v2-omni"]);
 
 function isMiMoReasoningOpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
@@ -855,6 +865,17 @@ function isMiMoReasoningOpenAICompatibleModel(model: Parameters<StreamFn>[0]): b
     model.api === "openai-completions" &&
     normalizedModelId !== undefined &&
     MIMO_REASONING_OPENAI_COMPATIBLE_MODEL_IDS.has(normalizedModelId)
+  );
+}
+
+function isMiMoReasoningAsVisibleTextOpenAICompatibleModel(
+  model: Parameters<StreamFn>[0],
+): boolean {
+  const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
+  return (
+    model.api === "openai-completions" &&
+    normalizedModelId !== undefined &&
+    MIMO_REASONING_AS_VISIBLE_TEXT_MODEL_IDS.has(normalizedModelId)
   );
 }
 

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -232,6 +232,125 @@ export function createDeepSeekV4OpenAICompatibleThinkingWrapper(params: {
   };
 }
 
+type ThinkingOnlyFinalTextStream = Awaited<ReturnType<StreamFn>>;
+
+function promoteThinkingOnlyFinalOutputToText(message: unknown): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  const record = message as { content?: unknown; stopReason?: unknown };
+  if (record.stopReason !== "stop" && record.stopReason !== "length") {
+    return;
+  }
+  if (!Array.isArray(record.content) || record.content.length === 0) {
+    return;
+  }
+
+  let hasVisibleText = false;
+  let hasToolCall = false;
+  let hasVisibleThinking = false;
+  for (const block of record.content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as { type?: unknown; text?: unknown; thinking?: unknown };
+    if (
+      typedBlock.type === "text" &&
+      typeof typedBlock.text === "string" &&
+      typedBlock.text.trim()
+    ) {
+      hasVisibleText = true;
+    }
+    if (typedBlock.type === "toolCall" || typedBlock.type === "tool_use") {
+      hasToolCall = true;
+    }
+    if (
+      typedBlock.type === "thinking" &&
+      typeof typedBlock.thinking === "string" &&
+      typedBlock.thinking.trim()
+    ) {
+      hasVisibleThinking = true;
+    }
+  }
+  if (hasVisibleText || hasToolCall || !hasVisibleThinking) {
+    return;
+  }
+
+  record.content = record.content.map((block) => {
+    if (!block || typeof block !== "object") {
+      return block;
+    }
+    const typedBlock = block as { type?: unknown; thinking?: unknown };
+    if (
+      typedBlock.type !== "thinking" ||
+      typeof typedBlock.thinking !== "string" ||
+      !typedBlock.thinking.trim()
+    ) {
+      return block;
+    }
+    return { type: "text", text: typedBlock.thinking };
+  });
+}
+
+function wrapThinkingOnlyFinalTextStream(
+  stream: ThinkingOnlyFinalTextStream,
+): ThinkingOnlyFinalTextStream {
+  const originalResult = stream.result.bind(stream);
+  stream.result = async () => {
+    const message = await originalResult();
+    promoteThinkingOnlyFinalOutputToText(message);
+    return message;
+  };
+
+  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
+  (stream as { [Symbol.asyncIterator]: typeof originalAsyncIterator })[Symbol.asyncIterator] =
+    function () {
+      const iterator = originalAsyncIterator();
+      return {
+        async next() {
+          const result = await iterator.next();
+          if (!result.done && result.value && typeof result.value === "object") {
+            const event = result.value as { partial?: unknown; message?: unknown };
+            promoteThinkingOnlyFinalOutputToText(event.partial);
+            promoteThinkingOnlyFinalOutputToText(event.message);
+          }
+          return result;
+        },
+        async return(value?: unknown) {
+          return iterator.return?.(value) ?? { done: true as const, value: undefined };
+        },
+        async throw(error?: unknown) {
+          return iterator.throw?.(error) ?? { done: true as const, value: undefined };
+        },
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
+    };
+  return stream;
+}
+
+/** @deprecated OpenAI-compatible provider stream helper; do not use from third-party plugins. */
+export function createThinkingOnlyFinalTextWrapper(params: {
+  baseStreamFn: StreamFn | undefined;
+  shouldPatchModel: (model: Parameters<StreamFn>[0]) => boolean;
+}): StreamFn | undefined {
+  if (!params.baseStreamFn) {
+    return undefined;
+  }
+  const underlying = params.baseStreamFn;
+  return (model, context, options) => {
+    const maybeStream = underlying(model, context, options);
+    if (!params.shouldPatchModel(model)) {
+      return maybeStream;
+    }
+    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+      return Promise.resolve(maybeStream).then((stream) => wrapThinkingOnlyFinalTextStream(stream));
+    }
+    return wrapThinkingOnlyFinalTextStream(maybeStream);
+  };
+}
+
 /** @deprecated Google provider-owned stream helper; do not use from third-party plugins. */
 export type GoogleThinkingLevel = "MINIMAL" | "LOW" | "MEDIUM" | "HIGH";
 /** @deprecated Google provider-owned stream helper; do not use from third-party plugins. */


### PR DESCRIPTION
## Summary

- Fixes Xiaomi MiMo V2 replies that appear blank when the provider returns the final visible answer in `reasoning_content`.
- Keeps request-side MiMo reasoning replay/passthrough intact for multi-turn tool calls.
- Adds response-side promotion only for terminal thinking-only `mimo-v2-pro` / `mimo-v2-omni` outputs, including custom Xiaomi-compatible OpenAI-completions proxy routes.
- Leaves stock OpenAI calls and non-target providers unchanged.

## Changed

- `extensions/xiaomi/stream.ts`: direct Xiaomi wrapper composes replay/passthrough with terminal reasoning-only visible-text promotion.
- `src/plugin-sdk/provider-stream-shared.ts`: shared stream helper promotes final thinking-only assistant output to text while preserving existing text and tool-call turns.
- `src/agents/pi-embedded-runner/extra-params.ts`: custom proxy fallback applies the same MiMo V2 response-side promotion when the Xiaomi plugin wrapper is not in the provider path.
- `extensions/xiaomi/index.test.ts` and `src/agents/pi-embedded-runner-extraparams.test.ts`: regression coverage for direct Xiaomi and proxy routes.

## Real behavior proof

Behavior addressed: Xiaomi MiMo `mimo-v2-pro` / `mimo-v2-omni` can return the final user-visible answer in `reasoning_content`; OpenClaw parsed that as thinking-only content, so the rendered reply could appear blank.

Real environment tested: local OpenClaw checkout plus a real Xiaomi console API key created temporarily for this verification and revoked afterward.

Exact steps or command run after this patch:
- `OPENCLAW_LIVE_TEST=1 XIAOMI_API_KEY=<temporary Xiaomi key> pnpm test extensions/xiaomi/xiaomi-chat.tmp.test.ts`
- `pnpm test extensions/xiaomi/index.test.ts src/agents/pi-embedded-runner-extraparams.test.ts src/plugin-sdk/provider-stream-shared.test.ts`
- `pnpm check:changed`
- `pnpm build`
- `codex-review --mode local --parallel-tests "pnpm test extensions/xiaomi/index.test.ts src/agents/pi-embedded-runner-extraparams.test.ts src/plugin-sdk/provider-stream-shared.test.ts"`

Evidence after fix: live `mimo-v2-pro` returned the requested marker `XIAOMI_VISIBLE_E2E_OK` as visible assistant text; focused tests passed; Codex review reported no actionable findings; changed gate passed on Blacksmith Testbox `tbx_01krnvk8eq4ncvaqhnkg4swy2a` with Actions run https://github.com/openclaw/openclaw/actions/runs/25919175341.

Observed result after fix: reasoning-only terminal MiMo V2 outputs are converted to visible text, while replay/tool-call reasoning and already-visible text remain unchanged.

What was not tested: live `mimo-v2-omni`; it is covered by the same unit wrapper path as `mimo-v2-pro`.

## Linked Issue

Closes #60261
