### PR TITLE
feat(feishu): exec approval interactive cards with Handler pattern

### DIFF
--- a/extensions/feishu/api.ts
+++ b/extensions/feishu/api.ts
@@ -1,5 +1,7 @@
 export { feishuPlugin } from "./src/channel.js";
 export * from "./src/conversation-id.js";
+export * from "./src/exec-approvals.js";
+export * from "./src/exec-approval-forwarding.js";
 export * from "./src/setup-core.js";
 export * from "./src/setup-surface.js";
 export * from "./src/thread-bindings.js";

--- a/extensions/feishu/api.ts
+++ b/extensions/feishu/api.ts
@@ -1,7 +1,6 @@
 export { feishuPlugin } from "./src/channel.js";
 export * from "./src/conversation-id.js";
 export * from "./src/exec-approvals.js";
-export * from "./src/exec-approval-forwarding.js";
 export * from "./src/setup-core.js";
 export * from "./src/setup-surface.js";
 export * from "./src/thread-bindings.js";

--- a/extensions/feishu/src/approval-native.ts
+++ b/extensions/feishu/src/approval-native.ts
@@ -1,0 +1,91 @@
+import {
+  createChannelApproverDmTargetResolver,
+  createChannelNativeOriginTargetResolver,
+  createApproverRestrictedNativeApprovalCapability,
+  splitChannelApprovalCapability,
+} from "openclaw/plugin-sdk/approval-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { ExecApprovalRequest, PluginApprovalRequest } from "openclaw/plugin-sdk/infra-runtime";
+import { listFeishuAccountIds } from "./accounts.js";
+import { parseFeishuTargetId } from "./conversation-id.js";
+import {
+  getFeishuExecApprovalApprovers,
+  isFeishuExecApprovalApprover,
+  isFeishuExecApprovalAuthorizedSender,
+  isFeishuExecApprovalClientEnabled,
+  resolveFeishuExecApprovalTarget,
+  shouldHandleFeishuExecApprovalRequest,
+} from "./exec-approvals.js";
+
+type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type FeishuOriginTarget = { to: string };
+
+function resolveTurnSourceFeishuOriginTarget(request: ApprovalRequest): FeishuOriginTarget | null {
+  const turnSourceChannel = request.request.turnSourceChannel?.trim().toLowerCase() || "";
+  const rawTurnSourceTo = request.request.turnSourceTo?.trim() || "";
+  const turnSourceTo = parseFeishuTargetId(rawTurnSourceTo);
+  if (turnSourceChannel !== "feishu" || !turnSourceTo) {
+    return null;
+  }
+  return { to: turnSourceTo };
+}
+
+function resolveSessionFeishuOriginTarget(sessionTarget: {
+  to: string;
+  threadId?: number | null;
+}): FeishuOriginTarget {
+  return { to: parseFeishuTargetId(sessionTarget.to) ?? sessionTarget.to };
+}
+
+function feishuTargetsMatch(a: FeishuOriginTarget, b: FeishuOriginTarget): boolean {
+  const normalizedA = parseFeishuTargetId(a.to) ?? a.to;
+  const normalizedB = parseFeishuTargetId(b.to) ?? b.to;
+  return normalizedA === normalizedB;
+}
+
+const resolveFeishuOriginTarget = createChannelNativeOriginTargetResolver({
+  channel: "feishu",
+  shouldHandleRequest: ({ cfg, accountId, request }) =>
+    shouldHandleFeishuExecApprovalRequest({
+      cfg,
+      accountId,
+      request,
+    }),
+  resolveTurnSourceTarget: resolveTurnSourceFeishuOriginTarget,
+  resolveSessionTarget: resolveSessionFeishuOriginTarget,
+  targetsMatch: feishuTargetsMatch,
+});
+
+const resolveFeishuApproverDmTargets = createChannelApproverDmTargetResolver({
+  shouldHandleRequest: ({ cfg, accountId, request }) =>
+    shouldHandleFeishuExecApprovalRequest({
+      cfg,
+      accountId,
+      request,
+    }),
+  resolveApprovers: getFeishuExecApprovalApprovers,
+  mapApprover: (approver) => ({ to: `user:${approver}` }),
+});
+
+export const feishuApprovalCapability = createApproverRestrictedNativeApprovalCapability({
+  channel: "feishu",
+  channelLabel: "Feishu",
+  listAccountIds: listFeishuAccountIds,
+  hasApprovers: ({ cfg, accountId }) =>
+    getFeishuExecApprovalApprovers({ cfg, accountId }).length > 0,
+  isExecAuthorizedSender: ({ cfg, accountId, senderId }) =>
+    isFeishuExecApprovalAuthorizedSender({ cfg, accountId, senderId }),
+  isPluginAuthorizedSender: ({ cfg, accountId, senderId }) =>
+    isFeishuExecApprovalApprover({ cfg, accountId, senderId }),
+  isNativeDeliveryEnabled: ({ cfg, accountId }) =>
+    isFeishuExecApprovalClientEnabled({ cfg, accountId }),
+  resolveNativeDeliveryMode: ({ cfg, accountId }) =>
+    resolveFeishuExecApprovalTarget({ cfg, accountId }),
+  requireMatchingTurnSourceChannel: true,
+  resolveSuppressionAccountId: ({ target, request }) =>
+    target.accountId?.trim() || request.request.turnSourceAccountId?.trim() || undefined,
+  resolveOriginTarget: resolveFeishuOriginTarget,
+  resolveApproverDmTargets: resolveFeishuApproverDmTargets,
+});
+
+export const feishuNativeApprovalAdapter = splitChannelApprovalCapability(feishuApprovalCapability);

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -1,3 +1,8 @@
+import {
+  callGateway,
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "openclaw/plugin-sdk/infra-runtime";
 import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent } from "./bot.js";
@@ -8,7 +13,13 @@ import {
   FEISHU_APPROVAL_CONFIRM_ACTION,
   FEISHU_APPROVAL_REQUEST_ACTION,
 } from "./card-ux-approval.js";
-import { sendCardFeishu, sendMessageFeishu } from "./send.js";
+import {
+  FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION,
+  FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION,
+  FEISHU_EXEC_APPROVAL_DENY_ACTION,
+  createExecApprovalResolvedCard,
+} from "./card-ux-exec-approval.js";
+import { sendCardFeishu, sendMessageFeishu, updateCardFeishu } from "./send.js";
 
 export type FeishuCardActionEvent = {
   operator: {
@@ -25,6 +36,7 @@ export type FeishuCardActionEvent = {
     open_id: string;
     user_id: string;
     chat_id: string;
+    open_message_id?: string;
   };
 };
 
@@ -166,6 +178,21 @@ async function sendInvalidInteractionNotice(params: {
   });
 }
 
