### PR TITLE
fix: apply exec approval checks to Telegram DM pairing sessions

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1216,9 +1216,25 @@ export const registerTelegramHandlers = ({
       }
       const senderId = callback.from?.id ? String(callback.from.id) : "";
       const senderUsername = callback.from?.username ?? "";
-      // DM callbacks must enforce the same sender authorization gate as normal DM commands.
+      // Exec approval callbacks from authorized approvers must not be blocked by the DM
+      // allowlist check. Approvers are trusted for approval operations regardless of
+      // whether they appear in channels.telegram.allowFrom. Without this, approval button
+      // presses from DM approvers time out and commands execute via askFallback="full",
+      // bypassing the configured exec approval policy entirely.
+      const isExecApprovalFromAuthorizedDmSender =
+        !isGroup &&
+        isApprovalCallback &&
+        Boolean(senderId) &&
+        isTelegramExecApprovalAuthorizedSender({
+          cfg: telegramDeps.loadConfig(),
+          accountId,
+          senderId,
+        });
+      // DM callbacks must enforce the same sender authorization gate as normal DM commands,
+      // except for authorized exec approvers handling approval button presses.
       const authorizationMode: TelegramEventAuthorizationMode =
-        !isGroup || (!execApprovalButtonsEnabled && inlineButtonsScope === "allowlist")
+        (!isGroup && !isExecApprovalFromAuthorizedDmSender) ||
+        (!execApprovalButtonsEnabled && inlineButtonsScope === "allowlist")
           ? "callback-allowlist"
           : "callback-scope";
       const senderAuthorization = authorizeTelegramEventSender({


### PR DESCRIPTION
## Summary

Exec approval callbacks from authorized approvers in Telegram DM sessions were being blocked by the DM allowlist authorization check in the callback handler, causing exec approval to be completely bypassed.

## Root Cause

When a command requires exec approval (`ask=always` or `ask=on-miss` with a miss), the `TelegramExecApprovalHandler` correctly sends an approval notification to the configured approver via Telegram DM. The approver presses the **Approve** or **Deny** button, generating a `callback_query`.

However, in the callback handler (`registerTelegramHandlers`), the sender authorization check uses `"callback-allowlist"` mode for all DM callbacks, which enforces the DM `allowFrom` allowlist. If the approver is in `channels.telegram.execApprovals.approvers` but **not** in `channels.telegram.allowFrom`, their approval callback is silently rejected.

With the callback rejected, the approval times out. The default `askFallback="full"` then allows the command to execute without any real approval, completely bypassing the configured exec approval policy.

This only affects Telegram DM sessions (DM pairing mode), not group/channel sessions.

## Changes

**`extensions/telegram/src/bot-handlers.runtime.ts`**

Added `isExecApprovalFromAuthorizedDmSender` check before determining `authorizationMode`. When the callback is an exec approval button press **and** the sender is a configured exec approver (via `isTelegramExecApprovalAuthorizedSender`), the authorization mode switches to `"callback-scope"` which does not enforce the DM `allowFrom` allowlist.

Security is preserved: the sender is still validated by the dedicated `isTelegramExecApprovalAuthorizedSender` check in the `isApprovalCallback` handler block immediately after.

Fixes openclaw/openclaw#60260