### PR TITLE
fix(plugins): auto-enable media provider plugins referenced from tools.media

### DIFF
--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -48,7 +48,7 @@ function makeRegistry(
     id: string;
     channels: string[];
     autoEnableWhenConfiguredProviders?: string[];
-    contracts?: { webFetchProviders?: string[] };
+    contracts?: { webFetchProviders?: string[]; mediaUnderstandingProviders?: string[] };
     channelConfigs?: Record<string, { schema: Record<string, unknown>; preferOver?: string[] }>;
   }>,
 ): PluginManifestRegistry {
@@ -695,6 +695,69 @@ describe("applyPluginAutoEnable", () => {
     });
 
     expect(result.config.plugins?.entries?.acme?.enabled).toBe(true);
+  });
+
+  it("auto-enables bundled media provider plugins referenced from tools.media config", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        tools: {
+          media: {
+            audio: {
+              models: [
+                {
+                  type: "provider",
+                  provider: "groq",
+                  model: "whisper-large-v3-turbo",
+                },
+              ],
+            },
+          },
+        },
+        plugins: {
+          allow: ["telegram"],
+        },
+      },
+      env: {},
+    });
+
+    expect(result.config.plugins?.entries?.groq?.enabled).toBe(true);
+    expect(result.config.plugins?.allow).toEqual(["telegram", "groq"]);
+    expect(result.autoEnabledReasons).toEqual({
+      groq: ["groq media provider configured"],
+    });
+    expect(result.changes).toContain("groq media provider configured, enabled automatically.");
+  });
+
+  it("auto-enables third-party media provider plugins referenced from tools.media config", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        tools: {
+          media: {
+            models: [
+              {
+                type: "provider",
+                provider: "acme-media",
+              },
+            ],
+          },
+        },
+      },
+      env: {},
+      manifestRegistry: makeRegistry([
+        {
+          id: "acme-media-plugin",
+          channels: [],
+          contracts: {
+            mediaUnderstandingProviders: ["acme-media"],
+          },
+        },
+      ]),
+    });
+
+    expect(result.config.plugins?.entries?.["acme-media-plugin"]?.enabled).toBe(true);
+    expect(result.autoEnabledReasons).toEqual({
+      "acme-media-plugin": ["acme-media media provider configured"],
+    });
   });
 
   it("auto-enables third-party provider plugins when manifest-owned web search config exists", () => {

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -6,6 +6,7 @@ import {
   listPotentialConfiguredChannelIds,
 } from "../channels/config-presence.js";
 import { getChatChannelMeta, normalizeChatChannelId } from "../channels/registry.js";
+import { normalizeMediaProviderId } from "../media-understanding/provider-id.js";
 import {
   BUNDLED_AUTO_ENABLE_PROVIDER_PLUGIN_IDS,
   BUNDLED_PLUGIN_CONTRACT_SNAPSHOTS,
@@ -57,6 +58,11 @@ export type PluginAutoEnableCandidate =
   | {
       pluginId: "acpx";
       kind: "acp-runtime-configured";
+    }
+  | {
+      pluginId: string;
+      kind: "media-provider-configured";
+      providerId: string;
     };
 
 export type PluginAutoEnableResult = {
@@ -205,6 +211,43 @@ function hasPluginOwnedToolConfig(cfg: OpenClawConfig, pluginId: string): boolea
   return false;
 }
 
+function collectConfiguredMediaProviderIds(cfg: OpenClawConfig): string[] {
+  const providerIds = new Set<string>();
+  const pushModels = (models: unknown) => {
+    if (!Array.isArray(models)) {
+      return;
+    }
+    for (const entry of models) {
+      if (!isRecord(entry)) {
+        continue;
+      }
+      const providerId = normalizeMediaProviderId(
+        typeof entry.provider === "string" ? entry.provider : "",
+      );
+      if (providerId) {
+        providerIds.add(providerId);
+      }
+    }
+  };
+
+  pushModels(cfg.tools?.media?.models);
+  pushModels(cfg.tools?.media?.audio?.models);
+  pushModels(cfg.tools?.media?.image?.models);
+  pushModels(cfg.tools?.media?.video?.models);
+
+  return [...providerIds].toSorted((left, right) => left.localeCompare(right));
+}
+
+const BUNDLED_MEDIA_PROVIDER_IDS = new Set(
+  BUNDLED_PLUGIN_CONTRACT_SNAPSHOTS.flatMap((entry) =>
+    entry.mediaUnderstandingProviderIds.map((id) => normalizeMediaProviderId(id)),
+  ).filter((id): id is string => id !== undefined),
+);
+
+function isBundledMediaProviderId(id: string): boolean {
+  return BUNDLED_MEDIA_PROVIDER_IDS.has(id);
+}
+
 function resolveProviderPluginsWithOwnedWebSearch(
   registry: PluginManifestRegistry,
 ): ReadonlySet<string> {
@@ -233,6 +276,28 @@ function resolveProviderPluginsWithOwnedWebFetch(): ReadonlySet<string> {
       (entry) => entry.pluginId,
     ),
   );
+}
+
+function resolveMediaUnderstandingProviderPluginIds(
+  registry: PluginManifestRegistry,
+): Readonly<Record<string, string>> {
+  const entries = new Map<string, string>(
+    BUNDLED_PLUGIN_CONTRACT_SNAPSHOTS.flatMap((entry) =>
+      entry.mediaUnderstandingProviderIds.map(
+        (providerId) => [normalizeMediaProviderId(providerId), entry.pluginId] as const,
+      ),
+    ).filter((pair): pair is [string, string] => pair[0] !== undefined),
+  );
+  for (const plugin of registry.plugins) {
+    for (const providerId of plugin.contracts?.mediaUnderstandingProviders ?? []) {
+      const normalizedProviderId = normalizeMediaProviderId(providerId);
+      if (!normalizedProviderId || entries.has(normalizedProviderId)) {
+        continue;
+      }
+      entries.set(normalizedProviderId, plugin.id);
+    }
+  }
+  return Object.fromEntries([...entries].toSorted(([left], [right]) => left.localeCompare(right)));
 }
 
 function resolvePluginIdForConfiguredWebFetchProvider(
@@ -383,16 +448,19 @@ function hasConfiguredWebFetchPluginEntry(cfg: OpenClawConfig): boolean {
 
 function configMayNeedPluginManifestRegistry(cfg: OpenClawConfig): boolean {
   const configuredChannels = cfg.channels as Record<string, unknown> | undefined;
-  if (!configuredChannels || typeof configuredChannels !== "object") {
-    return false;
+  if (configuredChannels && typeof configuredChannels === "object") {
+    for (const key of Object.keys(configuredChannels)) {
+      if (key === "defaults" || key === "modelByChannel") {
+        continue;
+      }
+      if (!normalizeChatChannelId(key)) {
+        return true;
+      }
+    }
   }
-  for (const key of Object.keys(configuredChannels)) {
-    if (key === "defaults" || key === "modelByChannel") {
-      continue;
-    }
-    if (!normalizeChatChannelId(key)) {
-      return true;
-    }
+  const mediaProviderIds = collectConfiguredMediaProviderIds(cfg);
+  if (mediaProviderIds.some((id) => !isBundledMediaProviderId(id))) {
+    return true;
   }
   return false;
 }
@@ -428,6 +496,9 @@ function configMayNeedPluginAutoEnable(cfg: OpenClawConfig, env: NodeJS.ProcessE
     hasConfiguredWebSearchPluginEntry(cfg) ||
     hasConfiguredWebFetchPluginEntry(cfg)
   ) {
+    return true;
+  }
+  if (collectConfiguredMediaProviderIds(cfg).length > 0) {
     return true;
   }
   return false;
@@ -516,6 +587,8 @@ export function resolvePluginAutoEnableCandidateReason(
       return `${candidate.pluginId} tool configured`;
     case "acp-runtime-configured":
       return "ACP runtime configured";
+    case "media-provider-configured":
+      return `${candidate.providerId} media provider configured`;
   }
 }
 
@@ -549,6 +622,19 @@ function resolveConfiguredPlugins(
         providerId,
       });
     }
+  }
+  const configuredMediaProviderIds = collectConfiguredMediaProviderIds(cfg);
+  const mediaProviderPluginIds = resolveMediaUnderstandingProviderPluginIds(registry);
+  for (const providerId of configuredMediaProviderIds) {
+    const pluginId = mediaProviderPluginIds[providerId];
+    if (!pluginId) {
+      continue;
+    }
+    changes.push({
+      pluginId,
+      kind: "media-provider-configured",
+      providerId,
+    });
   }
   const webFetchProvider =
     typeof cfg.tools?.web?.fetch?.provider === "string" ? cfg.tools.web.fetch.provider : undefined;


### PR DESCRIPTION
## Problem

After the plugin activation refactor (`f911bbc353`), bundled media provider plugins like Groq silently stop working even when:
- `GROQ_API_KEY` is set in env
- `tools.media.audio.models` explicitly references `provider: groq`

The auto-enable logic handles channel plugins and web search/fetch providers, but never checks `tools.media` config for media understanding providers. Groq (and likely Deepgram) fall through to "bundled, disabled by default."

Multiple users affected since 2026.3.31 / 2026.4.x.

Fixes #59875, fixes #59502, fixes #54695, fixes #59437

## Solution

- Add `collectConfiguredMediaProviderIds()` to scan all `tools.media.{models,audio,image,video}.models` entries for provider references
- Add `resolveMediaUnderstandingProviderPluginIds()` to map provider IDs → plugin IDs (bundled snapshots + third-party manifests via `mediaUnderstandingProviders` contract)
- Wire both into `resolveConfiguredPlugins()` so referenced media providers get auto-enabled
- Update `configMayNeedPluginAutoEnable()` and `configMayNeedPluginManifestRegistry()` guards
- Add `"media-provider-configured"` kind to `PluginAutoEnableCandidate` union type

## Review feedback addressed (v2)

- **P1 (greptile):** Normalize bundled provider IDs via `normalizeMediaProviderId()` before map insertion to avoid alias mismatches (e.g. `"gemini"` → `"google"`)
- **P1 (codex):** Move media provider check outside the channels-only early return in `configMayNeedPluginManifestRegistry` so third-party media plugins can resolve without channel config
- **P2 (greptile):** Skip registry loading for bundled-only media providers via `isBundledMediaProviderId()` gate

## Testing

- Added tests for bundled (Groq) and third-party media provider plugin auto-enable
- Manually verified: Groq audio transcription works with only `tools.media.audio.models: [{ provider: "groq" }]` — no `plugins.entries.groq.enabled: true` workaround needed
- Existing tests pass: `vitest run src/config/plugin-auto-enable.test.ts && vitest run src/plugins/providers.test.ts`

## AI-assisted

This PR was authored with AI assistance (Claude Opus 4.6). Fully tested locally (unit tests + manual Groq transcription verification on a dev OpenClaw instance). We understand what the code does — it extends the existing plugin auto-enable pattern to cover media understanding providers the same way it already covers channels, browser, and web search/fetch providers.