### PR TITLE
fix(whatsapp): exclude DM allowFrom from group policy sender bypass

### DIFF
--- a/src/web/auto-reply/monitor/group-activation.test.ts
+++ b/src/web/auto-reply/monitor/group-activation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock the internal modules so we can unit-test resolveGroupPolicyFor
+// without needing the full runtime.
+vi.mock("../../../config/sessions.js", () => ({
+  resolveGroupSessionKey: vi.fn(({ From }: { From: string }) => ({ id: From })),
+  loadSessionStore: vi.fn(),
+  resolveStorePath: vi.fn(),
+}));
+
+vi.mock("../../../config/group-policy.js", () => ({
+  resolveChannelGroupPolicy: vi.fn(
+    (params: { hasGroupAllowFrom?: boolean; groupId?: string }) => params,
+  ),
+  resolveChannelGroupRequireMention: vi.fn(),
+}));
+
+import { resolveChannelGroupPolicy } from "../../../config/group-policy.js";
+import { resolveGroupPolicyFor } from "./group-activation.js";
+
+describe("resolveGroupPolicyFor", () => {
+  it("does not set hasGroupAllowFrom when only DM allowFrom is configured", () => {
+    // Regression: DM allowFrom entries (added by pairing) were incorrectly
+    // treated as group-level sender filtering, causing groupPolicy=allowlist
+    // with no groups to auto-reply to ALL groups instead of blocking them.
+    const cfg = {
+      channels: {
+        whatsapp: {
+          allowFrom: ["+1234567890"],
+        },
+      },
+    } as never;
+
+    resolveGroupPolicyFor(cfg, "group@g.us");
+
+    expect(resolveChannelGroupPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({ hasGroupAllowFrom: false }),
+    );
+  });
+
+  it("sets hasGroupAllowFrom when groupAllowFrom is configured", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupAllowFrom: ["+1234567890"],
+        },
+      },
+    } as never;
+
+    resolveGroupPolicyFor(cfg, "group@g.us");
+
+    expect(resolveChannelGroupPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({ hasGroupAllowFrom: true }),
+    );
+  });
+
+  it("does not set hasGroupAllowFrom when both allowFrom and empty groupAllowFrom are present", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          allowFrom: ["+1234567890"],
+          groupAllowFrom: [],
+        },
+      },
+    } as never;
+
+    resolveGroupPolicyFor(cfg, "group@g.us");
+
+    expect(resolveChannelGroupPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({ hasGroupAllowFrom: false }),
+    );
+  });
+});

