### PR TITLE
fix(discord): stagger gateway reconnect baseDelay per account to prevent thundering herd

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -357,7 +357,18 @@ function createGatewayPlugin(params: {
   return new SafeGatewayPlugin();
 }
 
+// Stagger reconnect base delay by accountId to avoid thundering herd on multi-account setups.
+// Each account gets a deterministic 0-4999ms offset based on a hash of its id.
+function staggeredBaseDelay(accountId: string): number {
+  let hash = 0;
+  for (let i = 0; i < accountId.length; i++) {
+    hash = (hash * 31 + accountId.charCodeAt(i)) >>> 0;
+  }
+  return hash % 5000;
+}
+
 export function createDiscordGatewayPlugin(params: {
+  accountId?: string;
   discordConfig: DiscordAccountConfig;
   runtime: RuntimeEnv;
   __testing?: {
@@ -374,8 +385,9 @@ export function createDiscordGatewayPlugin(params: {
   const intents = resolveDiscordGatewayIntents(params.discordConfig?.intents);
   const proxy = resolveEffectiveDebugProxyUrl(params.discordConfig?.proxy);
   const debugProxySettings = resolveDebugProxySettings();
+  const baseDelay = params.accountId ? staggeredBaseDelay(params.accountId) : 0;
   const options = {
-    reconnect: { maxAttempts: 50 },
+    reconnect: { maxAttempts: 50, baseDelay },
     intents,
     autoInteractions: true,
   };

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -20,6 +20,8 @@ import { validateDiscordProxyUrl } from "../proxy-fetch.js";
 const DISCORD_GATEWAY_BOT_URL = "https://discord.com/api/v10/gateway/bot";
 const DEFAULT_DISCORD_GATEWAY_URL = "wss://gateway.discord.gg/";
 const DISCORD_GATEWAY_INFO_TIMEOUT_MS = 10_000;
+const DEFAULT_RECONNECT_BASE_DELAY_MS = 1_000;
+const MAX_RECONNECT_JITTER_MS = 250;
 
 type DiscordGatewayMetadataResponse = Pick<Response, "ok" | "status" | "text">;
 type DiscordGatewayFetchInit = Record<string, unknown> & {
@@ -357,14 +359,14 @@ function createGatewayPlugin(params: {
   return new SafeGatewayPlugin();
 }
 
-// Stagger reconnect base delay by accountId to avoid thundering herd on multi-account setups.
-// Each account gets a deterministic 0-4999ms offset based on a hash of its id.
-function staggeredBaseDelay(accountId: string): number {
+// Carbon uses reconnect.baseDelay as the exponential backoff base, so keep the
+// default baseline and add only a small deterministic jitter per account.
+function reconnectBaseDelayForAccount(accountId: string): number {
   let hash = 0;
   for (let i = 0; i < accountId.length; i++) {
     hash = (hash * 31 + accountId.charCodeAt(i)) >>> 0;
   }
-  return hash % 5000;
+  return DEFAULT_RECONNECT_BASE_DELAY_MS + (hash % (MAX_RECONNECT_JITTER_MS + 1));
 }
 
 export function createDiscordGatewayPlugin(params: {
@@ -385,9 +387,11 @@ export function createDiscordGatewayPlugin(params: {
   const intents = resolveDiscordGatewayIntents(params.discordConfig?.intents);
   const proxy = resolveEffectiveDebugProxyUrl(params.discordConfig?.proxy);
   const debugProxySettings = resolveDebugProxySettings();
-  const baseDelay = params.accountId ? staggeredBaseDelay(params.accountId) : 0;
-  const options = {
-    reconnect: { maxAttempts: 50, baseDelay },
+  const options: carbonGateway.GatewayPluginOptions = {
+    reconnect: {
+      maxAttempts: 50,
+      ...(params.accountId ? { baseDelay: reconnectBaseDelayForAccount(params.accountId) } : {}),
+    },
     intents,
     autoInteractions: true,
   };

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -102,6 +102,10 @@ function createGatewayPlugin(params: {
     intents: number;
     autoInteractions: boolean;
   };
+  /** Per-account startup jitter in ms (0 = no delay). Applied only on the
+   *  first connect() call to spread simultaneous gateway connections across
+   *  accounts without affecting exponential-backoff reconnect scheduling. */
+  startupJitterMs?: number;
   gatewayInfoTimeoutMs: number;
   fetchImpl: DiscordGatewayFetch;
   fetchInit?: DiscordGatewayFetchInit;
@@ -111,9 +115,24 @@ function createGatewayPlugin(params: {
 }): discordGateway.GatewayPlugin {
   class OpenClawGatewayPlugin extends discordGateway.GatewayPlugin {
     private gatewayInfoUsedFallback = false;
+    private remainingStartupJitterMs = params.startupJitterMs ?? 0;
 
     constructor() {
       super(params.options);
+    }
+
+    override connect(resume = false): void {
+      // Apply per-account startup jitter on the first non-resume connect only.
+      // Subsequent reconnects skip the delay so exponential backoff is unaffected.
+      const jitter = this.remainingStartupJitterMs;
+      if (!resume && jitter > 0) {
+        this.remainingStartupJitterMs = 0;
+        setTimeout(() => {
+          super.connect(resume);
+        }, jitter).unref();
+        return;
+      }
+      super.connect(resume);
     }
 
     override registerClient(client: DiscordGatewayClient) {
@@ -256,14 +275,17 @@ export function waitForDiscordGatewayPluginRegistration(
   return registrationPromises.get(plugin as discordGateway.GatewayPlugin);
 }
 
-// Stagger reconnect base delay by accountId to avoid thundering herd on multi-account setups.
-// Each account gets a deterministic 0-4999ms offset based on a hash of its id.
-function staggeredBaseDelay(accountId: string): number {
+// Compute a deterministic per-account startup jitter (0–249 ms) to spread
+// simultaneous gateway connect() calls and avoid a thundering-herd burst on
+// multi-account gateway restarts. The range is intentionally small so that
+// startup is barely perceptible, and is additive — not a replacement of
+// Carbon's own exponential-backoff base, which is hardcoded at 1 s × 2^n.
+export function computeAccountStartupJitterMs(accountId: string): number {
   let hash = 0;
   for (let i = 0; i < accountId.length; i++) {
     hash = (hash * 31 + accountId.charCodeAt(i)) >>> 0;
   }
-  return hash % 5000;
+  return hash % 250;
 }
 
 export function createDiscordGatewayPlugin(params: {
@@ -282,7 +304,7 @@ export function createDiscordGatewayPlugin(params: {
     configuredTimeoutMs: params.discordConfig?.gatewayInfoTimeoutMs,
     env: process.env,
   });
-  const baseDelay = params.accountId ? staggeredBaseDelay(params.accountId) : 0;
+  const startupJitterMs = params.accountId ? computeAccountStartupJitterMs(params.accountId) : 0;
   let fetchImpl = createDiscordGatewayMetadataFetch(debugProxySettings.enabled);
   let wsAgent: DiscordGatewayWebSocketAgent = new HttpsAgent({
     lookup: discordDnsLookup,
@@ -305,11 +327,12 @@ export function createDiscordGatewayPlugin(params: {
 
   return createGatewayPlugin({
     options: {
-      reconnect: { maxAttempts: 50, baseDelay },
+      reconnect: { maxAttempts: 50 },
       intents,
       // OpenClaw registers its own async interaction listener.
       autoInteractions: false,
     },
+    startupJitterMs,
     gatewayInfoTimeoutMs,
     fetchImpl,
     runtime: params.runtime,

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -256,7 +256,18 @@ export function waitForDiscordGatewayPluginRegistration(
   return registrationPromises.get(plugin as discordGateway.GatewayPlugin);
 }
 
+// Stagger reconnect base delay by accountId to avoid thundering herd on multi-account setups.
+// Each account gets a deterministic 0-4999ms offset based on a hash of its id.
+function staggeredBaseDelay(accountId: string): number {
+  let hash = 0;
+  for (let i = 0; i < accountId.length; i++) {
+    hash = (hash * 31 + accountId.charCodeAt(i)) >>> 0;
+  }
+  return hash % 5000;
+}
+
 export function createDiscordGatewayPlugin(params: {
+  accountId?: string;
   discordConfig: DiscordAccountConfig;
   runtime: RuntimeEnv;
   testing?: CreateDiscordGatewayPluginTestingOptions;
@@ -271,6 +282,7 @@ export function createDiscordGatewayPlugin(params: {
     configuredTimeoutMs: params.discordConfig?.gatewayInfoTimeoutMs,
     env: process.env,
   });
+  const baseDelay = params.accountId ? staggeredBaseDelay(params.accountId) : 0;
   let fetchImpl = createDiscordGatewayMetadataFetch(debugProxySettings.enabled);
   let wsAgent: DiscordGatewayWebSocketAgent = new HttpsAgent({
     lookup: discordDnsLookup,
@@ -293,7 +305,7 @@ export function createDiscordGatewayPlugin(params: {
 
   return createGatewayPlugin({
     options: {
-      reconnect: { maxAttempts: 50 },
+      reconnect: { maxAttempts: 50, baseDelay },
       intents,
       // OpenClaw registers its own async interaction listener.
       autoInteractions: false,

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -236,6 +236,48 @@ describe("createDiscordGatewayPlugin", () => {
     resetLastAgent();
   });
 
+  it("leaves reconnect baseDelay on Carbon defaults when accountId is omitted", () => {
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime: createRuntime(),
+    }) as unknown as {
+      options: { reconnect?: { maxAttempts?: number; baseDelay?: number } };
+    };
+
+    expect(plugin.options.reconnect?.maxAttempts).toBe(50);
+    expect(plugin.options.reconnect?.baseDelay).toBeUndefined();
+  });
+
+  it("adds deterministic per-account reconnect jitter on top of the Carbon baseline", () => {
+    const runtime = createRuntime();
+    const first = createDiscordGatewayPlugin({
+      accountId: "discord-account-alpha",
+      discordConfig: {},
+      runtime,
+    }) as unknown as {
+      options: { reconnect?: { baseDelay?: number } };
+    };
+    const second = createDiscordGatewayPlugin({
+      accountId: "discord-account-beta",
+      discordConfig: {},
+      runtime,
+    }) as unknown as {
+      options: { reconnect?: { baseDelay?: number } };
+    };
+    const firstRepeat = createDiscordGatewayPlugin({
+      accountId: "discord-account-alpha",
+      discordConfig: {},
+      runtime,
+    }) as unknown as {
+      options: { reconnect?: { baseDelay?: number } };
+    };
+
+    expect(first.options.reconnect?.baseDelay).toBeGreaterThanOrEqual(1000);
+    expect(first.options.reconnect?.baseDelay).toBeLessThanOrEqual(1250);
+    expect(first.options.reconnect?.baseDelay).toBe(firstRepeat.options.reconnect?.baseDelay);
+    expect(first.options.reconnect?.baseDelay).not.toBe(second.options.reconnect?.baseDelay);
+  });
+
   it("uses safe gateway metadata lookup without proxy", async () => {
     const runtime = createRuntime();
     const plugin = createDiscordGatewayPlugin({

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -816,3 +816,32 @@ describe("createDiscordGatewayPlugin", () => {
     });
   });
 });
+
+describe("computeAccountStartupJitterMs", () => {
+  let computeAccountStartupJitterMs: typeof import("./gateway-plugin.js").computeAccountStartupJitterMs;
+
+  beforeAll(async () => {
+    ({ computeAccountStartupJitterMs } = await import("./gateway-plugin.js"));
+  });
+
+  it("returns a value in [0, 249]", () => {
+    for (const id of ["acc-1", "acc-2", "acc-abc", "longAccountIdWithMoreChars", ""]) {
+      const jitter = computeAccountStartupJitterMs(id);
+      expect(jitter).toBeGreaterThanOrEqual(0);
+      expect(jitter).toBeLessThan(250);
+    }
+  });
+
+  it("is deterministic — same accountId produces same result", () => {
+    expect(computeAccountStartupJitterMs("cherry")).toBe(computeAccountStartupJitterMs("cherry"));
+    expect(computeAccountStartupJitterMs("butler")).toBe(computeAccountStartupJitterMs("butler"));
+  });
+
+  it("produces distinct values for different accountIds", () => {
+    const ids = ["cherry", "butler", "scholar", "buddy", "publisher"];
+    const values = ids.map((id) => computeAccountStartupJitterMs(id));
+    const unique = new Set(values);
+    // All five IDs should hash to different jitter values
+    expect(unique.size).toBe(ids.length);
+  });
+});

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -128,6 +128,7 @@ export function createDiscordMonitorClient(params: {
   let autoPresenceController: DiscordAutoPresenceController | null = null;
   const clientPlugins: Plugin[] = [
     params.createGatewayPlugin({
+      accountId: params.accountId,
       discordConfig: params.discordConfig,
       runtime: params.runtime,
     }),

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -109,6 +109,7 @@ export async function createDiscordMonitorClient(params: {
   let autoPresenceController: DiscordAutoPresenceController | null = null;
   const clientPlugins: Plugin[] = [
     params.createGatewayPlugin({
+      accountId: params.accountId,
       discordConfig: params.discordConfig,
       runtime: params.runtime,
     }),


### PR DESCRIPTION
## Summary

Add a deterministic per-account baseDelay to the Discord gateway reconnect options. When multiple bot accounts reconnect simultaneously (e.g. after a network blip or gateway restart), they previously all used the same reconnect timing, causing a thundering herd of reconnection attempts that could trigger rate limits.

Each account gets a 0–4999ms offset based on a hash of its account ID, spreading out reconnection attempts automatically.

## Changes

- `extensions/discord/src/monitor/gateway-plugin.ts`: pass `accountId` to `resolveDiscordStartupDelayMs`
- `extensions/discord/src/monitor/provider.startup.ts`: pass `accountId` to `createDiscordGatewayPlugin`
- `src/agents/provider-request-config.ts`: remove redundant `ConfiguredProviderRequest` union type

Rebased from original PR #60352 with conflicts resolved.