### PR TITLE
feat(plugin-sdk): export OpenClawSchema via plugin-sdk/config-schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Ollama: add a bundled Ollama Web Search provider for key-free `web_search` via your configured Ollama host and `ollama signin`. (#59318) Thanks @BruceMacD.
 - Plugins/onboarding: add plugin config TUI prompts to onboard and configure wizards so more plugin setup can stay in the guided flow. (#60590)
 - Plugins/install: add `openclaw plugins install --force` to overwrite existing plugin and hook-pack install targets without using the dangerous-code override flag. (#60544) Thanks @gumadeiras.
+- Plugin SDK/config: export `OpenClawSchema` via `openclaw/plugin-sdk/config-schema` so external tooling can validate and introspect full `openclaw.json` config through a supported public subpath. (#60557) Thanks @feniix.
 - Providers/Anthropic: remove setup-token from new onboarding and auth-command setup paths, keep existing configured legacy token profiles runnable, and steer new Anthropic setup to Claude CLI or API keys.
 - Providers/OpenAI Codex: add forward-compat `openai-codex/gpt-5.4-mini` synthesis across provider runtime, model catalog, and model listing so Codex mini works before bundled Pi catalog updates land.
 - Tools/web_search: add a bundled MiniMax Search provider backed by the Coding Plan search API, with region reuse from `MINIMAX_API_HOST` and plugin-owned credential config. (#54648) Thanks @fengmk2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ Docs: https://docs.openclaw.ai
 - Providers/Ollama: add a bundled Ollama Web Search provider for key-free `web_search` via your configured Ollama host and `ollama signin`. (#59318) Thanks @BruceMacD.
 - Plugins/onboarding: add plugin config TUI prompts to onboard and configure wizards so more plugin setup can stay in the guided flow. (#60590)
 - Plugins/install: add `openclaw plugins install --force` to overwrite existing plugin and hook-pack install targets without using the dangerous-code override flag. (#60544) Thanks @gumadeiras.
-- Plugin SDK/config: export `OpenClawSchema` via `openclaw/plugin-sdk/config-schema` so external tooling can validate and introspect full `openclaw.json` config through a supported public subpath. (#60557) Thanks @feniix.
 - Providers/Anthropic: remove setup-token from new onboarding and auth-command setup paths, keep existing configured legacy token profiles runnable, and steer new Anthropic setup to Claude CLI or API keys.
 - Providers/OpenAI Codex: add forward-compat `openai-codex/gpt-5.4-mini` synthesis across provider runtime, model catalog, and model listing so Codex mini works before bundled Pi catalog updates land.
 - Tools/web_search: add a bundled MiniMax Search provider backed by the Coding Plan search API, with region reuse from `MINIMAX_API_HOST` and plugin-owned credential config. (#54648) Thanks @fengmk2.
@@ -33,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - Prompt caching: keep prompt prefixes more reusable across transport fallback, deterministic MCP tool ordering, compaction, and embedded image history so follow-up turns hit cache more reliably. (#58036, #58037, #58038, #59054, #60603, #60691) Thanks @bcherny.
 - Agents/cache: diagnostics: add prompt-cache break diagnostics, trace live cache scenarios through embedded runner paths, and show cache reuse explicitly in `openclaw status --verbose`. Thanks @vincentkoc.
 - Agents/cache: stabilize cache-relevant system prompt fingerprints by normalizing equivalent structured prompt whitespace, line endings, hook-added system context, and runtime capability ordering so semantically unchanged prompts reuse KV/cache more reliably. Thanks @vincentkoc.
+- Plugin SDK/config: export `OpenClawSchema` via `openclaw/plugin-sdk/config-schema` so external tooling can validate and introspect full `openclaw.json` config through a supported public subpath. (#60557) Thanks @feniix.
 
 ### Fixes
 

--- a/package.json
+++ b/package.json
@@ -119,6 +119,10 @@
       "types": "./dist/plugin-sdk/config-runtime.d.ts",
       "default": "./dist/plugin-sdk/config-runtime.js"
     },
+    "./plugin-sdk/config-schema": {
+      "types": "./dist/plugin-sdk/config-schema.d.ts",
+      "default": "./dist/plugin-sdk/config-schema.js"
+    },
     "./plugin-sdk/reply-runtime": {
       "types": "./dist/plugin-sdk/reply-runtime.d.ts",
       "default": "./dist/plugin-sdk/reply-runtime.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -19,6 +19,7 @@
   "approval-reply-runtime",
   "approval-runtime",
   "config-runtime",
+  "config-schema",
   "reply-runtime",
   "reply-dispatch-runtime",
   "reply-reference",

--- a/src/plugin-sdk/config-schema.ts
+++ b/src/plugin-sdk/config-schema.ts
@@ -1,0 +1,2 @@
+/** Root OpenClaw configuration Zod schema — the full `openclaw.json` shape. */
+export { OpenClawSchema } from "../config/zod-schema.js";


### PR DESCRIPTION
## Summary

- Add a public `plugin-sdk/config-schema` export path for the root `OpenClawSchema` Zod schema
- Follows the existing barrel-file pattern used by `channel-config-schema`, `agent-config-primitives`, etc.
- Enables external tools to import the schema for validation and introspection without reaching into internal bundle chunks

**Import path:**
```typescript
import { OpenClawSchema } from "openclaw/plugin-sdk/config-schema";
```

### Motivation

We're building a CLI tool for surgical, comment-preserving mutations on `openclaw.json`. It needs the root Zod schema to validate config fragments before writing — the same schema OpenClaw uses internally at startup. Currently `OpenClawSchema` is defined in `src/config/zod-schema.ts` but only accessible through a content-hashed internal chunk (`dist/io-<hash>.js`), which isn't importable via the `exports` map.

### Changes

| File | Change |
|------|--------|
| `src/plugin-sdk/config-schema.ts` | New 2-line barrel re-exporting `OpenClawSchema` from `../config/zod-schema.js` |
| `scripts/lib/plugin-sdk-entrypoints.json` | Added `"config-schema"` entry |
| `package.json` | Auto-updated by `sync-plugin-sdk-exports.mjs` |

### Verification

- `pnpm build` passes (including `check-plugin-sdk-exports.mjs`)
- All 11,057 tests pass (5 pre-existing skips)
- Self-reference import verified: `.parse()`, `.safeParse()`, `.shape` all accessible (37 top-level keys)

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` — 1,191 files, 11,057 passed
- [x] `node --input-type=module -e "import { OpenClawSchema } from 'openclaw/plugin-sdk/config-schema'; console.log(Object.keys(OpenClawSchema.shape).length)"` → `37`