### PR TITLE
Validate browser profile CDP endpoints on create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/node pairing: require `operator.pairing` for node approvals end-to-end, while still requiring `operator.write` or `operator.admin` when the pending node commands need those higher scopes. (#60461) Thanks @eleqtrizit.
 - Providers/OpenRouter: gate Anthropic prompt-cache `cache_control` markers to native/default OpenRouter routes and preserve them for native OpenRouter hosts behind custom provider ids. Thanks @vincentkoc.
 - Browser/CDP: validate both initial and discovered CDP websocket endpoints before connect so strict SSRF policy blocks cross-host pivots and direct websocket targets. (#60469) Thanks @eleqtrizit.
+- Browser/profiles: reject remote browser profile `cdpUrl` values that violate strict SSRF policy before saving config, with clearer validation errors for blocked endpoints. (#60477) Thanks @eleqtrizit.
 
 ## 2026.4.1
 

--- a/extensions/browser/src/browser/profiles-service.test.ts
+++ b/extensions/browser/src/browser/profiles-service.test.ts
@@ -141,6 +141,30 @@ describe("BrowserProfilesService", () => {
     );
   });
 
+  it("rejects private-network cdpUrl when strict SSRF mode is enabled", async () => {
+    const resolved = resolveBrowserConfig({
+      ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
+    });
+    const { ctx } = createCtx(resolved);
+
+    vi.mocked(loadConfig).mockReturnValue({
+      browser: {
+        ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
+        profiles: {},
+      },
+    });
+
+    const service = createBrowserProfilesService(ctx);
+
+    await expect(
+      service.createProfile({
+        name: "remote",
+        cdpUrl: "http://10.0.0.42:9222",
+      }),
+    ).rejects.toThrow(/private\/internal\/special-use ip address/i);
+    expect(writeConfigFile).not.toHaveBeenCalled();
+  });
+
   it("creates existing-session profiles as attach-only local entries", async () => {
     const resolved = resolveBrowserConfig({});
     const { ctx, state } = createCtx(resolved);

--- a/extensions/browser/src/browser/profiles-service.ts
+++ b/extensions/browser/src/browser/profiles-service.ts
@@ -127,7 +127,7 @@ export function createBrowserProfilesService(ctx: BrowserRouteContext) {
         parsed = parseHttpUrl(rawCdpUrl, "browser.profiles.cdpUrl");
         await assertCdpEndpointAllowed(parsed.normalized, state.resolved.ssrfPolicy);
       } catch (err) {
-        throw new BrowserValidationError(String(err));
+        throw new BrowserValidationError(err instanceof Error ? err.message : String(err));
       }
       if (driver === "existing-session") {
         throw new BrowserValidationError(

--- a/extensions/browser/src/browser/profiles-service.ts
+++ b/extensions/browser/src/browser/profiles-service.ts
@@ -4,6 +4,7 @@ import type { BrowserProfileConfig, OpenClawConfig } from "../config/config.js";
 import { loadConfig, writeConfigFile } from "../config/config.js";
 import { deriveDefaultBrowserCdpPortRange } from "../config/port-defaults.js";
 import { resolveUserPath } from "../utils.js";
+import { assertCdpEndpointAllowed } from "./cdp.helpers.js";
 import { resolveOpenClawUserDataDir } from "./chrome.js";
 import { parseHttpUrl, resolveProfile } from "./config.js";
 import {
@@ -124,6 +125,7 @@ export function createBrowserProfilesService(ctx: BrowserRouteContext) {
       let parsed: ReturnType<typeof parseHttpUrl>;
       try {
         parsed = parseHttpUrl(rawCdpUrl, "browser.profiles.cdpUrl");
+        await assertCdpEndpointAllowed(parsed.normalized, state.resolved.ssrfPolicy);
       } catch (err) {
         throw new BrowserValidationError(String(err));
       }


### PR DESCRIPTION
## Summary
- validates remote browser profile `cdpUrl` values against the configured browser network policy before saving them
- keeps remote profile creation behavior unchanged for deployments that still allow private-network endpoints

## Changes
- calls the existing CDP endpoint policy guard in `createProfile()` after URL normalization and before config persistence
- adds a regression test that rejects a private-network `cdpUrl` when strict browser SSRF mode is enabled

## Validation
- ran `pnpm test -- extensions/browser/src/browser/profiles-service.test.ts`
- verified the new strict-mode regression test fails without the guard and passes with the guard in place
- attempted local agentic review via `claude -p "/review"`; that workflow expected an existing PR, and a follow-up offline diff review timed out without findings

## Notes
- `pnpm check` currently fails on unrelated pre-existing TypeScript issues in `extensions/feishu/src/setup-surface.ts`, `extensions/matrix/src/exec-approvals.ts`, and `extensions/signal/src/core.test.ts`
