### PR TITLE
Keep gateway CLI timeout client-side after accepted runs

### DIFF
--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -3,8 +3,26 @@ import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const mockedGatewayAcceptedOwnershipError = vi.hoisted(
+  () =>
+    class GatewayAcceptedOwnershipError extends Error {
+      accepted: Record<string, unknown>;
+      cause?: unknown;
+
+      constructor(params: { method: string; accepted: Record<string, unknown>; cause?: unknown }) {
+        super(`gateway accepted ownership of ${params.method}`);
+        this.name = "GatewayAcceptedOwnershipError";
+        this.accepted = params.accepted;
+        this.cause = params.cause;
+      }
+    },
+);
+
 vi.mock("../gateway/call.js", () => ({
+  GatewayAcceptedOwnershipError: mockedGatewayAcceptedOwnershipError,
   callGateway: vi.fn(),
+  isGatewayAcceptedOwnershipError: (err: unknown) =>
+    err instanceof mockedGatewayAcceptedOwnershipError,
   randomIdempotencyKey: () => "idem-1",
 }));
 vi.mock("./agent.js", () => ({
@@ -13,7 +31,7 @@ vi.mock("./agent.js", () => ({
 
 import type { OpenClawConfig } from "../config/config.js";
 import * as configModule from "../config/config.js";
-import { callGateway } from "../gateway/call.js";
+import * as gatewayCallModule from "../gateway/call.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { agentCliCommand } from "./agent-via-gateway.js";
 import { agentCommand } from "./agent.js";
@@ -58,7 +76,7 @@ async function withTempStore(
 }
 
 function mockGatewaySuccessReply(text = "hello") {
-  vi.mocked(callGateway).mockResolvedValue({
+  vi.mocked(gatewayCallModule.callGateway).mockResolvedValue({
     runId: "idem-1",
     status: "ok",
     result: {
@@ -89,9 +107,28 @@ describe("agentCliCommand", () => {
 
       await agentCliCommand({ message: "hi", to: "+1555", timeout: "0" }, runtime);
 
-      expect(callGateway).toHaveBeenCalledTimes(1);
-      const request = vi.mocked(callGateway).mock.calls[0]?.[0] as { timeoutMs?: number };
+      expect(gatewayCallModule.callGateway).toHaveBeenCalledTimes(1);
+      const request = vi.mocked(gatewayCallModule.callGateway).mock.calls[0]?.[0] as {
+        timeoutMs?: number;
+      };
       expect(request.timeoutMs).toBe(2_147_000_000);
+      expect((request as { params?: { timeout?: unknown } }).params?.timeout).toBeUndefined();
+    });
+  });
+
+  it("keeps gateway timeout client-side instead of forwarding it into the accepted run", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555", timeout: "1" }, runtime);
+
+      expect(gatewayCallModule.callGateway).toHaveBeenCalledTimes(1);
+      const request = vi.mocked(gatewayCallModule.callGateway).mock.calls[0]?.[0] as {
+        timeoutMs?: number;
+        params?: { timeout?: unknown };
+      };
+      expect(request.timeoutMs).toBe(31_000);
+      expect(request.params?.timeout).toBeUndefined();
     });
   });
 
@@ -101,20 +138,50 @@ describe("agentCliCommand", () => {
 
       await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
 
-      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(gatewayCallModule.callGateway).toHaveBeenCalledTimes(1);
       expect(agentCommand).not.toHaveBeenCalled();
       expect(runtime.log).toHaveBeenCalledWith("hello");
     });
   });
 
+  it("does not fall back locally after gateway acceptance", async () => {
+    await withTempStore(async () => {
+      vi.mocked(gatewayCallModule.callGateway).mockRejectedValue(
+        new mockedGatewayAcceptedOwnershipError({
+          method: "agent",
+          accepted: {
+            runId: "run-accepted",
+            status: "accepted",
+            acceptedAt: 123,
+          },
+          cause: new Error("gateway request timeout for agent"),
+        }),
+      );
+
+      const response = await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+
+      expect(gatewayCallModule.callGateway).toHaveBeenCalledTimes(1);
+      expect(agentCommand).not.toHaveBeenCalled();
+      expect(runtime.error).toHaveBeenCalledWith(
+        "Gateway accepted run run-accepted; not falling back to embedded after gateway transport failure.",
+      );
+      expect(response).toMatchObject({
+        runId: "run-accepted",
+        status: "accepted",
+      });
+    });
+  });
+
   it("falls back to embedded agent when gateway fails", async () => {
     await withTempStore(async () => {
-      vi.mocked(callGateway).mockRejectedValue(new Error("gateway not connected"));
+      vi.mocked(gatewayCallModule.callGateway).mockRejectedValue(
+        new Error("gateway not connected"),
+      );
       mockLocalAgentReply();
 
       await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
 
-      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(gatewayCallModule.callGateway).toHaveBeenCalledTimes(1);
       expect(agentCommand).toHaveBeenCalledTimes(1);
       expect(runtime.log).toHaveBeenCalledWith("local");
     });
@@ -133,7 +200,7 @@ describe("agentCliCommand", () => {
         runtime,
       );
 
-      expect(callGateway).not.toHaveBeenCalled();
+      expect(gatewayCallModule.callGateway).not.toHaveBeenCalled();
       expect(agentCommand).toHaveBeenCalledTimes(1);
       expect(vi.mocked(agentCommand).mock.calls[0]?.[0]).toMatchObject({
         cleanupBundleMcpOnRunEnd: true,
@@ -144,7 +211,9 @@ describe("agentCliCommand", () => {
 
   it("does not force bundle MCP cleanup on gateway fallback", async () => {
     await withTempStore(async () => {
-      vi.mocked(callGateway).mockRejectedValue(new Error("gateway not connected"));
+      vi.mocked(gatewayCallModule.callGateway).mockRejectedValue(
+        new Error("gateway not connected"),
+      );
       mockLocalAgentReply();
 
       await agentCliCommand({ message: "hi", to: "+1555" }, runtime);

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -4,7 +4,11 @@ import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.js";
 import { withProgress } from "../cli/progress.js";
 import { loadConfig } from "../config/config.js";
-import { callGateway, randomIdempotencyKey } from "../gateway/call.js";
+import {
+  callGateway,
+  isGatewayAcceptedOwnershipError,
+  randomIdempotencyKey,
+} from "../gateway/call.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import {
@@ -143,7 +147,6 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
           replyChannel: opts.replyChannel,
           replyAccountId: opts.replyAccount,
           bestEffortDeliver: opts.bestEffortDeliver,
-          timeout: timeoutSeconds,
           lane: opts.lane,
           extraSystemPrompt: opts.extraSystemPrompt,
           idempotencyKey,
@@ -192,6 +195,21 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
   try {
     return await agentViaGatewayCommand(opts, runtime);
   } catch (err) {
+    if (isGatewayAcceptedOwnershipError(err)) {
+      const accepted = err.accepted as GatewayAgentResponse;
+      if (opts.json) {
+        writeRuntimeJson(runtime, accepted);
+      } else {
+        const runId =
+          typeof accepted?.runId === "string" && accepted.runId.trim().length > 0
+            ? accepted.runId.trim()
+            : "unknown";
+        runtime.error?.(
+          `Gateway accepted run ${runId}; not falling back to embedded after gateway transport failure.`,
+        );
+      }
+      return accepted;
+    }
     runtime.error?.(`Gateway agent failed; falling back to embedded: ${String(err)}`);
     return await agentCommand(localOpts, runtime, deps);
   }


### PR DESCRIPTION
## Executive Summary

This PR fixes the accepted-timeout regression on the live operational CLI path by keeping `openclaw agent --timeout ...` as a client-side wait budget instead of forwarding it into the gateway-owned accepted run.

## What Was Changed
- Removed forwarded inner timeout from the gateway CLI request in `src/commands/agent-via-gateway.ts`
- Added focused regression coverage in `src/commands/agent-via-gateway.test.ts` asserting the timeout remains client-side and is not forwarded into the accepted run

## What Was Tested
- Targeted test pass for the command path
- Real operational proof via `/opt/homebrew/bin/openclaw agent --session-id ... --timeout 1 --json`
- Follow-up completion proof via `agent.wait`

## What Was Verified
- CLI returned `status: accepted` immediately
- Accepted run later completed `status: ok`
- No timeout-continuation prompt was appended to the transcript
- No fallback-model retry / embedded fallback evidence in the proof transcripts
- No session file locked, EPERM, or SQLITE_BUSY tied to the proof sessions

## What Was Not Verified
- Exhaustive behavior across every caller path
- Broader gateway/agent integration beyond the focused test and live operational proofs

## Notes

This PR intentionally excludes unrelated dirty local regression work already present in the repo.