### PR TITLE
fix: prevent OOM in `openclaw logs --follow` via stdout backpressure

### DIFF
--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -150,10 +150,10 @@ function createLogWriters() {
   });
 
   return {
-    logLine: (text: string) => writer.writeLine(process.stdout, text),
-    errorLine: (text: string) => writer.writeLine(process.stderr, text),
+    logLine: (text: string) => writer.writeLineAsync(process.stdout, text),
+    errorLine: (text: string) => writer.writeLineAsync(process.stderr, text),
     emitJsonLine: (payload: Record<string, unknown>, toStdErr = false) =>
-      writer.write(toStdErr ? process.stderr : process.stdout, `${JSON.stringify(payload)}\n`),
+      writer.writeAsync(toStdErr ? process.stderr : process.stdout, `${JSON.stringify(payload)}\n`),
   };
 }
 
@@ -162,8 +162,8 @@ async function emitGatewayError(
   opts: LogsCliOptions,
   mode: "json" | "text",
   rich: boolean,
-  emitJsonLine: (payload: Record<string, unknown>, toStdErr?: boolean) => boolean,
-  errorLine: (text: string) => boolean,
+  emitJsonLine: (payload: Record<string, unknown>, toStdErr?: boolean) => Promise<boolean>,
+  errorLine: (text: string) => Promise<boolean>,
 ) {
   const runtime = await loadLogsCliRuntime();
   const message = "Gateway not reachable. Is it running and accessible?";
@@ -173,7 +173,7 @@ async function emitGatewayError(
   const details = runtime.buildGatewayConnectionDetails({ url: opts.url });
   if (mode === "json") {
     if (
-      !emitJsonLine(
+      !(await emitJsonLine(
         {
           type: "error",
           message,
@@ -182,20 +182,20 @@ async function emitGatewayError(
           hint,
         },
         true,
-      )
+      ))
     ) {
       return;
     }
     return;
   }
 
-  if (!errorLine(colorize(rich, theme.error, message))) {
+  if (!(await errorLine(colorize(rich, theme.error, message)))) {
     return;
   }
-  if (!errorLine(details.message)) {
+  if (!(await errorLine(details.message))) {
     return;
   }
-  errorLine(colorize(rich, theme.muted, hint));
+  await errorLine(colorize(rich, theme.muted, hint));
 }
 
 export function registerLogsCli(program: Command) {
@@ -251,12 +251,12 @@ export function registerLogsCli(program: Command) {
       if (jsonMode) {
         if (first) {
           if (
-            !emitJsonLine({
+            !(await emitJsonLine({
               type: "meta",
               file: payload.file,
               cursor: payload.cursor,
               size: payload.size,
-            })
+            }))
           ) {
             return;
           }
@@ -264,31 +264,31 @@ export function registerLogsCli(program: Command) {
         for (const line of lines) {
           const parsed = parseLogLine(line);
           if (parsed) {
-            if (!emitJsonLine({ type: "log", ...parsed })) {
+            if (!(await emitJsonLine({ type: "log", ...parsed }))) {
               return;
             }
           } else {
-            if (!emitJsonLine({ type: "raw", raw: line })) {
+            if (!(await emitJsonLine({ type: "raw", raw: line }))) {
               return;
             }
           }
         }
         if (payload.truncated) {
           if (
-            !emitJsonLine({
+            !(await emitJsonLine({
               type: "notice",
               message: "Log tail truncated (increase --max-bytes).",
-            })
+            }))
           ) {
             return;
           }
         }
         if (payload.reset) {
           if (
-            !emitJsonLine({
+            !(await emitJsonLine({
               type: "notice",
               message: "Log cursor reset (file rotated).",
-            })
+            }))
           ) {
             return;
           }
@@ -296,30 +296,30 @@ export function registerLogsCli(program: Command) {
       } else {
         if (first && payload.file) {
           const prefix = pretty ? colorize(rich, theme.muted, "Log file:") : "Log file:";
-          if (!logLine(`${prefix} ${payload.file}`)) {
+          if (!(await logLine(`${prefix} ${payload.file}`))) {
             return;
           }
         }
         for (const line of lines) {
           if (
-            !logLine(
+            !(await logLine(
               formatLogLine(line, {
                 pretty,
                 rich,
                 localTime,
               }),
-            )
+            ))
           ) {
             return;
           }
         }
         if (payload.truncated) {
-          if (!errorLine("Log tail truncated (increase --max-bytes).")) {
+          if (!(await errorLine("Log tail truncated (increase --max-bytes)."))) {
             return;
           }
         }
         if (payload.reset) {
-          if (!errorLine("Log cursor reset (file rotated).")) {
+          if (!(await errorLine("Log cursor reset (file rotated)."))) {
             return;
           }
         }

--- a/src/terminal/stream-writer.test.ts
+++ b/src/terminal/stream-writer.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { createSafeStreamWriter } from "./stream-writer.js";
 
@@ -37,5 +38,87 @@ describe("createSafeStreamWriter", () => {
     expect(writer.write(stream, "hi")).toBe(false);
     expect(writer.isClosed()).toBe(true);
     expect(onBrokenPipe).toHaveBeenCalledTimes(1);
+  });
+
+  describe("writeAsync / writeLineAsync (backpressure)", () => {
+    it("resolves immediately when stream.write returns true (buffer not full)", async () => {
+      const writer = createSafeStreamWriter();
+      const writeFn = vi.fn(() => true);
+      const stream = { write: writeFn } as unknown as NodeJS.WriteStream;
+
+      const result = await writer.writeAsync(stream, "hello");
+      expect(result).toBe(true);
+      expect(writeFn).toHaveBeenCalledWith("hello");
+    });
+
+    it("awaits drain when stream.write returns false (buffer full)", async () => {
+      const writer = createSafeStreamWriter();
+      const emitter = new EventEmitter();
+      let writeCount = 0;
+      const writeFn = vi.fn(() => ++writeCount > 1);
+      const stream = {
+        write: writeFn,
+        once: (event: string, cb: () => void) => emitter.once(event, cb),
+      } as unknown as NodeJS.WriteStream;
+
+      // Start the async write — it should block waiting for drain
+      const promise = writer.writeAsync(stream, "hello");
+
+      // Emit drain to unblock
+      emitter.emit("drain");
+
+      const result = await promise;
+      expect(result).toBe(true);
+      expect(writeFn).toHaveBeenCalledWith("hello");
+    });
+
+    it("returns false immediately when closed", async () => {
+      const writer = createSafeStreamWriter();
+      const writeFn = vi.fn(() => true);
+      const stream = { write: writeFn } as unknown as NodeJS.WriteStream;
+
+      // Close via broken pipe
+      const brokenStream = {
+        write: vi.fn(() => {
+          const err = new Error("EPIPE") as NodeJS.ErrnoException;
+          err.code = "EPIPE";
+          throw err;
+        }),
+      } as unknown as NodeJS.WriteStream;
+      writer.write(brokenStream, "trigger close");
+      expect(writer.isClosed()).toBe(true);
+
+      const result = await writer.writeAsync(stream, "after close");
+      expect(result).toBe(false);
+      // stream.write should NOT have been called after close
+      expect(writeFn).not.toHaveBeenCalled();
+    });
+
+    it("writeLineAsync appends newline and awaits drain", async () => {
+      const writer = createSafeStreamWriter();
+      const writeFn = vi.fn(() => true);
+      const stream = { write: writeFn } as unknown as NodeJS.WriteStream;
+
+      const result = await writer.writeLineAsync(stream, "a line");
+      expect(result).toBe(true);
+      expect(writeFn).toHaveBeenCalledWith("a line\n");
+    });
+
+    it("handles EPIPE in writeAsync and closes the writer", async () => {
+      const onBrokenPipe = vi.fn();
+      const writer = createSafeStreamWriter({ onBrokenPipe });
+      const stream = {
+        write: vi.fn(() => {
+          const err = new Error("EPIPE") as NodeJS.ErrnoException;
+          err.code = "EPIPE";
+          throw err;
+        }),
+      } as unknown as NodeJS.WriteStream;
+
+      const result = await writer.writeAsync(stream, "boom");
+      expect(result).toBe(false);
+      expect(writer.isClosed()).toBe(true);
+      expect(onBrokenPipe).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/terminal/stream-writer.ts
+++ b/src/terminal/stream-writer.ts
@@ -6,6 +6,8 @@ export type SafeStreamWriterOptions = {
 export type SafeStreamWriter = {
   write: (stream: NodeJS.WriteStream, text: string) => boolean;
   writeLine: (stream: NodeJS.WriteStream, text: string) => boolean;
+  writeAsync: (stream: NodeJS.WriteStream, text: string) => Promise<boolean>;
+  writeLineAsync: (stream: NodeJS.WriteStream, text: string) => Promise<boolean>;
   reset: () => void;
   isClosed: () => boolean;
 };
@@ -56,9 +58,37 @@ export function createSafeStreamWriter(options: SafeStreamWriterOptions = {}): S
   const writeLine = (stream: NodeJS.WriteStream, text: string): boolean =>
     write(stream, `${text}\n`);
 
+  // Async variant: awaits the stream's `drain` event when the write buffer is
+  // full (stream.write returns false). This prevents unbounded heap growth when
+  // stdout is backed up (e.g. piped to `less`, Ctrl+S paused, slow redirect).
+  const writeAsync = async (stream: NodeJS.WriteStream, text: string): Promise<boolean> => {
+    if (closed) {
+      return false;
+    }
+    try {
+      options.beforeWrite?.();
+    } catch (err) {
+      return handleError(err, process.stderr);
+    }
+    try {
+      if (!stream.write(text)) {
+        // Buffer full — pause until the stream drains before accepting more data.
+        await new Promise<void>((resolve) => stream.once("drain", resolve));
+      }
+      return !closed;
+    } catch (err) {
+      return handleError(err, stream);
+    }
+  };
+
+  const writeLineAsync = (stream: NodeJS.WriteStream, text: string): Promise<boolean> =>
+    writeAsync(stream, `${text}\n`);
+
   return {
     write,
     writeLine,
+    writeAsync,
+    writeLineAsync,
     reset: () => {
       closed = false;
       notified = false;


### PR DESCRIPTION
## Problem

`openclaw logs --follow` could exhaust the Node.js heap (~4.1 GB) when stdout was backed up — e.g. piped to `less`, paused with Ctrl+S, or redirected to a slow sink. Three WSL crash dumps totalling 9.6 GB were produced today as evidence.

## Root cause

`createSafeStreamWriter` discarded the boolean return value of `stream.write()`. When the write buffer is full, `stream.write()` returns `false` as a backpressure signal. Because this was ignored, the polling loop continued fetching and buffering log lines indefinitely, growing the heap until Node.js OOM'd.

## Fix

- Add `writeAsync` and `writeLineAsync` to `SafeStreamWriter`. These await the stream's `drain` event when `stream.write()` returns `false`, naturally pausing the caller until the consumer catches up.
- Switch `createLogWriters()` in `logs-cli.ts` to use the async variants.
- Await every `logLine`, `errorLine`, and `emitJsonLine` call in the polling loop and error path.
- Make `emitGatewayError` async to propagate `await` through the error path.

The sync `write`/`writeLine` methods are unchanged — no regression for other callers.

## Tests

5 new unit tests added to `stream-writer.test.ts`:
- Fast path: resolves immediately when buffer is free
- Slow path: awaits `drain` when buffer is full
- Closed-writer short-circuit
- `writeLineAsync` newline appending
- EPIPE handling in async path

**46/46 tests pass** across `src/terminal/` and `src/cli/logs-cli.test.ts`. Lint clean.