### PR TITLE
fix(config): surface legacy channel streaming aliases

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -652,6 +652,62 @@ describe("doctor config flow", () => {
     });
   });
 
+  it("warns clearly about legacy channel streaming aliases and points to doctor --fix", async () => {
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    try {
+      await runDoctorConfigWithInput({
+        config: {
+          channels: {
+            telegram: {
+              streamMode: "block",
+            },
+            discord: {
+              streaming: false,
+            },
+            slack: {
+              streaming: true,
+            },
+          },
+        },
+        run: loadAndMaybeMigrateDoctorConfig,
+      });
+
+      expect(
+        noteSpy.mock.calls.some(
+          ([message, title]) =>
+            title === "Legacy config keys detected" &&
+            String(message).includes("channels.telegram:") &&
+            String(message).includes("channels.telegram.streamMode is legacy"),
+        ),
+      ).toBe(true);
+      expect(
+        noteSpy.mock.calls.some(
+          ([message, title]) =>
+            title === "Legacy config keys detected" &&
+            String(message).includes("channels.discord:") &&
+            String(message).includes("boolean channels.discord.streaming are legacy"),
+        ),
+      ).toBe(true);
+      expect(
+        noteSpy.mock.calls.some(
+          ([message, title]) =>
+            title === "Legacy config keys detected" &&
+            String(message).includes("channels.slack:") &&
+            String(message).includes("boolean channels.slack.streaming are legacy"),
+        ),
+      ).toBe(true);
+      expect(
+        noteSpy.mock.calls.some(
+          ([message, title]) =>
+            title === "Doctor" &&
+            String(message).includes('Run "openclaw doctor --fix" to migrate legacy config keys.'),
+        ),
+      ).toBe(true);
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
   it("sanitizes config-derived doctor warnings and changes before logging", async () => {
     const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
     try {

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -591,6 +591,55 @@ describe("config strict validation", () => {
     });
   });
 
+  it("accepts legacy channel streaming aliases via auto-migration and reports legacyIssues", async () => {
+    await withTempHome(async (home) => {
+      await writeOpenClawConfig(home, {
+        channels: {
+          telegram: {
+            streamMode: "block",
+          },
+          discord: {
+            streaming: false,
+            accounts: {
+              work: {
+                streamMode: "block",
+              },
+            },
+          },
+          slack: {
+            streaming: true,
+          },
+        },
+      });
+
+      const snap = await readConfigFileSnapshot();
+
+      expect(snap.valid).toBe(true);
+      expect(snap.legacyIssues.some((issue) => issue.path === "channels.telegram")).toBe(true);
+      expect(snap.legacyIssues.some((issue) => issue.path === "channels.discord")).toBe(true);
+      expect(snap.legacyIssues.some((issue) => issue.path === "channels.discord.accounts")).toBe(
+        true,
+      );
+      expect(snap.legacyIssues.some((issue) => issue.path === "channels.slack")).toBe(true);
+      expect(snap.sourceConfig.channels?.telegram).toMatchObject({
+        streaming: "block",
+      });
+      expect(
+        (snap.sourceConfig.channels?.telegram as Record<string, unknown> | undefined)?.streamMode,
+      ).toBeUndefined();
+      expect(snap.sourceConfig.channels?.discord).toMatchObject({
+        streaming: "off",
+      });
+      expect(snap.sourceConfig.channels?.discord?.accounts?.work).toMatchObject({
+        streaming: "block",
+      });
+      expect(snap.sourceConfig.channels?.slack).toMatchObject({
+        streaming: "partial",
+        nativeStreaming: true,
+      });
+    });
+  });
+
   it("accepts legacy plugins.entries.*.config.tts provider keys via auto-migration", async () => {
     await withTempHome(async (home) => {
       await writeOpenClawConfig(home, {

--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -482,6 +482,32 @@ describe("legacy migrate sandbox scope aliases", () => {
   });
 });
 
+describe("legacy migrate channel streaming aliases", () => {
+  it("migrates telegram and discord streaming aliases", () => {
+    const res = migrateLegacyConfig({
+      channels: {
+        telegram: {
+          streamMode: "block",
+        },
+        discord: {
+          streaming: false,
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Moved channels.telegram.streamMode → channels.telegram.streaming (block).",
+    );
+    expect(res.changes).toContain("Normalized channels.discord.streaming boolean → enum (off).");
+    expect(res.config?.channels?.telegram).toMatchObject({
+      streaming: "block",
+    });
+    expect(res.config?.channels?.discord).toMatchObject({
+      streaming: "off",
+    });
+  });
+});
+
 describe("legacy migrate x_search auth", () => {
   it("moves only legacy x_search auth into plugin-owned xai config", () => {
     const res = migrateLegacyConfig({

--- a/src/config/legacy.migrations.channels.ts
+++ b/src/config/legacy.migrations.channels.ts
@@ -61,6 +61,41 @@ function migrateThreadBindingsTtlHoursForPath(params: {
   return true;
 }
 
+function hasLegacyTelegramStreamingKeys(value: unknown): boolean {
+  const entry = getRecord(value);
+  if (!entry) {
+    return false;
+  }
+  return entry.streamMode !== undefined;
+}
+
+function hasLegacyDiscordStreamingKeys(value: unknown): boolean {
+  const entry = getRecord(value);
+  if (!entry) {
+    return false;
+  }
+  return entry.streamMode !== undefined || typeof entry.streaming === "boolean";
+}
+
+function hasLegacySlackStreamingKeys(value: unknown): boolean {
+  const entry = getRecord(value);
+  if (!entry) {
+    return false;
+  }
+  return entry.streamMode !== undefined || typeof entry.streaming === "boolean";
+}
+
+function hasLegacyStreamingKeysInAccounts(
+  value: unknown,
+  matchEntry: (entry: Record<string, unknown>) => boolean,
+): boolean {
+  const accounts = getRecord(value);
+  if (!accounts) {
+    return false;
+  }
+  return Object.values(accounts).some((entry) => matchEntry(getRecord(entry) ?? {}));
+}
+
 const THREAD_BINDING_RULES: LegacyConfigRule[] = [
   {
     path: ["session", "threadBindings"],
@@ -79,6 +114,45 @@ const THREAD_BINDING_RULES: LegacyConfigRule[] = [
     message:
       "channels.discord.accounts.<id>.threadBindings.ttlHours was renamed to channels.discord.accounts.<id>.threadBindings.idleHours (auto-migrated on load).",
     match: (value) => hasLegacyThreadBindingTtlInAccounts(value),
+  },
+];
+
+const CHANNEL_STREAMING_RULES: LegacyConfigRule[] = [
+  {
+    path: ["channels", "telegram"],
+    message:
+      "channels.telegram.streamMode is legacy; use channels.telegram.streaming instead (auto-migrated on load).",
+    match: (value) => hasLegacyTelegramStreamingKeys(value),
+  },
+  {
+    path: ["channels", "telegram", "accounts"],
+    message:
+      "channels.telegram.accounts.<id>.streamMode is legacy; use channels.telegram.accounts.<id>.streaming instead (auto-migrated on load).",
+    match: (value) => hasLegacyStreamingKeysInAccounts(value, hasLegacyTelegramStreamingKeys),
+  },
+  {
+    path: ["channels", "discord"],
+    message:
+      "channels.discord.streamMode and boolean channels.discord.streaming are legacy; use channels.discord.streaming with enum values instead (auto-migrated on load).",
+    match: (value) => hasLegacyDiscordStreamingKeys(value),
+  },
+  {
+    path: ["channels", "discord", "accounts"],
+    message:
+      "channels.discord.accounts.<id>.streamMode and boolean channels.discord.accounts.<id>.streaming are legacy; use channels.discord.accounts.<id>.streaming with enum values instead (auto-migrated on load).",
+    match: (value) => hasLegacyStreamingKeysInAccounts(value, hasLegacyDiscordStreamingKeys),
+  },
+  {
+    path: ["channels", "slack"],
+    message:
+      "channels.slack.streamMode and boolean channels.slack.streaming are legacy; use channels.slack.streaming with enum values instead (auto-migrated on load).",
+    match: (value) => hasLegacySlackStreamingKeys(value),
+  },
+  {
+    path: ["channels", "slack", "accounts"],
+    message:
+      "channels.slack.accounts.<id>.streamMode and boolean channels.slack.accounts.<id>.streaming are legacy; use channels.slack.accounts.<id>.streaming with enum values instead (auto-migrated on load).",
+    match: (value) => hasLegacyStreamingKeysInAccounts(value, hasLegacySlackStreamingKeys),
   },
 ];
 
@@ -136,6 +210,7 @@ export const LEGACY_CONFIG_MIGRATIONS_CHANNELS: LegacyConfigMigrationSpec[] = [
     id: "channels.streaming-keys->channels.streaming",
     describe:
       "Normalize legacy streaming keys to channels.<provider>.streaming (Telegram/Discord/Slack)",
+    legacyRules: CHANNEL_STREAMING_RULES,
     apply: (raw, changes) => {
       const channels = getRecord(raw.channels);
       if (!channels) {


### PR DESCRIPTION
## Summary

- Problem: legacy channel streaming aliases (`streamMode`, boolean `streaming`) were auto-migrated silently, but they were not surfaced through `legacyIssues` or doctor guidance.
- Why it matters: users keep stale config shapes without a clear migration signal, even though the runtime canonical form is already `streaming` enum-based.
- What changed: added legacy detection rules for Telegram, Discord, and Slack streaming aliases, with focused tests for runtime migration, config snapshot reporting, and doctor messaging.
- What did NOT change (scope boundary): no changes to the actual streaming rewrite behavior, no schema/baseline changes, no broader channel config cleanup.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the shared channel streaming migration in `legacy.migrations.channels.ts` had rewrite logic but no `legacyRules`, so config snapshots and doctor could not report these aliases as legacy inputs.
- Missing detection / guardrail: no config snapshot or doctor-flow tests asserted `legacyIssues` for channel streaming aliases.
- Prior context (`git blame`, prior PR, issue, or refactor if known): follow-up to the doctor-driven legacy config cleanup slices for Talk and sandbox aliases.
- Why this regressed now: older compatibility debt, not a new regression from a single refactor.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/legacy-migrate.test.ts`, `src/config/config-misc.test.ts`, `src/commands/doctor-config-flow.test.ts`
- Scenario the test should lock in: legacy channel streaming aliases are still auto-migrated, but now also surface in `legacyIssues` and doctor guidance.
- Why this is the smallest reliable guardrail: the missing behavior is shared config migration metadata plus doctor presentation, not channel runtime delivery.
- Existing test that already covers this (if any): migration behavior existed in channel-specific legacy tests, but not the snapshot/doctor visibility layer.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `openclaw doctor` now explicitly flags legacy channel streaming aliases for Telegram, Discord, and Slack.
- Config snapshots now report those aliases in `legacyIssues` while still auto-migrating them.

## Diagram (if applicable)

```text
Before:
legacy channel streaming config -> silent auto-migration -> canonical config

After:
legacy channel streaming config -> legacyIssues/doctor warning -> same auto-migration -> canonical config
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Telegram / Discord / Slack config surfaces
- Relevant config (redacted): legacy `streamMode`, boolean `streaming`

### Steps

1. Load config or run doctor on a config that uses channel `streamMode` or boolean `streaming`.
2. Observe legacy reporting and canonicalized output.
3. Run the focused tests.

### Expected

- Config still auto-migrates to canonical streaming settings.
- Doctor and config snapshot report the legacy alias usage.

### Actual

- Verified by targeted tests below.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Telegram `streamMode`, Discord boolean `streaming`, Discord account `streamMode`, Slack boolean `streaming`, doctor warning/hint output.
- Edge cases checked: migration semantics unchanged; Slack still resolves to `streaming: "partial"` plus `nativeStreaming: true` for boolean `true`.
- What you did **not** verify: full `pnpm test`, repo-wide `pnpm check`, channel runtime behavior outside config migration/doctor reporting.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: there may be additional channel-specific legacy streaming aliases outside these shared Telegram/Discord/Slack entry points.
  - Mitigation: this PR scopes to the shared migration seam that already owns the canonical rewrite behavior and adds tests for top-level plus account-scoped coverage.
