### PR TITLE
fix(providers): auto-select anthropic-messages API for Claude models on GitHub Copilot

### DIFF
--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -96,6 +96,35 @@ function resolveRuntimeHooks(params?: {
   return params?.runtimeHooks ?? DEFAULT_PROVIDER_RUNTIME_HOOKS;
 }
 
+/**
+ * When the provider is github-copilot and the model is a Claude model,
+ * default to anthropic-messages API instead of openai-responses.
+ *
+ * The Anthropic Messages API supports prompt caching on GitHub Copilot,
+ * which keeps TTFB constant (~0.7-0.9s) regardless of context size.
+ * The OpenAI chat/completions API does NOT cache Claude prompts, causing
+ * TTFB to scale linearly — at 100k+ tokens, prefill can exceed the 60s
+ * LLM idle timeout.
+ *
+ * Other model families (GPT, Gemini) already get caching via the default
+ * OpenAI API on GitHub Copilot, so no override is needed for them.
+ */
+function inferNativeApiForCopilotModel(
+  provider: string | undefined,
+  modelId: string | undefined,
+): ModelDefinitionConfig["api"] | undefined {
+  if (!provider || !modelId) return undefined;
+  const normalizedProvider = provider.toLowerCase();
+  if (normalizedProvider !== "github-copilot") return undefined;
+
+  const normalizedModel = modelId.toLowerCase();
+  if (normalizedModel.includes("claude")) {
+    return "anthropic-messages";
+  }
+  // GPT / Gemini / o-series: keep default openai-responses (already cached)
+  return undefined;
+}
+
 function normalizeResolvedTransportApi(api: unknown): ModelDefinitionConfig["api"] | undefined {
   switch (api) {
     case "anthropic-messages":
@@ -341,12 +370,14 @@ function applyConfiguredProviderOverrides(params: {
     cfg: params.cfg,
     runtimeHooks: params.runtimeHooks,
   });
+  const inferredApi =
+    resolvedTransport.api ??
+    normalizeResolvedTransportApi(discoveredModel.api) ??
+    inferNativeApiForCopilotModel(params.provider, discoveredModel.id) ??
+    "openai-responses";
   const requestConfig = resolveProviderRequestConfig({
     provider: params.provider,
-    api:
-      resolvedTransport.api ??
-      normalizeResolvedTransportApi(discoveredModel.api) ??
-      "openai-responses",
+    api: inferredApi,
     baseUrl: resolvedTransport.baseUrl ?? discoveredModel.baseUrl,
     discoveredHeaders,
     providerHeaders,
@@ -359,7 +390,7 @@ function applyConfiguredProviderOverrides(params: {
   return attachModelProviderRequestTransport(
     {
       ...discoveredModel,
-      api: requestConfig.api ?? "openai-responses",
+      api: requestConfig.api ?? inferredApi,
       baseUrl: requestConfig.baseUrl ?? discoveredModel.baseUrl,
       reasoning: configuredModel?.reasoning ?? discoveredModel.reasoning,
       input: normalizedInput,


### PR DESCRIPTION
## Problem

When Claude models are configured under the `github-copilot` provider without an explicit `api` field, OpenClaw defaults to `openai-responses` (OpenAI chat/completions format). This format **does not support Anthropic prompt caching**, causing:

1. **Time-to-first-token scales linearly with context size** — no caching means full prefill every request
2. **LLM idle timeouts for large sessions** — at ~100k+ tokens, prefill exceeds `DEFAULT_LLM_IDLE_TIMEOUT_MS` (60s), causing `FailoverError: LLM request timed out`
3. **All fallback models fail in sequence** — because the timeout is on the client side, not the API

This affects any user who configures GitHub Copilot with Claude models without explicitly setting `api: anthropic-messages`.

## Solution

Add `inferAnthropicApiForCopilotClaude()` in `src/agents/pi-embedded-runner/model.ts` that automatically selects `anthropic-messages` as the transport API when:
- Provider is `github-copilot`
- Model ID contains `claude`

The explicit `api` config field still takes precedence (non-breaking).

## Benchmark

Tested on GitHub Copilot Enterprise (`api.enterprise.githubcopilot.com`), streaming mode, same prompt content:

| Prompt size | Anthropic API (TTFB) | OpenAI API (TTFB) | Speedup |
|-------------|:---:|:---:|:---:|
| ~3k tokens | 0.89s | 3.25s | **3.6x** |
| ~15k tokens | 0.71s | 4.75s | **6.7x** |
| ~60k tokens | 0.69s | 9.47s | **13.5x** |

With Anthropic Messages API, TTFB stays constant (~0.7-0.9s) regardless of prompt size due to prompt caching. With OpenAI API, it grows linearly.

## Impact

- Eliminates unexpected timeouts for GitHub Copilot + Claude users with large contexts
- ~4-14x faster time-to-first-token depending on context size
- Zero config change required for existing users
- Users who explicitly set `api` are unaffected

Fixes #60174