### PR TITLE
fix(cache): preserve full 3-turn history image cache window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Ollama: add bundled Ollama Web Search provider for key-free web_search via your configured Ollama host and `ollama signin`. (#59318) Thanks @BruceMacD.
 - Plugins/install: add `openclaw plugins install --force` to overwrite existing plugin and hook-pack install targets without using the dangerous-code override flag. (#60544) Thanks @gumadeiras.
 - Providers/transport: add shared proxy/TLS/auth-aware request transport support across model-provider paths, including Anthropic and Google native transport runtimes, so provider request overrides work beyond OpenAI-family traffic.
+- Cache/history images: preserve the full 3-turn embedded Pi image-cache window so prompt-cache prefix reuse survives one more assistant turn. (#60603) Thanks @gumadeiras.
 
 ### Fixes
 
@@ -192,7 +193,6 @@ Docs: https://docs.openclaw.ai
 - Exec/node hosts: stop forwarding the gateway workspace cwd to remote node exec when no workdir was explicitly requested, so cross-platform node approvals fall back to the node default cwd instead of failing with `SYSTEM_RUN_DENIED`. (#58977) Thanks @Starhappysh.
 - TUI/chat: keep pending local sends visible and reconciled across history reloads, make busy/error recovery clearer through fallback and terminal-error paths, and reclaim transcript width for long links and paths. (#59800) Thanks @vincentkoc.
 - Exec approvals/channels: decouple initiating-surface approval availability from native delivery enablement so Telegram, Slack, and Discord still expose approvals when approvers exist and native target routing is configured separately. (#59776) Thanks @joelnishanth.
-- Cache/history images: preserve the full 3-turn embedded Pi image-cache window so prompt-cache prefix reuse survives one more assistant turn. (#60603) Thanks @gumadeiras.
 
 ## 2026.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@ Docs: https://docs.openclaw.ai
 - Exec/node hosts: stop forwarding the gateway workspace cwd to remote node exec when no workdir was explicitly requested, so cross-platform node approvals fall back to the node default cwd instead of failing with `SYSTEM_RUN_DENIED`. (#58977) Thanks @Starhappysh.
 - TUI/chat: keep pending local sends visible and reconciled across history reloads, make busy/error recovery clearer through fallback and terminal-error paths, and reclaim transcript width for long links and paths. (#59800) Thanks @vincentkoc.
 - Exec approvals/channels: decouple initiating-surface approval availability from native delivery enablement so Telegram, Slack, and Discord still expose approvals when approvers exist and native target routing is configured separately. (#59776) Thanks @joelnishanth.
+- Cache/history images: preserve the full 3-turn embedded Pi image-cache window so prompt-cache prefix reuse survives one more assistant turn. (#60603) Thanks @gumadeiras.
 
 ## 2026.4.1
 

--- a/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
@@ -42,18 +42,22 @@ describe("pruneProcessedHistoryImages", () => {
       assistantTurn(),
       userText(),
       assistantTurn(),
+      userText(),
+      assistantTurn(),
     ];
 
     const content = expectPrunedImageMessage(messages, "expected user array content");
     expect(content[0]?.type).toBe("text");
   });
 
-  it("keeps image blocks within the last 3 assistant turns to preserve prompt cache", () => {
+  it("keeps image blocks that belong to the third-most-recent assistant turn", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({
         role: "user",
         content: [{ type: "text", text: "See /tmp/photo.png" }, { ...image }],
       }),
+      assistantTurn(),
+      userText(),
       assistantTurn(),
       userText(),
       assistantTurn(),
@@ -94,6 +98,8 @@ describe("pruneProcessedHistoryImages", () => {
       assistantTurn(),
       userText(),
       assistantTurn(),
+      userText(),
+      assistantTurn(),
     ];
 
     expectPrunedImageMessage(messages, "expected toolResult array content");
@@ -105,6 +111,8 @@ describe("pruneProcessedHistoryImages", () => {
         role: "user",
         content: [{ type: "text", text: "old" }, { ...image }],
       }),
+      assistantTurn(),
+      userText(),
       assistantTurn(),
       userText(),
       assistantTurn(),
@@ -121,7 +129,7 @@ describe("pruneProcessedHistoryImages", () => {
     const oldContent = expectArrayMessageContent(messages[0], "expected old user content");
     expect(oldContent[1]).toMatchObject({ type: "text", text: PRUNED_HISTORY_IMAGE_MARKER });
 
-    const recentContent = expectArrayMessageContent(messages[4], "expected recent user content");
+    const recentContent = expectArrayMessageContent(messages[6], "expected recent user content");
     expect(recentContent[1]).toMatchObject({ type: "image", data: "abc" });
   });
 

--- a/src/agents/pi-embedded-runner/run/history-image-prune.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.ts
@@ -21,7 +21,7 @@ export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i]?.role === "assistant") {
       assistantSeen++;
-      if (assistantSeen >= PRESERVE_RECENT_ASSISTANT_TURNS) {
+      if (assistantSeen > PRESERVE_RECENT_ASSISTANT_TURNS) {
         pruneBeforeIndex = i;
         break;
       }


### PR DESCRIPTION
## Summary

- Problem: `pruneProcessedHistoryImages` started pruning at the third-most-recent assistant turn instead of after it.
- Why it matters: the user/toolResult image that produced that assistant reply was removed one turn too early, which breaks prompt-cache prefix reuse.
- What changed: moved the prune cutoff from `>= 3` assistant replies to `> 3` and updated the regression fixtures to lock the boundary in.
- What did NOT change (scope boundary): no broader session pruning policy changes; only the history image cutoff and tests.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #58038
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the reverse scan used `assistantSeen >= PRESERVE_RECENT_ASSISTANT_TURNS`, so the prune boundary landed on the preserved window instead of just before it.
- Missing detection / guardrail: the existing tests did not cover the exact 3-turn boundary.
- Contributing context (if known): this is a follow-up to #58038.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/history-image-prune.test.ts`
- Scenario the test should lock in: preserve the image blocks that belong to the third-most-recent assistant turn; start pruning only on the fourth assistant boundary.
- Why this is the smallest reliable guardrail: the bug is a pure cutoff bug inside `pruneProcessedHistoryImages`.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Images in embedded Pi session history now remain intact for the full last 3 assistant turns, so prompt-cache reuse is preserved for one more turn in affected histories.

## Diagram (if applicable)

```text
Before:
user(image) -> assistant -> user -> assistant -> user -> assistant
           ^ pruned too early at the 3-turn boundary

After:
user(image) -> assistant -> user -> assistant -> user -> assistant
           ^ kept until the next assistant turn ages it out
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): embedded Pi runner
- Relevant config (redacted): default local checkout

### Steps

1. Build a history with a user image followed by exactly 3 assistant turns.
2. Run `pruneProcessedHistoryImages`.
3. Add a fourth assistant turn and run it again.

### Expected

- The image survives the 3-turn boundary and is pruned only once it is older than 3 assistant replies.

### Actual

- Before this patch, the image was pruned at the 3-turn boundary.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted Vitest run for `pruneProcessedHistoryImages`; checked both preserved and pruned boundary cases.
- Edge cases checked: user and `toolResult` image blocks; mixed old/recent images in one history.
- What you did **not** verify: full Pi suite / full repo suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the unit-only gate misses unrelated runner interactions.
  - Mitigation: scope is a single pure helper; regression fixtures cover the exact boundary that was wrong.
