### PR TITLE
fix(kimi): ensure toolUse stopReason and strip tagged markup from TUI

### DIFF
--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -1,5 +1,6 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
+import { createAnthropicToolPayloadCompatibilityWrapper } from "openclaw/plugin-sdk/provider-stream";
 
 const TOOL_CALLS_SECTION_BEGIN = "<|tool_calls_section_begin|>";
 const TOOL_CALLS_SECTION_END = "<|tool_calls_section_end|>";
@@ -119,14 +120,63 @@ function rewriteKimiTaggedToolCallsInMessage(message: unknown): void {
     changed = true;
   }
 
-  if (!changed) {
+  if (changed) {
+    (message as { content: unknown[] }).content = nextContent;
+  }
+
+  // Ensure stopReason is "toolUse" whenever the message contains toolCall blocks,
+  // whether they came from native provider output or from tagged text rewrite.
+  const finalContent = changed ? nextContent : content;
+  const hasToolCall = finalContent.some(
+    (block) =>
+      block && typeof block === "object" && (block as { type?: unknown }).type === "toolCall",
+  );
+  const typedMessage = message as { stopReason?: unknown };
+  if (hasToolCall && typedMessage.stopReason === "stop") {
+    typedMessage.stopReason = "toolUse";
+  }
+}
+
+function stripKimiTaggedToolCalls(text: string, truncateIncomplete = false): string {
+  const begin = TOOL_CALLS_SECTION_BEGIN;
+  const end = TOOL_CALLS_SECTION_END;
+  let result = text;
+  let index = result.indexOf(begin);
+  while (index >= 0) {
+    const endIndex = result.indexOf(end, index);
+    if (endIndex < 0) {
+      // In-flight stream only: truncate at the incomplete begin tag to avoid UI flicker.
+      // Final messages leave the token untouched so legitimate explanations are not lost.
+      return truncateIncomplete ? result.slice(0, index) : result;
+    }
+    result = result.slice(0, index) + result.slice(endIndex + end.length);
+    index = result.indexOf(begin);
+  }
+  return result;
+}
+
+function stripKimiTaggedToolCallsInMessage(message: unknown, truncateIncomplete = false): void {
+  if (!message || typeof message !== "object") {
     return;
   }
 
-  (message as { content: unknown[] }).content = nextContent;
-  const typedMessage = message as { stopReason?: unknown };
-  if (typedMessage.stopReason === "stop") {
-    typedMessage.stopReason = "toolUse";
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    (message as { content: string }).content = stripKimiTaggedToolCalls(content, truncateIncomplete);
+    return;
+  }
+  if (!Array.isArray(content)) {
+    return;
+  }
+
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as { type?: unknown; text?: unknown };
+    if (typedBlock.type === "text" && typeof typedBlock.text === "string") {
+      typedBlock.text = stripKimiTaggedToolCalls(typedBlock.text, truncateIncomplete);
+    }
   }
 }
 
@@ -137,6 +187,9 @@ function wrapKimiTaggedToolCalls(
   stream.result = async () => {
     const message = await originalResult();
     rewriteKimiTaggedToolCallsInMessage(message);
+    // Final assistant message: strip only complete tag pairs; do not truncate
+    // incomplete sequences so legitimate explanations of the markup are preserved.
+    stripKimiTaggedToolCallsInMessage(message, false);
     return message;
   };
 
@@ -149,11 +202,24 @@ function wrapKimiTaggedToolCalls(
           const result = await iterator.next();
           if (!result.done && result.value && typeof result.value === "object") {
             const event = result.value as {
+              type?: unknown;
               partial?: unknown;
               message?: unknown;
+              reason?: unknown;
             };
             rewriteKimiTaggedToolCallsInMessage(event.partial);
             rewriteKimiTaggedToolCallsInMessage(event.message);
+            // Streaming partials may contain incomplete tag sections; truncate to avoid UI flicker.
+            // For the done event, treat the accumulated message as final and do not truncate.
+            const isDone = event.type === "done";
+            stripKimiTaggedToolCallsInMessage(event.partial, !isDone);
+            stripKimiTaggedToolCallsInMessage(event.message, !isDone);
+            if (isDone && typeof event.reason === "string") {
+              const msg = event.message as { stopReason?: unknown } | undefined;
+              if (msg?.stopReason === "toolUse") {
+                event.reason = "toolUse";
+              }
+            }
           }
           return result;
         },
@@ -178,4 +244,13 @@ export function createKimiToolCallMarkupWrapper(baseStreamFn: StreamFn | undefin
     }
     return wrapKimiTaggedToolCalls(maybeStream);
   };
+}
+
+export function wrapKimiProviderStream(baseStreamFn: StreamFn | undefined): StreamFn {
+  return createKimiToolCallMarkupWrapper(
+    createAnthropicToolPayloadCompatibilityWrapper(baseStreamFn, {
+      toolSchemaMode: "openai-functions",
+      toolChoiceMode: "openai-string-modes",
+    }),
+  );
 }


