### PR TITLE
feat(web-fetch): add allowRfc2544BenchmarkRange config for TUN proxy support

### DIFF
--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -69,11 +69,32 @@ await web_fetch({ url: "https://example.com/article" });
         maxRedirects: 3,
         readability: true, // use Readability extraction
         userAgent: "Mozilla/5.0 ...", // override User-Agent
+        allowRfc2544BenchmarkRange: false, // allow 198.18.0.0/15 (TUN proxy Fake-IP)
       },
     },
   },
 }
 ```
+
+### TUN Proxy Support
+
+If you use TUN-based proxies (like Clash Verge Rev) with Fake-IP DNS that assigns addresses in the 198.18.0.0/15 range, enable `allowRfc2544BenchmarkRange`:
+
+```json5
+{
+  tools: {
+    web: {
+      fetch: {
+        allowRfc2544BenchmarkRange: true,
+      },
+    },
+  },
+}
+```
+
+<Warning>
+**Security Note:** This option allows connections to RFC2544 benchmark addresses (198.18.0.0/15), which are normally blocked for security. Only enable this if you're using a TUN proxy that routes these addresses. Other private IP ranges (127.0.0.0/8, 10.0.0.0/8, 192.168.0.0/16, etc.) remain blocked.
+</Warning>
 
 ## Firecrawl fallback
 

--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -149,3 +149,75 @@ describe("web_fetch SSRF protection", () => {
     });
   });
 });
+
+describe("RFC2544 benchmark range (TUN proxy support)", () => {
+  const priorFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation((hostname) =>
+      resolvePinnedHostname(hostname, lookupMock),
+    );
+  });
+
+  afterEach(() => {
+    global.fetch = priorFetch;
+    lookupMock.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("blocks 198.18.0.0/15 by default", async () => {
+    const fetchSpy = setMockFetch();
+    const tool = await createWebFetchToolForTest();
+
+    await expectBlockedUrl(tool, "http://198.18.0.1/test", /private|internal|blocked/i);
+    await expectBlockedUrl(tool, "http://198.19.255.254/test", /private|internal|blocked/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it("allows 198.18.0.0/15 when allowRfc2544BenchmarkRange is enabled", async () => {
+    lookupMock.mockResolvedValue([{ address: "198.18.0.1", family: 4 }]);
+    setMockFetch().mockResolvedValue(textResponse("ok"));
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = await createWebFetchTool({
+      config: {
+        tools: {
+          web: {
+            fetch: {
+              cacheTtlMinutes: 0,
+              allowRfc2544BenchmarkRange: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = await tool?.execute?.("call", { url: "http://198.18.0.1/test" });
+    expect(result?.details).toMatchObject({
+      status: 200,
+      extractor: "raw",
+    });
+  });
+
+  it("blocks other private ranges even when RFC2544 is allowed", async () => {
+    const fetchSpy = setMockFetch();
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = await createWebFetchTool({
+      config: {
+        tools: {
+          web: {
+            fetch: {
+              allowRfc2544BenchmarkRange: true,
+            },
+          },
+        },
+      },
+    });
+
+    await expectBlockedUrl(tool, "http://127.0.0.1/test", /private|internal|blocked/i);
+    await expectBlockedUrl(tool, "http://10.0.0.1/test", /private|internal|blocked/i);
+    await expectBlockedUrl(tool, "http://192.168.1.1/test", /private|internal|blocked/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -89,6 +89,13 @@ function resolveFetchReadabilityEnabled(fetch?: WebFetchConfig): boolean {
   return true;
 }
 
+function resolveFetchAllowRfc2544BenchmarkRange(fetch?: WebFetchConfig): boolean {
+  if (typeof fetch?.allowRfc2544BenchmarkRange === "boolean") {
+    return fetch.allowRfc2544BenchmarkRange;
+  }
+  return false;
+}
+
 function resolveFetchMaxCharsCap(fetch?: WebFetchConfig): number {
   const raw =
     fetch && "maxCharsCap" in fetch && typeof fetch.maxCharsCap === "number"
@@ -245,6 +252,7 @@ type WebFetchRuntimeParams = {
   userAgent: string;
   readabilityEnabled: boolean;
   providerFallback: ReturnType<typeof resolveWebFetchDefinition>;
+  allowRfc2544BenchmarkRange: boolean;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -389,6 +397,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      allowRfc2544BenchmarkRange: params.allowRfc2544BenchmarkRange,
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
@@ -572,6 +581,7 @@ export function createWebFetchTool(options?: {
     return null;
   }
   const readabilityEnabled = resolveFetchReadabilityEnabled(fetch);
+  const allowRfc2544BenchmarkRange = resolveFetchAllowRfc2544BenchmarkRange(fetch);
   const providerFallback = resolveWebFetchDefinition({
     config: options?.config,
     sandboxed: options?.sandboxed,
@@ -609,6 +619,7 @@ export function createWebFetchTool(options?: {
         userAgent,
         readabilityEnabled,
         providerFallback,
+        allowRfc2544BenchmarkRange,
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-guarded-fetch.ts
+++ b/src/agents/tools/web-guarded-fetch.ts
@@ -7,19 +7,15 @@ import {
 } from "../../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 
-const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {
-  dangerouslyAllowPrivateNetwork: true,
-  allowRfc2544BenchmarkRange: true,
-};
-
 type WebToolGuardedFetchOptions = Omit<
   GuardedFetchOptions,
   "mode" | "proxy" | "dangerouslyAllowEnvProxyWithoutPinnedDns"
 > & {
   timeoutSeconds?: number;
   useEnvProxy?: boolean;
+  allowRfc2544BenchmarkRange?: boolean;
 };
-type WebToolEndpointFetchOptions = Omit<WebToolGuardedFetchOptions, "policy" | "useEnvProxy">;
+type WebToolEndpointFetchOptions = Omit<WebToolGuardedFetchOptions, "policy" | "useEnvProxy" | "allowRfc2544BenchmarkRange">;
 
 function resolveTimeoutMs(params: {
   timeoutMs?: number;
@@ -37,9 +33,16 @@ function resolveTimeoutMs(params: {
 export async function fetchWithWebToolsNetworkGuard(
   params: WebToolGuardedFetchOptions,
 ): Promise<GuardedFetchResult> {
-  const { timeoutSeconds, useEnvProxy, ...rest } = params;
+  const { timeoutSeconds, useEnvProxy, allowRfc2544BenchmarkRange, ...rest } = params;
+
+  const policy: SsrFPolicy = {
+    ...(useEnvProxy ? { dangerouslyAllowPrivateNetwork: true } : {}),
+    allowRfc2544BenchmarkRange: allowRfc2544BenchmarkRange === true,
+  };
+
   const resolved = {
     ...rest,
+    policy,
     timeoutMs: resolveTimeoutMs({ timeoutMs: rest.timeoutMs, timeoutSeconds }),
   };
   return fetchWithSsrFGuard(
@@ -68,8 +71,8 @@ export async function withTrustedWebToolsEndpoint<T>(
   return await withWebToolsNetworkGuard(
     {
       ...params,
-      policy: WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY,
       useEnvProxy: true,
+      allowRfc2544BenchmarkRange: true,
     },
     run,
   );

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -542,6 +542,8 @@ export type ToolsConfig = {
       userAgent?: string;
       /** Use Readability to extract main content (default: true). */
       readability?: boolean;
+      /** Allow RFC2544 benchmark range (198.18.0.0/15) for TUN proxy Fake-IP support (default: false). */
+      allowRfc2544BenchmarkRange?: boolean;
     };
   };
   media?: MediaToolsConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -325,6 +325,7 @@ export const ToolsWebFetchSchema = z
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
     readability: z.boolean().optional(),
+    allowRfc2544BenchmarkRange: z.boolean().optional(),
     // Keep the legacy Firecrawl fetch shape loadable so existing installs can
     // start and then migrate cleanly through doctor.
     firecrawl: z


### PR DESCRIPTION
## Summary
Fixes #60393 - Adds configurable support for RFC2544 benchmark range (198.18.0.0/15) to enable web_fetch with TUN-based proxies using Fake-IP DNS.

## Problem
Users with TUN-based proxies (like Clash Verge Rev) that use Fake-IP DNS cannot use the `web_fetch` tool because it blocks connections to the 198.18.0.0/15 range. This range is used by TUN proxies to transparently route traffic through the proxy for real IP resolution. While standard tools like `curl` and browsers work through the TUN stack, OpenClaw's SSRF protection rejects these connections before they reach the TUN layer.

## Root Cause
The SSRF protection system in `src/shared/net/ip.ts:37` defines RFC2544_BENCHMARK_PREFIX (198.18.0.0/15) as a blocked range. The `isBlockedSpecialUseIpv4Address()` function blocks this range by default. While the SSRF policy system already supported `allowRfc2544BenchmarkRange`, it was hardcoded to `true` in `WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY` and not exposed in user configuration.

## Changes
- Added `allowRfc2544BenchmarkRange` field to `ToolsWebFetchSchema` in config schema (defaults to `false`)
- Added `resolveFetchAllowRfc2544BenchmarkRange()` resolution function in `web-fetch.ts`
- Updated `WebFetchRuntimeParams` type to include the new field
- Threaded configuration through `createWebFetchTool()` and `runWebFetch()`
- Replaced hardcoded SSRF policy in `web-guarded-fetch.ts` with dynamic policy building
- Added 3 comprehensive test cases covering default blocking, opt-in allowing, and security validation
- Documented the option in `docs/tools/web-fetch.md` with security warnings

## Why This Is Safe
- **Secure by default**: Option defaults to `false`, maintaining current security posture
- **Opt-in only**: Users must explicitly enable in configuration
- **Scoped exception**: Only affects 198.18.0.0/15 range
- **Other protections remain**: All other private IP ranges (127.0.0.0/8, 10.0.0.0/8, 192.168.0.0/16, etc.) remain blocked
- **Backward compatible**: Existing configurations continue to work unchanged

## Testing

**Test coverage:**
- ✅ 8/8 tests pass in `web-fetch.ssrf.test.ts` (including 3 new RFC2544 tests)
- ✅ 8/8 tests pass in `ip.test.ts` (IP classification)
- ✅ 25/25 tests pass in `ssrf.test.ts` (SSRF protection)

**New test cases:**
1. Verifies 198.18.0.0/15 is blocked by default
2. Verifies 198.18.0.0/15 is allowed when config option is enabled
3. Verifies other private ranges remain blocked even when RFC2544 is allowed

## Configuration Example

Users with TUN proxies can enable this in their config:

\`\`\`json5
{
  "tools": {
    "web": {
      "fetch": {
        "allowRfc2544BenchmarkRange": true
      }
    }
  }
}
\`\`\`

## Related
- Fixes #60393
- Addresses use case for TUN-based proxy users (Clash Verge Rev, etc.)