### PR TITLE
fix(plugins): exclude venv dirs and downgrade workspace manifest errors

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -28,6 +28,9 @@ const SCANNED_DIRECTORY_IGNORE_NAMES = new Set([
   "coverage",
   "dist",
   "node_modules",
+  ".venv",
+  "venv",
+  "env",
 ]);
 
 export type PluginCandidate = {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -414,8 +414,13 @@ export function loadPluginManifestRegistry(
             })
           : loadPluginManifest(candidate.rootDir, rejectHardlinks);
     if (!manifestRes.ok) {
+      // Downgrade to warn for workspace origin since workspace discovery is opportunistic
+      // (any file matching extension patterns) and a missing manifest just means it's not a plugin
+      const isWorkspaceMissingManifest =
+        candidate.origin === "workspace" &&
+        manifestRes.error.includes("plugin manifest not found");
       diagnostics.push({
-        level: "error",
+        level: isWorkspaceMissingManifest ? "warn" : "error",
         message: manifestRes.error,
         source: manifestRes.manifestPath,
       });


### PR DESCRIPTION
- Add .venv, venv, env to SCANNED_DIRECTORY_IGNORE_NAMES to skip Python virtual environments
- Downgrade "plugin manifest not found" from error to warn for workspace origin candidates, since workspace discovery is opportunistic and a missing manifest just means it's not a plugin

Fixes: https://github.com/openclaw/openclaw/issues/60686