### PR DESCRIPTION
## Summary

  - Problem: The Kimi Coding provider sometimes returns tool calls as tagged text markup (`<|tool_calls_section_begin|>...<|tool_calls_section_end|>`). Our wrapper correctly rewrote this into `toolCall` blocks, but `message.stopReason` remained `"stop"`,
   causing `pi-agent-core` to overwrite it from the `done` event and prematurely end the turn without executing tools. Additionally, the raw tags leaked into the TUI during streaming.
  - Why it matters: Users would see raw tool-call tags in the UI and the tool would never execute, breaking the agent loop for Kimi.
  - What changed:
    - In `extensions/kimi-coding/stream.ts`:
      - Sync `event.reason = "toolUse"` on `done` events when the message contains tool calls.
      - Ensure `stopReason` is updated only when it is `"stop"` (preserving real terminal states like `"length"`, `"error"`, or `"aborted"`).
      - Add `stripKimiTaggedToolCalls` directly in the Kimi wrapper, applied to both streaming partials and the final `stream.result()` message.
      - Distinguish between in-flight partials (truncate at an incomplete `<|tool_calls_section_begin|>` to avoid UI flicker) and the final message (remove only complete tag pairs, so legitimate explanations of the markup are not silently truncated).
    - No changes are made to generic TUI text formatting; the Kimi-specific stripping is constrained to the provider wrapper.
  - What did NOT change (scope boundary): No changes to other providers' stream behavior or global TUI sanitation rules.

  ## Change Type (select all)

  - [x] Bug fix

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration

  ## Linked Issue/PR

  - Related # (fixed during local debugging session)

  ## Root Cause (if applicable)

  - Root cause: `pi-agent-core`'s proxy layer overwrites `partial.stopReason` from `event.reason` on `done` events. Since the Kimi wrapper only updated `message.stopReason` but the original `done` event still carried `reason === "stop"`, the downstream
  state ended up as `"stop"` even though the message contained `toolCall` blocks.
  - Missing detection / guardrail: The wrapper only updated `stopReason` inside the `changed` branch (when tagged text was rewritten), but Kimi can also emit native `tool_use` blocks where `changed` is false. We now always scan the final content for
  `toolCall` blocks. Additionally, an initial attempt placed tag stripping in generic TUI formatters, which would have side-effected non-Kimi text; that has been moved back into the Kimi-specific wrapper with proper in-flight vs final handling.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [ ] Seam / integration test
  - Target test or file: `extensions/kimi-coding/stream.ts`
  - Scenario the test should lock in: A Kimi stream carrying tagged tool calls must result in `stopReason === "toolUse"`, raw tag markup must not appear in the streamed UI, and final messages that legitimately mention the markup tokens must not be
  truncated.
  - Existing test that already covers this (if any): None specifically for Kimi tagged tool calls.
  - If no new test is added, why not: Provider is still experimental; local live verification was performed.

  ## User-visible / Behavior Changes

  - Kimi tool calls now execute correctly instead of ending the turn early.
  - Raw `<|tool_calls_section_begin|>` markup no longer flashes in the TUI during streaming.
  - Final assistant replies that explain or quote Kimi markup are no longer at risk of silent truncation.

  ## Diagram (if applicable)

  N/A

  ## Security Impact (required)

  - New permissions/capabilities? (`No`)
  - Secrets/tokens handling changed? (`No`)
  - New/changed network calls? (`No`)
  - Command/tool execution surface changed? (`No`)
  - Data access scope changed? (`No`)

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Model/provider: Kimi Coding (`sk-kimi-*`)
  - Integration/channel: TUI (`openclaw message send` / `openclaw agent`)

  ### Steps

  1. Configure a Kimi Coding model with tool access.
  2. Send a message that triggers a tool call.
  3. Observe the streamed output and whether the tool executes.

  ### Expected

  - `stopReason` is `"toolUse"`.
  - Tool is invoked.
  - No raw tag markup appears in the TUI during streaming.
  - Final replies that mention the markup tokens are preserved intact.

  ### Actual

  - Before fix:
    - The TUI displayed the raw tool-call block text (e.g. `<|tool_calls_section_begin|><|tool_call_begin|>functions.read:0<|tool_call_argument_begin|>...`), making it look like the model had emitted a tool call.
    - However, the tool was never actually executed; the conversation ended immediately and the agent turn terminated.
  - After fix:
    - `stopReason` correctly becomes `"toolUse"`.
    - The tool executes normally and returns its result.
    - Streaming tags are stripped before they reach the UI.
    - Final messages explaining the markup are not truncated.

  ## Evidence

  - [x] Trace/log snippets (local live run verified)

  ## Human Verification (required)

  - Verified scenarios: Kimi native `tool_use` block path and Kimi tagged text rewrite path.
  - Edge cases checked: Incomplete begin tags during streaming are truncated cleanly; final messages with literal begin tokens are preserved.
  - What you did **not** verify: Other providers are unaffected (change is scoped to the Kimi wrapper).

  ## Review Conversations

  - [x] N/A - no prior bot review conversations for this branch.

  ## Compatibility / Migration

  - Backward compatible? (`Yes`)
  - Config/env changes? (`No`)
  - Migration needed? (`No`)

  ## Risks and Mitigations

  None.