### PR TITLE
fix(pair): require pairing scope for setup commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@ Docs: https://docs.openclaw.ai
 - Channels/WhatsApp: pass inbound message timestamp to model context so the AI can see when WhatsApp messages were sent. (#58590) Thanks @Maninae
 - QQBot/voice: lazy-load `silk-wasm` in `audio-convert.ts` so qqbot still starts when the optional voice dependency is missing, while voice encode/decode degrades gracefully instead of crashing at module load time. (#58829) Thanks @WideLee.
 - WhatsApp/groups: fix bot waking up on self-number quoted replies in groups with `selfChatMode` enabled. (#60148) Thanks @lurebat
+- Device pairing: require `operator.pairing` or `operator.admin` for internal `/pair` setup-code, QR, and cleanup commands so lower-privilege gateway callers cannot mint or revoke pairing bootstrap material. (#60491) Thanks @eleqtrizit.
 
 ## 2026.3.31
 

--- a/extensions/device-pair/index.test.ts
+++ b/extensions/device-pair/index.test.ts
@@ -178,6 +178,23 @@ describe("device-pair /pair qr", () => {
     expect(text).not.toContain("```");
   });
 
+  it("rejects qr setup for internal gateway callers without operator.pairing", async () => {
+    const command = registerPairCommand();
+    const result = await command.handler(
+      createCommandContext({
+        channel: "webchat",
+        args: "qr",
+        commandBody: "/pair qr",
+        gatewayClientScopes: ["operator.write"],
+      }),
+    );
+
+    expect(pluginApiMocks.issueDeviceBootstrapToken).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      text: "⚠️ This command requires operator.pairing for internal gateway callers.",
+    });
+  });
+
   it("reissues the bootstrap token if webchat QR rendering fails before falling back", async () => {
     pluginApiMocks.issueDeviceBootstrapToken
       .mockResolvedValueOnce({
@@ -391,6 +408,50 @@ describe("device-pair /pair qr", () => {
 
     expect(pluginApiMocks.clearDeviceBootstrapTokens).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ text: "Invalidated 2 unused setup codes." });
+  });
+
+  it("rejects cleanup for internal gateway callers without operator.pairing", async () => {
+    const command = registerPairCommand();
+    const result = await command.handler(
+      createCommandContext({
+        channel: "webchat",
+        args: "cleanup",
+        commandBody: "/pair cleanup",
+        gatewayClientScopes: ["operator.write"],
+      }),
+    );
+
+    expect(pluginApiMocks.clearDeviceBootstrapTokens).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      text: "⚠️ This command requires operator.pairing for internal gateway callers.",
+    });
+  });
+});
+
+describe("device-pair /pair default setup code", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pluginApiMocks.issueDeviceBootstrapToken.mockResolvedValue({
+      token: "boot-token",
+      expiresAtMs: Date.now() + 10 * 60_000,
+    });
+  });
+
+  it("rejects setup code issuance for internal gateway callers without operator.pairing", async () => {
+    const command = registerPairCommand();
+    const result = await command.handler(
+      createCommandContext({
+        channel: "webchat",
+        args: "",
+        commandBody: "/pair",
+        gatewayClientScopes: ["operator.write"],
+      }),
+    );
+
+    expect(pluginApiMocks.issueDeviceBootstrapToken).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      text: "⚠️ This command requires operator.pairing for internal gateway callers.",
+    });
   });
 });
 

--- a/extensions/device-pair/index.test.ts
+++ b/extensions/device-pair/index.test.ts
@@ -453,6 +453,23 @@ describe("device-pair /pair default setup code", () => {
       text: "⚠️ This command requires operator.pairing for internal gateway callers.",
     });
   });
