### PR TITLE
Reject unapproved device token roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 - Prompt caching: route Codex Responses and Anthropic Vertex through boundary-aware cache shaping, and report the actual outbound system prompt in cache traces so cache reuse and misses line up with what providers really receive. Thanks @vincentkoc.
 - MiniMax/pricing: keep bundled MiniMax highspeed pricing distinct in provider catalogs and preserve the lower M2.5 cache-read pricing when onboarding older MiniMax models. (#54214) Thanks @octo-patch.
 - Agents/cache: preserve the full 3-turn prompt-cache image window across tool loops, keep colliding bundled MCP tool definitions deterministic, and reapply Anthropic Vertex cache shaping after payload hook replacements so KV/cache reuse stays stable. Thanks @vincentkoc.
+- Device pairing: reject rotating device tokens into roles that were never approved during pairing, and keep reconnect role checks bounded to the paired device's approved role set. (#60462) Thanks @eleqtrizit.
 
 ## 2026.4.2
 

--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -113,6 +113,8 @@ describe("deviceHandlers", () => {
   it("disconnects active clients after rotating a device token", async () => {
     getPairedDeviceMock.mockResolvedValue({
       deviceId: "device-1",
+      role: "operator",
+      roles: ["operator"],
       scopes: ["operator.pairing"],
       tokens: {
         operator: {
@@ -170,6 +172,47 @@ describe("deviceHandlers", () => {
         rotatedAtMs: 789,
       },
       undefined,
+    );
+  });
+
+  it("rejects rotating a token for a role that was never approved", async () => {
+    getPairedDeviceMock.mockResolvedValue({
+      deviceId: "device-1",
+      role: "operator",
+      roles: ["operator"],
+      scopes: ["operator.pairing"],
+      tokens: {
+        operator: {
+          token: "old-token",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          createdAtMs: 123,
+        },
+      },
+    });
+    const opts = createOptions(
+      "device.token.rotate",
+      {
+        deviceId: "device-1",
+        role: "node",
+      },
+      {
+        client: {
+          connect: {
+            scopes: ["operator.pairing"],
+          },
+        } as never,
+      },
+    );
+
+    await deviceHandlers["device.token.rotate"](opts);
+
+    expect(rotateDeviceTokenMock).not.toHaveBeenCalled();
+    expect(opts.context.disconnectClientsForDevice).not.toHaveBeenCalled();
+    expect(opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "device token rotation denied" }),
     );
   });
 

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -1,6 +1,7 @@
 import {
   approveDevicePairing,
   getPairedDevice,
+  listApprovedPairedDeviceRoles,
   listDevicePairing,
   removePairedDevice,
   type DeviceAuthToken,
@@ -196,6 +197,7 @@ export const deviceHandlers: GatewayRequestHandlers = {
       role: string;
       scopes?: string[];
     };
+    const normalizedRole = role.trim();
     const pairedDevice = await getPairedDevice(deviceId);
     if (!pairedDevice) {
       logDeviceTokenRotationDenied({
@@ -211,9 +213,23 @@ export const deviceHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    if (!listApprovedPairedDeviceRoles(pairedDevice).includes(normalizedRole)) {
+      logDeviceTokenRotationDenied({
+        log: context.logGateway,
+        deviceId,
+        role,
+        reason: "unknown-device-or-role",
+      });
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, DEVICE_TOKEN_ROTATION_DENIED_MESSAGE),
+      );
+      return;
+    }
     const callerScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
     const requestedScopes = normalizeDeviceAuthScopes(
-      scopes ?? pairedDevice.tokens?.[role.trim()]?.scopes ?? pairedDevice.scopes,
+      scopes ?? pairedDevice.tokens?.[normalizedRole]?.scopes ?? pairedDevice.scopes,
     );
     const missingScope = resolveMissingRequestedScope({
       role,

--- a/src/gateway/server.device-token-rotate-authz.test.ts
+++ b/src/gateway/server.device-token-rotate-authz.test.ts
@@ -239,4 +239,41 @@ describe("gateway device.token.rotate caller scope guard", () => {
       started.envSnapshot.restore();
     }
   });
+
+  test("rejects rotating a token for an unapproved role on an existing paired device", async () => {
+    const started = await startServerWithClient("secret");
+    const attacker = await issueOperatorToken({
+      name: "rotate-unapproved-role",
+      approvedScopes: ["operator.pairing"],
+      tokenScopes: ["operator.pairing"],
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+
+    let pairingWs: WebSocket | undefined;
+    try {
+      pairingWs = await connectPairingScopedOperator({
+        port: started.port,
+        identityPath: attacker.identityPath,
+        deviceToken: attacker.token,
+      });
+
+      const rotate = await rpcReq(pairingWs, "device.token.rotate", {
+        deviceId: attacker.deviceId,
+        role: "node",
+      });
+
+      expect(rotate.ok).toBe(false);
+      expect(rotate.error?.message).toBe("device token rotation denied");
+
+      const paired = await getPairedDevice(attacker.deviceId);
+      expect(paired?.tokens?.node).toBeUndefined();
+      expect(paired?.tokens?.operator?.scopes).toEqual(["operator.pairing"]);
+    } finally {
+      pairingWs?.close();
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
 });

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -803,6 +803,52 @@ describe("device pairing tokens", () => {
     expect(hasEffectivePairedDeviceRole(device, "operator")).toBe(true);
   });
 
+  test("filters active token roles to the approved pairing role set", async () => {
+    const now = Date.now();
+    const device: PairedDevice = {
+      deviceId: "device-filtered",
+      publicKey: "pk-filtered",
+      role: "operator",
+      roles: ["operator"],
+      tokens: {
+        node: {
+          token: "forged-node-token",
+          role: "node",
+          scopes: [],
+          createdAtMs: now,
+        },
+        operator: {
+          token: "real-operator-token",
+          role: "operator",
+          scopes: ["operator.read"],
+          createdAtMs: now,
+        },
+      },
+      createdAtMs: now,
+      approvedAtMs: now,
+    };
+
+    expect(listEffectivePairedDeviceRoles(device)).toEqual(["operator"]);
+    expect(hasEffectivePairedDeviceRole(device, "node")).toBe(false);
+  });
+
+  test("rejects rotating a token for a role that was never approved", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    await setupPairedOperatorDevice(baseDir, ["operator.pairing"]);
+
+    await expect(
+      rotateDeviceToken({
+        deviceId: "device-1",
+        role: "node",
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "unknown-device-or-role" });
+
+    const paired = await getPairedDevice("device-1", baseDir);
+    expect(paired?.tokens?.node).toBeUndefined();
+    expect(paired && listEffectivePairedDeviceRoles(paired)).toEqual(["operator"]);
+  });
+
   test("removes paired devices by device id", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
     await setupPairedOperatorDevice(baseDir, ["operator.read"]);

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -168,12 +168,19 @@ function listActiveTokenRoles(
   );
 }
 
+export function listApprovedPairedDeviceRoles(
+  device: Pick<PairedDevice, "role" | "roles">,
+): string[] {
+  return mergeRoles(device.roles, device.role) ?? [];
+}
+
 export function listEffectivePairedDeviceRoles(
   device: Pick<PairedDevice, "role" | "roles" | "tokens">,
 ): string[] {
   const activeTokenRoles = listActiveTokenRoles(device.tokens);
   if (activeTokenRoles && activeTokenRoles.length > 0) {
-    return activeTokenRoles;
+    const approvedRoles = new Set(listApprovedPairedDeviceRoles(device));
+    return activeTokenRoles.filter((role) => approvedRoles.has(role));
   }
   // Only fall back to legacy role fields when the tokens map is absent
   // or has no entries at all (empty object from a fresh pairing record).
@@ -182,7 +189,7 @@ export function listEffectivePairedDeviceRoles(
   if (device.tokens && Object.keys(device.tokens).length > 0) {
     return [];
   }
-  return mergeRoles(device.roles, device.role) ?? [];
+  return listApprovedPairedDeviceRoles(device);
 }
 
 export function hasEffectivePairedDeviceRole(
@@ -871,6 +878,9 @@ function resolveDeviceTokenUpdateContext(params: {
   }
   const role = normalizeRole(params.role);
   if (!role) {
+    return null;
+  }
+  if (!listApprovedPairedDeviceRoles(device).includes(role)) {
     return null;
   }
   const tokens = cloneDeviceTokens(device);


### PR DESCRIPTION
## Summary
- Rejects device token rotations for roles that were not approved during pairing
- Keeps reconnect role checks aligned with the paired device's approved role set

## Changes
- Added an approved-role helper in device pairing and used it when rotating device tokens
- Filtered effective token-backed roles against the approved pairing roles before reconnect authorization
- Added regression coverage for unapproved role rotation at both the infra and gateway layers

## Validation
- Ran `corepack pnpm test -- src/infra/device-pairing.test.ts`
- Ran `corepack pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server.device-token-rotate-authz.test.ts`
- Ran `corepack pnpm build` and hit unrelated pre-existing failures in `extensions/feishu/src/setup-surface.ts`, `extensions/matrix/src/exec-approvals.ts`, and `extensions/signal/src/core.test.ts`
- Ran local agentic review with `claude -p "/review"`; it requested PR context via `gh` and produced no actionable code feedback before PR creation

## Notes
- Compatibility risk is low because the change only rejects role values outside the device's approved pairing record
- Residual validation gap: full repo build is currently blocked by unrelated existing type errors outside this patch
