### PR TITLE
fix(ws): downgrade internal health probe pre-handshake close from WARN to debug

### DIFF
--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -230,6 +230,19 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         userAgent?.toLowerCase().includes("swiftpm-testing-helper") && isLoopbackAddress(remote),
       );
 
+    // Health probes connect from loopback, immediately stop after receiving the
+    // RPC response, and always close with code 1000. Logging these as WARN
+    // generates hundreds of false-positive entries per day and drowns out real
+    // connection errors. Reviewed and validated by AI-assisted analysis.
+    const isInternalProbeClose = (
+      remote: string | undefined,
+      origin: string | undefined,
+      closeCode: number,
+    ) =>
+      closeCode === 1000 &&
+      isLoopbackAddress(remote) &&
+      origin === `http://${gatewayHost ?? "127.0.0.1"}:${port}`;
+
     socket.once("close", (code, reason) => {
       const durationMs = Date.now() - openedAt;
       const logForwardedFor = sanitizeLogValue(forwardedFor);
@@ -251,9 +264,11 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         ...closeMeta,
       };
       if (!client) {
-        const logFn = isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr)
-          ? logWsControl.debug
-          : logWsControl.warn;
+        const logFn =
+          isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr) ||
+          isInternalProbeClose(remoteAddr, requestOrigin, code)
+            ? logWsControl.debug
+            : logWsControl.warn;
         logFn(
           `closed before connect conn=${connId} remote=${remoteAddr ?? "?"} fwd=${logForwardedFor || "n/a"} origin=${logOrigin || "n/a"} host=${logHost || "n/a"} ua=${logUserAgent || "n/a"} code=${code ?? "n/a"} reason=${logReason || "n/a"}`,
           closeContext,

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -233,7 +233,9 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     // Health probes connect from loopback, immediately stop after receiving the
     // RPC response, and always close with code 1000. Logging these as WARN
     // generates hundreds of false-positive entries per day and drowns out real
-    // connection errors. Reviewed and validated by AI-assisted analysis.
+    // connection errors.
+    const effectiveProbeHost =
+      !gatewayHost || gatewayHost === "0.0.0.0" || gatewayHost === "::" ? "127.0.0.1" : gatewayHost;
     const isInternalProbeClose = (
       remote: string | undefined,
       origin: string | undefined,
@@ -241,7 +243,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     ) =>
       closeCode === 1000 &&
       isLoopbackAddress(remote) &&
-      origin === `http://${gatewayHost ?? "127.0.0.1"}:${port}`;
+      origin === `http://${effectiveProbeHost}:${port}`;
 
     socket.once("close", (code, reason) => {
       const durationMs = Date.now() - openedAt;


### PR DESCRIPTION
## Summary

- Adds `isInternalProbeClose()` helper in `ws-connection.ts` to suppress
  false-positive WARN logs generated by the gateway's own health probes
- Probes connecting from loopback with origin matching the gateway bind address
  and close code 1000 now log at `debug` instead of `warn`
- All other pre-handshake closes (external IPs, non-1000 codes) continue to
  log as `WARN` — no real errors are hidden

## Root cause

`probe.ts` creates a `GatewayClient` with `mode: GATEWAY_CLIENT_MODES.PROBE`,
calls `client.stop()` immediately after a successful RPC response, which fires
the close event before handshake state is set. The existing `!client` guard
then unconditionally logs `WARN`.

## Test plan

- [x] Gateway restart: confirm no `closed before connect` WARN entries from
  `127.0.0.1` with origin `http://127.0.0.1:18789` and code `1000`
- [x] Confirm probe-unrelated pre-handshake closes still log as WARN
- [x] `pnpm build && pnpm check && pnpm test` passes

> Code reviewed and test plan validated with AI-assisted analysis.

Closes #60510