### PR TITLE
memory: add recent continuity snapshots

### DIFF
--- a/packages/memory-host-sdk/src/host/continuity.test.ts
+++ b/packages/memory-host-sdk/src/host/continuity.test.ts
@@ -1,0 +1,180 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildContinuityManifest,
+  formatContinuityManifest,
+  hasMaterialContinuityChange,
+  parseContinuityDocument,
+  RECENT_CONTINUITY_LATEST,
+  renderContinuitySnapshotMarkdown,
+} from "./continuity.js";
+
+const tempDirs: string[] = [];
+
+async function makeWorkspace(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-continuity-"));
+  tempDirs.push(dir);
+  await fs.mkdir(path.join(dir, "memory", "recent", "snapshots"), { recursive: true });
+  return dir;
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) {
+      continue;
+    }
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("parseContinuityDocument", () => {
+  it("parses recent snapshot frontmatter and sections", () => {
+    const content = renderContinuitySnapshotMarkdown({
+      status: "active",
+      priority: "high",
+      updatedAt: "2026-04-03T09:00:00.000Z",
+      supersedes: "memory/recent/latest.md",
+      source: "session-memory:command",
+      project: "memory-system",
+      sessionKey: "agent:main:main",
+      validUntil: "2026-04-04T09:00:00.000Z",
+      currentTask: "Implement continuity manifest",
+      currentPhase: "v1 delivery",
+      latestUserRequest: "Absorb Claude memory patterns",
+      blockers: ["Need stable parsing"],
+      nextSteps: ["Wire post-compaction context"],
+      keyArtifacts: ["src/memory/continuity.ts"],
+      conversationSummary: "The user wants a lighter but more resilient memory system.",
+    });
+
+    const parsed = parseContinuityDocument(content);
+    expect(parsed.status).toBe("active");
+    expect(parsed.priority).toBe("high");
+    expect(parsed.project).toBe("memory-system");
+    expect(parsed.currentTask).toBe("Implement continuity manifest");
+    expect(parsed.currentPhase).toBe("v1 delivery");
+    expect(parsed.latestUserRequest).toBe("Absorb Claude memory patterns");
+    expect(parsed.blockers).toEqual(["Need stable parsing"]);
+    expect(parsed.nextSteps).toEqual(["Wire post-compaction context"]);
+    expect(parsed.keyArtifacts).toEqual(["src/memory/continuity.ts"]);
+  });
+
+  it("parses legacy markdown field headers", () => {
+    const legacy = `# 当前进度说明
+
+- 项目：系统修复
+- 状态：active
+- 优先级：highest
+- 当前阶段：记忆系统迭代 v1 落地与验证
+- 当前主任务：补近场快照与恢复索引
+- 当前阻塞：还没做第二轮验证
+- 下一步：跑针对性测试
+`;
+
+    const parsed = parseContinuityDocument(legacy);
+    expect(parsed.project).toBe("系统修复");
+    expect(parsed.status).toBe("active");
+    expect(parsed.priority).toBe("highest");
+    expect(parsed.currentPhase).toBe("记忆系统迭代 v1 落地与验证");
+    expect(parsed.currentTask).toBe("补近场快照与恢复索引");
+    expect(parsed.blockers).toEqual(["还没做第二轮验证"]);
+    expect(parsed.nextSteps).toEqual(["跑针对性测试"]);
+  });
+});
+
+describe("hasMaterialContinuityChange", () => {
+  it("ignores validUntil-only changes", () => {
+    const previous = renderContinuitySnapshotMarkdown({
+      status: "active",
+      priority: "high",
+      updatedAt: "2026-04-03T09:00:00.000Z",
+      source: "session-memory:command",
+      project: "memory-system",
+      sessionKey: "agent:main:main",
+      validUntil: "2026-04-04T09:00:00.000Z",
+      currentTask: "Implement continuity manifest",
+      currentPhase: "v1 delivery",
+      latestUserRequest: "Absorb Claude memory patterns",
+      blockers: [],
+      nextSteps: ["Wire post-compaction context"],
+      keyArtifacts: [],
+    });
+
+    const next = {
+      status: "active",
+      priority: "high",
+      updatedAt: "2026-04-03T10:00:00.000Z",
+      source: "session-memory:command",
+      project: "memory-system",
+      sessionKey: "agent:main:main",
+      validUntil: "2026-04-05T09:00:00.000Z",
+      currentTask: "Implement continuity manifest",
+      currentPhase: "v1 delivery",
+      latestUserRequest: "Absorb Claude memory patterns",
+      blockers: [],
+      nextSteps: ["Wire post-compaction context"],
+      keyArtifacts: [],
+    };
+
+    expect(hasMaterialContinuityChange(previous, next)).toBe(false);
+  });
+});
+
+describe("buildContinuityManifest", () => {
+  it("sorts active recent continuity ahead of stale memory", async () => {
+    const workspace = await makeWorkspace();
+    const latestPath = path.join(workspace, RECENT_CONTINUITY_LATEST);
+    await fs.writeFile(
+      latestPath,
+      renderContinuitySnapshotMarkdown({
+        status: "active",
+        priority: "highest",
+        updatedAt: "2026-04-03T09:00:00.000Z",
+        source: "session-memory:command",
+        project: "system-repair",
+        sessionKey: "agent:main:main",
+        validUntil: "2026-04-04T09:00:00.000Z",
+        currentTask: "Ship memory iteration",
+        currentPhase: "verification",
+        latestUserRequest: "Implement the meeting plan",
+        blockers: ["Need to finish tests"],
+        nextSteps: ["Run vitest"],
+        keyArtifacts: ["memory/recent/latest.md"],
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(workspace, "memory", "active-topics.md"),
+      `# Active Topics
+
+- 状态：active
+- 优先级：high
+- updated_at：2026-04-03 15:00 CST
+- 当前主任务：记忆系统迭代与官方贡献目标
+`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(workspace, "memory", "2026-03-20.md"),
+      `# Old Daily
+
+- 状态：stale
+- 优先级：low
+- updated_at：2026-03-20 09:00 CST
+- 当前主任务：旧项目
+`,
+      "utf-8",
+    );
+
+    const manifest = await buildContinuityManifest({ workspaceDir: workspace });
+    expect(manifest[0]?.path).toBe("memory/recent/latest.md");
+    expect(manifest[1]?.path).toBe("memory/active-topics.md");
+
+    const formatted = formatContinuityManifest(manifest, 2);
+    expect(formatted).toContain("[active/highest] memory/recent/latest.md");
+    expect(formatted).toContain("[active/high] memory/active-topics.md");
+  });
+});

--- a/packages/memory-host-sdk/src/host/continuity.test.ts
+++ b/packages/memory-host-sdk/src/host/continuity.test.ts
@@ -60,6 +60,9 @@ describe("parseContinuityDocument", () => {
     expect(parsed.blockers).toEqual(["Need stable parsing"]);
     expect(parsed.nextSteps).toEqual(["Wire post-compaction context"]);
     expect(parsed.keyArtifacts).toEqual(["src/memory/continuity.ts"]);
+    expect(parsed.conversationSummary).toBe(
+      "The user wants a lighter but more resilient memory system.",
+    );
   });
 
   it("parses legacy markdown field headers", () => {

--- a/packages/memory-host-sdk/src/host/continuity.ts
+++ b/packages/memory-host-sdk/src/host/continuity.ts
@@ -1,0 +1,637 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import YAML from "yaml";
+import { parseFrontmatterBlock } from "../../../../src/markdown/frontmatter.js";
+import { listMemoryFiles } from "./internal.js";
+
+export const RECENT_CONTINUITY_DIR = "memory/recent";
+export const RECENT_CONTINUITY_LATEST = `${RECENT_CONTINUITY_DIR}/latest.md`;
+export const RECENT_CONTINUITY_SNAPSHOTS_DIR = `${RECENT_CONTINUITY_DIR}/snapshots`;
+
+export type ContinuitySnapshotState = {
+  status: string;
+  priority: string;
+  updatedAt: string;
+  supersedes?: string;
+  source: string;
+  project: string;
+  sessionKey: string;
+  validUntil: string;
+  currentTask: string;
+  currentPhase: string;
+  latestUserRequest: string;
+  blockers: string[];
+  nextSteps: string[];
+  keyArtifacts: string[];
+  conversationSummary?: string;
+};
+
+export type ParsedContinuityDocument = {
+  title?: string;
+  type?: string;
+  status?: string;
+  priority?: string;
+  updatedAt?: string;
+  supersedes?: string;
+  source?: string;
+  project?: string;
+  sessionKey?: string;
+  validUntil?: string;
+  currentTask?: string;
+  currentPhase?: string;
+  latestUserRequest?: string;
+  blockers: string[];
+  nextSteps: string[];
+  keyArtifacts: string[];
+  conversationSummary?: string;
+  summary?: string;
+};
+
+export type ContinuityManifestEntry = {
+  path: string;
+  absPath: string;
+  mtimeMs: number;
+  status?: string;
+  priority?: string;
+  updatedAt?: string;
+  supersedes?: string;
+  type?: string;
+  project?: string;
+  title?: string;
+  summary?: string;
+};
+
+const HEAD_MAX_LINES = 30;
+const HEAD_MAX_BYTES = 12_000;
+const MAX_MANIFEST_FILES = 200;
+
+const STATUS_ORDER: Record<string, number> = {
+  active: 0,
+  blocked: 1,
+  pending: 2,
+  stale: 3,
+  superseded: 4,
+  archived: 5,
+  unknown: 6,
+};
+
+const PRIORITY_ORDER: Record<string, number> = {
+  highest: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  unknown: 4,
+};
+
+const LEGACY_KEY_ALIASES: Record<string, string> = {
+  status: "status",
+  状态: "status",
+  priority: "priority",
+  优先级: "priority",
+  updated_at: "updated_at",
+  updatedat: "updated_at",
+  更新时间: "updated_at",
+  supersedes: "supersedes",
+  覆盖: "supersedes",
+  取代: "supersedes",
+  project: "project",
+  项目: "project",
+  当前项目: "project",
+  topic: "topic",
+  主题: "topic",
+  当前主任务: "current_task",
+  current_task: "current_task",
+  currenttask: "current_task",
+  当前阶段: "current_phase",
+  current_phase: "current_phase",
+  currentphase: "current_phase",
+  当前阻塞: "blockers",
+  blockers: "blockers",
+  下一步: "next_steps",
+  next_steps: "next_steps",
+  nextsteps: "next_steps",
+  关键文件: "key_artifacts",
+  关键产物: "key_artifacts",
+  key_artifacts: "key_artifacts",
+  keyartifacts: "key_artifacts",
+  description: "description",
+  目标: "description",
+  当前重点: "description",
+};
+
+function normalizeWhitespace(value: string | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function normalizeList(values: string[]): string[] {
+  return values.map((value) => normalizeWhitespace(value)).filter(Boolean);
+}
+
+function canonicalizeStatus(raw: string | undefined): string | undefined {
+  const value = normalizeWhitespace(raw).toLowerCase();
+  if (!value) {
+    return undefined;
+  }
+  switch (value) {
+    case "active":
+    case "doing":
+    case "in_progress":
+    case "in-progress":
+    case "working":
+      return "active";
+    case "blocked":
+      return "blocked";
+    case "pending":
+    case "todo":
+    case "planned":
+      return "pending";
+    case "stale":
+    case "superseded":
+    case "archived":
+      return value;
+    default:
+      return value;
+  }
+}
+
+function canonicalizePriority(raw: string | undefined): string | undefined {
+  const value = normalizeWhitespace(raw).toLowerCase();
+  if (!value) {
+    return undefined;
+  }
+  switch (value) {
+    case "p0":
+    case "highest":
+      return "highest";
+    case "p1":
+    case "high":
+      return "high";
+    case "p2":
+    case "medium":
+      return "medium";
+    case "p3":
+    case "low":
+      return "low";
+    default:
+      return value;
+  }
+}
+
+function parseTimestampMs(raw: string | undefined, fallback: number): number {
+  const value = normalizeWhitespace(raw);
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function compareByContinuityPriority(
+  left: Pick<ContinuityManifestEntry, "status" | "priority" | "updatedAt" | "mtimeMs">,
+  right: Pick<ContinuityManifestEntry, "status" | "priority" | "updatedAt" | "mtimeMs">,
+): number {
+  const leftStatus =
+    STATUS_ORDER[canonicalizeStatus(left.status) ?? "unknown"] ?? STATUS_ORDER.unknown;
+  const rightStatus =
+    STATUS_ORDER[canonicalizeStatus(right.status) ?? "unknown"] ?? STATUS_ORDER.unknown;
+  if (leftStatus !== rightStatus) {
+    return leftStatus - rightStatus;
+  }
+
+  const leftPriority =
+    PRIORITY_ORDER[canonicalizePriority(left.priority) ?? "unknown"] ?? PRIORITY_ORDER.unknown;
+  const rightPriority =
+    PRIORITY_ORDER[canonicalizePriority(right.priority) ?? "unknown"] ?? PRIORITY_ORDER.unknown;
+  if (leftPriority !== rightPriority) {
+    return leftPriority - rightPriority;
+  }
+
+  const leftTime = parseTimestampMs(left.updatedAt, left.mtimeMs);
+  const rightTime = parseTimestampMs(right.updatedAt, right.mtimeMs);
+  return rightTime - leftTime;
+}
+
+function readYamlString(map: Record<string, string>, key: string): string | undefined {
+  const value = normalizeWhitespace(map[key]);
+  return value || undefined;
+}
+
+function canonicalizeLegacyKey(label: string): string | undefined {
+  const normalized = normalizeWhitespace(label).toLowerCase().replace(/\s+/g, "_");
+  return LEGACY_KEY_ALIASES[label] ?? LEGACY_KEY_ALIASES[normalized];
+}
+
+function parseLegacyFieldHeader(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const lines = content.replace(/\r\n/g, "\n").split("\n").slice(0, HEAD_MAX_LINES);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const match =
+      trimmed.match(/^-+\s*\*\*([^*]+)\*\*\s*[：:]\s*(.+)$/) ??
+      trimmed.match(/^-+\s*([^：:]+?)\s*[：:]\s*(.+)$/) ??
+      trimmed.match(/^([A-Za-z0-9_\-\u4e00-\u9fff\s]+?)\s*[：:]\s*(.+)$/);
+    if (!match) {
+      continue;
+    }
+
+    const key = canonicalizeLegacyKey(match[1] ?? "");
+    const value = normalizeWhitespace(match[2]);
+    if (!key || !value) {
+      continue;
+    }
+    result[key] = value;
+  }
+
+  return result;
+}
+
+function extractHeading(content: string): string | undefined {
+  const lines = content.replace(/\r\n/g, "\n").split("\n");
+  for (const line of lines) {
+    const match = line.match(/^#\s+(.+?)\s*$/);
+    if (match?.[1]) {
+      return normalizeWhitespace(match[1]);
+    }
+  }
+  return undefined;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractSection(content: string, title: string): string | undefined {
+  const pattern = new RegExp(
+    `^##\\s+${escapeRegExp(title)}\\s*$([\\s\\S]*?)(?=^##\\s+|\\Z)`,
+    "gim",
+  );
+  const match = pattern.exec(content);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  return match[1].trim();
+}
+
+function sectionToList(section: string | undefined): string[] {
+  if (!section) {
+    return [];
+  }
+  const lines = section
+    .split(/\r?\n/g)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^[-*]\s*/, "").trim())
+    .filter(Boolean);
+  const normalized = normalizeList(lines);
+  if (normalized.length === 1 && normalized[0]?.toLowerCase() === "none") {
+    return [];
+  }
+  return normalized;
+}
+
+function firstOfList(section: string | undefined): string | undefined {
+  const list = sectionToList(section);
+  return list[0];
+}
+
+function stripFrontmatter(content: string): string {
+  const normalized = content.replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) {
+    return normalized;
+  }
+  const endIndex = normalized.indexOf("\n---\n", 4);
+  if (endIndex === -1) {
+    return normalized;
+  }
+  return normalized.slice(endIndex + 5);
+}
+
+function truncateText(value: string | undefined, maxChars: number): string | undefined {
+  const normalized = normalizeWhitespace(value);
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxChars - 3))}...`;
+}
+
+async function readHead(absPath: string, maxLines: number, maxBytes: number): Promise<string> {
+  const handle = await fs.open(absPath, "r");
+  try {
+    const buffer = Buffer.alloc(maxBytes);
+    const { bytesRead } = await handle.read(buffer, 0, maxBytes, 0);
+    return buffer
+      .subarray(0, bytesRead)
+      .toString("utf-8")
+      .replace(/\r\n/g, "\n")
+      .split("\n")
+      .slice(0, maxLines)
+      .join("\n");
+  } finally {
+    await handle.close();
+  }
+}
+
+function pickSummary(
+  fields: ParsedContinuityDocument,
+  legacy: Record<string, string>,
+): string | undefined {
+  return (
+    truncateText(fields.currentTask, 180) ??
+    truncateText(fields.currentPhase, 180) ??
+    truncateText(fields.latestUserRequest, 180) ??
+    truncateText(legacy.description, 180) ??
+    truncateText(legacy.topic, 180) ??
+    truncateText(fields.title, 180)
+  );
+}
+
+export function parseContinuityDocument(content: string): ParsedContinuityDocument {
+  const frontmatter = parseFrontmatterBlock(content);
+  const legacy = parseLegacyFieldHeader(stripFrontmatter(content));
+  const heading = extractHeading(stripFrontmatter(content));
+
+  const blockers =
+    sectionToList(extractSection(content, "Current Blockers")) ??
+    sectionToList(extractSection(content, "Blockers"));
+  const nextSteps =
+    sectionToList(extractSection(content, "Next Steps")) ??
+    sectionToList(extractSection(content, "Next Step"));
+  const keyArtifacts = sectionToList(extractSection(content, "Key Artifacts"));
+
+  const parsed: ParsedContinuityDocument = {
+    title: heading ?? readYamlString(frontmatter, "title"),
+    type: readYamlString(frontmatter, "type"),
+    status: canonicalizeStatus(readYamlString(frontmatter, "status") ?? legacy.status),
+    priority: canonicalizePriority(readYamlString(frontmatter, "priority") ?? legacy.priority),
+    updatedAt: readYamlString(frontmatter, "updated_at") ?? legacy.updated_at,
+    supersedes: readYamlString(frontmatter, "supersedes") ?? legacy.supersedes,
+    source: readYamlString(frontmatter, "source"),
+    project: readYamlString(frontmatter, "project") ?? legacy.project,
+    sessionKey: readYamlString(frontmatter, "session_key"),
+    validUntil: readYamlString(frontmatter, "valid_until"),
+    currentTask:
+      firstOfList(extractSection(content, "Current Task")) ??
+      readYamlString(frontmatter, "current_task") ??
+      legacy.current_task,
+    currentPhase:
+      firstOfList(extractSection(content, "Current Phase")) ??
+      readYamlString(frontmatter, "current_phase") ??
+      legacy.current_phase,
+    latestUserRequest:
+      firstOfList(extractSection(content, "Latest User Request")) ??
+      readYamlString(frontmatter, "latest_user_request"),
+    blockers:
+      blockers.length > 0 ? blockers : normalizeList((legacy.blockers ?? "").split(/[；;]+/g)),
+    nextSteps:
+      nextSteps.length > 0 ? nextSteps : normalizeList((legacy.next_steps ?? "").split(/[；;]+/g)),
+    keyArtifacts:
+      keyArtifacts.length > 0
+        ? keyArtifacts
+        : normalizeList((legacy.key_artifacts ?? "").split(/[；;]+/g)),
+    conversationSummary:
+      extractSection(content, "Conversation Summary") ??
+      readYamlString(frontmatter, "conversation_summary"),
+    summary: undefined,
+  };
+
+  parsed.summary = pickSummary(parsed, legacy);
+  return parsed;
+}
+
+export function hasMaterialContinuityChange(
+  previousContent: string | undefined,
+  nextState: ContinuitySnapshotState,
+): boolean {
+  if (!previousContent) {
+    return true;
+  }
+  const previous = parseContinuityDocument(previousContent);
+  const canonicalPrevious = JSON.stringify({
+    status: canonicalizeStatus(previous.status),
+    priority: canonicalizePriority(previous.priority),
+    project: normalizeWhitespace(previous.project),
+    currentTask: normalizeWhitespace(previous.currentTask),
+    currentPhase: normalizeWhitespace(previous.currentPhase),
+    latestUserRequest: normalizeWhitespace(previous.latestUserRequest),
+    blockers: normalizeList(previous.blockers),
+    nextSteps: normalizeList(previous.nextSteps),
+    keyArtifacts: normalizeList(previous.keyArtifacts),
+  });
+  const canonicalNext = JSON.stringify({
+    status: canonicalizeStatus(nextState.status),
+    priority: canonicalizePriority(nextState.priority),
+    project: normalizeWhitespace(nextState.project),
+    currentTask: normalizeWhitespace(nextState.currentTask),
+    currentPhase: normalizeWhitespace(nextState.currentPhase),
+    latestUserRequest: normalizeWhitespace(nextState.latestUserRequest),
+    blockers: normalizeList(nextState.blockers),
+    nextSteps: normalizeList(nextState.nextSteps),
+    keyArtifacts: normalizeList(nextState.keyArtifacts),
+  });
+  return canonicalPrevious !== canonicalNext;
+}
+
+export function renderContinuitySnapshotMarkdown(state: ContinuitySnapshotState): string {
+  const frontmatter = YAML.stringify({
+    type: "recent_snapshot",
+    status: state.status,
+    priority: state.priority,
+    updated_at: state.updatedAt,
+    supersedes: state.supersedes,
+    source: state.source,
+    project: state.project,
+    session_key: state.sessionKey,
+    valid_until: state.validUntil,
+  }).trimEnd();
+
+  const lines = [
+    "---",
+    frontmatter,
+    "---",
+    "",
+    "# Recent Continuity Snapshot",
+    "",
+    "## Current Task",
+    `- ${state.currentTask || "unknown"}`,
+    "",
+    "## Current Phase",
+    `- ${state.currentPhase || "unknown"}`,
+    "",
+    "## Latest User Request",
+    `- ${state.latestUserRequest || "unknown"}`,
+    "",
+    "## Current Blockers",
+    ...(state.blockers.length > 0 ? state.blockers.map((entry) => `- ${entry}`) : ["- none"]),
+    "",
+    "## Next Steps",
+    ...(state.nextSteps.length > 0 ? state.nextSteps.map((entry) => `- ${entry}`) : ["- none"]),
+    "",
+    "## Key Artifacts",
+    ...(state.keyArtifacts.length > 0
+      ? state.keyArtifacts.map((entry) => `- ${entry}`)
+      : ["- none"]),
+  ];
+
+  if (normalizeWhitespace(state.conversationSummary)) {
+    lines.push("", "## Conversation Summary", "", normalizeWhitespace(state.conversationSummary));
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export async function readRecentContinuitySnapshot(workspaceDir: string): Promise<{
+  path: string;
+  content: string;
+} | null> {
+  const latestPath = path.join(workspaceDir, RECENT_CONTINUITY_LATEST);
+  try {
+    const content = await fs.readFile(latestPath, "utf-8");
+    return {
+      path: RECENT_CONTINUITY_LATEST,
+      content,
+    };
+  } catch {}
+
+  const snapshotsDir = path.join(workspaceDir, RECENT_CONTINUITY_SNAPSHOTS_DIR);
+  try {
+    const entries = await fs.readdir(snapshotsDir, { withFileTypes: true });
+    const files = await Promise.all(
+      entries
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+        .map(async (entry) => {
+          const absPath = path.join(snapshotsDir, entry.name);
+          const stat = await fs.stat(absPath);
+          return { absPath, mtimeMs: stat.mtimeMs };
+        }),
+    );
+    const latest = files.toSorted((a, b) => b.mtimeMs - a.mtimeMs)[0];
+    if (!latest) {
+      return null;
+    }
+    const content = await fs.readFile(latest.absPath, "utf-8");
+    return {
+      path: path.relative(workspaceDir, latest.absPath).replace(/\\/g, "/"),
+      content,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function buildContinuityManifest(params: {
+  workspaceDir: string;
+  extraPaths?: string[];
+  maxFiles?: number;
+}): Promise<ContinuityManifestEntry[]> {
+  const files = await listMemoryFiles(params.workspaceDir, params.extraPaths);
+  const statEntries = await Promise.all(
+    files.map(async (absPath) => {
+      try {
+        const stat = await fs.stat(absPath);
+        return { absPath, mtimeMs: stat.mtimeMs };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const selected = statEntries
+    .filter((entry): entry is { absPath: string; mtimeMs: number } => Boolean(entry))
+    .toSorted((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, params.maxFiles ?? MAX_MANIFEST_FILES);
+
+  const parsed = await Promise.all(
+    selected.map(async ({ absPath, mtimeMs }) => {
+      try {
+        const head = await readHead(absPath, HEAD_MAX_LINES, HEAD_MAX_BYTES);
+        const doc = parseContinuityDocument(head);
+        return {
+          path: path.relative(params.workspaceDir, absPath).replace(/\\/g, "/"),
+          absPath,
+          mtimeMs,
+          status: doc.status,
+          priority: doc.priority,
+          updatedAt: doc.updatedAt,
+          supersedes: doc.supersedes,
+          type: doc.type,
+          project: doc.project,
+          title: doc.title,
+          summary: doc.summary,
+        } satisfies ContinuityManifestEntry;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const manifestEntries: ContinuityManifestEntry[] = [];
+  for (const entry of parsed) {
+    if (entry) {
+      manifestEntries.push(entry);
+    }
+  }
+  return manifestEntries.toSorted(compareByContinuityPriority);
+}
+
+export function formatContinuityManifest(
+  entries: ContinuityManifestEntry[],
+  maxEntries: number = 5,
+): string {
+  const limited = entries.slice(0, maxEntries);
+  if (limited.length === 0) {
+    return "";
+  }
+  const lines = limited.map((entry) => {
+    const status = canonicalizeStatus(entry.status) ?? "unknown";
+    const priority = canonicalizePriority(entry.priority) ?? "unknown";
+    const stamp = normalizeWhitespace(entry.updatedAt) || new Date(entry.mtimeMs).toISOString();
+    const summary = truncateText(entry.summary ?? entry.title, 180) ?? "no summary";
+    return `- [${status}/${priority}] ${entry.path} (${stamp}): ${summary}`;
+  });
+  return `<continuity-manifest>\n${lines.join("\n")}\n</continuity-manifest>`;
+}
+
+export function formatContinuitySnapshotForPrompt(
+  content: string,
+  maxChars: number = 1200,
+): string {
+  const parsed = parseContinuityDocument(content);
+  const lines: string[] = [];
+  if (parsed.project) {
+    lines.push(`Project: ${parsed.project}`);
+  }
+  if (parsed.currentTask) {
+    lines.push(`Current task: ${parsed.currentTask}`);
+  }
+  if (parsed.currentPhase) {
+    lines.push(`Current phase: ${parsed.currentPhase}`);
+  }
+  if (parsed.latestUserRequest) {
+    lines.push(`Latest user request: ${parsed.latestUserRequest}`);
+  }
+  if (parsed.blockers.length > 0) {
+    lines.push(`Blockers: ${parsed.blockers.join(" | ")}`);
+  }
+  if (parsed.nextSteps.length > 0) {
+    lines.push(`Next steps: ${parsed.nextSteps.join(" | ")}`);
+  }
+  if (parsed.keyArtifacts.length > 0) {
+    lines.push(`Key artifacts: ${parsed.keyArtifacts.join(" | ")}`);
+  }
+  if (parsed.conversationSummary) {
+    lines.push(`Conversation summary: ${normalizeWhitespace(parsed.conversationSummary)}`);
+  }
+  const text = lines.join("\n").trim();
+  if (!text) {
+    return "";
+  }
+  return text.length <= maxChars ? text : `${text.slice(0, Math.max(0, maxChars - 3))}...`;
+}

--- a/packages/memory-host-sdk/src/host/continuity.ts
+++ b/packages/memory-host-sdk/src/host/continuity.ts
@@ -267,7 +267,7 @@ function escapeRegExp(value: string): string {
 
 function extractSection(content: string, title: string): string | undefined {
   const pattern = new RegExp(
-    `^##\\s+${escapeRegExp(title)}\\s*$([\\s\\S]*?)(?=^##\\s+|\\Z)`,
+    `^##\\s+${escapeRegExp(title)}\\s*$([\\s\\S]*?)(?=^##\\s+|(?![\\s\\S]))`,
     "gim",
   );
   const match = pattern.exec(content);

--- a/src/agents/pi-hooks/compaction-safeguard.test.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.test.ts
@@ -5,6 +5,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderContinuitySnapshotMarkdown } from "../../../packages/memory-host-sdk/src/host/continuity.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import * as compactionModule from "../compaction.js";
 import { buildEmbeddedExtensionFactories } from "../pi-embedded-runner/extensions.js";