--- a/src/web/auto-reply/monitor/group-activation.ts
+++ b/src/web/auto-reply/monitor/group-activation.ts
@@ -19,9 +19,9 @@ export function resolveGroupPolicyFor(cfg: ReturnType<typeof loadConfig>, conver
   const whatsappCfg = cfg.channels?.whatsapp as
     | { groupAllowFrom?: string[]; allowFrom?: string[] }
     | undefined;
-  const hasGroupAllowFrom = Boolean(
-    whatsappCfg?.groupAllowFrom?.length || whatsappCfg?.allowFrom?.length,
-  );
+  // Only check groupAllowFrom — DM allowFrom entries (from pairing) should
+  // not grant group access or bypass the group allowlist gate.
+  const hasGroupAllowFrom = Boolean(whatsappCfg?.groupAllowFrom?.length);
   return resolveChannelGroupPolicy({
     cfg,
     channel: "whatsapp",

--- a/tasks/pr-monitor-report.md
+++ b/tasks/pr-monitor-report.md
@@ -1,6 +1,6 @@
 # PR Monitor Report
 
-**Last updated:** 2026-04-02  
+**Last updated:** 2026-04-03  
 **Contributor:** suboss87  
 **Repo:** openclaw/openclaw  
 **Note:** GitHub API not available (no `gh` CLI or `mcp__github__*` tools). Analysis performed via git inspection of the fork remote (`suboss87/openclaw`).
@@ -100,9 +100,13 @@ The PR's contrast fix targets a color scheme that no longer exists in main. The 
 
 ---
 
-## Actions Taken This Run
+## Actions Taken This Run (2026-04-03)
 
-No actions taken. All rebases from the previous run are still clean.
+No actions taken. All branches are unchanged since the 2026-04-02 run 2 check:
+- All four branch tips are identical to the last run.
+- Main has only moved by the two prior monitor report chore commits (`3921cca`, `f3654bd`) — no code changes that would cause conflicts.
+- `feat/cron-fresh-session-option` and `fix/subagent-identity-fallback` remain conflict-free with current main.
+- `fix/chat-send-button-contrast` structural conflict with redesigned button styles remains unresolved (needs human decision).
 
 ---
 
@@ -134,3 +138,4 @@ PR statuses above are inferred from git history analysis only.
 |------|--------|--------|--------|--------|---------|
 | 2026-04-02 (run 1) | MERGED | Rebased onto main | Flagged obsolete | Rebased onto main | Rebased #45584 + #54730 |
 | 2026-04-02 (run 2) | MERGED | Clean (no new conflicts) | Still conflicted | Clean (no new conflicts) | None |
+| 2026-04-03 (run 3) | MERGED | Clean (no new conflicts) | Still conflicted | Clean (no new conflicts) | None |

--- a/tasks/pr-monitor-report.md
+++ b/tasks/pr-monitor-report.md
@@ -1,6 +1,6 @@
 # PR Monitor Report
 
-**Last updated:** 2026-04-03  
+**Last updated:** 2026-04-03 (run 4)  
 **Contributor:** suboss87  
 **Repo:** openclaw/openclaw  
 **Note:** GitHub API not available (no `gh` CLI or `mcp__github__*` tools). Analysis performed via git inspection of the fork remote (`suboss87/openclaw`).
@@ -100,12 +100,12 @@ The PR's contrast fix targets a color scheme that no longer exists in main. The 
 
 ---
 
-## Actions Taken This Run (2026-04-03)
+## Actions Taken This Run (2026-04-03 run 4)
 
-No actions taken. All branches are unchanged since the 2026-04-02 run 2 check:
+No actions taken. All branches are unchanged since the 2026-04-03 run 3 check:
 - All four branch tips are identical to the last run.
-- Main has only moved by the two prior monitor report chore commits (`3921cca`, `f3654bd`) — no code changes that would cause conflicts.
-- `feat/cron-fresh-session-option` and `fix/subagent-identity-fallback` remain conflict-free with current main.
+- Main has only moved by one new monitor report chore commit (`2d3afee`) — no code changes that would cause conflicts.
+- `feat/cron-fresh-session-option` and `fix/subagent-identity-fallback` remain conflict-free with current main (3 commits behind, all are monitor report chores).
 - `fix/chat-send-button-contrast` structural conflict with redesigned button styles remains unresolved (needs human decision).
 
 ---
@@ -139,3 +139,4 @@ PR statuses above are inferred from git history analysis only.
 | 2026-04-02 (run 1) | MERGED | Rebased onto main | Flagged obsolete | Rebased onto main | Rebased #45584 + #54730 |
 | 2026-04-02 (run 2) | MERGED | Clean (no new conflicts) | Still conflicted | Clean (no new conflicts) | None |
 | 2026-04-03 (run 3) | MERGED | Clean (no new conflicts) | Still conflicted | Clean (no new conflicts) | None |
+| 2026-04-03 (run 4) | MERGED | Clean (no new conflicts) | Still conflicted | Clean (no new conflicts) | None |

--- a/tasks/pr-monitor-report.md
+++ b/tasks/pr-monitor-report.md
@@ -1,6 +1,6 @@
 # PR Monitor Report
 
-**Date:** 2026-04-02  
+**Last updated:** 2026-04-02  
 **Contributor:** suboss87  
 **Repo:** openclaw/openclaw  
 **Note:** GitHub API not available (no `gh` CLI or `mcp__github__*` tools). Analysis performed via git inspection of the fork remote (`suboss87/openclaw`).
@@ -12,9 +12,9 @@
 | PR | Branch | Status | Merge Conflicts | Actions Taken |
 |----|--------|--------|-----------------|---------------|
 | #45911 | fix/telegram-approval-callback-fallback | **MERGED** | N/A | None |
-| #45584 | feat/cron-fresh-session-option | Open | ~~Yes~~ → Resolved | Rebased onto main, force-pushed |
-| #54363 | fix/chat-send-button-contrast | Open | Yes — **Obsolete** | None (see notes) |
-| #54730 | fix/subagent-identity-fallback | Open | ~~Yes~~ → Resolved | Rebased onto main, force-pushed |
+| #45584 | feat/cron-fresh-session-option | Open, clean | No | None needed |
+| #54363 | fix/chat-send-button-contrast | Open, **conflict** | Yes — obsolete fix | None (see notes) |
+| #54730 | fix/subagent-identity-fallback | Open, clean | No | None needed |
 
 ---
 
@@ -32,9 +32,14 @@ The commit was authored by a maintainer (Ayaan Zaidi) with the upstream squash-m
 
 ---
 
-### #45584 — feat/cron-fresh-session-option — Open, Rebased
+### #45584 — feat/cron-fresh-session-option — Open, Clean
 
-**Contribution:** Single commit (`55edd323f`) by suboss87 adding a `freshSession` boolean to cron job config. Touches:
+**Branch tip:** `cb7f5c9630 feat(cron): add freshSession option to control session reuse per job`  
+**Merge base with main:** `89065a6b2e` (chore: add PR monitor report)  
+**Commits ahead of main:** 1  
+**Commits behind main:** 1 (only `3921ccaf96 chore(tasks): update PR monitor report` — no conflict)
+
+**Contribution:** Adds a `freshSession` boolean to cron job config. Touches:
 - `src/cron/isolated-agent/run.ts`
 - `src/cron/isolated-agent/session.test.ts`
 - `src/cron/isolated-agent/run.skill-filter.test.ts`
@@ -42,69 +47,74 @@ The commit was authored by a maintainer (Ayaan Zaidi) with the upstream squash-m
 - `src/cron/types-shared.ts`
 - `src/gateway/protocol/schema/cron.ts`
 
-**Conflict situation:** Branch was 3+ weeks behind main (merge-base 2026-03-13). Cherry-pick onto current main applied cleanly with auto-merge.
-
-**Action taken:** Rebased branch onto current main via cherry-pick. Force-pushed to `origin/feat/cron-fresh-session-option`.
-- Old tip: `55edd323fd3df7b582a48fb174d5f46ed1e7a186`
-- New tip: `cb7f5c963...` (clean cherry-pick on main)
-
-**Needs human attention:** Cannot post rebase comment to PR (no GitHub access). Maintainer should note rebase and re-run CI.
+**Status:** Branch is clean (rebased in previous run). Only divergence from main is the tasks report file — no conflicts.  
+**Action taken this run:** None.  
+**Needs human attention:** Cannot check CI or review comments (no GitHub API). Maintainer should verify CI is green.
 
 ---
 
 ### #54363 — fix/chat-send-button-contrast — Open, Needs Human Attention
 
-**Contribution:** Single commit (`76c2ea44d`) by suboss87 fixing WCAG AA contrast on `.chat-send-btn` icon by changing `color: var(--text-strong)` → `color: #fff` against `background: var(--muted-strong)`.
+**Branch tip:** `76c2ea44d8 fix(ui): improve chat send button icon contrast in light theme`  
+**Merge base with main:** `6472949f25` (fix(plugins): normalize bundled provider ids — old commit from ~Mar 25)  
+**Commits ahead of main:** 1  
+**Commits behind main:** many (branch is significantly behind)
 
-**Conflict situation:** The upstream main redesigned `.chat-send-btn` after the PR was opened:
-- **PR target (old):** `background: var(--muted-strong); color: var(--text-strong)`
-- **Current main:** `background: var(--accent); color: var(--accent-foreground)`
+**Contribution:** Single commit changing `.chat-send-btn` `color` from `var(--text-strong)` → `#fff` to fix WCAG AA contrast against `var(--muted-strong)` background.
 
-The button now uses the `--accent` / `--accent-foreground` color pair, which is designed for sufficient contrast. The PR's fix (hardcoding `#fff` against `--muted-strong`) no longer applies to the current code.
+**Conflict analysis:** `git cherry-pick` of this commit onto current main results in a **content conflict** in `ui/src/styles/chat/layout.css`. The upstream button was redesigned — comparison:
 
-**Action taken:** None. The PR fix is obsolete as written. Cannot auto-resolve because:
-1. The button's background color changed, making the original fix inapplicable.
-2. If the new `var(--accent-foreground)` still has a contrast problem in light theme, it needs a fresh analysis and different fix.
+| Property | PR branch | Current main |
+|----------|-----------|--------------|
+| `background` | `var(--muted-strong)` | `var(--accent)` |
+| `color` | `#fff` (hardcoded) | `var(--accent-foreground)` |
+| `:hover` background | `var(--muted)` | `var(--accent-hover)` |
+
+The PR's contrast fix targets a color scheme that no longer exists in main. The `--accent`/`--accent-foreground` pair was introduced as part of a button redesign.
+
+**Action taken this run:** None. Auto-resolving this conflict would require deciding whether `var(--accent-foreground)` already meets WCAG AA, which requires visual/color analysis, not just a code merge.
 
 **Needs human attention:**
-- Verify whether the new `var(--accent)` + `var(--accent-foreground)` button meets WCAG AA contrast.
-- If yes: close PR #54363 as the issue was fixed differently.
-- If no: update PR with a revised fix targeting the new color scheme.
+1. Verify whether the new `var(--accent)` + `var(--accent-foreground)` button meets WCAG AA (4.5:1) in light theme.
+2. If yes: close PR #54363 — the issue was fixed differently by the redesign.
+3. If no: update PR with a revised fix targeting the new `--accent`/`--accent-foreground` color scheme.
 
 ---
 
-### #54730 — fix/subagent-identity-fallback — Open, Rebased
+### #54730 — fix/subagent-identity-fallback — Open, Clean
 
-**Contribution:** Two commits by suboss87:
-1. `11cc40e01` — `fix(ui): prefer per-agent identity for subagents over global ui.assistant`
-   - Adds `isDefaultAgent` logic to `resolveAssistantIdentity()` so subagents use their own configured identity rather than the global `ui.assistant` setting
-   - Adds 70 lines of tests in `assistant-identity.test.ts`
-2. `bf6f12db3` — `refactor: hoist resolveDefaultAgentId to avoid redundant call`
-   - Addresses Greptile review feedback; extracts `defaultAgentId` to avoid calling `resolveDefaultAgentId` twice
+**Branch tip:** `8fb20f890e refactor: hoist resolveDefaultAgentId to avoid redundant call`  
+**Merge base with main:** `89065a6b2e` (chore: add PR monitor report)  
+**Commits ahead of main:** 2  
+**Commits behind main:** 1 (only `3921ccaf96 chore(tasks): update PR monitor report` — no conflict)
 
-**Conflict situation:** The refactor commit (`bf6f12db3`) conflicted because it was based on the fix commit's intermediate state. The fix commit itself applied cleanly to current main.
+**Contribution:** Two commits:
+1. `7870292d6c` — `fix(ui): prefer per-agent identity for subagents over global ui.assistant`  
+   Adds `isDefaultAgent` logic to `resolveAssistantIdentity()` so subagents use their own configured identity rather than the global `ui.assistant` setting. Adds ~70 lines of tests.
+2. `8fb20f890e` — `refactor: hoist resolveDefaultAgentId to avoid redundant call`  
+   Addresses Greptile review feedback; extracts `defaultAgentId` to avoid calling `resolveDefaultAgentId` twice.
 
-**Action taken:** Rebased both commits in order (fix first, then refactor) onto current main via cherry-pick. Both applied cleanly in sequence.
-- Old branch tip: `bf6f12db328ec33549563463e04b9ee1cb38fee3`
-- New branch tip: `8fb20f890...` (two clean cherry-picks on main)
-- Force-pushed to `origin/fix/subagent-identity-fallback`
-
-**Needs human attention:** Cannot post rebase comment to PR (no GitHub access). Maintainer should note rebase and re-run CI.
+**Status:** Branch is clean (rebased in previous run). Only divergence from main is the tasks report file — no conflicts.  
+**Action taken this run:** None.  
+**Needs human attention:** Cannot check CI or review comments (no GitHub API). Maintainer should verify CI is green.
 
 ---
 
-## Actions Taken Summary
+## Actions Taken This Run
 
-1. **PR #45584** — Rebased `feat/cron-fresh-session-option` onto current `main`. Force-pushed to `origin/feat/cron-fresh-session-option`.
-2. **PR #54730** — Rebased `fix/subagent-identity-fallback` (2 commits) onto current `main`. Force-pushed to `origin/fix/subagent-identity-fallback`.
+No actions taken. All rebases from the previous run are still clean.
+
+---
 
 ## PRs Requiring Human Attention
 
 | PR | Reason |
 |----|--------|
-| openclaw/openclaw#45584 | Needs CI re-run after rebase; maintainer should note rebase in PR |
-| openclaw/openclaw#54363 | Conflict is structural (button redesigned in main); needs human decision on whether fix is still needed |
-| openclaw/openclaw#54730 | Needs CI re-run after rebase; maintainer should note rebase in PR |
+| openclaw/openclaw#45584 | Cannot verify CI/review status (no GitHub API) |
+| openclaw/openclaw#54363 | Structural conflict; needs human decision on WCAG status of redesigned button |
+| openclaw/openclaw#54730 | Cannot verify CI/review status (no GitHub API) |
+
+---
 
 ## Blocker: No GitHub API Access
 
@@ -115,3 +125,12 @@ Cannot perform the following without `gh` CLI or `mcp__github__*` tools:
 - Resolve bot review conversations
 
 PR statuses above are inferred from git history analysis only.
+
+---
+
+## Run History
+
+| Date | #45911 | #45584 | #54363 | #54730 | Actions |
+|------|--------|--------|--------|--------|---------|
+| 2026-04-02 (run 1) | MERGED | Rebased onto main | Flagged obsolete | Rebased onto main | Rebased #45584 + #54730 |
+| 2026-04-02 (run 2) | MERGED | Clean (no new conflicts) | Still conflicted | Clean (no new conflicts) | None |

--- a/tasks/pr-monitor-report.md
+++ b/tasks/pr-monitor-report.md
@@ -1,0 +1,53 @@
+# PR Monitor Report
+
+**Date:** 2026-04-01  
+**Contributor:** suboss87  
+**Repo:** openclaw/openclaw
+
+---
+
+## PRs Checked
+
+| PR | Branch | Status | CI | Review | Conflicts | Actions Taken |
+|----|--------|--------|----|--------|-----------|---------------|
+| #45911 | fix/telegram-approval-callback-fallback | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | None |
+| #45584 | feat/cron-fresh-session-option | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | None |
+| #54363 | fix/chat-send-button-contrast | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | None |
+| #54730 | fix/subagent-identity-fallback | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | None |
+
+---
+
+## Blocker: GitHub Access Unavailable
+
+This monitoring run was unable to complete because **neither the `gh` CLI nor the GitHub MCP server tools are available** in this environment:
+
+- `gh` CLI: not installed (`command not found`)
+- `mcp__github__*` tools: not present in the deferred tool registry
+
+No PR data, review comments, CI results, or merge-conflict status could be retrieved.
+
+---
+
+## Actions Taken
+
+None. No changes were made to any branch or PR.
+
+---
+
+## PRs Requiring Human Attention
+
+All four PRs need manual review until GitHub access is restored:
+
+- openclaw/openclaw#45911 — fix/telegram-approval-callback-fallback
+- openclaw/openclaw#45584 — feat/cron-fresh-session-option
+- openclaw/openclaw#54363 — fix/chat-send-button-contrast
+- openclaw/openclaw#54730 — fix/subagent-identity-fallback
+
+---
+
+## Resolution
+
+To unblock future monitoring runs, one of the following must be present:
+
+1. **`gh` CLI** installed and authenticated (`gh auth login`), or
+2. **GitHub MCP server** configured in Claude Code settings with a valid token for the `suboss87/openclaw` → `openclaw/openclaw` scope.

--- a/tasks/pr-monitor-report.md
+++ b/tasks/pr-monitor-report.md
@@ -1,53 +1,117 @@
 # PR Monitor Report
 
-**Date:** 2026-04-01  
+**Date:** 2026-04-02  
 **Contributor:** suboss87  
-**Repo:** openclaw/openclaw
+**Repo:** openclaw/openclaw  
+**Note:** GitHub API not available (no `gh` CLI or `mcp__github__*` tools). Analysis performed via git inspection of the fork remote (`suboss87/openclaw`).
 
 ---
 
 ## PRs Checked
 
-| PR | Branch | Status | CI | Review | Conflicts | Actions Taken |
-|----|--------|--------|----|--------|-----------|---------------|
-| #45911 | fix/telegram-approval-callback-fallback | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | None |
-| #45584 | feat/cron-fresh-session-option | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | None |
-| #54363 | fix/chat-send-button-contrast | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | None |
-| #54730 | fix/subagent-identity-fallback | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | None |
+| PR | Branch | Status | Merge Conflicts | Actions Taken |
+|----|--------|--------|-----------------|---------------|
+| #45911 | fix/telegram-approval-callback-fallback | **MERGED** | N/A | None |
+| #45584 | feat/cron-fresh-session-option | Open | ~~Yes~~ → Resolved | Rebased onto main, force-pushed |
+| #54363 | fix/chat-send-button-contrast | Open | Yes — **Obsolete** | None (see notes) |
+| #54730 | fix/subagent-identity-fallback | Open | ~~Yes~~ → Resolved | Rebased onto main, force-pushed |
 
 ---
 
-## Blocker: GitHub Access Unavailable
+## PR Detail
 
-This monitoring run was unable to complete because **neither the `gh` CLI nor the GitHub MCP server tools are available** in this environment:
+### #45911 — fix/telegram-approval-callback-fallback — MERGED
 
-- `gh` CLI: not installed (`command not found`)
-- `mcp__github__*` tools: not present in the deferred tool registry
+The branch tip commit is:
+```
+14fd49c36 fix: keep telegram plugin fallback explicit (#45911) (thanks @suboss87)
+Author: Ayaan Zaidi <hi@obviy.us>
+Date:   Sun Mar 29 10:44:27 2026 +0530
+```
+The commit was authored by a maintainer (Ayaan Zaidi) with the upstream squash-merge format `(#45911) (thanks @suboss87)`. This confirms the PR was merged upstream. No action needed.
 
-No PR data, review comments, CI results, or merge-conflict status could be retrieved.
+---
+
+### #45584 — feat/cron-fresh-session-option — Open, Rebased
+
+**Contribution:** Single commit (`55edd323f`) by suboss87 adding a `freshSession` boolean to cron job config. Touches:
+- `src/cron/isolated-agent/run.ts`
+- `src/cron/isolated-agent/session.test.ts`
+- `src/cron/isolated-agent/run.skill-filter.test.ts`
+- `src/cron/service/jobs.ts`
+- `src/cron/types-shared.ts`
+- `src/gateway/protocol/schema/cron.ts`
+
+**Conflict situation:** Branch was 3+ weeks behind main (merge-base 2026-03-13). Cherry-pick onto current main applied cleanly with auto-merge.
+
+**Action taken:** Rebased branch onto current main via cherry-pick. Force-pushed to `origin/feat/cron-fresh-session-option`.
+- Old tip: `55edd323fd3df7b582a48fb174d5f46ed1e7a186`
+- New tip: `cb7f5c963...` (clean cherry-pick on main)
+
+**Needs human attention:** Cannot post rebase comment to PR (no GitHub access). Maintainer should note rebase and re-run CI.
 
 ---
 
-## Actions Taken
+### #54363 — fix/chat-send-button-contrast — Open, Needs Human Attention
 
-None. No changes were made to any branch or PR.
+**Contribution:** Single commit (`76c2ea44d`) by suboss87 fixing WCAG AA contrast on `.chat-send-btn` icon by changing `color: var(--text-strong)` → `color: #fff` against `background: var(--muted-strong)`.
+
+**Conflict situation:** The upstream main redesigned `.chat-send-btn` after the PR was opened:
+- **PR target (old):** `background: var(--muted-strong); color: var(--text-strong)`
+- **Current main:** `background: var(--accent); color: var(--accent-foreground)`
+
+The button now uses the `--accent` / `--accent-foreground` color pair, which is designed for sufficient contrast. The PR's fix (hardcoding `#fff` against `--muted-strong`) no longer applies to the current code.
+
+**Action taken:** None. The PR fix is obsolete as written. Cannot auto-resolve because:
+1. The button's background color changed, making the original fix inapplicable.
+2. If the new `var(--accent-foreground)` still has a contrast problem in light theme, it needs a fresh analysis and different fix.
+
+**Needs human attention:**
+- Verify whether the new `var(--accent)` + `var(--accent-foreground)` button meets WCAG AA contrast.
+- If yes: close PR #54363 as the issue was fixed differently.
+- If no: update PR with a revised fix targeting the new color scheme.
 
 ---
+
+### #54730 — fix/subagent-identity-fallback — Open, Rebased
+
+**Contribution:** Two commits by suboss87:
+1. `11cc40e01` — `fix(ui): prefer per-agent identity for subagents over global ui.assistant`
+   - Adds `isDefaultAgent` logic to `resolveAssistantIdentity()` so subagents use their own configured identity rather than the global `ui.assistant` setting
+   - Adds 70 lines of tests in `assistant-identity.test.ts`
+2. `bf6f12db3` — `refactor: hoist resolveDefaultAgentId to avoid redundant call`
+   - Addresses Greptile review feedback; extracts `defaultAgentId` to avoid calling `resolveDefaultAgentId` twice
+
+**Conflict situation:** The refactor commit (`bf6f12db3`) conflicted because it was based on the fix commit's intermediate state. The fix commit itself applied cleanly to current main.
+
+**Action taken:** Rebased both commits in order (fix first, then refactor) onto current main via cherry-pick. Both applied cleanly in sequence.
+- Old branch tip: `bf6f12db328ec33549563463e04b9ee1cb38fee3`
+- New branch tip: `8fb20f890...` (two clean cherry-picks on main)
+- Force-pushed to `origin/fix/subagent-identity-fallback`
+
+**Needs human attention:** Cannot post rebase comment to PR (no GitHub access). Maintainer should note rebase and re-run CI.
+
+---
+
+## Actions Taken Summary
+
+1. **PR #45584** — Rebased `feat/cron-fresh-session-option` onto current `main`. Force-pushed to `origin/feat/cron-fresh-session-option`.
+2. **PR #54730** — Rebased `fix/subagent-identity-fallback` (2 commits) onto current `main`. Force-pushed to `origin/fix/subagent-identity-fallback`.
 
 ## PRs Requiring Human Attention
 
-All four PRs need manual review until GitHub access is restored:
+| PR | Reason |
+|----|--------|
+| openclaw/openclaw#45584 | Needs CI re-run after rebase; maintainer should note rebase in PR |
+| openclaw/openclaw#54363 | Conflict is structural (button redesigned in main); needs human decision on whether fix is still needed |
+| openclaw/openclaw#54730 | Needs CI re-run after rebase; maintainer should note rebase in PR |
 
-- openclaw/openclaw#45911 — fix/telegram-approval-callback-fallback
-- openclaw/openclaw#45584 — feat/cron-fresh-session-option
-- openclaw/openclaw#54363 — fix/chat-send-button-contrast
-- openclaw/openclaw#54730 — fix/subagent-identity-fallback
+## Blocker: No GitHub API Access
 
----
+Cannot perform the following without `gh` CLI or `mcp__github__*` tools:
+- Check actual PR open/closed/merged status via GitHub API
+- Read review comments or CI check results
+- Post rebase notifications to PRs
+- Resolve bot review conversations
 
-## Resolution
-
-To unblock future monitoring runs, one of the following must be present:
-
-1. **`gh` CLI** installed and authenticated (`gh auth login`), or
-2. **GitHub MCP server** configured in Claude Code settings with a valid token for the `suboss87/openclaw` → `openclaw/openclaw` scope.
+PR statuses above are inferred from git history analysis only.


### PR DESCRIPTION
## Summary

- **Problem:** `resolveGroupPolicyFor` in `src/web/auto-reply/monitor/group-activation.ts` included `channels.whatsapp.allowFrom` (the DM allowlist) when computing `hasGroupAllowFrom`. When users pair via DM, their phone number enters `allowFrom`, which then triggers `senderFilterBypass` in `resolveChannelGroupPolicy` — causing `groupPolicy="allowlist"` with no groups defined to auto-reply to **ALL** groups instead of fail-closed blocking them.
- **Why it matters:** This is a security-adjacent regression — bots respond in groups they were never authorized for, leaking context and potentially sensitive data.
- **What changed:** Removed `whatsappCfg?.allowFrom?.length` from the `hasGroupAllowFrom` computation. Only `groupAllowFrom` (intentional group-level sender filtering) is checked now.
- **What did NOT change:** No changes to the core `resolveChannelGroupPolicy` logic, no changes to DM allowFrom behavior, no changes to other channels.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #56957

## User-visible / Behavior Changes

- WhatsApp bots with `groupPolicy: "allowlist"` and no explicit `groups` configured will now correctly **block all group messages** instead of auto-replying to every group when DM `allowFrom` entries exist.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: WhatsApp (web)
- Relevant config (redacted):
```yaml
channels:
  whatsapp:
    groupPolicy: allowlist
    allowFrom:
      - "+1234567890"  # added by DM pairing
    # no groups defined
    # no groupAllowFrom defined
```

### Steps

1. Pair a WhatsApp number via DM (adds phone to `allowFrom`)
2. Set `groupPolicy: "allowlist"` with no `groups` and no `groupAllowFrom`
3. Send a message in any WhatsApp group the bot is in

### Expected

- Group message is blocked (fail-closed, since no groups are allowlisted)

### Actual (before fix)

- Group message is auto-replied to (DM `allowFrom` triggers `senderFilterBypass`)

## Evidence

- [x] Failing test/log before + passing after
- 3 regression tests added in `src/web/auto-reply/monitor/group-activation.test.ts`:
  - DM-only `allowFrom` → `hasGroupAllowFrom: false` (the regression case)
  - `groupAllowFrom` configured → `hasGroupAllowFrom: true`
  - Empty `groupAllowFrom` with DM `allowFrom` → `hasGroupAllowFrom: false`

## Human Verification (required)

- Verified scenarios: Code-level review confirms only `groupAllowFrom` is checked; DM `allowFrom` no longer leaks into group policy bypass
- Edge cases checked: Empty `groupAllowFrom` array, missing `groupAllowFrom` key, both `allowFrom` + `groupAllowFrom` present
- What you did **not** verify: Live WhatsApp deployment (no access to production bot)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; or add explicit `groupAllowFrom` entries to restore previous behavior intentionally
- Files/config to restore: `src/web/auto-reply/monitor/group-activation.ts`
- Known bad symptoms: If users relied on DM pairing to implicitly allow group access, they will need to add explicit `groupAllowFrom` entries

## Risks and Mitigations

- Risk: Users who relied on the buggy behavior (DM pairing granting implicit group access) may see groups suddenly blocked
  - Mitigation: This was never intended behavior per the design of `groupAllowFrom` vs `allowFrom`; users should configure `groupAllowFrom` explicitly for group sender filtering