### PR TITLE
feat(security): add destructive-commands.ts — catalog of HIL-required exec patterns for agentic workloads

### DIFF
--- a/src/security/destructive-commands.test.ts
+++ b/src/security/destructive-commands.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALL_DESTRUCTIVE_PATTERNS,
+  KUBECTL_DESTRUCTIVE_PATTERNS,
+  TERRAFORM_DESTRUCTIVE_PATTERNS,
+  GCLOUD_DESTRUCTIVE_PATTERNS,
+  FILESYSTEM_DESTRUCTIVE_PATTERNS,
+  GIT_DESTRUCTIVE_PATTERNS,
+} from "./destructive-commands.js";
+
+describe("destructive-commands", () => {
+  it("ALL_DESTRUCTIVE_PATTERNS is non-empty", () => {
+    expect(ALL_DESTRUCTIVE_PATTERNS.length).toBeGreaterThan(0);
+  });
+
+  it("kubectl read-only commands are NOT in destructive patterns", () => {
+    const safeOps = ["kubectl get pods", "kubectl describe node", "kubectl logs app-123"];
+    for (const cmd of safeOps) {
+      const matches = KUBECTL_DESTRUCTIVE_PATTERNS.some((p) =>
+        cmd.startsWith(p.replace(" *", ""))
+      );
+      expect(matches).toBe(false);
+    }
+  });
+
+  it("kubectl destructive commands ARE in patterns", () => {
+    const destructive = ["kubectl delete pod foo", "kubectl drain node-1", "kubectl apply -f manifest.yaml"];
+    for (const cmd of destructive) {
+      const matches = KUBECTL_DESTRUCTIVE_PATTERNS.some((p) =>
+        cmd.startsWith(p.split(" *")[0])
+      );
+      expect(matches).toBe(true);
+    }
+  });
+
+  it("terraform safe commands are NOT in destructive patterns", () => {
+    const safe = ["terraform plan", "terraform init", "terraform validate"];
+    for (const cmd of safe) {
+      const matches = TERRAFORM_DESTRUCTIVE_PATTERNS.some((p) =>
+        cmd.startsWith(p.split(" *")[0])
+      );
+      expect(matches).toBe(false);
+    }
+  });
+
+  it("terraform destructive commands ARE in patterns", () => {
+    const destructive = ["terraform apply", "terraform destroy -auto-approve", "terraform taint resource"];
+    for (const cmd of destructive) {
+      const matches = TERRAFORM_DESTRUCTIVE_PATTERNS.some((p) =>
+        cmd.startsWith(p.split(" *")[0])
+      );
+      expect(matches).toBe(true);
+    }
+  });
+
+  it("rm is in filesystem destructive patterns", () => {
+    expect(FILESYSTEM_DESTRUCTIVE_PATTERNS).toContain("rm *");
+  });
+
+  it("git push --force is in git destructive patterns", () => {
+    const hasForce = GIT_DESTRUCTIVE_PATTERNS.some((p) => p.includes("force"));
+    expect(hasForce).toBe(true);
+  });
+
+  it("all patterns are non-empty strings ending with *", () => {
+    for (const pattern of ALL_DESTRUCTIVE_PATTERNS) {
+      expect(typeof pattern).toBe("string");
+      expect(pattern.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("no duplicate patterns", () => {
+    const unique = new Set(ALL_DESTRUCTIVE_PATTERNS);
+    expect(unique.size).toBe(ALL_DESTRUCTIVE_PATTERNS.length);
+  });
+});

--- a/src/security/destructive-commands.ts
+++ b/src/security/destructive-commands.ts
@@ -1,0 +1,172 @@
+/**
+ * Destructive command patterns for exec approval policy.
+ *
+ * These patterns identify commands with irreversible or high-blast-radius effects.
+ * When used with `security=allowlist` + `ask=on-miss`, any command matching these
+ * patterns will require explicit HIL (Human-in-the-Loop) approval before execution.
+ *
+ * Usage:
+ *   Import DESTRUCTIVE_COMMAND_PATTERNS in exec approval policy initialization.
+ *   These patterns are intentionally NOT in the default safe-bin allowlist.
+ *
+ * Design principles:
+ *   - Allowlist-first: safe operations are pre-approved; destructive ones prompt
+ *   - Prefix-matched: patterns cover the command verb + key flags, not full strings
+ *   - Conservative: when in doubt, require approval
+ *   - Spoofing-resistant: approval decision is bound to the session token in the
+ *     gateway's approval flow, not to agent-asserted metadata
+ *
+ * @see exec-approvals.ts for the approval protocol
+ * @see exec-safe-bin-policy.ts for the safe default allowlist
+ */
+
+/**
+ * Commands that delete, destroy, or irreversibly modify Kubernetes resources.
+ * Read-only kubectl commands (get, describe, logs, rollout status) are safe.
+ */
+export const KUBECTL_DESTRUCTIVE_PATTERNS = [
+  "kubectl delete *",
+  "kubectl drain *",
+  "kubectl cordon *",
+  "kubectl uncordon *",
+  "kubectl taint *",
+  "kubectl replace *",
+  "kubectl apply *", // Intentionally requires approval — applies cluster state changes
+  "kubectl patch *",
+  "kubectl scale *",
+  "kubectl rollout restart *",
+  "kubectl rollout undo *",
+  "kubectl label * --overwrite *",
+  "kubectl annotate * --overwrite *",
+] as const;
+
+/**
+ * Terraform commands that mutate infrastructure state.
+ * terraform plan, init, validate are safe; apply/destroy/taint/import are not.
+ */
+export const TERRAFORM_DESTRUCTIVE_PATTERNS = [
+  "terraform apply *",
+  "terraform destroy *",
+  "terraform taint *",
+  "terraform untaint *",
+  "terraform import *",
+  "terraform state rm *",
+  "terraform state mv *",
+  "terraform workspace delete *",
+  "terraform workspace new *",
+] as const;
+
+/**
+ * GCP gcloud commands that create, update, or delete cloud resources.
+ * gcloud * list/describe/get are safe.
+ */
+export const GCLOUD_DESTRUCTIVE_PATTERNS = [
+  "gcloud * delete *",
+  "gcloud * create *",
+  "gcloud * update *",
+  "gcloud * set *",
+  "gcloud * add *",
+  "gcloud * remove *",
+  "gcloud * deploy *",
+  "gcloud * patch *",
+  "gcloud * disable *",
+  "gcloud * enable *",
+  "gcloud secrets versions *",
+] as const;
+
+/**
+ * File system operations with irreversible effects.
+ * cp, mv, mkdir, touch are safe; rm and overwrite-redirects are not.
+ */
+export const FILESYSTEM_DESTRUCTIVE_PATTERNS = [
+  "rm *",
+  "rmdir *",
+  "shred *",
+  "dd *",
+  "truncate *",
+  // Shell redirections with > (overwrite) can't be caught here —
+  // handled by exec-approvals-analysis.ts shell chain analysis
+] as const;
+
+/**
+ * Git operations that rewrite history or force-push to shared branches.
+ * Normal git add/commit/push/pull/checkout are safe.
+ */
+export const GIT_DESTRUCTIVE_PATTERNS = [
+  "git push *--force*",
+  "git push *-f *",
+  "git push origin main *",
+  "git push origin master *",
+  "git push origin production *",
+  "git reset --hard *",
+  "git clean -fd *",
+  "git rebase -i *",
+  "git filter-branch *",
+  "git reflog delete *",
+] as const;
+
+/**
+ * Database operations that mutate or destroy data.
+ */
+export const DATABASE_DESTRUCTIVE_PATTERNS = [
+  "psql * -c *DROP*",
+  "psql * -c *TRUNCATE*",
+  "psql * -c *DELETE*",
+  "psql * -c *ALTER*",
+  "psql * -c *CREATE*",
+  "mysql * -e *DROP*",
+  "mysql * -e *TRUNCATE*",
+  "sqlite3 * *DROP*",
+] as const;
+
+/**
+ * Process signals that terminate or suspend processes.
+ * SIGTERM (15) to a specific PID is usually safe; SIGKILL (-9) and broadcast
+ * kills (kill -9 -1 which kills all processes) are destructive.
+ */
+export const PROCESS_DESTRUCTIVE_PATTERNS = [
+  "kill -9 *",
+  "kill -KILL *",
+  "killall *",
+  "pkill -9 *",
+] as const;
+
+/**
+ * SSH operations that modify remote state at scale.
+ * Read-only SSH commands are generally safe; mass operations are not.
+ */
+export const SSH_DESTRUCTIVE_PATTERNS = [
+  "ssh * sudo rm *",
+  "ssh * sudo systemctl disable *",
+  "ssh * sudo systemctl stop *",
+] as const;
+
+/**
+ * All destructive command patterns combined.
+ * Use this as the basis for a HIL-required exec approval policy.
+ *
+ * @example
+ * ```ts
+ * // In exec approval initialization:
+ * import { ALL_DESTRUCTIVE_PATTERNS } from "./destructive-commands.js";
+ *
+ * const requiresHIL = ALL_DESTRUCTIVE_PATTERNS.some(pattern =>
+ *   matchAllowlist(command, [{ pattern }])
+ * );
+ * if (requiresHIL) {
+ *   // Route to ask=always approval flow
+ * }
+ * ```
+ */
+export const ALL_DESTRUCTIVE_PATTERNS = [
+  ...KUBECTL_DESTRUCTIVE_PATTERNS,
+  ...TERRAFORM_DESTRUCTIVE_PATTERNS,
+  ...GCLOUD_DESTRUCTIVE_PATTERNS,
+  ...FILESYSTEM_DESTRUCTIVE_PATTERNS,
+  ...GIT_DESTRUCTIVE_PATTERNS,
+  ...DATABASE_DESTRUCTIVE_PATTERNS,
+  ...PROCESS_DESTRUCTIVE_PATTERNS,
+  ...SSH_DESTRUCTIVE_PATTERNS,
+] as const;
+
+export type DestructiveCommandPattern = (typeof ALL_DESTRUCTIVE_PATTERNS)[number];


### PR DESCRIPTION
## Summary

Adds `src/security/destructive-commands.ts` — a curated catalog of command patterns that should require Human-in-the-Loop (HIL) approval when running in agentic contexts.

## Motivation

When autonomous agents run in agentic workflows (sub-agent spawning, background cron jobs, multi-step orchestration), they can inadvertently execute destructive commands like `kubectl delete`, `terraform destroy`, or `rm -rf` without the user realizing it's happening.

OpenClaw already has an excellent exec approval system (`ask=on-miss`, `security=allowlist`). This PR adds a canonical reference catalog of patterns that **should not** be on any default allowlist.

## What's in the catalog

Patterns organized by tool category, each with a comment explaining rationale:
- **Kubernetes**: `kubectl delete`, `kubectl drain`, `kubectl apply` (state changes), scale, rollout restart/undo
- **Terraform**: `terraform apply`, `terraform destroy`, taint, import, state mutations
- **GCP gcloud**: create, delete, update, set, deploy, disable/enable operations
- **Filesystem**: `rm`, `rmdir`, `shred`, `dd`, `truncate`
- **Git**: `push --force`, push to main/master/production, `reset --hard`, `filter-branch`
- **Database**: DROP, TRUNCATE, DELETE, ALTER via psql/mysql/sqlite3
- **Process**: `kill -9`, `killall`, `pkill -9`
- **SSH**: remote destructive sudo commands

## Design — safe operations explicitly excluded

- `kubectl get/describe/logs/rollout status` → NOT in the list (read-only)
- `terraform plan/init/validate` → NOT in the list (read-only)
- `gcloud * list/describe/get` → NOT in the list (read-only)
- Normal `git push` → NOT in the list (only force variants)

## Usage with existing approval system

```ts
import { ALL_DESTRUCTIVE_PATTERNS } from './security/destructive-commands.js';

// Example: in exec approval policy initialization
const requiresHIL = ALL_DESTRUCTIVE_PATTERNS.some(pattern =>
  matchAllowlist(command, [{ pattern }])
);
```

With `security=allowlist` + `ask=on-miss` in exec-approvals.json, any command not on the safe allowlist automatically triggers the approval flow — including anything matching these patterns.

## Tests

`src/security/destructive-commands.test.ts` covers:
- Safe kubectl/terraform operations are NOT matched
- Destructive operations ARE matched
- No duplicates in the full pattern set

## Related

Companion to issue #60497 (agent fabricates success after exec failure). Requiring approval before destructive commands run is the proactive complement to fail-closed exec behavior after the fact.

Also complements:
- `dangerous-tools.ts` (tool-level deny list)
- `exec-safe-bin-policy.ts` (safe binary allowlist)

---
*Contributed by a user running BMAD agentic orchestration on a 200-core bare-metal Hive cluster. We hit these failure modes the hard way and built these patterns from production incidents.*