### PR TITLE
test: avoid loading the bundled iMessage facade in the default test plugin

### DIFF
--- a/src/test-utils/imessage-test-plugin.test.ts
+++ b/src/test-utils/imessage-test-plugin.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  listImportedBundledPluginFacadeIds,
+  resetFacadeRuntimeStateForTest,
+} from "../plugin-sdk/facade-runtime.js";
+import { createIMessageTestPlugin } from "./imessage-test-plugin.js";
+
+afterEach(() => {
+  resetFacadeRuntimeStateForTest();
+});
+
+describe("createIMessageTestPlugin", () => {
+  it("does not load the bundled iMessage facade by default", () => {
+    expect(listImportedBundledPluginFacadeIds()).toEqual([]);
+
+    createIMessageTestPlugin();
+
+    expect(listImportedBundledPluginFacadeIds()).toEqual([]);
+  });
+});

--- a/src/test-utils/imessage-test-plugin.ts
+++ b/src/test-utils/imessage-test-plugin.ts
@@ -1,22 +1,43 @@
 import { normalizeIMessageHandle } from "../channels/plugins/normalize/imessage.js";
 import type { ChannelOutboundAdapter, ChannelPlugin } from "../channels/plugins/types.js";
+import { resolveOutboundSendDep } from "../infra/outbound/send-deps.js";
 import { collectStatusIssuesFromLastError } from "../plugin-sdk/status-helpers.js";
-import { loadBundledPluginPublicSurfaceSync } from "./bundled-plugin-public-surface.js";
 
-let defaultIMessageOutbound: ChannelOutboundAdapter | null = null;
-
-function getDefaultIMessageOutbound(): ChannelOutboundAdapter {
-  if (defaultIMessageOutbound) {
-    return defaultIMessageOutbound;
-  }
-  defaultIMessageOutbound = loadBundledPluginPublicSurfaceSync<{
-    imessageOutbound: ChannelOutboundAdapter;
-  }>({
-    pluginId: "imessage",
-    artifactBasename: "src/outbound-adapter.js",
-  }).imessageOutbound;
-  return defaultIMessageOutbound;
-}
+const defaultIMessageOutbound: ChannelOutboundAdapter = {
+  deliveryMode: "direct",
+  sendText: async ({ to, text, accountId, replyToId, deps, cfg }) => {
+    const sendIMessage = resolveOutboundSendDep<
+      (
+        target: string,
+        content: string,
+        opts?: Record<string, unknown>,
+      ) => Promise<{ messageId: string }>
+    >(deps, "imessage");
+    const result = await sendIMessage?.(to, text, {
+      config: cfg,
+      accountId: accountId ?? undefined,
+      replyToId: replyToId ?? undefined,
+    });
+    return { channel: "imessage", messageId: result?.messageId ?? "imessage-test-stub" };
+  },
+  sendMedia: async ({ to, text, mediaUrl, accountId, replyToId, deps, cfg, mediaLocalRoots }) => {
+    const sendIMessage = resolveOutboundSendDep<
+      (
+        target: string,
+        content: string,
+        opts?: Record<string, unknown>,
+      ) => Promise<{ messageId: string }>
+    >(deps, "imessage");
+    const result = await sendIMessage?.(to, text, {
+      config: cfg,
+      mediaUrl,
+      accountId: accountId ?? undefined,
+      replyToId: replyToId ?? undefined,
+      mediaLocalRoots,
+    });
+    return { channel: "imessage", messageId: result?.messageId ?? "imessage-test-stub" };
+  },
+};
 
 export const createIMessageTestPlugin = (params?: {
   outbound?: ChannelOutboundAdapter;
@@ -38,7 +59,7 @@ export const createIMessageTestPlugin = (params?: {
   status: {
     collectStatusIssues: (accounts) => collectStatusIssuesFromLastError("imessage", accounts),
   },
-  outbound: params?.outbound ?? getDefaultIMessageOutbound(),
+  outbound: params?.outbound ?? defaultIMessageOutbound,
   messaging: {
     targetResolver: {
       looksLikeId: (raw) => {


### PR DESCRIPTION
## Summary

- stop `createIMessageTestPlugin()` from loading the real bundled iMessage outbound adapter by default
- use a cheap local outbound stub for metadata and alias-normalization tests, while still honoring injected `sendIMessage` deps
- add a regression test that proves the helper no longer marks the iMessage bundled facade as imported just by being constructed

## Why

The previous default path went through `loadBundledPluginPublicSurfaceSync(...)`, which populated global facade-runtime caches and pulled in the real iMessage outbound module graph even in tests that only needed plugin metadata.

## Verification

- `pnpm check`
- `pnpm test -- src/test-utils/imessage-test-plugin.test.ts src/gateway/hooks.test.ts src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts src/infra/outbound/message.channels.test.ts`
