### PR TITLE
feat(agents): support derived model refs with routeTo

### DIFF
--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -192,4 +192,27 @@ describe("resolveContextTokensForModel", () => {
 
     expect(result).toBe(200_000);
   });
+
+  it("prefers per-model contextTokens on derived model refs", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-6": { params: { context1m: true } },
+              "anthropic/claude-opus-4-6-500k": {
+                routeTo: "anthropic/claude-opus-4-6",
+                contextTokens: 500_000,
+                params: { context1m: true },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      provider: "anthropic",
+      model: "claude-opus-4-6-500k",
+    });
+    expect(result).toBe(500_000);
+  });
 });
+

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -9,7 +9,11 @@ import { consumeRootOptionToken, FLAG_TERMINATOR } from "../infra/cli-root-optio
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
 import { lookupCachedContextTokens, MODEL_CONTEXT_TOKEN_CACHE } from "./context-cache.js";
 import { CONTEXT_WINDOW_RUNTIME_STATE } from "./context-runtime-state.js";
-import { normalizeProviderId } from "./model-selection.js";
+import {
+  findConfiguredAgentModelEntry,
+  normalizeProviderId,
+  resolveRoutedModelRef,
+} from "./model-selection.js";
 
 export { resetContextWindowCacheForTest } from "./context-runtime-state.js";
 
