### PR TITLE
fix(exec): accept allowlist metadata in approval sync

### DIFF
--- a/src/gateway/protocol/exec-approvals-validators.test.ts
+++ b/src/gateway/protocol/exec-approvals-validators.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { validateExecApprovalsNodeSetParams, validateExecApprovalsSetParams } from "./index.js";
+
+describe("exec approvals protocol validators", () => {
+  const file = {
+    version: 1 as const,
+    agents: {
+      main: {
+        allowlist: [
+          {
+            pattern: "=command:613b5a60181648fd",
+            source: "allow-always" as const,
+            commandText: 'powershell -NoProfile -Command "Write-Output hi"',
+            lastUsedCommand: 'powershell -NoProfile -Command "Write-Output hi"',
+          },
+        ],
+      },
+    },
+  };
+
+  it("accepts gateway exec approvals payloads with durable allow-always metadata", () => {
+    expect(validateExecApprovalsSetParams({ file, baseHash: "hash-1" })).toBe(true);
+  });
+
+  it("accepts node exec approvals payloads with durable allow-always metadata", () => {
+    expect(
+      validateExecApprovalsNodeSetParams({
+        nodeId: "node-1",
+        file,
+        baseHash: "hash-1",
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -5,6 +5,8 @@ export const ExecApprovalsAllowlistEntrySchema = Type.Object(
   {
     id: Type.Optional(NonEmptyString),
     pattern: Type.String(),
+    source: Type.Optional(Type.Literal("allow-always")),
+    commandText: Type.Optional(Type.String()),
     argPattern: Type.Optional(Type.String()),
     lastUsedAt: Type.Optional(Type.Integer({ minimum: 0 })),
     lastUsedCommand: Type.Optional(Type.String()),

--- a/ui/src/ui/controllers/exec-approvals.ts
+++ b/ui/src/ui/controllers/exec-approvals.ts
@@ -11,6 +11,8 @@ export type ExecApprovalsDefaults = {
 export type ExecApprovalsAllowlistEntry = {
   id?: string;
   pattern: string;
+  source?: "allow-always";
+  commandText?: string;
   lastUsedAt?: number;
   lastUsedCommand?: string;
   lastResolvedPath?: string;


### PR DESCRIPTION
## Summary
- accept llowlist[].source and llowlist[].commandText in exec approvals protocol payloads
- align the Control UI exec approvals allowlist type with the runtime metadata fields it round-trips
- add validator coverage for gateway and node exec approvals saves

## Testing
- pnpm.cmd exec vitest run src/gateway/protocol/exec-approvals-validators.test.ts
- pnpm.cmd lint src/gateway/protocol/schema/exec-approvals.ts src/gateway/protocol/exec-approvals-validators.test.ts ui/src/ui/controllers/exec-approvals.ts
- pnpm.cmd check

Fixes #60000