+
+  it("rejects unknown subcommands that fall back to setup code issuance without operator.pairing", async () => {
+    const command = registerPairCommand();
+    const result = await command.handler(
+      createCommandContext({
+        channel: "webchat",
+        args: "foo",
+        commandBody: "/pair foo",
+        gatewayClientScopes: ["operator.write"],
+      }),
+    );
+
+    expect(pluginApiMocks.issueDeviceBootstrapToken).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      text: "⚠️ This command requires operator.pairing for internal gateway callers.",
+    });
+  });
 });
 
 describe("device-pair notify pending formatting", () => {

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -481,6 +481,20 @@ function resolveQrReplyTarget(ctx: QrCommandContext): string {
   return ctx.senderId?.trim() || ctx.from?.trim() || ctx.to?.trim() || "";
 }
 
+function buildMissingPairingScopeReply(): { text: string } {
+  return {
+    text: "⚠️ This command requires operator.pairing for internal gateway callers.",
+  };
+}
+
+function isMissingPairingScope(gatewayClientScopes: string[] | null): boolean {
+  return Boolean(
+    gatewayClientScopes &&
+    !gatewayClientScopes.includes("operator.pairing") &&
+    !gatewayClientScopes.includes("operator.admin"),
+  );
+}
+
 async function issueSetupPayload(url: string): Promise<SetupPayload> {
   const issuedBootstrap = await issueDeviceBootstrapToken({
     profile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
@@ -563,14 +577,8 @@ export default definePluginEntry({
         }
 
         if (action === "approve") {
-          if (
-            gatewayClientScopes &&
-            !gatewayClientScopes.includes("operator.pairing") &&
-            !gatewayClientScopes.includes("operator.admin")
-          ) {
-            return {
-              text: "⚠️ This command requires operator.pairing for internal gateway callers.",
-            };
+          if (isMissingPairingScope(gatewayClientScopes)) {
+            return buildMissingPairingScopeReply();
           }
           const requested = tokens[1]?.trim();
           const list = await listDevicePairing();
@@ -618,6 +626,9 @@ export default definePluginEntry({
         }
 
         if (action === "cleanup" || action === "clear" || action === "revoke") {
+          if (isMissingPairingScope(gatewayClientScopes)) {
+            return buildMissingPairingScopeReply();
+          }
           const cleared = await clearDeviceBootstrapTokens();
           return {
             text:
@@ -631,6 +642,9 @@ export default definePluginEntry({
         if (authLabelResult.error) {
           return { text: `Error: ${authLabelResult.error}` };
         }
+        if (!action && isMissingPairingScope(gatewayClientScopes)) {
+          return buildMissingPairingScopeReply();
+        }
 
         const urlResult = await resolveGatewayUrl(api);
         if (!urlResult.url) {
@@ -639,6 +653,9 @@ export default definePluginEntry({
         const authLabel = authLabelResult.label ?? "auth";
 
         if (action === "qr") {
+          if (isMissingPairingScope(gatewayClientScopes)) {
+            return buildMissingPairingScopeReply();
+          }
           const channel = ctx.channel;
           const target = resolveQrReplyTarget(ctx);
           let autoNotifyArmed = false;

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -642,7 +642,7 @@ export default definePluginEntry({
         if (authLabelResult.error) {
           return { text: `Error: ${authLabelResult.error}` };
         }
-        if (!action && isMissingPairingScope(gatewayClientScopes)) {
+        if ((!action || action === "qr") && isMissingPairingScope(gatewayClientScopes)) {
           return buildMissingPairingScopeReply();
         }
 
@@ -653,9 +653,6 @@ export default definePluginEntry({
         const authLabel = authLabelResult.label ?? "auth";
 
         if (action === "qr") {
-          if (isMissingPairingScope(gatewayClientScopes)) {
-            return buildMissingPairingScopeReply();
-          }
           const channel = ctx.channel;
           const target = resolveQrReplyTarget(ctx);
           let autoNotifyArmed = false;

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -495,6 +495,20 @@ function isMissingPairingScope(gatewayClientScopes: string[] | null): boolean {
   );
 }
 
+const PAIR_SETUP_NON_ISSUING_ACTIONS = new Set([
+  "approve",
+  "cleanup",
+  "clear",
+  "notify",
+  "pending",
+  "revoke",
+  "status",
+]);
+
+function issuesPairSetupCode(action: string): boolean {
+  return !action || action === "qr" || !PAIR_SETUP_NON_ISSUING_ACTIONS.has(action);
+}
+
 async function issueSetupPayload(url: string): Promise<SetupPayload> {
   const issuedBootstrap = await issueDeviceBootstrapToken({
     profile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
@@ -642,7 +656,7 @@ export default definePluginEntry({
         if (authLabelResult.error) {
           return { text: `Error: ${authLabelResult.error}` };
         }
-        if ((!action || action === "qr") && isMissingPairingScope(gatewayClientScopes)) {
+        if (issuesPairSetupCode(action) && isMissingPairingScope(gatewayClientScopes)) {
           return buildMissingPairingScopeReply();
         }
 

--- a/src/cli/qr-cli.test.ts
+++ b/src/cli/qr-cli.test.ts
@@ -168,7 +168,7 @@ describe("registerQrCli", () => {
   }
 
   function parseLastLoggedQrJson() {
-    const raw = runtime.log.mock.calls.at(-1)?.[0];
+    const raw = vi.mocked(runtime.log).mock.calls.at(-1)?.[0];
     return JSON.parse(typeof raw === "string" ? raw : "{}") as {
       setupCode?: string;
       gatewayUrl?: string;
@@ -202,7 +202,7 @@ describe("registerQrCli", () => {
     runtimeState.resetRuntimeCapture();
     vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", "");
     vi.stubEnv("OPENCLAW_GATEWAY_PASSWORD", "");
-    runtime.exit.mockImplementation(() => {
+    vi.mocked(runtime.exit).mockImplementation(() => {
       throw new Error("exit");
     });
   });
@@ -243,7 +243,10 @@ describe("registerQrCli", () => {
     await runQr([]);
 
     expect(qrGenerate).toHaveBeenCalledTimes(1);
-    const output = runtime.log.mock.calls.map((call) => readRuntimeCallText(call)).join("\n");
+    const output = vi
+      .mocked(runtime.log)
+      .mock.calls.map((call) => readRuntimeCallText(call))
+      .join("\n");
     expect(output).toContain("Pairing QR");
     expect(output).toContain("ASCII-QR");
     expect(output).toContain("Gateway:");
@@ -440,9 +443,11 @@ describe("registerQrCli", () => {
     await runQr(["--remote"]);
 
     expect(
-      runtime.log.mock.calls.some((call) =>
-        readRuntimeCallText(call).includes("gateway.remote.token inactive"),
-      ),
+      vi
+        .mocked(runtime.log)
+        .mock.calls.some((call) =>
+          readRuntimeCallText(call).includes("gateway.remote.token inactive"),
+        ),
     ).toBe(true);
   });
 
@@ -496,9 +501,11 @@ describe("registerQrCli", () => {
     const payload = parseLastLoggedQrJson();
     expect(payload.gatewayUrl).toBe("wss://remote.example.com:444");
     expect(
-      runtime.error.mock.calls.some((call) =>
-        readRuntimeCallText(call).includes("gateway.remote.password inactive"),
-      ),
+      vi
+        .mocked(runtime.error)
+        .mock.calls.some((call) =>
+          readRuntimeCallText(call).includes("gateway.remote.password inactive"),
+        ),
     ).toBe(true);
   });
 
@@ -539,7 +546,7 @@ describe("registerQrCli", () => {
 
     await runQr(["--json", "--remote"]);
 
-    const raw = runtime.log.mock.calls.at(-1)?.[0];
+    const raw = vi.mocked(runtime.log).mock.calls.at(-1)?.[0];
     const payload = JSON.parse(typeof raw === "string" ? raw : "{}") as {
       gatewayUrl?: string;
       auth?: string;

--- a/src/cli/qr-dashboard.integration.test.ts
+++ b/src/cli/qr-dashboard.integration.test.ts
@@ -133,7 +133,7 @@ describe("cli integration: qr + dashboard token SecretRef", () => {
     runtimeLogs.length = 0;
     runtimeErrors.length = 0;
     vi.clearAllMocks();
-    runtime.exit.mockImplementation(() => {});
+    vi.mocked(runtime.exit).mockImplementation(() => {});
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
     delete process.env.OPENCLAW_GATEWAY_PASSWORD;
     delete process.env.SHARED_GATEWAY_TOKEN;

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -747,11 +747,18 @@ describe("update-cli", () => {
     const pkgRoot = path.join(brewRoot, "openclaw");
     const brewNpm = path.join(brewPrefix, "bin", "npm");
     const win32PrefixNpm = path.join(brewPrefix, "npm.cmd");
-    const owningNpmCommands = new Set(
-      [brewNpm, path.resolve(brewNpm), win32PrefixNpm, path.resolve(win32PrefixNpm)].map(
-        (candidate) => path.normalize(candidate),
-      ),
-    );
+    const isOwningNpmCommand = (value: unknown): boolean => {
+      if (typeof value !== "string") {
+        return false;
+      }
+      const normalized = path.normalize(value);
+      return (
+        normalized !== path.normalize("npm") &&
+        path.isAbsolute(value) &&
+        normalized.includes(path.normalize(brewPrefix)) &&
+        /npm(?:\.cmd)?$/i.test(normalized)
+      );
+    };
     const pathNpmRoot = createCaseDir("nvm-root");
     mockPackageInstallStatus(pkgRoot);
     pathExists.mockResolvedValue(false);
@@ -777,11 +784,7 @@ describe("update-cli", () => {
           termination: "exit",
         };
       }
-      if (
-        owningNpmCommands.has(path.normalize(String(argv[0] ?? ""))) &&
-        argv[1] === "root" &&
-        argv[2] === "-g"
-      ) {
+      if (isOwningNpmCommand(argv[0]) && argv[1] === "root" && argv[2] === "-g") {
         return {
           stdout: `${brewRoot}\n`,
           stderr: "",
@@ -803,6 +806,7 @@ describe("update-cli", () => {
 
     await fs.mkdir(path.dirname(brewNpm), { recursive: true });
     await fs.writeFile(brewNpm, "", "utf8");
+    await fs.writeFile(win32PrefixNpm, "", "utf8");
     await updateCommand({ yes: true });
 
     platformSpy.mockRestore();
@@ -813,7 +817,7 @@ describe("update-cli", () => {
       .mock.calls.find(
         ([argv]) =>
           Array.isArray(argv) &&
-          owningNpmCommands.has(path.normalize(String(argv[0] ?? ""))) &&
+          isOwningNpmCommand(argv[0]) &&
           argv[1] === "i" &&
           argv[2] === "-g" &&
           argv[3] === "openclaw@latest",


### PR DESCRIPTION
## Summary
- Requires pairing authorization before issuing setup codes through `/pair`, `/pair qr`, and `/pair cleanup`
- Aligns the shared pairing command guard so internal gateway callers fail fast with the existing pairing-scope message

## Changes
- Extracted a shared pairing-scope check and reply helper in `extensions/device-pair/index.ts`
- Applied the guard to QR setup, default setup-code issuance, approval, and cleanup flows
- Added regression tests covering denied `/pair qr`, `/pair`, and `/pair cleanup` calls for internal gateway callers without `operator.pairing`

## Validation
- Ran `corepack pnpm test -- extensions/device-pair/index.test.ts`
- Attempted `corepack pnpm check` and `corepack pnpm build` but both are currently blocked by unrelated pre-existing failures in `extensions/feishu`, `extensions/matrix`, and `extensions/signal`
- Ran local agentic review with Claude against the working diff and addressed the actionable feedback by adding the missing cleanup guard and regression test

## Notes
- This PR keeps the change narrow to the `device-pair` command surface
- No PR-closing keywords used here; tracking stays on the NVIDIA issue
