### PR TITLE
fix: handle edge cases in plugin config TUI prompts

### DIFF
--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -42,6 +42,21 @@ describe("discoverConfigurablePlugins", () => {
     expect(result).toHaveLength(0);
   });
 
+  it("excludes sensitive fields from promptable hints", () => {
+    const plugins = [
+      makeManifestPlugin("secret-plugin", {
+        endpoint: { label: "Endpoint" },
+        apiKey: { label: "API Key", sensitive: true },
+      }),
+    ];
+    const result = discoverConfigurablePlugins({ manifestPlugins: plugins });
+    expect(result).toHaveLength(1);
+    // sensitive fields are still included in uiHints for discovery —
+    // they are skipped at prompt time, not at discovery time
+    expect(result[0].uiHints.endpoint).toBeDefined();
+    expect(result[0].uiHints.apiKey).toBeDefined();
+  });
+
   it("excludes plugins where all fields are advanced", () => {
     const plugins = [
       makeManifestPlugin("all-advanced", {

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -152,6 +152,16 @@ async function promptPluginFields(params: {
     const label = hint.label ?? key;
     const helpSuffix = hint.help ? ` — ${hint.help}` : "";
 
+    // Skip sensitive fields — WizardPrompter has no masked input;
+    // direct users to openclaw config set or the Web UI instead.
+    if (hint.sensitive) {
+      await prompter.note(
+        `"${label}" is sensitive. Set it via:\n  openclaw config set plugins.entries.${plugin.id}.config.${key} <value>\nor use the Web UI Settings page.`,
+        "Sensitive field",
+      );
+      continue;
+    }
+
     // Handle enum fields with select
     if (schemaProp?.enum && Array.isArray(schemaProp.enum)) {
       const options = schemaProp.enum.map((v) => ({
@@ -193,17 +203,21 @@ async function promptPluginFields(params: {
     if (schemaProp?.type === "array") {
       const currentStr = Array.isArray(currentValue) ? (currentValue as unknown[]).join(", ") : "";
       const input = await prompter.text({
-        message: `${label} (comma-separated)${helpSuffix}`,
+        message: `${label} (comma-separated, empty to clear)${helpSuffix}`,
         initialValue: currentStr,
         placeholder: hint.placeholder ?? "value1, value2",
       });
       const trimmed = input.trim();
-      if (trimmed) {
-        const values = trimmed
-          .split(",")
-          .map((v) => v.trim())
-          .filter(Boolean);
-        updatedConfig[key] = values;
+      if (trimmed !== currentStr) {
+        if (trimmed) {
+          const values = trimmed
+            .split(",")
+            .map((v) => v.trim())
+            .filter(Boolean);
+          updatedConfig[key] = values;
+        } else {
+          updatedConfig[key] = undefined;
+        }
         changed = true;
       }
       continue;
@@ -220,10 +234,15 @@ async function promptPluginFields(params: {
     if (trimmed !== currentStr) {
       // Try to parse as number if schema says number
       if (schemaProp?.type === "number") {
-        const parsed = Number(trimmed);
-        if (Number.isFinite(parsed)) {
-          updatedConfig[key] = parsed;
+        if (trimmed === "") {
+          updatedConfig[key] = undefined;
           changed = true;
+        } else {
+          const parsed = Number(trimmed);
+          if (Number.isFinite(parsed)) {
+            updatedConfig[key] = parsed;
+            changed = true;
+          }
         }
       } else {
         updatedConfig[key] = trimmed || undefined;


### PR DESCRIPTION
Follow-up to #60590 addressing review feedback from Greptile.

## Fixes

1. **Sensitive fields (P1):** Fields with `sensitive: true` in `uiHints` are now skipped with a note directing users to `openclaw config set` or the Web UI, since `WizardPrompter` has no masked input method.

2. **Number field clearing (P2):** Clearing a number field now stores `undefined` instead of `0` (`Number("") === 0` was a bug).

3. **Array field clearing (P2):** Empty input now clears array fields to `undefined` instead of silently keeping the old value.