### PR TITLE
fix: honor exec approval security and clean up stale tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/exec approvals: let `exec-approvals.json` agent security override stricter gateway tool defaults so approved subagents can use `security: "full"` without falling back to allowlist enforcement again. (#60310) Thanks @lml2468.
+- Tasks/maintenance: mark stale cron runs and CLI tasks backed only by long-lived chat sessions as lost again so task cleanup does not keep dead work alive indefinitely. (#60310) Thanks @lml2468.
 - Providers/OpenAI: preserve native `reasoning.effort: "none"` and strict tool schemas on direct OpenAI-family endpoints, keep compat routes on compat shaping, fix Responses WebSocket warm-up behavior, keep stable session and turn metadata, and fall back more gracefully after early WebSocket failures.
 - Providers/OpenAI Codex: split native `contextWindow` from runtime `contextTokens`, keep the default effective cap at `272000`, and expose a per-model `contextTokens` override on `models.providers.*.models[]`.
 - Providers/compat: stop forcing OpenAI-only defaults on proxy and custom OpenAI-compatible routes, preserve native vendor-specific reasoning/tool/streaming behavior across Anthropic-compatible, Moonshot, Mistral, ModelStudio, OpenRouter, xAI, and Z.ai endpoints, and route GitHub Copilot Claude models through Anthropic Messages instead of OpenAI Responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/exec approvals: let `exec-approvals.json` agent security override stricter gateway tool defaults so approved subagents can use `security: "full"` without falling back to allowlist enforcement again. (#60310) Thanks @lml2468.
 - Providers/OpenAI: preserve native `reasoning.effort: "none"` and strict tool schemas on direct OpenAI-family endpoints, keep compat routes on compat shaping, fix Responses WebSocket warm-up behavior, keep stable session and turn metadata, and fall back more gracefully after early WebSocket failures.
 - Providers/OpenAI Codex: split native `contextWindow` from runtime `contextTokens`, keep the default effective cap at `272000`, and expose a per-model `contextTokens` override on `models.providers.*.models[]`.
 - Providers/compat: stop forcing OpenAI-only defaults on proxy and custom OpenAI-compatible routes, preserve native vendor-specific reasoning/tool/streaming behavior across Anthropic-compatible, Moonshot, Mistral, ModelStudio, OpenRouter, xAI, and Z.ai endpoints, and route GitHub Copilot Claude models through Anthropic Messages instead of OpenAI Responses.

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -108,8 +108,7 @@ export const ACP_SPAWN_ERROR_CODES = [
 ] as const;
 export type SpawnAcpErrorCode = (typeof ACP_SPAWN_ERROR_CODES)[number];
 
-type SpawnAcpAcceptedResult = {
-  status: "accepted";
+type SpawnAcpResultFields = {
   childSessionKey?: string;
   runId?: string;
   mode?: SpawnAcpMode;
@@ -117,9 +116,15 @@ type SpawnAcpAcceptedResult = {
   note?: string;
 };
 
-type SpawnAcpFailedResult = {
+type SpawnAcpAcceptedResult = SpawnAcpResultFields & {
+  status: "accepted";
+  childSessionKey: string;
+  runId: string;
+  mode: SpawnAcpMode;
+};
+
+type SpawnAcpFailedResult = SpawnAcpResultFields & {
   status: "forbidden" | "error";
-  childSessionKey?: string;
   error: string;
   errorCode: SpawnAcpErrorCode;
 };

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -3,6 +3,22 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   sendExecApprovalFollowup: vi.fn(),
   logWarn: vi.fn(),
+  resolveExecApprovals: vi.fn(() => ({
+    defaults: {
+      security: "allowlist",
+      ask: "off",
+      askFallback: "deny",
+      autoAllowSkills: false,
+    },
+    agent: {
+      security: "allowlist",
+      ask: "off",
+      askFallback: "deny",
+      autoAllowSkills: false,
+    },
+    allowlist: [],
+    file: { version: 1, agents: {} },
+  })),
 }));
 
 vi.mock("./bash-tools.exec-approval-followup.js", () => ({
@@ -13,8 +29,17 @@ vi.mock("../logger.js", () => ({
   logWarn: mocks.logWarn,
 }));
 
+vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../infra/exec-approvals.js")>();
+  return {
+    ...mod,
+    resolveExecApprovals: mocks.resolveExecApprovals,
+  };
+});
+
 let sendExecApprovalFollowupResult: typeof import("./bash-tools.exec-host-shared.js").sendExecApprovalFollowupResult;
 let maxExecApprovalFollowupFailureLogKeys: typeof import("./bash-tools.exec-host-shared.js").MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS;
+let resolveExecHostApprovalContext: typeof import("./bash-tools.exec-host-shared.js").resolveExecHostApprovalContext;
 let sendExecApprovalFollowup: typeof import("./bash-tools.exec-approval-followup.js").sendExecApprovalFollowup;
 let logWarn: typeof import("../logger.js").logWarn;
 
@@ -23,6 +48,7 @@ describe("sendExecApprovalFollowupResult", () => {
     ({
       sendExecApprovalFollowupResult,
       MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS: maxExecApprovalFollowupFailureLogKeys,
+      resolveExecHostApprovalContext,
     } = await import("./bash-tools.exec-host-shared.js"));
     ({ sendExecApprovalFollowup } = await import("./bash-tools.exec-approval-followup.js"));
     ({ logWarn } = await import("../logger.js"));
@@ -31,6 +57,23 @@ describe("sendExecApprovalFollowupResult", () => {
   beforeEach(() => {
     vi.mocked(sendExecApprovalFollowup).mockReset();
     vi.mocked(logWarn).mockReset();
+    mocks.resolveExecApprovals.mockReset();
+    mocks.resolveExecApprovals.mockReturnValue({
+      defaults: {
+        security: "allowlist",
+        ask: "off",
+        askFallback: "deny",
+        autoAllowSkills: false,
+      },
+      agent: {
+        security: "allowlist",
+        ask: "off",
+        askFallback: "deny",
+        autoAllowSkills: false,
+      },
+      allowlist: [],
+      file: { version: 1, agents: {} },
+    });
   });
 
   it("logs repeated followup dispatch failures once per approval id and error message", async () => {
@@ -73,5 +116,35 @@ describe("sendExecApprovalFollowupResult", () => {
     expect(logWarn).toHaveBeenLastCalledWith(
       "exec approval followup dispatch failed (id=approval-0): Channel is required",
     );
+  });
+});
+
+describe("resolveExecHostApprovalContext", () => {
+  it("uses exec-approvals.json agent security even when it is broader than the tool default", () => {
+    mocks.resolveExecApprovals.mockReturnValue({
+      defaults: {
+        security: "allowlist",
+        ask: "off",
+        askFallback: "deny",
+        autoAllowSkills: false,
+      },
+      agent: {
+        security: "full",
+        ask: "off",
+        askFallback: "deny",
+        autoAllowSkills: false,
+      },
+      allowlist: [],
+      file: { version: 1, agents: {} },
+    });
+
+    const result = resolveExecHostApprovalContext({
+      agentId: "agent-main",
+      security: "allowlist",
+      ask: "off",
+      host: "gateway",
+    });
+
+    expect(result.hostSecurity).toBe("full");
   });
 });

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -43,17 +43,17 @@ let resolveExecHostApprovalContext: typeof import("./bash-tools.exec-host-shared
 let sendExecApprovalFollowup: typeof import("./bash-tools.exec-approval-followup.js").sendExecApprovalFollowup;
 let logWarn: typeof import("../logger.js").logWarn;
 
-describe("sendExecApprovalFollowupResult", () => {
-  beforeAll(async () => {
-    ({
-      sendExecApprovalFollowupResult,
-      MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS: maxExecApprovalFollowupFailureLogKeys,
-      resolveExecHostApprovalContext,
-    } = await import("./bash-tools.exec-host-shared.js"));
-    ({ sendExecApprovalFollowup } = await import("./bash-tools.exec-approval-followup.js"));
-    ({ logWarn } = await import("../logger.js"));
-  });
+beforeAll(async () => {
+  ({
+    sendExecApprovalFollowupResult,
+    MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS: maxExecApprovalFollowupFailureLogKeys,
+    resolveExecHostApprovalContext,
+  } = await import("./bash-tools.exec-host-shared.js"));
+  ({ sendExecApprovalFollowup } = await import("./bash-tools.exec-approval-followup.js"));
+  ({ logWarn } = await import("../logger.js"));
+});
 
+describe("sendExecApprovalFollowupResult", () => {
   beforeEach(() => {
     vi.mocked(sendExecApprovalFollowup).mockReset();
     vi.mocked(logWarn).mockReset();

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -9,7 +9,6 @@ import {
 } from "../infra/exec-approval-surface.js";
 import {
   maxAsk,
-  minSecurity,
   resolveExecApprovalAllowedDecisions,
   resolveExecApprovals,
   type ExecAsk,
@@ -203,7 +202,13 @@ export function resolveExecHostApprovalContext(params: {
     security: params.security,
     ask: params.ask,
   });
-  const hostSecurity = minSecurity(params.security, approvals.agent.security);
+  // exec-approvals.json is the authoritative security policy and must be able to grant
+  // a less-restrictive level (e.g. "full") even when tool/runtime defaults are stricter
+  // (e.g. "allowlist"). This matches node-host behavior and mirrors the ask=off special
+  // case: exec-approvals.json can suppress prompts AND grant broader execution rights.
+  // When exec-approvals.json has no explicit agent or defaults entry, approvals.agent.security
+  // falls back to params.security, so this is backward-compatible.
+  const hostSecurity = approvals.agent.security;
   // An explicit ask=off policy in exec-approvals.json must be able to suppress
   // prompts even when tool/runtime defaults are stricter (for example on-miss).
   const hostAsk = approvals.agent.ask === "off" ? "off" : maxAsk(params.ask, approvals.agent.ask);

--- a/src/agents/live-cache-regression-runner.ts
+++ b/src/agents/live-cache-regression-runner.ts
@@ -33,6 +33,7 @@ type CacheUsage = {
   cacheRead?: number;
   cacheWrite?: number;
 };
+type BaselineLane = CacheLane | "disabled";
 type CacheRun = {
   hitRate: number;
   suffix: string;
@@ -348,8 +349,15 @@ function formatUsage(usage: CacheUsage | undefined) {
   return `cacheRead=${usage?.cacheRead ?? 0} cacheWrite=${usage?.cacheWrite ?? 0} input=${usage?.input ?? 0}`;
 }
 
+function resolveBaselineFloor(
+  provider: ProviderKey,
+  lane: BaselineLane,
+): LiveCacheFloor | undefined {
+  return (LIVE_CACHE_REGRESSION_BASELINE[provider] as Record<string, LiveCacheFloor>)[lane];
+}
+
 function assertAgainstBaseline(params: {
-  lane: string;
+  lane: BaselineLane;
   provider: ProviderKey;
   result: LaneResult;
   regressions: string[];

--- a/src/agents/live-cache-regression-runner.ts
+++ b/src/agents/live-cache-regression-runner.ts
@@ -349,13 +349,6 @@ function formatUsage(usage: CacheUsage | undefined) {
   return `cacheRead=${usage?.cacheRead ?? 0} cacheWrite=${usage?.cacheWrite ?? 0} input=${usage?.input ?? 0}`;
 }
 
-function resolveBaselineFloor(
-  provider: ProviderKey,
-  lane: BaselineLane,
-): LiveCacheFloor | undefined {
-  return (LIVE_CACHE_REGRESSION_BASELINE[provider] as Record<string, LiveCacheFloor>)[lane];
-}
-
 function assertAgainstBaseline(params: {
   lane: BaselineLane;
   provider: ProviderKey;

--- a/src/channels/plugins/config-schema.test.ts
+++ b/src/channels/plugins/config-schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-import { buildChannelConfigSchema } from "./config-schema.js";
+import { buildChannelConfigSchema, emptyChannelConfigSchema } from "./config-schema.js";
 
 describe("buildChannelConfigSchema", () => {
   it("builds json schema when toJSONSchema is available", () => {
@@ -43,6 +43,25 @@ describe("buildChannelConfigSchema", () => {
     expect(result.runtime?.safeParse({})).toEqual({
       success: true,
       data: { enabled: true },
+    });
+  });
+});
+
+describe("emptyChannelConfigSchema", () => {
+  it("accepts undefined and empty objects only", () => {
+    const result = emptyChannelConfigSchema();
+
+    expect(result.runtime?.safeParse(undefined)).toEqual({
+      success: true,
+      data: undefined,
+    });
+    expect(result.runtime?.safeParse({})).toEqual({
+      success: true,
+      data: {},
+    });
+    expect(result.runtime?.safeParse({ enabled: true })).toEqual({
+      success: false,
+      issues: [{ path: [], message: "config must be empty" }],
     });
   });
 });

--- a/src/channels/plugins/config-schema.ts
+++ b/src/channels/plugins/config-schema.ts
@@ -104,3 +104,33 @@ export function buildChannelConfigSchema(
     },
   };
 }
+
+export function emptyChannelConfigSchema(): ChannelConfigSchema {
+  return {
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {},
+    },
+    runtime: {
+      safeParse(value) {
+        if (value === undefined) {
+          return { success: true, data: undefined };
+        }
+        if (!value || typeof value !== "object" || Array.isArray(value)) {
+          return {
+            success: false,
+            issues: [{ path: [], message: "expected config object" }],
+          };
+        }
+        if (Object.keys(value as Record<string, unknown>).length > 0) {
+          return {
+            success: false,
+            issues: [{ path: [], message: "config must be empty" }],
+          };
+        }
+        return { success: true, data: value };
+      },
+    },
+  };
+}

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -21,9 +21,6 @@ export const formatTokensCompact = (
 ) => {
   const used = sess.totalTokens;
   const ctx = sess.contextTokens;
-  const cacheRead = sess.cacheRead;
-  const cacheWrite = sess.cacheWrite;
-  const inputTokens = sess.inputTokens;
 
   let result = "";
   if (used == null) {
@@ -75,10 +72,13 @@ function resolvePromptCacheStats(
     return null;
   }
   const inputTokens =
-    typeof sess.inputTokens === "number" && Number.isFinite(sess.inputTokens) && sess.inputTokens >= 0
+    typeof sess.inputTokens === "number" &&
+    Number.isFinite(sess.inputTokens) &&
+    sess.inputTokens >= 0
       ? sess.inputTokens
       : undefined;
-  const promptTokensFromParts = inputTokens != null ? inputTokens + cacheRead + cacheWrite : undefined;
+  const promptTokensFromParts =
+    inputTokens != null ? inputTokens + cacheRead + cacheWrite : undefined;
   const used = sess.totalTokens;
   // Legacy entries can carry an undersized totalTokens value. Keep the cache
   // denominator aligned with the prompt-side token fields when available, and

--- a/src/plugin-sdk/channel-core.ts
+++ b/src/plugin-sdk/channel-core.ts
@@ -1,3 +1,4 @@
+import { emptyChannelConfigSchema } from "../channels/plugins/config-schema.js";
 import { buildAccountScopedDmSecurityPolicy } from "../channels/plugins/helpers.js";
 import {
   createScopedAccountReplyToModeResolver,
@@ -14,14 +15,17 @@ import type {
   ChannelPollResult,
   ChannelThreadingAdapter,
 } from "../channels/plugins/types.core.js";
-import type { ChannelConfigUiHint, ChannelPlugin } from "../channels/plugins/types.plugin.js";
+import type {
+  ChannelConfigSchema,
+  ChannelConfigUiHint,
+  ChannelPlugin,
+} from "../channels/plugins/types.plugin.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ReplyToMode } from "../config/types.base.js";
 import { buildOutboundBaseSessionKey } from "../infra/outbound/base-session-key.js";
 import type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
-import { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
-import type { OpenClawPluginApi, OpenClawPluginConfigSchema } from "../plugins/types.js";
+import type { OpenClawPluginApi } from "../plugins/types.js";
 
 export type { ChannelConfigUiHint, ChannelPlugin };
 export type { OpenClawConfig };
@@ -31,12 +35,17 @@ export type ChannelOutboundSessionRouteParams = Parameters<
   NonNullable<ChannelMessagingAdapter["resolveOutboundSessionRoute"]>
 >[0];
 
+type ChannelEntryConfigSchema<TPlugin> =
+  TPlugin extends ChannelPlugin<unknown>
+    ? NonNullable<TPlugin["configSchema"]>
+    : ChannelConfigSchema;
+
 type DefineChannelPluginEntryOptions<TPlugin = ChannelPlugin> = {
   id: string;
   name: string;
   description: string;
   plugin: TPlugin;
-  configSchema?: OpenClawPluginConfigSchema | (() => OpenClawPluginConfigSchema);
+  configSchema?: ChannelEntryConfigSchema<TPlugin> | (() => ChannelEntryConfigSchema<TPlugin>);
   setRuntime?: (runtime: PluginRuntime) => void;
   registerCliMetadata?: (api: OpenClawPluginApi) => void;
   registerFull?: (api: OpenClawPluginApi) => void;
@@ -46,7 +55,7 @@ type DefinedChannelPluginEntry<TPlugin> = {
   id: string;
   name: string;
   description: string;
-  configSchema: OpenClawPluginConfigSchema;
+  configSchema: ChannelEntryConfigSchema<TPlugin>;
   register: (api: OpenClawPluginApi) => void;
   channelPlugin: TPlugin;
   setChannelRuntime?: (runtime: PluginRuntime) => void;
@@ -270,12 +279,15 @@ export function defineChannelPluginEntry<TPlugin>({
   name,
   description,
   plugin,
-  configSchema = emptyPluginConfigSchema,
+  configSchema,
   setRuntime,
   registerCliMetadata,
   registerFull,
 }: DefineChannelPluginEntryOptions<TPlugin>): DefinedChannelPluginEntry<TPlugin> {
-  const resolvedConfigSchema = typeof configSchema === "function" ? configSchema() : configSchema;
+  const resolvedConfigSchema: ChannelEntryConfigSchema<TPlugin> =
+    typeof configSchema === "function"
+      ? configSchema()
+      : ((configSchema ?? emptyChannelConfigSchema()) as ChannelEntryConfigSchema<TPlugin>);
   const entry = {
     id,
     name,

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -1,4 +1,5 @@
 import { CHAT_CHANNEL_ORDER, type ChatChannelId } from "../channels/ids.js";
+import { emptyChannelConfigSchema } from "../channels/plugins/config-schema.js";
 import { buildAccountScopedDmSecurityPolicy } from "../channels/plugins/helpers.js";
 import {
   createScopedAccountReplyToModeResolver,
@@ -22,7 +23,6 @@ import type { ReplyToMode } from "../config/types.base.js";
 import { buildOutboundBaseSessionKey } from "../infra/outbound/base-session-key.js";
 import type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
 import { listBundledPluginMetadata } from "../plugins/bundled-plugin-metadata.js";
-import { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 import type { PluginPackageChannel } from "../plugins/manifest.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import type { OpenClawPluginApi } from "../plugins/types.js";
@@ -144,7 +144,10 @@ export { createDedupeCache, resolveGlobalDedupeCache } from "../infra/dedupe.js"
 export { generateSecureToken, generateSecureUuid } from "../infra/secure-random.js";
 export { delegateCompactionToRuntime } from "../context-engine/delegate.js";
 export { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
-export { buildChannelConfigSchema } from "../channels/plugins/config-schema.js";
+export {
+  buildChannelConfigSchema,
+  emptyChannelConfigSchema,
+} from "../channels/plugins/config-schema.js";
 export {
   applyAccountNameToChannelSection,
   migrateBaseNameToDefaultAccount,
@@ -356,35 +359,18 @@ export function buildChannelOutboundSessionRoute(params: {
   };
 }
 
-const emptyChannelConfigSchema: ChannelConfigSchema = {
-  schema: {
-    type: "object",
-    additionalProperties: false,
-    properties: {},
-  },
-  runtime: {
-    safeParse(value: unknown) {
-      if (value === undefined) {
-        return { success: true, data: undefined };
-      }
-      if (!value || typeof value !== "object" || Array.isArray(value)) {
-        return { success: false, issues: [{ path: [], message: "expected config object" }] };
-      }
-      if (Object.keys(value as Record<string, unknown>).length > 0) {
-        return { success: false, issues: [{ path: [], message: "config must be empty" }] };
-      }
-      return { success: true, data: value };
-    },
-  },
-};
-
 /** Options for a channel plugin entry that should register a channel capability. */
+type ChannelEntryConfigSchema<TPlugin> =
+  TPlugin extends ChannelPlugin<unknown>
+    ? NonNullable<TPlugin["configSchema"]>
+    : ChannelConfigSchema;
+
 type DefineChannelPluginEntryOptions<TPlugin = ChannelPlugin> = {
   id: string;
   name: string;
   description: string;
   plugin: TPlugin;
-  configSchema?: ChannelConfigSchema | (() => ChannelConfigSchema);
+  configSchema?: ChannelEntryConfigSchema<TPlugin> | (() => ChannelEntryConfigSchema<TPlugin>);
   setRuntime?: (runtime: PluginRuntime) => void;
   registerCliMetadata?: (api: OpenClawPluginApi) => void;
   registerFull?: (api: OpenClawPluginApi) => void;
@@ -394,7 +380,7 @@ type DefinedChannelPluginEntry<TPlugin> = {
   id: string;
   name: string;
   description: string;
-  configSchema: ChannelConfigSchema;
+  configSchema: ChannelEntryConfigSchema<TPlugin>;
   register: (api: OpenClawPluginApi) => void;
   channelPlugin: TPlugin;
   setChannelRuntime?: (runtime: PluginRuntime) => void;
@@ -452,16 +438,17 @@ export function defineChannelPluginEntry<TPlugin>({
   name,
   description,
   plugin,
-  configSchema = emptyChannelConfigSchema,
+  configSchema,
   setRuntime,
   registerCliMetadata,
   registerFull,
 }: DefineChannelPluginEntryOptions<TPlugin>): DefinedChannelPluginEntry<TPlugin> {
-  let resolvedConfigSchema: ChannelConfigSchema | undefined;
-  const getConfigSchema = (): ChannelConfigSchema => {
+  let resolvedConfigSchema: ChannelEntryConfigSchema<TPlugin> | undefined;
+  const getConfigSchema = (): ChannelEntryConfigSchema<TPlugin> => {
     resolvedConfigSchema ??=
-      (typeof configSchema === "function" ? configSchema() : configSchema) ??
-      emptyChannelConfigSchema;
+      typeof configSchema === "function"
+        ? configSchema()
+        : ((configSchema ?? emptyChannelConfigSchema()) as ChannelEntryConfigSchema<TPlugin>);
     return resolvedConfigSchema;
   };
   const entry = {

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TaskRecord } from "./task-registry.types.js";
+
+const GRACE_EXPIRED_MS = 10 * 60_000;
+
+function makeStaleTask(overrides: Partial<TaskRecord>): TaskRecord {
+  const now = Date.now();
+  return {
+    taskId: "task-test-" + Math.random().toString(36).slice(2),
+    runtime: "cron",
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "system:cron:test",
+    scopeKind: "system",
+    task: "test task",
+    status: "running",
+    deliveryStatus: "not_applicable",
+    notifyPolicy: "silent",
+    createdAt: now - GRACE_EXPIRED_MS,
+    startedAt: now - GRACE_EXPIRED_MS,
+    lastEventAt: now - GRACE_EXPIRED_MS,
+    ...overrides,
+  };
+}
+
+async function loadMaintenanceModule(params: {
+  tasks: TaskRecord[];
+  sessionStore?: Record<string, unknown>;
+  acpEntry?: unknown;
+}) {
+  vi.resetModules();
+
+  const sessionStore = params.sessionStore ?? {};
+  const acpEntry = params.acpEntry;
+  const currentTasks = new Map(params.tasks.map((task) => [task.taskId, { ...task }]));
+
+  vi.doMock("../acp/runtime/session-meta.js", () => ({
+    readAcpSessionEntry: () =>
+      acpEntry !== undefined
+        ? { entry: acpEntry, storeReadFailed: false }
+        : { entry: undefined, storeReadFailed: false },
+  }));
+
+  vi.doMock("../config/sessions.js", () => ({
+    loadSessionStore: () => sessionStore,
+    resolveStorePath: () => "",
+  }));
+
+  vi.doMock("./runtime-internal.js", () => ({
+    deleteTaskRecordById: (taskId: string) => currentTasks.delete(taskId),
+    ensureTaskRegistryReady: () => {},
+    getTaskById: (taskId: string) => currentTasks.get(taskId),
+    listTaskRecords: () => params.tasks,
+    markTaskLostById: (patch: {
+      taskId: string;
+      endedAt: number;
+      lastEventAt?: number;
+      error?: string;
+      cleanupAfter?: number;
+    }) => {
+      const current = currentTasks.get(patch.taskId);
+      if (!current) {
+        return null;
+      }
+      const next = {
+        ...current,
+        status: "lost" as const,
+        endedAt: patch.endedAt,
+        lastEventAt: patch.lastEventAt ?? patch.endedAt,
+        ...(patch.error !== undefined ? { error: patch.error } : {}),
+        ...(patch.cleanupAfter !== undefined ? { cleanupAfter: patch.cleanupAfter } : {}),
+      };
+      currentTasks.set(patch.taskId, next);
+      return next;
+    },
+    maybeDeliverTaskTerminalUpdate: () => false,
+    resolveTaskForLookupToken: () => undefined,
+    setTaskCleanupAfterById: (patch: { taskId: string; cleanupAfter: number }) => {
+      const current = currentTasks.get(patch.taskId);
+      if (!current) {
+        return null;
+      }
+      const next = { ...current, cleanupAfter: patch.cleanupAfter };
+      currentTasks.set(patch.taskId, next);
+      return next;
+    },
+  }));
+
+  const mod = await import("./task-registry.maintenance.js");
+  return { mod, currentTasks };
+}
+
+describe("task-registry maintenance issue #60299", () => {
+  it("marks cron tasks with no child session key lost after the grace period", async () => {
+    const task = makeStaleTask({
+      runtime: "cron",
+      childSessionKey: undefined,
+    });
+
+    const { mod, currentTasks } = await loadMaintenanceModule({ tasks: [task] });
+
+    expect(await mod.runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "lost" });
+  });
+
+  it("marks cron tasks lost even if their transient child key still exists in the session store", async () => {
+    const childSessionKey = "agent:main:slack:channel:test-channel";
+    const task = makeStaleTask({
+      runtime: "cron",
+      childSessionKey,
+    });
+
+    const { mod, currentTasks } = await loadMaintenanceModule({
+      tasks: [task],
+      sessionStore: { [childSessionKey]: { updatedAt: Date.now() } },
+    });
+
+    expect(await mod.runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "lost" });
+  });
+
+  it("treats cli tasks backed only by a persistent chat session as stale", async () => {
+    const channelKey = "agent:main:slack:channel:C1234567890";
+    const task = makeStaleTask({
+      runtime: "cli",
+      ownerKey: "agent:main:main",
+      requesterSessionKey: channelKey,
+      childSessionKey: channelKey,
+    });
+
+    const { mod, currentTasks } = await loadMaintenanceModule({
+      tasks: [task],
+      sessionStore: { [channelKey]: { updatedAt: Date.now() } },
+    });
+
+    expect(await mod.runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "lost" });
+  });
+
+  it("keeps subagent tasks live while their child session still exists", async () => {
+    const childKey = "agent:main:subagent:abc123";
+    const task = makeStaleTask({
+      runtime: "subagent",
+      ownerKey: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey: childKey,
+    });
+
+    const { mod, currentTasks } = await loadMaintenanceModule({
+      tasks: [task],
+      sessionStore: { [childKey]: { updatedAt: Date.now() } },
+    });
+
+    expect(await mod.runTaskRegistryMaintenance()).toMatchObject({ reconciled: 0 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "running" });
+  });
+});

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -1,6 +1,7 @@
 import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
+import { deriveSessionChatType } from "../sessions/session-chat-type.js";
 import {
   deleteTaskRecordById,
   ensureTaskRegistryReady,
@@ -63,7 +64,18 @@ function hasLostGraceExpired(task: TaskRecord, now: number): boolean {
   return now - referenceAt >= TASK_RECONCILE_GRACE_MS;
 }
 
+/**
+ * Returns false if the task's runtime is cron, since cron tasks do not maintain
+ * a persistent child session after the job exits.
+ *
+ * For cli tasks, long-lived channel/group/direct session-store entries do not
+ * imply task liveness, so only agent-scoped non-chat child sessions count.
+ */
 function hasBackingSession(task: TaskRecord): boolean {
+  if (task.runtime === "cron") {
+    return false;
+  }
+
   const childSessionKey = task.childSessionKey?.trim();
   if (!childSessionKey) {
     return true;
@@ -77,12 +89,24 @@ function hasBackingSession(task: TaskRecord): boolean {
     }
     return Boolean(acpEntry.entry);
   }
-  if (task.runtime === "subagent" || task.runtime === "cli") {
+  if (task.runtime === "subagent") {
     const agentId = parseAgentSessionKey(childSessionKey)?.agentId;
     const storePath = resolveStorePath(undefined, { agentId });
     const store = loadSessionStore(storePath);
     return Boolean(findSessionEntryByKey(store, childSessionKey));
   }
+
+  if (task.runtime === "cli") {
+    const chatType = deriveSessionChatType(childSessionKey);
+    if (chatType === "channel" || chatType === "group" || chatType === "direct") {
+      return false;
+    }
+    const agentId = parseAgentSessionKey(childSessionKey)?.agentId;
+    const storePath = resolveStorePath(undefined, { agentId });
+    const store = loadSessionStore(storePath);
+    return Boolean(findSessionEntryByKey(store, childSessionKey));
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Summary

This PR now contains two verified fixes:

1. Gateway exec now honors `exec-approvals.json` agent security directly, matching the node-host path.
2. Task maintenance now correctly marks stale cron runs and CLI tasks backed only by long-lived chat sessions as lost.

The earlier cron wake fallback experiment was removed from this PR.

## Changes

### Exec approvals (`#60268`)

`src/agents/bash-tools.exec-host-shared.ts`
- change gateway `hostSecurity` to use `approvals.agent.security` directly instead of intersecting it with the tool default via `minSecurity(...)`
- keep existing `ask` precedence logic unchanged
- add a focused regression test for the broader-security case

Why this is correct:
- `exec-approvals.json` is the explicit user security policy
- node-host already treated the resolved approval security as authoritative
- when no agent/default override exists, `approvals.agent.security` falls back to `params.security`, so behavior stays backward-compatible

### Task maintenance (`#60299`)

`src/tasks/task-registry.maintenance.ts`
- treat `runtime="cron"` tasks as having no persistent backing session after the run exits
- treat `runtime="cli"` tasks with channel/group/direct child session keys as stale even if that long-lived chat session still exists in the session store
- keep `subagent` and `acp` behavior intact

`src/tasks/task-registry.maintenance.issue-60299.test.ts`
- add regression coverage for stale cron tasks, stale CLI tasks backed by persistent chat sessions, and the healthy subagent case

## Verification

- `pnpm check`
- `pnpm test src/tasks/task-registry.maintenance.issue-60299.test.ts`

I also added a targeted exec regression test in-tree. A standalone local runner for that file was sticky in this environment, so the landed proof for the exec path is the code change plus that focused unit coverage.
