### PR TITLE
fix: suppress transient network errors in uncaughtException handler

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -172,13 +172,25 @@ export async function runCli(argv: string[] = process.argv) {
 
     const { buildProgram } = await import("./program.js");
     const program = buildProgram();
-    const { installUnhandledRejectionHandler } = await import("../infra/unhandled-rejections.js");
+    const { installUnhandledRejectionHandler, isAbortError, isTransientNetworkError } =
+      await import("../infra/unhandled-rejections.js");
 
     // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
     // These log the error and exit gracefully instead of crashing without trace.
     installUnhandledRejectionHandler();
 
     process.on("uncaughtException", (error) => {
+      if (isAbortError(error)) {
+        console.warn("[openclaw] Suppressed uncaught AbortError:", formatUncaughtError(error));
+        return;
+      }
+      if (isTransientNetworkError(error)) {
+        console.warn(
+          "[openclaw] Non-fatal uncaught exception (continuing):",
+          formatUncaughtError(error),
+        );
+        return;
+      }
       console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
       process.exit(1);
     });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -172,28 +172,36 @@ export async function runCli(argv: string[] = process.argv) {
 
     const { buildProgram } = await import("./program.js");
     const program = buildProgram();
-    const { installUnhandledRejectionHandler, isAbortError, isTransientNetworkError } =
-      await import("../infra/unhandled-rejections.js");
+    const {
+      installUnhandledRejectionHandler,
+      isAbortError,
+      isTransientNetworkError,
+      isTransientSqliteError,
+    } = await import("../infra/unhandled-rejections.js");
 
     // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
     // These log the error and exit gracefully instead of crashing without trace.
-    installUnhandledRejectionHandler();
+    // Guard: skip registration when already installed by src/index.ts to avoid
+    // duplicate handlers (see P2 review feedback on PR #60627).
+    if (process.listenerCount("uncaughtException") === 0) {
+      installUnhandledRejectionHandler();
 
-    process.on("uncaughtException", (error) => {
-      if (isAbortError(error)) {
-        console.warn("[openclaw] Suppressed uncaught AbortError:", formatUncaughtError(error));
-        return;
-      }
-      if (isTransientNetworkError(error)) {
-        console.warn(
-          "[openclaw] Non-fatal uncaught exception (continuing):",
-          formatUncaughtError(error),
-        );
-        return;
-      }
-      console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
-      process.exit(1);
-    });
+      process.on("uncaughtException", (error) => {
+        if (isAbortError(error)) {
+          console.warn("[openclaw] Suppressed uncaught AbortError:", formatUncaughtError(error));
+          return;
+        }
+        if (isTransientNetworkError(error) || isTransientSqliteError(error)) {
+          console.warn(
+            "[openclaw] Non-fatal uncaught exception (continuing):",
+            formatUncaughtError(error),
+          );
+          return;
+        }
+        console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
+        process.exit(1);
+      });
+    }
 
     const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
     // Register the primary command (builtin or subcli) so help and command parsing

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -181,11 +181,14 @@ export async function runCli(argv: string[] = process.argv) {
 
     // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
     // These log the error and exit gracefully instead of crashing without trace.
-    // Guard: skip registration when already installed by src/index.ts to avoid
-    // duplicate handlers (see P2 review feedback on PR #60627).
-    if (process.listenerCount("uncaughtException") === 0) {
+    // Guard each event type independently so that an external listener on one
+    // event (e.g., a test harness adding "uncaughtException") does not prevent
+    // the other handler from being installed.
+    if (process.listenerCount("unhandledRejection") === 0) {
       installUnhandledRejectionHandler();
+    }
 
+    if (process.listenerCount("uncaughtException") === 0) {
       process.on("uncaughtException", (error) => {
         if (isAbortError(error)) {
           console.warn("[openclaw] Suppressed uncaught AbortError:", formatUncaughtError(error));

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   installUnhandledRejectionHandler,
   isAbortError,
   isTransientNetworkError,
+  isTransientSqliteError,
 } from "./infra/unhandled-rejections.js";
 
 type LegacyCliDeps = {
@@ -96,7 +97,7 @@ if (isMain) {
       console.warn("[openclaw] Suppressed uncaught AbortError:", formatUncaughtError(error));
       return;
     }
-    if (isTransientNetworkError(error)) {
+    if (isTransientNetworkError(error) || isTransientSqliteError(error)) {
       console.warn(
         "[openclaw] Non-fatal uncaught exception (continuing):",
         formatUncaughtError(error),

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,11 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { formatUncaughtError } from "./infra/errors.js";
 import { isMainModule } from "./infra/is-main.js";
-import { installUnhandledRejectionHandler } from "./infra/unhandled-rejections.js";
+import {
+  installUnhandledRejectionHandler,
+  isAbortError,
+  isTransientNetworkError,
+} from "./infra/unhandled-rejections.js";
 
 type LegacyCliDeps = {
   installGaxiosFetchCompat: () => Promise<void>;
@@ -88,6 +92,17 @@ if (isMain) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    if (isAbortError(error)) {
+      console.warn("[openclaw] Suppressed uncaught AbortError:", formatUncaughtError(error));
+      return;
+    }
+    if (isTransientNetworkError(error)) {
+      console.warn(
+        "[openclaw] Non-fatal uncaught exception (continuing):",
+        formatUncaughtError(error),
+      );
+      return;
+    }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     process.exit(1);
   });


### PR DESCRIPTION
## Summary

The gateway's `uncaughtException` handler unconditionally calls `process.exit(1)`, causing the process to crash on transient `ENETUNREACH` errors that surface through undici's synchronous callback chain (e.g., Telegram fetch fallback). The sibling `unhandledRejection` handler already suppresses these via `isTransientNetworkError()`, but the `uncaughtException` path was missing the same check.

This PR wires up `isTransientNetworkError` and `isAbortError` checks in **both** `uncaughtException` handlers:

- **`src/index.ts:94`** — main module entry (static import)
- **`src/cli/run-main.ts:182`** — CLI runner entry (dynamic import, matching existing pattern)

Transient errors are now logged as warnings and the process continues, matching the existing `unhandledRejection` behavior. Non-transient exceptions still exit.

## Root cause

Introduced in `183601c` (`fix: honor line default setup status`) by @Takhoffman — the `uncaughtException` handlers were added without the transient-error guard that `installUnhandledRejectionHandler()` already provides.

## Completeness (G8)

Grepped entire codebase for `uncaughtException` — only 2 sites exist (`src/index.ts`, `src/cli/run-main.ts`). Both are fixed.

## Verification (G9)

Call path: undici sync callback → Node `uncaughtException` event → handler checks `isTransientNetworkError(error)` → returns early with `console.warn` instead of `process.exit(1)`.

`isTransientNetworkError` already covers `ENETUNREACH` (in `TRANSIENT_NETWORK_CODES` set, line 33 of `src/infra/unhandled-rejections.ts`) and is exercised by existing tests in `src/infra/unhandled-rejections.test.ts`.

## Test plan

- [x] Existing `isTransientNetworkError` unit tests cover `ENETUNREACH` and all transient codes
- [x] Lint passes (oxlint: 0 warnings, 0 errors on both files)
- [ ] Manual: trigger `ENETUNREACH` via brief network outage with Telegram channel configured — gateway should log warning and continue

Closes #60515