### PR TITLE
fix(security): close active April 4 transport and auth gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security: reject configured explicit provider proxy URLs that target private or internal hosts, disconnect stale shared-auth clients after `config.set` auth rotation, and neutralize Discord outbound mention pings across text, media, webhook, and payload sends. Thanks @vincentkoc.
 - Media understanding: honor explicit image-model configuration before native-vision skips, including `agents.defaults.imageModel`, `tools.media.image.models`, and provider image defaults such as MiniMax VL when the active chat model is text-only. Fixes #47614, #63722, #69171.
 - Codex/media understanding: support `codex/*` image models through bounded Codex app-server image turns, while keeping `openai-codex/*` on the OpenAI Codex OAuth route and validating app-server responses against generated protocol contracts. Fixes #70201.
 - Providers/OpenAI Codex: synthesize the `openai-codex/gpt-5.5` OAuth model row when Codex catalog discovery omits it, so cron and subagent runs do not fail with `Unknown model` while the account is authenticated.

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -160,6 +160,26 @@ describe("discordOutbound", () => {
     });
   });
 
+  it("neutralizes mentions for webhook thread text replies", async () => {
+    mockDiscordBoundThreadManager(hoisted);
+
+    await discordOutbound.sendText?.({
+      cfg: {},
+      to: "channel:parent-1",
+      text: "Hello @everyone <@123>",
+      accountId: "default",
+      threadId: "thread-1",
+    });
+
+    expect(hoisted.sendWebhookMessageDiscordMock).toHaveBeenCalledWith(
+      "Hello @\u200beveryone <@\u200b123>",
+      expect.objectContaining({
+        webhookId: "wh-1",
+        webhookToken: "tok-1",
+      }),
+    );
+  });
+
   it("routes poll sends to thread target when threadId is provided", async () => {
     const result = await discordOutbound.sendPoll?.({
       cfg: {},
@@ -280,7 +300,7 @@ describe("discordOutbound", () => {
     expect(hoisted.sendMessageDiscordMock).not.toHaveBeenCalled();
   });
 
-  it("neutralizes approval mentions only for approval payloads", async () => {
+  it("neutralizes approval mentions in payload sends", async () => {
     await discordOutbound.sendPayload?.({
       cfg: {},
       to: "channel:123456",
@@ -306,7 +326,7 @@ describe("discordOutbound", () => {
     );
   });
 
-  it("leaves non-approval mentions unchanged", async () => {
+  it("neutralizes non-approval mentions in payload sends", async () => {
     await discordOutbound.sendPayload?.({
       cfg: {},
       to: "channel:123456",
@@ -319,7 +339,7 @@ describe("discordOutbound", () => {
 
     expect(hoisted.sendMessageDiscordMock).toHaveBeenCalledWith(
       "channel:123456",
-      "Hello @everyone",
+      "Hello @\u200beveryone",
       expect.objectContaining({
         accountId: "default",
       }),

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -60,29 +60,23 @@ function loadDiscordThreadBindings(): Promise<DiscordThreadBindingsModule> {
   return discordThreadBindingsPromise;
 }
 
-function hasApprovalChannelData(payload: { channelData?: unknown }): boolean {
-  const channelData = payload.channelData;
-  if (!channelData || typeof channelData !== "object" || Array.isArray(channelData)) {
-    return false;
-  }
-  return Boolean((channelData as { execApproval?: unknown }).execApproval);
-}
-
-function neutralizeDiscordApprovalMentions(value: string): string {
+function neutralizeDiscordOutboundMentions(value: string): string {
   return value
     .replace(/@everyone/gi, "@\u200beveryone")
     .replace(/@here/gi, "@\u200bhere")
-    .replace(/<@/g, "<@\u200b")
-    .replace(/<#/g, "<#\u200b");
+    .replace(/<@(?!\u200b)/g, "<@\u200b")
+    .replace(/<#(?!\u200b)/g, "<#\u200b");
 }
 
-function normalizeDiscordApprovalPayload<T extends { text?: string; channelData?: unknown }>(
-  payload: T,
-): T {
-  return hasApprovalChannelData(payload) && payload.text
+function sanitizeDiscordOutboundText(value: string): string {
+  return neutralizeDiscordOutboundMentions(value);
+}
+
+function normalizeDiscordOutboundPayload<T extends { text?: string }>(payload: T): T {
+  return payload.text
     ? {
         ...payload,
-        text: neutralizeDiscordApprovalMentions(payload.text),
+        text: sanitizeDiscordOutboundText(payload.text),
       }
     : payload;
 }
@@ -141,7 +135,7 @@ async function maybeSendDiscordWebhookText(params: {
     binding,
   });
   const { sendWebhookMessageDiscord } = await loadDiscordSendRuntime();
-  const result = await sendWebhookMessageDiscord(params.text, {
+  const result = await sendWebhookMessageDiscord(sanitizeDiscordOutboundText(params.text), {
     webhookId: binding.webhookId,
     webhookToken: binding.webhookToken,
     accountId: binding.accountId,
@@ -159,7 +153,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
   chunker: null,
   textChunkLimit: DISCORD_TEXT_CHUNK_LIMIT,
   pollMaxOptions: 10,
-  normalizePayload: ({ payload }) => normalizeDiscordApprovalPayload(payload),
+  normalizePayload: ({ payload }) => normalizeDiscordOutboundPayload(payload),
   presentationCapabilities: {
     supported: true,
     buttons: true,
@@ -187,7 +181,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
   },
   resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
   sendPayload: async (ctx) => {
-    const payload = normalizeDiscordApprovalPayload({
+    const payload = normalizeDiscordOutboundPayload({
       ...ctx.payload,
       text: ctx.payload.text ?? "",
     });
@@ -202,11 +196,18 @@ export const discordOutbound: ChannelOutboundAdapter = {
             payload.interactive,
           )
         : undefined);
-    const componentSpec = rawComponentSpec
-      ? rawComponentSpec.text
-        ? rawComponentSpec
-        : {
+    const normalizedComponentSpec =
+      rawComponentSpec && rawComponentSpec.text
+        ? {
             ...rawComponentSpec,
+            text: sanitizeDiscordOutboundText(rawComponentSpec.text),
+          }
+        : rawComponentSpec;
+    const componentSpec = normalizedComponentSpec
+      ? normalizedComponentSpec.text
+        ? normalizedComponentSpec
+        : {
+            ...normalizedComponentSpec,
             text: payload.text?.trim() ? payload.text : undefined,
           }
       : undefined;
@@ -249,7 +250,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
             cfg: ctx.cfg,
           });
         }
-        return await send(target, text, {
+        return await send(target, sanitizeDiscordOutboundText(text), {
           verbose: false,
           mediaUrl,
           mediaAccess: ctx.mediaAccess,
@@ -283,13 +284,17 @@ export const discordOutbound: ChannelOutboundAdapter = {
       const send =
         resolveOutboundSendDep<DiscordSendFn>(deps, "discord") ??
         (await loadDiscordSendRuntime()).sendMessageDiscord;
-      return await send(resolveDiscordOutboundTarget({ to, threadId }), text, {
-        verbose: false,
-        replyTo: replyToId ?? undefined,
-        accountId: accountId ?? undefined,
-        silent: silent ?? undefined,
-        cfg,
-      });
+      return await send(
+        resolveDiscordOutboundTarget({ to, threadId }),
+        sanitizeDiscordOutboundText(text),
+        {
+          verbose: false,
+          replyTo: replyToId ?? undefined,
+          accountId: accountId ?? undefined,
+          silent: silent ?? undefined,
+          cfg,
+        },
+      );
     },
     sendMedia: async ({
       cfg,
@@ -307,16 +312,20 @@ export const discordOutbound: ChannelOutboundAdapter = {
       const send =
         resolveOutboundSendDep<DiscordSendFn>(deps, "discord") ??
         (await loadDiscordSendRuntime()).sendMessageDiscord;
-      return await send(resolveDiscordOutboundTarget({ to, threadId }), text, {
-        verbose: false,
-        mediaUrl,
-        mediaLocalRoots,
-        mediaReadFile,
-        replyTo: replyToId ?? undefined,
-        accountId: accountId ?? undefined,
-        silent: silent ?? undefined,
-        cfg,
-      });
+      return await send(
+        resolveDiscordOutboundTarget({ to, threadId }),
+        sanitizeDiscordOutboundText(text),
+        {
+          verbose: false,
+          mediaUrl,
+          mediaLocalRoots,
+          mediaReadFile,
+          replyTo: replyToId ?? undefined,
+          accountId: accountId ?? undefined,
+          silent: silent ?? undefined,
+          cfg,
+        },
+      );
     },
     sendPoll: async ({ cfg, to, poll, accountId, threadId, silent }) =>
       await (

--- a/src/agents/provider-request-config.test.ts
+++ b/src/agents/provider-request-config.test.ts
@@ -96,7 +96,7 @@ describe("provider request config", () => {
         },
         proxy: {
           mode: "explicit-proxy",
-          url: "http://proxy.internal:8443",
+          url: "http://proxy.example.com:8443",
           tls: {
             ca: "proxy-ca",
           },
@@ -128,7 +128,7 @@ describe("provider request config", () => {
     expect(resolved.proxy).toEqual({
       configured: true,
       mode: "explicit-proxy",
-      proxyUrl: "http://proxy.internal:8443",
+      proxyUrl: "http://proxy.example.com:8443",
       tls: {
         configured: true,
         ca: "proxy-ca",
@@ -262,7 +262,7 @@ describe("provider request config", () => {
         },
         proxy: {
           mode: "explicit-proxy",
-          url: "http://proxy.internal:8443",
+          url: "http://proxy.example.com:8443",
           tls: {
             ca: "proxy-ca",
           },
@@ -283,7 +283,7 @@ describe("provider request config", () => {
       },
       proxy: {
         mode: "explicit-proxy",
-        url: "http://proxy.internal:8443",
+        url: "http://proxy.example.com:8443",
         tls: {
           ca: "proxy-ca",
         },
@@ -336,7 +336,7 @@ describe("provider request config", () => {
         },
         proxy: {
           mode: "explicit-proxy",
-          url: "http://proxy.internal:8443",
+          url: "http://proxy.example.com:8443",
         },
       }),
     ).toEqual({
@@ -345,7 +345,7 @@ describe("provider request config", () => {
       },
       proxy: {
         mode: "explicit-proxy",
-        url: "http://proxy.internal:8443",
+        url: "http://proxy.example.com:8443",
       },
     });
   });
@@ -377,6 +377,17 @@ describe("provider request config", () => {
         { allowPrivateNetwork: true },
       ),
     ).toEqual({ allowPrivateNetwork: true });
+  });
+
+  it("rejects configured explicit proxies that target blocked internal hosts", () => {
+    expect(() =>
+      sanitizeConfiguredProviderRequest({
+        proxy: {
+          mode: "explicit-proxy",
+          url: "http://169.254.169.254:8080",
+        },
+      }),
+    ).toThrow(/request\.proxy\.url must not target private or internal hosts/i);
   });
 
   it("merges configured request overrides with later entries winning", () => {

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -5,7 +5,7 @@ import type {
   ConfiguredProviderRequest,
 } from "../config/types.provider-request.js";
 import { assertSecretInputResolved } from "../config/types.secrets.js";
-import type { PinnedDispatcherPolicy } from "../infra/net/ssrf.js";
+import { isBlockedHostnameOrIp, type PinnedDispatcherPolicy } from "../infra/net/ssrf.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import type {
   ProviderRequestCapabilities,
@@ -177,6 +177,26 @@ function sanitizeConfiguredRequestString(value: unknown, path: string): string |
   return trimmed ? trimmed : undefined;
 }
 
+function sanitizeConfiguredExplicitProxyUrl(value: unknown, path: string): string | undefined {
+  const url = sanitizeConfiguredRequestString(value, path);
+  if (!url) {
+    return undefined;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`${path} must be a valid http or https URL`);
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error(`${path} must use http or https`);
+  }
+  if (isBlockedHostnameOrIp(parsed.hostname)) {
+    throw new Error(`${path} must not target private or internal hosts`);
+  }
+  return url;
+}
+
 export function sanitizeConfiguredProviderRequest(
   request: ConfiguredProviderRequest | undefined,
 ): ProviderRequestTransportOverrides | undefined {
@@ -279,7 +299,7 @@ export function sanitizeConfiguredProviderRequest(
         ...(tls ? { tls } : {}),
       };
     } else if (rawProxy.mode === "explicit-proxy") {
-      const url = sanitizeConfiguredRequestString(rawProxy.url, "request.proxy.url");
+      const url = sanitizeConfiguredExplicitProxyUrl(rawProxy.url, "request.proxy.url");
       if (url) {
         proxy = {
           mode: "explicit-proxy",

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -72,7 +72,7 @@ beforeEach(() => {
 });
 
 describe("config shared auth disconnects", () => {
-  it("does not disconnect shared-auth clients for config.set auth writes without restart", async () => {
+  it("disconnects shared-auth clients for config.set auth writes without restart", async () => {
     const prevConfig: OpenClawConfig = {
       gateway: {
         auth: {
@@ -103,7 +103,7 @@ describe("config shared auth disconnects", () => {
     await flushConfigHandlerMicrotasks();
 
     expect(writeConfigFileMock).toHaveBeenCalledWith(nextConfig, {});
-    expect(disconnectClientsUsingSharedGatewayAuth).not.toHaveBeenCalled();
+    expect(disconnectClientsUsingSharedGatewayAuth).toHaveBeenCalledTimes(1);
     expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -456,6 +456,7 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!(await ensureResolvableSecretRefsOrRespond({ config: parsed.config, respond }))) {
       return;
     }
+    const disconnectSharedAuthClients = didSharedGatewayAuthChange(snapshot.config, parsed.config);
     await writeConfigFile(parsed.config, writeOptions);
     respond(
       true,
@@ -467,6 +468,7 @@ export const configHandlers: GatewayRequestHandlers = {
       undefined,
     );
     queueSharedGatewayAuthGenerationRefresh(true, parsed.config, context);
+    queueSharedGatewayAuthDisconnect(disconnectSharedAuthClients, context);
   },
   "config.patch": async ({ params, respond, client, context }) => {
     if (!assertValidParams(params, validateConfigPatchParams, "config.patch", respond)) {


### PR DESCRIPTION
## Summary

- Problem: config-time explicit provider proxies accepted blocked internal hosts, `config.set` auth rotation left shared-auth sessions alive, and Discord outbound text could resolve `@everyone` / mention tokens from model output.
- Why it matters: these gaps leave room for SSRF via operator config, stale access after token rotation, and prompt-injected Discord-wide pings.
- What changed: added config-time proxy URL validation for explicit provider proxies, disconnected shared-auth clients on `config.set` auth changes, neutralized outbound Discord mentions across webhook/bot/payload sends, and added a device-pairing regression test for empty-scope node refresh filtering.
- What did NOT change (scope boundary): no repo-wide auth model changes, no new proxy opt-ins, no Android/mobile pairing work, no docs changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #60387
- Related #59848
- Related #60208
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: security-sensitive paths trusted operator/config surfaces inconsistently, so config-time proxy overrides skipped the existing SSRF classifier, `config.set` skipped the shared-auth disconnect path used by patch/apply, and Discord mention neutralization only covered approval payloads.
- Missing detection / guardrail: no focused regression coverage for config-time proxy validation, `config.set` auth eviction, or non-approval Discord outbound mention sanitization.
- Prior context (`git blame`, prior PR, issue, or refactor if known): report items came from #59848, #60387, and the April 4 security triage sweep; device-scope regression guard locks in the already-fixed empty-scope pairing path from #60208.
- Why this regressed now: transport/auth seams were hardened incrementally at runtime but not uniformly at adjacent config/send entry points.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/provider-request-config.test.ts`, `src/gateway/server-methods/config.shared-auth.test.ts`, `extensions/discord/src/outbound-adapter.test.ts`, `src/infra/device-pairing.test.ts`
- Scenario the test should lock in: blocked explicit proxies fail during config sanitization, `config.set` auth rotation evicts shared-auth clients, all Discord outbound text neutralizes dangerous mentions, and empty-scope node refreshes never inherit stale `operator.*` scopes.
- Why this is the smallest reliable guardrail: each issue is owned by a narrow seam with deterministic behavior and no external dependency requirement.
- Existing test that already covers this (if any): the device-pairing implementation was already fixed; this PR adds the missing explicit regression lock.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Configured explicit provider proxies now reject private/internal/special-use hosts during config sanitization.
- Rotating gateway shared auth via `config.set` now disconnects sessions authenticated with the old shared secret.
- Discord outbound text now neutralizes `@everyone`, `@here`, user mentions, and channel mentions before send.

## Diagram (if applicable)

```text
Before:
[config/set/send] -> [partial validation] -> [proxy/session/mention gap]

After:
[config/set/send] -> [targeted guardrail at entry seam] -> [blocked host / disconnected stale session / neutralized mention]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: shared gateway auth rotation now disconnects stale sessions sooner; explicit provider proxies fail closed on blocked/private/internal hosts; Discord outbound text strips mention-triggering syntax before delivery.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local worktree under `~/.codex/worktrees`
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): provider `request.proxy.url`, gateway shared auth token, Discord outbound payload text

### Steps

1. Configure an explicit provider proxy to a blocked host, rotate gateway auth through `config.set`, and send Discord outbound text containing `@everyone` or `<@123>`.
2. Run the targeted regression suites.
3. Confirm the config is rejected, stale shared-auth sessions are evicted, and outbound mentions are neutralized.

### Expected

- Blocked explicit proxies fail closed.
- `config.set` auth rotation disconnects stale shared-auth clients.
- Discord outbound text cannot resolve destructive mentions.

### Actual

- Verified locally after the patch set.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: provider proxy sanitizer rejects blocked hosts; `config.set` shared-auth disconnect path fires; Discord webhook/bot/payload sends neutralize mentions; empty-scope node token refresh strips stale operator scopes.
- Edge cases checked: Discord neutralization is idempotent for already-sanitized mention forms; provider sanitizer still accepts public `http`/`https` proxies.
- What you did **not** verify: repo-wide `pnpm check`; CI; unrelated Android/mobile flows.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: operators using private/internal explicit provider proxies will now fail validation.
  - Mitigation: this is the intended fail-closed SSRF policy and matches existing runtime fetch guarding.
- Risk: shared-auth `config.set` rotation now disconnects existing clients immediately.
  - Mitigation: that behavior is the expected security posture for credential rotation and is now covered by regression tests.
