### PR TITLE
OpenAI provider concurrency limiter (LLM_MAX_CONCURRENT)

### DIFF
--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1,4 +1,5 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { withProviderLimiter } from "../utils/providerLimiters";
 import {
   calculateCost,
   createAssistantMessageEventStream,
@@ -904,10 +905,12 @@ function createOpenAIResponsesTransportStreamFn(): StreamFn {
         if (nextParams !== undefined) {
           params = nextParams as typeof params;
         }
-        const responseStream = (await client.responses.create(
-          params as never,
-          options?.signal ? { signal: options.signal } : undefined,
-        )) as unknown as AsyncIterable<unknown>;
+     const responseStream = (await withProviderLimiter('openai', () =>
+client.responses.create(
+params as never,
+options?.signal ? { signal: options.signal } : undefined,
+)
+)) as unknown as AsyncIterable<unknown>;
         stream.push({ type: "start", partial: output as never });
         await processResponsesStream(responseStream, output, stream, model, {
           serviceTier: (options as OpenAIResponsesOptions | undefined)?.serviceTier,
@@ -1035,10 +1038,12 @@ function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
         if (nextParams !== undefined) {
           params = nextParams as typeof params;
         }
-        const responseStream = (await client.responses.create(
-          params as never,
-          options?.signal ? { signal: options.signal } : undefined,
-        )) as unknown as AsyncIterable<unknown>;
+        const responseStream = (await withProviderLimiter('openai', () =>
+client.responses.create(
+params as never,
+options?.signal ? { signal: options.signal } : undefined,
+)
+)) as unknown as AsyncIterable<unknown>;
         stream.push({ type: "start", partial: output as never });
         await processResponsesStream(responseStream, output, stream, model);
         if (options?.signal?.aborted) {

--- a/src/utils/providerLimiters.ts
+++ b/src/utils/providerLimiters.ts
@@ -1,0 +1,36 @@
+type Task<T> = () => Promise<T> | T;
+
+function makeLimiter(max: number) {
+let active = 0;
+const q: { task: Task<unknown>; resolve: (v: unknown) => void; reject: (e: unknown) => void }[] = [];
+const runNext = () => {
+if (active >= max) return;
+const next = q.shift();
+if (!next) return;
+active++;
+Promise.resolve()
+.then(next.task)
+.then(next.resolve, next.reject)
+.finally(() => {
+active--;
+runNext();
+});
+};
+return async <T>(fn: Task<T>): Promise<T> =>
+new Promise<T>((resolve, reject) => {
+q.push({ task: fn as Task<unknown>, resolve, reject });
+runNext();
+});
+}
+
+const cap = Math.max(1, Number(process.env.LLM_MAX_CONCURRENT || '2'));
+const perProvider = new Map<string, ReturnType<typeof makeLimiter>>();
+
+export function withProviderLimiter<T>(provider: 'openai' | 'anthropic', task: Task<T>): Promise<T> {
+let lim = perProvider.get(provider);
+if (!lim) {
+lim = makeLimiter(cap);
+perProvider.set(provider, lim);
+}
+return lim(task);
+}


### PR DESCRIPTION
Wraps OpenAI (incl. Azure) responses.create and chat.completions.create with a provider-agnostic limiter (default cap=2 per provider via LLM_MAX_CONCURRENT).