### PR TITLE
fix(feishu): parse interactive card post-format fallback content

### DIFF
--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -257,6 +257,122 @@ describe("getMessageFeishu", () => {
     );
   });
 
+  it("extracts text from interactive cards with top-level nested post-format fallback elements", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_card_fallback",
+            chat_id: "oc_card_fallback",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                title: "🤖 clawdbot",
+                elements: [
+                  [
+                    { tag: "img", image_key: "img_v3_example" },
+                    { tag: "text", text: "Daily report summary" },
+                    { tag: "text", text: "13 people missing reports" },
+                  ],
+                ],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_card_fallback",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_card_fallback",
+        chatId: "oc_card_fallback",
+        contentType: "interactive",
+        content: "🤖 clawdbot\nDaily report summary\n13 people missing reports",
+      }),
+    );
+  });
+
+  it("extracts header.title.content from interactive card templates", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_card_header",
+            chat_id: "oc_card_header",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                header: { title: { content: "Card Title" } },
+                elements: [{ tag: "markdown", content: "body text" }],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_card_header",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_card_header",
+        chatId: "oc_card_header",
+        contentType: "interactive",
+        content: "Card Title\nbody text",
+      }),
+    );
+  });
+
+  it("trims post-format text fallback nodes before joining anchor text", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_card_links",
+            chat_id: "oc_card_links",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                title: "Report",
+                elements: [
+                  [
+                    { tag: "text", text: "See: " },
+                    { tag: "a", text: "Weekly Report", href: "https://example.com/report" },
+                  ],
+                ],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_card_links",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_card_links",
+        chatId: "oc_card_links",
+        contentType: "interactive",
+        content: "Report\nSee:\nWeekly Report (https://example.com/report)",
+      }),
+    );
+  });
+
   it("extracts text content from post messages", async () => {
     mockClientGet.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -225,6 +225,9 @@ function extractInteractiveElementText(
   element: unknown,
   variables: Map<string, string>,
 ): string | undefined {
+  if (Array.isArray(element)) {
+    return extractInteractiveElementsText(element, variables) || undefined;
+  }
   if (!isRecord(element)) {
     return undefined;
   }
@@ -240,6 +243,18 @@ function extractInteractiveElementText(
   if (tag === "plain_text" && typeof element.content === "string") {
     return applyCardTemplateVariables(element.content, variables);
   }
+  if (tag === "text" && typeof element.text === "string") {
+    const renderedText = applyCardTemplateVariables(element.text, variables).trim();
+    return renderedText || undefined;
+  }
+  if (tag === "a" && typeof element.text === "string") {
+    const label = applyCardTemplateVariables(element.text, variables).trim();
+    if (!label) {
+      return undefined;
+    }
+    const href = typeof element.href === "string" ? element.href.trim() : "";
+    return href ? `${label} (${href})` : label;
+  }
   return undefined;
 }
 
@@ -250,11 +265,33 @@ function extractInteractiveElementsText(
   const texts: string[] = [];
   for (const element of elements) {
     const text = extractInteractiveElementText(element, variables);
-    if (text !== undefined) {
+    if (text) {
       texts.push(text);
     }
   }
   return texts.join("\n").trim();
+}
+
+function readInteractiveTitleTexts(
+  parsed: Record<string, unknown>,
+  variables: Map<string, string>,
+): string[] {
+  const header = isRecord(parsed.header) ? parsed.header : undefined;
+  const headerTitle = isRecord(header?.title) ? header.title : undefined;
+  const candidates = [headerTitle?.content, parsed.title];
+
+  const titles: string[] = [];
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const title = applyCardTemplateVariables(candidate, variables).trim();
+    if (title) {
+      titles.push(title);
+      break;
+    }
+  }
+  return titles;
 }
 
 function readInteractiveElementArrays(parsed: Record<string, unknown>): unknown[][] {
@@ -292,14 +329,17 @@ function parseInteractiveCardContent(parsed: unknown): string {
   }
 
   const variables = readCardTemplateVariables(parsed);
+  const titleTexts = readInteractiveTitleTexts(parsed, variables);
   for (const elements of readInteractiveElementArrays(parsed)) {
-    const text = extractInteractiveElementsText(elements, variables);
+    const elementText = extractInteractiveElementsText(elements, variables);
+    const text = [...titleTexts, elementText].filter(Boolean).join("\n").trim();
     if (text) {
       return text;
     }
   }
 
-  return parseInteractivePostFallback(parsed) ?? INTERACTIVE_CARD_FALLBACK_TEXT;
+  const titleText = titleTexts.join("\n").trim();
+  return titleText || parseInteractivePostFallback(parsed) || INTERACTIVE_CARD_FALLBACK_TEXT;
 }
 
 function parseFeishuMessageContent(rawContent: string, msgType: string): string {


### PR DESCRIPTION
## Summary

Fix `parseInteractiveCardContent()` to handle Feishu API post-format fallback content for interactive card messages.

Fixes #60380
Related: #41609 #48281

## Problem

When reading card messages via `GET /im/v1/messages/{message_id}`, Feishu returns `body.content` in a **post-style fallback format** — nested arrays with `tag:"text"` elements — instead of the original card template JSON. The existing parser only handled card template format (`div`/`markdown` tags), causing all fallback content to silently return `"[Interactive Card]"`.

**Before:** Any `message(action=read)` on a card → `"[Interactive Card]"`
**After:** Extracts title + text content from both card template and post-format fallback

## Example

API returns this for a card message:
```json
{
  "title": "🤖 clawdbot",
  "elements": [[
    {"tag": "img", "image_key": "img_v3_02ad_..."},
    {"tag": "text", "text": "Daily report summary"},
    {"tag": "text", "text": "13 people missing reports"}
  ]]
}
```

- **Before:** `"[Interactive Card]"`
- **After:** `"🤖 clawdbot\nDaily report summary\n13 people missing reports"`

## Changes

**`extensions/feishu/src/send.ts`**
- Handle nested arrays in `elements` (post-format fallback `[[...]]`)
- Extract `tag:"text"` and `tag:"a"` elements from fallback content
- Extract card title from `header.title.content` (template) or top-level `title` (fallback)
- Support `tag:"plain_text"` elements
- Return title even when elements array is missing

**`extensions/feishu/src/send.test.ts`**
- Add test: post-format fallback with nested arrays and title
- Add test: card template with `header.title.content`
- Add test: link extraction from `tag:"a"` elements with href

## Testing

- [x] Verified with real Feishu API responses from production bot
- [x] Existing card template format tests still pass (div/markdown)
- [x] 3 new test cases covering fallback scenarios
