### PR TITLE
test: restore secrets runtime suite isolation cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Outbound/runtime seams: split delivery, target-resolution, and session/transcript helper loading into narrower runtime seams so outbound hot paths and their owner tests avoid broader setup fan-out. (#60311) Thanks @shakkernerd.
 - Plugins/browser seams: split browser and WhatsApp plugin-sdk seams into narrower browser, approval-auth, and target-helper facades so hot paths and owner tests avoid broader runtime fan-out. (#60376) Thanks @shakkernerd.
 - Tests/runtime: trim local unit-test import/runtime fan-out across browser, WhatsApp, cron, task, and reply flows so owner suites start faster with lower shared-worker overhead while preserving the same focused behavior coverage. (#60249) Thanks @shakkernerd.
+- Tests/secrets runtime: restore split secrets suite cache and env isolation cleanup so broader runs do not leak stale plugin or provider snapshot state. (#60395) Thanks @shakkernerd.
 
 ### Fixes
 

--- a/src/secrets/runtime.auth.integration.test.ts
+++ b/src/secrets/runtime.auth.integration.test.ts
@@ -3,27 +3,24 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
-import {
-  clearConfigCache,
-  clearRuntimeConfigSnapshot,
-  loadConfig,
-  writeConfigFile,
-} from "../config/config.js";
+import { loadConfig, writeConfigFile } from "../config/config.js";
 import { withTempHome } from "../config/home-env.test-harness.js";
-import { captureEnv, withEnvAsync } from "../test-utils/env.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import {
   asConfig,
+  beginSecretsRuntimeIsolationForTest,
   createOpenAIFileRuntimeConfig,
   createOpenAIFileRuntimeFixture,
   EMPTY_LOADABLE_PLUGIN_ORIGINS,
+  endSecretsRuntimeIsolationForTest,
   expectResolvedOpenAIRuntime,
   loadAuthStoreWithProfiles,
   OPENAI_ENV_KEY_REF,
   OPENAI_FILE_KEY_REF,
+  type SecretsRuntimeEnvSnapshot,
 } from "./runtime.integration.test-helpers.js";
 import {
   activateSecretsRuntimeSnapshot,
-  clearSecretsRuntimeSnapshot,
   getActiveSecretsRuntimeSnapshot,
   prepareSecretsRuntimeSnapshot,
 } from "./runtime.js";
@@ -31,25 +28,14 @@ import {
 vi.unmock("../version.js");
 
 describe("secrets runtime snapshot auth integration", () => {
-  let envSnapshot: ReturnType<typeof captureEnv>;
+  let envSnapshot: SecretsRuntimeEnvSnapshot;
 
   beforeEach(() => {
-    envSnapshot = captureEnv([
-      "OPENCLAW_BUNDLED_PLUGINS_DIR",
-      "OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE",
-      "OPENCLAW_VERSION",
-    ]);
-    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
-    process.env.OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE = "1";
-    delete process.env.OPENCLAW_VERSION;
+    envSnapshot = beginSecretsRuntimeIsolationForTest();
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
-    envSnapshot.restore();
-    clearSecretsRuntimeSnapshot();
-    clearRuntimeConfigSnapshot();
-    clearConfigCache();
+    endSecretsRuntimeIsolationForTest(envSnapshot);
   });
 
   it("activates runtime snapshots for loadConfig and ensureAuthProfileStore", async () => {

--- a/src/secrets/runtime.gateway-auth.integration.test.ts
+++ b/src/secrets/runtime.gateway-auth.integration.test.ts
@@ -2,23 +2,20 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import {
-  clearConfigCache,
-  clearRuntimeConfigSnapshot,
-  loadConfig,
-  writeConfigFile,
-} from "../config/config.js";
+import { loadConfig, writeConfigFile } from "../config/config.js";
 import { withTempHome } from "../config/home-env.test-harness.js";
-import { captureEnv, withEnvAsync } from "../test-utils/env.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import {
   asConfig,
+  beginSecretsRuntimeIsolationForTest,
   EMPTY_LOADABLE_PLUGIN_ORIGINS,
+  endSecretsRuntimeIsolationForTest,
   loadAuthStoreWithProfiles,
   SECRETS_RUNTIME_INTEGRATION_TIMEOUT_MS,
+  type SecretsRuntimeEnvSnapshot,
 } from "./runtime.integration.test-helpers.js";
 import {
   activateSecretsRuntimeSnapshot,
-  clearSecretsRuntimeSnapshot,
   getActiveSecretsRuntimeSnapshot,
   prepareSecretsRuntimeSnapshot,
 } from "./runtime.js";
@@ -26,25 +23,14 @@ import {
 vi.unmock("../version.js");
 
 describe("secrets runtime snapshot gateway-auth integration", () => {
-  let envSnapshot: ReturnType<typeof captureEnv>;
+  let envSnapshot: SecretsRuntimeEnvSnapshot;
 
   beforeEach(() => {
-    envSnapshot = captureEnv([
-      "OPENCLAW_BUNDLED_PLUGINS_DIR",
-      "OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE",
-      "OPENCLAW_VERSION",
-    ]);
-    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
-    process.env.OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE = "1";
-    delete process.env.OPENCLAW_VERSION;
+    envSnapshot = beginSecretsRuntimeIsolationForTest();
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
-    envSnapshot.restore();
-    clearSecretsRuntimeSnapshot();
-    clearRuntimeConfigSnapshot();
-    clearConfigCache();
+    endSecretsRuntimeIsolationForTest(envSnapshot);
   });
 
   it("fails fast at startup when gateway auth SecretRef is active and unresolved", async () => {

--- a/src/secrets/runtime.integration.test-helpers.ts
+++ b/src/secrets/runtime.integration.test-helpers.ts
@@ -1,10 +1,17 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { expect } from "vitest";
+import { expect, vi } from "vitest";
 import { ensureAuthProfileStore, type AuthProfileStore } from "../agents/auth-profiles.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { loadConfig } from "../config/config.js";
+import { clearConfigCache, clearRuntimeConfigSnapshot, loadConfig } from "../config/config.js";
+import { clearPluginDiscoveryCache } from "../plugins/discovery.js";
+import { clearPluginLoaderCache } from "../plugins/loader.js";
+import { clearPluginManifestRegistryCache } from "../plugins/manifest-registry.js";
 import type { PluginOrigin } from "../plugins/types.js";
+import { __testing as webFetchProvidersTesting } from "../plugins/web-fetch-providers.runtime.js";
+import { __testing as webSearchProvidersTesting } from "../plugins/web-search-providers.runtime.js";
+import { captureEnv } from "../test-utils/env.js";
+import { clearSecretsRuntimeSnapshot } from "./runtime.js";
 
 export const OPENAI_ENV_KEY_REF = {
   source: "env",
@@ -20,6 +27,7 @@ export const OPENAI_FILE_KEY_REF = {
 
 export const SECRETS_RUNTIME_INTEGRATION_TIMEOUT_MS = 300_000;
 export const EMPTY_LOADABLE_PLUGIN_ORIGINS: ReadonlyMap<string, PluginOrigin> = new Map();
+export type SecretsRuntimeEnvSnapshot = ReturnType<typeof captureEnv>;
 
 const allowInsecureTempSecretFile = process.platform === "win32";
 
@@ -105,4 +113,30 @@ export function expectResolvedOpenAIRuntime(agentDir: string) {
     type: "api_key",
     key: "sk-file-runtime",
   });
+}
+
+export function beginSecretsRuntimeIsolationForTest(): SecretsRuntimeEnvSnapshot {
+  const envSnapshot = captureEnv([
+    "OPENCLAW_BUNDLED_PLUGINS_DIR",
+    "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+    "OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE",
+    "OPENCLAW_VERSION",
+  ]);
+  delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+  process.env.OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE = "1";
+  delete process.env.OPENCLAW_VERSION;
+  return envSnapshot;
+}
+
+export function endSecretsRuntimeIsolationForTest(envSnapshot: SecretsRuntimeEnvSnapshot) {
+  vi.restoreAllMocks();
+  envSnapshot.restore();
+  clearSecretsRuntimeSnapshot();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+  clearPluginLoaderCache();
+  clearPluginDiscoveryCache();
+  clearPluginManifestRegistryCache();
+  webSearchProvidersTesting.resetWebSearchProviderSnapshotCacheForTests();
+  webFetchProvidersTesting.resetWebFetchProviderSnapshotCacheForTests();
 }


### PR DESCRIPTION
## Summary

- Follow-up to `#60249`: that PR already landed the broader plugin/secrets owner-suite split on `main`.
- This PR now keeps only the remaining secrets test-isolation fix that was missing from the split files.
- Specifically, it restores the current-main secrets suite cleanup through the shared helper used by:
  - `src/secrets/runtime.auth.integration.test.ts`
  - `src/secrets/runtime.gateway-auth.integration.test.ts`

## What changed

- Restored capture of `OPENCLAW_DISABLE_BUNDLED_PLUGINS` in the split secrets suites.
- Restored plugin loader/discovery/manifest cache cleanup after each suite run.
- Restored web-search and web-fetch provider snapshot cache resets after each suite run.
- Kept the cleanup in `src/secrets/runtime.integration.test-helpers.ts` so the split files stay aligned.

## Scope

- No product/runtime behavior change.
- Test-only follow-up fix.

## Verification

- `pnpm test -- src/secrets/runtime.auth.integration.test.ts src/secrets/runtime.gateway-auth.integration.test.ts`
  - Result: 2 files, 6 tests passed.

## Why this PR still exists after `#60249`

`#60249` absorbed the original suite split. The only remaining unique change from this branch was the missing secrets isolation cleanup, so this PR has been rewritten to just that fix.
