### PR TITLE
fix(openrouter): gate prompt cache markers by endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals/channels: decouple initiating-surface approval availability from native delivery enablement so Telegram, Slack, and Discord still expose approvals when approvers exist and native target routing is configured separately. (#59776) Thanks @joelnishanth.
 - Agents/logging: keep orphaned-user transcript repair warnings focused on interactive runs, and downgrade background-trigger repairs (`heartbeat`, `cron`, `memory`, `overflow`) to debug logs to reduce false-alarm gateway noise.
 - Gateway/node pairing: require `operator.pairing` for node approvals end-to-end, while still requiring `operator.write` or `operator.admin` when the pending node commands need those higher scopes. (#60461) Thanks @eleqtrizit.
+- Providers/OpenRouter: gate Anthropic prompt-cache `cache_control` markers to native/default OpenRouter routes and preserve them for native OpenRouter hosts behind custom provider ids. Thanks @vincentkoc.
 
 ## 2026.4.1
 

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -23,7 +23,6 @@ export default definePluginEntry({
     const {
       buildPassthroughGeminiSanitizingReplayPolicy,
       composeProviderStreamWrappers,
-      createOpenRouterSystemCacheWrapper,
       createOpenRouterWrapper,
       createProviderApiKeyAuthMethod,
       DEFAULT_CONTEXT_TOKENS,
@@ -146,7 +145,6 @@ export default definePluginEntry({
             ? (streamFn) => injectOpenRouterRouting(streamFn, providerRouting)
             : undefined,
           (streamFn) => createOpenRouterWrapper(streamFn, openRouterThinkingLevel),
-          (streamFn) => createOpenRouterSystemCacheWrapper(streamFn),
         );
       },
       isCacheTtlEligible: (ctx) => isOpenRouterCacheTtlModel(ctx.modelId),

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -17,6 +17,7 @@ import {
   shouldApplySiliconFlowThinkingOffCompat,
 } from "./moonshot-stream-wrappers.js";
 import { createOpenAIResponsesContextManagementWrapper } from "./openai-stream-wrappers.js";
+import { createOpenRouterSystemCacheWrapper } from "./proxy-stream-wrappers.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 
 const defaultProviderRuntimeDeps = {
@@ -328,6 +329,8 @@ function applyPrePluginStreamWrappers(ctx: ApplyExtraParamsContext): void {
 function applyPostPluginStreamWrappers(
   ctx: ApplyExtraParamsContext & { providerWrapperHandled: boolean },
 ): void {
+  ctx.agent.streamFn = createOpenRouterSystemCacheWrapper(ctx.agent.streamFn);
+
   if (!ctx.providerWrapperHandled) {
     // Guard Google-family payloads against invalid negative thinking budgets
     // emitted by upstream model-ID heuristics for Gemini 3.1 variants.

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
@@ -2,7 +2,10 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model } from "@mariozechner/pi-ai";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { createOpenRouterWrapper } from "./proxy-stream-wrappers.js";
+import {
+  createOpenRouterSystemCacheWrapper,
+  createOpenRouterWrapper,
+} from "./proxy-stream-wrappers.js";
 
 describe("proxy stream wrappers", () => {
   it("adds OpenRouter attribution headers to stream options", () => {
@@ -33,6 +36,81 @@ describe("proxy stream wrappers", () => {
           "X-Custom": "1",
         },
       },
+    ]);
+  });
+
+  it("injects cache_control markers for declared OpenRouter Anthropic models on the default route", () => {
+    const payload = {
+      messages: [{ role: "system", content: "system prompt" }],
+    };
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      options?.onPayload?.(payload, model);
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenRouterSystemCacheWrapper(baseStreamFn);
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "anthropic/claude-sonnet-4",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(payload.messages[0]?.content).toEqual([
+      { type: "text", text: "system prompt", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("does not inject cache_control markers for declared OpenRouter providers on custom proxy URLs", () => {
+    const payload = {
+      messages: [{ role: "system", content: "system prompt" }],
+    };
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      options?.onPayload?.(payload, model);
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenRouterSystemCacheWrapper(baseStreamFn);
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "anthropic/claude-sonnet-4",
+        baseUrl: "https://proxy.example.com/v1",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(payload.messages[0]?.content).toBe("system prompt");
+  });
+
+  it("injects cache_control markers for native OpenRouter hosts behind custom provider ids", () => {
+    const payload = {
+      messages: [{ role: "system", content: "system prompt" }],
+    };
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      options?.onPayload?.(payload, model);
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenRouterSystemCacheWrapper(baseStreamFn);
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "custom-openrouter",
+        id: "anthropic/claude-sonnet-4",
+        baseUrl: "https://openrouter.ai/api/v1",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(payload.messages[0]?.content).toEqual([
+      { type: "text", text: "system prompt", cache_control: { type: "ephemeral" } },
     ]);
   });
 });

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
@@ -53,7 +53,7 @@ describe("proxy stream wrappers", () => {
       {
         api: "openai-completions",
         provider: "openrouter",
-        id: "anthropic/claude-sonnet-4",
+        id: "anthropic/claude-sonnet-4.6",
       } as Model<"openai-completions">,
       { messages: [] },
       {},
@@ -78,7 +78,7 @@ describe("proxy stream wrappers", () => {
       {
         api: "openai-completions",
         provider: "openrouter",
-        id: "anthropic/claude-sonnet-4",
+        id: "anthropic/claude-sonnet-4.6",
         baseUrl: "https://proxy.example.com/v1",
       } as Model<"openai-completions">,
       { messages: [] },
@@ -102,7 +102,7 @@ describe("proxy stream wrappers", () => {
       {
         api: "openai-completions",
         provider: "custom-openrouter",
-        id: "anthropic/claude-sonnet-4",
+        id: "anthropic/claude-sonnet-4.6",
         baseUrl: "https://openrouter.ai/api/v1",
       } as Model<"openai-completions">,
       { messages: [] },

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -1,10 +1,11 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import { resolveProviderRequestPolicy } from "../provider-attribution.js";
 import { isProxyReasoningUnsupportedModelHint } from "../../plugin-sdk/provider-model-shared.js";
 import { resolveProviderRequestPolicyConfig } from "../provider-request-config.js";
 import { applyAnthropicEphemeralCacheControlMarkers } from "./anthropic-cache-control-payload.js";
-import { isOpenRouterAnthropicModelRef } from "./anthropic-family-cache-semantics.js";
+import { isAnthropicModelRef } from "./anthropic-family-cache-semantics.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 const KILOCODE_FEATURE_HEADER = "X-KILOCODE-FEATURE";
 const KILOCODE_FEATURE_DEFAULT = "openclaw";
@@ -58,10 +59,24 @@ function normalizeProxyReasoningPayload(payload: unknown, thinkingLevel?: ThinkL
 export function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
+    const provider = typeof model.provider === "string" ? model.provider : undefined;
+    const modelId = typeof model.id === "string" ? model.id : undefined;
+    // Keep OpenRouter-specific cache markers on verified OpenRouter routes
+    // (or the provider's default route), but not on arbitrary OpenAI proxies.
+    const endpointClass = resolveProviderRequestPolicy({
+      provider,
+      api: typeof model.api === "string" ? model.api : undefined,
+      baseUrl: typeof model.baseUrl === "string" ? model.baseUrl : undefined,
+      capability: "llm",
+      transport: "stream",
+    }).endpointClass;
     if (
-      typeof model.provider !== "string" ||
-      typeof model.id !== "string" ||
-      !isOpenRouterAnthropicModelRef(model.provider, model.id)
+      !modelId ||
+      !isAnthropicModelRef(modelId) ||
+      !(
+        endpointClass === "openrouter" ||
+        (endpointClass === "default" && provider?.trim().toLowerCase() === "openrouter")
+      )
     ) {
       return underlying(model, context, options);
     }


### PR DESCRIPTION
AI-assisted: Codex
Testing: focused test + build
Session log: available in Codex session history

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenRouter prompt-cache `cache_control` markers were keyed to provider/plugin identity instead of endpoint classification.
- Why it matters: `provider: openrouter` on a custom OpenAI-compatible proxy could receive OpenRouter/Anthropic-only payload mutations, while custom provider ids pointed at native OpenRouter missed the cache optimization.
- What changed: cache marker wrapping now runs in the generic post-plugin path and gates on shared request policy so only native/default OpenRouter routes receive the mutation.
- What did NOT change (scope boundary): reasoning/routing behavior, non-Anthropic models, and non-OpenRouter transports.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the cache wrapper was only installed by the OpenRouter plugin and only checked `provider === "openrouter"`, so it diverged from the transport stack's endpoint-based OpenRouter detection.
- Missing detection / guardrail: there was no direct regression test covering default OpenRouter, custom proxy URL, and custom provider id on native OpenRouter as separate cases.
- Contributing context (if known): other OpenRouter-specific behavior already used endpoint classification, so the cache path drifted from the shared policy.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts`
- Scenario the test should lock in: default-route OpenRouter keeps Anthropic cache markers, custom proxy URLs do not get the mutation, and custom provider ids on native OpenRouter still get the mutation.
- Why this is the smallest reliable guardrail: the behavior is determined in the stream-wrapper/policy boundary before any live provider call.
- Existing test that already covers this (if any): the same file already covered header behavior on the OpenRouter wrapper.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Native/default OpenRouter routes keep Anthropic prompt-cache `cache_control` markers.
- Custom OpenAI-compatible proxy deployments declared as OpenRouter stop receiving OpenRouter-only cache payload mutations.
- Custom provider ids pointed at native OpenRouter now get the same cache marker behavior as the builtin OpenRouter plugin.
- Changelog entry added under the active release block: `Thanks @vincentkoc`.

## Diagram (if applicable)

```text
Before:
[provider=openrouter] -> [cache wrapper checks provider id only] -> [custom proxy may get OpenRouter-only cache mutation]
[custom provider id -> openrouter.ai] -> [no openrouter plugin wrapper] -> [cache mutation missing]

After:
[request policy resolves endpoint class] -> [native/default OpenRouter only] -> [cache mutation applied when Anthropic-compatible]
[custom proxy endpoint] -> [not classified as OpenRouter] -> [payload left untouched]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 15.6.1
- Runtime/container: local shared Codex worktree, Node v25.8.2, pnpm 10.32.1
- Model/provider: OpenRouter + Anthropic-model request path
- Integration/channel (if any): N/A
- Relevant config (redacted): builtin `openrouter` provider on default route vs custom `baseUrl`, plus custom provider id targeting `https://openrouter.ai/api/v1`

### Steps

1. Send an Anthropic-model request through builtin OpenRouter on the default route.
2. Send the same shape through `provider: openrouter` with a custom OpenAI-compatible `baseUrl`.
3. Send the same shape through a custom provider id whose `baseUrl` is native OpenRouter.

### Expected

- Step 1 keeps prompt-cache markers.
- Step 2 does not inject OpenRouter-only cache markers into proxy traffic.
- Step 3 keeps prompt-cache markers despite the custom provider id.

### Actual

- Matches expected with the new wrapper gating and regression tests.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification snippets:

- `pnpm test src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts`
- `pnpm build`
- `pnpm check` currently fails in untouched files on this branch (`src/agents/pi-embedded-runner/compact.hooks.harness.ts`, `src/agents/pi-embedded-runner/run/setup.ts`) with existing TS2883 portability errors; those files are not part of this diff.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused regression coverage for default OpenRouter, custom proxy URL, and custom provider id on native OpenRouter; post-rebase `pnpm build` passes.
- Edge cases checked: non-Anthropic requests remain unmodified by the cache wrapper gate; OpenRouter plugin wrapper composition still works with the generic post-plugin wrapper path.
- What you did **not** verify: live network calls to OpenRouter or a third-party proxy; full `pnpm check` is blocked by untouched TS2883 errors outside this change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: unusual provider configs could still be misclassified if request-policy detection changes independently later.
  - Mitigation: the cache path now reuses the shared policy helper and has direct regression coverage for the three relevant endpoint classes.
