### PR TITLE
docs: correct overstated prompt-cache comments from #58036 #58037 #58038

### DIFF
--- a/src/agents/pi-bundle-mcp-materialize.ts
+++ b/src/agents/pi-bundle-mcp-materialize.ts
@@ -112,8 +112,9 @@ export async function materializeBundleMcpToolsForRun(params: {
     });
   }
 
-  // Defensive sort for stable prompt-cache keys. Collision suffixes above are
-  // iteration-order-dependent, so this cannot fix name collisions.
+  // Sort tools by name so the tools block in API requests is stable across
+  // turns (defensive — listTools() order is usually stable but not guaranteed).
+  // Cannot fix name collisions: collision suffixes above are order-dependent.
   tools.sort((a, b) => a.name.localeCompare(b.name));
 
   return {

--- a/src/agents/pi-bundle-mcp-materialize.ts
+++ b/src/agents/pi-bundle-mcp-materialize.ts
@@ -112,7 +112,7 @@ export async function materializeBundleMcpToolsForRun(params: {
     });
   }
 
-  // Sort tools by name so the tools block in API requests is stable across
+  // Sort tools deterministically by name so the tools block in API requests is stable across
   // turns (defensive — listTools() order is usually stable but not guaranteed).
   // Cannot fix name collisions: collision suffixes above are order-dependent.
   tools.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/agents/pi-bundle-mcp-materialize.ts
+++ b/src/agents/pi-bundle-mcp-materialize.ts
@@ -112,9 +112,8 @@ export async function materializeBundleMcpToolsForRun(params: {
     });
   }
 
