### PR TITLE
fix(discord): advertise upload-file action in message tool

### DIFF
--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -71,6 +71,71 @@ describe("handleDiscordMessageAction", () => {
     );
   });
 
+  it("defaults content to empty string for upload-file without message", async () => {
+    await handleDiscordMessageAction({
+      action: "upload-file",
+      params: {
+        to: "channel:456",
+        filePath: "https://example.com/file.png",
+      },
+      cfg: {
+        channels: { discord: { token: "tok" } },
+      } as OpenClawConfig,
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sendMessage",
+        to: "channel:456",
+        content: "",
+        mediaUrl: "https://example.com/file.png",
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("forwards message content for upload-file when provided", async () => {
+    await handleDiscordMessageAction({
+      action: "upload-file",
+      params: {
+        to: "channel:456",
+        filePath: "https://example.com/file.png",
+        message: "Here is the file",
+      },
+      cfg: {
+        channels: { discord: { token: "tok" } },
+      } as OpenClawConfig,
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sendMessage",
+        to: "channel:456",
+        content: "Here is the file",
+        mediaUrl: "https://example.com/file.png",
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("rejects upload-file when no file path is provided", async () => {
+    await expect(
+      handleDiscordMessageAction({
+        action: "upload-file",
+        params: {
+          to: "channel:456",
+        },
+        cfg: {
+          channels: { discord: { token: "tok" } },
+        } as OpenClawConfig,
+      }),
+    ).rejects.toThrow(/upload-file requires filePath, path, or media/);
+
+    expect(handleDiscordActionMock).not.toHaveBeenCalled();
+  });
+
   it("rejects reactions when no message id source is available", async () => {
     await expect(
       handleDiscordMessageAction({

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -109,7 +109,7 @@ export async function handleDiscordMessageAction(
         action: "sendMessage",
         accountId: accountId ?? undefined,
         to,
-        content: content ?? undefined,
+        content: content ?? "",
         mediaUrl,
         filename: filename ?? undefined,
         replyTo: replyTo ?? undefined,

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -90,6 +90,35 @@ export async function handleDiscordMessageAction(
     );
   }
 
+  if (action === "upload-file") {
+    const to = readStringParam(params, "to", { required: true });
+    const mediaUrl =
+      readStringParam(params, "media", { trim: false }) ??
+      readStringParam(params, "path", { trim: false }) ??
+      readStringParam(params, "filePath", { trim: false });
+    if (!mediaUrl) {
+      throw new Error("upload-file requires filePath, path, or media");
+    }
+    const filename = readStringParam(params, "filename");
+    const content =
+      readStringParam(params, "message", { allowEmpty: true }) ??
+      readStringParam(params, "initialComment", { allowEmpty: true });
+    const replyTo = readStringParam(params, "replyTo");
+    return await handleDiscordAction(
+      {
+        action: "sendMessage",
+        accountId: accountId ?? undefined,
+        to,
+        content: content ?? undefined,
+        mediaUrl,
+        filename: filename ?? undefined,
+        replyTo: replyTo ?? undefined,
+      },
+      cfg,
+      actionOptions,
+    );
+  }
+
   if (action === "poll") {
     const to = readStringParam(params, "to", { required: true });
     const question = readStringParam(params, "pollQuestion", {

--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -53,7 +53,15 @@ describe("discordMessageActions", () => {
     expect(discovery?.capabilities).toEqual(["interactive", "components"]);
     expect(discovery?.schema).not.toBeNull();
     expect(discovery?.actions).toEqual(
-      expect.arrayContaining(["send", "poll", "react", "reactions", "emoji-list", "permissions"]),
+      expect.arrayContaining([
+        "send",
+        "upload-file",
+        "poll",
+        "react",
+        "reactions",
+        "emoji-list",
+        "permissions",
+      ]),
     );
     expect(discovery?.actions).not.toContain("channel-create");
     expect(discovery?.actions).not.toContain("role-add");
@@ -90,9 +98,7 @@ describe("discordMessageActions", () => {
       accountId: "work",
     });
 
-    expect(defaultDiscovery?.actions).toEqual(
-      expect.arrayContaining(["send", "poll"]),
-    );
+    expect(defaultDiscovery?.actions).toEqual(expect.arrayContaining(["send", "poll"]));
     expect(defaultDiscovery?.actions).not.toContain("react");
     expect(workDiscovery?.actions).toEqual(
       expect.arrayContaining(["send", "react", "reactions", "emoji-list"]),

--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -67,6 +67,40 @@ describe("discordMessageActions", () => {
     expect(discovery?.actions).not.toContain("role-add");
   });
 
+  it("includes upload-file in discovered actions when messages is enabled", () => {
+    const discovery = discordMessageActions.describeMessageTool?.({
+      cfg: {
+        channels: {
+          discord: {
+            token: "Bot token-main",
+            actions: {
+              messages: true,
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(discovery?.actions).toContain("upload-file");
+  });
+
+  it("excludes upload-file from discovered actions when messages is disabled", () => {
+    const discovery = discordMessageActions.describeMessageTool?.({
+      cfg: {
+        channels: {
+          discord: {
+            token: "Bot token-main",
+            actions: {
+              messages: false,
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(discovery?.actions).not.toContain("upload-file");
+  });
+
   it("honors account-scoped action gates during discovery", () => {
     const cfg = {
       channels: {

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -89,6 +89,7 @@ function describeDiscordMessageTool({
     actions.add("read");
     actions.add("edit");
     actions.add("delete");
+    actions.add("upload-file");
   }
   if (discovery.isEnabled("pins")) {
     actions.add("pin");

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -85,11 +85,11 @@ function describeDiscordMessageTool({
     actions.add("reactions");
     actions.add("emoji-list");
   }
+  actions.add("upload-file");
   if (discovery.isEnabled("messages")) {
     actions.add("read");
     actions.add("edit");
     actions.add("delete");
-    actions.add("upload-file");
   }
   if (discovery.isEnabled("pins")) {
     actions.add("pin");

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -85,11 +85,11 @@ function describeDiscordMessageTool({
     actions.add("reactions");
     actions.add("emoji-list");
   }
-  actions.add("upload-file");
   if (discovery.isEnabled("messages")) {
     actions.add("read");
     actions.add("edit");
     actions.add("delete");
+    actions.add("upload-file");
   }
   if (discovery.isEnabled("pins")) {
     actions.add("pin");


### PR DESCRIPTION
## Summary
- The Discord channel's `describeDiscordMessageTool` never added `upload-file` to its advertised actions, so agents could not discover or use explicit file-first uploads on Discord — unlike Slack, BlueBubbles, Google Chat, and MS Teams which all expose it.
- Add `upload-file` to the `messages` action gate in discovery, and add a corresponding `upload-file` handler that routes through the existing `sendMessage` runtime (which already supports media uploads via `mediaUrl`/`filename`).

Closes #60652

## Root cause
- **File**: `extensions/discord/src/channel-actions.ts`, lines 88-92
- **Introducing commit**: `3a3fdf1` (Peter Steinberger, 2026-04-04) — the `messages` gate added `read`, `edit`, `delete` but omitted `upload-file` and `download-file`
- **Core registry** (`src/channels/plugins/message-action-names.ts:57-58`) already defines both `download-file` and `upload-file` as valid action names

## What changed
| File | Change |
|------|--------|
| `extensions/discord/src/channel-actions.ts` | Add `actions.add("upload-file")` under the `messages` gate |
| `extensions/discord/src/actions/handle-action.ts` | Add `upload-file` handler that validates `filePath`/`path`/`media`, then routes through `sendMessage` |

## Call path verification
```
describeDiscordMessageTool (channel-actions.ts:65)
  → discovery.isEnabled("messages") (line 88)
    → actions.add("upload-file") (NEW, line 92)

handleDiscordMessageAction (handle-action.ts:19)
  → action === "upload-file" (NEW, line 93)
    → handleDiscordAction({ action: "sendMessage", ... }) (line 107)
      → handleDiscordMessagingAction (runtime.ts:68)
        → case "sendMessage" (runtime.messaging.ts:295)
          → sendMessageDiscord (with mediaUrl + filename)
```

## G8: Codebase-wide pattern check
Channels that already advertise `upload-file`: Slack, BlueBubbles, Google Chat, MS Teams.
Channels that do NOT advertise `upload-file`: Telegram, Mattermost, Matrix, WhatsApp, Signal, IRC, Line, etc.

`download-file` is NOT added here because Discord lacks a dedicated file-download API endpoint (Slack has `files.info`). Discord attachments are served via CDN URLs returned in message objects — the existing `read` action already surfaces those URLs.

## Test plan
- [x] Existing `channel-actions.test.ts` uses `expect.arrayContaining` — adding `upload-file` does not break existing assertions
- [x] Contract test (`registry-actions.ts`) has `messages: false` for Discord — unaffected
- [ ] Manual: configure a Discord bot token, verify `upload-file` appears in discovered actions
- [ ] Manual: send `action: "upload-file"` with `to`, `media`, and optional `filename` — verify file is uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)