### PR TITLE
fix(slack): never hydrate thread starter media for thread replies

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -4,8 +4,9 @@ import path from "node:path";
 import type { App } from "@slack/bolt";
 import { resolveEnvelopeFormatOptions } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { SlackMessageEvent } from "../../types.js";
+import * as mediaModule from "../media.js";
 import { resolveSlackThreadContextData } from "./prepare-thread-context.js";
 import { createInboundSlackTestContext, createSlackTestAccount } from "./prepare.test-helpers.js";
 
@@ -144,5 +145,193 @@ describe("resolveSlackThreadContextData", () => {
     expect(result.threadLabel).toContain("starter from Alice");
     expect(result.threadHistoryBody).toContain("starter from Alice");
     expect(result.threadHistoryBody).not.toContain("blocked follow-up");
+  });
+});
+
+describe("resolveSlackThreadContextData — thread starter media", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+
+  function makeTmpStorePath() {
+    if (!fixtureRoot) {
+      throw new Error("fixtureRoot missing");
+    }
+    const dir = path.join(fixtureRoot, `case-media-${caseId++}`);
+    fs.mkdirSync(dir);
+    return { dir, storePath: path.join(dir, "sessions.json") };
+  }
+
+  function makeTmpStorePathWithSession(sessionKey: string) {
+    const { dir, storePath } = makeTmpStorePath();
+    // Write a minimal session store with updatedAt so readSessionUpdatedAt returns a value.
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({ [sessionKey]: { updatedAt: Date.now() - 60_000 } }),
+    );
+    return { dir, storePath };
+  }
+
+  beforeAll(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-slack-thread-media-"));
+  });
+
+  afterAll(() => {
+    if (fixtureRoot) {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+      fixtureRoot = "";
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function createThreadContext() {
+    return createInboundSlackTestContext({
+      cfg: {
+        channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+      } as OpenClawConfig,
+      appClient: {
+        conversations: {
+          replies: vi.fn().mockResolvedValue({
+            messages: [],
+            response_metadata: { next_cursor: "" },
+          }),
+        },
+      } as unknown as App["client"],
+      defaultRequireMention: false,
+      replyToMode: "all",
+    });
+  }
+
+  const starterFiles = [
+    { id: "F001", name: "photo.jpg", url_private_download: "https://files.slack.com/photo.jpg" },
+  ];
+  const fakeMedia = [
+    { path: "/tmp/photo.jpg", contentType: "image/jpeg", placeholder: "[Slack file: photo.jpg]" },
+  ];
+
+  it("never hydrates thread starter media for a new thread session (first turn)", async () => {
+    const { storePath } = makeTmpStorePath(); // no prior session
+    const resolveSlackMediaSpy = vi
+      .spyOn(mediaModule, "resolveSlackMedia")
+      .mockResolvedValue(fakeMedia);
+
+    const result = await resolveSlackThreadContextData({
+      ctx: createThreadContext(),
+      account: createSlackTestAccount({ thread: { initialHistoryLimit: 0 } }),
+      message: {
+        channel: "C123",
+        channel_type: "channel",
+        user: "U1",
+        text: "follow-up reply",
+        ts: "101.000",
+        thread_ts: "100.000",
+      } as SlackMessageEvent,
+      isThreadReply: true,
+      threadTs: "100.000",
+      threadStarter: {
+        text: "starter with image",
+        userId: "U1",
+        ts: "100.000",
+        files: starterFiles,
+      },
+      roomLabel: "#general",
+      storePath,
+      sessionKey: "thread-session",
+      allowFromLower: ["u1"],
+      allowNameMatching: false,
+      contextVisibilityMode: "all",
+      envelopeOptions: resolveEnvelopeFormatOptions({} as OpenClawConfig),
+      effectiveDirectMedia: null,
+    });
+
+    // Thread replies never hydrate parent media — the image was already
+    // processed on the channel-level turn that started the thread.
+    expect(result.threadStarterMedia).toBeNull();
+    expect(resolveSlackMediaSpy).not.toHaveBeenCalled();
+  });
+
+  it("never hydrates thread starter media for subsequent replies in an existing session", async () => {
+    const sessionKey = "thread-session";
+    const { storePath } = makeTmpStorePathWithSession(sessionKey); // existing session
+    const resolveSlackMediaSpy = vi
+      .spyOn(mediaModule, "resolveSlackMedia")
+      .mockResolvedValue(fakeMedia);
+
+    const result = await resolveSlackThreadContextData({
+      ctx: createThreadContext(),
+      account: createSlackTestAccount({ thread: { initialHistoryLimit: 0 } }),
+      message: {
+        channel: "C123",
+        channel_type: "channel",
+        user: "U1",
+        text: "second reply",
+        ts: "102.000",
+        thread_ts: "100.000",
+      } as SlackMessageEvent,
+      isThreadReply: true,
+      threadTs: "100.000",
+      threadStarter: {
+        text: "starter with image",
+        userId: "U1",
+        ts: "100.000",
+        files: starterFiles,
+      },
+      roomLabel: "#general",
+      storePath,
+      sessionKey,
+      allowFromLower: ["u1"],
+      allowNameMatching: false,
+      contextVisibilityMode: "all",
+      envelopeOptions: resolveEnvelopeFormatOptions({} as OpenClawConfig),
+      effectiveDirectMedia: null,
+    });
+
+    expect(result.threadStarterMedia).toBeNull();
+    expect(resolveSlackMediaSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT hydrate thread starter media when the reply has its own direct media", async () => {
+    const { storePath } = makeTmpStorePath(); // new session
+    const resolveSlackMediaSpy = vi
+      .spyOn(mediaModule, "resolveSlackMedia")
+      .mockResolvedValue(fakeMedia);
+    const ownMedia = [
+      { path: "/tmp/own.jpg", contentType: "image/jpeg", placeholder: "[Slack file: own.jpg]" },
+    ];
+
+    const result = await resolveSlackThreadContextData({
+      ctx: createThreadContext(),
+      account: createSlackTestAccount({ thread: { initialHistoryLimit: 0 } }),
+      message: {
+        channel: "C123",
+        channel_type: "channel",
+        user: "U1",
+        text: "reply with own image",
+        ts: "101.000",
+        thread_ts: "100.000",
+      } as SlackMessageEvent,
+      isThreadReply: true,
+      threadTs: "100.000",
+      threadStarter: {
+        text: "starter with image",
+        userId: "U1",
+        ts: "100.000",
+        files: starterFiles,
+      },
+      roomLabel: "#general",
+      storePath,
+      sessionKey: "thread-session",
+      allowFromLower: ["u1"],
+      allowNameMatching: false,
+      contextVisibilityMode: "all",
+      envelopeOptions: resolveEnvelopeFormatOptions({} as OpenClawConfig),
+      effectiveDirectMedia: ownMedia, // reply has its own media
+    });
+
+    // Thread replies never hydrate parent media regardless of own media
+    expect(result.threadStarterMedia).toBeNull();
+    expect(resolveSlackMediaSpy).not.toHaveBeenCalled();
   });
 });

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -102,20 +102,27 @@ export async function resolveSlackThreadContextData(params: {
       senderAllowed: starterAllowed,
     });
 
+  const threadInitialHistoryLimit = params.account.config?.thread?.initialHistoryLimit ?? 20;
+  threadSessionPreviousTimestamp = readSessionUpdatedAt({
+    storePath: params.storePath,
+    sessionKey: params.sessionKey,
+  });
+
   if (starter?.text && includeStarterContext) {
     threadStarterBody = starter.text;
     const snippet = starter.text.replace(/\s+/g, " ").slice(0, 80);
     threadLabel = `Slack thread ${params.roomLabel}${snippet ? `: ${snippet}` : ""}`;
-    if (!params.effectiveDirectMedia && starter.files && starter.files.length > 0) {
-      threadStarterMedia = await resolveSlackMedia({
-        files: starter.files,
-        token: params.ctx.botToken,
-        maxBytes: params.ctx.mediaMaxBytes,
-      });
-      if (threadStarterMedia) {
-        const starterPlaceholders = threadStarterMedia.map((item) => item.placeholder).join(", ");
-        logVerbose(`slack: hydrated thread starter file ${starterPlaceholders} from root message`);
-      }
+    // Never hydrate thread starter media for thread replies. The parent
+    // image was already processed on the channel-level turn that started
+    // the thread.  Re-downloading it into every thread session (even just
+    // the first turn) wastes bandwidth and vision tokens, and causes the
+    // model to narrate a photo the user didn't attach to their reply.
+    // The starter *text* is still included via threadStarterBody, which
+    // gives the model sufficient context about the parent message.
+    if (starter.files && starter.files.length > 0) {
+      logVerbose(
+        `slack: skipped thread starter media (${starter.files.length} file(s)) — thread replies never hydrate parent media`,
+      );
     }
   } else {
     threadLabel = `Slack thread ${params.roomLabel}`;
@@ -125,12 +132,6 @@ export async function resolveSlackThreadContextData(params: {
       `slack: omitted thread starter from context (mode=${params.contextVisibilityMode}, sender_allowed=${starterAllowed ? "yes" : "no"})`,
     );
   }
-
-  const threadInitialHistoryLimit = params.account.config?.thread?.initialHistoryLimit ?? 20;
-  threadSessionPreviousTimestamp = readSessionUpdatedAt({
-    storePath: params.storePath,
-    sessionKey: params.sessionKey,
-  });
 
   if (threadInitialHistoryLimit > 0 && !threadSessionPreviousTimestamp) {
     const threadHistory = await resolveSlackThreadHistory({

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -695,8 +695,11 @@ export async function prepareSlackMessage(params: {
     effectiveDirectMedia,
   });
 
-  // Use direct media (including forwarded attachment media) if available, else thread starter media
-  const effectiveMedia = effectiveDirectMedia ?? threadStarterMedia;
+  // Use the reply's own direct media if available.
+  // Thread starter media is never hydrated for thread replies (the parent
+  // image was already processed on the channel-level turn), so the
+  // fallback here is always null — kept only as a defensive guard.
+  const effectiveMedia = effectiveDirectMedia ?? null;
   const firstMedia = effectiveMedia?.[0];
 
   const inboundHistory =


### PR DESCRIPTION
Fixes #60335

## Problem

When a Slack thread was started with an image, thread replies re-injected the parent's media into the model payload — even when the reply contained no files of its own:

- Vision token waste (10 replies = 10× the cost for one image)
- Incorrect agent responses narrating a photo the user did not send
- Different UUID filenames on each reply (image re-downloaded each time)

## Root cause

`prepare-thread-context.ts` downloaded and returned `threadStarterMedia` for thread replies. `prepare.ts` then used it as a fallback whenever `effectiveDirectMedia` was null — which is true for every text-only reply in the thread.

The initial fix (v1) suppressed re-download only for *existing* thread sessions (turns 2+). But the **first** inbound thread reply still got the image because the thread session didn't exist yet — even though the image had already been processed on the channel-level turn that created the thread.

## Fix

**`prepare-thread-context.ts`** — unconditionally skip thread starter media hydration for all thread replies. The starter *text* is still included via `threadStarterBody`, giving the model sufficient context about the parent message:

```ts
// Never hydrate thread starter media for thread replies. The parent
// image was already processed on the channel-level turn that started
// the thread.
if (starter.files && starter.files.length > 0) {
  logVerbose(
    `slack: skipped thread starter media (${starter.files.length} file(s)) — thread replies never hydrate parent media`,
  );
}
```

**`prepare.ts`** — simplified to only use direct media (the fallback to `threadStarterMedia` is now always null):

```ts
const effectiveMedia = effectiveDirectMedia ?? null;
```

If the reply itself has files (`effectiveDirectMedia`), those are still processed normally. The existing `filterInheritedParentFiles` guard continues to strip any parent files that Slack may inherit into the reply event.

## Tests

3 targeted cases in `prepare-thread-context.test.ts`:

1. **New session (first turn)** → starter media NOT hydrated, `resolveSlackMedia` not called ✅
2. **Existing session (subsequent reply)** → same: not hydrated ✅  
3. **Reply with own media** → same: not hydrated (own media used instead) ✅

## Dogfooding Results (Apr 3, 2026)

Tested on a live OpenClaw instance running this patch:

| # | Scenario | Result |
|---|----------|--------|
| 1 | Parent message with image (ultrasound) | ✅ Image seen by agent (expected) |
| 2 | First text-only reply in thread | ✅ No image received (previously would re-inject parent image) |
| 3 | Second text-only reply in thread | ✅ No image received |
| 4 | Reply with a *different* image (engine bay photo) | ✅ Only new image received, no parent bleed-through |

**4/4 passed.** Parent image no longer leaks into thread replies. New images attached to replies are delivered correctly on their own.