### PR TITLE
fix(cron): replay interrupted recurring jobs on first restart

### DIFF
--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -115,7 +115,7 @@ describe("CronService restart catch-up", () => {
     );
   });
 
-  it("clears stale running markers without replaying interrupted startup jobs", async () => {
+  it("replays interrupted recurring cron jobs on startup", async () => {
     const dueAt = Date.parse("2025-12-13T16:00:00.000Z");
     const staleRunningAt = Date.parse("2025-12-13T16:30:00.000Z");
 
@@ -137,8 +137,13 @@ describe("CronService restart catch-up", () => {
           },
         },
       ],
-      async ({ cron, enqueueSystemEvent }) => {
-        expect(enqueueSystemEvent).not.toHaveBeenCalled();
+      async ({ cron, enqueueSystemEvent, requestHeartbeatNow }) => {
+        // Recurring jobs interrupted during execution should be replayed (#60495)
+        expect(enqueueSystemEvent).toHaveBeenCalledWith(
+          "resume stale marker",
+          expect.objectContaining({ agentId: undefined }),
+        );
+        expect(requestHeartbeatNow).toHaveBeenCalled();
         expect(noopLogger.warn).toHaveBeenCalledWith(
           expect.objectContaining({ jobId: "restart-stale-running" }),
           "cron: clearing stale running marker on startup",
@@ -147,8 +152,8 @@ describe("CronService restart catch-up", () => {
         const listedJobs = await cron.list({ includeDisabled: true });
         const updated = listedJobs.find((job) => job.id === "restart-stale-running");
         expect(updated?.state.runningAtMs).toBeUndefined();
-        expect(updated?.state.lastStatus).toBeUndefined();
-        expect(updated?.state.lastRunAtMs).toBeUndefined();
+        expect(updated?.state.lastStatus).toBe("ok");
+        expect(updated?.state.lastRunAtMs).toBe(Date.parse("2025-12-13T17:00:00.000Z"));
         expect((updated?.state.nextRunAtMs ?? 0) > Date.parse("2025-12-13T17:00:00.000Z")).toBe(
           true,
         );

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -112,7 +112,11 @@ export async function start(state: CronServiceState) {
           "cron: clearing stale running marker on startup",
         );
         job.state.runningAtMs = undefined;
-        startupInterruptedJobIds.add(job.id);
+        // Only skip interrupted one-shot jobs from startup catchup.
+        // Recurring jobs (cron/every) should be retried if past due (#60495).
+        if (job.schedule.kind === "at") {
+          startupInterruptedJobIds.add(job.id);
+        }
       }
     }
     if (startupInterruptedJobIds.size > 0) {


### PR DESCRIPTION
## Summary

When OpenClaw restarts while a recurring cron job is running, the job is not retried on startup. It is only caught on a **second** restart when `runMissedJobs()` finds the next scheduled time past due again.

**Root cause:** In `start()` (`src/cron/service/ops.ts`), all interrupted jobs — regardless of schedule kind — are added to `startupInterruptedJobIds` and skipped by `runMissedJobs()`. After the skip, `recomputeNextRuns()` advances `nextRunAtMs` to the next future slot without executing the missed run.

**Fix:** Only add one-shot (`kind === "at"`) jobs to the skip set. Recurring jobs (`cron`/`every`) are now eligible for startup catchup via `runMissedJobs()`, which already handles them correctly when their `nextRunAtMs` is past due.

- Updated `restart-catchup` test to verify interrupted recurring jobs ARE replayed
- One-shot (`at`) job test remains unchanged (still skipped on restart)

Fixes #60495

## Test plan

- [ ] Existing test "replays interrupted recurring cron jobs on startup" passes (updated from previous "clears stale running markers" test)
- [ ] Existing test "does not replay interrupted one-shot jobs on startup" still passes
- [ ] Manual: create a cron job, restart while running, verify it retries on first restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)