### PR TITLE
fix(agents): add channelData marker to exec-approval-unavailable payloads

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.exec-approval-unavailable.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.exec-approval-unavailable.test.ts
@@ -1,0 +1,433 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
+import type {
+  PluginHookBeforeDispatchResult,
+  PluginTargetedInboundClaimOutcome,
+} from "../../plugins/hooks.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
+import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
+import type { MsgContext } from "../templating.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { ReplyDispatcher } from "./reply-dispatcher.js";
+import { buildTestCtx } from "./test-ctx.js";
+
+type AbortResult = { handled: boolean; aborted: boolean; stoppedSubagents?: number };
+
+const mocks = vi.hoisted(() => ({
+  routeReply: vi.fn(async (_params: unknown) => ({ ok: true, messageId: "mock" })),
+  tryFastAbortFromMessage: vi.fn<() => Promise<AbortResult>>(async () => ({
+    handled: false,
+    aborted: false,
+  })),
+}));
+const diagnosticMocks = vi.hoisted(() => ({
+  logMessageQueued: vi.fn(),
+  logMessageProcessed: vi.fn(),
+  logSessionStateChange: vi.fn(),
+}));
+const hookMocks = vi.hoisted(() => ({
+  registry: {
+    plugins: [] as Array<{
+      id: string;
+      status: "loaded" | "disabled" | "error";
+    }>,
+  },
+  runner: {
+    hasHooks: vi.fn<(hookName?: string) => boolean>(() => false),
+    runInboundClaim: vi.fn(async () => undefined),
+    runInboundClaimForPlugin: vi.fn(async () => undefined),
+    runInboundClaimForPluginOutcome: vi.fn<() => Promise<PluginTargetedInboundClaimOutcome>>(
+      async () => ({ status: "no_handler" as const }),
+    ),
+    runMessageReceived: vi.fn(async () => {}),
+    runBeforeDispatch: vi.fn<
+      (_event: unknown, _ctx: unknown) => Promise<PluginHookBeforeDispatchResult | undefined>
+    >(async () => undefined),
+  },
+}));
+const internalHookMocks = vi.hoisted(() => ({
+  createInternalHookEvent: vi.fn(),
+  triggerInternalHook: vi.fn(async () => {}),
+}));
+const acpMocks = vi.hoisted(() => ({
+  listAcpSessionEntries: vi.fn(async () => []),
+  readAcpSessionEntry: vi.fn<() => unknown>(() => null),
+  upsertAcpSessionMeta: vi.fn(async () => null),
+  requireAcpRuntimeBackend: vi.fn<() => unknown>(),
+}));
+const sessionBindingMocks = vi.hoisted(() => ({
+  listBySession: vi.fn<(targetSessionKey: string) => SessionBindingRecord[]>(() => []),
+  resolveByConversation: vi.fn<
+    (ref: {
+      channel: string;
+      accountId: string;
+      conversationId: string;
+      parentConversationId?: string;
+    }) => SessionBindingRecord | null
+  >(() => null),
+  touch: vi.fn(),
+}));
+const sessionStoreMocks = vi.hoisted(() => ({
+  currentEntry: undefined as Record<string, unknown> | undefined,
+  loadSessionStore: vi.fn(() => ({})),
+  resolveStorePath: vi.fn(() => "/tmp/mock-sessions.json"),
+  resolveSessionStoreEntry: vi.fn(() => ({ existing: sessionStoreMocks.currentEntry })),
+}));
+const agentEventMocks = vi.hoisted(() => ({
+  emitAgentEvent: vi.fn(),
+}));
+const ttsMocks = vi.hoisted(() => {
+  const state = {
+    synthesizeFinalAudio: false,
+  };
+  return {
+    state,
+    maybeApplyTtsToPayload: vi.fn(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as {
+        payload: ReplyPayload;
+        kind: "tool" | "block" | "final";
+      };
+      if (
+        state.synthesizeFinalAudio &&
+        params.kind === "final" &&
+        typeof params.payload?.text === "string" &&
+        params.payload.text.trim()
+      ) {
+        return {
+          ...params.payload,
+          mediaUrl: "https://example.com/tts-synth.opus",
+          audioAsVoice: true,
+        };
+      }
+      return params.payload;
+    }),
+    normalizeTtsAutoMode: vi.fn((value: unknown) =>
+      typeof value === "string" ? value : undefined,
+    ),
+    resolveTtsConfig: vi.fn((_cfg: OpenClawConfig) => ({ mode: "final" })),
+  };
+});
+
+vi.mock("./route-reply.runtime.js", () => ({
+  isRoutableChannel: (channel: string | undefined) =>
+    Boolean(
+      channel &&
+      [
+        "telegram",
+        "slack",
+        "discord",
+        "signal",
+        "imessage",
+        "whatsapp",
+        "feishu",
+        "mattermost",
+      ].includes(channel),
+    ),
+  routeReply: mocks.routeReply,
+}));
+
+vi.mock("./route-reply.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./route-reply.js")>();
+  return {
+    ...actual,
+    routeReply: mocks.routeReply,
+  };
+});
+
+vi.mock("./abort.runtime.js", () => ({
+  tryFastAbortFromMessage: mocks.tryFastAbortFromMessage,
+  formatAbortReplyText: (stoppedSubagents?: number) => {
+    if (typeof stoppedSubagents !== "number" || stoppedSubagents <= 0) {
+      return "⚙️ Agent was aborted.";
+    }
+    const label = stoppedSubagents === 1 ? "sub-agent" : "sub-agents";
+    return `⚙️ Agent was aborted. Stopped ${stoppedSubagents} ${label}.`;
+  },
+}));
+
+vi.mock("../../logging/diagnostic.js", () => ({
+  logMessageQueued: diagnosticMocks.logMessageQueued,
+  logMessageProcessed: diagnosticMocks.logMessageProcessed,
+  logSessionStateChange: diagnosticMocks.logSessionStateChange,
+}));
+vi.mock("../../config/sessions/store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions/store.js")>();
+  return {
+    ...actual,
+    loadSessionStore: sessionStoreMocks.loadSessionStore,
+    resolveSessionStoreEntry: sessionStoreMocks.resolveSessionStoreEntry,
+  };
+});
+vi.mock("../../config/sessions/paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions/paths.js")>();
+  return {
+    ...actual,
+    resolveStorePath: sessionStoreMocks.resolveStorePath,
+  };
+});
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookMocks.runner,
+  getGlobalPluginRegistry: () => hookMocks.registry,
+}));
+vi.mock("../../hooks/internal-hooks.js", () => ({
+  createInternalHookEvent: internalHookMocks.createInternalHookEvent,
+  triggerInternalHook: internalHookMocks.triggerInternalHook,
+}));
+vi.mock("../../acp/runtime/session-meta.js", () => ({
+  listAcpSessionEntries: acpMocks.listAcpSessionEntries,
+  readAcpSessionEntry: acpMocks.readAcpSessionEntry,
+  upsertAcpSessionMeta: acpMocks.upsertAcpSessionMeta,
+}));
+vi.mock("../../acp/runtime/registry.js", () => ({
+  requireAcpRuntimeBackend: acpMocks.requireAcpRuntimeBackend,
+}));
+vi.mock("../../infra/outbound/session-binding-service.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../infra/outbound/session-binding-service.js")>();
+  return {
+    ...actual,
+    getSessionBindingService: () => ({
+      bind: vi.fn(async () => {
+        throw new Error("bind not mocked");
+      }),
+      getCapabilities: vi.fn(() => ({
+        adapterAvailable: true,
+        bindSupported: true,
+        unbindSupported: true,
+        placements: ["current", "child"] as const,
+      })),
+      listBySession: (targetSessionKey: string) =>
+        sessionBindingMocks.listBySession(targetSessionKey),
+      resolveByConversation: sessionBindingMocks.resolveByConversation,
+      touch: sessionBindingMocks.touch,
+      unbind: vi.fn(async () => []),
+    }),
+  };
+});
+vi.mock("../../infra/agent-events.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/agent-events.js")>();
+  return {
+    ...actual,
+    emitAgentEvent: (params: unknown) => agentEventMocks.emitAgentEvent(params),
+  };
+});
+vi.mock("../../tts/tts.js", () => ({
+  maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
+  normalizeTtsAutoMode: (value: unknown) => ttsMocks.normalizeTtsAutoMode(value),
+  resolveTtsConfig: (cfg: OpenClawConfig) => ttsMocks.resolveTtsConfig(cfg),
+}));
+vi.mock("../../tts/tts.runtime.js", () => ({
+  maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
+}));
+vi.mock("../../tts/tts-config.js", () => ({
+  normalizeTtsAutoMode: (value: unknown) => ttsMocks.normalizeTtsAutoMode(value),
+  resolveConfiguredTtsMode: (cfg: OpenClawConfig) => ttsMocks.resolveTtsConfig(cfg).mode,
+}));
+
+const noAbortResult = { handled: false, aborted: false } as const;
+const emptyConfig = {} as OpenClawConfig;
+let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
+let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
+let acpManagerTesting: typeof import("../../acp/control-plane/manager.js").__testing;
+let pluginBindingTesting: typeof import("../../plugins/conversation-binding.js").__testing;
+
+function createDispatcher(): ReplyDispatcher {
+  return {
+    sendToolResult: vi.fn(() => true),
+    sendBlockReply: vi.fn(() => true),
+    sendFinalReply: vi.fn(() => true),
+    waitForIdle: vi.fn(async () => {}),
+    getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+    getFailedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+    markComplete: vi.fn(),
+  };
+}
+
+function setNoAbort() {
+  mocks.tryFastAbortFromMessage.mockResolvedValue(noAbortResult);
+}
+
+describe("dispatchReplyFromConfig — resolveToolDeliveryPayload exec-approval-unavailable in group context", () => {
+  beforeAll(async () => {
+    ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
+    ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
+    ({ __testing: acpManagerTesting } = await import("../../acp/control-plane/manager.js"));
+    ({ __testing: pluginBindingTesting } = await import("../../plugins/conversation-binding.js"));
+  });
+
+  beforeEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+    acpManagerTesting.resetAcpSessionManagerForTests();
+    resetInboundDedupe();
+    mocks.routeReply.mockReset();
+    mocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
+    acpMocks.listAcpSessionEntries.mockReset().mockResolvedValue([]);
+    diagnosticMocks.logMessageQueued.mockClear();
+    diagnosticMocks.logMessageProcessed.mockClear();
+    diagnosticMocks.logSessionStateChange.mockClear();
+    hookMocks.runner.hasHooks.mockClear();
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    hookMocks.runner.runInboundClaim.mockClear();
+    hookMocks.runner.runInboundClaim.mockResolvedValue(undefined);
+    hookMocks.runner.runInboundClaimForPlugin.mockClear();
+    hookMocks.runner.runInboundClaimForPlugin.mockResolvedValue(undefined);
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockClear();
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
+      status: "no_handler",
+    });
+    hookMocks.runner.runMessageReceived.mockClear();
+    hookMocks.runner.runBeforeDispatch.mockClear();
+    hookMocks.runner.runBeforeDispatch.mockResolvedValue(undefined);
+    hookMocks.registry.plugins = [];
+    internalHookMocks.createInternalHookEvent.mockClear();
+    internalHookMocks.createInternalHookEvent.mockImplementation(createInternalHookEventPayload);
+    internalHookMocks.triggerInternalHook.mockClear();
+    acpMocks.readAcpSessionEntry.mockReset();
+    acpMocks.readAcpSessionEntry.mockReturnValue(null);
+    acpMocks.upsertAcpSessionMeta.mockReset();
+    acpMocks.upsertAcpSessionMeta.mockResolvedValue(null);
+    acpMocks.requireAcpRuntimeBackend.mockReset();
+    agentEventMocks.emitAgentEvent.mockReset();
+    sessionBindingMocks.listBySession.mockReset();
+    sessionBindingMocks.listBySession.mockReturnValue([]);
+    pluginBindingTesting.reset();
+    sessionBindingMocks.resolveByConversation.mockReset();
+    sessionBindingMocks.resolveByConversation.mockReturnValue(null);
+    sessionBindingMocks.touch.mockReset();
+    sessionStoreMocks.currentEntry = undefined;
+    sessionStoreMocks.loadSessionStore.mockClear();
+    sessionStoreMocks.resolveStorePath.mockClear();
+    sessionStoreMocks.resolveSessionStoreEntry.mockClear();
+    ttsMocks.state.synthesizeFinalAudio = false;
+    ttsMocks.maybeApplyTtsToPayload.mockClear();
+    ttsMocks.normalizeTtsAutoMode.mockClear();
+    ttsMocks.resolveTtsConfig.mockClear();
+    ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
+    setNoAbort();
+  });
+
+  it("delivers exec-approval-unavailable tool result with channelData marker in group context", async () => {
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram", ChatType: "group" });
+
+    const unavailablePayload: ReplyPayload = {
+      text: "Exec approval is required, but no interactive approval client is currently available.",
+      channelData: {
+        execApprovalUnavailable: { reason: "no-approval-route" },
+      },
+    };
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ) => {
+      if (opts?.onToolResult) {
+        await opts.onToolResult(unavailablePayload);
+      }
+      return { text: "" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    const delivered = (dispatcher.sendToolResult as ReturnType<typeof vi.fn>).mock.calls[0][0] as ReplyPayload;
+    expect(delivered.channelData?.execApprovalUnavailable).toEqual({ reason: "no-approval-route" });
+  });
+
+  it("delivers exec-approval-pending tool result in group context (existing behavior preserved)", async () => {
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram", ChatType: "group" });
+
+    const approvalPayload: ReplyPayload = {
+      text: "Approval required.\nRun: /approve abc123 allow-once",
+      channelData: {
+        execApproval: {
+          approvalId: "abc123",
+          approvalSlug: "abc1",
+          allowedDecisions: ["allow-once", "allow-always", "deny"],
+        },
+      },
+    };
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ) => {
+      if (opts?.onToolResult) {
+        await opts.onToolResult(approvalPayload);
+      }
+      return { text: "" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    const delivered = (dispatcher.sendToolResult as ReturnType<typeof vi.fn>).mock.calls[0][0] as ReplyPayload;
+    expect(delivered.channelData?.execApproval).toBeDefined();
+  });
+
+  it("delivers exec-approval-unavailable with initiating-platform-disabled reason in group context", async () => {
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram", ChatType: "group" });
+
+    const unavailablePayload: ReplyPayload = {
+      text: "Exec approval is required, but chat exec approvals are not enabled on this platform.",
+      channelData: {
+        execApprovalUnavailable: { reason: "initiating-platform-disabled" },
+      },
+    };
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ) => {
+      if (opts?.onToolResult) {
+        await opts.onToolResult(unavailablePayload);
+      }
+      return { text: "" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    const delivered = (dispatcher.sendToolResult as ReturnType<typeof vi.fn>).mock.calls[0][0] as ReplyPayload;
+    expect(delivered.channelData?.execApprovalUnavailable).toEqual({
+      reason: "initiating-platform-disabled",
+    });
+  });
+
+  it("delivers exec-approval-unavailable with initiating-platform-unsupported reason in group context", async () => {
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram", ChatType: "group" });
+
+    const unavailablePayload: ReplyPayload = {
+      text: "Exec approval is required, but this platform does not support chat exec approvals.",
+      channelData: {
+        execApprovalUnavailable: { reason: "initiating-platform-unsupported" },
+      },
+    };
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ) => {
+      if (opts?.onToolResult) {
+        await opts.onToolResult(unavailablePayload);
+      }
+      return { text: "" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    const delivered = (dispatcher.sendToolResult as ReturnType<typeof vi.fn>).mock.calls[0][0] as ReplyPayload;
+    expect(delivered.channelData?.execApprovalUnavailable).toEqual({
+      reason: "initiating-platform-unsupported",
+    });
+  });
+});

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -636,13 +636,22 @@ export async function dispatchReplyFromConfig(params: {
       if (shouldSendToolSummaries) {
         return payload;
       }
-      const execApproval =
+      const cd =
         payload.channelData &&
         typeof payload.channelData === "object" &&
         !Array.isArray(payload.channelData)
-          ? payload.channelData.execApproval
+          ? payload.channelData
           : undefined;
+      const execApproval = cd?.execApproval;
       if (execApproval && typeof execApproval === "object" && !Array.isArray(execApproval)) {
+        return payload;
+      }
+      const execApprovalUnavailable = cd?.execApprovalUnavailable;
+      if (
+        execApprovalUnavailable &&
+        typeof execApprovalUnavailable === "object" &&
+        !Array.isArray(execApprovalUnavailable)
+      ) {
         return payload;
       }
       // Group/native flows intentionally suppress tool summary text, but media-only

--- a/src/infra/exec-approval-reply.exec-approval-unavailable.test.ts
+++ b/src/infra/exec-approval-reply.exec-approval-unavailable.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { buildExecApprovalUnavailableReplyPayload } from "./exec-approval-reply.js";
+
+describe("buildExecApprovalUnavailableReplyPayload — channelData marker", () => {
+  it("includes execApprovalUnavailable channelData for no-approval-route", () => {
+    const payload = buildExecApprovalUnavailableReplyPayload({
+      reason: "no-approval-route",
+    });
+    expect(payload.channelData).toBeDefined();
+    expect((payload.channelData as Record<string, unknown>).execApprovalUnavailable).toEqual({
+      reason: "no-approval-route",
+    });
+  });
+
+  it("includes execApprovalUnavailable channelData for initiating-platform-disabled", () => {
+    const payload = buildExecApprovalUnavailableReplyPayload({
+      reason: "initiating-platform-disabled",
+      channelLabel: "WhatsApp",
+    });
+    expect(payload.channelData).toBeDefined();
+    expect((payload.channelData as Record<string, unknown>).execApprovalUnavailable).toEqual({
+      reason: "initiating-platform-disabled",
+    });
+  });
+
+  it("includes execApprovalUnavailable channelData for initiating-platform-unsupported", () => {
+    const payload = buildExecApprovalUnavailableReplyPayload({
+      reason: "initiating-platform-unsupported",
+    });
+    expect(payload.channelData).toBeDefined();
+    expect((payload.channelData as Record<string, unknown>).execApprovalUnavailable).toEqual({
+      reason: "initiating-platform-unsupported",
+    });
+  });
+
+  it("includes channelData with params.reason (not literal) for sentApproverDms path", () => {
+    const payload = buildExecApprovalUnavailableReplyPayload({
+      reason: "no-approval-route",
+      sentApproverDms: true,
+    });
+    expect(payload.channelData).toBeDefined();
+    const cd = payload.channelData as Record<string, unknown>;
+    expect(cd.execApprovalUnavailable).toEqual({
+      reason: "no-approval-route",
+    });
+    // Verify we use the typed reason, not a string literal
+    expect((cd.execApprovalUnavailable as Record<string, unknown>).reason).toBe("no-approval-route");
+  });
+
+  it("does NOT include execApproval (only execApprovalUnavailable)", () => {
+    const payload = buildExecApprovalUnavailableReplyPayload({
+      reason: "no-approval-route",
+    });
+    const cd = payload.channelData as Record<string, unknown>;
+    expect(cd.execApproval).toBeUndefined();
+    expect(cd.execApprovalUnavailable).toBeDefined();
+  });
+
+  it("preserves text content alongside channelData marker", () => {
+    const payload = buildExecApprovalUnavailableReplyPayload({
+      reason: "initiating-platform-disabled",
+      channelLabel: "WhatsApp",
+      warningText: "⚠️ Warning",
+    });
+    expect(payload.text).toContain("⚠️ Warning");
+    expect(payload.text).toContain("WhatsApp");
+    expect(payload.channelData).toBeDefined();
+  });
+});

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -335,6 +335,9 @@ describe("exec approval reply helpers", () => {
       }),
     ).toEqual({
       text: "Careful.\n\nApproval required. I sent approval DMs to the approvers for this account.",
+      channelData: {
+        execApprovalUnavailable: { reason: "no-approval-route" },
+      },
     });
   });
 

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -332,6 +332,9 @@ export function buildExecApprovalUnavailableReplyPayload(
     lines.push(getExecApprovalApproverDmNoticeText());
     return {
       text: lines.join("\n\n"),
+      channelData: {
+        execApprovalUnavailable: { reason: params.reason },
+      },
     };
   }
 
@@ -360,5 +363,8 @@ export function buildExecApprovalUnavailableReplyPayload(
 
   return {
     text: lines.join("\n\n"),
+    channelData: {
+      execApprovalUnavailable: { reason: params.reason },
+    },
   };
 }


### PR DESCRIPTION
## Summary

- **Problem:** `buildExecApprovalUnavailableReplyPayload` returns `{ text: "..." }` with no `channelData` marker, making exec-approval-unavailable payloads indistinguishable from regular assistant text at delivery gates.
- **Why it matters:** In flows where delivery gates filter by payload type (e.g. the `resolveToolDeliveryPayload` group/native flow, and the proposed `replyMode: "tool-only"` gate in #57914), unmarked unavailable payloads are silently dropped. This causes a total blackout: `deterministicApprovalPromptSent` is set despite the message never reaching the user, then all subsequent assistant text is also suppressed.
- **What changed:** Added `channelData.execApprovalUnavailable` with the typed `reason` field to all return paths of `buildExecApprovalUnavailableReplyPayload`, and updated `resolveToolDeliveryPayload` to recognize the new marker alongside the existing `execApproval` check.
- **What did NOT change (scope boundary):** No changes to the `replyMode` tool-only gate (that remains in #57914). No interface changes, no config changes, no new abstractions.

> **AI-assisted:** This PR was researched, planned, and implemented with AI assistance (Claude Opus 4.6 via OpenClaw).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #57914 (proposed `replyMode: "tool-only"` gate — this PR fixes a prerequisite payload marking issue)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** `buildExecApprovalUnavailableReplyPayload` was implemented as text-only, while its sibling `buildExecApprovalPendingReplyPayload` correctly sets `channelData.execApproval`. The unavailable path was never gated before, so the missing marker was harmless until delivery gates that filter by `channelData` were introduced.
- **Missing detection / guardrail:** No type-level or runtime enforcement that system payloads include `channelData` markers. `onToolResult` returns `Promise<void>` with no delivery confirmation.
- **Prior context:** `buildExecApprovalPendingReplyPayload` (line 254) correctly sets `channelData.execApproval`. The unavailable builder (line 322) was likely written before the `channelData`-based gating pattern was established.
- **Why this regressed now:** Not a regression per se — the missing marker was always present but only became observable when `resolveToolDeliveryPayload` (and the proposed tool-only gate) started filtering tool results by `channelData` shape.
- **If unknown, what was ruled out:** N/A — root cause is clear.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/infra/exec-approval-reply.tool-only.test.ts` (6 tests for builder channelData), `src/auto-reply/reply/dispatch-from-config.tool-only.test.ts` (4 tests for delivery gate)
- **Scenario the test should lock in:** `buildExecApprovalUnavailableReplyPayload` always produces `channelData.execApprovalUnavailable` with the correct `reason` on ALL return paths (sentApproverDms and main). `resolveToolDeliveryPayload` passes unavailable payloads through instead of dropping them.
- **Why this is the smallest reliable guardrail:** Unit tests on the builder function directly verify the payload shape. Dispatch tests verify the gate behavior with the marker present.
- **Existing test that already covers this (if any):** `exec-approval-reply.test.ts:329-339` — updated from `toEqual({ text })` to include the new `channelData`.
- **If no new test is added, why not:** N/A — new tests added.

## User-visible / Behavior Changes

- Users on platforms without native exec approval support will now correctly see the "exec approval unavailable" message instead of experiencing a silent blackout where no messages are delivered.

## Diagram (if applicable)

```text
Before:
[exec tool] -> buildUnavailablePayload -> { text: "..." }
           -> resolveToolDeliveryPayload -> no execApproval marker -> DROPPED
           -> deterministicApprovalPromptSent = true -> ALL TEXT SUPPRESSED

After:
[exec tool] -> buildUnavailablePayload -> { text: "...", channelData: { execApprovalUnavailable: { reason } } }
           -> resolveToolDeliveryPayload -> execApprovalUnavailable marker found -> DELIVERED
           -> user sees the unavailable message
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.3.0, arm64)
- Runtime/container: Node v25.6.1
- Model/provider: Any (payload-level fix, model-independent)
- Integration/channel (if any): Any channel without native exec approval (e.g. WhatsApp, platforms with approvals disabled)
- Relevant config (redacted): `execApprovals` configured but no approval route available

### Steps

1. Configure OpenClaw with exec approvals enabled but no approval client available
2. Trigger an exec tool call requiring approval
3. Before fix: silent blackout (no message delivered, all subsequent text suppressed)
4. After fix: user sees the "exec approval unavailable" message with the reason

### Expected

- User receives the exec-approval-unavailable message explaining how to set up approval

### Actual

- Before fix: total blackout — no message delivered, `deterministicApprovalPromptSent` silences everything

## Evidence

- [x] Failing test/log before + passing after
- Updated existing test at `exec-approval-reply.test.ts:329-339` (was `toEqual({ text })`, now includes `channelData`)
- New unit tests: 6 in `exec-approval-reply.tool-only.test.ts`, 4 in `dispatch-from-config.tool-only.test.ts`

## Human Verification (required)

- Verified scenarios: Code review of all 3 changed files, verified line numbers with grep against upstream, confirmed test assertions match expected payload shapes
- Edge cases checked: sentApproverDms path (early return), all 3 reason types, dual-marker edge case (both execApproval and execApprovalUnavailable)
- What you did **not** verify: Full E2E through `pi-embedded-subscribe` handlers (requires full PI runtime). Runtime verification on a live instance pending.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `shouldSuppressLocalExecApprovalPrompt` in `exec-approval-local.ts` passes `hint.kind: "approval-pending"` for all payloads including unavailable ones. If a future plugin uses `hint.kind` for suppression decisions, unavailable payloads could be incorrectly suppressed.
  - Mitigation: No plugin currently implements `shouldSuppressLocalPayloadPrompt`. The `channelData` marker (`execApprovalUnavailable` vs `execApproval`) provides a reliable distinguishing mechanism at the payload level. Tracked as tech debt TD-1 for a future `hint.kind: "approval-unavailable"` addition.

- Risk: `onToolResult` returns `Promise<void>` — no delivery confirmation. `deterministicApprovalPromptSent` is set regardless of whether delivery succeeded.
  - Mitigation: This PR ensures the specific `execApprovalUnavailable` payload passes through gates. The general `onToolResult` delivery confirmation gap is tracked as tech debt TD-2.