### PR TITLE
perf: skip bootstrap file injection on session continuation messages

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -92,7 +92,8 @@ import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
 import { resolveTranscriptPolicy } from "../../transcript-policy.js";
-import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
+import { DEFAULT_BOOTSTRAP_FILENAME, type WorkspaceBootstrapFile } from "../../workspace.js";
+import type { EmbeddedContextFile } from "../../pi-embedded-helpers.js";
 import { isRunnerAbortError } from "../abort.js";
 import { isCacheTtlEligibleProvider } from "../cache-ttl.js";
 import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
@@ -357,16 +358,24 @@ export async function runEmbeddedAttempt(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
-    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
-      await resolveBootstrapContextForRun({
-        workspaceDir: effectiveWorkspace,
-        config: params.config,
-        sessionKey: params.sessionKey,
-        sessionId: params.sessionId,
-        warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
-        contextMode: params.bootstrapContextMode,
-        runKind: params.bootstrapContextRunKind,
-      });
+    // Skip loading workspace bootstrap files on continuation messages — they were
+    // already injected on the first message and are still in the conversation
+    // history. This avoids re-injecting ~35k tokens of static content per turn.
+    const isSessionContinuation = await fs
+      .stat(params.sessionFile)
+      .then(() => true)
+      .catch(() => false);
+    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } = isSessionContinuation
+      ? { bootstrapFiles: [] as WorkspaceBootstrapFile[], contextFiles: [] as EmbeddedContextFile[] }
+      : await resolveBootstrapContextForRun({
+          workspaceDir: effectiveWorkspace,
+          config: params.config,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+          contextMode: params.bootstrapContextMode,
+          runKind: params.bootstrapContextRunKind,
+        });
     const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
     const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
     const bootstrapAnalysis = analyzeBootstrapBudget({


### PR DESCRIPTION
## Summary

Workspace bootstrap files (AGENTS.md, CLAUDE.md, USER.md, etc.) are static content that rarely changes mid-conversation. Previously they were re-injected into the system prompt on **every message**, wasting ~35k tokens per turn in multi-message conversations.

This PR checks if the session file already exists before loading bootstrap files. On continuation messages (session file exists), the bootstrap injection is skipped entirely since the files were already included in the first message and remain in the conversation history.

### What changed

- **src/agents/pi-embedded-runner/run/attempt.ts** -- Added session file existence check before `resolveBootstrapContextForRun`. If session file exists (continuation), returns empty bootstrap/context arrays instead of re-loading all workspace files.

### Measured impact (from issue analysis)

- **~93.5% token reduction** over multi-message conversations
- **~$1.51 saved per 100-message conversation**
- First message still gets full workspace context (no change)
- Agents can still use the read tool to access workspace files on subsequent turns

Closes #9157

## Test plan

- [x] Existing bootstrap-files tests pass (5/5)
- [x] oxlint clean
- [ ] Verify first message in a new session still loads all workspace files
- [ ] Verify second+ messages skip bootstrap file loading
- [ ] Verify agent can still read workspace files via tool on continuation messages
- [ ] No regression in conversation quality across multi-turn sessions

