### PR TITLE
fix(extensions): avoid spurious bundled channel startup warnings

### DIFF
--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -10,8 +10,7 @@ import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/config-runtime";
 import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk/core";
 import { resolveChannelMediaMaxBytes } from "openclaw/plugin-sdk/media-runtime";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/outbound-runtime";
-import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-runtime";
-import { chunkText } from "openclaw/plugin-sdk/reply-runtime";
+import { chunkText, resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { buildOutboundBaseSessionKey, type RoutePeer } from "openclaw/plugin-sdk/routing";
 import {
   buildBaseChannelStatusSummary,

--- a/extensions/slack/src/message-actions.ts
+++ b/extensions/slack/src/message-actions.ts
@@ -1,4 +1,4 @@
-import { createActionGate } from "openclaw/plugin-sdk/agent-runtime";
+import { createActionGate } from "openclaw/plugin-sdk/channel-actions";
 import type { ChannelMessageActionName } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { ChannelToolSend } from "openclaw/plugin-sdk/tool-send";

--- a/extensions/whatsapp/src/channel-outbound.ts
+++ b/extensions/whatsapp/src/channel-outbound.ts
@@ -1,8 +1,16 @@
-import { chunkText } from "openclaw/plugin-sdk/reply-runtime";
+import { chunkText } from "openclaw/plugin-sdk/reply-chunking";
 import { createWhatsAppOutboundBase } from "./outbound-base.js";
 import { resolveWhatsAppOutboundTarget } from "./resolve-outbound-target.js";
 import { getWhatsAppRuntime } from "./runtime.js";
-import { sendMessageWhatsApp, sendPollWhatsApp } from "./send.js";
+
+type WhatsAppSendRuntime = typeof import("./send.runtime.js");
+
+let whatsappSendRuntimePromise: Promise<WhatsAppSendRuntime> | null = null;
+
+async function loadWhatsAppSendRuntime() {
+  whatsappSendRuntimePromise ??= import("./send.runtime.js");
+  return await whatsappSendRuntimePromise;
+}
 
 export function normalizeWhatsAppPayloadText(text: string | undefined): string {
   return (text ?? "").replace(/^(?:[ \t]*\r?\n)+/, "");
@@ -11,8 +19,10 @@ export function normalizeWhatsAppPayloadText(text: string | undefined): string {
 export const whatsappChannelOutbound = {
   ...createWhatsAppOutboundBase({
     chunker: chunkText,
-    sendMessageWhatsApp,
-    sendPollWhatsApp,
+    sendMessageWhatsApp: async (...args) =>
+      (await loadWhatsAppSendRuntime()).sendMessageWhatsApp(...args),
+    sendPollWhatsApp: async (...args) =>
+      (await loadWhatsAppSendRuntime()).sendPollWhatsApp(...args),
     shouldLogVerbose: () => getWhatsAppRuntime().logging.shouldLogVerbose(),
     resolveTarget: ({ to, allowFrom, mode }) =>
       resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),

--- a/extensions/whatsapp/src/send.runtime.ts
+++ b/extensions/whatsapp/src/send.runtime.ts
@@ -1,0 +1,1 @@
+export { sendMessageWhatsApp, sendPollWhatsApp, sendReactionWhatsApp } from "./send.js";

--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -4,6 +4,7 @@ import { importFreshModule } from "../../../test/helpers/import-fresh.ts";
 afterEach(() => {
   vi.doUnmock("../../plugins/discovery.js");
   vi.doUnmock("../../plugins/manifest-registry.js");
+  vi.doUnmock("../../logging/subsystem.js");
 });
 
 describe("bundled channel entry shape guards", () => {
@@ -28,5 +29,41 @@ describe("bundled channel entry shape guards", () => {
 
     expect(bundled.listBundledChannelPlugins()).toEqual([]);
     expect(bundled.listBundledChannelSetupPlugins()).toEqual([]);
+  });
+
+  it("loads bundled signal, slack, and whatsapp entries without recursive load warnings", async () => {
+    const warn = vi.fn();
+    vi.doMock("../../logging/subsystem.js", () => ({
+      createSubsystemLogger: () => ({
+        warn,
+        info: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      }),
+    }));
+
+    const bundled = await importFreshModule<typeof import("./bundled.js")>(
+      import.meta.url,
+      "./bundled.js?scope=real-bundled-recursive-load-warnings",
+    );
+
+    expect(bundled.listBundledChannelPlugins().map((plugin) => plugin.id)).toEqual(
+      expect.arrayContaining(["signal", "slack", "whatsapp"]),
+    );
+    expect(
+      warn.mock.calls.some(([message]) =>
+        String(message).includes("failed to load bundled channel signal"),
+      ),
+    ).toBe(false);
+    expect(
+      warn.mock.calls.some(([message]) =>
+        String(message).includes("failed to load bundled channel slack"),
+      ),
+    ).toBe(false);
+    expect(
+      warn.mock.calls.some(([message]) =>
+        String(message).includes("failed to load bundled channel whatsapp"),
+      ),
+    ).toBe(false);
   });
 });

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -217,8 +217,9 @@ function loadGeneratedBundledChannelEntries(): readonly GeneratedBundledChannelE
     }
     seenIds.add(manifest.id);
 
+    let sourcePath = candidate.source;
     try {
-      const sourcePath = resolvePreferredBundledChannelSource(candidate, manifest);
+      sourcePath = resolvePreferredBundledChannelSource(candidate, manifest);
       const entry = resolveChannelPluginModuleEntry(
         loadBundledModule(sourcePath, candidate.rootDir),
       );
@@ -243,7 +244,7 @@ function loadGeneratedBundledChannelEntries(): readonly GeneratedBundledChannelE
       });
     } catch (error) {
       log.warn(
-        `[channels] failed to load bundled channel ${manifest.id} from ${candidate.source}: ${String(error)}`,
+        `[channels] failed to load bundled channel ${manifest.id} from ${sourcePath}: ${String(error)}`,
       );
     }
   }

--- a/src/plugin-sdk/extension-shared.ts
+++ b/src/plugin-sdk/extension-shared.ts
@@ -1,6 +1,6 @@
 import type { z } from "zod";
 import { runPassiveAccountLifecycle } from "./channel-lifecycle.core.js";
-import { createLoggerBackedRuntime } from "./runtime.js";
+import { createLoggerBackedRuntime } from "./runtime-logger.js";
 export { safeParseJsonWithSchema, safeParseWithSchema } from "../utils/zod-parse.js";
 
 type PassiveChannelStatusSnapshot = {

--- a/src/plugin-sdk/runtime-logger.ts
+++ b/src/plugin-sdk/runtime-logger.ts
@@ -1,0 +1,80 @@
+import { format } from "node:util";
+import type { OutputRuntimeEnv, RuntimeEnv } from "../runtime.js";
+
+/** Minimal logger contract accepted by runtime-adapter helpers. */
+export type LoggerLike = {
+  info: (message: string) => void;
+  error: (message: string) => void;
+};
+
+/** Adapt a simple logger into the RuntimeEnv contract used by shared plugin SDK helpers. */
+export function createLoggerBackedRuntime(params: {
+  logger: LoggerLike;
+  exitError?: (code: number) => Error;
+}): OutputRuntimeEnv {
+  return {
+    log: (...args) => {
+      params.logger.info(format(...args));
+    },
+    error: (...args) => {
+      params.logger.error(format(...args));
+    },
+    writeStdout: (value) => {
+      params.logger.info(value);
+    },
+    writeJson: (value, space = 2) => {
+      params.logger.info(JSON.stringify(value, null, space > 0 ? space : undefined));
+    },
+    exit: (code: number): never => {
+      throw params.exitError?.(code) ?? new Error(`exit ${code}`);
+    },
+  };
+}
+
+/** Reuse an existing runtime when present, otherwise synthesize one from the provided logger. */
+export function resolveRuntimeEnv(params: {
+  runtime: RuntimeEnv;
+  logger: LoggerLike;
+  exitError?: (code: number) => Error;
+}): RuntimeEnv;
+export function resolveRuntimeEnv(params: {
+  runtime?: undefined;
+  logger: LoggerLike;
+  exitError?: (code: number) => Error;
+}): OutputRuntimeEnv;
+export function resolveRuntimeEnv(params: {
+  runtime?: RuntimeEnv;
+  logger: LoggerLike;
+  exitError?: (code: number) => Error;
+}): RuntimeEnv | OutputRuntimeEnv {
+  return params.runtime ?? createLoggerBackedRuntime(params);
+}
+
+/** Resolve a runtime that treats exit requests as unsupported errors instead of process termination. */
+export function resolveRuntimeEnvWithUnavailableExit(params: {
+  runtime: RuntimeEnv;
+  logger: LoggerLike;
+  unavailableMessage?: string;
+}): RuntimeEnv;
+export function resolveRuntimeEnvWithUnavailableExit(params: {
+  runtime?: undefined;
+  logger: LoggerLike;
+  unavailableMessage?: string;
+}): OutputRuntimeEnv;
+export function resolveRuntimeEnvWithUnavailableExit(params: {
+  runtime?: RuntimeEnv;
+  logger: LoggerLike;
+  unavailableMessage?: string;
+}): RuntimeEnv | OutputRuntimeEnv {
+  if (params.runtime) {
+    return resolveRuntimeEnv({
+      runtime: params.runtime,
+      logger: params.logger,
+      exitError: () => new Error(params.unavailableMessage ?? "Runtime exit not available"),
+    });
+  }
+  return resolveRuntimeEnv({
+    logger: params.logger,
+    exitError: () => new Error(params.unavailableMessage ?? "Runtime exit not available"),
+  });
+}


### PR DESCRIPTION
## Summary

- Problem: `openclaw gateway --verbose` startup could log spurious `[channels] failed to load bundled channel ... TypeError` warnings while bundled channel discovery was initializing Signal, Slack, and WhatsApp.
- Why it matters: startup logs looked like bundled channels were broken even though the channels still registered, which made real regressions harder to spot and left fragile startup import cycles in place.
- What changed: 
  - **Signal**: Narrowed chunking imports to `plugin-sdk/reply-chunking`.
  - **Slack**: Moved message-action gating off a broader startup import surface.
  - **WhatsApp**: Decoupled outbound sending by introducing a dedicated `send.runtime.ts` to avoid broad startup dependencies.
  - **Core/SDK**: Kept `extension-shared` off the broader `plugin-sdk/runtime` startup path through a tiny internal logger helper (`runtime-logger.ts`).
  - **Loader**: Fixed bundled-loader warning paths to report the actual attempted entrypoint, and expanded the bundled loader regression test around the startup warning path.
- What did NOT change (scope boundary): no channel behavior changes, no setup/config surface changes, no broader bundled-loader redesign, and no public Plugin SDK contract changes.

## Change Type 

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope 

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Root Cause 

- Root cause: Signal, Slack, and WhatsApp startup imports pulled in broader SDK/runtime seams that looped back into bundled channel discovery while those same channels were still being initialized.
- Missing detection / guardrail: there was no regression test asserting that the affected bundled channel entries load without bundled-loader warning logs.
- Contributing context: Signal still used a broader reply surface for chunking, Slack still touched a broader startup runtime seam for message-action gating, WhatsApp outbound logic lacked strict import boundaries, and `extension-shared` still reached through the broader runtime entrypoint during startup-sensitive imports.

## Regression Test Plan

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/channels/plugins/bundled.shape-guard.test.ts`
- Scenario the test should lock in: loading the affected real bundled channel entries does not emit `failed to load bundled channel ...` warnings.
- Why this is the smallest reliable guardrail: it exercises the real bundled discovery + module loading path where the recursive startup warnings were happening, without needing a full gateway boot.
- Existing test that already covers this: none for the real bundled startup warning path.

## User-visible / Behavior Changes

`openclaw gateway --verbose` no longer logs the spurious bundled Signal, Slack, or WhatsApp `TypeError` startup warnings from recursive bundled-channel scans.

## Diagram

```text
Before:
19:36:51+08:00 [channels] failed to load bundled channel signal from /opt/openclaw-main/openclaw/dist-runtime/extensions/signal/index.js: TypeError: Cannot read properties of undefined (reading 't')
19:36:51+08:00 [channels] failed to load bundled channel signal from /opt/openclaw-main/openclaw/dist-runtime/extensions/signal/index.js: TypeError: Cannot read properties of undefined (reading 't')
19:36:51+08:00 [channels] failed to load bundled channel slack from /opt/openclaw-main/openclaw/dist-runtime/extensions/slack/index.js: TypeError: Cannot read properties of undefined (reading 'n')

🦞 OpenClaw 2026.4.4 (3f457ca) — Somewhere between 'hello world' and 'oh god what have I built.'

After:
🦞 OpenClaw 2026.4.4 (32b33a7) — Automation with claws: minimal fuss, maximal pinch.
[clean startup logs]
```

## Security Impact

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout
- Model/provider: N/A
- Integration/channel: bundled Signal, Slack, and WhatsApp channel startup
- Relevant config: local bundled extension build output under `dist/` / `dist-runtime/`

### Steps

1. Build the repo.
2. Trigger bundled channel discovery, for example via `openclaw gateway --verbose`.
3. Inspect startup logs for bundled channel load warnings.

### Expected

- Signal, Slack, and WhatsApp bundled channels load without `failed to load bundled channel ... TypeError` warnings during startup.

### Actual

- Before the fix, startup logged two Signal warnings and one Slack warning caused by recursive bundled-channel rescans during hot-path import.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified scenarios: reproduced the original built-artifact Signal/Slack warnings, confirmed the warnings disappeared after the seam narrowing and startup-path changes, ran `pnpm plugin-sdk:api:check`, ran `pnpm test src/channels/plugins/bundled.shape-guard.test.ts`, and ran `pnpm build` after rebasing onto latest `upstream/main`.
- Edge cases checked: kept bundled loader behavior unchanged apart from better warning source paths; confirmed Signal, Slack, and WhatsApp still appear in bundled channel discovery after the fix; confirmed the PR does not change the tracked Plugin SDK baseline.
- What you did **not** verify: a full live Slack, Signal, or WhatsApp message roundtrip, and I did not broaden scope into unrelated startup warnings outside these recursive bundled-load paths.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Risks and Mitigations

- Risk:
  - A future hot-path refactor could reintroduce broad startup imports and bring back recursive bundled-load warnings on another channel.
- Mitigation:
  - The bundled loader regression test now locks the startup warning path, and the changed startup imports now prefer narrower seams or lazy runtime boundaries.
