### PR TITLE
fix(agents): restore exec host=node routing and per-call override from auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/device pairing: require non-admin paired-device sessions to manage only their own device for token rotate/revoke and paired-device removal, blocking cross-device token theft inside pairing-scoped sessions. (#50627) Thanks @coygeek.
 - CLI/skills JSON: route `skills list --json`, `skills info --json`, and `skills check --json` output to stdout instead of stderr so machine-readable consumers receive JSON on the expected stream again. (#60914; fixes #57599; landed from contributor PR #57611 by @Aftabbs) Thanks @Aftabbs.
 - Agents/subagents: honor allowlist validation, auth-profile handoff, and session override state when a subagent retries after `LiveSessionModelSwitchError`. (#58178) Thanks @openperf.
+- Agents/exec: restore `host=node` routing for node-pinned and `host=auto` sessions, while still blocking sandboxed `auto` sessions from jumping to gateway. (#60788) Thanks @openperf.
 
 ## 2026.4.2
 

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -86,24 +86,72 @@ describe("resolveExecTarget", () => {
     });
   });
 
-  it("rejects host overrides when configured host is auto", () => {
-    expect(() =>
+  it("allows per-call host=node override when configured host is auto", () => {
+    expect(
       resolveExecTarget({
         configuredTarget: "auto",
         requestedTarget: "node",
         elevatedRequested: false,
         sandboxAvailable: false,
       }),
-    ).toThrow("exec host not allowed");
+    ).toMatchObject({
+      configuredTarget: "auto",
+      requestedTarget: "node",
+      selectedTarget: "node",
+      effectiveHost: "node",
+    });
   });
 
-  it("also rejects gateway override when configured host is auto", () => {
+  it("allows per-call host=gateway override when configured host is auto and no sandbox", () => {
+    expect(
+      resolveExecTarget({
+        configuredTarget: "auto",
+        requestedTarget: "gateway",
+        elevatedRequested: false,
+        sandboxAvailable: false,
+      }),
+    ).toMatchObject({
+      configuredTarget: "auto",
+      requestedTarget: "gateway",
+      selectedTarget: "gateway",
+      effectiveHost: "gateway",
+    });
+  });
+
+  it("rejects per-call host=gateway override from auto when sandbox is available", () => {
     expect(() =>
       resolveExecTarget({
         configuredTarget: "auto",
         requestedTarget: "gateway",
         elevatedRequested: false,
         sandboxAvailable: true,
+      }),
+    ).toThrow("exec host not allowed");
+  });
+
+  it("allows per-call host=sandbox override when configured host is auto", () => {
+    expect(
+      resolveExecTarget({
+        configuredTarget: "auto",
+        requestedTarget: "sandbox",
+        elevatedRequested: false,
+        sandboxAvailable: true,
+      }),
+    ).toMatchObject({
+      configuredTarget: "auto",
+      requestedTarget: "sandbox",
+      selectedTarget: "sandbox",
+      effectiveHost: "sandbox",
+    });
+  });
+
+  it("rejects cross-host override when configured target is a concrete host", () => {
+    expect(() =>
+      resolveExecTarget({
+        configuredTarget: "node",
+        requestedTarget: "gateway",
+        elevatedRequested: false,
+        sandboxAvailable: false,
       }),
     ).toThrow("exec host not allowed");
   });
@@ -151,7 +199,7 @@ describe("resolveExecTarget", () => {
     });
   });
 
-  it("still forces elevated requests onto the gateway host", () => {
+  it("forces elevated requests onto the gateway host when configured target is auto", () => {
     expect(
       resolveExecTarget({
         configuredTarget: "auto",
@@ -164,6 +212,56 @@ describe("resolveExecTarget", () => {
       requestedTarget: "sandbox",
       selectedTarget: "gateway",
       effectiveHost: "gateway",
+    });
+  });
+
+  it("honours node target for elevated requests when configured target is node", () => {
+    expect(
+      resolveExecTarget({
+        configuredTarget: "node",
+        requestedTarget: "node",
+        elevatedRequested: true,
+        sandboxAvailable: false,
+      }),
+    ).toMatchObject({
+      configuredTarget: "node",
+      requestedTarget: "node",
+      selectedTarget: "node",
+      effectiveHost: "node",
+    });
+  });
+
+  it("routes to node for elevated when configured=node and no per-call override", () => {
+    expect(
+      resolveExecTarget({
+        configuredTarget: "node",
+        elevatedRequested: true,
+        sandboxAvailable: false,
+      }),
+    ).toMatchObject({
+      configuredTarget: "node",
+      requestedTarget: null,
+      selectedTarget: "node",
+      effectiveHost: "node",
+    });
+  });
+
+  it("silently discards mismatched requestedTarget under elevated+node", () => {
+    // When elevated is requested and configuredTarget is "node", the elevated
+    // path always returns "node" regardless of requestedTarget. This is
+    // intentional — elevated overrides per-call host selection.
+    expect(
+      resolveExecTarget({
+        configuredTarget: "node",
+        requestedTarget: "gateway",
+        elevatedRequested: true,
+        sandboxAvailable: false,
+      }),
+    ).toMatchObject({
+      configuredTarget: "node",
+      requestedTarget: "gateway",
+      selectedTarget: "node",
+      effectiveHost: "node",
     });
   });
 });

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -220,11 +220,31 @@ export function renderExecTargetLabel(target: ExecTarget) {
 export function isRequestedExecTargetAllowed(params: {
   configuredTarget: ExecTarget;
   requestedTarget: ExecTarget;
+  sandboxAvailable?: boolean;
 }) {
-  // `auto` is a routing strategy, not a wildcard allowlist. Keep per-call host
-  // selection pinned to the configured/session-selected target so a sandboxed
-  // session cannot silently hop to gateway or node.
-  return params.requestedTarget === params.configuredTarget;
+  // Exact match is always allowed (e.g. configured=node, requested=node).
+  if (params.requestedTarget === params.configuredTarget) {
+    return true;
+  }
+  // `auto` is a routing strategy that selects a host at runtime. Per-call
+  // overrides to a concrete host are allowed so agents and directives can
+  // pin individual commands to a specific target without requiring a global
+  // config change.
+  //
+  // However, when a sandbox runtime is available the session is implicitly
+  // sandboxed — allowing a per-call jump to gateway would bypass sandbox
+  // confinement. Only overrides *to* sandbox (or node, which has its own
+  // approval layer) are safe in that scenario. The ask/approval flow
+  // remains the primary security gate for all non-sandbox hosts.
+  if (params.configuredTarget === "auto") {
+    if (params.sandboxAvailable && params.requestedTarget === "gateway") {
+      return false;
+    }
+    return true;
+  }
+  // Non-auto configured targets require an exact match to prevent silent
+  // host-hopping (e.g. a node-pinned session should not route to gateway).
+  return false;
 }
 
 export function resolveExecTarget(params: {
@@ -236,11 +256,17 @@ export function resolveExecTarget(params: {
   const configuredTarget = params.configuredTarget ?? "auto";
   const requestedTarget = params.requestedTarget ?? null;
   if (params.elevatedRequested) {
+    // Elevated execution runs with host-level permissions. When the target is
+    // explicitly pinned to "node", honour that binding — the node's own
+    // approval/security layer handles elevated semantics on the remote host.
+    // Only redirect to gateway when the configured target is auto/sandbox
+    // (i.e. the intent is local elevated execution on the gateway machine).
+    const elevatedTarget = configuredTarget === "node" ? ("node" as const) : ("gateway" as const);
     return {
       configuredTarget,
       requestedTarget,
-      selectedTarget: "gateway" as const,
-      effectiveHost: "gateway" as const,
+      selectedTarget: elevatedTarget,
+      effectiveHost: elevatedTarget,
     };
   }
   if (
@@ -248,6 +274,7 @@ export function resolveExecTarget(params: {
     !isRequestedExecTargetAllowed({
       configuredTarget,
       requestedTarget,
+      sandboxAvailable: params.sandboxAvailable,
     })
   ) {
     throw new Error(


### PR DESCRIPTION
### Summary

- **Problem**: Since 2026.4.2, `exec host=node` no longer routes commands to paired nodes — every command executes on the gateway instead. All four configuration paths are broken: global `tools.exec.host: "node"` silently runs on gateway; `tools.exec.host: "auto"` with per-call `host=node` throws `"exec host not allowed"`; subagent `host=node` also throws; and disabling elevated does not help. This leaves **zero remaining paths** to execute commands on paired nodes from agents (#60772, same root cause as stale #20669).

- **Root Cause**: Two regressions in `resolveExecTarget()` and `isRequestedExecTargetAllowed()` in `src/agents/bash-tools.exec-runtime.ts`:
  1. **Elevated override** (line 238–245): `elevatedRequested` unconditionally returns `effectiveHost: "gateway"`, ignoring `configuredTarget: "node"`. When a channel has elevated defaults enabled (`defaultLevel: "on"`), the elevated mode resolves to `"ask"` → `elevatedRequested = true` → gateway forced, even though the user explicitly configured `host=node`.
  2. **Strict equality gate** (line 224–228): `isRequestedExecTargetAllowed` uses `requestedTarget === configuredTarget`. When `configuredTarget` is `"auto"`, any per-call override to a concrete host (`node`, `gateway`, `sandbox`) is rejected. The comment says *"auto is a routing strategy, not a wildcard allowlist"*, but this contradicts the documented behavior where `auto` should allow runtime host selection.

- **Fix**:
  1. **Elevated**: When `configuredTarget === "node"`, preserve `effectiveHost: "node"` instead of forcing gateway. The node's own approval/security layer handles elevated semantics on the remote host. All other configured targets (`auto`, `sandbox`, `gateway`) still redirect elevated to gateway as before.
  2. **Auto override**: Allow `isRequestedExecTargetAllowed` to return `true` when `configuredTarget === "auto"`, enabling per-call overrides to any concrete host. Non-auto concrete targets still require exact match to prevent silent host-hopping.

- **What changed**:
  - `src/agents/bash-tools.exec-runtime.ts`: Fixed `isRequestedExecTargetAllowed` to allow per-call overrides under `auto`; fixed `resolveExecTarget` elevated path to honour `node` binding.
  - `src/agents/bash-tools.exec-runtime.test.ts`: Updated 2 existing tests and added 5 new tests covering auto→node override, auto→gateway override, auto→sandbox override, cross-host rejection for concrete targets, elevated+node routing, and elevated+node without per-call override.

- **What did NOT change (scope boundary)**: Node transport layer (`bash-tools.exec-host-node.ts`), approval policy resolution (`exec-approvals.ts`), sandbox isolation checks in `bash-tools.exec.ts`, and the elevated gate logic in `createExecTool.execute` are all untouched. The fix is strictly limited to target *selection* in `resolveExecTarget`.

### Reproduction

1. Pair a Windows node (connected, `system.run` capability advertised).
2. Set `tools.exec.host: "node"` and `tools.exec.node: "<node-id>"` in config.
3. Run `exec hostname` from an agent session.
4. **Before fix**: Returns gateway hostname (Linux). **After fix**: Returns node hostname (Windows).
5. Alternatively, set `tools.exec.host: "auto"` and run `exec host=node: hostname`.
6. **Before fix**: Throws "exec host not allowed". **After fix**: Routes to node correctly.

### Risk / Mitigation

- **Risk**: Allowing per-call overrides under `auto` could let a sandboxed session escape to gateway/node.
- **Mitigation**: Sandbox isolation is enforced independently in `bash-tools.exec.ts` (line 1338: `target.selectedTarget === "sandbox" && !sandbox` check) and by the approval layer (line 1322: `host === "sandbox" ? "deny" : "full"`). The new tests explicitly verify that cross-host overrides between concrete targets (e.g. `node` → `gateway`) are still rejected. The elevated fix only applies to `configuredTarget === "node"`, which is an explicit admin choice — no implicit escalation path is opened.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Agent Tools
- [x] Exec Runtime

### Linked Issue/PR

Fixes #60772
