### PR TITLE
infra: atomically replace sync JSON writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp/watchdog: reset watchdog timeout after reconnect so quiet channels no longer enter a tight reconnect loop from stale message timestamps carried across connection runs. (#60007) Thanks @MonkeyLeeT.
 - Agents/fallback: persist selected fallback overrides before retry attempts start, prefer persisted overrides during live-session reconciliation, and keep provider-scoped auth-profile failover from snapping retries back to stale primary selections.
 - Agents/MCP: sort MCP tools deterministically by name so the tools block in API requests is stable across turns, preventing unnecessary prompt-cache busting from non-deterministic `listTools()` order. (#58037) Thanks @bcherny.
+- Infra/json-file: preserve symlink-backed JSON stores and Windows overwrite fallback when atomically saving small sync JSON state files. (#60589) Thanks @gumadeiras.
 
 ## 2026.4.2
 

--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -142,6 +142,24 @@ describe("json-file helpers", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "does not create missing target directories through an existing symlink",
+    async () => {
+      await withTempDir({ prefix: "openclaw-json-file-" }, async (root) => {
+        const missingTargetDir = path.join(root, "missing-target");
+        const targetPath = path.join(missingTargetDir, "config.json");
+        const linkPath = path.join(root, "config-link.json");
+        fs.symlinkSync(targetPath, linkPath);
+
+        expect(() => saveJsonFile(linkPath, SAVED_PAYLOAD)).toThrow(
+          expect.objectContaining({ code: "ENOENT" }),
+        );
+        expect(fs.existsSync(missingTargetDir)).toBe(false);
+        expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(true);
+      });
+    },
+  );
+
   it("falls back to copy when rename-based overwrite fails", async () => {
     await withJsonPath(({ root, pathname }) => {
       writeExistingJson(pathname);

--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -4,8 +4,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { loadJsonFile, saveJsonFile } from "./json-file.js";
 
+const SAVED_PAYLOAD = { enabled: true, count: 2 };
+const PREVIOUS_JSON = '{"enabled":false}\n';
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function writeExistingJson(pathname: string) {
+  fs.writeFileSync(pathname, PREVIOUS_JSON, "utf8");
 }
 
 async function withJsonPath<T>(
@@ -48,11 +55,11 @@ describe("json-file helpers", () => {
   it("creates parent dirs, writes a trailing newline, and loads the saved object", async () => {
     await withTempDir({ prefix: "openclaw-json-file-" }, async (root) => {
       const pathname = path.join(root, "nested", "config.json");
-      saveJsonFile(pathname, { enabled: true, count: 2 });
+      saveJsonFile(pathname, SAVED_PAYLOAD);
 
       const raw = fs.readFileSync(pathname, "utf8");
       expect(raw.endsWith("\n")).toBe(true);
-      expect(loadJsonFile(pathname)).toEqual({ enabled: true, count: 2 });
+      expect(loadJsonFile(pathname)).toEqual(SAVED_PAYLOAD);
 
       const fileMode = fs.statSync(pathname).mode & 0o777;
       const dirMode = fs.statSync(path.dirname(pathname)).mode & 0o777;
@@ -72,29 +79,27 @@ describe("json-file helpers", () => {
     },
     {
       name: "existing JSON files",
-      setup: (pathname: string) => {
-        fs.writeFileSync(pathname, '{"enabled":false}\n', "utf8");
-      },
+      setup: writeExistingJson,
     },
   ])("writes the latest payload for $name", async ({ setup }) => {
     await withJsonPath(({ pathname }) => {
       setup(pathname);
-      saveJsonFile(pathname, { enabled: true, count: 2 });
-      expect(loadJsonFile(pathname)).toEqual({ enabled: true, count: 2 });
+      saveJsonFile(pathname, SAVED_PAYLOAD);
+      expect(loadJsonFile(pathname)).toEqual(SAVED_PAYLOAD);
     });
   });
 
   it("writes through a sibling temp file before replacing the destination", async () => {
     await withJsonPath(({ pathname }) => {
-      fs.writeFileSync(pathname, '{"enabled":false}\n', "utf8");
+      writeExistingJson(pathname);
       const renameSpy = vi.spyOn(fs, "renameSync");
 
-      saveJsonFile(pathname, { enabled: true, count: 2 });
+      saveJsonFile(pathname, SAVED_PAYLOAD);
 
       const renameCall = renameSpy.mock.calls.find(([, target]) => target === pathname);
       expect(renameCall?.[0]).toMatch(new RegExp(`^${escapeRegExp(pathname)}\\..+\\.tmp$`));
       expect(renameSpy).toHaveBeenCalledWith(renameCall?.[0], pathname);
-      expect(loadJsonFile(pathname)).toEqual({ enabled: true, count: 2 });
+      expect(loadJsonFile(pathname)).toEqual(SAVED_PAYLOAD);
     });
   });
 
@@ -106,21 +111,21 @@ describe("json-file helpers", () => {
         const targetPath = path.join(targetDir, "config.json");
         const linkPath = path.join(root, "config-link.json");
         fs.mkdirSync(targetDir, { recursive: true });
-        fs.writeFileSync(targetPath, '{"enabled":false}\n', "utf8");
+        writeExistingJson(targetPath);
         fs.symlinkSync(targetPath, linkPath);
 
-        saveJsonFile(linkPath, { enabled: true, count: 2 });
+        saveJsonFile(linkPath, SAVED_PAYLOAD);
 
         expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(true);
-        expect(loadJsonFile(targetPath)).toEqual({ enabled: true, count: 2 });
-        expect(loadJsonFile(linkPath)).toEqual({ enabled: true, count: 2 });
+        expect(loadJsonFile(targetPath)).toEqual(SAVED_PAYLOAD);
+        expect(loadJsonFile(linkPath)).toEqual(SAVED_PAYLOAD);
       });
     },
   );
 
   it("falls back to copy when rename-based overwrite fails", async () => {
     await withJsonPath(({ root, pathname }) => {
-      fs.writeFileSync(pathname, '{"enabled":false}\n', "utf8");
+      writeExistingJson(pathname);
       const copySpy = vi.spyOn(fs, "copyFileSync");
       const renameSpy = vi.spyOn(fs, "renameSync").mockImplementationOnce(() => {
         const err = new Error("EPERM") as NodeJS.ErrnoException;
@@ -128,11 +133,11 @@ describe("json-file helpers", () => {
         throw err;
       });
 
-      saveJsonFile(pathname, { enabled: true, count: 2 });
+      saveJsonFile(pathname, SAVED_PAYLOAD);
 
       expect(renameSpy).toHaveBeenCalledOnce();
       expect(copySpy).toHaveBeenCalledOnce();
-      expect(loadJsonFile(pathname)).toEqual({ enabled: true, count: 2 });
+      expect(loadJsonFile(pathname)).toEqual(SAVED_PAYLOAD);
       expect(fs.readdirSync(root)).toEqual(["config.json"]);
     });
   });

--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { loadJsonFile, saveJsonFile } from "./json-file.js";
 
@@ -72,6 +72,22 @@ describe("json-file helpers", () => {
     await withJsonPath(({ pathname }) => {
       setup(pathname);
       saveJsonFile(pathname, { enabled: true, count: 2 });
+      expect(loadJsonFile(pathname)).toEqual({ enabled: true, count: 2 });
+    });
+  });
+
+  it("writes through a sibling temp file before replacing the destination", async () => {
+    await withJsonPath(({ pathname }) => {
+      fs.writeFileSync(pathname, '{"enabled":false}\n', "utf8");
+      const renameSpy = vi.spyOn(fs, "renameSync");
+
+      saveJsonFile(pathname, { enabled: true, count: 2 });
+
+      const renameCall = renameSpy.mock.calls.find(([, target]) => target === pathname);
+      expect(renameCall?.[0]).toMatch(
+        new RegExp(`^${pathname.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\..+\\.tmp$`),
+      );
+      expect(renameSpy).toHaveBeenCalledWith(renameCall?.[0], pathname);
       expect(loadJsonFile(pathname)).toEqual({ enabled: true, count: 2 });
     });
   });

--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -1,8 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { loadJsonFile, saveJsonFile } from "./json-file.js";
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 async function withJsonPath<T>(
   run: (params: { root: string; pathname: string }) => Promise<T> | T,
@@ -13,6 +17,10 @@ async function withJsonPath<T>(
 }
 
 describe("json-file helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it.each([
     {
       name: "missing files",
@@ -84,11 +92,48 @@ describe("json-file helpers", () => {
       saveJsonFile(pathname, { enabled: true, count: 2 });
 
       const renameCall = renameSpy.mock.calls.find(([, target]) => target === pathname);
-      expect(renameCall?.[0]).toMatch(
-        new RegExp(`^${pathname.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\..+\\.tmp$`),
-      );
+      expect(renameCall?.[0]).toMatch(new RegExp(`^${escapeRegExp(pathname)}\\..+\\.tmp$`));
       expect(renameSpy).toHaveBeenCalledWith(renameCall?.[0], pathname);
       expect(loadJsonFile(pathname)).toEqual({ enabled: true, count: 2 });
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "preserves symlink destinations when replacing existing JSON files",
+    async () => {
+      await withTempDir({ prefix: "openclaw-json-file-" }, async (root) => {
+        const targetDir = path.join(root, "target");
+        const targetPath = path.join(targetDir, "config.json");
+        const linkPath = path.join(root, "config-link.json");
+        fs.mkdirSync(targetDir, { recursive: true });
+        fs.writeFileSync(targetPath, '{"enabled":false}\n', "utf8");
+        fs.symlinkSync(targetPath, linkPath);
+
+        saveJsonFile(linkPath, { enabled: true, count: 2 });
+
+        expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(true);
+        expect(loadJsonFile(targetPath)).toEqual({ enabled: true, count: 2 });
+        expect(loadJsonFile(linkPath)).toEqual({ enabled: true, count: 2 });
+      });
+    },
+  );
+
+  it("falls back to copy when rename-based overwrite fails", async () => {
+    await withJsonPath(({ root, pathname }) => {
+      fs.writeFileSync(pathname, '{"enabled":false}\n', "utf8");
+      const copySpy = vi.spyOn(fs, "copyFileSync");
+      const renameSpy = vi.spyOn(fs, "renameSync").mockImplementationOnce(() => {
+        const err = new Error("EPERM") as NodeJS.ErrnoException;
+        err.code = "EPERM";
+        throw err;
+      });
+
+      saveJsonFile(pathname, { enabled: true, count: 2 });
+
+      expect(renameSpy).toHaveBeenCalledOnce();
+      expect(copySpy).toHaveBeenCalledOnce();
+      expect(loadJsonFile(pathname)).toEqual({ enabled: true, count: 2 });
+      expect(fs.readdirSync(root)).toEqual(["config.json"]);
     });
   });
 });

--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -123,6 +123,25 @@ describe("json-file helpers", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "creates a missing target file through an existing symlink",
+    async () => {
+      await withTempDir({ prefix: "openclaw-json-file-" }, async (root) => {
+        const targetDir = path.join(root, "target");
+        const targetPath = path.join(targetDir, "config.json");
+        const linkPath = path.join(root, "config-link.json");
+        fs.mkdirSync(targetDir, { recursive: true });
+        fs.symlinkSync(targetPath, linkPath);
+
+        saveJsonFile(linkPath, SAVED_PAYLOAD);
+
+        expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(true);
+        expect(loadJsonFile(targetPath)).toEqual(SAVED_PAYLOAD);
+        expect(loadJsonFile(linkPath)).toEqual(SAVED_PAYLOAD);
+      });
+    },
+  );
+
   it("falls back to copy when rename-based overwrite fails", async () => {
     await withJsonPath(({ root, pathname }) => {
       writeExistingJson(pathname);

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -31,17 +31,41 @@ function trySyncDirectory(pathname: string) {
   }
 }
 
+function readSymlinkTargetPath(linkPath: string): string {
+  const target = fs.readlinkSync(linkPath);
+  return path.resolve(path.dirname(linkPath), target);
+}
+
 function resolveJsonWriteTarget(pathname: string): string {
-  let stat: fs.Stats;
-  try {
-    stat = fs.lstatSync(pathname);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
+  let currentPath = pathname;
+  const visited = new Set<string>();
+
+  for (;;) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(currentPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      return currentPath;
     }
-    return pathname;
+
+    if (!stat.isSymbolicLink()) {
+      return currentPath;
+    }
+
+    if (visited.has(currentPath)) {
+      const err = new Error(
+        `Too many symlink levels while resolving ${pathname}`,
+      ) as NodeJS.ErrnoException;
+      err.code = "ELOOP";
+      throw err;
+    }
+
+    visited.add(currentPath);
+    currentPath = readSymlinkTargetPath(currentPath);
   }
-  return stat.isSymbolicLink() ? fs.realpathSync(pathname) : pathname;
 }
 
 function renameJsonFileWithFallback(tmpPath: string, pathname: string) {

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -13,6 +13,24 @@ function trySetSecureMode(pathname: string) {
   }
 }
 
+function trySyncDirectory(pathname: string) {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(path.dirname(pathname), "r");
+    fs.fsyncSync(fd);
+  } catch {
+    // best-effort; some platforms/filesystems do not support syncing directories.
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+}
+
 function resolveJsonWriteTarget(pathname: string): string {
   let stat: fs.Stats;
   try {
@@ -42,10 +60,20 @@ function renameJsonFileWithFallback(tmpPath: string, pathname: string) {
   }
 }
 
-export function loadJsonFile(pathname: string): unknown {
+function writeTempJsonFile(pathname: string, payload: string) {
+  const fd = fs.openSync(pathname, "w", JSON_FILE_MODE);
+  try {
+    fs.writeFileSync(fd, payload, "utf8");
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+export function loadJsonFile<T = unknown>(pathname: string): T | undefined {
   try {
     const raw = fs.readFileSync(pathname, "utf8");
-    return JSON.parse(raw) as unknown;
+    return JSON.parse(raw) as T;
   } catch {
     return undefined;
   }
@@ -58,13 +86,11 @@ export function saveJsonFile(pathname: string, data: unknown) {
 
   fs.mkdirSync(path.dirname(targetPath), { recursive: true, mode: JSON_DIR_MODE });
   try {
-    fs.writeFileSync(tmpPath, payload, {
-      encoding: "utf8",
-      mode: JSON_FILE_MODE,
-    });
+    writeTempJsonFile(tmpPath, payload);
     trySetSecureMode(tmpPath);
     renameJsonFileWithFallback(tmpPath, targetPath);
     trySetSecureMode(targetPath);
+    trySyncDirectory(targetPath);
   } finally {
     try {
       fs.rmSync(tmpPath, { force: true });

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -1,11 +1,9 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
 export function loadJsonFile(pathname: string): unknown {
   try {
-    if (!fs.existsSync(pathname)) {
-      return undefined;
-    }
     const raw = fs.readFileSync(pathname, "utf8");
     return JSON.parse(raw) as unknown;
   } catch {
@@ -15,9 +13,29 @@ export function loadJsonFile(pathname: string): unknown {
 
 export function saveJsonFile(pathname: string, data: unknown) {
   const dir = path.dirname(pathname);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const tmpPath = `${pathname}.${randomUUID()}.tmp`;
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    fs.writeFileSync(tmpPath, `${JSON.stringify(data, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    try {
+      fs.chmodSync(tmpPath, 0o600);
+    } catch {
+      // best-effort on platforms without chmod support
+    }
+    fs.renameSync(tmpPath, pathname);
+    try {
+      fs.chmodSync(pathname, 0o600);
+    } catch {
+      // best-effort on platforms without chmod support
+    }
+  } finally {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {
+      // best-effort cleanup when rename does not happen
+    }
   }
-  fs.writeFileSync(pathname, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-  fs.chmodSync(pathname, 0o600);
 }

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -36,9 +36,10 @@ function readSymlinkTargetPath(linkPath: string): string {
   return path.resolve(path.dirname(linkPath), target);
 }
 
-function resolveJsonWriteTarget(pathname: string): string {
+function resolveJsonWriteTarget(pathname: string): { targetPath: string; followsSymlink: boolean } {
   let currentPath = pathname;
   const visited = new Set<string>();
+  let followsSymlink = false;
 
   for (;;) {
     let stat: fs.Stats;
@@ -48,11 +49,11 @@ function resolveJsonWriteTarget(pathname: string): string {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
         throw error;
       }
-      return currentPath;
+      return { targetPath: currentPath, followsSymlink };
     }
 
     if (!stat.isSymbolicLink()) {
-      return currentPath;
+      return { targetPath: currentPath, followsSymlink };
     }
 
     if (visited.has(currentPath)) {
@@ -64,6 +65,7 @@ function resolveJsonWriteTarget(pathname: string): string {
     }
 
     visited.add(currentPath);
+    followsSymlink = true;
     currentPath = readSymlinkTargetPath(currentPath);
   }
 }
@@ -104,11 +106,13 @@ export function loadJsonFile<T = unknown>(pathname: string): T | undefined {
 }
 
 export function saveJsonFile(pathname: string, data: unknown) {
-  const targetPath = resolveJsonWriteTarget(pathname);
+  const { targetPath, followsSymlink } = resolveJsonWriteTarget(pathname);
   const tmpPath = `${targetPath}.${randomUUID()}.tmp`;
   const payload = `${JSON.stringify(data, null, 2)}\n`;
 
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true, mode: JSON_DIR_MODE });
+  if (!followsSymlink) {
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true, mode: JSON_DIR_MODE });
+  }
   try {
     writeTempJsonFile(tmpPath, payload);
     trySetSecureMode(tmpPath);

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -2,6 +2,43 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
+function trySetSecureMode(pathname: string) {
+  try {
+    fs.chmodSync(pathname, 0o600);
+  } catch {
+    // best-effort on platforms without chmod support
+  }
+}
+
+function resolveJsonWriteTarget(pathname: string): string {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(pathname);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+    return pathname;
+  }
+  return stat.isSymbolicLink() ? fs.realpathSync(pathname) : pathname;
+}
+
+function renameJsonFileWithFallback(tmpPath: string, pathname: string) {
+  try {
+    fs.renameSync(tmpPath, pathname);
+    return;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    // Windows does not reliably support rename-based overwrite for existing files.
+    if (code === "EPERM" || code === "EEXIST") {
+      fs.copyFileSync(tmpPath, pathname);
+      fs.rmSync(tmpPath, { force: true });
+      return;
+    }
+    throw error;
+  }
+}
+
 export function loadJsonFile(pathname: string): unknown {
   try {
     const raw = fs.readFileSync(pathname, "utf8");
@@ -12,25 +49,18 @@ export function loadJsonFile(pathname: string): unknown {
 }
 
 export function saveJsonFile(pathname: string, data: unknown) {
-  const dir = path.dirname(pathname);
-  const tmpPath = `${pathname}.${randomUUID()}.tmp`;
+  const targetPath = resolveJsonWriteTarget(pathname);
+  const dir = path.dirname(targetPath);
+  const tmpPath = `${targetPath}.${randomUUID()}.tmp`;
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   try {
     fs.writeFileSync(tmpPath, `${JSON.stringify(data, null, 2)}\n`, {
       encoding: "utf8",
       mode: 0o600,
     });
-    try {
-      fs.chmodSync(tmpPath, 0o600);
-    } catch {
-      // best-effort on platforms without chmod support
-    }
-    fs.renameSync(tmpPath, pathname);
-    try {
-      fs.chmodSync(pathname, 0o600);
-    } catch {
-      // best-effort on platforms without chmod support
-    }
+    trySetSecureMode(tmpPath);
+    renameJsonFileWithFallback(tmpPath, targetPath);
+    trySetSecureMode(targetPath);
   } finally {
     try {
       fs.rmSync(tmpPath, { force: true });

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -2,9 +2,12 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
+const JSON_FILE_MODE = 0o600;
+const JSON_DIR_MODE = 0o700;
+
 function trySetSecureMode(pathname: string) {
   try {
-    fs.chmodSync(pathname, 0o600);
+    fs.chmodSync(pathname, JSON_FILE_MODE);
   } catch {
     // best-effort on platforms without chmod support
   }
@@ -50,13 +53,14 @@ export function loadJsonFile(pathname: string): unknown {
 
 export function saveJsonFile(pathname: string, data: unknown) {
   const targetPath = resolveJsonWriteTarget(pathname);
-  const dir = path.dirname(targetPath);
   const tmpPath = `${targetPath}.${randomUUID()}.tmp`;
-  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const payload = `${JSON.stringify(data, null, 2)}\n`;
+
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true, mode: JSON_DIR_MODE });
   try {
-    fs.writeFileSync(tmpPath, `${JSON.stringify(data, null, 2)}\n`, {
+    fs.writeFileSync(tmpPath, payload, {
       encoding: "utf8",
-      mode: 0o600,
+      mode: JSON_FILE_MODE,
     });
     trySetSecureMode(tmpPath);
     renameJsonFileWithFallback(tmpPath, targetPath);


### PR DESCRIPTION
## Summary
- replace sync JSON writes with sibling-temp atomic rename semantics
- remove the pre-read `existsSync` check so reads rely on direct read/parse fallback
- add regression coverage for the temp-path replacement flow

## Verification
- `pnpm format src/infra/json-file.ts src/infra/json-file.test.ts`
- direct concurrent writer/reader script against `src/infra/json-file.ts` (`parseFailures: 0` across 835 reads)
- `pnpm test -- src/infra/json-file.test.ts` hung in this environment, so I did not count it as passing

Part of #54295.
