### PR TITLE
refactor(providers): centralize native provider detection

### DIFF
--- a/extensions/mistral/api.test.ts
+++ b/extensions/mistral/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { applyMistralModelCompat } from "./api.js";
+import { default as mistralPlugin } from "./index.js";
 
 function supportsStore(model: { compat?: unknown }): boolean | undefined {
   return (model.compat as { supportsStore?: boolean } | undefined)?.supportsStore;
@@ -47,5 +48,54 @@ describe("applyMistralModelCompat", () => {
       },
     };
     expect(applyMistralModelCompat(model)).toBe(model);
+  });
+
+  it("contributes Mistral compat for native, provider-family, and hinted custom routes", () => {
+    const registerProvider = (mistralPlugin as { register?: (api: unknown) => void }).register;
+    let contributeResolvedModelCompat:
+      | ((params: { modelId: string; model: Record<string, unknown> }) => unknown)
+      | undefined;
+
+    registerProvider?.({
+      registerProvider: (provider: {
+        contributeResolvedModelCompat?: typeof contributeResolvedModelCompat;
+      }) => {
+        contributeResolvedModelCompat = provider.contributeResolvedModelCompat;
+      },
+      registerMediaUnderstandingProvider: () => {},
+    });
+
+    expect(
+      contributeResolvedModelCompat?.({
+        modelId: "mistral-large-latest",
+        model: {
+          provider: "mistral",
+          api: "openai-completions",
+          baseUrl: "https://proxy.example/v1",
+        },
+      }),
+    ).toBeDefined();
+
+    expect(
+      contributeResolvedModelCompat?.({
+        modelId: "custom-model",
+        model: {
+          provider: "custom-mistral-host",
+          api: "openai-completions",
+          baseUrl: "https://api.mistral.ai/v1",
+        },
+      }),
+    ).toBeDefined();
+
+    expect(
+      contributeResolvedModelCompat?.({
+        modelId: "mistralai/mistral-small-3.2",
+        model: {
+          provider: "openrouter",
+          api: "openai-completions",
+          baseUrl: "https://openrouter.ai/api/v1",
+        },
+      }),
+    ).toBeDefined();
   });
 });

--- a/extensions/mistral/index.ts
+++ b/extensions/mistral/index.ts
@@ -1,4 +1,5 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { resolveProviderRequestCapabilities } from "openclaw/plugin-sdk/provider-http";
 import { applyMistralModelCompat, MISTRAL_MODEL_COMPAT_PATCH } from "./api.js";
 import { mistralMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { applyMistralConfig, MISTRAL_DEFAULT_MODEL_REF } from "./onboard.js";
@@ -15,17 +16,6 @@ const MISTRAL_MODEL_HINTS = [
   "ministral",
 ] as const;
 
-function isMistralBaseUrl(baseUrl: unknown): boolean {
-  if (typeof baseUrl !== "string" || !baseUrl.trim()) {
-    return false;
-  }
-  try {
-    return new URL(baseUrl).hostname.toLowerCase() === "api.mistral.ai";
-  } catch {
-    return baseUrl.toLowerCase().includes("api.mistral.ai");
-  }
-}
-
 function isMistralModelHint(modelId: string): boolean {
   const normalized = modelId.trim().toLowerCase();
   return MISTRAL_MODEL_HINTS.some(
@@ -39,12 +29,30 @@ function isMistralModelHint(modelId: string): boolean {
 
 function shouldContributeMistralCompat(params: {
   modelId: string;
-  model: { api?: unknown; baseUrl?: unknown };
+  model: { api?: unknown; baseUrl?: unknown; provider?: unknown; compat?: unknown };
 }): boolean {
   if (params.model.api !== "openai-completions") {
     return false;
   }
-  return isMistralBaseUrl(params.model.baseUrl) || isMistralModelHint(params.modelId);
+
+  const capabilities = resolveProviderRequestCapabilities({
+    provider: typeof params.model.provider === "string" ? params.model.provider : undefined,
+    api: "openai-completions",
+    baseUrl: typeof params.model.baseUrl === "string" ? params.model.baseUrl : undefined,
+    capability: "llm",
+    transport: "stream",
+    modelId: params.modelId,
+    compat:
+      params.model.compat && typeof params.model.compat === "object"
+        ? (params.model.compat as { supportsStore?: boolean })
+        : undefined,
+  });
+
+  return (
+    capabilities.knownProviderFamily === "mistral" ||
+    capabilities.endpointClass === "mistral-public" ||
+    isMistralModelHint(params.modelId)
+  );
 }
 
 function buildMistralReplayPolicy() {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -117,4 +117,72 @@ describe("openai transport stream", () => {
       totalTokens: 9,
     });
   });
+
+  it("keeps OpenRouter thinking format for declared OpenRouter providers on custom proxy URLs", async () => {
+    const streamFn = buildTransportAwareSimpleStreamFn(
+      attachModelProviderRequestTransport(
+        {
+          id: "anthropic/claude-sonnet-4",
+          name: "Claude Sonnet 4",
+          api: "openai-completions",
+          provider: "openrouter",
+          baseUrl: "https://proxy.example.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } satisfies Model<"openai-completions">,
+        {
+          proxy: {
+            mode: "explicit-proxy",
+            url: "http://proxy.internal:8443",
+          },
+        },
+      ),
+    );
+
+    expect(streamFn).toBeTypeOf("function");
+    let capturedPayload: Record<string, unknown> | undefined;
+    let resolveCaptured!: () => void;
+    const captured = new Promise<void>((resolve) => {
+      resolveCaptured = resolve;
+    });
+
+    void streamFn!(
+      {
+        id: "anthropic/claude-sonnet-4",
+        name: "Claude Sonnet 4",
+        api: "openclaw-openai-completions-transport",
+        provider: "openrouter",
+        baseUrl: "https://proxy.example.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } as Model<"openclaw-openai-completions-transport">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        reasoningEffort: "high",
+        onPayload: async (payload) => {
+          capturedPayload = payload as Record<string, unknown>;
+          resolveCaptured();
+          return payload;
+        },
+      } as never,
+    );
+
+    await captured;
+
+    expect(capturedPayload).toMatchObject({
+      reasoning: {
+        effort: "high",
+      },
+    });
+  });
 });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -185,4 +185,72 @@ describe("openai transport stream", () => {
       },
     });
   });
