### PR TITLE
fix(session): fall back to reset archive in chat.history when primary transcript is missing

### DIFF
--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -285,25 +285,28 @@ export function findLatestResetArchive(
 ): string | undefined {
   const prefix = `${sessionId}.jsonl.reset.`;
 
+  // Scan all dirs before deciding; pick the globally newest archive so that
+  // a more-recent file in the legacy dir is not missed when the primary dir
+  // also contains archives (e.g. after a store-path migration).
+  let latestTimestamp = -Infinity;
+  let latestPath: string | undefined;
+
   for (const dir of searchDirs) {
     try {
       const entries = fs.readdirSync(dir, { withFileTypes: true });
-      const archives = entries
-        .filter(
-          (d) =>
-            d.isFile() &&
-            d.name.startsWith(prefix) &&
-            // Validate the timestamp suffix so only well-formed archives are returned.
-            parseSessionArchiveTimestamp(d.name, "reset") != null,
-        )
-        .map((d) => d.name)
-        .toSorted(); // archive timestamps are ISO-derived and sort lexicographically
-      if (archives.length > 0) {
-        return path.join(dir, archives[archives.length - 1]);
+      for (const d of entries) {
+        if (!d.isFile() || !d.name.startsWith(prefix)) {
+          continue;
+        }
+        const ts = parseSessionArchiveTimestamp(d.name, "reset");
+        if (ts != null && ts > latestTimestamp) {
+          latestTimestamp = ts;
+          latestPath = path.join(dir, d.name);
+        }
       }
     } catch {
       // Skip unreadable dirs (missing legacy dir is the common case).
     }
   }
-  return undefined;
+  return latestPath;
 }

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -274,16 +274,26 @@ export async function cleanupArchivedSessionTranscripts(opts: {
  * so that chat.history returns archived content instead of an empty response
  * after a daily or manual session reset.
  *
- * Searches all provided directories in order, stopping at the first dir that
- * contains a matching archive. The caller should derive searchDirs from the
- * same candidate paths used to locate primary transcripts (including the legacy
- * `~/.openclaw/sessions` dir) so archive lookup stays consistent.
+ * Searches all provided directories in order. The caller should derive searchDirs
+ * from the same candidate paths used to locate primary transcripts (including the
+ * legacy `~/.openclaw/sessions` dir) so archive lookup stays consistent.
+ *
+ * @param candidateBasenames - basenames of the resolved candidate transcript paths
+ *   (e.g. `["<sessionId>.jsonl", "<sessionId>-<agentId>.jsonl"]`). Archives are
+ *   named `<transcriptBasename>.reset.<timestamp>`, so matching against all
+ *   candidate basenames avoids missing archives for non-canonical transcript names.
+ *   Falls back to `<sessionId>.jsonl.reset.*` when not provided.
  */
 export function findLatestResetArchive(
   sessionId: string,
   searchDirs: readonly string[],
+  candidateBasenames?: readonly string[],
 ): string | undefined {
-  const prefix = `${sessionId}.jsonl.reset.`;
+  // Build one prefix per candidate basename; fall back to the canonical name.
+  const prefixes =
+    candidateBasenames && candidateBasenames.length > 0
+      ? candidateBasenames.map((b) => `${b}.reset.`)
+      : [`${sessionId}.jsonl.reset.`];
 
   // Scan all dirs before deciding; pick the globally newest archive so that
   // a more-recent file in the legacy dir is not missed when the primary dir
@@ -295,7 +305,7 @@ export function findLatestResetArchive(
     try {
       const entries = fs.readdirSync(dir, { withFileTypes: true });
       for (const d of entries) {
-        if (!d.isFile() || !d.name.startsWith(prefix)) {
+        if (!d.isFile() || !prefixes.some((p) => d.name.startsWith(p))) {
           continue;
         }
         const ts = parseSessionArchiveTimestamp(d.name, "reset");

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -274,31 +274,28 @@ export async function cleanupArchivedSessionTranscripts(opts: {
  * so that chat.history returns archived content instead of an empty response
  * after a daily or manual session reset.
  *
- * Searches both the provided sessions dir and the legacy `~/.openclaw/sessions`
- * directory, consistent with how resolveSessionTranscriptCandidates locates
- * primary transcripts.
+ * Searches all provided directories in order, stopping at the first dir that
+ * contains a matching archive. The caller should derive searchDirs from the
+ * same candidate paths used to locate primary transcripts (including the legacy
+ * `~/.openclaw/sessions` dir) so archive lookup stays consistent.
  */
-export function findLatestResetArchive(sessionId: string, sessionsDir: string): string | undefined {
+export function findLatestResetArchive(
+  sessionId: string,
+  searchDirs: readonly string[],
+): string | undefined {
   const prefix = `${sessionId}.jsonl.reset.`;
 
-  // Mirror the legacy-dir fallback in resolveSessionTranscriptCandidates so
-  // archives created before a state-dir migration are also found.
-  const dirsToSearch: string[] = [sessionsDir];
-  try {
-    const home = resolveRequiredHomeDir(process.env, os.homedir);
-    const legacyDir = path.join(home, ".openclaw", "sessions");
-    if (path.resolve(legacyDir) !== path.resolve(sessionsDir)) {
-      dirsToSearch.push(legacyDir);
-    }
-  } catch {
-    // Ignore home-dir resolution failures; primary dir is still searched.
-  }
-
-  for (const dir of dirsToSearch) {
+  for (const dir of searchDirs) {
     try {
       const entries = fs.readdirSync(dir, { withFileTypes: true });
       const archives = entries
-        .filter((d) => d.isFile() && d.name.startsWith(prefix))
+        .filter(
+          (d) =>
+            d.isFile() &&
+            d.name.startsWith(prefix) &&
+            // Validate the timestamp suffix so only well-formed archives are returned.
+            parseSessionArchiveTimestamp(d.name, "reset") != null,
+        )
         .map((d) => d.name)
         .toSorted(); // archive timestamps are ISO-derived and sort lexicographically
       if (archives.length > 0) {

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -267,3 +267,20 @@ export async function cleanupArchivedSessionTranscripts(opts: {
 
   return { removed, scanned };
 }
+
+/**
+ * Returns the path of the most recent `.reset.<timestamp>` archive for the given
+ * session, or undefined if none exist. Used as a fallback in readSessionMessages
+ * so that chat.history returns archived content instead of an empty response
+ * after a daily or manual session reset.
+ */
+export function findLatestResetArchive(sessionId: string, sessionsDir: string): string | undefined {
+  try {
+    const prefix = `${sessionId}.jsonl.reset.`;
+    const files = fs.readdirSync(sessionsDir);
+    const archives = files.filter((name) => name.startsWith(prefix)).toSorted(); // archive timestamps are ISO-derived and sort lexicographically
+    return archives.length > 0 ? path.join(sessionsDir, archives[archives.length - 1]) : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -19,7 +19,7 @@ export type ArchivedSessionTranscript = {
   archivedPath: string;
 };
 
-function classifySessionTranscriptCandidate(
+export function classifySessionTranscriptCandidate(
   sessionId: string,
   sessionFile?: string,
 ): "current" | "stale" | "custom" {

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -273,14 +273,40 @@ export async function cleanupArchivedSessionTranscripts(opts: {
  * session, or undefined if none exist. Used as a fallback in readSessionMessages
  * so that chat.history returns archived content instead of an empty response
  * after a daily or manual session reset.
+ *
+ * Searches both the provided sessions dir and the legacy `~/.openclaw/sessions`
+ * directory, consistent with how resolveSessionTranscriptCandidates locates
+ * primary transcripts.
  */
 export function findLatestResetArchive(sessionId: string, sessionsDir: string): string | undefined {
+  const prefix = `${sessionId}.jsonl.reset.`;
+
+  // Mirror the legacy-dir fallback in resolveSessionTranscriptCandidates so
+  // archives created before a state-dir migration are also found.
+  const dirsToSearch: string[] = [sessionsDir];
   try {
-    const prefix = `${sessionId}.jsonl.reset.`;
-    const files = fs.readdirSync(sessionsDir);
-    const archives = files.filter((name) => name.startsWith(prefix)).toSorted(); // archive timestamps are ISO-derived and sort lexicographically
-    return archives.length > 0 ? path.join(sessionsDir, archives[archives.length - 1]) : undefined;
+    const home = resolveRequiredHomeDir(process.env, os.homedir);
+    const legacyDir = path.join(home, ".openclaw", "sessions");
+    if (path.resolve(legacyDir) !== path.resolve(sessionsDir)) {
+      dirsToSearch.push(legacyDir);
+    }
   } catch {
-    return undefined;
+    // Ignore home-dir resolution failures; primary dir is still searched.
   }
+
+  for (const dir of dirsToSearch) {
+    try {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      const archives = entries
+        .filter((d) => d.isFile() && d.name.startsWith(prefix))
+        .map((d) => d.name)
+        .toSorted(); // archive timestamps are ISO-derived and sort lexicographically
+      if (archives.length > 0) {
+        return path.join(dir, archives[archives.length - 1]);
+      }
+    } catch {
+      // Skip unreadable dirs (missing legacy dir is the common case).
+    }
+  }
+  return undefined;
 }

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -727,6 +727,40 @@ describe("readSessionMessages — reset archive fallback", () => {
       fs.rmSync(legacyDir, { recursive: true, force: true });
     }
   });
+
+  test("finds reset archive for non-canonical sessionFile transcript name", () => {
+    // When a session uses a topic-scoped sessionFile (e.g. <sessionId>-topic-<id>.jsonl),
+    // the reset archive is named after that file, not the plain <sessionId>.jsonl.
+    // findLatestResetArchive must match archives for all candidate basenames.
+    //
+    // Use fs.realpathSync to resolve /tmp → /private/tmp on macOS so that
+    // resolvePathWithinSessionsDir's symlink-aware relative-path check keeps the
+    // candidate instead of treating it as outside the sessions directory.
+    const sessionId = "aa000000-0000-4000-8000-000000000006";
+    const realTmpDir = fs.realpathSync(tmpDir);
+    const realStorePath = path.join(realTmpDir, "sessions.json");
+    const topicSessionFile = path.join(realTmpDir, `${sessionId}-topic-42.jsonl`);
+    const archivePath = `${topicSessionFile}.reset.2026-03-12T04-00-00.000Z`;
+    fs.writeFileSync(
+      archivePath,
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({ message: { role: "user", content: "topic-name archived message" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    try {
+      // Primary file absent; sessionFile candidate has non-canonical basename.
+      const out = readSessionMessages(sessionId, realStorePath, topicSessionFile);
+      expect(out).toHaveLength(1);
+      expect((out[0] as { role: string; content: string }).content).toBe(
+        "topic-name archived message",
+      );
+    } finally {
+      fs.rmSync(archivePath, { force: true });
+    }
+  });
 });
 
 describe("readSessionPreviewItemsFromTranscript", () => {

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -698,6 +698,35 @@ describe("readSessionMessages — reset archive fallback", () => {
     const out = readSessionMessages(sessionId, storePath);
     expect(out).toHaveLength(0);
   });
+
+  test("finds reset archive in legacy ~/.openclaw/sessions dir when not in store dir", () => {
+    const sessionId = "aa000000-0000-4000-8000-000000000005";
+    // Simulate a legacy-layout archive: home dir is remapped to tmpDir so the
+    // legacy path becomes <tmpDir>/.openclaw/sessions.
+    const legacyDir = path.join(tmpDir, ".openclaw", "sessions");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    const archivePath = path.join(legacyDir, `${sessionId}.jsonl.reset.2026-03-12T04-00-00.000Z`);
+    fs.writeFileSync(
+      archivePath,
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({ message: { role: "user", content: "legacy archived message" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    // Point HOME at tmpDir so resolveRequiredHomeDir resolves the fake legacy path.
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+    try {
+      const out = readSessionMessages(sessionId, storePath);
+      expect(out).toHaveLength(1);
+      expect((out[0] as { role: string; content: string }).content).toBe("legacy archived message");
+    } finally {
+      process.env.HOME = origHome;
+      fs.rmSync(legacyDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("readSessionPreviewItemsFromTranscript", () => {

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -794,6 +794,77 @@ describe("readSessionMessages — reset archive fallback", () => {
   });
 });
 
+describe("readSessionTitleFieldsFromTranscript — reset archive fallback", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  registerTempSessionStore("openclaw-session-title-fallback-test-", (nextTmpDir, nextStorePath) => {
+    tmpDir = nextTmpDir;
+    storePath = nextStorePath;
+  });
+
+  afterEach(() => {
+    for (const f of fs.readdirSync(tmpDir)) {
+      if (f.includes(".reset.")) {
+        fs.rmSync(path.join(tmpDir, f));
+      }
+    }
+  });
+
+  test("derives firstUserMessage from reset archive when primary file is missing", () => {
+    const sessionId = "bb000000-0000-4000-8000-000000000001";
+    const archivePath = path.join(tmpDir, `${sessionId}.jsonl.reset.2026-03-12T04-00-00.000Z`);
+    fs.writeFileSync(
+      archivePath,
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({ message: { role: "user", content: "hello from archived chat" } }),
+        JSON.stringify({ message: { role: "assistant", content: "archived assistant reply" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const out = readSessionTitleFieldsFromTranscript(sessionId, storePath);
+    expect(out.firstUserMessage).toBe("hello from archived chat");
+    expect(out.lastMessagePreview).toBe("archived assistant reply");
+  });
+
+  test("prefers primary transcript over reset archive when both exist", () => {
+    const sessionId = "bb000000-0000-4000-8000-000000000002";
+    const primaryPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const archivePath = path.join(tmpDir, `${sessionId}.jsonl.reset.2026-03-12T04-00-00.000Z`);
+
+    fs.writeFileSync(
+      primaryPath,
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({ message: { role: "user", content: "current title" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      archivePath,
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({ message: { role: "user", content: "archived title" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const out = readSessionTitleFieldsFromTranscript(sessionId, storePath);
+    expect(out.firstUserMessage).toBe("current title");
+
+    fs.rmSync(primaryPath);
+  });
+
+  test("returns null fields when neither primary nor archive exists", () => {
+    const sessionId = "bb000000-0000-4000-8000-000000000003";
+    const out = readSessionTitleFieldsFromTranscript(sessionId, storePath);
+    expect(out.firstUserMessage).toBeNull();
+    expect(out.lastMessagePreview).toBeNull();
+  });
+});
+
 describe("readSessionPreviewItemsFromTranscript", () => {
   let tmpDir: string;
   let storePath: string;

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -761,6 +761,37 @@ describe("readSessionMessages — reset archive fallback", () => {
       fs.rmSync(archivePath, { force: true });
     }
   });
+
+  test("does not return archive belonging to a stale (different) session", () => {
+    // resolveSessionTranscriptCandidates includes a stale sessionFile (a path whose
+    // embedded session ID differs from the requested one) for compatibility.
+    // The reset-archive fallback must not pick up archives for that stale basename,
+    // or it would return another session's messages.
+    const sessionId = "aa000000-0000-4000-8000-000000000007";
+    const staleSessionId = "bb000000-0000-4000-8000-000000000008";
+    const realTmpDir = fs.realpathSync(tmpDir);
+    const realStorePath = path.join(realTmpDir, "sessions.json");
+    // Stale sessionFile: belongs to a different session.
+    const staleSessionFile = path.join(realTmpDir, `${staleSessionId}.jsonl`);
+    // Only a reset archive for the stale file exists — no archive for sessionId.
+    const staleArchivePath = `${staleSessionFile}.reset.2026-03-12T04-00-00.000Z`;
+    fs.writeFileSync(
+      staleArchivePath,
+      [
+        JSON.stringify({ type: "session", version: 1, id: staleSessionId }),
+        JSON.stringify({ message: { role: "user", content: "stale session message" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+    try {
+      // Pass the stale sessionFile so it appears as a candidate.
+      const out = readSessionMessages(sessionId, realStorePath, staleSessionFile);
+      // Must not return the stale session's archive content.
+      expect(out).toHaveLength(0);
+    } finally {
+      fs.rmSync(staleArchivePath, { force: true });
+    }
+  });
 });
 
 describe("readSessionPreviewItemsFromTranscript", () => {

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -605,6 +605,101 @@ describe("readSessionMessages", () => {
   );
 });
 
+describe("readSessionMessages — reset archive fallback", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  registerTempSessionStore("openclaw-session-reset-fallback-test-", (nextTmpDir, nextStorePath) => {
+    tmpDir = nextTmpDir;
+    storePath = nextStorePath;
+  });
+
+  afterEach(() => {
+    // Clean up any archive files written during each test.
+    for (const f of fs.readdirSync(tmpDir)) {
+      if (f.includes(".reset.")) {
+        fs.rmSync(path.join(tmpDir, f));
+      }
+    }
+  });
+
+  test("returns messages from the most recent reset archive when primary file is missing", () => {
+    const sessionId = "aa000000-0000-4000-8000-000000000001";
+    const archivePath = path.join(tmpDir, `${sessionId}.jsonl.reset.2026-03-12T04-00-00.000Z`);
+    const lines = [
+      JSON.stringify({ type: "session", version: 1, id: sessionId }),
+      JSON.stringify({ message: { role: "user", content: "archived message" } }),
+    ];
+    fs.writeFileSync(archivePath, lines.join("\n"), "utf-8");
+
+    const out = readSessionMessages(sessionId, storePath);
+    expect(out).toHaveLength(1);
+    expect((out[0] as { role: string; content: string }).content).toBe("archived message");
+  });
+
+  test("prefers primary transcript over reset archive when both exist", () => {
+    const sessionId = "aa000000-0000-4000-8000-000000000002";
+    const primaryPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const archivePath = path.join(tmpDir, `${sessionId}.jsonl.reset.2026-03-12T04-00-00.000Z`);
+
+    fs.writeFileSync(
+      primaryPath,
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({ message: { role: "user", content: "current message" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      archivePath,
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({ message: { role: "user", content: "archived message" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const out = readSessionMessages(sessionId, storePath);
+    expect(out).toHaveLength(1);
+    expect((out[0] as { role: string; content: string }).content).toBe("current message");
+
+    fs.rmSync(primaryPath);
+  });
+
+  test("picks the latest archive when multiple reset archives exist", () => {
+    const sessionId = "aa000000-0000-4000-8000-000000000003";
+    const older = path.join(tmpDir, `${sessionId}.jsonl.reset.2026-03-11T04-00-00.000Z`);
+    const newer = path.join(tmpDir, `${sessionId}.jsonl.reset.2026-03-12T04-00-00.000Z`);
+
+    fs.writeFileSync(
+      older,
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({ message: { role: "user", content: "older archive" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      newer,
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({ message: { role: "user", content: "newer archive" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const out = readSessionMessages(sessionId, storePath);
+    expect(out).toHaveLength(1);
+    expect((out[0] as { role: string; content: string }).content).toBe("newer archive");
+  });
+
+  test("returns empty array when neither primary nor archive exists", () => {
+    const sessionId = "aa000000-0000-4000-8000-000000000004";
+    const out = readSessionMessages(sessionId, storePath);
+    expect(out).toHaveLength(0);
+  });
+});
+
 describe("readSessionPreviewItemsFromTranscript", () => {
   let tmpDir: string;
   let storePath: string;

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -222,9 +222,7 @@ export {
   archiveFileOnDisk,
   archiveSessionTranscripts,
   cleanupArchivedSessionTranscripts,
-  findLatestResetArchive,
   resolveSessionTranscriptCandidates,
-  unarchiveSessionTranscript,
 } from "./session-transcript-files.fs.js";
 
 export function capArrayByJsonBytes<T>(

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -108,7 +108,8 @@ export function readSessionMessages(
   // primary transcript resolution (including legacy ~/.openclaw/sessions).
   if (!filePath && sessionId) {
     const searchDirs = Array.from(new Set(candidates.map((c) => path.dirname(c))));
-    filePath = findLatestResetArchive(sessionId, searchDirs);
+    const candidateBasenames = candidates.map((c) => path.basename(c));
+    filePath = findLatestResetArchive(sessionId, searchDirs, candidateBasenames);
   }
   if (!filePath) {
     return [];

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -104,8 +104,11 @@ export function readSessionMessages(
   // Fall back to the most recent reset archive when no primary transcript exists.
   // This ensures chat.history returns content after a daily or manual session reset
   // rather than an empty response (related: #42336, #56131, #57139).
-  if (!filePath && storePath && sessionId) {
-    filePath = findLatestResetArchive(sessionId, path.dirname(storePath));
+  // Derive search dirs from the same candidate paths so archive lookup mirrors
+  // primary transcript resolution (including legacy ~/.openclaw/sessions).
+  if (!filePath && sessionId) {
+    const searchDirs = Array.from(new Set(candidates.map((c) => path.dirname(c))));
+    filePath = findLatestResetArchive(sessionId, searchDirs);
   }
   if (!filePath) {
     return [];

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { SessionManager, type SessionEntry } from "@mariozechner/pi-coding-agent";
 import { deriveSessionTotalTokens, hasNonzeroUsage, normalizeUsage } from "../agents/usage.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
@@ -13,6 +14,7 @@ import {
   archiveFileOnDisk,
   archiveSessionTranscripts,
   cleanupArchivedSessionTranscripts,
+  findLatestResetArchive,
 } from "./session-transcript-files.fs.js";
 import type { SessionPreviewItem } from "./session-utils.types.js";
 
@@ -98,7 +100,13 @@ export function readSessionMessages(
 ): unknown[] {
   const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, sessionFile);
 
-  const filePath = candidates.find((p) => fs.existsSync(p));
+  let filePath = candidates.find((p) => fs.existsSync(p));
+  // Fall back to the most recent reset archive when no primary transcript exists.
+  // This ensures chat.history returns content after a daily or manual session reset
+  // rather than an empty response (related: #42336, #56131, #57139).
+  if (!filePath && storePath && sessionId) {
+    filePath = findLatestResetArchive(sessionId, path.dirname(storePath));
+  }
   if (!filePath) {
     return [];
   }

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -14,6 +14,7 @@ import {
   archiveFileOnDisk,
   archiveSessionTranscripts,
   cleanupArchivedSessionTranscripts,
+  classifySessionTranscriptCandidate,
   findLatestResetArchive,
 } from "./session-transcript-files.fs.js";
 import type { SessionPreviewItem } from "./session-utils.types.js";
@@ -108,7 +109,11 @@ export function readSessionMessages(
   // primary transcript resolution (including legacy ~/.openclaw/sessions).
   if (!filePath && sessionId) {
     const searchDirs = Array.from(new Set(candidates.map((c) => path.dirname(c))));
-    const candidateBasenames = candidates.map((c) => path.basename(c));
+    // Exclude stale candidates (paths whose embedded session ID belongs to a different session)
+    // to prevent returning another session's archived messages.
+    const candidateBasenames = candidates
+      .filter((c) => classifySessionTranscriptCandidate(sessionId, c) !== "stale")
+      .map((c) => path.basename(c));
     filePath = findLatestResetArchive(sessionId, searchDirs, candidateBasenames);
   }
   if (!filePath) {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -222,7 +222,9 @@ export {
   archiveFileOnDisk,
   archiveSessionTranscripts,
   cleanupArchivedSessionTranscripts,
+  findLatestResetArchive,
   resolveSessionTranscriptCandidates,
+  unarchiveSessionTranscript,
 } from "./session-transcript-files.fs.js";
 
 export function capArrayByJsonBytes<T>(
@@ -259,7 +261,19 @@ export function readSessionTitleFieldsFromTranscript(
   opts?: { includeInterSession?: boolean },
 ): SessionTitleFields {
   const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, sessionFile, agentId);
-  const filePath = candidates.find((p) => fs.existsSync(p));
+  let filePath = candidates.find((p) => fs.existsSync(p));
+  // Fall back to the most recent reset archive when no primary transcript exists,
+  // mirroring readSessionMessages so derivedTitle (firstUserMessage) and
+  // lastMessagePreview survive a daily or manual session reset. Without this,
+  // listSessionsFromStore falls through to formatSessionIdPrefix and the UI
+  // shows a raw sessionId instead of the human-readable first user message.
+  if (!filePath && sessionId) {
+    const searchDirs = Array.from(new Set(candidates.map((c) => path.dirname(c))));
+    const candidateBasenames = candidates
+      .filter((c) => classifySessionTranscriptCandidate(sessionId, c) !== "stale")
+      .map((c) => path.basename(c));
+    filePath = findLatestResetArchive(sessionId, searchDirs, candidateBasenames);
+  }
   if (!filePath) {
     return { firstUserMessage: null, lastMessagePreview: null };
   }


### PR DESCRIPTION
## Summary

When a session resets (daily 4 AM reset or manual `/new`/`/reset`), the primary transcript is archived as `<sessionId>.jsonl.reset.<timestamp>`. After the reset, `chat.history` and `sessions_history` returned an empty response for that session key because `readSessionMessages` only checked the primary file path.

This PR makes `readSessionMessages` fall back to the most recent `.reset.*` archive when no primary transcript exists, so context is not silently lost after a reset.

## Changes

- `src/gateway/session-transcript-files.fs.ts`: add `findLatestResetArchive(sessionId, sessionsDir)` — scans for and returns the path of the most recent reset archive for a session
- `src/gateway/session-utils.fs.ts`: call `findLatestResetArchive` as a fallback in `readSessionMessages` when no primary transcript is found
- `src/gateway/session-utils.fs.test.ts`: 4 new tests covering the fallback (archive used when primary missing, primary preferred when both exist, latest archive picked when multiple exist, empty when neither exists)

## Behaviour

- No change when the primary transcript exists (existing path unaffected)
- When the primary transcript is missing, the most recent `.reset.<timestamp>` archive is served instead of an empty result
- Sessions with no primary and no archive still return `[]`

## Related issues

Fixes part of #45003. Also related to #42336, #56131, #57139.

Note: this PR addresses the symptom (empty `chat.history` after reset). Two follow-up proposals are outlined in #45003 — fixing the daily-reset trigger logic (PR 2) and exposing archives in the UI sidebar (PR 3).

## Test plan

- [x] `pnpm test -- src/gateway/session-utils.fs.test.ts` — all 55 tests pass
- [x] No regressions in existing `readSessionMessages` tests
- [x] New tests cover all four cases: archive fallback, primary preference, latest-archive selection, empty result

Note: `pnpm tsgo` has a pre-existing regression in `src/channels/plugins/contracts/registry.ts` (missing `OpenClawConfig` import, introduced in upstream commit `4b93000d11`) unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)