### PR TITLE
matrix: force SSSS recreation on backup reset when SSSS key is broken (bad MAC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Docs: https://docs.openclaw.ai
 - Discord/mentions: treat `@everyone` and `@here` as valid mention-gate triggers in guild preflight so mention-required bots still respond to those broadcasts. (#60343) Thanks @geekhuashan.
 - Matrix: allow secret-storage recreation during automatic repair bootstrap so clients that lose their recovery key can recover and persist new cross-signing keys. (#59846) Thanks @al3mart.
 - Matrix/crypto persistence: capture and write the IndexedDB snapshot while holding the snapshot file lock so concurrent gateway and CLI persists cannot overwrite newer crypto state. (#59851) Thanks @al3mart.
-- Matrix/backup reset: recreate secret storage during backup reset when stale SSSS state blocks durable backup-key reload, including no-backup repair paths. (#60599) thanks @emonty.
 - Ollama/auth: prefer real cloud auth over local marker during model auth resolution so cloud-backed Ollama auth does not get shadowed by stale local-only markers.
 - Plugins/Kimi Coding: parse tagged Kimi tool-call text into structured tool calls on the provider stream path so tools execute instead of echoing raw markup. (#60051) Thanks @obviyus.
 - Channels/passive hooks: emit passive message hooks for mention-skipped Telegram and Signal group messages when `ingest` is enabled, including wildcard/default fallback and per-group override handling. (#60018) Thanks @obviyus.
@@ -113,6 +112,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Anthropic Vertex: read ADC files directly during auth discovery so explicit Google credentials and default ADC no longer depend on `existsSync` preflight checks. (#60592) Thanks @gumadeiras.
 - Android/Talk Mode: restore spoken assistant replies on node-scoped sessions by keeping reply routing synced to the resolved node session key and pausing mic capture during reply playback. (#60306) Thanks @MKV21.
 - Cron: replay interrupted recurring jobs on the first gateway restart instead of clearing the stale running marker and skipping catch-up until a second restart. (#60583) Thanks @joelnishanth.
+- Matrix/backup reset: recreate secret storage during backup reset when stale SSSS state blocks durable backup-key reload, including no-backup repair paths. (#60599) thanks @emonty.
 
 ## 2026.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - Discord/mentions: treat `@everyone` and `@here` as valid mention-gate triggers in guild preflight so mention-required bots still respond to those broadcasts. (#60343) Thanks @geekhuashan.
 - Matrix: allow secret-storage recreation during automatic repair bootstrap so clients that lose their recovery key can recover and persist new cross-signing keys. (#59846) Thanks @al3mart.
 - Matrix/crypto persistence: capture and write the IndexedDB snapshot while holding the snapshot file lock so concurrent gateway and CLI persists cannot overwrite newer crypto state. (#59851) Thanks @al3mart.
+- Matrix/backup reset: recreate secret storage during backup reset when stale SSSS state blocks durable backup-key reload, including no-backup repair paths. (#60599) thanks @emonty.
 - Ollama/auth: prefer real cloud auth over local marker during model auth resolution so cloud-backed Ollama auth does not get shadowed by stale local-only markers.
 - Plugins/Kimi Coding: parse tagged Kimi tool-call text into structured tool calls on the provider stream path so tools execute instead of echoing raw markup. (#60051) Thanks @obviyus.
 - Channels/passive hooks: emit passive message hooks for mention-skipped Telegram and Signal group messages when `ingest` is enabled, including wildcard/default fallback and per-group override handling. (#60018) Thanks @obviyus.

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -319,7 +319,9 @@ Verbose restore diagnostics:
 openclaw matrix verify backup restore --verbose
 ```
 
-Delete the current server backup and create a fresh backup baseline:
+Delete the current server backup and create a fresh backup baseline. If the stored
+backup key cannot be loaded cleanly, this reset can also recreate secret storage so
+future cold starts can load the new backup key:
 
 ```bash
 openclaw matrix verify backup reset --yes
@@ -366,8 +368,11 @@ If the homeserver requires interactive auth to upload cross-signing keys, OpenCl
 
 Use `--force-reset-cross-signing` only when you intentionally want to discard the current cross-signing identity and create a new one.
 
-If you intentionally want to discard the current room-key backup and start a new backup baseline for future messages, use `openclaw matrix verify backup reset --yes`.
-Do this only when you accept that unrecoverable old encrypted history will stay unavailable.
+If you intentionally want to discard the current room-key backup and start a new
+backup baseline for future messages, use `openclaw matrix verify backup reset --yes`.
+Do this only when you accept that unrecoverable old encrypted history will stay
+unavailable and that OpenClaw may recreate secret storage if the current backup
+secret cannot be loaded safely.
 
 ### Fresh backup baseline
 

--- a/docs/install/migrating-matrix.md
+++ b/docs/install/migrating-matrix.md
@@ -275,7 +275,10 @@ If the old store reports room keys that were never backed up, OpenClaw warns ins
 - Meaning: the stored key does not match the active Matrix backup.
 - What to do: rerun `openclaw matrix verify device "<your-recovery-key>"` with the correct key.
 
-If you accept losing unrecoverable old encrypted history, you can instead reset the current backup baseline with `openclaw matrix verify backup reset --yes`.
+If you accept losing unrecoverable old encrypted history, you can instead reset the
+current backup baseline with `openclaw matrix verify backup reset --yes`. When the
+stored backup secret is broken, that reset may also recreate secret storage so the
+new backup key can load correctly after restart.
 
 `Backup trust chain is not verified on this device. Re-run 'openclaw matrix verify device <key>'.`
 

--- a/extensions/matrix/src/cli.test.ts
+++ b/extensions/matrix/src/cli.test.ts
@@ -870,7 +870,7 @@ describe("matrix CLI verification commands", () => {
     await program.parseAsync(["matrix", "verify", "status"], { from: "user" });
 
     expect(console.log).toHaveBeenCalledWith(
-      "- If you want a fresh backup baseline and accept losing unrecoverable history, run 'openclaw matrix verify backup reset --yes'.",
+      "- If you want a fresh backup baseline and accept losing unrecoverable history, run 'openclaw matrix verify backup reset --yes'. This may also repair secret storage so the new backup key can be loaded after restart.",
     );
   });
 

--- a/extensions/matrix/src/cli.ts
+++ b/extensions/matrix/src/cli.ts
@@ -610,14 +610,14 @@ function buildVerificationGuidance(
       `Backup key mismatch on this device. Re-run '${formatMatrixCliCommand("verify device <key>", accountId)}' with the matching recovery key.`,
     );
     nextSteps.add(
-      `If you want a fresh backup baseline and accept losing unrecoverable history, run '${formatMatrixCliCommand("verify backup reset --yes", accountId)}'.`,
+      `If you want a fresh backup baseline and accept losing unrecoverable history, run '${formatMatrixCliCommand("verify backup reset --yes", accountId)}'. This may also repair secret storage so the new backup key can be loaded after restart.`,
     );
   } else if (backupIssue.code === "untrusted-signature") {
     nextSteps.add(
       `Backup trust chain is not verified on this device. Re-run '${formatMatrixCliCommand("verify device <key>", accountId)}' if you have the correct recovery key.`,
     );
     nextSteps.add(
-      `If you want a fresh backup baseline and accept losing unrecoverable history, run '${formatMatrixCliCommand("verify backup reset --yes", accountId)}'.`,
+      `If you want a fresh backup baseline and accept losing unrecoverable history, run '${formatMatrixCliCommand("verify backup reset --yes", accountId)}'. This may also repair secret storage so the new backup key can be loaded after restart.`,
     );
   } else if (backupIssue.code === "indeterminate") {
     nextSteps.add(
@@ -949,7 +949,9 @@ export function registerMatrixCli(params: { program: Command }): void {
 
   backup
     .command("reset")
-    .description("Delete the current server backup and create a fresh room-key backup baseline")
+    .description(
+      "Delete the current server backup and create a fresh room-key backup baseline, repairing secret storage if needed for a durable reset",
+    )
     .option("--account <id>", "Account ID (for multi-account setups)")
     .option("--yes", "Confirm destructive backup reset", false)
     .option("--verbose", "Show detailed diagnostics")

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1918,6 +1918,74 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(result.backup.matchesDecryptionKey).toBe(false);
   });
 
+  it("forces SSSS recreation when the pre-reset backup status shows a bad MAC key-load error", async () => {
+    // Simulates the state after a cross-signing bootstrap that recreated SSSS but left the
+    // old m.megolm_backup.v1 SSSS entry (encrypted with the old key) on the homeserver.
+    // getRoomKeyBackupStatus calls resolveRoomKeyBackupLocalState twice per invocation
+    // (once before and once after the load attempt), so getSessionBackupPrivateKey
+    // returns null for the first two calls (pre-reset, decryptionKeyCached = false
+    // → load is attempted → bad MAC) then a real key thereafter (post-reset).
+    const bootstrapSecretStorage = vi.fn(async () => {});
+    const checkKeyBackupAndEnable = vi.fn(async () => {});
+    const loadSessionBackupPrivateKeyFromSecretStorage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Error decrypting secret m.megolm_backup.v1: bad MAC"));
+    const getSessionBackupPrivateKey = vi
+      .fn()
+      .mockResolvedValueOnce(null)             // pre-reset pass 1: no key cached
+      .mockResolvedValueOnce(null)             // pre-reset pass 2: still no key after failed load
+      .mockResolvedValue(new Uint8Array([1])); // post-reset: key is present after bootstrap
+    const getSecretStorageStatus = vi.fn(async () => ({
+      ready: true,
+      defaultKeyId: "key-new",
+    }));
+    matrixJsClient.getCrypto = vi.fn(() => ({
+      on: vi.fn(),
+      bootstrapSecretStorage,
+      checkKeyBackupAndEnable,
+      loadSessionBackupPrivateKeyFromSecretStorage,
+      getSessionBackupPrivateKey,
+      getSecretStorageStatus,
+      getActiveSessionBackupVersion: vi.fn(async () => "22000"),
+      getKeyBackupInfo: vi.fn(async () => ({
+        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
+        auth_data: {},
+        version: "22000",
+      })),
+      isKeyBackupTrusted: vi.fn(async () => ({
+        trusted: true,
+        matchesDecryptionKey: true,
+      })),
+    }));
+
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      encryption: true,
+    });
+    vi.spyOn(client, "doRequest").mockImplementation(async (method, endpoint) => {
+      if (method === "GET" && String(endpoint).includes("/room_keys/version")) {
+        return { version: "21999" };
+      }
+      if (method === "DELETE" && String(endpoint).includes("/room_keys/version/21999")) {
+        return {};
+      }
+      return {};
+    });
+
+    const result = await client.resetRoomKeyBackup();
+
+    expect(result.success).toBe(true);
+    expect(result.createdVersion).toBe("22000");
+    // bootstrapSecretStorage must have been called with setupNewSecretStorage: true
+    // because the pre-reset bad MAC status triggered forceNewSecretStorage.
+    expect(bootstrapSecretStorage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        setupNewKeyBackup: true,
+        setupNewSecretStorage: true,
+      }),
+    );
+    expect(loadSessionBackupPrivateKeyFromSecretStorage).toHaveBeenCalledTimes(1);
+  });
+
   it("reports bootstrap failure when cross-signing keys are not published", async () => {
     matrixJsClient.getUserId = vi.fn(() => "@bot:example.org");
     matrixJsClient.getDeviceId = vi.fn(() => "DEVICE123");

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1918,13 +1918,11 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(result.backup.matchesDecryptionKey).toBe(false);
   });
 
-  it("forces SSSS recreation when the pre-reset backup status shows a bad MAC key-load error", async () => {
+  it("forces SSSS recreation when backup-secret access fails with bad MAC before reset", async () => {
     // Simulates the state after a cross-signing bootstrap that recreated SSSS but left the
     // old m.megolm_backup.v1 SSSS entry (encrypted with the old key) on the homeserver.
-    // getRoomKeyBackupStatus calls resolveRoomKeyBackupLocalState twice per invocation
-    // (once before and once after the load attempt), so getSessionBackupPrivateKey
-    // returns null for the first two calls (pre-reset, decryptionKeyCached = false
-    // → load is attempted → bad MAC) then a real key thereafter (post-reset).
+    // The reset preflight now probes backup-secret access directly, so a missing cached
+    // key plus a repairable secret-storage load failure should force SSSS recreation.
     const bootstrapSecretStorage = vi.fn(async () => {});
     const checkKeyBackupAndEnable = vi.fn(async () => {});
     const loadSessionBackupPrivateKeyFromSecretStorage = vi
@@ -1932,9 +1930,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       .mockRejectedValueOnce(new Error("Error decrypting secret m.megolm_backup.v1: bad MAC"));
     const getSessionBackupPrivateKey = vi
       .fn()
-      .mockResolvedValueOnce(null)             // pre-reset pass 1: no key cached
-      .mockResolvedValueOnce(null)             // pre-reset pass 2: still no key after failed load
-      .mockResolvedValue(new Uint8Array([1])); // post-reset: key is present after bootstrap
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(new Uint8Array([1]));
     const getSecretStorageStatus = vi.fn(async () => ({
       ready: true,
       defaultKeyId: "key-new",
@@ -1977,6 +1974,121 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(result.createdVersion).toBe("22000");
     // bootstrapSecretStorage must have been called with setupNewSecretStorage: true
     // because the pre-reset bad MAC status triggered forceNewSecretStorage.
+    expect(bootstrapSecretStorage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        setupNewKeyBackup: true,
+        setupNewSecretStorage: true,
+      }),
+    );
+    expect(loadSessionBackupPrivateKeyFromSecretStorage).toHaveBeenCalledTimes(1);
+  });
+
+  it("forces SSSS recreation when backup-secret access is broken even without a current server backup", async () => {
+    const bootstrapSecretStorage = vi.fn(async () => {});
+    const checkKeyBackupAndEnable = vi.fn(async () => {});
+    const loadSessionBackupPrivateKeyFromSecretStorage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Error decrypting secret m.megolm_backup.v1: bad MAC"));
+    const getSessionBackupPrivateKey = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(new Uint8Array([1]));
+    const getActiveSessionBackupVersion = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue("22001");
+    matrixJsClient.getCrypto = vi.fn(() => ({
+      on: vi.fn(),
+      bootstrapSecretStorage,
+      checkKeyBackupAndEnable,
+      loadSessionBackupPrivateKeyFromSecretStorage,
+      getActiveSessionBackupVersion,
+      getSessionBackupPrivateKey,
+      getKeyBackupInfo: vi.fn(async () => ({
+        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
+        auth_data: {},
+        version: "22001",
+      })),
+      isKeyBackupTrusted: vi.fn(async () => ({
+        trusted: true,
+        matchesDecryptionKey: true,
+      })),
+    }));
+
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      encryption: true,
+    });
+    const doRequest = vi.spyOn(client, "doRequest").mockImplementation(async (method, endpoint) => {
+      if (method === "GET" && String(endpoint).includes("/room_keys/version")) {
+        return {};
+      }
+      return {};
+    });
+
+    const result = await client.resetRoomKeyBackup();
+
+    expect(result.success).toBe(true);
+    expect(result.previousVersion).toBe(null);
+    expect(result.deletedVersion).toBe(null);
+    expect(result.createdVersion).toBe("22001");
+    expect(bootstrapSecretStorage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        setupNewKeyBackup: true,
+        setupNewSecretStorage: true,
+      }),
+    );
+    expect(loadSessionBackupPrivateKeyFromSecretStorage).toHaveBeenCalledTimes(1);
+    expect(doRequest).not.toHaveBeenCalledWith(
+      "DELETE",
+      expect.stringContaining("/room_keys/version/"),
+    );
+  });
+
+  it("forces SSSS recreation when backup-secret access returns a falsey callback error before reset", async () => {
+    const bootstrapSecretStorage = vi.fn(async () => {});
+    const checkKeyBackupAndEnable = vi.fn(async () => {});
+    const loadSessionBackupPrivateKeyFromSecretStorage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("getSecretStorageKey callback returned falsey"));
+    const getSessionBackupPrivateKey = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(new Uint8Array([1]));
+    matrixJsClient.getCrypto = vi.fn(() => ({
+      on: vi.fn(),
+      bootstrapSecretStorage,
+      checkKeyBackupAndEnable,
+      loadSessionBackupPrivateKeyFromSecretStorage,
+      getActiveSessionBackupVersion: vi.fn(async () => "22002"),
+      getSessionBackupPrivateKey,
+      getKeyBackupInfo: vi.fn(async () => ({
+        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
+        auth_data: {},
+        version: "22002",
+      })),
+      isKeyBackupTrusted: vi.fn(async () => ({
+        trusted: true,
+        matchesDecryptionKey: true,
+      })),
+    }));
+
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      encryption: true,
+    });
+    vi.spyOn(client, "doRequest").mockImplementation(async (method, endpoint) => {
+      if (method === "GET" && String(endpoint).includes("/room_keys/version")) {
+        return { version: "22000" };
+      }
+      if (method === "DELETE" && String(endpoint).includes("/room_keys/version/22000")) {
+        return {};
+      }
+      return {};
+    });
+
+    const result = await client.resetRoomKeyBackup();
+
+    expect(result.success).toBe(true);
+    expect(result.createdVersion).toBe("22002");
     expect(bootstrapSecretStorage).toHaveBeenCalledWith(
       expect.objectContaining({
         setupNewKeyBackup: true,

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -25,7 +25,7 @@ import { matrixEventToRaw, parseMxc } from "./sdk/event-helpers.js";
 import { MatrixAuthedHttpClient } from "./sdk/http-client.js";
 import { MATRIX_IDB_PERSIST_INTERVAL_MS } from "./sdk/idb-persistence-lock.js";
 import { ConsoleLogger, LogService, noop } from "./sdk/logger.js";
-import { MatrixRecoveryKeyStore } from "./sdk/recovery-key-store.js";
+import { MatrixRecoveryKeyStore, isRepairableSecretStorageAccessError } from "./sdk/recovery-key-store.js";
 import { createMatrixGuardedFetch, type HttpMethod, type QueryParams } from "./sdk/transport.js";
 import type {
   MatrixClientEventMap,
@@ -1151,6 +1151,18 @@ export class MatrixClient {
 
     previousVersion = await this.resolveRoomKeyBackupVersion();
 
+    // Check whether the SSSS key is currently broken (bad MAC or callback failure)
+    // before deleting the old backup. If so, we must force SSSS recreation during
+    // the bootstrap below; otherwise bootstrapSecretStorage writes the new backup
+    // key to SSSS encrypted with a key that does not match recovery_key.json, causing
+    // every subsequent cold-start loadSessionBackupPrivateKeyFromSecretStorage call
+    // to fail with bad MAC even after an apparently successful reset.
+    const preResetBackupStatus = previousVersion ? await this.getRoomKeyBackupStatus() : null;
+    const ssssKeyIsBroken =
+      preResetBackupStatus?.keyLoadAttempted === true &&
+      typeof preResetBackupStatus.keyLoadError === "string" &&
+      isRepairableSecretStorageAccessError(new Error(preResetBackupStatus.keyLoadError));
+
     try {
       if (previousVersion) {
         try {
@@ -1168,6 +1180,12 @@ export class MatrixClient {
 
       await this.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey(crypto, {
         setupNewKeyBackup: true,
+        // Force SSSS recreation when the existing SSSS key is broken (bad MAC), so
+        // the new backup key is written into a fresh SSSS consistent with recovery_key.json.
+        forceNewSecretStorage: ssssKeyIsBroken,
+        // Also allow recreation if bootstrapSecretStorage itself surfaces a repairable
+        // error (e.g. bad MAC from a different SSSS entry).
+        allowSecretStorageRecreateWithoutRecoveryKey: true,
       });
       await this.enableTrustedRoomKeyBackupIfPossible(crypto);
 

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -1445,7 +1445,7 @@ export class MatrixClient {
   private async shouldForceSecretStorageRecreationForBackupReset(
     crypto: MatrixCryptoBootstrapApi,
   ): Promise<boolean> {
-    const { decryptionKeyCached } = await this.resolveRoomKeyBackupLocalState(crypto);
+    const decryptionKeyCached = await this.resolveCachedRoomKeyBackupDecryptionKey(crypto);
     if (decryptionKeyCached !== false) {
       return false;
     }

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -25,7 +25,10 @@ import { matrixEventToRaw, parseMxc } from "./sdk/event-helpers.js";
 import { MatrixAuthedHttpClient } from "./sdk/http-client.js";
 import { MATRIX_IDB_PERSIST_INTERVAL_MS } from "./sdk/idb-persistence-lock.js";
 import { ConsoleLogger, LogService, noop } from "./sdk/logger.js";
-import { MatrixRecoveryKeyStore, isRepairableSecretStorageAccessError } from "./sdk/recovery-key-store.js";
+import {
+  MatrixRecoveryKeyStore,
+  isRepairableSecretStorageAccessError,
+} from "./sdk/recovery-key-store.js";
 import { createMatrixGuardedFetch, type HttpMethod, type QueryParams } from "./sdk/transport.js";
 import type {
   MatrixClientEventMap,
@@ -1151,17 +1154,11 @@ export class MatrixClient {
 
     previousVersion = await this.resolveRoomKeyBackupVersion();
 
-    // Check whether the SSSS key is currently broken (bad MAC or callback failure)
-    // before deleting the old backup. If so, we must force SSSS recreation during
-    // the bootstrap below; otherwise bootstrapSecretStorage writes the new backup
-    // key to SSSS encrypted with a key that does not match recovery_key.json, causing
-    // every subsequent cold-start loadSessionBackupPrivateKeyFromSecretStorage call
-    // to fail with bad MAC even after an apparently successful reset.
-    const preResetBackupStatus = previousVersion ? await this.getRoomKeyBackupStatus() : null;
-    const ssssKeyIsBroken =
-      preResetBackupStatus?.keyLoadAttempted === true &&
-      typeof preResetBackupStatus.keyLoadError === "string" &&
-      isRepairableSecretStorageAccessError(new Error(preResetBackupStatus.keyLoadError));
+    // Probe backup-secret access directly before reset. This keeps the reset preflight
+    // focused on durable secret-storage health instead of the broader backup status flow,
+    // and still catches stale SSSS/recovery-key state even when the server backup is gone.
+    const forceNewSecretStorage =
+      await this.shouldForceSecretStorageRecreationForBackupReset(crypto);
 
     try {
       if (previousVersion) {
@@ -1182,7 +1179,7 @@ export class MatrixClient {
         setupNewKeyBackup: true,
         // Force SSSS recreation when the existing SSSS key is broken (bad MAC), so
         // the new backup key is written into a fresh SSSS consistent with recovery_key.json.
-        forceNewSecretStorage: ssssKeyIsBroken,
+        forceNewSecretStorage,
         // Also allow recreation if bootstrapSecretStorage itself surfaces a repairable
         // error (e.g. bad MAC from a different SSSS entry).
         allowSecretStorageRecreateWithoutRecoveryKey: true,
@@ -1443,6 +1440,26 @@ export class MatrixClient {
       this.resolveCachedRoomKeyBackupDecryptionKey(crypto),
     ]);
     return { activeVersion, decryptionKeyCached };
+  }
+
+  private async shouldForceSecretStorageRecreationForBackupReset(
+    crypto: MatrixCryptoBootstrapApi,
+  ): Promise<boolean> {
+    const { decryptionKeyCached } = await this.resolveRoomKeyBackupLocalState(crypto);
+    if (decryptionKeyCached !== false) {
+      return false;
+    }
+    const loadSessionBackupPrivateKeyFromSecretStorage =
+      crypto.loadSessionBackupPrivateKeyFromSecretStorage; // pragma: allowlist secret
+    if (typeof loadSessionBackupPrivateKeyFromSecretStorage !== "function") {
+      return false;
+    }
+    try {
+      await loadSessionBackupPrivateKeyFromSecretStorage.call(crypto); // pragma: allowlist secret
+      return false;
+    } catch (err) {
+      return isRepairableSecretStorageAccessError(err);
+    }
   }
 
   private async resolveRoomKeyBackupTrustState(


### PR DESCRIPTION
## Problem

After a cross-signing bootstrap that recreates SSSS (new key ID), the old `m.megolm_backup.v1` SSSS entry remains on the homeserver encrypted under the **previous** key. A subsequent `openclaw matrix verify backup reset --yes` appears to succeed — the SDK has the new backup key active in its session memory — but every subsequent cold-start invocation of `loadSessionBackupPrivateKeyFromSecretStorage` fails with:

```
Error: Matrix room key backup is not usable: backup decryption key could not be loaded from secret storage (Error decrypting secret m.megolm_backup.v1: bad MAC).
```

This happens because `bootstrapSecretStorage({ setupNewKeyBackup: true })` writes the new backup key to SSSS encrypted with whatever key `getSecretStorageKey` returned — which, coming from a stale `recovery_key.json`, is the wrong key. The in-process status check passes (the backup key is already in the SDK session), but every fresh invocation fails.

## Fix

Before deleting the old backup, call `getRoomKeyBackupStatus()` to check whether the SSSS key is currently broken (`keyLoadAttempted && keyLoadError` matches `isRepairableSecretStorageAccessError`). If it is, pass `forceNewSecretStorage: true` to `bootstrapSecretStorageWithRecoveryKey` so the SDK creates fresh SSSS alongside the new backup — ensuring the backup key is written into SSSS with a key that is consistent with `recovery_key.json`.

Also add `allowSecretStorageRecreateWithoutRecoveryKey: true` as a defence for bad MAC errors that surface from within `bootstrapSecretStorage` itself (the existing catch handler in `bootstrapSecretStorageWithRecoveryKey` handles this case when the flag is set).

## Changes

- `extensions/matrix/src/matrix/sdk.ts`: pre-reset SSSS health check + `forceNewSecretStorage`/`allowSecretStorageRecreateWithoutRecoveryKey` flags on `bootstrapSecretStorageWithRecoveryKey`
- `extensions/matrix/src/matrix/sdk.test.ts`: new test for the bad MAC → forced SSSS recreation path, verifying `bootstrapSecretStorage` is called with `setupNewSecretStorage: true`

## Testing

The new unit test covers the exact scenario: `getSessionBackupPrivateKey` returns `null` for the two pre-reset passes (triggering the load attempt and bad MAC), then a real key afterwards; `loadSessionBackupPrivateKeyFromSecretStorage` throws bad MAC on its single call; the test asserts `bootstrapSecretStorage` was called with `{ setupNewKeyBackup: true, setupNewSecretStorage: true }` and that the reset returns success.