### PR TITLE
fix: skip service_tier injection for Anthropic OAuth tokens (fixes #60279)

### DIFF
--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -1,6 +1,11 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { __testing, createAnthropicBetaHeadersWrapper } from "./stream-wrappers.js";
+import {
+  __testing,
+  createAnthropicBetaHeadersWrapper,
+  createAnthropicFastModeWrapper,
+  createAnthropicServiceTierWrapper,
+} from "./stream-wrappers.js";
 
 const CONTEXT_1M_BETA = "context-1m-2025-08-07";
 const OAUTH_BETA = "oauth-2025-04-20";
@@ -40,5 +45,102 @@ describe("anthropic stream wrappers", () => {
     expect(headers?.["anthropic-beta"]).toBeDefined();
     expect(headers?.["anthropic-beta"]).toContain(CONTEXT_1M_BETA);
     expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("createAnthropicFastModeWrapper", () => {
+  function runFastModeWrapper(params: {
+    apiKey?: string;
+    provider?: string;
+    api?: string;
+    baseUrl?: string;
+    enabled?: boolean;
+  }): Record<string, unknown> | undefined {
+    const captured: { payload?: Record<string, unknown> } = {};
+    const base: StreamFn = (_model, _context, options) => {
+      // Record the payload passed via onPayload
+      if (options?.onPayload) {
+        const payload: Record<string, unknown> = {};
+        options.onPayload(payload, _model);
+        captured.payload = payload;
+      }
+      return {} as never;
+    };
+    const wrapper = createAnthropicFastModeWrapper(base, params.enabled ?? true);
+    wrapper(
+      {
+        provider: params.provider ?? "anthropic",
+        api: params.api ?? "anthropic-messages",
+        baseUrl: params.baseUrl,
+        id: "claude-sonnet-4-6",
+      } as never,
+      {} as never,
+      { apiKey: params.apiKey } as never,
+    );
+    return captured.payload;
+  }
+
+  it("does not inject service_tier for OAuth setup-token", () => {
+    const payload = runFastModeWrapper({ apiKey: "sk-ant-oat01-test-token" });
+    expect(payload?.service_tier).toBeUndefined();
+  });
+
+  it("injects service_tier for regular API keys", () => {
+    const payload = runFastModeWrapper({ apiKey: "sk-ant-api03-test-key" });
+    expect(payload?.service_tier).toBe("auto");
+  });
+
+  it("injects service_tier=standard_only when disabled for API keys", () => {
+    const payload = runFastModeWrapper({ apiKey: "sk-ant-api03-test-key", enabled: false });
+    expect(payload?.service_tier).toBe("standard_only");
+  });
+
+  it("does not inject service_tier for non-anthropic provider", () => {
+    const payload = runFastModeWrapper({
+      apiKey: "sk-ant-api03-test-key",
+      provider: "openai",
+      api: "openai-completions",
+    });
+    expect(payload?.service_tier).toBeUndefined();
+  });
+});
+
+describe("createAnthropicServiceTierWrapper", () => {
+  function runServiceTierWrapper(params: {
+    apiKey?: string;
+    provider?: string;
+    api?: string;
+    serviceTier?: "auto" | "standard_only";
+  }): Record<string, unknown> | undefined {
+    const captured: { payload?: Record<string, unknown> } = {};
+    const base: StreamFn = (_model, _context, options) => {
+      if (options?.onPayload) {
+        const payload: Record<string, unknown> = {};
+        options.onPayload(payload, _model);
+        captured.payload = payload;
+      }
+      return {} as never;
+    };
+    const wrapper = createAnthropicServiceTierWrapper(base, params.serviceTier ?? "auto");
+    wrapper(
+      {
+        provider: params.provider ?? "anthropic",
+        api: params.api ?? "anthropic-messages",
+        id: "claude-sonnet-4-6",
+      } as never,
+      {} as never,
+      { apiKey: params.apiKey } as never,
+    );
+    return captured.payload;
+  }
+
+  it("does not inject service_tier for OAuth setup-token", () => {
+    const payload = runServiceTierWrapper({ apiKey: "sk-ant-oat01-test-token" });
+    expect(payload?.service_tier).toBeUndefined();
+  });
+
+  it("injects service_tier for regular API keys", () => {
+    const payload = runServiceTierWrapper({ apiKey: "sk-ant-api03-test-key" });
+    expect(payload?.service_tier).toBe("auto");
   });
 });

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -161,7 +161,10 @@ export function createAnthropicFastModeWrapper(
   const underlying = baseStreamFn ?? streamSimple;
   const serviceTier = resolveAnthropicFastServiceTier(enabled);
   return (model, context, options) => {
-    if (!allowsAnthropicServiceTier(model)) {
+    // OAuth tokens (sk-ant-oat*) use a different auth path that does not support
+    // the service_tier payload field. Injecting it causes Anthropic to reject
+    // the request with HTTP 401 "OAuth authentication is currently not supported".
+    if (!allowsAnthropicServiceTier(model) || isAnthropicOAuthApiKey(options?.apiKey)) {
       return underlying(model, context, options);
     }
 
@@ -179,7 +182,10 @@ export function createAnthropicServiceTierWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
-    if (!allowsAnthropicServiceTier(model)) {
+    // OAuth tokens (sk-ant-oat*) use a different auth path that does not support
+    // the service_tier payload field. Injecting it causes Anthropic to reject
+    // the request with HTTP 401 "OAuth authentication is currently not supported".
+    if (!allowsAnthropicServiceTier(model) || isAnthropicOAuthApiKey(options?.apiKey)) {
       return underlying(model, context, options);
     }
 


### PR DESCRIPTION
## Summary

Restores the `isAnthropicOAuthApiKey()` guard in `createAnthropicFastModeWrapper` and `createAnthropicServiceTierWrapper` that was accidentally dropped during the 2026.3.28 refactor introducing `wrapStreamFn` in `extensions/anthropic`.

## Root Cause

The 2026.3.28 refactor moved Anthropic stream wrappers from `src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts` into the provider plugin (`extensions/anthropic/stream-wrappers.ts`). The legacy `createAnthropicFastModeWrapper` had an explicit guard:

```ts
if (
  model.api !== "anthropic-messages" ||
  model.provider !== "anthropic" ||
  !isAnthropicPublicApiBaseUrl(model.baseUrl) ||
  isAnthropicOAuthApiKey(options?.apiKey)  // <-- guard for OAuth
) {
  return underlying(model, context, options);  // skip service_tier
}
```

The new plugin implementation replaced these checks with `allowsAnthropicServiceTier(model)`, which correctly gates on provider/api/endpoint but **omits the OAuth token check**. As a result, when fast mode or an explicit `serviceTier` is configured, `service_tier` gets injected into the payload for OAuth-authenticated requests. Anthropic rejects these with:

```json
{"type":"error","error":{"type":"authentication_error","message":"OAuth authentication is currently not supported"}}
```

## Changes

- `extensions/anthropic/stream-wrappers.ts`: Add `isAnthropicOAuthApiKey(options?.apiKey)` guard to both `createAnthropicFastModeWrapper` and `createAnthropicServiceTierWrapper`
- `extensions/anthropic/stream-wrappers.test.ts`: Add test cases verifying OAuth tokens skip service_tier injection while regular API keys still receive it

## Testing

- TypeScript compilation passes (`npx tsc --noEmit`)
- All pre-commit checks pass (lint, tsgo, conflict markers)
- New unit tests cover:
  - OAuth token → no service_tier injected (fast mode wrapper)
  - Regular API key → service_tier injected (fast mode wrapper)
  - OAuth token → no service_tier injected (service tier wrapper)
  - Regular API key → service_tier injected (service tier wrapper)

Fixes #60279