### PR TITLE
fix(cron): return strictly future time for every-schedule boundary hits

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -103,6 +103,22 @@ describe("cron schedule", () => {
     expect(next).toBe(anchor + 30_000);
   });
 
+  it("returns strictly future time when now is exactly at an interval boundary", () => {
+    const anchor = Date.parse("2025-12-13T00:00:00.000Z");
+    const everyMs = 30_000;
+    // now is exactly at anchor + 1*everyMs
+    const now1 = anchor + everyMs;
+    const next1 = computeNextRunAtMs({ kind: "every", everyMs, anchorMs: anchor }, now1);
+    expect(next1).toBe(anchor + 2 * everyMs);
+    expect(next1).toBeGreaterThan(now1);
+
+    // now is exactly at anchor + 3*everyMs
+    const now3 = anchor + 3 * everyMs;
+    const next3 = computeNextRunAtMs({ kind: "every", everyMs, anchorMs: anchor }, now3);
+    expect(next3).toBe(anchor + 4 * everyMs);
+    expect(next3).toBeGreaterThan(now3);
+  });
+
   it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
     const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
     const next = computeNextRunAtMs(

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -93,7 +93,7 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
       return anchor;
     }
     const elapsed = nowMs - anchor;
-    const steps = Math.max(1, Math.floor((elapsed + everyMs - 1) / everyMs));
+    const steps = Math.floor(elapsed / everyMs) + 1;
     return anchor + steps * everyMs;
   }
 


### PR DESCRIPTION
Ran into a scheduling oddity while debugging a cron job that fires every 5 minutes on my self-hosted setup. Noticed the timer layer's `MIN_REFIRE_GAP_MS` guard was occasionally kicking in — quick 2-second delays that shouldn't be there on a clean 5-minute interval.

Traced it to `computeNextRunAtMs` in `schedule.ts`. When `nowMs` lands exactly on an interval boundary (`anchor + k * everyMs`), the ceiling-division formula returns the *current* boundary instead of the next one:

```
elapsed = 30000, everyMs = 30000
ceil(30000 / 30000) = 1
anchor + 1 * 30000 = 30000 = nowMs  ← not in the future
```

The timer layer's `MIN_REFIRE_GAP_MS` safety net (line 45 of `timer.ts`) catches this and prevents a spin-loop, but the schedule function itself should return a strictly future timestamp — which is what every other schedule kind already does (the `cron` path has the same contract enforced at line 117: `nextMs <= nowMs` triggers retry logic).

**Before:** `computeNextRunAtMs({kind:"every", everyMs:30000, anchorMs:0}, 30000)` → `30000` (equals now)

**After:** `computeNextRunAtMs({kind:"every", everyMs:30000, anchorMs:0}, 30000)` → `60000` (next interval)

The fix replaces `Math.max(1, Math.floor((elapsed + everyMs - 1) / everyMs))` with `Math.floor(elapsed / everyMs) + 1`. The `+1` unconditionally advances past the current step, matching the contract that "next run" means strictly after `nowMs`.

**Test added:** A new test case `"returns strictly future time when now is exactly at an interval boundary"` that checks both the first and third boundaries to confirm the result is always `> nowMs`.

- [x] AI-assisted (Claude)
- [x] Fully tested — all 23 schedule tests pass including the new boundary case
- [x] I understand what the code does