### PR TITLE
feat(memory-core): add dreaming promotion with weighted recall thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/browser seams: split browser and WhatsApp plugin-sdk seams into narrower browser, approval-auth, and target-helper facades so hot paths and owner tests avoid broader runtime fan-out. (#60376) Thanks @shakkernerd.
 - Tests/runtime: trim local unit-test import/runtime fan-out across browser, WhatsApp, cron, task, and reply flows so owner suites start faster with lower shared-worker overhead while preserving the same focused behavior coverage. (#60249) Thanks @shakkernerd.
 - Tests/secrets runtime: restore split secrets suite cache and env isolation cleanup so broader runs do not leak stale plugin or provider snapshot state. (#60395) Thanks @shakkernerd.
+- Memory/dreaming (experimental): add opt-in weighted short-term recall promotion to `MEMORY.md`, managed dreaming modes (`off|core|rem|deep`), and a `/dreaming` command plus Dreams UI so durable memory promotion can run on background cadence without manual scheduling. (#60569) Thanks @vignesh07.
 
 ### Fixes
 

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -83,6 +83,7 @@ Dreaming is the overnight reflection pass for memory. It is called "dreaming" be
 - It is opt-in and disabled by default.
 - Enable it with `plugins.entries.memory-core.config.shortTermPromotion.dreaming.enabled=true`.
 - When enabled, `memory-core` automatically creates and maintains a managed nightly cron job.
+- Set `shortTermPromotion.dreaming.limit` to `0` if you want dreaming enabled but automatic promotion effectively paused.
 - Ranking uses weighted signals: recall frequency, retrieval relevance, query diversity, and temporal recency (recent recalls decay over time).
 - Promotion into `MEMORY.md` only happens when quality thresholds are met, so long-term memory stays high signal instead of collecting one-off details.
 

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -118,4 +118,4 @@ Notes:
 - `memory status` includes any extra paths configured via `memorySearch.extraPaths`.
 - If effectively active memory remote API key fields are configured as SecretRefs, the command resolves those values from the active gateway snapshot. If gateway is unavailable, the command fails fast.
 - Gateway version skew note: this command path requires a gateway that supports `secrets.resolve`; older gateways return an unknown-method error.
-- Dreaming cadence defaults to each mode's preset schedule. Override cadence with `plugins.entries.memory-core.config.dreaming.frequency` (`core|deep|rem`) and fine-tune with `timezone`, `limit`, `minScore`, `minRecallCount`, and `minUniqueQueries`.
+- Dreaming cadence defaults to each mode's preset schedule. Override cadence with `plugins.entries.memory-core.config.dreaming.frequency` as a cron expression (for example `0 3 * * *`) and fine-tune with `timezone`, `limit`, `minScore`, `minRecallCount`, and `minUniqueQueries`.

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -66,7 +66,7 @@ openclaw memory index --agent main --verbose
 
 - Ranks short-term candidates from `memory/YYYY-MM-DD.md` using weighted recall signals (`frequency`, `relevance`, `query diversity`, `recency`).
 - Uses recall events captured when `memory_search` returns daily-memory hits.
-- Optional auto-dreaming mode: when `plugins.entries.memory-core.config.shortTermPromotion.dreaming.enabled=true`, `memory-core` auto-manages a nightly cron job that triggers promotion in the background (no manual `openclaw cron add` required).
+- Optional auto-dreaming mode: when `plugins.entries.memory-core.config.dreaming.mode` is `core`, `deep`, or `rem`, `memory-core` auto-manages a cron job that triggers promotion in the background (no manual `openclaw cron add` required).
 - `--agent <id>`: scope to a single agent (default: the default agent).
 - `--limit <n>`: max candidates to return/apply.
 - `--min-score <n>`: minimum weighted promotion score.
@@ -81,17 +81,17 @@ openclaw memory index --agent main --verbose
 Dreaming is the overnight reflection pass for memory. It is called "dreaming" because the system revisits what was recalled during the day and decides what is worth keeping long-term.
 
 - It is opt-in and disabled by default.
-- Enable it with `plugins.entries.memory-core.config.shortTermPromotion.dreaming.enabled=true`.
-- When enabled, `memory-core` automatically creates and maintains a managed nightly cron job.
-- Set `shortTermPromotion.dreaming.limit` to `0` if you want dreaming enabled but automatic promotion effectively paused.
+- Enable it with `plugins.entries.memory-core.config.dreaming.mode`.
+- When enabled, `memory-core` automatically creates and maintains a managed cron job.
+- Set `dreaming.limit` to `0` if you want dreaming enabled but automatic promotion effectively paused.
 - Ranking uses weighted signals: recall frequency, retrieval relevance, query diversity, and temporal recency (recent recalls decay over time).
 - Promotion into `MEMORY.md` only happens when quality thresholds are met, so long-term memory stays high signal instead of collecting one-off details.
 
-Default promotion thresholds:
+Default mode presets:
 
-- `minScore=0.75`
-- `minRecallCount=3`
-- `minUniqueQueries=2`
+- `core`: daily at `0 3 * * *`, `minScore=0.75`, `minRecallCount=3`, `minUniqueQueries=2`
+- `deep`: every 12 hours (`0 */12 * * *`), `minScore=0.8`, `minRecallCount=3`, `minUniqueQueries=3`
+- `rem`: every 6 hours (`0 */6 * * *`), `minScore=0.85`, `minRecallCount=4`, `minUniqueQueries=3`
 
 Example:
 
@@ -101,10 +101,8 @@ Example:
     "entries": {
       "memory-core": {
         "config": {
-          "shortTermPromotion": {
-            "dreaming": {
-              "enabled": true
-            }
+          "dreaming": {
+            "mode": "core"
           }
         }
       }
@@ -119,4 +117,4 @@ Notes:
 - `memory status` includes any extra paths configured via `memorySearch.extraPaths`.
 - If effectively active memory remote API key fields are configured as SecretRefs, the command resolves those values from the active gateway snapshot. If gateway is unavailable, the command fails fast.
 - Gateway version skew note: this command path requires a gateway that supports `secrets.resolve`; older gateways return an unknown-method error.
-- Dreaming schedule defaults to `0 3 * * *`; override with `plugins.entries.memory-core.config.shortTermPromotion.dreaming.cron`, `timezone`, `limit`, `minScore`, `minRecallCount`, and `minUniqueQueries`.
+- Dreaming cadence defaults to each mode's preset schedule. Override cadence with `plugins.entries.memory-core.config.dreaming.frequency` (`core|deep|rem`) and fine-tune with `timezone`, `limit`, `minScore`, `minRecallCount`, and `minUniqueQueries`.

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -1,8 +1,9 @@
 ---
-summary: "CLI reference for `openclaw memory` (status/index/search)"
+summary: "CLI reference for `openclaw memory` (status/index/search/promote)"
 read_when:
   - You want to index or search semantic memory
   - You’re debugging memory availability or indexing
+  - You want to promote recalled short-term memory into `MEMORY.md`
 title: "memory"
 ---
 
@@ -24,6 +25,9 @@ openclaw memory status --deep
 openclaw memory index --force
 openclaw memory search "meeting notes"
 openclaw memory search --query "deployment" --max-results 20
+openclaw memory promote --limit 10 --min-score 0.75
+openclaw memory promote --apply
+openclaw memory promote --json --min-recall-count 0 --min-unique-queries 0
 openclaw memory status --json
 openclaw memory status --deep --index
 openclaw memory status --deep --index --verbose
@@ -58,9 +62,60 @@ openclaw memory index --agent main --verbose
 - `--min-score <n>`: filter out low-score matches.
 - `--json`: print JSON results.
 
+`memory promote`:
+
+- Ranks short-term candidates from `memory/YYYY-MM-DD.md` using weighted recall signals (`frequency`, `relevance`, `query diversity`, `recency`).
+- Uses recall events captured when `memory_search` returns daily-memory hits.
+- Optional auto-dreaming mode: when `plugins.entries.memory-core.config.shortTermPromotion.dreaming.enabled=true`, `memory-core` auto-manages a nightly cron job that triggers promotion in the background (no manual `openclaw cron add` required).
+- `--agent <id>`: scope to a single agent (default: the default agent).
+- `--limit <n>`: max candidates to return/apply.
+- `--min-score <n>`: minimum weighted promotion score.
+- `--min-recall-count <n>`: minimum recall count required for a candidate.
+- `--min-unique-queries <n>`: minimum distinct query count required for a candidate.
+- `--apply`: append selected candidates into `MEMORY.md` and mark them promoted.
+- `--include-promoted`: include already promoted candidates in output.
+- `--json`: print JSON output.
+
+## Dreaming
+
+Dreaming is the overnight reflection pass for memory. It is called "dreaming" because the system revisits what was recalled during the day and decides what is worth keeping long-term.
+
+- It is opt-in and disabled by default.
+- Enable it with `plugins.entries.memory-core.config.shortTermPromotion.dreaming.enabled=true`.
+- When enabled, `memory-core` automatically creates and maintains a managed nightly cron job.
+- Ranking uses weighted signals: recall frequency, retrieval relevance, query diversity, and temporal recency (recent recalls decay over time).
+- Promotion into `MEMORY.md` only happens when quality thresholds are met, so long-term memory stays high signal instead of collecting one-off details.
+
+Default promotion thresholds:
+
+- `minScore=0.75`
+- `minRecallCount=3`
+- `minUniqueQueries=2`
+
+Example:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "memory-core": {
+        "config": {
+          "shortTermPromotion": {
+            "dreaming": {
+              "enabled": true
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 Notes:
 
 - `memory index --verbose` prints per-phase details (provider, model, sources, batch activity).
 - `memory status` includes any extra paths configured via `memorySearch.extraPaths`.
 - If effectively active memory remote API key fields are configured as SecretRefs, the command resolves those values from the active gateway snapshot. If gateway is unavailable, the command fails fast.
 - Gateway version skew note: this command path requires a gateway that supports `secrets.resolve`; older gateways return an unknown-method error.
+- Dreaming schedule defaults to `0 3 * * *`; override with `plugins.entries.memory-core.config.shortTermPromotion.dreaming.cron`, `timezone`, `limit`, `minScore`, `minRecallCount`, and `minUniqueQueries`.

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -82,6 +82,7 @@ Dreaming is the overnight reflection pass for memory. It is called "dreaming" be
 
 - It is opt-in and disabled by default.
 - Enable it with `plugins.entries.memory-core.config.dreaming.mode`.
+- You can toggle modes from chat with `/dreaming off|core|rem|deep`. Run `/dreaming` (or `/dreaming options`) to see what each mode does.
 - When enabled, `memory-core` automatically creates and maintains a managed cron job.
 - Set `dreaming.limit` to `0` if you want dreaming enabled but automatic promotion effectively paused.
 - Ranking uses weighted signals: recall frequency, retrieval relevance, query diversity, and temporal recency (recent recalls decay over time).

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -76,7 +76,7 @@ openclaw memory index --agent main --verbose
 - `--include-promoted`: include already promoted candidates in output.
 - `--json`: print JSON output.
 
-## Dreaming
+## Dreaming (experimental)
 
 Dreaming is the overnight reflection pass for memory. It is called "dreaming" because the system revisits what was recalled during the day and decides what is worth keeping long-term.
 

--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -403,9 +403,7 @@ describe("spawnAndCollect", () => {
       { signal: controller.signal },
     );
 
-    setTimeout(() => {
-      controller.abort();
-    }, 10);
+    controller.abort();
 
     const result = await resultPromise;
     expect(result.error?.name).toBe("AbortError");

--- a/extensions/feishu/src/monitor.webhook.test-helpers.ts
+++ b/extensions/feishu/src/monitor.webhook.test-helpers.ts
@@ -4,6 +4,9 @@ import { vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import type { monitorFeishuProvider } from "./monitor.js";
 
+const WEBHOOK_READY_MAX_ATTEMPTS = 200;
+const WEBHOOK_READY_RETRY_DELAY_MS = 50;
+
 export async function getFreePort(): Promise<number> {
   const server = createServer();
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
@@ -16,7 +19,7 @@ export async function getFreePort(): Promise<number> {
 }
 
 async function waitUntilServerReady(url: string): Promise<void> {
-  for (let i = 0; i < 50; i += 1) {
+  for (let i = 0; i < WEBHOOK_READY_MAX_ATTEMPTS; i += 1) {
     try {
       const response = await fetch(url, { method: "GET" });
       if (response.status >= 200 && response.status < 500) {
@@ -25,7 +28,7 @@ async function waitUntilServerReady(url: string): Promise<void> {
     } catch {
       // retry
     }
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await new Promise((resolve) => setTimeout(resolve, WEBHOOK_READY_RETRY_DELAY_MS));
   }
   throw new Error(`server did not start: ${url}`);
 }
@@ -84,6 +87,7 @@ export async function withRunningWebhookMonitor(
     config: cfg,
     runtime,
     abortSignal: abortController.signal,
+    accountId: params.accountId,
   });
 
   const url = `http://127.0.0.1:${port}${params.path}`;

--- a/extensions/feishu/src/monitor.webhook.test-helpers.ts
+++ b/extensions/feishu/src/monitor.webhook.test-helpers.ts
@@ -6,6 +6,7 @@ import type { monitorFeishuProvider } from "./monitor.js";
 
 const WEBHOOK_READY_MAX_ATTEMPTS = 200;
 const WEBHOOK_READY_RETRY_DELAY_MS = 50;
+const WEBHOOK_MONITOR_START_MAX_ATTEMPTS = 4;
 
 export async function getFreePort(): Promise<number> {
   const server = createServer();
@@ -72,31 +73,44 @@ export async function withRunningWebhookMonitor(
   monitor: typeof monitorFeishuProvider,
   run: (url: string) => Promise<void>,
 ) {
-  const port = await getFreePort();
-  const cfg = buildWebhookConfig({
-    accountId: params.accountId,
-    path: params.path,
-    port,
-    encryptKey: params.encryptKey,
-    verificationToken: params.verificationToken,
-  });
+  let startupError: unknown;
+  for (let attempt = 1; attempt <= WEBHOOK_MONITOR_START_MAX_ATTEMPTS; attempt += 1) {
+    const port = await getFreePort();
+    const cfg = buildWebhookConfig({
+      accountId: params.accountId,
+      path: params.path,
+      port,
+      encryptKey: params.encryptKey,
+      verificationToken: params.verificationToken,
+    });
 
-  const abortController = new AbortController();
-  const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
-  const monitorPromise = monitor({
-    config: cfg,
-    runtime,
-    abortSignal: abortController.signal,
-    accountId: params.accountId,
-  });
+    const abortController = new AbortController();
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const monitorPromise = monitor({
+      config: cfg,
+      runtime,
+      abortSignal: abortController.signal,
+      accountId: params.accountId,
+    });
 
-  const url = `http://127.0.0.1:${port}${params.path}`;
-  await waitUntilServerReady(url);
-
-  try {
-    await run(url);
-  } finally {
-    abortController.abort();
-    await monitorPromise;
+    const url = `http://127.0.0.1:${port}${params.path}`;
+    try {
+      await waitUntilServerReady(url);
+      try {
+        await run(url);
+      } finally {
+        abortController.abort();
+        await monitorPromise.catch(() => undefined);
+      }
+      return;
+    } catch (error) {
+      startupError = error;
+      abortController.abort();
+      await monitorPromise.catch(() => undefined);
+      if (attempt < WEBHOOK_MONITOR_START_MAX_ATTEMPTS) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * WEBHOOK_READY_RETRY_DELAY_MS));
+      }
+    }
   }
+  throw startupError instanceof Error ? startupError : new Error("failed to start webhook monitor");
 }

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -1,5 +1,6 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { registerMemoryCli } from "./src/cli.js";
+import { registerShortTermPromotionDreaming } from "./src/dreaming.js";
 import {
   buildMemoryFlushPlan,
   DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES,
@@ -25,6 +26,7 @@ export default definePluginEntry({
   kind: "memory",
   register(api) {
     registerBuiltInMemoryEmbeddingProviders(api);
+    registerShortTermPromotionDreaming(api);
     api.registerMemoryPromptSection(buildPromptSection);
     api.registerMemoryFlushPlan(buildMemoryFlushPlan);
     api.registerMemoryRuntime(memoryRuntime);

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -1,5 +1,6 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { registerMemoryCli } from "./src/cli.js";
+import { registerDreamingCommand } from "./src/dreaming-command.js";
 import { registerShortTermPromotionDreaming } from "./src/dreaming.js";
 import {
   buildMemoryFlushPlan,
@@ -27,6 +28,7 @@ export default definePluginEntry({
   register(api) {
     registerBuiltInMemoryEmbeddingProviders(api);
     registerShortTermPromotionDreaming(api);
+    registerDreamingCommand(api);
     api.registerMemoryPromptSection(buildPromptSection);
     api.registerMemoryFlushPlan(buildMemoryFlushPlan);
     api.registerMemoryRuntime(memoryRuntime);

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -1,9 +1,84 @@
 {
   "id": "memory-core",
   "kind": "memory",
+  "uiHints": {
+    "shortTermPromotion.dreaming.enabled": {
+      "label": "Enable Dreaming Promotion",
+      "help": "Automatically schedule nightly short-term to long-term memory promotion."
+    },
+    "shortTermPromotion.dreaming.cron": {
+      "label": "Dreaming Cron",
+      "placeholder": "0 3 * * *",
+      "help": "Cron expression for the managed dreaming job."
+    },
+    "shortTermPromotion.dreaming.timezone": {
+      "label": "Dreaming Timezone",
+      "placeholder": "America/Los_Angeles",
+      "help": "IANA timezone for the managed dreaming cron schedule."
+    },
+    "shortTermPromotion.dreaming.limit": {
+      "label": "Promotion Limit",
+      "placeholder": "10",
+      "help": "Maximum short-term candidates promoted per dreaming run."
+    },
+    "shortTermPromotion.dreaming.minScore": {
+      "label": "Promotion Min Score",
+      "placeholder": "0.75",
+      "help": "Minimum weighted rank required for automatic promotion."
+    },
+    "shortTermPromotion.dreaming.minRecallCount": {
+      "label": "Promotion Min Recalls",
+      "placeholder": "3",
+      "help": "Minimum recall count required for automatic promotion."
+    },
+    "shortTermPromotion.dreaming.minUniqueQueries": {
+      "label": "Promotion Min Queries",
+      "placeholder": "2",
+      "help": "Minimum unique query count required for automatic promotion."
+    }
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "shortTermPromotion": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "dreaming": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "cron": {
+                "type": "string"
+              },
+              "timezone": {
+                "type": "string"
+              },
+              "limit": {
+                "type": "number",
+                "minimum": 1
+              },
+              "minScore": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "minRecallCount": {
+                "type": "number",
+                "minimum": 0
+              },
+              "minUniqueQueries": {
+                "type": "number",
+                "minimum": 0
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -19,7 +19,7 @@
     "shortTermPromotion.dreaming.limit": {
       "label": "Promotion Limit",
       "placeholder": "10",
-      "help": "Maximum short-term candidates promoted per dreaming run."
+      "help": "Maximum short-term candidates promoted per dreaming run (set to 0 to skip promotions)."
     },
     "shortTermPromotion.dreaming.minScore": {
       "label": "Promotion Min Score",
@@ -60,7 +60,7 @@
               },
               "limit": {
                 "type": "number",
-                "minimum": 1
+                "minimum": 0
               },
               "minScore": {
                 "type": "number",

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -9,8 +9,8 @@
     },
     "dreaming.frequency": {
       "label": "Dreaming Frequency",
-      "placeholder": "core",
-      "help": "Optional cadence override: core, deep, or rem."
+      "placeholder": "0 3 * * *",
+      "help": "Optional cron cadence override for managed dreaming runs."
     },
     "dreaming.timezone": {
       "label": "Dreaming Timezone",
@@ -51,8 +51,7 @@
             "enum": ["off", "core", "deep", "rem"]
           },
           "frequency": {
-            "type": "string",
-            "enum": ["core", "deep", "rem"]
+            "type": "string"
           },
           "timezone": {
             "type": "string"

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -2,36 +2,37 @@
   "id": "memory-core",
   "kind": "memory",
   "uiHints": {
-    "shortTermPromotion.dreaming.enabled": {
-      "label": "Enable Dreaming Promotion",
-      "help": "Automatically schedule nightly short-term to long-term memory promotion."
+    "dreaming.mode": {
+      "label": "Dreaming Mode",
+      "placeholder": "core",
+      "help": "Select dreaming mode: off, core, deep, or rem."
     },
-    "shortTermPromotion.dreaming.cron": {
-      "label": "Dreaming Cron",
-      "placeholder": "0 3 * * *",
-      "help": "Cron expression for the managed dreaming job."
+    "dreaming.frequency": {
+      "label": "Dreaming Frequency",
+      "placeholder": "core",
+      "help": "Optional cadence override: core, deep, or rem."
     },
-    "shortTermPromotion.dreaming.timezone": {
+    "dreaming.timezone": {
       "label": "Dreaming Timezone",
       "placeholder": "America/Los_Angeles",
       "help": "IANA timezone for the managed dreaming cron schedule."
     },
-    "shortTermPromotion.dreaming.limit": {
+    "dreaming.limit": {
       "label": "Promotion Limit",
       "placeholder": "10",
       "help": "Maximum short-term candidates promoted per dreaming run (set to 0 to skip promotions)."
     },
-    "shortTermPromotion.dreaming.minScore": {
+    "dreaming.minScore": {
       "label": "Promotion Min Score",
       "placeholder": "0.75",
       "help": "Minimum weighted rank required for automatic promotion."
     },
-    "shortTermPromotion.dreaming.minRecallCount": {
+    "dreaming.minRecallCount": {
       "label": "Promotion Min Recalls",
       "placeholder": "3",
       "help": "Minimum recall count required for automatic promotion."
     },
-    "shortTermPromotion.dreaming.minUniqueQueries": {
+    "dreaming.minUniqueQueries": {
       "label": "Promotion Min Queries",
       "placeholder": "2",
       "help": "Minimum unique query count required for automatic promotion."
@@ -41,43 +42,40 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
-      "shortTermPromotion": {
+      "dreaming": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "dreaming": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "enabled": {
-                "type": "boolean"
-              },
-              "cron": {
-                "type": "string"
-              },
-              "timezone": {
-                "type": "string"
-              },
-              "limit": {
-                "type": "number",
-                "minimum": 0
-              },
-              "minScore": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 1
-              },
-              "minRecallCount": {
-                "type": "number",
-                "minimum": 0
-              },
-              "minUniqueQueries": {
-                "type": "number",
-                "minimum": 0
-              }
-            }
+          "mode": {
+            "type": "string",
+            "enum": ["off", "core", "deep", "rem"]
+          },
+          "frequency": {
+            "type": "string",
+            "enum": ["core", "deep", "rem"]
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 0
+          },
+          "minScore": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "minRecallCount": {
+            "type": "number",
+            "minimum": 0
+          },
+          "minUniqueQueries": {
+            "type": "number",
+            "minimum": 0
           }
-        }
+        },
+        "required": ["mode"]
       }
     }
   }

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -760,7 +760,7 @@ export async function runMemorySearch(
         typeof (manager as { status?: () => { workspaceDir?: string } }).status === "function"
           ? manager.status().workspaceDir
           : undefined;
-      await recordShortTermRecalls({
+      void recordShortTermRecalls({
         workspaceDir,
         query,
         results,

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -25,7 +25,17 @@ import {
   withProgress,
   withProgressTotals,
 } from "./cli.host.runtime.js";
-import type { MemoryCommandOptions, MemorySearchCommandOptions } from "./cli.types.js";
+import type {
+  MemoryCommandOptions,
+  MemoryPromoteCommandOptions,
+  MemorySearchCommandOptions,
+} from "./cli.types.js";
+import {
+  applyShortTermPromotions,
+  recordShortTermRecalls,
+  rankShortTermPromotionCandidates,
+  resolveShortTermRecallStorePath,
+} from "./short-term-promotion.js";
 
 type MemoryManager = NonNullable<Awaited<ReturnType<typeof getMemorySearchManager>>["manager"]>;
 type MemoryManagerPurpose = Parameters<typeof getMemorySearchManager>[0]["purpose"];
@@ -746,6 +756,17 @@ export async function runMemorySearch(
         process.exitCode = 1;
         return;
       }
+      const workspaceDir =
+        typeof (manager as { status?: () => { workspaceDir?: string } }).status === "function"
+          ? manager.status().workspaceDir
+          : undefined;
+      await recordShortTermRecalls({
+        workspaceDir,
+        query,
+        results,
+      }).catch(() => {
+        // Recall tracking is best-effort and must not block normal search results.
+      });
       if (opts.json) {
         defaultRuntime.writeJson({ results });
         return;
@@ -766,6 +787,130 @@ export async function runMemorySearch(
         );
         lines.push(colorize(rich, theme.muted, result.snippet));
         lines.push("");
+      }
+      defaultRuntime.log(lines.join("\n").trim());
+    },
+  });
+}
+
+export async function runMemoryPromote(opts: MemoryPromoteCommandOptions) {
+  const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory promote");
+  emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
+  const agentId = resolveAgent(cfg, opts.agent);
+
+  await withMemoryManagerForAgent({
+    cfg,
+    agentId,
+    purpose: "status",
+    run: async (manager) => {
+      const status = manager.status();
+      const workspaceDir = status.workspaceDir?.trim();
+      if (!workspaceDir) {
+        defaultRuntime.error("Memory promote requires a resolvable workspace directory.");
+        process.exitCode = 1;
+        return;
+      }
+
+      let candidates: Awaited<ReturnType<typeof rankShortTermPromotionCandidates>>;
+      try {
+        candidates = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          limit: opts.limit,
+          minScore: opts.minScore,
+          minRecallCount: opts.minRecallCount,
+          minUniqueQueries: opts.minUniqueQueries,
+          includePromoted: Boolean(opts.includePromoted),
+        });
+      } catch (err) {
+        defaultRuntime.error(`Memory promote ranking failed: ${formatErrorMessage(err)}`);
+        process.exitCode = 1;
+        return;
+      }
+
+      let applyResult: Awaited<ReturnType<typeof applyShortTermPromotions>> | undefined;
+      if (opts.apply) {
+        try {
+          applyResult = await applyShortTermPromotions({
+            workspaceDir,
+            candidates,
+            limit: opts.limit,
+            minScore: opts.minScore,
+            minRecallCount: opts.minRecallCount,
+            minUniqueQueries: opts.minUniqueQueries,
+          });
+        } catch (err) {
+          defaultRuntime.error(`Memory promote apply failed: ${formatErrorMessage(err)}`);
+          process.exitCode = 1;
+          return;
+        }
+      }
+
+      const storePath = resolveShortTermRecallStorePath(workspaceDir);
+
+      if (opts.json) {
+        defaultRuntime.writeJson({
+          workspaceDir,
+          storePath,
+          candidates,
+          apply: applyResult
+            ? {
+                applied: applyResult.applied,
+                memoryPath: applyResult.memoryPath,
+                appliedCandidates: applyResult.appliedCandidates,
+              }
+            : undefined,
+        });
+        return;
+      }
+
+      if (candidates.length === 0) {
+        defaultRuntime.log("No short-term recall candidates.");
+        defaultRuntime.log(`Recall store: ${shortenHomePath(storePath)}`);
+        return;
+      }
+
+      const rich = isRich();
+      const lines: string[] = [];
+      lines.push(
+        `${colorize(rich, theme.heading, "Short-Term Promotion Candidates")} ${colorize(
+          rich,
+          theme.muted,
+          `(${agentId})`,
+        )}`,
+      );
+      lines.push(`${colorize(rich, theme.muted, "Recall store:")} ${shortenHomePath(storePath)}`);
+      for (const candidate of candidates) {
+        lines.push(
+          `${colorize(rich, theme.success, candidate.score.toFixed(3))} ${colorize(
+            rich,
+            theme.accent,
+            `${shortenHomePath(candidate.path)}:${candidate.startLine}-${candidate.endLine}`,
+          )}`,
+        );
+        lines.push(
+          colorize(
+            rich,
+            theme.muted,
+            `recalls=${candidate.recallCount} avg=${candidate.avgScore.toFixed(3)} queries=${candidate.uniqueQueries} age=${candidate.ageDays.toFixed(1)}d`,
+          ),
+        );
+        if (candidate.snippet) {
+          lines.push(colorize(rich, theme.muted, candidate.snippet));
+        }
+        lines.push("");
+      }
+      if (applyResult) {
+        if (applyResult.applied > 0) {
+          lines.push(
+            colorize(
+              rich,
+              theme.success,
+              `Promoted ${applyResult.applied} candidate(s) to ${shortenHomePath(applyResult.memoryPath)}.`,
+            ),
+          );
+        } else {
+          lines.push(colorize(rich, theme.warn, "No candidates met apply criteria."));
+        }
       }
       defaultRuntime.log(lines.join("\n").trim());
     },

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -107,6 +107,25 @@ describe("memory cli", () => {
     );
   }
 
+  async function waitFor<T>(task: () => Promise<T>, timeoutMs: number = 1500): Promise<T> {
+    const startedAt = Date.now();
+    let lastError: unknown;
+    while (Date.now() - startedAt < timeoutMs) {
+      try {
+        return await task();
+      } catch (error) {
+        lastError = error;
+        await new Promise((resolve) => {
+          setTimeout(resolve, 20);
+        });
+      }
+    }
+    if (lastError instanceof Error) {
+      throw lastError;
+    }
+    throw new Error("Timed out waiting for async test condition");
+  }
+
   async function runMemoryCli(args: string[]) {
     const program = new Command();
     program.name("test");
@@ -615,7 +634,7 @@ describe("memory cli", () => {
       await runMemoryCli(["search", "glacier", "--json"]);
 
       const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");
-      const storeRaw = await fs.readFile(storePath, "utf-8");
+      const storeRaw = await waitFor(async () => await fs.readFile(storePath, "utf-8"));
       const store = JSON.parse(storeRaw) as {
         entries?: Record<string, { path: string; recallCount: number }>;
       };

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -9,6 +9,7 @@ import {
   spyRuntimeJson,
   spyRuntimeLogs,
 } from "../../../src/cli/test-runtime-capture.js";
+import { recordShortTermRecalls } from "./short-term-promotion.js";
 
 const getMemorySearchManager = vi.hoisted(() => vi.fn());
 const loadConfig = vi.hoisted(() => vi.fn(() => ({})));
@@ -147,6 +148,15 @@ describe("memory cli", () => {
     }
   }
 
+  async function withTempWorkspace(run: (workspaceDir: string) => Promise<void>) {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-cli-promote-"));
+    try {
+      await run(workspaceDir);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  }
+
   async function expectCloseFailureAfterCommand(params: {
     args: string[];
     manager: Record<string, unknown>;
@@ -252,6 +262,8 @@ describe("memory cli", () => {
     expect(helpText).toContain("Quick search using positional query.");
     expect(helpText).toContain('openclaw memory search --query "deployment" --max-results 20');
     expect(helpText).toContain("Limit results for focused troubleshooting.");
+    expect(helpText).toContain("openclaw memory promote --apply");
+    expect(helpText).toContain("Append top-ranked short-term candidates into MEMORY.md.");
   });
 
   it("prints vector error when unavailable", async () => {
@@ -579,5 +591,148 @@ describe("memory cli", () => {
     expect(Array.isArray(payload.results)).toBe(true);
     expect(payload.results).toHaveLength(1);
     expect(close).toHaveBeenCalled();
+  });
+
+  it("records short-term recall entries from memory search hits", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const close = vi.fn(async () => {});
+      const search = vi.fn(async () => [
+        {
+          path: "memory/2026-04-03.md",
+          startLine: 1,
+          endLine: 2,
+          score: 0.91,
+          snippet: "Move backups to S3 Glacier.",
+          source: "memory",
+        },
+      ]);
+      mockManager({
+        search,
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      await runMemoryCli(["search", "glacier", "--json"]);
+
+      const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");
+      const storeRaw = await fs.readFile(storePath, "utf-8");
+      const store = JSON.parse(storeRaw) as {
+        entries?: Record<string, { path: string; recallCount: number }>;
+      };
+      const entries = Object.values(store.entries ?? {});
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        path: "memory/2026-04-03.md",
+        recallCount: 1,
+      });
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("prints no candidates when promote has no short-term recall data", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      const log = spyRuntimeLogs(defaultRuntime);
+      await runMemoryCli(["promote"]);
+
+      expect(log).toHaveBeenCalledWith("No short-term recall candidates.");
+      expect(close).toHaveBeenCalled();
+      expect(process.exitCode).toBeUndefined();
+    });
+  });
+
+  it("prints promote candidates as json", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "router notes",
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            startLine: 4,
+            endLine: 8,
+            score: 0.86,
+            snippet: "Configured VLAN 10 for IoT on router",
+            source: "memory",
+          },
+        ],
+      });
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      const writeJson = spyRuntimeJson(defaultRuntime);
+      await runMemoryCli([
+        "promote",
+        "--json",
+        "--min-score",
+        "0",
+        "--min-recall-count",
+        "0",
+        "--min-unique-queries",
+        "0",
+      ]);
+
+      const payload = firstWrittenJsonArg<{ candidates: unknown[] }>(writeJson);
+      expect(payload).not.toBeNull();
+      if (!payload) {
+        throw new Error("expected json payload");
+      }
+      expect(Array.isArray(payload.candidates)).toBe(true);
+      expect(payload.candidates).toHaveLength(1);
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("applies top promote candidates into MEMORY.md", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "network setup",
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 10,
+            endLine: 14,
+            score: 0.91,
+            snippet: "Gateway host uses local mode and binds loopback port 18789",
+            source: "memory",
+          },
+        ],
+      });
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      const log = spyRuntimeLogs(defaultRuntime);
+      await runMemoryCli([
+        "promote",
+        "--apply",
+        "--min-score",
+        "0",
+        "--min-recall-count",
+        "0",
+        "--min-unique-queries",
+        "0",
+      ]);
+
+      const memoryPath = path.join(workspaceDir, "MEMORY.md");
+      const memoryText = await fs.readFile(memoryPath, "utf-8");
+      expect(memoryText).toContain("Promoted From Short-Term Memory");
+      expect(memoryText).toContain("memory/2026-04-01.md:10-14");
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("Promoted 1 candidate(s) to"));
+      expect(close).toHaveBeenCalled();
+    });
   });
 });

--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -4,7 +4,16 @@ import {
   formatHelpExamples,
   theme,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-cli";
-import type { MemoryCommandOptions, MemorySearchCommandOptions } from "./cli.types.js";
+import type {
+  MemoryCommandOptions,
+  MemoryPromoteCommandOptions,
+  MemorySearchCommandOptions,
+} from "./cli.types.js";
+import {
+  DEFAULT_PROMOTION_MIN_RECALL_COUNT,
+  DEFAULT_PROMOTION_MIN_SCORE,
+  DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES,
+} from "./short-term-promotion.js";
 
 type MemoryCliRuntime = typeof import("./cli.runtime.js");
 
@@ -30,6 +39,11 @@ async function runMemorySearch(queryArg: string | undefined, opts: MemorySearchC
   await runtime.runMemorySearch(queryArg, opts);
 }
 
+async function runMemoryPromote(opts: MemoryPromoteCommandOptions) {
+  const runtime = await loadMemoryCliRuntime();
+  await runtime.runMemoryPromote(opts);
+}
+
 export function registerMemoryCli(program: Command) {
   const memory = program
     .command("memory")
@@ -45,6 +59,14 @@ export function registerMemoryCli(program: Command) {
           [
             'openclaw memory search --query "deployment" --max-results 20',
             "Limit results for focused troubleshooting.",
+          ],
+          [
+            `openclaw memory promote --limit 10 --min-score ${DEFAULT_PROMOTION_MIN_SCORE}`,
+            "Review weighted short-term candidates for long-term memory.",
+          ],
+          [
+            "openclaw memory promote --apply",
+            "Append top-ranked short-term candidates into MEMORY.md.",
           ],
           ["openclaw memory status --json", "Output machine-readable JSON (good for scripts)."],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/memory", "docs.openclaw.ai/cli/memory")}\n`,
@@ -83,5 +105,32 @@ export function registerMemoryCli(program: Command) {
     .option("--json", "Print JSON")
     .action(async (queryArg: string | undefined, opts: MemorySearchCommandOptions) => {
       await runMemorySearch(queryArg, opts);
+    });
+
+  memory
+    .command("promote")
+    .description("Rank short-term recalls and optionally append top entries to MEMORY.md")
+    .option("--agent <id>", "Agent id (default: default agent)")
+    .option("--limit <n>", "Max candidates", (value: string) => Number(value))
+    .option(
+      "--min-score <n>",
+      `Minimum weighted score (default: ${DEFAULT_PROMOTION_MIN_SCORE})`,
+      (value: string) => Number(value),
+    )
+    .option(
+      "--min-recall-count <n>",
+      `Minimum recall count (default: ${DEFAULT_PROMOTION_MIN_RECALL_COUNT})`,
+      (value: string) => Number(value),
+    )
+    .option(
+      "--min-unique-queries <n>",
+      `Minimum distinct query count (default: ${DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES})`,
+      (value: string) => Number(value),
+    )
+    .option("--apply", "Append selected candidates to MEMORY.md", false)
+    .option("--include-promoted", "Include already promoted candidates", false)
+    .option("--json", "Print JSON")
+    .action(async (opts: MemoryPromoteCommandOptions) => {
+      await runMemoryPromote(opts);
     });
 }

--- a/extensions/memory-core/src/cli.types.ts
+++ b/extensions/memory-core/src/cli.types.ts
@@ -12,3 +12,12 @@ export type MemorySearchCommandOptions = MemoryCommandOptions & {
   maxResults?: number;
   minScore?: number;
 };
+
+export type MemoryPromoteCommandOptions = MemoryCommandOptions & {
+  limit?: number;
+  minScore?: number;
+  minRecallCount?: number;
+  minUniqueQueries?: number;
+  apply?: boolean;
+  includePromoted?: boolean;
+};

--- a/extensions/memory-core/src/dreaming-command.test.ts
+++ b/extensions/memory-core/src/dreaming-command.test.ts
@@ -1,0 +1,145 @@
+import type {
+  OpenClawPluginCommandDefinition,
+  PluginCommandContext,
+} from "openclaw/plugin-sdk/core";
+import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
+import { describe, expect, it, vi } from "vitest";
+import { registerDreamingCommand } from "./dreaming-command.js";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function resolveStoredDreaming(config: OpenClawConfig): Record<string, unknown> {
+  const entry = asRecord(config.plugins?.entries?.["memory-core"]);
+  const pluginConfig = asRecord(entry?.config);
+  return asRecord(pluginConfig?.dreaming) ?? {};
+}
+
+function createHarness(initialConfig: OpenClawConfig = {}) {
+  let command: OpenClawPluginCommandDefinition | undefined;
+  let runtimeConfig: OpenClawConfig = initialConfig;
+
+  const runtime = {
+    config: {
+      loadConfig: vi.fn(() => runtimeConfig),
+      writeConfigFile: vi.fn(async (nextConfig: OpenClawConfig) => {
+        runtimeConfig = nextConfig;
+      }),
+    },
+  } as unknown as OpenClawPluginApi["runtime"];
+
+  const api = {
+    runtime,
+    registerCommand: vi.fn((definition: OpenClawPluginCommandDefinition) => {
+      command = definition;
+    }),
+  } as unknown as OpenClawPluginApi;
+
+  registerDreamingCommand(api);
+
+  if (!command) {
+    throw new Error("memory-core did not register /dreaming");
+  }
+
+  return {
+    command,
+    runtime,
+    getRuntimeConfig: () => runtimeConfig,
+  };
+}
+
+function createCommandContext(args?: string): PluginCommandContext {
+  return {
+    channel: "webchat",
+    isAuthorizedSender: true,
+    commandBody: args ? `/dreaming ${args}` : "/dreaming",
+    args,
+    config: {},
+    requestConversationBinding: async () => ({ status: "error", message: "unsupported" }),
+    detachConversationBinding: async () => ({ removed: false }),
+    getCurrentConversationBinding: async () => null,
+  };
+}
+
+describe("memory-core /dreaming command", () => {
+  it("registers with an options-aware description", () => {
+    const { command } = createHarness();
+    expect(command.name).toBe("dreaming");
+    expect(command.acceptsArgs).toBe(true);
+    expect(command.description).toContain("off|core|rem|deep");
+  });
+
+  it("shows mode explanations when invoked without args", async () => {
+    const { command } = createHarness();
+    const result = await command.handler(createCommandContext());
+
+    expect(result.text).toContain("Usage: /dreaming off|core|rem|deep");
+    expect(result.text).toContain("Dreaming status:");
+    expect(result.text).toContain("- off: disable automatic short-term to long-term promotion.");
+    expect(result.text).toContain("- core: cadence=0 3 * * *;");
+    expect(result.text).toContain("- rem: cadence=0 */6 * * *;");
+    expect(result.text).toContain("- deep: cadence=0 */12 * * *;");
+  });
+
+  it("persists mode changes under plugins.entries.memory-core.config.dreaming.mode", async () => {
+    const { command, runtime, getRuntimeConfig } = createHarness({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                minScore: 0.9,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const result = await command.handler(createCommandContext("rem"));
+
+    expect(runtime.config.writeConfigFile).toHaveBeenCalledTimes(1);
+    expect(resolveStoredDreaming(getRuntimeConfig())).toMatchObject({
+      mode: "rem",
+      minScore: 0.9,
+    });
+    expect(result.text).toContain("Dreaming mode set to rem.");
+    expect(result.text).toContain("minScore=0.9");
+  });
+
+  it("returns status without mutating config", async () => {
+    const { command, runtime } = createHarness({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                mode: "deep",
+                timezone: "America/Los_Angeles",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const result = await command.handler(createCommandContext("status"));
+
+    expect(result.text).toContain("Dreaming status:");
+    expect(result.text).toContain("- mode: deep");
+    expect(result.text).toContain("- cadence: 0 */12 * * * (America/Los_Angeles)");
+    expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("shows usage for invalid args and does not mutate config", async () => {
+    const { command, runtime } = createHarness();
+    const result = await command.handler(createCommandContext("unknown-mode"));
+
+    expect(result.text).toContain("Usage: /dreaming off|core|rem|deep");
+    expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/memory-core/src/dreaming-command.ts
+++ b/extensions/memory-core/src/dreaming-command.ts
@@ -1,0 +1,168 @@
+import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
+import { resolveShortTermPromotionDreamingConfig } from "./dreaming.js";
+
+type DreamingMode = "off" | "core" | "rem" | "deep";
+
+const DREAMING_MODE_LIST = [
+  "off",
+  "core",
+  "rem",
+  "deep",
+] as const satisfies readonly DreamingMode[];
+const DEFAULT_DREAMING_MODE: DreamingMode = "off";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function normalizeDreamingMode(value: unknown): DreamingMode | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (
+    normalized === "off" ||
+    normalized === "core" ||
+    normalized === "rem" ||
+    normalized === "deep"
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+function resolveMemoryCorePluginConfig(cfg: OpenClawConfig): Record<string, unknown> {
+  const entry = asRecord(cfg.plugins?.entries?.["memory-core"]);
+  return asRecord(entry?.config) ?? {};
+}
+
+function resolveDreamingModeFromConfig(pluginConfig: Record<string, unknown>): DreamingMode {
+  const dreaming = asRecord(pluginConfig.dreaming);
+  return normalizeDreamingMode(dreaming?.mode) ?? DEFAULT_DREAMING_MODE;
+}
+
+function updateDreamingModeInConfig(cfg: OpenClawConfig, mode: DreamingMode): OpenClawConfig {
+  const entries = { ...(cfg.plugins?.entries ?? {}) };
+  const existingEntry = asRecord(entries["memory-core"]) ?? {};
+  const existingConfig = asRecord(existingEntry.config) ?? {};
+  const existingDreaming = asRecord(existingConfig.dreaming) ?? {};
+  entries["memory-core"] = {
+    ...existingEntry,
+    config: {
+      ...existingConfig,
+      dreaming: {
+        ...existingDreaming,
+        mode,
+      },
+    },
+  };
+
+  return {
+    ...cfg,
+    plugins: {
+      ...cfg.plugins,
+      entries,
+    },
+  };
+}
+
+function formatModeGuideLine(mode: DreamingMode): string {
+  if (mode === "off") {
+    return "- off: disable automatic short-term to long-term promotion.";
+  }
+  const resolved = resolveShortTermPromotionDreamingConfig({
+    pluginConfig: {
+      dreaming: {
+        mode,
+      },
+    },
+  });
+  return (
+    `- ${mode}: cadence=${resolved.cron}; ` +
+    `minScore=${resolved.minScore}, minRecallCount=${resolved.minRecallCount}, ` +
+    `minUniqueQueries=${resolved.minUniqueQueries}.`
+  );
+}
+
+function formatModeGuide(): string {
+  return DREAMING_MODE_LIST.map((mode) => formatModeGuideLine(mode)).join("\n");
+}
+
+function formatStatus(cfg: OpenClawConfig): string {
+  const pluginConfig = resolveMemoryCorePluginConfig(cfg);
+  const mode = resolveDreamingModeFromConfig(pluginConfig);
+  const resolved = resolveShortTermPromotionDreamingConfig({
+    pluginConfig,
+    cfg,
+  });
+  const cadence = resolved.enabled ? resolved.cron : "disabled";
+  const timezone = resolved.enabled && resolved.timezone ? ` (${resolved.timezone})` : "";
+
+  return [
+    "Dreaming status:",
+    `- mode: ${mode}`,
+    `- cadence: ${cadence}${timezone}`,
+    `- limit: ${resolved.limit}`,
+    `- thresholds: minScore=${resolved.minScore}, minRecallCount=${resolved.minRecallCount}, minUniqueQueries=${resolved.minUniqueQueries}`,
+  ].join("\n");
+}
+
+function formatUsage(includeStatus: string): string {
+  return [
+    "Usage: /dreaming off|core|rem|deep",
+    "Use /dreaming status for current settings.",
+    "",
+    includeStatus,
+    "",
+    "Modes:",
+    formatModeGuide(),
+  ].join("\n");
+}
+
+export function registerDreamingCommand(api: OpenClawPluginApi): void {
+  api.registerCommand({
+    name: "dreaming",
+    description: "Configure memory dreaming mode (off|core|rem|deep).",
+    acceptsArgs: true,
+    handler: async (ctx) => {
+      const args = ctx.args?.trim() ?? "";
+      const firstToken = args.split(/\s+/).filter(Boolean)[0]?.toLowerCase() ?? "";
+      const currentConfig = api.runtime.config.loadConfig();
+
+      if (
+        !firstToken ||
+        firstToken === "help" ||
+        firstToken === "options" ||
+        firstToken === "modes"
+      ) {
+        return { text: formatUsage(formatStatus(currentConfig)) };
+      }
+
+      if (firstToken === "status") {
+        return { text: formatStatus(currentConfig) };
+      }
+
+      const requestedMode = normalizeDreamingMode(firstToken);
+      if (!requestedMode) {
+        return { text: formatUsage(formatStatus(currentConfig)) };
+      }
+
+      const nextConfig = updateDreamingModeInConfig(currentConfig, requestedMode);
+      await api.runtime.config.writeConfigFile(nextConfig);
+
+      return {
+        text: [
+          `Dreaming mode set to ${requestedMode}.`,
+          "",
+          formatStatus(nextConfig),
+          "",
+          "Modes:",
+          formatModeGuide(),
+        ].join("\n"),
+      };
+    },
+  });
+}

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -1,0 +1,421 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing,
+  reconcileShortTermDreamingCronJob,
+  resolveShortTermPromotionDreamingConfig,
+  runShortTermDreamingPromotionIfTriggered,
+} from "./dreaming.js";
+import { recordShortTermRecalls } from "./short-term-promotion.js";
+
+const constants = __testing.constants;
+
+type CronParam = NonNullable<Parameters<typeof reconcileShortTermDreamingCronJob>[0]["cron"]>;
+type CronJobLike = Awaited<ReturnType<CronParam["list"]>>[number];
+type CronAddInput = Parameters<CronParam["add"]>[0];
+type CronPatch = Parameters<CronParam["update"]>[1];
+
+function createLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function createCronHarness(initialJobs: CronJobLike[] = []) {
+  const jobs: CronJobLike[] = [...initialJobs];
+  const addCalls: CronAddInput[] = [];
+  const updateCalls: Array<{ id: string; patch: CronPatch }> = [];
+  const removeCalls: string[] = [];
+
+  const cron: CronParam = {
+    async list() {
+      return jobs.map((job) => ({
+        ...job,
+        ...(job.schedule ? { schedule: { ...job.schedule } } : {}),
+        ...(job.payload ? { payload: { ...job.payload } } : {}),
+      }));
+    },
+    async add(input) {
+      addCalls.push(input);
+      jobs.push({
+        id: `job-${jobs.length + 1}`,
+        name: input.name,
+        description: input.description,
+        enabled: input.enabled,
+        schedule: { ...input.schedule },
+        sessionTarget: input.sessionTarget,
+        wakeMode: input.wakeMode,
+        payload: { ...input.payload },
+        createdAtMs: Date.now(),
+      });
+      return {};
+    },
+    async update(id, patch) {
+      updateCalls.push({ id, patch });
+      const index = jobs.findIndex((entry) => entry.id === id);
+      if (index < 0) {
+        return {};
+      }
+      const current = jobs[index]!;
+      jobs[index] = {
+        ...current,
+        ...(patch.name ? { name: patch.name } : {}),
+        ...(patch.description ? { description: patch.description } : {}),
+        ...(typeof patch.enabled === "boolean" ? { enabled: patch.enabled } : {}),
+        ...(patch.schedule ? { schedule: { ...patch.schedule } } : {}),
+        ...(patch.sessionTarget ? { sessionTarget: patch.sessionTarget } : {}),
+        ...(patch.wakeMode ? { wakeMode: patch.wakeMode } : {}),
+        ...(patch.payload ? { payload: { ...patch.payload } } : {}),
+      };
+      return {};
+    },
+    async remove(id) {
+      removeCalls.push(id);
+      const index = jobs.findIndex((entry) => entry.id === id);
+      if (index >= 0) {
+        jobs.splice(index, 1);
+      }
+      return { removed: index >= 0 };
+    },
+  };
+
+  return { cron, jobs, addCalls, updateCalls, removeCalls };
+}
+
+describe("short-term dreaming config", () => {
+  it("uses defaults and user timezone fallback", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          userTimezone: "America/Los_Angeles",
+        },
+      },
+    } as OpenClawConfig;
+    const resolved = resolveShortTermPromotionDreamingConfig({
+      pluginConfig: {},
+      cfg,
+    });
+    expect(resolved).toEqual({
+      enabled: false,
+      cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+      timezone: "America/Los_Angeles",
+      limit: constants.DEFAULT_DREAMING_LIMIT,
+      minScore: constants.DEFAULT_DREAMING_MIN_SCORE,
+      minRecallCount: constants.DEFAULT_DREAMING_MIN_RECALL_COUNT,
+      minUniqueQueries: constants.DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
+    });
+  });
+
+  it("reads explicit dreaming config values", () => {
+    const resolved = resolveShortTermPromotionDreamingConfig({
+      pluginConfig: {
+        shortTermPromotion: {
+          dreaming: {
+            enabled: true,
+            cron: "15 2 * * *",
+            timezone: "UTC",
+            limit: 7,
+            minScore: 0.4,
+            minRecallCount: 2,
+            minUniqueQueries: 3,
+          },
+        },
+      },
+    });
+    expect(resolved).toEqual({
+      enabled: true,
+      cron: "15 2 * * *",
+      timezone: "UTC",
+      limit: 7,
+      minScore: 0.4,
+      minRecallCount: 2,
+      minUniqueQueries: 3,
+    });
+  });
+
+  it("falls back to defaults when thresholds are negative", () => {
+    const resolved = resolveShortTermPromotionDreamingConfig({
+      pluginConfig: {
+        shortTermPromotion: {
+          dreaming: {
+            enabled: true,
+            minScore: -0.2,
+            minRecallCount: -2,
+            minUniqueQueries: -4,
+          },
+        },
+      },
+    });
+    expect(resolved).toMatchObject({
+      enabled: true,
+      minScore: constants.DEFAULT_DREAMING_MIN_SCORE,
+      minRecallCount: constants.DEFAULT_DREAMING_MIN_RECALL_COUNT,
+      minUniqueQueries: constants.DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
+    });
+  });
+});
+
+describe("short-term dreaming cron reconciliation", () => {
+  it("creates a managed cron job when enabled", async () => {
+    const harness = createCronHarness();
+    const logger = createLogger();
+    const result = await reconcileShortTermDreamingCronJob({
+      cron: harness.cron,
+      config: {
+        enabled: true,
+        cron: "0 1 * * *",
+        timezone: "UTC",
+        limit: 8,
+        minScore: 0.5,
+        minRecallCount: 4,
+        minUniqueQueries: 5,
+      },
+      logger,
+    });
+
+    expect(result.status).toBe("added");
+    expect(harness.addCalls).toHaveLength(1);
+    expect(harness.addCalls[0]).toMatchObject({
+      name: constants.MANAGED_DREAMING_CRON_NAME,
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: {
+        kind: "systemEvent",
+        text: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      },
+      schedule: {
+        kind: "cron",
+        expr: "0 1 * * *",
+        tz: "UTC",
+      },
+    });
+  });
+
+  it("updates drifted managed jobs and prunes duplicates", async () => {
+    const desiredConfig = {
+      enabled: true,
+      cron: "0 3 * * *",
+      timezone: "America/Los_Angeles",
+      limit: 10,
+      minScore: constants.DEFAULT_DREAMING_MIN_SCORE,
+      minRecallCount: constants.DEFAULT_DREAMING_MIN_RECALL_COUNT,
+      minUniqueQueries: constants.DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
+    } as const;
+    const desired = __testing.buildManagedDreamingCronJob(desiredConfig);
+    const stalePrimary: CronJobLike = {
+      id: "job-primary",
+      name: desired.name,
+      description: desired.description,
+      enabled: false,
+      schedule: { kind: "cron", expr: "0 9 * * *" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: {
+        kind: "systemEvent",
+        text: "stale-text",
+      },
+      createdAtMs: 1,
+    };
+    const duplicate: CronJobLike = {
+      ...desired,
+      id: "job-duplicate",
+      createdAtMs: 2,
+    };
+    const unmanaged: CronJobLike = {
+      id: "job-unmanaged",
+      name: "other",
+      description: "not managed",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 8 * * *" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "hello" },
+      createdAtMs: 3,
+    };
+    const harness = createCronHarness([stalePrimary, duplicate, unmanaged]);
+    const logger = createLogger();
+
+    const result = await reconcileShortTermDreamingCronJob({
+      cron: harness.cron,
+      config: desiredConfig,
+      logger,
+    });
+
+    expect(result.status).toBe("updated");
+    expect(result.removed).toBe(1);
+    expect(harness.removeCalls).toEqual(["job-duplicate"]);
+    expect(harness.updateCalls).toHaveLength(1);
+    expect(harness.updateCalls[0]).toMatchObject({
+      id: "job-primary",
+      patch: {
+        enabled: true,
+        schedule: desired.schedule,
+        payload: desired.payload,
+      },
+    });
+  });
+
+  it("removes managed dreaming jobs when disabled", async () => {
+    const managedJob: CronJobLike = {
+      id: "job-managed",
+      name: constants.MANAGED_DREAMING_CRON_NAME,
+      description: `${constants.MANAGED_DREAMING_CRON_TAG} test`,
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 3 * * *" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: constants.DREAMING_SYSTEM_EVENT_TEXT },
+      createdAtMs: 10,
+    };
+    const unmanagedJob: CronJobLike = {
+      id: "job-other",
+      name: "Daily report",
+      description: "other",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 7 * * *" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "report" },
+      createdAtMs: 11,
+    };
+    const harness = createCronHarness([managedJob, unmanagedJob]);
+    const logger = createLogger();
+
+    const result = await reconcileShortTermDreamingCronJob({
+      cron: harness.cron,
+      config: {
+        enabled: false,
+        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+        limit: constants.DEFAULT_DREAMING_LIMIT,
+        minScore: constants.DEFAULT_DREAMING_MIN_SCORE,
+        minRecallCount: constants.DEFAULT_DREAMING_MIN_RECALL_COUNT,
+        minUniqueQueries: constants.DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
+      },
+      logger,
+    });
+
+    expect(result).toEqual({ status: "disabled", removed: 1 });
+    expect(harness.removeCalls).toEqual(["job-managed"]);
+    expect(harness.jobs.map((entry) => entry.id)).toEqual(["job-other"]);
+  });
+});
+
+describe("short-term dreaming trigger", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  it("applies promotions when the managed dreaming heartbeat event fires", async () => {
+    const logger = createLogger();
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-dreaming-"));
+    tempDirs.push(workspaceDir);
+
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "backup policy",
+      results: [
+        {
+          path: "memory/2026-04-02.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.9,
+          snippet: "Move backups to S3 Glacier.",
+          source: "memory",
+        },
+      ],
+    });
+
+    const result = await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      trigger: "heartbeat",
+      workspaceDir,
+      config: {
+        enabled: true,
+        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+        limit: 10,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      },
+      logger,
+    });
+
+    expect(result?.handled).toBe(true);
+    const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+    expect(memoryText).toContain("Move backups to S3 Glacier.");
+  });
+
+  it("keeps one-off recalls out of long-term memory under default thresholds", async () => {
+    const logger = createLogger();
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-dreaming-strict-"));
+    tempDirs.push(workspaceDir);
+
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "glacier",
+      results: [
+        {
+          path: "memory/2026-04-03.md",
+          startLine: 1,
+          endLine: 2,
+          score: 0.95,
+          snippet: "Move backups to S3 Glacier.",
+          source: "memory",
+        },
+      ],
+    });
+
+    const result = await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      trigger: "heartbeat",
+      workspaceDir,
+      config: {
+        enabled: true,
+        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+        limit: constants.DEFAULT_DREAMING_LIMIT,
+        minScore: constants.DEFAULT_DREAMING_MIN_SCORE,
+        minRecallCount: constants.DEFAULT_DREAMING_MIN_RECALL_COUNT,
+        minUniqueQueries: constants.DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
+      },
+      logger,
+    });
+
+    expect(result?.handled).toBe(true);
+    const memoryText = await fs
+      .readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8")
+      .catch((err: unknown) => {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          return "";
+        }
+        throw err;
+      });
+    expect(memoryText).toBe("");
+  });
+
+  it("ignores non-heartbeat triggers", async () => {
+    const logger = createLogger();
+    const result = await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      trigger: "user",
+      workspaceDir: "/tmp/workspace",
+      config: {
+        enabled: true,
+        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+        limit: 10,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      },
+      logger,
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -122,7 +122,7 @@ describe("short-term dreaming config", () => {
       pluginConfig: {
         dreaming: {
           mode: "deep",
-          frequency: "rem",
+          frequency: "15 2 * * *",
           timezone: "UTC",
           limit: 7,
           minScore: 0.4,
@@ -133,7 +133,7 @@ describe("short-term dreaming config", () => {
     });
     expect(resolved).toEqual({
       enabled: true,
-      cron: constants.DREAMING_PRESET_DEFAULTS.rem.cron,
+      cron: "15 2 * * *",
       timezone: "UTC",
       limit: 7,
       minScore: 0.4,

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -120,22 +120,20 @@ describe("short-term dreaming config", () => {
   it("reads explicit dreaming config values", () => {
     const resolved = resolveShortTermPromotionDreamingConfig({
       pluginConfig: {
-        shortTermPromotion: {
-          dreaming: {
-            enabled: true,
-            cron: "15 2 * * *",
-            timezone: "UTC",
-            limit: 7,
-            minScore: 0.4,
-            minRecallCount: 2,
-            minUniqueQueries: 3,
-          },
+        dreaming: {
+          mode: "deep",
+          frequency: "rem",
+          timezone: "UTC",
+          limit: 7,
+          minScore: 0.4,
+          minRecallCount: 2,
+          minUniqueQueries: 3,
         },
       },
     });
     expect(resolved).toEqual({
       enabled: true,
-      cron: "15 2 * * *",
+      cron: constants.DREAMING_PRESET_DEFAULTS.rem.cron,
       timezone: "UTC",
       limit: 7,
       minScore: 0.4,
@@ -147,11 +145,9 @@ describe("short-term dreaming config", () => {
   it("accepts limit=0 as an explicit no-op promotion cap", () => {
     const resolved = resolveShortTermPromotionDreamingConfig({
       pluginConfig: {
-        shortTermPromotion: {
-          dreaming: {
-            enabled: true,
-            limit: 0,
-          },
+        dreaming: {
+          mode: "core",
+          limit: 0,
         },
       },
     });
@@ -161,22 +157,31 @@ describe("short-term dreaming config", () => {
   it("falls back to defaults when thresholds are negative", () => {
     const resolved = resolveShortTermPromotionDreamingConfig({
       pluginConfig: {
-        shortTermPromotion: {
-          dreaming: {
-            enabled: true,
-            minScore: -0.2,
-            minRecallCount: -2,
-            minUniqueQueries: -4,
-          },
+        dreaming: {
+          mode: "rem",
+          minScore: -0.2,
+          minRecallCount: -2,
+          minUniqueQueries: -4,
         },
       },
     });
     expect(resolved).toMatchObject({
       enabled: true,
-      minScore: constants.DEFAULT_DREAMING_MIN_SCORE,
-      minRecallCount: constants.DEFAULT_DREAMING_MIN_RECALL_COUNT,
-      minUniqueQueries: constants.DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
+      minScore: constants.DREAMING_PRESET_DEFAULTS.rem.minScore,
+      minRecallCount: constants.DREAMING_PRESET_DEFAULTS.rem.minRecallCount,
+      minUniqueQueries: constants.DREAMING_PRESET_DEFAULTS.rem.minUniqueQueries,
     });
+  });
+
+  it("keeps dreaming disabled when mode is off", () => {
+    const resolved = resolveShortTermPromotionDreamingConfig({
+      pluginConfig: {
+        dreaming: {
+          mode: "off",
+        },
+      },
+    });
+    expect(resolved.enabled).toBe(false);
   });
 });
 

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -26,7 +26,10 @@ function createLogger() {
   };
 }
 
-function createCronHarness(initialJobs: CronJobLike[] = []) {
+function createCronHarness(
+  initialJobs: CronJobLike[] = [],
+  opts?: { removeResult?: "boolean" | "unknown" },
+) {
   const jobs: CronJobLike[] = [...initialJobs];
   const addCalls: CronAddInput[] = [];
   const updateCalls: Array<{ id: string; patch: CronPatch }> = [];
@@ -79,6 +82,9 @@ function createCronHarness(initialJobs: CronJobLike[] = []) {
       const index = jobs.findIndex((entry) => entry.id === id);
       if (index >= 0) {
         jobs.splice(index, 1);
+      }
+      if (opts?.removeResult === "unknown") {
+        return {};
       }
       return { removed: index >= 0 };
     },
@@ -138,6 +144,20 @@ describe("short-term dreaming config", () => {
     });
   });
 
+  it("accepts limit=0 as an explicit no-op promotion cap", () => {
+    const resolved = resolveShortTermPromotionDreamingConfig({
+      pluginConfig: {
+        shortTermPromotion: {
+          dreaming: {
+            enabled: true,
+            limit: 0,
+          },
+        },
+      },
+    });
+    expect(resolved.limit).toBe(0);
+  });
+
   it("falls back to defaults when thresholds are negative", () => {
     const resolved = resolveShortTermPromotionDreamingConfig({
       pluginConfig: {
@@ -157,6 +177,22 @@ describe("short-term dreaming config", () => {
       minRecallCount: constants.DEFAULT_DREAMING_MIN_RECALL_COUNT,
       minUniqueQueries: constants.DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
     });
+  });
+});
+
+describe("short-term dreaming startup event parsing", () => {
+  it("resolves cron service from gateway startup event deps", () => {
+    const harness = createCronHarness();
+    const resolved = __testing.resolveCronServiceFromStartupEvent({
+      type: "gateway",
+      action: "startup",
+      context: {
+        deps: {
+          cron: harness.cron,
+        },
+      },
+    });
+    expect(resolved).toBe(harness.cron);
   });
 });
 
@@ -302,6 +338,38 @@ describe("short-term dreaming cron reconciliation", () => {
     expect(result).toEqual({ status: "disabled", removed: 1 });
     expect(harness.removeCalls).toEqual(["job-managed"]);
     expect(harness.jobs.map((entry) => entry.id)).toEqual(["job-other"]);
+  });
+
+  it("does not overcount removed jobs when cron remove result is unknown", async () => {
+    const managedJob: CronJobLike = {
+      id: "job-managed",
+      name: constants.MANAGED_DREAMING_CRON_NAME,
+      description: `${constants.MANAGED_DREAMING_CRON_TAG} test`,
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 3 * * *" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: constants.DREAMING_SYSTEM_EVENT_TEXT },
+      createdAtMs: 10,
+    };
+    const harness = createCronHarness([managedJob], { removeResult: "unknown" });
+    const logger = createLogger();
+
+    const result = await reconcileShortTermDreamingCronJob({
+      cron: harness.cron,
+      config: {
+        enabled: false,
+        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+        limit: constants.DEFAULT_DREAMING_LIMIT,
+        minScore: constants.DEFAULT_DREAMING_MIN_SCORE,
+        minRecallCount: constants.DEFAULT_DREAMING_MIN_RECALL_COUNT,
+        minUniqueQueries: constants.DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
+      },
+      logger,
+    });
+
+    expect(result.removed).toBe(0);
+    expect(harness.removeCalls).toEqual(["job-managed"]);
   });
 });
 

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -98,14 +98,6 @@ function normalizeTrimmedString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function normalizePositiveInt(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return fallback;
-  }
-  const floored = Math.floor(value);
-  return floored > 0 ? floored : fallback;
-}
-
 function normalizeNonNegativeInt(value: unknown, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return fallback;
@@ -176,7 +168,7 @@ function isManagedDreamingJob(job: ManagedCronJobLike): boolean {
 }
 
 function compareOptionalStrings(a: string | undefined, b: string | undefined): boolean {
-  return (a ?? undefined) === (b ?? undefined);
+  return a === b;
 }
 
 function buildManagedDreamingPatch(
@@ -251,7 +243,7 @@ function resolveCronServiceFromStartupEvent(event: unknown): CronServiceLike | n
   }
   const context = asRecord(payload.context);
   const deps = asRecord(context?.deps);
-  const cronCandidate = deps?.cron;
+  const cronCandidate = context?.cron ?? deps?.cron;
   if (!cronCandidate || typeof cronCandidate !== "object") {
     return null;
   }
@@ -278,7 +270,7 @@ export function resolveShortTermPromotionDreamingConfig(params: {
   const cron = normalizeTrimmedString(dreaming?.cron) ?? DEFAULT_DREAMING_CRON_EXPR;
   const timezone =
     normalizeTrimmedString(dreaming?.timezone) ?? resolveTimezoneFallback(params.cfg);
-  const limit = normalizePositiveInt(dreaming?.limit, DEFAULT_DREAMING_LIMIT);
+  const limit = normalizeNonNegativeInt(dreaming?.limit, DEFAULT_DREAMING_LIMIT);
   const minScore = normalizeScore(dreaming?.minScore, DEFAULT_DREAMING_MIN_SCORE);
   const minRecallCount = normalizeNonNegativeInt(
     dreaming?.minRecallCount,
@@ -317,7 +309,7 @@ export async function reconcileShortTermDreamingCronJob(params: {
     let removed = 0;
     for (const job of managed) {
       const result = await cron.remove(job.id);
-      if (result.removed !== false) {
+      if (result.removed === true) {
         removed += 1;
       }
     }
@@ -338,7 +330,7 @@ export async function reconcileShortTermDreamingCronJob(params: {
   let removed = 0;
   for (const duplicate of duplicates) {
     const result = await cron.remove(duplicate.id);
-    if (result.removed !== false) {
+    if (result.removed === true) {
       removed += 1;
     }
   }

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -136,14 +136,6 @@ function normalizeTrimmedString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function normalizeDreamingPreset(value: unknown): DreamingPreset | undefined {
-  const normalized = normalizeTrimmedString(value)?.toLowerCase();
-  if (normalized === "core" || normalized === "deep" || normalized === "rem") {
-    return normalized;
-  }
-  return undefined;
-}
-
 function normalizeDreamingMode(value: unknown): DreamingMode {
   const normalized = normalizeTrimmedString(value)?.toLowerCase();
   if (
@@ -326,11 +318,8 @@ export function resolveShortTermPromotionDreamingConfig(params: {
   const mode = normalizeDreamingMode(dreaming?.mode);
   const enabled = mode !== "off";
   const thresholdPreset: DreamingPreset = mode === "off" ? DEFAULT_DREAMING_PRESET : mode;
-  const frequencyPreset = normalizeDreamingPreset(dreaming?.frequency) ?? thresholdPreset;
   const thresholdDefaults = DREAMING_PRESET_DEFAULTS[thresholdPreset];
-  const frequencyDefaults = DREAMING_PRESET_DEFAULTS[frequencyPreset];
-
-  const cron = frequencyDefaults.cron;
+  const cron = normalizeTrimmedString(dreaming?.frequency) ?? thresholdDefaults.cron;
   const timezone =
     normalizeTrimmedString(dreaming?.timezone) ?? resolveTimezoneFallback(params.cfg);
   const limit = normalizeNonNegativeInt(dreaming?.limit, thresholdDefaults.limit);

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -1,0 +1,463 @@
+import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
+import {
+  applyShortTermPromotions,
+  DEFAULT_PROMOTION_MIN_RECALL_COUNT,
+  DEFAULT_PROMOTION_MIN_SCORE,
+  DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES,
+  rankShortTermPromotionCandidates,
+} from "./short-term-promotion.js";
+
+const MANAGED_DREAMING_CRON_NAME = "Memory Dreaming Promotion";
+const MANAGED_DREAMING_CRON_TAG = "[managed-by=memory-core.short-term-promotion]";
+const DREAMING_SYSTEM_EVENT_TEXT = "__openclaw_memory_core_short_term_promotion_dream__";
+const DEFAULT_DREAMING_CRON_EXPR = "0 3 * * *";
+const DEFAULT_DREAMING_LIMIT = 10;
+const DEFAULT_DREAMING_MIN_SCORE = DEFAULT_PROMOTION_MIN_SCORE;
+const DEFAULT_DREAMING_MIN_RECALL_COUNT = DEFAULT_PROMOTION_MIN_RECALL_COUNT;
+const DEFAULT_DREAMING_MIN_UNIQUE_QUERIES = DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES;
+
+type Logger = Pick<OpenClawPluginApi["logger"], "info" | "warn" | "error">;
+
+type CronSchedule = { kind: "cron"; expr: string; tz?: string };
+type CronPayload = { kind: "systemEvent"; text: string };
+type ManagedCronJobCreate = {
+  name: string;
+  description: string;
+  enabled: boolean;
+  schedule: CronSchedule;
+  sessionTarget: "main";
+  wakeMode: "next-heartbeat";
+  payload: CronPayload;
+};
+
+type ManagedCronJobPatch = {
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+  schedule?: CronSchedule;
+  sessionTarget?: "main";
+  wakeMode?: "next-heartbeat";
+  payload?: CronPayload;
+};
+
+type ManagedCronJobLike = {
+  id: string;
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+  schedule?: {
+    kind?: string;
+    expr?: string;
+    tz?: string;
+  };
+  sessionTarget?: string;
+  wakeMode?: string;
+  payload?: {
+    kind?: string;
+    text?: string;
+  };
+  createdAtMs?: number;
+};
+
+type CronServiceLike = {
+  list: (opts?: { includeDisabled?: boolean }) => Promise<ManagedCronJobLike[]>;
+  add: (input: ManagedCronJobCreate) => Promise<unknown>;
+  update: (id: string, patch: ManagedCronJobPatch) => Promise<unknown>;
+  remove: (id: string) => Promise<{ removed?: boolean }>;
+};
+
+export type ShortTermPromotionDreamingConfig = {
+  enabled: boolean;
+  cron: string;
+  timezone?: string;
+  limit: number;
+  minScore: number;
+  minRecallCount: number;
+  minUniqueQueries: number;
+};
+
+type ReconcileResult =
+  | { status: "unavailable"; removed: number }
+  | { status: "disabled"; removed: number }
+  | { status: "added"; removed: number }
+  | { status: "updated"; removed: number }
+  | { status: "noop"; removed: number };
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function normalizeTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizePositiveInt(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  const floored = Math.floor(value);
+  return floored > 0 ? floored : fallback;
+}
+
+function normalizeNonNegativeInt(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  const floored = Math.floor(value);
+  if (floored < 0) {
+    return fallback;
+  }
+  return floored;
+}
+
+function normalizeScore(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  if (value < 0 || value > 1) {
+    return fallback;
+  }
+  return value;
+}
+
+function formatErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
+function resolveTimezoneFallback(cfg: OpenClawConfig | undefined): string | undefined {
+  const agents = asRecord(cfg?.agents);
+  const defaults = asRecord(agents?.defaults);
+  return normalizeTrimmedString(defaults?.userTimezone);
+}
+
+function resolveManagedCronDescription(config: ShortTermPromotionDreamingConfig): string {
+  return `${MANAGED_DREAMING_CRON_TAG} Promote weighted short-term recalls into MEMORY.md (limit=${config.limit}, minScore=${config.minScore.toFixed(3)}, minRecallCount=${config.minRecallCount}, minUniqueQueries=${config.minUniqueQueries}).`;
+}
+
+function buildManagedDreamingCronJob(
+  config: ShortTermPromotionDreamingConfig,
+): ManagedCronJobCreate {
+  return {
+    name: MANAGED_DREAMING_CRON_NAME,
+    description: resolveManagedCronDescription(config),
+    enabled: true,
+    schedule: {
+      kind: "cron",
+      expr: config.cron,
+      ...(config.timezone ? { tz: config.timezone } : {}),
+    },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: {
+      kind: "systemEvent",
+      text: DREAMING_SYSTEM_EVENT_TEXT,
+    },
+  };
+}
+
+function isManagedDreamingJob(job: ManagedCronJobLike): boolean {
+  const description = normalizeTrimmedString(job.description);
+  if (description?.includes(MANAGED_DREAMING_CRON_TAG)) {
+    return true;
+  }
+  const name = normalizeTrimmedString(job.name);
+  const payloadText = normalizeTrimmedString(job.payload?.text);
+  return name === MANAGED_DREAMING_CRON_NAME && payloadText === DREAMING_SYSTEM_EVENT_TEXT;
+}
+
+function compareOptionalStrings(a: string | undefined, b: string | undefined): boolean {
+  return (a ?? undefined) === (b ?? undefined);
+}
+
+function buildManagedDreamingPatch(
+  job: ManagedCronJobLike,
+  desired: ManagedCronJobCreate,
+): ManagedCronJobPatch | null {
+  const patch: ManagedCronJobPatch = {};
+
+  if (!compareOptionalStrings(normalizeTrimmedString(job.name), desired.name)) {
+    patch.name = desired.name;
+  }
+  if (!compareOptionalStrings(normalizeTrimmedString(job.description), desired.description)) {
+    patch.description = desired.description;
+  }
+  if (job.enabled !== true) {
+    patch.enabled = true;
+  }
+
+  const scheduleKind = normalizeTrimmedString(job.schedule?.kind)?.toLowerCase();
+  const scheduleExpr = normalizeTrimmedString(job.schedule?.expr);
+  const scheduleTz = normalizeTrimmedString(job.schedule?.tz);
+  if (
+    scheduleKind !== "cron" ||
+    !compareOptionalStrings(scheduleExpr, desired.schedule.expr) ||
+    !compareOptionalStrings(scheduleTz, desired.schedule.tz)
+  ) {
+    patch.schedule = desired.schedule;
+  }
+
+  const sessionTarget = normalizeTrimmedString(job.sessionTarget)?.toLowerCase();
+  if (sessionTarget !== "main") {
+    patch.sessionTarget = "main";
+  }
+  const wakeMode = normalizeTrimmedString(job.wakeMode)?.toLowerCase();
+  if (wakeMode !== "next-heartbeat") {
+    patch.wakeMode = "next-heartbeat";
+  }
+
+  const payloadKind = normalizeTrimmedString(job.payload?.kind)?.toLowerCase();
+  const payloadText = normalizeTrimmedString(job.payload?.text);
+  if (payloadKind !== "systemevent" || !compareOptionalStrings(payloadText, desired.payload.text)) {
+    patch.payload = desired.payload;
+  }
+
+  return Object.keys(patch).length > 0 ? patch : null;
+}
+
+function sortManagedJobs(managed: ManagedCronJobLike[]): ManagedCronJobLike[] {
+  return managed.toSorted((a, b) => {
+    const aCreated =
+      typeof a.createdAtMs === "number" && Number.isFinite(a.createdAtMs)
+        ? a.createdAtMs
+        : Number.MAX_SAFE_INTEGER;
+    const bCreated =
+      typeof b.createdAtMs === "number" && Number.isFinite(b.createdAtMs)
+        ? b.createdAtMs
+        : Number.MAX_SAFE_INTEGER;
+    if (aCreated !== bCreated) {
+      return aCreated - bCreated;
+    }
+    return a.id.localeCompare(b.id);
+  });
+}
+
+function resolveCronServiceFromStartupEvent(event: unknown): CronServiceLike | null {
+  const payload = asRecord(event);
+  if (!payload) {
+    return null;
+  }
+  if (payload.type !== "gateway" || payload.action !== "startup") {
+    return null;
+  }
+  const context = asRecord(payload.context);
+  const deps = asRecord(context?.deps);
+  const cronCandidate = deps?.cron;
+  if (!cronCandidate || typeof cronCandidate !== "object") {
+    return null;
+  }
+  const cron = cronCandidate as Partial<CronServiceLike>;
+  if (
+    typeof cron.list !== "function" ||
+    typeof cron.add !== "function" ||
+    typeof cron.update !== "function" ||
+    typeof cron.remove !== "function"
+  ) {
+    return null;
+  }
+  return cron as CronServiceLike;
+}
+
+export function resolveShortTermPromotionDreamingConfig(params: {
+  pluginConfig?: Record<string, unknown>;
+  cfg?: OpenClawConfig;
+}): ShortTermPromotionDreamingConfig {
+  const shortTermPromotion = asRecord(params.pluginConfig?.shortTermPromotion);
+  const dreaming = asRecord(shortTermPromotion?.dreaming);
+
+  const enabled = dreaming?.enabled === true;
+  const cron = normalizeTrimmedString(dreaming?.cron) ?? DEFAULT_DREAMING_CRON_EXPR;
+  const timezone =
+    normalizeTrimmedString(dreaming?.timezone) ?? resolveTimezoneFallback(params.cfg);
+  const limit = normalizePositiveInt(dreaming?.limit, DEFAULT_DREAMING_LIMIT);
+  const minScore = normalizeScore(dreaming?.minScore, DEFAULT_DREAMING_MIN_SCORE);
+  const minRecallCount = normalizeNonNegativeInt(
+    dreaming?.minRecallCount,
+    DEFAULT_DREAMING_MIN_RECALL_COUNT,
+  );
+  const minUniqueQueries = normalizeNonNegativeInt(
+    dreaming?.minUniqueQueries,
+    DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
+  );
+
+  return {
+    enabled,
+    cron,
+    ...(timezone ? { timezone } : {}),
+    limit,
+    minScore,
+    minRecallCount,
+    minUniqueQueries,
+  };
+}
+
+export async function reconcileShortTermDreamingCronJob(params: {
+  cron: CronServiceLike | null;
+  config: ShortTermPromotionDreamingConfig;
+  logger: Logger;
+}): Promise<ReconcileResult> {
+  const cron = params.cron;
+  if (!cron) {
+    return { status: "unavailable", removed: 0 };
+  }
+
+  const allJobs = await cron.list({ includeDisabled: true });
+  const managed = allJobs.filter(isManagedDreamingJob);
+
+  if (!params.config.enabled) {
+    let removed = 0;
+    for (const job of managed) {
+      const result = await cron.remove(job.id);
+      if (result.removed !== false) {
+        removed += 1;
+      }
+    }
+    if (removed > 0) {
+      params.logger.info(`memory-core: removed ${removed} managed dreaming cron job(s).`);
+    }
+    return { status: "disabled", removed };
+  }
+
+  const desired = buildManagedDreamingCronJob(params.config);
+  if (managed.length === 0) {
+    await cron.add(desired);
+    params.logger.info("memory-core: created managed dreaming cron job.");
+    return { status: "added", removed: 0 };
+  }
+
+  const [primary, ...duplicates] = sortManagedJobs(managed);
+  let removed = 0;
+  for (const duplicate of duplicates) {
+    const result = await cron.remove(duplicate.id);
+    if (result.removed !== false) {
+      removed += 1;
+    }
+  }
+
+  const patch = buildManagedDreamingPatch(primary, desired);
+  if (!patch) {
+    if (removed > 0) {
+      params.logger.info("memory-core: pruned duplicate managed dreaming cron jobs.");
+    }
+    return { status: "noop", removed };
+  }
+
+  await cron.update(primary.id, patch);
+  params.logger.info("memory-core: updated managed dreaming cron job.");
+  return { status: "updated", removed };
+}
+
+export async function runShortTermDreamingPromotionIfTriggered(params: {
+  cleanedBody: string;
+  trigger?: string;
+  workspaceDir?: string;
+  config: ShortTermPromotionDreamingConfig;
+  logger: Logger;
+}): Promise<{ handled: true; reason: string } | undefined> {
+  if (params.trigger !== "heartbeat") {
+    return undefined;
+  }
+  if (params.cleanedBody.trim() !== DREAMING_SYSTEM_EVENT_TEXT) {
+    return undefined;
+  }
+  if (!params.config.enabled) {
+    return { handled: true, reason: "memory-core: short-term dreaming disabled" };
+  }
+
+  const workspaceDir = normalizeTrimmedString(params.workspaceDir);
+  if (!workspaceDir) {
+    params.logger.warn(
+      "memory-core: dreaming promotion skipped because workspaceDir is unavailable.",
+    );
+    return { handled: true, reason: "memory-core: short-term dreaming missing workspace" };
+  }
+
+  try {
+    const candidates = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      limit: params.config.limit,
+      minScore: params.config.minScore,
+      minRecallCount: params.config.minRecallCount,
+      minUniqueQueries: params.config.minUniqueQueries,
+    });
+    const applied = await applyShortTermPromotions({
+      workspaceDir,
+      candidates,
+      limit: params.config.limit,
+      minScore: params.config.minScore,
+      minRecallCount: params.config.minRecallCount,
+      minUniqueQueries: params.config.minUniqueQueries,
+    });
+    params.logger.info(
+      `memory-core: dreaming promotion complete (candidates=${candidates.length}, applied=${applied.applied}).`,
+    );
+  } catch (err) {
+    params.logger.error(`memory-core: dreaming promotion failed: ${formatErrorMessage(err)}`);
+  }
+
+  return { handled: true, reason: "memory-core: short-term dreaming processed" };
+}
+
+export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void {
+  api.registerHook(
+    "gateway:startup",
+    async (event: unknown) => {
+      const config = resolveShortTermPromotionDreamingConfig({
+        pluginConfig: api.pluginConfig,
+        cfg: api.config,
+      });
+      const cron = resolveCronServiceFromStartupEvent(event);
+      if (!cron && config.enabled) {
+        api.logger.warn(
+          "memory-core: managed dreaming cron could not be reconciled (cron service unavailable).",
+        );
+      }
+      await reconcileShortTermDreamingCronJob({
+        cron,
+        config,
+        logger: api.logger,
+      });
+    },
+    { name: "memory-core-short-term-dreaming-cron" },
+  );
+
+  api.on("before_agent_reply", async (event, ctx) => {
+    const config = resolveShortTermPromotionDreamingConfig({
+      pluginConfig: api.pluginConfig,
+      cfg: api.config,
+    });
+    return await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: event.cleanedBody,
+      trigger: ctx.trigger,
+      workspaceDir: ctx.workspaceDir,
+      config,
+      logger: api.logger,
+    });
+  });
+}
+
+export const __testing = {
+  buildManagedDreamingCronJob,
+  buildManagedDreamingPatch,
+  isManagedDreamingJob,
+  resolveCronServiceFromStartupEvent,
+  constants: {
+    MANAGED_DREAMING_CRON_NAME,
+    MANAGED_DREAMING_CRON_TAG,
+    DREAMING_SYSTEM_EVENT_TEXT,
+    DEFAULT_DREAMING_CRON_EXPR,
+    DEFAULT_DREAMING_LIMIT,
+    DEFAULT_DREAMING_MIN_SCORE,
+    DEFAULT_DREAMING_MIN_RECALL_COUNT,
+    DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
+  },
+};

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -15,6 +15,44 @@ const DEFAULT_DREAMING_LIMIT = 10;
 const DEFAULT_DREAMING_MIN_SCORE = DEFAULT_PROMOTION_MIN_SCORE;
 const DEFAULT_DREAMING_MIN_RECALL_COUNT = DEFAULT_PROMOTION_MIN_RECALL_COUNT;
 const DEFAULT_DREAMING_MIN_UNIQUE_QUERIES = DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES;
+const DEFAULT_DREAMING_MODE = "off";
+const DEFAULT_DREAMING_PRESET = "core";
+
+type DreamingPreset = "core" | "deep" | "rem";
+type DreamingMode = DreamingPreset | "off";
+
+const DREAMING_PRESET_DEFAULTS: Record<
+  DreamingPreset,
+  {
+    cron: string;
+    limit: number;
+    minScore: number;
+    minRecallCount: number;
+    minUniqueQueries: number;
+  }
+> = {
+  core: {
+    cron: DEFAULT_DREAMING_CRON_EXPR,
+    limit: DEFAULT_DREAMING_LIMIT,
+    minScore: DEFAULT_DREAMING_MIN_SCORE,
+    minRecallCount: DEFAULT_DREAMING_MIN_RECALL_COUNT,
+    minUniqueQueries: DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
+  },
+  deep: {
+    cron: "0 */12 * * *",
+    limit: DEFAULT_DREAMING_LIMIT,
+    minScore: 0.8,
+    minRecallCount: 3,
+    minUniqueQueries: 3,
+  },
+  rem: {
+    cron: "0 */6 * * *",
+    limit: DEFAULT_DREAMING_LIMIT,
+    minScore: 0.85,
+    minRecallCount: 4,
+    minUniqueQueries: 3,
+  },
+};
 
 type Logger = Pick<OpenClawPluginApi["logger"], "info" | "warn" | "error">;
 
@@ -96,6 +134,27 @@ function normalizeTrimmedString(value: unknown): string | undefined {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeDreamingPreset(value: unknown): DreamingPreset | undefined {
+  const normalized = normalizeTrimmedString(value)?.toLowerCase();
+  if (normalized === "core" || normalized === "deep" || normalized === "rem") {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeDreamingMode(value: unknown): DreamingMode {
+  const normalized = normalizeTrimmedString(value)?.toLowerCase();
+  if (
+    normalized === "off" ||
+    normalized === "core" ||
+    normalized === "deep" ||
+    normalized === "rem"
+  ) {
+    return normalized;
+  }
+  return DEFAULT_DREAMING_MODE;
 }
 
 function normalizeNonNegativeInt(value: unknown, fallback: number): number {
@@ -263,22 +322,26 @@ export function resolveShortTermPromotionDreamingConfig(params: {
   pluginConfig?: Record<string, unknown>;
   cfg?: OpenClawConfig;
 }): ShortTermPromotionDreamingConfig {
-  const shortTermPromotion = asRecord(params.pluginConfig?.shortTermPromotion);
-  const dreaming = asRecord(shortTermPromotion?.dreaming);
+  const dreaming = asRecord(params.pluginConfig?.dreaming);
+  const mode = normalizeDreamingMode(dreaming?.mode);
+  const enabled = mode !== "off";
+  const thresholdPreset: DreamingPreset = mode === "off" ? DEFAULT_DREAMING_PRESET : mode;
+  const frequencyPreset = normalizeDreamingPreset(dreaming?.frequency) ?? thresholdPreset;
+  const thresholdDefaults = DREAMING_PRESET_DEFAULTS[thresholdPreset];
+  const frequencyDefaults = DREAMING_PRESET_DEFAULTS[frequencyPreset];
 
-  const enabled = dreaming?.enabled === true;
-  const cron = normalizeTrimmedString(dreaming?.cron) ?? DEFAULT_DREAMING_CRON_EXPR;
+  const cron = frequencyDefaults.cron;
   const timezone =
     normalizeTrimmedString(dreaming?.timezone) ?? resolveTimezoneFallback(params.cfg);
-  const limit = normalizeNonNegativeInt(dreaming?.limit, DEFAULT_DREAMING_LIMIT);
-  const minScore = normalizeScore(dreaming?.minScore, DEFAULT_DREAMING_MIN_SCORE);
+  const limit = normalizeNonNegativeInt(dreaming?.limit, thresholdDefaults.limit);
+  const minScore = normalizeScore(dreaming?.minScore, thresholdDefaults.minScore);
   const minRecallCount = normalizeNonNegativeInt(
     dreaming?.minRecallCount,
-    DEFAULT_DREAMING_MIN_RECALL_COUNT,
+    thresholdDefaults.minRecallCount,
   );
   const minUniqueQueries = normalizeNonNegativeInt(
     dreaming?.minUniqueQueries,
-    DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
+    thresholdDefaults.minUniqueQueries,
   );
 
   return {
@@ -446,10 +509,13 @@ export const __testing = {
     MANAGED_DREAMING_CRON_NAME,
     MANAGED_DREAMING_CRON_TAG,
     DREAMING_SYSTEM_EVENT_TEXT,
+    DEFAULT_DREAMING_MODE,
+    DEFAULT_DREAMING_PRESET,
     DEFAULT_DREAMING_CRON_EXPR,
     DEFAULT_DREAMING_LIMIT,
     DEFAULT_DREAMING_MIN_SCORE,
     DEFAULT_DREAMING_MIN_RECALL_COUNT,
     DEFAULT_DREAMING_MIN_UNIQUE_QUERIES,
+    DREAMING_PRESET_DEFAULTS,
   },
 };

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -87,6 +87,39 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("serializes concurrent recall writes so counts are not lost", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await Promise.all(
+        Array.from({ length: 20 }, (_, index) =>
+          recordShortTermRecalls({
+            workspaceDir,
+            query: `backup-${index % 4}`,
+            results: [
+              {
+                path: "memory/2026-04-03.md",
+                startLine: 1,
+                endLine: 2,
+                score: 0.9,
+                snippet: "Move backups to S3 Glacier.",
+                source: "memory",
+              },
+            ],
+          }),
+        ),
+      );
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      expect(ranked).toHaveLength(1);
+      expect(ranked[0]?.recallCount).toBe(20);
+      expect(ranked[0]?.uniqueQueries).toBe(4);
+    });
+  });
+
   it("uses default thresholds for promotion", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await recordShortTermRecalls({

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1,0 +1,228 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  applyShortTermPromotions,
+  isShortTermMemoryPath,
+  rankShortTermPromotionCandidates,
+  recordShortTermRecalls,
+  resolveShortTermRecallStorePath,
+} from "./short-term-promotion.js";
+
+describe("short-term promotion", () => {
+  async function withTempWorkspace(run: (workspaceDir: string) => Promise<void>) {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-promote-"));
+    try {
+      await run(workspaceDir);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  }
+
+  it("detects short-term daily memory paths", () => {
+    expect(isShortTermMemoryPath("memory/2026-04-03.md")).toBe(true);
+    expect(isShortTermMemoryPath("2026-04-03.md")).toBe(true);
+    expect(isShortTermMemoryPath("notes/2026-04-03.md")).toBe(false);
+    expect(isShortTermMemoryPath("MEMORY.md")).toBe(false);
+    expect(isShortTermMemoryPath("memory/network.md")).toBe(false);
+  });
+
+  it("records recalls and ranks candidates with weighted scores", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "router",
+        results: [
+          {
+            path: "memory/2026-04-02.md",
+            startLine: 3,
+            endLine: 5,
+            score: 0.9,
+            snippet: "Configured VLAN 10 on Omada router",
+            source: "memory",
+          },
+          {
+            path: "MEMORY.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.99,
+            snippet: "Long-term note",
+            source: "memory",
+          },
+        ],
+      });
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "iot vlan",
+        results: [
+          {
+            path: "memory/2026-04-02.md",
+            startLine: 3,
+            endLine: 5,
+            score: 0.8,
+            snippet: "Configured VLAN 10 on Omada router",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+
+      expect(ranked).toHaveLength(1);
+      expect(ranked[0]?.path).toBe("memory/2026-04-02.md");
+      expect(ranked[0]?.recallCount).toBe(2);
+      expect(ranked[0]?.uniqueQueries).toBe(2);
+      expect(ranked[0]?.score).toBeGreaterThan(0);
+
+      const storePath = resolveShortTermRecallStorePath(workspaceDir);
+      const raw = await fs.readFile(storePath, "utf-8");
+      expect(raw).toContain("memory/2026-04-02.md");
+      expect(raw).not.toContain("Long-term note");
+    });
+  });
+
+  it("uses default thresholds for promotion", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "glacier",
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 2,
+            score: 0.96,
+            snippet: "Move backups to S3 Glacier.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({ workspaceDir });
+      expect(ranked).toHaveLength(0);
+    });
+  });
+
+  it("treats negative threshold overrides as invalid and keeps defaults", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "glacier",
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 2,
+            score: 0.96,
+            snippet: "Move backups to S3 Glacier.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: -1,
+        minRecallCount: -1,
+        minUniqueQueries: -1,
+      });
+      expect(ranked).toHaveLength(0);
+    });
+  });
+
+  it("enforces default thresholds during apply even when candidates are passed directly", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: [
+          {
+            key: "memory:memory/2026-04-03.md:1:2",
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 2,
+            source: "memory",
+            snippet: "Move backups to S3 Glacier.",
+            recallCount: 1,
+            avgScore: 0.95,
+            maxScore: 0.95,
+            uniqueQueries: 1,
+            firstRecalledAt: new Date().toISOString(),
+            lastRecalledAt: new Date().toISOString(),
+            ageDays: 0,
+            score: 0.95,
+            components: {
+              frequency: 0.2,
+              relevance: 0.95,
+              diversity: 0.2,
+              recency: 1,
+            },
+          },
+        ],
+      });
+
+      expect(applied.applied).toBe(0);
+    });
+  });
+
+  it("applies promotion candidates to MEMORY.md and marks them promoted", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "gateway host",
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 10,
+            endLine: 12,
+            score: 0.92,
+            snippet: "Gateway binds loopback and port 18789",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      expect(applied.applied).toBe(1);
+
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).toContain("Promoted From Short-Term Memory");
+      expect(memoryText).toContain("memory/2026-04-01.md:10-12");
+
+      const rankedAfter = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      expect(rankedAfter).toHaveLength(0);
+
+      const rankedIncludingPromoted = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        includePromoted: true,
+      });
+      expect(rankedIncludingPromoted).toHaveLength(1);
+      expect(rankedIncludingPromoted[0]?.promotedAt).toBeTruthy();
+    });
+  });
+});

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -258,4 +258,51 @@ describe("short-term promotion", () => {
       expect(rankedIncludingPromoted[0]?.promotedAt).toBeTruthy();
     });
   });
+
+  it("does not re-append candidates that were promoted in a prior run", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "gateway host",
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 10,
+            endLine: 12,
+            score: 0.92,
+            snippet: "Gateway binds loopback and port 18789",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      const first = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      expect(first.applied).toBe(1);
+
+      const second = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      expect(second.applied).toBe(0);
+
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      const sectionCount = memoryText.match(/Promoted From Short-Term Memory/g)?.length ?? 0;
+      expect(sectionCount).toBe(1);
+    });
+  });
 });

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1,0 +1,581 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+
+const SHORT_TERM_PATH_RE = /(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/;
+const SHORT_TERM_BASENAME_RE = /^(\d{4})-(\d{2})-(\d{2})\.md$/;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_RECENCY_HALF_LIFE_DAYS = 14;
+export const DEFAULT_PROMOTION_MIN_SCORE = 0.75;
+export const DEFAULT_PROMOTION_MIN_RECALL_COUNT = 3;
+export const DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES = 2;
+const SHORT_TERM_STORE_RELATIVE_PATH = path.join("memory", ".dreams", "short-term-recall.json");
+
+export type PromotionWeights = {
+  frequency: number;
+  relevance: number;
+  diversity: number;
+  recency: number;
+};
+
+export const DEFAULT_PROMOTION_WEIGHTS: PromotionWeights = {
+  frequency: 0.35,
+  relevance: 0.35,
+  diversity: 0.15,
+  recency: 0.15,
+};
+
+export type ShortTermRecallEntry = {
+  key: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  source: "memory";
+  snippet: string;
+  recallCount: number;
+  totalScore: number;
+  maxScore: number;
+  firstRecalledAt: string;
+  lastRecalledAt: string;
+  queryHashes: string[];
+  promotedAt?: string;
+};
+
+type ShortTermRecallStore = {
+  version: 1;
+  updatedAt: string;
+  entries: Record<string, ShortTermRecallEntry>;
+};
+
+export type PromotionComponents = {
+  frequency: number;
+  relevance: number;
+  diversity: number;
+  recency: number;
+};
+
+export type PromotionCandidate = {
+  key: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  source: "memory";
+  snippet: string;
+  recallCount: number;
+  avgScore: number;
+  maxScore: number;
+  uniqueQueries: number;
+  promotedAt?: string;
+  firstRecalledAt: string;
+  lastRecalledAt: string;
+  ageDays: number;
+  score: number;
+  components: PromotionComponents;
+};
+
+export type RankShortTermPromotionOptions = {
+  workspaceDir: string;
+  limit?: number;
+  minScore?: number;
+  minRecallCount?: number;
+  minUniqueQueries?: number;
+  includePromoted?: boolean;
+  recencyHalfLifeDays?: number;
+  weights?: Partial<PromotionWeights>;
+  nowMs?: number;
+};
+
+export type ApplyShortTermPromotionsOptions = {
+  workspaceDir: string;
+  candidates: PromotionCandidate[];
+  limit?: number;
+  minScore?: number;
+  minRecallCount?: number;
+  minUniqueQueries?: number;
+  nowMs?: number;
+};
+
+export type ApplyShortTermPromotionsResult = {
+  memoryPath: string;
+  applied: number;
+  appliedCandidates: PromotionCandidate[];
+};
+
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
+}
+
+function toFiniteScore(value: unknown, fallback: number): number {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    return fallback;
+  }
+  if (num < 0 || num > 1) {
+    return fallback;
+  }
+  return num;
+}
+
+function normalizeSnippet(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "";
+  }
+  return trimmed.replace(/\s+/g, " ");
+}
+
+function normalizeMemoryPath(rawPath: string): string {
+  return rawPath.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function buildEntryKey(result: {
+  path: string;
+  startLine: number;
+  endLine: number;
+  source: string;
+}): string {
+  return `${result.source}:${normalizeMemoryPath(result.path)}:${result.startLine}:${result.endLine}`;
+}
+
+function hashQuery(query: string): string {
+  return createHash("sha1").update(query.trim().toLowerCase()).digest("hex").slice(0, 12);
+}
+
+function mergeQueryHashes(existing: string[], queryHash: string): string[] {
+  if (!queryHash) {
+    return existing;
+  }
+  const next = existing.filter(Boolean);
+  if (!next.includes(queryHash)) {
+    next.push(queryHash);
+  }
+  const maxHashes = 32;
+  if (next.length <= maxHashes) {
+    return next;
+  }
+  return next.slice(next.length - maxHashes);
+}
+
+function emptyStore(nowIso: string): ShortTermRecallStore {
+  return {
+    version: 1,
+    updatedAt: nowIso,
+    entries: {},
+  };
+}
+
+function normalizeStore(raw: unknown, nowIso: string): ShortTermRecallStore {
+  if (!raw || typeof raw !== "object") {
+    return emptyStore(nowIso);
+  }
+  const record = raw as Record<string, unknown>;
+  const entriesRaw = record.entries;
+  const entries: Record<string, ShortTermRecallEntry> = {};
+
+  if (entriesRaw && typeof entriesRaw === "object") {
+    for (const [key, value] of Object.entries(entriesRaw as Record<string, unknown>)) {
+      if (!value || typeof value !== "object") {
+        continue;
+      }
+      const entry = value as Record<string, unknown>;
+      const entryPath = typeof entry.path === "string" ? normalizeMemoryPath(entry.path) : "";
+      const startLine = Number(entry.startLine);
+      const endLine = Number(entry.endLine);
+      const source = entry.source === "memory" ? "memory" : null;
+      if (!entryPath || !Number.isInteger(startLine) || !Number.isInteger(endLine) || !source) {
+        continue;
+      }
+
+      const recallCount = Math.max(0, Math.floor(Number(entry.recallCount) || 0));
+      const totalScore = Math.max(0, Number(entry.totalScore) || 0);
+      const maxScore = clampScore(Number(entry.maxScore) || 0);
+      const firstRecalledAt =
+        typeof entry.firstRecalledAt === "string" ? entry.firstRecalledAt : nowIso;
+      const lastRecalledAt =
+        typeof entry.lastRecalledAt === "string" ? entry.lastRecalledAt : nowIso;
+      const promotedAt = typeof entry.promotedAt === "string" ? entry.promotedAt : undefined;
+      const snippet = typeof entry.snippet === "string" ? normalizeSnippet(entry.snippet) : "";
+      const queryHashes = Array.isArray(entry.queryHashes)
+        ? entry.queryHashes.filter(
+            (hash): hash is string => typeof hash === "string" && hash.length > 0,
+          )
+        : [];
+
+      const normalizedKey = key || buildEntryKey({ path: entryPath, startLine, endLine, source });
+      entries[normalizedKey] = {
+        key: normalizedKey,
+        path: entryPath,
+        startLine,
+        endLine,
+        source,
+        snippet,
+        recallCount,
+        totalScore,
+        maxScore,
+        firstRecalledAt,
+        lastRecalledAt,
+        queryHashes,
+        ...(promotedAt ? { promotedAt } : {}),
+      };
+    }
+  }
+
+  return {
+    version: 1,
+    updatedAt: typeof record.updatedAt === "string" ? record.updatedAt : nowIso,
+    entries,
+  };
+}
+
+function toFinitePositive(value: unknown, fallback: number): number {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) {
+    return fallback;
+  }
+  return num;
+}
+
+function toFiniteNonNegativeInt(value: unknown, fallback: number): number {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    return fallback;
+  }
+  const floored = Math.floor(num);
+  if (floored < 0) {
+    return fallback;
+  }
+  return floored;
+}
+
+function normalizeWeights(weights?: Partial<PromotionWeights>): PromotionWeights {
+  const merged = {
+    ...DEFAULT_PROMOTION_WEIGHTS,
+    ...(weights ?? {}),
+  };
+  const frequency = Math.max(0, merged.frequency);
+  const relevance = Math.max(0, merged.relevance);
+  const diversity = Math.max(0, merged.diversity);
+  const recency = Math.max(0, merged.recency);
+  const sum = frequency + relevance + diversity + recency;
+  if (sum <= 0) {
+    return { ...DEFAULT_PROMOTION_WEIGHTS };
+  }
+  return {
+    frequency: frequency / sum,
+    relevance: relevance / sum,
+    diversity: diversity / sum,
+    recency: recency / sum,
+  };
+}
+
+function calculateRecencyComponent(ageDays: number, halfLifeDays: number): number {
+  if (!Number.isFinite(ageDays) || ageDays < 0) {
+    return 1;
+  }
+  if (!Number.isFinite(halfLifeDays) || halfLifeDays <= 0) {
+    return 1;
+  }
+  const lambda = Math.LN2 / halfLifeDays;
+  return Math.exp(-lambda * ageDays);
+}
+
+function resolveStorePath(workspaceDir: string): string {
+  return path.join(workspaceDir, SHORT_TERM_STORE_RELATIVE_PATH);
+}
+
+async function readStore(workspaceDir: string, nowIso: string): Promise<ShortTermRecallStore> {
+  const storePath = resolveStorePath(workspaceDir);
+  try {
+    const raw = await fs.readFile(storePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    return normalizeStore(parsed, nowIso);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return emptyStore(nowIso);
+    }
+    throw err;
+  }
+}
+
+async function writeStore(workspaceDir: string, store: ShortTermRecallStore): Promise<void> {
+  const storePath = resolveStorePath(workspaceDir);
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  const tmpPath = `${storePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
+  await fs.rename(tmpPath, storePath);
+}
+
+export function isShortTermMemoryPath(filePath: string): boolean {
+  const normalized = normalizeMemoryPath(filePath);
+  if (SHORT_TERM_PATH_RE.test(normalized)) {
+    return true;
+  }
+  return SHORT_TERM_BASENAME_RE.test(normalized);
+}
+
+export async function recordShortTermRecalls(params: {
+  workspaceDir?: string;
+  query: string;
+  results: MemorySearchResult[];
+  nowMs?: number;
+}): Promise<void> {
+  const workspaceDir = params.workspaceDir?.trim();
+  if (!workspaceDir) {
+    return;
+  }
+  const query = params.query.trim();
+  if (!query) {
+    return;
+  }
+  const relevant = params.results.filter(
+    (result) => result.source === "memory" && isShortTermMemoryPath(result.path),
+  );
+  if (relevant.length === 0) {
+    return;
+  }
+
+  const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const queryHash = hashQuery(query);
+  const store = await readStore(workspaceDir, nowIso);
+
+  for (const result of relevant) {
+    const key = buildEntryKey(result);
+    const normalizedPath = normalizeMemoryPath(result.path);
+    const existing = store.entries[key];
+    const snippet = normalizeSnippet(result.snippet);
+    const score = clampScore(result.score);
+    const recallCount = Math.max(1, Math.floor(existing?.recallCount ?? 0) + 1);
+    const totalScore = Math.max(0, (existing?.totalScore ?? 0) + score);
+    const maxScore = Math.max(existing?.maxScore ?? 0, score);
+    const queryHashes = mergeQueryHashes(existing?.queryHashes ?? [], queryHash);
+
+    store.entries[key] = {
+      key,
+      path: normalizedPath,
+      startLine: Math.max(1, Math.floor(result.startLine)),
+      endLine: Math.max(1, Math.floor(result.endLine)),
+      source: "memory",
+      snippet: snippet || existing?.snippet || "",
+      recallCount,
+      totalScore,
+      maxScore,
+      firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
+      lastRecalledAt: nowIso,
+      queryHashes,
+      ...(existing?.promotedAt ? { promotedAt: existing.promotedAt } : {}),
+    };
+  }
+
+  store.updatedAt = nowIso;
+  await writeStore(workspaceDir, store);
+}
+
+export async function rankShortTermPromotionCandidates(
+  options: RankShortTermPromotionOptions,
+): Promise<PromotionCandidate[]> {
+  const workspaceDir = options.workspaceDir.trim();
+  if (!workspaceDir) {
+    return [];
+  }
+
+  const nowMs = Number.isFinite(options.nowMs) ? (options.nowMs as number) : Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const minScore = toFiniteScore(options.minScore, DEFAULT_PROMOTION_MIN_SCORE);
+  const minRecallCount = toFiniteNonNegativeInt(
+    options.minRecallCount,
+    DEFAULT_PROMOTION_MIN_RECALL_COUNT,
+  );
+  const minUniqueQueries = toFiniteNonNegativeInt(
+    options.minUniqueQueries,
+    DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES,
+  );
+  const includePromoted = Boolean(options.includePromoted);
+  const halfLifeDays = toFinitePositive(
+    options.recencyHalfLifeDays,
+    DEFAULT_RECENCY_HALF_LIFE_DAYS,
+  );
+  const weights = normalizeWeights(options.weights);
+
+  const store = await readStore(workspaceDir, nowIso);
+  const candidates: PromotionCandidate[] = [];
+
+  for (const entry of Object.values(store.entries)) {
+    if (!entry || entry.source !== "memory" || !isShortTermMemoryPath(entry.path)) {
+      continue;
+    }
+    if (!includePromoted && entry.promotedAt) {
+      continue;
+    }
+    if (!Number.isFinite(entry.recallCount) || entry.recallCount <= 0) {
+      continue;
+    }
+    if (entry.recallCount < minRecallCount) {
+      continue;
+    }
+
+    const avgScore = clampScore(entry.totalScore / Math.max(1, entry.recallCount));
+    const frequency = clampScore(Math.log1p(entry.recallCount) / Math.log1p(10));
+    const uniqueQueries = entry.queryHashes?.length ?? 0;
+    if (uniqueQueries < minUniqueQueries) {
+      continue;
+    }
+    const diversity = clampScore(uniqueQueries / 5);
+    const lastRecalledAtMs = Date.parse(entry.lastRecalledAt);
+    const ageDays = Number.isFinite(lastRecalledAtMs)
+      ? Math.max(0, (nowMs - lastRecalledAtMs) / DAY_MS)
+      : 0;
+    const recency = clampScore(calculateRecencyComponent(ageDays, halfLifeDays));
+
+    const score =
+      weights.frequency * frequency +
+      weights.relevance * avgScore +
+      weights.diversity * diversity +
+      weights.recency * recency;
+
+    if (score < minScore) {
+      continue;
+    }
+
+    candidates.push({
+      key: entry.key,
+      path: entry.path,
+      startLine: entry.startLine,
+      endLine: entry.endLine,
+      source: entry.source,
+      snippet: entry.snippet,
+      recallCount: entry.recallCount,
+      avgScore,
+      maxScore: clampScore(entry.maxScore),
+      uniqueQueries,
+      promotedAt: entry.promotedAt,
+      firstRecalledAt: entry.firstRecalledAt,
+      lastRecalledAt: entry.lastRecalledAt,
+      ageDays,
+      score: clampScore(score),
+      components: {
+        frequency,
+        relevance: avgScore,
+        diversity,
+        recency,
+      },
+    });
+  }
+
+  const sorted = candidates.toSorted((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    if (b.recallCount !== a.recallCount) {
+      return b.recallCount - a.recallCount;
+    }
+    return a.path.localeCompare(b.path);
+  });
+
+  const limit = Number.isFinite(options.limit)
+    ? Math.max(0, Math.floor(options.limit as number))
+    : sorted.length;
+  return sorted.slice(0, limit);
+}
+
+function buildPromotionSection(candidates: PromotionCandidate[], nowMs: number): string {
+  const sectionDate = new Date(nowMs).toISOString().slice(0, 10);
+  const lines = ["", `## Promoted From Short-Term Memory (${sectionDate})`, ""];
+
+  for (const candidate of candidates) {
+    const source = `${candidate.path}:${candidate.startLine}-${candidate.endLine}`;
+    const snippet = candidate.snippet || "(no snippet captured)";
+    lines.push(
+      `- ${snippet} [score=${candidate.score.toFixed(3)} recalls=${candidate.recallCount} avg=${candidate.avgScore.toFixed(3)} source=${source}]`,
+    );
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+function withTrailingNewline(content: string): string {
+  if (!content) {
+    return "";
+  }
+  return content.endsWith("\n") ? content : `${content}\n`;
+}
+
+export async function applyShortTermPromotions(
+  options: ApplyShortTermPromotionsOptions,
+): Promise<ApplyShortTermPromotionsResult> {
+  const workspaceDir = options.workspaceDir.trim();
+  const nowMs = Number.isFinite(options.nowMs) ? (options.nowMs as number) : Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const limit = Number.isFinite(options.limit)
+    ? Math.max(0, Math.floor(options.limit as number))
+    : options.candidates.length;
+  const minScore = toFiniteScore(options.minScore, DEFAULT_PROMOTION_MIN_SCORE);
+  const minRecallCount = toFiniteNonNegativeInt(
+    options.minRecallCount,
+    DEFAULT_PROMOTION_MIN_RECALL_COUNT,
+  );
+  const minUniqueQueries = toFiniteNonNegativeInt(
+    options.minUniqueQueries,
+    DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES,
+  );
+
+  const selected = options.candidates
+    .filter(
+      (candidate) =>
+        !candidate.promotedAt &&
+        candidate.score >= minScore &&
+        candidate.recallCount >= minRecallCount &&
+        candidate.uniqueQueries >= minUniqueQueries,
+    )
+    .slice(0, limit);
+
+  const memoryPath = path.join(workspaceDir, "MEMORY.md");
+  if (selected.length === 0) {
+    return {
+      memoryPath,
+      applied: 0,
+      appliedCandidates: [],
+    };
+  }
+
+  const existingMemory = await fs.readFile(memoryPath, "utf-8").catch((err: unknown) => {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return "";
+    }
+    throw err;
+  });
+
+  const header = existingMemory.trim().length > 0 ? "" : "# Long-Term Memory\n\n";
+  const section = buildPromotionSection(selected, nowMs);
+  await fs.writeFile(
+    memoryPath,
+    `${header}${withTrailingNewline(existingMemory)}${section}`,
+    "utf-8",
+  );
+
+  const store = await readStore(workspaceDir, nowIso);
+  for (const candidate of selected) {
+    const entry = store.entries[candidate.key];
+    if (!entry) {
+      continue;
+    }
+    entry.promotedAt = nowIso;
+  }
+  store.updatedAt = nowIso;
+  await writeStore(workspaceDir, store);
+
+  return {
+    memoryPath,
+    applied: selected.length,
+    appliedCandidates: selected,
+  };
+}
+
+export function resolveShortTermRecallStorePath(workspaceDir: string): string {
+  return resolveStorePath(workspaceDir);
+}

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -11,7 +11,10 @@ export const DEFAULT_PROMOTION_MIN_SCORE = 0.75;
 export const DEFAULT_PROMOTION_MIN_RECALL_COUNT = 3;
 export const DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES = 2;
 const SHORT_TERM_STORE_RELATIVE_PATH = path.join("memory", ".dreams", "short-term-recall.json");
-const storeWriteQueues = new Map<string, Promise<void>>();
+const SHORT_TERM_LOCK_RELATIVE_PATH = path.join("memory", ".dreams", "short-term-promotion.lock");
+const SHORT_TERM_LOCK_WAIT_TIMEOUT_MS = 10_000;
+const SHORT_TERM_LOCK_STALE_MS = 60_000;
+const SHORT_TERM_LOCK_RETRY_DELAY_MS = 40;
 
 export type PromotionWeights = {
   frequency: number;
@@ -288,20 +291,51 @@ function resolveStorePath(workspaceDir: string): string {
   return path.join(workspaceDir, SHORT_TERM_STORE_RELATIVE_PATH);
 }
 
-async function queueStoreWrite<T>(workspaceDir: string, task: () => Promise<T>): Promise<T> {
-  const storePath = resolveStorePath(workspaceDir);
-  const previous = storeWriteQueues.get(storePath) ?? Promise.resolve();
-  const queuedTask = previous.catch(() => undefined).then(task);
-  const tail = queuedTask.then(
-    () => undefined,
-    () => undefined,
-  );
-  storeWriteQueues.set(storePath, tail);
-  try {
-    return await queuedTask;
-  } finally {
-    if (storeWriteQueues.get(storePath) === tail) {
-      storeWriteQueues.delete(storePath);
+function resolveLockPath(workspaceDir: string): string {
+  return path.join(workspaceDir, SHORT_TERM_LOCK_RELATIVE_PATH);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function withShortTermLock<T>(workspaceDir: string, task: () => Promise<T>): Promise<T> {
+  const lockPath = resolveLockPath(workspaceDir);
+  await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  const startedAt = Date.now();
+
+  while (true) {
+    let lockHandle: Awaited<ReturnType<typeof fs.open>> | undefined;
+    try {
+      lockHandle = await fs.open(lockPath, "wx");
+      await lockHandle.writeFile(`${process.pid}:${Date.now()}\n`, "utf-8").catch(() => undefined);
+      try {
+        return await task();
+      } finally {
+        await lockHandle.close().catch(() => undefined);
+        await fs.unlink(lockPath).catch(() => undefined);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") {
+        throw err;
+      }
+
+      const ageMs = await fs
+        .stat(lockPath)
+        .then((stats) => Date.now() - stats.mtimeMs)
+        .catch(() => 0);
+      if (ageMs > SHORT_TERM_LOCK_STALE_MS) {
+        await fs.unlink(lockPath).catch(() => undefined);
+        continue;
+      }
+
+      if (Date.now() - startedAt >= SHORT_TERM_LOCK_WAIT_TIMEOUT_MS) {
+        throw new Error(`Timed out waiting for short-term promotion lock at ${lockPath}`);
+      }
+
+      await sleep(SHORT_TERM_LOCK_RETRY_DELAY_MS);
     }
   }
 }
@@ -360,7 +394,7 @@ export async function recordShortTermRecalls(params: {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
   const nowIso = new Date(nowMs).toISOString();
   const queryHash = hashQuery(query);
-  await queueStoreWrite(workspaceDir, async () => {
+  await withShortTermLock(workspaceDir, async () => {
     const store = await readStore(workspaceDir, nowIso);
 
     for (const result of relevant) {
@@ -544,43 +578,55 @@ export async function applyShortTermPromotions(
     options.minUniqueQueries,
     DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES,
   );
-
-  const selected = options.candidates
-    .filter(
-      (candidate) =>
-        !candidate.promotedAt &&
-        candidate.score >= minScore &&
-        candidate.recallCount >= minRecallCount &&
-        candidate.uniqueQueries >= minUniqueQueries,
-    )
-    .slice(0, limit);
-
   const memoryPath = path.join(workspaceDir, "MEMORY.md");
-  if (selected.length === 0) {
-    return {
-      memoryPath,
-      applied: 0,
-      appliedCandidates: [],
-    };
-  }
 
-  const existingMemory = await fs.readFile(memoryPath, "utf-8").catch((err: unknown) => {
-    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
-      return "";
-    }
-    throw err;
-  });
-
-  const header = existingMemory.trim().length > 0 ? "" : "# Long-Term Memory\n\n";
-  const section = buildPromotionSection(selected, nowMs);
-  await fs.writeFile(
-    memoryPath,
-    `${header}${withTrailingNewline(existingMemory)}${section}`,
-    "utf-8",
-  );
-
-  await queueStoreWrite(workspaceDir, async () => {
+  return await withShortTermLock(workspaceDir, async () => {
     const store = await readStore(workspaceDir, nowIso);
+    const selected = options.candidates
+      .filter((candidate) => {
+        if (candidate.promotedAt) {
+          return false;
+        }
+        if (candidate.score < minScore) {
+          return false;
+        }
+        if (candidate.recallCount < minRecallCount) {
+          return false;
+        }
+        if (candidate.uniqueQueries < minUniqueQueries) {
+          return false;
+        }
+        const latest = store.entries[candidate.key];
+        if (latest?.promotedAt) {
+          return false;
+        }
+        return true;
+      })
+      .slice(0, limit);
+
+    if (selected.length === 0) {
+      return {
+        memoryPath,
+        applied: 0,
+        appliedCandidates: [],
+      };
+    }
+
+    const existingMemory = await fs.readFile(memoryPath, "utf-8").catch((err: unknown) => {
+      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+        return "";
+      }
+      throw err;
+    });
+
+    const header = existingMemory.trim().length > 0 ? "" : "# Long-Term Memory\n\n";
+    const section = buildPromotionSection(selected, nowMs);
+    await fs.writeFile(
+      memoryPath,
+      `${header}${withTrailingNewline(existingMemory)}${section}`,
+      "utf-8",
+    );
+
     for (const candidate of selected) {
       const entry = store.entries[candidate.key];
       if (!entry) {
@@ -590,13 +636,13 @@ export async function applyShortTermPromotions(
     }
     store.updatedAt = nowIso;
     await writeStore(workspaceDir, store);
-  });
 
-  return {
-    memoryPath,
-    applied: selected.length,
-    appliedCandidates: selected,
-  };
+    return {
+      memoryPath,
+      applied: selected.length,
+      appliedCandidates: selected,
+    };
+  });
 }
 
 export function resolveShortTermRecallStorePath(workspaceDir: string): string {

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -295,6 +295,43 @@ function resolveLockPath(workspaceDir: string): string {
   return path.join(workspaceDir, SHORT_TERM_LOCK_RELATIVE_PATH);
 }
 
+function parseLockOwnerPid(raw: string): number | null {
+  const match = raw.trim().match(/^(\d+):/);
+  if (!match) {
+    return null;
+  }
+  const pid = Number.parseInt(match[1] ?? "", 10);
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return null;
+  }
+  return pid;
+}
+
+function isProcessLikelyAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ESRCH") {
+      return false;
+    }
+    // EPERM and unknown errors are treated as alive to avoid stealing active locks.
+    return true;
+  }
+}
+
+async function canStealStaleLock(lockPath: string): Promise<boolean> {
+  const ownerPid = await fs
+    .readFile(lockPath, "utf-8")
+    .then((raw) => parseLockOwnerPid(raw))
+    .catch(() => null);
+  if (ownerPid === null) {
+    return true;
+  }
+  return !isProcessLikelyAlive(ownerPid);
+}
+
 async function sleep(ms: number): Promise<void> {
   await new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
@@ -327,8 +364,10 @@ async function withShortTermLock<T>(workspaceDir: string, task: () => Promise<T>
         .then((stats) => Date.now() - stats.mtimeMs)
         .catch(() => 0);
       if (ageMs > SHORT_TERM_LOCK_STALE_MS) {
-        await fs.unlink(lockPath).catch(() => undefined);
-        continue;
+        if (await canStealStaleLock(lockPath)) {
+          await fs.unlink(lockPath).catch(() => undefined);
+          continue;
+        }
       }
 
       if (Date.now() - startedAt >= SHORT_TERM_LOCK_WAIT_TIMEOUT_MS) {
@@ -648,3 +687,9 @@ export async function applyShortTermPromotions(
 export function resolveShortTermRecallStorePath(workspaceDir: string): string {
   return resolveStorePath(workspaceDir);
 }
+
+export const __testing = {
+  parseLockOwnerPid,
+  canStealStaleLock,
+  isProcessLikelyAlive,
+};

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
@@ -11,6 +11,7 @@ export const DEFAULT_PROMOTION_MIN_SCORE = 0.75;
 export const DEFAULT_PROMOTION_MIN_RECALL_COUNT = 3;
 export const DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES = 2;
 const SHORT_TERM_STORE_RELATIVE_PATH = path.join("memory", ".dreams", "short-term-recall.json");
+const storeWriteQueues = new Map<string, Promise<void>>();
 
 export type PromotionWeights = {
   frequency: number;
@@ -287,6 +288,24 @@ function resolveStorePath(workspaceDir: string): string {
   return path.join(workspaceDir, SHORT_TERM_STORE_RELATIVE_PATH);
 }
 
+async function queueStoreWrite<T>(workspaceDir: string, task: () => Promise<T>): Promise<T> {
+  const storePath = resolveStorePath(workspaceDir);
+  const previous = storeWriteQueues.get(storePath) ?? Promise.resolve();
+  const queuedTask = previous.catch(() => undefined).then(task);
+  const tail = queuedTask.then(
+    () => undefined,
+    () => undefined,
+  );
+  storeWriteQueues.set(storePath, tail);
+  try {
+    return await queuedTask;
+  } finally {
+    if (storeWriteQueues.get(storePath) === tail) {
+      storeWriteQueues.delete(storePath);
+    }
+  }
+}
+
 async function readStore(workspaceDir: string, nowIso: string): Promise<ShortTermRecallStore> {
   const storePath = resolveStorePath(workspaceDir);
   try {
@@ -304,7 +323,7 @@ async function readStore(workspaceDir: string, nowIso: string): Promise<ShortTer
 async function writeStore(workspaceDir: string, store: ShortTermRecallStore): Promise<void> {
   const storePath = resolveStorePath(workspaceDir);
   await fs.mkdir(path.dirname(storePath), { recursive: true });
-  const tmpPath = `${storePath}.${process.pid}.${Date.now()}.tmp`;
+  const tmpPath = `${storePath}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
   await fs.writeFile(tmpPath, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
   await fs.rename(tmpPath, storePath);
 }
@@ -341,38 +360,40 @@ export async function recordShortTermRecalls(params: {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
   const nowIso = new Date(nowMs).toISOString();
   const queryHash = hashQuery(query);
-  const store = await readStore(workspaceDir, nowIso);
+  await queueStoreWrite(workspaceDir, async () => {
+    const store = await readStore(workspaceDir, nowIso);
 
-  for (const result of relevant) {
-    const key = buildEntryKey(result);
-    const normalizedPath = normalizeMemoryPath(result.path);
-    const existing = store.entries[key];
-    const snippet = normalizeSnippet(result.snippet);
-    const score = clampScore(result.score);
-    const recallCount = Math.max(1, Math.floor(existing?.recallCount ?? 0) + 1);
-    const totalScore = Math.max(0, (existing?.totalScore ?? 0) + score);
-    const maxScore = Math.max(existing?.maxScore ?? 0, score);
-    const queryHashes = mergeQueryHashes(existing?.queryHashes ?? [], queryHash);
+    for (const result of relevant) {
+      const key = buildEntryKey(result);
+      const normalizedPath = normalizeMemoryPath(result.path);
+      const existing = store.entries[key];
+      const snippet = normalizeSnippet(result.snippet);
+      const score = clampScore(result.score);
+      const recallCount = Math.max(1, Math.floor(existing?.recallCount ?? 0) + 1);
+      const totalScore = Math.max(0, (existing?.totalScore ?? 0) + score);
+      const maxScore = Math.max(existing?.maxScore ?? 0, score);
+      const queryHashes = mergeQueryHashes(existing?.queryHashes ?? [], queryHash);
 
-    store.entries[key] = {
-      key,
-      path: normalizedPath,
-      startLine: Math.max(1, Math.floor(result.startLine)),
-      endLine: Math.max(1, Math.floor(result.endLine)),
-      source: "memory",
-      snippet: snippet || existing?.snippet || "",
-      recallCount,
-      totalScore,
-      maxScore,
-      firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
-      lastRecalledAt: nowIso,
-      queryHashes,
-      ...(existing?.promotedAt ? { promotedAt: existing.promotedAt } : {}),
-    };
-  }
+      store.entries[key] = {
+        key,
+        path: normalizedPath,
+        startLine: Math.max(1, Math.floor(result.startLine)),
+        endLine: Math.max(1, Math.floor(result.endLine)),
+        source: "memory",
+        snippet: snippet || existing?.snippet || "",
+        recallCount,
+        totalScore,
+        maxScore,
+        firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
+        lastRecalledAt: nowIso,
+        queryHashes,
+        ...(existing?.promotedAt ? { promotedAt: existing.promotedAt } : {}),
+      };
+    }
 
-  store.updatedAt = nowIso;
-  await writeStore(workspaceDir, store);
+    store.updatedAt = nowIso;
+    await writeStore(workspaceDir, store);
+  });
 }
 
 export async function rankShortTermPromotionCandidates(
@@ -558,16 +579,18 @@ export async function applyShortTermPromotions(
     "utf-8",
   );
 
-  const store = await readStore(workspaceDir, nowIso);
-  for (const candidate of selected) {
-    const entry = store.entries[candidate.key];
-    if (!entry) {
-      continue;
+  await queueStoreWrite(workspaceDir, async () => {
+    const store = await readStore(workspaceDir, nowIso);
+    for (const candidate of selected) {
+      const entry = store.entries[candidate.key];
+      if (!entry) {
+        continue;
+      }
+      entry.promotedAt = nowIso;
     }
-    entry.promotedAt = nowIso;
-  }
-  store.updatedAt = nowIso;
-  await writeStore(workspaceDir, store);
+    store.updatedAt = nowIso;
+    await writeStore(workspaceDir, store);
+  });
 
   return {
     memoryPath,

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -21,6 +21,25 @@ import {
   expectUnavailableMemorySearchDetails,
 } from "./tools.test-helpers.js";
 
+async function waitFor<T>(task: () => Promise<T>, timeoutMs: number = 1500): Promise<T> {
+  const startedAt = Date.now();
+  let lastError: unknown;
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      return await task();
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+    }
+  }
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+  throw new Error("Timed out waiting for async test condition");
+}
+
 beforeEach(() => {
   resetMemoryToolMockState({
     backend: "builtin",
@@ -175,7 +194,7 @@ describe("memory tools", () => {
       await tool.execute("call_recall_persist", { query: "glacier backup" });
 
       const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");
-      const storeRaw = await fs.readFile(storePath, "utf-8");
+      const storeRaw = await waitFor(async () => await fs.readFile(storePath, "utf-8"));
       const store = JSON.parse(storeRaw) as {
         entries?: Record<string, { path: string; recallCount: number }>;
       };

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   getMemorySearchManagerMockCalls,
@@ -6,6 +9,7 @@ import {
   setMemoryBackend,
   setMemoryReadFileImpl,
   setMemorySearchImpl,
+  setMemoryWorkspaceDir,
   type MemoryReadParams,
 } from "../../../test/helpers/memory-tool-manager-mock.js";
 import {
@@ -149,5 +153,40 @@ describe("memory tools", () => {
     });
     expect(getReadAgentMemoryFileMockCalls()).toBe(1);
     expect(getMemorySearchManagerMockCalls()).toBe(0);
+  });
+
+  it("persists short-term recall events from memory_search tool hits", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-tools-recall-"));
+    try {
+      setMemoryBackend("builtin");
+      setMemoryWorkspaceDir(workspaceDir);
+      setMemorySearchImpl(async () => [
+        {
+          path: "memory/2026-04-03.md",
+          startLine: 1,
+          endLine: 2,
+          score: 0.95,
+          snippet: "Move backups to S3 Glacier.",
+          source: "memory" as const,
+        },
+      ]);
+
+      const tool = createMemorySearchToolOrThrow();
+      await tool.execute("call_recall_persist", { query: "glacier backup" });
+
+      const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");
+      const storeRaw = await fs.readFile(storePath, "utf-8");
+      const store = JSON.parse(storeRaw) as {
+        entries?: Record<string, { path: string; recallCount: number }>;
+      };
+      const entries = Object.values(store.entries ?? {});
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        path: "memory/2026-04-03.md",
+        recallCount: 1,
+      });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/memory-core/src/tools.recall-tracking.test.ts
+++ b/extensions/memory-core/src/tools.recall-tracking.test.ts
@@ -1,0 +1,138 @@
+import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetMemoryToolMockState,
+  setMemoryBackend,
+  setMemorySearchImpl,
+} from "../../../test/helpers/memory-tool-manager-mock.js";
+import type { OpenClawConfig } from "../api.js";
+import { createMemorySearchTool } from "./tools.js";
+
+type RecordShortTermRecallsFn = (params: {
+  workspaceDir?: string;
+  query: string;
+  results: MemorySearchResult[];
+  nowMs?: number;
+}) => Promise<void>;
+
+const recallTrackingMock = vi.hoisted(() => ({
+  recordShortTermRecalls: vi.fn<RecordShortTermRecallsFn>(async () => {}),
+}));
+
+vi.mock("./short-term-promotion.js", () => ({
+  recordShortTermRecalls: recallTrackingMock.recordShortTermRecalls,
+}));
+
+function asOpenClawConfig(config: Partial<OpenClawConfig>): OpenClawConfig {
+  return config as OpenClawConfig;
+}
+
+function createSearchTool(config: OpenClawConfig) {
+  const tool = createMemorySearchTool({ config });
+  if (!tool) {
+    throw new Error("memory_search tool missing");
+  }
+  return tool;
+}
+
+describe("memory_search recall tracking", () => {
+  beforeEach(() => {
+    resetMemoryToolMockState();
+    recallTrackingMock.recordShortTermRecalls.mockReset();
+    recallTrackingMock.recordShortTermRecalls.mockResolvedValue(undefined);
+  });
+
+  it("records only surfaced results after qmd clamp", async () => {
+    setMemoryBackend("qmd");
+    setMemorySearchImpl(async () => [
+      {
+        path: "memory/2026-04-03.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.95,
+        snippet: "A".repeat(80),
+        source: "memory" as const,
+      },
+      {
+        path: "memory/2026-04-02.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.92,
+        snippet: "B".repeat(80),
+        source: "memory" as const,
+      },
+    ]);
+
+    const tool = createSearchTool(
+      asOpenClawConfig({
+        agents: { list: [{ id: "main", default: true }] },
+        memory: {
+          backend: "qmd",
+          citations: "on",
+          qmd: { limits: { maxInjectedChars: 100 } },
+        },
+      }),
+    );
+
+    const result = await tool.execute("call_recall_clamp", { query: "backup glacier" });
+    const details = result.details as { results: Array<{ path: string }> };
+    expect(details.results).toHaveLength(1);
+    expect(details.results[0]?.path).toBe("memory/2026-04-03.md");
+
+    expect(recallTrackingMock.recordShortTermRecalls).toHaveBeenCalledTimes(1);
+    const [firstCall] = recallTrackingMock.recordShortTermRecalls.mock.calls;
+    expect(firstCall).toBeDefined();
+    const recallParams = firstCall[0];
+    expect(recallParams.results).toHaveLength(1);
+    expect(recallParams.results[0]?.path).toBe("memory/2026-04-03.md");
+    expect(recallParams.results[0]?.snippet).not.toContain("Source:");
+  });
+
+  it("does not block tool results on slow best-effort recall writes", async () => {
+    let resolveRecall: (() => void) | undefined;
+    recallTrackingMock.recordShortTermRecalls.mockImplementationOnce(
+      async () =>
+        await new Promise<void>((resolve) => {
+          resolveRecall = resolve;
+        }),
+    );
+
+    const tool = createSearchTool(
+      asOpenClawConfig({
+        agents: { list: [{ id: "main", default: true }] },
+      }),
+    );
+    setMemorySearchImpl(async () => [
+      {
+        path: "memory/2026-04-03.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.95,
+        snippet: "Move backups to S3 Glacier.",
+        source: "memory" as const,
+      },
+    ]);
+
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      const result = (await Promise.race([
+        tool.execute("call_recall_non_blocking", { query: "glacier" }),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(() => {
+            reject(new Error("memory_search waited on recall persistence"));
+          }, 200);
+        }),
+      ])) as Awaited<ReturnType<typeof tool.execute>>;
+
+      const details = result.details as { results: Array<{ path: string }> };
+      expect(details.results).toHaveLength(1);
+      expect(details.results[0]?.path).toBe("memory/2026-04-03.md");
+      expect(recallTrackingMock.recordShortTermRecalls).toHaveBeenCalledTimes(1);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      resolveRecall?.();
+    }
+  });
+});

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -5,6 +5,7 @@ import {
   type AnyAgentTool,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import { recordShortTermRecalls } from "./short-term-promotion.js";
 import {
   clampResultsByInjectedChars,
@@ -21,6 +22,45 @@ import {
   MemoryGetSchema,
   MemorySearchSchema,
 } from "./tools.shared.js";
+
+function buildRecallKey(
+  result: Pick<MemorySearchResult, "source" | "path" | "startLine" | "endLine">,
+): string {
+  return `${result.source}:${result.path}:${result.startLine}:${result.endLine}`;
+}
+
+function resolveRecallTrackingResults(
+  rawResults: MemorySearchResult[],
+  surfacedResults: MemorySearchResult[],
+): MemorySearchResult[] {
+  if (surfacedResults.length === 0 || rawResults.length === 0) {
+    return surfacedResults;
+  }
+  const rawByKey = new Map<string, MemorySearchResult>();
+  for (const raw of rawResults) {
+    const key = buildRecallKey(raw);
+    if (!rawByKey.has(key)) {
+      rawByKey.set(key, raw);
+    }
+  }
+  return surfacedResults.map((surfaced) => rawByKey.get(buildRecallKey(surfaced)) ?? surfaced);
+}
+
+function queueShortTermRecallTracking(params: {
+  workspaceDir?: string;
+  query: string;
+  rawResults: MemorySearchResult[];
+  surfacedResults: MemorySearchResult[];
+}): void {
+  const trackingResults = resolveRecallTrackingResults(params.rawResults, params.surfacedResults);
+  void recordShortTermRecalls({
+    workspaceDir: params.workspaceDir,
+    query: params.query,
+    results: trackingResults,
+  }).catch(() => {
+    // Recall tracking is best-effort and must never block memory recall.
+  });
+}
 
 export function createMemorySearchTool(options: {
   config?: OpenClawConfig;
@@ -56,19 +96,18 @@ export function createMemorySearchTool(options: {
             sessionKey: options.agentSessionKey,
           });
           const status = memory.manager.status();
-          await recordShortTermRecalls({
-            workspaceDir: status.workspaceDir,
-            query,
-            results: rawResults,
-          }).catch(() => {
-            // Recall tracking is best-effort and must never block memory recall.
-          });
           const decorated = decorateCitations(rawResults, includeCitations);
           const resolved = resolveMemoryBackendConfig({ cfg, agentId });
           const results =
             status.backend === "qmd"
               ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
               : decorated;
+          queueShortTermRecallTracking({
+            workspaceDir: status.workspaceDir,
+            query,
+            rawResults,
+            surfacedResults: results,
+          });
           const searchMode = (status.custom as { searchMode?: string } | undefined)?.searchMode;
           return jsonResult({
             results,

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -5,6 +5,7 @@ import {
   type AnyAgentTool,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { recordShortTermRecalls } from "./short-term-promotion.js";
 import {
   clampResultsByInjectedChars,
   decorateCitations,
@@ -55,6 +56,13 @@ export function createMemorySearchTool(options: {
             sessionKey: options.agentSessionKey,
           });
           const status = memory.manager.status();
+          await recordShortTermRecalls({
+            workspaceDir: status.workspaceDir,
+            query,
+            results: rawResults,
+          }).catch(() => {
+            // Recall tracking is best-effort and must never block memory recall.
+          });
           const decorated = decorateCitations(rawResults, includeCitations);
           const resolved = resolveMemoryBackendConfig({ cfg, agentId });
           const results =

--- a/extensions/telegram/src/setup-surface.test.ts
+++ b/extensions/telegram/src/setup-surface.test.ts
@@ -215,7 +215,7 @@ describe("telegramSetupWizard.dmPolicy", () => {
     });
 
     const next = telegramSetupWizard.dmPolicy?.setPolicy(cfg, "open");
-    expect(next?.channels?.telegram?.dmPolicy).toBe("disabled");
+    expect(next?.channels?.telegram?.dmPolicy).toBeUndefined();
     expect(next?.channels?.telegram?.accounts?.alerts?.dmPolicy).toBe("open");
   });
 

--- a/extensions/telegram/src/setup-surface.test.ts
+++ b/extensions/telegram/src/setup-surface.test.ts
@@ -215,7 +215,7 @@ describe("telegramSetupWizard.dmPolicy", () => {
     });
 
     const next = telegramSetupWizard.dmPolicy?.setPolicy(cfg, "open");
-    expect(next?.channels?.telegram?.dmPolicy).toBeUndefined();
+    expect(next?.channels?.telegram?.dmPolicy).toBe("disabled");
     expect(next?.channels?.telegram?.accounts?.alerts?.dmPolicy).toBe("open");
   });
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -855,6 +855,7 @@ export async function startGatewayServer(
     broadcast,
   });
   let { cron, storePath: cronStorePath } = cronState;
+  deps.cron = cron;
 
   const { getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } =
     channelManager;
@@ -1423,6 +1424,7 @@ export async function startGatewayServer(
               cronState = nextState.cronState;
               cron = cronState.cron;
               cronStorePath = cronState.storePath;
+              deps.cron = cron;
               channelHealthMonitor = nextState.channelHealthMonitor;
             },
             startChannel,

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -43,8 +43,8 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
     'export { probeIMessage } from "./src/probe.js";',
     'export type { IMessageProbe } from "./src/probe.js";',
     'export { sendMessageIMessage } from "./src/send.js";',
+    'export { chunkTextForOutbound } from "./src/channel-api.js";',
     'export type IMessageAccountConfig = Omit< NonNullable<NonNullable<RuntimeApiOpenClawConfig["channels"]>["imessage"]>, "accounts" | "defaultAccount" >;',
-    'export function chunkTextForOutbound(text: string, limit: number): string[] { const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; chunks.push(remaining.slice(0, breakAt).trimEnd()); remaining = remaining.slice(breakAt).trimStart(); } if (remaining.length > 0 || text.length === 0) { chunks.push(remaining); } return chunks; }',
   ],
   [bundledPluginFile("googlechat", "runtime-api.ts")]: [
     'export * from "openclaw/plugin-sdk/googlechat";',

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -59,8 +59,9 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
     'export { setMatrixThreadBindingIdleTimeoutBySessionKey, setMatrixThreadBindingMaxAgeBySessionKey } from "./src/matrix/thread-bindings-shared.js";',
     'export { setMatrixRuntime } from "./src/runtime.js";',
     'export { writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";',
-    'export type { ChannelDirectoryEntry, ChannelMessageActionContext, OpenClawConfig, PluginRuntime, RuntimeLogger, RuntimeEnv, WizardPrompter } from "openclaw/plugin-sdk/matrix-runtime-shared";',
-    'export { formatZonedTimestamp } from "openclaw/plugin-sdk/matrix-runtime-shared";',
+    'export type { ChannelDirectoryEntry, ChannelMessageActionContext, OpenClawConfig, PluginRuntime, RuntimeLogger, WizardPrompter } from "openclaw/plugin-sdk/core";',
+    'export type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";',
+    'export { formatZonedTimestamp } from "openclaw/plugin-sdk/core";',
     'export function chunkTextForOutbound(text: string, limit: number): string[] { const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; chunks.push(remaining.slice(0, breakAt).trimEnd()); remaining = remaining.slice(breakAt).trimStart(); } if (remaining.length > 0 || text.length === 0) { chunks.push(remaining); } return chunks; }',
   ],
   [bundledPluginFile("nextcloud-talk", "runtime-api.ts")]: [

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -856,10 +856,15 @@ describe("plugin-sdk subpath exports", () => {
     ]);
     expect("createScopedPairingAccess" in channelPairingSdk).toBe(false);
 
-    expectSourceMentions("channel-reply-pipeline", ["createChannelReplyPipeline"]);
-    expect("createTypingCallbacks" in channelReplyPipelineSdk).toBe(true);
-    expect("createReplyPrefixContext" in channelReplyPipelineSdk).toBe(true);
-    expect("createReplyPrefixOptions" in channelReplyPipelineSdk).toBe(true);
+    expectSourceMentions("channel-reply-pipeline", [
+      "createChannelReplyPipeline",
+      "createTypingCallbacks",
+      "createReplyPrefixContext",
+      "createReplyPrefixOptions",
+    ]);
+    expect(typeof channelReplyPipelineSdk.createTypingCallbacks).toBe("function");
+    expect(typeof channelReplyPipelineSdk.createReplyPrefixContext).toBe("function");
+    expect(typeof channelReplyPipelineSdk.createReplyPrefixOptions).toBe("function");
 
     expect(pluginSdkSubpaths.length).toBeGreaterThan(representativeRuntimeSmokeSubpaths.length);
     for (const [index, id] of representativeRuntimeSmokeSubpaths.entries()) {

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -47,7 +47,7 @@ export function initializeGlobalHookRunner(registry: PluginRegistry): void {
 
   const hookCount = registry.hooks.length;
   if (hookCount > 0) {
-    log.info(`hook runner initialized with ${hookCount} registered hooks`);
+    log.debug(`hook runner initialized with ${hookCount} registered hooks`);
   }
 }
 

--- a/test/helpers/memory-tool-manager-mock.ts
+++ b/test/helpers/memory-tool-manager-mock.ts
@@ -6,6 +6,7 @@ export type MemoryReadResult = { text: string; path: string };
 type MemoryBackend = "builtin" | "qmd";
 
 let backend: MemoryBackend = "builtin";
+let workspaceDir = "/workspace";
 let searchImpl: SearchImpl = async () => [];
 let readFileImpl: (params: MemoryReadParams) => Promise<MemoryReadResult> = async (params) => ({
   text: "",
@@ -20,7 +21,7 @@ const stubManager = {
     files: 1,
     chunks: 1,
     dirty: false,
-    workspaceDir: "/workspace",
+    workspaceDir,
     dbPath: "/workspace/.memory/index.sqlite",
     provider: "builtin",
     model: "builtin",
@@ -68,6 +69,10 @@ export function setMemoryBackend(next: MemoryBackend): void {
   backend = next;
 }
 
+export function setMemoryWorkspaceDir(next: string): void {
+  workspaceDir = next;
+}
+
 export function setMemorySearchImpl(next: SearchImpl): void {
   searchImpl = next;
 }
@@ -84,6 +89,7 @@ export function resetMemoryToolMockState(overrides?: {
   readFileImpl?: (params: MemoryReadParams) => Promise<MemoryReadResult>;
 }): void {
   backend = overrides?.backend ?? "builtin";
+  workspaceDir = "/workspace";
   searchImpl = overrides?.searchImpl ?? (async () => []);
   readFileImpl =
     overrides?.readFileImpl ??

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -45,6 +45,7 @@ export const en: TranslationMap = {
     aiAgents: "AI & Agents",
     debug: "Debug",
     logs: "Logs",
+    dreams: "Dreams",
   },
   subtitles: {
     agents: "Workspaces, tools, identities.",
@@ -65,6 +66,7 @@ export const en: TranslationMap = {
     aiAgents: "Agents, models, skills, tools, memory, session.",
     debug: "Snapshots, events, RPC.",
     logs: "Live gateway logs.",
+    dreams: "Memory consolidation while sleeping.",
   },
   overview: {
     access: {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -5,6 +5,7 @@
 @import "./styles/chat.css";
 @import "./styles/config.css";
 @import "./styles/usage.css";
+@import "./styles/dreams.css";
 @import "@create-markdown/preview/themes/system.css";
 
 .cm-preview {

--- a/ui/src/styles/dreams.css
+++ b/ui/src/styles/dreams.css
@@ -1,0 +1,332 @@
+/* ===========================================
+   Dreams Tab – Sleeping Lobster Animation
+   =========================================== */
+
+.dreams {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 64px);
+  overflow: hidden;
+  user-select: none;
+}
+
+/* ---- Breathing lobster ---- */
+
+.dreams__lobster {
+  animation: dreams-breathe 4s ease-in-out infinite;
+  filter: drop-shadow(0 0 40px rgba(255, 77, 77, 0.25));
+  transition: filter 0.6s ease;
+}
+
+.dreams__lobster svg {
+  width: 160px;
+  height: 160px;
+}
+
+@keyframes dreams-breathe {
+  0%,
+  100% {
+    transform: scale(1) translateY(0);
+  }
+  50% {
+    transform: scale(1.04) translateY(-4px);
+  }
+}
+
+/* ---- Sleeping eyes overlay ---- */
+
+.dreams__eyes {
+  animation: dreams-blink 6s ease-in-out infinite;
+}
+
+@keyframes dreams-blink {
+  0%,
+  90%,
+  100% {
+    opacity: 1;
+  }
+  95% {
+    opacity: 0;
+  }
+}
+
+/* ---- Floating Z's ---- */
+
+.dreams__z {
+  position: absolute;
+  font-family: var(--mono);
+  font-weight: 700;
+  color: var(--accent);
+  opacity: 0;
+  animation: dreams-float-z 4s ease-out infinite;
+}
+
+.dreams__z:nth-child(1) {
+  font-size: 14px;
+  right: calc(50% - 100px);
+  top: calc(50% - 80px);
+  animation-delay: 0s;
+}
+
+.dreams__z:nth-child(2) {
+  font-size: 20px;
+  right: calc(50% - 130px);
+  top: calc(50% - 120px);
+  animation-delay: 1.2s;
+}
+
+.dreams__z:nth-child(3) {
+  font-size: 28px;
+  right: calc(50% - 160px);
+  top: calc(50% - 170px);
+  animation-delay: 2.4s;
+}
+
+@keyframes dreams-float-z {
+  0% {
+    opacity: 0;
+    transform: translateY(10px) rotate(-5deg);
+  }
+  15% {
+    opacity: 0.7;
+  }
+  80% {
+    opacity: 0.3;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-40px) rotate(10deg);
+  }
+}
+
+/* ---- Stars ---- */
+
+.dreams__star {
+  position: absolute;
+  border-radius: 50%;
+  animation: dreams-twinkle 3s ease-in-out infinite alternate;
+}
+
+@keyframes dreams-twinkle {
+  0% {
+    opacity: 0.15;
+    transform: scale(0.8);
+  }
+  100% {
+    opacity: 0.7;
+    transform: scale(1.2);
+  }
+}
+
+/* ---- Dream thought bubble ---- */
+
+.dreams__bubble {
+  position: absolute;
+  top: calc(50% - 200px);
+  left: calc(50% - 200px);
+  padding: 16px 20px;
+  background: var(--accent-subtle);
+  border: 1px solid rgba(255, 92, 92, 0.12);
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  animation: dreams-bubble-float 6s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.dreams__bubble-label {
+  font-size: 11px;
+  color: var(--accent-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.dreams__bubble-text {
+  font-size: 16px;
+  color: var(--accent);
+  font-style: italic;
+  opacity: 0.8;
+  min-width: 180px;
+  text-align: center;
+}
+
+@keyframes dreams-bubble-float {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.8;
+  }
+  50% {
+    transform: translateY(-8px);
+    opacity: 1;
+  }
+}
+
+/* Bubble trail dots */
+.dreams__bubble-dot {
+  position: absolute;
+  border-radius: 50%;
+  background: var(--accent-subtle);
+  border: 1px solid rgba(255, 92, 92, 0.1);
+  animation: dreams-bubble-float 6s ease-in-out infinite;
+}
+
+/* ---- Moon ---- */
+
+.dreams__moon {
+  position: absolute;
+  top: 40px;
+  right: 80px;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #fef3c7, #fbbf24);
+  box-shadow:
+    0 0 40px rgba(251, 191, 36, 0.2),
+    0 0 80px rgba(251, 191, 36, 0.08);
+  opacity: 0.7;
+  animation: dreams-moon-glow 8s ease-in-out infinite alternate;
+}
+
+@keyframes dreams-moon-glow {
+  0% {
+    box-shadow:
+      0 0 40px rgba(251, 191, 36, 0.2),
+      0 0 80px rgba(251, 191, 36, 0.08);
+    opacity: 0.6;
+  }
+  100% {
+    box-shadow:
+      0 0 50px rgba(251, 191, 36, 0.3),
+      0 0 100px rgba(251, 191, 36, 0.12);
+    opacity: 0.8;
+  }
+}
+
+/* ---- Ambient glow under lobster ---- */
+
+.dreams__glow {
+  position: absolute;
+  top: calc(50% + 40px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 240px;
+  height: 100px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, rgba(255, 77, 77, 0.08) 0%, transparent 70%);
+  pointer-events: none;
+  animation: dreams-glow-pulse 4s ease-in-out infinite;
+}
+
+@keyframes dreams-glow-pulse {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* ---- Stats bar ---- */
+
+.dreams__stats {
+  position: absolute;
+  bottom: 40px;
+  display: flex;
+  align-items: center;
+  gap: 48px;
+}
+
+.dreams__stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.dreams__stat-value {
+  font-size: 28px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.dreams__stat-label {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.dreams__stat-divider {
+  width: 1px;
+  height: 32px;
+  background: var(--border);
+}
+
+/* ---- Status line ---- */
+
+.dreams__status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin-top: 32px;
+}
+
+.dreams__status-label {
+  font-size: 13px;
+  color: var(--muted);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+
+.dreams__status-detail {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--ok-muted);
+}
+
+.dreams__status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ok);
+  animation: dreams-dot-pulse 2s ease-in-out infinite;
+}
+
+@keyframes dreams-dot-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.4);
+  }
+  50% {
+    opacity: 0.7;
+    box-shadow: 0 0 8px 2px rgba(34, 197, 94, 0.2);
+  }
+}
+
+/* ---- Idle / inactive state ---- */
+
+.dreams--idle .dreams__lobster {
+  filter: drop-shadow(0 0 20px rgba(255, 77, 77, 0.1));
+}
+
+.dreams--idle .dreams__status-dot {
+  background: var(--muted);
+  animation: none;
+}
+
+.dreams--idle .dreams__status-detail {
+  color: var(--muted);
+}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -143,6 +143,20 @@ const lazyLogs = createLazy(() => import("./views/logs.ts"));
 const lazyNodes = createLazy(() => import("./views/nodes.ts"));
 const lazySessions = createLazy(() => import("./views/sessions.ts"));
 const lazySkills = createLazy(() => import("./views/skills.ts"));
+const lazyDreams = createLazy(() => import("./views/dreams.ts"));
+
+function isDreamingEnabled(configValue: Record<string, unknown> | null): boolean {
+  if (!configValue) {
+    return false;
+  }
+  const plugins = configValue.plugins as Record<string, unknown> | undefined;
+  const entries = plugins?.entries as Record<string, unknown> | undefined;
+  const memoryCore = entries?.["memory-core"] as Record<string, unknown> | undefined;
+  const config = memoryCore?.config as Record<string, unknown> | undefined;
+  const dreaming = config?.dreaming as Record<string, unknown> | undefined;
+  const mode = dreaming?.mode;
+  return typeof mode === "string" && mode !== "off";
+}
 
 let clawhubSearchTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -509,8 +523,13 @@ export function renderApp(state: AppViewState) {
             <div class="sidebar-shell__body">
               <nav class="sidebar-nav">
                 ${TAB_GROUPS.map((group) => {
+                  const dreamingOn = isDreamingEnabled(configValue);
+                  const visibleTabs = group.tabs.filter((tab) => tab !== "dreams" || dreamingOn);
+                  if (visibleTabs.length === 0) {
+                    return nothing;
+                  }
                   const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
-                  const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
+                  const hasActiveTab = visibleTabs.some((tab) => tab === state.tab);
                   const showItems = navCollapsed || hasActiveTab || !isGroupCollapsed;
 
                   return html`
@@ -537,7 +556,7 @@ export function renderApp(state: AppViewState) {
                           `
                         : nothing}
                       <div class="nav-section__items">
-                        ${group.tabs.map((tab) =>
+                        ${visibleTabs.map((tab) =>
                           renderTab(state, tab, { collapsed: navCollapsed }),
                         )}
                       </div>
@@ -2002,6 +2021,18 @@ export function renderApp(state: AppViewState) {
                 onRefresh: () => loadLogs(state, { reset: true }),
                 onExport: (lines, label) => state.exportLogs(lines, label),
                 onScroll: (event) => state.handleLogsScroll(event),
+              }),
+            )
+          : nothing}
+        ${state.tab === "dreams"
+          ? lazyRender(lazyDreams, (m) =>
+              m.renderDreams({
+                active: true,
+                shortTermCount: 0,
+                longTermCount: 0,
+                promotedCount: 0,
+                dreamingOf: null,
+                nextCycle: null,
               }),
             )
           : nothing}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -343,6 +343,7 @@ export function renderApp(state: AppViewState) {
   const chatAvatarUrl = state.chatAvatarUrl ?? assistantAvatarUrl ?? null;
   const configValue =
     state.configForm ?? (state.configSnapshot?.config as Record<string, unknown> | null);
+  const dreamingOn = isDreamingEnabled(configValue);
   const basePath = normalizeBasePath(state.basePath ?? "");
   const resolvedAgentId =
     state.agentsSelectedId ??
@@ -523,13 +524,8 @@ export function renderApp(state: AppViewState) {
             <div class="sidebar-shell__body">
               <nav class="sidebar-nav">
                 ${TAB_GROUPS.map((group) => {
-                  const dreamingOn = isDreamingEnabled(configValue);
-                  const visibleTabs = group.tabs.filter((tab) => tab !== "dreams" || dreamingOn);
-                  if (visibleTabs.length === 0) {
-                    return nothing;
-                  }
                   const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
-                  const hasActiveTab = visibleTabs.some((tab) => tab === state.tab);
+                  const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
                   const showItems = navCollapsed || hasActiveTab || !isGroupCollapsed;
 
                   return html`
@@ -556,7 +552,7 @@ export function renderApp(state: AppViewState) {
                           `
                         : nothing}
                       <div class="nav-section__items">
-                        ${visibleTabs.map((tab) =>
+                        ${group.tabs.map((tab) =>
                           renderTab(state, tab, { collapsed: navCollapsed }),
                         )}
                       </div>
@@ -2027,7 +2023,7 @@ export function renderApp(state: AppViewState) {
         ${state.tab === "dreams"
           ? lazyRender(lazyDreams, (m) =>
               m.renderDreams({
-                active: true,
+                active: dreamingOn,
                 shortTermCount: 0,
                 longTermCount: 0,
                 promotedCount: 0,

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -84,6 +84,14 @@ describe("control UI routing", () => {
     expect(window.location.pathname).toBe("/channels");
   });
 
+  it("keeps dreams navigation visible even when dreaming is disabled", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
+    const dreamsLink = app.querySelector<HTMLAnchorElement>('a.nav-item[href="/dreams"]');
+    expect(dreamsLink).not.toBeNull();
+  });
+
   it("renders the refreshed top navigation shell", async () => {
     const app = mountApp("/chat");
     await app.updateComplete;

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -7,7 +7,7 @@ export const TAB_GROUPS = [
     label: "control",
     tabs: ["overview", "channels", "instances", "sessions", "usage", "cron"],
   },
-  { label: "agent", tabs: ["agents", "skills", "nodes"] },
+  { label: "agent", tabs: ["agents", "skills", "nodes", "dreams"] },
   {
     label: "settings",
     tabs: [
@@ -41,7 +41,8 @@ export type Tab =
   | "infrastructure"
   | "aiAgents"
   | "debug"
-  | "logs";
+  | "logs"
+  | "dreams";
 
 const TAB_PATHS: Record<Tab, string> = {
   agents: "/agents",
@@ -62,6 +63,7 @@ const TAB_PATHS: Record<Tab, string> = {
   aiAgents: "/ai-agents",
   debug: "/debug",
   logs: "/logs",
+  dreams: "/dreams",
 };
 
 const PATH_TO_TAB = new Map(Object.entries(TAB_PATHS).map(([tab, path]) => [path, tab as Tab]));
@@ -183,6 +185,8 @@ export function iconForTab(tab: Tab): IconName {
       return "bug";
     case "logs":
       return "scrollText";
+    case "dreams":
+      return "moon";
     default:
       return "folder";
   }

--- a/ui/src/ui/views/dreams.test.ts
+++ b/ui/src/ui/views/dreams.test.ts
@@ -1,0 +1,110 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import { renderDreams, type DreamsProps } from "./dreams.ts";
+
+function buildProps(overrides?: Partial<DreamsProps>): DreamsProps {
+  return {
+    active: true,
+    shortTermCount: 47,
+    longTermCount: 182,
+    promotedCount: 12,
+    dreamingOf: null,
+    nextCycle: "4:00 AM",
+    ...overrides,
+  };
+}
+
+function renderInto(props: DreamsProps): HTMLDivElement {
+  const container = document.createElement("div");
+  render(renderDreams(props), container);
+  return container;
+}
+
+describe("dreams view", () => {
+  it("renders the sleeping lobster SVG", () => {
+    const container = renderInto(buildProps());
+    const svg = container.querySelector(".dreams__lobster svg");
+    expect(svg).not.toBeNull();
+  });
+
+  it("shows three floating Z elements", () => {
+    const container = renderInto(buildProps());
+    const zs = container.querySelectorAll(".dreams__z");
+    expect(zs.length).toBe(3);
+  });
+
+  it("renders stars", () => {
+    const container = renderInto(buildProps());
+    const stars = container.querySelectorAll(".dreams__star");
+    expect(stars.length).toBe(12);
+  });
+
+  it("renders moon", () => {
+    const container = renderInto(buildProps());
+    expect(container.querySelector(".dreams__moon")).not.toBeNull();
+  });
+
+  it("displays memory stats", () => {
+    const container = renderInto(buildProps());
+    const values = container.querySelectorAll(".dreams__stat-value");
+    expect(values.length).toBe(3);
+    expect(values[0]?.textContent).toBe("47");
+    expect(values[1]?.textContent).toBe("182");
+    expect(values[2]?.textContent).toBe("12");
+  });
+
+  it("shows dream bubble when active", () => {
+    const container = renderInto(buildProps({ active: true }));
+    expect(container.querySelector(".dreams__bubble")).not.toBeNull();
+  });
+
+  it("hides dream bubble when idle", () => {
+    const container = renderInto(buildProps({ active: false }));
+    expect(container.querySelector(".dreams__bubble")).toBeNull();
+  });
+
+  it("shows custom dreamingOf text when provided", () => {
+    const container = renderInto(buildProps({ dreamingOf: "reindexing old chats…" }));
+    const text = container.querySelector(".dreams__bubble-text");
+    expect(text?.textContent).toBe("reindexing old chats…");
+  });
+
+  it("cycles through phrases when dreamingOf is null", () => {
+    const container = renderInto(buildProps({ dreamingOf: null }));
+    const text = container.querySelector(".dreams__bubble-text");
+    // Should be one of the built-in phrases, not empty
+    expect(text?.textContent?.length).toBeGreaterThan(5);
+    expect(text?.textContent).toContain("…");
+  });
+
+  it("shows active status label when active", () => {
+    const container = renderInto(buildProps({ active: true }));
+    const label = container.querySelector(".dreams__status-label");
+    expect(label?.textContent).toBe("Memory Dreaming Active");
+  });
+
+  it("shows idle status label when inactive", () => {
+    const container = renderInto(buildProps({ active: false }));
+    const label = container.querySelector(".dreams__status-label");
+    expect(label?.textContent).toBe("Dreaming Idle");
+  });
+
+  it("applies idle class when not active", () => {
+    const container = renderInto(buildProps({ active: false }));
+    expect(container.querySelector(".dreams--idle")).not.toBeNull();
+  });
+
+  it("shows next cycle info when provided", () => {
+    const container = renderInto(buildProps({ nextCycle: "4:00 AM" }));
+    const detail = container.querySelector(".dreams__status-detail span");
+    expect(detail?.textContent).toContain("4:00 AM");
+  });
+
+  it("omits next cycle when null", () => {
+    const container = renderInto(buildProps({ nextCycle: null }));
+    const detail = container.querySelector(".dreams__status-detail span");
+    expect(detail?.textContent).not.toContain("next cycle");
+  });
+});

--- a/ui/src/ui/views/dreams.ts
+++ b/ui/src/ui/views/dreams.ts
@@ -1,0 +1,204 @@
+import { html, nothing } from "lit";
+
+export type DreamsProps = {
+  active: boolean;
+  shortTermCount: number;
+  longTermCount: number;
+  promotedCount: number;
+  dreamingOf: string | null;
+  nextCycle: string | null;
+};
+
+const DREAM_PHRASES = [
+  "consolidating memories…",
+  "tidying the knowledge graph…",
+  "replaying today's conversations…",
+  "weaving short-term into long-term…",
+  "defragmenting the mind palace…",
+  "filing away loose thoughts…",
+  "connecting distant dots…",
+  "composting old context windows…",
+  "alphabetizing the subconscious…",
+  "promoting promising hunches…",
+  "forgetting what doesn't matter…",
+  "dreaming in embeddings…",
+  "reorganizing the memory attic…",
+  "softly indexing the day…",
+  "nurturing fledgling insights…",
+  "simmering half-formed ideas…",
+  "whispering to the vector store…",
+];
+
+let _dreamIndex = Math.floor(Math.random() * DREAM_PHRASES.length);
+let _dreamLastSwap = 0;
+const DREAM_SWAP_MS = 6_000;
+
+function currentDreamPhrase(): string {
+  const now = Date.now();
+  if (now - _dreamLastSwap > DREAM_SWAP_MS) {
+    _dreamLastSwap = now;
+    _dreamIndex = (_dreamIndex + 1) % DREAM_PHRASES.length;
+  }
+  return DREAM_PHRASES[_dreamIndex];
+}
+
+// Stars with deterministic positions so they don't shuffle on re-render
+const STARS: {
+  top: number;
+  left: number;
+  size: number;
+  delay: number;
+  hue: "neutral" | "accent";
+}[] = [
+  { top: 8, left: 15, size: 3, delay: 0, hue: "neutral" },
+  { top: 12, left: 72, size: 2, delay: 1.4, hue: "neutral" },
+  { top: 22, left: 35, size: 3, delay: 0.6, hue: "accent" },
+  { top: 18, left: 88, size: 2, delay: 2.1, hue: "neutral" },
+  { top: 35, left: 8, size: 2, delay: 0.9, hue: "neutral" },
+  { top: 45, left: 92, size: 2, delay: 1.7, hue: "neutral" },
+  { top: 55, left: 25, size: 3, delay: 2.5, hue: "accent" },
+  { top: 65, left: 78, size: 2, delay: 0.3, hue: "neutral" },
+  { top: 75, left: 45, size: 2, delay: 1.1, hue: "neutral" },
+  { top: 82, left: 60, size: 3, delay: 1.8, hue: "accent" },
+  { top: 30, left: 55, size: 2, delay: 0.4, hue: "neutral" },
+  { top: 88, left: 18, size: 2, delay: 2.3, hue: "neutral" },
+];
+
+// The real vector lobster with sleeping modifications:
+// - eyes are closed (horizontal lines instead of open circles)
+// - antennae droop slightly
+const sleepingLobster = html`
+  <svg viewBox="0 0 120 120" fill="none">
+    <defs>
+      <linearGradient id="dream-lob-g" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#ff4d4d" />
+        <stop offset="100%" stop-color="#991b1b" />
+      </linearGradient>
+    </defs>
+    <!-- Body -->
+    <path
+      d="M60 10C30 10 15 35 15 55C15 75 30 95 45 100L45 110L55 110L55 100C55 100 60 102 65 100L65 110L75 110L75 100C90 95 105 75 105 55C105 35 90 10 60 10Z"
+      fill="url(#dream-lob-g)"
+    />
+    <!-- Left Claw -->
+    <path d="M20 45C5 40 0 50 5 60C10 70 20 65 25 55C28 48 25 45 20 45Z" fill="url(#dream-lob-g)" />
+    <!-- Right Claw -->
+    <path
+      d="M100 45C115 40 120 50 115 60C110 70 100 65 95 55C92 48 95 45 100 45Z"
+      fill="url(#dream-lob-g)"
+    />
+    <!-- Antennae (drooping for sleep) -->
+    <path d="M45 15Q38 8 35 14" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round" />
+    <path d="M75 15Q82 8 85 14" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round" />
+    <!-- Closed eyes — curved lines -->
+    <path
+      d="M39 36Q45 32 51 36"
+      stroke="#050810"
+      stroke-width="2.5"
+      stroke-linecap="round"
+      fill="none"
+    />
+    <path
+      d="M69 36Q75 32 81 36"
+      stroke="#050810"
+      stroke-width="2.5"
+      stroke-linecap="round"
+      fill="none"
+    />
+  </svg>
+`;
+
+export function renderDreams(props: DreamsProps) {
+  const idle = !props.active;
+  const dreamText = props.dreamingOf ?? currentDreamPhrase();
+
+  return html`
+    <section class="dreams ${idle ? "dreams--idle" : ""}">
+      <!-- Stars -->
+      ${STARS.map(
+        (s) => html`
+          <div
+            class="dreams__star"
+            style="
+              top: ${s.top}%;
+              left: ${s.left}%;
+              width: ${s.size}px;
+              height: ${s.size}px;
+              background: ${s.hue === "accent" ? "var(--accent-muted)" : "var(--text)"};
+              animation-delay: ${s.delay}s;
+            "
+          ></div>
+        `,
+      )}
+
+      <!-- Moon -->
+      <div class="dreams__moon"></div>
+
+      <!-- Dream thought bubble -->
+      ${props.active
+        ? html`
+            <div class="dreams__bubble">
+              <span class="dreams__bubble-text">${dreamText}</span>
+            </div>
+            <div
+              class="dreams__bubble-dot"
+              style="top: calc(50% - 100px); left: calc(50% - 80px); width: 12px; height: 12px; animation-delay: 0.2s;"
+            ></div>
+            <div
+              class="dreams__bubble-dot"
+              style="top: calc(50% - 70px); left: calc(50% - 50px); width: 8px; height: 8px; animation-delay: 0.4s;"
+            ></div>
+          `
+        : nothing}
+
+      <!-- Ambient glow -->
+      <div class="dreams__glow"></div>
+
+      <!-- Sleeping lobster -->
+      <div class="dreams__lobster">${sleepingLobster}</div>
+
+      <!-- Floating Z's -->
+      <span class="dreams__z">z</span>
+      <span class="dreams__z">z</span>
+      <span class="dreams__z">Z</span>
+
+      <!-- Status line -->
+      <div class="dreams__status">
+        <span class="dreams__status-label"
+          >${props.active ? "Memory Dreaming Active" : "Dreaming Idle"}</span
+        >
+        <div class="dreams__status-detail">
+          <div class="dreams__status-dot"></div>
+          <span>
+            ${props.promotedCount} promoted
+            ${props.nextCycle ? html`· next cycle ${props.nextCycle}` : nothing}
+          </span>
+        </div>
+      </div>
+
+      <!-- Stats bar -->
+      <div class="dreams__stats">
+        <div class="dreams__stat">
+          <span class="dreams__stat-value" style="color: var(--text-strong);"
+            >${props.shortTermCount}</span
+          >
+          <span class="dreams__stat-label">Short-term</span>
+        </div>
+        <div class="dreams__stat-divider"></div>
+        <div class="dreams__stat">
+          <span class="dreams__stat-value" style="color: var(--accent);"
+            >${props.longTermCount}</span
+          >
+          <span class="dreams__stat-label">Long-term</span>
+        </div>
+        <div class="dreams__stat-divider"></div>
+        <div class="dreams__stat">
+          <span class="dreams__stat-value" style="color: var(--accent-2);"
+            >${props.promotedCount}</span
+          >
+          <span class="dreams__stat-label">Promoted Tonight</span>
+        </div>
+      </div>
+    </section>
+  `;
+}

--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -136,6 +136,7 @@ export const sharedVitestConfig = {
       "ui/src/ui/views/chat.test.ts",
       "ui/src/ui/views/nodes.devices.test.ts",
       "ui/src/ui/views/skills.test.ts",
+      "ui/src/ui/views/dreams.test.ts",
       "ui/src/ui/views/usage-render-details.test.ts",
       "ui/src/ui/controllers/agents.test.ts",
       "ui/src/ui/controllers/chat.test.ts",

--- a/vitest.unit-paths.mjs
+++ b/vitest.unit-paths.mjs
@@ -5,6 +5,15 @@ export const unitTestIncludePatterns = [
   "src/**/*.test.ts",
   "packages/**/*.test.ts",
   "test/**/*.test.ts",
+  "ui/src/ui/app-chat.test.ts",
+  "ui/src/ui/chat/**/*.test.ts",
+  "ui/src/ui/views/agents-utils.test.ts",
+  "ui/src/ui/views/channels.test.ts",
+  "ui/src/ui/views/chat.test.ts",
+  "ui/src/ui/views/dreams.test.ts",
+  "ui/src/ui/views/usage-render-details.test.ts",
+  "ui/src/ui/controllers/agents.test.ts",
+  "ui/src/ui/controllers/chat.test.ts",
 ];
 
 export const boundaryTestFiles = [
@@ -34,7 +43,6 @@ export const unitTestAdditionalExcludePatterns = [
   `${BUNDLED_PLUGIN_ROOT_DIR}/**`,
   "src/browser/**",
   "src/line/**",
-  "src/acp/**",
   "src/agents/**",
   "src/auto-reply/**",
   "src/commands/**",
@@ -53,7 +61,6 @@ export const unitTestAdditionalExcludePatterns = [
   "src/config/schema.base.generated.test.ts",
   "src/config/schema.help.quality.test.ts",
   "test/**",
-  "ui/src/ui/**",
 ];
 
 const sharedBaseExcludePatterns = [


### PR DESCRIPTION
## Summary
- add short-term recall persistence in both `memory_search` tool and `openclaw memory search` CLI paths
- add `openclaw memory promote` ranking/apply flow backed by `memory/.dreams/short-term-recall.json`
- add managed opt-in dreaming flow that auto-creates/reconciles a nightly cron job and promotes candidates in background
- set default promotion thresholds to practical starter values: `minScore=0.75`, `minRecallCount=3`, `minUniqueQueries=2`
- add dreaming docs section and config/UI schema for dreaming settings

## Details
- short-term candidates come from daily files (`memory/YYYY-MM-DD.md` and basename variant)
- ranking uses weighted signals: frequency, relevance, query diversity, and temporal recency
- manual promotion remains available (`memory promote`) while dreaming is opt-in via config
- threshold parsing is hardened so invalid negative overrides fall back to defaults

## Tests
- `pnpm check`
- `pnpm test -- extensions/memory-core/src/short-term-promotion.test.ts extensions/memory-core/src/dreaming.test.ts extensions/memory-core/src/tools.citations.test.ts`
- `pnpm test -- extensions/memory-core/src/cli.test.ts`
- `pnpm test -- extensions/memory-core/src/tools.test.ts`