-  // Sort tools deterministically by name so the tools block in API requests is
-  // stable across turns. MCP's listTools() does not guarantee order, and any
-  // change in the tools array busts the prompt cache at the tools block.
+  // Defensive sort for stable prompt-cache keys. Collision suffixes above are
+  // iteration-order-dependent, so this cannot fix name collisions.
   tools.sort((a, b) => a.name.localeCompare(b.name));
 
   return {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1569,9 +1569,8 @@ export async function runEmbeddedAttempt(
           (sessionManager.getLeafEntry() as { id?: string } | null | undefined)?.id ?? null;
 
         try {
-          // Idempotent cleanup for legacy sessions with persisted image payloads.
-          // Only mutates user turns older than a few assistant replies so recent
-          // history stays byte-identical for prompt-cache prefix matching.
+          // Legacy cleanup: prune old persisted image blocks. The delay
+          // also reduces prompt-cache churn.
           const didPruneImages = pruneProcessedHistoryImages(activeSession.messages);
           if (didPruneImages) {
             activeSession.agent.state.messages = activeSession.messages;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1569,8 +1569,9 @@ export async function runEmbeddedAttempt(
           (sessionManager.getLeafEntry() as { id?: string } | null | undefined)?.id ?? null;
 
         try {
-          // Prune old image blocks to limit context growth; skips recent
-          // turns to reduce prompt-cache churn.
+          // Prune old image blocks to limit context growth. Only mutates
+          // turns older than a few assistant replies; the delay also reduces
+          // prompt-cache churn.
           const didPruneImages = pruneProcessedHistoryImages(activeSession.messages);
           if (didPruneImages) {
             activeSession.agent.state.messages = activeSession.messages;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1569,9 +1569,9 @@ export async function runEmbeddedAttempt(
           (sessionManager.getLeafEntry() as { id?: string } | null | undefined)?.id ?? null;
 
         try {
-          // Prune old image blocks to limit context growth. Only mutates
-          // turns older than a few assistant replies; the delay also reduces
-          // prompt-cache churn.
+          // Idempotent cleanup: prune old image blocks to limit context
+          // growth. Only mutates turns older than a few assistant replies;
+          // the delay also reduces prompt-cache churn.
           const didPruneImages = pruneProcessedHistoryImages(activeSession.messages);
           if (didPruneImages) {
             activeSession.agent.state.messages = activeSession.messages;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1569,8 +1569,8 @@ export async function runEmbeddedAttempt(
           (sessionManager.getLeafEntry() as { id?: string } | null | undefined)?.id ?? null;
 
         try {
-          // Legacy cleanup: prune old persisted image blocks. The delay
-          // also reduces prompt-cache churn.
+          // Prune old image blocks to limit context growth; skips recent
+          // turns to reduce prompt-cache churn.
           const didPruneImages = pruneProcessedHistoryImages(activeSession.messages);
           if (didPruneImages) {
             activeSession.agent.state.messages = activeSession.messages;

--- a/src/agents/pi-embedded-runner/run/history-image-prune.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.ts
@@ -3,9 +3,9 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 export const PRUNED_HISTORY_IMAGE_MARKER = "[image data removed - already processed by model]";
 
 /**
- * Number of most-recent assistant turns whose preceding user/toolResult image blocks are
- * kept intact. Pruning these would diverge the request bytes from what the provider
- * cached on the previous turn, invalidating the prompt-cache prefix.
+ * Number of most-recent completed turns whose preceding user/toolResult image
+ * blocks are kept intact. Counts all completed turns, not just image-bearing
+ * ones, so text-only turns consume the window.
  */
 const PRESERVE_RECENT_COMPLETED_TURNS = 3;
 
@@ -46,10 +46,10 @@ function resolvePruneBeforeIndex(messages: AgentMessage[]): number {
 }
 
 /**
- * Idempotent cleanup for legacy sessions that persisted image blocks in history.
- * Called each run; mutates only completed turns older than
- * {@link PRESERVE_RECENT_COMPLETED_TURNS} so recent turns remain
- * byte-identical for prompt caching.
+ * Idempotent cleanup: prune persisted image blocks from completed turns older
+ * than {@link PRESERVE_RECENT_COMPLETED_TURNS}. The delay also reduces
+ * prompt-cache churn, though prefix stability additionally depends on the
+ * replay sanitizer being idempotent.
  */
 export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
   const pruneBeforeIndex = resolvePruneBeforeIndex(messages);

--- a/src/agents/pi-embedded-runner/run/history-image-prune.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.ts
@@ -5,8 +5,7 @@ export const PRUNED_HISTORY_IMAGE_MARKER = "[image data removed - already proces
 /**
  * Number of most-recent completed turns whose preceding user/toolResult image
  * blocks are kept intact. Counts all completed turns, not just image-bearing
- * ones, so text-only turns consume the window and pruning older turns reduces
- * prompt-cache churn.
+ * ones, so text-only turns consume the window.
  */
 const PRESERVE_RECENT_COMPLETED_TURNS = 3;
 

--- a/src/agents/pi-embedded-runner/run/history-image-prune.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.ts
@@ -5,7 +5,8 @@ export const PRUNED_HISTORY_IMAGE_MARKER = "[image data removed - already proces
 /**
  * Number of most-recent completed turns whose preceding user/toolResult image
  * blocks are kept intact. Counts all completed turns, not just image-bearing
- * ones, so text-only turns consume the window.
+ * ones, so text-only turns consume the window and pruning older turns reduces
+ * prompt-cache churn.
  */
 const PRESERVE_RECENT_COMPLETED_TURNS = 3;
 

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -109,7 +109,7 @@ function compactExistingToolResultsInPlace(params: {
 
   let reduced = 0;
   // Compact newest-first so more of the cached prefix survives: rewriting
-  // messages[k] for small k invalidates the cache from that point onward.
+  // messages[k] for small k invalidates the provider prompt cache from that point onward.
   // Tradeoff: the model loses recent tool output instead of old.
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -108,8 +108,9 @@ function compactExistingToolResultsInPlace(params: {
   }
 
   let reduced = 0;
-  // Compact newest-first so the cached prefix stays intact: rewriting messages[k]
-  // for small k invalidates the provider prompt cache from that point onward.
+  // Compact newest-first so more of the cached prefix survives: rewriting
+  // messages[k] for small k invalidates the cache from that point onward.
+  // Tradeoff: the model loses recent tool output instead of old.
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (!isToolResultMessage(msg)) {
@@ -181,8 +182,8 @@ function enforceToolResultContextBudgetInPlace(params: {
     return;
   }
 
-  // Compact newest tool outputs first to preserve the cached prefix; stop once
-  // the context is back under budget.
+  // Compact newest tool outputs first so more of the cached prefix survives;
+  // stop once the context is back under budget.
   compactExistingToolResultsInPlace({
     messages,
     charsNeeded: currentChars - contextBudgetChars,


### PR DESCRIPTION
## Summary

Correct comments that overstated the prompt-cache benefits of #58036, #58037, and #58038. No behavior changes — only comments.

- `tool-result-context-guard.ts`: "prefix stays intact" → "more of the prefix survives"; note the model-quality tradeoff (loses recent tool output instead of old).
- `pi-bundle-mcp-materialize.ts`: add "usually stable but not guaranteed" context; note that collision suffixes are iteration-order-dependent and the sort cannot fix name collisions.
- `history-image-prune.ts`: drop misleading "legacy sessions" framing (this runs on all sessions); replace overstated "byte-identical" cache claim with accurate "reduces churn" + note dependency on replay sanitizer idempotency; document that text-only turns consume the window; fix "user turns" → "user/toolResult turns".
- `attempt.ts`: matching callsite comment update.

## Test plan

- [x] Comment-only changes, no behavior change — `pnpm check` passes.

🤖 Generated with [Claude Code](https://claude.ai/code)