### PR TITLE
fix(qqbot): support HTML entities in media tags (&lt; &gt;)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- QQBot/media-tags: support HTML entity-encoded angle brackets (`&lt;`/`&gt;`) in media-tag regexes so entity-escaped `<qqimg>` tags from upstream are correctly parsed and normalized. (#60493) Thanks @ylc0919.
 - Slack/media: preserve bearer auth across same-origin `files.slack.com` redirects while still stripping it on cross-origin Slack CDN hops, so `url_private_download` image attachments load again. (#62960) Thanks @vincentkoc.
 - Control UI: guard stale session-history reloads during fast session switches so the selected session and rendered transcript stay in sync. (#62975) Thanks @scoootscooob.
 

--- a/extensions/qqbot/src/utils/media-tags.test.ts
+++ b/extensions/qqbot/src/utils/media-tags.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { FUZZY_MEDIA_TAG_REGEX, SELF_CLOSING_TAG_REGEX } from './media-tags';
+
+describe('media-tags with HTML entities', () => {
+  it('extracts URL from entity-encoded fuzzy tag', () => {
+    const input = '&lt;qqimg&gt;https://example.com/a.png&lt;/qqimg&gt;';
+    const match = FUZZY_MEDIA_TAG_REGEX.exec(input);
+    expect(match?.[2]).toBe('https://example.com/a.png');
+  });
+
+  it('extracts URL from mixed entity+plain tag', () => {
+    const input = '&lt;qqimg&gt;https://example.com/b.png</qqimg>';
+    const match = FUZZY_MEDIA_TAG_REGEX.exec(input);
+    expect(match?.[2]).toBe('https://example.com/b.png');
+  });
+
+  it('extracts file from entity-encoded self-closing tag', () => {
+    const input = '&lt;qqmedia file="https://example.com/c.zip" /&gt;';
+    const match = SELF_CLOSING_TAG_REGEX.exec(input);
+    expect(match?.[2]).toBe('https://example.com/c.zip');
+  });
+
+  it('does not match invalid input', () => {
+    const input = 'no tag here';
+    const match = FUZZY_MEDIA_TAG_REGEX.exec(input);
+    expect(match).toBeNull();
+  });
+});

--- a/extensions/qqbot/src/utils/media-tags.test.ts
+++ b/extensions/qqbot/src/utils/media-tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { FUZZY_MEDIA_TAG_REGEX, SELF_CLOSING_TAG_REGEX } from './media-tags';
+import { FUZZY_MEDIA_TAG_REGEX, SELF_CLOSING_TAG_REGEX } from './media-tags.js';
 
 describe('media-tags with HTML entities', () => {
   it('extracts URL from entity-encoded fuzzy tag', () => {

--- a/extensions/qqbot/src/utils/media-tags.test.ts
+++ b/extensions/qqbot/src/utils/media-tags.test.ts
@@ -4,24 +4,28 @@ import { FUZZY_MEDIA_TAG_REGEX, SELF_CLOSING_TAG_REGEX } from './media-tags';
 describe('media-tags with HTML entities', () => {
   it('extracts URL from entity-encoded fuzzy tag', () => {
     const input = '&lt;qqimg&gt;https://example.com/a.png&lt;/qqimg&gt;';
+    FUZZY_MEDIA_TAG_REGEX.lastIndex = 0; 
     const match = FUZZY_MEDIA_TAG_REGEX.exec(input);
     expect(match?.[2]).toBe('https://example.com/a.png');
   });
 
   it('extracts URL from mixed entity+plain tag', () => {
     const input = '&lt;qqimg&gt;https://example.com/b.png</qqimg>';
+    FUZZY_MEDIA_TAG_REGEX.lastIndex = 0; 
     const match = FUZZY_MEDIA_TAG_REGEX.exec(input);
     expect(match?.[2]).toBe('https://example.com/b.png');
   });
 
   it('extracts file from entity-encoded self-closing tag', () => {
     const input = '&lt;qqmedia file="https://example.com/c.zip" /&gt;';
+    SELF_CLOSING_TAG_REGEX.lastIndex = 0;
     const match = SELF_CLOSING_TAG_REGEX.exec(input);
     expect(match?.[2]).toBe('https://example.com/c.zip');
   });
 
   it('does not match invalid input', () => {
     const input = 'no tag here';
+    FUZZY_MEDIA_TAG_REGEX.lastIndex = 0; 
     const match = FUZZY_MEDIA_TAG_REGEX.exec(input);
     expect(match).toBeNull();
   });

--- a/extensions/qqbot/src/utils/media-tags.ts
+++ b/extensions/qqbot/src/utils/media-tags.ts
@@ -52,7 +52,7 @@ const TAG_NAME_PATTERN = ALL_TAG_NAMES.join("|");
 const LEFT_BRACKET = "(?:[<＜<]|&lt;)";
 const RIGHT_BRACKET = "(?:[>＞>]|&gt;)";
 /** Match self-closing media-tag syntax with file/src/path/url attributes. */
-const SELF_CLOSING_TAG_REGEX = new RegExp(
+export const SELF_CLOSING_TAG_REGEX = new RegExp(
   "`?" +
     LEFT_BRACKET + "\\s*(" +
     TAG_NAME_PATTERN +
@@ -70,7 +70,7 @@ const SELF_CLOSING_TAG_REGEX = new RegExp(
 );
 
 /** Match malformed wrapped media tags that should be normalized. */
-const FUZZY_MEDIA_TAG_REGEX = new RegExp(
+export const FUZZY_MEDIA_TAG_REGEX = new RegExp(
   "`?" +
     LEFT_BRACKET + "\\s*(" +
     TAG_NAME_PATTERN +

--- a/extensions/qqbot/src/utils/media-tags.ts
+++ b/extensions/qqbot/src/utils/media-tags.ts
@@ -74,13 +74,13 @@ const FUZZY_MEDIA_TAG_REGEX = new RegExp(
   "`?" +
     LEFT_BRACKET + "\\s*(" +
     TAG_NAME_PATTERN +
-    ")\\s*[>＞>]" +
+    ")\\s*" + RIGHT_BRACKET +
     "[\"']?\\s*" +
     "([^<＜<＞>\"'`]+?)" +
     "\\s*[\"']?" +
     LEFT_BRACKET + "\\s*/?\\s*(?:" +
     TAG_NAME_PATTERN +
-    ")\\s*[>＞>]" +
+    ")\\s*" + RIGHT_BRACKET +
     "`?",
   "gi",
 );

--- a/extensions/qqbot/src/utils/media-tags.ts
+++ b/extensions/qqbot/src/utils/media-tags.ts
@@ -49,10 +49,12 @@ ALL_TAG_NAMES.sort((a, b) => b.length - a.length);
 
 const TAG_NAME_PATTERN = ALL_TAG_NAMES.join("|");
 
+const LEFT_BRACKET = "(?:[<＜<]|&lt;)";
+const RIGHT_BRACKET = "(?:[>＞>]|&gt;)";
 /** Match self-closing media-tag syntax with file/src/path/url attributes. */
 const SELF_CLOSING_TAG_REGEX = new RegExp(
   "`?" +
-    "[<＜<]\\s*(" +
+    LEFT_BRACKET + "\\s*(" +
     TAG_NAME_PATTERN +
     ")" +
     "(?:\\s+(?!file|src|path|url)[a-z_-]+\\s*=\\s*[\"']?[^\"'/>＞>]*?[\"']?)*" +
@@ -62,7 +64,7 @@ const SELF_CLOSING_TAG_REGEX = new RegExp(
     "[\"']?" +
     "(?:\\s+[a-z_-]+\\s*=\\s*[\"']?[^\"'/>＞>]*?[\"']?)*" +
     "\\s*/?" +
-    "\\s*[>＞>]" +
+    "\\s*" + RIGHT_BRACKET +
     "`?",
   "gi",
 );
@@ -70,13 +72,13 @@ const SELF_CLOSING_TAG_REGEX = new RegExp(
 /** Match malformed wrapped media tags that should be normalized. */
 const FUZZY_MEDIA_TAG_REGEX = new RegExp(
   "`?" +
-    "[<＜<]\\s*(" +
+    LEFT_BRACKET + "\\s*(" +
     TAG_NAME_PATTERN +
     ")\\s*[>＞>]" +
     "[\"']?\\s*" +
     "([^<＜<＞>\"'`]+?)" +
     "\\s*[\"']?" +
-    "[<＜<]\\s*/?\\s*(?:" +
+    LEFT_BRACKET + "\\s*/?\\s*(?:" +
     TAG_NAME_PATTERN +
     ")\\s*[>＞>]" +
     "`?",
@@ -94,13 +96,13 @@ function resolveTagName(raw: string): (typeof VALID_TAGS)[number] {
 
 /** Match wrapped tags whose bodies need newline and tab cleanup. */
 const MULTILINE_TAG_CLEANUP = new RegExp(
-  "([<＜<]\\s*(?:" +
+  "(" + LEFT_BRACKET + "\\s*(?:" +
     TAG_NAME_PATTERN +
-    ")\\s*[>＞>])" +
+    ")\\s*" + RIGHT_BRACKET + ")" +
     "([\\s\\S]*?)" +
-    "([<＜<]\\s*/?\\s*(?:" +
+    "(" + LEFT_BRACKET + "\\s*/?\\s*(?:" +
     TAG_NAME_PATTERN +
-    ")\\s*[>＞>])",
+    ")\\s*" + RIGHT_BRACKET + ")",
   "gi",
 );
 


### PR DESCRIPTION
## Summary

- **Problem:** The `qqbot` plugin's media tag parser (`<qqimg>`, `<qqmedia>`, etc.) does not recognize HTML entities such as `&lt;` and `&gt;`. When a message contains `&lt;qqimg&gt;...&lt;/qqimg&gt;` (common when copied from platforms that escape HTML), the tag is ignored and media files fail to load.
- **Why it matters:** Sometimes, messages from web sources or other chat systems that are sent to users have escaped angle brackets. Without entity support, media sharing breaks silently.
- **What changed:** Extended the regex matching for left and right brackets to also match `&lt;` and `&gt;` entities. Introduced `LEFT_BRACKET = "(?:[<＜<]|&lt;)"` and `RIGHT_BRACKET = "(?:[>＞>]|&gt;)"`, then updated `SELF_CLOSING_TAG_REGEX`, `FUZZY_MEDIA_TAG_REGEX`, and `MULTILINE_TAG_CLEANUP` to use these patterns.
- **What did NOT change (scope boundary):** Only the bracket matching is extended. The internal content (URL/path) is **not** entity‑decoded (e.g., `&amp;` inside the URL remains as is). The change does not affect existing plain‑angle‑bracket tags, self‑closing syntax, or any other parsing logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** The original regex patterns hardcoded `[<＜<]` and `[>＞>]` for left/right brackets, without considering HTML entity representations.
- **Missing detection / guardrail:** There was no pre‑processing step to decode entities before matching, nor an extended pattern to match them directly.
- **Prior context:** Not a regression – the plugin never supported entities. This is a long‑standing missing feature uncovered by real‑world usage.
- **Why this regressed now:** N/A.
- **If unknown, what was ruled out:** N/A.

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**  
  - [ ] Unit test  
  - [x] Seam / integration test  
  - [ ] End-to-end test  
  - [ ] Existing coverage already sufficient  
- **Target test or file:** `extensions/qqbot/src/utils/media-tags.test.ts` (if exists; currently not present in the PR – the change is small and regex‑only)
- **Scenario the test should lock in:** Input `&lt;qqimg&gt;https://example.com/a.png&lt;/qqimg&gt;` → output should extract `https://example.com/a.png`.
- **Why this is the smallest reliable guardrail:** A unit test on the `parseMediaTags` function (or the regex extractor) would directly verify the new entity matching without needing a full plugin integration.
- **Existing test that already covers this (if any):** None.
- **If no new test is added, why not:** The change is a minimal, non‑invasive extension of existing regex patterns. The project does not currently have unit tests for this utility file (as observed). Adding a test suite would be out of scope for this bug fix.


## User-visible / Behavior Changes

- **Before:** A message like `&lt;qqimg&gt;https://example.com/pic.png&lt;/qqimg&gt;` would be treated as plain text; the media tag was not recognized, and no file was sent.
- **After:** The same message is now parsed correctly – the entity‑encoded tags are recognized, the URL extracted, and the media file is transmitted as expected.
- No changes to configuration, defaults, or existing tag syntax.

## Diagram (if applicable)

N/A

## Security Impact (required)

- **New permissions/capabilities?** No
- **Secrets/tokens handling changed?** No
- **New/changed network calls?** No
- **Command/tool execution surface changed?** No
- **Data access scope changed?** No

## Repro + Verification

### Environment

- OS:Windows10 
- Runtime/container:Node.js 24+
- Model/provider:deepseek
- Integration/channel (if any):qqbot
- Relevant config (redacted):default qqbot plugin config

### Steps

1. Build the plugin with the change applied.
2. Send a message containing `&lt;qqimg&gt;https://example.com/test.png&lt;/qqimg&gt;` to a QQ chat that the bot monitors.
3. Observe bot's log/output.

### Expected

- The bot extracts `https://example.com/test.png` and processes it as a media file (download/upload as appropriate).

### Actual

- (Before change) Tag ignored, media not sent.
- (After change) Tag recognized, media sent successfully.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)
- Before:
<img width="699" height="373" alt="image" src="https://github.com/user-attachments/assets/385311e0-4fd4-49bc-a989-6079735b86d4" />
- After:
<img width="707" height="568" alt="image" src="https://github.com/user-attachments/assets/396a5c3b-b0fa-4fab-8d48-383cdf64603b" />

## Human Verification (required)

- **Verified scenarios:**
  - Plain `<qqimg>url</qqimg>` still works.
  - Entity‑encoded `&lt;qqimg&gt;url&lt;/qqimg&gt;` works.
  - Self‑closing `<qqmedia file="..."/>` with entities around it works (e.g., `&lt;qqmedia file="x"/&gt;`).
  - Mixed entity‑encoded open tag + plain close tag (`&lt;qqimg&gt;url</qqimg>`) – works because the regex matches entities independently per bracket.
- **Edge cases checked:**
  - Multiple spaces inside entity tags.
  - URL containing `&amp;` (e.g., `?a=1&amp;b=2`) – still extracted correctly (the URL content is not decoded).
  - Malformed tags (e.g., missing closing slash) – existing fuzzy matching still works with entities.
- **What I did **not** verify:** Full end‑to‑end message round‑trip with actual QQ API (tested with bot logs and local extraction only).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- **Backward compatible?** Yes
- **Config/env changes?** No
- **Migration needed?** No
- **If yes, exact upgrade steps:** N/A

## Risks and Mitigations

**None.** The change is purely additive – it extends the regex character class to include `&lt;` and `&gt;`. It does not modify existing matching logic for plain angle brackets, so no regression is expected. The regex remains efficient (no backtracking explosion). No external dependencies added.
