### PR TITLE
fix(cron): notify user via primary delivery channel on job failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals/node host: forward prepared `system.run` approval plans on the async node invoke path so mutable script operands keep their approval-time binding and drift revalidation instead of dropping back to unbound execution.
 - Synology Chat/security: default low-level HTTPS helper TLS verification to on so helper/API defaults match the shipped safe account default, and only explicit `allowInsecureSsl: true` opts out.
 - Android/canvas security: require exact normalized A2UI URL matches before forwarding canvas bridge actions, rejecting query mismatches and descendant paths while still allowing fragment-only A2UI navigation.
+- Cron: send failure notifications through the job's primary delivery channel using the same session context as successful delivery when no explicit `failureDestination` is configured. (#60622) Thanks @artwalker.
 
 ## 2026.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,7 +201,6 @@ Docs: https://docs.openclaw.ai
 - Mattermost/slash commands: harden native slash-command callback token validation to use constant-time secret comparison, matching the existing interaction-token path.
 - Agents/scheduling: route delayed follow-up requests toward cron only when cron is actually available, while keeping background `exec`/`process` guidance scoped to work that starts now. (#60811) Thanks @vincentkoc.
 - Cron/security: reject unsafe custom `sessionTarget: "session:..."` IDs earlier during cron add, update, and execution so malformed custom session keys fail closed with clear errors.
-- Cron: send failure notifications through the job's primary delivery channel using the same session context as successful delivery when no explicit `failureDestination` is configured. (#60622) Thanks @artwalker.
 
 ## 2026.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,7 @@ Docs: https://docs.openclaw.ai
 - Mattermost/slash commands: harden native slash-command callback token validation to use constant-time secret comparison, matching the existing interaction-token path.
 - Agents/scheduling: route delayed follow-up requests toward cron only when cron is actually available, while keeping background `exec`/`process` guidance scoped to work that starts now. (#60811) Thanks @vincentkoc.
 - Cron/security: reject unsafe custom `sessionTarget: "session:..."` IDs earlier during cron add, update, and execution so malformed custom session keys fail closed with clear errors.
+- Cron: send failure notifications through the job's primary delivery channel using the same session context as successful delivery when no explicit `failureDestination` is configured. (#60622) Thanks @artwalker.
 
 ## 2026.4.1
 

--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -95,6 +95,27 @@ describe("sendFailureNotificationAnnounce", () => {
     );
   });
 
+  it("passes sessionKey through to delivery-target resolution", async () => {
+    await sendFailureNotificationAnnounce(
+      {} as never,
+      {} as never,
+      "main",
+      "job-1",
+      {
+        channel: "telegram",
+        sessionKey: "agent:main:telegram:direct:123:thread:99",
+      },
+      "Cron failed",
+    );
+
+    expect(mocks.resolveDeliveryTarget).toHaveBeenCalledWith({} as never, "main", {
+      channel: "telegram",
+      to: undefined,
+      accountId: undefined,
+      sessionKey: "agent:main:telegram:direct:123:thread:99",
+    });
+  });
+
   it("does not send when target resolution fails", async () => {
     mocks.resolveDeliveryTarget.mockResolvedValue({
       ok: false,

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -32,13 +32,14 @@ export async function sendFailureNotificationAnnounce(
   cfg: OpenClawConfig,
   agentId: string,
   jobId: string,
-  target: { channel?: string; to?: string; accountId?: string },
+  target: { channel?: string; to?: string; accountId?: string; sessionKey?: string },
   message: string,
 ): Promise<void> {
   const resolvedTarget = await resolveDeliveryTarget(cfg, agentId, {
     channel: target.channel as CronMessageChannel | undefined,
     to: target.to,
     accountId: target.accountId,
+    sessionKey: target.sessionKey,
   });
 
   if (!resolvedTarget.ok) {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -483,7 +483,7 @@ export function buildGatewayCronService(params: {
             } else {
               // No explicit failureDestination — fall back to primary delivery channel (#60608)
               const primaryPlan = resolveCronDeliveryPlan(job);
-              if (primaryPlan.mode === "announce" && primaryPlan.requested && primaryPlan.to) {
+              if (primaryPlan.mode === "announce" && primaryPlan.requested) {
                 const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
                 void sendFailureNotificationAnnounce(
                   params.deps,

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -477,7 +477,7 @@ export function buildGatewayCronService(params: {
                     to: failureDest.to,
                     accountId: failureDest.accountId,
                   },
-                  `[Cron Failure] ${failureMessage}`,
+                  `⚠️ ${failureMessage}`,
                 );
               }
             } else {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -9,7 +9,11 @@ import {
   resolveAgentMainSessionKey,
 } from "../config/sessions.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { resolveFailureDestination, sendFailureNotificationAnnounce } from "../cron/delivery.js";
+import {
+  resolveCronDeliveryPlan,
+  resolveFailureDestination,
+  sendFailureNotificationAnnounce,
+} from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { resolveDeliveryTarget } from "../cron/isolated-agent/delivery-target.js";
 import {
@@ -420,12 +424,13 @@ export function buildGatewayCronService(params: {
         }
 
         if (evt.status === "error" && job) {
-          const failureDest = resolveFailureDestination(job, params.cfg.cron?.failureDestination);
-          if (failureDest) {
-            const isBestEffort = job.delivery?.bestEffort === true;
+          const isBestEffort = job.delivery?.bestEffort === true;
+          if (!isBestEffort) {
+            const failureMessage = `Cron job "${job.name}" failed: ${evt.error ?? "unknown error"}`;
+            const failureDest = resolveFailureDestination(job, params.cfg.cron?.failureDestination);
 
-            if (!isBestEffort) {
-              const failureMessage = `Cron job "${job.name}" failed: ${evt.error ?? "unknown error"}`;
+            if (failureDest) {
+              // Explicit failureDestination configured — use it
               const failurePayload = {
                 jobId: job.id,
                 jobName: job.name,
@@ -473,6 +478,24 @@ export function buildGatewayCronService(params: {
                     accountId: failureDest.accountId,
                   },
                   `[Cron Failure] ${failureMessage}`,
+                );
+              }
+            } else {
+              // No explicit failureDestination — fall back to primary delivery channel (#60608)
+              const primaryPlan = resolveCronDeliveryPlan(job);
+              if (primaryPlan.mode === "announce" && primaryPlan.requested && primaryPlan.to) {
+                const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
+                void sendFailureNotificationAnnounce(
+                  params.deps,
+                  runtimeConfig,
+                  agentId,
+                  job.id,
+                  {
+                    channel: primaryPlan.channel,
+                    to: primaryPlan.to,
+                    accountId: primaryPlan.accountId,
+                  },
+                  `⚠️ ${failureMessage}`,
                 );
               }
             }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -476,6 +476,7 @@ export function buildGatewayCronService(params: {
                     channel: failureDest.channel,
                     to: failureDest.to,
                     accountId: failureDest.accountId,
+                    sessionKey: job.sessionKey,
                   },
                   `⚠️ ${failureMessage}`,
                 );
@@ -494,6 +495,7 @@ export function buildGatewayCronService(params: {
                     channel: primaryPlan.channel,
                     to: primaryPlan.to,
                     accountId: primaryPlan.accountId,
+                    sessionKey: job.sessionKey,
                   },
                   `⚠️ ${failureMessage}`,
                 );

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -24,6 +24,8 @@ const fetchWithSsrFGuardMock = vi.hoisted(() =>
   })),
 );
 
+const sendFailureNotificationAnnounceMock = vi.hoisted(() => vi.fn(async () => undefined));
+
 vi.mock("../infra/net/fetch-guard.js", () => ({
   fetchWithSsrFGuard: (...args: unknown[]) =>
     (
@@ -34,6 +36,17 @@ vi.mock("../infra/net/fetch-guard.js", () => ({
       }>
     )(...args),
 }));
+
+vi.mock("../cron/delivery.js", async () => {
+  const actual = await vi.importActual<typeof import("../cron/delivery.js")>("../cron/delivery.js");
+  return {
+    ...actual,
+    sendFailureNotificationAnnounce: (...args: unknown[]) =>
+      (
+        sendFailureNotificationAnnounceMock as unknown as (...innerArgs: unknown[]) => Promise<void>
+      )(...args),
+  };
+});
 
 installGatewayTestHooks({ scope: "suite" });
 const CRON_WAIT_TIMEOUT_MS = 3_000;
@@ -232,6 +245,7 @@ describe("gateway server cron", () => {
   beforeEach(() => {
     // Keep polling helpers deterministic even if other tests left fake timers enabled.
     vi.useRealTimers();
+    sendFailureNotificationAnnounceMock.mockClear();
   });
 
   test("handles cron CRUD, normalization, and patch semantics", { timeout: 20_000 }, async () => {
@@ -975,6 +989,61 @@ describe("gateway server cron", () => {
       await cleanupCronTestRun({ ws, server, prevSkipCron });
     }
   }, 60_000);
+
+  test("falls back to the primary delivery channel on job failure and preserves sessionKey", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-failure-primary-fallback-",
+      cronEnabled: false,
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      cronIsolatedRun.mockResolvedValueOnce({ status: "error", summary: "delivery failed" });
+      const jobId = await addWebhookCronJob({
+        ws,
+        name: "primary delivery fallback",
+        sessionTarget: "isolated",
+        delivery: {
+          mode: "announce",
+          channel: "last",
+        },
+      });
+
+      const updateRes = await rpcReq(ws, "cron.update", {
+        id: jobId,
+        patch: {
+          sessionKey: "agent:main:telegram:direct:123:thread:99",
+        },
+      });
+      expect(updateRes.ok).toBe(true);
+
+      const finished = waitForCronEvent(
+        ws,
+        (payload) => payload?.jobId === jobId && payload?.action === "finished",
+      );
+      await runCronJobForce(ws, jobId);
+      await finished;
+
+      expect(sendFailureNotificationAnnounceMock).toHaveBeenCalledTimes(1);
+      expect(sendFailureNotificationAnnounceMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(String),
+        jobId,
+        {
+          channel: "last",
+          to: undefined,
+          accountId: undefined,
+          sessionKey: "agent:main:telegram:direct:123:thread:99",
+        },
+        '⚠️ Cron job "primary delivery fallback" failed: unknown error',
+      );
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  }, 45_000);
 
   test("ignores non-string cron.webhookToken values without crashing webhook delivery", async () => {
     const { prevSkipCron } = await setupCronTestRun({


### PR DESCRIPTION
## Summary

When a cron job fails (LLM timeout, tool error, etc.) and has no explicit `failureDestination`, send the error notification to the job's **primary delivery channel** — the same channel that receives successful output.

Previously, job failures were only visible in gateway logs. Users running autonomous cron agents (e.g., market scanners, scheduled reports) had no way to know their jobs were silently failing.

Fixes #60608.

## Changes

**`src/gateway/server-cron.ts`**: In the cron event handler's error path, added a fallback that sends failure notifications via `sendFailureNotificationAnnounce()` to the primary delivery channel when no explicit `failureDestination` is configured.

- Resolves primary delivery plan via existing `resolveCronDeliveryPlan()`
- Only fires for `mode: "announce"` with a valid `to` target
- Respects `bestEffort` opt-out (moved check outside both paths)
- No double-send: explicit `failureDestination` takes priority
- Fire-and-forget pattern matches existing delivery code
- Message format: `⚠️ Cron job "job-name" failed: error message`

## Motivation

Running autonomous cron agents on a headless VPS, we experienced multiple consecutive LLM timeouts with zero Telegram notifications. The only way to discover failures was SSH into the server and read logs. This is a common pain point for anyone running scheduled AI agent tasks.

## Test plan

- [ ] Existing `delivery.failure-notify.test.ts` tests still pass
- [ ] Job with `delivery: { mode: "announce", channel: "telegram", to: "123" }` and no `failureDestination` → error sends notification to Telegram
- [ ] Job with `delivery: { bestEffort: true }` → no notification on failure
- [ ] Job with explicit `failureDestination` → existing behavior preserved, no double-send
- [ ] Job with `delivery: { mode: "none" }` → no notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)