+
+  it("keeps OpenRouter thinking format for native OpenRouter hosts behind custom provider ids", async () => {
+    const streamFn = buildTransportAwareSimpleStreamFn(
+      attachModelProviderRequestTransport(
+        {
+          id: "anthropic/claude-sonnet-4",
+          name: "Claude Sonnet 4",
+          api: "openai-completions",
+          provider: "custom-openrouter",
+          baseUrl: "https://openrouter.ai/api/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } satisfies Model<"openai-completions">,
+        {
+          proxy: {
+            mode: "explicit-proxy",
+            url: "http://proxy.internal:8443",
+          },
+        },
+      ),
+    );
+
+    expect(streamFn).toBeTypeOf("function");
+    let capturedPayload: Record<string, unknown> | undefined;
+    let resolveCaptured!: () => void;
+    const captured = new Promise<void>((resolve) => {
+      resolveCaptured = resolve;
+    });
+
+    void streamFn!(
+      {
+        id: "anthropic/claude-sonnet-4",
+        name: "Claude Sonnet 4",
+        api: "openclaw-openai-completions-transport",
+        provider: "custom-openrouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } as Model<"openclaw-openai-completions-transport">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        reasoningEffort: "high",
+        onPayload: async (payload) => {
+          capturedPayload = payload as Record<string, unknown>;
+          resolveCaptured();
+          return payload;
+        },
+      } as never,
+    );
+
+    await captured;
+
+    expect(capturedPayload).toMatchObject({
+      reasoning: {
+        effort: "high",
+      },
+    });
+  });
 });

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1366,7 +1366,9 @@ function detectCompat(model: OpenAIModeModel) {
     requiresThinkingAsText: false,
     thinkingFormat: isZai
       ? "zai"
-      : provider === "openrouter" || capabilities.attributionProvider === "openrouter"
+      : provider === "openrouter" ||
+          capabilities.endpointClass === "openrouter" ||
+          capabilities.attributionProvider === "openrouter"
         ? "openrouter"
         : "openai",
     openRouterRouting: {},

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -13,6 +13,7 @@ import OpenAI, { AzureOpenAI } from "openai";
 import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import { resolveProviderRequestCapabilities } from "./provider-attribution.js";
 import {
   buildProviderRequestDispatcherPolicy,
   getModelProviderRequestTransport,
@@ -1317,6 +1318,18 @@ async function processOpenAICompletionsStream(
 function detectCompat(model: OpenAIModeModel) {
   const provider = model.provider;
   const baseUrl = model.baseUrl ?? "";
+  const capabilities = resolveProviderRequestCapabilities({
+    provider,
+    api: model.api,
+    baseUrl: model.baseUrl,
+    capability: "llm",
+    transport: "stream",
+    modelId: model.id,
+    compat:
+      model.compat && typeof model.compat === "object"
+        ? (model.compat as { supportsStore?: boolean })
+        : undefined,
+  });
   const isZai = provider === "zai" || baseUrl.includes("api.z.ai");
   const isNonStandard =
     provider === "cerebras" ||
@@ -1353,7 +1366,7 @@ function detectCompat(model: OpenAIModeModel) {
     requiresThinkingAsText: false,
     thinkingFormat: isZai
       ? "zai"
-      : provider === "openrouter" || baseUrl.includes("openrouter.ai")
+      : capabilities.attributionProvider === "openrouter"
         ? "openrouter"
         : "openai",
     openRouterRouting: {},

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1366,7 +1366,7 @@ function detectCompat(model: OpenAIModeModel) {
     requiresThinkingAsText: false,
     thinkingFormat: isZai
       ? "zai"
-      : capabilities.attributionProvider === "openrouter"
+      : provider === "openrouter" || capabilities.attributionProvider === "openrouter"
         ? "openrouter"
         : "openai",
     openRouterRouting: {},

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -206,6 +206,27 @@ describe("provider attribution", () => {
     });
   });
 
+  it("classifies native Mistral hosts centrally", () => {
+    expect(resolveProviderEndpoint("https://api.mistral.ai/v1")).toMatchObject({
+      endpointClass: "mistral-public",
+      hostname: "api.mistral.ai",
+    });
+
+    expect(
+      resolveProviderRequestCapabilities({
+        provider: "mistral",
+        api: "openai-completions",
+        baseUrl: "https://api.mistral.ai/v1",
+        capability: "llm",
+        transport: "stream",
+      }),
+    ).toMatchObject({
+      endpointClass: "mistral-public",
+      isKnownNativeEndpoint: true,
+      knownProviderFamily: "mistral",
+    });
+  });
+
   it("treats OpenRouter-hosted Responses routes as explicit proxy-like endpoints", () => {
     expect(
       resolveProviderRequestPolicy({

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -35,6 +35,7 @@ export type ProviderEndpointClass =
   | "default"
   | "anthropic-public"
   | "github-copilot-native"
+  | "mistral-public"
   | "moonshot-native"
   | "modelstudio-native"
   | "openai-public"
@@ -201,6 +202,9 @@ export function resolveProviderEndpoint(
   }
   if (host === "api.anthropic.com") {
     return { endpointClass: "anthropic-public", hostname: host };
+  }
+  if (host === "api.mistral.ai") {
+    return { endpointClass: "mistral-public", hostname: host };
   }
   if (host.endsWith(".githubcopilot.com")) {
     return { endpointClass: "github-copilot-native", hostname: host };
@@ -498,6 +502,7 @@ export function resolveProviderRequestCapabilities(
   const isKnownNativeEndpoint =
     endpointClass === "anthropic-public" ||
     endpointClass === "github-copilot-native" ||
+    endpointClass === "mistral-public" ||
     endpointClass === "moonshot-native" ||
     endpointClass === "modelstudio-native" ||
     endpointClass === "openai-public" ||


### PR DESCRIPTION
## Summary

- Problem: native-provider detection still lived in a few local seams (`mistral` host sniffing, OpenRouter route detection inside transport compat), even after the shared provider request classifier landed.
- Why it matters: duplicated native-vs-proxy checks drift over time and reintroduce the exact request-policy inconsistency we just spent several PRs centralizing.
- What changed: added native Mistral endpoint classification to the shared resolver, moved Mistral compat contribution onto shared request capabilities, and switched OpenAI transport OpenRouter thinking-format detection to use shared request capabilities instead of a local host check.
- What did NOT change (scope boundary): this does not remove all provider-specific protocol quirks in `openai-transport-stream.ts`; provider-specific request-shape compatibility for vendors like Groq, xAI, Z.ai, and Chutes still lives there for now.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #60327
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: request-policy centralization landed incrementally, but some provider-local host detection survived in plugin seams and transport compat helpers.
- Missing detection / guardrail: no single invariant was enforcing that native-vs-proxy classification must come from the shared resolver once available.
- Prior context (`git blame`, prior PR, issue, or refactor if known): follow-up cleanup after the request-policy and model-request transport work.
- Why this regressed now: not a fresh regression; residual duplication left behind after larger centralization tranches.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/provider-attribution.test.ts`
  - `extensions/mistral/api.test.ts`
  - `src/agents/openai-transport-stream.test.ts`
  - `src/agents/pi-model-discovery.auth.test.ts`
- Scenario the test should lock in: native Mistral endpoint detection and OpenRouter transport compat route detection continue to work through the shared request-policy layer.
- Why this is the smallest reliable guardrail: it hits the exact seams where the duplicated logic used to live.
- Existing test that already covers this (if any): transport seam tests already existed; this PR extends them.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- None intended beyond keeping native-provider compat behavior consistent when provider-local base URL handling changes.

## Diagram (if applicable)

```text
Before:
plugin/transport code -> local host sniffing -> native behavior

After:
plugin/transport code -> shared provider request capabilities -> native behavior
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local worktree
- Model/provider: Mistral, OpenRouter transport compat
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Resolve a native or provider-family Mistral model through the catalog/discovery path.
2. Resolve OpenRouter transport compat for an OpenRouter model.
3. Verify the shared request capabilities drive the same behavior.

### Expected

- Native provider detection comes from the shared classifier, without local host sniffing.

### Actual

- Before this PR, Mistral and one OpenRouter transport path still used local detection.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - native Mistral hosts classify centrally
  - Mistral compat still applies for provider-family, native-hosted custom, and hinted OpenRouter Mistral model IDs
  - OpenAI transport compat still recognizes OpenRouter through shared request capabilities
- Edge cases checked:
  - custom Mistral provider on a proxy still gets Mistral compat through provider family
  - custom provider on native Mistral host still gets Mistral compat without a Mistral provider id
- What you did **not** verify:
  - full `pnpm test`
  - full `pnpm build`

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: subtle behavior drift if shared endpoint classification semantics differ from the old local sniffers.
  - Mitigation: targeted tests cover native host, provider-family, and model-hint fallback paths.
