### PR TITLE
test(telegram): align silent-ingest hook-runtime mock helper

### DIFF
--- a/extensions/telegram/src/bot-message-context.silent-ingest.test.ts
+++ b/extensions/telegram/src/bot-message-context.silent-ingest.test.ts
@@ -15,10 +15,8 @@ const internalHookMocks = vi.hoisted(() => ({
   triggerInternalHook: vi.fn(async () => undefined),
 }));
 
-vi.mock("openclaw/plugin-sdk/hook-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/hook-runtime")>(
-    "openclaw/plugin-sdk/hook-runtime",
-  );
+vi.mock("openclaw/plugin-sdk/hook-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/hook-runtime")>();
   return {
     ...actual,
     createInternalHookEvent: internalHookMocks.createInternalHookEvent,


### PR DESCRIPTION
## Summary
- align `hook-runtime` mock style in `bot-message-context.silent-ingest.test.ts`
- use `importOriginal` callback form for consistency with current test conventions

## Context
Follow-up after silent-ingest fix landed in #60018; this keeps the leftover test delta separate and minimal.

## Testing
- not run locally due unrelated current upstream typecheck break in pre-commit hook