@@ -1938,6 +1939,40 @@ async function expectWorkspaceSummaryEmptyForAgentsAlias(
 }
 
 describe("readWorkspaceContextForSummary", () => {
+  it("includes recent continuity snapshot when present in workspace memory", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-compaction-context-"));
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(root);
+    try {
+      fs.writeFileSync(path.join(root, "AGENTS.md"), "## Session Startup\n\nRead startup files.\n");
+      fs.mkdirSync(path.join(root, "memory", "recent", "snapshots"), { recursive: true });
+      fs.writeFileSync(
+        path.join(root, "memory", "recent", "latest.md"),
+        renderContinuitySnapshotMarkdown({
+          status: "active",
+          priority: "high",
+          updatedAt: "2026-04-03T09:00:00.000Z",
+          source: "session-memory:command",
+          project: "system-repair",
+          sessionKey: "agent:main:main",
+          validUntil: "2026-04-04T09:00:00.000Z",
+          currentTask: "Ship memory iteration",
+          currentPhase: "verification",
+          latestUserRequest: "Implement the meeting plan",
+          blockers: ["Need to finish tests"],
+          nextSteps: ["Run vitest"],
+          keyArtifacts: ["memory/recent/latest.md"],
+        }),
+      );
+
+      const summary = await readWorkspaceContextForSummary();
+      expect(summary).toContain("<recent-continuity-snapshot>");
+      expect(summary).toContain("Ship memory iteration");
+    } finally {
+      cwdSpy.mockRestore();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it.runIf(process.platform !== "win32")(
     "returns empty when AGENTS.md is a symlink escape",
     async () => {

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -2,6 +2,12 @@ import fs from "node:fs";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext, FileOperations } from "@mariozechner/pi-coding-agent";
+import {
+  buildContinuityManifest,
+  formatContinuityManifest,
+  formatContinuitySnapshotForPrompt,
+  readRecentContinuitySnapshot,
+} from "../../../packages/memory-host-sdk/src/host/continuity.js";
 import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -541,17 +547,38 @@ async function readWorkspaceContextForSummary(): Promise<string> {
       sections = extractSections(content, ["Every Session", "Safety"]);
     }
 
-    if (sections.length === 0) {
+    const recentSnapshot = await readRecentContinuitySnapshot(workspaceDir);
+    const recentSnapshotText = recentSnapshot
+      ? formatContinuitySnapshotForPrompt(recentSnapshot.content, 800)
+      : "";
+    const continuityManifest = formatContinuityManifest(
+      await buildContinuityManifest({ workspaceDir }),
+      4,
+    );
+
+    if (sections.length === 0 && !recentSnapshotText && !continuityManifest) {
       return "";
     }
 
-    const combined = sections.join("\n\n");
-    const safeContent =
-      combined.length > MAX_SUMMARY_CONTEXT_CHARS
-        ? combined.slice(0, MAX_SUMMARY_CONTEXT_CHARS) + "\n...[truncated]..."
-        : combined;
+    const blocks: string[] = [];
+    if (sections.length > 0) {
+      const combined = sections.join("\n\n");
+      const safeContent =
+        combined.length > MAX_SUMMARY_CONTEXT_CHARS
+          ? combined.slice(0, MAX_SUMMARY_CONTEXT_CHARS) + "\n...[truncated]..."
+          : combined;
+      blocks.push(`<workspace-critical-rules>\n${safeContent}\n</workspace-critical-rules>`);
+    }
+    if (recentSnapshotText) {
+      blocks.push(
+        `<recent-continuity-snapshot>\n${recentSnapshotText}\n</recent-continuity-snapshot>`,
+      );
+    }
+    if (continuityManifest) {
+      blocks.push(continuityManifest);
+    }
 
-    return `\n\n<workspace-critical-rules>\n${safeContent}\n</workspace-critical-rules>`;
+    return blocks.length > 0 ? `\n\n${blocks.join("\n\n")}` : "";
   } catch {
     return "";
   }

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderContinuitySnapshotMarkdown } from "../../../packages/memory-host-sdk/src/host/continuity.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
 
@@ -42,6 +43,33 @@ describe("readPostCompactionContext", () => {
     expect(result).toBeNull();
   });
 
+  it("injects recent continuity snapshot even when AGENTS.md is missing", async () => {
+    fs.mkdirSync(path.join(tmpDir, "memory", "recent", "snapshots"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "memory", "recent", "latest.md"),
+      renderContinuitySnapshotMarkdown({
+        status: "active",
+        priority: "high",
+        updatedAt: "2026-04-03T09:00:00.000Z",
+        source: "session-memory:command",
+        project: "system-repair",
+        sessionKey: "agent:main:main",
+        validUntil: "2026-04-04T09:00:00.000Z",
+        currentTask: "Ship memory iteration",
+        currentPhase: "verification",
+        latestUserRequest: "Implement the meeting plan",
+        blockers: ["Need to finish tests"],
+        nextSteps: ["Run vitest"],
+        keyArtifacts: ["memory/recent/latest.md"],
+      }),
+    );
+
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Recent continuity snapshot");
+    expect(result).toContain("Ship memory iteration");
+  });
+
   it("returns null when AGENTS.md has no relevant sections", async () => {
     fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), "# My Agent\n\nSome content.\n");
     const result = await readPostCompactionContext(tmpDir);
@@ -68,6 +96,51 @@ Not relevant.
     expect(result).toContain("WORKFLOW_AUTO.md");
     expect(result).toContain("Post-compaction context refresh");
     expect(result).not.toContain("Other Section");
+  });
+
+  it("includes continuity manifest hints when recent memory files exist", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "AGENTS.md"),
+      `## Session Startup
+
+Read startup files.
+`,
+    );
+    fs.mkdirSync(path.join(tmpDir, "memory", "recent", "snapshots"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "memory", "recent", "latest.md"),
+      renderContinuitySnapshotMarkdown({
+        status: "active",
+        priority: "highest",
+        updatedAt: "2026-04-03T09:00:00.000Z",
+        source: "session-memory:command",
+        project: "system-repair",
+        sessionKey: "agent:main:main",
+        validUntil: "2026-04-04T09:00:00.000Z",
+        currentTask: "Ship memory iteration",
+        currentPhase: "verification",
+        latestUserRequest: "Implement the meeting plan",
+        blockers: ["Need to finish tests"],
+        nextSteps: ["Run vitest"],
+        keyArtifacts: ["memory/recent/latest.md"],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "memory", "active-topics.md"),
+      `# Active Topics
+
+- 状态：active
+- 优先级：high
+- updated_at：2026-04-03 15:00 CST
+- 当前主任务：记忆系统迭代与官方贡献目标
+`,
+    );
+
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Continuity manifest");
+    expect(result).toContain("memory/recent/latest.md");
+    expect(result).toContain("memory/active-topics.md");
   });
 
   it("extracts Red Lines section", async () => {

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -1,5 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
+import {
+  buildContinuityManifest,
+  formatContinuityManifest,
+  formatContinuitySnapshotForPrompt,
+  readRecentContinuitySnapshot,
+} from "../../../packages/memory-host-sdk/src/host/continuity.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { resolveUserTimezone } from "../../agents/date-time.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -73,16 +79,15 @@ export async function readPostCompactionContext(
       rootPath: workspaceDir,
       boundaryLabel: "workspace root",
     });
-    if (!opened.ok) {
-      return null;
-    }
-    const content = (() => {
-      try {
-        return fs.readFileSync(opened.fd, "utf-8");
-      } finally {
-        fs.closeSync(opened.fd);
-      }
-    })();
+    const content = opened.ok
+      ? (() => {
+          try {
+            return fs.readFileSync(opened.fd, "utf-8");
+          } finally {
+            fs.closeSync(opened.fd);
+          }
+        })()
+      : "";
 
     // Extract configured sections from AGENTS.md (default: Session Startup + Red Lines).
     // An explicit empty array disables post-compaction context injection entirely.
@@ -96,7 +101,7 @@ export async function readPostCompactionContext(
     }
 
     const foundSectionNames: string[] = [];
-    let sections = extractSections(content, sectionNames, foundSectionNames);
+    let sections = content ? extractSections(content, sectionNames, foundSectionNames) : [];
 
     // Fall back to legacy section names ("Every Session" / "Safety") when using
     // defaults and the current headings aren't found — preserves compatibility
@@ -106,11 +111,20 @@ export async function readPostCompactionContext(
     const isDefaultSections =
       !Array.isArray(configuredSections) ||
       matchesSectionSet(configuredSections, DEFAULT_POST_COMPACTION_SECTIONS);
-    if (sections.length === 0 && isDefaultSections) {
+    if (content && sections.length === 0 && isDefaultSections) {
       sections = extractSections(content, LEGACY_POST_COMPACTION_SECTIONS, foundSectionNames);
     }
 
-    if (sections.length === 0) {
+    const recentSnapshot = await readRecentContinuitySnapshot(workspaceDir);
+    const recentSnapshotText = recentSnapshot
+      ? formatContinuitySnapshotForPrompt(recentSnapshot.content)
+      : "";
+    const continuityManifest = formatContinuityManifest(
+      await buildContinuityManifest({ workspaceDir }),
+      5,
+    );
+
+    if (sections.length === 0 && !recentSnapshotText && !continuityManifest) {
       return null;
     }
 
@@ -129,6 +143,18 @@ export async function readPostCompactionContext(
       combined.length > MAX_CONTEXT_CHARS
         ? combined.slice(0, MAX_CONTEXT_CHARS) + "\n...[truncated]..."
         : combined;
+    const continuityBlocks: string[] = [];
+    if (recentSnapshotText) {
+      continuityBlocks.push(
+        `Recent continuity snapshot (${recentSnapshot?.path ?? "memory/recent/latest.md"}):\n\n${recentSnapshotText}`,
+      );
+    }
+    if (continuityManifest) {
+      continuityBlocks.push(
+        "Continuity manifest (use this to pick the next files before widening recovery):\n\n" +
+          continuityManifest,
+      );
+    }
 
     // When using the default section set, use precise prose that names the
     // "Session Startup" sequence explicitly. When custom sections are configured,
@@ -140,15 +166,23 @@ export async function readPostCompactionContext(
       : `Session was just compacted. The conversation summary above is a hint, NOT a substitute for your full startup sequence. ` +
         `Re-read the sections injected below (${displayNames.join(", ")}) and follow your configured startup procedure before responding to the user.`;
 
-    const sectionLabel = isDefaultSections
-      ? "Critical rules from AGENTS.md:"
-      : `Injected sections from AGENTS.md (${displayNames.join(", ")}):`;
+    const sectionLabel =
+      sections.length === 0
+        ? ""
+        : isDefaultSections
+          ? "Critical rules from AGENTS.md:"
+          : `Injected sections from AGENTS.md (${displayNames.join(", ")}):`;
 
-    return (
-      "[Post-compaction context refresh]\n\n" +
-      `${prose}\n\n` +
-      `${sectionLabel}\n\n${safeContent}\n\n${timeLine}`
-    );
+    const bodyParts = ["[Post-compaction context refresh]", "", prose];
+
+    if (sectionLabel && safeContent) {
+      bodyParts.push("", sectionLabel, "", safeContent);
+    }
+    if (continuityBlocks.length > 0) {
+      bodyParts.push("", ...continuityBlocks);
+    }
+    bodyParts.push("", timeLine);
+    return bodyParts.join("\n");
   } catch {
     return null;
   }

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -71,7 +71,13 @@ async function runNewWithPreviousSessionEntry(params: {
   action?: "new" | "reset";
   sessionKey?: string;
   workspaceDirOverride?: string;
-}): Promise<{ files: string[]; memoryContent: string }> {
+}): Promise<{
+  files: string[];
+  archiveFiles: string[];
+  memoryContent: string;
+  recentLatestContent: string;
+  snapshotFiles: string[];
+}> {
   const event = createHookEvent(
     "command",
     params.action ?? "new",
@@ -91,16 +97,39 @@ async function runNewWithPreviousSessionEntry(params: {
 
   const memoryDir = path.join(params.tempDir, "memory");
   const files = await fs.readdir(memoryDir);
+  const archiveFiles = files.filter((name) => name.endsWith(".md"));
   const memoryContent =
-    files.length > 0 ? await fs.readFile(path.join(memoryDir, files[0]), "utf-8") : "";
-  return { files, memoryContent };
+    archiveFiles.length > 0
+      ? await fs.readFile(path.join(memoryDir, archiveFiles[0]), "utf-8")
+      : "";
+  const latestPath = path.join(memoryDir, "recent", "latest.md");
+  let recentLatestContent = "";
+  try {
+    recentLatestContent = await fs.readFile(latestPath, "utf-8");
+  } catch {
+    recentLatestContent = "";
+  }
+  const snapshotsDir = path.join(memoryDir, "recent", "snapshots");
+  let snapshotFiles: string[] = [];
+  try {
+    snapshotFiles = await fs.readdir(snapshotsDir);
+  } catch {
+    snapshotFiles = [];
+  }
+  return { files, archiveFiles, memoryContent, recentLatestContent, snapshotFiles };
 }
 
 async function runNewWithPreviousSession(params: {
   sessionContent: string;
   cfg?: (tempDir: string) => OpenClawConfig;
   action?: "new" | "reset";
-}): Promise<{ tempDir: string; files: string[]; memoryContent: string }> {
+}): Promise<{
+  tempDir: string;
+  files: string[];
+  memoryContent: string;
+  recentLatestContent: string;
+  snapshotFiles: string[];
+}> {
   const tempDir = await createCaseWorkspace("workspace");
   const sessionsDir = path.join(tempDir, "sessions");
   await fs.mkdir(sessionsDir, { recursive: true });
@@ -117,16 +146,66 @@ async function runNewWithPreviousSession(params: {
       agents: { defaults: { workspace: tempDir } },
     } satisfies OpenClawConfig);
 
-  const { files, memoryContent } = await runNewWithPreviousSessionEntry({
+  const { archiveFiles, memoryContent, recentLatestContent, snapshotFiles } =
+    await runNewWithPreviousSessionEntry({
+      tempDir,
+      cfg,
+      action: params.action,
+      previousSessionEntry: {
+        sessionId: "test-123",
+        sessionFile,
+      },
+    });
+  return {
     tempDir,
-    cfg,
-    action: params.action,
-    previousSessionEntry: {
-      sessionId: "test-123",
+    files: archiveFiles,
+    memoryContent,
+    recentLatestContent,
+    snapshotFiles,
+  };
+}
+
+async function runCompactionCheckpoint(params: {
+  sessionContent: string;
+  sessionKey?: string;
+}): Promise<{
+  tempDir: string;
+  archiveFiles: string[];
+  recentLatestContent: string;
+  snapshotFiles: string[];
+}> {
+  const tempDir = await createCaseWorkspace("workspace");
+  const sessionsDir = path.join(tempDir, "sessions");
+  await fs.mkdir(sessionsDir, { recursive: true });
+  const sessionFile = await writeWorkspaceFile({
+    dir: sessionsDir,
+    name: "active-session.jsonl",
+    content: params.sessionContent,
+  });
+
+  const event = createHookEvent(
+    "session",
+    "compact:before",
+    params.sessionKey ?? "agent:main:main",
+    {
+      workspaceDir: tempDir,
+      sessionId: "compact-123",
       sessionFile,
     },
-  });
-  return { tempDir, files, memoryContent };
+  );
+
+  await handler(event);
+
+  const memoryDir = path.join(tempDir, "memory");
+  const files = await fs.readdir(memoryDir);
+  const archiveFiles = files.filter((name) => /^\d{4}-\d{2}-\d{2}.*\.md$/.test(name));
+  const recentLatestContent = await fs.readFile(
+    path.join(memoryDir, "recent", "latest.md"),
+    "utf-8",
+  );
+  const snapshotFiles = await fs.readdir(path.join(memoryDir, "recent", "snapshots"));
+
+  return { tempDir, archiveFiles, recentLatestContent, snapshotFiles };
 }
 
 async function createSessionMemoryWorkspace(params?: {
@@ -232,6 +311,39 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: 2+2 equals 4");
   });
 
+  it("writes recent continuity latest and snapshot files", async () => {
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "We need to keep continuity stable" },
+      { role: "assistant", content: "I will add a recent snapshot layer" },
+      { role: "user", content: "Then wire it into compaction" },
+    ]);
+    const { recentLatestContent, snapshotFiles } = await runNewWithPreviousSession({
+      sessionContent,
+    });
+
+    expect(snapshotFiles.length).toBe(1);
+    expect(recentLatestContent).toContain("type: recent_snapshot");
+    expect(recentLatestContent).toContain("## Current Task");
+    expect(recentLatestContent).toContain("## Conversation Summary");
+    expect(recentLatestContent).toContain("We need to keep continuity stable");
+  });
+
+  it("writes only recent continuity on pre-compaction checkpoints", async () => {
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "We are about to hit compaction" },
+      { role: "assistant", content: "Capture the current task before the window shrinks" },
+    ]);
+
+    const { archiveFiles, recentLatestContent, snapshotFiles } = await runCompactionCheckpoint({
+      sessionContent,
+    });
+
+    expect(archiveFiles).toEqual([]);
+    expect(snapshotFiles.length).toBe(1);
+    expect(recentLatestContent).toContain("source: session-memory:compaction");
+    expect(recentLatestContent).toContain("We are about to hit compaction");
+  });
+
   it("creates memory file with session content on /reset command", async () => {
     const sessionContent = createMockSessionContent([
       { role: "user", content: "Please reset and keep notes" },
@@ -262,7 +374,7 @@ describe("session-memory hook", () => {
       ]),
     });
 
-    const { files, memoryContent } = await runNewWithPreviousSessionEntry({
+    const { archiveFiles, memoryContent } = await runNewWithPreviousSessionEntry({
       tempDir: naviWorkspace,
       cfg: {
         agents: {
@@ -278,7 +390,7 @@ describe("session-memory hook", () => {
       },
     });
 
-    expect(files.length).toBe(1);
+    expect(archiveFiles.length).toBe(1);
     expect(memoryContent).toContain("user: Remember this under Navi");
     expect(memoryContent).toContain("assistant: Stored in the bound workspace");
     expect(memoryContent).toContain("- **Session Key**: agent:navi:main");
@@ -410,7 +522,7 @@ describe("session-memory hook", () => {
   });
 
   it("handles reset-path session pointers from previousSessionEntry", async () => {
-    const { sessionsDir } = await createSessionMemoryWorkspace();
+    const { tempDir, sessionsDir } = await createSessionMemoryWorkspace();
 
     const sessionId = "reset-pointer-session";
     const resetSessionFile = await writeWorkspaceFile({
@@ -428,14 +540,27 @@ describe("session-memory hook", () => {
       sessionId,
     });
     expect(previousSessionFile).toBeUndefined();
+    const { archiveFiles, memoryContent } = await runNewWithPreviousSessionEntry({
+      tempDir,
+      cfg: {
+        agents: { defaults: { workspace: tempDir } },
+      } satisfies OpenClawConfig,
+      previousSessionEntry: {
+        sessionId,
+        sessionFile: resetSessionFile,
+      },
+    });
+    expect(archiveFiles.length).toBe(1);
 
-    const memoryContent = await getRecentSessionContentWithResetFallback(resetSessionFile);
+    const transcriptContent = await getRecentSessionContentWithResetFallback(resetSessionFile);
+    expect(transcriptContent).toContain("user: Message from reset pointer");
+    expect(transcriptContent).toContain("assistant: Recovered directly from reset file");
     expect(memoryContent).toContain("user: Message from reset pointer");
     expect(memoryContent).toContain("assistant: Recovered directly from reset file");
   });
 
   it("recovers transcript when previousSessionEntry.sessionFile is missing", async () => {
-    const { sessionsDir } = await createSessionMemoryWorkspace();
+    const { tempDir, sessionsDir } = await createSessionMemoryWorkspace();
 
     const sessionId = "missing-session-file";
     await writeWorkspaceFile({
@@ -457,8 +582,20 @@ describe("session-memory hook", () => {
       sessionId,
     });
     expect(previousSessionFile).toBe(path.join(sessionsDir, `${sessionId}.jsonl`));
+    const { archiveFiles, memoryContent } = await runNewWithPreviousSessionEntry({
+      tempDir,
+      cfg: {
+        agents: { defaults: { workspace: tempDir } },
+      } satisfies OpenClawConfig,
+      previousSessionEntry: {
+        sessionId,
+      },
+    });
+    expect(archiveFiles.length).toBe(1);
 
-    const memoryContent = await getRecentSessionContentWithResetFallback(previousSessionFile!);
+    const transcriptContent = await getRecentSessionContentWithResetFallback(previousSessionFile!);
+    expect(transcriptContent).toContain("user: Recovered with missing sessionFile pointer");
+    expect(transcriptContent).toContain("assistant: Recovered by sessionId fallback");
     expect(memoryContent).toContain("user: Recovered with missing sessionFile pointer");
     expect(memoryContent).toContain("assistant: Recovered by sessionId fallback");
   });

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -9,6 +9,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+  hasMaterialContinuityChange,
+  RECENT_CONTINUITY_LATEST,
+  RECENT_CONTINUITY_SNAPSHOTS_DIR,
+  renderContinuitySnapshotMarkdown,
+} from "../../../../packages/memory-host-sdk/src/host/continuity.js";
+import {
   resolveAgentIdByWorkspacePath,
   resolveAgentWorkspaceDir,
 } from "../../../agents/agent-scope.js";
@@ -23,10 +29,79 @@ import {
 } from "../../../routing/session-key.js";
 import { resolveHookConfig } from "../../config.js";
 import type { HookHandler } from "../../hooks.js";
+import { generateContinuitySnapshotViaLLM } from "../../llm-session-memory.js";
 import { generateSlugViaLLM } from "../../llm-slug-generator.js";
 import { findPreviousSessionFile, getRecentSessionContentWithResetFallback } from "./transcript.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
+
+function normalizeList(values: string[]): string[] {
+  return values.map((value) => value.trim()).filter(Boolean);
+}
+
+async function readOptionalFile(pathname: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(pathname, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+function buildRecentSnapshotState(params: {
+  now: Date;
+  validHours: number;
+  source: string;
+  project?: string;
+  sessionKey: string;
+  currentTask?: string;
+  currentPhase?: string;
+  latestUserRequest?: string;
+  blockers?: string[];
+  nextSteps?: string[];
+  keyArtifacts?: string[];
+  conversationSummary?: string;
+  status?: string;
+  priority?: string;
+  supersedes?: string;
+}): {
+  status: string;
+  priority: string;
+  updatedAt: string;
+  supersedes?: string;
+  source: string;
+  project: string;
+  sessionKey: string;
+  validUntil: string;
+  currentTask: string;
+  currentPhase: string;
+  latestUserRequest: string;
+  blockers: string[];
+  nextSteps: string[];
+  keyArtifacts: string[];
+  conversationSummary?: string;
+} {
+  const updatedAt = params.now.toISOString();
+  const validUntil = new Date(
+    params.now.getTime() + params.validHours * 60 * 60 * 1000,
+  ).toISOString();
+  return {
+    status: params.status ?? "active",
+    priority: params.priority ?? "high",
+    updatedAt,
+    supersedes: params.supersedes,
+    source: params.source,
+    project: params.project?.trim() || "unknown",
+    sessionKey: params.sessionKey,
+    validUntil,
+    currentTask: params.currentTask?.trim() || "unknown",
+    currentPhase: params.currentPhase?.trim() || "unknown",
+    latestUserRequest: params.latestUserRequest?.trim() || "unknown",
+    blockers: normalizeList(params.blockers ?? []),
+    nextSteps: normalizeList(params.nextSteps ?? []),
+    keyArtifacts: normalizeList(params.keyArtifacts ?? []),
+    conversationSummary: params.conversationSummary?.trim() || undefined,
+  };
+}
 
 function resolveDisplaySessionKey(params: {
   cfg?: OpenClawConfig;
@@ -48,17 +123,18 @@ function resolveDisplaySessionKey(params: {
 }
 
 /**
- * Save session context to memory when /new or /reset command is triggered
+ * Save session context to memory on reset pivots and compaction checkpoints.
  */
 const saveSessionToMemory: HookHandler = async (event) => {
-  // Only trigger on reset/new commands
-  const isResetCommand = event.action === "new" || event.action === "reset";
-  if (event.type !== "command" || !isResetCommand) {
+  const isResetCommand =
+    event.type === "command" && (event.action === "new" || event.action === "reset");
+  const isCompactionCheckpoint = event.type === "session" && event.action === "compact:before";
+  if (!isResetCommand && !isCompactionCheckpoint) {
     return;
   }
 
   try {
-    log.debug("Hook triggered for reset/new command", { action: event.action });
+    log.debug("Session memory hook triggered", { type: event.type, action: event.action });
 
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;
@@ -84,17 +160,21 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const now = new Date(event.timestamp);
     const dateStr = now.toISOString().split("T")[0]; // YYYY-MM-DD
 
-    // Generate descriptive slug from session using LLM
-    // Prefer previousSessionEntry (old session before /new) over current (which may be empty)
-    const sessionEntry = (context.previousSessionEntry || context.sessionEntry || {}) as Record<
-      string,
-      unknown
-    >;
-    const currentSessionId = sessionEntry.sessionId as string;
-    let currentSessionFile = (sessionEntry.sessionFile as string) || undefined;
+    // Prefer the pre-reset session on /new|/reset, otherwise use the active session
+    // provided by the compaction checkpoint event.
+    const sessionEntry = (
+      isResetCommand ? context.previousSessionEntry || context.sessionEntry : context.sessionEntry
+    ) as Record<string, unknown>;
+    const currentSessionId =
+      (sessionEntry?.sessionId as string) ||
+      (typeof context.sessionId === "string" ? context.sessionId : undefined) ||
+      "unknown";
+    let currentSessionFile =
+      (sessionEntry?.sessionFile as string) ||
+      (typeof context.sessionFile === "string" ? context.sessionFile : undefined);
 
-    // If sessionFile is empty or looks like a new/reset file, try to find the previous session file.
-    if (!currentSessionFile || currentSessionFile.includes(".reset.")) {
+    // On /new|/reset we may need to walk back to the pre-rotation transcript.
+    if (isResetCommand && (!currentSessionFile || currentSessionFile.includes(".reset."))) {
       const sessionsDirs = new Set<string>();
       if (currentSessionFile) {
         sessionsDirs.add(path.dirname(currentSessionFile));
@@ -130,9 +210,17 @@ const saveSessionToMemory: HookHandler = async (event) => {
       typeof hookConfig?.messages === "number" && hookConfig.messages > 0
         ? hookConfig.messages
         : 15;
+    const validHours =
+      typeof hookConfig?.validHours === "number" && hookConfig.validHours > 0
+        ? Math.floor(hookConfig.validHours)
+        : 24;
+    const writeArchive = hookConfig?.archive !== false;
+    const writeRecent = hookConfig?.recent !== false;
 
     let slug: string | null = null;
     let sessionContent: string | null = null;
+    let extractedContinuity: Awaited<ReturnType<typeof generateContinuitySnapshotViaLLM>> | null =
+      null;
 
     if (sessionFile) {
       // Get recent conversation content, with fallback to rotated reset transcript.
@@ -149,12 +237,21 @@ const saveSessionToMemory: HookHandler = async (event) => {
         process.env.VITEST === "1" ||
         process.env.NODE_ENV === "test";
       const allowLlmSlug = !isTestEnv && hookConfig?.llmSlug !== false;
+      const allowLlmExtract = !isTestEnv && hookConfig?.llmExtract !== false;
+
+      if (sessionContent && cfg && allowLlmExtract) {
+        extractedContinuity = await generateContinuitySnapshotViaLLM({
+          sessionContent,
+          cfg,
+        });
+      }
 
       if (sessionContent && cfg && allowLlmSlug) {
-        log.debug("Calling generateSlugViaLLM...");
-        // Use LLM to generate a descriptive slug
-        slug = await generateSlugViaLLM({ sessionContent, cfg });
-        log.debug("Generated slug", { slug });
+        slug = extractedContinuity?.slug ?? (await generateSlugViaLLM({ sessionContent, cfg }));
+        log.debug("Generated slug", {
+          slug,
+          usedContinuityExtract: Boolean(extractedContinuity?.slug),
+        });
       }
     }
 
@@ -165,50 +262,94 @@ const saveSessionToMemory: HookHandler = async (event) => {
       log.debug("Using fallback timestamp slug", { slug });
     }
 
-    // Create filename with date and slug
-    const filename = `${dateStr}-${slug}.md`;
-    const memoryFilePath = path.join(memoryDir, filename);
-    log.debug("Memory file path resolved", {
-      filename,
-      path: memoryFilePath.replace(os.homedir(), "~"),
-    });
-
-    // Format time as HH:MM:SS UTC
-    const timeStr = now.toISOString().split("T")[1].split(".")[0];
-
     // Extract context details
-    const sessionId = (sessionEntry.sessionId as string) || "unknown";
-    const source = (context.commandSource as string) || "unknown";
+    const sessionId = currentSessionId || "unknown";
+    const source = isResetCommand ? (context.commandSource as string) || "command" : "compaction";
 
-    // Build Markdown entry
-    const entryParts = [
-      `# Session: ${dateStr} ${timeStr} UTC`,
-      "",
-      `- **Session Key**: ${displaySessionKey}`,
-      `- **Session ID**: ${sessionId}`,
-      `- **Source**: ${source}`,
-      "",
-    ];
+    if (writeArchive && isResetCommand) {
+      const filename = `${dateStr}-${slug}.md`;
+      const memoryFilePath = path.join(memoryDir, filename);
+      log.debug("Memory file path resolved", {
+        filename,
+        path: memoryFilePath.replace(os.homedir(), "~"),
+      });
 
-    // Include conversation content if available
-    if (sessionContent) {
-      entryParts.push("## Conversation Summary", "", sessionContent, "");
+      const timeStr = now.toISOString().split("T")[1].split(".")[0];
+      const entryParts = [
+        `# Session: ${dateStr} ${timeStr} UTC`,
+        "",
+        `- **Session Key**: ${displaySessionKey}`,
+        `- **Session ID**: ${sessionId}`,
+        `- **Source**: ${source}`,
+        "",
+      ];
+
+      if (sessionContent) {
+        entryParts.push("## Conversation Summary", "", sessionContent, "");
+      }
+
+      const entry = entryParts.join("\n");
+      await writeFileWithinRoot({
+        rootDir: memoryDir,
+        relativePath: filename,
+        data: entry,
+        encoding: "utf-8",
+      });
+      log.info(`Session context saved to ${memoryFilePath.replace(os.homedir(), "~")}`);
     }
 
-    const entry = entryParts.join("\n");
+    if (writeRecent) {
+      const latestRelativePath = RECENT_CONTINUITY_LATEST;
+      const latestAbsPath = path.join(workspaceDir, latestRelativePath);
+      const previousLatest = await readOptionalFile(latestAbsPath);
+      const snapshotState = buildRecentSnapshotState({
+        now,
+        validHours,
+        source: `session-memory:${source}`,
+        project: extractedContinuity?.project,
+        sessionKey: displaySessionKey,
+        currentTask: extractedContinuity?.currentTask,
+        currentPhase: extractedContinuity?.currentPhase,
+        latestUserRequest: extractedContinuity?.latestUserRequest,
+        blockers: extractedContinuity?.blockers,
+        nextSteps: extractedContinuity?.nextSteps,
+        keyArtifacts: extractedContinuity?.keyArtifacts,
+        conversationSummary:
+          extractedContinuity?.conversationSummary ?? sessionContent ?? undefined,
+        status: extractedContinuity?.status,
+        priority: extractedContinuity?.priority,
+        supersedes: previousLatest ? latestRelativePath : undefined,
+      });
 
-    // Write under memory root with alias-safe file validation.
-    await writeFileWithinRoot({
-      rootDir: memoryDir,
-      relativePath: filename,
-      data: entry,
-      encoding: "utf-8",
-    });
-    log.debug("Memory file written successfully");
-
-    // Log completion (but don't send user-visible confirmation - it's internal housekeeping)
-    const relPath = memoryFilePath.replace(os.homedir(), "~");
-    log.info(`Session context saved to ${relPath}`);
+      if (hasMaterialContinuityChange(previousLatest, snapshotState)) {
+        const snapshotFileName = `${dateStr}-${now
+          .toISOString()
+          .split("T")[1]
+          .split(".")[0]
+          .replace(/:/g, "")}-${slug}.md`;
+        const snapshotRelativePath = `${RECENT_CONTINUITY_SNAPSHOTS_DIR}/${snapshotFileName}`;
+        const snapshotContent = renderContinuitySnapshotMarkdown(snapshotState);
+        await writeFileWithinRoot({
+          rootDir: memoryDir,
+          relativePath: snapshotRelativePath.replace(/^memory\//, ""),
+          data: snapshotContent,
+          encoding: "utf-8",
+          mkdir: true,
+        });
+        await writeFileWithinRoot({
+          rootDir: memoryDir,
+          relativePath: latestRelativePath.replace(/^memory\//, ""),
+          data: snapshotContent,
+          encoding: "utf-8",
+          mkdir: true,
+        });
+        log.info(`Recent continuity snapshot saved to ${snapshotRelativePath}`);
+      } else {
+        log.debug(
+          "Skipping recent continuity snapshot write because state did not change materially",
+        );
+      }
+    }
   } catch (err) {
     if (err instanceof Error) {
       log.error("Failed to save session memory", {

--- a/src/hooks/llm-session-memory.ts
+++ b/src/hooks/llm-session-memory.ts
@@ -1,0 +1,192 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  resolveDefaultAgentId,
+  resolveAgentDir,
+  resolveAgentEffectiveModelPrimary,
+  resolveAgentWorkspaceDir,
+} from "../agents/agent-scope.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { parseModelRef } from "../agents/model-selection.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("llm-session-memory");
+
+export type GeneratedContinuitySnapshot = {
+  slug?: string;
+  project?: string;
+  currentTask?: string;
+  currentPhase?: string;
+  latestUserRequest?: string;
+  blockers: string[];
+  nextSteps: string[];
+  keyArtifacts: string[];
+  status?: string;
+  priority?: string;
+  conversationSummary?: string;
+};
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => normalizeString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+}
+
+function normalizeStatus(value: unknown): string | undefined {
+  const normalized = normalizeString(value)?.toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (["active", "blocked", "pending", "stale"].includes(normalized)) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizePriority(value: unknown): string | undefined {
+  const normalized = normalizeString(value)?.toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (["highest", "high", "medium", "low"].includes(normalized)) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function sanitizeSlug(value: unknown): string | undefined {
+  const normalized = normalizeString(value)
+    ?.toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 30);
+  return normalized || undefined;
+}
+
+function extractJsonObject(text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]+?)```/i);
+  if (fenced?.[1]) {
+    return fenced[1].trim();
+  }
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) {
+    return null;
+  }
+  return trimmed.slice(start, end + 1);
+}
+
+export async function generateContinuitySnapshotViaLLM(params: {
+  sessionContent: string;
+  cfg: OpenClawConfig;
+}): Promise<GeneratedContinuitySnapshot | null> {
+  let tempSessionFile: string | null = null;
+
+  try {
+    const agentId = resolveDefaultAgentId(params.cfg);
+    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
+    const agentDir = resolveAgentDir(params.cfg, agentId);
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-memory-"));
+    tempSessionFile = path.join(tempDir, "session.jsonl");
+
+    const prompt = [
+      "Extract near-field continuity state from this conversation excerpt.",
+      "Return JSON only.",
+      "Schema:",
+      "{",
+      '  "slug": "short-kebab-case-topic",',
+      '  "project": "short project name or unknown",',
+      '  "currentTask": "single current in-flight task",',
+      '  "currentPhase": "short current phase",',
+      '  "latestUserRequest": "latest concrete request to continue",',
+      '  "status": "active|blocked|pending|stale",',
+      '  "priority": "highest|high|medium|low",',
+      '  "blockers": ["current blocker 1"],',
+      '  "nextSteps": ["next step 1"],',
+      '  "keyArtifacts": ["relevant file, system, or artifact"],',
+      '  "conversationSummary": "2-4 sentence summary focused on in-flight work"',
+      "}",
+      "Rules:",
+      "- Focus on current active work, not timeless background.",
+      "- Keep blockers and next steps concrete and short.",
+      '- If unknown, use "unknown" or [].',
+      "",
+      "Conversation excerpt:",
+      params.sessionContent.slice(0, 4000),
+    ].join("\n");
+
+    const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, agentId);
+    const parsed = modelRef ? parseModelRef(modelRef, DEFAULT_PROVIDER) : null;
+    const provider = parsed?.provider ?? DEFAULT_PROVIDER;
+    const model = parsed?.model ?? DEFAULT_MODEL;
+
+    const result = await runEmbeddedPiAgent({
+      sessionId: `continuity-memory-${Date.now()}`,
+      sessionKey: "temp:continuity-memory",
+      agentId,
+      sessionFile: tempSessionFile,
+      workspaceDir,
+      agentDir,
+      config: params.cfg,
+      prompt,
+      provider,
+      model,
+      timeoutMs: 20_000,
+      runId: `continuity-memory-${Date.now()}`,
+    });
+
+    const rawText = result.payloads?.[0]?.text;
+    if (!rawText) {
+      return null;
+    }
+    const jsonText = extractJsonObject(rawText);
+    if (!jsonText) {
+      return null;
+    }
+    const parsedJson = JSON.parse(jsonText) as Record<string, unknown>;
+    return {
+      slug: sanitizeSlug(parsedJson.slug),
+      project: normalizeString(parsedJson.project),
+      currentTask: normalizeString(parsedJson.currentTask),
+      currentPhase: normalizeString(parsedJson.currentPhase),
+      latestUserRequest: normalizeString(parsedJson.latestUserRequest),
+      blockers: normalizeStringList(parsedJson.blockers),
+      nextSteps: normalizeStringList(parsedJson.nextSteps),
+      keyArtifacts: normalizeStringList(parsedJson.keyArtifacts),
+      status: normalizeStatus(parsedJson.status),
+      priority: normalizePriority(parsedJson.priority),
+      conversationSummary: normalizeString(parsedJson.conversationSummary),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+    log.error(`Failed to generate continuity snapshot: ${message}`);
+    return null;
+  } finally {
+    if (tempSessionFile) {
+      try {
+        await fs.rm(path.dirname(tempSessionFile), { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors.
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: long-running sessions can keep transcripts and memory archives but still lose the clearest current in-flight state across `/new`, `/reset`, and compaction.
- Why it matters: the next turn can feel detached even when history exists, which shows up as partial continuity loss rather than missing storage.
- What changed: add an additive `memory/recent` continuity layer with `latest.md` plus timestamped snapshots, wire it into reset/new, compact-before, and post-compaction recovery, and place the continuity helpers under the current `packages/memory-host-sdk` layout used by upstream main.
- What did NOT change (scope boundary): no retrieval ranking changes, no rollback journal/promotion, no dream/background scheduler, and no replacement of QMD/vector memory/transcripts.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #60742
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: N/A
- Scenario the test should lock in: N/A
- Why this is the smallest reliable guardrail: N/A
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: feature slice, not a regression fix

## User-visible / Behavior Changes

- `/new` and `/reset` still write archive notes, and now also write a recent continuity snapshot.
- `session:compact:before` writes a recent continuity snapshot without requiring a full archive note.
- Post-compaction recovery can read the recent continuity layer before broader history.

## Diagram (if applicable)

```text
Before:
[active work] -> [reset/compact] -> [broad history survives] -> [current task state is less obvious]

After:
[active work] -> [recent continuity snapshot] -> [reset/compact] -> [recent state restored first]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - The runtime now writes an additional recent continuity file in the existing workspace memory area.
  - Mitigation: additive only, same workspace boundary, no new external transport, and no broader retrieval/promotion behavior in this slice.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local development checkout
- Model/provider: N/A for core file-writing/recovery wiring; continuity extraction helper covered in local test flow
- Integration/channel (if any): none
- Relevant config (redacted): default local workspace memory flow

### Steps

1. Trigger `/new` or `/reset` on a session with active work state.
2. Trigger `session:compact:before` and inspect the resulting workspace memory files.
3. Run post-compaction recovery context generation.

### Expected

- `memory/recent/latest.md` and snapshots reflect the current in-flight task state.
- Recovery helpers surface recent continuity before broader history.

### Actual

- Local tests pass for continuity parsing/rendering, archive/reset wiring, compaction safeguard context, and post-compaction refresh.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused validation run locally:

- `packages/memory-host-sdk/src/host/continuity.test.ts`
- `src/hooks/bundled/session-memory/handler.test.ts`
- `src/auto-reply/reply/post-compaction-context.test.ts`
- `src/agents/pi-hooks/compaction-safeguard.test.ts`
- Result: 4 files, 132 tests passed
- `tsc -p tsconfig.json --noEmit` passed

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - recent continuity documents render and parse round-trip
  - material-change detection avoids noisy snapshot rewrites
  - reset/new paths continue archive writes and add continuity writes
  - post-compaction helpers and safeguard summaries include recent continuity
- Edge cases checked:
  - timestamp-only changes do not force rewrites
  - compact-before path can write continuity without full archive note
- What you did **not** verify:
  - live rollout against an actively running production workspace

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk:
  - Recent continuity snapshots could add noise if written too often.
  - Mitigation:
    - material-change detection avoids rewriting on trivial timestamp-only changes.
- Risk:
  - Review scope could sprawl into broader memory architecture discussion.
  - Mitigation:
    - this slice is intentionally limited to recent continuity only, with follow-up work kept out of this PR.
