### PR TITLE
Fix: ensurePluginAllowlisted initializes allowlist array when undefined

### DIFF
--- a/src/config/plugins-allowlist.ts
+++ b/src/config/plugins-allowlist.ts
@@ -1,8 +1,8 @@
 import type { OpenClawConfig } from "./config.js";
 
 export function ensurePluginAllowlisted(cfg: OpenClawConfig, pluginId: string): OpenClawConfig {
-  const allow = cfg.plugins?.allow;
-  if (!Array.isArray(allow) || allow.includes(pluginId)) {
+  const allow = cfg.plugins?.allow ?? [];
+  if (allow.includes(pluginId)) {
     return cfg;
   }
   return {


### PR DESCRIPTION
Good day,

This PR fixes issue #60596 where `ensurePluginAllowlisted` in `src/config/plugins-allowlist.ts` silently no-ops when `plugins.allow` is `undefined` (not yet initialized).

## Problem

The original code:


When `plugins.allow` is undefined, `!Array.isArray(allow)` is true, so it returns early without adding the plugin to the allowlist.

## Fix

Initialize the array on first use:


This is a one-line change that properly bootstraps the allowlist array on first use.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
Jah-yee
https://github.com/Jah-yee