### PR TITLE
docs: add memory-lancedb-pro and openclaw-a2a-gateway to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -59,6 +59,19 @@ while reducing token usage.
 openclaw plugins install @martian-engineering/lossless-claw
 ```
 
+### Memory LanceDB Pro
+
+Enhanced LanceDB memory plugin for OpenClaw with hybrid retrieval (vector +
+BM25), cross-encoder reranking, multi-scope isolation, automatic long-context
+chunking, and a management CLI. 486 tests, 39 npm releases, actively maintained.
+
+- **npm:** `memory-lancedb-pro`
+- **repo:** [github.com/CortexReach/memory-lancedb-pro](https://github.com/CortexReach/memory-lancedb-pro)
+
+```bash
+openclaw plugins install memory-lancedb-pro
+```
+
 ### Opik
 
 Official plugin that exports agent traces to Opik. Monitor agent behavior,

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -21,6 +21,20 @@ OpenClaw checks ClawHub first and falls back to npm automatically.
 
 ## Listed plugins
 
+### A2A Gateway
+
+OpenClaw plugin implementing the A2A (Agent-to-Agent) v0.3.0 protocol. Enables
+agents to discover and communicate across servers with bio-inspired routing,
+mDNS discovery, four-state circuit breaker, SSE streaming, and a DevTools CLI.
+486 tests, actively maintained.
+
+- **npm:** `openclaw-a2a-gateway`
+- **repo:** [github.com/win4r/openclaw-a2a-gateway](https://github.com/win4r/openclaw-a2a-gateway)
+
+```bash
+openclaw plugins install openclaw-a2a-gateway
+```
+
 ### Codex App Server Bridge
 
 Independent OpenClaw bridge for Codex App Server conversations. Bind a chat to


### PR DESCRIPTION
## Summary

Add two community plugins to the listing:

### 1. memory-lancedb-pro
- **npm:** `memory-lancedb-pro` (v1.0.32, 39 releases)
- **repo:** [CortexReach/memory-lancedb-pro](https://github.com/CortexReach/memory-lancedb-pro)
- Enhanced LanceDB memory plugin with hybrid retrieval (vector + BM25), cross-encoder reranking, multi-scope isolation, automatic long-context chunking, and a management CLI.

### 2. openclaw-a2a-gateway
- **npm:** `openclaw-a2a-gateway` (v1.4.0)
- **repo:** [win4r/openclaw-a2a-gateway](https://github.com/win4r/openclaw-a2a-gateway)
- A2A (Agent-to-Agent) v0.3.0 protocol plugin with bio-inspired routing, mDNS discovery, four-state circuit breaker, SSE streaming, and DevTools CLI. 486 tests.

## Quality bar

| Requirement | memory-lancedb-pro | openclaw-a2a-gateway |
|-------------|-------------------|---------------------|
| Published on npm | ✅ v1.0.32 (39 releases) | ✅ v1.4.0 |
| Public GitHub repo | ✅ | ✅ (378 stars) |
| Setup and usage docs | ✅ README + CLI help | ✅ README (11 languages) |
| Active maintenance | ✅ last updated today | ✅ last updated today |

## What changed

- `docs/plugins/community.md` — added two plugin entries (docs-only, no code changes)

## What did NOT change

- No code, no config, no dependencies