### PR TITLE
matrix: retry credentials after legacy migration race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Docs: https://docs.openclaw.ai
 - Agents/fallback: persist selected fallback overrides before retry attempts start, prefer persisted overrides during live-session reconciliation, and keep provider-scoped auth-profile failover from snapping retries back to stale primary selections.
 - Agents/MCP: sort MCP tools deterministically by name so the tools block in API requests is stable across turns, preventing unnecessary prompt-cache busting from non-deterministic `listTools()` order. (#58037) Thanks @bcherny.
 - Infra/json-file: preserve symlink-backed JSON stores and Windows overwrite fallback when atomically saving small sync JSON state files. (#60589) Thanks @gumadeiras.
+- Matrix/credentials: read the current and legacy credential files directly during migration fallback so concurrent legacy rename races still resolve to the stored credentials. (#60591) Thanks @gumadeiras.
 
 ## 2026.4.2
 

--- a/extensions/matrix/src/matrix/credentials-read.ts
+++ b/extensions/matrix/src/matrix/credentials-read.ts
@@ -76,6 +76,28 @@ function parseMatrixCredentialsFile(filePath: string): MatrixStoredCredentials |
   return parsed as MatrixStoredCredentials;
 }
 
+function loadCurrentMatrixCredentialsIfPresent(credPath: string): MatrixStoredCredentials | null {
+  try {
+    return fs.existsSync(credPath) ? parseMatrixCredentialsFile(credPath) : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseLegacyMatrixCredentialsWithRetry(params: {
+  legacyPath: string;
+  credPath: string;
+}): MatrixStoredCredentials | null {
+  try {
+    return parseMatrixCredentialsFile(params.legacyPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      throw error;
+    }
+    return loadCurrentMatrixCredentialsIfPresent(params.credPath);
+  }
+}
+
 export function resolveMatrixCredentialsDir(
   env: NodeJS.ProcessEnv = process.env,
   stateDir?: string,
@@ -107,7 +129,7 @@ export function loadMatrixCredentials(
       return null;
     }
 
-    const parsed = parseMatrixCredentialsFile(legacyPath);
+    const parsed = parseLegacyMatrixCredentialsWithRetry({ legacyPath, credPath });
     if (!parsed) {
       return null;
     }

--- a/extensions/matrix/src/matrix/credentials-read.ts
+++ b/extensions/matrix/src/matrix/credentials-read.ts
@@ -21,6 +21,16 @@ export type MatrixStoredCredentials = {
   lastUsedAt?: string;
 };
 
+type MatrixCredentialsFileLoadResult =
+  | {
+      kind: "loaded";
+      source: "current" | "legacy";
+      credentials: MatrixStoredCredentials | null;
+    }
+  | {
+      kind: "missing";
+    };
+
 function resolveStateDir(env: NodeJS.ProcessEnv): string {
   try {
     return getMatrixRuntime().state.resolveStateDir(env, os.homedir);
@@ -36,7 +46,7 @@ function resolveStateDir(env: NodeJS.ProcessEnv): string {
   }
 }
 
-function resolveLegacyMatrixCredentialsPath(env: NodeJS.ProcessEnv): string | null {
+function resolveLegacyMatrixCredentialsPath(env: NodeJS.ProcessEnv): string {
   return path.join(resolveMatrixCredentialsDir(env), "credentials.json");
 }
 
@@ -76,17 +86,14 @@ function parseMatrixCredentialsFile(filePath: string): MatrixStoredCredentials |
   return parsed as MatrixStoredCredentials;
 }
 
-function loadMatrixCredentialsFile(filePath: string):
-  | {
-      kind: "loaded";
-      credentials: MatrixStoredCredentials | null;
-    }
-  | {
-      kind: "missing";
-    } {
+function loadMatrixCredentialsFile(
+  filePath: string,
+  source: "current" | "legacy",
+): MatrixCredentialsFileLoadResult {
   try {
     return {
       kind: "loaded",
+      source,
       credentials: parseMatrixCredentialsFile(filePath),
     };
   } catch (error) {
@@ -97,16 +104,15 @@ function loadMatrixCredentialsFile(filePath: string):
   }
 }
 
-function loadLegacyMatrixCredentialsWithCurrentRetry(params: {
+function loadLegacyMatrixCredentialsWithCurrentFallback(params: {
   legacyPath: string;
-  credPath: string;
-}): MatrixStoredCredentials | null {
-  const legacy = loadMatrixCredentialsFile(params.legacyPath);
+  currentPath: string;
+}): MatrixCredentialsFileLoadResult {
+  const legacy = loadMatrixCredentialsFile(params.legacyPath, "legacy");
   if (legacy.kind === "loaded") {
-    return legacy.credentials;
+    return legacy;
   }
-  const current = loadMatrixCredentialsFile(params.credPath);
-  return current.kind === "loaded" ? current.credentials : null;
+  return loadMatrixCredentialsFile(params.currentPath, "current");
 }
 
 export function resolveMatrixCredentialsDir(
@@ -129,9 +135,9 @@ export function loadMatrixCredentials(
   env: NodeJS.ProcessEnv = process.env,
   accountId?: string | null,
 ): MatrixStoredCredentials | null {
-  const credPath = resolveMatrixCredentialsPath(env, accountId);
+  const currentPath = resolveMatrixCredentialsPath(env, accountId);
   try {
-    const current = loadMatrixCredentialsFile(credPath);
+    const current = loadMatrixCredentialsFile(currentPath, "current");
     if (current.kind === "loaded") {
       return current.credentials;
     }
@@ -141,19 +147,24 @@ export function loadMatrixCredentials(
       return null;
     }
 
-    const parsed = loadLegacyMatrixCredentialsWithCurrentRetry({ legacyPath, credPath });
-    if (!parsed) {
+    const loaded = loadLegacyMatrixCredentialsWithCurrentFallback({
+      legacyPath,
+      currentPath,
+    });
+    if (loaded.kind !== "loaded" || !loaded.credentials) {
       return null;
     }
 
-    try {
-      fs.mkdirSync(path.dirname(credPath), { recursive: true });
-      fs.renameSync(legacyPath, credPath);
-    } catch {
-      // Keep returning the legacy credentials even if migration fails.
+    if (loaded.source === "legacy") {
+      try {
+        fs.mkdirSync(path.dirname(currentPath), { recursive: true });
+        fs.renameSync(legacyPath, currentPath);
+      } catch {
+        // Keep returning the legacy credentials even if migration fails.
+      }
     }
 
-    return parsed;
+    return loaded.credentials;
   } catch {
     return null;
   }

--- a/extensions/matrix/src/matrix/credentials-read.ts
+++ b/extensions/matrix/src/matrix/credentials-read.ts
@@ -76,26 +76,37 @@ function parseMatrixCredentialsFile(filePath: string): MatrixStoredCredentials |
   return parsed as MatrixStoredCredentials;
 }
 
-function loadCurrentMatrixCredentialsIfPresent(credPath: string): MatrixStoredCredentials | null {
+function loadMatrixCredentialsFile(filePath: string):
+  | {
+      kind: "loaded";
+      credentials: MatrixStoredCredentials | null;
+    }
+  | {
+      kind: "missing";
+    } {
   try {
-    return fs.existsSync(credPath) ? parseMatrixCredentialsFile(credPath) : null;
-  } catch {
-    return null;
+    return {
+      kind: "loaded",
+      credentials: parseMatrixCredentialsFile(filePath),
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return { kind: "missing" };
+    }
+    throw error;
   }
 }
 
-function parseLegacyMatrixCredentialsWithRetry(params: {
+function loadLegacyMatrixCredentialsWithCurrentRetry(params: {
   legacyPath: string;
   credPath: string;
 }): MatrixStoredCredentials | null {
-  try {
-    return parseMatrixCredentialsFile(params.legacyPath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
-      throw error;
-    }
-    return loadCurrentMatrixCredentialsIfPresent(params.credPath);
+  const legacy = loadMatrixCredentialsFile(params.legacyPath);
+  if (legacy.kind === "loaded") {
+    return legacy.credentials;
   }
+  const current = loadMatrixCredentialsFile(params.credPath);
+  return current.kind === "loaded" ? current.credentials : null;
 }
 
 export function resolveMatrixCredentialsDir(
@@ -120,16 +131,17 @@ export function loadMatrixCredentials(
 ): MatrixStoredCredentials | null {
   const credPath = resolveMatrixCredentialsPath(env, accountId);
   try {
-    if (fs.existsSync(credPath)) {
-      return parseMatrixCredentialsFile(credPath);
+    const current = loadMatrixCredentialsFile(credPath);
+    if (current.kind === "loaded") {
+      return current.credentials;
     }
 
     const legacyPath = resolveLegacyMigrationSourcePath(env, accountId);
-    if (!legacyPath || !fs.existsSync(legacyPath)) {
+    if (!legacyPath) {
       return null;
     }
 
-    const parsed = parseLegacyMatrixCredentialsWithRetry({ legacyPath, credPath });
+    const parsed = loadLegacyMatrixCredentialsWithCurrentRetry({ legacyPath, credPath });
     if (!parsed) {
       return null;
     }

--- a/extensions/matrix/src/matrix/credentials-read.ts
+++ b/extensions/matrix/src/matrix/credentials-read.ts
@@ -21,10 +21,12 @@ export type MatrixStoredCredentials = {
   lastUsedAt?: string;
 };
 
+type MatrixCredentialsSource = "current" | "legacy";
+
 type MatrixCredentialsFileLoadResult =
   | {
       kind: "loaded";
-      source: "current" | "legacy";
+      source: MatrixCredentialsSource;
       credentials: MatrixStoredCredentials | null;
     }
   | {
@@ -88,7 +90,7 @@ function parseMatrixCredentialsFile(filePath: string): MatrixStoredCredentials |
 
 function loadMatrixCredentialsFile(
   filePath: string,
-  source: "current" | "legacy",
+  source: MatrixCredentialsSource,
 ): MatrixCredentialsFileLoadResult {
   try {
     return {
@@ -183,9 +185,7 @@ export function clearMatrixCredentials(
       continue;
     }
     try {
-      if (fs.existsSync(filePath)) {
-        fs.unlinkSync(filePath);
-      }
+      fs.unlinkSync(filePath);
     } catch {
       // ignore
     }

--- a/extensions/matrix/src/matrix/credentials.test.ts
+++ b/extensions/matrix/src/matrix/credentials.test.ts
@@ -113,6 +113,50 @@ describe("matrix credentials storage", () => {
     expect(fs.existsSync(currentPath)).toBe(true);
   });
 
+  it("returns migrated credentials when another process moves the legacy file mid-read", () => {
+    const stateDir = setupStateDir({
+      channels: {
+        matrix: {
+          accounts: {
+            ops: {},
+          },
+        },
+      },
+    });
+    const legacyPath = path.join(stateDir, "credentials", "matrix", "credentials.json");
+    const currentPath = resolveMatrixCredentialsPath({}, "ops");
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        homeserver: "https://matrix.example.org",
+        userId: "@bot:example.org",
+        accessToken: "legacy-token",
+        createdAt: "2026-03-01T10:00:00.000Z",
+      }),
+    );
+
+    const originalReadFileSync = fs.readFileSync.bind(fs);
+    let moved = false;
+    vi.spyOn(fs, "readFileSync").mockImplementation(((
+      filePath: fs.PathOrFileDescriptor,
+      options?: fs.ObjectEncodingOptions | BufferEncoding | null,
+    ) => {
+      if (!moved && filePath === legacyPath) {
+        fs.renameSync(legacyPath, currentPath);
+        moved = true;
+      }
+      return originalReadFileSync(filePath, options as never);
+    }) as typeof fs.readFileSync);
+
+    const loaded = loadMatrixCredentials({}, "ops");
+
+    expect(loaded?.accessToken).toBe("legacy-token");
+    expect(moved).toBe(true);
+    expect(fs.existsSync(legacyPath)).toBe(false);
+    expect(fs.existsSync(currentPath)).toBe(true);
+  });
+
   it("does not migrate legacy default credentials during a non-selected account read", () => {
     const stateDir = setupStateDir({
       channels: {

--- a/extensions/matrix/src/matrix/credentials.test.ts
+++ b/extensions/matrix/src/matrix/credentials.test.ts
@@ -16,6 +16,7 @@ describe("matrix credentials storage", () => {
   const tempDirs: string[] = [];
 
   afterEach(() => {
+    vi.restoreAllMocks();
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -138,7 +139,7 @@ describe("matrix credentials storage", () => {
 
     const originalReadFileSync = fs.readFileSync.bind(fs);
     let moved = false;
-    vi.spyOn(fs, "readFileSync").mockImplementation(((
+    const readFileSpy = vi.spyOn(fs, "readFileSync").mockImplementation(((
       filePath: fs.PathOrFileDescriptor,
       options?: fs.ObjectEncodingOptions | BufferEncoding | null,
     ) => {
@@ -148,13 +149,97 @@ describe("matrix credentials storage", () => {
       }
       return originalReadFileSync(filePath, options as never);
     }) as typeof fs.readFileSync);
+    try {
+      const loaded = loadMatrixCredentials({}, "ops");
 
-    const loaded = loadMatrixCredentials({}, "ops");
+      expect(loaded?.accessToken).toBe("legacy-token");
+      expect(moved).toBe(true);
+      expect(fs.existsSync(legacyPath)).toBe(false);
+      expect(fs.existsSync(currentPath)).toBe(true);
+    } finally {
+      readFileSpy.mockRestore();
+    }
+  });
 
-    expect(loaded?.accessToken).toBe("legacy-token");
-    expect(moved).toBe(true);
-    expect(fs.existsSync(legacyPath)).toBe(false);
-    expect(fs.existsSync(currentPath)).toBe(true);
+  it("does not rename the legacy path after falling back to already-migrated current credentials", () => {
+    const stateDir = setupStateDir({
+      channels: {
+        matrix: {
+          accounts: {
+            ops: {},
+          },
+        },
+      },
+    });
+    const legacyPath = path.join(stateDir, "credentials", "matrix", "credentials.json");
+    const currentPath = resolveMatrixCredentialsPath({}, "ops");
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        homeserver: "https://matrix.example.org",
+        userId: "@bot:example.org",
+        accessToken: "legacy-token",
+        createdAt: "2026-03-01T10:00:00.000Z",
+      }),
+    );
+
+    const originalReadFileSync = fs.readFileSync.bind(fs);
+    const originalRenameSync = fs.renameSync.bind(fs);
+    const renameSpy = vi.spyOn(fs, "renameSync");
+    let migrated = false;
+    const readFileSpy = vi.spyOn(fs, "readFileSync").mockImplementation(((
+      filePath: fs.PathOrFileDescriptor,
+      options?: fs.ObjectEncodingOptions | BufferEncoding | null,
+    ) => {
+      if (!migrated && filePath === legacyPath && fs.existsSync(legacyPath)) {
+        originalRenameSync(legacyPath, currentPath);
+        fs.writeFileSync(
+          currentPath,
+          JSON.stringify({
+            homeserver: "https://matrix.example.org",
+            userId: "@bot:example.org",
+            accessToken: "current-token",
+            createdAt: "2026-03-01T10:00:00.000Z",
+          }),
+        );
+        migrated = true;
+        try {
+          return originalReadFileSync(filePath, options as never);
+        } finally {
+          fs.writeFileSync(
+            legacyPath,
+            JSON.stringify({
+              homeserver: "https://matrix.example.org",
+              userId: "@bot:example.org",
+              accessToken: "recreated-stale-legacy-token",
+              createdAt: "2026-03-01T10:00:00.000Z",
+            }),
+          );
+        }
+      }
+      return originalReadFileSync(filePath, options as never);
+    }) as typeof fs.readFileSync);
+
+    try {
+      const loaded = loadMatrixCredentials({}, "ops");
+
+      expect(loaded?.accessToken).toBe("current-token");
+      expect(renameSpy).not.toHaveBeenCalled();
+      expect(
+        JSON.parse(fs.readFileSync(currentPath, "utf8")) as { accessToken: string },
+      ).toMatchObject({
+        accessToken: "current-token",
+      });
+      expect(
+        JSON.parse(fs.readFileSync(legacyPath, "utf8")) as { accessToken: string },
+      ).toMatchObject({
+        accessToken: "recreated-stale-legacy-token",
+      });
+    } finally {
+      readFileSpy.mockRestore();
+      renameSpy.mockRestore();
+    }
   });
 
   it("does not migrate legacy default credentials during a non-selected account read", () => {


### PR DESCRIPTION
## Summary
- retry the current Matrix credentials path when the legacy file disappears during migration
- keep the migration path returning stored credentials instead of transiently falling back to `null`
- add regression coverage for the legacy-to-current rename race

## Verification
- `pnpm format extensions/matrix/src/matrix/credentials-read.ts extensions/matrix/src/matrix/credentials.test.ts`
- `pnpm test -- extensions/matrix/src/matrix/credentials.test.ts` timed out in this environment, so I did not count it as passing

Part of #54295.
