### PR TITLE
fix(infra): treat undefined/null unhandled rejections as non-fatal

### DIFF
--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -170,6 +170,22 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
       expectExitCodeFromUnhandled(slackErr, [1]);
     });
 
+    it("does not exit on undefined reason (e.g., Slack socket-mode reject())", () => {
+      expectExitCodeFromUnhandled(undefined, []);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[openclaw] Non-fatal unhandled rejection (no error object):",
+        "undefined",
+      );
+    });
+
+    it("does not exit on null reason", () => {
+      expectExitCodeFromUnhandled(null, []);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[openclaw] Non-fatal unhandled rejection (no error object):",
+        "null",
+      );
+    });
+
     it("does not exit on AbortError and logs suppression warning", () => {
       const abortErr = new Error("This operation was aborted");
       abortErr.name = "AbortError";

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -345,6 +345,14 @@ export function installUnhandledRejectionHandler(): void {
       return;
     }
 
+    // Rejections with no reason (undefined/null) are almost always third-party SDK
+    // bugs (e.g., Slack socket-mode calling reject() without an argument after a
+    // WebSocket 408). There is zero diagnostic value in crashing — log and continue.
+    if (reason === undefined || reason === null) {
+      console.warn("[openclaw] Non-fatal unhandled rejection (no error object):", String(reason));
+      return;
+    }
+
     // AbortError is typically an intentional cancellation (e.g., during shutdown)
     // Log it but don't crash - these are expected during graceful shutdown
     if (isAbortError(reason)) {


### PR DESCRIPTION
## Summary

- Third-party SDKs (e.g., `@slack/socket-mode`) sometimes call `reject()` without an argument after transient WebSocket errors (HTTP 408). The `undefined` reason bypasses all classifiers (`isAbortError`, `isFatalError`, `isTransientNetworkError` all early-return `false` for falsy values) and falls through to `process.exit(1)`, crashing the gateway unnecessarily.
- Adds an early check for `undefined`/`null` rejection reasons, logging a warning and continuing instead of crashing.
- Adds test coverage for both `undefined` and `null` rejection reasons.

## Context

Observed in production: Slack's socket-mode WebSocket received a 408 from Slack servers, the Bolt SDK rejected with `undefined`, and the gateway crashed. The channel's own reconnect loop (`monitorSlackProvider`) would have handled the socket recovery if the process had stayed alive.

## Test plan

- [x] `vitest run src/infra/unhandled-rejections.test.ts` — all pass
- [x] `vitest run src/infra/unhandled-rejections.fatal-detection.test.ts` — all pass (49 tests including 2 new)
- [x] `pnpm check` — all checks pass (tsgo, lint, format)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)