### PR TITLE
fix: initialize plugins.allow when undefined in ensurePluginAllowlisted

### DIFF
--- a/src/config/plugins-allowlist.test.ts
+++ b/src/config/plugins-allowlist.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "./config.js";
+import { ensurePluginAllowlisted } from "./plugins-allowlist.js";
+
+describe("ensurePluginAllowlisted", () => {
+  it("initializes allow to [pluginId] when plugins.allow is undefined", () => {
+    const cfg = { plugins: {} } as OpenClawConfig;
+    const result = ensurePluginAllowlisted(cfg, "my-plugin");
+    expect(result.plugins?.allow).toEqual(["my-plugin"]);
+  });
+
+  it("initializes plugins.allow to [pluginId] when plugins is undefined", () => {
+    const cfg = {} as OpenClawConfig;
+    const result = ensurePluginAllowlisted(cfg, "my-plugin");
+    expect(result.plugins?.allow).toEqual(["my-plugin"]);
+  });
+
+  it("appends pluginId to an existing allow array", () => {
+    const cfg = { plugins: { allow: ["other-plugin"] } } as OpenClawConfig;
+    const result = ensurePluginAllowlisted(cfg, "my-plugin");
+    expect(result.plugins?.allow).toEqual(["other-plugin", "my-plugin"]);
+  });
+
+  it("returns cfg unchanged when pluginId is already present", () => {
+    const cfg = { plugins: { allow: ["my-plugin"] } } as OpenClawConfig;
+    const result = ensurePluginAllowlisted(cfg, "my-plugin");
+    expect(result).toBe(cfg);
+  });
+
+  it("preserves existing items when appending", () => {
+    const cfg = { plugins: { allow: ["a", "b"] } } as OpenClawConfig;
+    const result = ensurePluginAllowlisted(cfg, "c");
+    expect(result.plugins?.allow).toEqual(["a", "b", "c"]);
+  });
+});

--- a/src/config/plugins-allowlist.ts
+++ b/src/config/plugins-allowlist.ts
@@ -2,14 +2,14 @@ import type { OpenClawConfig } from "./config.js";
 
 export function ensurePluginAllowlisted(cfg: OpenClawConfig, pluginId: string): OpenClawConfig {
   const allow = cfg.plugins?.allow;
-  if (!Array.isArray(allow) || allow.includes(pluginId)) {
+  if (Array.isArray(allow) && allow.includes(pluginId)) {
     return cfg;
   }
   return {
     ...cfg,
     plugins: {
       ...cfg.plugins,
-      allow: [...allow, pluginId],
+      allow: [...(Array.isArray(allow) ? allow : []), pluginId],
     },
   };
 }


### PR DESCRIPTION
## Problem

When `plugins.allow` is `undefined` (not set at all in config), `ensurePluginAllowlisted` returns the config unchanged — newly installed plugins are never added to the allowlist.

**Root cause:** The guard `!Array.isArray(allow)` evaluates to `true` when `allow` is `undefined`, triggering the early return.

## Fix

Change the guard to only early-return when the plugin is already present in an existing array. When `allow` is `undefined`, initialize it as a new array containing the plugin id.

**Before:**
```ts
if (!Array.isArray(allow) || allow.includes(pluginId)) {
  return cfg;
}
return { ...cfg, plugins: { ...cfg.plugins, allow: [...allow, pluginId] } };
```

**After:**
```ts
if (Array.isArray(allow) && allow.includes(pluginId)) {
  return cfg;
}
return { ...cfg, plugins: { ...cfg.plugins, allow: [...(Array.isArray(allow) ? allow : []), pluginId] } };
```

## Tests

Added `src/config/plugins-allowlist.test.ts` covering:
- `plugins.allow` undefined → initializes to `[pluginId]`
- `plugins` undefined → initializes to `[pluginId]`
- Existing allow array → appends
- Already present → returns unchanged (reference equality)
- Multiple existing items → preserved when appending

Fixes #60596