### PR TITLE
fix(gateway): preserve aborted tool turns on shutdown

### DIFF
--- a/src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts
+++ b/src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts
@@ -124,6 +124,51 @@ describe("flushPendingToolResultsAfterIdle", () => {
     expect(getMessages(sm).map((m) => m.role)).toEqual(["assistant", "user"]);
   });
 
+  it("marks the pending assistant turn aborted when abort flush is requested", async () => {
+    const sm = guardSessionManager(SessionManager.inMemory());
+    const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
+    const idle = deferred<void>();
+    const agent = { waitForIdle: () => idle.promise };
+
+    appendMessage(assistantToolCall("call_abort_1"));
+
+    const flushPromise = flushPendingToolResultsAfterIdle({
+      agent,
+      sessionManager: sm,
+      timeoutMs: 1_000,
+      flushMode: "abort",
+    });
+    idle.resolve();
+    await flushPromise;
+
+    const messages = getMessages(sm) as Array<{ role: string; stopReason?: string }>;
+    expect(messages.map((m) => m.role)).toEqual(["assistant"]);
+    expect(messages[0]?.stopReason).toBe("aborted");
+  });
+
+  it("marks the pending assistant turn aborted after timeout when abort cleanup is requested", async () => {
+    const sm = guardSessionManager(SessionManager.inMemory());
+    const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
+    vi.useFakeTimers();
+    const agent = { waitForIdle: () => new Promise<void>(() => {}) };
+
+    appendMessage(assistantToolCall("call_abort_2"));
+
+    const flushPromise = flushPendingToolResultsAfterIdle({
+      agent,
+      sessionManager: sm,
+      timeoutMs: 30,
+      abortPendingOnTimeout: true,
+      flushMode: "abort",
+    });
+    await vi.advanceTimersByTimeAsync(30);
+    await flushPromise;
+
+    const messages = getMessages(sm) as Array<{ role: string; stopReason?: string }>;
+    expect(messages.map((m) => m.role)).toEqual(["assistant"]);
+    expect(messages[0]?.stopReason).toBe("aborted");
+  });
+
   it("clears timeout handle when waitForIdle resolves first", async () => {
     const sm = guardSessionManager(SessionManager.inMemory());
     vi.useFakeTimers();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -727,6 +727,10 @@ export async function runEmbeddedAttempt(
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
     let removeToolResultContextGuard: (() => void) | undefined;
+    let aborted = Boolean(params.abortSignal?.aborted);
+    let yieldAborted = false;
+    let timedOut = false;
+    let timedOutDuringCompaction = false;
     try {
       await repairSessionFileIfNeeded({
         sessionFile: params.sessionFile,
@@ -1208,19 +1212,18 @@ export async function runEmbeddedAttempt(
           }
         }
       } catch (err) {
+        const abortPendingCleanup = Boolean(params.abortSignal?.aborted);
         await flushPendingToolResultsAfterIdle({
           agent: activeSession?.agent,
           sessionManager,
-          clearPendingOnTimeout: true,
+          clearPendingOnTimeout: !abortPendingCleanup,
+          abortPendingOnTimeout: abortPendingCleanup,
+          flushMode: abortPendingCleanup ? "abort" : "flush",
         });
         activeSession.dispose();
         throw err;
       }
 
-      let aborted = Boolean(params.abortSignal?.aborted);
-      let yieldAborted = false;
-      let timedOut = false;
-      let timedOutDuringCompaction = false;
       const getAbortReason = (signal: AbortSignal): unknown =>
         "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
       const makeTimeoutAbortReason = (): Error => {
@@ -2031,10 +2034,13 @@ export async function runEmbeddedAttempt(
           /* best-effort */
         }
         try {
+          const abortPendingCleanup = aborted && !timedOut && !yieldAborted;
           await flushPendingToolResultsAfterIdle({
             agent: session?.agent,
             sessionManager,
-            clearPendingOnTimeout: true,
+            clearPendingOnTimeout: !abortPendingCleanup,
+            abortPendingOnTimeout: abortPendingCleanup,
+            flushMode: abortPendingCleanup ? "abort" : "flush",
           });
         } catch {
           /* best-effort */

--- a/src/agents/pi-embedded-runner/wait-for-idle-before-flush.ts
+++ b/src/agents/pi-embedded-runner/wait-for-idle-before-flush.ts
@@ -5,6 +5,7 @@ type IdleAwareAgent = {
 type ToolResultFlushManager = {
   flushPendingToolResults?: (() => void) | undefined;
   clearPendingToolResults?: (() => void) | undefined;
+  abortPendingToolCalls?: (() => void) | undefined;
 };
 
 export const DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS = 30_000;
@@ -45,13 +46,23 @@ export async function flushPendingToolResultsAfterIdle(opts: {
   sessionManager: ToolResultFlushManager | null | undefined;
   timeoutMs?: number;
   clearPendingOnTimeout?: boolean;
+  abortPendingOnTimeout?: boolean;
+  flushMode?: "flush" | "abort";
 }): Promise<void> {
   const timedOut = await waitForAgentIdleBestEffort(
     opts.agent,
     opts.timeoutMs ?? DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS,
   );
+  if (timedOut && opts.abortPendingOnTimeout && opts.sessionManager?.abortPendingToolCalls) {
+    opts.sessionManager.abortPendingToolCalls();
+    return;
+  }
   if (timedOut && opts.clearPendingOnTimeout && opts.sessionManager?.clearPendingToolResults) {
     opts.sessionManager.clearPendingToolResults();
+    return;
+  }
+  if (opts.flushMode === "abort") {
+    opts.sessionManager?.abortPendingToolCalls?.();
     return;
   }
   opts.sessionManager?.flushPendingToolResults?.();

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -169,6 +169,28 @@ describe("handleAgentEnd", () => {
     expect(ctx.log.debug).toHaveBeenCalledWith("embedded run agent end: runId=run-1 isError=false");
   });
 
+  it("includes aborted stopReason on lifecycle end events", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(
+      {
+        role: "assistant",
+        stopReason: "aborted",
+        content: [{ type: "text", text: "" }],
+      },
+      { onAgentEvent },
+    );
+
+    await handleAgentEnd(ctx);
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        stopReason: "aborted",
+      },
+    });
+  });
+
   it("flushes orphaned tool media as a media-only block reply", async () => {
     const ctx = createContext(undefined);
     ctx.state.pendingToolMediaUrls = ["/tmp/reply.opus"];

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -38,6 +38,10 @@ export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
 export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
   const lastAssistant = ctx.state.lastAssistant;
   const isError = isAssistantMessage(lastAssistant) && lastAssistant.stopReason === "error";
+  const stopReason =
+    isAssistantMessage(lastAssistant) && typeof lastAssistant.stopReason === "string"
+      ? lastAssistant.stopReason
+      : undefined;
 
   if (isError && lastAssistant) {
     const friendlyError = formatAssistantErrorText(lastAssistant, {
@@ -93,11 +97,15 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
       data: {
         phase: "end",
         endedAt: Date.now(),
+        ...(stopReason ? { stopReason } : {}),
       },
     });
     void ctx.params.onAgentEvent?.({
       stream: "lifecycle",
-      data: { phase: "end" },
+      data: {
+        phase: "end",
+        ...(stopReason ? { stopReason } : {}),
+      },
     });
   }
 

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -11,6 +11,8 @@ export type GuardedSessionManager = SessionManager & {
   flushPendingToolResults?: () => void;
   /** Clear pending tool calls without persisting synthetic tool results. Idempotent. */
   clearPendingToolResults?: () => void;
+  /** Mark the owning assistant turn aborted and clear pending tool calls. Idempotent. */
+  abortPendingToolCalls?: () => void;
 };
 
 /**
@@ -73,5 +75,6 @@ export function guardSessionManager(
   });
   (sessionManager as GuardedSessionManager).flushPendingToolResults = guard.flushPendingToolResults;
   (sessionManager as GuardedSessionManager).clearPendingToolResults = guard.clearPendingToolResults;
+  (sessionManager as GuardedSessionManager).abortPendingToolCalls = guard.abortPendingToolCalls;
   return sessionManager as GuardedSessionManager;
 }

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -122,6 +122,40 @@ describe("installSessionToolResultGuard", () => {
     expect(guard.getPendingIds()).toEqual([]);
   });
 
+  it("marks the matching assistant turn aborted when pending tool calls are aborted", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm);
+
+    sm.appendMessage(toolCallMessage);
+    guard.abortPendingToolCalls();
+
+    const messages = expectPersistedRoles(sm, ["assistant"]) as Array<{
+      role: string;
+      stopReason?: string;
+    }>;
+    expect(messages[0]?.stopReason).toBe("aborted");
+    expect(guard.getPendingIds()).toEqual([]);
+  });
+
+  it("does not append a synthetic tool result when aborting pending tool calls", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm);
+
+    sm.appendMessage(toolCallMessage);
+    guard.abortPendingToolCalls();
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: "hello?",
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = getPersistedMessages(sm);
+    expect(messages.map((message) => message.role)).toEqual(["assistant", "user"]);
+    expect(messages.some((message) => message.role === "toolResult")).toBe(false);
+  });
+
   it("clears pending on user interruption when synthetic tool results are disabled", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm, {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -22,6 +22,21 @@ type SessionManagerWithRawAppend = SessionManager & {
   [RAW_APPEND_MESSAGE]?: SessionManager["appendMessage"];
 };
 
+type SessionMessageEntryLike = {
+  type?: string;
+  id?: string;
+  parentId?: string | null;
+  message?: AgentMessage;
+};
+
+type SessionManagerWithRewrite = {
+  fileEntries?: Array<{ type?: string } | SessionMessageEntryLike>;
+  byId?: Map<string, SessionMessageEntryLike>;
+  leafId?: string | null;
+  _rewriteFile?: () => void;
+  getSessionFile?: () => string | null | undefined;
+};
+
 /**
  * Truncate oversized text content blocks in a tool result message.
  * Returns the original message if under the limit, or a new message with
@@ -122,6 +137,7 @@ export function installSessionToolResultGuard(
 ): {
   flushPendingToolResults: () => void;
   clearPendingToolResults: () => void;
+  abortPendingToolCalls: () => void;
   getPendingIds: () => string[];
 } {
   const originalAppend = getRawSessionAppendMessage(sessionManager);
@@ -184,6 +200,70 @@ export function installSessionToolResultGuard(
   };
 
   const clearPendingToolResults = () => {
+    pendingState.clear();
+  };
+
+  const abortPendingToolCalls = () => {
+    if (pendingState.size() === 0) {
+      return;
+    }
+
+    const pendingIds = new Set(pendingState.getPendingIds());
+    const sessionManagerWithRewrite = sessionManager as unknown as SessionManagerWithRewrite;
+    const byId = sessionManagerWithRewrite.byId;
+    const sessionFile = sessionManagerWithRewrite.getSessionFile?.();
+
+    const findMatchingAssistant = (): SessionMessageEntryLike | undefined => {
+      let current =
+        typeof sessionManagerWithRewrite.leafId === "string" && sessionManagerWithRewrite.leafId
+          ? byId?.get(sessionManagerWithRewrite.leafId)
+          : undefined;
+
+      while (current) {
+        if (current.type === "message" && current.message?.role === "assistant") {
+          const toolCalls = extractToolCallsFromAssistant(current.message);
+          if (toolCalls.some((toolCall) => pendingIds.has(toolCall.id))) {
+            return current;
+          }
+        }
+        const parentId =
+          typeof current.parentId === "string" && current.parentId.trim() ? current.parentId : null;
+        current = parentId ? byId?.get(parentId) : undefined;
+      }
+
+      const fileEntries = sessionManagerWithRewrite.fileEntries ?? [];
+      for (let i = fileEntries.length - 1; i >= 0; i -= 1) {
+        const entry = fileEntries[i] as SessionMessageEntryLike | undefined;
+        if (entry?.type !== "message" || entry.message?.role !== "assistant") {
+          continue;
+        }
+        const toolCalls = extractToolCallsFromAssistant(entry.message);
+        if (toolCalls.some((toolCall) => pendingIds.has(toolCall.id))) {
+          return entry;
+        }
+      }
+      return undefined;
+    };
+
+    const matchingAssistant = findMatchingAssistant();
+    if (!matchingAssistant || matchingAssistant.message?.role !== "assistant") {
+      pendingState.clear();
+      return;
+    }
+
+    const assistant = matchingAssistant.message;
+    if (assistant.stopReason !== "aborted") {
+      matchingAssistant.message = { ...assistant, stopReason: "aborted" };
+      sessionManagerWithRewrite._rewriteFile?.();
+      if (sessionFile && matchingAssistant.id) {
+        emitSessionTranscriptUpdate({
+          sessionFile,
+          sessionKey: opts?.sessionKey,
+          message: matchingAssistant.message,
+          messageId: matchingAssistant.id,
+        });
+      }
+    }
     pendingState.clear();
   };
 
@@ -284,6 +364,7 @@ export function installSessionToolResultGuard(
   return {
     flushPendingToolResults,
     clearPendingToolResults,
+    abortPendingToolCalls,
     getPendingIds: pendingState.getPendingIds,
   };
 }

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -200,7 +200,35 @@ describe("runGatewayLoop", () => {
         reason: "gateway stopping",
         restartExpectedMs: null,
       });
+      expect(markGatewayDraining).toHaveBeenCalledTimes(1);
+      expect(abortEmbeddedPiRun).not.toHaveBeenCalled();
       expect(runtime.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  it("aborts active runs and waits briefly before closing on SIGTERM", async () => {
+    vi.clearAllMocks();
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      getActiveTaskCount.mockReturnValueOnce(1);
+      getActiveEmbeddedRunCount.mockReturnValueOnce(2);
+      waitForActiveTasks.mockResolvedValueOnce({ drained: true });
+      waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: true });
+
+      const { close, exited } = await createSignaledLoopHarness();
+      const sigterm = captureSignal("SIGTERM");
+
+      sigterm();
+
+      await expect(exited).resolves.toBe(0);
+      expect(markGatewayDraining).toHaveBeenCalledTimes(1);
+      expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "all" });
+      expect(waitForActiveTasks).toHaveBeenCalledWith(5_000);
+      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(5_000);
+      expect(close).toHaveBeenCalledWith({
+        reason: "gateway stopping",
+        restartExpectedMs: null,
+      });
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -101,8 +101,71 @@ export async function runGatewayLoop(params: {
   };
 
   const DRAIN_TIMEOUT_MS = 90_000;
+  const STOP_ABORT_SETTLE_TIMEOUT_MS = 5_000;
   const SUPERVISOR_STOP_TIMEOUT_MS = 30_000;
   const SHUTDOWN_TIMEOUT_MS = SUPERVISOR_STOP_TIMEOUT_MS - 5_000;
+
+  const drainBeforeShutdown = async (isRestart: boolean) => {
+    // Reject new enqueues immediately during the drain window so sessions get
+    // an explicit restart/stop failure instead of silent task loss.
+    markGatewayDraining();
+    const activeTasks = getActiveTaskCount();
+    const activeRuns = getActiveEmbeddedRunCount();
+
+    if (isRestart) {
+      // Best-effort abort for compacting runs so long compaction operations
+      // don't hold session write locks across restart boundaries.
+      if (activeRuns > 0) {
+        abortEmbeddedPiRun(undefined, { mode: "compacting" });
+      }
+
+      if (activeTasks > 0 || activeRuns > 0) {
+        gatewayLog.info(
+          `draining ${activeTasks} active task(s) and ${activeRuns} active embedded run(s) before restart (timeout ${DRAIN_TIMEOUT_MS}ms)`,
+        );
+        const [tasksDrain, runsDrain] = await Promise.all([
+          activeTasks > 0
+            ? waitForActiveTasks(DRAIN_TIMEOUT_MS)
+            : Promise.resolve({ drained: true }),
+          activeRuns > 0
+            ? waitForActiveEmbeddedRuns(DRAIN_TIMEOUT_MS)
+            : Promise.resolve({ drained: true }),
+        ]);
+        if (tasksDrain.drained && runsDrain.drained) {
+          gatewayLog.info("all active work drained");
+        } else {
+          gatewayLog.warn("drain timeout reached; proceeding with restart");
+          // Final best-effort abort to avoid carrying active runs into the
+          // next lifecycle when drain time budget is exhausted.
+          abortEmbeddedPiRun(undefined, { mode: "all" });
+        }
+      }
+      return;
+    }
+
+    if (activeRuns > 0) {
+      abortEmbeddedPiRun(undefined, { mode: "all" });
+    }
+
+    if (activeTasks > 0 || activeRuns > 0) {
+      gatewayLog.info(
+        `settling ${activeTasks} active task(s) and ${activeRuns} active embedded run(s) before shutdown (timeout ${STOP_ABORT_SETTLE_TIMEOUT_MS}ms)`,
+      );
+      const [tasksDrain, runsDrain] = await Promise.all([
+        activeTasks > 0
+          ? waitForActiveTasks(STOP_ABORT_SETTLE_TIMEOUT_MS)
+          : Promise.resolve({ drained: true }),
+        activeRuns > 0
+          ? waitForActiveEmbeddedRuns(STOP_ABORT_SETTLE_TIMEOUT_MS)
+          : Promise.resolve({ drained: true }),
+      ]);
+      if (tasksDrain.drained && runsDrain.drained) {
+        gatewayLog.info("all active work settled before shutdown");
+      } else {
+        gatewayLog.warn("shutdown settle timeout reached; proceeding with stop");
+      }
+    }
+  };
 
   const request = (action: GatewayRunSignalAction, signal: string) => {
     if (shuttingDown) {
@@ -125,43 +188,7 @@ export async function runGatewayLoop(params: {
 
     void (async () => {
       try {
-        // On restart, wait for in-flight agent turns to finish before
-        // tearing down the server so buffered messages are delivered.
-        if (isRestart) {
-          // Reject new enqueues immediately during the drain window so
-          // sessions get an explicit restart error instead of silent task loss.
-          markGatewayDraining();
-          const activeTasks = getActiveTaskCount();
-          const activeRuns = getActiveEmbeddedRunCount();
-
-          // Best-effort abort for compacting runs so long compaction operations
-          // don't hold session write locks across restart boundaries.
-          if (activeRuns > 0) {
-            abortEmbeddedPiRun(undefined, { mode: "compacting" });
-          }
-
-          if (activeTasks > 0 || activeRuns > 0) {
-            gatewayLog.info(
-              `draining ${activeTasks} active task(s) and ${activeRuns} active embedded run(s) before restart (timeout ${DRAIN_TIMEOUT_MS}ms)`,
-            );
-            const [tasksDrain, runsDrain] = await Promise.all([
-              activeTasks > 0
-                ? waitForActiveTasks(DRAIN_TIMEOUT_MS)
-                : Promise.resolve({ drained: true }),
-              activeRuns > 0
-                ? waitForActiveEmbeddedRuns(DRAIN_TIMEOUT_MS)
-                : Promise.resolve({ drained: true }),
-            ]);
-            if (tasksDrain.drained && runsDrain.drained) {
-              gatewayLog.info("all active work drained");
-            } else {
-              gatewayLog.warn("drain timeout reached; proceeding with restart");
-              // Final best-effort abort to avoid carrying active runs into the
-              // next lifecycle when drain time budget is exhausted.
-              abortEmbeddedPiRun(undefined, { mode: "all" });
-            }
-          }
-        }
+        await drainBeforeShutdown(isRestart);
 
         await server?.close({
           reason: isRestart ? "gateway restarting" : "gateway stopping",

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -87,6 +87,33 @@ describe("session lifecycle state", () => {
     });
   });
 
+  it("maps phase end events with aborted stop reason to killed", () => {
+    expect(
+      deriveGatewaySessionLifecycleSnapshot({
+        session: {
+          updatedAt: 1_000,
+          status: "running",
+          startedAt: 1_100,
+        },
+        event: {
+          ts: 2_000,
+          data: {
+            phase: "end",
+            endedAt: 1_700,
+            stopReason: "aborted",
+          },
+        },
+      }),
+    ).toEqual({
+      updatedAt: 1_700,
+      status: "killed",
+      startedAt: 1_100,
+      endedAt: 1_700,
+      runtimeMs: 600,
+      abortedLastRun: true,
+    });
+  });
+
   it("maps aborted lifecycle end events without stopReason to timeout", () => {
     expect(
       derivePersistedSessionLifecyclePatch({


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Gateway `SIGTERM` could terminate while an embedded run still had pending tool calls, leaving the transcript with an assistant tool-call turn but no matching tool result.
- Why it matters: On next load, transcript repair synthesized a missing tool-result error, which corrupted the recovered turn and caused the agent run to fail after restart.
- What changed: Shutdown-aborted runs now rewrite the owning assistant transcript entry to `stopReason: "aborted"`, `SIGTERM`/`SIGINT` perform a bounded drain-and-abort path before close, and lifecycle end events carry aborted stop reasons so session state persists as killed.
- What did NOT change (scope boundary): This does not add new transcript message types, does not append shutdown-specific synthetic `toolResult` entries, and does not change normal successful/error tool cleanup behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The `SIGTERM` shutdown path stopped the gateway without giving active embedded runs a reliable chance to persist an aborted terminal state, and the pending-tool timeout fallback cleared guard state instead of marking the owning assistant turn aborted.
- Missing detection / guardrail: There was no shutdown-path test asserting that aborted in-flight tool turns are persisted as `stopReason: "aborted"`, and no guard in pending-tool cleanup to preserve that terminal state on abort.
- Prior context (`git blame`, prior PR, issue, or refactor if known): The transcript-repair path already explicitly skips synthetic repair for assistant turns with `stopReason === "aborted"`, but the gateway/runtime path never wrote that state during shutdown aborts.
- Why this regressed now: Unknown; the behavior appears latent and becomes visible when restart or shutdown lands while an in-flight tool call is still unresolved.
- If unknown, what was ruled out: This is not caused by transcript repair itself; the corruption starts earlier because the transcript is persisted without an aborted terminal marker.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/session-tool-result-guard.test.ts`, `src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts`, `src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts`, `src/gateway/session-lifecycle-state.test.ts`, `src/cli/gateway-cli/run-loop.test.ts`
- Scenario the test should lock in: `SIGTERM` with active embedded runs aborts and settles before close; aborted pending tool calls rewrite the owning assistant turn to `stopReason: "aborted"`; transcript repair then skips synthetic missing-tool insertion; lifecycle state persists the run as killed.
- Why this is the smallest reliable guardrail: The bug spans shutdown orchestration, pending-tool cleanup, and transcript/lifecycle persistence, so targeted unit/seam coverage on those boundaries catches the regression without requiring a full end-to-end harness.
- Existing test that already covers this (if any): None before this change.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Gateway shutdown/restart no longer leaves dangling in-flight tool-call turns that get repaired into synthetic missing-tool errors on next session load.
- Sessions whose last run was shutdown-aborted now persist as aborted/killed instead of appearing to finish normally.

## Diagram (if applicable)

```text
Before:
[gateway SIGTERM] -> [embedded run interrupted] -> [pending tool state cleared] -> [assistant tool-call turn left dangling] -> [next load inserts synthetic missing tool result]

After:
[gateway SIGTERM] -> [gateway marks draining + aborts runs] -> [run finalizer rewrites assistant turn stopReason=aborted] -> [next load skips synthetic repair] -> [session persists as killed]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: `Darwin 25.4.0`
- Runtime/container: local Node.js `v25.8.1`, pnpm `10.32.1`
- Model/provider: Codex desktop / GPT-5.4 (AI-assisted implementation)
- Integration/channel (if any): gateway + embedded run shutdown path
- Relevant config (redacted): default local dev config; no special env required for the targeted tests

### Steps

1. Start a gateway session with an embedded run that emits an assistant tool call and leaves the tool result in flight.
2. Trigger gateway restart or stop so the process receives `SIGTERM` while that tool call is still unresolved.
3. Reload the affected session transcript.

### Expected

- The interrupted assistant turn is persisted as aborted.
- Transcript repair does not synthesize a missing tool-result error for that turn.
- Session lifecycle state records the last run as killed/aborted.

### Actual

- Before this change, the gateway could stop before aborted state was persisted, leaving a dangling tool call.
- Transcript repair then inserted a synthetic missing-tool error result on reload and the recovered run failed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran targeted tests covering abort-aware pending-tool cleanup, wait-for-idle abort behavior, lifecycle stopReason propagation, session lifecycle killed-state persistence, and `SIGTERM` run-loop shutdown behavior.
- Edge cases checked: Abort cleanup after idle settles, abort cleanup after idle timeout, and non-abort timeout cleanup retaining the previous synthetic flush behavior.
- What you did **not** verify: I did not run a manual live gateway restart against an external channel/plugin setup.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Rewriting the wrong assistant transcript entry when multiple assistant turns exist near shutdown.
  - Mitigation: Abort cleanup only rewrites the latest persisted assistant on the current leaf whose tool-call ids intersect the tracked pending ids, and tests cover the targeted pending-call matching behavior.
- Risk: Shutdown waits too long or not long enough for abort finalizers.
  - Mitigation: `SIGTERM`/`SIGINT` use a bounded settle window before forced close, and existing normal shutdown completion semantics remain unchanged.

## AI-assisted disclosure

- This PR was implemented with Codex assistance.
- Testing degree: fully tested with targeted automated coverage.
- I understand the code paths changed here: gateway shutdown orchestration, embedded-run pending-tool cleanup, transcript persistence, and lifecycle stop-reason propagation.
- Local review: `codex review --base upstream/main` was started while preparing this PR; no findings surfaced in the emitted output during the run.
- Session logs/prompts: available from the Codex session used to prepare this branch.

## Testing

```bash
pnpm vitest run src/agents/session-tool-result-guard.test.ts src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts src/gateway/session-lifecycle-state.test.ts src/cli/gateway-cli/run-loop.test.ts
NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc -p tsconfig.json --noEmit
```
