### PR TITLE
fix(acp): treat missing cwd as stale bound session

### DIFF
--- a/src/acp/persistent-bindings.lifecycle.test.ts
+++ b/src/acp/persistent-bindings.lifecycle.test.ts
@@ -15,6 +15,10 @@ const resolveMocks = vi.hoisted(() => ({
   resolveConfiguredAcpBindingSpecBySessionKey: vi.fn(),
 }));
 
+const bindingServiceMocks = vi.hoisted(() => ({
+  unbind: vi.fn(),
+}));
+
 vi.mock("./control-plane/manager.js", () => ({
   getAcpSessionManager: () => ({
     closeSession: managerMocks.closeSession,
@@ -30,6 +34,12 @@ vi.mock("./runtime/session-meta.js", () => ({
 vi.mock("./persistent-bindings.resolve.js", () => ({
   resolveConfiguredAcpBindingSpecBySessionKey:
     resolveMocks.resolveConfiguredAcpBindingSpecBySessionKey,
+}));
+
+vi.mock("../infra/outbound/session-binding-service.js", () => ({
+  getSessionBindingService: () => ({
+    unbind: (input: unknown) => bindingServiceMocks.unbind(input),
+  }),
 }));
 const baseCfg = {
   session: { mainKey: "main", scope: "per-sender" },
@@ -53,6 +63,7 @@ beforeEach(() => {
   managerMocks.updateSessionRuntimeOptions.mockReset().mockResolvedValue(undefined);
   sessionMetaMocks.readAcpSessionEntry.mockReset().mockReturnValue(undefined);
   resolveMocks.resolveConfiguredAcpBindingSpecBySessionKey.mockReset().mockReturnValue(null);
+  bindingServiceMocks.unbind.mockReset().mockResolvedValue([]);
 });
 
 describe("resetAcpSessionInPlace", () => {
@@ -91,5 +102,68 @@ describe("resetAcpSessionInPlace", () => {
         backendId: "acpx",
       }),
     );
+  });
+
+  it("unbinds stale bindings and returns skipped when the ACP cwd is gone", async () => {
+    const sessionKey = "agent:claude:acp:binding:demo-binding:default:stale";
+    sessionMetaMocks.readAcpSessionEntry.mockReturnValue({
+      acp: {
+        agent: "claude",
+        mode: "persistent",
+        backend: "acpx",
+        runtimeOptions: { cwd: "/tmp/opik-runtime-pr2" },
+      },
+    });
+    managerMocks.initializeSession.mockRejectedValueOnce(
+      new Error("ACP runtime working directory does not exist: /tmp/opik-runtime-pr2"),
+    );
+
+    const result = await resetAcpSessionInPlace({
+      cfg: baseCfg,
+      sessionKey,
+      reason: "new",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      skipped: true,
+      error: "ACP runtime working directory does not exist: /tmp/opik-runtime-pr2",
+    });
+    expect(bindingServiceMocks.unbind).toHaveBeenCalledWith({
+      targetSessionKey: sessionKey,
+      reason: "acp-session-init-failed",
+    });
+  });
+
+  it("still returns skipped when stale-binding cleanup fails", async () => {
+    const sessionKey = "agent:claude:acp:binding:demo-binding:default:stale";
+    sessionMetaMocks.readAcpSessionEntry.mockReturnValue({
+      acp: {
+        agent: "claude",
+        mode: "persistent",
+        backend: "acpx",
+        runtimeOptions: { cwd: "/tmp/opik-runtime-pr2" },
+      },
+    });
+    managerMocks.initializeSession.mockRejectedValueOnce(
+      new Error("ACP runtime working directory does not exist: /tmp/opik-runtime-pr2"),
+    );
+    bindingServiceMocks.unbind.mockRejectedValueOnce(new Error("unbind failed"));
+
+    const result = await resetAcpSessionInPlace({
+      cfg: baseCfg,
+      sessionKey,
+      reason: "new",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      skipped: true,
+      error: "ACP runtime working directory does not exist: /tmp/opik-runtime-pr2",
+    });
+    expect(bindingServiceMocks.unbind).toHaveBeenCalledWith({
+      targetSessionKey: sessionKey,
+      reason: "acp-session-init-failed",
+    });
   });
 });

--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionAcpMeta } from "../config/sessions/types.js";
 import { logVerbose } from "../globals.js";
+import { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
 import { getAcpSessionManager } from "./control-plane/manager.js";
 import { resolveAcpAgentFromSessionKey } from "./control-plane/manager.utils.js";
 import { resolveConfiguredAcpBindingSpecBySessionKey } from "./persistent-bindings.resolve.js";
@@ -10,7 +11,9 @@ import {
   type ConfiguredAcpBindingSpec,
   type ResolvedConfiguredAcpBinding,
 } from "./persistent-bindings.types.js";
+import { toAcpRuntimeError } from "./runtime/errors.js";
 import { readAcpSessionEntry } from "./runtime/session-meta.js";
+import { isAcpStaleSessionError } from "./runtime/stale-session.js";
 
 function sessionMatchesConfiguredBinding(params: {
   cfg: OpenClawConfig;
@@ -212,7 +215,32 @@ export async function resetAcpSessionInPlace(params: {
     }
     return { ok: true };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const acpError = toAcpRuntimeError({
+      error,
+      fallbackCode: "ACP_SESSION_INIT_FAILED",
+      fallbackMessage: "ACP session reset failed.",
+    });
+    const message = acpError.message;
+    if (isAcpStaleSessionError({ code: acpError.code, message })) {
+      try {
+        const removedBindings = await getSessionBindingService().unbind({
+          targetSessionKey: sessionKey,
+          reason: "acp-session-init-failed",
+        });
+        logVerbose(
+          `acp-configured-binding: removed ${removedBindings.length} stale binding(s) for ${sessionKey} after reset failure: ${message}`,
+        );
+      } catch (unbindError) {
+        logVerbose(
+          `acp-configured-binding: failed to unbind stale bindings for ${sessionKey}: ${unbindError instanceof Error ? unbindError.message : String(unbindError)}`,
+        );
+      }
+      return {
+        ok: false,
+        skipped: true,
+        error: message,
+      };
+    }
     logVerbose(`acp-configured-binding: failed reset for ${sessionKey}: ${message}`);
     return {
       ok: false,

--- a/src/acp/runtime/stale-session.ts
+++ b/src/acp/runtime/stale-session.ts
@@ -2,8 +2,11 @@ const STALE_ACP_SESSION_MESSAGE_RE =
   /(ACP (session )?metadata is missing|missing ACP metadata|Session is not ACP-enabled|Resource not found|working directory does not exist)/i;
 
 export function isAcpStaleSessionError(params: { code: string; message: string }): boolean {
+  if (params.code !== "ACP_SESSION_INIT_FAILED") {
+    return false;
+  }
   if (!STALE_ACP_SESSION_MESSAGE_RE.test(params.message)) {
     return false;
   }
-  return params.code === "ACP_SESSION_INIT_FAILED" || params.code === "ACP_TURN_FAILED";
+  return true;
 }

--- a/src/acp/runtime/stale-session.ts
+++ b/src/acp/runtime/stale-session.ts
@@ -1,0 +1,9 @@
+const STALE_ACP_SESSION_MESSAGE_RE =
+  /(ACP (session )?metadata is missing|missing ACP metadata|Session is not ACP-enabled|Resource not found|working directory does not exist)/i;
+
+export function isAcpStaleSessionError(params: { code: string; message: string }): boolean {
+  if (!STALE_ACP_SESSION_MESSAGE_RE.test(params.message)) {
+    return false;
+  }
+  return params.code === "ACP_SESSION_INIT_FAILED" || params.code === "ACP_TURN_FAILED";
+}

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -737,6 +737,56 @@ describe("tryDispatchAcpReply", () => {
     );
   });
 
+  it("unbinds stale bindings on ACP runTurn missing-cwd failures", async () => {
+    const aliasSessionKey = "main";
+    const canonicalSessionKey = "agent:main:main";
+    managerMocks.resolveSession.mockReturnValue({
+      kind: "ready",
+      sessionKey: canonicalSessionKey,
+      meta: createAcpSessionMeta(),
+    });
+    const { AcpRuntimeError: FreshAcpRuntimeError } = await import("../../acp/runtime/errors.js");
+    managerMocks.runTurn.mockRejectedValueOnce(
+      new FreshAcpRuntimeError(
+        "ACP_SESSION_INIT_FAILED",
+        "ACP runtime working directory does not exist: /tmp/opik-runtime-pr2",
+      ),
+    );
+    bindingServiceMocks.unbind.mockResolvedValueOnce([
+      {
+        bindingId: "telegram:default:topic-1",
+        targetSessionKey: canonicalSessionKey,
+        targetKind: "session",
+        conversation: {
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "-1003817967251:topic:11345",
+        },
+        status: "active",
+        boundAt: 0,
+      },
+    ]);
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "test",
+      dispatcher,
+      sessionKeyOverride: aliasSessionKey,
+    });
+
+    expect(bindingServiceMocks.unbind).toHaveBeenCalledTimes(1);
+    expect(bindingServiceMocks.unbind).toHaveBeenCalledWith({
+      targetSessionKey: canonicalSessionKey,
+      reason: "acp-session-init-failed",
+    });
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isError: true,
+        text: expect.stringContaining("working directory does not exist"),
+      }),
+    );
+  });
+
   it("uses canonical session keys for bound-session identity notices", async () => {
     const aliasSessionKey = "main";
     const canonicalSessionKey = "agent:main:main";

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -737,6 +737,35 @@ describe("tryDispatchAcpReply", () => {
     );
   });
 
+  it("does not unbind valid bindings on ACP turn-time resource errors", async () => {
+    const aliasSessionKey = "main";
+    const canonicalSessionKey = "agent:main:main";
+    managerMocks.resolveSession.mockReturnValue({
+      kind: "ready",
+      sessionKey: canonicalSessionKey,
+      meta: createAcpSessionMeta(),
+    });
+    const { AcpRuntimeError: FreshAcpRuntimeError } = await import("../../acp/runtime/errors.js");
+    managerMocks.runTurn.mockRejectedValueOnce(
+      new FreshAcpRuntimeError("ACP_TURN_FAILED", "Resource not found: tool output artifact"),
+    );
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "test",
+      dispatcher,
+      sessionKeyOverride: aliasSessionKey,
+    });
+
+    expect(bindingServiceMocks.unbind).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isError: true,
+        text: expect.stringContaining("Resource not found: tool output artifact"),
+      }),
+    );
+  });
+
   it("unbinds stale bindings on ACP runTurn missing-cwd failures", async () => {
     const aliasSessionKey = "main";
     const canonicalSessionKey = "agent:main:main";

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -9,6 +9,7 @@ import {
   resolveSessionIdentityFromMeta,
 } from "../../acp/runtime/session-identity.js";
 import { readAcpSessionEntry } from "../../acp/runtime/session-meta.js";
+import { isAcpStaleSessionError } from "../../acp/runtime/stale-session.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
@@ -232,12 +233,7 @@ export type AcpDispatchAttemptResult = {
 const ACP_STALE_BINDING_UNBIND_REASON = "acp-session-init-failed";
 
 function isStaleSessionInitError(params: { code: string; message: string }): boolean {
-  if (params.code !== "ACP_SESSION_INIT_FAILED") {
-    return false;
-  }
-  return /(ACP (session )?metadata is missing|missing ACP metadata|Session is not ACP-enabled|Resource not found)/i.test(
-    params.message,
-  );
+  return isAcpStaleSessionError(params);
 }
 
 async function maybeUnbindStaleBoundConversations(params: {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -232,15 +232,11 @@ export type AcpDispatchAttemptResult = {
 
 const ACP_STALE_BINDING_UNBIND_REASON = "acp-session-init-failed";
 
-function isStaleSessionInitError(params: { code: string; message: string }): boolean {
-  return isAcpStaleSessionError(params);
-}
-
 async function maybeUnbindStaleBoundConversations(params: {
   targetSessionKey: string;
   error: { code: string; message: string };
 }): Promise<void> {
-  if (!isStaleSessionInitError(params.error)) {
+  if (!isAcpStaleSessionError(params.error)) {
     return;
   }
   try {


### PR DESCRIPTION
## Summary

- Problem: topic-bound ACP sessions could stay bound to a deleted runtime working directory like `/tmp/opik-runtime-pr2`, causing repeated `ACP_SESSION_INIT_FAILED` errors instead of recovering.
- Why it matters: the bound conversation stayed wedged on a dead ACP session, so normal replies, `/new`, and `/reset` could keep failing even after a replacement session existed.
- What changed: classify missing-`cwd` ACP init failures as stale-session errors, unbind stale conversation bindings on dispatch failures, and apply the same stale cleanup on in-place reset failures.
- What did NOT change (scope boundary): no ACP protocol/backend changes, no new commands, no changes to non-stale ACP failures.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #60420
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: stale-session cleanup recognized missing metadata/resource-not-found cases, but did not treat `ACP runtime working directory does not exist` as a stale ACP session.
- Missing detection / guardrail: the stale-session classifier did not include the deleted-working-directory failure mode, and reset-path cleanup did not unbind stale bindings after init failure.
- Prior context (`git blame`, prior PR, issue, or refactor if known): related stale-binding cleanup already exists in dispatch flows and `#60420` appears to tighten adjacent dispatch cleanup, but the missing-`cwd` case and reset path were still uncovered.
- Why this regressed now: ACP workspaces were moved out of `/tmp`, leaving old topic bindings pointing at deleted runtime directories.
- If unknown, what was ruled out: ruled out generic ACP runtime breakage; the failure reproduced specifically when the bound session's configured `cwd` no longer existed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/dispatch-acp.test.ts`, `src/acp/persistent-bindings.lifecycle.test.ts`
- Scenario the test should lock in: missing-`cwd` ACP init failures are treated as stale sessions, stale bindings are unbound, and `/new` / `/reset` return the skipped/rebind path instead of staying wedged.
- Why this is the smallest reliable guardrail: both affected code paths are pure session/binding orchestration logic and can be reproduced deterministically with mocked ACP manager failures.
- Existing test that already covers this (if any): stale missing-metadata dispatch cleanup already had nearby coverage.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Bound conversations that point at deleted ACP working directories now drop the stale binding instead of repeatedly targeting the dead session.
- `/new` and `/reset` stop staying wedged on missing-`cwd` ACP sessions and fall back to the normal rebind path.

## Diagram (if applicable)

```text
Before:
[bound topic] -> [ACP session with deleted cwd] -> [init failed] -> [binding stays] -> [repeated failures]

After:
[bound topic] -> [ACP session with deleted cwd] -> [init failed] -> [stale binding removed] -> [rebind path]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: NixOS
- Runtime/container: local OpenClaw checkout
- Model/provider: N/A
- Integration/channel (if any): ACP / Telegram-bound conversation routing
- Relevant config (redacted): ACP persistent session bound to a session key whose runtime `cwd` no longer exists

### Steps

1. Bind a conversation to an ACP session whose runtime options point at a working directory that no longer exists.
2. Send a normal message or trigger `/new` / `/reset` for that bound session.
3. Observe ACP init failure handling.

### Expected

- Missing-`cwd` init failure is treated as stale, the stale binding is removed, and the conversation can be rebound.

### Actual

- Before this patch, the stale binding remained attached to the dead ACP session and failures repeated.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: built the branch, ran the new lifecycle stale-binding tests directly, and ran the dispatch missing-`cwd` regression test directly in the main checkout against the same patch.
- Edge cases checked: stale cleanup still returns skipped when unbind itself fails; generic non-stale ACP init failures do not get reclassified.
- What you did **not** verify: full end-to-end Telegram reproduction on upstream branch; full repo `pnpm check` is currently failing on unrelated existing upstream issues.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: message-based stale-session classification could over-match an unexpected future ACP init error.
  - Mitigation: classification still requires ACP init/turn failure codes and only adds the specific missing-`cwd` phrase to the existing stale-session family.
- Risk: reset-path cleanup could mask an unbind failure.
  - Mitigation: unbind failures are logged, and the user still gets the skipped/rebind path instead of a wedged session.

## Tests

- `pnpm build`
- `pnpm exec vitest run --config vitest.config.ts --maxWorkers 1 --reporter=verbose src/acp/persistent-bindings.lifecycle.test.ts`
- `pnpm exec vitest run --config vitest.config.ts --reporter=verbose src/auto-reply/reply/dispatch-acp.test.ts -t "unbinds stale bindings on ACP runTurn missing-cwd failures"`
- `pnpm check` currently fails on unrelated existing upstream type/test issues on `upstream/main`

## AI Assistance

- Codex assisted with implementation, review follow-up, validation, and PR drafting.
