### PR TITLE
fix(zalouser): migrate legacy group allow aliases

### DIFF
--- a/docs/.generated/config-baseline.channel.json
+++ b/docs/.generated/config-baseline.channel.json
@@ -31146,16 +31146,6 @@
       "hasChildren": true
     },
     {
-      "path": "channels.zalouser.accounts.*.groups.*.allow",
-      "kind": "channel",
-      "type": "boolean",
-      "required": false,
-      "deprecated": false,
-      "sensitive": false,
-      "tags": [],
-      "hasChildren": false
-    },
-    {
       "path": "channels.zalouser.accounts.*.groups.*.enabled",
       "kind": "channel",
       "type": "boolean",
@@ -31448,16 +31438,6 @@
       "sensitive": false,
       "tags": [],
       "hasChildren": true
-    },
-    {
-      "path": "channels.zalouser.groups.*.allow",
-      "kind": "channel",
-      "type": "boolean",
-      "required": false,
-      "deprecated": false,
-      "sensitive": false,
-      "tags": [],
-      "hasChildren": false
     },
     {
       "path": "channels.zalouser.groups.*.enabled",

--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -59186,16 +59186,6 @@
       "hasChildren": true
     },
     {
-      "path": "channels.zalouser.accounts.*.groups.*.allow",
-      "kind": "channel",
-      "type": "boolean",
-      "required": false,
-      "deprecated": false,
-      "sensitive": false,
-      "tags": [],
-      "hasChildren": false
-    },
-    {
       "path": "channels.zalouser.accounts.*.groups.*.enabled",
       "kind": "channel",
       "type": "boolean",
@@ -59488,16 +59478,6 @@
       "sensitive": false,
       "tags": [],
       "hasChildren": true
-    },
-    {
-      "path": "channels.zalouser.groups.*.allow",
-      "kind": "channel",
-      "type": "boolean",
-      "required": false,
-      "deprecated": false,
-      "sensitive": false,
-      "tags": [],
-      "hasChildren": false
     },
     {
       "path": "channels.zalouser.groups.*.enabled",

--- a/extensions/zalouser/src/config-schema.ts
+++ b/extensions/zalouser/src/config-schema.ts
@@ -9,7 +9,6 @@ import {
 import { z } from "openclaw/plugin-sdk/zod";
 
 const groupConfigSchema = z.object({
-  allow: z.boolean().optional(),
   enabled: z.boolean().optional(),
   requireMention: z.boolean().optional(),
   tools: ToolPolicySchema,

--- a/extensions/zalouser/src/doctor.test.ts
+++ b/extensions/zalouser/src/doctor.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { zalouserDoctor } from "./doctor.js";
+
+describe("zalouser doctor", () => {
+  it("normalizes legacy group allow aliases to enabled", () => {
+    const normalize = zalouserDoctor.normalizeCompatibilityConfig;
+    expect(normalize).toBeDefined();
+    if (!normalize) {
+      return;
+    }
+
+    const result = normalize({
+      cfg: {
+        channels: {
+          zalouser: {
+            groups: {
+              "group:trusted": {
+                allow: true,
+              },
+            },
+            accounts: {
+              work: {
+                groups: {
+                  "group:legacy": {
+                    allow: false,
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as never,
+    });
+
+    expect(result.config.channels?.zalouser?.groups?.["group:trusted"]).toEqual({
+      enabled: true,
+    });
+    expect(result.config.channels?.zalouser?.accounts?.work?.groups?.["group:legacy"]).toEqual({
+      enabled: false,
+    });
+    expect(result.changes).toEqual(
+      expect.arrayContaining([
+        "Moved channels.zalouser.groups.group:trusted.allow → channels.zalouser.groups.group:trusted.enabled (true).",
+        "Moved channels.zalouser.accounts.work.groups.group:legacy.allow → channels.zalouser.accounts.work.groups.group:legacy.enabled (false).",
+      ]),
+    );
+  });
+});

--- a/extensions/zalouser/src/doctor.ts
+++ b/extensions/zalouser/src/doctor.ts
@@ -1,4 +1,8 @@
-import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
+import type {
+  ChannelDoctorAdapter,
+  ChannelDoctorConfigMutation,
+  ChannelDoctorLegacyConfigRule,
+} from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { collectProviderDangerousNameMatchingScopes } from "openclaw/plugin-sdk/runtime";
 import { isZalouserMutableGroupEntry } from "./security-audit.js";
@@ -12,6 +16,143 @@ function asObjectRecord(value: unknown): Record<string, unknown> | null {
 function sanitizeForLog(value: string): string {
   return value.replace(/[\u0000-\u001f\u007f]+/g, " ").trim();
 }
+
+function hasLegacyZalouserGroupAllowAlias(value: unknown): boolean {
+  const group = asObjectRecord(value);
+  return Boolean(group && typeof group.allow === "boolean");
+}
+
+function hasLegacyZalouserGroupAllowAliases(value: unknown): boolean {
+  const groups = asObjectRecord(value);
+  return Boolean(
+    groups && Object.values(groups).some((group) => hasLegacyZalouserGroupAllowAlias(group)),
+  );
+}
+
+function hasLegacyZalouserAccountGroupAllowAliases(value: unknown): boolean {
+  const accounts = asObjectRecord(value);
+  if (!accounts) {
+    return false;
+  }
+  return Object.values(accounts).some((account) => {
+    const accountRecord = asObjectRecord(account);
+    return Boolean(accountRecord && hasLegacyZalouserGroupAllowAliases(accountRecord.groups));
+  });
+}
+
+function normalizeZalouserGroupAllowAliases(params: {
+  groups: Record<string, unknown>;
+  pathPrefix: string;
+  changes: string[];
+}): { groups: Record<string, unknown>; changed: boolean } {
+  let changed = false;
+  const nextGroups: Record<string, unknown> = { ...params.groups };
+  for (const [groupId, groupValue] of Object.entries(params.groups)) {
+    const group = asObjectRecord(groupValue);
+    if (!group || typeof group.allow !== "boolean") {
+      continue;
+    }
+    const nextGroup = { ...group };
+    if (typeof nextGroup.enabled !== "boolean") {
+      nextGroup.enabled = group.allow;
+    }
+    delete nextGroup.allow;
+    nextGroups[groupId] = nextGroup;
+    changed = true;
+    params.changes.push(
+      `Moved ${params.pathPrefix}.${groupId}.allow → ${params.pathPrefix}.${groupId}.enabled (${String(nextGroup.enabled)}).`,
+    );
+  }
+  return { groups: nextGroups, changed };
+}
+
+function normalizeZalouserCompatibilityConfig(cfg: OpenClawConfig): ChannelDoctorConfigMutation {
+  const channels = asObjectRecord(cfg.channels);
+  const zalouser = asObjectRecord(channels?.zalouser);
+  if (!zalouser) {
+    return { config: cfg, changes: [] };
+  }
+
+  const changes: string[] = [];
+  let updatedZalouser: Record<string, unknown> = zalouser;
+  let changed = false;
+
+  const groups = asObjectRecord(updatedZalouser.groups);
+  if (groups) {
+    const normalized = normalizeZalouserGroupAllowAliases({
+      groups,
+      pathPrefix: "channels.zalouser.groups",
+      changes,
+    });
+    if (normalized.changed) {
+      updatedZalouser = { ...updatedZalouser, groups: normalized.groups };
+      changed = true;
+    }
+  }
+
+  const accounts = asObjectRecord(updatedZalouser.accounts);
+  if (accounts) {
+    let accountsChanged = false;
+    const nextAccounts: Record<string, unknown> = { ...accounts };
+    for (const [accountId, accountValue] of Object.entries(accounts)) {
+      const account = asObjectRecord(accountValue);
+      if (!account) {
+        continue;
+      }
+      const accountGroups = asObjectRecord(account.groups);
+      if (!accountGroups) {
+        continue;
+      }
+      const normalized = normalizeZalouserGroupAllowAliases({
+        groups: accountGroups,
+        pathPrefix: `channels.zalouser.accounts.${accountId}.groups`,
+        changes,
+      });
+      if (!normalized.changed) {
+        continue;
+      }
+      nextAccounts[accountId] = {
+        ...account,
+        groups: normalized.groups,
+      };
+      accountsChanged = true;
+    }
+    if (accountsChanged) {
+      updatedZalouser = { ...updatedZalouser, accounts: nextAccounts };
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    return { config: cfg, changes: [] };
+  }
+
+  return {
+    config: {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        zalouser: updatedZalouser as OpenClawConfig["channels"]["zalouser"],
+      },
+    },
+    changes,
+  };
+}
+
+const ZALOUSER_LEGACY_CONFIG_RULES: ChannelDoctorLegacyConfigRule[] = [
+  {
+    path: ["channels", "zalouser", "groups"],
+    message:
+      "channels.zalouser.groups.<id>.allow is legacy; use channels.zalouser.groups.<id>.enabled instead (auto-migrated on load).",
+    match: hasLegacyZalouserGroupAllowAliases,
+  },
+  {
+    path: ["channels", "zalouser", "accounts"],
+    message:
+      "channels.zalouser.accounts.<id>.groups.<id>.allow is legacy; use channels.zalouser.accounts.<id>.groups.<id>.enabled instead (auto-migrated on load).",
+    match: hasLegacyZalouserAccountGroupAllowAliases,
+  },
+];
 
 export function collectZalouserMutableAllowlistWarnings(cfg: OpenClawConfig): string[] {
   const hits: Array<{ path: string; entry: string }> = [];
@@ -53,5 +194,7 @@ export const zalouserDoctor: ChannelDoctorAdapter = {
   groupModel: "hybrid",
   groupAllowFromFallbackToAllowFrom: false,
   warnOnEmptyGroupSenderAllowlist: false,
+  legacyConfigRules: ZALOUSER_LEGACY_CONFIG_RULES,
+  normalizeCompatibilityConfig: ({ cfg }) => normalizeZalouserCompatibilityConfig(cfg),
   collectMutableAllowlistWarnings: ({ cfg }) => collectZalouserMutableAllowlistWarnings(cfg),
 };

--- a/extensions/zalouser/src/group-policy.test.ts
+++ b/extensions/zalouser/src/group-policy.test.ts
@@ -37,7 +37,7 @@ describe("zalouser group policy helpers", () => {
 
   it("finds the first matching group entry", () => {
     const groups = {
-      "group:123": { allow: true },
+      "group:123": { enabled: true },
       "team-alpha": { requireMention: false },
       "*": { requireMention: true },
     };
@@ -49,12 +49,12 @@ describe("zalouser group policy helpers", () => {
         includeGroupIdAlias: true,
       }),
     );
-    expect(entry).toEqual({ allow: true });
+    expect(entry).toEqual({ enabled: true });
   });
 
   it("evaluates allow/enable flags", () => {
-    expect(isZalouserGroupEntryAllowed({ allow: true, enabled: true })).toBe(true);
-    expect(isZalouserGroupEntryAllowed({ allow: false })).toBe(false);
+    expect(isZalouserGroupEntryAllowed({ enabled: true })).toBe(true);
+    expect(isZalouserGroupEntryAllowed({ allow: false } as never)).toBe(false);
     expect(isZalouserGroupEntryAllowed({ enabled: false })).toBe(false);
     expect(isZalouserGroupEntryAllowed(undefined)).toBe(false);
   });

--- a/extensions/zalouser/src/group-policy.ts
+++ b/extensions/zalouser/src/group-policy.ts
@@ -77,5 +77,6 @@ export function isZalouserGroupEntryAllowed(entry: ZalouserGroupConfig | undefin
   if (!entry) {
     return false;
   }
-  return entry.allow !== false && entry.enabled !== false;
+  const legacyAllow = (entry as ZalouserGroupConfig & { allow?: unknown }).allow;
+  return legacyAllow !== false && entry.enabled !== false;
 }

--- a/extensions/zalouser/src/monitor.group-gating.test.ts
+++ b/extensions/zalouser/src/monitor.group-gating.test.ts
@@ -348,8 +348,8 @@ describe("zalouser monitor group mention gating", () => {
           groupPolicy: "allowlist",
           groupAllowFrom: ["*"],
           groups: {
-            "group:g-trusted-001": { allow: true },
-            "Trusted Team": { allow: true },
+            "group:g-trusted-001": { enabled: true },
+            "Trusted Team": { enabled: true },
           },
         },
       },
@@ -525,7 +525,7 @@ describe("zalouser monitor group mention gating", () => {
           groupPolicy: "allowlist",
           allowFrom: ["123"],
           groups: {
-            "group:g-1": { allow: true, requireMention: true },
+            "group:g-1": { enabled: true, requireMention: true },
           },
         },
       },

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -204,7 +204,7 @@ function isSenderAllowed(senderId: string | undefined, allowFrom: string[]): boo
 function resolveGroupRequireMention(params: {
   groupId: string;
   groupName?: string | null;
-  groups: Record<string, { allow?: boolean; enabled?: boolean; requireMention?: boolean }>;
+  groups: Record<string, { enabled?: boolean; requireMention?: boolean }>;
   allowNameMatching?: boolean;
 }): boolean {
   const entry = findZalouserGroupEntry(

--- a/extensions/zalouser/src/setup-surface.test.ts
+++ b/extensions/zalouser/src/setup-surface.test.ts
@@ -160,6 +160,23 @@ describe("zalouser setup wizard", () => {
     ).toBe(true);
   });
 
+  it("writes canonical enabled entries for configured groups", async () => {
+    const prompter = createQuickstartPrompter({
+      groupAccess: true,
+      groupPolicy: "allowlist",
+      textByMessage: {
+        "Zalo groups allowlist (comma-separated)": "Family, Work",
+      },
+    });
+
+    const result = await runSetup({ prompter });
+
+    expect(result.cfg.channels?.zalouser?.groups).toEqual({
+      Family: { enabled: true, requireMention: true },
+      Work: { enabled: true, requireMention: true },
+    });
+  });
+
   it("preserves non-quickstart forceAllowFrom behavior", async () => {
     const note = vi.fn(async (_message: string, _title?: string) => {});
     const seen: string[] = [];

--- a/extensions/zalouser/src/setup-surface.ts
+++ b/extensions/zalouser/src/setup-surface.ts
@@ -94,7 +94,7 @@ function setZalouserGroupAllowlist(
   groupKeys: string[],
 ): OpenClawConfig {
   const groups = Object.fromEntries(
-    groupKeys.map((key) => [key, { allow: true, requireMention: true }]),
+    groupKeys.map((key) => [key, { enabled: true, requireMention: true }]),
   );
   return setZalouserAccountScopedConfig(cfg, accountId, {
     groups,

--- a/extensions/zalouser/src/types.ts
+++ b/extensions/zalouser/src/types.ts
@@ -88,7 +88,6 @@ export type ZaloAuthStatus = {
 export type ZalouserToolConfig = { allow?: string[]; deny?: string[] };
 
 export type ZalouserGroupConfig = {
-  allow?: boolean;
   enabled?: boolean;
   requireMention?: boolean;
   tools?: ZalouserToolConfig;

--- a/src/channels/plugins/contract-surfaces.test.ts
+++ b/src/channels/plugins/contract-surfaces.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getBundledChannelContractSurfaceModule } from "./contract-surfaces.js";
+
+describe("bundled channel contract surfaces", () => {
+  it("resolves Telegram contract surfaces from a source checkout", () => {
+    const surface = getBundledChannelContractSurfaceModule<{
+      normalizeTelegramCommandName?: (value: string) => string;
+    }>({
+      pluginId: "telegram",
+      preferredBasename: "contract-surfaces.ts",
+    });
+
+    expect(surface).not.toBeNull();
+    expect(surface?.normalizeTelegramCommandName?.("/Hello-World")).toBe("hello_world");
+  });
+});

--- a/src/channels/plugins/contract-surfaces.ts
+++ b/src/channels/plugins/contract-surfaces.ts
@@ -61,6 +61,16 @@ function createModuleLoader() {
 
 const loadModule = createModuleLoader();
 
+function getContractSurfaceDiscoveryEnv(): NodeJS.ProcessEnv {
+  if (RUNNING_FROM_BUILT_ARTIFACT) {
+    return process.env;
+  }
+  return {
+    ...process.env,
+    VITEST: process.env.VITEST || "1",
+  };
+}
+
 function matchesPreferredBasename(
   basename: ContractSurfaceBasename,
   preferredBasename: ContractSurfaceBasename | undefined,
@@ -153,9 +163,11 @@ function loadBundledChannelContractSurfaceEntries(): Array<{
   pluginId: string;
   surface: unknown;
 }> {
-  const discovery = discoverOpenClawPlugins({ cache: false });
+  const env = getContractSurfaceDiscoveryEnv();
+  const discovery = discoverOpenClawPlugins({ cache: false, env });
   const manifestRegistry = loadPluginManifestRegistry({
     cache: false,
+    env,
     config: {},
     candidates: discovery.candidates,
     diagnostics: discovery.diagnostics,
@@ -204,9 +216,11 @@ export function getBundledChannelContractSurfaceModule<T = unknown>(params: {
   if (cachedPreferredSurfaceModules.has(cacheKey)) {
     return (cachedPreferredSurfaceModules.get(cacheKey) ?? null) as T | null;
   }
-  const discovery = discoverOpenClawPlugins({ cache: false });
+  const env = getContractSurfaceDiscoveryEnv();
+  const discovery = discoverOpenClawPlugins({ cache: false, env });
   const manifestRegistry = loadPluginManifestRegistry({
     cache: false,
+    env,
     config: {},
     candidates: discovery.candidates,
     diagnostics: discovery.diagnostics,

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -15318,9 +15318,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           additionalProperties: {
             type: "object",
             properties: {
-              allow: {
-                type: "boolean",
-              },
               enabled: {
                 type: "boolean",
               },
@@ -15435,9 +15432,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                 additionalProperties: {
                   type: "object",
                   properties: {
-                    allow: {
-                      type: "boolean",
-                    },
                     enabled: {
                       type: "boolean",
                     },

--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -558,7 +558,7 @@ describe("legacy migrate nested channel enabled aliases", () => {
     });
   });
 
-  it("moves legacy allow toggles into enabled for slack, googlechat, discord, and matrix", () => {
+  it("moves legacy allow toggles into enabled for slack, googlechat, discord, matrix, and zalouser", () => {
     const res = migrateLegacyConfig({
       channels: {
         slack: {
@@ -633,6 +633,22 @@ describe("legacy migrate nested channel enabled aliases", () => {
             },
           },
         },
+        zalouser: {
+          groups: {
+            "group:trusted": {
+              allow: false,
+            },
+          },
+          accounts: {
+            work: {
+              groups: {
+                "group:legacy": {
+                  allow: true,
+                },
+              },
+            },
+          },
+        },
       },
     });
 
@@ -660,6 +676,12 @@ describe("legacy migrate nested channel enabled aliases", () => {
     expect(res.changes).toContain(
       "Moved channels.matrix.accounts.work.rooms.!legacy:example.org.allow → channels.matrix.accounts.work.rooms.!legacy:example.org.enabled (true).",
     );
+    expect(res.changes).toContain(
+      "Moved channels.zalouser.groups.group:trusted.allow → channels.zalouser.groups.group:trusted.enabled (false).",
+    );
+    expect(res.changes).toContain(
+      "Moved channels.zalouser.accounts.work.groups.group:legacy.allow → channels.zalouser.accounts.work.groups.group:legacy.enabled (true).",
+    );
     expect(res.config?.channels?.slack?.channels?.ops).toEqual({
       enabled: false,
     });
@@ -673,6 +695,12 @@ describe("legacy migrate nested channel enabled aliases", () => {
       enabled: false,
     });
     expect(res.config?.channels?.matrix?.accounts?.work?.rooms?.["!legacy:example.org"]).toEqual({
+      enabled: true,
+    });
+    expect(res.config?.channels?.zalouser?.groups?.["group:trusted"]).toEqual({
+      enabled: false,
+    });
+    expect(res.config?.channels?.zalouser?.accounts?.work?.groups?.["group:legacy"]).toEqual({
       enabled: true,
     });
   });


### PR DESCRIPTION
## Summary

- Problem: Zalo Personal still exposed legacy `groups.*.allow` booleans after the rest of the channel config surface had moved to canonical `enabled`.
- Why it matters: users still saw two public toggle shapes, setup wrote the old alias, and config migration/generation work was blocked by bundled channel contract-surface discovery preferring stale built artifacts over the source checkout.
- What changed: Zalo Personal now exposes `enabled` as the public group toggle, setup writes `enabled`, runtime/doctor still normalize legacy `allow`, and the bundled channel contract-surface loader now resolves source-checkout surfaces correctly for generators and config helpers.
- What did NOT change (scope boundary): this does not remove raw-config compatibility for existing Zalo Personal configs, and it does not broaden into other remaining alias families.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #60690
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Zalo Personal plugin never got the same phase-2 `allow -> enabled` public-contract cleanup that core channels and Matrix already received.
- Missing detection / guardrail: Zalo Personal had no legacy doctor rules or compatibility normalizer for `groups.*.allow`, and the generic bundled contract-surface loader preferred stale built plugin trees when running from a source checkout.
- Contributing context (if known): bundled channel source tools (`config:channels`, Telegram command config helpers) were discovering bundled plugin contract surfaces from `dist/extensions` instead of the source `extensions` tree unless `VITEST` happened to be set.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/channels/plugins/contract-surfaces.test.ts`
  - `extensions/zalouser/src/doctor.test.ts`
  - `src/config/legacy-migrate.test.ts`
- Scenario the test should lock in: source-checkout contract-surface resolution continues to find Telegram, and Zalo Personal legacy `groups.*.allow` stays loadable while the public contract only exposes `enabled`.
- Why this is the smallest reliable guardrail: the break spans source discovery, generated channel metadata, plugin doctor normalization, and public config-schema generation.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `channels.zalouser.groups.*.allow` and `channels.zalouser.accounts.*.groups.*.allow` are no longer public config keys.
- Zalo Personal onboarding/setup now writes `enabled` for group allowlists.
- Existing `allow` configs still normalize through migration/doctor compatibility.

## Diagram (if applicable)

```text
Before:
Zalo Personal setup/config -> writes group.allow -> legacy alias stays public

After:
Zalo Personal setup/config -> writes group.enabled -> doctor/runtime normalize old allow -> one public toggle
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Codex worktree
- Model/provider: N/A
- Integration/channel (if any): Zalo Personal, bundled channel contract surfaces
- Relevant config (redacted): `channels.zalouser.groups`, `channels.zalouser.accounts.*.groups`

### Steps

1. Keep a source checkout with bundled channel plugins under `extensions/*`.
2. Define legacy Zalo Personal group entries with `allow`.
3. Run config generators and legacy migration/doctor paths.

### Expected

- Source checkout loaders resolve bundled channel contract surfaces correctly.
- Zalo Personal public schema/baselines expose `enabled`, not `allow`.
- Legacy `allow` entries still normalize on load.

### Actual

- Matches expected locally for generator + drift + lint verification.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm exec oxlint src/channels/plugins/contract-surfaces.ts src/channels/plugins/contract-surfaces.test.ts extensions/zalouser/src/types.ts extensions/zalouser/src/config-schema.ts extensions/zalouser/src/group-policy.ts extensions/zalouser/src/group-policy.test.ts extensions/zalouser/src/monitor.ts extensions/zalouser/src/monitor.group-gating.test.ts extensions/zalouser/src/setup-surface.ts extensions/zalouser/src/setup-surface.test.ts extensions/zalouser/src/doctor.ts extensions/zalouser/src/doctor.test.ts src/config/legacy-migrate.test.ts`
  - `pnpm config:channels:gen`
  - `pnpm config:docs:gen`
  - `pnpm config:docs:check`
  - direct loader sanity: `getBundledChannelContractSurfaceModule({ pluginId: "telegram" })` now resolves from source checkout
- Edge cases checked:
  - top-level and account-scoped Zalo Personal group aliases
  - setup wizard writes canonical `enabled`
  - source-checkout contract-surface resolution for Telegram command config helpers
- What you did **not** verify:
  - local Vitest completion in this worktree remains unreliable for some lanes, so I did not claim a broader green wrapper-test run than what actually finished cleanly
  - I did not run repo-wide `pnpm test` / `pnpm build`

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: source-checkout contract-surface discovery now forces source-preferred bundled discovery when running outside built artifacts.
  - Mitigation: the override is scoped to `src/channels/plugins/contract-surfaces.ts`; built/runtime artifacts still use normal environment-driven discovery.
- Risk: local Vitest wrapper behavior is still noisy in this worktree.
  - Mitigation: I added direct guardrail tests and verified the generated metadata/baseline outputs instead of overstating local test coverage.
