### PR TITLE
fix(auto-reply): preserve reasoning markers during block coalescing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/marketplace: block remote marketplace symlink escapes without rewriting ordinary local marketplace install paths. (#60556) Thanks @eleqtrizit.
 - Plugins/Kimi Coding: keep native Anthropic tool payloads on the Kimi coding endpoint while still parsing tagged tool-call text on the response path, so tool calls execute again instead of echoing raw markup. (#60391) Thanks @Eric-Guo.
 - Plugins/install: preserve `--dangerously-force-unsafe-install` across linked plugin probes and linked hook-pack fallback probes so local `--link` installs honor the documented unsafe override. (#60624) Thanks @JerrettDavis.
+- Auto-reply/reasoning: preserve reasoning and compaction markers while coalescing adjacent reply blocks so hidden reasoning does not leak when mixed with visible text on channels like WhatsApp. Thanks @mcaxtr.
 
 ## 2026.4.2
 

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -24,6 +24,8 @@ export function createBlockReplyCoalescer(params: {
   let bufferText = "";
   let bufferReplyToId: ReplyPayload["replyToId"];
   let bufferAudioAsVoice: ReplyPayload["audioAsVoice"];
+  let bufferIsReasoning: ReplyPayload["isReasoning"];
+  let bufferIsCompactionNotice: ReplyPayload["isCompactionNotice"];
   let idleTimer: NodeJS.Timeout | undefined;
 
   const clearIdleTimer = () => {
@@ -38,6 +40,8 @@ export function createBlockReplyCoalescer(params: {
     bufferText = "";
     bufferReplyToId = undefined;
     bufferAudioAsVoice = undefined;
+    bufferIsReasoning = undefined;
+    bufferIsCompactionNotice = undefined;
   };
 
   const scheduleIdleFlush = () => {
@@ -67,6 +71,8 @@ export function createBlockReplyCoalescer(params: {
       text: bufferText,
       replyToId: bufferReplyToId,
       audioAsVoice: bufferAudioAsVoice,
+      isReasoning: bufferIsReasoning,
+      isCompactionNotice: bufferIsCompactionNotice,
     };
     resetBuffer();
     await onFlush(payload);
@@ -97,6 +103,8 @@ export function createBlockReplyCoalescer(params: {
       }
       bufferReplyToId = payload.replyToId;
       bufferAudioAsVoice = payload.audioAsVoice;
+      bufferIsReasoning = payload.isReasoning;
+      bufferIsCompactionNotice = payload.isCompactionNotice;
       bufferText = text;
       void flush({ force: true });
       return;
@@ -107,13 +115,22 @@ export function createBlockReplyCoalescer(params: {
       payload.replyToId &&
       (!bufferReplyToId || bufferReplyToId !== payload.replyToId),
     );
-    if (bufferText && (replyToConflict || bufferAudioAsVoice !== payload.audioAsVoice)) {
+    const visibilityConflict =
+      bufferText &&
+      (bufferIsReasoning !== payload.isReasoning ||
+        bufferIsCompactionNotice !== payload.isCompactionNotice);
+    if (
+      bufferText &&
+      (replyToConflict || bufferAudioAsVoice !== payload.audioAsVoice || visibilityConflict)
+    ) {
       void flush({ force: true });
     }
 
     if (!bufferText) {
       bufferReplyToId = payload.replyToId;
       bufferAudioAsVoice = payload.audioAsVoice;
+      bufferIsReasoning = payload.isReasoning;
+      bufferIsCompactionNotice = payload.isCompactionNotice;
     }
 
     const nextText = bufferText ? `${bufferText}${joiner}${text}` : text;
@@ -122,6 +139,8 @@ export function createBlockReplyCoalescer(params: {
         void flush({ force: true });
         bufferReplyToId = payload.replyToId;
         bufferAudioAsVoice = payload.audioAsVoice;
+        bufferIsReasoning = payload.isReasoning;
+        bufferIsCompactionNotice = payload.isCompactionNotice;
         if (text.length >= maxChars) {
           void onFlush(payload);
           return;

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -764,6 +764,50 @@ describe("block reply coalescer", () => {
     coalescer.stop();
   });
 
+  it("does not coalesce reasoning blocks into visible reply text", async () => {
+    const flushes: Array<{ text?: string; isReasoning?: boolean }> = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 200, idleMs: 0, joiner: "\n\n" },
+      shouldAbort: () => false,
+      onFlush: (payload) => {
+        flushes.push({
+          text: payload.text,
+          isReasoning: payload.isReasoning,
+        });
+      },
+    });
+
+    coalescer.enqueue({ text: "Reasoning:\n_hidden_", isReasoning: true });
+    coalescer.enqueue({ text: "Visible answer" });
+    await coalescer.flush({ force: true });
+
+    expect(flushes).toEqual([
+      { text: "Reasoning:\n_hidden_", isReasoning: true },
+      { text: "Visible answer", isReasoning: undefined },
+    ]);
+    coalescer.stop();
+  });
+
+  it("preserves compaction notice markers across flushes", async () => {
+    const flushes: Array<{ text?: string; isCompactionNotice?: boolean }> = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 200, idleMs: 0, joiner: "\n\n" },
+      shouldAbort: () => false,
+      onFlush: (payload) => {
+        flushes.push({
+          text: payload.text,
+          isCompactionNotice: payload.isCompactionNotice,
+        });
+      },
+    });
+
+    coalescer.enqueue({ text: "Compacting context...", isCompactionNotice: true });
+    await coalescer.flush({ force: true });
+
+    expect(flushes).toEqual([{ text: "Compacting context...", isCompactionNotice: true }]);
+    coalescer.stop();
+  });
+
   it("flushes immediately per enqueue when flushOnEnqueue is set", async () => {
     const cases = [
       {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: WhatsApp could leak reasoning text when a reasoning block and visible answer text were coalesced into the same streamed block reply.
- Problem: hidden reasoning could leak when a reasoning block and visible answer text were coalesced into the same streamed block reply; WhatsApp is where this was reproduced and validated end-to-end.
- Why it matters: reasoning-only payloads were already suppressed, but mixed replies could still expose hidden thinking to end users on WhatsApp.
- What changed: preserve reply visibility markers during shared block coalescing and flush when a reasoning/notice block would otherwise merge with visible text.
- What did NOT change (scope boundary): no WhatsApp plugin transport behavior, prompt behavior, or Telegram reasoning-lane behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the shared block coalescer buffered only text, replyToId, and audioAsVoice; it dropped `isReasoning`, so a hidden reasoning block followed by visible text could flush as one normal payload.
- Missing detection / guardrail: there was channel coverage for reasoning-only payload suppression, but no coalescer-level regression test for mixed reasoning + visible block streams.
- Contributing context (if known): WhatsApp had an earlier channel-side suppression fix for standalone reasoning payloads, which made the remaining shared-path gap show up specifically on mixed streamed replies.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/reply-utils.test.ts`
- Scenario the test should lock in: a reasoning block followed by visible answer text must not coalesce into one unmarked visible payload.
- Why this is the smallest reliable guardrail: the bug is introduced entirely inside the shared block coalescer before channel delivery starts.
- Existing test that already covers this (if any): existing WhatsApp delivery tests only covered reasoning-only payload suppression.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Channels using the shared block-coalescing path now preserve reasoning/notice visibility boundaries correctly. The reported and validated user-facing fix is that WhatsApp no longer leaks reasoning text when streamed reasoning and visible answer content arrive in adjacent block replies.

## Diagram (if applicable)

```text
Before:
[reasoning block][answer block] -> [shared coalescer merges text only] -> [unmarked visible payload] -> [WhatsApp sends leaked reasoning]

After:
[reasoning block][answer block] -> [shared coalescer preserves markers / flushes boundary] -> [reasoning suppressed][answer delivered]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local dev worktree
- Model/provider: streamed embedded agent path
- Integration/channel (if any): shared reply streaming path; reproduced and validated on WhatsApp
- Relevant config (redacted): default block streaming with coalescing enabled

### Steps

1. Send a prompt that produces a hidden reasoning block followed by visible answer text in the same streamed turn.
2. Let the shared block coalescer merge adjacent block replies before WhatsApp delivery.
3. Observe the final WhatsApp reply body.

### Expected

- The channel should suppress the reasoning block and only deliver the visible answer text.

### Actual

- Before this change, the coalescer could merge the two blocks into one normal text payload, causing WhatsApp to send the reasoning text with the answer.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran scoped auto-reply Vitest coverage for the coalescer regression and block reply pipeline; branch was also validated end-to-end on WhatsApp by the reporter after push.
- Edge cases checked: reasoning-only suppression still works, visible answer blocks still flush, compaction notices keep their marker.
- What you did **not** verify: I did not personally run a live WhatsApp session in this branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: changing shared coalescer flush boundaries could alter block grouping for other channels that use the shared path.
  - Mitigation: the new flush condition is limited to visibility-marker changes (`isReasoning` / `isCompactionNotice`), and scoped tests cover the shared behavior directly.
