### PR TITLE
fix(anthropic): restore OAuth guard in service-tier stream wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Anthropic: skip `service_tier` injection for OAuth-authenticated stream wrapper requests so Claude OAuth requests stop failing with HTTP 401. (#60356) thanks @openperf.
 ## 2026.4.5
 
 ### Breaking

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __testing,
   createAnthropicBetaHeadersWrapper,
+  createAnthropicFastModeWrapper,
+  createAnthropicServiceTierWrapper,
   wrapAnthropicProviderStream,
 } from "./stream-wrappers.js";
 
@@ -46,6 +48,33 @@ describe("anthropic stream wrappers", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("skips service_tier for OAuth token in composed stream chain", () => {
+    const captured: { headers?: Record<string, string>; payload?: Record<string, unknown> } = {};
+    const base: StreamFn = (model, _context, options) => {
+      captured.headers = options?.headers;
+      const payload = {} as Record<string, unknown>;
+      options?.onPayload?.(payload as never, model as never);
+      captured.payload = payload;
+      return {} as never;
+    };
+
+    const wrapped = wrapAnthropicProviderStream({
+      streamFn: base,
+      modelId: "claude-sonnet-4-6",
+      extraParams: { context1m: true, serviceTier: "auto" },
+    } as never);
+
+    wrapped?.(
+      { provider: "anthropic", api: "anthropic-messages", id: "claude-sonnet-4-6" } as never,
+      {} as never,
+      { apiKey: "sk-ant-oat01-oauth-token" } as never,
+    );
+
+    expect(captured.headers?.["anthropic-beta"]).toContain(OAUTH_BETA);
+    expect(captured.headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
+    expect(captured.payload?.service_tier).toBeUndefined();
+  });
+
   it("composes the anthropic provider stream chain from extra params", () => {
     const captured: { headers?: Record<string, string>; payload?: Record<string, unknown> } = {};
     const base: StreamFn = (model, _context, options) => {
@@ -70,5 +99,120 @@ describe("anthropic stream wrappers", () => {
 
     expect(captured.headers?.["anthropic-beta"]).toContain(CONTEXT_1M_BETA);
     expect(captured.payload).toMatchObject({ service_tier: "auto" });
+  });
+});
+
+describe("createAnthropicFastModeWrapper", () => {
+  function runFastModeWrapper(params: {
+    apiKey?: string;
+    provider?: string;
+    api?: string;
+    baseUrl?: string;
+    enabled?: boolean;
+  }): Record<string, unknown> | undefined {
+    const captured: { payload?: Record<string, unknown> } = {};
+    const base: StreamFn = (_model, _context, options) => {
+      if (options?.onPayload) {
+        const payload: Record<string, unknown> = {};
+        options.onPayload(payload, _model);
+        captured.payload = payload;
+      }
+      return {} as never;
+    };
+
+    const wrapper = createAnthropicFastModeWrapper(base, params.enabled ?? true);
+    wrapper(
+      {
+        provider: params.provider ?? "anthropic",
+        api: params.api ?? "anthropic-messages",
+        baseUrl: params.baseUrl,
+        id: "claude-sonnet-4-6",
+      } as never,
+      {} as never,
+      { apiKey: params.apiKey } as never,
+    );
+    return captured.payload;
+  }
+
+  it("does not inject service_tier for OAuth token", () => {
+    const payload = runFastModeWrapper({ apiKey: "sk-ant-oat01-test-token" });
+    expect(payload?.service_tier).toBeUndefined();
+  });
+
+  it("injects service_tier for regular API keys", () => {
+    const payload = runFastModeWrapper({ apiKey: "sk-ant-api03-test-key" });
+    expect(payload?.service_tier).toBe("auto");
+  });
+
+  it("injects service_tier=standard_only when disabled for API keys", () => {
+    const payload = runFastModeWrapper({ apiKey: "sk-ant-api03-test-key", enabled: false });
+    expect(payload?.service_tier).toBe("standard_only");
+  });
+
+  it("does not inject service_tier for non-anthropic provider", () => {
+    const payload = runFastModeWrapper({
+      apiKey: "sk-ant-api03-test-key",
+      provider: "openai",
+      api: "openai-completions",
+    });
+    expect(payload?.service_tier).toBeUndefined();
+  });
+});
+
+describe("createAnthropicServiceTierWrapper", () => {
+  function runServiceTierWrapper(params: {
+    apiKey?: string;
+    provider?: string;
+    api?: string;
+    serviceTier?: "auto" | "standard_only";
+  }): Record<string, unknown> | undefined {
+    const captured: { payload?: Record<string, unknown> } = {};
+    const base: StreamFn = (_model, _context, options) => {
+      if (options?.onPayload) {
+        const payload: Record<string, unknown> = {};
+        options.onPayload(payload, _model);
+        captured.payload = payload;
+      }
+      return {} as never;
+    };
+
+    const wrapper = createAnthropicServiceTierWrapper(base, params.serviceTier ?? "auto");
+    wrapper(
+      {
+        provider: params.provider ?? "anthropic",
+        api: params.api ?? "anthropic-messages",
+        id: "claude-sonnet-4-6",
+      } as never,
+      {} as never,
+      { apiKey: params.apiKey } as never,
+    );
+    return captured.payload;
+  }
+
+  it("does not inject service_tier for OAuth token", () => {
+    const payload = runServiceTierWrapper({ apiKey: "sk-ant-oat01-test-token" });
+    expect(payload?.service_tier).toBeUndefined();
+  });
+
+  it("injects service_tier for regular API keys", () => {
+    const payload = runServiceTierWrapper({ apiKey: "sk-ant-api03-test-key" });
+    expect(payload?.service_tier).toBe("auto");
+  });
+
+  it("injects service_tier=standard_only for regular API keys", () => {
+    const payload = runServiceTierWrapper({
+      apiKey: "sk-ant-api03-test-key",
+      serviceTier: "standard_only",
+    });
+    expect(payload?.service_tier).toBe("standard_only");
+  });
+
+  it("does not inject service_tier for non-anthropic provider", () => {
+    const payload = runServiceTierWrapper({
+      apiKey: "sk-ant-api03-test-key",
+      provider: "openai",
+      api: "openai-completions",
+    });
+    expect(payload?.service_tier).toBeUndefined();
   });
 });

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -152,6 +152,10 @@ export function createAnthropicFastModeWrapper(
   const underlying = baseStreamFn ?? streamSimple;
   const serviceTier = resolveAnthropicFastServiceTier(enabled);
   return (model, context, options) => {
+    if (isAnthropicOAuthApiKey(options?.apiKey)) {
+      return underlying(model, context, options);
+    }
+
     const payloadPolicy = resolveAnthropicPayloadPolicy({
       provider: typeof model.provider === "string" ? model.provider : undefined,
       api: typeof model.api === "string" ? model.api : undefined,
@@ -174,6 +178,10 @@ export function createAnthropicServiceTierWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
+    if (isAnthropicOAuthApiKey(options?.apiKey)) {
+      return underlying(model, context, options);
+    }
+
     const payloadPolicy = resolveAnthropicPayloadPolicy({
       provider: typeof model.provider === "string" ? model.provider : undefined,
       api: typeof model.api === "string" ? model.api : undefined,

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2727,7 +2727,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.service_tier).toBe("standard_only");
   });
 
-  it("injects configured Anthropic service_tier into OAuth-authenticated Anthropic payloads", () => {
+  it("does not inject configured Anthropic service_tier into OAuth-authenticated Anthropic payloads", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "anthropic",
       applyModelId: "claude-sonnet-4-5",
@@ -2755,7 +2755,7 @@ describe("applyExtraParamsToAgent", () => {
       },
       payload: {},
     });
-    expect(payload.service_tier).toBe("standard_only");
+    expect(payload.service_tier).toBeUndefined();
   });
 
   it("does not warn for valid Anthropic serviceTier values", () => {
@@ -2840,7 +2840,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.service_tier).toBe("standard_only");
   });
 
-  it("lets explicit Anthropic service_tier override OAuth fast mode defaults", () => {
+  it("does not inject explicit Anthropic service_tier for OAuth auth even when fast mode is enabled", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "anthropic",
       applyModelId: "claude-sonnet-4-5",
@@ -2869,10 +2869,10 @@ describe("applyExtraParamsToAgent", () => {
       },
       payload: {},
     });
-    expect(payload.service_tier).toBe("standard_only");
+    expect(payload.service_tier).toBeUndefined();
   });
 
-  it("injects Anthropic fast mode service_tier for OAuth auth", () => {
+  it("does not inject Anthropic fast mode service_tier for OAuth auth", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "anthropic",
       applyModelId: "claude-sonnet-4-5",
@@ -2888,10 +2888,10 @@ describe("applyExtraParamsToAgent", () => {
       },
       payload: {},
     });
-    expect(payload.service_tier).toBe("auto");
+    expect(payload.service_tier).toBeUndefined();
   });
 
-  it("injects Anthropic standard_only service_tier for OAuth auth when fastMode is false", () => {
+  it("does not inject Anthropic standard_only service_tier for OAuth auth when fastMode is false", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "anthropic",
       applyModelId: "claude-sonnet-4-5",
@@ -2907,7 +2907,7 @@ describe("applyExtraParamsToAgent", () => {
       },
       payload: {},
     });
-    expect(payload.service_tier).toBe("standard_only");
+    expect(payload.service_tier).toBeUndefined();
   });
 
   it("does not inject Anthropic fast mode service_tier for proxied base URLs", () => {


### PR DESCRIPTION
### Summary

*   **Problem:** Anthropic OAuth token users (`sk-ant-oat*`) receive HTTP 401 "OAuth authentication is currently not supported" on OpenClaw v2026.3.28+. The error occurs when `service_tier` is injected into the request payload for OAuth-authenticated requests.
*   **Root Cause:** Commit `59c23de` ("refactor(anthropic): move stream wrappers into plugin") migrated the stream wrappers but dropped the `isAnthropicOAuthApiKey(options?.apiKey)` guard. The subsequent refactor in `be526d6` ("refactor: split provider stream sdk seams") introduced the new `resolveAnthropicPayloadPolicy` and `streamWithPayloadPatch` architecture, but still did not restore the OAuth check. As a result, `service_tier` is injected via the payload patch for OAuth requests, and Anthropic's API rejects the combination with HTTP 401.
*   **Fix:** Restore the `isAnthropicOAuthApiKey(options?.apiKey)` guard at the beginning of the return closures in both `createAnthropicFastModeWrapper` and `createAnthropicServiceTierWrapper`. When the guard matches, the wrapper returns the underlying stream directly, bypassing the `resolveAnthropicPayloadPolicy` evaluation and payload patching. This is the exact behavior present in v2026.3.24 (`cff6dc9`).
*   **What changed:**
    *   `extensions/anthropic/stream-wrappers.ts`: Added early-return `if (isAnthropicOAuthApiKey(options?.apiKey))` blocks to both `createAnthropicFastModeWrapper` and `createAnthropicServiceTierWrapper`.
    *   `extensions/anthropic/stream-wrappers.test.ts`: Added comprehensive test suites for both wrappers, including 6 new test cases covering OAuth token skip, regular API key injection, `standard_only` behavior, and non-Anthropic provider skip. Also added a test for the composed stream chain.
*   **What did NOT change (scope boundary):**
    *   `createAnthropicBetaHeadersWrapper` — already has its own OAuth guard, untouched.
    *   `resolveAnthropicPayloadPolicy` — correctly resolves model-level capabilities, untouched.
    *   No changes to the Anthropic SDK client creation or Bearer/x-api-key auth logic.

### Reproduction

1.  Configure an Anthropic OAuth token (`sk-ant-oat01-...`) in `auth-profiles.json`
2.  Update to OpenClaw v2026.3.28+ (or current main)
3.  Send any model request using `anthropic/claude-*`
4.  Observe HTTP 401: "OAuth authentication is currently not supported"

### Risk / Mitigation

*   **Risk:** Minimal. The fix restores the exact guard that existed in v2026.3.24 (`cff6dc9`, line 365) and adapts it to the new payload policy architecture. The guard only affects OAuth token users by skipping `service_tier` injection.
*   **Mitigation:** Extensive new test cases verify that (a) OAuth tokens skip `service_tier` injection, (b) regular API keys still receive `service_tier` injection, and (c) non-Anthropic providers are unaffected. The existing `createAnthropicBetaHeadersWrapper` tests remain unchanged and passing.

### Change Type (select all)
- [x] Bug fix

### Scope (select all touched areas)
- [ ] Gateway
- [x] Extensions
- [x] Tests

### Linked Issue/PR
Fixes #60279

