### PR TITLE
Control UI: use a dedicated loading style for the Cron refresh button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Docs: https://docs.openclaw.ai
 - Outbound/sanitizer: strip leaked `<tool_call>`, `<function_calls>`, and model special tokens from shared user-visible assistant text, including truncated tool-call streams, so internal scaffolding no longer bleeds into replies across surfaces. (#60619) Thanks @oliviareid-svg.
 - Control UI/avatar: honor `ui.assistant.avatar` when serving `/avatar/:agentId` so Appearance UI avatar paths stop falling back to initials placeholders. (#60778) Thanks @hannasdev.
 - Control UI/Overview: prevent gateway access token/password visibility toggle buttons from overlapping their inputs at narrow widths. (#56924) Thanks @bbddbb1.
+- Control UI/cron: highlight the Cron refresh button while refresh is in flight so the page's loading state stays visible even when prior data remains on screen. (#60394) Thanks @coder-zhuzm.
 
 ## 2026.4.2
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -909,6 +909,13 @@
   min-width: 0;
 }
 
+.btn.cron-refresh-btn--loading {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--primary-foreground);
+  box-shadow: 0 1px 3px var(--accent-subtle);
+}
+
 .cron-workspace {
   margin-top: 16px;
   display: grid;
@@ -1307,6 +1314,11 @@
 }
 
 :root[data-theme-mode="light"] .btn.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+:root[data-theme-mode="light"] .btn.cron-refresh-btn--loading {
   background: var(--accent);
   border-color: var(--accent);
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -659,7 +659,8 @@
   flex-shrink: 0;
 }
 
-.btn.primary {
+.btn.primary,
+.btn.cron-refresh-btn--loading {
   border-color: var(--accent);
   background: var(--accent);
   color: var(--primary-foreground);
@@ -907,13 +908,6 @@
   justify-content: flex-end;
   gap: 10px;
   min-width: 0;
-}
-
-.btn.cron-refresh-btn--loading {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: var(--primary-foreground);
-  box-shadow: 0 1px 3px var(--accent-subtle);
 }
 
 .cron-workspace {
@@ -1313,11 +1307,7 @@
   color: var(--accent);
 }
 
-:root[data-theme-mode="light"] .btn.primary {
-  background: var(--accent);
-  border-color: var(--accent);
-}
-
+:root[data-theme-mode="light"] .btn.primary,
 :root[data-theme-mode="light"] .btn.cron-refresh-btn--loading {
   background: var(--accent);
   border-color: var(--accent);

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -418,7 +418,11 @@ export function renderCron(props: CronProps) {
         </div>
       </div>
       <div class="cron-summary-strip__actions">
-        <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
+        <button
+          class=${props.loading ? "btn primary" : "btn"}
+          ?disabled=${props.loading}
+          @click=${props.onRefresh}
+        >
           ${props.loading ? t("cron.summary.refreshing") : t("cron.summary.refresh")}
         </button>
         ${props.error ? html`<span class="muted">${props.error}</span>` : nothing}

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -419,7 +419,7 @@ export function renderCron(props: CronProps) {
       </div>
       <div class="cron-summary-strip__actions">
         <button
-          class=${props.loading ? "btn primary" : "btn"}
+          class=${props.loading ? "btn cron-refresh-btn--loading" : "btn"}
           ?disabled=${props.loading}
           @click=${props.onRefresh}
         >


### PR DESCRIPTION
## Summary

- Problem: The Cron page refresh state is easy to miss because the page keeps showing the previous data while a refresh is in progress.
- Why it matters: When users switch back to the Cron tab or click refresh, it can look like the page is serving cached data and not updating.
- What changed: The Cron refresh button now switches to a dedicated loading class that uses the current theme accent while loading.
- What did NOT change (scope boundary): This PR does not change Cron fetching behavior, refresh timing, caching/state retention, or backend APIs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The Cron page preserves prior data while refreshing, but the only visible loading signal was the refresh button text changing to "Refreshing", which had low visual emphasis.
- Missing detection / guardrail: No stronger visual treatment highlighted the in-progress refresh state in the page actions.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: It does not appear to be a new regression; this looks like an existing UX gap in the current Cron refresh flow.
- If unknown, what was ruled out: Verified that the Cron tab does re-fetch on re-entry; the issue is refresh visibility, not missing network activity.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: N/A
- Scenario the test should lock in: When the Cron page enters a loading state, the refresh action should visibly switch to the dedicated loading/highlighted style.
- Why this is the smallest reliable guardrail: This is primarily a user-visible styling/state issue and is best validated at the rendered UI level.
- Existing test that already covers this (if any): None known.
- If no new test is added, why not: This PR is a small visual-only adjustment and was verified manually in the local Control UI in both dark and light themes.

## User-visible / Behavior Changes

- On the Cron page, the refresh button now uses a dedicated loading style with the current theme accent while loading.
- The loading style works in both dark mode and light mode.
- The button returns to the normal style after loading completes.

## Diagram (if applicable)

```text
Before:
[user switches back to Cron / clicks refresh] -> [old data stays visible] -> [button text changes only]

After:
[user switches back to Cron / clicks refresh] -> [old data stays visible] -> [refresh button uses dedicated loading highlight] -> [refresh state is easier to notice]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local gateway + Control UI
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local gateway with token auth

### Steps

1. Open the local Control UI and navigate to the Cron page.
2. Trigger a Cron refresh or switch away from the Cron tab and back.
3. Observe the refresh action while loading is in progress in dark mode and light mode.

### Expected

- The refresh state is clearly visible while loading is in progress.
- The loading style is applied consistently in both dark mode and light mode.

### Actual

- The refresh button switches to the dedicated loading/highlighted style while loading.
- The loading style renders correctly in both dark mode and light mode.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Verified locally that the Cron refresh button becomes visually highlighted during loading and returns to the default style afterward.
- Edge cases checked: Verified both manual refresh and returning to the Cron tab, where the page refreshes while prior data remains visible; verified the loading style in both dark mode and light mode.
- What you did **not** verify: Did not add automated test coverage; did not verify unrelated Cron data-fetching behavior beyond confirming the existing refresh flow.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: The stronger loading style could be seen as too prominent for some reviewers.
  - Mitigation: The change is scoped to the existing loading state only and uses a dedicated Cron loading class, so it does not depend on `.btn.primary` semantics or future `:disabled` overrides.
