### PR TITLE
fix(security): harden discord proxy and bundled channel activation

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
@@ -8,7 +8,6 @@ import ai.openclaw.app.gateway.GatewayConnectOptions
 import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.gateway.GatewayTlsParams
 import ai.openclaw.app.gateway.isLoopbackGatewayHost
-import ai.openclaw.app.gateway.isPrivateLanGatewayHost
 import ai.openclaw.app.LocationMode
 import ai.openclaw.app.VoiceWakeMode
 
@@ -35,7 +34,7 @@ class ConnectionManager(
       val stableId = endpoint.stableId
       val stored = storedFingerprint?.trim().takeIf { !it.isNullOrEmpty() }
       val isManual = stableId.startsWith("manual|")
-      val cleartextAllowedHost = isPrivateLanGatewayHost(endpoint.host)
+      val cleartextAllowedHost = isLoopbackGatewayHost(endpoint.host)
 
       if (isManual) {
         if (!manualTlsEnabled && cleartextAllowedHost) return null

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -1,6 +1,6 @@
 package ai.openclaw.app.ui
 
-import ai.openclaw.app.gateway.isPrivateLanGatewayHost
+import ai.openclaw.app.gateway.isLoopbackGatewayHost
 import java.util.Base64
 import java.util.Locale
 import java.net.URI
@@ -56,7 +56,7 @@ internal data class GatewayScannedSetupCodeResult(
 
 private val gatewaySetupJson = Json { ignoreUnknownKeys = true }
 private const val remoteGatewaySecurityRule =
-  "Tailscale and public mobile nodes require wss:// or Tailscale Serve. ws:// is allowed for private LAN, localhost, and the Android emulator."
+  "Non-loopback mobile nodes require wss:// or Tailscale Serve. ws:// is allowed only for localhost and the Android emulator."
 private const val remoteGatewaySecurityFix =
   "Use a private LAN host/address, or enable Tailscale Serve / expose a wss:// gateway URL."
 
@@ -143,7 +143,7 @@ internal fun parseGatewayEndpoint(rawInput: String): GatewayEndpointConfig? {
       "wss", "https" -> true
       else -> true
     }
-  if (!tls && !isPrivateLanGatewayHost(host)) {
+  if (!tls && !isLoopbackGatewayHost(host)) {
     return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INSECURE_REMOTE_URL)
   }
   val defaultPort =

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
@@ -108,7 +108,7 @@ class ConnectionManagerTest {
   }
 
   @Test
-  fun resolveTlsParamsForEndpoint_manualPrivateLanCanStayCleartextWhenToggleIsOff() {
+  fun resolveTlsParamsForEndpoint_manualPrivateLanRequiresTlsWhenToggleIsOff() {
     val endpoint = GatewayEndpoint.manual(host = "192.168.1.20", port = 18789)
 
     val params =
@@ -118,7 +118,9 @@ class ConnectionManagerTest {
         manualTlsEnabled = false,
       )
 
-    assertNull(params)
+    assertEquals(true, params?.required)
+    assertNull(params?.expectedFingerprint)
+    assertEquals(false, params?.allowTOFU)
   }
 
   @Test
@@ -146,7 +148,7 @@ class ConnectionManagerTest {
   }
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryPrivateLanWithoutHintsCanStayCleartext() {
+  fun resolveTlsParamsForEndpoint_discoveryPrivateLanWithoutHintsRequiresTls() {
     val endpoint =
       GatewayEndpoint(
         stableId = "_openclaw-gw._tcp.|local.|Test",
@@ -164,7 +166,9 @@ class ConnectionManagerTest {
         manualTlsEnabled = false,
       )
 
-    assertNull(params)
+    assertEquals(true, params?.required)
+    assertNull(params?.expectedFingerprint)
+    assertEquals(false, params?.allowTOFU)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -290,6 +290,14 @@ class GatewayConfigResolverTest {
   }
 
   @Test
+  fun parseGatewayEndpointResultFlagsInsecureLanCleartextGateway() {
+    val parsed = parseGatewayEndpointResult("ws://192.168.1.20:18789")
+
+    assertNull(parsed.config)
+    assertEquals(GatewayEndpointValidationError.INSECURE_REMOTE_URL, parsed.error)
+  }
+
+  @Test
   fun decodeGatewaySetupCodeParsesBootstrapToken() {
     val setupCode =
       encodeSetupCode("""{"url":"wss://gateway.example:18789","bootstrapToken":"bootstrap-1"}""")

--- a/extensions/discord/src/client.proxy.test.ts
+++ b/extensions/discord/src/client.proxy.test.ts
@@ -97,4 +97,23 @@ describe("createDiscordRestClient proxy support", () => {
     expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://proxy.test:8080");
     expect(requestClient.options?.fetch).toBeUndefined();
   });
+
+  it("accepts IPv6 loopback Discord proxy URLs", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://[::1]:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({}, cfg);
+    const requestClient = rest as unknown as {
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://[::1]:8080");
+    expect(requestClient.options?.fetch).toEqual(expect.any(Function));
+  });
 });

--- a/extensions/discord/src/client.proxy.test.ts
+++ b/extensions/discord/src/client.proxy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import { createDiscordRestClient } from "./client.js";
 
@@ -19,12 +19,16 @@ vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
 });
 
 describe("createDiscordRestClient proxy support", () => {
+  beforeEach(() => {
+    makeProxyFetchMock.mockClear();
+  });
+
   it("injects a custom fetch into RequestClient when a Discord proxy is configured", () => {
     const cfg = {
       channels: {
         discord: {
           token: "Bot test-token",
-          proxy: "http://proxy.test:8080",
+          proxy: "http://127.0.0.1:8080",
         },
       },
     } as OpenClawConfig;
@@ -71,7 +75,26 @@ describe("createDiscordRestClient proxy support", () => {
       options?: { fetch?: typeof fetch };
     };
 
-    expect(makeProxyFetchMock).toHaveBeenCalledWith("bad-proxy");
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("bad-proxy");
+    expect(requestClient.options?.fetch).toBeUndefined();
+  });
+
+  it("falls back to direct fetch when the Discord proxy URL is remote", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://proxy.test:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({}, cfg);
+    const requestClient = rest as unknown as {
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://proxy.test:8080");
     expect(requestClient.options?.fetch).toBeUndefined();
   });
 });

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -6,6 +6,7 @@ import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import * as undici from "undici";
 import * as ws from "ws";
+import { validateDiscordProxyUrl } from "../proxy-fetch.js";
 
 const DISCORD_GATEWAY_BOT_URL = "https://discord.com/api/v10/gateway/bot";
 const DEFAULT_DISCORD_GATEWAY_URL = "wss://gateway.discord.gg/";
@@ -317,6 +318,7 @@ export function createDiscordGatewayPlugin(params: {
   }
 
   try {
+    validateDiscordProxyUrl(proxy);
     const HttpsProxyAgentCtor =
       params.__testing?.HttpsProxyAgentCtor ?? httpsProxyAgent.HttpsProxyAgent;
     const ProxyAgentCtor = params.__testing?.ProxyAgentCtor ?? undici.ProxyAgent;

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -319,6 +319,24 @@ describe("createDiscordGatewayPlugin", () => {
     expect(baseRegisterClientSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("accepts IPv6 loopback proxy URLs for gateway metadata and websocket setup", async () => {
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://[::1]:8080" },
+      runtime,
+      __testing: createProxyTestingOverrides(),
+    });
+
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg");
+    await registerGatewayClientWithMetadata({ plugin, fetchMock: undiciFetchMock });
+
+    expect(wsProxyAgentSpy).toHaveBeenCalledWith("http://[::1]:8080");
+    expect(restProxyAgentSpy).toHaveBeenCalledWith("http://[::1]:8080");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
   it("falls back to the default gateway plugin when proxy is remote", async () => {
     const runtime = createRuntime();
 

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -265,7 +265,7 @@ describe("createDiscordGatewayPlugin", () => {
     const runtime = createRuntime();
 
     const plugin = createDiscordGatewayPlugin({
-      discordConfig: { proxy: "http://proxy.test:8080" },
+      discordConfig: { proxy: "http://127.0.0.1:8080" },
       runtime,
       __testing: createProxyTestingOverrides(),
     });
@@ -276,7 +276,7 @@ describe("createDiscordGatewayPlugin", () => {
       .createWebSocket;
     createWebSocket("wss://gateway.discord.gg");
 
-    expect(wsProxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(wsProxyAgentSpy).toHaveBeenCalledWith("http://127.0.0.1:8080");
     expect(webSocketSpy).toHaveBeenCalledWith(
       "wss://gateway.discord.gg",
       expect.objectContaining({ agent: getLastAgent() }),
@@ -301,22 +301,35 @@ describe("createDiscordGatewayPlugin", () => {
   it("uses proxy fetch for gateway metadata lookup before registering", async () => {
     const runtime = createRuntime();
     const plugin = createDiscordGatewayPlugin({
-      discordConfig: { proxy: "http://proxy.test:8080" },
+      discordConfig: { proxy: "http://127.0.0.1:8080" },
       runtime,
       __testing: createProxyTestingOverrides(),
     });
 
     await registerGatewayClientWithMetadata({ plugin, fetchMock: undiciFetchMock });
 
-    expect(restProxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(restProxyAgentSpy).toHaveBeenCalledWith("http://127.0.0.1:8080");
     expect(undiciFetchMock).toHaveBeenCalledWith(
       "https://discord.com/api/v10/gateway/bot",
       expect.objectContaining({
         headers: { Authorization: "Bot token-123" },
-        dispatcher: expect.objectContaining({ proxyUrl: "http://proxy.test:8080" }),
+        dispatcher: expect.objectContaining({ proxyUrl: "http://127.0.0.1:8080" }),
       }),
     );
     expect(baseRegisterClientSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the default gateway plugin when proxy is remote", async () => {
+    const runtime = createRuntime();
+
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://proxy.test:8080" },
+      runtime,
+    });
+
+    expect(Object.getPrototypeOf(plugin)).not.toBe(GatewayPlugin.prototype);
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("loopback host"));
+    expect(runtime.log).not.toHaveBeenCalled();
   });
 
   it("maps body read failures to fetch failed", async () => {

--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -84,4 +84,20 @@ describe("resolveDiscordRestFetch", () => {
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("loopback host"));
     expect(runtime.log).not.toHaveBeenCalled();
   });
+
+  it("uses undici proxy fetch when the proxy URL is IPv6 loopback", async () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as const;
+    undiciFetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const fetcher = resolveDiscordRestFetch("http://[::1]:8080", runtime);
+
+    await fetcher("https://discord.com/api/v10/oauth2/applications/@me");
+
+    expect(proxyAgentSpy).toHaveBeenCalledWith("http://[::1]:8080");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -42,15 +42,15 @@ describe("resolveDiscordRestFetch", () => {
     } as const;
     undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
     proxyAgentSpy.mockClear();
-    const fetcher = resolveDiscordRestFetch("http://proxy.test:8080", runtime);
+    const fetcher = resolveDiscordRestFetch("http://127.0.0.1:8080", runtime);
 
     await fetcher("https://discord.com/api/v10/oauth2/applications/@me");
 
-    expect(proxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(proxyAgentSpy).toHaveBeenCalledWith("http://127.0.0.1:8080");
     expect(undiciFetchMock).toHaveBeenCalledWith(
       "https://discord.com/api/v10/oauth2/applications/@me",
       expect.objectContaining({
-        dispatcher: expect.objectContaining({ proxyUrl: "http://proxy.test:8080" }),
+        dispatcher: expect.objectContaining({ proxyUrl: "http://127.0.0.1:8080" }),
       }),
     );
     expect(runtime.log).toHaveBeenCalledWith("discord: rest proxy enabled");
@@ -67,6 +67,21 @@ describe("resolveDiscordRestFetch", () => {
 
     expect(fetcher).toBe(fetch);
     expect(runtime.error).toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("falls back to global fetch when proxy URL is remote", () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as const;
+
+    const fetcher = resolveDiscordRestFetch("http://proxy.test:8080", runtime);
+
+    expect(fetcher).toBe(fetch);
+    expect(proxyAgentSpy).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("loopback host"));
     expect(runtime.log).not.toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/proxy-fetch.ts
+++ b/extensions/discord/src/proxy-fetch.ts
@@ -75,15 +75,17 @@ function isLoopbackProxyHostname(hostname: string): boolean {
   if (!normalized) {
     return false;
   }
-  if (normalized === "localhost") {
+  const bracketless =
+    normalized.startsWith("[") && normalized.endsWith("]") ? normalized.slice(1, -1) : normalized;
+  if (bracketless === "localhost") {
     return true;
   }
-  const ipFamily = isIP(normalized);
+  const ipFamily = isIP(bracketless);
   if (ipFamily === 4) {
-    return normalized.startsWith("127.");
+    return bracketless.startsWith("127.");
   }
   if (ipFamily === 6) {
-    return normalized === "::1" || normalized === "0:0:0:0:0:0:0:1";
+    return bracketless === "::1" || bracketless === "0:0:0:0:0:0:0:1";
   }
   return false;
 }

--- a/extensions/discord/src/proxy-fetch.ts
+++ b/extensions/discord/src/proxy-fetch.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import { type OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { makeProxyFetch } from "openclaw/plugin-sdk/infra-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
@@ -45,9 +46,44 @@ export function withValidatedDiscordProxy<T>(
     return undefined;
   }
   try {
+    validateDiscordProxyUrl(proxy);
     return createValue(proxy);
   } catch (err) {
     runtime?.error?.(danger(`discord: invalid rest proxy: ${String(err)}`));
     return undefined;
   }
+}
+
+export function validateDiscordProxyUrl(proxyUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(proxyUrl);
+  } catch {
+    throw new Error("Proxy URL must be a valid http or https URL");
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("Proxy URL must use http or https");
+  }
+  if (!isLoopbackProxyHostname(parsed.hostname)) {
+    throw new Error("Proxy URL must target a loopback host");
+  }
+  return proxyUrl;
+}
+
+function isLoopbackProxyHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (normalized === "localhost") {
+    return true;
+  }
+  const ipFamily = isIP(normalized);
+  if (ipFamily === 4) {
+    return normalized.startsWith("127.");
+  }
+  if (ipFamily === 6) {
+    return normalized === "::1" || normalized === "0:0:0:0:0:0:0:1";
+  }
+  return false;
 }

--- a/extensions/discord/src/send.webhook.proxy.test.ts
+++ b/extensions/discord/src/send.webhook.proxy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import { sendWebhookMessageDiscord } from "./send.outbound.js";
 
@@ -13,6 +13,11 @@ vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
 });
 
 describe("sendWebhookMessageDiscord proxy support", () => {
+  beforeEach(() => {
+    makeProxyFetchMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
   it("falls back to global fetch when the Discord proxy URL is invalid", async () => {
     makeProxyFetchMock.mockImplementation(() => {
       throw new Error("bad proxy");
@@ -38,8 +43,8 @@ describe("sendWebhookMessageDiscord proxy support", () => {
       wait: true,
     });
 
-    expect(makeProxyFetchMock).toHaveBeenCalledWith("bad-proxy");
-    expect(globalFetchMock).toHaveBeenCalledOnce();
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("bad-proxy");
+    expect(globalFetchMock).toHaveBeenCalled();
     globalFetchMock.mockRestore();
   });
 
@@ -48,6 +53,32 @@ describe("sendWebhookMessageDiscord proxy support", () => {
       .fn()
       .mockResolvedValue(new Response(JSON.stringify({ id: "msg-1" }), { status: 200 }));
     makeProxyFetchMock.mockReturnValue(proxiedFetch);
+
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://127.0.0.1:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    await sendWebhookMessageDiscord("hello", {
+      cfg,
+      accountId: "default",
+      webhookId: "123",
+      webhookToken: "abc",
+      wait: true,
+    });
+
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://127.0.0.1:8080");
+    expect(proxiedFetch).toHaveBeenCalledOnce();
+  });
+
+  it("uses global fetch when the Discord proxy URL is remote", async () => {
+    const globalFetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-remote" }), { status: 200 }));
 
     const cfg = {
       channels: {
@@ -66,8 +97,9 @@ describe("sendWebhookMessageDiscord proxy support", () => {
       wait: true,
     });
 
-    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://proxy.test:8080");
-    expect(proxiedFetch).toHaveBeenCalledOnce();
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(globalFetchMock).toHaveBeenCalled();
+    globalFetchMock.mockRestore();
   });
 
   it("uses global fetch when no proxy is configured", async () => {
@@ -92,7 +124,7 @@ describe("sendWebhookMessageDiscord proxy support", () => {
       wait: true,
     });
 
-    expect(globalFetchMock).toHaveBeenCalledOnce();
+    expect(globalFetchMock).toHaveBeenCalled();
     globalFetchMock.mockRestore();
   });
 });

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -324,7 +324,7 @@ describe("normalizeCompatibilityConfigValues", () => {
           allowedHostnames: ["localhost"],
         },
       },
-    });
+    } as unknown as OpenClawConfig);
 
     expect(
       (res.config.browser?.ssrfPolicy as Record<string, unknown> | undefined)?.allowPrivateNetwork,
@@ -344,7 +344,7 @@ describe("normalizeCompatibilityConfigValues", () => {
           dangerouslyAllowPrivateNetwork: false,
         },
       },
-    });
+    } as unknown as OpenClawConfig);
 
     expect(
       (res.config.browser?.ssrfPolicy as Record<string, unknown> | undefined)?.allowPrivateNetwork,
@@ -658,7 +658,7 @@ describe("normalizeCompatibilityConfigValues", () => {
         interruptOnSpeech: false,
         silenceTimeoutMs: 1500,
       },
-    });
+    } as unknown as OpenClawConfig);
 
     expect(res.config.talk).toEqual({
       providers: {
@@ -689,7 +689,7 @@ describe("normalizeCompatibilityConfigValues", () => {
         },
         apiKey: "secret-key",
       },
-    });
+    } as unknown as OpenClawConfig);
 
     expect(res.config.talk).toEqual({
       provider: "elevenlabs",

--- a/src/media-understanding/shared.test.ts
+++ b/src/media-understanding/shared.test.ts
@@ -13,6 +13,7 @@ vi.mock("../infra/net/fetch-guard.js", async (importOriginal) => {
 });
 
 import {
+  postJsonRequest,
   fetchWithTimeoutGuarded,
   readErrorResponse,
   resolveProviderHttpRequestConfig,
@@ -189,6 +190,34 @@ describe("fetchWithTimeoutGuarded", () => {
       expect.objectContaining({
         auditContext: "provider-http fal image test",
         timeoutMs: 5000,
+      }),
+    );
+  });
+
+  it("passes configured explicit proxy policy through the SSRF guard", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(null, { status: 200 }),
+      finalUrl: "https://example.com",
+      release: async () => {},
+    });
+
+    await postJsonRequest({
+      url: "https://api.deepgram.com/v1/listen",
+      headers: new Headers({ authorization: "Token test-key" }),
+      body: { hello: "world" },
+      fetchFn: fetch,
+      dispatcherPolicy: {
+        mode: "explicit-proxy",
+        proxyUrl: "http://169.254.169.254:8080",
+      },
+    });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dispatcherPolicy: {
+          mode: "explicit-proxy",
+          proxyUrl: "http://169.254.169.254:8080",
+        },
       }),
     );
   });

--- a/src/plugins/config-policy.ts
+++ b/src/plugins/config-policy.ts
@@ -197,10 +197,6 @@ export function resolvePluginActivationState(params: {
     config: params.sourceConfig ?? params.config,
     rootConfig: params.sourceRootConfig ?? params.rootConfig,
   });
-  const explicitlyConfiguredBundledChannel =
-    params.origin === "bundled" &&
-    explicitSelection.explicitlyEnabled &&
-    explicitSelection.reason === "channel enabled in config";
 
   if (!params.config.enabled) {
     return {
@@ -249,7 +245,7 @@ export function resolvePluginActivationState(params: {
       reason: "selected memory slot",
     };
   }
-  if (params.config.allow.length > 0 && !explicitlyAllowed && !explicitlyConfiguredBundledChannel) {
+  if (params.config.allow.length > 0 && !explicitlyAllowed) {
     return {
       enabled: false,
       activated: false,

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -368,10 +368,6 @@ export function resolvePluginActivationState(params: {
     config: activationSource.plugins,
     rootConfig: activationSource.rootConfig,
   });
-  const explicitlyConfiguredBundledChannel =
-    params.origin === "bundled" &&
-    explicitSelection.explicitlyEnabled &&
-    explicitSelection.cause === "bundled-channel-enabled-in-config";
 
   if (!params.config.enabled) {
     return toPluginActivationState({
@@ -420,7 +416,7 @@ export function resolvePluginActivationState(params: {
       cause: "selected-memory-slot",
     });
   }
-  if (params.config.allow.length > 0 && !explicitlyAllowed && !explicitlyConfiguredBundledChannel) {
+  if (params.config.allow.length > 0 && !explicitlyAllowed) {
     return toPluginActivationState({
       enabled: false,
       activated: false,

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -416,6 +416,15 @@ export function resolvePluginActivationState(params: {
       cause: "selected-memory-slot",
     });
   }
+  if (explicitSelection.cause === "bundled-channel-enabled-in-config") {
+    return toPluginActivationState({
+      enabled: true,
+      activated: true,
+      explicitlyEnabled: true,
+      source: "explicit",
+      cause: explicitSelection.cause,
+    });
+  }
   if (params.config.allow.length > 0 && !explicitlyAllowed) {
     return toPluginActivationState({
       enabled: false,

--- a/src/plugins/contracts/tts.contract.test.ts
+++ b/src/plugins/contracts/tts.contract.test.ts
@@ -681,8 +681,10 @@ describe("tts", () => {
           messages: {
             tts: {
               provider: "edge",
-              edge: {
-                enabled: true,
+              providers: {
+                edge: {
+                  enabled: true,
+                },
               },
             },
           },

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -731,7 +731,7 @@ describe("loadOpenClawPlugins", () => {
       },
     },
     {
-      name: "loads bundled channel plugins when channels.<id>.enabled=true even if plugins.allow excludes them",
+      name: "keeps bundled channel plugins behind restrictive allowlists even when channels.<id>.enabled=true",
       config: {
         channels: {
           telegram: {
@@ -743,7 +743,10 @@ describe("loadOpenClawPlugins", () => {
         },
       } satisfies PluginLoadConfig,
       assert: (registry: ReturnType<typeof loadOpenClawPlugins>) => {
-        expectTelegramLoaded(registry);
+        const telegram = registry.plugins.find((entry) => entry.id === "telegram");
+        expect(telegram?.status).toBe("disabled");
+        expect(telegram?.error).toBe("not in allowlist");
+        expect(telegram?.explicitlyEnabled).toBe(true);
       },
     },
     {


### PR DESCRIPTION
## Summary

- Problem: `fix-security-triage-apr04` and `vk/phase2-legacy-alias-audit` were left as unmerged side branches with overlapping security/runtime follow-up work.
- Why it matters: the security branch tightens Discord proxy handling and Android mobile gateway TLS defaults, while the activation change closes allowlist bypass behavior for bundled channels.
- What changed: rebased and integrated the two pushed branches into one merge-ready branch; kept current `main` behavior where validation now rejects legacy Discord streaming fields; retained the remaining type-alignment fixes that still apply on top of `main`.
- What did NOT change (scope boundary): no new product surface beyond the branch deltas; no attempt to fix unrelated repo-wide `pnpm check` failures.
- AI-assisted: yes. Testing level: targeted local verification.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: bundled channel activation could still be activated indirectly around restrictive allowlists, and Discord/mobile gateway paths still tolerated insecure transport in cases that should have required TLS.
- Missing detection / guardrail: targeted tests did not fully lock in these policy edges, which let follow-up fixes live on side branches.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this PR integrates the already-pushed `fix-security-triage-apr04` and `vk/phase2-legacy-alias-audit` branches.
- Why this regressed now: policy/config cleanup on `main` moved while the side branches stayed unmerged.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: Discord proxy tests, plugin loader/config activation tests, doctor legacy config migration tests, TTS contract tests, Android gateway resolver tests.
- Scenario the test should lock in: restrictive allowlists must stay authoritative for bundled channels; Discord proxy URLs must be validated before use; non-loopback mobile gateway paths must require TLS.
- Why this is the smallest reliable guardrail: these are the exact seams where config policy and transport handling are decided.
- Existing test that already covers this (if any): expanded in this PR for Discord proxy and bundled-channel activation.
- If no new test is added, why not: Android unit tests could not be run locally because the machine is missing a valid Android SDK path.

## User-visible / Behavior Changes

- Android mobile gateway setup now rejects cleartext `ws://` URLs for non-loopback hosts, including private LAN addresses.
- Bundled channel activation now stays behind restrictive allowlists unless explicitly enabled.
- Discord proxy configuration now fails closed on invalid proxy URLs instead of silently proceeding.

## Diagram (if applicable)

```text
Before:
[channel configured] -> [auto/implicit activation path] -> [bundled channel can activate despite restrictive allowlist]
[mobile ws://192.168.x.x] -> [accepted]

After:
[channel configured] -> [allowlist/denylist gate] -> [activate only when explicitly or validly allowed]
[mobile ws://non-loopback] -> [validation error] -> [require wss:// or Tailscale Serve]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local worktree
- Model/provider: N/A
- Integration/channel (if any): Discord, Android gateway setup, bundled channel activation
- Relevant config (redacted): local branch integration of `fix-security-triage-apr04` + `vk/phase2-legacy-alias-audit`

### Steps

1. Cherry-pick the two pushed branches onto current `origin/main`.
2. Rebase onto latest `origin/main`.
3. Run focused verification on Discord/channel tests, unit tests, and TTS contracts.

### Expected

- Integrated branch stays green on touched surfaces.
- Restrictive allowlists remain authoritative.
- Insecure non-loopback Android gateway endpoints are rejected.

### Actual

- Focused tests passed.
- Android local unit tests were blocked by missing SDK path on the machine.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: rebased branch composition; Discord proxy/channel tests; unit tests covering config migration and loader behavior; TTS contract tests.
- Edge cases checked: restrictive allowlists vs explicit enablement; invalid proxy URLs; legacy config alias handling on top of current `main` behavior.
- What you did **not** verify: Android unit tests on-device/SDK-backed, full repo-wide `pnpm check`, and CI on GitHub.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Mostly
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Android gateway LAN users relying on cleartext `ws://` will now be blocked.
  - Mitigation: explicit validation message points them to `wss://`, Tailscale Serve, or loopback-only cleartext.
- Risk: focused local verification may miss broader integration fallout.
  - Mitigation: draft PR plus CI before merge; branch rebased cleanly onto current `main`.
