### PR TITLE
Android: restore Talk Mode reply TTS on node sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Docs: https://docs.openclaw.ai
 - Infra/json-file: preserve symlink-backed JSON stores and Windows overwrite fallback when atomically saving small sync JSON state files. (#60589) Thanks @gumadeiras.
 - Matrix/credentials: read the current and legacy credential files directly during migration fallback so concurrent legacy rename races still resolve to the stored credentials. (#60591) Thanks @gumadeiras.
 - Providers/Anthropic Vertex: read ADC files directly during auth discovery so explicit Google credentials and default ADC no longer depend on `existsSync` preflight checks. (#60592) Thanks @gumadeiras.
+- Android/Talk Mode: restore spoken assistant replies on node-scoped sessions by keeping reply routing synced to the resolved node session key and pausing mic capture during reply playback. (#60306) Thanks @MKV21.
 
 ## 2026.4.2
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -345,6 +345,8 @@ class NodeRuntime(
       session = operatorSession,
       supportsChatSubscribe = false,
       isConnected = { operatorConnected },
+      onBeforeSpeak = { micCapture.pauseForTts() },
+      onAfterSpeak = { micCapture.resumeAfterTts() },
     ).also { speaker ->
       speaker.setPlaybackEnabled(prefs.speakerEnabled.value)
     }
@@ -416,14 +418,19 @@ class NodeRuntime(
       session = operatorSession,
       supportsChatSubscribe = true,
       isConnected = { operatorConnected },
+      onBeforeSpeak = { micCapture.pauseForTts() },
+      onAfterSpeak = { micCapture.resumeAfterTts() },
     )
   }
 
   private fun syncMainSessionKey(agentId: String?) {
     val resolvedKey = resolveNodeMainSessionKey(agentId)
+    // Always push the resolved session key into TalkMode, even when the
+    // state flow value is unchanged, so lazy TalkMode instances do not
+    // stay on the default "main" session key.
+    talkMode.setMainSessionKey(resolvedKey)
     if (_mainSessionKey.value == resolvedKey) return
     _mainSessionKey.value = resolvedKey
-    talkMode.setMainSessionKey(resolvedKey)
     chat.applyMainSessionKey(resolvedKey)
     updateHomeCanvasState()
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
@@ -14,11 +14,13 @@ import android.speech.SpeechRecognizer
 import androidx.core.content.ContextCompat
 import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -99,11 +101,21 @@ class MicCaptureManager(
   private var transcriptFlushJob: Job? = null
   private var pendingRunTimeoutJob: Job? = null
   private var stopRequested = false
+  private val ttsPauseLock = Any()
+  private var ttsPauseDepth = 0
+  private var resumeMicAfterTts = false
 
   fun setMicEnabled(enabled: Boolean) {
     if (_micEnabled.value == enabled) return
     _micEnabled.value = enabled
     if (enabled) {
+      if (isPausedForTts()) {
+        synchronized(ttsPauseLock) {
+          resumeMicAfterTts = true
+        }
+        _statusText.value = if (_isSending.value) "Speaking · waiting for reply" else "Speaking…"
+        return
+      }
       start()
       sendQueuedIfIdle()
     } else {
@@ -124,6 +136,58 @@ class MicCaptureManager(
         sendQueuedIfIdle()
       }
     }
+  }
+
+  suspend fun pauseForTts() {
+    val shouldPause =
+      synchronized(ttsPauseLock) {
+        ttsPauseDepth += 1
+        if (ttsPauseDepth > 1) return@synchronized false
+        resumeMicAfterTts = _micEnabled.value
+        val active = resumeMicAfterTts || recognizer != null || _isListening.value
+        if (!active) return@synchronized false
+        stopRequested = true
+        restartJob?.cancel()
+        restartJob = null
+        transcriptFlushJob?.cancel()
+        transcriptFlushJob = null
+        _isListening.value = false
+        _inputLevel.value = 0f
+        _liveTranscript.value = null
+        _statusText.value = if (_isSending.value) "Speaking · waiting for reply" else "Speaking…"
+        true
+      }
+    if (!shouldPause) return
+    withContext(Dispatchers.Main) {
+      recognizer?.cancel()
+      recognizer?.destroy()
+      recognizer = null
+    }
+  }
+
+  suspend fun resumeAfterTts() {
+    val shouldResume =
+      synchronized(ttsPauseLock) {
+        if (ttsPauseDepth == 0) return@synchronized false
+        ttsPauseDepth -= 1
+        if (ttsPauseDepth > 0) return@synchronized false
+        val resume = resumeMicAfterTts && _micEnabled.value
+        resumeMicAfterTts = false
+        if (!resume) {
+          _statusText.value =
+            when {
+              _micEnabled.value && _isSending.value -> "Listening · sending queued voice"
+              _micEnabled.value -> "Listening"
+              _isSending.value -> "Mic off · sending…"
+              else -> "Mic off"
+            }
+        }
+        resume
+      }
+    if (!shouldResume) return
+    stopRequested = false
+    start()
+    sendQueuedIfIdle()
   }
 
   fun onGatewayConnectionChanged(connected: Boolean) {
@@ -210,6 +274,9 @@ class MicCaptureManager(
       }
     }
   }
+
+  private fun isPausedForTts(): Boolean =
+    synchronized(ttsPauseLock) { ttsPauseDepth > 0 }
 
   private fun stop() {
     stopRequested = true

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
@@ -109,10 +109,16 @@ class MicCaptureManager(
     if (_micEnabled.value == enabled) return
     _micEnabled.value = enabled
     if (enabled) {
-      if (isPausedForTts()) {
+      val pausedForTts =
         synchronized(ttsPauseLock) {
-          resumeMicAfterTts = true
+          if (ttsPauseDepth > 0) {
+            resumeMicAfterTts = true
+            true
+          } else {
+            false
+          }
         }
+      if (pausedForTts) {
         _statusText.value = if (_isSending.value) "Speaking · waiting for reply" else "Speaking…"
         return
       }
@@ -274,9 +280,6 @@ class MicCaptureManager(
       }
     }
   }
-
-  private fun isPausedForTts(): Boolean =
-    synchronized(ttsPauseLock) { ttsPauseDepth > 0 }
 
   private fun stop() {
     stopRequested = true

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -275,6 +275,7 @@ class TalkModeManager(
   suspend fun speakAssistantReply(text: String) {
     if (!playbackEnabled) return
     val playbackToken = playbackGeneration.incrementAndGet()
+    cancelActivePlayback()
     ensureConfigLoaded()
     runPlaybackSession(playbackToken) {
       playAssistant(text, playbackToken)
@@ -681,8 +682,6 @@ class TalkModeManager(
     var shouldResumeAfterSpeak = false
     var previousJob: Job? = null
     try {
-      shouldResumeAfterSpeak = true
-      onBeforeSpeak()
       val claimedPlayback =
         synchronized(ttsJobLock) {
           if (!playbackEnabled || playbackToken != playbackGeneration.get()) {
@@ -699,6 +698,8 @@ class TalkModeManager(
       }
       previousJob?.takeIf { it !== currentJob }?.cancel()
       stopTextToSpeechPlayback()
+      shouldResumeAfterSpeak = true
+      onBeforeSpeak()
       ensurePlaybackActive(playbackToken)
       _isSpeaking.value = true
       _statusText.value = "Speaking…"

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -186,6 +187,7 @@ class TalkModeManager(
 
   fun playTtsForText(text: String) {
     val playbackToken = playbackGeneration.incrementAndGet()
+    cancelActivePlayback()
     scope.launch {
       reloadConfig()
       runPlaybackSession(playbackToken) {
@@ -676,14 +678,16 @@ class TalkModeManager(
     block: suspend () -> Unit,
   ) {
     val currentJob = coroutineContext[Job]
-    onBeforeSpeak()
-    val previousJob =
-      synchronized(ttsJobLock) {
-        val previous = ttsJob
-        ttsJob = currentJob
-        previous
-      }
+    var shouldResumeAfterSpeak = false
     try {
+      shouldResumeAfterSpeak = true
+      onBeforeSpeak()
+      val previousJob =
+        synchronized(ttsJobLock) {
+          val previous = ttsJob
+          ttsJob = currentJob
+          previous
+        }
       previousJob?.takeIf { it !== currentJob }?.cancel()
       stopTextToSpeechPlayback()
       ensurePlaybackActive(playbackToken)
@@ -697,8 +701,21 @@ class TalkModeManager(
         }
       }
       _isSpeaking.value = false
-      onAfterSpeak()
+      if (shouldResumeAfterSpeak) {
+        withContext(NonCancellable) {
+          onAfterSpeak()
+        }
+      }
     }
+  }
+
+  private fun cancelActivePlayback() {
+    val activeJob =
+      synchronized(ttsJobLock) {
+        ttsJob
+      }
+    activeJob?.cancel()
+    stopTextToSpeechPlayback()
   }
 
   private suspend fun speakWithSystemTts(text: String, directive: TalkDirective?, playbackToken: Long) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -168,6 +168,7 @@ class TalkModeManager(
           ?: waitForAssistantText(session, startedAt, if (ok) 12_000 else 25_000)
         if (!assistant.isNullOrBlank()) {
           val playbackToken = playbackGeneration.incrementAndGet()
+          cancelActivePlayback()
           _statusText.value = "Speaking…"
           runPlaybackSession(playbackToken) {
             playAssistant(assistant, playbackToken)
@@ -489,6 +490,7 @@ class TalkModeManager(
       }
       Log.d(tag, "assistant text ok chars=${assistant.length}")
       val playbackToken = playbackGeneration.incrementAndGet()
+      cancelActivePlayback()
       runPlaybackSession(playbackToken) {
         playAssistant(assistant, playbackToken)
       }
@@ -680,14 +682,12 @@ class TalkModeManager(
   ) {
     val currentJob = coroutineContext[Job]
     var shouldResumeAfterSpeak = false
-    var previousJob: Job? = null
     try {
       val claimedPlayback =
         synchronized(ttsJobLock) {
           if (!playbackEnabled || playbackToken != playbackGeneration.get()) {
             false
           } else {
-            previousJob = ttsJob
             ttsJob = currentJob
             true
           }
@@ -696,8 +696,7 @@ class TalkModeManager(
         ensurePlaybackActive(playbackToken)
         return
       }
-      previousJob?.takeIf { it !== currentJob }?.cancel()
-      stopTextToSpeechPlayback()
+      ensurePlaybackActive(playbackToken)
       shouldResumeAfterSpeak = true
       onBeforeSpeak()
       ensurePlaybackActive(playbackToken)

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -668,9 +668,6 @@ class TalkModeManager(
       }
       _statusText.value = "Speak failed: ${err.message ?: err::class.simpleName}"
       Log.w(tag, "system tts failed: ${err.message ?: err::class.simpleName}")
-    } finally {
-
-      _isSpeaking.value = false
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -22,6 +22,7 @@ import ai.openclaw.app.gateway.GatewaySession
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -46,6 +47,8 @@ class TalkModeManager(
   private val session: GatewaySession,
   private val supportsChatSubscribe: Boolean,
   private val isConnected: () -> Boolean,
+  private val onBeforeSpeak: suspend () -> Unit = {},
+  private val onAfterSpeak: suspend () -> Unit = {},
 ) {
   companion object {
     private const val tag = "TalkMode"
@@ -101,6 +104,7 @@ class TalkModeManager(
   private val playbackGeneration = AtomicLong(0L)
 
   private var ttsJob: Job? = null
+  private val ttsJobLock = Any()
   private val ttsLock = Any()
   private var textToSpeech: TextToSpeech? = null
   private var textToSpeechInit: CompletableDeferred<TextToSpeech>? = null
@@ -164,7 +168,9 @@ class TalkModeManager(
         if (!assistant.isNullOrBlank()) {
           val playbackToken = playbackGeneration.incrementAndGet()
           _statusText.value = "Speaking…"
-          playAssistant(assistant, playbackToken)
+          runPlaybackSession(playbackToken) {
+            playAssistant(assistant, playbackToken)
+          }
         } else {
           _statusText.value = "No reply"
         }
@@ -180,14 +186,11 @@ class TalkModeManager(
 
   fun playTtsForText(text: String) {
     val playbackToken = playbackGeneration.incrementAndGet()
-    ttsJob?.cancel()
-    ttsJob = scope.launch {
+    scope.launch {
       reloadConfig()
-      ensurePlaybackActive(playbackToken)
-      _isSpeaking.value = true
-      _statusText.value = "Speaking…"
-      playAssistant(text, playbackToken)
-      ttsJob = null
+      runPlaybackSession(playbackToken) {
+        playAssistant(text, playbackToken)
+      }
     }
   }
 
@@ -270,10 +273,10 @@ class TalkModeManager(
   suspend fun speakAssistantReply(text: String) {
     if (!playbackEnabled) return
     val playbackToken = playbackGeneration.incrementAndGet()
-    stopSpeaking(resetInterrupt = false)
     ensureConfigLoaded()
-    ensurePlaybackActive(playbackToken)
-    playAssistant(text, playbackToken)
+    runPlaybackSession(playbackToken) {
+      playAssistant(text, playbackToken)
+    }
   }
 
   private fun start() {
@@ -483,9 +486,9 @@ class TalkModeManager(
       }
       Log.d(tag, "assistant text ok chars=${assistant.length}")
       val playbackToken = playbackGeneration.incrementAndGet()
-      stopSpeaking(resetInterrupt = false)
-      ensurePlaybackActive(playbackToken)
-      playAssistant(assistant, playbackToken)
+      runPlaybackSession(playbackToken) {
+        playAssistant(assistant, playbackToken)
+      }
     } catch (err: Throwable) {
       if (err is CancellationException) {
         Log.d(tag, "finalize speech cancelled")
@@ -668,6 +671,36 @@ class TalkModeManager(
     } finally {
 
       _isSpeaking.value = false
+    }
+  }
+
+  private suspend fun runPlaybackSession(
+    playbackToken: Long,
+    block: suspend () -> Unit,
+  ) {
+    val currentJob = coroutineContext[Job]
+    onBeforeSpeak()
+    val previousJob =
+      synchronized(ttsJobLock) {
+        val previous = ttsJob
+        ttsJob = currentJob
+        previous
+      }
+    try {
+      previousJob?.takeIf { it !== currentJob }?.cancel()
+      stopTextToSpeechPlayback()
+      ensurePlaybackActive(playbackToken)
+      _isSpeaking.value = true
+      _statusText.value = "Speaking…"
+      block()
+    } finally {
+      synchronized(ttsJobLock) {
+        if (ttsJob === currentJob) {
+          ttsJob = null
+        }
+      }
+      _isSpeaking.value = false
+      onAfterSpeak()
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -679,15 +679,24 @@ class TalkModeManager(
   ) {
     val currentJob = coroutineContext[Job]
     var shouldResumeAfterSpeak = false
+    var previousJob: Job? = null
     try {
       shouldResumeAfterSpeak = true
       onBeforeSpeak()
-      val previousJob =
+      val claimedPlayback =
         synchronized(ttsJobLock) {
-          val previous = ttsJob
-          ttsJob = currentJob
-          previous
+          if (!playbackEnabled || playbackToken != playbackGeneration.get()) {
+            false
+          } else {
+            previousJob = ttsJob
+            ttsJob = currentJob
+            true
+          }
         }
+      if (!claimedPlayback) {
+        ensurePlaybackActive(playbackToken)
+        return
+      }
       previousJob?.takeIf { it !== currentJob }?.cancel()
       stopTextToSpeechPlayback()
       ensurePlaybackActive(playbackToken)


### PR DESCRIPTION
## Summary

- Problem: Android Talk Mode received assistant replies, but spoken playback on device could fail or stay silent.
- Why it matters: voice conversations looked successful in logs yet produced no audible assistant reply for Android users.
- What changed: keep `TalkModeManager` synced to the resolved node session key for reply-event routing, and pause/resume mic capture around Android TTS playback so the recognizer does not compete with reply audio.
- What did NOT change (scope boundary): no gateway protocol changes, no cross-platform TTS refactor, no non-Android channel behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Android Talk Mode had two coupled reply-playback failure points in this path:
  1. `TalkModeManager.mainSessionKey` could remain on the default `"main"` value while gateway chat events for Android Talk Mode arrived on the resolved node session key (for example `agent:main:node-...`). In that state, the event filter dropped reply chat events before reply TTS routing could start.
  2. Once reply TTS was routed correctly, Android still needed a safe handoff from live mic capture to reply playback. This path now pauses/resumes `MicCaptureManager` around Android TTS so the active `SpeechRecognizer` does not compete with reply audio on device-specific audio stacks.
- Missing detection / guardrail: no automated coverage exercised the Android Talk Mode path with both a node-scoped session key and active mic capture during reply playback.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Android reply playback already depended on `TalkModeManager`, and the legacy Talk Mode flow already treated recognizer-vs-TTS overlap as a real device issue; the newer path did not consistently preserve those same safeguards.
- Why this became user-visible: reply playback depended on both correct session-key routing and a safe handoff from live speech recognition to TTS playback.
- If unknown, what was ruled out: global TTS config was ruled out because Telegram TTS still worked; gateway logs showed `talk.config` and `chat.send` succeeding and assistant text events arriving.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: Android device/manual Talk Mode reply playback flow; a future seam test around `syncMainSessionKey(...)` plus `TalkModeManager.handleGatewayEvent(...)` would help but would not fully cover Android audio behavior.
- Scenario the test should lock in: when Android Talk Mode is enabled on a node-scoped session key, assistant `chat` final events for that session trigger spoken reply playback without losing the handoff from mic capture to TTS.
- Why this is the smallest reliable guardrail: the failure depended on real session-key wiring and Android TTS/recognizer behavior on device.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: the verified failure mode required a physical Android device and live Talk Mode flow; no small existing unit seam covers the end-to-end audio/session interaction.

## User-visible / Behavior Changes

Android Talk Mode now speaks assistant replies reliably again on node-scoped sessions, including the handoff from active mic capture to reply playback.

## Diagram (if applicable)

```text
Before:
[voice input]
  -> [gateway reply on resolved node session key]
  -> [TalkMode may miss reply event due to stale session key]
  -> [or TTS playback starts while recognizer is still active]
  -> [silent reply on device]

After:
[voice input]
  -> [TalkMode uses resolved session key]
  -> [reply event accepted]
  -> [pause mic capture]
  -> [speak reply]
  -> [resume mic capture]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Android 15 on Pixel 8 Pro (`husky`)
- Runtime/container: Android app `playDebug` build installed via adb
- Model/provider: not provider-specific; reproduced in Android Talk Mode against the connected OpenClaw gateway
- Integration/channel (if any): Android Talk Mode / gateway chat events
- Relevant config (redacted): Talk Mode enabled; gateway returned node-scoped session key (`agent:main:node-...`)

### Steps

1. Install and launch the clean `main` Android build on the connected Pixel 8 Pro.
2. Enable Talk Mode, speak a prompt, and wait for the agent reply.
3. Observe gateway logs and the phone behavior.
4. Install and launch this branch on the same device and repeat the same Talk Mode flow.

### Expected

- Assistant reply text is spoken aloud on Android.

### Actual

- On `main`, assistant text arrived but no spoken reply played.
- On this branch, the same flow speaks the assistant reply successfully.

## Evidence

Attach at least one:

- [x] Failing before + passing after on the same physical device
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence notes:
- Before: clean `main` build installed on the connected Pixel 8 Pro reproduced silent Talk Mode replies.
- After: branch `eb1ff899f1` installed on the same Pixel 8 Pro spoke the assistant reply successfully.

## Human Verification (required)

- Verified scenarios: reproduced silent Talk Mode replies on clean `main` build installed to a connected Pixel 8 Pro; installed this branch on the same device and confirmed spoken replies work again.
- Edge cases checked: Android app build/install succeeded; Android unit-test lane succeeded; `main` vs fix behavior compared on the same physical phone.
- What you did **not** verify: no emulator run, no additional OEM device matrix, no new automated end-to-end test added.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Android Talk Mode still depends on device-specific audio behavior once TTS starts.
  - Mitigation: keep mic capture paused during TTS playback so `SpeechRecognizer` and Android TTS do not compete for audio resources.
- Risk: no automated regression test locks in the physical-device reproduction.
  - Mitigation: PR includes concrete repro/verification steps on the same Pixel 8 Pro with `main` failing and the fix branch passing.
