### PR TITLE
fix: implement Windows stale gateway process cleanup before restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK/context engines: export the missing context-engine result and subagent lifecycle types from `openclaw/plugin-sdk` so context engine plugins can type `ContextEngine` implementations without local workarounds. (#61251) Thanks @DaevMithran.
 - Tasks/maintenance: reconcile stale cron and chat-backed CLI task rows against live cron-job and agent-run ownership instead of treating any persisted session key as proof that the task is still running. (#60310) Thanks @lml2468.
 - Update/npm: prefer the npm binary that owns the installed global OpenClaw prefix so mixed Homebrew-plus-nvm setups update the right install. (#60153) Thanks @jayeshp19.
+- Windows/restart: clean up stale gateway listeners before Windows self-restart and treat listener and argv probe failures as inconclusive, so scheduled-task relaunch no longer falls into an `EADDRINUSE` retry loop. (#60480) Thanks @arifahmedjoy.
 
 ## 2026.4.2
 

--- a/src/infra/gateway-processes.ts
+++ b/src/infra/gateway-processes.ts
@@ -1,114 +1,11 @@
 import { spawnSync } from "node:child_process";
 import fsSync from "node:fs";
-import { parseCmdScriptCommandLine } from "../daemon/cmd-argv.js";
 import { isGatewayArgv, parseProcCmdline } from "./gateway-process-argv.js";
 import { findGatewayPidsOnPortSync as findUnixGatewayPidsOnPortSync } from "./restart-stale-pids.js";
-
-const WINDOWS_GATEWAY_DISCOVERY_TIMEOUT_MS = 5_000;
-
-function extractWindowsCommandLine(raw: string): string | null {
-  const lines = raw
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
-  for (const line of lines) {
-    if (!line.toLowerCase().startsWith("commandline=")) {
-      continue;
-    }
-    const value = line.slice("commandline=".length).trim();
-    return value || null;
-  }
-  return lines.find((line) => line.toLowerCase() !== "commandline") ?? null;
-}
-
-function readWindowsProcessArgsViaPowerShell(pid: number): string[] | null {
-  const ps = spawnSync(
-    "powershell",
-    [
-      "-NoProfile",
-      "-Command",
-      `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" | Select-Object -ExpandProperty CommandLine)`,
-    ],
-    {
-      encoding: "utf8",
-      timeout: WINDOWS_GATEWAY_DISCOVERY_TIMEOUT_MS,
-      windowsHide: true,
-    },
-  );
-  if (ps.error || ps.status !== 0) {
-    return null;
-  }
-  const command = ps.stdout.trim();
-  return command ? parseCmdScriptCommandLine(command) : null;
-}
-
-function readWindowsProcessArgsViaWmic(pid: number): string[] | null {
-  const wmic = spawnSync(
-    "wmic",
-    ["process", "where", `ProcessId=${pid}`, "get", "CommandLine", "/value"],
-    {
-      encoding: "utf8",
-      timeout: WINDOWS_GATEWAY_DISCOVERY_TIMEOUT_MS,
-      windowsHide: true,
-    },
-  );
-  if (wmic.error || wmic.status !== 0) {
-    return null;
-  }
-  const command = extractWindowsCommandLine(wmic.stdout);
-  return command ? parseCmdScriptCommandLine(command) : null;
-}
-
-function readWindowsListeningPidsViaPowerShell(port: number): number[] | null {
-  const ps = spawnSync(
-    "powershell",
-    [
-      "-NoProfile",
-      "-Command",
-      `(Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess)`,
-    ],
-    {
-      encoding: "utf8",
-      timeout: WINDOWS_GATEWAY_DISCOVERY_TIMEOUT_MS,
-      windowsHide: true,
-    },
-  );
-  if (ps.error || ps.status !== 0) {
-    return null;
-  }
-  return ps.stdout
-    .split(/\r?\n/)
-    .map((line) => Number.parseInt(line.trim(), 10))
-    .filter((pid) => Number.isFinite(pid) && pid > 0);
-}
-
-function readWindowsListeningPidsViaNetstat(port: number): number[] {
-  const netstat = spawnSync("netstat", ["-ano", "-p", "tcp"], {
-    encoding: "utf8",
-    timeout: WINDOWS_GATEWAY_DISCOVERY_TIMEOUT_MS,
-    windowsHide: true,
-  });
-  if (netstat.error || netstat.status !== 0) {
-    return [];
-  }
-  const pids = new Set<number>();
-  for (const line of netstat.stdout.split(/\r?\n/)) {
-    const match = line.match(/^\s*TCP\s+(\S+):(\d+)\s+\S+\s+LISTENING\s+(\d+)\s*$/i);
-    if (!match) {
-      continue;
-    }
-    const parsedPort = Number.parseInt(match[2] ?? "", 10);
-    const pid = Number.parseInt(match[3] ?? "", 10);
-    if (parsedPort === port && Number.isFinite(pid) && pid > 0) {
-      pids.add(pid);
-    }
-  }
-  return [...pids];
-}
-
-function readWindowsListeningPidsOnPortSync(port: number): number[] {
-  return readWindowsListeningPidsViaPowerShell(port) ?? readWindowsListeningPidsViaNetstat(port);
-}
+import {
+  readWindowsListeningPidsOnPortSync,
+  readWindowsProcessArgsSync,
+} from "./windows-port-pids.js";
 
 export function readGatewayProcessArgsSync(pid: number): string[] | null {
   if (process.platform === "linux") {
@@ -130,7 +27,7 @@ export function readGatewayProcessArgsSync(pid: number): string[] | null {
     return command ? command.split(/\s+/) : null;
   }
   if (process.platform === "win32") {
-    return readWindowsProcessArgsViaPowerShell(pid) ?? readWindowsProcessArgsViaWmic(pid);
+    return readWindowsProcessArgsSync(pid);
   }
   return null;
 }

--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -1,14 +1,17 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-// This entire file tests lsof-based Unix port polling. The feature is a deliberate
-// no-op on Windows (findGatewayPidsOnPortSync returns [] immediately). Running these
-// tests on a Windows CI runner would require lsof which does not exist there, so we
-// skip the suite entirely and rely on the Linux/macOS runners for coverage.
+// This file primarily tests lsof-based Unix port polling. On Windows,
+// findGatewayPidsOnPortSync delegates to findVerifiedGatewayListenerPidsOnPortSync
+// (PowerShell/netstat discovery in gateway-processes.ts) instead of returning [].
+// Running lsof-dependent tests on a Windows CI runner is not possible, so the suite
+// is skipped on Windows; cross-platform tests mock process.platform to win32.
 const isWindows = process.platform === "win32";
 
 const mockSpawnSync = vi.hoisted(() => vi.fn());
 const mockResolveGatewayPort = vi.hoisted(() => vi.fn(() => 18789));
 const mockRestartWarn = vi.hoisted(() => vi.fn());
+const mockReadWindowsListeningPids = vi.hoisted(() => vi.fn((_port: number, _timeoutMs?: number): number[] => []));
+const mockReadWindowsProcessArgs = vi.hoisted(() => vi.fn((_pid: number, _timeoutMs?: number): string[] | null => null));
 
 vi.mock("node:child_process", async () => {
   const { mockNodeBuiltinModule } = await import("../../test/helpers/node-builtin-mocks.js");
@@ -35,6 +38,15 @@ vi.mock("../logging/subsystem.js", () => ({
     info: vi.fn(),
     error: vi.fn(),
   })),
+}));
+
+vi.mock("./gateway-processes.js", () => ({}));
+
+vi.mock("./windows-port-pids.js", () => ({
+  readWindowsListeningPidsOnPortSync: (port: number, timeoutMs?: number) =>
+    mockReadWindowsListeningPids(port, timeoutMs),
+  readWindowsProcessArgsSync: (pid: number, timeoutMs?: number) =>
+    mockReadWindowsProcessArgs(pid, timeoutMs),
 }));
 
 import { resolveLsofCommandSync } from "./ports-lsof.js";
@@ -101,7 +113,11 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
     mockSpawnSync.mockReset();
     mockResolveGatewayPort.mockReset();
     mockRestartWarn.mockReset();
+    mockReadWindowsListeningPids.mockReset();
+    mockReadWindowsProcessArgs.mockReset();
     mockResolveGatewayPort.mockReturnValue(18789);
+    mockReadWindowsListeningPids.mockReturnValue([]);
+    mockReadWindowsProcessArgs.mockReturnValue(null);
     __testing.setSleepSyncOverride(() => {});
   });
 
@@ -189,16 +205,33 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(result).toEqual([stalePid]); // deduped — not [pid, pid]
     });
 
