### PR TITLE
fix(browser): validate cdp websocket pivots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@ Docs: https://docs.openclaw.ai
 - Agents/logging: keep orphaned-user transcript repair warnings focused on interactive runs, and downgrade background-trigger repairs (`heartbeat`, `cron`, `memory`, `overflow`) to debug logs to reduce false-alarm gateway noise.
 - Gateway/node pairing: require `operator.pairing` for node approvals end-to-end, while still requiring `operator.write` or `operator.admin` when the pending node commands need those higher scopes. (#60461) Thanks @eleqtrizit.
 - Providers/OpenRouter: gate Anthropic prompt-cache `cache_control` markers to native/default OpenRouter routes and preserve them for native OpenRouter hosts behind custom provider ids. Thanks @vincentkoc.
+- Browser/CDP: validate both initial and discovered CDP websocket endpoints before connect so strict SSRF policy blocks cross-host pivots and direct websocket targets. (#60469) Thanks @eleqtrizit.
 
 ## 2026.4.1
 

--- a/extensions/browser/src/browser/cdp.test.ts
+++ b/extensions/browser/src/browser/cdp.test.ts
@@ -244,6 +244,19 @@ describe("cdp", () => {
     ).rejects.toBeInstanceOf(SsrFBlockedError);
   });
 
+  it("blocks the initial /json/version fetch when the cdpUrl host is outside strict SSRF policy", async () => {
+    await expect(
+      createTargetViaCdp({
+        cdpUrl: "http://169.254.169.254:9222",
+        url: "https://example.com",
+        ssrfPolicy: {
+          dangerouslyAllowPrivateNetwork: false,
+          allowedHostnames: ["127.0.0.1"],
+        },
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+  });
+
   it("evaluates javascript via CDP", async () => {
     const wsPort = await startWsServerWithMessages((msg, socket) => {
       if (msg.method === "Runtime.enable") {

--- a/extensions/browser/src/browser/cdp.test.ts
+++ b/extensions/browser/src/browser/cdp.test.ts
@@ -257,6 +257,19 @@ describe("cdp", () => {
     ).rejects.toBeInstanceOf(SsrFBlockedError);
   });
 
+  it("blocks direct websocket cdp urls outside strict SSRF policy", async () => {
+    await expect(
+      createTargetViaCdp({
+        cdpUrl: "ws://169.254.169.254:9222/devtools/browser/PIVOT",
+        url: "https://example.com",
+        ssrfPolicy: {
+          dangerouslyAllowPrivateNetwork: false,
+          allowedHostnames: ["127.0.0.1"],
+        },
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+  });
+
   it("evaluates javascript via CDP", async () => {
     const wsPort = await startWsServerWithMessages((msg, socket) => {
       if (msg.method === "Runtime.enable") {

--- a/extensions/browser/src/browser/cdp.test.ts
+++ b/extensions/browser/src/browser/cdp.test.ts
@@ -227,6 +227,23 @@ describe("cdp", () => {
     expect(created.targetId).toBe("TARGET_LOCAL");
   });
 
+  it("blocks cross-host websocket pivots returned by /json/version in strict SSRF mode", async () => {
+    const httpPort = await startVersionHttpServer({
+      webSocketDebuggerUrl: "ws://169.254.169.254:9222/devtools/browser/PIVOT",
+    });
+
+    await expect(
+      createTargetViaCdp({
+        cdpUrl: `http://127.0.0.1:${httpPort}`,
+        url: "https://example.com",
+        ssrfPolicy: {
+          dangerouslyAllowPrivateNetwork: false,
+          allowedHostnames: ["127.0.0.1"],
+        },
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+  });
+
   it("evaluates javascript via CDP", async () => {
     const wsPort = await startWsServerWithMessages((msg, socket) => {
       if (msg.method === "Runtime.enable") {

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -1,6 +1,7 @@
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import {
   appendCdpPath,
+  assertCdpEndpointAllowed,
   fetchJson,
   isLoopbackHost,
   isWebSocketUrl,
@@ -194,6 +195,7 @@ export async function createTargetViaCdp(opts: {
     if (!wsUrl) {
       throw new Error("CDP /json/version missing webSocketDebuggerUrl");
     }
+    await assertCdpEndpointAllowed(wsUrl, opts.ssrfPolicy);
   }
 
   return await withCdpSocket(wsUrl, async (send) => {

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -186,6 +186,7 @@ export async function createTargetViaCdp(opts: {
     wsUrl = opts.cdpUrl;
   } else {
     // Standard HTTP(S) CDP endpoint — discover WebSocket URL via /json/version.
+    await assertCdpEndpointAllowed(opts.cdpUrl, opts.ssrfPolicy);
     const version = await fetchJson<{ webSocketDebuggerUrl?: string }>(
       appendCdpPath(opts.cdpUrl, "/json/version"),
       1500,

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -183,6 +183,7 @@ export async function createTargetViaCdp(opts: {
   let wsUrl: string;
   if (isWebSocketUrl(opts.cdpUrl)) {
     // Direct WebSocket URL — skip /json/version discovery.
+    await assertCdpEndpointAllowed(opts.cdpUrl, opts.ssrfPolicy);
     wsUrl = opts.cdpUrl;
   } else {
     // Standard HTTP(S) CDP endpoint — discover WebSocket URL via /json/version.

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -6,11 +6,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
+import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import {
   decorateOpenClawProfile,
   ensureProfileCleanExit,
   findChromeExecutableMac,
   findChromeExecutableWindows,
+  getChromeWebSocketUrl,
   isChromeCdpReady,
   isChromeReachable,
   resolveBrowserExecutableForPlatform,
@@ -326,6 +328,39 @@ describe("browser chrome helpers", () => {
     ).resolves.toBe(false);
 
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks cross-host websocket pivots returned by /json/version in strict SSRF mode", async () => {
+    const server = createServer((req, res) => {
+      if (req.url === "/json/version") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            webSocketDebuggerUrl: "ws://169.254.169.254:9222/devtools/browser/pivot",
+          }),
+        );
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+      server.once("error", reject);
+    });
+
+    try {
+      const addr = server.address() as AddressInfo;
+      await expect(
+        getChromeWebSocketUrl(`http://127.0.0.1:${addr.port}`, 50, {
+          dangerouslyAllowPrivateNetwork: false,
+          allowedHostnames: ["127.0.0.1"],
+        }),
+      ).rejects.toBeInstanceOf(SsrFBlockedError);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("reports cdpReady only when Browser.getVersion command succeeds", async () => {

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -200,7 +200,9 @@ export async function getChromeWebSocketUrl(
   if (!wsUrl) {
     return null;
   }
-  return normalizeCdpWsUrl(wsUrl, cdpUrl);
+  const normalizedWsUrl = normalizeCdpWsUrl(wsUrl, cdpUrl);
+  await assertCdpEndpointAllowed(normalizedWsUrl, ssrfPolicy);
+  return normalizedWsUrl;
 }
 
 async function canRunCdpHealthCommand(


### PR DESCRIPTION
## Summary
- Validates the resolved CDP WebSocket endpoint before opening the second-hop connection
- Adds regression coverage for strict SSRF mode when `/json/version` returns a cross-host WebSocket URL

## Changes
- Re-validates the normalized `webSocketDebuggerUrl` in `extensions/browser/src/browser/chrome.ts`
- Re-validates the discovered WebSocket target in `extensions/browser/src/browser/cdp.ts`
- Adds regression tests covering a `/json/version` response that pivots from `127.0.0.1` to `169.254.169.254`

## Validation
- Ran `corepack pnpm test -- extensions/browser/src/browser/chrome.test.ts extensions/browser/src/browser/cdp.test.ts`
- Verified both strict-mode regression tests fail closed with `SsrFBlockedError`
- Attempted local agentic review via `claude -p "/review"`; the slash command stalled on a GitHub approval prompt, so I used a manual local diff review instead

## Notes
- `corepack pnpm build` and the default pre-commit `pnpm check` currently fail on unrelated existing type errors in `extensions/feishu/src/setup-surface.ts:43` and `extensions/signal/src/core.test.ts`