@@ -387,8 +391,22 @@ export function resolveContextTokensForModel(params: {
   });
   const explicitProvider = params.provider?.trim();
   if (ref) {
+    const configuredEntry = findConfiguredAgentModelEntry({
+      cfg: params.cfg,
+      provider: ref.provider,
+      model: ref.model,
+    })?.entry;
+    if (typeof configuredEntry?.contextTokens === "number" && configuredEntry.contextTokens > 0) {
+      return configuredEntry.contextTokens;
+    }
+    const routedRef = resolveRoutedModelRef({
+      cfg: params.cfg,
+      provider: ref.provider,
+      model: ref.model,
+      defaultProvider: explicitProvider || ref.provider,
+    });
     const modelParams = resolveConfiguredModelParams(params.cfg, ref.provider, ref.model);
-    if (modelParams?.context1m === true && isAnthropic1MModel(ref.provider, ref.model)) {
+    if (modelParams?.context1m === true && isAnthropic1MModel(routedRef.provider, routedRef.model)) {
       return ANTHROPIC_CONTEXT_1M_TOKENS;
     }
     // Only do the config direct scan when the caller explicitly passed a

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -16,6 +16,7 @@ import {
   resolveSubagentConfiguredModelSelection,
   resolveThinkingDefault,
   resolveModelRefFromString,
+  resolveRoutedModelRef,
 } from "./model-selection.js";
 
 const EXPLICIT_ALLOWLIST_CONFIG = {
@@ -983,5 +984,40 @@ describe("resolveSubagentConfiguredModelSelection", () => {
     expect(resolveSubagentConfiguredModelSelection({ cfg, agentId: "research" })).toBe(
       "google/gemini-2.5-pro",
     );
+  });
+});
+
+
+describe("resolveRoutedModelRef", () => {
+  it("returns the original ref when no routeTo is configured", () => {
+    expect(
+      resolveRoutedModelRef({
+        cfg: { agents: { defaults: { models: { "anthropic/claude-opus-4-6": {} } } } } as OpenClawConfig,
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      }),
+    ).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+  });
+
+  it("follows routeTo for derived model refs", () => {
+    expect(
+      resolveRoutedModelRef({
+        cfg: {
+          agents: {
+            defaults: {
+              models: {
+                "anthropic/claude-opus-4-6": {},
+                "anthropic/claude-opus-4-6-500k": {
+                  routeTo: "anthropic/claude-opus-4-6",
+                  contextTokens: 500_000,
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        provider: "anthropic",
+        model: "claude-opus-4-6-500k",
+      }),
+    ).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
   });
 });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -1,5 +1,6 @@
 import { resolveThinkingDefaultForModel } from "../auto-reply/thinking.shared.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { AgentModelEntryConfig } from "../config/types.agent-defaults.js";
 import {
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
@@ -68,6 +69,69 @@ export type ModelAliasIndex = {
   byAlias: Map<string, { alias: string; ref: ModelRef }>;
   byKey: Map<string, string[]>;
 };
+
+export type AgentModelEntryResolved = {
+  key: string;
+  entry: AgentModelEntryConfig;
+};
+
+export function findConfiguredAgentModelEntry(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+  model: string;
+}): AgentModelEntryResolved | undefined {
+  const rawModels = params.cfg?.agents?.defaults?.models;
+  if (!rawModels) {
+    return undefined;
+  }
+  const targetKey = modelKey(params.provider, params.model);
+  for (const [keyRaw, entryRaw] of Object.entries(rawModels)) {
+    const parsed = parseModelRef(String(keyRaw ?? ""), params.provider);
+    if (!parsed) {
+      continue;
+    }
+    if (modelKey(parsed.provider, parsed.model) !== targetKey) {
+      continue;
+    }
+    return { key: keyRaw, entry: (entryRaw ?? {}) as AgentModelEntryConfig };
+  }
+  return undefined;
+}
+
+export function resolveRoutedModelRef(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+  model: string;
+  defaultProvider?: string;
+  maxHops?: number;
+}): ModelRef {
+  const defaultProvider = params.defaultProvider ?? params.provider;
+  const maxHops = Math.max(1, params.maxHops ?? 4);
+  let current: ModelRef = { provider: params.provider, model: params.model };
+  const seen = new Set<string>();
+  for (let i = 0; i < maxHops; i += 1) {
+    const key = modelKey(current.provider, current.model);
+    if (seen.has(key)) {
+      break;
+    }
+    seen.add(key);
+    const configured = findConfiguredAgentModelEntry({
+      cfg: params.cfg,
+      provider: current.provider,
+      model: current.model,
+    });
+    const routeTo = configured?.entry?.routeTo?.trim();
+    if (!routeTo) {
+      break;
+    }
+    const parsed = parseModelRef(routeTo, defaultProvider);
+    if (!parsed) {
+      break;
+    }
+    current = parsed;
+  }
+  return current;
+}
 
 function normalizeAliasKey(value: string): string {
   return value.trim().toLowerCase();

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   buildForwardCompatTemplate,
   expectResolvedForwardCompatFallbackWithRegistryResult,
@@ -156,3 +156,39 @@ describe("resolveModel forward-compat tail", () => {
 
   it("builds a zai forward-compat fallback for glm-5", runZaiForwardCompatFallback);
 });
+
+
+it("routes derived model refs to their configured upstream model", () => {
+  const result = resolveModelWithRegistry({
+    provider: "anthropic",
+    modelId: "claude-opus-4-6-500k",
+    agentDir: "/tmp/agent",
+    cfg: {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-opus-4-6-500k": {
+              routeTo: "anthropic/claude-opus-4-6",
+              contextTokens: 500_000,
+            },
+          },
+        },
+      },
+    } as never,
+    modelRegistry: createRegistry([
+      {
+        provider: "anthropic",
+        modelId: "claude-opus-4-6",
+        model: {
+          ...ANTHROPIC_OPUS_TEMPLATE,
+          id: "claude-opus-4-6",
+          name: "Claude Opus 4.6",
+        },
+      },
+    ]),
+    runtimeHooks: createRuntimeHooks(),
+  });
+  expect(result?.id).toBe("claude-opus-4-6");
+  expect(result?.provider).toBe("anthropic");
+});
+

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -16,7 +16,11 @@ import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
 import { isSecretRefHeaderValueMarker } from "../model-auth-markers.js";
-import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
+import {
+  findNormalizedProviderValue,
+  normalizeProviderId,
+  resolveRoutedModelRef,
+} from "../model-selection.js";
 import {
   buildSuppressedBuiltInModelError,
   shouldSuppressBuiltInModel,
@@ -612,7 +616,17 @@ export function resolveModelWithRegistry(params: {
   agentDir?: string;
   runtimeHooks?: ProviderRuntimeHooks;
 }): Model<Api> | undefined {
-  const explicitModel = resolveExplicitModelWithRegistry(params);
+  const routed = resolveRoutedModelRef({
+    cfg: params.cfg,
+    provider: params.provider,
+    model: params.modelId,
+    defaultProvider: params.provider,
+  });
+  const effectiveParams =
+    routed.provider === params.provider && routed.model === params.modelId
+      ? params
+      : { ...params, provider: routed.provider, modelId: routed.model };
+  const explicitModel = resolveExplicitModelWithRegistry(effectiveParams);
   if (explicitModel?.kind === "suppressed") {
     return undefined;
   }
@@ -620,12 +634,12 @@ export function resolveModelWithRegistry(params: {
     return explicitModel.model;
   }
 
-  const pluginDynamicModel = resolvePluginDynamicModelWithRegistry(params);
+  const pluginDynamicModel = resolvePluginDynamicModelWithRegistry(effectiveParams);
   if (pluginDynamicModel) {
     return pluginDynamicModel;
   }
 
-  return resolveConfiguredFallbackModel(params);
+  return resolveConfiguredFallbackModel(effectiveParams);
 }
 
 export function resolveModel(

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -2610,6 +2610,14 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                     alias: {
                       type: "string",
                     },
+                    routeTo: {
+                      type: "string",
+                    },
+                    contextTokens: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
                     params: {
                       type: "object",
                       propertyNames: {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -10,6 +10,10 @@ import type { MemorySearchConfig } from "./types.tools.js";
 
 export type AgentModelEntryConfig = {
   alias?: string;
+  /** Route this selectable model ref to another provider/model at execution time. */
+  routeTo?: string;
+  /** Local context budget override used for compaction/status even when routeTo points upstream elsewhere. */
+  contextTokens?: number;
   /** Provider-specific API parameters (e.g., GLM-4.7 thinking mode). */
   params?: Record<string, unknown>;
   /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -30,6 +30,10 @@ export const AgentDefaultsSchema = z
         z
           .object({
             alias: z.string().optional(),
+            /** Route this selectable model ref to another provider/model at execution time. */
+            routeTo: z.string().optional(),
+            /** Local context budget override used for compaction/status even when routeTo points upstream elsewhere. */
+            contextTokens: z.number().int().positive().optional(),
             /** Provider-specific API parameters (e.g., GLM-4.7 thinking mode). */
             params: z.record(z.string(), z.unknown()).optional(),
             /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */


### PR DESCRIPTION
## Summary

Adds support for **derived/virtual model refs** in `agents.defaults.models` by introducing:

- `routeTo?: string`
- `contextTokens?: number`

This allows users to expose multiple selectable model variants in `/models` and the model picker while still routing execution to a single upstream model.

Example:

```json5
agents: {
  defaults: {
    models: {
      "anthropic/claude-opus-4-6": {
        alias: "opus",
        params: { context1m: true },
      },
      "anthropic/claude-opus-4-6-500k": {
        alias: "opus-4.6-500k",
        routeTo: "anthropic/claude-opus-4-6",
        contextTokens: 500000,
        params: { context1m: true },
      },
      "anthropic/claude-opus-4-6-256k": {
        alias: "opus-4.6-256k",
        routeTo: "anthropic/claude-opus-4-6",
        contextTokens: 256000,
        params: { context1m: true },
      },
    },
  },
}
```

With this config:
- `/models anthropic` can list all three selectable refs
- `/model opus-4.6-500k` selects the derived ref
- runtime requests still execute against `anthropic/claude-opus-4-6`
- local compaction/status/context budgeting uses the derived ref's `contextTokens`

## Why

This is useful when the upstream provider supports a very large context window (for example 1M), but the user wants:

- a **smaller local budget** for cost control
- multiple **named variants** of the same upstream model
- to keep the **built-in model untouched**
- those variants to be **selectable from the picker**, not just by overriding the original ref

This also complements the per-model context override request in #31278 by enabling multiple selectable variants instead of only overriding a single built-in ref.

## Implementation

- Extend `AgentModelEntryConfig` / zod schema with `routeTo` and `contextTokens`
- Add `findConfiguredAgentModelEntry()` and `resolveRoutedModelRef()` in `src/agents/model-selection.ts`
- Teach `resolveContextTokensForModel()` to prefer per-entry `contextTokens`
- Route `resolveModelWithRegistry()` through `routeTo` before resolving the upstream runtime model
- Regenerate `src/config/schema.base.generated.ts`

## Tests

Added/updated tests covering:

- routing derived refs to the configured upstream model
- honoring per-entry `contextTokens` on derived refs
- generated base config schema staying in sync

Test command used:

```bash
corepack pnpm exec vitest --config vitest.tmp-virtual-model.config.ts run
```

(Using a temporary scoped Vitest config to target the affected unit tests.)

## Related

- Closes or advances: #31278
