### PR TITLE
fix(config): initialize plugins.allow when undefined in ensurePluginAllowlisted

### DIFF
--- a/src/config/plugins-allowlist.ts
+++ b/src/config/plugins-allowlist.ts
@@ -1,8 +1,8 @@
 import type { OpenClawConfig } from "./config.js";
 
 export function ensurePluginAllowlisted(cfg: OpenClawConfig, pluginId: string): OpenClawConfig {
-  const allow = cfg.plugins?.allow;
-  if (!Array.isArray(allow) || allow.includes(pluginId)) {
+  const allow = cfg.plugins?.allow ?? [];
+  if (allow.includes(pluginId)) {
     return cfg;
   }
   return {

--- a/src/plugins/enable.test.ts
+++ b/src/plugins/enable.test.ts
@@ -49,6 +49,15 @@ describe("enablePluginInConfig", () => {
       },
     },
     {
+      name: "initializes plugins.allow when undefined",
+      cfg: {} as OpenClawConfig,
+      pluginId: "google",
+      expectedEnabled: true,
+      assert: (result: ReturnType<typeof enablePluginInConfig>) => {
+        expectEnabledAllowlist(result, ["google"]);
+      },
+    },
+    {
       name: "adds plugin to allowlist when allowlist is configured",
       cfg: {
         plugins: {


### PR DESCRIPTION
## Summary
Closes #60596

**Root cause**: `ensurePluginAllowlisted()` in `src/config/plugins-allowlist.ts:5` returns early when `plugins.allow` is `undefined` instead of initializing it to `[]`. The guard `!Array.isArray(allow)` evaluates to `true` for `undefined`, causing the function to no-op. Introduced in `183601c` (Tak Hoffman, 2026-04-03).

**Fix**: Use nullish coalescing (`cfg.plugins?.allow ?? []`) to default `allow` to an empty array, then only skip when the plugin is already present. 1-line semantic change.

**Single-site check**: Grepped for `!Array.isArray(allow)` across the codebase — found 2 other sites (`bundled-compat.ts:10`, `validation.ts:586`) but those are intentional guards that bail from compat/validation logic when no allowlist exists. Only `plugins-allowlist.ts` needs the fix.

**Call path**: `gateway/server.impl.ts:425` → `applyPluginAutoEnable()` → `materializePluginAutoEnableCandidates()` → `ensurePluginAllowlisted()`. Also called from `plugins/enable.ts:22` → `enablePluginInConfig()`. Both paths are exercised on every gateway start and plugin install.

## Test plan
- [x] Added test case "initializes plugins.allow when undefined" in `src/plugins/enable.test.ts`
- [ ] Gateway starts without `plugins.allow` in config → no warning spam
- [ ] Plugin allowlisting works correctly when `plugins.allow` is pre-configured (existing tests cover this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)