### PR TITLE
fix(browser): remove fromSurface: false for Chrome 146+ screenshot compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@ Docs: https://docs.openclaw.ai
 - Providers/OpenRouter: gate Anthropic prompt-cache `cache_control` markers to native/default OpenRouter routes and preserve them for native OpenRouter hosts behind custom provider ids. Thanks @vincentkoc.
 - Browser/CDP: validate both initial and discovered CDP websocket endpoints before connect so strict SSRF policy blocks cross-host pivots and direct websocket targets. (#60469) Thanks @eleqtrizit.
 - Browser/profiles: reject remote browser profile `cdpUrl` values that violate strict SSRF policy before saving config, with clearer validation errors for blocked endpoints. (#60477) Thanks @eleqtrizit.
+- Browser/screenshots: stop sending `fromSurface: false` on CDP screenshots so managed Chrome 146+ browsers can capture images again. (#60682) Thanks @mvanhorn.
 - Mattermost/slash commands: harden native slash-command callback token validation to use constant-time secret comparison, matching the existing interaction-token path.
 
 ## 2026.4.1

--- a/extensions/browser/src/browser/cdp.screenshot-params.test.ts
+++ b/extensions/browser/src/browser/cdp.screenshot-params.test.ts
@@ -87,16 +87,16 @@ beforeEach(() => {
 });
 
 describe("CDP screenshot params", () => {
-  it("viewport screenshot uses fromSurface: false without clip or emulation override", async () => {
+  it("viewport screenshot omits fromSurface without clip or emulation override", async () => {
     await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X", format: "png" });
 
     const call = sentMessages.find((m) => m.method === "Page.captureScreenshot");
     expect(call).toBeDefined();
     expect(call!.params).toMatchObject({
       format: "png",
-      fromSurface: false,
       captureBeyondViewport: true,
     });
+    expect(call!.params).not.toHaveProperty("fromSurface");
     expect(call!.params).not.toHaveProperty("clip");
 
     const emulationCalls = sentMessages.filter(

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -119,13 +119,13 @@ export async function captureScreenshot(opts: {
       format === "jpeg" ? Math.max(0, Math.min(100, Math.round(opts.quality ?? 85))) : undefined;
 
     try {
-      // fromSurface: false avoids a Chromium compositor bug where cross-origin
-      // image textures are lost when fromSurface: true + captureBeyondViewport: true
-      // extends the capture surface (see https://issues.chromium.org/40760789).
+      // Chromium bug 40760789 (cross-origin textures missing with
+      // fromSurface: true + captureBeyondViewport: true) was fixed around
+      // Chrome 130. Chrome 146+ managed/headful browsers now reject
+      // fromSurface: false, so we omit it and keep captureBeyondViewport: true.
       const result = (await send("Page.captureScreenshot", {
         format,
         ...(quality !== undefined ? { quality } : {}),
-        fromSurface: false,
         captureBeyondViewport: true,
       })) as { data?: string };
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: `Page.captureScreenshot` passes `fromSurface: false`, which Chrome 146+ rejects for managed/headful browsers, returning "Unable to capture screenshot"
- Why it matters: `browser screenshot` is broken on Chrome 146+ while `browser snapshot` (DOM-based) still works
- What changed: Removed `fromSurface: false` from the CDP call in `extensions/browser/src/browser/cdp.ts:124`. Updated the comment to explain the Chromium bug (40760789) was fixed around Chrome 130 and `fromSurface: false` now fails on 146+. Updated test assertion.
- What did NOT change (scope boundary): `captureBeyondViewport: true` remains. No other screenshot parameters touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #60540
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Chromium behavior change in Chrome 146+. `fromSurface: false` tells Chrome to capture from the compositor surface rather than the rendered surface. Chrome 146+ managed/headful browsers reject this parameter, returning empty screenshot data. The original workaround was for Chromium bug [40760789](https://issues.chromium.org/40760789) (cross-origin image textures lost with `fromSurface: true` + `captureBeyondViewport: true`), which was fixed around Chrome 130.
- Missing detection / guardrail: No Chrome version detection around the `fromSurface` parameter
- Contributing context (if known): The Chromium bug was reported and fixed upstream. The workaround outlived the bug.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/browser/src/browser/cdp.screenshot-params.test.ts`
- Scenario: Updated existing test to assert `fromSurface` is omitted from CDP params rather than set to `false`

This contribution was developed with AI assistance (Codex).