### PR TITLE
fix(config): migrate legacy talk config via doctor

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1187,6 +1187,41 @@ describe("doctor config flow", () => {
     }
   });
 
+  it("warns clearly about legacy talk config and points to doctor --fix", async () => {
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    try {
+      await runDoctorConfigWithInput({
+        config: {
+          talk: {
+            voiceId: "voice-1",
+            modelId: "eleven_v3",
+          },
+        },
+        run: loadAndMaybeMigrateDoctorConfig,
+      });
+
+      expect(
+        noteSpy.mock.calls.some(
+          ([message, title]) =>
+            title === "Legacy config keys detected" &&
+            String(message).includes("talk:") &&
+            String(message).includes(
+              "talk.voiceId/talk.voiceAliases/talk.modelId/talk.outputFormat/talk.apiKey",
+            ),
+        ),
+      ).toBe(true);
+      expect(
+        noteSpy.mock.calls.some(
+          ([message, title]) =>
+            title === "Doctor" &&
+            String(message).includes('Run "openclaw doctor --fix" to migrate legacy config keys.'),
+        ),
+      ).toBe(true);
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
   it("migrates top-level heartbeat visibility into channels.defaults.heartbeat on repair", async () => {
     const result = await runDoctorConfigWithInput({
       repair: true,

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -153,16 +153,26 @@ describe("web search provider config", () => {
 });
 
 describe("talk.voiceAliases", () => {
-  it("accepts a string map of voice aliases", () => {
-    const res = validateConfigObject({
-      talk: {
-        voiceAliases: {
-          Clawd: "EXAVITQu4vr4xnSDxMaL",
-          Roger: "CwhRBWXzGAHq8TQ4Fs17",
+  it("accepts a string map of voice aliases via legacy talk migration", async () => {
+    await withTempHome(async (home) => {
+      await writeOpenClawConfig(home, {
+        talk: {
+          voiceAliases: {
+            Clawd: "EXAVITQu4vr4xnSDxMaL",
+            Roger: "CwhRBWXzGAHq8TQ4Fs17",
+          },
         },
-      },
+      });
+
+      const snap = await readConfigFileSnapshot();
+
+      expect(snap.valid).toBe(true);
+      expect(snap.legacyIssues.some((issue) => issue.path === "talk")).toBe(true);
+      expect(snap.sourceConfig.talk?.providers?.elevenlabs?.voiceAliases).toEqual({
+        Clawd: "EXAVITQu4vr4xnSDxMaL",
+        Roger: "CwhRBWXzGAHq8TQ4Fs17",
+      });
     });
-    expect(res.ok).toBe(true);
   });
 
   it("rejects non-string voice alias values", () => {
@@ -510,6 +520,37 @@ describe("config strict validation", () => {
       });
       expect(
         (snap.sourceConfig.messages?.tts as Record<string, unknown> | undefined)?.elevenlabs,
+      ).toBeUndefined();
+    });
+  });
+
+  it("accepts legacy talk flat fields via auto-migration and reports legacyIssues", async () => {
+    await withTempHome(async (home) => {
+      await writeOpenClawConfig(home, {
+        talk: {
+          voiceId: "voice-1",
+          modelId: "eleven_v3",
+          apiKey: "test-key",
+        },
+      });
+
+      const snap = await readConfigFileSnapshot();
+
+      expect(snap.valid).toBe(true);
+      expect(snap.legacyIssues.some((issue) => issue.path === "talk")).toBe(true);
+      expect(snap.sourceConfig.talk?.providers?.elevenlabs).toEqual({
+        voiceId: "voice-1",
+        modelId: "eleven_v3",
+        apiKey: "test-key",
+      });
+      expect(
+        (snap.sourceConfig.talk as Record<string, unknown> | undefined)?.voiceId,
+      ).toBeUndefined();
+      expect(
+        (snap.sourceConfig.talk as Record<string, unknown> | undefined)?.modelId,
+      ).toBeUndefined();
+      expect(
+        (snap.sourceConfig.talk as Record<string, unknown> | undefined)?.apiKey,
       ).toBeUndefined();
     });
   });

--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -286,6 +286,81 @@ describe("legacy migrate tts provider shape", () => {
   });
 });
 
+describe("legacy migrate talk provider shape", () => {
+  it("moves legacy talk fields into talk.providers.elevenlabs", () => {
+    const res = migrateLegacyConfig({
+      talk: {
+        voiceId: "voice-1",
+        modelId: "eleven_v3",
+        outputFormat: "pcm_44100",
+        apiKey: "test-key",
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Moved talk legacy fields (voiceId, modelId, outputFormat, apiKey) → talk.providers.elevenlabs (filled missing provider fields only).",
+    );
+    expect(res.config?.talk).toEqual({
+      providers: {
+        elevenlabs: {
+          voiceId: "voice-1",
+          modelId: "eleven_v3",
+          outputFormat: "pcm_44100",
+          apiKey: "test-key",
+        },
+      },
+    });
+  });
+
+  it("merges legacy talk fields into the active provider without overwriting explicit provider values", () => {
+    const res = migrateLegacyConfig({
+      talk: {
+        provider: "acme",
+        providers: {
+          acme: {
+            voiceId: "provider-voice",
+          },
+        },
+        voiceId: "legacy-voice",
+        modelId: "acme-model",
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Moved talk legacy fields (voiceId, modelId) → talk.providers.acme (filled missing provider fields only).",
+    );
+    expect(res.config?.talk).toEqual({
+      provider: "acme",
+      providers: {
+        acme: {
+          voiceId: "provider-voice",
+          modelId: "acme-model",
+        },
+      },
+    });
+  });
+
+  it("leaves legacy talk fields in place when the target provider is ambiguous", () => {
+    const res = migrateLegacyConfig({
+      talk: {
+        providers: {
+          acme: { voiceId: "acme-voice" },
+          elevenlabs: { voiceId: "eleven-voice" },
+        },
+        voiceId: "legacy-voice",
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Skipped talk legacy field migration because talk.providers defines multiple providers and talk.provider is unset; move talk.voiceId/talk.voiceAliases/talk.modelId/talk.outputFormat/talk.apiKey under the intended provider manually.",
+    );
+    expect(res.config).toBeNull();
+    expect(res.changes).toContain(
+      "Migration applied, but config still invalid; fix remaining issues manually.",
+    );
+  });
+});
+
 describe("legacy migrate x_search auth", () => {
   it("moves only legacy x_search auth into plugin-owned xai config", () => {
     const res = migrateLegacyConfig({

--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -340,6 +340,45 @@ describe("legacy migrate talk provider shape", () => {
     });
   });
 
+  it("treats empty talk.providers as legacy-only talk config", () => {
+    const res = migrateLegacyConfig({
+      talk: {
+        providers: {},
+        voiceId: "voice-1",
+        modelId: "eleven_v3",
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Moved talk legacy fields (voiceId, modelId) → talk.providers.elevenlabs (filled missing provider fields only).",
+    );
+    expect(res.config?.talk).toEqual({
+      providers: {
+        elevenlabs: {
+          voiceId: "voice-1",
+          modelId: "eleven_v3",
+        },
+      },
+    });
+  });
+
+  it("does not trust blocked talk.provider ids during migration", () => {
+    const res = migrateLegacyConfig({
+      talk: {
+        provider: "__proto__",
+        voiceId: "legacy-voice",
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Skipped talk legacy field migration because talk.providers defines multiple providers and talk.provider is unset; move talk.voiceId/talk.voiceAliases/talk.modelId/talk.outputFormat/talk.apiKey under the intended provider manually.",
+    );
+    expect(res.config).toBeNull();
+    expect(res.changes).toContain(
+      "Migration applied, but config still invalid; fix remaining issues manually.",
+    );
+  });
+
   it("leaves legacy talk fields in place when the target provider is ambiguous", () => {
     const res = migrateLegacyConfig({
       talk: {

--- a/src/config/legacy.migrations.runtime.ts
+++ b/src/config/legacy.migrations.runtime.ts
@@ -15,6 +15,7 @@ import {
 } from "./legacy.shared.js";
 import { DEFAULT_GATEWAY_PORT } from "./paths.js";
 import { isBlockedObjectKey } from "./prototype-keys.js";
+import { LEGACY_TALK_PROVIDER_ID } from "./talk.js";
 
 const AGENT_HEARTBEAT_KEYS = new Set([
   "every",
@@ -36,6 +37,13 @@ const AGENT_HEARTBEAT_KEYS = new Set([
 const CHANNEL_HEARTBEAT_KEYS = new Set(["showOk", "showAlerts", "useIndicator"]);
 const LEGACY_TTS_PROVIDER_KEYS = ["openai", "elevenlabs", "microsoft", "edge"] as const;
 const LEGACY_TTS_PLUGIN_IDS = new Set(["voice-call"]);
+const LEGACY_TALK_FIELD_KEYS = [
+  "voiceId",
+  "voiceAliases",
+  "modelId",
+  "outputFormat",
+  "apiKey",
+] as const;
 
 function isLegacyGatewayBindHostAlias(value: unknown): boolean {
   if (typeof value !== "string") {
@@ -133,6 +141,72 @@ function hasLegacyTtsProviderKeys(value: unknown): boolean {
     return false;
   }
   return LEGACY_TTS_PROVIDER_KEYS.some((key) => Object.prototype.hasOwnProperty.call(tts, key));
+}
+
+function hasLegacyTalkFields(value: unknown): boolean {
+  const talk = getRecord(value);
+  if (!talk) {
+    return false;
+  }
+  return LEGACY_TALK_FIELD_KEYS.some((key) => Object.prototype.hasOwnProperty.call(talk, key));
+}
+
+function resolveTalkMigrationTargetProviderId(talk: Record<string, unknown>): string | null {
+  const explicitProvider =
+    typeof talk.provider === "string" && talk.provider.trim() ? talk.provider.trim() : null;
+  const providers = getRecord(talk.providers);
+  if (explicitProvider) {
+    return explicitProvider;
+  }
+  if (!providers) {
+    return LEGACY_TALK_PROVIDER_ID;
+  }
+  const providerIds = Object.keys(providers).filter((key) => !isBlockedObjectKey(key));
+  if (providerIds.length === 1) {
+    return providerIds[0] ?? null;
+  }
+  return null;
+}
+
+function migrateLegacyTalkFields(raw: Record<string, unknown>, changes: string[]): void {
+  const talk = getRecord(raw.talk);
+  if (!talk || !hasLegacyTalkFields(talk)) {
+    return;
+  }
+
+  const providerId = resolveTalkMigrationTargetProviderId(talk);
+  if (!providerId) {
+    changes.push(
+      "Skipped talk legacy field migration because talk.providers defines multiple providers and talk.provider is unset; move talk.voiceId/talk.voiceAliases/talk.modelId/talk.outputFormat/talk.apiKey under the intended provider manually.",
+    );
+    return;
+  }
+
+  const providers = ensureRecord(talk, "providers");
+  const existingProvider = getRecord(providers[providerId]) ?? {};
+  const migratedProvider = structuredClone(existingProvider);
+  const legacyFields: Record<string, unknown> = {};
+  const movedKeys: string[] = [];
+  for (const key of LEGACY_TALK_FIELD_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(talk, key)) {
+      continue;
+    }
+    legacyFields[key] = talk[key];
+    delete talk[key];
+    movedKeys.push(key);
+  }
+  if (movedKeys.length === 0) {
+    return;
+  }
+
+  mergeMissing(migratedProvider, legacyFields);
+  providers[providerId] = migratedProvider;
+  talk.providers = providers;
+  raw.talk = talk;
+
+  changes.push(
+    `Moved talk legacy fields (${movedKeys.join(", ")}) → talk.providers.${providerId} (filled missing provider fields only).`,
+  );
 }
 
 function hasLegacyDiscordAccountTtsProviderKeys(value: unknown): boolean {
@@ -293,7 +367,22 @@ const LEGACY_TTS_RULES: LegacyConfigRule[] = [
   },
 ];
 
+const TALK_RULE: LegacyConfigRule = {
+  path: ["talk"],
+  message:
+    "talk.voiceId/talk.voiceAliases/talk.modelId/talk.outputFormat/talk.apiKey are legacy; use talk.providers.<provider> instead (auto-migrated on load).",
+  match: (value) => hasLegacyTalkFields(value),
+};
+
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME: LegacyConfigMigrationSpec[] = [
+  defineLegacyConfigMigration({
+    id: "talk.legacy-fields->talk.providers",
+    describe: "Move legacy Talk flat fields into talk.providers.<provider>",
+    legacyRules: [TALK_RULE],
+    apply: (raw, changes) => {
+      migrateLegacyTalkFields(raw, changes);
+    },
+  }),
   defineLegacyConfigMigration({
     id: "tools.web.x_search.apiKey->plugins.entries.xai.config.webSearch.apiKey",
     describe: "Move legacy x_search auth into the xAI plugin webSearch config",

--- a/src/config/legacy.migrations.runtime.ts
+++ b/src/config/legacy.migrations.runtime.ts
@@ -156,12 +156,18 @@ function resolveTalkMigrationTargetProviderId(talk: Record<string, unknown>): st
     typeof talk.provider === "string" && talk.provider.trim() ? talk.provider.trim() : null;
   const providers = getRecord(talk.providers);
   if (explicitProvider) {
+    if (isBlockedObjectKey(explicitProvider)) {
+      return null;
+    }
     return explicitProvider;
   }
   if (!providers) {
     return LEGACY_TALK_PROVIDER_ID;
   }
   const providerIds = Object.keys(providers).filter((key) => !isBlockedObjectKey(key));
+  if (providerIds.length === 0) {
+    return LEGACY_TALK_PROVIDER_ID;
+  }
   if (providerIds.length === 1) {
     return providerIds[0] ?? null;
   }


### PR DESCRIPTION
## What changed
- Added a legacy config migration for flat `talk.*` fields (`voiceId`, `voiceAliases`, `modelId`, `outputFormat`, `apiKey`) so `openclaw doctor --fix` can rewrite them into `talk.providers.<provider>`.
- Legacy Talk migration picks a target provider only when it is unambiguous:
  - `talk.provider` when set
  - the single configured provider when only one exists
  - `elevenlabs` for legacy-only Talk config
- When Talk providers are ambiguous, doctor leaves the config alone and emits an explicit manual-fix message instead of guessing.
- Folded in the doctor wording cleanup so doctor now says `Legacy config keys detected` and points users to `openclaw doctor --fix` to migrate legacy keys.
- Included the Telegram inactive SecretRef doctor fix so the warning is honest when credentials are configured but unavailable in the current command path.

## Why
Talk legacy flat fields were still a blind spot in doctor. They already normalized on read, but users got no migration signal and `doctor --fix` could not rewrite them into the canonical provider-scoped shape.

## Impact
- Users with legacy Talk config now get a real migration path through doctor.
- `readConfigFileSnapshot()` reports Talk legacy usage in `legacyIssues` and exposes the migrated source config shape.
- Doctor avoids unsafe rewrites when Talk provider selection is ambiguous.

## Validation
Passed:
- `pnpm test -- src/commands/doctor/providers/telegram.test.ts src/commands/doctor-config-flow.test.ts`
- Earlier targeted run after fixes to the non-Telegram surfaces covered:
  - `src/config/legacy-migrate.test.ts`
  - `src/config/config-misc.test.ts`
  - `src/commands/doctor/shared/config-flow-steps.test.ts`

Attempted but blocked by another worktree's local heavy-check lock:
- `pnpm test -- src/config/legacy-migrate.test.ts src/config/config-misc.test.ts src/commands/doctor/providers/telegram.test.ts src/commands/doctor/shared/config-flow-steps.test.ts src/commands/doctor-config-flow.test.ts`
