### PR TITLE
fix: allow explicit host requests when tools.exec.host=auto

### DIFF
--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -86,26 +86,36 @@ describe("resolveExecTarget", () => {
     });
   });
 
-  it("rejects host overrides when configured host is auto", () => {
-    expect(() =>
+  it("allows explicit node request when configured host is auto", () => {
+    expect(
       resolveExecTarget({
         configuredTarget: "auto",
         requestedTarget: "node",
         elevatedRequested: false,
         sandboxAvailable: false,
       }),
-    ).toThrow("exec host not allowed");
+    ).toMatchObject({
+      configuredTarget: "auto",
+      requestedTarget: "node",
+      selectedTarget: "node",
+      effectiveHost: "node",
+    });
   });
 
-  it("also rejects gateway override when configured host is auto", () => {
-    expect(() =>
+  it("also allows gateway override when configured host is auto", () => {
+    expect(
       resolveExecTarget({
         configuredTarget: "auto",
         requestedTarget: "gateway",
         elevatedRequested: false,
         sandboxAvailable: true,
       }),
-    ).toThrow("exec host not allowed");
+    ).toMatchObject({
+      configuredTarget: "auto",
+      requestedTarget: "gateway",
+      selectedTarget: "gateway",
+      effectiveHost: "gateway",
+    });
   });
 
   it("allows explicit auto request when configured host is auto", () => {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -221,9 +221,10 @@ export function isRequestedExecTargetAllowed(params: {
   configuredTarget: ExecTarget;
   requestedTarget: ExecTarget;
 }) {
-  // `auto` is a routing strategy, not a wildcard allowlist. Keep per-call host
-  // selection pinned to the configured/session-selected target so a sandboxed
-  // session cannot silently hop to gateway or node.
+  // When configured to `auto`, allow agents to explicitly request any host.
+  // `auto` means "default to sandbox when available, otherwise gateway" but
+  // should not block explicit host requests like `host=node`.
+  if (params.configuredTarget === "auto") return true;
   return params.requestedTarget === params.configuredTarget;
 }
 


### PR DESCRIPTION
## Summary

When `tools.exec.host` is set to `"auto"` (the default), agents were blocked from explicitly requesting `host=node` or `host=gateway`. This fix makes `isRequestedExecTargetAllowed` return `true` when `configuredTarget` is `"auto"`, allowing agents to explicitly choose any host while preserving the default auto behavior (sandbox when available, otherwise gateway).

## Changes

- Modified `isRequestedExecTargetAllowed` in `src/agents/bash-tools.exec-runtime.ts` to return `true` when `configuredTarget === "auto"`
- Updated corresponding tests in `src/agents/bash-tools.exec-runtime.test.ts` to expect success instead of throwing

## Testing

The fix changes two test cases that previously expected `exec host not allowed` errors to now expect successful execution with the requested host.


Fixes openclaw/openclaw#60570