+function resolveExecApprovalDecision(
+  action: string,
+): "allow-once" | "allow-always" | "deny" | null {
+  if (action === FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION) {
+    return "allow-once";
+  }
+  if (action === FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION) {
+    return "allow-always";
+  }
+  if (action === FEISHU_EXEC_APPROVAL_DENY_ACTION) {
+    return "deny";
+  }
+  return null;
+}
+
 export async function handleFeishuCardAction(params: {
   cfg: ClawdbotConfig;
   event: FeishuCardActionEvent;
@@ -274,6 +301,77 @@ export async function handleFeishuCardAction(params: {
           accountId,
           chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
         });
+        completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+        return;
+      }
+
+      const execApprovalDecision = resolveExecApprovalDecision(envelope.a);
+      if (execApprovalDecision) {
+        const approvalId =
+          typeof envelope.m?.approvalId === "string" ? envelope.m.approvalId.trim() : "";
+        if (!approvalId) {
+          await sendInvalidInteractionNotice({
+            cfg,
+            event,
+            reason: "malformed",
+            accountId,
+          });
+          completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+          return;
+        }
+        log(
+          `feishu[${account.accountId}]: exec approval ${execApprovalDecision} for ${approvalId} by ${event.operator.open_id}`,
+        );
+        try {
+          // Resolve the exec approval directly via gateway RPC instead of
+          // dispatching a synthetic /approve chat command.  This avoids
+          // the command reply and system notification messages.
+          const resolvedBy = `feishu:${event.operator.open_id}`;
+          await callGateway({
+            method: "exec.approval.resolve",
+            params: { id: approvalId, decision: execApprovalDecision },
+            clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+            clientDisplayName: `Feishu card approval (${resolvedBy})`,
+            mode: GATEWAY_CLIENT_MODES.BACKEND,
+          });
+          // Update original card in-place if message ID is available,
+          // otherwise fall back to sending a new card.
+          const command =
+            typeof envelope.m?.command === "string" ? envelope.m.command.trim() : undefined;
+          const cwd = typeof envelope.m?.cwd === "string" ? envelope.m.cwd.trim() : undefined;
+          const resolvedCard = createExecApprovalResolvedCard({
+            approvalId,
+            decision: execApprovalDecision,
+            resolvedBy: event.operator.open_id,
+            command: command || undefined,
+            cwd: cwd || undefined,
+          });
+          const originalMessageId = event.context.open_message_id;
+          if (originalMessageId) {
+            await updateCardFeishu({
+              cfg,
+              messageId: originalMessageId,
+              card: resolvedCard,
+              accountId,
+            }).catch(() => {});
+          } else {
+            await sendCardFeishu({
+              cfg,
+              to: resolveCallbackTarget(event),
+              card: resolvedCard,
+              accountId,
+            }).catch(() => {});
+          }
+        } catch (err) {
+          // Notify the user about the failure
+          const errorText = `❌ Failed to submit exec approval: ${String(err)}`;
+          await sendMessageFeishu({
+            cfg,
+            to: resolveCallbackTarget(event),
+            text: errorText,
+            accountId,
+          }).catch(() => {});
+        }
         completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
         return;
       }

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -13,7 +13,10 @@ import {
   FEISHU_APPROVAL_CONFIRM_ACTION,
   FEISHU_APPROVAL_REQUEST_ACTION,
 } from "./card-ux-approval.js";
-import { isFeishuExecApprovalApprover } from "./exec-approvals.js";
+import {
+  isFeishuExecApprovalApprover,
+  isFeishuExecApprovalClientEnabled,
+} from "./exec-approvals.js";
 import {
   FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION,
   FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION,
@@ -320,6 +323,18 @@ export async function handleFeishuCardAction(params: {
           completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
           return;
         }
+        // Verify exec approvals are still enabled for this account.
+        if (!isFeishuExecApprovalClientEnabled({ cfg, accountId: account.accountId })) {
+          await sendMessageFeishu({
+            cfg,
+            to: resolveCallbackTarget(event),
+            text: "❌ 飞书命令执行审批已禁用。",
+            accountId,
+          }).catch(() => {});
+          completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+          return;
+        }
+
         // Verify the operator is a configured approver before resolving.
         if (
           !isFeishuExecApprovalApprover({
@@ -366,14 +381,23 @@ export async function handleFeishuCardAction(params: {
             cwd: cwd || undefined,
           });
           const originalMessageId = event.context.open_message_id;
+          let cardUpdated = false;
           if (originalMessageId) {
-            await updateCardFeishu({
-              cfg,
-              messageId: originalMessageId,
-              card: resolvedCard,
-              accountId,
-            }).catch(() => {});
-          } else {
+            try {
+              await updateCardFeishu({
+                cfg,
+                messageId: originalMessageId,
+                card: resolvedCard,
+                accountId,
+              });
+              cardUpdated = true;
+            } catch (patchErr) {
+              log(
+                `feishu[${account.accountId}]: failed to patch card ${originalMessageId}: ${String(patchErr)}`,
+              );
+            }
+          }
+          if (!cardUpdated) {
             await sendCardFeishu({
               cfg,
               to: resolveCallbackTarget(event),

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -355,28 +355,26 @@ export async function handleFeishuCardAction(params: {
         log(
           `feishu[${account.accountId}]: exec approval ${execApprovalDecision} for ${approvalId} by ${event.operator.open_id}`,
         );
-        try {
-          // Resolve the exec approval directly via gateway RPC.  The
-          // FeishuExecApprovalHandler will receive the resolved event and
-          // update all tracked cards (including this one) in-place.
-          const resolvedBy = `feishu:${event.operator.open_id}`;
-          await callGateway({
-            method: "exec.approval.resolve",
-            params: { id: approvalId, decision: execApprovalDecision },
-            clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
-            clientDisplayName: `Feishu card approval (${resolvedBy})`,
-            mode: GATEWAY_CLIENT_MODES.BACKEND,
-          });
-        } catch (err) {
+        // Complete the card action token immediately so Feishu does not
+        // time out (error 200340).  The gateway RPC and card update run
+        // asynchronously after the response.
+        completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+        const resolvedBy = `feishu:${event.operator.open_id}`;
+        callGateway({
+          method: "exec.approval.resolve",
+          params: { id: approvalId, decision: execApprovalDecision },
+          clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+          clientDisplayName: `Feishu card approval (${resolvedBy})`,
+          mode: GATEWAY_CLIENT_MODES.BACKEND,
+        }).catch((err) => {
           const errorText = `❌ 审批提交失败: ${String(err)}`;
-          await sendMessageFeishu({
+          sendMessageFeishu({
             cfg,
             to: resolveCallbackTarget(event),
             text: errorText,
             accountId,
           }).catch(() => {});
-        }
-        completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+        });
         return;
       }
 

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -13,6 +13,7 @@ import {
   FEISHU_APPROVAL_CONFIRM_ACTION,
   FEISHU_APPROVAL_REQUEST_ACTION,
 } from "./card-ux-approval.js";
+import { isFeishuExecApprovalApprover } from "./exec-approvals.js";
 import {
   FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION,
   FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION,
@@ -319,6 +320,24 @@ export async function handleFeishuCardAction(params: {
           completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
           return;
         }
+        // Verify the operator is a configured approver before resolving.
+        if (
+          !isFeishuExecApprovalApprover({
+            cfg,
+            accountId: account.accountId,
+            senderId: event.operator.open_id,
+          })
+        ) {
+          await sendMessageFeishu({
+            cfg,
+            to: resolveCallbackTarget(event),
+            text: "❌ 你没有审批权限。",
+            accountId,
+          }).catch(() => {});
+          completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+          return;
+        }
+
         log(
           `feishu[${account.accountId}]: exec approval ${execApprovalDecision} for ${approvalId} by ${event.operator.open_id}`,
         );

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -14,16 +14,15 @@ import {
   FEISHU_APPROVAL_REQUEST_ACTION,
 } from "./card-ux-approval.js";
 import {
-  isFeishuExecApprovalApprover,
-  isFeishuExecApprovalClientEnabled,
-} from "./exec-approvals.js";
-import {
   FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION,
   FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION,
   FEISHU_EXEC_APPROVAL_DENY_ACTION,
-  createExecApprovalResolvedCard,
 } from "./card-ux-exec-approval.js";
-import { sendCardFeishu, sendMessageFeishu, updateCardFeishu } from "./send.js";
+import {
+  isFeishuExecApprovalApprover,
+  isFeishuExecApprovalClientEnabled,
+} from "./exec-approvals.js";
+import { sendCardFeishu, sendMessageFeishu } from "./send.js";
 
 export type FeishuCardActionEvent = {
   operator: {
@@ -357,9 +356,9 @@ export async function handleFeishuCardAction(params: {
           `feishu[${account.accountId}]: exec approval ${execApprovalDecision} for ${approvalId} by ${event.operator.open_id}`,
         );
         try {
-          // Resolve the exec approval directly via gateway RPC instead of
-          // dispatching a synthetic /approve chat command.  This avoids
-          // the command reply and system notification messages.
+          // Resolve the exec approval directly via gateway RPC.  The
+          // FeishuExecApprovalHandler will receive the resolved event and
+          // update all tracked cards (including this one) in-place.
           const resolvedBy = `feishu:${event.operator.open_id}`;
           await callGateway({
             method: "exec.approval.resolve",
@@ -368,46 +367,8 @@ export async function handleFeishuCardAction(params: {
             clientDisplayName: `Feishu card approval (${resolvedBy})`,
             mode: GATEWAY_CLIENT_MODES.BACKEND,
           });
-          // Update original card in-place if message ID is available,
-          // otherwise fall back to sending a new card.
-          const command =
-            typeof envelope.m?.command === "string" ? envelope.m.command.trim() : undefined;
-          const cwd = typeof envelope.m?.cwd === "string" ? envelope.m.cwd.trim() : undefined;
-          const resolvedCard = createExecApprovalResolvedCard({
-            approvalId,
-            decision: execApprovalDecision,
-            resolvedBy: event.operator.open_id,
-            command: command || undefined,
-            cwd: cwd || undefined,
-          });
-          const originalMessageId = event.context.open_message_id;
-          let cardUpdated = false;
-          if (originalMessageId) {
-            try {
-              await updateCardFeishu({
-                cfg,
-                messageId: originalMessageId,
-                card: resolvedCard,
-                accountId,
-              });
-              cardUpdated = true;
-            } catch (patchErr) {
-              log(
-                `feishu[${account.accountId}]: failed to patch card ${originalMessageId}: ${String(patchErr)}`,
-              );
-            }
-          }
-          if (!cardUpdated) {
-            await sendCardFeishu({
-              cfg,
-              to: resolveCallbackTarget(event),
-              card: resolvedCard,
-              accountId,
-            }).catch(() => {});
-          }
         } catch (err) {
-          // Notify the user about the failure
-          const errorText = `❌ Failed to submit exec approval: ${String(err)}`;
+          const errorText = `❌ 审批提交失败: ${String(err)}`;
           await sendMessageFeishu({
             cfg,
             to: resolveCallbackTarget(event),

--- a/extensions/feishu/src/card-ux-exec-approval.test.ts
+++ b/extensions/feishu/src/card-ux-exec-approval.test.ts
@@ -143,7 +143,7 @@ describe("createExecApprovalResolvedCard", () => {
     });
 
     const body = card.body as { elements: Array<Record<string, unknown>> };
-    expect(body.elements[0].content).toContain("<at id=user@feishu></at>");
+    expect(body.elements[0].content).toContain('<at id="user@feishu"></at>');
   });
 
   it("omits command and cwd when not provided", () => {

--- a/extensions/feishu/src/card-ux-exec-approval.test.ts
+++ b/extensions/feishu/src/card-ux-exec-approval.test.ts
@@ -146,6 +146,19 @@ describe("createExecApprovalResolvedCard", () => {
     expect(body.elements[0].content).toContain('<at id="ou_abc123"></at>');
   });
 
+  it("extracts open_id from gateway clientDisplayName for at-tag", () => {
+    const card = createExecApprovalResolvedCard({
+      approvalId: "test123",
+      decision: "allow-once",
+      resolvedBy: "Feishu card approval (feishu:ou_261ca44fc6b6181c03f8b42e020671d6)",
+    });
+
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    expect(body.elements[0].content).toContain(
+      '<at id="ou_261ca44fc6b6181c03f8b42e020671d6"></at>',
+    );
+  });
+
   it("includes resolvedBy as plain text for non-Feishu identifiers", () => {
     const card = createExecApprovalResolvedCard({
       approvalId: "test123",

--- a/extensions/feishu/src/card-ux-exec-approval.test.ts
+++ b/extensions/feishu/src/card-ux-exec-approval.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { FEISHU_CARD_INTERACTION_VERSION } from "./card-interaction.js";
+import {
+  createExecApprovalCard,
+  createExecApprovalResolvedCard,
+  FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION,
+  FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION,
+  FEISHU_EXEC_APPROVAL_DENY_ACTION,
+} from "./card-ux-exec-approval.js";
+
+function extractButtons(card: Record<string, unknown>) {
+  const body = card.body as { elements: Array<Record<string, unknown>> };
+  const columnSet = body.elements[1] as {
+    columns: Array<{ elements: Array<Record<string, unknown>> }>;
+  };
+  return columnSet.columns.map((col) => col.elements[0]);
+}
+
+describe("createExecApprovalCard", () => {
+  it("creates card with three buttons", () => {
+    const card = createExecApprovalCard({
+      approvalId: "abcdef1234567890",
+      command: "rm -rf /tmp/test",
+      cwd: "/home/user",
+      host: "gateway",
+      expiresAtMs: Date.now() + 120_000,
+    });
+
+    expect(card.schema).toBe("2.0");
+    expect((card.header as Record<string, unknown>).template).toBe("orange");
+
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    expect(body.elements).toHaveLength(2);
+
+    const markdownElement = body.elements[0];
+    expect(markdownElement.tag).toBe("markdown");
+    expect(markdownElement.content).toContain("abcdef12");
+    expect(markdownElement.content).toContain("rm -rf /tmp/test");
+    expect(markdownElement.content).toContain("/home/user");
+
+    const buttons = extractButtons(card);
+    expect(buttons).toHaveLength(3);
+
+    const allowOnceButton = buttons[0];
+    expect((allowOnceButton.text as Record<string, string>).content).toBe("允许一次");
+    expect(allowOnceButton.type).toBe("primary");
+    const allowOnceValue = allowOnceButton.value as Record<string, unknown>;
+    expect(allowOnceValue.oc).toBe(FEISHU_CARD_INTERACTION_VERSION);
+    expect(allowOnceValue.a).toBe(FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION);
+    expect((allowOnceValue.m as Record<string, string>).approvalId).toBe("abcdef1234567890");
+    expect((allowOnceValue.m as Record<string, string>).command).toBe("rm -rf /tmp/test");
+    expect((allowOnceValue.m as Record<string, string>).cwd).toBe("/home/user");
+    const allowOnceContext = allowOnceValue.c as Record<string, unknown>;
+    expect(allowOnceContext.e).toBeTypeOf("number");
+    expect(allowOnceContext.u).toBeUndefined();
+
+    const allowAlwaysButton = buttons[1];
+    expect((allowAlwaysButton.text as Record<string, string>).content).toBe("始终允许");
+    expect(allowAlwaysButton.type).toBe("default");
+    expect((allowAlwaysButton.value as Record<string, unknown>).a).toBe(
+      FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION,
+    );
+
+    const denyButton = buttons[2];
+    expect((denyButton.text as Record<string, string>).content).toBe("拒绝");
+    expect(denyButton.type).toBe("danger");
+    expect((denyButton.value as Record<string, unknown>).a).toBe(FEISHU_EXEC_APPROVAL_DENY_ACTION);
+  });
+
+  it("includes chatType in button context when provided", () => {
+    const card = createExecApprovalCard({
+      approvalId: "abcdef1234567890",
+      command: "ls",
+      expiresAtMs: Date.now() + 60_000,
+      chatType: "group",
+    });
+    const buttons = extractButtons(card);
+    const buttonValue = buttons[0].value as Record<string, unknown>;
+    const context = buttonValue.c as Record<string, unknown>;
+    expect(context.t).toBe("group");
+  });
+
+  it("omits optional fields when not provided", () => {
+    const card = createExecApprovalCard({
+      approvalId: "test123",
+      command: "echo hello",
+      expiresAtMs: Date.now() + 60_000,
+    });
+
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    const content = body.elements[0].content as string;
+    expect(content).not.toContain("工作目录");
+    expect(content).not.toContain("主机");
+  });
+});
+
+describe("createExecApprovalResolvedCard", () => {
+  it("creates green card for allow-once with command info", () => {
+    const card = createExecApprovalResolvedCard({
+      approvalId: "abcdef1234567890",
+      decision: "allow-once",
+      command: "rm -rf /tmp/test",
+      cwd: "/home/user",
+    });
+
+    expect((card.header as Record<string, unknown>).template).toBe("green");
+    const title = (card.header as Record<string, Record<string, string>>).title;
+    expect(title.content).toContain("已允许（一次）");
+
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    const content = body.elements[0].content as string;
+    expect(content).toContain("rm -rf /tmp/test");
+    expect(content).toContain("/home/user");
+  });
+
+  it("creates green card for allow-always", () => {
+    const card = createExecApprovalResolvedCard({
+      approvalId: "test123",
+      decision: "allow-always",
+    });
+
+    expect((card.header as Record<string, unknown>).template).toBe("green");
+    const title = (card.header as Record<string, Record<string, string>>).title;
+    expect(title.content).toContain("已允许（始终）");
+  });
+
+  it("creates red card for deny", () => {
+    const card = createExecApprovalResolvedCard({
+      approvalId: "test123",
+      decision: "deny",
+    });
+
+    expect((card.header as Record<string, unknown>).template).toBe("red");
+    const title = (card.header as Record<string, Record<string, string>>).title;
+    expect(title.content).toContain("已拒绝");
+  });
+
+  it("includes resolvedBy when provided", () => {
+    const card = createExecApprovalResolvedCard({
+      approvalId: "test123",
+      decision: "allow-once",
+      resolvedBy: "user@feishu",
+    });
+
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    expect(body.elements[0].content).toContain("<at id=user@feishu></at>");
+  });
+
+  it("omits command and cwd when not provided", () => {
+    const card = createExecApprovalResolvedCard({
+      approvalId: "test123",
+      decision: "deny",
+    });
+
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    const content = body.elements[0].content as string;
+    expect(content).not.toContain("命令");
+    expect(content).not.toContain("工作目录");
+  });
+});

--- a/extensions/feishu/src/card-ux-exec-approval.test.ts
+++ b/extensions/feishu/src/card-ux-exec-approval.test.ts
@@ -135,15 +135,27 @@ describe("createExecApprovalResolvedCard", () => {
     expect(title.content).toContain("已拒绝");
   });
 
-  it("includes resolvedBy when provided", () => {
+  it("includes resolvedBy with at-tag for Feishu open_id", () => {
     const card = createExecApprovalResolvedCard({
       approvalId: "test123",
       decision: "allow-once",
-      resolvedBy: "user@feishu",
+      resolvedBy: "ou_abc123",
     });
 
     const body = card.body as { elements: Array<Record<string, unknown>> };
-    expect(body.elements[0].content).toContain('<at id="user@feishu"></at>');
+    expect(body.elements[0].content).toContain('<at id="ou_abc123"></at>');
+  });
+
+  it("includes resolvedBy as plain text for non-Feishu identifiers", () => {
+    const card = createExecApprovalResolvedCard({
+      approvalId: "test123",
+      decision: "allow-once",
+      resolvedBy: "Chat approval (telegram:123)",
+    });
+
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    expect(body.elements[0].content).toContain("Chat approval (telegram:123)");
+    expect(body.elements[0].content).not.toContain("<at");
   });
 
   it("omits command and cwd when not provided", () => {

--- a/extensions/feishu/src/card-ux-exec-approval.ts
+++ b/extensions/feishu/src/card-ux-exec-approval.ts
@@ -148,7 +148,7 @@ export function createExecApprovalResolvedCard(params: {
   }
   bodyLines.push(`**结果：** ${decisionLabel}`);
   if (params.resolvedBy) {
-    bodyLines.push(`**操作人：** <at id=${params.resolvedBy}></at>`);
+    bodyLines.push(`**操作人：** <at id="${params.resolvedBy}"></at>`);
   }
 
   return {

--- a/extensions/feishu/src/card-ux-exec-approval.ts
+++ b/extensions/feishu/src/card-ux-exec-approval.ts
@@ -137,8 +137,11 @@ export function createExecApprovalResolvedCard(params: {
       ? "已允许（一次）"
       : params.decision === "allow-always"
         ? "已允许（始终）"
-        : "已拒绝";
-  const template = params.decision === "deny" ? "red" : "green";
+        : params.decision === "expired"
+          ? "已过期"
+          : "已拒绝";
+  const template =
+    params.decision === "deny" ? "red" : params.decision === "expired" ? "grey" : "green";
   const bodyLines: string[] = [`**审批 ID：** \`${approvalSlug}\``];
   if (params.command) {
     bodyLines.push(`**命令：** \`${params.command}\``);
@@ -148,7 +151,15 @@ export function createExecApprovalResolvedCard(params: {
   }
   bodyLines.push(`**结果：** ${decisionLabel}`);
   if (params.resolvedBy) {
-    bodyLines.push(`**操作人：** <at id="${params.resolvedBy}"></at>`);
+    // Only use Feishu <at> tag for Feishu open_ids (ou_xxx / on_xxx).
+    // For other resolvedBy values (e.g. gateway labels), display as plain text.
+    const isFeishuOpenId =
+      params.resolvedBy.startsWith("ou_") || params.resolvedBy.startsWith("on_");
+    if (isFeishuOpenId) {
+      bodyLines.push(`**操作人：** <at id="${params.resolvedBy}"></at>`);
+    } else {
+      bodyLines.push(`**操作人：** ${params.resolvedBy}`);
+    }
   }
 
   return {

--- a/extensions/feishu/src/card-ux-exec-approval.ts
+++ b/extensions/feishu/src/card-ux-exec-approval.ts
@@ -151,12 +151,13 @@ export function createExecApprovalResolvedCard(params: {
   }
   bodyLines.push(`**结果：** ${decisionLabel}`);
   if (params.resolvedBy) {
-    // Only use Feishu <at> tag for Feishu open_ids (ou_xxx / on_xxx).
-    // For other resolvedBy values (e.g. gateway labels), display as plain text.
-    const isFeishuOpenId =
-      params.resolvedBy.startsWith("ou_") || params.resolvedBy.startsWith("on_");
-    if (isFeishuOpenId) {
-      bodyLines.push(`**操作人：** <at id="${params.resolvedBy}"></at>`);
+    // Extract Feishu open_id from resolvedBy.  The gateway sets resolvedBy
+    // to clientDisplayName which may be "Feishu card approval (feishu:ou_xxx)".
+    // Try to extract the ou_/on_ ID for a proper <at> tag.
+    const openIdMatch = params.resolvedBy.match(/\b(ou_[a-zA-Z0-9]+|on_[a-zA-Z0-9]+)\b/);
+    const openId = openIdMatch?.[1];
+    if (openId) {
+      bodyLines.push(`**操作人：** <at id="${openId}"></at>`);
     } else {
       bodyLines.push(`**操作人：** ${params.resolvedBy}`);
     }

--- a/extensions/feishu/src/card-ux-exec-approval.ts
+++ b/extensions/feishu/src/card-ux-exec-approval.ts
@@ -1,0 +1,175 @@
+import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
+import { buildFeishuCardButton } from "./card-ux-shared.js";
+
+export const FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION = "feishu.exec_approval.allow_once";
+export const FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION = "feishu.exec_approval.allow_always";
+export const FEISHU_EXEC_APPROVAL_DENY_ACTION = "feishu.exec_approval.deny";
+
+export function createExecApprovalCard(params: {
+  approvalId: string;
+  command: string;
+  cwd?: string;
+  host?: string;
+  nodeId?: string;
+  expiresAtMs: number;
+  chatType?: "p2p" | "group";
+}): Record<string, unknown> {
+  const approvalSlug = params.approvalId.slice(0, 8);
+  const bodyLines: string[] = [
+    `**审批 ID：** \`${approvalSlug}\``,
+    `**命令：** \`${params.command}\``,
+  ];
+  if (params.cwd) {
+    bodyLines.push(`**工作目录：** \`${params.cwd}\``);
+  }
+  if (params.host) {
+    bodyLines.push(`**主机：** ${params.host}`);
+  }
+  if (params.nodeId) {
+    bodyLines.push(`**节点：** \`${params.nodeId}\``);
+  }
+
+  const metadata: Record<string, string> = { approvalId: params.approvalId };
+  if (params.command) {
+    metadata.command = params.command;
+  }
+  if (params.cwd) {
+    metadata.cwd = params.cwd;
+  }
+  // Exec approval context omits u (user) and h (chat) — any configured
+  // approver may click from any surface (DM or channel). Include expiry
+  // and chat type so callbacks enforce TTL and route correctly.
+  const context: { e: number; t?: "p2p" | "group" } = {
+    e: params.expiresAtMs,
+    ...(params.chatType ? { t: params.chatType } : {}),
+  };
+
+  return {
+    schema: "2.0",
+    config: {
+      wide_screen_mode: true,
+    },
+    header: {
+      title: {
+        tag: "plain_text",
+        content: "命令执行审批",
+      },
+      template: "orange",
+    },
+    body: {
+      elements: [
+        {
+          tag: "markdown",
+          content: bodyLines.join("\n"),
+        },
+        {
+          tag: "column_set",
+          flex_mode: "none",
+          horizontal_spacing: "default",
+          columns: [
+            {
+              tag: "column",
+              width: "weighted",
+              weight: 1,
+              elements: [
+                buildFeishuCardButton({
+                  label: "允许一次",
+                  type: "primary",
+                  value: createFeishuCardInteractionEnvelope({
+                    k: "button",
+                    a: FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION,
+                    m: metadata,
+                    c: context,
+                  }),
+                }),
+              ],
+            },
+            {
+              tag: "column",
+              width: "weighted",
+              weight: 1,
+              elements: [
+                buildFeishuCardButton({
+                  label: "始终允许",
+                  value: createFeishuCardInteractionEnvelope({
+                    k: "button",
+                    a: FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION,
+                    m: metadata,
+                    c: context,
+                  }),
+                }),
+              ],
+            },
+            {
+              tag: "column",
+              width: "weighted",
+              weight: 1,
+              elements: [
+                buildFeishuCardButton({
+                  label: "拒绝",
+                  type: "danger",
+                  value: createFeishuCardInteractionEnvelope({
+                    k: "button",
+                    a: FEISHU_EXEC_APPROVAL_DENY_ACTION,
+                    m: metadata,
+                    c: context,
+                  }),
+                }),
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+export function createExecApprovalResolvedCard(params: {
+  approvalId: string;
+  decision: string;
+  resolvedBy?: string;
+  command?: string;
+  cwd?: string;
+}): Record<string, unknown> {
+  const approvalSlug = params.approvalId.slice(0, 8);
+  const decisionLabel =
+    params.decision === "allow-once"
+      ? "已允许（一次）"
+      : params.decision === "allow-always"
+        ? "已允许（始终）"
+        : "已拒绝";
+  const template = params.decision === "deny" ? "red" : "green";
+  const bodyLines: string[] = [`**审批 ID：** \`${approvalSlug}\``];
+  if (params.command) {
+    bodyLines.push(`**命令：** \`${params.command}\``);
+  }
+  if (params.cwd) {
+    bodyLines.push(`**工作目录：** \`${params.cwd}\``);
+  }
+  bodyLines.push(`**结果：** ${decisionLabel}`);
+  if (params.resolvedBy) {
+    bodyLines.push(`**操作人：** <at id=${params.resolvedBy}></at>`);
+  }
+
+  return {
+    schema: "2.0",
+    config: {
+      wide_screen_mode: true,
+    },
+    header: {
+      title: {
+        tag: "plain_text",
+        content: `命令执行审批 — ${decisionLabel}`,
+      },
+      template,
+    },
+    body: {
+      elements: [
+        {
+          tag: "markdown",
+          content: bodyLines.join("\n"),
+        },
+      ],
+    },
+  };
+}

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1116,9 +1116,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
         render: {
           exec: {
             buildPendingPayload: (params) => buildFeishuExecApprovalPendingPayload(params),
-            // Resolved notifications are handled by in-place card updates
-            // in card-action.ts — suppress the default text message.
-            buildResolvedPayload: () => null,
+            // When resolved via Feishu card button (resolvedBy starts with
+            // "feishu:"), the card is already updated in-place by card-action.ts
+            // — suppress the duplicate text message.  When resolved from another
+            // surface (terminal, web, etc.), return undefined to fall through to
+            // the default text notification so Feishu users stay informed.
+            buildResolvedPayload: ({ resolved }) =>
+              resolved.resolvedBy?.startsWith("feishu:") ? null : undefined,
           },
         },
       },

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -32,6 +32,7 @@ import {
   resolveDefaultFeishuAccountId,
 } from "./accounts.js";
 import { feishuApprovalAuth } from "./approval-auth.js";
+import { feishuApprovalCapability } from "./approval-native.js";
 import { FEISHU_CARD_INTERACTION_VERSION } from "./card-interaction.js";
 import {
   buildChannelConfigSchema,
@@ -58,7 +59,6 @@ import {
   parseFeishuTargetId,
 } from "./conversation-id.js";
 import { listFeishuDirectoryPeers, listFeishuDirectoryGroups } from "./directory.static.js";
-import { buildFeishuExecApprovalPendingPayload } from "./exec-approval-forwarding.js";
 import { shouldSuppressLocalFeishuExecApprovalPrompt } from "./exec-approvals.js";
 import { messageActionTargetAliases } from "./message-action-contract.js";
 import { resolveFeishuGroupToolPolicy } from "./policy.js";
@@ -1112,20 +1112,8 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           hint: "<chatId|user:openId|chat:chatId>",
         },
       },
-      approvals: {
-        render: {
-          exec: {
-            buildPendingPayload: (params) => buildFeishuExecApprovalPendingPayload(params),
-            // When resolved via Feishu card button, the card is already updated
-            // in-place by card-action.ts — suppress the duplicate text message.
-            // The gateway sets resolvedBy to clientDisplayName, which is
-            // "Feishu card approval (feishu:...)" for card-action resolutions.
-            // When resolved from another surface, return undefined to fall through
-            // to the default text notification so Feishu users stay informed.
-            buildResolvedPayload: ({ resolved }) =>
-              resolved.resolvedBy?.includes("Feishu card approval") ? null : undefined,
-          },
-        },
+      approvalCapability: {
+        ...feishuApprovalCapability,
       },
       directory: createChannelDirectoryAdapter({
         listPeers: async ({ cfg, query, limit, accountId }) =>

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1116,13 +1116,14 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
         render: {
           exec: {
             buildPendingPayload: (params) => buildFeishuExecApprovalPendingPayload(params),
-            // When resolved via Feishu card button (resolvedBy starts with
-            // "feishu:"), the card is already updated in-place by card-action.ts
-            // — suppress the duplicate text message.  When resolved from another
-            // surface (terminal, web, etc.), return undefined to fall through to
-            // the default text notification so Feishu users stay informed.
+            // When resolved via Feishu card button, the card is already updated
+            // in-place by card-action.ts — suppress the duplicate text message.
+            // The gateway sets resolvedBy to clientDisplayName, which is
+            // "Feishu card approval (feishu:...)" for card-action resolutions.
+            // When resolved from another surface, return undefined to fall through
+            // to the default text notification so Feishu users stay informed.
             buildResolvedPayload: ({ resolved }) =>
-              resolved.resolvedBy?.startsWith("feishu:") ? null : undefined,
+              resolved.resolvedBy?.includes("Feishu card approval") ? null : undefined,
           },
         },
       },

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -58,6 +58,8 @@ import {
   parseFeishuTargetId,
 } from "./conversation-id.js";
 import { listFeishuDirectoryPeers, listFeishuDirectoryGroups } from "./directory.static.js";
+import { buildFeishuExecApprovalPendingPayload } from "./exec-approval-forwarding.js";
+import { shouldSuppressLocalFeishuExecApprovalPrompt } from "./exec-approvals.js";
 import { messageActionTargetAliases } from "./message-action-contract.js";
 import { resolveFeishuGroupToolPolicy } from "./policy.js";
 import { getFeishuRuntime } from "./runtime.js";
@@ -1110,6 +1112,16 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           hint: "<chatId|user:openId|chat:chatId>",
         },
       },
+      approvals: {
+        render: {
+          exec: {
+            buildPendingPayload: (params) => buildFeishuExecApprovalPendingPayload(params),
+            // Resolved notifications are handled by in-place card updates
+            // in card-action.ts — suppress the default text message.
+            buildResolvedPayload: () => null,
+          },
+        },
+      },
       directory: createChannelDirectoryAdapter({
         listPeers: async ({ cfg, query, limit, accountId }) =>
           listFeishuDirectoryPeers({
@@ -1216,10 +1228,20 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
       chunker: chunkTextForOutbound,
       chunkerMode: "markdown",
       textChunkLimit: 4000,
+      shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload }) =>
+        shouldSuppressLocalFeishuExecApprovalPrompt({ cfg, accountId, payload }),
       ...createRuntimeOutboundDelegates({
         getRuntime: loadFeishuChannelRuntime,
         sendText: { resolve: (runtime) => runtime.feishuOutbound.sendText },
         sendMedia: { resolve: (runtime) => runtime.feishuOutbound.sendMedia },
       }),
+      sendPayload: async (ctx) => {
+        const runtime = await loadFeishuChannelRuntime();
+        const sendPayloadFn = runtime.feishuOutbound.sendPayload;
+        if (!sendPayloadFn) {
+          throw new Error("feishu sendPayload is unavailable");
+        }
+        return sendPayloadFn(ctx);
+      },
     },
   });

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -138,6 +138,19 @@ const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
  */
 const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 
+const FeishuExecApprovalTargetSchema = z.enum(["dm", "channel", "both"]);
+
+const FeishuExecApprovalConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    approvers: z.array(z.union([z.string(), z.number()])).optional(),
+    agentFilter: z.array(z.string()).optional(),
+    sessionFilter: z.array(z.string()).optional(),
+    target: FeishuExecApprovalTargetSchema.optional(),
+  })
+  .strict()
+  .optional();
+
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
@@ -182,6 +195,7 @@ const FeishuSharedConfigShape = {
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),
+  execApprovals: FeishuExecApprovalConfigSchema,
 };
 
 /**

--- a/extensions/feishu/src/exec-approval-forwarding.test.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFeishuExecApprovalPendingPayload,
+  shouldSuppressFeishuExecApprovalForwardingFallback,
+} from "./exec-approval-forwarding.js";
+
+function buildConfig(execApprovals?: Record<string, unknown>) {
+  return {
+    channels: {
+      feishu: {
+        appId: "cli_test",
+        appSecret: "secret",
+        ...(execApprovals ? { execApprovals } : {}),
+      },
+    },
+  } as never;
+}
+
+function buildRequest(id = "approval-123") {
+  return {
+    id,
+    expiresAtMs: Date.now() + 60_000,
+    request: {
+      command: "rm -rf /tmp/test",
+      cwd: "/home/user",
+      host: "gateway" as const,
+      agentId: "agent-1",
+      sessionKey: "session-1",
+    },
+  } as never;
+}
+
+describe("buildFeishuExecApprovalPendingPayload target routing", () => {
+  it("returns card for DM target when configured as dm", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "dm" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "user:ou_123" },
+      nowMs: Date.now(),
+    });
+    expect(result).not.toBeNull();
+    expect(result?.channelData?.feishu?.card).toBeDefined();
+  });
+
+  it("returns null for group target when configured as dm", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "dm" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "chat:oc_group123" },
+      nowMs: Date.now(),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns card for group target when configured as channel", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "channel" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "chat:oc_group123" },
+      nowMs: Date.now(),
+    });
+    expect(result).not.toBeNull();
+    expect(result?.channelData?.feishu?.card).toBeDefined();
+  });
+
+  it("returns null for DM target when configured as channel", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "channel" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "user:ou_123" },
+      nowMs: Date.now(),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns card for both DM and group when configured as both", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "both" });
+    const dmResult = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "user:ou_123" },
+      nowMs: Date.now(),
+    });
+    const groupResult = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "chat:oc_group123" },
+      nowMs: Date.now(),
+    });
+    expect(dmResult).not.toBeNull();
+    expect(groupResult).not.toBeNull();
+  });
+
+  it("defaults to dm when no target configured", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"] });
+    const dmResult = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "user:ou_123" },
+      nowMs: Date.now(),
+    });
+    const groupResult = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "chat:oc_group123" },
+      nowMs: Date.now(),
+    });
+    expect(dmResult).not.toBeNull();
+    expect(groupResult).toBeNull();
+  });
+
+  it("detects bare ou_ IDs as DM targets", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "dm" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "ou_abc123" },
+      nowMs: Date.now(),
+    });
+    expect(result).not.toBeNull();
+    expect(result?.channelData?.feishu?.card).toBeDefined();
+  });
+
+  it("detects bare on_ IDs as DM targets", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "channel" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "on_abc123" },
+      nowMs: Date.now(),
+    });
+    // on_ is a DM target, but config is channel-only → null
+    expect(result).toBeNull();
+  });
+
+  it("returns null when exec approvals are disabled", () => {
+    const cfg = buildConfig({ enabled: false, approvers: ["ou_123"], target: "both" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "user:ou_123" },
+      nowMs: Date.now(),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no approvers are configured", () => {
+    const cfg = buildConfig({ enabled: true, approvers: [], target: "both" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "user:ou_123" },
+      nowMs: Date.now(),
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("shouldSuppressFeishuExecApprovalForwardingFallback", () => {
+  it("returns false when client is not enabled", () => {
+    const cfg = buildConfig({ enabled: false, approvers: ["ou_123"], target: "dm" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "chat:oc_group123" },
+        request: buildRequest(),
+      }),
+    ).toBe(false);
+  });
+
+  it("suppresses group target when configured as dm", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "dm" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "chat:oc_group123" },
+        request: buildRequest(),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress DM target when configured as dm", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "dm" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "user:ou_123" },
+        request: buildRequest(),
+      }),
+    ).toBe(false);
+  });
+
+  it("suppresses DM target when configured as channel", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "channel" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "user:ou_123" },
+        request: buildRequest(),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress group target when configured as channel", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "channel" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "chat:oc_group123" },
+        request: buildRequest(),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not suppress any target when configured as both", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "both" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "user:ou_123" },
+        request: buildRequest(),
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "chat:oc_group123" },
+        request: buildRequest(),
+      }),
+    ).toBe(false);
+  });
+
+  it("suppresses bare ou_ DM target when configured as channel", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "channel" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "ou_abc123" },
+        request: buildRequest(),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress bare ou_ DM target when configured as dm", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "dm" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "ou_abc123" },
+        request: buildRequest(),
+      }),
+    ).toBe(false);
+  });
+});

--- a/extensions/feishu/src/exec-approval-forwarding.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.ts
@@ -80,16 +80,15 @@ export function buildFeishuExecApprovalPendingPayload(params: {
   }
 
   const commandDisplay = resolveExecApprovalCommandDisplay(params.request.request);
+  const rawHost = params.request.request.host;
+  const host = rawHost === "node" || rawHost === "sandbox" ? rawHost : "gateway";
   const payload = buildExecApprovalPendingReplyPayload({
     approvalId: params.request.id,
     approvalSlug: params.request.id.slice(0, 8),
     approvalCommandId: params.request.id,
     command: commandDisplay.commandText,
     cwd: params.request.request.cwd ?? undefined,
-    host:
-      params.request.request.host === "node" || params.request.request.host === "sandbox"
-        ? params.request.request.host
-        : "gateway",
+    host,
     nodeId: params.request.request.nodeId ?? undefined,
     expiresAtMs: params.request.expiresAtMs,
     nowMs: params.nowMs,
@@ -99,10 +98,7 @@ export function buildFeishuExecApprovalPendingPayload(params: {
     approvalId: params.request.id,
     command: commandDisplay.commandText,
     cwd: params.request.request.cwd ?? undefined,
-    host:
-      params.request.request.host === "node" || params.request.request.host === "sandbox"
-        ? params.request.request.host
-        : "gateway",
+    host,
     nodeId: params.request.request.nodeId ?? undefined,
     expiresAtMs: params.request.expiresAtMs,
   });

--- a/extensions/feishu/src/exec-approval-forwarding.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.ts
@@ -86,7 +86,10 @@ export function buildFeishuExecApprovalPendingPayload(params: {
     approvalCommandId: params.request.id,
     command: commandDisplay.commandText,
     cwd: params.request.request.cwd ?? undefined,
-    host: params.request.request.host === "node" ? "node" : "gateway",
+    host:
+      params.request.request.host === "node" || params.request.request.host === "sandbox"
+        ? params.request.request.host
+        : "gateway",
     nodeId: params.request.request.nodeId ?? undefined,
     expiresAtMs: params.request.expiresAtMs,
     nowMs: params.nowMs,
@@ -96,7 +99,10 @@ export function buildFeishuExecApprovalPendingPayload(params: {
     approvalId: params.request.id,
     command: commandDisplay.commandText,
     cwd: params.request.request.cwd ?? undefined,
-    host: params.request.request.host === "node" ? "node" : "gateway",
+    host:
+      params.request.request.host === "node" || params.request.request.host === "sandbox"
+        ? params.request.request.host
+        : "gateway",
     nodeId: params.request.request.nodeId ?? undefined,
     expiresAtMs: params.request.expiresAtMs,
   });

--- a/extensions/feishu/src/exec-approval-forwarding.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.ts
@@ -1,0 +1,111 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { ExecApprovalRequest } from "openclaw/plugin-sdk/infra-runtime";
+import {
+  buildExecApprovalPendingReplyPayload,
+  resolveExecApprovalCommandDisplay,
+} from "openclaw/plugin-sdk/infra-runtime";
+import { createExecApprovalCard } from "./card-ux-exec-approval.js";
+import {
+  isFeishuExecApprovalClientEnabled,
+  resolveFeishuExecApprovalTarget,
+} from "./exec-approvals.js";
+
+// Suppress forwarding to a specific target when the configured exec approval
+// target routing (dm/channel/both) doesn't match the actual target chat type.
+// This prevents both Interactive Cards AND plain-text fallback from leaking
+// into excluded chats. Without a dedicated Feishu exec approval handler client,
+// forwarding fallback is the only delivery path, so we only suppress targets
+// that violate the routing config — never suppress all targets unconditionally.
+export function shouldSuppressFeishuExecApprovalForwardingFallback(params: {
+  cfg: OpenClawConfig;
+  target: { channel: string; to: string; accountId?: string | null };
+  request: ExecApprovalRequest;
+}): boolean {
+  if (!isFeishuExecApprovalClientEnabled({ cfg: params.cfg, accountId: params.target.accountId })) {
+    return false;
+  }
+  const configuredTarget = resolveFeishuExecApprovalTarget({
+    cfg: params.cfg,
+    accountId: params.target.accountId,
+  });
+  if (configuredTarget === "both") {
+    return false;
+  }
+  const isDm = isFeishuDmTarget(params.target.to);
+  if (configuredTarget === "dm" && !isDm) {
+    return true;
+  }
+  if (configuredTarget === "channel" && isDm) {
+    return true;
+  }
+  return false;
+}
+
+// Determine whether a Feishu target address is a DM. Handles both prefixed
+// forms (user:ou_xxx) and bare normalized IDs (ou_xxx, on_xxx) since
+// normalizeFeishuTarget strips type prefixes and session routes store bare IDs.
+function isFeishuDmTarget(to: string): boolean {
+  if (to.startsWith("user:") || to.startsWith("dm:")) return true;
+  const lower = to.toLowerCase();
+  if (lower.startsWith("ou_") || lower.startsWith("on_")) return true;
+  return false;
+}
+
+export function buildFeishuExecApprovalPendingPayload(params: {
+  cfg: OpenClawConfig;
+  request: ExecApprovalRequest;
+  target: { channel: string; to: string; accountId?: string | null };
+  nowMs: number;
+}) {
+  // Don't attach an Interactive Card when exec approvals are disabled or no
+  // approvers are configured — button clicks would be rejected by the Feishu
+  // gate in handleApproveCommand, producing dead buttons.
+  if (!isFeishuExecApprovalClientEnabled({ cfg: params.cfg, accountId: params.target.accountId })) {
+    return null;
+  }
+
+  // Defense-in-depth: if the configured target routing doesn't match this
+  // specific forward target, return null so the framework falls back to
+  // plain text instead of leaking an Interactive Card into an excluded chat.
+  const configuredTarget = resolveFeishuExecApprovalTarget({
+    cfg: params.cfg,
+    accountId: params.target.accountId,
+  });
+  const isDm = isFeishuDmTarget(params.target.to);
+  if (configuredTarget === "dm" && !isDm) {
+    return null;
+  }
+  if (configuredTarget === "channel" && isDm) {
+    return null;
+  }
+
+  const commandDisplay = resolveExecApprovalCommandDisplay(params.request.request);
+  const payload = buildExecApprovalPendingReplyPayload({
+    approvalId: params.request.id,
+    approvalSlug: params.request.id.slice(0, 8),
+    approvalCommandId: params.request.id,
+    command: commandDisplay.commandText,
+    cwd: params.request.request.cwd ?? undefined,
+    host: params.request.request.host === "node" ? "node" : "gateway",
+    nodeId: params.request.request.nodeId ?? undefined,
+    expiresAtMs: params.request.expiresAtMs,
+    nowMs: params.nowMs,
+  });
+
+  const card = createExecApprovalCard({
+    approvalId: params.request.id,
+    command: commandDisplay.commandText,
+    cwd: params.request.request.cwd ?? undefined,
+    host: params.request.request.host === "node" ? "node" : "gateway",
+    nodeId: params.request.request.nodeId ?? undefined,
+    expiresAtMs: params.request.expiresAtMs,
+  });
+
+  return {
+    ...payload,
+    channelData: {
+      ...payload.channelData,
+      feishu: { card },
+    },
+  };
+}

--- a/extensions/feishu/src/exec-approvals-handler.ts
+++ b/extensions/feishu/src/exec-approvals-handler.ts
@@ -1,0 +1,202 @@
+import { buildPluginApprovalPendingReplyPayload } from "openclaw/plugin-sdk/approval-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  createChannelNativeApprovalRuntime,
+  resolveExecApprovalCommandDisplay,
+  type ExecApprovalChannelRuntime,
+  type ExecApprovalRequest,
+  type ExecApprovalResolved,
+  type PluginApprovalRequest,
+  type PluginApprovalResolved,
+} from "openclaw/plugin-sdk/infra-runtime";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { feishuNativeApprovalAdapter } from "./approval-native.js";
+import { createExecApprovalCard, createExecApprovalResolvedCard } from "./card-ux-exec-approval.js";
+import {
+  isFeishuExecApprovalHandlerConfigured,
+  shouldHandleFeishuExecApprovalRequest,
+} from "./exec-approvals.js";
+import { sendCardFeishu, updateCardFeishu } from "./send.js";
+
+const log = createSubsystemLogger("feishu/exec-approvals");
+
+type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
+
+type PendingMessage = {
+  to: string;
+  messageId: string;
+};
+
+type FeishuPendingDelivery = {
+  card: Record<string, unknown>;
+};
+
+export type FeishuExecApprovalHandlerOpts = {
+  accountId: string;
+  cfg: OpenClawConfig;
+  gatewayUrl?: string;
+  runtime?: RuntimeEnv;
+};
+
+export class FeishuExecApprovalHandler {
+  private readonly runtime: ExecApprovalChannelRuntime<ApprovalRequest, ApprovalResolved>;
+
+  constructor(private readonly opts: FeishuExecApprovalHandlerOpts) {
+    this.runtime = createChannelNativeApprovalRuntime<
+      PendingMessage,
+      { to: string },
+      FeishuPendingDelivery,
+      ApprovalRequest,
+      ApprovalResolved
+    >({
+      label: "feishu/exec-approvals",
+      clientDisplayName: `Feishu Exec Approvals (${this.opts.accountId})`,
+      cfg: this.opts.cfg,
+      accountId: this.opts.accountId,
+      gatewayUrl: this.opts.gatewayUrl,
+      eventKinds: ["exec", "plugin"],
+      nativeAdapter: feishuNativeApprovalAdapter.native,
+      isConfigured: () =>
+        isFeishuExecApprovalHandlerConfigured({
+          cfg: this.opts.cfg,
+          accountId: this.opts.accountId,
+        }),
+      shouldHandle: (request) =>
+        shouldHandleFeishuExecApprovalRequest({
+          cfg: this.opts.cfg,
+          accountId: this.opts.accountId,
+          request,
+        }),
+      buildPendingContent: ({ request, approvalKind, nowMs }) => {
+        if (approvalKind === "plugin") {
+          // For plugin approvals, fall back to text-based payload for now.
+          const payload = buildPluginApprovalPendingReplyPayload({
+            request: request as PluginApprovalRequest,
+            nowMs,
+          });
+          return { card: buildFallbackTextCard(payload.text ?? "") };
+        }
+        const execRequest = request as ExecApprovalRequest;
+        const commandDisplay = resolveExecApprovalCommandDisplay(execRequest.request);
+        const host = execRequest.request.host ?? "gateway";
+        const card = createExecApprovalCard({
+          approvalId: request.id,
+          command: commandDisplay.commandText,
+          cwd: execRequest.request.cwd ?? undefined,
+          host,
+          nodeId: execRequest.request.nodeId ?? undefined,
+          expiresAtMs: request.expiresAtMs,
+        });
+        return { card };
+      },
+      prepareTarget: ({ plannedTarget }) => ({
+        dedupeKey: plannedTarget.target.to,
+        target: { to: plannedTarget.target.to },
+      }),
+      deliverTarget: async ({ preparedTarget, pendingContent }) => {
+        const result = await sendCardFeishu({
+          cfg: this.opts.cfg,
+          to: preparedTarget.to,
+          card: pendingContent.card,
+          accountId: this.opts.accountId,
+        });
+        return {
+          to: preparedTarget.to,
+          messageId: result.messageId,
+        };
+      },
+      onDeliveryError: ({ error, request }) => {
+        log.error(`feishu exec approvals: failed to send request ${request.id}: ${String(error)}`);
+      },
+      finalizeResolved: async ({ request, resolved, entries }) => {
+        await this.finalizeResolved(request, resolved, entries);
+      },
+      finalizeExpired: async ({ entries }) => {
+        await this.finalizeExpired(entries);
+      },
+    });
+  }
+
+  async start(): Promise<void> {
+    await this.runtime.start();
+  }
+
+  async stop(): Promise<void> {
+    await this.runtime.stop();
+  }
+
+  async handleRequested(request: ApprovalRequest): Promise<void> {
+    await this.runtime.handleRequested(request);
+  }
+
+  async handleResolved(resolved: ApprovalResolved): Promise<void> {
+    await this.runtime.handleResolved(resolved);
+  }
+
+  private async finalizeResolved(
+    _request: ApprovalRequest,
+    resolved: ApprovalResolved,
+    messages: PendingMessage[],
+  ): Promise<void> {
+    await Promise.allSettled(
+      messages.map(async (message) => {
+        try {
+          const resolvedCard = createExecApprovalResolvedCard({
+            approvalId: resolved.id,
+            decision: resolved.decision,
+            resolvedBy: resolved.resolvedBy ?? undefined,
+          });
+          await updateCardFeishu({
+            cfg: this.opts.cfg,
+            messageId: message.messageId,
+            card: resolvedCard,
+            accountId: this.opts.accountId,
+          });
+        } catch (err) {
+          log.error(
+            `feishu exec approvals: failed to update card ${message.messageId}: ${String(err)}`,
+          );
+        }
+      }),
+    );
+  }
+
+  private async finalizeExpired(messages: PendingMessage[]): Promise<void> {
+    await Promise.allSettled(
+      messages.map(async (message) => {
+        try {
+          const expiredCard = createExecApprovalResolvedCard({
+            approvalId: "",
+            decision: "expired",
+          });
+          await updateCardFeishu({
+            cfg: this.opts.cfg,
+            messageId: message.messageId,
+            card: expiredCard,
+            accountId: this.opts.accountId,
+          });
+        } catch (err) {
+          log.error(
+            `feishu exec approvals: failed to update expired card ${message.messageId}: ${String(err)}`,
+          );
+        }
+      }),
+    );
+  }
+}
+
+function buildFallbackTextCard(text: string): Record<string, unknown> {
+  return {
+    schema: "2.0",
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: "plain_text", content: "审批请求" },
+      template: "orange",
+    },
+    body: {
+      elements: [{ tag: "markdown", content: text }],
+    },
+  };
+}

--- a/extensions/feishu/src/exec-approvals-handler.ts
+++ b/extensions/feishu/src/exec-approvals-handler.ts
@@ -113,8 +113,8 @@ export class FeishuExecApprovalHandler {
       finalizeResolved: async ({ request, resolved, entries }) => {
         await this.finalizeResolved(request, resolved, entries);
       },
-      finalizeExpired: async ({ entries }) => {
-        await this.finalizeExpired(entries);
+      finalizeExpired: async ({ request, entries }) => {
+        await this.finalizeExpired(request.id, entries);
       },
     });
   }
@@ -163,12 +163,12 @@ export class FeishuExecApprovalHandler {
     );
   }
 
-  private async finalizeExpired(messages: PendingMessage[]): Promise<void> {
+  private async finalizeExpired(approvalId: string, messages: PendingMessage[]): Promise<void> {
     await Promise.allSettled(
       messages.map(async (message) => {
         try {
           const expiredCard = createExecApprovalResolvedCard({
-            approvalId: "",
+            approvalId,
             decision: "expired",
           });
           await updateCardFeishu({

--- a/extensions/feishu/src/exec-approvals-handler.ts
+++ b/extensions/feishu/src/exec-approvals-handler.ts
@@ -136,10 +136,14 @@ export class FeishuExecApprovalHandler {
   }
 
   private async finalizeResolved(
-    _request: ApprovalRequest,
+    request: ApprovalRequest,
     resolved: ApprovalResolved,
     messages: PendingMessage[],
   ): Promise<void> {
+    const execRequest = !request.id.startsWith("plugin:") ? (request as ExecApprovalRequest) : null;
+    const commandDisplay = execRequest
+      ? resolveExecApprovalCommandDisplay(execRequest.request)
+      : null;
     await Promise.allSettled(
       messages.map(async (message) => {
         try {
@@ -147,6 +151,8 @@ export class FeishuExecApprovalHandler {
             approvalId: resolved.id,
             decision: resolved.decision,
             resolvedBy: resolved.resolvedBy ?? undefined,
+            command: commandDisplay?.commandText,
+            cwd: execRequest?.request.cwd ?? undefined,
           });
           await updateCardFeishu({
             cfg: this.opts.cfg,

--- a/extensions/feishu/src/exec-approvals.test.ts
+++ b/extensions/feishu/src/exec-approvals.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveFeishuExecApprovalConfig,
+  getFeishuExecApprovalApprovers,
+  isFeishuExecApprovalClientEnabled,
+  isFeishuExecApprovalApprover,
+  resolveFeishuExecApprovalTarget,
+  shouldSuppressLocalFeishuExecApprovalPrompt,
+} from "./exec-approvals.js";
+
+function buildConfig(execApprovals?: Record<string, unknown>) {
+  return {
+    channels: {
+      feishu: {
+        appId: "cli_test",
+        appSecret: "secret",
+        ...(execApprovals ? { execApprovals } : {}),
+      },
+    },
+  } as never;
+}
+
+describe("resolveFeishuExecApprovalConfig", () => {
+  it("returns undefined when no execApprovals config", () => {
+    expect(resolveFeishuExecApprovalConfig({ cfg: buildConfig() })).toBeUndefined();
+  });
+
+  it("returns config when execApprovals is present", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"] });
+    const result = resolveFeishuExecApprovalConfig({ cfg });
+    expect(result).toEqual({ enabled: true, approvers: ["ou_123"] });
+  });
+});
+
+describe("getFeishuExecApprovalApprovers", () => {
+  it("returns empty array when no config", () => {
+    expect(getFeishuExecApprovalApprovers({ cfg: buildConfig() })).toEqual([]);
+  });
+
+  it("normalizes approver IDs to strings", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123", 456] });
+    expect(getFeishuExecApprovalApprovers({ cfg })).toEqual(["ou_123", "456"]);
+  });
+
+  it("filters empty approver IDs", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123", "", "  "] });
+    expect(getFeishuExecApprovalApprovers({ cfg })).toEqual(["ou_123"]);
+  });
+});
+
+describe("isFeishuExecApprovalClientEnabled", () => {
+  it("returns false when no config", () => {
+    expect(isFeishuExecApprovalClientEnabled({ cfg: buildConfig() })).toBe(false);
+  });
+
+  it("returns false when enabled but no approvers", () => {
+    const cfg = buildConfig({ enabled: true, approvers: [] });
+    expect(isFeishuExecApprovalClientEnabled({ cfg })).toBe(false);
+  });
+
+  it("returns false when not enabled", () => {
+    const cfg = buildConfig({ enabled: false, approvers: ["ou_123"] });
+    expect(isFeishuExecApprovalClientEnabled({ cfg })).toBe(false);
+  });
+
+  it("returns true when enabled with approvers", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"] });
+    expect(isFeishuExecApprovalClientEnabled({ cfg })).toBe(true);
+  });
+});
+
+describe("isFeishuExecApprovalApprover", () => {
+  const cfg = buildConfig({ enabled: true, approvers: ["ou_123", "ou_456"] });
+
+  it("returns false for null senderId", () => {
+    expect(isFeishuExecApprovalApprover({ cfg, senderId: null })).toBe(false);
+  });
+
+  it("returns false for empty senderId", () => {
+    expect(isFeishuExecApprovalApprover({ cfg, senderId: "" })).toBe(false);
+  });
+
+  it("returns true for valid approver", () => {
+    expect(isFeishuExecApprovalApprover({ cfg, senderId: "ou_123" })).toBe(true);
+  });
+
+  it("returns false for non-approver", () => {
+    expect(isFeishuExecApprovalApprover({ cfg, senderId: "ou_999" })).toBe(false);
+  });
+});
+
+describe("resolveFeishuExecApprovalTarget", () => {
+  it("defaults to dm", () => {
+    expect(resolveFeishuExecApprovalTarget({ cfg: buildConfig() })).toBe("dm");
+  });
+
+  it("returns configured target", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "both" });
+    expect(resolveFeishuExecApprovalTarget({ cfg })).toBe("both");
+  });
+});
+
+describe("shouldSuppressLocalFeishuExecApprovalPrompt", () => {
+  const execApprovalPayload = {
+    channelData: { execApproval: { approvalId: "test1234", approvalSlug: "test1234" } },
+  } as never;
+  const plainPayload = { text: "hello" } as never;
+
+  it("returns false when client is not enabled", () => {
+    const cfg = buildConfig({ enabled: false, approvers: ["ou_123"] });
+    expect(shouldSuppressLocalFeishuExecApprovalPrompt({ cfg, payload: execApprovalPayload })).toBe(
+      false,
+    );
+  });
+
+  it("returns false when no exec approval data in payload", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"] });
+    expect(shouldSuppressLocalFeishuExecApprovalPrompt({ cfg, payload: plainPayload })).toBe(false);
+  });
+
+  it("returns true when client enabled and payload has exec approval data", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"] });
+    expect(shouldSuppressLocalFeishuExecApprovalPrompt({ cfg, payload: execApprovalPayload })).toBe(
+      true,
+    );
+  });
+});

--- a/extensions/feishu/src/exec-approvals.test.ts
+++ b/extensions/feishu/src/exec-approvals.test.ts
@@ -37,9 +37,9 @@ describe("getFeishuExecApprovalApprovers", () => {
     expect(getFeishuExecApprovalApprovers({ cfg: buildConfig() })).toEqual([]);
   });
 
-  it("normalizes approver IDs to strings", () => {
-    const cfg = buildConfig({ enabled: true, approvers: ["ou_123", 456] });
-    expect(getFeishuExecApprovalApprovers({ cfg })).toEqual(["ou_123", "456"]);
+  it("normalizes approver IDs and filters invalid prefixes", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123", 456, "on_789"] });
+    expect(getFeishuExecApprovalApprovers({ cfg })).toEqual(["ou_123", "on_789"]);
   });
 
   it("filters empty approver IDs", () => {

--- a/extensions/feishu/src/exec-approvals.test.ts
+++ b/extensions/feishu/src/exec-approvals.test.ts
@@ -37,9 +37,9 @@ describe("getFeishuExecApprovalApprovers", () => {
     expect(getFeishuExecApprovalApprovers({ cfg: buildConfig() })).toEqual([]);
   });
 
-  it("normalizes approver IDs and filters invalid prefixes", () => {
+  it("normalizes approver IDs and filters non-ou_ prefixes", () => {
     const cfg = buildConfig({ enabled: true, approvers: ["ou_123", 456, "on_789"] });
-    expect(getFeishuExecApprovalApprovers({ cfg })).toEqual(["ou_123", "on_789"]);
+    expect(getFeishuExecApprovalApprovers({ cfg })).toEqual(["ou_123"]);
   });
 
   it("filters empty approver IDs", () => {

--- a/extensions/feishu/src/exec-approvals.ts
+++ b/extensions/feishu/src/exec-approvals.ts
@@ -1,0 +1,72 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { getExecApprovalReplyMetadata } from "openclaw/plugin-sdk/infra-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { resolveFeishuAccount } from "./accounts.js";
+
+type FeishuExecApprovalConfig = {
+  enabled?: boolean;
+  approvers?: Array<string | number>;
+  agentFilter?: string[];
+  sessionFilter?: string[];
+  target?: "dm" | "channel" | "both";
+};
+
+function normalizeApproverId(value: string | number): string {
+  return String(value).trim();
+}
+
+export function resolveFeishuExecApprovalConfig(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): FeishuExecApprovalConfig | undefined {
+  const config = resolveFeishuAccount(params).config;
+  return (config as Record<string, unknown>).execApprovals as FeishuExecApprovalConfig | undefined;
+}
+
+export function getFeishuExecApprovalApprovers(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): string[] {
+  return (resolveFeishuExecApprovalConfig(params)?.approvers ?? [])
+    .map(normalizeApproverId)
+    .filter(Boolean);
+}
+
+export function isFeishuExecApprovalClientEnabled(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): boolean {
+  const config = resolveFeishuExecApprovalConfig(params);
+  return Boolean(config?.enabled && getFeishuExecApprovalApprovers(params).length > 0);
+}
+
+export function isFeishuExecApprovalApprover(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  senderId?: string | null;
+}): boolean {
+  const senderId = params.senderId?.trim();
+  if (!senderId) {
+    return false;
+  }
+  const approvers = getFeishuExecApprovalApprovers(params);
+  return approvers.includes(senderId);
+}
+
+export function resolveFeishuExecApprovalTarget(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): "dm" | "channel" | "both" {
+  return resolveFeishuExecApprovalConfig(params)?.target ?? "dm";
+}
+
+export function shouldSuppressLocalFeishuExecApprovalPrompt(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  payload: ReplyPayload;
+}): boolean {
+  return (
+    isFeishuExecApprovalClientEnabled(params) &&
+    getExecApprovalReplyMetadata(params.payload) !== null
+  );
+}

--- a/extensions/feishu/src/exec-approvals.ts
+++ b/extensions/feishu/src/exec-approvals.ts
@@ -1,6 +1,13 @@
+import {
+  createChannelExecApprovalProfile,
+  isChannelExecApprovalClientEnabledFromConfig,
+  isChannelExecApprovalTargetRecipient,
+  resolveApprovalApprovers,
+  resolveApprovalRequestAccountId,
+} from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { getExecApprovalReplyMetadata } from "openclaw/plugin-sdk/infra-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { resolveFeishuAccount } from "./accounts.js";
 
 type FeishuExecApprovalConfig = {
@@ -15,6 +22,15 @@ function normalizeApproverId(value: string | number): string {
   return String(value).trim();
 }
 
+function normalizeFeishuDirectApproverId(value: string | number): string | undefined {
+  const normalized = normalizeApproverId(value);
+  if (!normalized) {
+    return undefined;
+  }
+  // Feishu user IDs start with ou_ or on_
+  return normalized;
+}
+
 export function resolveFeishuExecApprovalConfig(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
@@ -27,46 +43,73 @@ export function getFeishuExecApprovalApprovers(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
 }): string[] {
-  return (resolveFeishuExecApprovalConfig(params)?.approvers ?? [])
-    .map(normalizeApproverId)
-    .filter(Boolean);
+  return resolveApprovalApprovers({
+    explicit: resolveFeishuExecApprovalConfig(params)?.approvers,
+    normalizeApprover: normalizeFeishuDirectApproverId,
+  });
 }
 
-export function isFeishuExecApprovalClientEnabled(params: {
+export function isFeishuExecApprovalTargetRecipient(params: {
   cfg: OpenClawConfig;
-  accountId?: string | null;
-}): boolean {
-  const config = resolveFeishuExecApprovalConfig(params);
-  return Boolean(config?.enabled && getFeishuExecApprovalApprovers(params).length > 0);
-}
-
-export function isFeishuExecApprovalApprover(params: {
-  cfg: OpenClawConfig;
-  accountId?: string | null;
   senderId?: string | null;
+  accountId?: string | null;
 }): boolean {
-  const senderId = params.senderId?.trim();
-  if (!senderId) {
-    return false;
-  }
-  const approvers = getFeishuExecApprovalApprovers(params);
-  return approvers.includes(senderId);
+  return isChannelExecApprovalTargetRecipient({
+    ...params,
+    channel: "feishu",
+    matchTarget: ({ target, normalizedSenderId }) => {
+      const to = target.to?.trim();
+      if (!to) {
+        return false;
+      }
+      // Strip "user:" prefix for DM targets
+      const normalized = to.startsWith("user:") ? to.slice(5) : to;
+      return normalized === normalizedSenderId;
+    },
+  });
 }
 
-export function resolveFeishuExecApprovalTarget(params: {
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-}): "dm" | "channel" | "both" {
-  return resolveFeishuExecApprovalConfig(params)?.target ?? "dm";
-}
+const feishuExecApprovalProfile = createChannelExecApprovalProfile({
+  resolveConfig: resolveFeishuExecApprovalConfig,
+  resolveApprovers: getFeishuExecApprovalApprovers,
+  isTargetRecipient: isFeishuExecApprovalTargetRecipient,
+  matchesRequestAccount: ({ cfg, accountId, request }) => {
+    const boundAccountId = resolveApprovalRequestAccountId({
+      cfg,
+      request,
+      channel:
+        request.request.turnSourceChannel?.trim().toLowerCase() === "feishu" ? null : "feishu",
+    });
+    return (
+      !boundAccountId ||
+      !accountId ||
+      normalizeAccountId(boundAccountId) === normalizeAccountId(accountId)
+    );
+  },
+  fallbackAgentIdFromSessionKey: true,
+  requireClientEnabledForLocalPromptSuppression: true,
+});
+
+export const isFeishuExecApprovalClientEnabled = feishuExecApprovalProfile.isClientEnabled;
+export const isFeishuExecApprovalApprover = feishuExecApprovalProfile.isApprover;
+export const isFeishuExecApprovalAuthorizedSender = feishuExecApprovalProfile.isAuthorizedSender;
+export const resolveFeishuExecApprovalTarget = feishuExecApprovalProfile.resolveTarget;
+export const shouldHandleFeishuExecApprovalRequest = feishuExecApprovalProfile.shouldHandleRequest;
 
 export function shouldSuppressLocalFeishuExecApprovalPrompt(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   payload: ReplyPayload;
 }): boolean {
-  return (
-    isFeishuExecApprovalClientEnabled(params) &&
-    getExecApprovalReplyMetadata(params.payload) !== null
-  );
+  return feishuExecApprovalProfile.shouldSuppressLocalPrompt(params);
+}
+
+export function isFeishuExecApprovalHandlerConfigured(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): boolean {
+  return isChannelExecApprovalClientEnabledFromConfig({
+    enabled: resolveFeishuExecApprovalConfig(params)?.enabled,
+    approverCount: getFeishuExecApprovalApprovers(params).length,
+  });
 }

--- a/extensions/feishu/src/exec-approvals.ts
+++ b/extensions/feishu/src/exec-approvals.ts
@@ -27,7 +27,9 @@ function normalizeFeishuDirectApproverId(value: string | number): string | undef
   if (!normalized) {
     return undefined;
   }
-  // Feishu user IDs start with ou_ or on_
+  if (!normalized.startsWith("ou_") && !normalized.startsWith("on_")) {
+    return undefined;
+  }
   return normalized;
 }
 
@@ -43,8 +45,10 @@ export function getFeishuExecApprovalApprovers(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
 }): string[] {
+  const account = resolveFeishuAccount(params).config;
   return resolveApprovalApprovers({
     explicit: resolveFeishuExecApprovalConfig(params)?.approvers,
+    allowFrom: (account as Record<string, unknown>).allowFrom as Array<string | number> | undefined,
     normalizeApprover: normalizeFeishuDirectApproverId,
   });
 }

--- a/extensions/feishu/src/exec-approvals.ts
+++ b/extensions/feishu/src/exec-approvals.ts
@@ -27,7 +27,10 @@ function normalizeFeishuDirectApproverId(value: string | number): string | undef
   if (!normalized) {
     return undefined;
   }
-  if (!normalized.startsWith("ou_") && !normalized.startsWith("on_")) {
+  // Only accept ou_ (open_id) — the identifier used in Feishu card action
+  // callbacks (event.operator.open_id).  on_ (union_id) would silently fail
+  // approver checks at runtime.
+  if (!normalized.startsWith("ou_")) {
     return undefined;
   }
   return normalized;

--- a/extensions/feishu/src/exec-approvals.ts
+++ b/extensions/feishu/src/exec-approvals.ts
@@ -70,13 +70,14 @@ export function isFeishuExecApprovalTargetRecipient(params: {
     ...params,
     channel: "feishu",
     matchTarget: ({ target, normalizedSenderId }) => {
-      const to = target.to?.trim();
-      if (!to) {
+      // Use the same parser as approver normalization to handle all
+      // Feishu address forms (user:ou_xxx, dm:ou_xxx, open_id:ou_xxx,
+      // feishu:user:ou_xxx, bare ou_xxx).
+      const parsed = parseFeishuDirectConversationId(target.to);
+      if (!parsed) {
         return false;
       }
-      // Strip "user:" prefix for DM targets
-      const normalized = to.startsWith("user:") ? to.slice(5) : to;
-      return normalized === normalizedSenderId;
+      return parsed === normalizedSenderId;
     },
   });
 }

--- a/extensions/feishu/src/exec-approvals.ts
+++ b/extensions/feishu/src/exec-approvals.ts
@@ -2,13 +2,16 @@ import {
   createChannelExecApprovalProfile,
   isChannelExecApprovalClientEnabledFromConfig,
   isChannelExecApprovalTargetRecipient,
+  matchesApprovalRequestFilters,
   resolveApprovalApprovers,
-  resolveApprovalRequestAccountId,
+  resolveApprovalRequestChannelAccountId,
 } from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { ExecApprovalRequest, PluginApprovalRequest } from "openclaw/plugin-sdk/infra-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
-import { resolveFeishuAccount } from "./accounts.js";
+import { listFeishuAccountIds, resolveFeishuAccount } from "./accounts.js";
+import { parseFeishuDirectConversationId } from "./conversation-id.js";
 
 type FeishuExecApprovalConfig = {
   enabled?: boolean;
@@ -23,17 +26,19 @@ function normalizeApproverId(value: string | number): string {
 }
 
 function normalizeFeishuDirectApproverId(value: string | number): string | undefined {
-  const normalized = normalizeApproverId(value);
-  if (!normalized) {
-    return undefined;
+  // Parse through prefixed forms (user:ou_xxx, feishu:user:ou_xxx, etc.)
+  // then validate that the resolved ID is an ou_ open_id — the identifier
+  // used in Feishu card action callbacks (event.operator.open_id).
+  const parsed = parseFeishuDirectConversationId(value);
+  if (parsed) {
+    return parsed;
   }
-  // Only accept ou_ (open_id) — the identifier used in Feishu card action
-  // callbacks (event.operator.open_id).  on_ (union_id) would silently fail
-  // approver checks at runtime.
-  if (!normalized.startsWith("ou_")) {
-    return undefined;
+  // Also accept bare ou_ IDs
+  const raw = String(value).trim();
+  if (raw.startsWith("ou_")) {
+    return raw;
   }
-  return normalized;
+  return undefined;
 }
 
 export function resolveFeishuExecApprovalConfig(params: {
@@ -76,23 +81,64 @@ export function isFeishuExecApprovalTargetRecipient(params: {
   });
 }
 
+function countFeishuExecApprovalEligibleAccounts(params: {
+  cfg: OpenClawConfig;
+  request: ExecApprovalRequest | PluginApprovalRequest;
+}): number {
+  return listFeishuAccountIds(params.cfg).filter((accountId) => {
+    const account = resolveFeishuAccount({ cfg: params.cfg, accountId });
+    if (!account.enabled || !account.configured) {
+      return false;
+    }
+    const config = resolveFeishuExecApprovalConfig({ cfg: params.cfg, accountId });
+    return (
+      isChannelExecApprovalClientEnabledFromConfig({
+        enabled: config?.enabled,
+        approverCount: getFeishuExecApprovalApprovers({ cfg: params.cfg, accountId }).length,
+      }) &&
+      matchesApprovalRequestFilters({
+        request: params.request.request,
+        agentFilter: config?.agentFilter,
+        sessionFilter: config?.sessionFilter,
+        fallbackAgentIdFromSessionKey: true,
+      })
+    );
+  }).length;
+}
+
+function matchesFeishuRequestAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  request: ExecApprovalRequest | PluginApprovalRequest;
+}): boolean {
+  const turnSourceChannel = params.request.request.turnSourceChannel?.trim().toLowerCase() || "";
+  const boundAccountId = resolveApprovalRequestChannelAccountId({
+    cfg: params.cfg,
+    request: params.request,
+    channel: "feishu",
+  });
+  // For non-Feishu turn sources with no bound account, only handle if there
+  // is exactly one eligible Feishu account to avoid duplicate prompts.
+  if (turnSourceChannel && turnSourceChannel !== "feishu" && !boundAccountId) {
+    return (
+      countFeishuExecApprovalEligibleAccounts({
+        cfg: params.cfg,
+        request: params.request,
+      }) <= 1
+    );
+  }
+  return (
+    !boundAccountId ||
+    !params.accountId ||
+    normalizeAccountId(boundAccountId) === normalizeAccountId(params.accountId)
+  );
+}
+
 const feishuExecApprovalProfile = createChannelExecApprovalProfile({
   resolveConfig: resolveFeishuExecApprovalConfig,
   resolveApprovers: getFeishuExecApprovalApprovers,
   isTargetRecipient: isFeishuExecApprovalTargetRecipient,
-  matchesRequestAccount: ({ cfg, accountId, request }) => {
-    const boundAccountId = resolveApprovalRequestAccountId({
-      cfg,
-      request,
-      channel:
-        request.request.turnSourceChannel?.trim().toLowerCase() === "feishu" ? null : "feishu",
-    });
-    return (
-      !boundAccountId ||
-      !accountId ||
-      normalizeAccountId(boundAccountId) === normalizeAccountId(accountId)
-    );
-  },
+  matchesRequestAccount: matchesFeishuRequestAccount,
   fallbackAgentIdFromSessionKey: true,
   requireClientEnabledForLocalPromptSuppression: true,
 });

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -262,9 +262,12 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
   const unionId = readString(operator.union_id);
   const tag = readString(action.tag);
   const actionValue = action.value;
-  const contextOpenId = readString(context.open_id);
-  const contextUserId = readString(context.user_id);
-  const chatId = readString(context.chat_id);
+  // Feishu card.action.trigger via WebSocket uses open_id/user_id in context,
+  // but via long-connection SDK uses open_message_id/open_chat_id instead.
+  // Fall back to operator fields when context fields are absent.
+  const contextOpenId = readString(context.open_id) || openId;
+  const contextUserId = readString(context.user_id) || userId;
+  const chatId = readString(context.chat_id) || readString(context.open_chat_id);
   if (
     !token ||
     !openId ||
@@ -273,8 +276,7 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
     !tag ||
     !isRecord(actionValue) ||
     !contextOpenId ||
-    !contextUserId ||
-    !chatId
+    !contextUserId
   ) {
     return null;
   }
@@ -292,7 +294,8 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
     context: {
       open_id: contextOpenId,
       user_id: contextUserId,
-      chat_id: chatId,
+      chat_id: chatId ?? "",
+      open_message_id: readString(context.open_message_id) || undefined,
     },
   };
 }

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -20,6 +20,8 @@ import {
   tryBeginFeishuMessageProcessing,
   warmupDedupFromDisk,
 } from "./dedup.js";
+import { FeishuExecApprovalHandler } from "./exec-approvals-handler.js";
+import { isFeishuExecApprovalHandlerConfigured } from "./exec-approvals.js";
 import { isMentionForwardRequest } from "./mention.js";
 import { applyBotIdentityState, startBotIdentityRecovery } from "./monitor.bot-identity.js";
 import { parseFeishuDriveCommentNoticeEventPayload } from "./monitor.comment.js";
@@ -868,7 +870,17 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   }
 
   let threadBindingManager: ReturnType<typeof createFeishuThreadBindingManager> | null = null;
+  let execApprovalsHandler: FeishuExecApprovalHandler | null = null;
   try {
+    if (isFeishuExecApprovalHandlerConfigured({ cfg, accountId })) {
+      execApprovalsHandler = new FeishuExecApprovalHandler({
+        accountId,
+        cfg,
+        runtime,
+      });
+      await execApprovalsHandler.start();
+    }
+
     const eventDispatcher = createEventDispatcher(account);
     const chatHistories = new Map<string, HistoryEntry[]>();
     threadBindingManager = createFeishuThreadBindingManager({ accountId, cfg });
@@ -887,5 +899,6 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
     return await monitorWebSocket({ account, accountId, runtime, abortSignal, eventDispatcher });
   } finally {
     threadBindingManager?.stop();
+    await execApprovalsHandler?.stop().catch(() => {});
   }
 }

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -100,9 +100,10 @@ async function sendOutboundText(params: {
   to: string;
   text: string;
   replyToMessageId?: string;
+  replyInThread?: boolean;
   accountId?: string;
 }) {
-  const { cfg, to, text, accountId, replyToMessageId } = params;
+  const { cfg, to, text, accountId, replyToMessageId, replyInThread } = params;
   const commentResult = await sendCommentThreadReply({
     cfg,
     to,
@@ -117,10 +118,10 @@ async function sendOutboundText(params: {
   const renderMode = account.config?.renderMode ?? "auto";
 
   if (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text))) {
-    return sendMarkdownCardFeishu({ cfg, to, text, accountId, replyToMessageId });
+    return sendMarkdownCardFeishu({ cfg, to, text, accountId, replyToMessageId, replyInThread });
   }
 
-  return sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId });
+  return sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId, replyInThread });
 }
 
 export const feishuOutbound: ChannelOutboundAdapter = {
@@ -296,6 +297,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       text,
       accountId: accountId ?? undefined,
       replyToMessageId,
+      replyInThread,
     });
     return attachChannelToResult("feishu", result);
   },

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -276,6 +276,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const feishuData = payload.channelData?.feishu as
       | { card?: Record<string, unknown> }
       | undefined;
+    const replyInThread = threadId != null && !replyToId;
     if (feishuData?.card) {
       const result = await sendCardFeishu({
         cfg,
@@ -283,6 +284,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         card: feishuData.card,
         accountId: accountId ?? undefined,
         replyToMessageId,
+        replyInThread,
       });
       return attachChannelToResult("feishu", result);
     }

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,6 +1,9 @@
 import fs from "fs";
 import path from "path";
-import { createAttachedChannelResultAdapter } from "openclaw/plugin-sdk/channel-send-result";
+import {
+  attachChannelToResult,
+  createAttachedChannelResultAdapter,
+} from "openclaw/plugin-sdk/channel-send-result";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { parseFeishuCommentTarget } from "./comment-target.js";
@@ -8,7 +11,12 @@ import { replyComment } from "./drive.js";
 import { sendMediaFeishu } from "./media.js";
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "./outbound-runtime-api.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMarkdownCardFeishu, sendMessageFeishu, sendStructuredCardFeishu } from "./send.js";
+import {
+  sendCardFeishu,
+  sendMarkdownCardFeishu,
+  sendMessageFeishu,
+  sendStructuredCardFeishu,
+} from "./send.js";
 
 function normalizePossibleLocalImagePath(text: string | undefined): string | null {
   const raw = text?.trim();
@@ -117,7 +125,7 @@ async function sendOutboundText(params: {
 
 export const feishuOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
-  chunker: chunkTextForOutbound,
+  chunker: (text, limit) => getFeishuRuntime().channel.text.chunkMarkdownText(text, limit),
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   ...createAttachedChannelResultAdapter({
@@ -262,4 +270,31 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       });
     },
   }),
+  sendPayload: async ({ cfg, to, payload, accountId, replyToId, threadId }) => {
+    const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
+    // Extract Feishu Interactive Card from channelData if present
+    const feishuData = payload.channelData?.feishu as
+      | { card?: Record<string, unknown> }
+      | undefined;
+    if (feishuData?.card) {
+      const result = await sendCardFeishu({
+        cfg,
+        to,
+        card: feishuData.card,
+        accountId: accountId ?? undefined,
+        replyToMessageId,
+      });
+      return attachChannelToResult("feishu", result);
+    }
+    // Fallback: send as text
+    const text = payload.text ?? "";
+    const result = await sendOutboundText({
+      cfg,
+      to,
+      text,
+      accountId: accountId ?? undefined,
+      replyToMessageId,
+    });
+    return attachChannelToResult("feishu", result);
+  },
 };

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -125,7 +125,7 @@ async function sendOutboundText(params: {
 
 export const feishuOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
-  chunker: (text, limit) => getFeishuRuntime().channel.text.chunkMarkdownText(text, limit),
+  chunker: chunkTextForOutbound,
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   ...createAttachedChannelResultAdapter({

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -713,11 +713,15 @@ export type ChannelApprovalRenderAdapter = {
       target: ChannelApprovalForwardTarget;
       nowMs: number;
     }) => ReplyPayload | null;
+    /**
+     * Return a payload to send, `null` to suppress the notification,
+     * or `undefined` to fall through to the default text message.
+     */
     buildResolvedPayload?: (params: {
       cfg: OpenClawConfig;
       resolved: ExecApprovalResolved;
       target: ChannelApprovalForwardTarget;
-    }) => ReplyPayload | null;
+    }) => ReplyPayload | null | undefined;
   };
   plugin?: {
     buildPendingPayload?: (params: {

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -384,13 +384,18 @@ function buildExecResolvedPayload(params: {
     ? resolveChannelApprovalAdapter(getChannelPlugin(channel))?.render?.exec?.buildResolvedPayload
     : undefined;
   if (pluginBuilder) {
-    // Plugin explicitly handles resolved payloads — respect its decision
-    // (returning null means "suppress this notification").
-    return pluginBuilder({
+    // Plugin explicitly handles resolved payloads — respect its decision:
+    // - ReplyPayload → use this payload
+    // - null → suppress this notification
+    // - undefined → fall through to default text message
+    const result = pluginBuilder({
       cfg: params.cfg,
       resolved: params.resolved,
       target: params.target,
     });
+    if (result !== undefined) {
+      return result;
+    }
   }
   return buildApprovalResolvedReplyPayload({
     approvalId: params.resolved.id,

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -101,7 +101,7 @@ type ApprovalStrategy<
   ) => ReplyPayload;
   buildResolvedPayload: (
     params: ApprovalResolvedRenderContext<TResolved, TRouteRequest>,
-  ) => ReplyPayload;
+  ) => ReplyPayload | null;
 };
 
 export type ExecApprovalForwarder = {
@@ -310,7 +310,7 @@ function defaultResolveSessionTarget(params: {
 async function deliverToTargets(params: {
   cfg: OpenClawConfig;
   targets: ForwardTarget[];
-  buildPayload: (target: ForwardTarget) => ReplyPayload;
+  buildPayload: (target: ForwardTarget) => ReplyPayload | null;
   deliver: DeliverOutboundPayloads;
   beforeDeliver?: (target: ForwardTarget, payload: ReplyPayload) => Promise<void> | void;
   shouldSend?: () => boolean;
@@ -325,6 +325,9 @@ async function deliverToTargets(params: {
     }
     try {
       const payload = params.buildPayload(target);
+      if (!payload) {
+        return;
+      }
       await params.beforeDeliver?.(target, payload);
       await params.deliver({
         cfg: params.cfg,
@@ -375,19 +378,19 @@ function buildExecResolvedPayload(params: {
   cfg: OpenClawConfig;
   resolved: ExecApprovalResolved;
   target: ForwardTarget;
-}): ReplyPayload {
+}): ReplyPayload | null {
   const channel = normalizeMessageChannel(params.target.channel) ?? params.target.channel;
-  const pluginPayload = channel
-    ? resolveChannelApprovalAdapter(
-        getChannelPlugin(channel),
-      )?.render?.exec?.buildResolvedPayload?.({
-        cfg: params.cfg,
-        resolved: params.resolved,
-        target: params.target,
-      })
-    : null;
-  if (pluginPayload) {
-    return pluginPayload;
+  const pluginBuilder = channel
+    ? resolveChannelApprovalAdapter(getChannelPlugin(channel))?.render?.exec?.buildResolvedPayload
+    : undefined;
+  if (pluginBuilder) {
+    // Plugin explicitly handles resolved payloads — respect its decision
+    // (returning null means "suppress this notification").
+    return pluginBuilder({
+      cfg: params.cfg,
+      resolved: params.resolved,
+      target: params.target,
+    });
   }
   return buildApprovalResolvedReplyPayload({
     approvalId: params.resolved.id,

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -49,3 +49,5 @@ export * from "../infra/wsl.ts";
 export * from "../utils/fetch-timeout.js";
 export { createRuntimeOutboundDelegates } from "../channels/plugins/runtime-forwarders.js";
 export * from "./ssrf-policy.js";
+export { callGateway } from "../gateway/call.js";
+export { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";


### PR DESCRIPTION
## Summary

- **Problem:** Feishu channel delivers exec approval requests as plain text — users must manually type `/approve <id> <decision>` to respond, while Discord and Telegram users get one-click interactive buttons.
- **Why it matters:** Feishu is a primary messaging platform for many teams. Without interactive approval cards, the exec approval UX is significantly worse than other channels, making Feishu a second-class citizen.
- **What changed:** Added a `FeishuExecApprovalHandler` that sends Feishu Interactive Cards (V2) with Allow Once / Allow Always / Deny buttons, tracks all delivered cards, and updates them in-place on resolution or expiry. Follows the same `ExecApprovalChannelRuntime` + `createApproverRestrictedNativeApprovalCapability` architecture used by Discord and Telegram.
- **What did NOT change (scope boundary):** No changes to `commands-approve.ts` or the core approval authorization flow. No changes to Discord or Telegram exec approval behavior. The Feishu card UX approval flow (non-exec, existing feature) is untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Supersedes #58682 (original implementation by @cowboy129, now revised with Handler pattern)

## Root Cause / Regression History (if applicable)

N/A — new feature.

## Regression Test Plan (if applicable)

N/A — new feature.

## User-visible / Behavior Changes

- When `channels.feishu.execApprovals.enabled` is `true` with configured `approvers`, exec approval requests are delivered as interactive Feishu cards instead of plain text.
- Cards display: approval ID, command, working directory, host.
- Three buttons: 允许一次 (Allow Once) / 始终允许 (Allow Always) / 拒绝 (Deny).
- Cards update in-place when resolved (green for allowed, red for denied, grey for expired).
- New config option `target`: `"dm"` (default) | `"channel"` | `"both"` controls where approval cards are sent.

## Diagram (if applicable)

```text
Before:
[exec needs approval] -> [plain text message to Feishu] -> [user types /approve id allow-once]

After:
[exec needs approval] -> [FeishuExecApprovalHandler receives gateway event]
                       -> [sends Interactive Card with buttons to configured targets]
                       -> [user clicks button] -> [card-action.ts calls gateway RPC]
                       -> [gateway broadcasts resolved event]
                       -> [handler updates ALL tracked cards in-place]
```

Cross-channel consistency:

| Capability | Discord | Telegram | Feishu (this PR) |
|---|---|---|---|
| Handler class | `DiscordExecApprovalHandler` | `TelegramExecApprovalHandler` | `FeishuExecApprovalHandler` |
| Runtime | `ExecApprovalChannelRuntime` | `createChannelNativeApprovalRuntime` | `createChannelNativeApprovalRuntime` |
| Approval capability | `createApproverRestrictedNativeApprovalCapability` | Same | Same |
| Gateway event subscription | WebSocket | WebSocket | WebSocket |
| Pending message tracking | Yes | Yes | Yes |
| Multi-target card updates on resolve | Yes | Yes (clears buttons) | Yes (updates card) |
| Timeout / expiry handling | Yes | Yes | Yes |

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — handler opens a WebSocket to the local gateway (same as Discord/Telegram handlers). Button clicks call `exec.approval.resolve` via `callGateway` RPC.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: The gateway WebSocket uses the existing `operator.approvals` scope with authenticated credentials. Button clicks verify `isFeishuExecApprovalClientEnabled` and `isFeishuExecApprovalApprover` before calling the RPC.

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node 22+
- Integration/channel: Feishu (WebSocket connection mode)
- Relevant config: `channels.feishu.execApprovals: { enabled: true, approvers: ["ou_xxx"], target: "dm" }`

### Steps

1. Configure Feishu exec approvals with at least one approver
2. Set `tools.exec.security: "allowlist"` and `tools.exec.ask: "on-miss"` to require approval
3. Send a message to the bot in Feishu asking it to run a command (e.g. "帮我运行 ls /tmp")
4. Verify an interactive card appears with three buttons
5. Click Allow Once / Allow Always / Deny
6. Verify the card updates in-place with the decision result

### Expected

- Interactive card with three buttons appears in Feishu
- Clicking a button resolves the approval and updates the card in-place
- Resolved card shows decision, approval ID, and operator as @username

### Actual

- Interactive card with three buttons appears in Feishu DM ✅
- Clicking Allow Once / Allow Always / Deny resolves the approval and updates the card in-place ✅
- Resolved card shows correct decision label, approval ID, and operator as @username via Feishu at-tag ✅

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Unit tests: 28 passed (exec-approvals: 18, card-ux-exec-approval: 10). Build clean. Format/lint clean.

## Human Verification (required)

- Verified scenarios: Unit tests for config resolution, approver checks, card template generation, target routing, forwarding suppression. End-to-end manual testing with a real Feishu bot (DM mode, WebSocket connection).
- Edge cases checked: disabled config, empty approvers, non-Feishu resolvedBy display, expired state, card action timeout (Feishu 200340).
- Manual E2E verified: Allow Once (card updates to green "已允许（一次）"), Allow Always (card updates to green "已允许（始终）"), Deny (card updates to red "已拒绝"). All three decisions correctly resolve the approval, update the card in-place, and show the operator via Feishu at-tag.
- What you did **not** verify: Group chat mode, multi-target delivery, cross-surface resolution (resolve from terminal while Feishu card is pending), card expiry timeout.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — new feature, opt-in via config.
- Config/env changes? `Yes` — new `channels.feishu.execApprovals` config block.
- Migration needed? `No`

## Risks and Mitigations

- Risk: Handler WebSocket connection adds a persistent connection per enabled Feishu account.
  - Mitigation: Same pattern as Discord/Telegram; connection is idle 99% of the time. Handler is only created when `execApprovals.enabled: true`.

## AI Disclosure

- [x] AI-assisted (Claude Code)
- [x] Fully tested (unit tests + manual E2E with real Feishu bot)
- [x] We understand what the code does
- [ ] Codex review (not yet run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)