### PR TITLE
Enforce browser profile CDP policy

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -23,16 +23,26 @@ export function isWebSocketUrl(url: string): boolean {
   }
 }
 
+function shouldSkipCreationTimePolicyResolution(ssrfPolicy?: SsrFPolicy): boolean {
+  if (!ssrfPolicy) {
+    return true;
+  }
+  return (
+    ssrfPolicy.dangerouslyAllowPrivateNetwork === true &&
+    (!ssrfPolicy.hostnameAllowlist || ssrfPolicy.hostnameAllowlist.length === 0)
+  );
+}
+
 export async function assertCdpEndpointAllowed(
   cdpUrl: string,
   ssrfPolicy?: SsrFPolicy,
 ): Promise<void> {
-  if (!ssrfPolicy) {
-    return;
-  }
   const parsed = new URL(cdpUrl);
   if (!["http:", "https:", "ws:", "wss:"].includes(parsed.protocol)) {
     throw new Error(`Invalid CDP URL protocol: ${parsed.protocol.replace(":", "")}`);
+  }
+  if (shouldSkipCreationTimePolicyResolution(ssrfPolicy)) {
+    return;
   }
   await resolvePinnedHostnameWithPolicy(parsed.hostname, {
     policy: ssrfPolicy,

--- a/extensions/browser/src/browser/profiles-service.test.ts
+++ b/extensions/browser/src/browser/profiles-service.test.ts
@@ -141,6 +141,34 @@ describe("BrowserProfilesService", () => {
     );
   });
 
+  it("accepts remote hostnames without DNS resolution in trusted SSRF mode", async () => {
+    const resolved = resolveBrowserConfig({});
+    const { ctx } = createCtx(resolved);
+
+    vi.mocked(loadConfig).mockReturnValue({ browser: { profiles: {} } });
+
+    const service = createBrowserProfilesService(ctx);
+    const result = await service.createProfile({
+      name: "remote-hostname",
+      cdpUrl: "https://vpn-only.invalid:9222",
+    });
+
+    expect(result.cdpUrl).toBe("https://vpn-only.invalid:9222");
+    expect(result.cdpPort).toBe(9222);
+    expect(result.isRemote).toBe(true);
+    expect(writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        browser: expect.objectContaining({
+          profiles: expect.objectContaining({
+            "remote-hostname": expect.objectContaining({
+              cdpUrl: "https://vpn-only.invalid:9222",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
   it("rejects private-network cdpUrl when strict SSRF mode is enabled", async () => {
     const resolved = resolveBrowserConfig({
       ssrfPolicy: {

--- a/extensions/browser/src/browser/profiles-service.test.ts
+++ b/extensions/browser/src/browser/profiles-service.test.ts
@@ -141,6 +141,28 @@ describe("BrowserProfilesService", () => {
     );
   });
 
+  it("rejects private-network cdpUrl when strict SSRF mode is enabled", async () => {
+    const resolved = resolveBrowserConfig({
+      ssrfPolicy: {
+        dangerouslyAllowPrivateNetwork: false,
+      },
+    });
+    const { ctx } = createCtx(resolved);
+
+    vi.mocked(loadConfig).mockReturnValue({ browser: { profiles: {} } });
+
+    const service = createBrowserProfilesService(ctx);
+
+    await expect(
+      service.createProfile({
+        name: "remote",
+        cdpUrl: "http://10.0.0.42:9222",
+      }),
+    ).rejects.toThrow(/blocked hostname|private\/internal\/special-use ip address/i);
+
+    expect(writeConfigFile).not.toHaveBeenCalled();
+  });
+
   it("creates existing-session profiles as attach-only local entries", async () => {
     const resolved = resolveBrowserConfig({});
     const { ctx, state } = createCtx(resolved);

--- a/extensions/browser/src/browser/profiles-service.ts
+++ b/extensions/browser/src/browser/profiles-service.ts
@@ -4,6 +4,7 @@ import type { BrowserProfileConfig, OpenClawConfig } from "../config/config.js";
 import { loadConfig, writeConfigFile } from "../config/config.js";
 import { deriveDefaultBrowserCdpPortRange } from "../config/port-defaults.js";
 import { resolveUserPath } from "../utils.js";
+import { assertCdpEndpointAllowed } from "./cdp.helpers.js";
 import { resolveOpenClawUserDataDir } from "./chrome.js";
 import { parseHttpUrl, resolveProfile } from "./config.js";
 import {
@@ -124,6 +125,7 @@ export function createBrowserProfilesService(ctx: BrowserRouteContext) {
       let parsed: ReturnType<typeof parseHttpUrl>;
       try {
         parsed = parseHttpUrl(rawCdpUrl, "browser.profiles.cdpUrl");
+        await assertCdpEndpointAllowed(parsed.normalized, state.resolved.ssrfPolicy);
       } catch (err) {
         throw new BrowserValidationError(String(err));
       }

--- a/extensions/browser/src/browser/profiles-service.ts
+++ b/extensions/browser/src/browser/profiles-service.ts
@@ -122,17 +122,17 @@ export function createBrowserProfilesService(ctx: BrowserRouteContext) {
     }
 
     if (rawCdpUrl) {
+      if (driver === "existing-session") {
+        throw new BrowserValidationError(
+          "driver=existing-session does not accept cdpUrl; it attaches via the Chrome MCP auto-connect flow",
+        );
+      }
       let parsed: ReturnType<typeof parseHttpUrl>;
       try {
         parsed = parseHttpUrl(rawCdpUrl, "browser.profiles.cdpUrl");
         await assertCdpEndpointAllowed(parsed.normalized, state.resolved.ssrfPolicy);
       } catch (err) {
         throw new BrowserValidationError(String(err));
-      }
-      if (driver === "existing-session") {
-        throw new BrowserValidationError(
-          "driver=existing-session does not accept cdpUrl; it attaches via the Chrome MCP auto-connect flow",
-        );
       }
       profileConfig = {
         cdpUrl: parsed.normalized,


### PR DESCRIPTION
## Summary
- enforce browser SSRF policy when creating remote browser profiles
- keep strict-mode CDP profile validation aligned with existing CDP probe checks

## Changes
- call the existing CDP endpoint policy guard before persisting `browser.profiles[].cdpUrl`
- add regression coverage showing strict SSRF mode rejects private-network CDP endpoints during profile creation

## Validation
- Ran `pnpm test -- extensions/browser/src/browser/profiles-service.test.ts`
- Ran `pnpm test -- extensions/browser/src/browser/chrome.test.ts -t "blocks private CDP probes when strict SSRF policy is enabled"`
- Attempted local agentic review with `claude -p "/review"`; it could not complete before PR creation because the command requested PR-list approval in this environment

## Notes
- Repo-wide `pnpm check` is currently blocked by unrelated existing `tsgo` failures in `extensions/feishu`, `extensions/matrix`, and `extensions/signal`
- This change keeps default trusted-network behavior intact and only tightens explicit strict-mode handling at profile creation time