-    it("returns [] and skips lsof on win32", () => {
-      // The entire describe block is skipped on Windows (isWindows guard at top),
-      // so this test only runs on Linux/macOS. It mocks platform to win32 for the
-      // single assertion without needing to restore — the suite-level skipIf means
-      // this will never run on an actual Windows runner where the mock could leak.
+    it("delegates to Windows port helpers on win32 and skips lsof", () => {
       const origDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
       try {
+        mockReadWindowsListeningPids.mockReturnValue([]);
         expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
+        expect(mockReadWindowsListeningPids).toHaveBeenCalledWith(18789);
+        // lsof must NOT be invoked — Windows uses PowerShell/netstat
         expect(mockSpawnSync).not.toHaveBeenCalled();
+      } finally {
+        if (origDescriptor) {
+          Object.defineProperty(process, "platform", origDescriptor);
+        }
+      }
+    });
+
+    it("returns verified gateway pids from Windows helpers on win32", () => {
+      const origDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+      const stalePid = process.pid + 900;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        mockReadWindowsListeningPids.mockReturnValue([stalePid]);
+        // Simulate a verified gateway process (must pass real isGatewayArgv)
+        mockReadWindowsProcessArgs.mockReturnValue(["openclaw", "gateway"]);
+        expect(findGatewayPidsOnPortSync(18789)).toEqual([stalePid]);
+        expect(mockReadWindowsListeningPids).toHaveBeenCalledWith(18789);
+        expect(mockReadWindowsProcessArgs).toHaveBeenCalledWith(stalePid);
       } finally {
         if (origDescriptor) {
           Object.defineProperty(process, "platform", origDescriptor);

--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -663,9 +663,12 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
         });
         let fakeNow = 0;
         __testing.setDateNowOverride(() => fakeNow);
-        mockReadWindowsListeningPidsResult.mockImplementation(() => {
-          fakeNow += 2001;
-          return { ok: false, permanent: false };
+        mockReadWindowsListeningPidsResult.mockImplementation((_port, timeoutMs) => {
+          if (timeoutMs === 400) {
+            fakeNow += 2001;
+            return { ok: false, permanent: false };
+          }
+          return { ok: true, pids: [stalePid] };
         });
         let aliveChecks = 0;
         const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
@@ -685,6 +688,34 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
           expect.stringContaining("port 18789 still in use after 2000ms"),
         );
         expect(killSpy).toHaveBeenCalledWith(stalePid, 0);
+      } finally {
+        __testing.setDateNowOverride(null);
+        if (origDescriptor) {
+          Object.defineProperty(process, "platform", origDescriptor);
+        }
+      }
+    });
+
+    it("waits for port release when the initial Windows stale-pid probe is inconclusive", () => {
+      const origDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        let fakeNow = 0;
+        __testing.setDateNowOverride(() => fakeNow);
+        mockReadWindowsListeningPidsResult.mockImplementation((_port, timeoutMs) => {
+          if (timeoutMs === 400) {
+            fakeNow += 2001;
+          }
+          return { ok: false, permanent: false };
+        });
+        const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+
+        expect(cleanStaleGatewayProcessesSync()).toEqual([]);
+        expect(mockReadWindowsListeningPidsResult).toHaveBeenCalledWith(18789, 400);
+        expect(mockRestartWarn).toHaveBeenCalledWith(
+          expect.stringContaining("port 18789 still in use after 2000ms"),
+        );
+        expect(killSpy).not.toHaveBeenCalled();
       } finally {
         __testing.setDateNowOverride(null);
         if (origDescriptor) {
@@ -718,6 +749,53 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
         expect(mockSpawnSync).toHaveBeenCalledWith(
           expect.stringContaining("taskkill.exe"),
           ["/T", "/PID", String(stalePid)],
+          expect.objectContaining({ timeout: 5000 }),
+        );
+      } finally {
+        if (origDescriptor) {
+          Object.defineProperty(process, "platform", origDescriptor);
+        }
+      }
+    });
+
+    it("treats Windows EPERM liveness checks as alive and still forces taskkill", () => {
+      const origDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+      const stalePid = process.pid + 912;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        mockReadWindowsListeningPidsResult.mockReturnValue({ ok: true, pids: [stalePid] });
+        mockReadWindowsProcessArgs.mockReturnValue(["openclaw", "gateway"]);
+        mockSpawnSync
+          .mockReturnValueOnce({
+            error: null,
+            status: 1,
+            stdout: "",
+            stderr: "access denied",
+          })
+          .mockReturnValueOnce({
+            error: null,
+            status: 1,
+            stdout: "",
+            stderr: "still denied",
+          });
+        vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+          if (signal === 0 && pid === stalePid) {
+            throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+          }
+          return true;
+        });
+
+        expect(cleanStaleGatewayProcessesSync()).toEqual([]);
+        expect(mockSpawnSync).toHaveBeenNthCalledWith(
+          1,
+          expect.stringContaining("taskkill.exe"),
+          ["/T", "/PID", String(stalePid)],
+          expect.objectContaining({ timeout: 5000 }),
+        );
+        expect(mockSpawnSync).toHaveBeenNthCalledWith(
+          2,
+          expect.stringContaining("taskkill.exe"),
+          ["/F", "/T", "/PID", String(stalePid)],
           expect.objectContaining({ timeout: 5000 }),
         );
       } finally {

--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -21,6 +21,11 @@ const mockReadWindowsListeningPidsResult = vi.hoisted(() =>
 const mockReadWindowsProcessArgs = vi.hoisted(() =>
   vi.fn((_pid: number, _timeoutMs?: number): string[] | null => null),
 );
+const mockReadWindowsProcessArgsResult = vi.hoisted(() =>
+  vi.fn<(_pid: number, _timeoutMs?: number) => MockWindowsProcessArgsResult>(
+    (_pid: number, _timeoutMs?: number) => ({ ok: true, args: null }),
+  ),
+);
 
 vi.mock("node:child_process", async () => {
   const { mockNodeBuiltinModule } = await import("../../test/helpers/node-builtin-mocks.js");
@@ -58,6 +63,8 @@ vi.mock("./windows-port-pids.js", () => ({
     mockReadWindowsListeningPidsResult(port, timeoutMs),
   readWindowsProcessArgsSync: (pid: number, timeoutMs?: number) =>
     mockReadWindowsProcessArgs(pid, timeoutMs),
+  readWindowsProcessArgsResultSync: (pid: number, timeoutMs?: number) =>
+    mockReadWindowsProcessArgsResult(pid, timeoutMs),
 }));
 
 import { resolveLsofCommandSync } from "./ports-lsof.js";
@@ -78,6 +85,10 @@ type MockLsofResult = {
 
 type MockWindowsListeningPidsResult =
   | { ok: true; pids: number[] }
+  | { ok: false; permanent: boolean };
+
+type MockWindowsProcessArgsResult =
+  | { ok: true; args: string[] | null }
   | { ok: false; permanent: boolean };
 
 function createLsofResult(overrides: Partial<MockLsofResult> = {}): MockLsofResult {
@@ -131,10 +142,12 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
     mockReadWindowsListeningPids.mockReset();
     mockReadWindowsListeningPidsResult.mockReset();
     mockReadWindowsProcessArgs.mockReset();
+    mockReadWindowsProcessArgsResult.mockReset();
     mockResolveGatewayPort.mockReturnValue(18789);
     mockReadWindowsListeningPids.mockReturnValue([]);
     mockReadWindowsListeningPidsResult.mockReturnValue({ ok: true, pids: [] });
     mockReadWindowsProcessArgs.mockReturnValue(null);
+    mockReadWindowsProcessArgsResult.mockReturnValue({ ok: true, args: null });
     __testing.setSleepSyncOverride(() => {});
   });
 
@@ -655,6 +668,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       try {
         mockReadWindowsListeningPids.mockReturnValue([stalePid]);
         mockReadWindowsProcessArgs.mockReturnValue(["openclaw", "gateway"]);
+        mockReadWindowsProcessArgsResult.mockReturnValue({ ok: true, args: ["openclaw", "gateway"] });
         mockSpawnSync.mockReturnValue({
           error: null,
           status: 0,
@@ -724,6 +738,36 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       }
     });
 
+    it("waits for port release when Windows listener argv inspection is inconclusive", () => {
+      const origDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+      const stalePid = process.pid + 913;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        let fakeNow = 0;
+        __testing.setDateNowOverride(() => fakeNow);
+        mockReadWindowsListeningPidsResult.mockImplementation((_port, timeoutMs) => {
+          if (timeoutMs === 400) {
+            fakeNow += 2001;
+          }
+          return { ok: true, pids: [stalePid] };
+        });
+        mockReadWindowsProcessArgsResult.mockReturnValue({ ok: false, permanent: false });
+        const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+
+        expect(cleanStaleGatewayProcessesSync()).toEqual([]);
+        expect(mockReadWindowsProcessArgsResult).toHaveBeenCalledWith(stalePid, undefined);
+        expect(mockRestartWarn).toHaveBeenCalledWith(
+          expect.stringContaining("port 18789 still in use after 2000ms"),
+        );
+        expect(killSpy).not.toHaveBeenCalled();
+      } finally {
+        __testing.setDateNowOverride(null);
+        if (origDescriptor) {
+          Object.defineProperty(process, "platform", origDescriptor);
+        }
+      }
+    });
+
     it("does not report Windows pids as killed when taskkill fails", () => {
       const origDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
       const stalePid = process.pid + 911;
@@ -731,6 +775,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       try {
         mockReadWindowsListeningPids.mockReturnValue([stalePid]);
         mockReadWindowsProcessArgs.mockReturnValue(["openclaw", "gateway"]);
+        mockReadWindowsProcessArgsResult.mockReturnValue({ ok: true, args: ["openclaw", "gateway"] });
         mockReadWindowsListeningPidsResult.mockReturnValue({ ok: true, pids: [stalePid] });
         mockSpawnSync.mockReturnValue({
           error: null,
@@ -765,6 +810,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       try {
         mockReadWindowsListeningPidsResult.mockReturnValue({ ok: true, pids: [stalePid] });
         mockReadWindowsProcessArgs.mockReturnValue(["openclaw", "gateway"]);
+        mockReadWindowsProcessArgsResult.mockReturnValue({ ok: true, args: ["openclaw", "gateway"] });
         mockSpawnSync
           .mockReturnValueOnce({
             error: null,

--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -10,8 +10,17 @@ const isWindows = process.platform === "win32";
 const mockSpawnSync = vi.hoisted(() => vi.fn());
 const mockResolveGatewayPort = vi.hoisted(() => vi.fn(() => 18789));
 const mockRestartWarn = vi.hoisted(() => vi.fn());
-const mockReadWindowsListeningPids = vi.hoisted(() => vi.fn((_port: number, _timeoutMs?: number): number[] => []));
-const mockReadWindowsProcessArgs = vi.hoisted(() => vi.fn((_pid: number, _timeoutMs?: number): string[] | null => null));
+const mockReadWindowsListeningPids = vi.hoisted(() =>
+  vi.fn((_port: number, _timeoutMs?: number): number[] => []),
+);
+const mockReadWindowsListeningPidsResult = vi.hoisted(() =>
+  vi.fn<(_port: number, _timeoutMs?: number) => MockWindowsListeningPidsResult>(
+    (_port: number, _timeoutMs?: number) => ({ ok: true, pids: [] }),
+  ),
+);
+const mockReadWindowsProcessArgs = vi.hoisted(() =>
+  vi.fn((_pid: number, _timeoutMs?: number): string[] | null => null),
+);
 
 vi.mock("node:child_process", async () => {
   const { mockNodeBuiltinModule } = await import("../../test/helpers/node-builtin-mocks.js");
@@ -45,6 +54,8 @@ vi.mock("./gateway-processes.js", () => ({}));
 vi.mock("./windows-port-pids.js", () => ({
   readWindowsListeningPidsOnPortSync: (port: number, timeoutMs?: number) =>
     mockReadWindowsListeningPids(port, timeoutMs),
+  readWindowsListeningPidsResultSync: (port: number, timeoutMs?: number) =>
+    mockReadWindowsListeningPidsResult(port, timeoutMs),
   readWindowsProcessArgsSync: (pid: number, timeoutMs?: number) =>
     mockReadWindowsProcessArgs(pid, timeoutMs),
 }));
@@ -64,6 +75,10 @@ type MockLsofResult = {
   stdout: string;
   stderr: string;
 };
+
+type MockWindowsListeningPidsResult =
+  | { ok: true; pids: number[] }
+  | { ok: false; permanent: boolean };
 
 function createLsofResult(overrides: Partial<MockLsofResult> = {}): MockLsofResult {
   return {
@@ -114,9 +129,11 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
     mockResolveGatewayPort.mockReset();
     mockRestartWarn.mockReset();
     mockReadWindowsListeningPids.mockReset();
+    mockReadWindowsListeningPidsResult.mockReset();
     mockReadWindowsProcessArgs.mockReset();
     mockResolveGatewayPort.mockReturnValue(18789);
     mockReadWindowsListeningPids.mockReturnValue([]);
+    mockReadWindowsListeningPidsResult.mockReturnValue({ ok: true, pids: [] });
     mockReadWindowsProcessArgs.mockReturnValue(null);
     __testing.setSleepSyncOverride(() => {});
   });
@@ -211,7 +228,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       try {
         mockReadWindowsListeningPids.mockReturnValue([]);
         expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
-        expect(mockReadWindowsListeningPids).toHaveBeenCalledWith(18789);
+        expect(mockReadWindowsListeningPids).toHaveBeenCalledWith(18789, undefined);
         // lsof must NOT be invoked — Windows uses PowerShell/netstat
         expect(mockSpawnSync).not.toHaveBeenCalled();
       } finally {
@@ -230,8 +247,8 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
         // Simulate a verified gateway process (must pass real isGatewayArgv)
         mockReadWindowsProcessArgs.mockReturnValue(["openclaw", "gateway"]);
         expect(findGatewayPidsOnPortSync(18789)).toEqual([stalePid]);
-        expect(mockReadWindowsListeningPids).toHaveBeenCalledWith(18789);
-        expect(mockReadWindowsProcessArgs).toHaveBeenCalledWith(stalePid);
+        expect(mockReadWindowsListeningPids).toHaveBeenCalledWith(18789, undefined);
+        expect(mockReadWindowsProcessArgs).toHaveBeenCalledWith(stalePid, undefined);
       } finally {
         if (origDescriptor) {
           Object.defineProperty(process, "platform", origDescriptor);
@@ -629,6 +646,85 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
       expect(cleanStaleGatewayProcessesSync()).toEqual([]);
       expect(killSpy).not.toHaveBeenCalled();
+    });
+
+    it("treats failed Windows port probes as inconclusive, not free", () => {
+      const origDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+      const stalePid = process.pid + 910;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        mockReadWindowsListeningPids.mockReturnValue([stalePid]);
+        mockReadWindowsProcessArgs.mockReturnValue(["openclaw", "gateway"]);
+        mockSpawnSync.mockReturnValue({
+          error: null,
+          status: 0,
+          stdout: "",
+          stderr: "",
+        });
+        let fakeNow = 0;
+        __testing.setDateNowOverride(() => fakeNow);
+        mockReadWindowsListeningPidsResult.mockImplementation(() => {
+          fakeNow += 2001;
+          return { ok: false, permanent: false };
+        });
+        let aliveChecks = 0;
+        const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+          if (signal === 0 && pid === stalePid) {
+            aliveChecks += 1;
+            if (aliveChecks < 3) {
+              return true;
+            }
+            throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+          }
+          return true;
+        });
+
+        expect(cleanStaleGatewayProcessesSync()).toEqual([stalePid]);
+        expect(mockReadWindowsListeningPidsResult).toHaveBeenCalledWith(18789, 400);
+        expect(mockRestartWarn).toHaveBeenCalledWith(
+          expect.stringContaining("port 18789 still in use after 2000ms"),
+        );
+        expect(killSpy).toHaveBeenCalledWith(stalePid, 0);
+      } finally {
+        __testing.setDateNowOverride(null);
+        if (origDescriptor) {
+          Object.defineProperty(process, "platform", origDescriptor);
+        }
+      }
+    });
+
+    it("does not report Windows pids as killed when taskkill fails", () => {
+      const origDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+      const stalePid = process.pid + 911;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        mockReadWindowsListeningPids.mockReturnValue([stalePid]);
+        mockReadWindowsProcessArgs.mockReturnValue(["openclaw", "gateway"]);
+        mockReadWindowsListeningPidsResult.mockReturnValue({ ok: true, pids: [stalePid] });
+        mockSpawnSync.mockReturnValue({
+          error: null,
+          status: 1,
+          stdout: "",
+          stderr: "access denied",
+        });
+        vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+          if (signal === 0 && pid === stalePid) {
+            return true;
+          }
+          return true;
+        });
+
+        expect(cleanStaleGatewayProcessesSync()).toEqual([]);
+        expect(mockSpawnSync).toHaveBeenCalledWith(
+          expect.stringContaining("taskkill.exe"),
+          ["/T", "/PID", String(stalePid)],
+          expect.objectContaining({ timeout: 5000 }),
+        );
+      } finally {
+        if (origDescriptor) {
+          Object.defineProperty(process, "platform", origDescriptor);
+        }
+      }
     });
   });
 

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -1,7 +1,13 @@
 import { spawnSync } from "node:child_process";
+import path from "node:path";
 import { resolveGatewayPort } from "../config/paths.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isGatewayArgv } from "./gateway-process-argv.js";
 import { resolveLsofCommandSync } from "./ports-lsof.js";
+import {
+  readWindowsListeningPidsOnPortSync,
+  readWindowsProcessArgsSync,
+} from "./windows-port-pids.js";
 
 const SPAWN_TIMEOUT_MS = 2000;
 const STALE_SIGTERM_WAIT_MS = 600;
@@ -79,6 +85,20 @@ function parsePidsFromLsofOutput(stdout: string): number[] {
 }
 
 /**
+ * Windows: find listening PIDs on the port, then verify each is an openclaw
+ * gateway process via command-line inspection. Excludes the current process.
+ */
+function findVerifiedWindowsGatewayPidsOnPortSync(port: number): number[] {
+  const rawPids = readWindowsListeningPidsOnPortSync(port);
+  return Array.from(new Set(rawPids))
+    .filter((pid) => Number.isFinite(pid) && pid > 0 && pid !== process.pid)
+    .filter((pid) => {
+      const args = readWindowsProcessArgsSync(pid);
+      return args != null && isGatewayArgv(args, { allowGatewayBinary: true });
+    });
+}
+
+/**
  * Find PIDs of gateway processes listening on the given port using synchronous lsof.
  * Returns only PIDs that belong to openclaw gateway processes (not the current process).
  */
@@ -87,7 +107,9 @@ export function findGatewayPidsOnPortSync(
   spawnTimeoutMs = SPAWN_TIMEOUT_MS,
 ): number[] {
   if (process.platform === "win32") {
-    return [];
+    // Use the shared Windows port inspection (PowerShell / netstat) with
+    // command-line verification to find only openclaw gateway processes.
+    return findVerifiedWindowsGatewayPidsOnPortSync(port);
   }
   const lsof = resolveLsofCommandSync();
   const res = spawnSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"], {
@@ -139,6 +161,9 @@ export function findGatewayPidsOnPortSync(
 type PollResult = { free: true } | { free: false } | { free: null; permanent: boolean };
 
 function pollPortOnce(port: number): PollResult {
+  if (process.platform === "win32") {
+    return pollPortOnceWindows(port);
+  }
   try {
     const lsof = resolveLsofCommandSync();
     const res = spawnSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"], {
@@ -179,11 +204,32 @@ function pollPortOnce(port: number): PollResult {
 }
 
 /**
+ * Windows-specific port poll.
+ * Uses a short timeout (POLL_SPAWN_TIMEOUT_MS) so a single slow PowerShell
+ * invocation cannot exceed the waitForPortFreeSync wall-clock budget.
+ * Only checks whether any process is listening — no gateway verification
+ * needed because we already killed the stale gateway in the prior step.
+ */
+function pollPortOnceWindows(port: number): PollResult {
+  try {
+    const pids = readWindowsListeningPidsOnPortSync(port, POLL_SPAWN_TIMEOUT_MS);
+    return pids.length === 0 ? { free: true } : { free: false };
+  } catch {
+    return { free: null, permanent: false };
+  }
+}
+
+/**
  * Synchronously terminate stale gateway processes.
  * Callers must pass a non-empty pids array.
- * Sends SIGTERM, waits briefly, then SIGKILL for survivors.
+ *
+ * On Unix: sends SIGTERM, waits briefly, then SIGKILL for survivors.
+ * On Windows: uses taskkill (graceful first, then /F for force-kill).
  */
 function terminateStaleProcessesSync(pids: number[]): number[] {
+  if (process.platform === "win32") {
+    return terminateStaleProcessesWindows(pids);
+  }
   const killed: number[] = [];
   for (const pid of pids) {
     try {
@@ -203,6 +249,51 @@ function terminateStaleProcessesSync(pids: number[]): number[] {
       process.kill(pid, "SIGKILL");
     } catch {
       // already gone
+    }
+  }
+  sleepSync(STALE_SIGKILL_WAIT_MS);
+  return killed;
+}
+
+/**
+ * Windows-specific process termination using taskkill.
+ * Sends a graceful taskkill first (/T for tree), waits, then escalates to /F.
+ */
+function terminateStaleProcessesWindows(pids: number[]): number[] {
+  const taskkillPath = path.join(
+    process.env.SystemRoot ?? "C:\\Windows",
+    "System32",
+    "taskkill.exe",
+  );
+  const killed: number[] = [];
+  for (const pid of pids) {
+    try {
+      // Graceful termination (sends WM_CLOSE to the process tree)
+      spawnSync(taskkillPath, ["/T", "/PID", String(pid)], {
+        stdio: "ignore",
+        timeout: 5000,
+        windowsHide: true,
+      });
+      killed.push(pid);
+    } catch {
+      // Process may already be gone
+    }
+  }
+  if (killed.length === 0) {
+    return killed;
+  }
+  sleepSync(STALE_SIGTERM_WAIT_MS);
+  // Force-kill survivors
+  for (const pid of killed) {
+    try {
+      process.kill(pid, 0); // Check if still alive
+      spawnSync(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
+        stdio: "ignore",
+        timeout: 5000,
+        windowsHide: true,
+      });
+    } catch {
+      // Already gone
     }
   }
   sleepSync(STALE_SIGKILL_WAIT_MS);

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -6,6 +6,7 @@ import { isGatewayArgv } from "./gateway-process-argv.js";
 import { resolveLsofCommandSync } from "./ports-lsof.js";
 import {
   readWindowsListeningPidsOnPortSync,
+  readWindowsListeningPidsResultSync,
   readWindowsProcessArgsSync,
 } from "./windows-port-pids.js";
 
@@ -212,8 +213,11 @@ function pollPortOnce(port: number): PollResult {
  */
 function pollPortOnceWindows(port: number): PollResult {
   try {
-    const pids = readWindowsListeningPidsOnPortSync(port, POLL_SPAWN_TIMEOUT_MS);
-    return pids.length === 0 ? { free: true } : { free: false };
+    const result = readWindowsListeningPidsResultSync(port, POLL_SPAWN_TIMEOUT_MS);
+    if (!result.ok) {
+      return { free: null, permanent: result.permanent };
+    }
+    return result.pids.length === 0 ? { free: true } : { free: false };
   } catch {
     return { free: null, permanent: false };
   }
@@ -267,37 +271,44 @@ function terminateStaleProcessesWindows(pids: number[]): number[] {
   );
   const killed: number[] = [];
   for (const pid of pids) {
-    try {
-      // Graceful termination (sends WM_CLOSE to the process tree)
-      spawnSync(taskkillPath, ["/T", "/PID", String(pid)], {
-        stdio: "ignore",
-        timeout: 5000,
-        windowsHide: true,
-      });
+    const graceful = spawnSync(taskkillPath, ["/T", "/PID", String(pid)], {
+      stdio: "ignore",
+      timeout: 5000,
+      windowsHide: true,
+    });
+    const gracefulFailed = graceful.error != null || (graceful.status ?? 0) !== 0;
+    if (!gracefulFailed && !isProcessAlive(pid)) {
       killed.push(pid);
-    } catch {
-      // Process may already be gone
+      continue;
+    }
+    sleepSync(STALE_SIGTERM_WAIT_MS);
+    if (!isProcessAlive(pid)) {
+      killed.push(pid);
+      continue;
+    }
+    const forced = spawnSync(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
+      stdio: "ignore",
+      timeout: 5000,
+      windowsHide: true,
+    });
+    if (forced.error != null || (forced.status ?? 0) !== 0) {
+      continue;
+    }
+    sleepSync(STALE_SIGKILL_WAIT_MS);
+    if (!isProcessAlive(pid)) {
+      killed.push(pid);
     }
   }
-  if (killed.length === 0) {
-    return killed;
-  }
-  sleepSync(STALE_SIGTERM_WAIT_MS);
-  // Force-kill survivors
-  for (const pid of killed) {
-    try {
-      process.kill(pid, 0); // Check if still alive
-      spawnSync(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
-        stdio: "ignore",
-        timeout: 5000,
-        windowsHide: true,
-      });
-    } catch {
-      // Already gone
-    }
-  }
-  sleepSync(STALE_SIGKILL_WAIT_MS);
   return killed;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -90,14 +90,17 @@ function parsePidsFromLsofOutput(stdout: string): number[] {
  * Windows: find listening PIDs on the port, then verify each is an openclaw
  * gateway process via command-line inspection. Excludes the current process.
  */
-function findVerifiedWindowsGatewayPidsOnPortSync(port: number): number[] {
-  const rawPids = readWindowsListeningPidsOnPortSync(port);
+function filterVerifiedWindowsGatewayPids(rawPids: number[]): number[] {
   return Array.from(new Set(rawPids))
     .filter((pid) => Number.isFinite(pid) && pid > 0 && pid !== process.pid)
     .filter((pid) => {
       const args = readWindowsProcessArgsSync(pid);
       return args != null && isGatewayArgv(args, { allowGatewayBinary: true });
     });
+}
+
+function findVerifiedWindowsGatewayPidsOnPortSync(port: number): number[] {
+  return filterVerifiedWindowsGatewayPids(readWindowsListeningPidsOnPortSync(port));
 }
 
 function findVerifiedWindowsGatewayPidsOnPortResultSync(port: number): WindowsListeningPidsResult {
@@ -107,12 +110,7 @@ function findVerifiedWindowsGatewayPidsOnPortResultSync(port: number): WindowsLi
   }
   return {
     ok: true,
-    pids: Array.from(new Set(result.pids))
-      .filter((pid) => Number.isFinite(pid) && pid > 0 && pid !== process.pid)
-      .filter((pid) => {
-        const args = readWindowsProcessArgsSync(pid);
-        return args != null && isGatewayArgv(args, { allowGatewayBinary: true });
-      }),
+    pids: filterVerifiedWindowsGatewayPids(result.pids),
   };
 }
 

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -8,6 +8,7 @@ import {
   readWindowsListeningPidsOnPortSync,
   readWindowsListeningPidsResultSync,
   readWindowsProcessArgsSync,
+  type WindowsListeningPidsResult,
 } from "./windows-port-pids.js";
 
 const SPAWN_TIMEOUT_MS = 2000;
@@ -97,6 +98,22 @@ function findVerifiedWindowsGatewayPidsOnPortSync(port: number): number[] {
       const args = readWindowsProcessArgsSync(pid);
       return args != null && isGatewayArgv(args, { allowGatewayBinary: true });
     });
+}
+
+function findVerifiedWindowsGatewayPidsOnPortResultSync(port: number): WindowsListeningPidsResult {
+  const result = readWindowsListeningPidsResultSync(port);
+  if (!result.ok) {
+    return result;
+  }
+  return {
+    ok: true,
+    pids: Array.from(new Set(result.pids))
+      .filter((pid) => Number.isFinite(pid) && pid > 0 && pid !== process.pid)
+      .filter((pid) => {
+        const args = readWindowsProcessArgsSync(pid);
+        return args != null && isGatewayArgv(args, { allowGatewayBinary: true });
+      }),
+  };
 }
 
 /**
@@ -306,8 +323,8 @@ function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
   }
 }
 
@@ -361,7 +378,17 @@ export function cleanStaleGatewayProcessesSync(portOverride?: number): number[] 
       typeof portOverride === "number" && Number.isFinite(portOverride) && portOverride > 0
         ? Math.floor(portOverride)
         : resolveGatewayPort(undefined, process.env);
-    const stalePids = findGatewayPidsOnPortSync(port);
+    const stalePids =
+      process.platform === "win32"
+        ? (() => {
+            const result = findVerifiedWindowsGatewayPidsOnPortResultSync(port);
+            if (result.ok) {
+              return result.pids;
+            }
+            waitForPortFreeSync(port);
+            return [];
+          })()
+        : findGatewayPidsOnPortSync(port);
     if (stalePids.length === 0) {
       return [];
     }

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -7,7 +7,9 @@ import { resolveLsofCommandSync } from "./ports-lsof.js";
 import {
   readWindowsListeningPidsOnPortSync,
   readWindowsListeningPidsResultSync,
+  readWindowsProcessArgsResultSync,
   readWindowsProcessArgsSync,
+  type WindowsProcessArgsResult,
   type WindowsListeningPidsResult,
 } from "./windows-port-pids.js";
 
@@ -99,6 +101,26 @@ function filterVerifiedWindowsGatewayPids(rawPids: number[]): number[] {
     });
 }
 
+function filterVerifiedWindowsGatewayPidsResult(
+  rawPids: number[],
+  processArgsResult: (pid: number) => WindowsProcessArgsResult,
+): WindowsListeningPidsResult {
+  const verified: number[] = [];
+  for (const pid of Array.from(new Set(rawPids))) {
+    if (!Number.isFinite(pid) || pid <= 0 || pid === process.pid) {
+      continue;
+    }
+    const argsResult = processArgsResult(pid);
+    if (!argsResult.ok) {
+      return { ok: false, permanent: argsResult.permanent };
+    }
+    if (argsResult.args != null && isGatewayArgv(argsResult.args, { allowGatewayBinary: true })) {
+      verified.push(pid);
+    }
+  }
+  return { ok: true, pids: verified };
+}
+
 function findVerifiedWindowsGatewayPidsOnPortSync(port: number): number[] {
   return filterVerifiedWindowsGatewayPids(readWindowsListeningPidsOnPortSync(port));
 }
@@ -108,10 +130,9 @@ function findVerifiedWindowsGatewayPidsOnPortResultSync(port: number): WindowsLi
   if (!result.ok) {
     return result;
   }
-  return {
-    ok: true,
-    pids: filterVerifiedWindowsGatewayPids(result.pids),
-  };
+  return filterVerifiedWindowsGatewayPidsResult(result.pids, (pid) =>
+    readWindowsProcessArgsResultSync(pid),
+  );
 }
 
 /**

--- a/src/infra/windows-port-pids.ts
+++ b/src/infra/windows-port-pids.ts
@@ -1,0 +1,126 @@
+import { spawnSync } from "node:child_process";
+import { parseCmdScriptCommandLine } from "../daemon/cmd-argv.js";
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+// ---------------------------------------------------------------------------
+// Windows listening-PID discovery (PowerShell → netstat fallback)
+// ---------------------------------------------------------------------------
+
+function readListeningPidsViaPowerShell(port: number, timeoutMs: number): number[] | null {
+  const ps = spawnSync(
+    "powershell",
+    [
+      "-NoProfile",
+      "-Command",
+      `(Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess)`,
+    ],
+    {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      windowsHide: true,
+    },
+  );
+  if (ps.error || ps.status !== 0) {
+    return null;
+  }
+  return ps.stdout
+    .split(/\r?\n/)
+    .map((line) => Number.parseInt(line.trim(), 10))
+    .filter((pid) => Number.isFinite(pid) && pid > 0);
+}
+
+function readListeningPidsViaNetstat(port: number, timeoutMs: number): number[] {
+  const netstat = spawnSync("netstat", ["-ano", "-p", "tcp"], {
+    encoding: "utf8",
+    timeout: timeoutMs,
+    windowsHide: true,
+  });
+  if (netstat.error || netstat.status !== 0) {
+    return [];
+  }
+  const pids = new Set<number>();
+  for (const line of netstat.stdout.split(/\r?\n/)) {
+    const match = line.match(/^\s*TCP\s+(\S+):(\d+)\s+\S+\s+LISTENING\s+(\d+)\s*$/i);
+    if (!match) {
+      continue;
+    }
+    const parsedPort = Number.parseInt(match[2] ?? "", 10);
+    const pid = Number.parseInt(match[3] ?? "", 10);
+    if (parsedPort === port && Number.isFinite(pid) && pid > 0) {
+      pids.add(pid);
+    }
+  }
+  return [...pids];
+}
+
+export function readWindowsListeningPidsOnPortSync(
+  port: number,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): number[] {
+  return readListeningPidsViaPowerShell(port, timeoutMs) ?? readListeningPidsViaNetstat(port, timeoutMs);
+}
+
+// ---------------------------------------------------------------------------
+// Windows process-args reading (PowerShell → WMIC fallback)
+// ---------------------------------------------------------------------------
+
+function extractWindowsCommandLine(raw: string): string | null {
+  const lines = raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  for (const line of lines) {
+    if (!line.toLowerCase().startsWith("commandline=")) {
+      continue;
+    }
+    const value = line.slice("commandline=".length).trim();
+    return value || null;
+  }
+  return lines.find((line) => line.toLowerCase() !== "commandline") ?? null;
+}
+
+function readProcessArgsViaPowerShell(pid: number, timeoutMs: number): string[] | null {
+  const ps = spawnSync(
+    "powershell",
+    [
+      "-NoProfile",
+      "-Command",
+      `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" | Select-Object -ExpandProperty CommandLine)`,
+    ],
+    {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      windowsHide: true,
+    },
+  );
+  if (ps.error || ps.status !== 0) {
+    return null;
+  }
+  const command = ps.stdout.trim();
+  return command ? parseCmdScriptCommandLine(command) : null;
+}
+
+function readProcessArgsViaWmic(pid: number, timeoutMs: number): string[] | null {
+  const wmic = spawnSync(
+    "wmic",
+    ["process", "where", `ProcessId=${pid}`, "get", "CommandLine", "/value"],
+    {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      windowsHide: true,
+    },
+  );
+  if (wmic.error || wmic.status !== 0) {
+    return null;
+  }
+  const command = extractWindowsCommandLine(wmic.stdout);
+  return command ? parseCmdScriptCommandLine(command) : null;
+}
+
+export function readWindowsProcessArgsSync(
+  pid: number,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): string[] | null {
+  return readProcessArgsViaPowerShell(pid, timeoutMs) ?? readProcessArgsViaWmic(pid, timeoutMs);
+}

--- a/src/infra/windows-port-pids.ts
+++ b/src/infra/windows-port-pids.ts
@@ -7,6 +7,10 @@ export type WindowsListeningPidsResult =
   | { ok: true; pids: number[] }
   | { ok: false; permanent: boolean };
 
+export type WindowsProcessArgsResult =
+  | { ok: true; args: string[] | null }
+  | { ok: false; permanent: boolean };
+
 // ---------------------------------------------------------------------------
 // Windows listening-PID discovery (PowerShell → netstat fallback)
 // ---------------------------------------------------------------------------
@@ -100,8 +104,19 @@ function extractWindowsCommandLine(raw: string): string | null {
   return lines.find((line) => line.toLowerCase() !== "commandline") ?? null;
 }
 
-function readProcessArgsViaPowerShell(pid: number, timeoutMs: number): string[] | null {
-  const ps = spawnSync(
+export function readWindowsProcessArgsSync(
+  pid: number,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): string[] | null {
+  const result = readWindowsProcessArgsResultSync(pid, timeoutMs);
+  return result.ok ? result.args : null;
+}
+
+export function readWindowsProcessArgsResultSync(
+  pid: number,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): WindowsProcessArgsResult {
+  const powershell = spawnSync(
     "powershell",
     [
       "-NoProfile",
@@ -114,14 +129,10 @@ function readProcessArgsViaPowerShell(pid: number, timeoutMs: number): string[] 
       windowsHide: true,
     },
   );
-  if (ps.error || ps.status !== 0) {
-    return null;
+  if (!powershell.error && powershell.status === 0) {
+    const command = powershell.stdout.trim();
+    return { ok: true, args: command ? parseCmdScriptCommandLine(command) : null };
   }
-  const command = ps.stdout.trim();
-  return command ? parseCmdScriptCommandLine(command) : null;
-}
-
-function readProcessArgsViaWmic(pid: number, timeoutMs: number): string[] | null {
   const wmic = spawnSync(
     "wmic",
     ["process", "where", `ProcessId=${pid}`, "get", "CommandLine", "/value"],
@@ -131,16 +142,10 @@ function readProcessArgsViaWmic(pid: number, timeoutMs: number): string[] | null
       windowsHide: true,
     },
   );
-  if (wmic.error || wmic.status !== 0) {
-    return null;
+  if (!wmic.error && wmic.status === 0) {
+    const command = extractWindowsCommandLine(wmic.stdout);
+    return { ok: true, args: command ? parseCmdScriptCommandLine(command) : null };
   }
-  const command = extractWindowsCommandLine(wmic.stdout);
-  return command ? parseCmdScriptCommandLine(command) : null;
-}
-
-export function readWindowsProcessArgsSync(
-  pid: number,
-  timeoutMs = DEFAULT_TIMEOUT_MS,
-): string[] | null {
-  return readProcessArgsViaPowerShell(pid, timeoutMs) ?? readProcessArgsViaWmic(pid, timeoutMs);
+  const code = ((wmic.error ?? powershell.error) as NodeJS.ErrnoException | undefined)?.code;
+  return { ok: false, permanent: code === "ENOENT" || code === "EACCES" || code === "EPERM" };
 }

--- a/src/infra/windows-port-pids.ts
+++ b/src/infra/windows-port-pids.ts
@@ -3,6 +3,10 @@ import { parseCmdScriptCommandLine } from "../daemon/cmd-argv.js";
 
 const DEFAULT_TIMEOUT_MS = 5_000;
 
+export type WindowsListeningPidsResult =
+  | { ok: true; pids: number[] }
+  | { ok: false; permanent: boolean };
+
 // ---------------------------------------------------------------------------
 // Windows listening-PID discovery (PowerShell → netstat fallback)
 // ---------------------------------------------------------------------------
@@ -30,17 +34,9 @@ function readListeningPidsViaPowerShell(port: number, timeoutMs: number): number
     .filter((pid) => Number.isFinite(pid) && pid > 0);
 }
 
-function readListeningPidsViaNetstat(port: number, timeoutMs: number): number[] {
-  const netstat = spawnSync("netstat", ["-ano", "-p", "tcp"], {
-    encoding: "utf8",
-    timeout: timeoutMs,
-    windowsHide: true,
-  });
-  if (netstat.error || netstat.status !== 0) {
-    return [];
-  }
+function parseListeningPidsFromNetstat(stdout: string, port: number): number[] {
   const pids = new Set<number>();
-  for (const line of netstat.stdout.split(/\r?\n/)) {
+  for (const line of stdout.split(/\r?\n/)) {
     const match = line.match(/^\s*TCP\s+(\S+):(\d+)\s+\S+\s+LISTENING\s+(\d+)\s*$/i);
     if (!match) {
       continue;
@@ -58,7 +54,31 @@ export function readWindowsListeningPidsOnPortSync(
   port: number,
   timeoutMs = DEFAULT_TIMEOUT_MS,
 ): number[] {
-  return readListeningPidsViaPowerShell(port, timeoutMs) ?? readListeningPidsViaNetstat(port, timeoutMs);
+  const result = readWindowsListeningPidsResultSync(port, timeoutMs);
+  return result.ok ? result.pids : [];
+}
+
+export function readWindowsListeningPidsResultSync(
+  port: number,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): WindowsListeningPidsResult {
+  const powershellPids = readListeningPidsViaPowerShell(port, timeoutMs);
+  if (powershellPids != null) {
+    return { ok: true, pids: powershellPids };
+  }
+  const netstat = spawnSync("netstat", ["-ano", "-p", "tcp"], {
+    encoding: "utf8",
+    timeout: timeoutMs,
+    windowsHide: true,
+  });
+  if (netstat.error) {
+    const code = (netstat.error as NodeJS.ErrnoException).code;
+    return { ok: false, permanent: code === "ENOENT" || code === "EACCES" || code === "EPERM" };
+  }
+  if (netstat.status !== 0) {
+    return { ok: false, permanent: false };
+  }
+  return { ok: true, pids: parseListeningPidsFromNetstat(netstat.stdout, port) };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #60878

`findGatewayPidsOnPortSync()` in `src/infra/restart-stale-pids.ts` returned `[]` immediately on Windows (`process.platform === 'win32'`), causing `cleanStaleGatewayProcessesSync()` to silently skip killing old gateway processes during self-restart via the schtasks supervisor path (`triggerOpenClawRestart`).

This caused an **infinite retry loop** on Windows:
```
[gateway] already running under schtasks; waiting 5000ms before retrying startup
```

The new gateway instance could never bind port 18789 because the old process was never terminated.

## Root Cause

The self-restart path on Windows (`triggerOpenClawRestart` -> `relaunchGatewayScheduledTask`) calls `cleanStaleGatewayProcessesSync()` before spawning the schtasks restart script. But since `findGatewayPidsOnPortSync` returns `[]` on Windows, no stale processes are ever found or killed. The new schtasks-launched gateway then races the old one for the port and enters an unbounded retry loop.

Note: `openclaw daemon restart` works correctly because it uses the `restartScheduledTask()` path in `service.ts`, which properly calls `terminateScheduledTaskGatewayListeners()` with the Windows-aware `findVerifiedGatewayListenerPidsOnPortSync()`. Only the in-process self-restart path was broken.

## Changes

### New: `src/infra/windows-port-pids.ts`
Extracted all Windows-specific port scanning and process-args helpers from `gateway-processes.ts` into a shared module with configurable `timeoutMs` parameter. This:
- **Breaks the circular import** between `restart-stale-pids.ts` and `gateway-processes.ts` (both now import from `windows-port-pids.ts` instead of from each other)
- **Fixes poll budget overshoot**: Windows poll calls use `POLL_SPAWN_TIMEOUT_MS` (400ms) instead of the 5000ms default, keeping each poll within the `waitForPortFreeSync` 2s budget

### `src/infra/restart-stale-pids.ts`
- **`findGatewayPidsOnPortSync`**: On win32, discovers listening PIDs via `readWindowsListeningPidsOnPortSync` + verifies each with `readWindowsProcessArgsSync` / `isGatewayArgv`
- **`pollPortOnceWindows`**: Uses `readWindowsListeningPidsOnPortSync(port, 400)` — just checks if port has any listener, no verification needed (stale gateway already killed)
- **`terminateStaleProcessesSync`**: Add `terminateStaleProcessesWindows()` using `taskkill.exe` (graceful `/T` first, then `/F` force-kill) instead of `SIGTERM`/`SIGKILL`

### `src/infra/gateway-processes.ts`
- Delegates Windows helpers to the new `windows-port-pids.ts` module
- Removes ~100 lines of inlined Windows functions
- Keeps `findVerifiedGatewayListenerPidsOnPortSync` public API unchanged

### `src/infra/restart-stale-pids.test.ts`
- Mocks `windows-port-pids.js` (port scanning + process args) for the win32 platform-mock tests
- Updated win32 tests verify delegation to `readWindowsListeningPidsOnPortSync` and `readWindowsProcessArgsSync`
- Tests use real `isGatewayArgv` for full integration coverage

## Testing

- [x] Lightly tested: verified fix resolves the infinite restart loop on Windows 11
- [x] Confirmed `openclaw daemon restart` and `openclaw gateway call health` work after fix
- [x] Existing Unix tests unaffected — all 38 restart-stale-pids tests pass
- [x] All 6 gateway-processes tests pass after refactor
- [x] Updated test mocks verify win32 delegation with real `isGatewayArgv` validation