### PR TITLE
Upgrade @line/bot-sdk to v11

### DIFF
--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -1,4 +1,4 @@
-import type { MessageEvent, PostbackEvent } from "@line/bot-sdk";
+import type { webhook } from "@line/bot-sdk";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LineAccountConfig } from "./types.js";
@@ -104,12 +104,12 @@ function createReplayMessageEvent(params: {
     mode: "active",
     webhookEventId: params.webhookEventId,
     deliveryContext: { isRedelivery: params.isRedelivery },
-  } as MessageEvent;
+  } as webhook.MessageEvent;
 }
 
 function createTestMessageEvent(params: {
-  message: MessageEvent["message"];
-  source: MessageEvent["source"];
+  message: webhook.MessageEvent["message"];
+  source: webhook.MessageEvent["source"];
   webhookEventId: string;
   timestamp?: number;
   replyToken?: string;
@@ -124,7 +124,7 @@ function createTestMessageEvent(params: {
     mode: "active",
     webhookEventId: params.webhookEventId,
     deliveryContext: { isRedelivery: params.isRedelivery ?? false },
-  } as MessageEvent;
+  } as webhook.MessageEvent;
 }
 
 function createLineWebhookTestContext(params: {
@@ -176,7 +176,7 @@ function createOpenGroupReplayContext(
 
 async function expectGroupMessageBlocked(params: {
   processMessage: LineWebhookContext["processMessage"];
-  event: MessageEvent;
+  event: webhook.MessageEvent;
   context: Parameters<typeof handleLineWebhookEvents>[1];
 }) {
   await handleLineWebhookEvents([params.event], params.context);
@@ -184,7 +184,7 @@ async function expectGroupMessageBlocked(params: {
   expect(buildLineMessageContextMock).not.toHaveBeenCalled();
 }
 
-async function expectRequireMentionGroupMessageProcessed(event: MessageEvent) {
+async function expectRequireMentionGroupMessageProcessed(event: webhook.MessageEvent) {
   const processMessage = vi.fn();
   await handleLineWebhookEvents(
     [event],
@@ -199,7 +199,7 @@ async function expectRequireMentionGroupMessageProcessed(event: MessageEvent) {
 }
 
 async function startInflightReplayDuplicate(params: {
-  event: MessageEvent;
+  event: webhook.MessageEvent;
   processMessage: LineWebhookContext["processMessage"];
 }) {
   const context = createOpenGroupReplayContext(
@@ -244,7 +244,7 @@ describe("handleLineWebhookEvents", () => {
       mode: "active",
       webhookEventId: "evt-1",
       deliveryContext: { isRedelivery: false },
-    } as MessageEvent;
+    } as webhook.MessageEvent;
 
     await handleLineWebhookEvents([event], {
       cfg: { channels: { line: { groupPolicy: "disabled" } } },
@@ -292,7 +292,7 @@ describe("handleLineWebhookEvents", () => {
       mode: "active",
       webhookEventId: "evt-3",
       deliveryContext: { isRedelivery: false },
-    } as MessageEvent;
+    } as webhook.MessageEvent;
 
     await handleLineWebhookEvents([event], {
       cfg: {
@@ -331,7 +331,7 @@ describe("handleLineWebhookEvents", () => {
       mode: "active",
       webhookEventId: "evt-5",
       deliveryContext: { isRedelivery: false },
-    } as MessageEvent;
+    } as webhook.MessageEvent;
 
     await handleLineWebhookEvents([event], {
       cfg: {
@@ -366,7 +366,7 @@ describe("handleLineWebhookEvents", () => {
       mode: "active",
       webhookEventId: "evt-5a",
       deliveryContext: { isRedelivery: false },
-    } as MessageEvent;
+    } as webhook.MessageEvent;
 
     await handleLineWebhookEvents([event], {
       cfg: {
@@ -432,7 +432,7 @@ describe("handleLineWebhookEvents", () => {
       mode: "active",
       webhookEventId: "evt-4",
       deliveryContext: { isRedelivery: false },
-    } as MessageEvent;
+    } as webhook.MessageEvent;
 
     await handleLineWebhookEvents([event], {
       cfg: { channels: { line: { groupPolicy: "open" } } },
@@ -464,7 +464,7 @@ describe("handleLineWebhookEvents", () => {
       mode: "active",
       webhookEventId: "evt-5",
       deliveryContext: { isRedelivery: false },
-    } as MessageEvent;
+    } as webhook.MessageEvent;
 
     await handleLineWebhookEvents([event], {
       cfg: { channels: { line: { dmPolicy: "pairing" } } },
@@ -511,7 +511,7 @@ describe("handleLineWebhookEvents", () => {
       mode: "active",
       webhookEventId: "evt-6",
       deliveryContext: { isRedelivery: false },
-    } as MessageEvent;
+    } as webhook.MessageEvent;
 
     await handleLineWebhookEvents([event], {
       cfg: { channels: { line: { dmPolicy: "pairing" } } },
@@ -615,7 +615,7 @@ describe("handleLineWebhookEvents", () => {
       mode: "active",
       webhookEventId: "evt-dup-1",
       deliveryContext: { isRedelivery: false },
-    } as MessageEvent;
+    } as webhook.MessageEvent;
 
     const context: Parameters<typeof handleLineWebhookEvents>[1] = {
       cfg: {
@@ -646,7 +646,7 @@ describe("handleLineWebhookEvents", () => {
           ...event,
           webhookEventId: "evt-dup-redelivery",
           deliveryContext: { isRedelivery: true },
-        } as MessageEvent,
+        } as webhook.MessageEvent,
       ],
       context,
     );
@@ -672,7 +672,7 @@ describe("handleLineWebhookEvents", () => {
       mode: "active",
       webhookEventId: "evt-postback-1",
       deliveryContext: { isRedelivery: false },
-    } as PostbackEvent;
+    } as webhook.PostbackEvent;
 
     const context: Parameters<typeof handleLineWebhookEvents>[1] = {
       cfg: { channels: { line: { dmPolicy: "open" } } },
@@ -697,7 +697,7 @@ describe("handleLineWebhookEvents", () => {
           ...event,
           replyToken: "reply-token-2",
           deliveryContext: { isRedelivery: true },
-        } as PostbackEvent,
+        } as webhook.PostbackEvent,
       ],
       context,
     );
@@ -787,7 +787,7 @@ describe("handleLineWebhookEvents", () => {
         mention: {
           mentionees: [{ index: 0, length: 4, type: "user", isSelf: true }],
         },
-      } as unknown as MessageEvent["message"],
+      } as unknown as webhook.MessageEvent["message"],
       source: { type: "group", groupId: "group-mention", userId: "user-mention" },
       webhookEventId: "evt-mention-2",
     });
@@ -814,7 +814,7 @@ describe("handleLineWebhookEvents", () => {
         mention: {
           mentionees: [{ index: 0, length: 4, type: "all" }],
         },
-      } as MessageEvent["message"],
+      } as webhook.MessageEvent["message"],
       source: { type: "group", groupId: "group-mention", userId: "user-mention" },
       webhookEventId: "evt-mention-3",
     });
@@ -868,7 +868,7 @@ describe("handleLineWebhookEvents", () => {
         type: "text",
         text: "@other !status",
         mention: { mentionees: [{ index: 0, length: 6, type: "user", isSelf: false }] },
-      } as unknown as MessageEvent["message"],
+      } as unknown as webhook.MessageEvent["message"],
       source: { type: "group", groupId: "group-1", userId: "user-other" },
       webhookEventId: "evt-mention-other",
     });

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -1,12 +1,4 @@
-import type {
-  FollowEvent,
-  JoinEvent,
-  LeaveEvent,
-  MessageEvent,
-  PostbackEvent,
-  UnfollowEvent,
-  WebhookEvent,
-} from "@line/bot-sdk";
+import type { webhook } from "@line/bot-sdk";
 import {
   buildMentionRegexes,
   matchesMentionPatterns,
@@ -66,7 +58,7 @@ const LINE_DOWNLOADABLE_MESSAGE_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 function isDownloadableLineMessageType(
-  messageType: MessageEvent["message"]["type"],
+  messageType: webhook.MessageEvent["message"]["type"],
 ): messageType is "image" | "video" | "audio" | "file" {
   return LINE_DOWNLOADABLE_MESSAGE_TYPES.has(messageType);
 }
@@ -121,7 +113,7 @@ function pruneLineWebhookReplayCache(cache: LineWebhookReplayCache, nowMs: numbe
 }
 
 function buildLineWebhookReplayKey(
-  event: WebhookEvent,
+  event: webhook.Event,
   accountId: string,
 ): { key: string; eventId: string } | null {
   if (event.type === "message") {
@@ -166,7 +158,7 @@ type LineInFlightReplayResult = {
 };
 
 function getLineReplayCandidate(
-  event: WebhookEvent,
+  event: webhook.Event,
   context: LineHandlerContext,
 ): LineReplayCandidate | null {
   const replay = buildLineWebhookReplayKey(event, context.account.accountId);
@@ -285,7 +277,7 @@ async function sendLinePairingReply(params: {
 }
 
 async function shouldProcessLineEvent(
-  event: MessageEvent | PostbackEvent,
+  event: webhook.MessageEvent | webhook.PostbackEvent,
   context: LineHandlerContext,
 ): Promise<{ allowed: boolean; commandAuthorized: boolean }> {
   const denied = { allowed: false, commandAuthorized: false };
@@ -418,7 +410,7 @@ async function shouldProcessLineEvent(
 }
 
 function getLineMentionees(
-  message: MessageEvent["message"],
+  message: webhook.MessageEvent["message"],
 ): Array<{ type?: string; isSelf?: boolean }> {
   if (message.type !== "text") {
     return [];
@@ -431,15 +423,15 @@ function getLineMentionees(
   return Array.isArray(mentionees) ? mentionees : [];
 }
 
-function isLineBotMentioned(message: MessageEvent["message"]): boolean {
+function isLineBotMentioned(message: webhook.MessageEvent["message"]): boolean {
   return getLineMentionees(message).some((m) => m.isSelf === true || m.type === "all");
 }
 
-function hasAnyLineMention(message: MessageEvent["message"]): boolean {
+function hasAnyLineMention(message: webhook.MessageEvent["message"]): boolean {
   return getLineMentionees(message).length > 0;
 }
 
-function resolveEventRawText(event: MessageEvent | PostbackEvent): string {
+function resolveEventRawText(event: webhook.MessageEvent | webhook.PostbackEvent): string {
   if (event.type === "message") {
     const msg = event.message;
     if (msg.type === "text") {
@@ -455,7 +447,7 @@ function resolveEventRawText(event: MessageEvent | PostbackEvent): string {
 
 function resolveLineCommandAuthorized(params: {
   cfg: OpenClawConfig;
-  event: MessageEvent | PostbackEvent;
+  event: webhook.MessageEvent | webhook.PostbackEvent;
   senderId?: string;
   allow: NormalizedAllowFrom;
 }): boolean {
@@ -474,7 +466,7 @@ function resolveLineCommandAuthorized(params: {
   return commandGate.commandAuthorized;
 }
 
-async function handleMessageEvent(event: MessageEvent, context: LineHandlerContext): Promise<void> {
+async function handleMessageEvent(event: webhook.MessageEvent, context: LineHandlerContext): Promise<void> {
   const { cfg, account, runtime, mediaMaxBytes, processMessage } = context;
   const message = event.message;
 
@@ -581,33 +573,33 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   }
 }
 
-async function handleFollowEvent(event: FollowEvent, _context: LineHandlerContext): Promise<void> {
+async function handleFollowEvent(event: webhook.FollowEvent, _context: LineHandlerContext): Promise<void> {
   const userId = event.source.type === "user" ? event.source.userId : undefined;
   logVerbose(`line: user ${userId ?? "unknown"} followed`);
 }
 
 async function handleUnfollowEvent(
-  event: UnfollowEvent,
+  event: webhook.UnfollowEvent,
   _context: LineHandlerContext,
 ): Promise<void> {
   const userId = event.source.type === "user" ? event.source.userId : undefined;
   logVerbose(`line: user ${userId ?? "unknown"} unfollowed`);
 }
 
-async function handleJoinEvent(event: JoinEvent, _context: LineHandlerContext): Promise<void> {
+async function handleJoinEvent(event: webhook.JoinEvent, _context: LineHandlerContext): Promise<void> {
   const groupId = event.source.type === "group" ? event.source.groupId : undefined;
   const roomId = event.source.type === "room" ? event.source.roomId : undefined;
   logVerbose(`line: bot joined ${groupId ? `group ${groupId}` : `room ${roomId}`}`);
 }
 
-async function handleLeaveEvent(event: LeaveEvent, _context: LineHandlerContext): Promise<void> {
+async function handleLeaveEvent(event: webhook.LeaveEvent, _context: LineHandlerContext): Promise<void> {
   const groupId = event.source.type === "group" ? event.source.groupId : undefined;
   const roomId = event.source.type === "room" ? event.source.roomId : undefined;
   logVerbose(`line: bot left ${groupId ? `group ${groupId}` : `room ${roomId}`}`);
 }
 
 async function handlePostbackEvent(
-  event: PostbackEvent,
+  event: webhook.PostbackEvent,
   context: LineHandlerContext,
 ): Promise<void> {
   const data = event.postback.data;
@@ -632,7 +624,7 @@ async function handlePostbackEvent(
 }
 
 export async function handleLineWebhookEvents(
-  events: WebhookEvent[],
+  events: webhook.Event[],
   context: LineHandlerContext,
 ): Promise<void> {
   let firstError: unknown;
@@ -674,7 +666,7 @@ export async function handleLineWebhookEvents(
           await handlePostbackEvent(event, context);
           break;
         default:
-          logVerbose(`line: unhandled event type: ${(event as WebhookEvent).type}`);
+          logVerbose(`line: unhandled event type: ${(event as webhook.Event).type}`);
       }
       if (replayCandidate) {
         rememberLineReplayEvent(replayCandidate);

--- a/extensions/line/src/bot-message-context.test.ts
+++ b/extensions/line/src/bot-message-context.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { MessageEvent, PostbackEvent } from "@line/bot-sdk";
+import type { webhook } from "@line/bot-sdk";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-runtime";
 import { __testing as sessionBindingTesting } from "openclaw/plugin-sdk/conversation-runtime";
@@ -30,9 +30,9 @@ describe("buildLineMessageContext", () => {
   };
 
   const createMessageEvent = (
-    source: MessageEvent["source"],
-    overrides?: Partial<MessageEvent>,
-  ): MessageEvent =>
+    source: webhook.MessageEvent["source"],
+    overrides?: Partial<webhook.MessageEvent>,
+  ): webhook.MessageEvent =>
     ({
       type: "message",
       message: { id: "1", type: "text", text: "hello" },
@@ -43,12 +43,12 @@ describe("buildLineMessageContext", () => {
       webhookEventId: "evt-1",
       deliveryContext: { isRedelivery: false },
       ...overrides,
-    }) as MessageEvent;
+    }) as webhook.MessageEvent;
 
   const createPostbackEvent = (
-    source: PostbackEvent["source"],
-    overrides?: Partial<PostbackEvent>,
-  ): PostbackEvent =>
+    source: webhook.PostbackEvent["source"],
+    overrides?: Partial<webhook.PostbackEvent>,
+  ): webhook.PostbackEvent =>
     ({
       type: "postback",
       postback: { data: "action=select" },
@@ -59,7 +59,7 @@ describe("buildLineMessageContext", () => {
       webhookEventId: "evt-2",
       deliveryContext: { isRedelivery: false },
       ...overrides,
-    }) as PostbackEvent;
+    }) as webhook.PostbackEvent;
 
   beforeEach(async () => {
     setActivePluginRegistry(
@@ -184,7 +184,7 @@ describe("buildLineMessageContext", () => {
     const event = createMessageEvent(
       { type: "user", userId: "user-audio" },
       {
-        message: { id: "audio-1", type: "audio", duration: 1000 } as MessageEvent["message"],
+        message: { id: "audio-1", type: "audio", duration: 1000 } as webhook.MessageEvent["message"],
       },
     );
 
@@ -265,7 +265,7 @@ describe("buildLineMessageContext", () => {
       mode: "active",
       webhookEventId: "evt-1",
       deliveryContext: { isRedelivery: false },
-    } as MessageEvent;
+    } as webhook.MessageEvent;
 
     const context = await buildLineMessageContext({
       event,
@@ -303,7 +303,7 @@ describe("buildLineMessageContext", () => {
       mode: "active",
       webhookEventId: "evt-2",
       deliveryContext: { isRedelivery: false },
-    } as MessageEvent;
+    } as webhook.MessageEvent;
 
     const context = await buildLineMessageContext({
       event,

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -1,4 +1,4 @@
-import type { EventSource, MessageEvent, PostbackEvent, StickerEventMessage } from "@line/bot-sdk";
+import type { webhook } from "@line/bot-sdk";
 import {
   formatInboundEnvelope,
   formatLocationText,
@@ -32,7 +32,7 @@ interface MediaRef {
 }
 
 interface BuildLineMessageContextParams {
-  event: MessageEvent;
+  event: webhook.MessageEvent;
   allMedia: MediaRef[];
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
@@ -48,7 +48,7 @@ export type LineSourceInfo = {
   isGroup: boolean;
 };
 
-export function getLineSourceInfo(source: EventSource): LineSourceInfo {
+export function getLineSourceInfo(source: webhook.Source): LineSourceInfo {
   const userId =
     source.type === "user"
       ? source.userId
@@ -64,7 +64,7 @@ export function getLineSourceInfo(source: EventSource): LineSourceInfo {
   return { userId, groupId, roomId, isGroup };
 }
 
-function buildPeerId(source: EventSource): string {
+function buildPeerId(source: webhook.Source): string {
   const groupKey = resolveLineGroupHistoryKey({
     groupId: source.type === "group" ? source.groupId : undefined,
     roomId: source.type === "room" ? source.roomId : undefined,
@@ -79,7 +79,7 @@ function buildPeerId(source: EventSource): string {
 }
 
 async function resolveLineInboundRoute(params: {
-  source: EventSource;
+  source: webhook.Source;
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
 }): Promise<{
@@ -178,21 +178,19 @@ const STICKER_PACKAGES: Record<string, string> = {
   "11539": "Moon",
 };
 
-function describeStickerKeywords(sticker: StickerEventMessage): string {
-  const keywords = (sticker as StickerEventMessage & { keywords?: string[] }).keywords;
-  if (keywords && keywords.length > 0) {
-    return keywords.slice(0, 3).join(", ");
+function describeStickerKeywords(sticker: webhook.StickerMessageContent): string {
+  if (sticker.keywords && sticker.keywords.length > 0) {
+    return sticker.keywords.slice(0, 3).join(", ");
   }
 
-  const stickerText = (sticker as StickerEventMessage & { text?: string }).text;
-  if (stickerText) {
-    return stickerText;
+  if (sticker.text) {
+    return sticker.text;
   }
 
   return "";
 }
 
-function extractMessageText(message: MessageEvent["message"]): string {
+function extractMessageText(message: webhook.MessageEvent["message"]): string {
   if (message.type === "text") {
     return message.text;
   }
@@ -220,7 +218,7 @@ function extractMessageText(message: MessageEvent["message"]): string {
   return "";
 }
 
-function extractMediaPlaceholder(message: MessageEvent["message"]): string {
+function extractMediaPlaceholder(message: webhook.MessageEvent["message"]): string {
   switch (message.type) {
     case "image":
       return "<media:image>";
@@ -286,7 +284,7 @@ function resolveLineGroupSystemPrompt(
 async function finalizeLineInboundContext(params: {
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
-  event: MessageEvent | PostbackEvent;
+  event: webhook.MessageEvent | webhook.PostbackEvent;
   route: LineRouteInfo;
   source: LineSourceInfoWithPeerId;
   rawBody: string;
@@ -510,7 +508,7 @@ export async function buildLineMessageContext(params: BuildLineMessageContextPar
 }
 
 export async function buildLinePostbackContext(params: {
-  event: PostbackEvent;
+  event: webhook.PostbackEvent;
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
   commandAuthorized: boolean;

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -1,4 +1,4 @@
-import type { WebhookRequestBody } from "@line/bot-sdk";
+import type { webhook } from "@line/bot-sdk";
 import type { NextFunction, Request, Response } from "express";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
@@ -25,7 +25,7 @@ export interface LineBotOptions {
 }
 
 export interface LineBot {
-  handleWebhook: (body: WebhookRequestBody) => Promise<void>;
+  handleWebhook: (body: webhook.CallbackRequest) => Promise<void>;
   account: ResolvedLineAccount;
 }
 
@@ -48,7 +48,7 @@ export function createLineBot(opts: LineBotOptions): LineBot {
   const replayCache = createLineWebhookReplayCache();
   const groupHistories = new Map<string, HistoryEntry[]>();
 
-  const handleWebhook = async (body: WebhookRequestBody): Promise<void> => {
+  const handleWebhook = async (body: webhook.CallbackRequest): Promise<void> => {
     if (!body.events || body.events.length === 0) {
       return;
     }

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -1,4 +1,4 @@
-import type { WebhookRequestBody } from "@line/bot-sdk";
+import type { webhook } from "@line/bot-sdk";
 import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import {
@@ -53,7 +53,7 @@ export interface MonitorLineProviderOptions {
 
 export interface LineProviderMonitor {
   account: ResolvedLineAccount;
-  handleWebhook: (body: WebhookRequestBody) => Promise<void>;
+  handleWebhook: (body: webhook.CallbackRequest) => Promise<void>;
   stop: () => void;
 }
 

--- a/extensions/line/src/types.ts
+++ b/extensions/line/src/types.ts
@@ -1,12 +1,4 @@
-import type {
-  AudioMessage,
-  ImageMessage,
-  LocationMessage,
-  StickerMessage,
-  TextMessage,
-  VideoMessage,
-  WebhookEvent,
-} from "@line/bot-sdk";
+import type { messagingApi, webhook } from "@line/bot-sdk";
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 
 export type LineTokenSource = "config" | "env" | "file" | "none";
@@ -63,15 +55,15 @@ export interface ResolvedLineAccount {
 }
 
 export type LineMessageType =
-  | TextMessage
-  | ImageMessage
-  | VideoMessage
-  | AudioMessage
-  | StickerMessage
-  | LocationMessage;
+  | messagingApi.TextMessage
+  | messagingApi.ImageMessage
+  | messagingApi.VideoMessage
+  | messagingApi.AudioMessage
+  | messagingApi.StickerMessage
+  | messagingApi.LocationMessage;
 
 export interface LineWebhookContext {
-  event: WebhookEvent;
+  event: webhook.Event;
   replyToken?: string;
   userId?: string;
   groupId?: string;

--- a/extensions/line/src/webhook-node.ts
+++ b/extensions/line/src/webhook-node.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { WebhookRequestBody } from "@line/bot-sdk";
+import type { webhook } from "@line/bot-sdk";
 import { danger, logVerbose, type RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import {
   isRequestBodyLimitError,
@@ -27,7 +27,7 @@ type ReadBodyFn = (req: IncomingMessage, maxBytes: number, timeoutMs?: number) =
 
 export function createLineNodeWebhookHandler(params: {
   channelSecret: string;
-  bot: { handleWebhook: (body: WebhookRequestBody) => Promise<void> };
+  bot: { handleWebhook: (body: webhook.CallbackRequest) => Promise<void> };
   runtime: RuntimeEnv;
   readBody?: ReadBodyFn;
   maxBodyBytes?: number;

--- a/extensions/line/src/webhook-utils.ts
+++ b/extensions/line/src/webhook-utils.ts
@@ -1,9 +1,9 @@
-import type { WebhookRequestBody } from "@line/bot-sdk";
+import type { webhook } from "@line/bot-sdk";
 export { validateLineSignature } from "./signature.js";
 
-export function parseLineWebhookBody(rawBody: string): WebhookRequestBody | null {
+export function parseLineWebhookBody(rawBody: string): webhook.CallbackRequest | null {
   try {
-    return JSON.parse(rawBody) as WebhookRequestBody;
+    return JSON.parse(rawBody) as webhook.CallbackRequest;
   } catch {
     return null;
   }

--- a/extensions/line/src/webhook.ts
+++ b/extensions/line/src/webhook.ts
@@ -1,4 +1,4 @@
-import type { WebhookRequestBody } from "@line/bot-sdk";
+import type { webhook } from "@line/bot-sdk";
 import type { NextFunction, Request, Response } from "express";
 import { danger, logVerbose, type RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { parseLineWebhookBody, validateLineSignature } from "./webhook-utils.js";
@@ -7,7 +7,7 @@ const LINE_WEBHOOK_MAX_RAW_BODY_BYTES = 64 * 1024;
 
 export interface LineWebhookOptions {
   channelSecret: string;
-  onEvents: (body: WebhookRequestBody) => Promise<void>;
+  onEvents: (body: webhook.CallbackRequest) => Promise<void>;
   runtime?: RuntimeEnv;
 }
 
@@ -21,7 +21,7 @@ function readRawBody(req: Request): string | null {
   return Buffer.isBuffer(rawBody) ? rawBody.toString("utf-8") : rawBody;
 }
 
-function parseWebhookBody(rawBody?: string | null): WebhookRequestBody | null {
+function parseWebhookBody(rawBody?: string | null): webhook.CallbackRequest | null {
   if (!rawBody) {
     return null;
   }
@@ -83,7 +83,7 @@ export function createLineWebhookMiddleware(
 
 export interface StartLineWebhookOptions {
   channelSecret: string;
-  onEvents: (body: WebhookRequestBody) => Promise<void>;
+  onEvents: (body: webhook.CallbackRequest) => Promise<void>;
   runtime?: RuntimeEnv;
   path?: string;
 }

--- a/package.json
+++ b/package.json
@@ -1126,7 +1126,7 @@
     "@aws-sdk/client-bedrock": "3.1020.0",
     "@clack/prompts": "^1.1.0",
     "@homebridge/ciao": "^1.3.6",
-    "@line/bot-sdk": "^10.6.0",
+    "@line/bot-sdk": "^11.0.0",
     "@lydell/node-pty": "1.2.0-beta.3",
     "@mariozechner/pi-agent-core": "0.64.0",
     "@mariozechner/pi-ai": "0.64.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^1.3.6
         version: 1.3.6
       '@line/bot-sdk':
-        specifier: ^10.6.0
-        version: 10.6.0
+        specifier: ^11.0.0
+        version: 11.0.0
       '@lydell/node-pty':
         specifier: 1.2.0-beta.3
         version: 1.2.0-beta.3
@@ -603,6 +603,8 @@ importers:
         version: 7.15.0
 
   extensions/speech-core: {}
+
+  extensions/stepfun: {}
 
   extensions/synology-chat: {}
 
@@ -1784,8 +1786,8 @@ packages:
   '@larksuiteoapi/node-sdk@1.60.0':
     resolution: {integrity: sha512-MS1eXx7K6HHIyIcCBkJLb21okoa8ZatUGQWZaCCUePm6a37RWFmT6ZKlKvHxAanSX26wNuNlwP0RhgscsE+T6g==}
 
-  '@line/bot-sdk@10.6.0':
-    resolution: {integrity: sha512-4hSpglL/G/cW2JCcohaYz/BS0uOSJNV9IEYdMm0EiPEvDLayoI2hGq2D86uYPQFD2gvgkyhmzdShpWLG3P5r3w==}
+  '@line/bot-sdk@11.0.0':
+    resolution: {integrity: sha512-3NZJjeFm2BikwVRgA8osIVbgKhuL0CzphQOdrB8okXIC40qMRE4RRfHFN3G8/qTb/34RtB95mD4J/KW5MD+b8g==}
     engines: {node: '>=20'}
 
   '@lit-labs/signals@0.2.0':
@@ -8126,13 +8128,9 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@line/bot-sdk@10.6.0':
+  '@line/bot-sdk@11.0.0':
     dependencies:
       '@types/node': 24.12.0
-    optionalDependencies:
-      axios: 1.13.6
-    transitivePeerDependencies:
-      - debug
 
   '@lit-labs/signals@0.2.0':
     dependencies:


### PR DESCRIPTION
Hi openclaw team. I maintain `line-bot-sdk-nodejs`. This PR upgrades OpenClaw to `@line/bot-sdk` v11 and updates the LINE integration to the v11 type surface so we can avoid the dependency path behind #50800.

Closes #50800

Describe the problem and fix in 2–5 bullets:
- Problem: self-built Docker runtime images can fail during startup with `ERR_MODULE_NOT_FOUND` because OpenClaw is still on `@line/bot-sdk` v10 and that dependency path can resolve through `axios` in affected runtime layouts.
- Why it matters: affected deployments crash on boot before the service becomes usable.
- What changed: upgraded `@line/bot-sdk` from `^10.6.0` to `^11.0.0`, regenerated `pnpm-lock.yaml`, and updated the LINE integration’s TypeScript references to the v11 type namespaces (`webhook.*`, `messagingApi.*`, `webhook.CallbackRequest`, etc.).
- What did NOT change (scope boundary): no OpenClaw webhook flow, signature validation, reply logic, or non-LINE integrations were changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50800
- Related #50807, #50840
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: OpenClaw was pinned to `@line/bot-sdk` v10, and in the affected self-built Docker/pnpm runtime layout that dependency path could still require `axios`, causing startup to fail before the LINE integration could initialize.
- Missing detection / guardrail: there is no Docker/runtime smoke test that boots a self-built image with the LINE integration enabled and catches missing runtime dependencies.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #50800 reported the crash; #50807 and #50840 addressed the same issue by adding `axios` directly. This PR fixes the same problem by moving to `@line/bot-sdk` v11 instead.
- Why this regressed now: the failure surfaced in self-built runtime images where relying on the v10 dependency path was brittle under pnpm’s isolated resolution.
- If unknown, what was ruled out: this was not caused by a change in OpenClaw’s webhook business logic; the OpenClaw-side code changes here are limited to the dependency bump and the v11 type migration.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: Docker/runtime smoke test for a self-built image that installs the LINE integration and starts the CLI successfully.
- Scenario the test should lock in: build from source, start the runtime container, initialize the LINE integration, and verify startup does not fail with a missing module error from `@line/bot-sdk`.
- Why this is the smallest reliable guardrail: the original failure happens during dependency resolution in the runtime image, which pure unit tests do not exercise.
- Existing test that already covers this (if any): existing LINE integration tests cover the touched handler/context code paths, but not the runtime dependency graph in a self-built image.
- If no new test is added, why not: this PR is scoped to the SDK major-version upgrade plus the corresponding type-surface migration. A dedicated Docker/runtime smoke test would be the right follow-up guardrail for the original regression.

## User-visible / Behavior Changes

- Self-built Docker deployments using the LINE integration should no longer fail at startup with `ERR_MODULE_NOT_FOUND` for `axios` from `@line/bot-sdk` v10.
- No config, webhook contract, or user-facing command behavior is intended to change.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: self-built Docker runtime image from source
- Model/provider: N/A
- Integration/channel (if any): LINE
- Relevant config (redacted): LINE integration enabled in the runtime image

### Steps

1. Build a runtime image from the current source tree.
2. Deploy/start the `openclaw` container with the LINE integration enabled.
3. Inspect startup logs.

### Expected

- The container starts successfully without a module resolution failure from `@line/bot-sdk`.

### Actual

- Before this fix, startup could fail with `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'axios' imported from /app/node_modules/.pnpm/@line+bot-sdk@10.6.0/node_modules/@line/bot-sdk/dist/http-axios.js`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Example log from #50800:
```text
[openclaw] Failed to start CLI: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'axios' imported from /app/node_modules/.pnpm/@line+bot-sdk@10.6.0/node_modules/@line/bot-sdk/dist/http-axios.js
````

## Human Verification (required)

What you personally verified (not just CI), and how:

* Verified scenarios: reviewed every affected LINE integration source/test file for the v11 type export migration (`webhook.*`, `messagingApi.*`, `webhook.CallbackRequest`, updated message/source/event aliases) and confirmed the dependency + lockfile update is scoped to the SDK bump and corresponding type migration.
* Edge cases checked: message vs postback event typing, webhook request body typing, source typing (`user` / `group` / `room`), and sticker/message content type references.
* What you did **not** verify: full end-to-end Docker deployment behavior outside the touched LINE integration surface.

## Review Conversations

* [ ] I replied to or resolved every bot review conversation I addressed in this PR.
* [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

* Backward compatible? (`Yes`)
* Config/env changes? (`No`)
* Migration needed? (`No`)
* If yes, exact upgrade steps:

## Risks and Mitigations

* Risk: `@line/bot-sdk` v11 is a major-version upgrade and could include behavior differences beyond the type export changes touched here.

  * Mitigation: OpenClaw-side code changes are intentionally limited to the v11 type migration and the dependency/lockfile refresh; webhook handling logic itself was not rewritten.
* Risk: `pnpm-lock.yaml` regeneration may include minor workspace metadata churn alongside the SDK upgrade.

  * Mitigation: the application-code changes are isolated to the LINE integration files listed in this PR.
