### PR TITLE
feat(discord): add expiresAtMs and bindSession to component spec

### DIFF
--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -79,6 +79,14 @@ describe("discord components", () => {
       }),
     ).toThrow("filename");
   });
+
+  it("reads bindSession=false from spec", () => {
+    const spec = readDiscordComponentSpec({
+      blocks: [{ type: "text", text: "hello" }],
+      bindSession: false,
+    });
+    expect(spec?.bindSession).toBe(false);
+  });
 });
 
 describe("discord component registry", () => {

--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -87,6 +87,52 @@ describe("discord components", () => {
     });
     expect(spec?.bindSession).toBe(false);
   });
+
+  it("propagates expiresAtMs and clears route overrides when bindSession is false", () => {
+    const expiresAtMs = Date.now() + 60_000;
+    const spec = readDiscordComponentSpec({
+      text: "Choose a path",
+      bindSession: false,
+      expiresAtMs,
+      blocks: [
+        {
+          type: "actions",
+          buttons: [{ label: "Approve", style: "success", callbackData: "codex:approve" }],
+        },
+      ],
+      modal: {
+        title: "Details",
+        callbackData: "codex:modal",
+        fields: [{ type: "text", label: "Requester" }],
+      },
+    });
+    if (!spec) {
+      throw new Error("Expected component spec to be parsed");
+    }
+
+    expect(spec.bindSession).toBe(false);
+    expect(spec.expiresAtMs).toBe(expiresAtMs);
+
+    const result = buildDiscordComponentMessage({
+      spec,
+      sessionKey: "session-1",
+      agentId: "agent-1",
+      accountId: "account-1",
+    });
+
+    expect(result.entries).not.toHaveLength(0);
+    expect(result.modals).toHaveLength(1);
+    for (const entry of result.entries) {
+      expect(entry.sessionKey).toBeUndefined();
+      expect(entry.agentId).toBeUndefined();
+      expect(entry.accountId).toBeUndefined();
+      expect(entry.expiresAt).toBe(expiresAtMs);
+    }
+    expect(result.modals[0]?.sessionKey).toBeUndefined();
+    expect(result.modals[0]?.agentId).toBeUndefined();
+    expect(result.modals[0]?.accountId).toBeUndefined();
+    expect(result.modals[0]?.expiresAt).toBe(expiresAtMs);
+  });
 });
 
 describe("discord component registry", () => {

--- a/extensions/discord/src/components.ts
+++ b/extensions/discord/src/components.ts
@@ -788,14 +788,17 @@ export function buildDiscordComponentMessage(params: {
     | File
   > = [];
 
-  const boundSessionKey = params.spec.bindSession === false ? undefined : params.sessionKey;
+  const bindSession = params.spec.bindSession !== false;
+  const boundSessionKey = bindSession ? params.sessionKey : undefined;
+  const boundAgentId = bindSession ? params.agentId : undefined;
+  const boundAccountId = bindSession ? params.accountId : undefined;
 
   const addEntry = (entry: DiscordComponentEntry) => {
     entries.push({
       ...entry,
       sessionKey: boundSessionKey,
-      agentId: params.agentId,
-      accountId: params.accountId,
+      agentId: boundAgentId,
+      accountId: boundAccountId,
       reusable: entry.reusable ?? params.spec.reusable,
       expiresAt: entry.expiresAt ?? params.spec.expiresAtMs,
     });
@@ -894,8 +897,8 @@ export function buildDiscordComponentMessage(params: {
       callbackData: params.spec.modal.callbackData,
       fields,
       sessionKey: boundSessionKey,
-      agentId: params.agentId,
-      accountId: params.accountId,
+      agentId: boundAgentId,
+      accountId: boundAccountId,
       reusable: params.spec.reusable,
       expiresAt: params.spec.expiresAtMs,
       allowedUsers: params.spec.modal.allowedUsers,

--- a/extensions/discord/src/components.ts
+++ b/extensions/discord/src/components.ts
@@ -442,6 +442,8 @@ export function readDiscordComponentSpec(raw: unknown): DiscordComponentMessageS
     : undefined;
   const modalRaw = obj.modal;
   const reusable = typeof obj.reusable === "boolean" ? obj.reusable : undefined;
+  const expiresAtMs = readOptionalNumber(obj.expiresAtMs);
+  const bindSession = typeof obj.bindSession === "boolean" ? obj.bindSession : undefined;
   let modal: DiscordModalSpec | undefined;
   if (modalRaw !== undefined) {
     const modalObj = requireObject(modalRaw, "components.modal");
@@ -467,6 +469,8 @@ export function readDiscordComponentSpec(raw: unknown): DiscordComponentMessageS
   return {
     text: readOptionalString(obj.text),
     reusable,
+    expiresAtMs,
+    bindSession,
     container:
       typeof obj.container === "object" && obj.container && !Array.isArray(obj.container)
         ? {
@@ -784,13 +788,16 @@ export function buildDiscordComponentMessage(params: {
     | File
   > = [];
 
+  const boundSessionKey = params.spec.bindSession === false ? undefined : params.sessionKey;
+
   const addEntry = (entry: DiscordComponentEntry) => {
     entries.push({
       ...entry,
-      sessionKey: params.sessionKey,
+      sessionKey: boundSessionKey,
       agentId: params.agentId,
       accountId: params.accountId,
       reusable: entry.reusable ?? params.spec.reusable,
+      expiresAt: entry.expiresAt ?? params.spec.expiresAtMs,
     });
   };
 
@@ -886,10 +893,11 @@ export function buildDiscordComponentMessage(params: {
       title: params.spec.modal.title,
       callbackData: params.spec.modal.callbackData,
       fields,
-      sessionKey: params.sessionKey,
+      sessionKey: boundSessionKey,
       agentId: params.agentId,
       accountId: params.accountId,
       reusable: params.spec.reusable,
+      expiresAt: params.spec.expiresAtMs,
       allowedUsers: params.spec.modal.allowedUsers,
     });
 

--- a/extensions/discord/src/components.types.ts
+++ b/extensions/discord/src/components.types.ts
@@ -123,6 +123,10 @@ export type DiscordModalSpec = {
 export type DiscordComponentMessageSpec = {
   text?: string;
   reusable?: boolean;
+  /** Unix epoch timestamp in milliseconds after which the components expire. */
+  expiresAtMs?: number;
+  /** If false, route interactions through the channel's normal session instead of the sending session. */
+  bindSession?: boolean;
   container?: {
     accentColor?: string | number;
     spoiler?: boolean;

--- a/extensions/discord/src/message-tool-schema.ts
+++ b/extensions/discord/src/message-tool-schema.ts
@@ -97,6 +97,11 @@ export function createDiscordMessageToolComponentsSchema() {
           description: "Allow components to be used multiple times until they expire.",
         }),
       ),
+      expiresAtMs: Type.Optional(
+        Type.Number({
+          description: "Unix epoch timestamp in milliseconds after which the components expire.",
+        }),
+      ),
       container: Type.Optional(
         Type.Object({
           accentColor: Type.Optional(Type.String()),

--- a/extensions/discord/src/message-tool-schema.ts
+++ b/extensions/discord/src/message-tool-schema.ts
@@ -102,6 +102,12 @@ export function createDiscordMessageToolComponentsSchema() {
           description: "Unix epoch timestamp in milliseconds after which the components expire.",
         }),
       ),
+      bindSession: Type.Optional(
+        Type.Boolean({
+          description:
+            "If false, route interaction events through the channel's normal session instead of a bound session key.",
+        }),
+      ),
       container: Type.Optional(
         Type.Object({
           accentColor: Type.Optional(Type.String()),
@@ -113,7 +119,7 @@ export function createDiscordMessageToolComponentsSchema() {
     },
     {
       description:
-        "Discord components v2 payload. Set reusable=true to keep buttons, selects, and forms active until expiry.",
+        "Discord components v2 payload. Set reusable=true to keep buttons, selects, and forms active until expiry. Set bindSession=false to route interactions through the channel's normal session.",
     },
   );
 }


### PR DESCRIPTION
## Summary

Add two new optional fields to `DiscordComponentMessageSpec`:

1. **`expiresAtMs: number`** — Unix epoch timestamp in ms after which the component(s) expire. When set, the components are registered with an expiry time, making them unavailable after the specified moment.

2. **`bindSession: boolean`** — When `false`, interactions are not bound to the session that registered the components, allowing cross-session component usage.

Rebased from original PR #60355 with conflicts resolved.