### PR TITLE
fix(cron): resume interrupted recurring jobs on first restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/credentials: read the current and legacy credential files directly during migration fallback so concurrent legacy rename races still resolve to the stored credentials. (#60591) Thanks @gumadeiras.
 - Providers/Anthropic Vertex: read ADC files directly during auth discovery so explicit Google credentials and default ADC no longer depend on `existsSync` preflight checks. (#60592) Thanks @gumadeiras.
 - Android/Talk Mode: restore spoken assistant replies on node-scoped sessions by keeping reply routing synced to the resolved node session key and pausing mic capture during reply playback. (#60306) Thanks @MKV21.
+- Cron: replay interrupted recurring jobs on the first gateway restart instead of clearing the stale running marker and skipping catch-up until a second restart. (#60583) Thanks @joelnishanth.
 
 ## 2026.4.2
 

--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -115,7 +115,7 @@ describe("CronService restart catch-up", () => {
     );
   });
 
-  it("clears stale running markers without replaying interrupted startup jobs", async () => {
+  it("replays interrupted recurring job on first restart (#60495)", async () => {
     const dueAt = Date.parse("2025-12-13T16:00:00.000Z");
     const staleRunningAt = Date.parse("2025-12-13T16:30:00.000Z");
 
@@ -137,21 +137,23 @@ describe("CronService restart catch-up", () => {
           },
         },
       ],
-      async ({ cron, enqueueSystemEvent }) => {
-        expect(enqueueSystemEvent).not.toHaveBeenCalled();
+      async ({ cron, enqueueSystemEvent, requestHeartbeatNow }) => {
         expect(noopLogger.warn).toHaveBeenCalledWith(
           expect.objectContaining({ jobId: "restart-stale-running" }),
           "cron: clearing stale running marker on startup",
         );
 
+        expect(enqueueSystemEvent).toHaveBeenCalledWith(
+          "resume stale marker",
+          expect.objectContaining({ agentId: undefined }),
+        );
+        expect(requestHeartbeatNow).toHaveBeenCalled();
+
         const listedJobs = await cron.list({ includeDisabled: true });
         const updated = listedJobs.find((job) => job.id === "restart-stale-running");
         expect(updated?.state.runningAtMs).toBeUndefined();
-        expect(updated?.state.lastStatus).toBeUndefined();
-        expect(updated?.state.lastRunAtMs).toBeUndefined();
-        expect((updated?.state.nextRunAtMs ?? 0) > Date.parse("2025-12-13T17:00:00.000Z")).toBe(
-          true,
-        );
+        expect(updated?.state.lastStatus).toBe("ok");
+        expect(updated?.state.lastRunAtMs).toBe(Date.parse("2025-12-13T17:00:00.000Z"));
       },
     );
   });

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -65,7 +65,7 @@ function createMissedIsolatedJob(now: number): CronJob {
 }
 
 describe("cron service ops seam coverage", () => {
-  it("start clears stale running markers, skips startup replay, persists, and arms the timer", async () => {
+  it("start clears stale running markers, replays interrupted recurring jobs, persists, and arms the timer (#60495)", async () => {
     const { storePath } = await makeStorePath();
     const now = Date.parse("2026-03-23T12:00:00.000Z");
     const enqueueSystemEvent = vi.fn();
@@ -93,8 +93,9 @@ describe("cron service ops seam coverage", () => {
       expect.objectContaining({ jobId: "startup-interrupted" }),
       "cron: clearing stale running marker on startup",
     );
-    expect(enqueueSystemEvent).not.toHaveBeenCalled();
-    expect(requestHeartbeatNow).not.toHaveBeenCalled();
+    // Interrupted recurring jobs are now replayed on first restart (#60495)
+    expect(enqueueSystemEvent).toHaveBeenCalled();
+    expect(requestHeartbeatNow).toHaveBeenCalled();
     expect(state.timer).not.toBeNull();
 
     const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as {
@@ -103,7 +104,7 @@ describe("cron service ops seam coverage", () => {
     const job = persisted.jobs[0];
     expect(job).toBeDefined();
     expect(job?.state.runningAtMs).toBeUndefined();
-    expect(job?.state.lastStatus).toBeUndefined();
+    expect(job?.state.lastStatus).toBe("ok");
     expect((job?.state.nextRunAtMs ?? 0) > now).toBe(true);
 
     const delays = timeoutSpy.mock.calls

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -101,7 +101,8 @@ export async function start(state: CronServiceState) {
     return;
   }
 
-  const startupInterruptedJobIds = new Set<string>();
+  const interruptedOneShotIds = new Set<string>();
+  let clearedAnyRunningMarker = false;
   await locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
     const jobs = state.store?.jobs ?? [];
@@ -112,15 +113,23 @@ export async function start(state: CronServiceState) {
           "cron: clearing stale running marker on startup",
         );
         job.state.runningAtMs = undefined;
-        startupInterruptedJobIds.add(job.id);
+        clearedAnyRunningMarker = true;
+        // One-shot jobs are not retried after interruption; recurring jobs
+        // (cron/every) are eligible for startup catch-up so they don't
+        // require a second restart to recover (#60495).
+        if (job.schedule.kind === "at") {
+          interruptedOneShotIds.add(job.id);
+        }
       }
     }
-    if (startupInterruptedJobIds.size > 0) {
+    if (clearedAnyRunningMarker) {
       await persist(state);
     }
   });
 
-  await runMissedJobs(state, { skipJobIds: startupInterruptedJobIds });
+  await runMissedJobs(state, {
+    skipJobIds: interruptedOneShotIds.size > 0 ? interruptedOneShotIds : undefined,
+  });
 
   await locked(state, async () => {
     // Startup catch-up already persisted the latest in-memory store state, and


### PR DESCRIPTION
Closes #60495

## Summary

- When a gateway restart interrupts a running cron/every job, the job is now re-executed as part of startup catch-up on the **first** restart instead of requiring a second restart to recover.
- One-shot (schedule kind "at") jobs preserve the existing behavior and are not retried after interruption.

## Root Cause

The `start` function in `src/cron/service/ops.ts` collected all jobs with a stale `runningAtMs` marker into `startupInterruptedJobIds` and passed them to `runMissedJobs` as `skipJobIds`. This explicitly excluded interrupted jobs from startup catch-up. After `runMissedJobs` skipped them, `recomputeNextRuns` advanced their `nextRunAtMs` into the future, so the normal timer tick also would not fire them. Only a second restart (where `runningAtMs` was already cleared) allowed `runMissedJobs` to pick them up via the missed-slot detection path.

## Fix

Changed the skip list to only include interrupted **one-shot** jobs. Interrupted recurring jobs (cron/every) now have their `runningAtMs` cleared and are immediately eligible for startup catch-up, since their `nextRunAtMs` is still past-due (the incomplete run never reached `applyJobResult`).

## Changes

**`src/cron/service/ops.ts`** — replaced blanket `startupInterruptedJobIds` skip with `interruptedOneShotIds` that only collects one-shot jobs.

**`src/cron/service/ops.test.ts`** — updated the stale-running-marker test to expect the interrupted cron job to be replayed on first restart.

**`src/cron/service.restart-catchup.test.ts`** — updated the stale-marker test to expect the interrupted cron job to run and verify its `lastStatus` and `lastRunAtMs` are set.

## Test Plan

- [x] `npx vitest run src/cron/service.restart-catchup.test.ts` — 8/8 pass
- [x] `npx vitest run src/cron/service/ops.test.ts` — 5/5 pass
- [x] `npx vitest run src/cron/service.issue-regressions.test.ts` — 43/43 pass
- [x] `npx vitest run src/cron/service.issue-13992-regression.test.ts` — 6/6 pass
- [x] `npx vitest run src/cron/service.every-jobs-fire.test.ts` — 3/3 pass
- [x] No lint errors on touched files

## Risks and Mitigations

- **Interrupted recurring jobs now re-execute on first restart.** This is the intended fix. Previously they were silently skipped, causing data gaps for users relying on scheduled tasks. The interrupted run never completed, so retrying is the correct behavior.
- **One-shot behavior preserved.** Interrupted one-shots are still skipped, matching the existing design choice that one-shots are fire-and-forget.

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)