### PR TITLE
fix(cron): add --thread-id for cron add/edit and support paged job lookup in cron edit

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -152,6 +152,8 @@ function mockCronEditJobLookup(schedule: unknown): void {
 function mockCronEditPagedJobLookup(params: {
   schedule?: unknown;
   delivery?: { channel?: string; to?: string; mode?: string };
+  sessionTarget?: "main" | "isolated";
+  payload?: { kind?: "systemEvent" | "agentTurn"; text?: string; message?: string };
 }): void {
   callGatewayFromCli.mockImplementation(
     async (method: string, _opts: unknown, callParams?: unknown) => {
@@ -163,7 +165,15 @@ function mockCronEditPagedJobLookup(params: {
         if ((p.offset ?? 0) >= 200) {
           return {
             ok: true,
-            jobs: [{ id: "job-1", schedule: params.schedule, delivery: params.delivery }],
+            jobs: [
+              {
+                id: "job-1",
+                schedule: params.schedule,
+                delivery: params.delivery,
+                sessionTarget: params.sessionTarget ?? "isolated",
+                payload: params.payload ?? { kind: "agentTurn", message: "hello" },
+              },
+            ],
             hasMore: false,
             nextOffset: null,
           };
@@ -604,14 +614,27 @@ describe("cron cli", () => {
   });
 
   it("applies --thread-id on cron edit with explicit telegram delivery target", async () => {
-    const patch = await runCronEditAndGetPatch([
-      "--channel",
-      "telegram",
-      "--to",
-      "-1001234567890",
-      "--thread-id",
-      "48",
-    ]);
+    resetGatewayMock();
+    mockCronEditPagedJobLookup({
+      schedule: { kind: "cron", expr: "0 */2 * * *", tz: "UTC", staggerMs: 300_000 },
+      delivery: { channel: "telegram", to: "-1001234567890" },
+    });
+    const program = buildProgram();
+    await program.parseAsync(
+      [
+        "cron",
+        "edit",
+        "job-1",
+        "--channel",
+        "telegram",
+        "--to",
+        "-1001234567890",
+        "--thread-id",
+        "48",
+      ],
+      { from: "user" },
+    );
+    const patch = getGatewayCallParams<CronUpdatePatch>("cron.update");
     expect(patch?.patch?.payload?.kind).toBe("agentTurn");
     expect(patch?.patch?.delivery?.channel).toBe("telegram");
     expect(patch?.patch?.delivery?.to).toBe("-1001234567890:topic:48");
@@ -641,6 +664,20 @@ describe("cron cli", () => {
       "--thread-id",
       "48",
     ]);
+  });
+
+  it("rejects --thread-id for existing main/systemEvent jobs without explicit conversion", async () => {
+    resetGatewayMock();
+    mockCronEditPagedJobLookup({
+      schedule: { kind: "cron", expr: "0 */2 * * *", tz: "UTC", staggerMs: 300_000 },
+      sessionTarget: "main",
+      payload: { kind: "systemEvent", text: "tick" },
+      delivery: { channel: "telegram", to: "-1001234567890" },
+    });
+    const program = buildProgram();
+    await expect(
+      program.parseAsync(["cron", "edit", "job-1", "--thread-id", "48"], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
   });
 
   it("rejects --thread-id with --no-deliver on cron edit", async () => {

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -74,7 +74,7 @@ type CronUpdatePatch = {
 type CronAddParams = {
   schedule?: { kind?: string; staggerMs?: number };
   payload?: { model?: string; thinking?: string; lightContext?: boolean };
-  delivery?: { mode?: string; accountId?: string };
+  delivery?: { mode?: string; accountId?: string; to?: string };
   deleteAfterRun?: boolean;
   agentId?: string;
   sessionTarget?: string;
@@ -140,9 +140,42 @@ function mockCronEditJobLookup(schedule: unknown): void {
           ok: true,
           params: {},
           jobs: [{ id: "job-1", schedule }],
+          hasMore: false,
+          nextOffset: null,
         };
       }
       return { ok: true, params };
+    },
+  );
+}
+
+function mockCronEditPagedJobLookup(params: {
+  schedule?: unknown;
+  delivery?: { channel?: string; to?: string; mode?: string };
+}): void {
+  callGatewayFromCli.mockImplementation(
+    async (method: string, _opts: unknown, callParams?: unknown) => {
+      if (method === "cron.status") {
+        return { enabled: true };
+      }
+      if (method === "cron.list") {
+        const p = (callParams ?? {}) as { offset?: number };
+        if ((p.offset ?? 0) >= 200) {
+          return {
+            ok: true,
+            jobs: [{ id: "job-1", schedule: params.schedule, delivery: params.delivery }],
+            hasMore: false,
+            nextOffset: null,
+          };
+        }
+        return {
+          ok: true,
+          jobs: [{ id: "other-job", schedule: { kind: "cron", expr: "* * * * *" } }],
+          hasMore: true,
+          nextOffset: 200,
+        };
+      }
+      return { ok: true, params: callParams };
     },
   );
 }
@@ -372,6 +405,45 @@ describe("cron cli", () => {
     ]);
   });
 
+  it("applies --thread-id for telegram cron add delivery target", async () => {
+    const params = await runCronAddAndGetParams([
+      "--name",
+      "telegram-topic",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--channel",
+      "telegram",
+      "--to",
+      "-1001234567890",
+      "--thread-id",
+      "48",
+    ]);
+    expect(params?.delivery?.to).toBe("-1001234567890:topic:48");
+  });
+
+  it("rejects --thread-id without --channel telegram on cron add", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "add",
+      "--name",
+      "invalid-thread-id",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--to",
+      "-1001234567890",
+      "--thread-id",
+      "48",
+    ]);
+  });
+
   it.each([
     { command: "enable" as const, expectedEnabled: true },
     { command: "disable" as const, expectedEnabled: false },
@@ -491,6 +563,63 @@ describe("cron cli", () => {
     expect(patch?.patch?.delivery?.channel).toBe("telegram");
     expect(patch?.patch?.delivery?.to).toBe("19098680");
     expect(patch?.patch?.payload?.message).toBeUndefined();
+  });
+
+  it("applies --thread-id on cron edit with explicit telegram delivery target", async () => {
+    const patch = await runCronEditAndGetPatch([
+      "--channel",
+      "telegram",
+      "--to",
+      "-1001234567890",
+      "--thread-id",
+      "48",
+    ]);
+    expect(patch?.patch?.payload?.kind).toBe("agentTurn");
+    expect(patch?.patch?.delivery?.channel).toBe("telegram");
+    expect(patch?.patch?.delivery?.to).toBe("-1001234567890:topic:48");
+  });
+
+  it("rejects --thread-id with non-telegram channel on cron edit", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "edit",
+      "job-1",
+      "--channel",
+      "discord",
+      "--to",
+      "123",
+      "--thread-id",
+      "48",
+    ]);
+  });
+
+  it("rejects --thread-id when combined with --system-event on cron edit", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "edit",
+      "job-1",
+      "--system-event",
+      "tick",
+      "--thread-id",
+      "48",
+    ]);
+  });
+
+  it("resolves --thread-id existing target from page-2 cron.list lookup on edit", async () => {
+    resetGatewayMock();
+    mockCronEditPagedJobLookup({
+      schedule: { kind: "cron", expr: "0 */2 * * *", tz: "UTC", staggerMs: 300_000 },
+      delivery: { channel: "telegram", to: "-1001234567890" },
+    });
+    const program = buildProgram();
+    await program.parseAsync(["cron", "edit", "job-1", "--thread-id", "48"], { from: "user" });
+
+    const patch = getGatewayCallParams<CronUpdatePatch>("cron.update");
+    expect(patch?.patch?.delivery?.to).toBe("-1001234567890:topic:48");
+    const listCalls = callGatewayFromCli.mock.calls.filter((call) => call[0] === "cron.list");
+    expect(listCalls).toHaveLength(2);
+    expect((listCalls[0][2] as { offset?: number }).offset).toBe(0);
+    expect((listCalls[1][2] as { offset?: number }).offset).toBe(200);
   });
 
   it("supports --no-deliver on cron edit", async () => {
@@ -755,6 +884,27 @@ describe("cron cli", () => {
       tz: "UTC",
       staggerMs: 0,
     });
+  });
+
+  it("resolves --exact schedule from page-2 cron.list lookup on edit", async () => {
+    resetGatewayMock();
+    mockCronEditPagedJobLookup({
+      schedule: { kind: "cron", expr: "0 */2 * * *", tz: "UTC", staggerMs: 300_000 },
+    });
+    const program = buildProgram();
+    await program.parseAsync(["cron", "edit", "job-1", "--exact"], { from: "user" });
+
+    const patch = getGatewayCallParams<CronUpdatePatch>("cron.update");
+    expect(patch?.patch?.schedule).toEqual({
+      kind: "cron",
+      expr: "0 */2 * * *",
+      tz: "UTC",
+      staggerMs: 0,
+    });
+    const listCalls = callGatewayFromCli.mock.calls.filter((call) => call[0] === "cron.list");
+    expect(listCalls).toHaveLength(2);
+    expect((listCalls[0][2] as { offset?: number }).offset).toBe(0);
+    expect((listCalls[1][2] as { offset?: number }).offset).toBe(200);
   });
 
   it("rejects --exact on edit when existing job is not cron", async () => {

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -676,6 +676,8 @@ describe("cron cli", () => {
     expect(listCalls).toHaveLength(2);
     expect((listCalls[0][2] as { offset?: number }).offset).toBe(0);
     expect((listCalls[1][2] as { offset?: number }).offset).toBe(200);
+    expect((listCalls[0][2] as { sortBy?: string }).sortBy).toBe("name");
+    expect((listCalls[0][2] as { sortDir?: string }).sortDir).toBe("asc");
   });
 
   it("rejects --thread-id without --to when existing target is non-telegram", async () => {
@@ -1044,6 +1046,8 @@ describe("cron cli", () => {
     expect(listCalls).toHaveLength(2);
     expect((listCalls[0][2] as { offset?: number }).offset).toBe(0);
     expect((listCalls[1][2] as { offset?: number }).offset).toBe(200);
+    expect((listCalls[0][2] as { sortBy?: string }).sortBy).toBe("name");
+    expect((listCalls[0][2] as { sortDir?: string }).sortDir).toBe("asc");
   });
 
   it("uses a single paged lookup traversal for --exact + --thread-id on edit", async () => {

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -152,7 +152,7 @@ function mockCronEditJobLookup(schedule: unknown): void {
 function mockCronEditPagedJobLookup(params: {
   schedule?: unknown;
   delivery?: { channel?: string; to?: string; mode?: string };
-  sessionTarget?: "main" | "isolated";
+  sessionTarget?: string;
   payload?: { kind?: "systemEvent" | "agentTurn"; text?: string; message?: string };
 }): void {
   callGatewayFromCli.mockImplementation(
@@ -692,6 +692,34 @@ describe("cron cli", () => {
     await expect(
       program.parseAsync(["cron", "edit", "job-1", "--thread-id", "48"], { from: "user" }),
     ).rejects.toThrow("__exit__:1");
+  });
+
+  it("allows --thread-id for existing current agentTurn jobs", async () => {
+    resetGatewayMock();
+    mockCronEditPagedJobLookup({
+      schedule: { kind: "cron", expr: "0 */2 * * *", tz: "UTC", staggerMs: 300_000 },
+      sessionTarget: "current",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: { channel: "telegram", to: "-1001234567890" },
+    });
+    const program = buildProgram();
+    await program.parseAsync(["cron", "edit", "job-1", "--thread-id", "48"], { from: "user" });
+    const patch = getGatewayCallParams<CronUpdatePatch>("cron.update");
+    expect(patch?.patch?.delivery?.to).toBe("-1001234567890:topic:48");
+  });
+
+  it("allows --thread-id for existing session:<id> agentTurn jobs", async () => {
+    resetGatewayMock();
+    mockCronEditPagedJobLookup({
+      schedule: { kind: "cron", expr: "0 */2 * * *", tz: "UTC", staggerMs: 300_000 },
+      sessionTarget: "session:project-alpha-monitor",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: { channel: "telegram", to: "-1001234567890" },
+    });
+    const program = buildProgram();
+    await program.parseAsync(["cron", "edit", "job-1", "--thread-id", "48"], { from: "user" });
+    const patch = getGatewayCallParams<CronUpdatePatch>("cron.update");
+    expect(patch?.patch?.delivery?.to).toBe("-1001234567890:topic:48");
   });
 
   it("rejects --thread-id with --no-deliver on cron edit", async () => {

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -444,6 +444,27 @@ describe("cron cli", () => {
     ]);
   });
 
+  it("rejects empty --thread-id on cron add", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "add",
+      "--name",
+      "invalid-empty-thread-id",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--channel",
+      "telegram",
+      "--to",
+      "-1001234567890",
+      "--thread-id",
+      "   ",
+    ]);
+  });
+
   it("rejects --thread-id on systemEvent cron add jobs", async () => {
     await expectCronCommandExit([
       "cron",
@@ -626,6 +647,20 @@ describe("cron cli", () => {
     await expectCronCommandExit(["cron", "edit", "job-1", "--no-deliver", "--thread-id", "48"]);
   });
 
+  it("rejects empty --thread-id on cron edit", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "edit",
+      "job-1",
+      "--channel",
+      "telegram",
+      "--to",
+      "-1001234567890",
+      "--thread-id",
+      "   ",
+    ]);
+  });
+
   it("resolves --thread-id existing target from page-2 cron.list lookup on edit", async () => {
     resetGatewayMock();
     mockCronEditPagedJobLookup({
@@ -709,6 +744,21 @@ describe("cron cli", () => {
     const patch = getGatewayCallParams<CronUpdatePatch>("cron.update");
     expect(patch?.patch?.delivery?.mode).toBe("announce");
     expect(patch?.patch?.delivery?.to).toBe("-1001234567890:topic:48");
+  });
+
+  it("rejects --thread-id when re-targeting webhook job with --announce but without --to", async () => {
+    resetGatewayMock();
+    mockCronEditPagedJobLookup({
+      schedule: { kind: "cron", expr: "0 */2 * * *", tz: "UTC", staggerMs: 300_000 },
+      delivery: { mode: "webhook", channel: "telegram", to: "https://example.com/hook" },
+    });
+    const program = buildProgram();
+    await expect(
+      program.parseAsync(
+        ["cron", "edit", "job-1", "--announce", "--channel", "telegram", "--thread-id", "48"],
+        { from: "user" },
+      ),
+    ).rejects.toThrow("__exit__:1");
   });
 
   it("supports --no-deliver on cron edit", async () => {

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -654,6 +654,20 @@ describe("cron cli", () => {
     ]);
   });
 
+  it("rejects --thread-id with blank --channel on cron edit", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "edit",
+      "job-1",
+      "--channel",
+      "   ",
+      "--to",
+      "-1001234567890",
+      "--thread-id",
+      "48",
+    ]);
+  });
+
   it("rejects --thread-id when combined with --system-event on cron edit", async () => {
     await expectCronCommandExit([
       "cron",
@@ -695,6 +709,20 @@ describe("cron cli", () => {
       "-1001234567890",
       "--thread-id",
       "   ",
+    ]);
+  });
+
+  it("rejects --thread-id with blank --to on cron edit", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "edit",
+      "job-1",
+      "--channel",
+      "telegram",
+      "--to",
+      "   ",
+      "--thread-id",
+      "48",
     ]);
   });
 

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -444,6 +444,23 @@ describe("cron cli", () => {
     ]);
   });
 
+  it("rejects --thread-id on systemEvent cron add jobs", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "add",
+      "--name",
+      "invalid-system-event-thread-id",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "main",
+      "--system-event",
+      "tick",
+      "--thread-id",
+      "48",
+    ]);
+  });
+
   it.each([
     { command: "enable" as const, expectedEnabled: true },
     { command: "disable" as const, expectedEnabled: false },
@@ -620,6 +637,20 @@ describe("cron cli", () => {
     expect(listCalls).toHaveLength(2);
     expect((listCalls[0][2] as { offset?: number }).offset).toBe(0);
     expect((listCalls[1][2] as { offset?: number }).offset).toBe(200);
+  });
+
+  it("rejects --thread-id without --to when existing target is non-telegram", async () => {
+    resetGatewayMock();
+    mockCronEditPagedJobLookup({
+      schedule: { kind: "cron", expr: "0 */2 * * *", tz: "UTC", staggerMs: 300_000 },
+      delivery: { channel: "discord", to: "123" },
+    });
+    const program = buildProgram();
+    await expect(
+      program.parseAsync(["cron", "edit", "job-1", "--channel", "telegram", "--thread-id", "48"], {
+        from: "user",
+      }),
+    ).rejects.toThrow("__exit__:1");
   });
 
   it("supports --no-deliver on cron edit", async () => {
@@ -901,6 +932,31 @@ describe("cron cli", () => {
       tz: "UTC",
       staggerMs: 0,
     });
+    const listCalls = callGatewayFromCli.mock.calls.filter((call) => call[0] === "cron.list");
+    expect(listCalls).toHaveLength(2);
+    expect((listCalls[0][2] as { offset?: number }).offset).toBe(0);
+    expect((listCalls[1][2] as { offset?: number }).offset).toBe(200);
+  });
+
+  it("uses a single paged lookup traversal for --exact + --thread-id on edit", async () => {
+    resetGatewayMock();
+    mockCronEditPagedJobLookup({
+      schedule: { kind: "cron", expr: "0 */2 * * *", tz: "UTC", staggerMs: 300_000 },
+      delivery: { channel: "telegram", to: "-1001234567890" },
+    });
+    const program = buildProgram();
+    await program.parseAsync(["cron", "edit", "job-1", "--exact", "--thread-id", "48"], {
+      from: "user",
+    });
+
+    const patch = getGatewayCallParams<CronUpdatePatch>("cron.update");
+    expect(patch?.patch?.schedule).toEqual({
+      kind: "cron",
+      expr: "0 */2 * * *",
+      tz: "UTC",
+      staggerMs: 0,
+    });
+    expect(patch?.patch?.delivery?.to).toBe("-1001234567890:topic:48");
     const listCalls = callGatewayFromCli.mock.calls.filter((call) => call[0] === "cron.list");
     expect(listCalls).toHaveLength(2);
     expect((listCalls[0][2] as { offset?: number }).offset).toBe(0);

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -622,6 +622,10 @@ describe("cron cli", () => {
     ]);
   });
 
+  it("rejects --thread-id with --no-deliver on cron edit", async () => {
+    await expectCronCommandExit(["cron", "edit", "job-1", "--no-deliver", "--thread-id", "48"]);
+  });
+
   it("resolves --thread-id existing target from page-2 cron.list lookup on edit", async () => {
     resetGatewayMock();
     mockCronEditPagedJobLookup({
@@ -651,6 +655,60 @@ describe("cron cli", () => {
         from: "user",
       }),
     ).rejects.toThrow("__exit__:1");
+  });
+
+  it("rejects --thread-id for existing webhook jobs unless --announce is set", async () => {
+    resetGatewayMock();
+    mockCronEditPagedJobLookup({
+      schedule: { kind: "cron", expr: "0 */2 * * *", tz: "UTC", staggerMs: 300_000 },
+      delivery: { mode: "webhook", channel: "telegram", to: "https://example.com/hook" },
+    });
+    const program = buildProgram();
+    await expect(
+      program.parseAsync(
+        [
+          "cron",
+          "edit",
+          "job-1",
+          "--channel",
+          "telegram",
+          "--to",
+          "-1001234567890",
+          "--thread-id",
+          "48",
+        ],
+        {
+          from: "user",
+        },
+      ),
+    ).rejects.toThrow("__exit__:1");
+  });
+
+  it("allows --thread-id for existing webhook jobs when --announce is set", async () => {
+    resetGatewayMock();
+    mockCronEditPagedJobLookup({
+      schedule: { kind: "cron", expr: "0 */2 * * *", tz: "UTC", staggerMs: 300_000 },
+      delivery: { mode: "webhook", channel: "telegram", to: "https://example.com/hook" },
+    });
+    const program = buildProgram();
+    await program.parseAsync(
+      [
+        "cron",
+        "edit",
+        "job-1",
+        "--announce",
+        "--channel",
+        "telegram",
+        "--to",
+        "-1001234567890",
+        "--thread-id",
+        "48",
+      ],
+      { from: "user" },
+    );
+    const patch = getGatewayCallParams<CronUpdatePatch>("cron.update");
+    expect(patch?.patch?.delivery?.mode).toBe("announce");
+    expect(patch?.patch?.delivery?.to).toBe("-1001234567890:topic:48");
   });
 
   it("supports --no-deliver on cron edit", async () => {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -217,7 +217,11 @@ export function registerCronAddCommand(cron: Command) {
                   : "announce"
               : undefined;
 
-          const threadIdRaw = typeof opts.threadId === "string" ? opts.threadId.trim() : "";
+          const hasThreadIdOption = typeof opts.threadId === "string";
+          const threadIdRaw = hasThreadIdOption ? String(opts.threadId).trim() : "";
+          if (hasThreadIdOption && !threadIdRaw) {
+            throw new Error("--thread-id must be a non-empty numeric value");
+          }
           if (threadIdRaw && (!isIsolatedLikeSessionTarget || payload.kind !== "agentTurn")) {
             throw new Error("--thread-id is only supported for non-main agentTurn jobs");
           }

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -217,6 +217,11 @@ export function registerCronAddCommand(cron: Command) {
                   : "announce"
               : undefined;
 
+          const threadIdRaw = typeof opts.threadId === "string" ? opts.threadId.trim() : "";
+          if (threadIdRaw && (!isIsolatedLikeSessionTarget || payload.kind !== "agentTurn")) {
+            throw new Error("--thread-id is only supported for non-main agentTurn jobs");
+          }
+
           const nameRaw = typeof opts.name === "string" ? opts.name : "";
           const name = nameRaw.trim();
           if (!name) {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -98,6 +98,7 @@ export function registerCronAddCommand(cron: Command) {
         "--to <dest>",
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
       )
+      .option("--thread-id <id>", "Thread id (Telegram forum topic, must be a number)")
       .option("--account <id>", "Channel account id for delivery (multi-account setups)")
       .option("--best-effort-deliver", "Do not fail the job if delivery fails", false)
       .option("--json", "Output JSON", false)
@@ -250,7 +251,26 @@ export function registerCronAddCommand(cron: Command) {
                     typeof opts.channel === "string" && opts.channel.trim()
                       ? opts.channel.trim()
                       : undefined,
-                  to: typeof opts.to === "string" && opts.to.trim() ? opts.to.trim() : undefined,
+                  to: (() => {
+                    const toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
+                    const threadId = typeof opts.threadId === "string" ? opts.threadId.trim() : "";
+                    if (threadId && !/^\d+$/.test(threadId)) {
+                      throw new Error("--thread-id must be a numeric value");
+                    }
+                    const channel =
+                      typeof opts.channel === "string" ? opts.channel.trim().toLowerCase() : "";
+                    if (threadId && channel !== "telegram") {
+                      throw new Error("--thread-id requires --channel telegram");
+                    }
+                    const to = threadId ? toRaw.replace(/:(?:topic:)?\d+$/, "") : toRaw;
+                    if (to && threadId) {
+                      return `${to}:topic:${threadId}`;
+                    }
+                    if (threadId && !to) {
+                      throw new Error("--thread-id requires --to");
+                    }
+                    return to || undefined;
+                  })(),
                   accountId,
                   bestEffort: opts.bestEffortDeliver ? true : undefined,
                 }

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -230,14 +230,34 @@ export function registerCronEditCommand(cron: Command) {
           const hasDeliveryAccount = typeof opts.account === "string";
           const hasThreadId = typeof opts.threadId === "string";
           const hasBestEffort = typeof opts.bestEffortDeliver === "boolean";
-          const hasAgentTurnPatch =
+          const hasExplicitAgentTurnPayloadPatch =
             typeof opts.message === "string" ||
             Boolean(model) ||
             Boolean(thinking) ||
             hasTimeoutSeconds ||
             typeof opts.lightContext === "boolean" ||
             typeof opts.tools === "string" ||
-            opts.clearTools ||
+            opts.clearTools;
+          if (hasThreadId) {
+            const existing = await getExistingJob();
+            if (!existing) {
+              throw new Error(`Cron job ${id} not found`);
+            }
+            const effectiveSessionTarget =
+              typeof opts.session === "string" ? opts.session : existing.sessionTarget;
+            const existingPayloadKind =
+              (existing.payload as { kind?: string } | undefined)?.kind ?? undefined;
+            const effectivePayloadKind = hasSystemEventPatch
+              ? "systemEvent"
+              : hasExplicitAgentTurnPayloadPatch
+                ? "agentTurn"
+                : existingPayloadKind;
+            if (effectiveSessionTarget !== "isolated" || effectivePayloadKind !== "agentTurn") {
+              throw new Error("--thread-id is only supported for non-main agentTurn jobs");
+            }
+          }
+          const hasAgentTurnPatch =
+            hasExplicitAgentTurnPayloadPatch ||
             hasDeliveryModeFlag ||
             hasDeliveryTarget ||
             hasDeliveryAccount ||

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -61,6 +61,16 @@ async function findCronJobById(params: {
   return undefined;
 }
 
+function isIsolatedLikeSessionTarget(target: string | undefined): boolean {
+  if (typeof target !== "string") {
+    return false;
+  }
+  if (target === "isolated" || target === "current") {
+    return true;
+  }
+  return target.toLowerCase().startsWith("session:") && target.slice(8).trim().length > 0;
+}
+
 export function registerCronEditCommand(cron: Command) {
   addGatewayClientOptions(
     cron
@@ -258,7 +268,10 @@ export function registerCronEditCommand(cron: Command) {
               : hasExplicitAgentTurnPayloadPatch
                 ? "agentTurn"
                 : existingPayloadKind;
-            if (effectiveSessionTarget !== "isolated" || effectivePayloadKind !== "agentTurn") {
+            if (
+              !isIsolatedLikeSessionTarget(effectiveSessionTarget) ||
+              effectivePayloadKind !== "agentTurn"
+            ) {
               throw new Error("--thread-id is only supported for non-main agentTurn jobs");
             }
           }

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -123,6 +123,14 @@ export function registerCronEditCommand(cron: Command) {
       )
       .action(async (id, opts) => {
         try {
+          let cachedExistingJob: CronJob | null | undefined;
+          const getExistingJob = async (): Promise<CronJob | undefined> => {
+            if (cachedExistingJob !== undefined) {
+              return cachedExistingJob ?? undefined;
+            }
+            cachedExistingJob = (await findCronJobById({ id, opts })) ?? null;
+            return cachedExistingJob ?? undefined;
+          };
           if (opts.session === "main" && opts.message) {
             throw new Error(
               "Main jobs cannot use --message; use --system-event or --session isolated.",
@@ -197,7 +205,7 @@ export function registerCronEditCommand(cron: Command) {
           if (scheduleRequest.kind === "direct") {
             patch.schedule = scheduleRequest.schedule;
           } else if (scheduleRequest.kind === "patch-existing-cron") {
-            const existing = await findCronJobById({ id, opts });
+            const existing = await getExistingJob();
             if (!existing) {
               throw new Error(`unknown cron job id: ${id}`);
             }
@@ -294,7 +302,7 @@ export function registerCronEditCommand(cron: Command) {
               }
               let toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
               if (threadId && (!toRaw || typeof opts.channel !== "string")) {
-                const existing = await findCronJobById({ id, opts });
+                const existing = await getExistingJob();
                 if (!existing) {
                   throw new Error(`Cron job ${id} not found`);
                 }
@@ -311,6 +319,11 @@ export function registerCronEditCommand(cron: Command) {
                   }
                 }
                 if (!toRaw) {
+                  if (existingChannel.toLowerCase() !== "telegram") {
+                    throw new Error(
+                      "--thread-id requires --to when existing target is not Telegram",
+                    );
+                  }
                   toRaw = (existing.delivery as Record<string, string> | undefined)?.to ?? "";
                 }
               }

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -292,6 +292,9 @@ export function registerCronEditCommand(cron: Command) {
             }
             if (typeof opts.to === "string" || hasThreadId) {
               const threadId = typeof opts.threadId === "string" ? opts.threadId.trim() : "";
+              if (hasThreadId && !threadId) {
+                throw new Error("--thread-id must be a non-empty numeric value");
+              }
               if (threadId && !/^\d+$/.test(threadId)) {
                 throw new Error("--thread-id must be a numeric value");
               }
@@ -332,6 +335,11 @@ export function registerCronEditCommand(cron: Command) {
                   }
                 }
                 if (!toRaw) {
+                  if (existingMode === "webhook") {
+                    throw new Error(
+                      "--thread-id requires --to when re-targeting from webhook delivery",
+                    );
+                  }
                   if (existingChannel.toLowerCase() !== "telegram") {
                     throw new Error(
                       "--thread-id requires --to when existing target is not Telegram",

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -21,6 +21,44 @@ const assignIf = (
   }
 };
 
+async function findCronJobById(params: {
+  id: string;
+  opts: Record<string, unknown>;
+}): Promise<CronJob | undefined> {
+  const pageSize = 200;
+  let offset = 0;
+  const visitedOffsets = new Set<number>();
+  while (!visitedOffsets.has(offset)) {
+    visitedOffsets.add(offset);
+    const listed = (await callGatewayFromCli("cron.list", params.opts, {
+      includeDisabled: true,
+      limit: pageSize,
+      offset,
+    })) as {
+      jobs?: CronJob[];
+      hasMore?: boolean;
+      nextOffset?: number | null;
+    } | null;
+    const jobs = listed?.jobs ?? [];
+    const found = jobs.find((job) => job.id === params.id);
+    if (found) {
+      return found;
+    }
+    if (listed?.hasMore !== true) {
+      return undefined;
+    }
+    const candidate =
+      typeof listed.nextOffset === "number" && Number.isFinite(listed.nextOffset)
+        ? listed.nextOffset
+        : offset + jobs.length;
+    if (!Number.isFinite(candidate) || candidate <= offset) {
+      return undefined;
+    }
+    offset = candidate;
+  }
+  return undefined;
+}
+
 export function registerCronEditCommand(cron: Command) {
   addGatewayClientOptions(
     cron
@@ -65,6 +103,7 @@ export function registerCronEditCommand(cron: Command) {
         "--to <dest>",
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
       )
+      .option("--thread-id <id>", "Thread id (Telegram forum topic, must be a number)")
       .option("--account <id>", "Channel account id for delivery (multi-account setups)")
       .option("--best-effort-deliver", "Do not fail job if delivery fails")
       .option("--no-best-effort-deliver", "Fail job when delivery fails")
@@ -158,10 +197,7 @@ export function registerCronEditCommand(cron: Command) {
           if (scheduleRequest.kind === "direct") {
             patch.schedule = scheduleRequest.schedule;
           } else if (scheduleRequest.kind === "patch-existing-cron") {
-            const listed = (await callGatewayFromCli("cron.list", opts, {
-              includeDisabled: true,
-            })) as { jobs?: CronJob[] } | null;
-            const existing = (listed?.jobs ?? []).find((job) => job.id === id);
+            const existing = await findCronJobById({ id, opts });
             if (!existing) {
               throw new Error(`unknown cron job id: ${id}`);
             }
@@ -182,6 +218,7 @@ export function registerCronEditCommand(cron: Command) {
           const hasDeliveryModeFlag = opts.announce || typeof opts.deliver === "boolean";
           const hasDeliveryTarget = typeof opts.channel === "string" || typeof opts.to === "string";
           const hasDeliveryAccount = typeof opts.account === "string";
+          const hasThreadId = typeof opts.threadId === "string";
           const hasBestEffort = typeof opts.bestEffortDeliver === "boolean";
           const hasAgentTurnPatch =
             typeof opts.message === "string" ||
@@ -194,6 +231,7 @@ export function registerCronEditCommand(cron: Command) {
             hasDeliveryModeFlag ||
             hasDeliveryTarget ||
             hasDeliveryAccount ||
+            hasThreadId ||
             hasBestEffort;
           if (hasSystemEventPatch && hasAgentTurnPatch) {
             throw new Error("Choose at most one payload change");
@@ -226,7 +264,13 @@ export function registerCronEditCommand(cron: Command) {
             patch.payload = payload;
           }
 
-          if (hasDeliveryModeFlag || hasDeliveryTarget || hasDeliveryAccount || hasBestEffort) {
+          if (
+            hasDeliveryModeFlag ||
+            hasDeliveryTarget ||
+            hasDeliveryAccount ||
+            hasThreadId ||
+            hasBestEffort
+          ) {
             const delivery: Record<string, unknown> = {};
             if (hasDeliveryModeFlag) {
               delivery.mode = opts.announce || opts.deliver === true ? "announce" : "none";
@@ -238,9 +282,50 @@ export function registerCronEditCommand(cron: Command) {
               const channel = opts.channel.trim();
               delivery.channel = channel ? channel : undefined;
             }
-            if (typeof opts.to === "string") {
-              const to = opts.to.trim();
-              delivery.to = to ? to : undefined;
+            if (typeof opts.to === "string" || hasThreadId) {
+              const threadId = typeof opts.threadId === "string" ? opts.threadId.trim() : "";
+              if (threadId && !/^\d+$/.test(threadId)) {
+                throw new Error("--thread-id must be a numeric value");
+              }
+              const explicitChannel =
+                typeof opts.channel === "string" ? opts.channel.trim().toLowerCase() : "";
+              if (threadId && explicitChannel && explicitChannel !== "telegram") {
+                throw new Error("--thread-id requires --channel telegram");
+              }
+              let toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
+              if (threadId && (!toRaw || typeof opts.channel !== "string")) {
+                const existing = await findCronJobById({ id, opts });
+                if (!existing) {
+                  throw new Error(`Cron job ${id} not found`);
+                }
+                const existingChannel =
+                  (existing.delivery as Record<string, string> | undefined)?.channel ?? "";
+                const existingMode =
+                  (existing.delivery as Record<string, string> | undefined)?.mode ?? "";
+                if (typeof opts.channel !== "string") {
+                  if (existingMode === "webhook") {
+                    throw new Error("--thread-id is not supported for webhook delivery jobs");
+                  }
+                  if (existingChannel.toLowerCase() !== "telegram") {
+                    throw new Error("--thread-id requires --channel telegram");
+                  }
+                }
+                if (!toRaw) {
+                  toRaw = (existing.delivery as Record<string, string> | undefined)?.to ?? "";
+                }
+              }
+              const to = threadId ? toRaw.replace(/:(?:topic:)?\d+$/, "") : toRaw;
+              if (to && threadId) {
+                delivery.to = `${to}:topic:${threadId}`;
+              } else if (to) {
+                delivery.to = to;
+              } else if (threadId) {
+                throw new Error(
+                  "--thread-id requires a delivery target (use --to or ensure the job has one)",
+                );
+              } else if (typeof opts.to === "string") {
+                delivery.to = undefined;
+              }
             }
             if (typeof opts.account === "string") {
               const account = opts.account.trim();

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -34,6 +34,8 @@ async function findCronJobById(params: {
       includeDisabled: true,
       limit: pageSize,
       offset,
+      sortBy: "name",
+      sortDir: "asc",
     })) as {
       jobs?: CronJob[];
       hasMore?: boolean;

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -226,9 +226,15 @@ export function registerCronEditCommand(cron: Command) {
             : undefined;
           const hasTimeoutSeconds = Boolean(timeoutSeconds && Number.isFinite(timeoutSeconds));
           const hasDeliveryModeFlag = opts.announce || typeof opts.deliver === "boolean";
-          const hasDeliveryTarget = typeof opts.channel === "string" || typeof opts.to === "string";
+          const explicitChannelRaw =
+            typeof opts.channel === "string" ? opts.channel.trim() : undefined;
+          const explicitToRaw = typeof opts.to === "string" ? opts.to.trim() : undefined;
+          const explicitThreadIdRaw =
+            typeof opts.threadId === "string" ? opts.threadId.trim() : undefined;
+          const hasDeliveryTarget =
+            typeof explicitChannelRaw === "string" || typeof explicitToRaw === "string";
           const hasDeliveryAccount = typeof opts.account === "string";
-          const hasThreadId = typeof opts.threadId === "string";
+          const hasThreadId = typeof explicitThreadIdRaw === "string";
           const hasBestEffort = typeof opts.bestEffortDeliver === "boolean";
           const hasExplicitAgentTurnPayloadPatch =
             typeof opts.message === "string" ||
@@ -308,12 +314,11 @@ export function registerCronEditCommand(cron: Command) {
               // Back-compat: toggling best-effort alone has historically implied announce mode.
               delivery.mode = "announce";
             }
-            if (typeof opts.channel === "string") {
-              const channel = opts.channel.trim();
-              delivery.channel = channel ? channel : undefined;
+            if (typeof explicitChannelRaw === "string") {
+              delivery.channel = explicitChannelRaw || undefined;
             }
-            if (typeof opts.to === "string" || hasThreadId) {
-              const threadId = typeof opts.threadId === "string" ? opts.threadId.trim() : "";
+            if (typeof explicitToRaw === "string" || hasThreadId) {
+              const threadId = explicitThreadIdRaw ?? "";
               if (hasThreadId && !threadId) {
                 throw new Error("--thread-id must be a non-empty numeric value");
               }
@@ -324,7 +329,7 @@ export function registerCronEditCommand(cron: Command) {
                 throw new Error("--thread-id is not supported with --no-deliver");
               }
               const explicitChannel =
-                typeof opts.channel === "string" ? opts.channel.trim().toLowerCase() : "";
+                typeof explicitChannelRaw === "string" ? explicitChannelRaw.toLowerCase() : "";
               if (threadId && explicitChannel && explicitChannel !== "telegram") {
                 throw new Error("--thread-id requires --channel telegram");
               }
@@ -338,8 +343,8 @@ export function registerCronEditCommand(cron: Command) {
                   );
                 }
               }
-              let toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
-              if (threadId && (!toRaw || typeof opts.channel !== "string")) {
+              let toRaw = explicitToRaw ?? "";
+              if (threadId && (!toRaw || typeof explicitChannelRaw !== "string" || !explicitChannelRaw)) {
                 const existing = await getExistingJob();
                 if (!existing) {
                   throw new Error(`Cron job ${id} not found`);
@@ -348,7 +353,7 @@ export function registerCronEditCommand(cron: Command) {
                   (existing.delivery as Record<string, string> | undefined)?.channel ?? "";
                 const existingMode =
                   (existing.delivery as Record<string, string> | undefined)?.mode ?? "";
-                if (typeof opts.channel !== "string") {
+                if (typeof explicitChannelRaw !== "string" || !explicitChannelRaw) {
                   if (existingMode === "webhook") {
                     throw new Error("--thread-id is not supported for webhook delivery jobs");
                   }
@@ -379,7 +384,7 @@ export function registerCronEditCommand(cron: Command) {
                 throw new Error(
                   "--thread-id requires a delivery target (use --to or ensure the job has one)",
                 );
-              } else if (typeof opts.to === "string") {
+              } else if (typeof explicitToRaw === "string") {
                 delivery.to = undefined;
               }
             }

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -295,10 +295,23 @@ export function registerCronEditCommand(cron: Command) {
               if (threadId && !/^\d+$/.test(threadId)) {
                 throw new Error("--thread-id must be a numeric value");
               }
+              if (threadId && opts.deliver === false) {
+                throw new Error("--thread-id is not supported with --no-deliver");
+              }
               const explicitChannel =
                 typeof opts.channel === "string" ? opts.channel.trim().toLowerCase() : "";
               if (threadId && explicitChannel && explicitChannel !== "telegram") {
                 throw new Error("--thread-id requires --channel telegram");
+              }
+              if (threadId && !opts.announce && typeof opts.deliver !== "boolean") {
+                const existing = await getExistingJob();
+                const existingMode =
+                  (existing?.delivery as Record<string, string> | undefined)?.mode ?? "";
+                if (existingMode === "webhook") {
+                  throw new Error(
+                    "--thread-id is not supported for webhook delivery jobs unless --announce is set",
+                  );
+                }
               }
               let toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
               if (threadId && (!toRaw || typeof opts.channel !== "string")) {


### PR DESCRIPTION
## Summary

  Describe the problem and fix in 2–5 bullets:

  - Problem: `cron edit` only checked the first `cron.list` page when it needed existing job state (for example `--thread-id` without `--to`, or
  `--exact`).
  - Why it matters: on installs with more than 200 jobs, the target job may be on a later page, causing valid commands to fail.
  - What changed:
    - Added `--thread-id <id>` support to both `cron add` and `cron edit` (Telegram topic target composition).
    - Added `--thread-id` guardrails (numeric validation, Telegram-channel enforcement, and payload conflict validation).
    - Added paged lookup in `cron edit` using `offset/hasMore/nextOffset` until match or exhaustion.
    - Added regression tests for page-2 lookup cases for both `--thread-id` and `--exact`.
  - What did NOT change (scope boundary):
    - No gateway protocol/schema changes.
    - No unrelated refactor outside cron CLI behavior.

  ## Change Type (select all)

  - [x] Bug fix
  - [x] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #50982
  - Related #51581
  - [x] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)

  - Root cause: `cron edit` assumed first-page presence when resolving existing jobs from `cron.list`.
  - Missing detection / guardrail: no regression tests for page-2+ lookup in edit-time existing-job resolution.
  - Prior context (`git blame`, prior PR, issue, or refactor if known): follow-up from maintainer feedback on #51581.
  - Why this regressed now: thread-id and exact-edit flows rely on existing-job lookup, exposing the first-page-only assumption.
  - If unknown, what was ruled out: N/A.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
    - [ ] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `src/cli/cron-cli.test.ts`
  - Scenario the test should lock in:
    - `cron edit --thread-id` succeeds when the target job is found on page 2.
    - `cron edit --exact` succeeds when the target job is found on page 2.
  - Why this is the smallest reliable guardrail: the bug is in CLI paging/lookup control flow; unit tests are the smallest reliable lock.
  - Existing test that already covers this (if any): none prior to this PR.
  - If no new test is added, why not: N/A (new tests added).

  ## User-visible / Behavior Changes

  - `cron add` and `cron edit` now support `--thread-id <id>` for Telegram forum topic delivery targets.
  - `cron edit --thread-id` and `cron edit --exact` no longer fail incorrectly when the target job is not on the first `cron.list` page.
  - Invalid `--thread-id` combinations now fail with explicit CLI errors.

  ## Diagram (if applicable)

  ```text
  Before:
  cron edit --thread-id/--exact
    -> cron.list(offset=0 only)
    -> job not found (if job is on page 2+)

  After:
  cron edit --thread-id/--exact
    -> cron.list(offset=0)
    -> hasMore ? nextOffset
    -> cron.list(offset=nextOffset) ... until found/exhausted
    -> apply patch

  ## Security Impact (required)

  - New permissions/capabilities? (No)
  - Secrets/tokens handling changed? (No)
  - New/changed network calls? (No) (same gateway RPC surface; only paged iteration of existing cron.list)
  - Command/tool execution surface changed? (No)
  - Data access scope changed? (No)
  - If any Yes, explain risk + mitigation: N/A

  ## Repro + Verification

  ### Environment

  - OS: macOS (local dev machine)
  - Runtime/container: Node 22+, pnpm
  - Model/provider: N/A
  - Integration/channel (if any): Telegram delivery target formatting path
  - Relevant config (redacted): N/A

  ### Steps

  1. Ensure the target cron job is not on the first cron.list page (>200 jobs total).
  2. Run cron edit <id> --exact and/or cron edit <id> --thread-id <n>.
  3. Verify the CLI finds the target job and applies the update.

  ### Expected

  - Commands should succeed even when the target job is on page 2+.

  ### Actual

  - With this PR, behavior matches expected; page-2 regression tests pass.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [x] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios:
      - pnpm --dir /Users/chchen/Andy_Folder/Project/ai_tool/openclaw exec vitest src/cli/cron-cli.test.ts
      - Result: Test Files 1 passed, Tests 49 passed
  - Edge cases checked:
      - numeric thread-id validation
      - thread-id requires Telegram channel
      - --system-event + --thread-id conflict
      - page-2 lookup behavior for both --thread-id and --exact
  - What you did not verify:
      - full large-scale end-to-end run on a live instance with >200 real jobs (covered here via deterministic unit tests)

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for
  maintainers.

  ## Compatibility / Migration

  - Backward compatible? (Yes)
  - Config/env changes? (No)
  - Migration needed? (No)
  - If yes, exact upgrade steps: N/A

  ## Risks and Mitigations

  - Risk:
      - Additional cron.list calls for large job sets during edit-time lookup.
      - Mitigation:
      - Early-exit on match, bounded forward progress via nextOffset fallback, and loop protection with visited offsets.
  - Risk:
      - New thread-id validation may surface errors earlier for previously ambiguous CLI input.
      - Mitigation:
      - Added explicit tests for accepted and rejected combinations to lock expected behavior.