### PR TITLE
fix(kimi-coding): Make tool calling works again by remove OpenAI toolSchemaMode and toolChoiceMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/media understanding: enable bundled Groq and Deepgram providers by default so configured audio transcription models load without extra plugin activation config. (#59982) Thanks @yxjsxy.
 - Providers/OpenAI Codex: add forward-compat `openai-codex/gpt-5.4-mini` synthesis across provider runtime, model catalog, and model listing so Codex mini works before bundled Pi catalog updates land.
 - Plugins/marketplace: block remote marketplace symlink escapes without rewriting ordinary local marketplace install paths. (#60556) Thanks @eleqtrizit.
+- Plugins/Kimi Coding: keep native Anthropic tool payloads on the Kimi coding endpoint while still parsing tagged tool-call text on the response path, so tool calls execute again instead of echoing raw markup. (#60391) Thanks @Eric-Guo.
 
 ## 2026.4.2
 

--- a/extensions/kimi-coding/index.ts
+++ b/extensions/kimi-coding/index.ts
@@ -2,7 +2,7 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
 import { applyKimiCodeConfig, KIMI_CODING_MODEL_REF } from "./onboard.js";
 import { buildKimiCodingProvider } from "./provider-catalog.js";
-import { wrapKimiProviderStream } from "./stream.js";
+import { createKimiToolCallMarkupWrapper } from "./stream.js";
 
 const PLUGIN_ID = "kimi";
 const PROVIDER_ID = "kimi";
@@ -87,7 +87,7 @@ export default definePluginEntry({
         },
       },
       buildReplayPolicy: () => buildKimiReplayPolicy(),
-      wrapStreamFn: (ctx) => wrapKimiProviderStream(ctx.streamFn),
+      wrapStreamFn: (ctx) => createKimiToolCallMarkupWrapper(ctx.streamFn),
     });
   },
 });

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -1,6 +1,5 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
-import { createOpenAIAnthropicToolPayloadCompatibilityWrapper } from "openclaw/plugin-sdk/provider-stream";
 
 const TOOL_CALLS_SECTION_BEGIN = "<|tool_calls_section_begin|>";
 const TOOL_CALLS_SECTION_END = "<|tool_calls_section_end|>";
@@ -179,10 +178,4 @@ export function createKimiToolCallMarkupWrapper(baseStreamFn: StreamFn | undefin
     }
     return wrapKimiTaggedToolCalls(maybeStream);
   };
-}
-
-export function wrapKimiProviderStream(baseStreamFn: StreamFn | undefined): StreamFn {
-  return createKimiToolCallMarkupWrapper(
-    createOpenAIAnthropicToolPayloadCompatibilityWrapper(baseStreamFn),
-  );
 }

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -54,10 +54,7 @@ import {
   resolveExtraParams,
   resolvePreparedExtraParams,
 } from "./pi-embedded-runner.js";
-import {
-  createAnthropicToolPayloadCompatibilityWrapper,
-  createOpenAIAnthropicToolPayloadCompatibilityWrapper,
-} from "./pi-embedded-runner/anthropic-family-tool-payload-compat.js";
+import { createAnthropicToolPayloadCompatibilityWrapper } from "./pi-embedded-runner/anthropic-family-tool-payload-compat.js";
 import {
   createBedrockNoCacheWrapper,
   isAnthropicBedrockModel,
@@ -164,8 +161,14 @@ beforeEach(() => {
           params.context.thinkingLevel,
         );
       }
+      if (params.provider === "test-anthropic-tool-compat") {
+        return createAnthropicToolPayloadCompatibilityWrapper(params.context.streamFn, {
+          toolSchemaMode: "openai-functions",
+          toolChoiceMode: "openai-string-modes",
+        });
+      }
       if (params.provider === "kimi") {
-        return createOpenAIAnthropicToolPayloadCompatibilityWrapper(params.context.streamFn);
+        return params.context.streamFn;
       }
       if (params.provider === "minimax" || params.provider === "minimax-portal") {
         return createMinimaxFastModeWrapper(
@@ -1222,7 +1225,7 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
-  it("rewrites anthropic tool payloads for Kimi", () => {
+  it("keeps anthropic tool payloads native for Kimi", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {
@@ -1259,22 +1262,16 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.tools).toEqual([
       {
-        type: "function",
-        function: {
-          name: "read",
-          description: "Read file",
-          parameters: {
-            type: "object",
-            properties: { path: { type: "string" } },
-            required: ["path"],
-          },
+        name: "read",
+        description: "Read file",
+        input_schema: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
         },
       },
     ]);
-    expect(payloads[0]?.tool_choice).toEqual({
-      type: "function",
-      function: { name: "read" },
-    });
+    expect(payloads[0]?.tool_choice).toEqual({ type: "tool", name: "read" });
   });
 
   it("does not rewrite anthropic tool schema for non-kimi endpoints", () => {
@@ -1377,11 +1374,18 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "kimi", "proxy-model", undefined, "low");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "test-anthropic-tool-compat",
+      "proxy-model",
+      undefined,
+      "low",
+    );
 
     const model = {
       api: "anthropic-messages",
-      provider: "kimi",
+      provider: "test-anthropic-tool-compat",
       id: "proxy-model",
     } as Model<"anthropic-messages">;
     const context: Context = { messages: [] };


### PR DESCRIPTION
## Summary

- Problem: kimi-for-coding not usable after 2026.4.2 to current main version
- Why it matters: it cause openclaw un-usable for user, who using kimi-for-coding.
- What changed: Using anthropic style calling
- What did NOT change (scope boundary): every other part except for kimi-coding extension.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #60059
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Kimi code K2.5 always work in anthropic-message format.
- Missing detection / guardrail:
- Prior context (`git blame`, prior PR, issue, or refactor if known):
- Why this regressed now: Unknown
- If unknown, what was ruled out:

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

Before fix:

<img width="834" height="538" alt="image" src="https://github.com/user-attachments/assets/ebb6dd29-989c-46dc-b64c-c6c9e2c2cd8a" />


After fix:

<img width="851" height="538" alt="image" src="https://github.com/user-attachments/assets/cf945252-ba2d-4ee0-8252-2129b525edbf" />


## Diagram (if applicable)

N/A


## Security Impact (required)

- New permissions/capabilities?: `No`
- Secrets/tokens handling changed?: `No`
- New/changed network calls?: `Yes/No`
- Command/tool execution surface changed?: `Yes/No`
- Data access scope changed?: `Yes/No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: MacOS
- Runtime/container: brew install node@24
- Model/provider: kimi-for-coding
- Integration/channel (if any): kimi
- Relevant config (redacted): see below

```json ~/.openclaw/agents/main/agent/auth-profiles.json
{
  "version": 1,
  "profiles": {
    "kimi-coding:default": {
      "type": "api_key",
      "provider": "kimi-coding",
      "key": "sk-kimi-key"
    },
  },
  "lastGood": {
    "kimi-coding": "kimi-coding:default",
  },
  "usageStats": {
    "kimi-coding:default": {
      "lastUsed": 1775229293844,
      "errorCount": 0,
      "lastFailureAt": 1774701235004
    }
  }
}
```

### Steps

1. Say hello or /new

### Expected

- tool call executed

### Actual

我来获取这篇文章并全文翻译。 <|tool_calls_section_begin|> <|tool_call_begin|> functions.web_fetch:0 <|tool_call_argument_begin|> {"url": "https://socket.dev/blog/hidden-blast-radius-of-the-axios-compromise"} <|tool_call_end|> <|tool_calls_section_end|>

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Yew
- Edge cases checked: No

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `No`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: No need

## Risks and Mitigations

None
