### PR TITLE
fix: wake targeted ACP parent sessions when heartbeat is disabled

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -506,6 +506,28 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("does not bypass disabled agents for targeted event wakes", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+        list: [{ id: "main", heartbeat: { every: "1h" } }, { id: "ops" }],
+      },
+    };
+
+    const res = await runHeartbeatOnce({
+      cfg,
+      agentId: "ops",
+      reason: "exec-event",
+      sessionKey: "agent:ops:discord:alerts",
+      allowEventWakeWithoutHeartbeat: true,
+    });
+
+    expect(res.status).toBe("skipped");
+    if (res.status === "skipped") {
+      expect(res.reason).toBe("disabled");
+    }
+  });
+
   it("skips outside active hours", async () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { startHeartbeatRunner } from "./heartbeat-runner.js";
-import { requestHeartbeatNow, resetHeartbeatWakeStateForTests } from "./heartbeat-wake.js";
+import {
+  requestHeartbeatNow,
+  resetHeartbeatWakeStateForTests,
+  setHeartbeatsEnabled,
+} from "./heartbeat-wake.js";
 
 describe("startHeartbeatRunner", () => {
   type RunOnce = Parameters<typeof startHeartbeatRunner>[0]["runOnce"];
@@ -62,6 +66,7 @@ describe("startHeartbeatRunner", () => {
 
   afterEach(() => {
     resetHeartbeatWakeStateForTests();
+    setHeartbeatsEnabled(true);
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -280,6 +285,44 @@ describe("startHeartbeatRunner", () => {
       },
     });
     expect(runSpy.mock.calls.some((call) => call[0]?.agentId === "finance")).toBe(false);
+
+    runner.stop();
+  });
+
+  it("dispatches targeted ACP wake requests even when heartbeat is globally disabled", async () => {
+    useFakeHeartbeatTime();
+    setHeartbeatsEnabled(false);
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: {
+          defaults: {
+            heartbeat: {
+              every: "0",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    requestHeartbeatNow({
+      reason: "acp:spawn:stream",
+      sessionKey: "agent:main:main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(runSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "acp:spawn:stream",
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        allowEventWakeWithoutHeartbeat: true,
+      }),
+    );
 
     runner.stop();
   });

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -289,6 +289,46 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("does not re-arm interval timers while heartbeat is globally disabled", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startDefaultRunner(runSpy);
+
+    setHeartbeatsEnabled(false);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+
+    runner.stop();
+  });
+
+  it("resumes interval scheduling when heartbeat is re-enabled", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startDefaultRunner(runSpy);
+
+    setHeartbeatsEnabled(false);
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+
+    setHeartbeatsEnabled(true);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).toHaveBeenCalledTimes(2);
+
+    runner.stop();
+  });
+
   it("dispatches targeted ACP wake requests even when heartbeat is globally disabled", async () => {
     useFakeHeartbeatTime();
     setHeartbeatsEnabled(false);

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -529,6 +529,7 @@ export async function runHeartbeatOnce(opts: {
   sessionKey?: string;
   heartbeat?: HeartbeatConfig;
   reason?: string;
+  allowEventWakeWithoutHeartbeat?: boolean;
   deps?: HeartbeatDeps;
 }): Promise<HeartbeatRunResult> {
   const cfg = opts.cfg ?? loadConfig();
@@ -539,14 +540,25 @@ export async function runHeartbeatOnce(opts: {
     explicitAgentId || forcedSessionAgentId || resolveDefaultAgentId(cfg),
   );
   const heartbeat = opts.heartbeat ?? resolveHeartbeatConfig(cfg, agentId);
-  if (!areHeartbeatsEnabled()) {
-    return { status: "skipped", reason: "disabled" };
-  }
-  if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
-    return { status: "skipped", reason: "disabled" };
-  }
-  if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
-    return { status: "skipped", reason: "disabled" };
+  const reasonKind = resolveHeartbeatReasonKind(opts.reason);
+  const isSessionScopedEventWake =
+    Boolean(opts.sessionKey?.trim()) &&
+    (reasonKind === "exec-event" ||
+      reasonKind === "cron" ||
+      reasonKind === "wake" ||
+      reasonKind === "hook");
+  const allowEventWakeWithoutHeartbeat =
+    opts.allowEventWakeWithoutHeartbeat === true && isSessionScopedEventWake;
+  if (!allowEventWakeWithoutHeartbeat) {
+    if (!areHeartbeatsEnabled()) {
+      return { status: "skipped", reason: "disabled" };
+    }
+    if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
+      return { status: "skipped", reason: "disabled" };
+    }
+    if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
+      return { status: "skipped", reason: "disabled" };
+    }
   }
 
   const startedAt = opts.deps?.nowMs?.() ?? Date.now();
@@ -1071,18 +1083,6 @@ export function startHeartbeatRunner(opts: {
         reason: "disabled",
       } satisfies HeartbeatRunResult;
     }
-    if (!areHeartbeatsEnabled()) {
-      return {
-        status: "skipped",
-        reason: "disabled",
-      } satisfies HeartbeatRunResult;
-    }
-    if (state.agents.size === 0) {
-      return {
-        status: "skipped",
-        reason: "disabled",
-      } satisfies HeartbeatRunResult;
-    }
 
     const reason = params?.reason;
     const requestedAgentId = params?.agentId ? normalizeAgentId(params.agentId) : undefined;
@@ -1097,22 +1097,24 @@ export function startHeartbeatRunner(opts: {
 
     try {
       if (requestedSessionKey || requestedAgentId) {
-        const targetAgentId = requestedAgentId ?? resolveAgentIdFromSessionKey(requestedSessionKey);
-        const targetAgent = state.agents.get(targetAgentId);
-        if (!targetAgent) {
-          return { status: "skipped", reason: "disabled" };
-        }
+        const targetAgentId = normalizeAgentId(
+          requestedAgentId ?? resolveAgentIdFromSessionKey(requestedSessionKey),
+        );
+        const scheduledAgent = state.agents.get(targetAgentId);
+        const targetHeartbeat =
+          scheduledAgent?.heartbeat ?? resolveHeartbeatConfig(state.cfg, targetAgentId);
         try {
           const res = await runOnce({
             cfg: state.cfg,
-            agentId: targetAgent.agentId,
-            heartbeat: targetAgent.heartbeat,
+            agentId: targetAgentId,
+            heartbeat: targetHeartbeat,
             reason,
             sessionKey: requestedSessionKey,
+            allowEventWakeWithoutHeartbeat: true,
             deps: { runtime: state.runtime },
           });
-          if (res.status !== "skipped" || res.reason !== "disabled") {
-            advanceAgentSchedule(targetAgent, now);
+          if (scheduledAgent && (res.status !== "skipped" || res.reason !== "disabled")) {
+            advanceAgentSchedule(scheduledAgent, now);
           }
           return res.status === "ran" ? { status: "ran", durationMs: Date.now() - startedAt } : res;
         } catch (err) {
@@ -1120,9 +1122,24 @@ export function startHeartbeatRunner(opts: {
           log.error(`heartbeat runner: targeted runOnce threw unexpectedly: ${errMsg}`, {
             error: errMsg,
           });
-          advanceAgentSchedule(targetAgent, now);
+          if (scheduledAgent) {
+            advanceAgentSchedule(scheduledAgent, now);
+          }
           return { status: "failed", reason: errMsg };
         }
+      }
+
+      if (!areHeartbeatsEnabled()) {
+        return {
+          status: "skipped",
+          reason: "disabled",
+        } satisfies HeartbeatRunResult;
+      }
+      if (state.agents.size === 0) {
+        return {
+          status: "skipped",
+          reason: "disabled",
+        } satisfies HeartbeatRunResult;
       }
 
       for (const agent of state.agents.values()) {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -549,11 +549,11 @@ export async function runHeartbeatOnce(opts: {
       reasonKind === "hook");
   const allowEventWakeWithoutHeartbeat =
     opts.allowEventWakeWithoutHeartbeat === true && isSessionScopedEventWake;
+  if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
+    return { status: "skipped", reason: "disabled" };
+  }
   if (!allowEventWakeWithoutHeartbeat) {
     if (!areHeartbeatsEnabled()) {
-      return { status: "skipped", reason: "disabled" };
-    }
-    if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
       return { status: "skipped", reason: "disabled" };
     }
     if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1183,9 +1183,9 @@ export function startHeartbeatRunner(opts: {
       }
       return { status: "skipped", reason: isInterval ? "not-due" : "disabled" };
     } finally {
-      // Always re-arm the timer — except for requests-in-flight, where the
-      // wake layer (heartbeat-wake.ts) handles retry via schedule(DEFAULT_RETRY_MS).
-      if (!requestsInFlight) {
+      // Re-arm only when normal scheduling is active. Requests-in-flight retry
+      // is owned by heartbeat-wake.ts, and global disable should pause intervals.
+      if (!requestsInFlight && areHeartbeatsEnabled()) {
         scheduleNext();
       }
     }

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -18,7 +18,11 @@ export type HeartbeatWakeHandler = (opts: {
 let heartbeatsEnabled = true;
 
 export function setHeartbeatsEnabled(enabled: boolean) {
+  const wasEnabled = heartbeatsEnabled;
   heartbeatsEnabled = enabled;
+  if (!wasEnabled && enabled && handler) {
+    requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });
+  }
 }
 
 export function areHeartbeatsEnabled(): boolean {


### PR DESCRIPTION
## Summary
- allow targeted session wake requests (including `acp:spawn:*`) to execute even when periodic heartbeat scheduling is disabled
- move targeted wake handling ahead of global heartbeat-disabled / empty-schedule guards in `startHeartbeatRunner`
- add a scheduler regression test for ACP targeted wake behavior when heartbeat is disabled

## Why
Issue #52249 reports that ACP child completion can enqueue system events but never wake the parent when heartbeat is disabled. This change keeps periodic heartbeat disabled while still letting session-scoped event wakes run.

## Testing
- `pnpm exec vitest run --config vitest.unit.config.ts src/infra/heartbeat-runner.scheduler.test.ts`
- `pnpm exec vitest run --config vitest.unit.config.ts src/infra/heartbeat-wake.test.ts`
