### PR TITLE
fix: exec approval dialog buttons always visible for long commands

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2916,6 +2916,10 @@ td.data-table-key-col {
   border-radius: var(--radius-lg);
   padding: 20px;
   animation: scale-in 0.2s var(--ease-out);
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+  overflow: hidden;
 }
 
 .exec-approval-header {
@@ -2943,6 +2947,12 @@ td.data-table-key-col {
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
   padding: 4px 10px;
+}
+
+.exec-approval-body {
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
 }
 
 .exec-approval-command {
@@ -2987,6 +2997,7 @@ td.data-table-key-col {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  flex-shrink: 0;
 }
 
 /* ===========================================

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -78,10 +78,12 @@ export function renderExecApprovalPrompt(state: AppViewState) {
             ? html`<div class="exec-approval-queue">${queueCount} pending</div>`
             : nothing}
         </div>
-        ${isPlugin ? renderPluginBody(active) : renderExecBody(request)}
-        ${state.execApprovalError
-          ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
-          : nothing}
+        <div class="exec-approval-body">
+          ${isPlugin ? renderPluginBody(active) : renderExecBody(request)}
+          ${state.execApprovalError
+            ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
+            : nothing}
+        </div>
         <div class="exec-approval-actions">
           <button
             class="btn primary"


### PR DESCRIPTION
## Summary

The exec approval dialog's Allow/Deny buttons were pushed off-screen when reviewing long commands (many arguments, script invocations, etc.), requiring users to force-refresh or kill the session to escape.

This appeared with the 4.1 exec approval mandatory dialog feature.

## Root Cause

The `.exec-approval-card` had no `max-height` constraint, so it could grow taller than the viewport. When commands were long, the card overflowed the screen and the action buttons were completely inaccessible below the fold.

## Fix

Applied a flex column layout to the dialog card with `max-height: 90vh`, wrapped the scrollable body content (command + meta + error) in a `.exec-approval-body` div that grows and scrolls, and made the `.exec-approval-actions` footer `flex-shrink: 0` so it always stays visible at the bottom.

## Changes

- `ui/src/styles/components.css`:
  - `.exec-approval-card`: added `display: flex; flex-direction: column; max-height: 90vh; overflow: hidden`
  - `.exec-approval-body`: new class — `overflow-y: auto; flex: 1; min-height: 0` (scrollable content area)
  - `.exec-approval-actions`: added `flex-shrink: 0` (always pinned to bottom)
- `ui/src/ui/views/exec-approval.ts`: wrapped body content (command, meta rows, error) in `<div class="exec-approval-body">`

Fixes openclaw/openclaw#60293