### PR TITLE
fix(feishu): accept token-verified webhook challenges

### DIFF
--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -86,10 +86,84 @@ function isFeishuWebhookSignatureValid(params: {
   return timingSafeEqualString(computedSignature, signature);
 }
 
+function isMatchingFeishuVerificationToken(params: {
+  payload: Record<string, unknown>;
+  verificationToken?: string;
+}): boolean {
+  const expectedToken = params.verificationToken?.trim();
+  if (!expectedToken) {
+    return false;
+  }
+  const actualToken = typeof params.payload.token === "string" ? params.payload.token.trim() : "";
+  return actualToken.length > 0 && timingSafeEqualString(actualToken, expectedToken);
+}
+
+function decryptFeishuWebhookPayload(params: {
+  payload: Record<string, unknown>;
+  encryptKey?: string;
+}): Record<string, unknown> | null {
+  const ciphertext =
+    typeof params.payload.encrypt === "string" ? params.payload.encrypt.trim() : "";
+  const encryptKey = params.encryptKey?.trim();
+  if (!ciphertext || !encryptKey) {
+    return null;
+  }
+
+  try {
+    const encrypted = Buffer.from(ciphertext, "base64");
+    if (encrypted.length <= 16) {
+      return null;
+    }
+    const iv = encrypted.subarray(0, 16);
+    const body = encrypted.subarray(16);
+    const key = crypto.createHash("sha256").update(encryptKey).digest();
+    const decipher = crypto.createDecipheriv("aes-256-cbc", key, iv);
+    const plaintext = Buffer.concat([decipher.update(body), decipher.final()]).toString("utf8");
+    return parseFeishuWebhookPayload(plaintext);
+  } catch {
+    return null;
+  }
+}
+
+function isAuthorizedFeishuChallenge(params: {
+  payload: Record<string, unknown>;
+  signatureValid: boolean;
+  verificationToken?: string;
+  encryptKey?: string;
+}): boolean {
+  if (params.signatureValid) {
+    return true;
+  }
+
+  if (
+    isMatchingFeishuVerificationToken({
+      payload: params.payload,
+      verificationToken: params.verificationToken,
+    })
+  ) {
+    return true;
+  }
+
+  const decryptedPayload = decryptFeishuWebhookPayload({
+    payload: params.payload,
+    encryptKey: params.encryptKey,
+  });
+  return isMatchingFeishuVerificationToken({
+    payload: decryptedPayload ?? {},
+    verificationToken: params.verificationToken,
+  });
+}
+
 function respondText(res: http.ServerResponse, statusCode: number, body: string): void {
   res.statusCode = statusCode;
   res.setHeader("Content-Type", "text/plain; charset=utf-8");
   res.end(body);
+}
+
+function respondJson(res: http.ServerResponse, statusCode: number, body: unknown): void {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(body));
 }
 
 export async function monitorWebSocket({
@@ -204,31 +278,47 @@ export async function monitorWebhook({
           return;
         }
 
-        // Reject invalid signatures before any JSON parsing to keep the auth boundary strict.
-        if (
-          !isFeishuWebhookSignatureValid({
+        const payload = parseFeishuWebhookPayload(rawBody);
+        if (!payload) {
+          const signatureValid = isFeishuWebhookSignatureValid({
             headers: req.headers,
             rawBody,
             encryptKey: account.encryptKey,
-          })
-        ) {
-          respondText(res, 401, "Invalid signature");
-          return;
-        }
-
-        const payload = parseFeishuWebhookPayload(rawBody);
-        if (!payload) {
+          });
+          if (!signatureValid) {
+            respondText(res, 401, "Invalid signature");
+            return;
+          }
           respondText(res, 400, "Invalid JSON");
           return;
         }
 
+        const signatureValid = isFeishuWebhookSignatureValid({
+          headers: req.headers,
+          rawBody,
+          encryptKey: account.encryptKey,
+        });
         const { isChallenge, challenge } = Lark.generateChallenge(payload, {
           encryptKey: account.encryptKey ?? "",
         });
         if (isChallenge) {
-          res.statusCode = 200;
-          res.setHeader("Content-Type", "application/json; charset=utf-8");
-          res.end(JSON.stringify(challenge));
+          if (
+            !isAuthorizedFeishuChallenge({
+              payload,
+              signatureValid,
+              verificationToken: account.verificationToken,
+              encryptKey: account.encryptKey,
+            })
+          ) {
+            respondText(res, 401, "Invalid signature");
+            return;
+          }
+          respondJson(res, 200, challenge);
+          return;
+        }
+
+        if (!signatureValid) {
+          respondText(res, 401, "Invalid signature");
           return;
         }
 
@@ -236,9 +326,7 @@ export async function monitorWebhook({
           needCheck: false,
         });
         if (!res.headersSent) {
-          res.statusCode = 200;
-          res.setHeader("Content-Type", "application/json; charset=utf-8");
-          res.end(JSON.stringify(value));
+          respondJson(res, 200, value);
         }
       } catch (err) {
         if (isRequestBodyLimitError(err)) {

--- a/extensions/feishu/src/monitor.webhook-e2e.test.ts
+++ b/extensions/feishu/src/monitor.webhook-e2e.test.ts
@@ -116,6 +116,34 @@ describe("Feishu webhook signed-request e2e", () => {
     );
   });
 
+  it("accepts unsigned plaintext url_verification challenges when the verification token matches", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+
+    await withRunningWebhookMonitor(
+      {
+        accountId: "unsigned-challenge-with-token",
+        path: "/hook-e2e-unsigned-challenge-with-token",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const response = await fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            type: "url_verification",
+            challenge: "challenge-token",
+            token: "verify_token",
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({ challenge: "challenge-token" });
+      },
+    );
+  });
+
   it("rejects malformed short signatures with 401", async () => {
     probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
 
@@ -261,6 +289,39 @@ describe("Feishu webhook signed-request e2e", () => {
           }),
         };
         const response = await postSignedPayload(url, payload);
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({
+          challenge: "encrypted-challenge-token",
+        });
+      },
+    );
+  });
+
+  it("accepts unsigned encrypted url_verification challenges when the verification token matches", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+
+    await withRunningWebhookMonitor(
+      {
+        accountId: "unsigned-encrypted-challenge",
+        path: "/hook-e2e-unsigned-encrypted-challenge",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const payload = {
+          encrypt: encryptFeishuPayload("encrypt_key", {
+            type: "url_verification",
+            challenge: "encrypted-challenge-token",
+            token: "verify_token",
+          }),
+        };
+        const response = await fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(payload),
+        });
 
         expect(response.status).toBe(200);
         await expect(response.json()).resolves.toEqual({


### PR DESCRIPTION
## Summary

- Problem: Feishu/Lark webhook `url_verification` callbacks can arrive without the normal request signature during callback setup, which made OpenClaw return `401 Invalid signature` and fail callback validation.
- Why it matters: apps configured for webhook delivery could not complete callback setup even when the verification token and encrypt key were correct.
- What changed: allow `url_verification` challenges when either the normal signature is valid or the configured verification token matches the plaintext/encrypted challenge payload.
- What did NOT change (scope boundary): no WebSocket behavior changes, no non-challenge webhook auth relaxation, and no provider/model/runtime changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the webhook handler rejected unsigned requests before parsing challenge payloads, so Feishu/Lark callback verification could not fall back to verification-token-based validation.
- Missing detection / guardrail: webhook tests covered signed challenge flows, but not unsigned plaintext/encrypted `url_verification` requests with a matching verification token.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: the stricter auth boundary worked for signed runtime events but did not account for setup-time challenge requests.
- If unknown, what was ruled out: ruled out callback URL reachability, webhook path routing, and invalid verification token/encrypt key config.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/monitor.webhook-e2e.test.ts`
- Scenario the test should lock in: callback setup succeeds for unsigned plaintext and unsigned encrypted `url_verification` requests when the verification token matches.
- Why this is the smallest reliable guardrail: the bug lives at the HTTP webhook boundary and depends on the exact request body/auth interplay.
- Existing test that already covers this (if any): signed challenge coverage already existed in the same file.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Feishu/Lark webhook callback setup can now succeed when the platform sends unsigned challenge requests that still carry the configured verification token.

## Diagram (if applicable)

```text
Before:
[url_verification request without signature] -> [401 Invalid signature]

After:
[url_verification request] -> [signature valid OR verification token matches] -> [200 JSON challenge]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local gateway via user systemd
- Model/provider: Anthropic / Claude Sonnet 4.6 (not directly relevant to repro)
- Integration/channel (if any): Feishu / Lark webhook mode
- Relevant config (redacted): `channels.feishu.connectionMode=webhook`, `verificationToken` set, `encryptKey` set

### Steps

1. Configure a Feishu/Lark app for webhook delivery with a valid callback URL, verification token, and encrypt key.
2. Let the platform send callback verification requests in plaintext or encrypted challenge form without the normal runtime signature headers.
3. Observe the callback response.

### Expected

- OpenClaw returns `200` with the JSON challenge payload when the verification token matches.

### Actual

- Before the fix, OpenClaw returned `401 Invalid signature`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced callback failure against a real Lark app, then verified callback setup succeeded after the fix; also verified the targeted webhook e2e tests for signed plaintext, unsigned plaintext, and unsigned encrypted challenge flows.
- Edge cases checked: unsigned encrypted challenge path, unsigned plaintext challenge path, signed challenge path, and non-JSON invalid request handling.
- What you did **not** verify: broad full-suite validation and non-webhook Feishu delivery modes.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: accepting setup-time challenge requests based on verification-token matching could accidentally widen auth if applied to regular events.
  - Mitigation: the relaxed path is limited to `url_verification` challenge handling; non-challenge webhook events still require the normal signature validation.
